### PR TITLE
Use learn from keyboard view

### DIFF
--- a/CommunityFeatures.md
+++ b/CommunityFeatures.md
@@ -49,6 +49,8 @@ Synchronization modes accessible through the "LFO SYNC" shortcut.
 ### Audio Clip View
  - ([#141]) Holding the vertical encoder down while turning the horizontal encoder will shift the clip along the underlying audio file, similar to the same interface for instrument clips.
 
+### Keyboard View
+ - ([#151]) "Learn" can be used in keyboard view to learn a midi input to the current instrument, like when holding learn and pressing audition in normal clip view. This also works with kits, where each row can be learned individually.
 
 <h1 id="runtime-features">Runtime settings aka Community Features Menu</h1>
 

--- a/CommunityFeatures.md
+++ b/CommunityFeatures.md
@@ -80,3 +80,5 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#112]: https://github.com/SynthstromAudible/DelugeFirmware/pull/112
 [#122]: https://github.com/SynthstromAudible/DelugeFirmware/pull/122
 [#141]: https://github.com/SynthstromAudible/DelugeFirmware/pull/141
+[#151]: https://github.com/SynthstromAudible/DelugeFirmware/pull/151
+

--- a/src/deluge/gui/ui/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard_screen.cpp
@@ -422,15 +422,6 @@ doOther:
 		}
 	}
 
-	// Kit button
-	else if (x == kitButtonX && y == kitButtonY && currentUIMode == UI_MODE_NONE) {
-#if DELUGE_MODEL != DELUGE_MODEL_40_PAD
-		if (on) {
-			IndicatorLEDs::indicateAlertOnLed(keyboardLedX, keyboardLedX);
-		}
-#endif
-	}
-
 	else {
 		uiNeedsRendering(this, 0xFFFFFFFF, 0); //
 		int result = InstrumentClipMinder::buttonAction(x, y, on, inCardRoutine);
@@ -514,6 +505,21 @@ void KeyboardScreen::recalculateColours() {
 	for (int i = 0; i < displayHeight * clip->keyboardRowInterval + displayWidth; i++) {
 		clip->getMainColourFromY(clip->yScrollKeyboardScreen + i, 0, noteColours[i]);
 	}
+}
+
+void KeyboardScreen::changeInstrumentType(int newInstrumentType) {
+	if (currentSong->currentClip->output->type == newInstrumentType) return;
+  InstrumentClipMinder::changeInstrumentType(newInstrumentType);
+  instrumentClipView.recalculateColours();
+  recalculateColours();
+	uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
+}
+
+void KeyboardScreen::createNewInstrument(int newInstrumentType) {
+  InstrumentClipMinder::createNewInstrument(newInstrumentType);
+  instrumentClipView.recalculateColours();
+  recalculateColours();
+	uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 }
 
 bool KeyboardScreen::renderMainPads(uint32_t whichRows, uint8_t image[][displayWidth + sideBarWidth][3],

--- a/src/deluge/gui/ui/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard_screen.cpp
@@ -101,11 +101,13 @@ int KeyboardScreen::padAction(int x, int y, int velocity) {
 	}
 
 	if (isUIModeActiveExclusively(UI_MODE_MIDI_LEARN)) {
-		if (sdRoutineLock) return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
+		if (sdRoutineLock)
+			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 
 		if (instrument->type == INSTRUMENT_TYPE_KIT) {
 			NoteRow* noteRow = ((InstrumentClip*)instrument->activeClip)->getNoteRowOnScreen(yDisplay, currentSong);
-			if (!noteRow || !noteRow->drum) return ACTION_RESULT_DEALT_WITH;
+			if (!noteRow || !noteRow->drum)
+				return ACTION_RESULT_DEALT_WITH;
 			view.drumMidiLearnPadPressed(velocity, noteRow->drum, (Kit*)instrument);
 		}
 		else {
@@ -481,7 +483,7 @@ void KeyboardScreen::stopAllAuditioning(ModelStack* modelStack, bool switchOffOn
 				int noteCode = getNoteCodeFromCoords(padPresses[p].x, padPresses[p].y);
 				((MelodicInstrument*)getCurrentClip()->output)->endAuditioningForNote(modelStack, noteCode);
 				if (switchOffOnThisEndToo) {
-  				padPresses[p].x = 255;
+					padPresses[p].x = 255;
 				}
 			}
 		}
@@ -518,7 +520,8 @@ void KeyboardScreen::recalculateColours() {
 }
 
 void KeyboardScreen::changeInstrumentType(int newInstrumentType) {
-	if (getCurrentClip()->output->type == newInstrumentType) return;
+	if (getCurrentClip()->output->type == newInstrumentType)
+		return;
 	InstrumentClipMinder::changeInstrumentType(newInstrumentType);
 	instrumentClipView.recalculateColours();
 	recalculateColours();
@@ -545,8 +548,7 @@ bool KeyboardScreen::renderMainPads(uint32_t whichRows, uint8_t image[][displayW
 	Instrument* instrument = (Instrument*)getCurrentClip()->output;
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
-	ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-	    modelStack->addTimelineCounter(getCurrentClip());
+	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(getCurrentClip());
 
 	// Flashing default root note
 	if (uiTimerManager.isTimerSet(TIMER_DEFAULT_ROOT_NOTE)) {
@@ -619,7 +621,8 @@ doFullColour:
 						occupancyMask[y][x] = 64;
 					}
 					// Show root note within each octave as full colour
-					else if (!noteWithinOctave) goto doFullColour;
+					else if (!noteWithinOctave)
+						goto doFullColour;
 
 					// Or, if this note is just within the current scale, show it dim
 					else {
@@ -643,7 +646,8 @@ doFullColour:
 					noteCode++;
 					yDisplay++;
 					noteWithinOctave++;
-					if (noteWithinOctave == 12) noteWithinOctave = 0;
+					if (noteWithinOctave == 12)
+						noteWithinOctave = 0;
 				}
 			}
 		}
@@ -826,8 +830,7 @@ void KeyboardScreen::doScroll(int offset, bool force) {
 
 				((MelodicInstrument*)getCurrentClip()->output)
 				    ->beginAuditioningForNote(modelStack, noteCode,
-				                              ((Instrument*)getCurrentClip()->output)->defaultVelocity,
-				                              zeroMPEValues);
+				                              ((Instrument*)getCurrentClip()->output)->defaultVelocity, zeroMPEValues);
 			}
 		}
 	}
@@ -923,7 +926,7 @@ void KeyboardScreen::drawNoteCode(int noteCode) {
 	}
 
 	if (getCurrentClip()->output->type != INSTRUMENT_TYPE_KIT) {
-  	drawActualNoteCode(noteCode);
+		drawActualNoteCode(noteCode);
 	}
 }
 

--- a/src/deluge/gui/ui/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard_screen.h
@@ -58,6 +58,8 @@ public:
 	void changeInstrumentType(int newInstrumentType);
 	void createNewInstrument(int newInstrumentType);
 
+	void midiLearnFlash();
+
 #if HAVE_OLED
 	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 		InstrumentClipMinder::renderOLED(image);

--- a/src/deluge/gui/ui/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard_screen.h
@@ -55,6 +55,8 @@ public:
 	void exitAuditionMode();
 	void openedInBackground();
 	void stopAllAuditioning(ModelStack* modelStack, bool switchOffOnThisEndToo = true);
+	void changeInstrumentType(int newInstrumentType);
+	void createNewInstrument(int newInstrumentType);
 
 #if HAVE_OLED
 	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -292,15 +292,8 @@ doChangeInstrumentType:
 
 	// Kit button
 	else if (x == kitButtonX && y == kitButtonY) {
-		if (instrumentClipToLoadFor && instrumentClipToLoadFor->onKeyboardScreen) {
-#if DELUGE_MODEL != DELUGE_MODEL_40_PAD
-			IndicatorLEDs::indicateAlertOnLed(keyboardLedX, keyboardLedX);
-#endif
-		}
-		else {
-			newInstrumentType = INSTRUMENT_TYPE_KIT;
-			goto doChangeInstrumentType;
-		}
+		newInstrumentType = INSTRUMENT_TYPE_KIT;
+		goto doChangeInstrumentType;
 	}
 
 	// MIDI button

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -225,7 +225,8 @@ doReRender:
 	else if ((isNoUIModeActive() && Buttons::isButtonPressed(yEncButtonX, yEncButtonY))
 	         || (isUIModeActiveExclusively(UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON)
 	             && Buttons::isButtonPressed(clipViewButtonX, clipViewButtonY))) {
-		if (sdRoutineLock) return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE; // Just be safe - maybe not necessary
+		if (sdRoutineLock)
+			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE; // Just be safe - maybe not necessary
 		int squareSize = getPosFromSquare(1) - getPosFromSquare(0);
 		int shiftAmount = offset * squareSize;
 		Clip* clip = getCurrentClip();
@@ -248,7 +249,8 @@ doReRender:
 
 			// If there's no Consequence in the Action, that's probably because we deleted it a previous time with the code just below.
 			// Or possibly because the Action was created but there wasn't enough RAM to create the Consequence. Anyway, just go add a consequence now.
-			if (!action->firstConsequence) goto addConsequenceToAction;
+			if (!action->firstConsequence)
+				goto addConsequenceToAction;
 
 			ConsequenceClipHorizontalShift* consequence = (ConsequenceClipHorizontalShift*)action->firstConsequence;
 			consequence->amount += shiftAmount;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -433,7 +433,6 @@ doOther:
 		}
 	}
 
-	// Kit button. Unlike the other instrument-type buttons, whose code is in InstrumentClipMinder, this one is only allowed in the InstrumentClipView
 	else if (x == kitButtonX && y == kitButtonY && currentUIMode == UI_MODE_NONE) {
 		if (on) {
 			if (inCardRoutine) {

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1199,9 +1199,11 @@ void AudioClip::setPos(ModelStackWithTimelineCounter* modelStack, int32_t newPos
 
 bool AudioClip::shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int amount) {
 	// No horizontal shift when recording
-	if (recorder) return false;
+	if (recorder)
+		return false;
 	// No horizontal shift when no sample is loaded
-	if (!sampleHolder.audioFile) return false;
+	if (!sampleHolder.audioFile)
+		return false;
 
 	int64_t newStartPos = int64_t(sampleHolder.startPos) - getSamplesFromTicks(amount);
 	uint64_t sampleLength = ((Sample*)sampleHolder.audioFile)->lengthInSamples;

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -359,15 +359,8 @@ yesLoadInstrument:
 		}
 
 		else if (x == kitButtonX && y == kitButtonY) {
-			if (getCurrentClip()->onKeyboardScreen) {
-#if DELUGE_MODEL != DELUGE_MODEL_40_PAD
-				IndicatorLEDs::indicateAlertOnLed(keyboardLedX, keyboardLedX);
-#endif
-			}
-			else {
-				Browser::instrumentTypeToLoad = INSTRUMENT_TYPE_KIT;
-				goto yesLoadInstrument;
-			}
+			Browser::instrumentTypeToLoad = INSTRUMENT_TYPE_KIT;
+			goto yesLoadInstrument;
 		}
 	}
 
@@ -435,6 +428,15 @@ yesLoadInstrument:
 			else {
 				changeInstrumentType(INSTRUMENT_TYPE_SYNTH);
 			}
+		}
+	}
+	
+	else if (x == kitButtonX && y == kitButtonY) {
+		if (on && currentUIMode == UI_MODE_NONE) {
+			if (inCardRoutine) return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
+
+			if (Buttons::isNewOrShiftButtonPressed()) createNewInstrument(INSTRUMENT_TYPE_KIT);
+			else changeInstrumentType(INSTRUMENT_TYPE_KIT);
 		}
 	}
 

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -430,13 +430,16 @@ yesLoadInstrument:
 			}
 		}
 	}
-	
+
 	else if (x == kitButtonX && y == kitButtonY) {
 		if (on && currentUIMode == UI_MODE_NONE) {
-			if (inCardRoutine) return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			if (inCardRoutine)
+				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 
-			if (Buttons::isNewOrShiftButtonPressed()) createNewInstrument(INSTRUMENT_TYPE_KIT);
-			else changeInstrumentType(INSTRUMENT_TYPE_KIT);
+			if (Buttons::isNewOrShiftButtonPressed())
+				createNewInstrument(INSTRUMENT_TYPE_KIT);
+			else
+				changeInstrumentType(INSTRUMENT_TYPE_KIT);
 		}
 	}
 

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -31,7 +31,7 @@ class InstrumentClipMinder : public ClipMinder {
 public:
 	InstrumentClipMinder();
 	static void redrawNumericDisplay();
-	void createNewInstrument(int newInstrumentType);
+	virtual void createNewInstrument(int newInstrumentType);
 	void setLedStates();
 	void focusRegained();
 	int buttonAction(int x, int y, bool on, bool inCardRoutine);
@@ -43,7 +43,7 @@ public:
 	void selectEncoderAction(int offset);
 	static void drawMIDIControlNumber(int controlNumber, bool automationExists);
 	bool makeCurrentClipActiveOnInstrumentIfPossible(ModelStack* modelStack);
-	void changeInstrumentType(int newInstrumentType);
+	virtual void changeInstrumentType(int newInstrumentType);
 	void opened();
 
 #if HAVE_OLED

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2951,7 +2951,7 @@ traverseClips:
 			                                             INSTRUMENT_REMOVAL_NONE,
 			                                             (InstrumentClip*)favourClipForCloningParamManager,
 			                                             keepNoteRowsWithMIDIInput, true); // Will call audio routine
-			// TODO: deal with errors!
+			                                                                               // TODO: deal with errors!
 		}
 
 		// If this is the first Clip we dealt with, tell all the rest of the Clips to just clone it from this one (if there isn't already a ParamManager backed up in memory for them)

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2952,10 +2952,6 @@ traverseClips:
 			                                             (InstrumentClip*)favourClipForCloningParamManager,
 			                                             keepNoteRowsWithMIDIInput, true); // Will call audio routine
 			// TODO: deal with errors!
-
-			if (newOutput->type == INSTRUMENT_TYPE_KIT) {
-				instrumentClip->onKeyboardScreen = false;
-			}
 		}
 
 		// If this is the first Clip we dealt with, tell all the rest of the Clips to just clone it from this one (if there isn't already a ParamManager backed up in memory for them)


### PR DESCRIPTION
Another minor QOL thing ive been missing - being able to use the LEARN button in keyboard view.
It works with the new kit keyboard view as well.

While implementing this, i found a few places in the code where it still assumed that kits could not have a keyboard view. This means for instance, that a synth can now be changed to a kit by pressing the KIT button in keyboard view (as it can when being in normal instrument view)