### PR TITLE
Fix 'affect all' SVF clicks

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -352,7 +352,7 @@ void GlobalEffectable::setupFilterSetConfig(FilterSetConfig* filterSetConfig, in
 	    paramNeutralValues[PARAM_LOCAL_HPF_RESONANCE],
 	    cableToLinearParamShortcut(unpatchedParams->getValue(PARAM_UNPATCHED_GLOBALEFFECTABLE_HPF_RES)));
 
-	filterSetConfig->doLPF = (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE
+	filterSetConfig->doLPF = (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE || lpfMode == LPF_MODE_SVF
 	                          || unpatchedParams->getValue(PARAM_UNPATCHED_GLOBALEFFECTABLE_LPF_FREQ) < 2147483602);
 	filterSetConfig->doHPF = unpatchedParams->getValue(PARAM_UNPATCHED_GLOBALEFFECTABLE_HPF_FREQ) != -2147483648;
 


### PR DESCRIPTION
Fix for an issue in #105 - the SVF initializes with a zero value and clicks when enabled. The existing filters do not have this problem as they share a common state

Prior to this change the global filter would be disabled if the cutoff was maximized, this always enables the SVF if it is selected. This is the same behaviour as the drive LPF which can have a similar click.

This should be a short term fix, longer term I'll initialize with the previous output but that will require more filter refactoring first.