### PR TITLE
Increase resolution of patch cable strength in the sound editor

### DIFF
--- a/src/MenuItemPatchCableStrength.h
+++ b/src/MenuItemPatchCableStrength.h
@@ -18,16 +18,18 @@
 #ifndef MENUITEMPATCHCABLESTRENGTH_H_
 #define MENUITEMPATCHCABLESTRENGTH_H_
 
-#include "MenuItemInteger.h"
+#include "MenuItemDecimal.h"
 #include "MenuItemWithCCLearning.h"
 
-class MenuItemPatchCableStrength : public MenuItemIntegerContinuous, public MenuItemWithCCLearning {
+class MenuItemPatchCableStrength : public MenuItemDecimal, public MenuItemWithCCLearning {
 public:
-	MenuItemPatchCableStrength(char const* newName = NULL) : MenuItemIntegerContinuous(newName) {}
+	MenuItemPatchCableStrength(char const* newName = NULL) : MenuItemDecimal(newName) {}
 	void readCurrentValue() final;
 	void writeCurrentValue();
-	int getMinValue() final { return -50; }
-	int getMaxValue() final { return 50; }
+	int getMinValue() final { return -5000; }
+	int getMaxValue() final { return 5000; }
+	int getNumDecimalPlaces() final { return 2; }
+	virtual int getDefaultEditPos() { return 2; }
 	virtual int checkPermissionToBeginSession(Sound* sound, int whichThing, MultiRange** currentRange);
 	virtual ParamDescriptor getDestinationDescriptor() = 0;
 	virtual uint8_t getS() = 0;
@@ -61,15 +63,11 @@ public:
 	uint8_t shouldBlinkPatchingSourceShortcut(int s, uint8_t* colour);
 	MenuItem* patchingSourceShortcutPress(int s, bool previousPressStillActive);
 	MenuItem* selectButtonPress() final;
-#if !HAVE_OLED
-	void drawValue() final;
-#endif
 };
 
 class MenuItemPatchCableStrengthRange final : public MenuItemPatchCableStrength {
 public:
 	MenuItemPatchCableStrengthRange(char const* newName = NULL) : MenuItemPatchCableStrength(newName) {}
-	void drawValue();
 	ParamDescriptor getDestinationDescriptor();
 	uint8_t getS();
 	ParamDescriptor getLearningThing();


### PR DESCRIPTION
This is not nearly done yet but it would make sense to use draft PR:s to indicate what people are exploring/working on.

The Sound engine (and synth XML files) support much higher resolution for patch cable strength internally, than the -50 to +50 steps available in soundeditor when you make modulation mappings.
It is already possible to adjust the strength by editing the XML manually (or by some third party editor which could have implemented this), and the resolution could be increased in the sound editor only, while keeping full backward/forward compat of synth XML files.

to be done:
- [x] ~~rework the conversion code to use floats instead of magic integer constants~~, and allow even higher resolution on demand.
- [x] rework the OLED UI layout (the additional digits might overlap parameter name, need to use smaller font for digits)
- [x] ~~update the UI code for 7seg display~~ this should already be handled by MenuItemDecimal but a 7seg owner verifying this would be good