### PR TITLE
inital working SVF in LPF slot

### DIFF
--- a/src/FilterSet.cpp
+++ b/src/FilterSet.cpp
@@ -210,6 +210,7 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 		lpfLPF2.reset();
 		lpfLPF3.reset();
 		lpfLPF4.reset();
+		svf.reset();
 	}
 
 	// Half ladder
@@ -272,7 +273,7 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 	}
 
 	// Full ladder (drive)
-	else {
+	else if (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE){
 
 		if (filterSetConfig->doOversampling) {
 			int32_t* currentSample = startSample;
@@ -310,6 +311,16 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 			} while (currentSample < endSample);
 		}
 	}
+	else if (lpfMode == LPF_MODE_SVF){
+
+			int32_t* currentSample = startSample;
+			do {
+				SVF_outs outs = svf.doSVF(*currentSample, filterSetConfig->moveability, filterSetConfig->lpfRawResonance);
+				*currentSample = outs.lpf<<1;
+
+				currentSample += sampleIncrement;
+			} while (currentSample < endSample);
+		}
 }
 
 void FilterSet::reset() {
@@ -324,7 +335,7 @@ void FilterSet::reset() {
 	hpfLastWorkingValue = 2147483648;
 	hpfDoingAntialiasingNow = false;
 	hpfOnLastTime = false;
-
+	svf.reset();
 	lpfOnLastTime = false;
 	noiseLastValue = 0;
 }

--- a/src/FilterSetConfig.cpp
+++ b/src/FilterSetConfig.cpp
@@ -134,7 +134,7 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 				    (int32_t)540817); // We really want to keep the frequency from going lower than it has to - it causes problems
 
 				int32_t resonance = 2147483647 - (getMin(lpfResonance, resonanceUpperLimit) << 2); // Limits it
-
+				lpfRawResonance = resonance;
 				resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
 				processedResonance =
 				    2147483647
@@ -191,6 +191,11 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 				a = 536870912 - a;
 				int32_t gainModifier = 268435456 + a;
 				filterGain = multiply_32x32_rshift32(filterGain, gainModifier) << 3;
+			}
+
+			else if (lpfMode == LPF_MODE_SVF) {
+				//compensation not needed for SVF
+				filterGain = 0;
 			}
 
 			// Drive filter - increase output amplitude

--- a/src/FilterSetConfig.h
+++ b/src/FilterSetConfig.h
@@ -30,6 +30,8 @@ public:
 
 	int32_t processedResonance;                            // 1 represented as 1073741824
 	int32_t divideByTotalMoveabilityAndProcessedResonance; // 1 represented as 1073741824
+
+	//moveability is tan(f)/(1+tan(f))
 	int32_t moveability;                                   // 1 represented by 2147483648
 	int32_t divideBy1PlusTannedFrequency;                  // 1 represented by 2147483648
 

--- a/src/ModControllableAudio.cpp
+++ b/src/ModControllableAudio.cpp
@@ -1521,8 +1521,8 @@ void ModControllableAudio::switchLPFMode() {
 		displayText = "DRIVE LPF";
 		break;
 
-	case LPF_MODE_DIODE:
-		displayText = "DIODE LPF";
+	case LPF_MODE_SVF:
+		displayText = "SVF";
 		break;
 	}
 	numericDriver.displayPopup(displayText);

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -555,8 +555,8 @@ typedef enum SyncLevel_ {
 #define LPF_MODE_12DB 0
 #define LPF_MODE_TRANSISTOR_24DB 1
 #define LPF_MODE_TRANSISTOR_24DB_DRIVE 2
-#define LPF_MODE_DIODE 3
-#define NUM_LPF_MODES 3
+#define LPF_MODE_SVF 3
+#define NUM_LPF_MODES 4
 
 #define PHASER_NUM_ALLPASS_FILTERS 6
 

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1061,6 +1061,9 @@ char const* lpfTypeToString(int lpfType) {
 	case LPF_MODE_TRANSISTOR_24DB_DRIVE:
 		return "24dBDrive";
 
+	case LPF_MODE_SVF:
+		return "SVF";
+
 	default:
 		return "24dB";
 	}
@@ -1069,6 +1072,7 @@ char const* lpfTypeToString(int lpfType) {
 int stringToLPFType(char const* string) {
 	if (!strcmp(string, "24dB")) return LPF_MODE_TRANSISTOR_24DB;
 	else if (!strcmp(string, "24dBDrive")) return LPF_MODE_TRANSISTOR_24DB_DRIVE;
+	else if (!strcmp(string, "SVF")) return LPF_MODE_SVF;
 	else return LPF_MODE_12DB;
 }
 

--- a/src/soundeditor.cpp
+++ b/src/soundeditor.cpp
@@ -420,7 +420,7 @@ public:
 	void readCurrentValue() { soundEditor.currentValue = soundEditor.currentModControllable->lpfMode; }
 	void writeCurrentValue() { soundEditor.currentModControllable->lpfMode = soundEditor.currentValue; }
 	char const** getOptions() {
-		static char const* options[] = {"12dB", "24dB", "Drive", NULL};
+		static char const* options[] = {"12dB", "24dB", "Drive", "SVF", NULL};
 		return options;
 	}
 	int getNumOptions() { return NUM_LPF_MODES; }


### PR DESCRIPTION
This PR is a work in progress on overhauling the Deluge filters

Main goals:
- [ ] Augment HPF ladder filter with a morphable (low-band/notch-high) SVF. Maintain a classic switch to use the existing HPF
- [ ] Enable series/parallel switching of the two filters
- [ ] Enable oscillator routing seperately into each filter
- [ ] Add additional filter types to LPF slot (vocal, BPF bank, maybe more)

Side goals:
- [x] SVF lowpass filter in LPF slot 
- [ ] Refactor filter code to seperate ladder filter code from filter configuration 
- [ ] Refactor filter menu and configuration code so that a single list of filters can be maintained and automatically populate menus and configuration


Known issues:

- High SVF resonance clips if the note is close to the filter cutoff