### PR TITLE
keyboardScreen: support multiple note layouts

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -615,7 +615,7 @@ typedef enum SyncLevel_ {
 
 #define ALLOW_SPAM_MODE 0 // For debugging I think?
 
-#define KEYBOARD_ROW_INTERVAL 5
+#define KEYBOARD_ROW_INTERVAL_MAX 16
 
 // UART
 #define MIDI_TX_BUFFER_SIZE 1024

--- a/src/deluge/gui/ui/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard_screen.h
@@ -64,7 +64,7 @@ public:
 
 private:
 	int getNoteCodeFromCoords(int x, int y);
-	void doScroll(int offset);
+	void doScroll(int offset, bool force = false);
 	int getLowestAuditionedNote();
 	int getHighestAuditionedNote();
 	void enterScaleMode(int selectedRootNote = 2147483647);
@@ -72,8 +72,8 @@ private:
 	void drawNoteCode(int noteCode);
 
 	KeyboardPadPress padPresses[MAX_NUM_KEYBOARD_PAD_PRESSES];
-	uint8_t noteColours[displayHeight * KEYBOARD_ROW_INTERVAL + displayWidth][3];
-	bool yDisplayActive[displayHeight * KEYBOARD_ROW_INTERVAL + displayWidth];
+	uint8_t noteColours[displayHeight * KEYBOARD_ROW_INTERVAL_MAX + displayWidth][3];
+	bool yDisplayActive[displayHeight * KEYBOARD_ROW_INTERVAL_MAX + displayWidth];
 };
 
 extern KeyboardScreen keyboardScreen;

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -77,6 +77,8 @@ InstrumentClip::InstrumentClip(Song* song) : Clip(CLIP_TYPE_INSTRUMENT) {
 	midiSub = 128;  // Means none
 	midiPGM = 128;  // Means none
 
+	keyboardRowInterval = 5;
+
 	currentlyRecordingLinearly = false;
 
 	if (song) colourOffset -= song->rootNote;
@@ -103,7 +105,7 @@ InstrumentClip::InstrumentClip(Song* song) : Clip(CLIP_TYPE_INSTRUMENT) {
 		yScroll =
 		    0; // Only for safety. Shouldn't actually get here if we're not going to overwrite this elsewhere I think...
 	}
-	yScrollKeyboardScreen = 60 - (displayHeight >> 2) * KEYBOARD_ROW_INTERVAL;
+	yScrollKeyboardScreen = 60 - (displayHeight >> 2) * keyboardRowInterval;
 
 	instrumentTypeWhileLoading = 0;
 }
@@ -1219,7 +1221,7 @@ bool InstrumentClip::renderAsSingleRow(ModelStackWithTimelineCounter* modelStack
 
 	// Special case if we're a simple keyboard-mode Clip
 	if (onKeyboardScreen && !containsAnyNotes()) {
-		int increment = (displayWidth + (displayHeight * KEYBOARD_ROW_INTERVAL)) / displayWidth;
+		int increment = (displayWidth + (displayHeight * keyboardRowInterval)) / displayWidth;
 		for (int x = xStart; x < xEnd; x++) {
 			getMainColourFromY(yScrollKeyboardScreen + x * increment, 0, &image[x * 3]);
 		}
@@ -1994,6 +1996,7 @@ void InstrumentClip::writeDataToFile(Song* song) {
 	storageManager.writeAttribute("inKeyMode", inScaleMode);
 	storageManager.writeAttribute("yScroll", yScroll);
 	storageManager.writeAttribute("yScrollKeyboard", yScrollKeyboardScreen);
+	storageManager.writeAttribute("keyboardRowInterval", keyboardRowInterval);
 	if (onKeyboardScreen) storageManager.writeAttribute("onKeyboardScreen", (char*)"1");
 	if (wrapEditing) storageManager.writeAttribute("crossScreenEditLevel", wrapEditLevel);
 	if (output->type == INSTRUMENT_TYPE_KIT) storageManager.writeAttribute("affectEntire", affectEntire);
@@ -2198,6 +2201,10 @@ someError:
 
 		else if (!strcmp(tagName, "yScrollKeyboard")) {
 			yScrollKeyboardScreen = storageManager.readTagOrAttributeValueInt();
+		}
+
+		else if (!strcmp(tagName, "keyboardRowInterval")) {
+			keyboardRowInterval = storageManager.readTagOrAttributeValueInt();
 		}
 
 		else if (!strcmp(tagName, "crossScreenEditLevel")) {

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -113,6 +113,7 @@ public:
 
 	int yScroll;
 	int yScrollKeyboardScreen;
+	int keyboardRowInterval;
 
 	int32_t ticksTilNextNoteRowEvent;
 	int32_t noteRowsNumTicksBehindClip;


### PR DESCRIPTION
addresses https://github.com/SynthstromAudible/DelugeFirmware/issues/19

shift + <|> to change row offset. Limited to offsets between 1-12 seems reasonable (max value gives octave shift).

allowing offset=0 would make sense together with rows being mapped to velocity instead (could be a followup).

- [x] TODO: save/load this as part of saving a song.
- [x] UI fixes, like a popup showing the value, and fix colors not always updating