### PR TITLE
Windows - fixed broken toolchain path

### DIFF
--- a/scripts/toolchain/dbtenv.cmd
+++ b/scripts/toolchain/dbtenv.cmd
@@ -47,7 +47,7 @@ set "SSL_CERT_FILE=%DBT_TOOLCHAIN_ROOT%/python/Lib/site-packages/certifi/cacert.
 set "PYTHONHOME=%DBT_TOOLCHAIN_ROOT%\python"
 set "PYTHONPATH=%DBT_ROOT%\scripts;%PYTHONPATH%"
 set "PYTHONNOUSERSITE=1"
-set "PATH=%DBT_TOOLCHAIN_ROOT%\python;%DBT_TOOLCHAIN_ROOT%\python\Scripts;%DBT_TOOLCHAIN_ROOT%\gcc-arm-none-eabi\bin;%DBT_TOOLCHAIN_ROOT%\openocd\bin;%DBT_TOOLCHAIN_ROOT%\cmake\bin;%PATH%"
+set "PATH=%DBT_TOOLCHAIN_ROOT%\python;%DBT_TOOLCHAIN_ROOT%\python\Scripts;%DBT_TOOLCHAIN_ROOT%\arm-none-eabi-gcc\bin;%DBT_TOOLCHAIN_ROOT%\openocd\bin;%DBT_TOOLCHAIN_ROOT%\cmake\bin;%PATH%"
 set "PROMPT=(dbt) %PROMPT%"
 
 :already_set


### PR DESCRIPTION
- "gcc-arm-none-eabi" became "arm-none-eabi-gcc" with the switch to xpack releases and changing the path in the dbtenv.cmd was missed.

Tested to be working now in Windows 11, x86_64.

<img width="792" alt="image" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/273040/b3c26f14-cfcb-4061-8fbd-b31d37d83e8c">
