### PR TITLE
Add Debug launch profiles for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,55 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug 7SEG (GDB/JLinkGDB Remote)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceRoot}/dbt-build-debug-7seg/Deluge-debug-7seg.elf",
+      "MIMode": "gdb",
+      "miDebuggerPath": "arm-none-eabi-gdb",
+      "miDebuggerServerAddress": "localhost:2345",
+      "externalConsole": true,
+      "useExtendedRemote": true,
+      "cwd": "${workspaceRoot}",
+      "svdPath": "${workspaceRoot}/contrib/rza1.svd",
+    },
+    {
+      // NOTE: Do not try `load`ing the program using this config
+      "name": "Debug 7SEG (LLDB/JLinkGDB Remote)",
+      "type": "lldb",
+      "request": "launch",
+      "targetCreateCommands": [
+        "target create ${workspaceFolder}/dbt-build-debug-7seg/Deluge-debug-7seg.elf"
+      ],
+      "processCreateCommands": [
+        "gdb-remote localhost:2345"
+      ],
+    },
+    {
+      "name": "Debug OLED (GDB/JLinkGDB Remote)",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "${workspaceRoot}/dbt-build-debug-oled/Deluge-debug-oled.elf",
+      "MIMode": "gdb",
+      "miDebuggerPath": "arm-none-eabi-gdb",
+      "miDebuggerServerAddress": "localhost:2345",
+      "externalConsole": true,
+      "useExtendedRemote": true,
+      "cwd": "${workspaceRoot}",
+      "svdPath": "${workspaceRoot}/contrib/rza1.svd",
+    },
+    {
+      // NOTE: Do not try `load`ing the program using this config
+      "name": "Debug OLED (LLDB/JLinkGDB Remote)",
+      "type": "lldb",
+      "request": "launch",
+      "targetCreateCommands": [
+        "target create ${workspaceFolder}/dbt-build-debug-oled/Deluge-debug-oled.elf"
+      ],
+      "processCreateCommands": [
+        "gdb-remote localhost:2345"
+      ],
+    }
+  ]
+}

--- a/scripts/tasks/task-debug.py
+++ b/scripts/tasks/task-debug.py
@@ -1,0 +1,125 @@
+import argparse
+from pathlib import Path
+import shutil
+import util
+
+TARGET_DEVICE = "R7S721020"
+OPENOCD_PREFIX = "toolchain/win32-x64/openocd/openocd/scripts/"
+OPENOCD_TARGET_DEVICE_SWD = "contrib/renesas-rz-a1lu.cfg"
+OPENOCD_TARGET_DEVICE_JTAG = "contrib/renesas-rz-a1lu-jtag.cfg"
+
+
+def find_cmd_with_fallback(cmd, fallback):
+    which_result = shutil.which(cmd)
+    if which_result:
+        return which_result
+    else:
+        return fallback
+
+
+def absolute_path_str(path: str):
+    return str(Path(path).absolute())
+
+
+def jlink_gdb(cmd, device: str, endian: str, protocol: str, gdb_port:int):
+    if not cmd:
+        cmd = find_cmd_with_fallback(
+            "JLinkGDBServerCL", "C:\Program Files\SEGGER\JLink\JLinkGDBServerCL"
+        )
+
+    return [cmd, "-if", protocol, "-device", device, "-endian", endian, "-nogui",'-ir', '-port', str(gdb_port)]
+
+
+def openocd_gdb(cmd, interface: str, target: str, protocol: str, gdb_port: int):
+    if not cmd:
+        cmd = find_cmd_with_fallback(
+            "openocd", absolute_path_str("toolchain/win32-x64/openocd/bin/openocd.exe")
+        )
+
+    # if we haven't gotten an interface with a path already, qualify it
+    if len(target.split("/")) == 1:
+        target = f"target/{target}.cfg"
+
+    return [
+        cmd,
+        "-f",
+        absolute_path_str(OPENOCD_PREFIX + f"interface/{interface}.cfg"),
+        "-f",
+        absolute_path_str(target),
+        "-c",
+        f'"transport select {protocol}"',
+        "-c",
+        f'"gdb_port {gdb_port}"',
+    ]
+
+
+def argparser():
+    parser = argparse.ArgumentParser(
+        prog="task debug", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument(
+        "-j", "--jlink", action="store_true", help="Use JLinkGDB instead of OpenOCD"
+    )
+    parser.add_argument(
+        "-c",
+        "--command",
+        help="Explicitly define the Jlink or OpenOCD executable to call",
+        type=str,
+    )
+    parser.add_argument(
+        "-d", "--target-device", help="The target device", default=TARGET_DEVICE, type=str
+    )
+    parser.add_argument(
+        "-g", "--gdb-port", help="The port for gdb to listen on", default=2345, type=int
+    )
+    parser.add_argument(
+        "-v", "--verbose", help="Print the called command", action='store_true'
+    )    
+    parser.add_argument(
+        "-p",
+        "--protocol",
+        choices=["swd", "jtag"],
+        help="Select the communication protocol",
+        default="swd",
+    )
+    parser.add_argument(
+        "-i",
+        "--interface",
+        help="Select the debug interface (OpenOCD only)",
+        default="cmsis-dap",
+        type=str,
+    )
+    return parser
+
+def get_openocd_target(target: str, protocol: str) -> str:
+    if target == TARGET_DEVICE:
+        if protocol == "jtag":
+            target = OPENOCD_TARGET_DEVICE_JTAG
+        else:
+            target = OPENOCD_TARGET_DEVICE_SWD
+            if protocol != "swd":
+                print("Warning! Interface unsupported, falling back to SWD")
+    else:
+        target = target
+
+    return target
+
+
+def main():
+    args = argparser().parse_args()
+    if args.jlink:
+        cmd = jlink_gdb(args.command, args.target_device, "little", args.protocol, args.gdb_port)
+    else:
+        target = get_openocd_target(args.target_device, args.protocol)
+        cmd = openocd_gdb(args.command, args.interface, target, args.protocol, args.gdb_port)
+
+    if args.verbose:
+        print(' '.join(cmd))
+    util.run(cmd, False)
+
+
+if __name__ == "__main__":
+    try:
+        exit(main())
+    except KeyboardInterrupt:
+        exit(130)

--- a/scripts/tasks/util.py
+++ b/scripts/tasks/util.py
@@ -1,0 +1,95 @@
+import multiprocessing
+import subprocess
+import sys
+import shutil
+import sysconfig
+from pathlib import Path
+import time
+
+
+def run(args, redirect_input: bool = True, redirect_output: bool = True):
+    # start child process
+    process = subprocess.run(
+        args,
+        stdout=(sys.stdout if redirect_output else None),
+        stdin=(sys.stdin if redirect_input else None),
+        stderr=(sys.stderr if redirect_output else None),
+    )
+
+    return process.returncode
+
+
+def find_cmd_with_fallback(cmd:str, fallback: str = None):
+    if not fallback:
+        fallback = cmd
+    which_result = shutil.which(cmd)
+    if which_result:
+        return which_result
+    else:
+        return fallback
+
+
+def absolute_path_str(path: str):
+    return str(Path(path).absolute())
+
+
+def run_get_output(args):
+    return subprocess.run(args, stdout=subprocess.PIPE).stdout.decode().strip()
+
+
+def convert_path_if_mingw(path: str):
+    if sysconfig.get_platform().startswith("mingw"):
+        path = run_get_output(["cygpath", "-w", path])
+    return path
+
+
+def get_git_root():
+    git_root = run_get_output(["git", "rev-parse", "--show-toplevel"])
+    git_root = convert_path_if_mingw(git_root)
+    return Path(git_root)
+
+# from https://stackoverflow.com/a/34482761
+def progressbar(it, prefix:str, size:int=60, out=sys.stdout):
+    count = len(it)
+
+    def show(j):
+        x = int(size * j / count)
+        print(
+            f"{prefix}[{u'#'*x}{('-'*(size-x))}] {j}/{count}",
+            end="\r",
+            file=out,
+            flush=True,
+        )
+
+    show(0)
+    for i, item in enumerate(it):
+        yield item
+        show(i + 1)
+    print("", flush=True, file=out)
+
+def do_parallel(func, it):
+    p = multiprocessing.Process(target=func, args=it)
+    p.start()
+    p.join()
+  
+def do_parallel_progressbar(func, it, prefix:str, size:int=60, out=sys.stdout):
+    count = len(it)
+    def show(j):
+        x = int(size * j / count)
+        print(
+            f"{prefix}[{u'#'*x}{('-'*(size-x))}] {j}/{count}",
+            end="\r",
+            file=out,
+            flush=True,
+        )
+    show(0)    
+
+    pool = multiprocessing.Pool()
+    result = pool.map_async(func, it)
+    while not result.ready():
+        show(count - result._number_left)
+        time.sleep(1)
+    show(count)
+    pool.close()
+    pool.join()
+    print("", flush=True, file=out)


### PR DESCRIPTION
This adds VSCode launch profiles for debugging using a JLink running a remote GDB Server. There's also now a python script in the scripts/tasks folder that supports launching a debug server using either JLinkGDBServer or OpenOCD.

I personally have a script called task.py at the toplevel of the git directory that also lets me call any tasks in that folder as subcommands, (i.e. `python task.py debug` but I don't want to add too much stuff to the git root if we don't have to, unless there's approval/interest.