### PR TITLE
workflow: use versioned toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches:
       - 'community'
+env:
+  DBT_VERSION: 8
+
 jobs:
   build:
     name: Build ${{ matrix.profile }}-${{ matrix.hardware }}
@@ -19,13 +22,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Fetch container image
         run: |
-          docker pull ghcr.io/bobtwinkles/deluge-ci-images:main
+          docker pull ghcr.io/bobtwinkles/deluge-ci-images:v$DBT_VERSION
       - name: Run build
         run: |
           docker run --rm \
             --user=$(id --user):$(id --group) \
             -v $(pwd):/src \
-            ghcr.io/bobtwinkles/deluge-ci-images:main \
+            ghcr.io/bobtwinkles/deluge-ci-images:v$DBT_VERSION \
             --e2_target=dbt-build-${{ matrix.profile }}-${{ matrix.hardware }}
       - name: Publish built firmware (bin)
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This way commits that require atomic updates across `dbt` and the toolchain can work.