### PR TITLE
DBT additions, odds, and ends

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -15,6 +15,7 @@ REL_SOURCE_DIR = "src"
 PROJECT_SOURCE_DIR = os.path.abspath(REL_SOURCE_DIR)
 
 print("\nDeluge Build Tool (DBT)\n")
+print("For help use argument: --help\n")
 
 # Not really sure how the logger will be used yet, but wanted it
 # in here.
@@ -43,7 +44,7 @@ from dbt.util import (
 
 if GetOption("base_config") not in ["e2_xml"]:
     print("Error: invalid base config mode.")
-    Exit(1)
+    Return()
 
 # Start up a basic environment
 env = Environment(
@@ -56,64 +57,90 @@ env = Environment(
     MAXLINELENGTH=2048,
 )
 
+# Export a `compile_commands.json` for help
+# Note: no idea how well this plays with multiple targets at once
+env.Tool("compilation_db")
+env.CompilationDatabase()
+
+# Prepare for multiple target environments
+multienv = {}
+
 # Important parameter to avoid conflict with VariantDir when calling SConscripts
 # from another directory
 SConscriptChdir(False)
 
 # Our default operating mode.
 if GetOption("base_config") == "e2_xml":
-    env.SConscript(
-        os.path.join("site_scons", "e2_xml.scons"),
-        exports={"env": env, "log_parent": log},
-    )
+    if GetOption("e2_target"):
+        Default(GetOption("e2_target"))
+
+    # Launch and configure a new environment for each target BUILD_TARGETS
+    # contains plain commandline targets or the contents of -e2_target
+    # ONLY IF there are no commandline targets.
+    for target_entry in BUILD_TARGETS:
+        # Convert entry to plain string so there are no differences
+        # between plain commandline targets and "option" targets
+        target = str(target_entry)
+        multienv[target] = env.Clone(
+            BUILD_LABEL=target, BUILD_DIR=os.path.abspath(target)
+        )
+
+        if not multienv[target].SConscript(
+            os.path.join("site_scons", "e2_xml.scons"),
+            exports={"env": multienv[target], "log_parent": log},
+        ):
+            success = False
+            Return("success")
 
 # GENERIC ENVIRONMENT STUFF AND ACTIONS
 # In this area below the "if" block, we keep environment changes and actions that are
 # going to need doing regardless of the particular "mode" (eg: e2_xml).
 
-# Helper functions borrowed from FBT for wrapping lengthy commandlines into temp files.
-# This is primarily useful in windows, but shouldn't hurt anything on other platforms.
-wrap_tempfile(env, "LINKCOM")
-wrap_tempfile(env, "ARCOM")
+# Iterate again, this time over configured environments. This should work regardless of
+# --base_config setting!
+for target, t_env in multienv.items():
+    # Helper functions borrowed from FBT for wrapping lengthy commandlines into temp files.
+    # This is primarily useful in windows, but shouldn't hurt anything on other platforms.
+    wrap_tempfile(t_env, "LINKCOM")
+    wrap_tempfile(t_env, "ARCOM")
 
-# Export a `compile_commands.json` for help
-env.Tool("compilation_db")
-env.CompilationDatabase()
+    # VariantDir does the magic to ensure output goes to the dbt- whatever
+    # build directory. Careful: THIS CAN BE REALLY FINICKY if paths aren't set right
+    VariantDir(
+        os.path.join(t_env["BUILD_LABEL"], REL_SOURCE_DIR), "#src", duplicate=False
+    )
 
-# VariantDir does the magic to ensure output goes to the dbt- whatever
-# build directory. Careful: THIS CAN BE REALLY FINICKY if paths aren't set right
-VariantDir(os.path.join(env["BUILD_LABEL"], REL_SOURCE_DIR), "#src", duplicate=False)
+    # Load generic stuff (Builders, etc.) into the environment.
+    SConscript(os.path.join("site_scons", "generic_env.scons"), exports={"env": t_env})
 
-# Load generic stuff (Builders, etc.) into the environment.
-SConscript(os.path.join("site_scons", "generic_env.scons"), exports={"env": env})
+    # Using the specified include dirs rather than walking every path in src was
+    # preventing a successful .elf build so generically went with the latter approach.
+    # This will serve us better later, buuuuut could also potentially break something.
+    # ¯\_(ツ)_/¯
+    sources = walk_all_sources(REL_SOURCE_DIR, t_env["BUILD_LABEL"])
 
-# Using the specified include dirs rather than walking every path in src was
-# preventing a successful .elf build so generically went with the latter approach.
-# This will serve us better later, buuuuut could also potentially break something.
-# ¯\_(ツ)_/¯
-sources = walk_all_sources(REL_SOURCE_DIR, env["BUILD_LABEL"])
+    # Wrangle those sources into objects!
+    objects = t_env.Object(sources)
 
-# Wrangle those sources into objects!
-objects = env.Object(sources)
-
-# Turn those objects into a magical elf! (and a bonus .map file)
-elf_file = env.Program(
-    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=objects
-)
-# Touch the bonus map file so when we tell dbt to clean (-c) it removes as well
-env.MAPBuilder(
-    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
-)
-
-# Bin it.
-env.BINBuilder(
-    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
-)
-# Hex it.
-env.HEXBuilder(
-    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
-)
-# Size it.
-env.SIZBuilder(
-    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
-)
+    # Turn those objects into a magical elf! (and a bonus .map file)
+    elf_file = t_env.Program(
+        os.path.join(t_env["BUILD_DIR"], t_env["FIRMWARE_FILENAME"]), source=objects
+    )
+    # Touch it.
+    t_env.MAPBuilder(
+        os.path.join(t_env["BUILD_DIR"], t_env["FIRMWARE_FILENAME"]), source=elf_file
+    )
+    # Bin it.
+    t_env.BINBuilder(
+        os.path.join(t_env["BUILD_DIR"], t_env["FIRMWARE_FILENAME"]), source=elf_file
+    )
+    # Hex it.
+    t_env.HEXBuilder(
+        os.path.join(t_env["BUILD_DIR"], t_env["FIRMWARE_FILENAME"]), source=elf_file
+    )
+    # Size it.
+    t_env.SIZBuilder(
+        os.path.join(t_env["BUILD_DIR"], t_env["FIRMWARE_FILENAME"]), source=elf_file
+    )
+    # Technologic.
+    # Technologic.

--- a/SConstruct
+++ b/SConstruct
@@ -57,11 +57,6 @@ env = Environment(
     MAXLINELENGTH=2048,
 )
 
-# Export a `compile_commands.json` for help
-# Note: no idea how well this plays with multiple targets at once
-env.Tool("compilation_db")
-env.CompilationDatabase()
-
 # Prepare for multiple target environments
 multienv = {}
 
@@ -139,6 +134,13 @@ for target, t_env in multienv.items():
     VariantDir(
         os.path.join(t_env["BUILD_LABEL"], REL_SOURCE_DIR), "#src", duplicate=False
     )
+
+    # Export a `compile_commands.json` for help
+    # t_env["COMPILATIONDB_PATH_FILTER"] = t_env["BUILD_LABEL"]
+    t_env["COMPILATIONDB_USE_ABSPATH"] = True
+    t_env.Tool("compilation_db")
+    cdb_name = "compile_commands.json"
+    cdb = t_env.CompilationDatabase(os.path.join(t_env["BUILD_DIR"], cdb_name))
 
     # Load generic stuff (Builders, etc.) into the environment.
     SConscript(os.path.join("site_scons", "generic_env.scons"), exports={"env": t_env})

--- a/SConstruct
+++ b/SConstruct
@@ -45,116 +45,27 @@ if GetOption("base_config") not in ["e2_xml"]:
     print("Error: invalid base config mode.")
     Exit(1)
 
+# Start up a basic environment
+env = Environment(
+    ENV=os.environ.copy(),
+    tools=["gcc", "g++", "as", "ar", "link"],
+    TEMPFILE=TempFileMunge,
+    TEMPFILEARGESCFUNC=tempfile_arg_esc_func,
+    ABSPATHGETTERFUNC=extract_abs_dir_path,
+    SINGLEQUOTEFUNC=single_quote,
+    MAXLINELENGTH=2048,
+)
+
+# Important parameter to avoid conflict with VariantDir when calling SConscripts
+# from another directory
+SConscriptChdir(False)
+
 # Our default operating mode.
 if GetOption("base_config") == "e2_xml":
-    from dbt.project import E2Project
-
-    # Beep boop, human lifeform detected.
-    log.info("Detected e2_xml mode.")
-
-    # Crank up the e2studio XML parsing class
-    cproject = E2Project(log, GetLaunchDir())
-
-    # Brand and sort things appropriately so we follow the general scheme of,
-    # but don't overlap with e2 build directories.
-    e2_build_targets = list(cproject.get_build_targets())
-    dbt_build_targets = [p.replace("e2-build-", "dbt-build-") for p in e2_build_targets]
-    e2_build_targets.sort()
-    dbt_build_targets.sort()
-
-    if GetOption("e2_target") not in dbt_build_targets:
-        print(
-            'Error: "{}" is not a valid target in the e2_xml config.\n'.format(
-                GetOption("e2_target")
-            )
-        )
-        print("       Valid targets include:")
-        for bt in dbt_build_targets:
-            print("           {}".format(bt))
-        print("")
-        Return()
-
-
-    # And with all that out of the way, we start up our
-    # main/construction environment and configure the particulars
-    # for e2_xml targeting all within the "if" block.
-    build_label = GetOption("e2_target")
-    env = Environment(ENV=os.environ.copy(),
-                    tools=["gcc", "g++", "as", "ar", "link"],
-                    TEMPFILE=TempFileMunge,
-                    TEMPFILEARGESCFUNC=tempfile_arg_esc_func,
-                    ABSPATHGETTERFUNC=extract_abs_dir_path,
-                    SINGLEQUOTEFUNC=single_quote,
-                    MAXLINELENGTH=2048)
-
-    # Some shorthand for all the labels and directories we're
-    # going to need below.
-    dbt_target_index = dbt_build_targets.index(build_label)
-    e2_target = e2_build_targets[dbt_target_index]
-    build_dir = os.path.abspath(build_label)
-    source_dir = "src"
-    build_src_dir = os.path.join(build_dir, source_dir)
-    build_segs = build_label.split("-")
-    firmware_filename = cproject.get_target_filename(e2_target)
-
-    # Build construction environment for selected or default e2 target
-    env.Replace(**cproject.get_toolchain_tools(e2_target))
-    # log.debug([i for i, v in dict(env).items() if v])
-    env["CCFLAGS"] = " ".join(cproject.get_c_flags(e2_target))
-    env["CPPFLAGS"] = " ".join(cproject.get_cpp_flags(e2_target))
-
-    # Don't really know where this flag came from in the config, but it's in
-    # the e2studio makefiles.
-    env["CPPFLAGS"] += " -fdiagnostics-parseable-fixits"
-    env["ASMPATH"] = [str(p) for p in cproject.get_asm_includes(e2_target)]
-    env["CCPATH"] = [str(p) for p in cproject.get_c_includes(e2_target)]
-    env["CXXPATH"] = [str(p) for p in cproject.get_cpp_includes(e2_target)]
-    env["CPPPATH"] = env["ASMPATH"] + env["CCPATH"] + env["CXXPATH"]
-
-    # Defining the ...COMSTR variables suppresses seeing the build commands raw.
-    # Just comment these out if you hate things being hidden from you.
-    env["CCCOMSTR"] = "Compiling static object $TARGET"
-    env["CXXCOMSTR"] = "Compiling static object $TARGET"
-    env["ASPPCOMSTR"] = "Assembling $TARGET"
-    env["LINKCOMSTR"] = "Linking $TARGET"
-    env["BINCOMSTR"] = "Converting .elf to .bin."
-    env["HEXCOMSTR"] = "Converting .elf to .hex."
-
-    # The assembler commandline needed a little bit of fudging for this build.
-    env["ASPPFLAGS"] += " -x assembler-with-cpp"
-    env["ASPATH"] = " {}".format(
-        " ".join(['-I"{}"'.format(inc) for inc in env["ASMPATH"]])
+    env.SConscript(
+        os.path.join("site_scons", "e2_xml.scons"),
+        exports={"env": env, "log_parent": log},
     )
-    env[
-        "ASPPCOM"
-    ] = "$CC $ASPPFLAGS $CPPFLAGS $_CPPDEFFLAGS $_CPPINCFLAGS -c -o $TARGET $SOURCES"
-    env["ASCOM"] = "$CC $CCFLAGS $ASFLAGS $ASPATH -o $TARGET -c $SOURCE"
-    # env["CCCOM"] = "$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
-    # env["CXXCOM"] = "$CXX -o $TARGET -c $CXXFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
-
-    # Here be preprocessor defs. Doesn't yet include new/re defines from the commandline
-    # but it'll be easy to add if we want, for testing.
-    env["CPPDEFINES"] = cproject.get_preprocessor_defs(e2_target)
-
-    # Literally just says ".elf"
-    env["PROGSUFFIX"] = cproject.get_target_ext(e2_target)
-
-    # "Deluge-<build_type>-<model>" for the current e2 target
-    env["FIRMWARE_FILENAME"] = cproject.get_target_filename(e2_target)
-
-    # Had to fudge the linker command a bit to get both the mapfile in there,
-    # and g++ used to perform the linking step.
-    env["MAPFILE"] = "{}".format(
-        os.path.join(
-            build_dir, "{}.map".format(cproject.get_target_filename(e2_target))
-        )
-    )
-    env["LINKFLAGS"] = cproject.get_link_flags(e2_target)
-    env["LINKCOM"] = "$CXX $CPPFLAGS -o $TARGET $SOURCES $LINKFLAGS"
-    
-    
-    env["LIBPATH"] = [str(i) for i in cproject.get_link_libs_order(e2_target)]
-    # log.debug(env["LIBPATH"])
 
 # GENERIC ENVIRONMENT STUFF AND ACTIONS
 # In this area below the "if" block, we keep environment changes and actions that are
@@ -165,51 +76,40 @@ if GetOption("base_config") == "e2_xml":
 wrap_tempfile(env, "LINKCOM")
 wrap_tempfile(env, "ARCOM")
 
-# Happy little custom builders and their actions.
-env.Append(
-    BUILDERS={
-        "HEXBuilder": Builder(
-            action=Action(
-                '${OBJCOPY} -O ihex "${SOURCE}" "${TARGET}"',
-                "${HEXCOMSTR}",
-            ),
-            suffix=".hex",
-            src_suffix=".elf",
-        ),
-        "BINBuilder": Builder(
-            action=Action(
-                '${OBJCOPY} -O binary -S "${SOURCE}" "${TARGET}"',
-                "${BINCOMSTR}",
-            ),
-            suffix=".bin",
-            src_suffix=".elf",
-        ),
-    }
-)
-
-# Export a `compile_commands.json` for help
-env.Tool('compilation_db')
-env.CompilationDatabase()
-
 # VariantDir does the magic to ensure output goes to the dbt- whatever
 # build directory. Careful: THIS CAN BE REALLY FINICKY if paths aren't set right
-VariantDir(os.path.join(build_label, source_dir), "#src", duplicate=False)
+VariantDir(os.path.join(env["BUILD_LABEL"], REL_SOURCE_DIR), "#src", duplicate=False)
+
+# Load generic stuff (Builders, etc.) into the environment.
+SConscript(os.path.join("site_scons", "generic_env.scons"), exports={"env": env})
 
 # Using the specified include dirs rather than walking every path in src was
 # preventing a successful .elf build so generically went with the latter approach.
 # This will serve us better later, buuuuut could also potentially break something.
 # ¯\_(ツ)_/¯
-sources = walk_all_sources(source_dir, build_label)
+sources = walk_all_sources(REL_SOURCE_DIR, env["BUILD_LABEL"])
 
-# Wrangle those sources into objects! 
+# Wrangle those sources into objects!
 objects = env.Object(sources)
 
 # Turn those objects into a magical elf! (and a bonus .map file)
 elf_file = env.Program(
-    os.path.join(build_dir, env["FIRMWARE_FILENAME"]), source=objects
+    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=objects
+)
+# Touch the bonus map file so when we tell dbt to clean (-c) it removes as well
+env.MAPBuilder(
+    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
 )
 
 # Bin it.
-env.BINBuilder(os.path.join(build_dir, env["FIRMWARE_FILENAME"]), source=elf_file)
+env.BINBuilder(
+    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
+)
 # Hex it.
-env.HEXBuilder(os.path.join(build_dir, env["FIRMWARE_FILENAME"]), source=elf_file)
+env.HEXBuilder(
+    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
+)
+# Size it.
+env.SIZBuilder(
+    os.path.join(env["BUILD_DIR"], env["FIRMWARE_FILENAME"]), source=elf_file
+)

--- a/SConstruct
+++ b/SConstruct
@@ -76,6 +76,10 @@ if GetOption("base_config") == "e2_xml":
 wrap_tempfile(env, "LINKCOM")
 wrap_tempfile(env, "ARCOM")
 
+# Export a `compile_commands.json` for help
+env.Tool("compilation_db")
+env.CompilationDatabase()
+
 # VariantDir does the magic to ensure output goes to the dbt- whatever
 # build directory. Careful: THIS CAN BE REALLY FINICKY if paths aren't set right
 VariantDir(os.path.join(env["BUILD_LABEL"], REL_SOURCE_DIR), "#src", duplicate=False)

--- a/scripts/dbt/util.py
+++ b/scripts/dbt/util.py
@@ -6,7 +6,7 @@ from SCons.Errors import StopError
 from SCons.Subst import quote_spaces
 
 WINPATHSEP_RE = re.compile(r"\\([^\"'\\]|$)")
-SOURCEWALK_RE = re.compile(r"\.[cs][p]{0,2}", re.IGNORECASE)
+SOURCEWALK_RE = re.compile(r"\.[cs][p]{0,2}$", re.IGNORECASE)
 
 # Used by default when globbing for files with GlobRecursive
 # Excludes all files ending with ~, usually created by editors as backup files

--- a/site_scons/commandline.scons
+++ b/site_scons/commandline.scons
@@ -17,7 +17,6 @@ AddOption(
 AddOption(
     "--e2_target",
     dest="e2_target",
-    default="dbt-build-release-oled",
     type="string",
     nargs=1,
     action="store",

--- a/site_scons/commandline.scons
+++ b/site_scons/commandline.scons
@@ -21,5 +21,17 @@ AddOption(
     nargs=1,
     action="store",
     metavar="TARGET",
-    help='Build target directory as in e2studio, prefaced with "dbt-" instead of "e2-"',
+    help='Legacy single-target e2 option; target prefaced with "dbt-" instead of "e2-"',
 )
+
+# TODO: allow a default compile_commands.json to be symlinked as part of the build if specified.
+# AddOption(
+#     "--cdb_symlink",
+#     dest="cdb_symlink",
+#     type="string",
+#     nargs=1,
+#     action="store",
+#     metavar="TARGET",
+#     help="If a target is specified with this flag, its 'compile_commands.json' "
+#     "will be symlinked in the root directory",
+# )

--- a/site_scons/e2_xml.scons
+++ b/site_scons/e2_xml.scons
@@ -4,6 +4,9 @@ from dbt.project import E2Project
 Import("env")
 Import("log_parent")
 
+# Prep the return variable
+success = False
+
 # Beep boop, human lifeform detected.
 log = log_parent.getChild("e2_xml")
 log.info("Detected e2_xml mode.")
@@ -18,28 +21,28 @@ dbt_build_targets = [p.replace("e2-build-", "dbt-build-") for p in e2_build_targ
 e2_build_targets.sort()
 dbt_build_targets.sort()
 
-if GetOption("e2_target") not in dbt_build_targets:
+if env["BUILD_LABEL"] not in dbt_build_targets:
     print(
         'Error: "{}" is not a valid target in the e2_xml config.\n'.format(
-            GetOption("e2_target")
+            env["BUILD_LABEL"]
         )
     )
     print("       Valid targets include:")
     for bt in dbt_build_targets:
         print("           {}".format(bt))
     print("")
-    Return()
+    Return("success")
 
 # And with all that out of the way, we start up our
 # main/construction environment and configure the particulars
 # for e2_xml targeting all within the "if" block.
-build_label = GetOption("e2_target")
+build_label = env["BUILD_LABEL"]
 
 # Some shorthand for all the labels and directories we're
 # going to need below.
 dbt_target_index = dbt_build_targets.index(build_label)
 e2_target = e2_build_targets[dbt_target_index]
-build_dir = os.path.abspath(build_label)
+build_dir = env["BUILD_DIR"]
 source_dir = "src"
 build_src_dir = os.path.join(build_dir, source_dir)
 build_segs = build_label.split("-")
@@ -47,10 +50,6 @@ firmware_filename = cproject.get_target_filename(e2_target)
 
 # Build construction environment for selected or default e2 target
 env.Replace(**cproject.get_toolchain_tools(e2_target))
-
-# Stow where later commands can get hold of these
-env["BUILD_LABEL"] = build_label
-env["BUILD_DIR"] = build_dir
 
 # "Deluge-<build_type>-<model>" for the current e2 target
 env["FIRMWARE_FILENAME"] = firmware_filename
@@ -94,3 +93,7 @@ env["LINKCOM"] = "$CXX $CPPFLAGS -o $TARGET $SOURCES $LINKFLAGS"
 
 # This is questionably useful. I think it might actually be disabled in e2.
 env["LIBPATH"] = [str(i) for i in cproject.get_link_libs_order(e2_target)]
+
+success = True
+# Signal true back to SConstruct
+Return("success")

--- a/site_scons/e2_xml.scons
+++ b/site_scons/e2_xml.scons
@@ -1,8 +1,10 @@
 import os
-from dbt.project import E2Project
 
 Import("env")
 Import("log_parent")
+Import("cproject")
+Import("e2_build_targets")
+Import("dbt_build_targets")
 
 # Prep the return variable
 success = False
@@ -11,15 +13,6 @@ success = False
 log = log_parent.getChild("e2_xml")
 log.info("Detected e2_xml mode.")
 
-# Crank up the e2studio XML parsing class
-cproject = E2Project(log, GetLaunchDir())
-
-# Brand and sort things appropriately so we follow the general scheme of,
-# but don't overlap with e2 build directories.
-e2_build_targets = list(cproject.get_build_targets())
-dbt_build_targets = [p.replace("e2-build-", "dbt-build-") for p in e2_build_targets]
-e2_build_targets.sort()
-dbt_build_targets.sort()
 
 if env["BUILD_LABEL"] not in dbt_build_targets:
     print(

--- a/site_scons/e2_xml.scons
+++ b/site_scons/e2_xml.scons
@@ -1,0 +1,96 @@
+import os
+from dbt.project import E2Project
+
+Import("env")
+Import("log_parent")
+
+# Beep boop, human lifeform detected.
+log = log_parent.getChild("e2_xml")
+log.info("Detected e2_xml mode.")
+
+# Crank up the e2studio XML parsing class
+cproject = E2Project(log, GetLaunchDir())
+
+# Brand and sort things appropriately so we follow the general scheme of,
+# but don't overlap with e2 build directories.
+e2_build_targets = list(cproject.get_build_targets())
+dbt_build_targets = [p.replace("e2-build-", "dbt-build-") for p in e2_build_targets]
+e2_build_targets.sort()
+dbt_build_targets.sort()
+
+if GetOption("e2_target") not in dbt_build_targets:
+    print(
+        'Error: "{}" is not a valid target in the e2_xml config.\n'.format(
+            GetOption("e2_target")
+        )
+    )
+    print("       Valid targets include:")
+    for bt in dbt_build_targets:
+        print("           {}".format(bt))
+    print("")
+    Return()
+
+# And with all that out of the way, we start up our
+# main/construction environment and configure the particulars
+# for e2_xml targeting all within the "if" block.
+build_label = GetOption("e2_target")
+
+# Some shorthand for all the labels and directories we're
+# going to need below.
+dbt_target_index = dbt_build_targets.index(build_label)
+e2_target = e2_build_targets[dbt_target_index]
+build_dir = os.path.abspath(build_label)
+source_dir = "src"
+build_src_dir = os.path.join(build_dir, source_dir)
+build_segs = build_label.split("-")
+firmware_filename = cproject.get_target_filename(e2_target)
+
+# Build construction environment for selected or default e2 target
+env.Replace(**cproject.get_toolchain_tools(e2_target))
+
+# Stow where later commands can get hold of these
+env["BUILD_LABEL"] = build_label
+env["BUILD_DIR"] = build_dir
+
+# "Deluge-<build_type>-<model>" for the current e2 target
+env["FIRMWARE_FILENAME"] = firmware_filename
+
+# log.debug([i for i, v in dict(env).items() if v])
+env["CCFLAGS"] = " ".join(cproject.get_c_flags(e2_target))
+env["CPPFLAGS"] = " ".join(cproject.get_cpp_flags(e2_target))
+
+# Don't really know where this flag came from in the config, but it's in
+# the e2studio makefiles.
+env["CPPFLAGS"] += " -fdiagnostics-parseable-fixits"
+env["ASMPATH"] = [str(p) for p in cproject.get_asm_includes(e2_target)]
+env["CCPATH"] = [str(p) for p in cproject.get_c_includes(e2_target)]
+env["CXXPATH"] = [str(p) for p in cproject.get_cpp_includes(e2_target)]
+env["CPPPATH"] = env["ASMPATH"] + env["CCPATH"] + env["CXXPATH"]
+
+# The assembler commandline needed a little bit of fudging for this build.
+env["ASPPFLAGS"] += " -x assembler-with-cpp"
+env["ASPATH"] = " {}".format(" ".join(['-I"{}"'.format(inc) for inc in env["ASMPATH"]]))
+env[
+    "ASPPCOM"
+] = "$CC $ASPPFLAGS $CPPFLAGS $_CPPDEFFLAGS $_CPPINCFLAGS -c -o $TARGET $SOURCES"
+env["ASCOM"] = "$CC $CCFLAGS $ASFLAGS $ASPATH -o $TARGET -c $SOURCE"
+# env["CCCOM"] = "$CC -o $TARGET -c $CFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
+# env["CXXCOM"] = "$CXX -o $TARGET -c $CXXFLAGS $CCFLAGS $_CCCOMCOM $SOURCES"
+
+# Here be preprocessor defs. Doesn't yet include new/re defines from the commandline
+# but it'll be easy to add if we want, for testing.
+env["CPPDEFINES"] = cproject.get_preprocessor_defs(e2_target)
+
+# Literally just says ".elf"
+env["PROGSUFFIX"] = cproject.get_target_ext(e2_target)
+
+# Had to fudge the linker command a bit to get both the mapfile in there,
+# and g++ used to perform the linking step.
+env["MAPFILE"] = "{}".format(
+    os.path.join(build_dir, "{}.map".format(cproject.get_target_filename(e2_target)))
+)
+env["LINKFLAGS"] = cproject.get_link_flags(e2_target)
+env["LINKCOM"] = "$CXX $CPPFLAGS -o $TARGET $SOURCES $LINKFLAGS"
+
+# This is questionably useful. I think it might actually be disabled in e2.
+env["LIBPATH"] = [str(i) for i in cproject.get_link_libs_order(e2_target)]

--- a/site_scons/generic_env.scons
+++ b/site_scons/generic_env.scons
@@ -1,0 +1,49 @@
+Import("env")
+
+# Happy little custom builders and their actions.
+env.Append(
+    BUILDERS={
+        "HEXBuilder": Builder(
+            action=Action(
+                '${OBJCOPY} -O ihex "${SOURCE}" "${TARGET}"',
+                "${HEXCOMSTR}",
+            ),
+            suffix=".hex",
+            src_suffix=".elf",
+        ),
+        "BINBuilder": Builder(
+            action=Action(
+                '${OBJCOPY} -O binary -S "${SOURCE}" "${TARGET}"',
+                "${BINCOMSTR}",
+            ),
+            suffix=".bin",
+            src_suffix=".elf",
+        ),
+        "SIZBuilder": Builder(
+            action=Action(
+                '${SIZE} --format=berkeley "${SOURCE}" > "${TARGET}"',
+                "${SIZECOMSTR}",
+            ),
+            suffix=".siz",
+            src_suffix=".elf",
+        ),
+        # Fake-out map building target, so the map file gets cleaned up.
+        "MAPBuilder": Builder(
+            action=Action(Touch("${TARGET}"), "${TOUCHCOMSTR}"),
+            suffix=".map",
+            src_suffix=".elf",
+        ),
+    }
+)
+
+# Defining the ...COMSTR variables suppresses seeing the build commands raw.
+# Just comment these out if you hate things being hidden from you.
+env["CCCOMSTR"] = "Compiling static object $TARGET"
+env["CXXCOMSTR"] = "Compiling static object $TARGET"
+env["ASPPCOMSTR"] = "Assembling $TARGET"
+env["LINKCOMSTR"] = "Linking $TARGET"
+env["BINCOMSTR"] = "Converting .elf to .bin."
+env["HEXCOMSTR"] = "Converting .elf to .hex."
+env["SIZECOMSTR"] = "Saving .elf size information to .siz."
+env["TOUCHCOMSTR"] = "Encouraging $TARGET"
+env["FAKEDIRCOMSTR"] = "Giving moral support to directories."


### PR DESCRIPTION
See #70 for details on what's planned for this PR

Made some tired mistakes in my git workflow. Sorry about the mess.

**Edit: cleaned up the mess with rebase -i.**

Summary:

- In short, the big deal is simpler targeting and multi-targeting in more of a traditional makefiley manner. Eg:  `./dbt dbt-build-release-oled`
- No more default targeting (it was kinda confusing)
- -e2_target= still works when no direct targets are specified in the above manner, so this won't break the build scripts
- Restructured a bunch of stuff to allow for more modularity
- Probably more I'm forgetting.