### PR TITLE
Add VSCode tasks for building and debug server launch

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,77 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"type": "process",
+			"label": "Build 7SEG Debug",
+			"command": "./dbt",
+			"windows": {
+				"command": "./dbt.cmd",
+			},
+			"args":["dbt-build-debug-7seg"],
+			"group": { 
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"type": "process",
+			"label": "Build OLED Debug",
+			"command": "./dbt",
+			"windows": {
+				"command": "./dbt.cmd",
+			},
+			"args":["dbt-build-debug-oled"],
+			"group": { 
+				"kind": "build",
+				"isDefault": false
+			}
+		},
+		{
+			"type": "process",
+			"label": "Build 7SEG Release",
+			"command": "./dbt",
+			"windows": {
+				"command": "./dbt.cmd",
+			},
+			"args":["dbt-build-release-7seg"],
+			"group": { 
+				"kind": "build",
+				"isDefault": false
+			}
+		},
+		{
+			"type": "process",
+			"label": "Build OLED Release",
+			"command": "./dbt",
+			"windows": {
+				"command": "./dbt.cmd",
+			},
+			"args":["dbt-build-release-oled"],
+			"group": { 
+				"kind": "build",
+				"isDefault": false
+			}
+		},
+
+		{
+			"type": "process",
+			"label": "Run JLink GDB Server",
+			"problemMatcher": [],
+			"command": "python",	
+			"args": [
+				"scripts/tasks/task-debug.py",
+				"-j",
+			]
+		},
+		{
+			"type": "process",
+			"label": "Run OpenOCD GDB Server",
+			"problemMatcher": [],
+			"command": "python",
+			"args": [
+				"scripts/tasks/task-debug.py",
+			]
+		}
+	]
+}


### PR DESCRIPTION
This adds the relevant building tasks for 7SEG/OLED Debug/Release builds, as well as launch tasks for running the debug servers in VSCode in such a way that the previously added debug profiles (#140) can connect.