### PR TITLE
sound editor: "mod matrix" overview over all active patch cables

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -98,6 +98,9 @@ Synchronization modes accessible through the "LFO SYNC" shortcut.
 #### Sample Waveform View
  - ([#293]) When a sample has loop start and loop end points set, holding down loop start and tapping loop end will lock the loop points together. Moving one will move the other, keeping them the same distance apart. Use the same process to unlock the loop points. Use SHIFT+TURN<> to double or half the loop length.
 
+#### Sound Editor
+  - ([#157]) Add a "Mod Matrix" entry to the sound editor menu which shows a list of all currently active modulations.
+
 #### Takeover Mode
 
  - ([#170]) The Takeover menu consists of three modes that can be selected from:

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -84,6 +84,8 @@ public:
 	virtual bool isRangeDependent() { return false; }
 	virtual bool usesAffectEntire() { return false; }
 
+	virtual ActionResult timerCallback() { return ActionResult::DEALT_WITH; }
+
 	/// Can get overridden by getTitle(). Actual max num chars for OLED display is 14.
 	std::string title;
 

--- a/src/deluge/gui/menu_item/patch_cables.cpp
+++ b/src/deluge/gui/menu_item/patch_cables.cpp
@@ -1,0 +1,222 @@
+#include "patch_cables.h"
+#include "gui/ui/sound_editor.h"
+#include "gui/ui_timer_manager.h"
+#include "hid/display/oled.h"
+#include "modulation/params/param_manager.h"
+#include "modulation/patch/patch_cable_set.h"
+#include "patch_cable_strength/range.h"
+#include "patch_cable_strength/regular.h"
+#include "processing/sound/sound.h"
+#include "source_selection/range.h"
+#include "source_selection/regular.h"
+#include "util/container/static_vector.hpp"
+#include "util/functions.h"
+#include <fmt/core.h>
+
+namespace deluge::gui::menu_item {
+
+void PatchCables::beginSession(MenuItem* navigatedBackwardFrom) {
+	currentValue = 0;
+
+	if (navigatedBackwardFrom != nullptr) {
+		PatchCableSet* set = soundEditor.currentParamManager->getPatchCableSet();
+		currentValue = savedVal;
+		if (savedVal >= set->numPatchCables) {
+			currentValue = 0;
+		}
+	}
+
+#if HAVE_OLED
+	scrollPos = std::max((int32_t)0, currentValue - 1);
+#endif
+
+	renderOptions();
+	readValueAgain();
+}
+
+void PatchCables::readValueAgain() {
+#if HAVE_OLED
+	renderUIsForOled();
+#else
+	drawValue();
+#endif
+	blinkShortcutsSoon();
+}
+
+void PatchCables::renderOptions() {
+	options.clear();
+	PatchCableSet* set = soundEditor.currentParamManager->getPatchCableSet();
+
+	for (int i = 0; i < set->numPatchCables; i++) {
+		PatchCable* cable = &set->patchCables[i];
+		PatchSource src = cable->from;
+		PatchSource src2 = PatchSource::NOT_AVAILABLE;
+		ParamDescriptor desc = cable->destinationParamDescriptor;
+		if (!desc.isJustAParam()) {
+			src2 = desc.getTopLevelSource();
+		}
+		int dest = desc.getJustTheParam();
+
+		const int item_max_len = 30;
+		static char bufs[kMaxNumPatchCables][item_max_len];
+		char* buf = bufs[i];
+
+		const char* src_name = sourceToStringShort(src); // exactly 4 chars
+		const char* dest_name = patchedParamToStringShort(dest);
+
+		memcpy(buf, src_name, 4);
+		buf[4] = ' ';
+		int off = 0;
+		if (!desc.isJustAParam()) {
+			const char* src2_name = sourceToStringShort(src2);
+			memcpy(buf + 5, src2_name, 4);
+			buf[9] = ' ';
+			off = 5;
+		}
+
+		int32_t param_value = cable->param.getCurrentValue();
+		int32_t level = ((int64_t)param_value * 5000 + (1 << 29)) >> 30;
+		if (level >= 100 || level <= -100) {
+			fmt::vformat_to_n(buf + off + 5, 5, "{:4}", fmt::make_format_args(level / 100));
+		}
+		else {
+			fmt::vformat_to_n(buf + off + 5, 5, "{:4}", fmt::make_format_args((float)level / 100));
+		}
+
+		buf[off + 9] = ' ';
+		strncpy(buf + off + 10, dest_name, item_max_len - 10 - off);
+		buf[item_max_len - 1] = 0;
+
+		options.push_back(buf);
+	}
+}
+
+#if HAVE_OLED
+void PatchCables::drawPixelsForOled() {
+	drawItemsForOled(options, currentValue - scrollPos, scrollPos);
+}
+
+#else
+
+void PatchCables::drawValue() {
+	PatchCableSet* set = soundEditor.currentParamManager->getPatchCableSet();
+	if (set->numPatchCables == 0) {
+		numericDriver.setText("none", false, false);
+		return;
+	}
+
+	numericDriver.setScrollingText(options[currentValue].begin());
+}
+
+#endif
+
+void PatchCables::selectEncoderAction(int32_t offset) {
+	int32_t newValue = currentValue + offset;
+
+	PatchCableSet* set = soundEditor.currentParamManager->getPatchCableSet();
+
+#if HAVE_OLED
+	if (newValue >= set->numPatchCables || newValue < 0) {
+		return;
+	}
+#else
+	if (newValue >= set->numPatchCables) {
+		newValue -= set->numPatchCables;
+	}
+	else if (newValue < 0) {
+		newValue += set->numPatchCables;
+	}
+#endif
+
+	currentValue = newValue;
+
+#if HAVE_OLED
+	if (currentValue < scrollPos) {
+		scrollPos = currentValue;
+	}
+	else if (currentValue >= scrollPos + kOLEDMenuNumOptionsVisible) {
+		scrollPos++;
+	}
+#endif
+
+	readValueAgain(); // redraw
+}
+
+void PatchCables::blinkShortcutsSoon() {
+	// some throttling so menu scrolling doesn't become a lightning storm of flashes
+	uiTimerManager.setTimer(TIMER_UI_SPECIFIC, HAVE_OLED ? 500 : 200);
+	uiTimerManager.unsetTimer(TIMER_SHORTCUT_BLINK);
+}
+
+ActionResult PatchCables::timerCallback() {
+	blinkShortcuts();
+	return ActionResult::DEALT_WITH;
+}
+
+void PatchCables::blinkShortcuts() {
+	PatchCableSet* set = soundEditor.currentParamManager->getPatchCableSet();
+	PatchCable* cable = &set->patchCables[currentValue];
+	ParamDescriptor desc = cable->destinationParamDescriptor;
+	int dest = desc.getJustTheParam();
+
+	if (dest == ::Param::Global::VOLUME_POST_REVERB_SEND || dest == ::Param::Local::VOLUME) {
+		dest = ::Param::Global::VOLUME_POST_FX;
+	}
+
+	int32_t x, y;
+	if (soundEditor.findPatchedParam(dest, &x, &y)) {
+		soundEditor.setupShortcutBlink(x, y, 3);
+	}
+
+	PatchSource src = cable->from;
+	PatchSource src2 = PatchSource::NOT_AVAILABLE;
+	if (!desc.isJustAParam()) {
+		src2 = desc.getTopLevelSource();
+	}
+	blinkSrc = src;
+	blinkSrc2 = src2;
+	soundEditor.updateSourceBlinks(this);
+
+	soundEditor.blinkShortcut();
+}
+
+uint8_t PatchCables::shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour) {
+	if (s == blinkSrc) {
+		*colour = 0b110;
+		return 0;
+	}
+	else if (s == blinkSrc2) {
+		return 3; // something #patchingoverhaul2021
+	}
+	return 255;
+}
+
+MenuItem* PatchCables::selectButtonPress() {
+	PatchCableSet* set = soundEditor.currentParamManager->getPatchCableSet();
+	int val = currentValue;
+
+	if (val >= set->numPatchCables) {
+		// There were no items. If the user wants to create some, they need
+		// to select a source anyway, so take them back there.
+		return MenuItem::selectButtonPress();
+	}
+	PatchCable* cable = &set->patchCables[val];
+	savedVal = val;
+	ParamDescriptor desc = cable->destinationParamDescriptor;
+	int dest = desc.getJustTheParam();
+	soundEditor.patchingParamSelected = dest;
+
+	options.clear();
+	if (cable->destinationParamDescriptor.isJustAParam()) {
+		source_selection::regularMenu.s = cable->from;
+		return &patch_cable_strength::regularMenu;
+	}
+	else {
+		PatchSource src2 = desc.getTopLevelSource();
+		source_selection::regularMenu.s = src2;
+		source_selection::rangeMenu.s = cable->from;
+		return &patch_cable_strength::rangeMenu;
+	}
+}
+
+} // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/patch_cables.h
+++ b/src/deluge/gui/menu_item/patch_cables.h
@@ -1,0 +1,35 @@
+#include "definitions_cxx.hpp"
+#include "gui/menu_item/menu_item.h"
+
+namespace deluge::gui::menu_item {
+class PatchCables : public MenuItem {
+public:
+	PatchCables(char const* newName = nullptr) : MenuItem(newName) {}
+	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) final;
+	void selectEncoderAction(int32_t offset) final;
+	void readValueAgain() final;
+	MenuItem* selectButtonPress() final;
+	uint8_t shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour) final;
+
+#if HAVE_OLED
+	void drawPixelsForOled() final;
+	int scrollPos = 0; // Each instance needs to store this separately
+#else
+	void drawValue();
+#endif
+
+	void renderOptions();
+	void blinkShortcuts();
+	void blinkShortcutsSoon();
+	ActionResult timerCallback() override;
+
+	int32_t savedVal = 0;
+	int32_t currentValue = 0;
+
+	static_vector<std::string_view, kMaxNumPatchCables> options;
+
+	PatchSource blinkSrc = PatchSource::NOT_AVAILABLE;
+	PatchSource blinkSrc2 = PatchSource::NOT_AVAILABLE;
+};
+
+} // namespace deluge::gui::menu_item

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -93,6 +93,7 @@
 #include "gui/menu_item/patch_cable_strength/fixed.h"
 #include "gui/menu_item/patch_cable_strength/range.h"
 #include "gui/menu_item/patch_cable_strength/regular.h"
+#include "gui/menu_item/patch_cables.h"
 #include "gui/menu_item/patched_param.h"
 #include "gui/menu_item/patched_param/integer.h"
 #include "gui/menu_item/patched_param/integer_non_fm.h"
@@ -832,13 +833,36 @@ bend_range::PerFinger drumBendRangeMenu{"Bend range"}; // The single option avai
 patched_param::Integer volumeMenu{HAVE_OLED ? "Level" : "VOLUME", "Master level", ::Param::Global::VOLUME_POST_FX};
 patched_param::Pan panMenu{"PAN", ::Param::Local::PAN};
 
+PatchCables patchCablesMenu{"mod matrix"};
+
 menu_item::Submenu soundEditorRootMenu{
     "Sound",
     {
-        &source0Menu,    &source1Menu, &modulator0Menu,    &modulator1Menu,    &noiseMenu,    &masterTransposeMenu,
-        &vibratoMenu,    &lpfMenu,     &hpfMenu,           &filterRoutingMenu, &drumNameMenu, &synthModeMenu,
-        &env0Menu,       &env1Menu,    &lfo0Menu,          &lfo1Menu,          &voiceMenu,    &fxMenu,
-        &compressorMenu, &bendMenu,    &drumBendRangeMenu, &volumeMenu,        &panMenu,      &sequenceDirectionMenu,
+        &source0Menu,
+        &source1Menu,
+        &modulator0Menu,
+        &modulator1Menu,
+        &noiseMenu,
+        &masterTransposeMenu,
+        &vibratoMenu,
+        &lpfMenu,
+        &hpfMenu,
+        &filterRoutingMenu,
+        &drumNameMenu,
+        &synthModeMenu,
+        &env0Menu,
+        &env1Menu,
+        &lfo0Menu,
+        &lfo1Menu,
+        &voiceMenu,
+        &fxMenu,
+        &compressorMenu,
+        &bendMenu,
+        &drumBendRangeMenu,
+        &volumeMenu,
+        &panMenu,
+        &patchCablesMenu,
+        &sequenceDirectionMenu,
     },
 };
 

--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -7,6 +7,7 @@
 #include "gui/menu_item/multi_range.h"
 #include "gui/menu_item/osc/source/wave_index.h"
 #include "gui/menu_item/osc/sync.h"
+#include "gui/menu_item/patch_cables.h"
 #include "gui/menu_item/patched_param/integer_non_fm.h"
 #include "gui/menu_item/runtime_feature/settings.h"
 #include "gui/menu_item/sample/end.h"
@@ -36,6 +37,8 @@ extern deluge::gui::menu_item::Submenu<12> settingsRootMenu;
 namespace deluge::gui::menu_item::runtime_feature {
 extern Submenu<4> subMenuAutomation;
 }
+
+extern deluge::gui::menu_item::PatchCables patchCablesMenu;
 
 extern MenuItem* midiOrCVParamShortcuts[8];
 extern MenuItem* paramShortcutsForSounds[15][8];

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -76,7 +76,11 @@ public:
 	ActionResult horizontalEncoderAction(int32_t offset);
 	bool editingKit();
 
+	ActionResult timerCallback() override;
+
 	void setupShortcutBlink(int32_t x, int32_t y, int32_t frequency);
+	bool findPatchedParam(int32_t paramLookingFor, int32_t* xout, int32_t* yout);
+	void updateSourceBlinks(MenuItem* currentItem);
 
 	int32_t menuCurrentScroll;
 

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -570,6 +570,180 @@ PatchSource stringToSource(char const* string) {
 	return PatchSource::NONE;
 }
 
+// all should be four chars, to fit a fixed column layout
+char const* sourceToStringShort(PatchSource source) {
+	switch (source) {
+	case PatchSource::LFO_GLOBAL:
+		return "lfo1";
+
+	case PatchSource::LFO_LOCAL:
+		return "lfo2";
+
+	case PatchSource::ENVELOPE_0:
+		return "env1";
+
+	case PatchSource::ENVELOPE_1:
+		return "env2";
+
+	case PatchSource::VELOCITY:
+		return "velo";
+
+	case PatchSource::NOTE:
+		return "note";
+
+	case PatchSource::COMPRESSOR:
+		return "comp";
+
+	case PatchSource::RANDOM:
+		return "rand";
+
+	case PatchSource::AFTERTOUCH:
+		return "pres";
+
+	case PatchSource::X:
+		return "mpeX";
+
+	case PatchSource::Y:
+		return "mpeY";
+
+	default:
+		return "----";
+	}
+}
+
+// all should be max 10 chars, to fit a fixed column layout
+char const* patchedParamToStringShort(int32_t p) {
+	switch (p) {
+
+	case Param::Local::OSC_A_VOLUME:
+		return "Osc1 level";
+
+	case Param::Local::OSC_B_VOLUME:
+		return "Osc2 level";
+
+	case Param::Local::VOLUME:
+		return "Level";
+
+	case Param::Local::NOISE_VOLUME:
+		return "Noise";
+
+	case Param::Local::OSC_A_PHASE_WIDTH:
+		return "Osc1 PW";
+
+	case Param::Local::OSC_B_PHASE_WIDTH:
+		return "Osc2 PW";
+
+	case Param::Local::OSC_A_WAVE_INDEX:
+		return "Osc1 wave";
+
+	case Param::Local::OSC_B_WAVE_INDEX:
+		return "Osc2 wave";
+
+	case Param::Local::LPF_RESONANCE:
+		return "LPF reso";
+
+	case Param::Local::HPF_RESONANCE:
+		return "HPF reso";
+
+	case Param::Local::PAN:
+		return "Pan";
+
+	case Param::Local::MODULATOR_0_VOLUME:
+		return "Mod1 level";
+
+	case Param::Local::MODULATOR_1_VOLUME:
+		return "Mod2 level";
+
+	case Param::Local::LPF_FREQ:
+		return "LPf freq";
+
+	case Param::Local::PITCH_ADJUST:
+		return "Pitch";
+
+	case Param::Local::OSC_A_PITCH_ADJUST:
+		return "Osc1 pitch";
+
+	case Param::Local::OSC_B_PITCH_ADJUST:
+		return "Osc2 pitch";
+
+	case Param::Local::MODULATOR_0_PITCH_ADJUST:
+		return "Mod1 pitch";
+
+	case Param::Local::MODULATOR_1_PITCH_ADJUST:
+		return "Mod1 pitch";
+
+	case Param::Local::HPF_FREQ:
+		return "HPF freq";
+
+	case Param::Local::LFO_LOCAL_FREQ:
+		return "LFO2 rate";
+
+	case Param::Local::ENV_0_ATTACK:
+		return "Env1attack";
+
+	case Param::Local::ENV_0_DECAY:
+		return "Env1 decay";
+
+	case Param::Local::ENV_0_SUSTAIN:
+		return "Env1 sus";
+
+	case Param::Local::ENV_0_RELEASE:
+		return "Env1 rel";
+
+	case Param::Local::ENV_1_ATTACK:
+		return "Env2attack";
+
+	case Param::Local::ENV_1_DECAY:
+		return "Env2 decay";
+
+	case Param::Local::ENV_1_SUSTAIN:
+		return "Env2 sus";
+
+	case Param::Local::ENV_1_RELEASE:
+		return "Env2 rel";
+
+	case Param::Global::LFO_FREQ:
+		return "LFO1 rate";
+
+	case Param::Global::VOLUME_POST_FX:
+	case Param::Global::VOLUME_POST_REVERB_SEND:
+		return "Level";
+
+	case Param::Global::DELAY_RATE:
+		return "Delay rate";
+
+	case Param::Global::DELAY_FEEDBACK:
+		return "Delay feed";
+
+	case Param::Global::REVERB_AMOUNT:
+		return "Reverb amt";
+
+	case Param::Global::MOD_FX_RATE:
+		return "ModFX rate";
+
+	case Param::Global::MOD_FX_DEPTH:
+		return "ModFXdepth";
+
+	case Param::Global::ARP_RATE:
+		return "Arp. rate";
+
+	case Param::Local::MODULATOR_0_FEEDBACK:
+		return "Mod1 feed";
+
+	case Param::Local::MODULATOR_1_FEEDBACK:
+		return "Mod2 feed";
+
+	case Param::Local::CARRIER_0_FEEDBACK:
+		return "Osc1 feed";
+
+	case Param::Local::CARRIER_1_FEEDBACK:
+		return "Osc2 feed";
+
+	default:
+		__builtin_unreachable();
+		return NULL;
+	}
+}
 bool paramNeedsLPF(int32_t p, bool fromAutomation) {
 	switch (p) {
 

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -224,6 +224,10 @@ char const* getGlobalEffectableParamDisplayNameForOLED(int32_t p);
 
 char const* sourceToString(PatchSource source);
 PatchSource stringToSource(char const* string);
+char const* sourceToStringShort(PatchSource source);
+
+char const* patchedParamToStringShort(int32_t p);
+
 bool paramNeedsLPF(int32_t p, bool fromAutomation);
 int32_t shiftVolumeByDB(int32_t oldValue, float offset);
 int32_t quickLog(uint32_t input);


### PR DESCRIPTION
This provides a quick overview over all modulation which is active as part of a sound, similar to a "mod matrix" screen present in many synths.

TODO:
- [x] fine tune the UI for OLED. When a cable only have one source, we could fill in the current strength value in the "src2" slot
- [x] fine tune the UI for 7SEG. We want to use the blinkenlights to show source(s) and destination as the information doesn't fit on the screen.
- [ ] shift-delete for quick deletion?