### PR TITLE
Revert "sio: explain UNCACHED_MIRROR_OFFSET better"

### DIFF
--- a/src/drivers/RZA1/uart/sio_char.h
+++ b/src/drivers/RZA1/uart/sio_char.h
@@ -40,7 +40,6 @@
 /******************************************************************************
 Includes   <System Includes> , "Project Includes"
 ******************************************************************************/
-#include "cpu_specific.h"
 #include "devdrv_intc.h"
 #include "uart_all_cpus.h"
 
@@ -75,24 +74,17 @@ extern char_t midiTxBuffer[];
 
 // These are not thread safe! Do not call in ISRs.
 #define bufferPICUart(charToSend)                                                                                      \
-    do                                                                                                                 \
     {                                                                                                                  \
-        intptr_t writePos = uartItems[UART_ITEM_PIC].txBufferWritePos + UNCACHED_MIRROR_OFFSET;                        \
-        *(((volatile char_t*)(&picTxBuffer[0])) + writePos) = charToSend;                                              \
-                                                                                                                       \
-        uartItems[UART_ITEM_PIC].txBufferWritePos += 1;                                                                \
-        uartItems[UART_ITEM_PIC].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);                                         \
-    } while (0)
-
+        picTxBuffer[uartItems[UART_ITEM_PIC].txBufferWritePos + UNCACHED_MIRROR_OFFSET] = charToSend;                  \
+        uartItems[UART_ITEM_PIC].txBufferWritePos =                                                                    \
+            (uartItems[UART_ITEM_PIC].txBufferWritePos + 1) & (PIC_TX_BUFFER_SIZE - 1);                                \
+    }
 #define bufferMIDIUart(charToSend)                                                                                     \
-    do                                                                                                                 \
     {                                                                                                                  \
-        intptr_t writePos = uartItems[UART_ITEM_MIDI].txBufferWritePos + UNCACHED_MIRROR_OFFSET;                       \
-        *(((volatile char_t*)(&picTxBuffer[0])) + writePos) = charToSend;                                              \
-                                                                                                                       \
-        uartItems[UART_ITEM_MIDI].txBufferWritePos += 1;                                                               \
-        uartItems[UART_ITEM_MIDI].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);                                        \
-    } while (0)
+        midiTxBuffer[uartItems[UART_ITEM_MIDI].txBufferWritePos + UNCACHED_MIRROR_OFFSET] = charToSend;                \
+        uartItems[UART_ITEM_MIDI].txBufferWritePos =                                                                   \
+            (uartItems[UART_ITEM_MIDI].txBufferWritePos + 1) & (MIDI_TX_BUFFER_SIZE - 1);                              \
+    }
 
 // Aliases
 #define bufferPICIndicatorsUart(charToSend) bufferPICUart(charToSend)


### PR DESCRIPTION
This somehow causes random pads to flash on other Deluges. Actual fix/investigation to be tracked under #109