### PR TITLE
Fix debug build flags for text output

### DIFF
--- a/.cproject
+++ b/.cproject
@@ -128,6 +128,7 @@
 									<listOptionValue builtIn="false" value="IN_HARDWARE_DEBUG=1"/>
 									<listOptionValue builtIn="false" value="HAVE_RTT=1"/>
 									<listOptionValue builtIn="false" value="HAVE_OLED=1"/>
+									<listOptionValue builtIn="false" value="ENABLE_TEXT_OUTPUT=1"/>
 								</option>
 								<inputType id="ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input.231965655" superClass="ilg.gnuarmeclipse.managedbuild.cross.tool.cpp.compiler.input"/>
 								<inputType id="com.renesas.cdt.managedbuild.gcc.rz.inputType.compiler.c.393655903" superClass="com.renesas.cdt.managedbuild.gcc.rz.inputType.compiler.c"/>
@@ -1762,6 +1763,7 @@
 								<option id="com.renesas.cdt.managedbuild.gcc.rz.option.compiler.cpp.language.1989113927" name="Language standard" superClass="com.renesas.cdt.managedbuild.gcc.rz.option.compiler.cpp.language" useByScannerDiscovery="true" value="com.renesas.cdt.managedbuild.gcc.rz.option.compiler.cpp.language.default" valueType="enumerated"/>
 								<option IS_BUILTIN_EMPTY="false" IS_VALUE_EMPTY="false" id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs.1465009803" name="Defined symbols (-D)" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs" useByScannerDiscovery="true" valueType="definedSymbols">
 									<listOptionValue builtIn="false" value="IN_HARDWARE_DEBUG=1"/>
+									<listOptionValue builtIn="false" value="ENABLE_TEXT_OUTPUT=1"/>
 									<listOptionValue builtIn="false" value="HAVE_RTT=1"/>
 									<listOptionValue builtIn="false" value="HAVE_OLED=0"/>
 								</option>

--- a/src/drivers/All_CPUs/uart_all_cpus/uart_all_cpus.h
+++ b/src/drivers/All_CPUs/uart_all_cpus/uart_all_cpus.h
@@ -33,9 +33,9 @@
  * this might be what you want to do. If so, go to src/drivers/RZA1/cpu_specific.h,
  * and set HAVE_RTT to 0. Though this configuration hasn’t been tested for a while...
  */
-
+#ifndef ENABLE_TEXT_OUTPUT
 #define ENABLE_TEXT_OUTPUT 0
-
+#endif
 
 struct UartItem { // Exactly 8 bytes, so can align nicely to cache line
 	uint16_t txBufferWritePos;


### PR DESCRIPTION
Tiny PR to fix RTT output in the debug builds by adding an ifndef guard to enable_text_output and adding it to the preprocessor