### PR TITLE
fix for devices with more ports than deluge supports

### DIFF
--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -197,7 +197,7 @@ extern "C" void hostedDeviceConfigured(int ip, int midiDeviceNum) {
 	connectedDevice->setup();
 	int ports = connectedDevice->maxPortConnected;
 	for (int i = 0; i <= ports; i++) {
-		connectedUSBMIDIDevices[ip][0].device[i] = device;
+		connectedDevice->device[i] = device;
 	}
 
 	connectedDevice->sq = 0;

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -639,11 +639,12 @@ void MidiEngine::checkIncomingUsbMidi() {
 							}
 						}
 						//select appropriate device based on the cable number
-						if (cable <= connectedUSBMIDIDevices[ip][d].maxPortConnected) {
-							//in case the device uses more ports than we can support
-							midiMessageReceived(connectedUSBMIDIDevices[ip][d].device[cable], statusType, channel,
-							                    data1, data2, &timeLastBRDY[ip]);
+						if (cable > connectedUSBMIDIDevices[ip][d].maxPortConnected) {
+							//fallback to cable 0 since we don't support more than one port on hosted devices yet
+							cable = 0;
 						}
+						midiMessageReceived(connectedUSBMIDIDevices[ip][d].device[cable], statusType, channel, data1,
+						                    data2, &timeLastBRDY[ip]);
 					}
 				}
 


### PR DESCRIPTION
Fix for issue #123 by treating higher ports than the connected device as port 0. This matches the behaviour from the initial community release

