### PR TITLE
Correction of redundant definition.

### DIFF
--- a/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_plibusbip.c
+++ b/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_plibusbip.c
@@ -629,7 +629,7 @@ uint16_t usb_read_data_fast_rohan(uint16_t pipe)
     return USB_READEND; // It might also have been a READSHRT, but the distinction doesn't matter to us.
 }
 
-uint16_t g_usb_usbmode;
+extern uint16_t g_usb_usbmode;
 
 /***********************************************************************************************************************
  Function Name   : usb_pstd_read_data


### PR DESCRIPTION
- While 9.2.1 ignores it, 10.3 build fails if `g_usb_usbmode` is redefined. Fixing through `extern` prefix to reference existing definition.