### PR TITLE
Drum Randomizer

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -76,6 +76,7 @@
 #include "model/drum/midi_drum.h"
 #include "storage/multi_range/multi_range.h"
 #include "storage/audio/audio_file_holder.h"
+#include "model/settings/runtime_feature_settings.h"
 
 #if HAVE_OLED
 #include "hid/display/oled.h"
@@ -1119,7 +1120,8 @@ const uint32_t auditionPadActionUIModes[] = {UI_MODE_AUDITIONING,
 
 int InstrumentClipView::padAction(int x, int y, int velocity) {
 
-	if (x == 15 && y == 2 && velocity > 0) {
+	if (x == 15 && y == 2 && velocity > 0
+	    && runtimeFeatureSettings.get(RuntimeFeatureSettingType::DrumRandomizer) == RuntimeFeatureStateToggle::On) {
 		int numRandomized = 0;
 		for (int i = 0; i < 8; i++) {
 			if (getCurrentUI() == this && this->auditionPadIsPressed[i]) {

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -33,6 +33,7 @@ enum RuntimeFeatureStateToggle : uint32_t { Off = 0, On = 1 };
 /// Every setting needs to be delcared in here
 enum RuntimeFeatureSettingType : uint32_t {
 	// FileFolderSorting // @TODO: Replace with actual identifier on first use
+	DrumRandomizer,
 	MaxElement // Keep as boundary
 };
 
@@ -79,6 +80,14 @@ protected:
 
 	    // Please extend RuntimeFeatureSettingType and here for additional settings
 	    // Usage example -> (runtimeFeatureSettings.get(RuntimeFeatureSettingType::FileFolderSorting) == RuntimeFeatureStateToggle::On)
+
+	    [RuntimeFeatureSettingType::DrumRandomizer] =
+	        {.displayName = "Drum Randomizer",
+	         .xmlName = "drumRandomizer",
+	         .value = RuntimeFeatureStateToggle::On, // Default value
+	         .options = {{.displayName = "Off", .value = RuntimeFeatureStateToggle::Off},
+	                     {.displayName = "On", .value = RuntimeFeatureStateToggle::On},
+	                     {.displayName = NULL, .value = 0}}},
 	};
 
 private:


### PR DESCRIPTION
In KIT mode, while holding down the audition pad(s), pressing the [RANDOM] pad will randomly select a sample from the folder containing each sample.

Demo: https://youtu.be/gw_8WSeZs8o
\* The button combinations in the video are different from the current implementation.

**Known Issues:**
- Undo functionality is not available.
- There is a limit on the number of sample files within a folder (currntly 25 files) for processing speed.