### PR TITLE
Fix warnings

### DIFF
--- a/src/AudioClip.cpp
+++ b/src/AudioClip.cpp
@@ -1124,7 +1124,7 @@ void AudioClip::setPos(ModelStackWithTimelineCounter* modelStack, int32_t newPos
 
 uint64_t AudioClip::getCullImmunity() {
 	uint32_t distanceFromEnd = loopLength - getLivePos();
-	bool doingTimeStretching =
-	    (voiceSample && voiceSample->timeStretcher); // We're gonna cull time-stretching ones first
-	return ((uint64_t)voicePriority << 33) + ((uint32_t)!doingTimeStretching << 32) + distanceFromEnd;
+	// We're gonna cull time-stretching ones first
+	bool doingTimeStretching = (voiceSample && voiceSample->timeStretcher);
+	return ((uint64_t)voicePriority << 33) + ((uint64_t)!doingTimeStretching << 32) + distanceFromEnd;
 }

--- a/src/AudioFile.cpp
+++ b/src/AudioFile.cpp
@@ -96,7 +96,7 @@ int AudioFile::loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTable
 			switch (thisChunk.name) {
 
 			// Data chunk - "data"
-			case 'atad': {
+			case charsToIntegerConstant('d', 'a', 't', 'a'): {
 				foundDataChunk = true;
 				audioDataStartPosBytes = bytePosOfThisChunkData;
 				audioDataLengthBytes = bytesCurrentChunkNotRoundedUp;
@@ -122,7 +122,7 @@ doSetupWaveTable:
 			}
 
 			// Format chunk - "fmt "
-			case ' tmf': {
+			case charsToIntegerConstant('f', 'm', 't', ' '): {
 				foundFmtChunk = true;
 
 				// Read and process fmt chunk
@@ -178,7 +178,7 @@ doSetupWaveTable:
 			}
 
 			// Sample chunk - "smpl"
-			case 'lpms': {
+			case charsToIntegerConstant('s', 'm', 'p', 'l'): {
 				if (type == AUDIO_FILE_TYPE_SAMPLE) {
 
 					uint32_t data[9];
@@ -230,7 +230,7 @@ doSetupWaveTable:
 			}
 
 			// Instrument chunk - "inst"
-			case 'tsni': {
+			case charsToIntegerConstant('i', 'n', 's', 't'): {
 				if (type == AUDIO_FILE_TYPE_SAMPLE) {
 
 					uint8_t data[7];
@@ -248,12 +248,12 @@ doSetupWaveTable:
 			}
 
 			// Serum wavetable chunk - "clm "
-			case ' mlc': {
-				char data[6];
+			case charsToIntegerConstant('c', 'l', 'm', ' '): {
+				char data[7];
 				error = reader->readBytes((char*)data, 7);
 				if (error) break;
 
-				if ((*(uint32_t*)data & 0x00FFFFFF) == '>!<') {
+				if ((*(uint32_t*)data & 0x00FFFFFF) == charsToIntegerConstant('<', '!', '>', 0)) {
 					fileExplicitlySpecifiesSelfAsWaveTable = true;
 					int number = memToUIntOrError(&data[3], &data[7]);
 
@@ -274,7 +274,7 @@ doSetupWaveTable:
 			switch (thisChunk.name) {
 
 			// SSND
-			case 'DNSS': {
+			case charsToIntegerConstant('S', 'S', 'N', 'D'): {
 				foundDataChunk = true;
 
 				// Offset
@@ -292,7 +292,7 @@ doSetupWaveTable:
 			}
 
 			// COMM
-			case 'MMOC': {
+			case charsToIntegerConstant('C', 'O', 'M', 'M'): {
 				foundFmtChunk = true;
 
 				if (thisChunk.length != 18) return ERROR_FILE_UNSUPPORTED; // Why'd I do this?
@@ -334,7 +334,7 @@ doSetupWaveTable:
 			}
 
 			// MARK
-			case 'KRAM': {
+			case charsToIntegerConstant('M', 'A', 'R', 'K'): {
 				error = reader->readBytes((char*)&numMarkers, 2);
 				if (error) break;
 				numMarkers = swapEndianness2x16(numMarkers);
@@ -374,7 +374,7 @@ doSetupWaveTable:
 			}
 
 			// INST
-			case 'TSNI': {
+			case charsToIntegerConstant('I', 'N', 'S', 'T'): {
 				if (type == AUDIO_FILE_TYPE_SAMPLE) {
 					uint8_t data[8];
 					error = reader->readBytes((char*)data, 8);

--- a/src/AutoParam.cpp
+++ b/src/AutoParam.cpp
@@ -1613,7 +1613,7 @@ int AutoParam::readFromFile(int32_t readAutomationUpToPos) {
 	if (!firstChars) return NO_ERROR;
 
 	// If a decimal, then read the rest of the digits
-	if (*(uint16_t*)firstChars != 'x0') {
+	if (*(uint16_t*)firstChars != charsToIntegerConstant('0', 'x')) {
 		char buffer[12];
 		buffer[0] = firstChars[0];
 		buffer[1] = firstChars[1];

--- a/src/GlobalEffectable.cpp
+++ b/src/GlobalEffectable.cpp
@@ -121,7 +121,7 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 			if (on) {
 				modFXType++;
 				if (modFXType >= NUM_MOD_FX_TYPES) modFXType = 1;
-				char* displayText;
+				char const* displayText;
 				switch (modFXType) {
 				case MOD_FX_TYPE_FLANGER:
 					displayText = "FLANGER";
@@ -147,7 +147,7 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				if (currentModFXParam == NUM_MOD_FX_PARAMS) currentModFXParam = 0;
 				ensureModFXParamIsValid();
 
-				char* displayText;
+				char const* displayText;
 				switch (currentModFXParam) {
 				case MOD_FX_PARAM_DEPTH:
 					displayText = "DEPTH";
@@ -175,7 +175,7 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				currentFilterType++;
 				if (currentFilterType >= NUM_FILTER_TYPES) currentFilterType = 0;
 
-				char* displayText;
+				char const* displayText;
 				switch (currentFilterType) {
 				case FILTER_TYPE_LPF:
 					displayText = "LPF";

--- a/src/InstrumentClipView.cpp
+++ b/src/InstrumentClipView.cpp
@@ -2955,7 +2955,7 @@ void InstrumentClipView::enterDrumCreator(ModelStackWithNoteRow* modelStack, boo
 
 	Uart::println("enterDrumCreator");
 
-	char* prefix;
+	char const* prefix;
 	String soundName;
 
 	if (doRecording) prefix = "TEM"; // Means "temp". Actual "REC" name is set in audioRecorder

--- a/src/MemoryRegion.cpp
+++ b/src/MemoryRegion.cpp
@@ -597,7 +597,7 @@ void MemoryRegion::writeTempHeadersBeforeASteal(uint32_t newStartAddress, uint32
 // Returns new size, or same size if couldn't extend.
 uint32_t MemoryRegion::extendRightAsMuchAsEasilyPossible(void* address) {
 
-	uint32_t* __restrict__ header = (uint32_t*)(address - 4);
+	uint32_t* __restrict__ header = (uint32_t*)(static_cast<char*>(address) - 4);
 	uint32_t spaceSize = (*header & SPACE_SIZE_MASK);
 
 	uint32_t* __restrict__ lookRight = (uint32_t*)((uint32_t)address + spaceSize + 4);
@@ -631,7 +631,7 @@ uint32_t MemoryRegion::extendRightAsMuchAsEasilyPossible(void* address) {
 		*header = newHeaderData;
 
 		// Write footer
-		uint32_t* __restrict__ footer = (uint32_t*)(address + spaceSize);
+		uint32_t* __restrict__ footer = (uint32_t*)(static_cast<char*>(address) + spaceSize);
 		*footer = newHeaderData;
 	}
 

--- a/src/MenuItemSourceSelection.cpp
+++ b/src/MenuItemSourceSelection.cpp
@@ -82,7 +82,7 @@ void MenuItemSourceSelection::drawPixelsForOled() {
 #else
 
 void MenuItemSourceSelection::drawValue() {
-	char* text;
+	char const* text;
 	switch (sourceMenuContents[soundEditor.currentValue]) {
 	case PATCH_SOURCE_LFO_GLOBAL:
 		text = "LFO1";

--- a/src/ModControllableAudio.cpp
+++ b/src/ModControllableAudio.cpp
@@ -1474,7 +1474,7 @@ void ModControllableAudio::endStutter(ParamManagerForTimeline* paramManager) {
 void ModControllableAudio::switchDelayPingPong() {
 	delay.pingPong = !delay.pingPong;
 
-	char* displayText;
+	char const* displayText;
 	switch (delay.pingPong) {
 	case 0:
 		displayText = "Normal delay";

--- a/src/NoteRow.cpp
+++ b/src/NoteRow.cpp
@@ -2671,7 +2671,7 @@ doReadNoteData:
 
 			{
 				char const* firstChars = storageManager.readNextCharsOfTagOrAttributeValue(2);
-				if (!firstChars || *(uint16_t*)firstChars != 'x0') goto getOut;
+				if (!firstChars || *(uint16_t*)firstChars != charsToIntegerConstant('0', 'x')) goto getOut;
 			}
 
 			while (true) {

--- a/src/Output.cpp
+++ b/src/Output.cpp
@@ -271,7 +271,7 @@ bool Output::readTagFromFile(char const* tagName) {
 
 		{
 			char const* firstChars = storageManager.readNextCharsOfTagOrAttributeValue(2);
-			if (!firstChars || *(uint16_t*)firstChars != 'x0') goto getOut;
+			if (!firstChars || *(uint16_t*)firstChars != charsToIntegerConstant('0', 'x')) goto getOut;
 		}
 
 		while (true) {

--- a/src/drivers/All_CPUs/uart_all_cpus/uart_all_cpus.c
+++ b/src/drivers/All_CPUs/uart_all_cpus/uart_all_cpus.c
@@ -21,8 +21,10 @@
 #include "sio_char.h"
 #include <string.h>
 
+#include <math.h>
 #include "scif_iodefine.h"
 #include "devdrv_intc.h"
+#include "cfunctions.h"
 
 #include "RTT/SEGGER_RTT.h"
 

--- a/src/drivers/RZA1/diskio.c
+++ b/src/drivers/RZA1/diskio.c
@@ -1224,7 +1224,7 @@ DSTATUS disk_status(BYTE pdrv /* Physical drive nmuber to identify the drive */
     return diskStatus;
 }
 
-int32_t sdIntCallback(int32_t sd_port, int32_t cd)
+int sdIntCallback(int sd_port, int cd)
 {
     if (sd_port == SD_PORT)
     {

--- a/src/drivers/RZA1/intc/intc_handler.c
+++ b/src/drivers/RZA1/intc/intc_handler.c
@@ -66,11 +66,6 @@ Imported global variables and functions (from other files)
 /******************************************************************************
 Exported global variables and functions (to be accessed by other files)
 ******************************************************************************/
-#ifdef __ICCARM__
-/* ==== Prototype declaration ==== */
-void INTC_Handler_Interrupt(uint32_t icciar);
-__fiq __arm void FiqHandler_Interrupt(void);
-#endif
 
 /******************************************************************************
 * Function Name: INTC_Handler_Interrupt

--- a/src/drivers/RZA1/intc/intc_handler.h
+++ b/src/drivers/RZA1/intc/intc_handler.h
@@ -49,15 +49,6 @@ Variable Externs
 Functions Prototypes
 ******************************************************************************/
 void INTC_Handler_Interrupt(uint32_t icciar);
-#ifdef __CC_ARM
-__irq void FiqHandler_Interrupt(void);
-#endif
-#ifdef __ICCARM__
-__fiq __arm void FiqHandler_Interrupt(void);
-#endif
-#ifdef __GNUC__
-/*__irq*/ void FiqHandler_Interrupt(void) __attribute__((interrupt("FIQ")));
-#endif
 
 #endif /* INTC_HANDLER_H */
 

--- a/src/drivers/RZA1/sdhi/inc/sdif.h
+++ b/src/drivers/RZA1/sdhi/inc/sdif.h
@@ -245,7 +245,7 @@ int sd_format(int sd_port, int mode,int (*callback)(unsigned long,unsigned long)
 int sd_format2(int sd_port, int mode,unsigned long volserial,int (*callback)(unsigned long,unsigned long));
 int sd_mount(int sd_port, unsigned long mode,unsigned long voltage);
 int sd_read_sect(int sd_port, unsigned char *buff,unsigned long psn,long cnt);
-int sd_write_sect(int sd_port, unsigned char *buff,unsigned long psn,long cnt,int writemode);
+int sd_write_sect(int sd_port, unsigned char const *buff,unsigned long psn,long cnt,int writemode);
 int sd_get_type(int sd_port, unsigned char *type,unsigned char *speed,unsigned char *capa);
 int sd_get_size(int sd_port, unsigned long *user,unsigned long *protect);
 int sd_iswp(int sd_port);

--- a/src/drivers/RZA1/sdhi/src/sd/access/sd_read.c
+++ b/src/drivers/RZA1/sdhi/src/sd/access/sd_read.c
@@ -82,7 +82,7 @@ int doActualReadRohan(int sd_port, SDHNDL *hndl, unsigned char *buff, long cnt, 
 		// for this memory which hasn't been written/flushed back out yet, and that happens during the DMA transfer, overwriting the audio data in actual RAM.
 		// https://support.xilinx.com/s/article/64839?language=en_US - seems to concur with this, and actually suggests that it is normal and necessary to
 		// invalidate both before and after transfer.
-		v7_dma_inv_range(buff, buff + cnt * 512);
+		v7_dma_inv_range((intptr_t)buff, (intptr_t)(buff + cnt * 512));
 
 		/* ---- initialize DMAC ---- */
 		unsigned long reg_base_here = hndl->reg_base;

--- a/src/drivers/RZA1/sdhi/src/sd/access/sd_write.c
+++ b/src/drivers/RZA1/sdhi/src/sd/access/sd_write.c
@@ -48,7 +48,7 @@
 #pragma arm section zidata = "BSS_SDHI"
 #endif
 
-static int _sd_single_write(SDHNDL *hndl,unsigned char *buff,unsigned long psn,int mode);
+static int _sd_single_write(SDHNDL *hndl,unsigned char const*buff,unsigned long psn,int mode);
 
 /*****************************************************************************
  * ID           :
@@ -70,7 +70,7 @@ static int _sd_single_write(SDHNDL *hndl,unsigned char *buff,unsigned long psn,i
  *              : SD_ERR: end of error
  * Remark       : 
  *****************************************************************************/
-int sd_write_sect(int sd_port, unsigned char *buff,unsigned long psn,long cnt,int writemode)
+int sd_write_sect(int sd_port, unsigned char const*buff,unsigned long psn,long cnt,int writemode)
 {
 	SDHNDL *hndl;
 
@@ -139,7 +139,7 @@ int sd_write_sect(int sd_port, unsigned char *buff,unsigned long psn,long cnt,in
  *              : SD_ERR: end of error
  * Remark       : 
  *****************************************************************************/
-int _sd_write_sect(SDHNDL *hndl,unsigned char *buff,unsigned long psn,
+int _sd_write_sect(SDHNDL *hndl,unsigned char const*buff,unsigned long psn,
 	long cnt,int writemode)
 {
 	long i,j;
@@ -161,7 +161,7 @@ int _sd_write_sect(SDHNDL *hndl,unsigned char *buff,unsigned long psn,
 		mode = SD_MODE_DMA;	/* set DMA mode */
 
 		// Flush ram
-		v7_dma_flush_range(buff, buff + cnt * 512);
+		v7_dma_flush_range((intptr_t)buff, (intptr_t)(buff + cnt * 512));
 
 		#if		(TARGET_RZ_A1 == 1)
 		if(hndl->trans_mode & SD_MODE_DMA_64){
@@ -275,7 +275,9 @@ int _sd_write_sect(SDHNDL *hndl,unsigned char *buff,unsigned long psn,
 			/* enable All end, BWE and errors */
 			_sd_set_int_mask(hndl,SD_INFO1_MASK_DATA_TRNS,SD_INFO2_MASK_BWE);
 			/* software data transfer */
-			trans_ret = _sd_software_trans(hndl,buff,cnt,SD_TRANS_WRITE);
+			// it is safe to cast away const here because _sd_software_trans has pinky-promised not to write to the
+			// memory when in SD_TRANS_WRITE mode
+			trans_ret = _sd_software_trans(hndl,(unsigned char*)buff,cnt,SD_TRANS_WRITE);
 		}
 		else{	/* ==== DMA ==== */
 			/* disable card ins&rem interrupt for FIFO */
@@ -509,7 +511,7 @@ ErrExit:
  *              : SD_ERR: end of error
  * Remark       : 
  *****************************************************************************/
-static int _sd_single_write(SDHNDL *hndl,unsigned char *buff,unsigned long psn,
+static int _sd_single_write(SDHNDL *hndl,unsigned char const*buff,unsigned long psn,
 	int mode)
 {
 	int ret,trans_ret;
@@ -545,7 +547,9 @@ static int _sd_single_write(SDHNDL *hndl,unsigned char *buff,unsigned long psn,
 		/* enable All end, BWE and errors */
 		_sd_set_int_mask(hndl,SD_INFO1_MASK_DATA_TRNS,SD_INFO2_MASK_BWE);
 		/* software data transfer */
-		trans_ret = _sd_software_trans(hndl,buff,1,SD_TRANS_WRITE);
+		// it is safe to cast away const here because _sd_software_trans has pinky-promised not to write to the memory
+		// when in SD_TRANS_WRITE mode
+		trans_ret = _sd_software_trans(hndl,(unsigned char*)buff,1,SD_TRANS_WRITE);
 	}
 	else{	/* ==== DMA ==== */
 		/* disable card ins&rem interrupt for FIFO */

--- a/src/drivers/RZA1/sdhi/src/sd/inc/access/sd.h
+++ b/src/drivers/RZA1/sdhi/src/sd/inc/access/sd.h
@@ -552,8 +552,7 @@ int _sdio_dma_trans(SDHNDL *hndl,long cnt,unsigned short blocklen);
  /* no function */
 
 /* ---- sd_write.c ---- */
-int _sd_write_sect(SDHNDL *hndl,unsigned char *buff,unsigned long psn,
-	long cnt,int writemode);
+int _sd_write_sect(SDHNDL *hndl,unsigned char const *buff,unsigned long psn, long cnt,int writemode);
 
 /* ---- sd_io_read.c ---- */
 int _sdio_read(SDHNDL *hndl,unsigned char *buff,unsigned long func,

--- a/src/drivers/RZA1/ssi/drv_ssif.h
+++ b/src/drivers/RZA1/ssi/drv_ssif.h
@@ -82,65 +82,66 @@ typedef struct
     volatile uint32_t* ssitdmr; /* TDM mode register(SSITDMR) */
 } ssif_reg_t;
 
-static const ssif_reg_t ssif[SSI_CHANNEL_MAX] = {{
-                                                     /* ch0 */
-                                                     &SSIF0.SSICR,   /* control register(SSICR) */
-                                                     &SSIF0.SSIFCR,  /* FIFO control register(SSIFCR) */
-                                                     &SSIF0.SSISR,   /* status register(SSISR) */
-                                                     &SSIF0.SSIFSR,  /* FIFO status register(SSIFSR) */
-                                                     &SSIF0.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
-                                                     &SSIF0.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
-                                                     &SSIF0.SSITDMR  /* TDM mode register(SSITDMR) */
-                                                 },
+static const ssif_reg_t ssif[SSI_CHANNEL_MAX] = {
+    {
+        /* ch0 */
+        &SSIF0.SSICR,                       /* control register(SSICR) */
+        &SSIF0.SSIFCR,                      /* FIFO control register(SSIFCR) */
+        &SSIF0.SSISR,                       /* status register(SSISR) */
+        &SSIF0.SSIFSR,                      /* FIFO status register(SSIFSR) */
+        (volatile uint32_t*)&SSIF0.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
+        (volatile uint32_t*)&SSIF0.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
+        &SSIF0.SSITDMR                      /* TDM mode register(SSITDMR) */
+    },
     {
         /* ch1 */
-        &SSIF1.SSICR,   /* control register(SSICR) */
-        &SSIF1.SSIFCR,  /* FIFO control register(SSIFCR) */
-        &SSIF1.SSISR,   /* status register(SSISR) */
-        &SSIF1.SSIFSR,  /* FIFO status register(SSIFSR) */
-        &SSIF1.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
-        &SSIF1.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
-        &SSIF1.SSITDMR  /* TDM mode register(SSITDMR) */
+        &SSIF1.SSICR,                       /* control register(SSICR) */
+        &SSIF1.SSIFCR,                      /* FIFO control register(SSIFCR) */
+        &SSIF1.SSISR,                       /* status register(SSISR) */
+        &SSIF1.SSIFSR,                      /* FIFO status register(SSIFSR) */
+        (volatile uint32_t*)&SSIF1.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
+        (volatile uint32_t*)&SSIF1.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
+        &SSIF1.SSITDMR                      /* TDM mode register(SSITDMR) */
     },
     {
         /* ch2 */
-        &SSIF2.SSICR,   /* control register(SSICR) */
-        &SSIF2.SSIFCR,  /* FIFO control register(SSIFCR) */
-        &SSIF2.SSISR,   /* status register(SSISR) */
-        &SSIF2.SSIFSR,  /* FIFO status register(SSIFSR) */
-        &SSIF2.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
-        &SSIF2.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
-        &SSIF2.SSITDMR  /* TDM mode register(SSITDMR) */
+        &SSIF2.SSICR,                       /* control register(SSICR) */
+        &SSIF2.SSIFCR,                      /* FIFO control register(SSIFCR) */
+        &SSIF2.SSISR,                       /* status register(SSISR) */
+        &SSIF2.SSIFSR,                      /* FIFO status register(SSIFSR) */
+        (volatile uint32_t*)&SSIF2.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
+        (volatile uint32_t*)&SSIF2.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
+        &SSIF2.SSITDMR                      /* TDM mode register(SSITDMR) */
     },
     {
         /* ch3 */
-        &SSIF3.SSICR,   /* control register(SSICR) */
-        &SSIF3.SSIFCR,  /* FIFO control register(SSIFCR) */
-        &SSIF3.SSISR,   /* status register(SSISR) */
-        &SSIF3.SSIFSR,  /* FIFO status register(SSIFSR) */
-        &SSIF3.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
-        &SSIF3.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
-        &SSIF3.SSITDMR  /* TDM mode register(SSITDMR) */
+        &SSIF3.SSICR,                       /* control register(SSICR) */
+        &SSIF3.SSIFCR,                      /* FIFO control register(SSIFCR) */
+        &SSIF3.SSISR,                       /* status register(SSISR) */
+        &SSIF3.SSIFSR,                      /* FIFO status register(SSIFSR) */
+        (volatile uint32_t*)&SSIF3.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
+        (volatile uint32_t*)&SSIF3.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
+        &SSIF3.SSITDMR                      /* TDM mode register(SSITDMR) */
     },
     {
         /* ch4 */
-        &SSIF4.SSICR,   /* control register(SSICR) */
-        &SSIF4.SSIFCR,  /* FIFO control register(SSIFCR) */
-        &SSIF4.SSISR,   /* status register(SSISR) */
-        &SSIF4.SSIFSR,  /* FIFO status register(SSIFSR) */
-        &SSIF4.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
-        &SSIF4.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
-        &SSIF4.SSITDMR  /* TDM mode register(SSITDMR) */
+        &SSIF4.SSICR,                       /* control register(SSICR) */
+        &SSIF4.SSIFCR,                      /* FIFO control register(SSIFCR) */
+        &SSIF4.SSISR,                       /* status register(SSISR) */
+        &SSIF4.SSIFSR,                      /* FIFO status register(SSIFSR) */
+        (volatile uint32_t*)&SSIF4.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
+        (volatile uint32_t*)&SSIF4.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
+        &SSIF4.SSITDMR                      /* TDM mode register(SSITDMR) */
     },
     {
         /* ch5 */
-        &SSIF5.SSICR,   /* control register(SSICR) */
-        &SSIF5.SSIFCR,  /* FIFO control register(SSIFCR) */
-        &SSIF5.SSISR,   /* status register(SSISR) */
-        &SSIF5.SSIFSR,  /* FIFO status register(SSIFSR) */
-        &SSIF5.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
-        &SSIF5.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
-        &SSIF5.SSITDMR  /* TDM mode register(SSITDMR) */
+        &SSIF5.SSICR,                       /* control register(SSICR) */
+        &SSIF5.SSIFCR,                      /* FIFO control register(SSIFCR) */
+        &SSIF5.SSISR,                       /* status register(SSISR) */
+        &SSIF5.SSIFSR,                      /* FIFO status register(SSIFSR) */
+        (volatile uint32_t*)&SSIF5.SSIFTDR, /* Tx FIFO data register(SSIFTDR) */
+        (volatile uint32_t*)&SSIF5.SSIFRDR, /* Rx FIFO data register(SSIFRDR) */
+        &SSIF5.SSITDMR                      /* TDM mode register(SSITDMR) */
     }};
 
 #ifdef __cplusplus

--- a/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hdriver.c
+++ b/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hdriver.c
@@ -929,7 +929,7 @@ extern usb_msg_t* p_usb_scheduler_add_use;
  ***********************************************************************************************************************/
 void usb_hstd_hcd_task(usb_vp_int_t stacd)
 {
-    usb_utr_t* p_mess = p_usb_scheduler_add_use;
+    usb_utr_t* p_mess = (usb_utr_t*)p_usb_scheduler_add_use;
     usb_utr_t* ptr;
     usb_er_t err;
     uint16_t rootport;

--- a/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hhubsys.c
+++ b/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hhubsys.c
@@ -519,7 +519,7 @@ extern usb_msg_t* p_usb_scheduler_add_use;
  ***********************************************************************************************************************/
 void usb_hhub_task(usb_vp_int_t stacd)
 {
-    usb_utr_t* mess = p_usb_scheduler_add_use;
+    usb_utr_t* mess = (usb_utr_t*)p_usb_scheduler_add_use;
     usb_er_t err;
 
     switch (mess->msginfo)

--- a/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
+++ b/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
@@ -1509,7 +1509,7 @@ extern usb_msg_t* p_usb_scheduler_add_use;
  ***********************************************************************************************************************/
 void usb_hstd_mgr_task(usb_vp_int_t stacd)
 {
-    usb_utr_t* mess = p_usb_scheduler_add_use;
+    usb_utr_t* mess = (usb_utr_t*)p_usb_scheduler_add_use;
     usb_utr_t* ptr;
     usb_er_t err;
     usb_hcdreg_t* driver;

--- a/src/drivers/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
+++ b/src/drivers/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
@@ -490,7 +490,7 @@ extern usb_msg_t* p_usb_scheduler_add_use;
  ******************************************************************************/
 void usb_hmidi_task(usb_vp_int_t stacd)
 {
-    usb_utr_t* p_mess = p_usb_scheduler_add_use;
+    usb_utr_t* p_mess = (usb_utr_t*)p_usb_scheduler_add_use;
     usb_er_t err      = 0l;
 
     if (p_mess->msginfo == USB_HHID_TCMD_OPEN)

--- a/src/functions.h
+++ b/src/functions.h
@@ -166,6 +166,15 @@ inline int32_t lshiftAndSaturateUnknown(int32_t val, uint8_t lshift) {
 	return signed_saturate_operand_unknown(val, 32 - lshift) << lshift;
 }
 
+static constexpr uint32_t charsToIntegerConstant(char a, char b, char c, char d) {
+	return (static_cast<uint32_t>(a)) | (static_cast<uint32_t>(b) << 8) | (static_cast<uint32_t>(c) << 16)
+	       | (static_cast<uint32_t>(d) << 24);
+}
+
+static constexpr uint16_t charsToIntegerConstant(char a, char b) {
+	return (static_cast<uint16_t>(a)) | (static_cast<uint16_t>(b) << 8);
+}
+
 int32_t stringToInt(char const* string);
 int32_t stringToUIntOrError(char const* mem);
 int32_t memToUIntOrError(char const* mem, char const* const memEnd);

--- a/src/instrument.h
+++ b/src/instrument.h
@@ -44,7 +44,6 @@ class ModelStackWithThreeMainThings;
 class Instrument : public Output {
 public:
 	Instrument(int newType);
-	virtual char const* getFilePrefix() {}
 	// This needs to be initialized / defaulted to "SYNTHS" or "KITS" (for those Instrument types). The constructor does
 	// not do this, partly because I don't want it doing memory allocation, and also because in many cases, the function
 	// creating the object hard-sets this anyway.

--- a/src/kit.h
+++ b/src/kit.h
@@ -69,7 +69,6 @@ public:
 	SoundDrum* getDrumFromName(char const* name, bool onlyIfNoNoteRow = false);
 	int makeDrumNameUnique(String* name, int startAtNumber);
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, int maySendMIDIPGMs);
-	char const* getFilePrefix() { return "KIT"; }
 	void setupPatching(ModelStackWithTimelineCounter* modelStack);
 	void compensateInstrumentVolumeForResonance(ParamManagerForTimeline* paramManager, Song* song);
 	void deleteBackedUpParamManagers(Song* song);

--- a/src/playbackhandler.cpp
+++ b/src/playbackhandler.cpp
@@ -1652,7 +1652,7 @@ void PlaybackHandler::displaySwingAmount() {
 
 #else
 	char buffer[12];
-	char* toDisplay;
+	char const* toDisplay;
 	if (currentSong->swingAmount == 0) toDisplay = "OFF";
 	else {
 		intToString(currentSong->swingAmount + 50, buffer);

--- a/src/song.cpp
+++ b/src/song.cpp
@@ -1135,8 +1135,7 @@ int Song::readFromFile() {
 			storageManager.exitTag();
 			break;
 
-		// "xScr..."
-		case 'rcSx':
+		case charsToIntegerConstant('x', 'S', 'c', 'r'):
 
 			switch (*(((uint32_t*)tagName) + 1)) {
 

--- a/src/soundinstrument.h
+++ b/src/soundinstrument.h
@@ -54,7 +54,6 @@ public:
 	ModControllable* toModControllable();
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, int maySendMIDIPGMs);
 	void setupPatchingForAllParamManagers(Song* song);
-	char const* getFilePrefix() { return "SYNT"; }
 	void setupPatching(ModelStackWithTimelineCounter* modelStack);
 
 	void deleteBackedUpParamManagers(Song* song);


### PR DESCRIPTION
This cleans up the majority of the remaining warnings in the debug-oled build, with the exception of:
- Some `-Wstringop-overflow` warnings in the Segger code, which look like it's the compiler losing track of buffer sizes and not an actual problem. Further investigation required.
- `-Winvalid-offsetof` warnings from the `Patcher` code. I think that logic can be turned in to C++ templates to retain the same machine code while better explaining what we're doing to the compiler, but it will be pretty subtle work with far-reaching implications so I'm saving it for a followup.
- 160+ `-Wstack-usage` warnings in debug mode. I'm not sure what to do with these really, it's probably good to keep tabs on it but with that many warnings it's basically just noise. Maybe we can do something with `-fstack-usage` instead?

The release-oled build has a bunch of `-Wstringop-overflow` warnings in the PIC UART interaction that require separate investigation. It seems like a similar situation where the warning infrastructure loses the plot after some optimizations are applied and thinks the destination is of size zero.

This is probably easiest to review change by change, they don't really build on top of eachother just fix different warnings.