### PR TITLE
Fix even more warnings

### DIFF
--- a/src/MemoryRegion.cpp
+++ b/src/MemoryRegion.cpp
@@ -22,7 +22,7 @@
 #include "GeneralMemoryAllocator.h"
 #include "mtu_all_cpus.h"
 #include "functions.h"
-#include "numericdriver.h";
+#include "numericdriver.h"
 
 MemoryRegion::MemoryRegion() : emptySpaces(sizeof(EmptySpaceRecord)) {
 	numAllocations = 0;

--- a/src/RTT/SEGGER_RTT.c
+++ b/src/RTT/SEGGER_RTT.c
@@ -313,8 +313,14 @@ static void _DoInit(void) {
 	// Copy Id string in three steps to make sure "SEGGER RTT" is not found
 	// in initializer memory (usually flash) by J-Link
 	//
-	STRCPY(&p->acID[7], "RTT", 9);
-	STRCPY(&p->acID[0], "SEGGER", 7);
+	// GCC gets deeply confused by the UNCACHED_MIRROR_OFFSET trickery
+	// happening inside _SEGGER_RTT. It's not easy to explain what we're doing
+	// here either, so simply silence the warning for now.
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+	STRCPY((char*)&p->acID[7], "RTT", 9);
+	STRCPY((char*)&p->acID[0], "SEGGER", 7);
+#pragma GCC pop
 	p->acID[6] = ' ';
 }
 

--- a/src/drivers/All_CPUs/sd_all_cpus.c
+++ b/src/drivers/All_CPUs/sd_all_cpus.c
@@ -25,9 +25,6 @@
 #include "sdif.h"
 
 uint16_t stopTime;
-void sddev_start_timer(int msec);
-int sddev_check_timer(void);
-void sddev_end_timer(void);
 
 /******************************************************************************
 * Function Name: int sddev_power_on(int sd_port);

--- a/src/drivers/RZA1/diskio.c
+++ b/src/drivers/RZA1/diskio.c
@@ -1205,13 +1205,6 @@ DWORD get_fattime(void)
 
 #else
 
-/* Definitions of physical drive number for each drive */
-#define ATA 0 /* Example: Map ATA harddisk to physical drive 0 */
-#define MMC 1 /* Example: Map MMC/SD card to physical drive 1 */
-#define USB 2 /* Example: Map USB MSD to physical drive 2 */
-
-//int32_t cmd_sd_init(int32_t argc, char_t **argv);
-
 BYTE diskStatus = STA_NOINIT;
 
 /*-----------------------------------------------------------------------*/

--- a/src/drivers/RZA1/sdhi/inc/sdif.h
+++ b/src/drivers/RZA1/sdhi/inc/sdif.h
@@ -315,6 +315,9 @@ int sddev_loc_cpu(int sd_port);
 int sddev_unl_cpu(int sd_port);
 int sddev_cmd0_sdio_mount(int sd_port);
 int sddev_cmd8_sdio_mount(int sd_port);
+void sddev_start_timer(int msec);
+int sddev_check_timer(void);
+void sddev_end_timer(void);
 
 #ifdef    __cplusplus
 }

--- a/src/drivers/RZA1/sdhi/userdef/sd_dev_low.c
+++ b/src/drivers/RZA1/sdhi/userdef/sd_dev_low.c
@@ -48,6 +48,7 @@ Includes   <System Includes> , "Project Includes"
 #include "../inc/sdif.h"
 #include "../inc/sd_cfg.h"
 #include "sd_dev_dmacdrv.h"
+#include "sdif.h"
 #include "gpio_iobitmask.h"
 #include "uart_all_cpus.h"
 #include "Deluge.h"
@@ -99,9 +100,6 @@ static void sddev_sd_int_handler_0(uint32_t int_sense);
 static void sddev_sd_int_handler_1(uint32_t int_sense);
 static void sddev_sdio_int_handler_0(uint32_t int_sense);
 static void sddev_sdio_int_handler_1(uint32_t int_sense);
-static void sddev_start_timer(int msec);
-static void sddev_end_timer(void);
-static int  sddev_check_timer(void);
 
 /******************************************************************************
 * Function Name: int sddev_cmd0_sdio_mount(int sd_port);

--- a/src/drivers/RZA1/spibsc/spibsc_ioset_drv.c
+++ b/src/drivers/RZA1/spibsc/spibsc_ioset_drv.c
@@ -49,7 +49,7 @@ Includes   <System Includes> , "Project Includes"
 /******************************************************************************
 Typedef definitions
 ******************************************************************************/
-volatile struct st_spibsc* SPIBSC[SPIBSC_COUNT] = {SPIBSC_ADDRESS_LIST};
+volatile struct st_spibsc* SPIBSC[SPIBSC_COUNT] = SPIBSC_ADDRESS_LIST;
 
 /******************************************************************************
 Macro definitions

--- a/src/drivers/RZA1/uart/sio_char.c
+++ b/src/drivers/RZA1/uart/sio_char.c
@@ -183,7 +183,7 @@ static void MIDI_TX_INT_TrnEnd(uint32_t int_sense)
     tx_interrupt(UART_ITEM_MIDI);
 }
 
-const void (*txInterruptFunctions[])(uint32_t) = {PIC_TX_INT_TrnEnd, MIDI_TX_INT_TrnEnd};
+void (*const txInterruptFunctions[])(uint32_t) = {PIC_TX_INT_TrnEnd, MIDI_TX_INT_TrnEnd};
 
 const uint8_t txInterruptPriorities[] = {
     5,

--- a/src/drivers/RZA1/uart/sio_char.h
+++ b/src/drivers/RZA1/uart/sio_char.h
@@ -40,6 +40,7 @@
 /******************************************************************************
 Includes   <System Includes> , "Project Includes"
 ******************************************************************************/
+#include "cpu_specific.h"
 #include "devdrv_intc.h"
 #include "uart_all_cpus.h"
 
@@ -74,17 +75,24 @@ extern char_t midiTxBuffer[];
 
 // These are not thread safe! Do not call in ISRs.
 #define bufferPICUart(charToSend)                                                                                      \
+    do                                                                                                                 \
     {                                                                                                                  \
-        picTxBuffer[uartItems[UART_ITEM_PIC].txBufferWritePos + UNCACHED_MIRROR_OFFSET] = charToSend;                  \
-        uartItems[UART_ITEM_PIC].txBufferWritePos =                                                                    \
-            (uartItems[UART_ITEM_PIC].txBufferWritePos + 1) & (PIC_TX_BUFFER_SIZE - 1);                                \
-    }
+        intptr_t writePos = uartItems[UART_ITEM_PIC].txBufferWritePos + UNCACHED_MIRROR_OFFSET;                        \
+        *(((volatile char_t*)(&picTxBuffer[0])) + writePos) = charToSend;                                              \
+                                                                                                                       \
+        uartItems[UART_ITEM_PIC].txBufferWritePos += 1;                                                                \
+        uartItems[UART_ITEM_PIC].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);                                         \
+    } while (0)
+
 #define bufferMIDIUart(charToSend)                                                                                     \
+    do                                                                                                                 \
     {                                                                                                                  \
-        midiTxBuffer[uartItems[UART_ITEM_MIDI].txBufferWritePos + UNCACHED_MIRROR_OFFSET] = charToSend;                \
-        uartItems[UART_ITEM_MIDI].txBufferWritePos =                                                                   \
-            (uartItems[UART_ITEM_MIDI].txBufferWritePos + 1) & (MIDI_TX_BUFFER_SIZE - 1);                              \
-    }
+        intptr_t writePos = uartItems[UART_ITEM_MIDI].txBufferWritePos + UNCACHED_MIRROR_OFFSET;                       \
+        *(((volatile char_t*)(&picTxBuffer[0])) + writePos) = charToSend;                                              \
+                                                                                                                       \
+        uartItems[UART_ITEM_MIDI].txBufferWritePos += 1;                                                               \
+        uartItems[UART_ITEM_MIDI].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);                                        \
+    } while (0)
 
 // Aliases
 #define bufferPICIndicatorsUart(charToSend) bufferPICUart(charToSend)

--- a/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
+++ b/src/drivers/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
@@ -35,7 +35,7 @@
 #include "r_usb_reg_access.h"
 #include "definitions.h"
 
-#ifdef HAVE_OLED
+#if HAVE_OLED
 #include "oled.h"
 #else
 #include "numericdriver.h"
@@ -286,11 +286,11 @@ static uint16_t usb_hstd_enumeration(usb_utr_t* ptr)
 
                             if (1 != flg)
                             {
+                                // By Rohan. Means couldn't find an available "driver" for this device. It could be a 2nd hub.
 #if HAVE_OLED
                                 consoleTextIfAllBootedUp("USB device not recognized");
 #else
-                                displayPopupIfAllBootedUp(
-                                    "UNKN"); // By Rohan. Means couldn't find an available "driver" for this device. It could be a 2nd hub.
+                                displayPopupIfAllBootedUp("UNKN");
 #endif
                                 ctrl.address = g_usb_hstd_device_addr[ptr->ip]; /* USB Device address */
                                 ctrl.module  = ptr->ip;                         /* Module number setting */


### PR DESCRIPTION
I think this fixes the last of the pre-existing warnings (with the exception of the offsetof warnings). Release builds now warn about undefined behavior being invoked (using GCC 12); we seem to be missing some initialization of `AutoParameter`s somewhere. 