### PR TITLE
ignore cpu specific header file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /e2-build-release-oled/
 *.launch
 /toolchain/*
+src/drivers/RZA1/cpu_specific.h

--- a/src/drivers/RZA1/cpu_specific.h
+++ b/src/drivers/RZA1/cpu_specific.h
@@ -332,10 +332,10 @@ DMA channels:
 // eventually will be distinguished by build script flags
 // Change your build to change whether you're building OLED or not
 #ifndef HAVE_OLED
-#define HAVE_OLED 0
+#define HAVE_OLED 1
 #endif
 #ifndef HAVE_RTT
-#define HAVE_RTT 0
+#define HAVE_RTT 1
 #endif
 
 #define NUM_ENCODERS 6


### PR DESCRIPTION
This commit does two things:

1. Reverts the cpu_specific.h file to have HAVE_OLED and HAVE_RTT set to 1, matching the official branch, the comments in uart_all_cpus, and the code guide

2. Adds this file to gitignore so that user configurations do not cause extra changes. Once build scripts are written that could be reverted 