### PR TITLE
Bugfix/runtime setting scroll and uart

### DIFF
--- a/src/RZA1/uart/sio_char.h
+++ b/src/RZA1/uart/sio_char.h
@@ -75,17 +75,24 @@ extern char_t midiTxBuffer[];
 
 // These are not thread safe! Do not call in ISRs.
 #define bufferPICUart(charToSend)                                                                                      \
+    do                                                                                                                 \
     {                                                                                                                  \
-        picTxBuffer[uartItems[UART_ITEM_PIC].txBufferWritePos + UNCACHED_MIRROR_OFFSET] = charToSend;                  \
-        uartItems[UART_ITEM_PIC].txBufferWritePos =                                                                    \
-            (uartItems[UART_ITEM_PIC].txBufferWritePos + 1) & (PIC_TX_BUFFER_SIZE - 1);                                \
-    }
+        intptr_t writePos = uartItems[UART_ITEM_PIC].txBufferWritePos + UNCACHED_MIRROR_OFFSET;                        \
+        *(((volatile char_t*)(&picTxBuffer[0])) + writePos) = charToSend;                                              \
+                                                                                                                       \
+        uartItems[UART_ITEM_PIC].txBufferWritePos += 1;                                                                \
+        uartItems[UART_ITEM_PIC].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);                                         \
+    } while (0)
+
 #define bufferMIDIUart(charToSend)                                                                                     \
+    do                                                                                                                 \
     {                                                                                                                  \
-        midiTxBuffer[uartItems[UART_ITEM_MIDI].txBufferWritePos + UNCACHED_MIRROR_OFFSET] = charToSend;                \
-        uartItems[UART_ITEM_MIDI].txBufferWritePos =                                                                   \
-            (uartItems[UART_ITEM_MIDI].txBufferWritePos + 1) & (MIDI_TX_BUFFER_SIZE - 1);                              \
-    }
+        intptr_t writePos = uartItems[UART_ITEM_MIDI].txBufferWritePos + UNCACHED_MIRROR_OFFSET;                       \
+        *(((volatile char_t*)(&midiTxBuffer[0])) + writePos) = charToSend;                                             \
+                                                                                                                       \
+        uartItems[UART_ITEM_MIDI].txBufferWritePos += 1;                                                               \
+        uartItems[UART_ITEM_MIDI].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);                                        \
+    } while (0)
 
 // Aliases
 #define bufferPICIndicatorsUart(charToSend) bufferPICUart(charToSend)

--- a/src/deluge/gui/menu_item/menu_item_runtime_feature_setting.cpp
+++ b/src/deluge/gui/menu_item/menu_item_runtime_feature_setting.cpp
@@ -19,8 +19,6 @@
 #include "model/settings/runtime_feature_settings.h"
 #include "gui/ui/sound_editor.h"
 
-MenuItemRuntimeFeatureSetting runtimeFeatureSettingMenuItem;
-
 MenuItemRuntimeFeatureSetting::MenuItemRuntimeFeatureSetting(char const* newName) : MenuItemSelection(newName) {
 }
 

--- a/src/deluge/gui/menu_item/menu_item_runtime_feature_settings.cpp
+++ b/src/deluge/gui/menu_item/menu_item_runtime_feature_settings.cpp
@@ -22,8 +22,6 @@
 #include "hid/display/numeric_driver.h"
 #include <cstdio>
 
-MenuItemRuntimeFeatureSettings runtimeFeatureSettingsMenu;
-
 void MenuItemRuntimeFeatureSettings::beginSession(MenuItem* navigatedBackwardFrom) {
 	if (!navigatedBackwardFrom) {
 		lastActiveValue = 0; // Reset last active value
@@ -53,22 +51,14 @@ void MenuItemRuntimeFeatureSettings::selectEncoderAction(int offset) {
 	lastActiveValue = soundEditor.currentValue;
 
 #if HAVE_OLED
-	if (soundEditor.currentValue < soundEditor.menuCurrentScroll)
+	if (soundEditor.currentValue < soundEditor.menuCurrentScroll) {
 		soundEditor.menuCurrentScroll = soundEditor.currentValue;
-
-	if (offset >= 0) {
-		int d = soundEditor.currentValue;
-		int numSeen = 1;
-		while (true) {
-			d--;
-			if (d == soundEditor.menuCurrentScroll) break;
-			numSeen++;
-			if (numSeen >= OLED_MENU_NUM_OPTIONS_VISIBLE) {
-				soundEditor.menuCurrentScroll = d;
-				break;
-			}
-		}
 	}
+
+	if (soundEditor.currentValue > (soundEditor.menuCurrentScroll + (OLED_MENU_NUM_OPTIONS_VISIBLE - 1))) {
+		soundEditor.menuCurrentScroll = soundEditor.currentValue - (OLED_MENU_NUM_OPTIONS_VISIBLE - 1);
+	}
+
 #endif
 
 	drawValue();

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -2250,6 +2250,9 @@ public:
 // Colours submenu
 MenuItemSubmenu coloursSubmenu;
 
+MenuItemRuntimeFeatureSetting runtimeFeatureSettingMenuItem;
+MenuItemRuntimeFeatureSettings runtimeFeatureSettingsMenu;
+
 char const* firmwareString = "4.1.4-alpha3";
 
 // this class is haunted for some reason, clang-format mangles it


### PR DESCRIPTION
Fixes main issue of Issue https://github.com/SynthstromAudible/DelugeFirmware/issues/109 (initially caused by https://github.com/SynthstromAudible/DelugeFirmware/commit/fd4b6f606937166a8b3affd66d630d5cc761fe53 unsure about the second reported issue), Fixes scrolling with single menu item on OLED and should fix broken main menu (caused by undefined initialization order)