### PR TITLE
Compile-time signed_saturate bits parameter

### DIFF
--- a/src/AudioEngine.cpp
+++ b/src/AudioEngine.cpp
@@ -923,8 +923,8 @@ bool doSomeOutputting() {
 		}
 
 #else
-		i2sTXBufferPosNow[0] = lshiftAndSaturate(lAdjusted, AUDIO_OUTPUT_GAIN_DOUBLINGS);
-		i2sTXBufferPosNow[1] = lshiftAndSaturate(rAdjusted, AUDIO_OUTPUT_GAIN_DOUBLINGS);
+		i2sTXBufferPosNow[0] = lshiftAndSaturate<AUDIO_OUTPUT_GAIN_DOUBLINGS>(lAdjusted);
+		i2sTXBufferPosNow[1] = lshiftAndSaturate<AUDIO_OUTPUT_GAIN_DOUBLINGS>(rAdjusted);
 
 		outputBufferForResampling[numSamplesOutputted].l = i2sTXBufferPosNow[0];
 		outputBufferForResampling[numSamplesOutputted].r = i2sTXBufferPosNow[1];

--- a/src/AutoParam.cpp
+++ b/src/AutoParam.cpp
@@ -1887,7 +1887,7 @@ void AutoParam::copy(int32_t startPos, int32_t endPos, CopiedParamAutomation* co
 			newNode->value = getValueAtPos(startPos, modelStack);
 			newNode->interpolated = false;
 
-			if (isPatchCable) newNode->value = lshiftAndSaturate(newNode->value, 1);
+			if (isPatchCable) newNode->value = lshiftAndSaturate<1>(newNode->value);
 
 			n++;
 		}
@@ -1902,7 +1902,7 @@ void AutoParam::copy(int32_t startPos, int32_t endPos, CopiedParamAutomation* co
 			newNode->value = nodeToCopy->value;
 			newNode->interpolated = nodeToCopy->interpolated;
 
-			if (isPatchCable) newNode->value = lshiftAndSaturate(newNode->value, 1);
+			if (isPatchCable) newNode->value = lshiftAndSaturate<1>(newNode->value);
 
 			readingNodeI++;
 		}

--- a/src/FilterSet.cpp
+++ b/src/FilterSet.cpp
@@ -42,7 +42,7 @@ void FilterSet::renderHPF(int32_t* outputSample, FilterSetConfig* filterSetConfi
 		a = getTanHAntialiased(a, &hpfLastWorkingValue, 2 + extraSaturation);
 	}
 	else {
-		hpfLastWorkingValue = (uint32_t)lshiftAndSaturate(a, 2) + 2147483648u;
+		hpfLastWorkingValue = (uint32_t)lshiftAndSaturate<2>(a) + 2147483648u;
 		if (filterSetConfig->hpfProcessedResonance > 750000000) { // 400551738
 			a = getTanHUnknown(a, 2 + extraSaturation);
 		}
@@ -105,14 +105,14 @@ void FilterSet::renderHPFLong(int32_t* outputSample, int32_t* endSample, FilterS
 		// Only saturate / anti-alias if lots of resonance
 		if (hpfDoingAntialiasingNow) { // 890551738
 			if (needToFixSaturation) {
-				hpfLastWorkingValue = (uint32_t)lshiftAndSaturate(a, HPF_LONG_SATURATION) + 2147483648u;
+				hpfLastWorkingValue = (uint32_t)lshiftAndSaturate<HPF_LONG_SATURATION>(a) + 2147483648u;
 				needToFixSaturation = false;
 			}
 			a = getTanHAntialiased(a, &hpfLastWorkingValue, HPF_LONG_SATURATION);
 		}
 		else {
 			if (filterSetConfig->hpfProcessedResonance > 750000000) { // 400551738
-				a = getTanH(a, HPF_LONG_SATURATION);
+				a = getTanH<HPF_LONG_SATURATION>(a);
 			}
 		}
 

--- a/src/FilterSetConfig.cpp
+++ b/src/FilterSetConfig.cpp
@@ -115,7 +115,7 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 		}
 
 		int32_t tannedFrequency =
-		    instantTan(lshiftAndSaturate(lpfFrequency, 5)); // Between 0 and 8, by my making. 1 represented by 268435456
+		    instantTan(lshiftAndSaturate<5>(lpfFrequency)); // Between 0 and 8, by my making. 1 represented by 268435456
 		{
 
 			// Cold transistor ladder
@@ -219,7 +219,7 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 		int32_t extraFeedback = 1200000000;
 
 		int32_t tannedFrequency =
-		    instantTan(lshiftAndSaturate(hpfFrequency, 5)); // Between 0 and 8, by my making. 1 represented by 268435456
+		    instantTan(lshiftAndSaturate<5>(hpfFrequency)); // Between 0 and 8, by my making. 1 represented by 268435456
 
 		int32_t hpfDivideBy1PlusTannedFrequency =
 		    (int64_t)2147483648u * 134217728

--- a/src/LiveInputBuffer.cpp
+++ b/src/LiveInputBuffer.cpp
@@ -86,7 +86,7 @@ void LiveInputBuffer::giveInput(int numSamples, uint32_t currentTime, int inputT
 
 			int percussiveness = ((uint64_t)difference * 262144 / angle) >> 1;
 
-			percussiveness = getTanH(percussiveness, 23);
+			percussiveness = getTanH<23>(percussiveness);
 
 			percBuffer[(numRawSamplesProcessed >> PERC_BUFFER_REDUCTION_MAGNITUDE) & (INPUT_PERC_BUFFER_SIZE - 1)] =
 			    percussiveness;

--- a/src/LivePitchShifter.cpp
+++ b/src/LivePitchShifter.cpp
@@ -243,7 +243,7 @@ startRenderAgain:
 
 		crossfadeProgress += crossfadeIncrement * numSamplesThisTimestretchedRead;
 
-		int32_t newerHopAmplitudeAfter = lshiftAndSaturate(crossfadeProgress, 7);
+		int32_t newerHopAmplitudeAfter = lshiftAndSaturate<7>(crossfadeProgress);
 
 		int32_t newerHopAmplitudeIncrement =
 		    (int32_t)(newerHopAmplitudeAfter - newerHopAmplitudeNow) / (int32_t)numSamplesThisTimestretchedRead;

--- a/src/ModControllableAudio.cpp
+++ b/src/ModControllableAudio.cpp
@@ -423,14 +423,12 @@ void ModControllableAudio::processFX(StereoSample* buffer, int numSamples, int m
 			int32_t* workingBufferPos = delayWorkingBuffer;
 			do {
 				// Leave more headroom, because making it clip sounds bad with pure digital
-				workingBufferPos[0] =
-				    signed_saturate(
-				        multiply_32x32_rshift32(workingBufferPos[0], delayWorkingState->delayFeedbackAmount), 32 - 3)
-				    << 2;
-				workingBufferPos[1] =
-				    signed_saturate(
-				        multiply_32x32_rshift32(workingBufferPos[1], delayWorkingState->delayFeedbackAmount), 32 - 3)
-				    << 2;
+				workingBufferPos[0] = signed_saturate<32 - 3>(multiply_32x32_rshift32(
+				                          workingBufferPos[0], delayWorkingState->delayFeedbackAmount))
+				                      << 2;
+				workingBufferPos[1] = signed_saturate<32 - 3>(multiply_32x32_rshift32(
+				                          workingBufferPos[1], delayWorkingState->delayFeedbackAmount))
+				                      << 2;
 
 				workingBufferPos += 2;
 			} while (workingBufferPos != workingBufferEnd);
@@ -469,8 +467,8 @@ void ModControllableAudio::processFX(StereoSample* buffer, int numSamples, int m
 				}
 
 				else {
-					fromDelayL = signed_saturate(multiply_32x32_rshift32(fromDelayL, delayWorkingState->delayFeedbackAmount), 32 - 3) << 2;
-					fromDelayR = signed_saturate(multiply_32x32_rshift32(fromDelayR, delayWorkingState->delayFeedbackAmount), 32 - 3) << 2;
+					fromDelayL = signed_saturate<delayWorkingState->delayFeedbackAmount>(multiply_32x32_rshift32(fromDelayL), 32 - 3) << 2;
+					fromDelayR = signed_saturate<delayWorkingState->delayFeedbackAmount>(multiply_32x32_rshift32(fromDelayR), 32 - 3) << 2;
 				}
 				*/
 

--- a/src/Sample.cpp
+++ b/src/Sample.cpp
@@ -608,7 +608,7 @@ doLoading:
 
 				int percussiveness = ((uint64_t)difference * 262144 / angle) >> 1;
 
-				percussiveness = getTanH(percussiveness, 23);
+				percussiveness = getTanH<23>(percussiveness);
 
 				percCacheNow[startPosSamples >> PERC_BUFFER_REDUCTION_MAGNITUDE] = percussiveness;
 			}
@@ -1570,11 +1570,11 @@ void Sample::convertDataOnAnyClustersIfNecessary() {
 }
 
 int32_t Sample::getMaxPeakFromZero() {
-	int32_t halfValue = std::abs(getFoundValueCentrePoint() >> 1) + (maxValueFound >> 2)
-	                    - (minValueFound >> 2); // Comes out one >> of the value we actually want
-	return lshiftAndSaturate(
-	    halfValue,
-	    1); // Does the <<1 and saturates it - this was necessary, it was overflowing sometimes - I think when the audio clipped
+	// Comes out one >> of the value we actually want
+	int32_t halfValue = std::abs(getFoundValueCentrePoint() >> 1) + (maxValueFound >> 2) - (minValueFound >> 2);
+
+	// Does the <<1 and saturates it - this was necessary, it was overflowing sometimes - I think when the audio clipped
+	return lshiftAndSaturate<1>(halfValue);
 }
 
 int32_t Sample::getFoundValueCentrePoint() {

--- a/src/SampleRecorder.cpp
+++ b/src/SampleRecorder.cpp
@@ -831,7 +831,7 @@ doFinishCapturing:
 			else {
 				do {
 					int32_t rxL = *inputAddress;
-					if (applyGain) rxL = lshiftAndSaturate(rxL, 5);
+					if (applyGain) rxL = lshiftAndSaturate<5>(rxL);
 
 					char* __restrict__ readPos = (char*)&rxL + 1;
 					*(writePosNow++) = *(readPos++);
@@ -852,7 +852,7 @@ doFinishCapturing:
 
 					if (recordingNumChannels == 2) {
 						int32_t rxR = *(inputAddress + 1);
-						if (applyGain) rxR = lshiftAndSaturate(rxR, 5);
+						if (applyGain) rxR = lshiftAndSaturate<5>(rxR);
 
 						readPos = (char*)&rxR + 1;
 						*(writePosNow++) = *(readPos++);

--- a/src/VoiceSample.cpp
+++ b/src/VoiceSample.cpp
@@ -1124,7 +1124,7 @@ readTimestretched:
 
 				timeStretcher->crossfadeProgress += timeStretcher->crossfadeIncrement * numSamplesThisTimestretchedRead;
 
-				int32_t newerHopAmplitudeAfter = lshiftAndSaturate(timeStretcher->crossfadeProgress, 7);
+				int32_t newerHopAmplitudeAfter = lshiftAndSaturate<7>(timeStretcher->crossfadeProgress);
 
 				int32_t newerHopAmplitudeIncrement =
 				    (int32_t)(newerHopAmplitudeAfter - newerHopAmplitudeNow) / (int32_t)numSamplesThisTimestretchedRead;

--- a/src/WaveTable.cpp
+++ b/src/WaveTable.cpp
@@ -675,9 +675,10 @@ transformBandToTimeDomain:
 
 			// Copy 32-bit time domain data to final 16-bit destination
 			for (int i = 0; i < band->cycleSizeNoDuplicates; i++) {
-				destination[i] = signed_saturate(currentCycleInt32[i]
-				                                     >> (16 - MAGNITUDE_REDUCTION_FOR_FFT + initialBandCycleMagnitude),
-				                                 32 - 16); // This saturation is possibly a temporary solution...
+				destination[i] = signed_saturate<32 - 16>(
+				    currentCycleInt32[i]
+				    >> (16 - MAGNITUDE_REDUCTION_FOR_FFT
+				        + initialBandCycleMagnitude)); // This saturation is possibly a temporary solution...
 			}
 
 			// And copy the duplicate values again

--- a/src/drum.cpp
+++ b/src/drum.cpp
@@ -82,7 +82,7 @@ void Drum::getCombinedExpressionInputs(int16_t* combined) {
 	for (int i = 0; i < NUM_EXPRESSION_DIMENSIONS; i++) {
 		int32_t combinedValue =
 		    (int32_t)lastExpressionInputsReceived[0][i] + (int32_t)lastExpressionInputsReceived[1][i];
-		combined[i] = lshiftAndSaturate(combinedValue, 8);
+		combined[i] = lshiftAndSaturate<8>(combinedValue);
 	}
 }
 
@@ -94,7 +94,7 @@ void Drum::expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelS
 	lastExpressionInputsReceived[level][whichExpressionimension] = newValue >> 8; // Store value
 	int32_t combinedValue =
 	    (int32_t)newValue + ((int32_t)lastExpressionInputsReceived[!level][whichExpressionimension] << 8);
-	combinedValue = lshiftAndSaturate(combinedValue, 16);
+	combinedValue = lshiftAndSaturate<16>(combinedValue);
 
 	expressionValueChangesMustBeDoneSmoothly = true;
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -164,7 +164,7 @@ void functionsInit() {
 int32_t getFinalParameterValueHybrid(int32_t paramNeutralValue, int32_t patchedValue) {
 	// Allows for max output values of +- 1073741824, which the panning code understands as the full range from left to right
 	int32_t preLimits = (paramNeutralValue >> 2) + (patchedValue >> 1);
-	return signed_saturate(preLimits, 32 - 3) << 2;
+	return signed_saturate<32 - 3>(preLimits) << 2;
 }
 
 int32_t getFinalParameterValueVolume(int32_t paramNeutralValue, int32_t patchedValue) {
@@ -197,8 +197,9 @@ int32_t getFinalParameterValueVolume(int32_t paramNeutralValue, int32_t patchedV
 	positivePatchedValue = (positivePatchedValue >> 16) * (positivePatchedValue >> 15);
 
 	//return multiply_32x32_rshift32(positivePatchedValue, paramNeutralValue) << 5;
-	return lshiftAndSaturate(multiply_32x32_rshift32(positivePatchedValue, paramNeutralValue),
-	                         5); // Must saturate, otherwise mod fx depth can easily overflow
+
+	// Must saturate, otherwise mod fx depth can easily overflow
+	return lshiftAndSaturate<5>(multiply_32x32_rshift32(positivePatchedValue, paramNeutralValue));
 }
 
 int32_t getFinalParameterValueLinear(int32_t paramNeutralValue, int32_t patchedValue) {
@@ -211,8 +212,8 @@ int32_t getFinalParameterValueLinear(int32_t paramNeutralValue, int32_t patchedV
 
 	// positivePatchedValue's range is ideally 0 ("0") to 1073741824 ("2"), but potentially up to 2147483647 ("4"). 536870912 represents "1".
 
-	return lshiftAndSaturate(multiply_32x32_rshift32(positivePatchedValue, paramNeutralValue),
-	                         3); // Must saturate, otherwise sustain level can easily overflow
+	return lshiftAndSaturate<3>(multiply_32x32_rshift32(
+	    positivePatchedValue, paramNeutralValue)); // Must saturate, otherwise sustain level can easily overflow
 }
 
 int32_t getFinalParameterValueExp(int32_t paramNeutralValue, int32_t patchedValue) {

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -212,8 +212,8 @@ int32_t getFinalParameterValueLinear(int32_t paramNeutralValue, int32_t patchedV
 
 	// positivePatchedValue's range is ideally 0 ("0") to 1073741824 ("2"), but potentially up to 2147483647 ("4"). 536870912 represents "1".
 
-	return lshiftAndSaturate<3>(multiply_32x32_rshift32(
-	    positivePatchedValue, paramNeutralValue)); // Must saturate, otherwise sustain level can easily overflow
+	// Must saturate, otherwise sustain level can easily overflow
+	return lshiftAndSaturate<3>(multiply_32x32_rshift32(positivePatchedValue, paramNeutralValue));
 }
 
 int32_t getFinalParameterValueExp(int32_t paramNeutralValue, int32_t patchedValue) {

--- a/src/functions.h
+++ b/src/functions.h
@@ -102,8 +102,8 @@ static inline int32_t add_saturation(int32_t a, int32_t b) {
 }
 
 // computes limit((val >> rshift), 2**bits)
-static inline int32_t signed_saturate(int32_t val, uint8_t bits) __attribute__((always_inline, unused));
-static inline int32_t signed_saturate(int32_t val, uint8_t bits) {
+template <uint8_t bits> static inline int32_t signed_saturate(int32_t val) __attribute__((always_inline, unused));
+template <uint8_t bits> static inline int32_t signed_saturate(int32_t val) {
 	int32_t out;
 	asm("ssat %0, %1, %2" : "=r"(out) : "I"(bits), "r"(val));
 	return out;
@@ -115,50 +115,50 @@ inline int32_t signed_saturate_operand_unknown(int32_t val, int bits) {
 	// Despite having this switch at the per-audio-sample level, it doesn't introduce any slowdown compared to just always saturating by the same amount!
 	switch (bits) {
 	case 31:
-		return signed_saturate(val, 31);
+		return signed_saturate<31>(val);
 	case 30:
-		return signed_saturate(val, 30);
+		return signed_saturate<30>(val);
 	case 29:
-		return signed_saturate(val, 29);
+		return signed_saturate<29>(val);
 	case 28:
-		return signed_saturate(val, 28);
+		return signed_saturate<28>(val);
 	case 27:
-		return signed_saturate(val, 27);
+		return signed_saturate<27>(val);
 	case 26:
-		return signed_saturate(val, 26);
+		return signed_saturate<26>(val);
 	case 25:
-		return signed_saturate(val, 25);
+		return signed_saturate<25>(val);
 	case 24:
-		return signed_saturate(val, 24);
+		return signed_saturate<24>(val);
 	case 23:
-		return signed_saturate(val, 23);
+		return signed_saturate<23>(val);
 	case 22:
-		return signed_saturate(val, 22);
+		return signed_saturate<22>(val);
 	case 21:
-		return signed_saturate(val, 21);
+		return signed_saturate<21>(val);
 	case 20:
-		return signed_saturate(val, 20);
+		return signed_saturate<20>(val);
 	case 19:
-		return signed_saturate(val, 19);
+		return signed_saturate<19>(val);
 	case 18:
-		return signed_saturate(val, 18);
+		return signed_saturate<18>(val);
 	case 17:
-		return signed_saturate(val, 17);
+		return signed_saturate<17>(val);
 	case 16:
-		return signed_saturate(val, 16);
+		return signed_saturate<16>(val);
 	case 15:
-		return signed_saturate(val, 15);
+		return signed_saturate<15>(val);
 	case 14:
-		return signed_saturate(val, 14);
+		return signed_saturate<14>(val);
 	case 13:
-		return signed_saturate(val, 13);
+		return signed_saturate<13>(val);
 	default:
-		return signed_saturate(val, 12);
+		return signed_saturate<12>(val);
 	}
 }
 
-inline int32_t lshiftAndSaturate(int32_t val, uint8_t lshift) {
-	return signed_saturate(val, 32 - lshift) << lshift;
+template <uint8_t lshift> inline int32_t lshiftAndSaturate(int32_t val) {
+	return signed_saturate<32 - lshift>(val) << lshift;
 }
 
 // lshift must be greater than 0! Not 0
@@ -328,10 +328,10 @@ inline int32_t interpolateTableSigned2d(uint32_t inputX, uint32_t inputY, int nu
 	return multiply_32x32_rshift32(value1, strength1) + multiply_32x32_rshift32(value2, strength2);
 }
 
-inline int32_t getTanH(int32_t input, unsigned int saturationAmount) {
+template <unsigned saturationAmount> inline int32_t getTanH(int32_t input) {
 	uint32_t workingValue;
 
-	if (saturationAmount) workingValue = (uint32_t)lshiftAndSaturate(input, saturationAmount) + 2147483648u;
+	if (saturationAmount) workingValue = (uint32_t)lshiftAndSaturate<saturationAmount>(input) + 2147483648u;
 	else workingValue = (uint32_t)input + 2147483648u;
 
 	return interpolateTableSigned(workingValue, 32, tanHSmall, 8) >> (saturationAmount + 2);

--- a/src/patcher.cpp
+++ b/src/patcher.cpp
@@ -159,7 +159,7 @@ void Patcher::performPatching(uint32_t sourcesChanged, Sound* sound, ParamManage
 
 inline void Patcher::applyRangeAdjustment(int32_t* patchedValue, PatchCable* patchCable) {
 	int32_t small = multiply_32x32_rshift32(*patchedValue, *patchCable->rangeAdjustmentPointer);
-	*patchedValue = signed_saturate(small, 32 - 5) << 3; // Not sure if these limits are as wide as they could be...
+	*patchedValue = signed_saturate<32 - 5>(small) << 3; // Not sure if these limits are as wide as they could be...
 }
 
 // Declaring these next 4 as inline made no performance difference.
@@ -169,7 +169,7 @@ inline void Patcher::cableToLinearParamWithoutRangeAdjustment(int32_t sourceValu
 	int32_t madePositive =
 	    (scaledSource + 536870912); // 0 to 1073741824; 536870912 counts as "1" for next multiplication
 	int32_t preLimits = multiply_32x32_rshift32(*runningTotalCombination, madePositive);
-	*runningTotalCombination = lshiftAndSaturate(preLimits, 3);
+	*runningTotalCombination = lshiftAndSaturate<3>(preLimits);
 }
 
 inline void Patcher::cableToLinearParam(int32_t sourceValue, int32_t cableStrength, int32_t* runningTotalCombination,
@@ -179,7 +179,7 @@ inline void Patcher::cableToLinearParam(int32_t sourceValue, int32_t cableStreng
 	int32_t madePositive =
 	    (scaledSource + 536870912); // 0 to 1073741824; 536870912 counts as "1" for next multiplication
 	int32_t preLimits = multiply_32x32_rshift32(*runningTotalCombination, madePositive);
-	*runningTotalCombination = lshiftAndSaturate(preLimits, 3);
+	*runningTotalCombination = lshiftAndSaturate<3>(preLimits);
 }
 
 inline void Patcher::cableToExpParamWithoutRangeAdjustment(int32_t sourceValue, int32_t cableStrength,


### PR DESCRIPTION
This PR is to fix a build issue I found.


## Background
Unlike all of the other inline-assembly functions that are provided by `functions.h`, signed_saturate has one crucial difference:

The ARMv7A `ssat` instruction takes an immediate, not a register, for its second operand.

## The Problem
At sufficiently high optimization levels, this doesn't present a problem, as compile-time constants are combined and reduced down to a single immediate value before reaching the assembler. However, this is technically just hiding the problem that the signed_saturate function is taking what is potentially a run-time variable and trying to insert it into assembly code.

The assembler is, expectedly, not very happy about this when it tries to happen:
```
DelugeFirmware/src/functions.h:108:9: warning: 'asm' operand 1 probably does not match constraints
  108 |         asm("ssat %0, %1, %2" : "=r"(out) : "I"(bits), "r"(val));
      |         ^~~
DelugeFirmware/src/functions.h:108:9: error: impossible constraint in 'asm'
```
If the constraint is expanded to 'X' (any), we can see the source of the issue at the assembly stage:
```
Error: constant expression required -- `ssat r3,[fp,#-9],r3'
```
Which is, of course, that the compiler inserted a reference to a stack variable and the assembler has no idea what to do with it.

## The Solution
Thankfully, C++ already has facilities for strongly enforcing compile-time code evaluation of constants: templates.

By simply moving 'bits' from a function parameter to a template parameter, the compiler does this calculation before the generated assembly is passed off and everything is kept happy.

This does unfortunately trickle down to any functions that pass their own parameters to `signed_saturate`, but that's how compile-time constraints are meant to work in the first place.