### PR TITLE
Deluge Build Tool (DBT) - Cross-platform, Low dependency, SCons-based build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 /e2-build-release-oled/
 *.launch
 /toolchain/*
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /e2-build-debug-oled/
 /e2-build-release-7seg/
 /e2-build-release-oled/
+/dbt-build*
 *.launch
 /toolchain/*
 __pycache__
+.sconsign.dblite

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,176 @@
+import os
+import re
+import logging
+
+# Set the absolute current working directory so we can pass it around later
+REL_SOURCE_DIR = "src"
+PROJECT_SOURCE_DIR = os.path.abspath(REL_SOURCE_DIR)
+
+print("Deluge Build Tool (DBT)\n")
+
+logging.basicConfig(level=logging.DEBUG)
+log = logging.getLogger("DBT")
+log.debug("Project directory: {}".format(GetLaunchDir()))
+
+# Commandline arguments are defined in here
+cmd_vars = SConscript("site_scons/commandline.scons", exports={"log_parent": log})
+# cmd_env = Environment(
+#     toolpath=["#/scripts/dbt_tools"],
+#     tools=[
+#         ("dbt_help", {"vars": cmd_vars}),
+#     ],
+#     variables=cmd_vars,
+# )
+
+env_parent = DefaultEnvironment()
+env_parent["ENV"] = os.environ.copy()
+env_parent.Append(
+    BUILDERS={
+        "HEXBuilder": Builder(
+            action=Action(
+                '${OBJCOPY} -O ihex "${SOURCE}" "${TARGET}"',
+                "${HEXCOMSTR}",
+            ),
+            suffix=".hex",
+            src_suffix=".elf",
+        ),
+        "BINBuilder": Builder(
+            action=Action(
+                '${OBJCOPY} -O binary -S "${SOURCE}" "${TARGET}"',
+                "${BINCOMSTR}",
+            ),
+            suffix=".bin",
+            src_suffix=".elf",
+        ),
+    }
+)
+
+
+def create_source_globs(base, globs=["*.cpp", "*.CPP", "*.c", "*.C"], env=env_parent):
+    files = []
+    for glob in globs:
+        files.extend(env.Glob(os.path.join(base, glob), source=True, strings=True))
+
+    dirs = [
+        os.path.join(base, name)
+        for name in os.listdir(base)
+        if os.path.isdir(os.path.join(base, name)) and name[0] != "."
+    ]
+    dirs.sort()
+
+    for dir in dirs:
+        files.extend(create_source_globs(dir, globs, env))
+
+    return files
+
+
+if GetOption("base_config") not in ["e2_xml"]:
+    print("Error: invalid base config mode.")
+
+    Exit(2)
+
+
+if GetOption("base_config") == "e2_xml":
+    from dbt.project import E2Project
+
+    log.info("Detected e2_xml mode.")
+
+    cproject = E2Project(log, GetLaunchDir())
+
+    e2_build_targets = list(cproject.get_build_targets())
+    dbt_build_targets = [p.replace("e2-build-", "dbt-build-") for p in e2_build_targets]
+    e2_build_targets.sort()
+    dbt_build_targets.sort()
+
+    if GetOption("e2_target") not in dbt_build_targets:
+        print('Error: "{}" is not a valid target in the e2_xml config.\n'.format(tgt))
+        print("       Valid targets include:")
+        for bt in dbt_build_targets:
+            print("           {}".format(bt))
+        print("")
+        Return()
+
+    build_label = GetOption("e2_target")
+    env = env_parent.Clone()
+
+    # build_label = "{}build-{}-{}".format(
+    #     GetOption("build_dir_prefix"),
+    #     "debug" if GetOption("build_debug") else "release",
+    #     GetOption("build_model"),
+    # )
+
+    dbt_target_index = dbt_build_targets.index(build_label)
+    e2_target = e2_build_targets[dbt_target_index]
+    build_dir = os.path.abspath(build_label)
+    source_dir = "src"
+    build_src_dir = os.path.join(build_dir, source_dir)
+    build_segs = build_label.split("-")
+    firmware_filename = cproject.get_target_filename(e2_target)
+
+    # env.Replace(VARIANT_DIR=build_label, SOURCE_DIR=source_dir)
+    Mkdir(build_label)
+    Mkdir(os.path.relpath(os.path.join(build_dir, "src")))
+    env.VariantDir(
+        os.path.relpath(os.path.join(build_dir, "src")), "#src", duplicate=False
+    )
+
+    # Build construction environment for selected or default e2 target
+    env.Replace(**cproject.get_toolchain_tools(e2_target))
+    # log.debug([i for i, v in dict(env).items() if v])
+    env["ASFLAGS"] = " -x assembler-with-cpp"
+    env["ASMPATH"] = [
+        Dir("{}".format(inc)) for inc in list(cproject.get_asm_includes(e2_target))
+    ]
+    env["ASCOM"] = "$CC $CCFLAGS $ASFLAGS $ASPATH -o $TARGET -c $SOURCE"
+    env["ASPPCOMSTR"] = "Assembling $TARGET"
+    env["CCCOMSTR"] = "Compiling static object $TARGET"
+    env["CCFLAGS"] = cproject.get_c_flags(e2_target)
+    env["CPPFLAGS"] = cproject.get_cpp_flags(e2_target)
+    env["CPPFLAGS"].append("-fdiagnostics-parseable-fixits")
+    env["CPPPATH"] = [
+        Dir("{}".format(p))
+        for p in list(
+            cproject.get_asm_includes(e2_target)
+            + cproject.get_c_includes(e2_target)
+            + cproject.get_cpp_includes(e2_target)
+        )
+    ]
+    # log.debug(env["CPPPATH"])
+    env["ASPATH"] = " {}".format(
+        " ".join(['-I"{}"'.format(inc) for inc in env["ASMPATH"]])
+    )
+    env["CCCOM"] = "$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
+    env["CXXCOM"] = "$CXX -o $TARGET -c $CXXFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
+    env["CXXCOMSTR"] = "Compiling static object $TARGET"
+    env["CPPDEFINES"] = cproject.get_preprocessor_defs(e2_target)
+    env["PROGSUFFIX"] = cproject.get_target_ext(e2_target)
+    env["LINKCOMSTR"] = "Linking $TARGET"
+    build_src_dir = os.path.join(build_dir, "src")
+    env["MAPFILE"] = "{}".format(
+        os.path.join(
+            build_dir, "{}.map".format(cproject.get_target_filename(e2_target))
+        )
+    )
+    env["LINKFLAGS"] = cproject.get_link_flags(e2_target)
+    env["LINKCOM"] = "$CXX $CPPFLAGS -o $TARGET $SOURCES $LINKFLAGS"
+    env["FIRMWARE_FILENAME"] = cproject.get_target_filename(e2_target)
+    env["BINCOMSTR"] = "Converting .elf to .bin."
+    # env["LIBPATH"] = [str(i) for i in cproject.get_link_libs_order(e2_target)]
+    # log.debug(env["LIBPATH"])
+
+
+# Collect sources recursively through globbing
+asm_sources = create_source_globs("src", ["*.s", "*.S"], env=env)
+c_sources = create_source_globs("src", env=env)
+sources = [
+    File(os.path.relpath(os.path.join(build_dir, os.path.relpath(src))))
+    for src in asm_sources + c_sources
+]
+
+objects = env.Object(c_sources + asm_sources)
+
+elf_file = env.Program(
+    os.path.join(build_dir, env["FIRMWARE_FILENAME"]), source=objects
+)
+
+env.BINBuilder(env["FIRMWARE_FILENAME"], source=elf_file)

--- a/SConstruct
+++ b/SConstruct
@@ -1,54 +1,62 @@
 import os
 import re
 import logging
+import SCons
+import multiprocessing
 
+from SCons.Platform import TempFileMunge
+from SCons.Subst import quote_spaces
+
+# Progress indicator. Right now there are too many warnings for it to look cool. :(
 Progress(["OwO\r", "owo\r", "uwu\r", "owo\r"], interval=15)
 
-# Set the absolute current working directory so we can pass it around later
+# Set some important "globals" in case we need 'em later.
 REL_SOURCE_DIR = "src"
 PROJECT_SOURCE_DIR = os.path.abspath(REL_SOURCE_DIR)
 
-print("Deluge Build Tool (DBT)\n")
+print("\nDeluge Build Tool (DBT)\n")
 
-logging.basicConfig(level=logging.DEBUG)
+# Not really sure how the logger will be used yet, but wanted it
+# in here.
+logging.basicConfig(level=logging.INFO)
 log = logging.getLogger("DBT")
 log.debug("Project directory: {}".format(GetLaunchDir()))
 
 # Commandline arguments are defined in here
 cmd_vars = SConscript("site_scons/commandline.scons", exports={"log_parent": log})
-# cmd_env = Environment(
-#     toolpath=["#/scripts/dbt_tools"],
-#     tools=[
-#         ("dbt_help", {"vars": cmd_vars}),
-#     ],
-#     variables=cmd_vars,
-# )
 
+# Automagically set the number of jobs to the processor count.
+# This probably won't please everyone, but I figure most folks
+# favour a faster build.
+SetOption("num_jobs", multiprocessing.cpu_count())
 
-def walk_all_sources(base, prefix):
-    walker = list(os.walk(base))
-    sources = [
-        os.path.join(prefix, os.path.relpath(os.path.join(i[0], l)))
-        for i in walker
-        for l in i[2]
-        if re.match(r"\.[cs][p]{0,2}", os.path.splitext(l)[1], re.IGNORECASE)
-    ]
-    return sources
-
+# Import some useful helper library stuff courtesy of the Flipper folks.
+from dbt.util import (
+    tempfile_arg_esc_func,
+    single_quote,
+    extract_abs_dir,
+    extract_abs_dir_path,
+    wrap_tempfile,
+    path_as_posix,
+    walk_all_sources,
+)
 
 if GetOption("base_config") not in ["e2_xml"]:
     print("Error: invalid base config mode.")
+    Exit(1)
 
-    Exit(2)
-
-
+# Our default operating mode.
 if GetOption("base_config") == "e2_xml":
     from dbt.project import E2Project
 
+    # Beep boop, human lifeform detected.
     log.info("Detected e2_xml mode.")
 
+    # Crank up the e2studio XML parsing class
     cproject = E2Project(log, GetLaunchDir())
 
+    # Brand and sort things appropriately so we follow the general scheme of,
+    # but don't overlap with e2 build directories.
     e2_build_targets = list(cproject.get_build_targets())
     dbt_build_targets = [p.replace("e2-build-", "dbt-build-") for p in e2_build_targets]
     e2_build_targets.sort()
@@ -66,15 +74,21 @@ if GetOption("base_config") == "e2_xml":
         print("")
         Return()
 
+
+    # And with all that out of the way, we start up our
+    # main/construction environment and configure the particulars
+    # for e2_xml targeting all within the "if" block.
     build_label = GetOption("e2_target")
-    env = Environment(ENV=os.environ.copy())
+    env = Environment(ENV=os.environ.copy(),
+                    tools=["gcc", "g++", "as", "ar", "link"],
+                    TEMPFILE=TempFileMunge,
+                    TEMPFILEARGESCFUNC=tempfile_arg_esc_func,
+                    ABSPATHGETTERFUNC=extract_abs_dir_path,
+                    SINGLEQUOTEFUNC=single_quote,
+                    MAXLINELENGTH=2048)
 
-    # build_label = "{}build-{}-{}".format(
-    #     GetOption("build_dir_prefix"),
-    #     "debug" if GetOption("build_debug") else "release",
-    #     GetOption("build_model"),
-    # )
-
+    # Some shorthand for all the labels and directories we're
+    # going to need below.
     dbt_target_index = dbt_build_targets.index(build_label)
     e2_target = e2_build_targets[dbt_target_index]
     build_dir = os.path.abspath(build_label)
@@ -86,21 +100,28 @@ if GetOption("base_config") == "e2_xml":
     # Build construction environment for selected or default e2 target
     env.Replace(**cproject.get_toolchain_tools(e2_target))
     # log.debug([i for i, v in dict(env).items() if v])
-    env["ASPPFLAGS"] += " -x assembler-with-cpp"
     env["CCFLAGS"] = " ".join(cproject.get_c_flags(e2_target))
     env["CPPFLAGS"] = " ".join(cproject.get_cpp_flags(e2_target))
+
+    # Don't really know where this flag came from in the config, but it's in
+    # the e2studio makefiles.
     env["CPPFLAGS"] += " -fdiagnostics-parseable-fixits"
     env["ASMPATH"] = [str(p) for p in cproject.get_asm_includes(e2_target)]
     env["CCPATH"] = [str(p) for p in cproject.get_c_includes(e2_target)]
     env["CXXPATH"] = [str(p) for p in cproject.get_cpp_includes(e2_target)]
     env["CPPPATH"] = env["ASMPATH"] + env["CCPATH"] + env["CXXPATH"]
-    # log.debug(env["CPPPATH"])
 
+    # Defining the ...COMSTR variables suppresses seeing the build commands raw.
+    # Just comment these out if you hate things being hidden from you.
     env["CCCOMSTR"] = "Compiling static object $TARGET"
     env["CXXCOMSTR"] = "Compiling static object $TARGET"
     env["ASPPCOMSTR"] = "Assembling $TARGET"
     env["LINKCOMSTR"] = "Linking $TARGET"
+    env["BINCOMSTR"] = "Converting .elf to .bin."
+    env["HEXCOMSTR"] = "Converting .elf to .hex."
 
+    # The assembler commandline needed a little bit of fudging for this build.
+    env["ASPPFLAGS"] += " -x assembler-with-cpp"
     env["ASPATH"] = " {}".format(
         " ".join(['-I"{}"'.format(inc) for inc in env["ASMPATH"]])
     )
@@ -111,9 +132,18 @@ if GetOption("base_config") == "e2_xml":
     # env["CCCOM"] = "$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
     # env["CXXCOM"] = "$CXX -o $TARGET -c $CXXFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
 
+    # Here be preprocessor defs. Doesn't yet include new/re defines from the commandline
+    # but it'll be easy to add if we want, for testing.
     env["CPPDEFINES"] = cproject.get_preprocessor_defs(e2_target)
+
+    # Literally just says ".elf"
     env["PROGSUFFIX"] = cproject.get_target_ext(e2_target)
-    build_src_dir = os.path.join(build_dir, "src")
+
+    # "Deluge-<build_type>-<model>" for the current e2 target
+    env["FIRMWARE_FILENAME"] = cproject.get_target_filename(e2_target)
+
+    # Had to fudge the linker command a bit to get both the mapfile in there,
+    # and g++ used to perform the linking step.
     env["MAPFILE"] = "{}".format(
         os.path.join(
             build_dir, "{}.map".format(cproject.get_target_filename(e2_target))
@@ -121,12 +151,21 @@ if GetOption("base_config") == "e2_xml":
     )
     env["LINKFLAGS"] = cproject.get_link_flags(e2_target)
     env["LINKCOM"] = "$CXX $CPPFLAGS -o $TARGET $SOURCES $LINKFLAGS"
-    env["FIRMWARE_FILENAME"] = cproject.get_target_filename(e2_target)
-    env["BINCOMSTR"] = "Converting .elf to .bin."
+    
+    
     env["LIBPATH"] = [str(i) for i in cproject.get_link_libs_order(e2_target)]
     # log.debug(env["LIBPATH"])
 
+# GENERIC ENVIRONMENT STUFF AND ACTIONS
+# In this area below the "if" block, we keep environment changes and actions that are
+# going to need doing regardless of the particular "mode" (eg: e2_xml).
 
+# Helper functions borrowed from FBT for wrapping lengthy commandlines into temp files.
+# This is primarily useful in windows, but shouldn't hurt anything on other platforms.
+wrap_tempfile(env, "LINKCOM")
+wrap_tempfile(env, "ARCOM")
+
+# Happy little custom builders and their actions.
 env.Append(
     BUILDERS={
         "HEXBuilder": Builder(
@@ -149,17 +188,24 @@ env.Append(
 )
 
 # VariantDir does the magic to ensure output goes to the dbt- whatever
-# build directory. Careful: this is really finicky if paths aren't set right
+# build directory. Careful: THIS CAN BE REALLY FINICKY if paths aren't set right
 VariantDir(os.path.join(build_label, source_dir), "#src", duplicate=False)
 
 # Using the specified include dirs rather than walking every path in src was
 # preventing a successful .elf build so generically went with the latter approach.
+# This will serve us better later, buuuuut could also potentially break something.
+# ¯\_(ツ)_/¯
 sources = walk_all_sources(source_dir, build_label)
 
+# Wrangle those sources into objects! 
 objects = env.Object(sources)
 
+# Turn those objects into a magical elf! (and a bonus .map file)
 elf_file = env.Program(
     os.path.join(build_dir, env["FIRMWARE_FILENAME"]), source=objects
 )
 
+# Bin it.
 env.BINBuilder(os.path.join(build_dir, env["FIRMWARE_FILENAME"]), source=elf_file)
+# Hex it.
+env.HEXBuilder(os.path.join(build_dir, env["FIRMWARE_FILENAME"]), source=elf_file)

--- a/dbt
+++ b/dbt
@@ -37,16 +37,13 @@ fi
 # afterward (needs certifi in place).
 pip_cmd="python3 -m pip";
 pip_wheel_path="${TOOLCHAIN_ARCH_DIR}/python/wheel";
-pip_wheels=$(ls "${pip_wheel_path}" | grep -ve '^pip')
+pip_wheels=$(ls "${pip_wheel_path}")
 for wheel in $pip_wheels; do
     $pip_cmd install -q "${pip_wheel_path}/${wheel}"
 done
 $pip_cmd install -q --upgrade pip
-# Oops, forgot to bundle scons in the toolchain
-$pip_cmd show SCons 1>/dev/null 2>/dev/null
-if [ $? -eq 1 ]; then
-    $pip_cmd install -q SCons==4.5.2
-fi
+$pip_cmd install -q kconfiglib==14.1.0
 
-# $SCONS_EP $SCONS_DEFAULT_FLAGS "$@"
-echo "Beyond downloading and updating the toolchains, dbt is currently not fully functional."
+$SCONS_EP $SCONS_DEFAULT_FLAGS "$@"
+# $SCONS_EP "$@"
+# echo "Beyond downloading and updating the toolchains, dbt is currently not fully functional."

--- a/dbt
+++ b/dbt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Deluge Build Tool (DBT)
 # 
@@ -45,5 +45,3 @@ $pip_cmd install -q --upgrade pip
 $pip_cmd install -q kconfiglib==14.1.0
 
 $SCONS_EP $SCONS_DEFAULT_FLAGS "$@"
-# $SCONS_EP "$@"
-# echo "Beyond downloading and updating the toolchains, dbt is currently not fully functional."

--- a/dbt
+++ b/dbt
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+# Deluge Build Tool (DBT)
+# 
+# Build script for DelugeFirmware, blatantly borrowed from 'fbt' used by
+# flipperdevices/flipperzero-firmware and licensed under GNU GPL
+
+# shellcheck disable=SC2086 source=/dev/null
+# unofficial strict mode
+set -eu;
+
+# private variables
+N_GIT_THREADS="$(getconf _NPROCESSORS_ONLN)";
+SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)";
+SCONS_DEFAULT_FLAGS="--warn=target-not-built";
+SCONS_EP="python3 -m SCons";
+
+# public variables
+DBT_NOENV="${DBT_NOENV:-""}";
+DBT_NO_SYNC="${DBT_NO_SYNC:-""}";
+DBT_TOOLCHAIN_PATH="${DBT_TOOLCHAIN_PATH:-$SCRIPT_PATH}";
+DBT_VERBOSE="${DBT_VERBOSE:-""}";
+
+if [ -z "$DBT_NOENV" ]; then
+    DBT_VERBOSE="$DBT_VERBOSE" . "$SCRIPT_PATH/scripts/toolchain/dbtenv.sh";
+fi
+
+if [ -z "$DBT_NO_SYNC" ]; then
+    if [ ! -d "$SCRIPT_PATH/.git" ]; then
+        echo "\".git\" directory not found, please clone repo via \"git clone\"";
+        exit 1;
+    fi
+    git submodule update --init --depth 1 --jobs "$N_GIT_THREADS";
+fi
+
+# Install python wheels if not already installed, upgrade pip
+# afterward (needs certifi in place).
+pip_cmd="python3 -m pip";
+pip_wheel_path="${TOOLCHAIN_ARCH_DIR}/python/wheel";
+pip_wheels=$(ls "${pip_wheel_path}" | grep -ve '^pip')
+for wheel in $pip_wheels; do
+    $pip_cmd install -q "${pip_wheel_path}/${wheel}"
+done
+$pip_cmd install -q --upgrade pip
+# Oops, forgot to bundle scons in the toolchain
+$pip_cmd show SCons 1>/dev/null 2>/dev/null
+if [ $? -eq 1 ]; then
+    $pip_cmd install -q SCons==4.5.2
+fi
+
+# $SCONS_EP $SCONS_DEFAULT_FLAGS "$@"
+echo "Beyond downloading and updating the toolchains, dbt is currently not fully functional."

--- a/dbt.cmd
+++ b/dbt.cmd
@@ -1,0 +1,60 @@
+@echo off
+call "%~dp0scripts\toolchain\dbtenv.cmd" env
+
+if /i [%1] == [/h] (
+    goto :HELP
+)
+if /i [%1] == [/help] (
+    goto :HELP
+)
+if /i [%1] == [--help] (
+    goto :HELP
+)
+if /i [%1] == [-h] (
+    goto :HELP
+)
+if /i [%1] == [help] (
+    goto :HELP
+)
+
+set SCONS_EP=python -m SCons
+
+if [%DBT_NO_SYNC%] == [] (
+    if exist ".git" (
+        git submodule update --init --depth 1 --jobs %NUMBER_OF_PROCESSORS%
+    ) else (
+        echo Not in a git repo, please clone with "git clone"
+        exit /b 1
+    )
+)
+
+set "SCONS_DEFAULT_FLAGS=--warn=target-not-built"
+
+if not defined DBT_VERBOSE (
+    set "SCONS_DEFAULT_FLAGS=%SCONS_DEFAULT_FLAGS% -Q"
+)
+
+set PIP_CMD=python -m pip
+set "PIP_WHEEL_PATH=%DBT_TOOLCHAIN_ROOT%\python\wheel"
+del 
+for /R %PIP_WHEEL_PATH% %%G in (
+    certifi*.whl,
+    pyserial*.whl,
+    ansi*.whl
+) do (
+    %PIP_CMD% install -q "%PIP_WHEEL_PATH%\%%G"
+)
+%PIP_CMD% install -q --upgrade pip
+@REM Whoops, forgot to bundle scons in the toolchain
+%PIP_CMD% show SCons
+if [%ERRORLEVEL%] == [1]
+    %PIP_CMD% install -q SCons==4.5.2
+fi
+
+@REM %SCONS_EP% %SCONS_DEFAULT_FLAGS% %*
+echo Beyond downloading and updating the toolchains, dbt is currently not fully functional.
+exit
+
+:HELP
+echo Valid commands:
+echo TBD

--- a/dbt.cmd
+++ b/dbt.cmd
@@ -1,22 +1,6 @@
 @echo off
 call "%~dp0scripts\toolchain\dbtenv.cmd" env
 
-if /i [%1] == [/h] (
-    goto :HELP
-)
-if /i [%1] == [/help] (
-    goto :HELP
-)
-if /i [%1] == [--help] (
-    goto :HELP
-)
-if /i [%1] == [-h] (
-    goto :HELP
-)
-if /i [%1] == [help] (
-    goto :HELP
-)
-
 set SCONS_EP=python -m SCons
 
 if [%DBT_NO_SYNC%] == [] (
@@ -38,23 +22,17 @@ set PIP_CMD=python -m pip
 set "PIP_WHEEL_PATH=%DBT_TOOLCHAIN_ROOT%\python\wheel"
 del 
 for /R %PIP_WHEEL_PATH% %%G in (
-    certifi*.whl,
-    pyserial*.whl,
-    ansi*.whl
+    *.whl
 ) do (
     %PIP_CMD% install -q "%PIP_WHEEL_PATH%\%%G"
 )
 %PIP_CMD% install -q --upgrade pip
-@REM Whoops, forgot to bundle scons in the toolchain
-%PIP_CMD% show SCons
-if [%ERRORLEVEL%] == [1]
-    %PIP_CMD% install -q SCons==4.5.2
-fi
+@REM @REM Whoops, forgot to bundle scons in the toolchain
+@REM %PIP_CMD% show SCons
+@REM if [%ERRORLEVEL%] == [1]
+@REM     %PIP_CMD% install -q SCons==4.5.2
+@REM fi
 
 @REM %SCONS_EP% %SCONS_DEFAULT_FLAGS% %*
 echo Beyond downloading and updating the toolchains, dbt is currently not fully functional.
 exit
-
-:HELP
-echo Valid commands:
-echo TBD

--- a/dbt.cmd
+++ b/dbt.cmd
@@ -20,19 +20,11 @@ if not defined DBT_VERBOSE (
 
 set PIP_CMD=python -m pip
 set "PIP_WHEEL_PATH=%DBT_TOOLCHAIN_ROOT%\python\wheel"
-del 
 for /R %PIP_WHEEL_PATH% %%G in (
     *.whl
 ) do (
-    %PIP_CMD% install -q "%PIP_WHEEL_PATH%\%%G"
+    %PIP_CMD% install -q "%%G"
 )
 %PIP_CMD% install -q --upgrade pip
-@REM @REM Whoops, forgot to bundle scons in the toolchain
-@REM %PIP_CMD% show SCons
-@REM if [%ERRORLEVEL%] == [1]
-@REM     %PIP_CMD% install -q SCons==4.5.2
-@REM fi
 
-@REM %SCONS_EP% %SCONS_DEFAULT_FLAGS% %*
-echo Beyond downloading and updating the toolchains, dbt is currently not fully functional.
-exit
+%SCONS_EP% %SCONS_DEFAULT_FLAGS% %*

--- a/dbt_options.py
+++ b/dbt_options.py
@@ -1,0 +1,2 @@
+# Supported toolchain versions
+DBT_TOOLCHAIN_VERSIONS = ("9-2019-q4-major",)

--- a/dbt_options.py
+++ b/dbt_options.py
@@ -1,2 +1,0 @@
-# Supported toolchain versions
-DBT_TOOLCHAIN_VERSIONS = ("9-2019-q4-major",)

--- a/scripts/dbt/__init__.py
+++ b/scripts/dbt/__init__.py
@@ -1,1 +1,1 @@
-from dbt.project import EclipseProject
+from dbt.project import E2Project

--- a/scripts/dbt/__init__.py
+++ b/scripts/dbt/__init__.py
@@ -1,0 +1,1 @@
+from dbt.project import EclipseProject

--- a/scripts/dbt/dbt_entry.py
+++ b/scripts/dbt/dbt_entry.py
@@ -1,0 +1,14 @@
+from project import EclipseProject
+import logging
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+    log = logging.getLogger("DBT")
+    log.info("Starting...")
+    eclipse = EclipseProject(log)
+    log.info("Finishing.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dbt/dbt_entry.py
+++ b/scripts/dbt/dbt_entry.py
@@ -1,12 +1,12 @@
-from project import EclipseProject
+from project import E2Project
 import logging
 
 
 def main():
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
     log = logging.getLogger("DBT")
     log.info("Starting...")
-    eclipse = EclipseProject(log)
+    eclipse = E2Project(log)
     log.info("Finishing.")
 
 

--- a/scripts/dbt/project.py
+++ b/scripts/dbt/project.py
@@ -1,12 +1,22 @@
-from xml.etree import ElementTree as ET
+import os
 import logging
-
+from SCons.Script import *
+from xml.etree import ElementTree as ET
 
 CONFIG_DEBUG_PREFIX = "com.renesas.cdt.managedbuild.gcc.rz.configuration.debug."
 
 # Referenced
 # https://github.com/eclipse-embed-cdt/eclipse-plugins/blob/752ae80fe82e14770728ebd18626de9d183ca625/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.core/plugin.xml#L156
 SUPERCLASS_OPT_MAPPING = {
+    "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format.gdb": "-ggdb",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format.stabs": "-gstabs",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format.stabsplus": "-gstabs+",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format.dwarf2": "-gdwarf-2",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format.dwarf3": "-gdwarf-3",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format.dwarf4": "-gdwarf-4",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.format.dwarf5": "-gdwarf-5",
+    },
     "com.renesas.cdt.managedbuild.gcc.rz.option.optimizationLevel": {
         "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.none": "-O0",
         "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.optimize": "-O1",
@@ -31,9 +41,10 @@ SUPERCLASS_OPT_MAPPING = {
     "com.renesas.cdt.managedbuild.gcc.rz.option.instructionset": {
         "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.instructionset.arm": "-marm"
     },
-    "com.renesas.cdt.managedbuild.gcc.rz.option.architecture": {
-        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.arch.armv7-a": "-march=armv7-a"
-    },
+    # Commenting out the following to override e2studio and remove some warnings.
+    # "com.renesas.cdt.managedbuild.gcc.rz.option.architecture": {
+    #     "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.arch.armv7-a": "-march=armv7-a"
+    # },
     "com.renesas.cdt.managedbuild.gcc.rz.option.floatunit": {
         "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.fpu.unit.neon": "-mfpu=neon"
     },
@@ -61,20 +72,79 @@ SUPERCLASS_OPT_MAPPING = {
         "true": "-fdata-sections"
     },
     "ilg.gnuarmeclipse.managedbuild.cross.option.toolchain.name": {},
+    "com.renesas.cdt.managedbuild.gcc.rz.createlibgen": {},
+    "com.renesas.cdt.managedbuild.gcc.rz.option.warnings.nulldereference": {
+        "true": "-Wnull-dereference"
+    },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.lto": {"true": "-flto"},
+    # "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.nortti": {
+    #     "true": "-fno-rtti"
+    # },
+    # "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.noexceptions": {
+    #     "true": "-fno-exceptions"
+    # },
+    # "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.nothreadsafestatics": {
+    #     "true": "-fno-threadsafe-statics"
+    # },
+    # "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.nousecxaatexit": {
+    #     "true": "-fno-use-cxa-atexit"
+    # },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.gcsections": {
+        "true": "-Xlinker --gc-sections"
+    },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.strip": {"true": "-s"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.nodeflibs": {
+        "true": "-nodefaultlibs"
+    },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.nostdlibs": {
+        "true": "-nostdlib"
+    },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.createflash.choice": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.createflash.choice.ihex": "-O ihex",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.createflash.choice.srec": "-O srec",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.createflash.choice.symbolsrec": "-O symbolsrec",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.createflash.choice.binary": "-O binary",
+    },
+}
+
+SUPERCLASS_SETTABLE_COMMAND_MAP = {
+    "com.renesas.cdt.managedbuild.gcc.rz.option.warnStack": {
+        "command": "-Wstack-usage={}"
+    },
+    # "com.renesas.cdt.managedbuild.gcc.rz.option.linker.cpp.entrypoint": {
+    #     "command": "{}"
+    # },
+}
+
+SUPERCLASS_TOOL_OPTS = {
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.prefix": {"PREFIX": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.c": {"CC": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.cpp": {"CXX": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.ar": {"AR": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.objcopy": {"OBJCOPY": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.objdump": {"OBJDUMP": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.size": {"SIZE": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.make": {"MAKE": "{}"},
+    "ilg.gnuarmeclipse.managedbuild.cross.option.command.rm": {"RM": "{}"},
+}
+
+MACRO_VALUES = {
+    "${ProjName}": "Deluge",
+    "${ProjDirPath}": ".",
+    "&quot;": "",
+    '"': "",
 }
 
 
-class EclipseProject:
-    def __init__(self, logger: logging.Logger):
-        self._log = logger.getChild("EclipseProject")
-        self._log.info("Loading XML...")
-        self._tree = ET.parse(".cproject")
+class E2Project:
+    def __init__(self, logger: logging.Logger, project_path="."):
+        self._log = logger.getChild("E2Project")
+        self._log.debug("Loading XML...")
+        self._tree = ET.parse(os.path.join(project_path, ".cproject"))
         self._root = self._tree.getroot()
+        self._builds = {}
         self._configs = self._extract_debug_data()
         # self._log.info("Final config setup: {}".format(self._configs))
-
-        cl = self.generate_build_commands("e2-build-release-oled")
-        self._log.info(cl)
 
     def _extract_debug_data(self):
         debug_id_dict = {}
@@ -88,22 +158,220 @@ class EclipseProject:
         return debug_id_dict
 
     def _interpret_build_opts(self, node):
-        build_dict = {}
-
         for module in node.findall(
             ".//storageModule[@moduleId='cdtBuildSystem']/configuration"
         ):
-            self._log.info(
+            self._log.debug(
                 "Found build config for: {}".format(module.attrib.get("name"))
             )
-            build_dict[module.attrib.get("name")] = {
+            self._builds[module.attrib.get("name")] = {
                 "node": module,
+                "artifact_name": self.rmacro(module.attrib.get("artifactName")),
+                "artifact_extension": ".{}".format(
+                    module.attrib.get("artifactExtension", "elf")
+                ),
                 "description": module.attrib.get("description"),
                 "clean_command": module.attrib.get("cleanCommand"),
                 "postbuild_step": module.attrib.get("postbuildStep"),
                 "toolchain_options": self._interpret_toolchain_opts(module),
+                "tools": self._interpret_toolchain_tools(module),
+                "tool_asm": self._interpret_tool_asm(module),
+                "tool_c": self._interpret_tool_c(module),
+                "tool_cpp": self._interpret_tool_cpp(module),
+                "tool_link": self._interpret_tool_link(module),
+                "tool_ar": self._interpret_tool_ar(module),
+                "tool_flash": self._interpret_tool_flash(module),
             }
-        return build_dict
+        return self._builds
+
+    def rmacro(self, input: str):
+        output = input
+        for key, val in MACRO_VALUES.items():
+            output = output.replace(key, val)
+
+        return output
+
+    def _interpret_tool_asm(self, node):
+        opts = {}
+
+        for option in node.findall(
+            ".//tool[@superClass='com.renesas.cdt.managedbuild.gcc.rz.tool.assembler']/option"
+        ):
+            if (
+                option.attrib.get("superClass")
+                == "ilg.gnuarmeclipse.managedbuild.cross.option.assembler.usepreprocessor"
+            ):
+                opts["use_preprocessor"] = option.attrib.get("value", False)
+            if (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.option.assembler.include"
+            ):
+                opts["scanner_discovery"] = (
+                    True if option.attrib.get("useByScannerDiscovery") else False
+                )
+                opts["include_path"] = []
+                for entry in option:
+                    opts["include_path"].append(self.rmacro(entry.attrib.get("value")))
+
+        return opts
+
+    def _interpret_tool_c(self, node):
+        opts = {}
+
+        for option in node.findall(
+            ".//tool[@superClass='com.renesas.cdt.managedbuild.gcc.rz.tool.compiler.c']/option"
+        ):
+            if (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.option.compiler.include"
+            ):
+                opts["scanner_discovery"] = (
+                    True if option.attrib.get("useByScannerDiscovery") else False
+                )
+                opts["include_path"] = []
+                for entry in option:
+                    opts["include_path"].append(self.rmacro(entry.attrib.get("value")))
+
+        return opts
+
+    def _interpret_tool_cpp(self, node):
+        opts = {}
+        opts["command"] = []
+        opts["defs"] = []
+        opts["include_path"] = []
+        opts["other_optimization"] = []
+
+        for option in node.findall(
+            ".//tool[@superClass='com.renesas.cdt.managedbuild.gcc.rz.tool.compiler.cpp']/option"
+        ):
+            if (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.option.compiler.cpp.include"
+            ):
+                opts["scanner_discovery"] = (
+                    True if option.attrib.get("useByScannerDiscovery") else False
+                )
+                for entry in option:
+                    opts["include_path"].append(self.rmacro(entry.attrib.get("value")))
+            elif (
+                option.attrib.get("superClass")
+                == "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.compiler.defs"
+            ):
+                for ppdef in option:
+                    opts["defs"].append(ppdef.attrib.get("value"))
+            elif (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.option.compiler.cpp.otherOptimization"
+            ):
+                for oopt in option:
+                    opts["other_optimization"].append(oopt.attrib.get("value"))
+            else:
+                opts["command"].append(
+                    self.translate_build_opt_to_command(
+                        option.attrib.get("superClass"),
+                        option.attrib.get("value"),
+                        option.attrib.get("valueType"),
+                    )
+                )
+
+        return opts
+
+    def _interpret_tool_link(self, node):
+        opts = {}
+        opts["include_file"] = []
+        opts["include_path"] = []
+        opts["linkage_order"] = []
+        opts["other_objs"] = []
+        opts["script_files"] = []
+        opts["command"] = []
+
+        for option in node.findall(
+            ".//tool[@superClass='com.renesas.cdt.managedbuild.gcc.rz.tool.linker.cpp']/option"
+        ):
+            if (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.archives.cpp.includeFiles"
+            ):
+                for entry in option:
+                    opts["include_file"].append(self.rmacro(entry.attrib.get("value")))
+            elif (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.archives.cpp.includePath"
+            ):
+                for entry in option:
+                    opts["include_path"].append(self.rmacro(entry.attrib.get("value")))
+            elif (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.cpp.option.linkageOrder"
+            ):
+                for entry in option:
+                    opts["linkage_order"].append(self.rmacro(entry.attrib.get("value")))
+            elif (
+                option.attrib.get("superClass")
+                == "ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.otherobjs"
+            ):
+                for entry in option:
+                    opts["other_objs"].append(self.rmacro(entry.attrib.get("value")))
+            elif (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.option.linker.cpp.userDefined"
+            ):
+                for entry in option:
+                    opts["command"].append(self.rmacro(entry.attrib.get("value")))
+            elif (
+                option.attrib.get("superClass")
+                == "com.renesas.cdt.managedbuild.gcc.rz.option.cpp.linkerscript"
+            ):
+                for entry in option:
+                    opts["script_files"].append(self.rmacro(entry.attrib.get("value")))
+            else:
+                opts["command"].append(
+                    self.translate_build_opt_to_command(
+                        option.attrib.get("superClass"),
+                        option.attrib.get("value"),
+                        option.attrib.get("valueType"),
+                    )
+                )
+
+        return opts
+
+    def _interpret_tool_ar(self, node):
+        opts = {}
+
+        for option in node.findall(
+            ".//tool[@superClass='com.renesas.cdt.managedbuild.gcc.rz.tool.archiver']/option"
+        ):
+            continue
+
+        return opts
+
+    def _interpret_tool_flash(self, node):
+        opts = {}
+        opts["command"] = []
+
+        for option in node.findall(
+            ".//tool[@superClass='com.renesas.cdt.managedbuild.gcc.rz.tool.flash']/option"
+        ):
+            opts["command"].append(
+                self.translate_build_opt_to_command(
+                    option.attrib.get("superClass"),
+                    option.attrib.get("value"),
+                    option.attrib.get("valueType"),
+                )
+            )
+
+        return opts
+
+    def _interpret_toolchain_tools(self, node):
+        toolchain_tools = {}
+
+        for option in node.findall(".//toolChain/option"):
+            mapping = SUPERCLASS_TOOL_OPTS.get(option.attrib.get("superClass"))
+            if mapping and option.attrib.get("valueType") == "string":
+                for name, tool in mapping.items():
+                    toolchain_tools[name] = tool.format(option.attrib.get("value", ""))
+
+        return toolchain_tools
 
     def _interpret_toolchain_opts(self, node):
         toolchain_opts = {}
@@ -113,29 +381,125 @@ class EclipseProject:
                 "value": option.attrib.get("value"),
                 "value_type": option.attrib.get("valueType"),
             }
-            if option.attrib.get("valueType") in ("enumerated", "boolean"):
-                toolchain_opts[option.attrib.get("superClass")]["command"] = (
-                    self.translate_build_opt_to_argument(
-                        option.attrib.get("superClass"), option.attrib.get("value")
-                    ),
+            if option.attrib.get("valueType"):
+                toolchain_opts[option.attrib.get("superClass")][
+                    "command"
+                ] = self.translate_build_opt_to_command(
+                    option.attrib.get("superClass"),
+                    option.attrib.get("value"),
+                    option.attrib.get("valueType"),
                 )
 
         return toolchain_opts
 
-    def translate_build_opt_to_argument(self, super_class, value):
+    def translate_build_opt_to_command(self, super_class, value, val_type):
         mapping = SUPERCLASS_OPT_MAPPING.get(super_class)
-
-        if mapping:
+        if mapping and val_type in ("enumerated", "boolean"):
             mval = mapping.get(value)
             if mval:
                 return mval
 
+        mapping = SUPERCLASS_SETTABLE_COMMAND_MAP.get(super_class)
+        if mapping and val_type in ("string"):
+            mval = mapping.get("command")
+            if mval:
+                return mval.format(value)
+
         return ""
 
-    def generate_build_commands(self, target):
-        commandline = ""
-        for config, data in self._configs.items():
-            bo = data.get("build_opts")
-            targ = bo.get(target)
+    def get_build_targets(self):
+        return self._builds.keys()
 
-        return commandline
+    def get_target_ext(self, target):
+        return self._builds[target].get("artifact_extension")
+
+    def get_target_filename(self, target):
+        return self._builds[target].get("artifact_name")
+
+    def get_asm_includes(self, target):
+        return self._builds[target]["tool_asm"]["include_path"]
+
+    def get_c_includes(self, target):
+        return self._builds[target]["tool_c"]["include_path"]
+
+    def get_cpp_includes(self, target):
+        return self._builds[target]["tool_cpp"]["include_path"]
+
+    def get_build_args(self, target):
+        commands = []
+        targ_data = self._builds.get(target)
+        if targ_data:
+            for t_opt, vals in targ_data.get("toolchain_options", {}).items():
+                if not vals.get("command"):
+                    continue
+                commands.append(vals.get("command"))
+
+        return commands
+
+    def get_preprocessor_defs(self, target):
+        defs = self._builds[target]["tool_c"].get("defs", [])
+        defs.extend(self._builds[target]["tool_cpp"].get("defs", []))
+
+        return defs
+
+    def get_c_flags(self, target):
+        flags = self.get_build_args(target)
+
+        flags.extend(self._builds[target]["tool_c"].get("command", []))
+
+        return flags
+
+    def get_cpp_flags(self, target):
+        flags = self.get_build_args(target)
+
+        flags.extend(self._builds[target]["tool_cpp"].get("command", []))
+
+        return flags
+
+    def get_link_flags(self, target):
+        # flags = "{} ".format(" ".join(self.get_build_args(target)))
+        flags = " ".join(
+            [
+                "-T {}".format(os.path.basename(script))
+                for script in self._builds[target]["tool_link"].get("script_files", [])
+            ]
+        )
+        self._log.debug(flags)
+
+        flags += " -Wl,--start-group -Wl,--end-group -nostartfiles"
+
+        flags += " {}".format(
+            " ".join(self._builds[target]["tool_link"].get("command", []))
+        )
+
+        flags += ' -Wl,-Map,"$MAPFILE" -Wl,-estart --specs=rdimon.specs'
+
+        return flags
+
+    def get_link_libs_order(self, target):
+        libs = self._builds[target]["tool_link"].get("linkage_order", [])
+
+        return libs
+
+    def get_toolchain_tools(self, target):
+        tools = self._builds[target].get("tools", "")
+        if not tools:
+            return {}
+
+        prefix = self._builds[target]["tools"].get("PREFIX", "")
+        tools_map = {}
+
+        root_path = os.environ.get("DBT_TOOLCHAIN_PATH", "")
+
+        for tool, exec in tools.items():
+            if tool == "PREFIX":
+                continue
+            elif tool in ["MAKE", "RM"]:
+                tools_map[tool] = exec
+            else:
+                real_tool = "{}{}".format(prefix, exec)
+                tools_map[tool] = real_tool
+
+        # tools_map["LINK"] = "{}g++".format(prefix)
+
+        return tools_map

--- a/scripts/dbt/project.py
+++ b/scripts/dbt/project.py
@@ -1,0 +1,141 @@
+from xml.etree import ElementTree as ET
+import logging
+
+
+CONFIG_DEBUG_PREFIX = "com.renesas.cdt.managedbuild.gcc.rz.configuration.debug."
+
+# Referenced
+# https://github.com/eclipse-embed-cdt/eclipse-plugins/blob/752ae80fe82e14770728ebd18626de9d183ca625/plugins/org.eclipse.embedcdt.managedbuild.cross.arm.core/plugin.xml#L156
+SUPERCLASS_OPT_MAPPING = {
+    "com.renesas.cdt.managedbuild.gcc.rz.option.optimizationLevel": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.none": "-O0",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.optimize": "-O1",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.more": "-O2",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.most": "-O3",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.size": "-Os",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.fast": "-Ofast",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.optimization.level.debug": "-Og",
+    },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.level": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.level.none": "",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.level.minimal": "-g1",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.level.default": "-g",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.debugging.level.max": "-g3",
+    },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.architecture": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.architecture.arm": ""
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.family": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.mcpu.cortex-a9": "-mcpu=cortex-a9"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.instructionset": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.instructionset.arm": "-marm"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.architecture": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.arch.armv7-a": "-march=armv7-a"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.floatunit": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.fpu.unit.neon": "-mfpu=neon"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.floatabi": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.fpu.abi.hard": "-mfloat-abi=hard"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.endian": {
+        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.endianness.little": "-mlittle-endian",
+        "ilg.gnuarmeclipse.managedbuild.cross.option.arm.target.endianness.big": "-mbig-endian",
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.thumb": {
+        "true": "-mthumb-interwork",
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.freestanding": {
+        "true": "-ffreestanding"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.messagelenght": {
+        "true": "-fmessage-length=0"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.signedchar": {"true": "-fsigned-char"},
+    "com.renesas.cdt.managedbuild.gcc.rz.option.functionsection": {
+        "true": "-ffunction-sections"
+    },
+    "com.renesas.cdt.managedbuild.gcc.rz.option.datasections": {
+        "true": "-fdata-sections"
+    },
+    "ilg.gnuarmeclipse.managedbuild.cross.option.toolchain.name": {},
+}
+
+
+class EclipseProject:
+    def __init__(self, logger: logging.Logger):
+        self._log = logger.getChild("EclipseProject")
+        self._log.info("Loading XML...")
+        self._tree = ET.parse(".cproject")
+        self._root = self._tree.getroot()
+        self._configs = self._extract_debug_data()
+        # self._log.info("Final config setup: {}".format(self._configs))
+
+        cl = self.generate_build_commands("e2-build-release-oled")
+        self._log.info(cl)
+
+    def _extract_debug_data(self):
+        debug_id_dict = {}
+        for config in self._root.findall(
+            ".//storageModule[@moduleId='org.eclipse.cdt.core.settings']/cconfiguration"
+        ):
+            debug_id_dict[config.attrib.get("id").replace(CONFIG_DEBUG_PREFIX, "")] = {
+                "node": config,
+                "build_opts": self._interpret_build_opts(config),
+            }
+        return debug_id_dict
+
+    def _interpret_build_opts(self, node):
+        build_dict = {}
+
+        for module in node.findall(
+            ".//storageModule[@moduleId='cdtBuildSystem']/configuration"
+        ):
+            self._log.info(
+                "Found build config for: {}".format(module.attrib.get("name"))
+            )
+            build_dict[module.attrib.get("name")] = {
+                "node": module,
+                "description": module.attrib.get("description"),
+                "clean_command": module.attrib.get("cleanCommand"),
+                "postbuild_step": module.attrib.get("postbuildStep"),
+                "toolchain_options": self._interpret_toolchain_opts(module),
+            }
+        return build_dict
+
+    def _interpret_toolchain_opts(self, node):
+        toolchain_opts = {}
+
+        for option in node.findall(".//toolChain/option"):
+            toolchain_opts[option.attrib.get("superClass")] = {
+                "value": option.attrib.get("value"),
+                "value_type": option.attrib.get("valueType"),
+            }
+            if option.attrib.get("valueType") in ("enumerated", "boolean"):
+                toolchain_opts[option.attrib.get("superClass")]["command"] = (
+                    self.translate_build_opt_to_argument(
+                        option.attrib.get("superClass"), option.attrib.get("value")
+                    ),
+                )
+
+        return toolchain_opts
+
+    def translate_build_opt_to_argument(self, super_class, value):
+        mapping = SUPERCLASS_OPT_MAPPING.get(super_class)
+
+        if mapping:
+            mval = mapping.get(value)
+            if mval:
+                return mval
+
+        return ""
+
+    def generate_build_commands(self, target):
+        commandline = ""
+        for config, data in self._configs.items():
+            bo = data.get("build_opts")
+            targ = bo.get(target)
+
+        return commandline

--- a/scripts/dbt/util.py
+++ b/scripts/dbt/util.py
@@ -1,0 +1,80 @@
+import os
+import re
+
+import SCons
+from SCons.Errors import StopError
+from SCons.Subst import quote_spaces
+
+WINPATHSEP_RE = re.compile(r"\\([^\"'\\]|$)")
+SOURCEWALK_RE = re.compile(r"\.[cs][p]{0,2}", re.IGNORECASE)
+
+# Used by default when globbing for files with GlobRecursive
+# Excludes all files ending with ~, usually created by editors as backup files
+GLOB_FILE_EXCLUSION = ["*~"]
+
+
+def tempfile_arg_esc_func(arg):
+    arg = quote_spaces(arg)
+    if SCons.Platform.platform_default() != "win32":
+        return arg
+    # GCC requires double Windows slashes, let's use UNIX separator
+    return WINPATHSEP_RE.sub(r"/\1", arg)
+
+
+def wrap_tempfile(env, command):
+    env[command] = '${TEMPFILE("' + env[command] + '","$' + command + 'STR")}'
+
+
+def link_dir(target_path, source_path, is_windows):
+    # print(f"link_dir: {target_path} -> {source_path}")
+    if os.path.lexists(target_path) or os.path.exists(target_path):
+        os.unlink(target_path)
+    if is_windows:
+        # Crete junction
+        import _winapi
+
+        if not os.path.isdir(source_path):
+            raise StopError(f"Source directory {source_path} is not a directory")
+
+        if not os.path.exists(target_path):
+            _winapi.CreateJunction(source_path, target_path)
+    else:
+        os.symlink(source_path, target_path)
+
+
+def single_quote(arg_list):
+    return " ".join(f"'{arg}'" if " " in arg else str(arg) for arg in arg_list)
+
+
+def extract_abs_dir(node):
+    if isinstance(node, SCons.Node.FS.EntryProxy):
+        node = node.get()
+
+    for repo_dir in node.get_all_rdirs():
+        if os.path.exists(repo_dir.abspath):
+            return repo_dir
+
+
+def extract_abs_dir_path(node):
+    abs_dir_node = extract_abs_dir(node)
+    if abs_dir_node is None:
+        raise StopError(f"Can't find absolute path for {node.name}")
+
+    return abs_dir_node.abspath
+
+
+def path_as_posix(path):
+    if SCons.Platform.platform_default() == "win32":
+        return path.replace(os.path.sep, os.path.altsep)
+    return path
+
+
+def walk_all_sources(base, prefix):
+    walker = list(os.walk(base))
+    sources = [
+        os.path.join(prefix, os.path.relpath(os.path.join(i[0], l)))
+        for i in walker
+        for l in i[2]
+        if SOURCEWALK_RE.match(os.path.splitext(l)[1])
+    ]
+    return sources

--- a/scripts/toolchain/dbtenv.cmd
+++ b/scripts/toolchain/dbtenv.cmd
@@ -13,7 +13,7 @@ if not ["%DBT_NOENV%"] == [""] (
     exit /b 0
 )
 
-set "DBT_TOOLCHAIN_VERSION=6"
+set "DBT_TOOLCHAIN_VERSION=7"
 
 if ["%DBT_TOOLCHAIN_PATH%"] == [""] (
     set "DBT_TOOLCHAIN_PATH=%DBT_ROOT%"
@@ -43,11 +43,11 @@ if defined DBT_VERBOSE (
 )
 
 set "HOME=%USERPROFILE%"
-set "SSL_CERT_FILE=%DBT_TOOLCHAIN_ROOT%/python/lib/python3.10/site-packages/certifi/cacert.pem"
+set "SSL_CERT_FILE=%DBT_TOOLCHAIN_ROOT%/python/lib/python3.11/site-packages/certifi/cacert.pem"
 set "PYTHONHOME=%DBT_TOOLCHAIN_ROOT%\python"
 set "PYTHONPATH=%DBT_ROOT%\scripts;%PYTHONPATH%"
 set "PYTHONNOUSERSITE=1"
-set "PATH=%DBT_TOOLCHAIN_ROOT%\python;%DBT_TOOLCHAIN_ROOT%\python\Scripts;%DBT_TOOLCHAIN_ROOT%\gcc-arm\bin;%DBT_TOOLCHAIN_ROOT%\openocd\bin;%DBT_TOOLCHAIN_ROOT%\cmake\bin;%PATH%"
+set "PATH=%DBT_TOOLCHAIN_ROOT%\python;%DBT_TOOLCHAIN_ROOT%\python\Scripts;%DBT_TOOLCHAIN_ROOT%\gcc-arm-none-eabi\bin;%DBT_TOOLCHAIN_ROOT%\openocd\bin;%DBT_TOOLCHAIN_ROOT%\cmake\bin;%PATH%"
 set "PROMPT=(dbt) %PROMPT%"
 
 :already_set

--- a/scripts/toolchain/dbtenv.cmd
+++ b/scripts/toolchain/dbtenv.cmd
@@ -43,7 +43,7 @@ if defined DBT_VERBOSE (
 )
 
 set "HOME=%USERPROFILE%"
-set "SSL_CERT_FILE=%DBT_TOOLCHAIN_ROOT%/python/lib/python3.11/site-packages/certifi/cacert.pem"
+set "SSL_CERT_FILE=%DBT_TOOLCHAIN_ROOT%/python/Lib/site-packages/certifi/cacert.pem"
 set "PYTHONHOME=%DBT_TOOLCHAIN_ROOT%\python"
 set "PYTHONPATH=%DBT_ROOT%\scripts;%PYTHONPATH%"
 set "PYTHONNOUSERSITE=1"

--- a/scripts/toolchain/dbtenv.cmd
+++ b/scripts/toolchain/dbtenv.cmd
@@ -1,0 +1,61 @@
+@echo off
+
+if not ["%DBT_ROOT%"] == [""] (
+    goto already_set
+)
+
+set "DBT_ROOT=%~dp0\..\..\"
+pushd "%DBT_ROOT%"
+set "DBT_ROOT=%cd%"
+popd
+
+if not ["%DBT_NOENV%"] == [""] (
+    exit /b 0
+)
+
+set "DBT_TOOLCHAIN_VERSION=6"
+
+if ["%DBT_TOOLCHAIN_PATH%"] == [""] (
+    set "DBT_TOOLCHAIN_PATH=%DBT_ROOT%"
+)
+
+set "DBT_TOOLCHAIN_ROOT=%DBT_TOOLCHAIN_PATH%\toolchain\win32-x86_64"
+
+set "DBT_TOOLCHAIN_VERSION_FILE=%DBT_TOOLCHAIN_ROOT%\VERSION"
+
+if not exist "%DBT_TOOLCHAIN_ROOT%" (
+    powershell -ExecutionPolicy Bypass -File "%DBT_ROOT%\scripts\toolchain\windows-toolchain-download.ps1" %DBT_TOOLCHAIN_VERSION% "%DBT_TOOLCHAIN_ROOT%"
+)
+
+if not exist "%DBT_TOOLCHAIN_VERSION_FILE%" (
+    powershell -ExecutionPolicy Bypass -File "%DBT_ROOT%\scripts\toolchain\windows-toolchain-download.ps1" %DBT_TOOLCHAIN_VERSION% "%DBT_TOOLCHAIN_ROOT%"
+)
+
+set /p REAL_TOOLCHAIN_VERSION=<"%DBT_TOOLCHAIN_VERSION_FILE%"
+if not "%REAL_TOOLCHAIN_VERSION%" == "%DBT_TOOLCHAIN_VERSION%" (
+    echo DBT: starting toolchain upgrade process..
+    powershell -ExecutionPolicy Bypass -File "%DBT_ROOT%\scripts\toolchain\windows-toolchain-download.ps1" %DBT_TOOLCHAIN_VERSION% "%DBT_TOOLCHAIN_ROOT%"
+    set /p REAL_TOOLCHAIN_VERSION=<"%DBT_TOOLCHAIN_VERSION_FILE%"
+)
+
+if defined DBT_VERBOSE (
+    echo DBT: using toolchain version %REAL_TOOLCHAIN_VERSION%
+)
+
+set "HOME=%USERPROFILE%"
+set "SSL_CERT_FILE=%DBT_TOOLCHAIN_ROOT%/python/lib/python3.10/site-packages/certifi/cacert.pem"
+set "PYTHONHOME=%DBT_TOOLCHAIN_ROOT%\python"
+set "PYTHONPATH=%DBT_ROOT%\scripts;%PYTHONPATH%"
+set "PYTHONNOUSERSITE=1"
+set "PATH=%DBT_TOOLCHAIN_ROOT%\python;%DBT_TOOLCHAIN_ROOT%\python\Scripts;%DBT_TOOLCHAIN_ROOT%\gcc-arm\bin;%DBT_TOOLCHAIN_ROOT%\openocd\bin;%DBT_TOOLCHAIN_ROOT%\cmake\bin;%PATH%"
+set "PROMPT=(dbt) %PROMPT%"
+
+:already_set
+
+if not "%1" == "env" (
+    echo *********************************
+    echo *     dbt build environment     *
+    echo *********************************
+    cd "%DBT_ROOT%"
+    cmd /k
+)

--- a/scripts/toolchain/dbtenv.sh
+++ b/scripts/toolchain/dbtenv.sh
@@ -1,0 +1,345 @@
+#!/bin/sh
+
+# shellcheck disable=SC2034,SC2016,SC2086
+
+# public variables
+DEFAULT_SCRIPT_PATH="$(pwd -P)";
+DBT_TOOLCHAIN_VERSION="${DBT_TOOLCHAIN_VERSION:-"6"}";
+
+if [ -z ${DBT_TOOLCHAIN_PATH+x} ] ; then
+    DBT_TOOLCHAIN_PATH_WAS_SET=0;
+else
+    DBT_TOOLCHAIN_PATH_WAS_SET=1;
+fi
+
+DBT_TOOLCHAIN_PATH="${DBT_TOOLCHAIN_PATH:-$DEFAULT_SCRIPT_PATH}";
+DBT_VERBOSE="${DBT_VERBOSE:-""}";
+
+dbtenv_show_usage()
+{
+    echo "Running this script manually is wrong, please source it";
+    echo "Example:";
+    printf "\tsource scripts/toolchain/dbtenv.sh\n";
+    echo "To restore your environment, source dbtenv.sh with '--restore'."
+    echo "Example:";
+    printf "\tsource scripts/toolchain/dbtenv.sh --restore\n";
+}
+
+dbtenv_curl()
+{
+    curl --progress-bar -SLo "$1" "$2";
+}
+
+dbtenv_wget()
+{
+    wget --show-progress --progress=bar:force -qO "$1" "$2";
+}
+
+dbtenv_restore_env()
+{
+    TOOLCHAIN_ARCH_DIR_SED="$(echo "$TOOLCHAIN_ARCH_DIR" | sed 's/\//\\\//g')"
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/python\/bin://g")";
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/gcc-arm\/bin://g")";
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/openocd\/bin://g")";
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/cmake\/bin://g")";
+    # PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/openssl\/bin://g")";
+    if [ -n "${PS1:-""}" ]; then
+        PS1="$(echo "$PS1" | sed 's/\[dbt\]//g')";
+    elif [ -n "${PROMPT:-""}" ]; then
+        PROMPT="$(echo "$PROMPT" | sed 's/\[dbt\]//g')";
+    fi
+
+    if [ -n "$SAVED_SSL_CERT_FILE" ]; then
+        export SSL_CERT_FILE="$SAVED_SSL_CERT_FILE";
+        export REQUESTS_CA_BUNDLE="$SAVED_REQUESTS_CA_BUNDLE";
+    else
+        unset SSL_CERT_FILE;
+        unset REQUESTS_CA_BUNDLE;
+    fi
+
+    if [ "$SYS_TYPE" = "Linux" ]; then
+        if [ -n "$SAVED_TERMINFO_DIRS" ]; then
+            export TERMINFO_DIRS="$SAVED_TERMINFO_DIRS";
+        else
+            unset TERMINFO_DIRS;
+        fi
+        unset SAVED_TERMINFO_DIRS;
+    fi
+
+    export PYTHONNOUSERSITE="$SAVED_PYTHONNOUSERSITE";
+    export PYTHONPATH="$SAVED_PYTHONPATH";
+    export PYTHONHOME="$SAVED_PYTHONHOME";
+
+    unset SAVED_SSL_CERT_FILE;
+    unset SAVED_REQUESTS_CA_BUNDLE;
+    unset SAVED_PYTHONNOUSERSITE;
+    unset SAVED_PYTHONPATH;
+    unset SAVED_PYTHONHOME;
+
+    unset DBT_TOOLCHAIN_VERSION;
+    unset DBT_TOOLCHAIN_PATH;
+}
+
+dbtenv_check_sourced()
+{
+    case "${ZSH_EVAL_CONTEXT:-""}" in *:file:*)
+        setopt +o nomatch;  # disabling 'no match found' warning in zsh
+        return 0;;
+    esac
+    if [ ${0##*/} = "dbtenv.sh" ]; then  # exluding script itself
+        dbtenv_show_usage;
+        return 1;
+    fi
+    case ${0##*/} in dash|-dash|bash|-bash|ksh|-ksh|sh|-sh|*.sh|dbt|udbt)
+        return 0;;
+    esac
+    dbtenv_show_usage;
+    return 1;
+}
+
+dbtenv_check_if_sourced_multiple_times()
+{
+    if ! echo "${PS1:-""}" | grep -qF "[dbt]"; then
+        if ! echo "${PROMPT:-""}" | grep -qF "[dbt]"; then
+            return 0;
+        fi
+    fi
+    echo "Warning! DBT environment script was sourced more than once!";
+    echo "You might be doing things wrong, please open a new shell!";
+    return 1;
+}
+
+dbtenv_set_shell_prompt()
+{
+    if [ -n "${PS1:-""}" ]; then
+        PS1="[dbt]$PS1";
+    elif [ -n "${PROMPT:-""}" ]; then
+        PROMPT="[dbt]$PROMPT";
+    fi
+    return 0;  # all other shells
+}
+
+dbtenv_check_env_vars()
+{
+    # Return error if DBT_TOOLCHAIN_PATH is not set before script is sourced or if dbt executable is not in DEFAULT_SCRIPT_PATH
+    if [ "$DBT_TOOLCHAIN_PATH_WAS_SET" -eq 0 ] && [ ! -x "$DEFAULT_SCRIPT_PATH/dbt" ] && [ ! -x "$DEFAULT_SCRIPT_PATH/udbt" ] ; then
+        echo "Please source this script from [u]dbt root directory, or specify 'DBT_TOOLCHAIN_PATH' variable manually";
+        echo "Example:";
+        printf "\tDBT_TOOLCHAIN_PATH=DelugeFirmware source DelugeFirmware/scripts/dbtenv.sh\n";
+        echo "If current directory is right, type 'unset DBT_TOOLCHAIN_PATH' and try again"
+        return 1;
+    fi
+    return 0;
+}
+
+dbtenv_get_kernel_type()
+{
+    SYS_TYPE="$(uname -s)";
+    ARCH_TYPE="$(uname -m)";
+    if [ "$ARCH_TYPE" != "x86_64" ] && [ "$SYS_TYPE" != "Darwin" ]; then
+        echo "We only provide toolchain for x86_64 CPUs, sorry..";
+        return 1;
+    fi
+    if [ "$SYS_TYPE" = "Darwin" ]; then
+        dbtenv_check_rosetta || return 1;
+        TOOLCHAIN_ARCH_DIR="$DBT_TOOLCHAIN_PATH/toolchain/darwin-x86_64";
+        TOOLCHAIN_URL="https://github.com/litui/dbt-toolchain/releases/download/v$DBT_TOOLCHAIN_VERSION/dbt-toolchain-$DBT_TOOLCHAIN_VERSION-darwin-x86_64.tar.gz";
+    elif [ "$SYS_TYPE" = "Linux" ]; then
+        TOOLCHAIN_ARCH_DIR="$DBT_TOOLCHAIN_PATH/toolchain/linux-x86_64";
+        TOOLCHAIN_URL="https://github.com/litui/dbt-toolchain/releases/download/v$DBT_TOOLCHAIN_VERSION/dbt-toolchain-$DBT_TOOLCHAIN_VERSION-linux-x86_64.tar.gz";
+    elif echo "$SYS_TYPE" | grep -q "MINGW"; then
+        echo "In MinGW shell, use \"[u]dbt.cmd\" instead of \"[u]dbt\"";
+        return 1;
+    else
+        echo "Your system configuration is not supported. Sorry.. Please report us your configuration.";
+        return 1;
+    fi
+    return 0;
+}
+
+dbtenv_check_rosetta()
+{
+    if [ "$ARCH_TYPE" = "arm64" ]; then
+        if ! /usr/bin/pgrep -q oahd; then
+            echo "Deluge Build Toolchain needs Rosetta2 to run under Apple Silicon";
+            echo "Please install it by typing 'softwareupdate --install-rosetta --agree-to-license'";
+            return 1;
+        fi
+    fi
+    return 0;
+}
+
+dbtenv_check_tar()
+{
+    printf "Checking for tar..";
+    if ! tar --version > /dev/null 2>&1; then
+        echo "no";
+        return 1;
+    fi
+    echo "yes";
+    return 0;
+}
+
+dbtenv_check_downloaded_toolchain()
+{
+    printf "Checking if downloaded toolchain tgz exists..";
+    if [ ! -f "$DBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR" ]; then
+        echo "no";
+        return 1;
+    fi
+    echo "yes";
+    return 0;
+}
+
+dbtenv_download_toolchain_tar()
+{
+    echo "Downloading toolchain:";
+    mkdir -p "$DBT_TOOLCHAIN_PATH/toolchain" || return 1;
+    "$DBT_DOWNLOADER" "$DBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR.part" "$TOOLCHAIN_URL" || return 1;
+    # restoring original filename if file downloaded successfully
+    mv "$DBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR.part" "$DBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR"
+    echo "done";
+    return 0;
+}
+
+dbtenv_remove_old_tooclhain()
+{
+    printf "Removing old toolchain..";
+    rm -rf "${TOOLCHAIN_ARCH_DIR:?}";
+    echo "done";
+}
+
+dbtenv_show_unpack_percentage()
+{
+    LINE=0;
+    while read -r line; do
+        LINE=$(( LINE + 1 ));
+        if [ $(( LINE % 300 )) -eq 0 ]; then
+            printf "#";
+        fi
+    done
+    echo " 100.0%";
+}
+
+dbtenv_unpack_toolchain()
+{
+    echo "Unpacking toolchain to '$DBT_TOOLCHAIN_PATH/toolchain':";
+    tar -xvf "$DBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_TAR" -C "$DBT_TOOLCHAIN_PATH/toolchain" 2>&1 | dbtenv_show_unpack_percentage;
+    mkdir -p "$DBT_TOOLCHAIN_PATH/toolchain" || return 1;
+    mv "$DBT_TOOLCHAIN_PATH/toolchain/$TOOLCHAIN_DIR" "$TOOLCHAIN_ARCH_DIR" || return 1;
+    echo "done";
+    return 0;
+}
+
+dbtenv_cleanup()
+{
+    printf "Cleaning up..";
+    if [ -n "${DBT_TOOLCHAIN_PATH:-""}" ]; then
+        rm -rf "${DBT_TOOLCHAIN_PATH:?}/toolchain/"*.tar.gz;
+        rm -rf "${DBT_TOOLCHAIN_PATH:?}/toolchain/"*.part;
+    fi
+    echo "done";
+    trap - 2;
+    return 0;
+}
+
+dbtenv_curl_wget_check()
+{
+    printf "Checking curl..";
+    if ! curl --version > /dev/null 2>&1; then
+        echo "no";
+        printf "Checking wget..";
+        if ! wget --version > /dev/null 2>&1; then
+            echo "no";
+            echo "No curl or wget found in your PATH";
+            echo "Please provide it or download this file:";
+            echo;
+            echo "$TOOLCHAIN_URL";
+            echo;
+            echo "And place in $DBT_TOOLCHAIN_PATH/toolchain/ dir manually";
+            return 1;
+        fi
+        echo "yes"
+        DBT_DOWNLOADER="dbtenv_wget";
+        return 0;
+    fi
+    echo "yes"
+    DBT_DOWNLOADER="dbtenv_curl";
+    return 0;
+}
+
+dbtenv_check_download_toolchain()
+{
+    if [ ! -d "$TOOLCHAIN_ARCH_DIR" ]; then
+        dbtenv_download_toolchain || return 1;
+    elif [ ! -f "$TOOLCHAIN_ARCH_DIR/VERSION" ]; then
+        dbtenv_download_toolchain || return 1;
+    elif [ "$(cat "$TOOLCHAIN_ARCH_DIR/VERSION")" -lt "$DBT_TOOLCHAIN_VERSION" ]; then
+        echo "DBT: starting toolchain upgrade process.."
+        dbtenv_download_toolchain || return 1;
+    fi
+    return 0;
+}
+
+dbtenv_download_toolchain()
+{
+    dbtenv_check_tar || return 1;
+    TOOLCHAIN_TAR="$(basename "$TOOLCHAIN_URL")";
+    TOOLCHAIN_DIR="$(echo "$TOOLCHAIN_TAR" | sed "s/-$DBT_TOOLCHAIN_VERSION.tar.gz//g")";
+    trap dbtenv_cleanup 2;  # trap will be restored in dbtenv_cleanup
+    if ! dbtenv_check_downloaded_toolchain; then
+        dbtenv_curl_wget_check || return 1;
+        dbtenv_download_toolchain_tar || return 1;
+    fi
+    dbtenv_remove_old_tooclhain;
+    dbtenv_unpack_toolchain || return 1;
+    dbtenv_cleanup;
+    return 0;
+}
+
+dbtenv_print_version()
+{
+    if [ -n "$DBT_VERBOSE" ]; then
+        echo "DBT: using toolchain version $(cat "$TOOLCHAIN_ARCH_DIR/VERSION")";
+    fi
+}
+
+dbtenv_main()
+{
+    dbtenv_check_sourced || return 1;
+    dbtenv_get_kernel_type || return 1;
+    if [ "$1" = "--restore" ]; then
+        dbtenv_restore_env;
+        return 0;
+    fi
+    dbtenv_check_if_sourced_multiple_times;
+    dbtenv_check_env_vars || return 1;
+    dbtenv_check_download_toolchain || return 1;
+    dbtenv_set_shell_prompt;
+    dbtenv_print_version;
+    PATH="$TOOLCHAIN_ARCH_DIR/python/bin:$PATH";
+    PATH="$TOOLCHAIN_ARCH_DIR/gcc-arm/bin:$PATH";
+    PATH="$TOOLCHAIN_ARCH_DIR/openocd/bin:$PATH";
+    PATH="$TOOLCHAIN_ARCH_DIR/cmake/bin:$PATH";
+    # PATH="$TOOLCHAIN_ARCH_DIR/openssl/bin:$PATH";
+    export PATH;
+
+    export SAVED_SSL_CERT_FILE="${SSL_CERT_FILE:-""}";
+    export SAVED_REQUESTS_CA_BUNDLE="${REQUESTS_CA_BUNDLE:-""}";
+    export SAVED_PYTHONNOUSERSITE="${PYTHONNOUSERSITE:-""}";
+    export SAVED_PYTHONPATH="${PYTHONPATH:-""}";
+    export SAVED_PYTHONHOME="${PYTHONHOME:-""}";
+
+    export SSL_CERT_FILE="$TOOLCHAIN_ARCH_DIR/python/lib/python3.10/site-packages/certifi/cacert.pem";
+    export REQUESTS_CA_BUNDLE="$SSL_CERT_FILE";
+    export PYTHONNOUSERSITE=1;
+    export PYTHONPATH="$DEFAULT_SCRIPT_PATH/scripts";
+    export PYTHONHOME=;
+
+    if [ "$SYS_TYPE" = "Linux" ]; then
+        export SAVED_TERMINFO_DIRS="${TERMINFO_DIRS:-""}";
+        export TERMINFO_DIRS="$TOOLCHAIN_ARCH_DIR/ncurses/share/terminfo";
+    fi
+}
+
+dbtenv_main "${1:-""}";

--- a/scripts/toolchain/dbtenv.sh
+++ b/scripts/toolchain/dbtenv.sh
@@ -140,6 +140,13 @@ dbtenv_get_kernel_type()
     #     echo "We only provide toolchain for x86_64 CPUs, sorry..";
     #     return 1;
     # fi
+
+    # Fudge the architecture type if we happen to be on a platform that uses
+    # "aarch64" naming.
+    if [[ "${ARCH_TYPE}" == "aarch64" ]]; then
+        ARCH_TYPE="arm64"
+    fi
+
     if [[ "${SYS_TYPE}" == "darwin" || "${SYS_TYPE}" == "linux" ]]; then
         # Disabling rosetta checking now that we've got native arm64
         # dbtenv_check_rosetta || return 1;

--- a/scripts/toolchain/dbtenv.sh
+++ b/scripts/toolchain/dbtenv.sh
@@ -44,9 +44,9 @@ dbtenv_restore_env()
     PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/cmake\/bin://g")";
     # PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/openssl\/bin://g")";
     if [ -n "${PS1:-""}" ]; then
-        PS1="$(echo "$PS1" | sed 's/\[dbt\]//g')";
+        PS1="$(echo "$PS1" | sed 's/\[dbt\] //g')";
     elif [ -n "${PROMPT:-""}" ]; then
-        PROMPT="$(echo "$PROMPT" | sed 's/\[dbt\]//g')";
+        PROMPT="$(echo "$PROMPT" | sed 's/\[dbt\] //g')";
     fi
 
     if [ -n "$SAVED_SSL_CERT_FILE" ]; then
@@ -99,8 +99,8 @@ dbtenv_check_sourced()
 
 dbtenv_check_if_sourced_multiple_times()
 {
-    if ! echo "${PS1:-""}" | grep -qF "[dbt]"; then
-        if ! echo "${PROMPT:-""}" | grep -qF "[dbt]"; then
+    if ! echo "${PS1:-""}" | grep -qF "[dbt] "; then
+        if ! echo "${PROMPT:-""}" | grep -qF "[dbt] "; then
             return 0;
         fi
     fi
@@ -112,9 +112,9 @@ dbtenv_check_if_sourced_multiple_times()
 dbtenv_set_shell_prompt()
 {
     if [ -n "${PS1:-""}" ]; then
-        PS1="[dbt]$PS1";
+        PS1="[dbt] $PS1";
     elif [ -n "${PROMPT:-""}" ]; then
-        PROMPT="[dbt]$PROMPT";
+        PROMPT="[dbt] $PROMPT";
     fi
     return 0;  # all other shells
 }

--- a/scripts/toolchain/dbtenv.sh
+++ b/scripts/toolchain/dbtenv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # shellcheck disable=SC2034,SC2016,SC2086
 
@@ -39,7 +39,7 @@ dbtenv_restore_env()
 {
     TOOLCHAIN_ARCH_DIR_SED="$(echo "$TOOLCHAIN_ARCH_DIR" | sed 's/\//\\\//g')"
     PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/python\/bin://g")";
-    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/gcc-arm-none-eabi\/bin://g")";
+    PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/arm-none-eabi-gcc\/bin://g")";
     PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/openocd\/bin://g")";
     PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/cmake\/bin://g")";
     # PATH="$(echo "$PATH" | /usr/bin/sed "s/$TOOLCHAIN_ARCH_DIR_SED\/openssl\/bin://g")";
@@ -231,7 +231,14 @@ dbtenv_unpack_toolchain()
 
 dbtenv_cleanup()
 {
+    
+    # Kludgey but, quick path to getting rid of these
+    printf "Removing any nuisance mac dotfiles..";
+    find toolchain | grep -e '\/[.][^\/]*$' | sed -e 's/\(.*\)/rm \"\1\"/' | /usr/bin/env bash;
+    echo "done";
+
     printf "Cleaning up..";
+    
     if [ -n "${DBT_TOOLCHAIN_PATH:-""}" ]; then
         rm -rf "${DBT_TOOLCHAIN_PATH:?}/toolchain/"*.tar.gz;
         rm -rf "${DBT_TOOLCHAIN_PATH:?}/toolchain/"*.part;
@@ -316,7 +323,7 @@ dbtenv_main()
     dbtenv_set_shell_prompt;
     dbtenv_print_version;
     PATH="$TOOLCHAIN_ARCH_DIR/python/bin:$PATH";
-    PATH="$TOOLCHAIN_ARCH_DIR/gcc-arm-none-eabi/bin:$PATH";
+    PATH="$TOOLCHAIN_ARCH_DIR/arm-none-eabi-gcc/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/openocd/bin:$PATH";
     PATH="$TOOLCHAIN_ARCH_DIR/cmake/bin:$PATH";
     # PATH="$TOOLCHAIN_ARCH_DIR/openssl/bin:$PATH";

--- a/scripts/toolchain/windows-toolchain-download.ps1
+++ b/scripts/toolchain/windows-toolchain-download.ps1
@@ -1,0 +1,45 @@
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+[Net.ServicePointManager]::SecurityProtocol = "tls12, tls11, tls"
+# TODO: fix
+$download_dir = (Get-Item "$PSScriptRoot\..\..").FullName
+$toolchain_version = $args[0]
+$toolchain_target_path = $args[1]
+
+$toolchain_url = "https://github.com/litui/dbt-toolchain/releases/download/v$toolchain_version/dbt-toolchain-$toolchain_version-win32-x86_64.zip"
+$toolchain_dist_folder = "win32-x86_64"
+$toolchain_zip = "$toolchain_dist_folder-$toolchain_version.zip"
+
+$toolchain_zip_temp_path = "$download_dir\$toolchain_zip"
+$toolchain_dist_temp_path = "$download_dir\$toolchain_dist_folder"
+
+if (Test-Path -LiteralPath "$toolchain_target_path") {
+	Write-Host -NoNewline "Removing old Windows toolchain.."
+	Remove-Item -LiteralPath "$toolchain_target_path" -Force -Recurse
+	Write-Host "done!"
+}
+if (!(Test-Path -Path "$toolchain_zip_temp_path" -PathType Leaf)) {
+    Write-Host -NoNewline "Downloading Windows toolchain.."
+    $wc = New-Object net.webclient
+    $wc.Downloadfile("$toolchain_url", "$toolchain_zip_temp_path")
+    Write-Host "done!"
+}
+
+if (!(Test-Path -LiteralPath "$toolchain_target_path\..")) {
+    New-Item "$toolchain_target_path\.." -ItemType Directory -Force
+}
+
+Write-Host -NoNewline "Extracting Windows toolchain.."
+# This is faster than Expand-Archive
+Add-Type -Assembly "System.IO.Compression.Filesystem"
+[System.IO.Compression.ZipFile]::ExtractToDirectory("$toolchain_zip_temp_path", "$download_dir")
+# Expand-Archive -LiteralPath "$toolchain_zip_temp_path" -DestinationPath "$download_dir"
+
+Write-Host -NoNewline "moving.."
+Move-Item -LiteralPath "$toolchain_dist_temp_path" -Destination "$toolchain_target_path" -Force
+Write-Host "done!"
+
+Write-Host -NoNewline "Cleaning up temporary files.."
+Remove-Item -LiteralPath "$toolchain_zip_temp_path" -Force
+Write-Host "done!"
+

--- a/site_scons/commandline.scons
+++ b/site_scons/commandline.scons
@@ -1,0 +1,26 @@
+Import("log_parent")
+log = log_parent.getChild("commandline")
+
+log.debug("Adding commandline options.")
+
+AddOption(
+    "--base_config",
+    dest="base_config",
+    default="e2_xml",
+    type="string",
+    nargs=1,
+    action="store",
+    metavar="SOURCE",
+    help="Source of default environment options for the build (only 'e2_xml' for now)",
+)
+
+AddOption(
+    "--e2_target",
+    dest="e2_target",
+    default="dbt-build-release-oled",
+    type="string",
+    nargs=1,
+    action="store",
+    metavar="TARGET",
+    help='Build target directory as in e2studio, prefaced with "dbt-" instead of "e2-"',
+)


### PR DESCRIPTION
It's here, it's basic, it does the bare minimum!  It's the Deluge Build Tool, inspired (and, in part, borrowed) from the Flipper Build Tool (FBT) for Flipper Zero.

The current iteration runs just dandy and auto-pulls the latest arm-none-eabi-gcc 12.2 toolchain on the following architectures:
- win32-x86_64 (tested in Windows 11)
- linux-x86_64 (tested in Ubuntu)
- linux-arm64 (untested)
- darwin-x86_64 (Intel Mac)
- darwin-arm64 (Mac M1/M2 - No need for Rosetta, in theory!)

The toolchain is downloaded by the dbt script from [litui/dbt-toolchain](https://github.com/litui/dbt-toolchain/releases). Fully extracted it consumes around 1.2GB of storage on Mac (darwin-arm64). This breaks down as:

- openocd (9.2M) - xpack v0.12.0 - included for future use with hardware debuggers
- cmake (62M) - xpack v3.23.5 - included for optional use by those more acquainted with cmake; this is not used by DBT
- python (101M) - Standalone Install v3.11.3 - included for use in SCons scripting
- arm-none-eabi-gcc (831M) - xpack v12.2.1 - ARM cross-compile toolchain

As of right now, once the toolchain is in place, DBT parse the .cproject XML for details on many (but not all) of the build parameters, will build a specified target (or the default `dbt-build-release-oled`) from objects to firmware binaries (ELF, BIN, HEX), and drop them into a target build folder, very much like e2 Studio does. It can also (mostly) clean up after itself! Yay!

Please take this for a spin on your supported platform of choice and let me know here what works and what doesn't. I'll fix up bugs in this PR but will reserve new features for additional PRs (and I have quite a list of things I want to gradually add into this tool).