### PR TITLE
midi: initial support for SysEX messages

### DIFF
--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -123,6 +123,9 @@ public:
 	// Of course there'll usually just be one bit set, unless two of the same device are connected.
 	uint8_t connectionFlags;
 
+	uint8_t incomingSysexBuffer[128];
+	int incomingSysexPos = 0;
+
 protected:
 	virtual void
 	writeReferenceAttributesToFile() = 0; // These go both into MIDIDEVICES.XML and also any song/preset files where there's a reference to this Device.

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -477,7 +477,7 @@ checkDevice:
 
 void ConnectedUSBMIDIDevice::bufferMessage(uint32_t fullMessage) {
 	// If buffer already full, flush it
-	if (numMessagesQueued >= 16) {
+	if (numMessagesQueued >= MIDI_SEND_BUFFER_LEN) {
 		midiEngine
 		    .flushUSBMIDIOutput(); // TODO: this is actually far from perfect - what if already sending - and if we want to wait/check for that, we should be calling the routine.
 		                           // And ideally, we'd be able to flush for just one device.

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -30,9 +30,15 @@ class MIDIDeviceUSB;
 struct MIDIDeviceUSB;
 #endif
 
+// size in 32-bit messages
+// TODO: increasing this even more doesn't work. For now this gives
+// maximum SysEx send size of 96 bytes including start/end bytes
+// (3 payload bytes per USB-MIDI message)
+#define MIDI_SEND_BUFFER_LEN 32
+
 #ifdef __cplusplus
 /*A ConnectedUSBMIDIDevice is used directly to interface with the USB driver
- * When a ConnectedUSBMIDIDevice has a numMessagesQueued>16 and tries to add another,
+ * When a ConnectedUSBMIDIDevice has a numMessagesQueued>=MIDI_SEND_BUFFER_LEN and tries to add another,
  * all outputs are sent. The send routine calls the USB output function, points the
  * USB pipes FIFO buffer directly at the dataSendingNow array, and then sends.
  * Sends can also be triggered by the midiAndGateOutput interrupt
@@ -61,8 +67,8 @@ struct ConnectedUSBMIDIDevice {
 	uint8_t canHaveMIDISent;
 	uint16_t numBytesReceived;
 	uint8_t receiveData[64];
-	uint32_t preSendData[16];
-	uint8_t dataSendingNow[64];
+	uint32_t preSendData[MIDI_SEND_BUFFER_LEN];
+	uint8_t dataSendingNow[MIDI_SEND_BUFFER_LEN * 4];
 	uint8_t numMessagesQueued;
 
 	// This will show a value after the general flush function is called, throughout other Devices being sent to before this one, and until we've completed our send

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -176,7 +176,7 @@ bool anythingInUSBOutputBuffer = false;
 MidiEngine::MidiEngine() {
 	numSerialMidiInput = 0;
 	lastStatusByteSent = 0;
-	currentlyReceivingSysEx = false;
+	currentlyReceivingSysExSerial = false;
 	midiThru = false;
 
 	g_usb_peri_connected = 0; // Needs initializing with A2 driver
@@ -500,6 +500,7 @@ bool MidiEngine::checkIncomingSerialMidi() {
 	uint32_t* timer = uartGetCharWithTiming(TIMING_CAPTURE_ITEM_MIDI, (char*)&thisSerialByte);
 	if (timer) {
 		//Uart::println((unsigned int)thisSerialByte);
+		MIDIDevice* dev = &MIDIDeviceManager::dinMIDIPorts;
 
 		// If this is a status byte, then we have to store it as the first byte.
 		if (thisSerialByte & 0x80) {
@@ -514,28 +515,41 @@ bool MidiEngine::checkIncomingSerialMidi() {
 
 			// Or if it's a SysEx start...
 			case 0xF0:
-				currentlyReceivingSysEx = true;
+				currentlyReceivingSysExSerial = true;
 				Uart::println("Sysex start");
+				dev->incomingSysexBuffer[0] = thisSerialByte;
+				dev->incomingSysexPos = 1;
 				//numSerialMidiInput = 0; // This would throw away any running status stuff...
 				return true;
 			}
 
 			// If we didn't return for any of those, then it's just a regular old status message (or Sysex stop message). All these will end any ongoing SysEx
-			currentlyReceivingSysEx = false;
 
 			// If it was a Sysex stop, that's all we need to do
 			if (thisSerialByte == 0xF7) {
 				Uart::println("Sysex end");
+				if (currentlyReceivingSysExSerial) {
+					currentlyReceivingSysExSerial = false;
+					if (dev->incomingSysexPos < sizeof dev->incomingSysexBuffer) {
+						dev->incomingSysexBuffer[dev->incomingSysexPos++] = thisSerialByte;
+						midiSysexReceived(-1, -1, 0, dev->incomingSysexBuffer, dev->incomingSysexPos);
+					}
+				}
 				return true;
 			}
 
+			currentlyReceivingSysExSerial = false;
 			numSerialMidiInput = 0;
 		}
 
 		// If not a status byte...
 		else {
-			// If we're currently receiving a SysEx, throw it away
-			if (currentlyReceivingSysEx) {
+			// If we're currently receiving a SysEx, don't throw it away
+			if (currentlyReceivingSysExSerial) {
+				// TODO: allocate a GMA buffer to some bigger size
+				if (dev->incomingSysexPos < sizeof dev->incomingSysexBuffer) {
+					dev->incomingSysexBuffer[dev->incomingSysexPos++] = thisSerialByte;
+				}
 				Uart::print("Sysex: ");
 				Uart::println(thisSerialByte);
 				return true;
@@ -590,6 +604,114 @@ void MidiEngine::setupUSBHostReceiveTransfer(int ip, int midiDeviceNum) {
 
 uint8_t usbCurrentlyInitialized = false;
 
+void MidiEngine::checkIncomingUsbSysex(uint8_t const* msg, int ip, int d, int cable) {
+	ConnectedUSBMIDIDevice* connected = &connectedUSBMIDIDevices[ip][d];
+	if (cable > connectedUSBMIDIDevices[ip][d].maxPortConnected) {
+		//fallback to cable 0 since we don't support more than one port on hosted devices yet
+		cable = 0;
+	}
+	MIDIDevice* dev = connectedUSBMIDIDevices[ip][d].device[cable];
+
+	uint8_t statusType = msg[0] & 15;
+	int to_read = 0;
+	bool will_end = false;
+	if (statusType == 0x4) {
+		// sysex start or continue
+		if (msg[1] == 0xf0) {
+			dev->incomingSysexPos = 0;
+		}
+		to_read = 3;
+	}
+	else if (statusType >= 0x5 && statusType <= 0x7) {
+		to_read = statusType - 0x4; // read between 1-3 bytes
+		will_end = true;
+	}
+
+	for (int i = 0; i < to_read; i++) {
+		if (dev->incomingSysexPos >= sizeof(dev->incomingSysexBuffer)) {
+			// TODO: allocate a GMA buffer to some bigger size
+			dev->incomingSysexPos = 0;
+			return; // bail out
+		}
+		dev->incomingSysexBuffer[dev->incomingSysexPos++] = msg[i + 1];
+	}
+
+	if (will_end) {
+		if (dev->incomingSysexBuffer[0] == 0xf0) {
+			midiSysexReceived(ip, d, cable, dev->incomingSysexBuffer, dev->incomingSysexPos);
+		}
+		dev->incomingSysexPos = 0;
+	}
+}
+
+void MidiEngine::midiSysexReceived(int ip, int d, int cable, uint8_t* data, int len) {
+	if (len < 4) return;
+
+	// placeholder until we get a real manufacturer id.
+	if (data[1] == 0x7D) {
+		switch (data[2]) {
+		case 0: // PING test message, reply
+		{
+			uint8_t pong[] = {0xf0, data[1], 0x7f, 0x00, 0xf7};
+			if (len >= 5) {
+				pong[3] = data[3];
+			}
+			sendSysex(ip, d, cable, pong, sizeof pong);
+		} break;
+
+		case 1:
+			numericDriver.displayPopup(HAVE_OLED ? "hello sysex" : "SYSX");
+			break;
+
+		case 0x7f: // PONG, reserved
+		default:
+			break;
+		}
+	}
+}
+
+void MidiEngine::sendSysex(int ip, int d, int cable, uint8_t* data, int len) {
+	if (len < 4 || data[0] != 0xf0 || data[len - 1] != 0xf7) {
+		return;
+	}
+
+	if (ip < 0) {
+		// NB: beware of MIDI_TX_BUFFER_SIZE
+		for (int i = 0; i < len; i++) {
+			bufferMIDIUart(data[i]);
+		}
+	}
+	else {
+		int potentialNumDevices = getPotentialNumConnectedUSBMIDIDevices(ip);
+
+		if (d >= potentialNumDevices) return;
+		ConnectedUSBMIDIDevice* connectedDevice = &connectedUSBMIDIDevices[ip][d];
+		int maxPort = connectedDevice->maxPortConnected;
+		if (cable > maxPort) return;
+
+		int pos = 0;
+		while (pos < len) {
+			int status, byte0 = 0, byte1 = 0, byte2 = 0;
+			byte0 = data[pos];
+			if (pos == 0 || len - pos > 3) {
+				status = 0x4; // sysex start or continue
+				byte1 = data[pos + 1];
+				byte2 = data[pos + 2];
+				pos += 3;
+			}
+			else {
+				status = 0x4 + (len - pos); // sysex end with N bytes
+				if ((len - pos) > 1) byte1 = data[pos + 1];
+				if ((len - pos) > 2) byte2 = data[pos + 2];
+				pos = len;
+			}
+			status |= (cable << 4);
+			uint32_t packed = ((uint32_t)byte2 << 24) | ((uint32_t)byte1 << 16) | ((uint32_t)byte0 << 8) | status;
+			connectedDevice->bufferMessage(packed);
+		}
+	}
+}
+
 void MidiEngine::checkIncomingUsbMidi() {
 
 	if (!usbCurrentlyInitialized) return;
@@ -635,6 +757,7 @@ void MidiEngine::checkIncomingUsbMidi() {
 								statusType = 0x0F;
 							}
 							else { // Invalid, or sysex, or something
+								checkIncomingUsbSysex(readPos, ip, d, cable);
 								continue;
 							}
 						}
@@ -683,11 +806,11 @@ void MidiEngine::checkIncomingUsbMidi() {
 }
 
 int MidiEngine::getMidiMessageLength(uint8_t statusByte) {
-	if (statusByte == 0xF0    // System exclusive - TODO!
+	if (statusByte == 0xF0    // System exclusive - dynamic length
 	    || statusByte == 0xF4 // Undefined
 	    || statusByte == 0xF5 // Undefined
 	    || statusByte == 0xF6 // Tune request
-	    || statusByte == 0xF7 // End of exclusive - TODO
+	    || statusByte == 0xF7 // End of exclusive
 	    || statusByte == 0xF8 // Timing clock
 	    || statusByte == 0xF9 // Undefined
 	    || statusByte == 0xFA // Start

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -34,6 +34,9 @@ public:
 	void sendCC(int channel, int cc, int value, int filter);
 	bool checkIncomingSerialMidi();
 	void checkIncomingUsbMidi();
+
+	void checkIncomingUsbSysex(uint8_t const* message, int ip, int d, int cable);
+
 	void sendMidi(uint8_t statusType, uint8_t channel, uint8_t data1 = 0, uint8_t data2 = 0,
 	              int filter = MIDI_OUTPUT_FILTER_NO_MPE, bool sendUSB = true);
 	void sendClock(bool sendUSB = true, int howMany = 1);
@@ -43,6 +46,10 @@ public:
 	void sendContinue();
 	void flushMIDI();
 	void sendUsbMidi(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2, int filter);
+
+	// data should be a complete message with data[0] = 0xf0, data[len-1] = 0xf7
+	void sendSysex(int ip, int d, int cable, uint8_t* data, int len);
+
 	void sendSerialMidi(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
 	void sendPGMChange(int channel, int pgm, int filter);
 	void sendAllNotesOff(int channel, int filter);
@@ -65,11 +72,14 @@ private:
 	uint8_t numSerialMidiInput;
 	uint8_t lastStatusByteSent;
 
-	bool currentlyReceivingSysEx;
+	bool currentlyReceivingSysExSerial;
 
 	int getMidiMessageLength(uint8_t statusuint8_t);
 	void midiMessageReceived(MIDIDevice* fromDevice, uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2,
 	                         uint32_t* timer = NULL);
+
+	// or midi device?? whatever makes sense for a consumer as a reply address.
+	void midiSysexReceived(int ip, int d, int cable, uint8_t* data, int len);
 	int getPotentialNumConnectedUSBMIDIDevices(int ip);
 };
 


### PR DESCRIPTION
This is just the engine code, not doing anything useful yet. Supporting two simple messages for testing purposes:

F0 7D 00 XX F7:
  ping. reply with the same message on the same device (usb or serial)

F0 7D 01 F7:
  display a "hello sysex" popup message


The questions in https://github.com/SynthstromAudible/DelugeFirmware/issues/37 still apply. After discussion in discord, we will use the `0x7D` placeholder manufacturer ID, which is available for testing and non-commercial use (but getting a manufacturer id for Synthstrom would be great if we intend sysex support in the official firmware eventually).

