### PR TITLE
Add Python Black Formatter as a vscode recommend

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,8 @@
 {
 	"recommendations": [
 		"ms-vscode.cpptools",
-        "EditorConfig.EditorConfig",
-        "xaver.clang-format"
+		"EditorConfig.EditorConfig",
+		"xaver.clang-format",
+		"ms-python.black-formatter"
 	]
 }


### PR DESCRIPTION
- The out-of-the-box behaviour is being used for DBT