### PR TITLE
Update .gitignore to ignore doxygen output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /e2-build-release-7seg/
 /e2-build-release-oled/
 /dbt-build*
+/docs
 *.launch
 /toolchain/*
 compile_commands.json


### PR DESCRIPTION
The project doxyfile can place a large amount of data in docs/ that should not be checked into git