### PR TITLE
Add names to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+name: Build
+
 on:
   push:
     branches:

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,3 +1,5 @@
+name: Format Check
+
 on:
   push:
     branches:


### PR DESCRIPTION
This just makes navigating the GitHub UI slightly easier. Funny enough, despite the actions requiring approval to run, GitHub immediately renames the actions in their UI just because I created this PR.

That definitely couldn't be abused at all! _/sarcasm_

**Where this is seen:**
![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/525726/91226e90-252d-435a-b675-45116d4eac6d)

![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/525726/303ce5b2-b58e-411c-a480-9be8dd9fe76d)
