### PR TITLE
Quantize

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -59,7 +59,6 @@ struct EditPadPress {
 #define MPE_RECORD_LENGTH_FOR_NOTE_EDITING 3
 #define MPE_RECORD_INTERVAL_TIME (44100 >> 2) // 250ms
 
-#define NUDGEMODE_NUDGE 0
 #define NUDGEMODE_QUANTIZE 1
 #define NUDGEMODE_QUANTIZE_ALL 2
 
@@ -134,6 +133,8 @@ public:
 	void reportNoteOffForMPEEditing(ModelStackWithNoteRow* modelStack);
 	void dontDeleteNotesOnDepress();
 
+	void tempoEncoderAction(int8_t offset, bool encoderButtonPressed, bool shiftButtonPressed);
+
 	inline void getRowColour(int y, uint8_t color[3]) {
 		color[0] = rowColour[y][0];
 		color[1] = rowColour[y][1];
@@ -190,7 +191,6 @@ private:
 	uint8_t yDisplayOfNewNoteRow;
 
 	int32_t quantizeAmount;
-	int nudgeMode;
 
 	uint32_t getSquareWidth(int32_t square, int32_t effectiveLength);
 	void drawNoteCode(uint8_t yDisplay);
@@ -228,7 +228,7 @@ private:
 	ModelStackWithNoteRow* createNoteRowForYDisplay(ModelStackWithTimelineCounter* modelStack, int yDisplay);
 	ModelStackWithNoteRow* getOrCreateNoteRowForYDisplay(ModelStackWithTimelineCounter* modelStack, int yDisplay);
 
-	void quantizeNotes(int offset);
+	void quantizeNotes(int offset, int nudgeMode);
 };
 
 extern InstrumentClipView instrumentClipView;

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -59,6 +59,10 @@ struct EditPadPress {
 #define MPE_RECORD_LENGTH_FOR_NOTE_EDITING 3
 #define MPE_RECORD_INTERVAL_TIME (44100 >> 2) // 250ms
 
+#define NUDGEMODE_NUDGE 0
+#define NUDGEMODE_QUANTIZE 1
+#define NUDGEMODE_QUANTIZE_ALL 2
+
 class InstrumentClipView final : public ClipView, public InstrumentClipMinder {
 public:
 	InstrumentClipView();
@@ -185,6 +189,9 @@ private:
 	Drum* drumForNewNoteRow;
 	uint8_t yDisplayOfNewNoteRow;
 
+	int32_t quantizeAmount;
+	int nudgeMode;
+
 	uint32_t getSquareWidth(int32_t square, int32_t effectiveLength);
 	void drawNoteCode(uint8_t yDisplay);
 	void sendAuditionNote(bool on, uint8_t yDisplay, uint8_t velocity, uint32_t sampleSyncLength);
@@ -220,6 +227,8 @@ private:
 	void editNoteRowLength(ModelStackWithNoteRow* modelStack, int offset, int yDisplay);
 	ModelStackWithNoteRow* createNoteRowForYDisplay(ModelStackWithTimelineCounter* modelStack, int yDisplay);
 	ModelStackWithNoteRow* getOrCreateNoteRowForYDisplay(ModelStackWithTimelineCounter* modelStack, int yDisplay);
+
+	void quantizeNotes(int offset);
 };
 
 extern InstrumentClipView instrumentClipView;

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -25,6 +25,8 @@
 #include <new>
 #include "hid/buttons.h"
 #include "util/functions.h"
+#include "gui/views/instrument_clip_view.h"
+#include "model/settings/runtime_feature_settings.h"
 
 namespace Encoders {
 
@@ -131,9 +133,19 @@ checkResult:
 				break;
 
 			case ENCODER_TEMPO:
-				playbackHandler.tempoEncoderAction(limitedDetentPos,
-				                                   Buttons::isButtonPressed(tempoEncButtonX, tempoEncButtonY),
-				                                   Buttons::isShiftButtonPressed());
+				if (getCurrentUI() == &instrumentClipView
+				    && runtimeFeatureSettings.get(RuntimeFeatureSettingType::Quantize)
+				           == RuntimeFeatureStateToggle::On) {
+					instrumentClipView.tempoEncoderAction(limitedDetentPos,
+					                                      Buttons::isButtonPressed(tempoEncButtonX, tempoEncButtonY),
+					                                      Buttons::isShiftButtonPressed());
+				}
+				else {
+					playbackHandler.tempoEncoderAction(limitedDetentPos,
+					                                   Buttons::isButtonPressed(tempoEncButtonX, tempoEncButtonY),
+					                                   Buttons::isShiftButtonPressed());
+				}
+
 				break;
 
 			case ENCODER_SELECT:

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -34,6 +34,7 @@ enum RuntimeFeatureStateToggle : uint32_t { Off = 0, On = 1 };
 enum RuntimeFeatureSettingType : uint32_t {
 	// FileFolderSorting // @TODO: Replace with actual identifier on first use
 	DrumRandomizer,
+	Quantize,
 	MaxElement // Keep as boundary
 };
 
@@ -84,6 +85,14 @@ protected:
 	    [RuntimeFeatureSettingType::DrumRandomizer] =
 	        {.displayName = "Drum Randomizer",
 	         .xmlName = "drumRandomizer",
+	         .value = RuntimeFeatureStateToggle::On, // Default value
+	         .options = {{.displayName = "Off", .value = RuntimeFeatureStateToggle::Off},
+	                     {.displayName = "On", .value = RuntimeFeatureStateToggle::On},
+	                     {.displayName = NULL, .value = 0}}},
+
+	    [RuntimeFeatureSettingType::Quantize] =
+	        {.displayName = "Quantize",
+	         .xmlName = "quantize",
 	         .value = RuntimeFeatureStateToggle::On, // Default value
 	         .options = {{.displayName = "Off", .value = RuntimeFeatureStateToggle::Off},
 	                     {.displayName = "On", .value = RuntimeFeatureStateToggle::On},


### PR DESCRIPTION
This is a feature that enables quantization after recording.

In the Clip view, press the Note pad + shift + ◄► knob combination to switch between the NUDGE, QUANTIZE, and QUANTIZE ALL ROW modes. While pressing the note pad(s), press+turn the ◄►knob to the right to apply quantize, and to the left to apply humanize.

Demo: https://youtu.be/iAL447a1jD4

Issue:
- The switch operation between the Nudge feature and the Quantize feature is somewhat difficult. 