### PR TITLE
Sticky keys

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -28,6 +28,11 @@ Here is a list of general improvements that have been made, ordered from newest 
 
 - ([#395]) Load synth presets into kit rows by holding the audition pad and pressing synth. Saving kit rows to synth presets is not yet implemented.
 
+#### 3.6 - Global Interface
+
+- ([#118]) Sticky Shift - When enabled, tapping shift will lock shift on unless another button is also pressed during the short press duration.
+- ([#118]) Shift LED feedback can now be toggled manually.
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -312,6 +317,10 @@ In the main menu of the deluge (accessed by pressing "SHIFT" + the "SELECT" knob
   	* When On, In-Key and Isometric Keyboard layouts display incoming MIDI notes with their velocity.
 * Display Norns Layout
   	* When On, all incoming notes are rendered consecutively as white pads with velocity as brightness.
+* Sticky Shift
+  	* When On, tapping shift briefly will enable sticky keys while a long press will keep it on. Enabling this setting will automatically enable "Light Shift" as well.
+* Light Shift
+  	* When On, the Deluge will illuminate the shift button when shift is active. Mostly useful in conjunction with sticky shift.
 
 ## 6. Sysex Handling
 
@@ -340,18 +349,19 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#47]: https://github.com/SynthstromAudible/DelugeFirmware/pull/47
 [#103]: https://github.com/SynthstromAudible/DelugeFirmware/pull/103
 [#112]: https://github.com/SynthstromAudible/DelugeFirmware/pull/112
+[#118]: https://github.com/SynthstromAudible/DelugeFirmware/pull/118
 [#120]: https://github.com/SynthstromAudible/DelugeFirmware/pull/120
 [#122]: https://github.com/SynthstromAudible/DelugeFirmware/pull/122
 [#125]: https://github.com/SynthstromAudible/DelugeFirmware/pull/125
 [#129]: https://github.com/SynthstromAudible/DelugeFirmware/pull/129
-[#141]: https://github.com/SynthstromAudible/DelugeFirmware/pull/141
 [#137]: https://github.com/SynthstromAudible/DelugeFirmware/pull/137
 [#138]: https://github.com/SynthstromAudible/DelugeFirmware/pull/138
+[#141]: https://github.com/SynthstromAudible/DelugeFirmware/pull/141
 [#157]: https://github.com/SynthstromAudible/DelugeFirmware/pull/157
 [#163]: https://github.com/SynthstromAudible/DelugeFirmware/pull/163
-[#178]: https://github.com/SynthstromAudible/DelugeFirmware/pull/178
 [#170]: https://github.com/SynthstromAudible/DelugeFirmware/pull/170
 [#174]: https://github.com/SynthstromAudible/DelugeFirmware/pull/174
+[#178]: https://github.com/SynthstromAudible/DelugeFirmware/pull/178
 [#192]: https://github.com/SynthstromAudible/DelugeFirmware/pull/192
 [#196]: https://github.com/SynthstromAudible/DelugeFirmware/pull/196
 [#198]: https://github.com/SynthstromAudible/DelugeFirmware/pull/198

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -362,6 +362,11 @@ bool readButtonsAndPads() {
 		}
 	}
 
+	if (!sdRoutineLock && Buttons::shiftHasChanged()
+	    && runtimeFeatureSettings.get(RuntimeFeatureSettingType::LightShiftLed) == RuntimeFeatureStateToggle::On) {
+		indicator_leds::setLedState(indicator_leds::LED::SHIFT, Buttons::isShiftButtonPressed());
+	}
+
 #if SD_TEST_MODE_ENABLED_LOAD_SONGS
 
 	if (playbackHandler.currentlyPlaying) {

--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -18,6 +18,7 @@
 #include "settings.h"
 #include "devSysexSetting.h"
 #include "setting.h"
+#include "shift_is_sticky.h"
 
 #include "gui/ui/sound_editor.h"
 #include "hid/display/display.h"
@@ -48,6 +49,8 @@ Setting menuSyncScalingAction(RuntimeFeatureSettingType::SyncScalingAction);
 DevSysexSetting menuDevSysexAllowed(RuntimeFeatureSettingType::DevSysexAllowed);
 Setting menuHighlightIncomingNotes(RuntimeFeatureSettingType::HighlightIncomingNotes);
 Setting menuDisplayNornsLayout(RuntimeFeatureSettingType::DisplayNornsLayout);
+ShiftIsSticky menuShiftIsSticky{};
+Setting menuLightShiftLed(RuntimeFeatureSettingType::LightShiftLed);
 
 Submenu subMenuAutomation{
     l10n::String::STRING_FOR_AUTOMATION,
@@ -63,7 +66,7 @@ std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement - kNonTopLevelSettin
     &menuDrumRandomizer,         &menuMasterCompressorFx, &menuFineTempo,           &menuQuantize,
     &menuPatchCableResolution,   &menuCatchNotes,         &menuDeleteUnusedKitRows, &menuAltGoldenKnobDelayParams,
     &menuQuantizedStutterRate,   &subMenuAutomation,      &menuDevSysexAllowed,     &menuSyncScalingAction,
-    &menuHighlightIncomingNotes, &menuDisplayNornsLayout,
+    &menuHighlightIncomingNotes, &menuDisplayNornsLayout, &menuShiftIsSticky,       &menuLightShiftLed,
 };
 
 Settings::Settings(l10n::String name, l10n::String title)

--- a/src/deluge/gui/menu_item/runtime_feature/shift_is_sticky.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/shift_is_sticky.cpp
@@ -1,6 +1,4 @@
 /*
- * Copyright © 2021-2023 Synthstrom Audible Limited
- *
  * This file is part of The Synthstrom Audible Deluge Firmware.
  *
  * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
@@ -15,25 +13,28 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#pragma once
-
-#include "gui/menu_item/selection.h"
+#include "shift_is_sticky.h"
+#include "hid/buttons.h"
 #include "model/settings/runtime_feature_settings.h"
 
+#include <cstdint>
+
 namespace deluge::gui::menu_item::runtime_feature {
-class Settings;
-class Setting : public Selection<RUNTIME_FEATURE_SETTING_MAX_OPTIONS> {
-public:
-	explicit Setting(RuntimeFeatureSettingType ty);
 
-	void readCurrentValue() override;
-	void writeCurrentValue() override;
-	static_vector<std::string_view, RUNTIME_FEATURE_SETTING_MAX_OPTIONS> getOptions() override;
-	[[nodiscard]] std::string_view getName() const override;
-	[[nodiscard]] std::string_view getTitle() const override;
+void ShiftIsSticky::writeCurrentValue() {
+	Setting::writeCurrentValue();
 
-private:
-	friend class Settings;
-	uint32_t currentSettingIndex;
-};
+	if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::ShiftIsSticky) == RuntimeFeatureStateToggle::Off) {
+		Buttons::clearShiftSticky();
+	}
+	else {
+		// Enable shift LED lighting when sticky keys gets enabled, so people can actually tell that their shift key is
+		// down. People can still turn it off later if they want, but I think this is a good default.
+		//
+		// We can safely poke another setting here because exiting this menu is going to save the runtime feature
+		// settings anyway.
+		runtimeFeatureSettings.set(RuntimeFeatureSettingType::LightShiftLed, RuntimeFeatureStateToggle::On);
+	}
+}
+
 } // namespace deluge::gui::menu_item::runtime_feature

--- a/src/deluge/gui/menu_item/runtime_feature/shift_is_sticky.h
+++ b/src/deluge/gui/menu_item/runtime_feature/shift_is_sticky.h
@@ -17,23 +17,15 @@
 
 #pragma once
 
-#include "gui/menu_item/selection.h"
+#include "gui/menu_item/runtime_feature/setting.h"
 #include "model/settings/runtime_feature_settings.h"
 
 namespace deluge::gui::menu_item::runtime_feature {
-class Settings;
-class Setting : public Selection<RUNTIME_FEATURE_SETTING_MAX_OPTIONS> {
+class ShiftIsSticky final : public Setting {
 public:
-	explicit Setting(RuntimeFeatureSettingType ty);
+	ShiftIsSticky() : Setting(RuntimeFeatureSettingType::ShiftIsSticky) {}
 
-	void readCurrentValue() override;
 	void writeCurrentValue() override;
-	static_vector<std::string_view, RUNTIME_FEATURE_SETTING_MAX_OPTIONS> getOptions() override;
-	[[nodiscard]] std::string_view getName() const override;
-	[[nodiscard]] std::string_view getTitle() const override;
-
-private:
-	friend class Settings;
-	uint32_t currentSettingIndex;
 };
+
 } // namespace deluge::gui::menu_item::runtime_feature

--- a/src/deluge/hid/buttons.h
+++ b/src/deluge/hid/buttons.h
@@ -29,5 +29,16 @@ bool isShiftButtonPressed();
 bool isNewOrShiftButtonPressed();
 void noPressesHappening(bool inCardRoutine);
 
+/**
+ * Notify the button management code that the shift button should no longer be considered sticky. We need an explicit
+ * notification so we can clear the buttons.cpp:shiftIsHeld to avoid shift getting permanantly stuck.
+ */
+void clearShiftSticky();
+/**
+ * Determine if the shift button has changed since the last time someone asked.
+ * This implicitly clears the "shiftHasChangedSinceLastCheck" flag, so only the main loop should call this function.
+ */
+bool shiftHasChanged();
+
 extern bool recordButtonPressUsedUp;
 } // namespace Buttons

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -127,6 +127,14 @@ void RuntimeFeatureSettings::init() {
 	// DisplayNornsLayout
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::DisplayNornsLayout], "Display Norns layout",
 	                  "displayNornsLayout", RuntimeFeatureStateToggle::Off);
+
+	// ShiftIsSticky
+	SetupOnOffSetting(settings[RuntimeFeatureSettingType::ShiftIsSticky], "Sticky Shift", "stickyShift",
+	                  RuntimeFeatureStateToggle::Off);
+
+	// LightShiftLed
+	SetupOnOffSetting(settings[RuntimeFeatureSettingType::LightShiftLed], "Light Shift", "lightShift",
+	                  RuntimeFeatureStateToggle::Off);
 }
 
 void RuntimeFeatureSettings::readSettingsFromFile() {

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -53,6 +53,8 @@ enum RuntimeFeatureSettingType : uint32_t {
 	SyncScalingAction,
 	HighlightIncomingNotes,
 	DisplayNornsLayout,
+	ShiftIsSticky,
+	LightShiftLed,
 	MaxElement // Keep as boundary
 };
 
@@ -79,6 +81,13 @@ public:
 
 	// Traded type safety for option values for code simplicity and size, use enum from above to compare
 	inline uint32_t get(RuntimeFeatureSettingType type) { return settings[type].value; };
+
+	/**
+	 * Set a runtime feature setting.
+	 *
+	 * Make sure when you use this the settings are eventually written back to the SDCard!
+	 */
+	inline void set(RuntimeFeatureSettingType type, uint32_t value) { settings[type].value = value; }
 
 	void init();
 	void readSettingsFromFile();


### PR DESCRIPTION
Fixes #107 

TODO:
  - [x] Long press enable mode
  - [x] Illuminate shift when it's stuck on by sticky keys
  - [x] Audit the various test modes to make sure they will work with stickykeys (either by disabling it or adding appropriate calls to the shift mode code)
  - [ ] Custom UI class for the sticky keys menu (7seg compat + long press enable/time configuration)
  - [ ] Add audible indication when sticky keys enabled (if it's easy, this is a very silly feature)
