### PR TITLE
Disabled RTT in OpenOCD

### DIFF
--- a/contrib/renesas-rz-a1lu-jtag.cfg
+++ b/contrib/renesas-rz-a1lu-jtag.cfg
@@ -34,4 +34,9 @@ init
 halt
 arm semihosting enable
 cortex_a dbginit
-rtt server start 19021 0
+
+### RTT IS NOT CURRENTLY WORKING VIA OPENOCD
+### if using DelugeProbe, RTT messages are exposed by the probe 
+### via the first of two USB Serial (CDC) ports.
+### Disabled the following until OpenOCD support for RTT works:
+# rtt server start 19021 0

--- a/contrib/renesas-rz-a1lu.cfg
+++ b/contrib/renesas-rz-a1lu.cfg
@@ -32,4 +32,9 @@ init
 halt
 arm semihosting enable
 cortex_a dbginit
-rtt server start 19021 0
+
+### RTT IS NOT CURRENTLY WORKING VIA OPENOCD
+### if using DelugeProbe, RTT messages are exposed by the probe 
+### via the first of two USB Serial (CDC) ports.
+### Disabled the following until OpenOCD support for RTT works:
+# rtt server start 19021 0


### PR DESCRIPTION
RTT is available over USB serial CDC when using the DelugeProbe, however the OpenOCD RTT support does not seem to want to cooperate with the Deluge. Removing the exposed RTT port in OpenOCD configurations for now so as not to confuse folks.

Please use the DelugeProbe's serial RTT output.