### PR TITLE
Generate compile commands

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,6 @@
 [*]
 end_of_line = lf
-insert_final_newline = true
+insert_final_newline = false
 charset = utf-8
 
 [*.{c,cpp,h,hpp}]

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@
 /dbt-build*
 *.launch
 /toolchain/*
+compile_commands.json
 __pycache__
 .sconsign.dblite

--- a/SConstruct
+++ b/SConstruct
@@ -187,6 +187,10 @@ env.Append(
     }
 )
 
+# Export a `compile_commands.json` for help
+env.Tool('compilation_db')
+env.CompilationDatabase()
+
 # VariantDir does the magic to ensure output goes to the dbt- whatever
 # build directory. Careful: THIS CAN BE REALLY FINICKY if paths aren't set right
 VariantDir(os.path.join(build_label, source_dir), "#src", duplicate=False)


### PR DESCRIPTION
Generates a clang CompilationDB, handy for editors that are using clangd/ccls/etc.