### PR TITLE
ci: do not use a matrix for builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,13 +11,12 @@ on:
   merge_group:
   workflow_dispatch:
 
+env:
+  FIRMWARE_RETENTION_DAYS: 5
+
 jobs:
   build:
     name: Build ${{ matrix.profile }}-${{ matrix.hardware }}
-    strategy:
-      matrix:
-        profile: [ 'debug', 'release' ]
-        hardware: [ 'oled', '7seg' ]
     runs-on: ubuntu-latest
     steps:
       - name: check out repo
@@ -31,18 +30,42 @@ jobs:
             --user=$(id --user):$(id --group) \
             -v $(pwd):/src \
             ghcr.io/litui/dbt-toolchain:v$(cat toolchain/REQUIRED_VERSION) \
-            dbt-build-${{ matrix.profile }}-${{ matrix.hardware }}
-      - name: Publish built firmware (bin)
+            --spew \
+            all
+
+      - name: Publish built firmware (7seg-debug) (bin)
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.profile }}-${{ matrix.hardware }}.bin
-          path: dbt-build-${{ matrix.profile }}-${{ matrix.hardware }}/Deluge-${{ matrix.profile }}-${{ matrix.hardware }}.bin
+          name: debug-7seg.bin
+          path: dbt-build-debug-7seg/Deluge-debug-7seg.bin
           if-no-files-found: error
-          retention-days: 5
+          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+      - name: Publish built firmware (7seg-release) (bin)
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-7seg.bin
+          path: dbt-build-release-7seg/Deluge-release-7seg.bin
+          if-no-files-found: error
+          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+      - name: Publish built firmware (oled-debug) (bin)
+        uses: actions/upload-artifact@v3
+        with:
+          name: debug-oled.bin
+          path: dbt-build-debug-oled/Deluge-debug-oled.bin
+          if-no-files-found: error
+          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+      - name: Publish built firmware (oled-release) (bin)
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-oled.bin
+          path: dbt-build-release-oled/Deluge-release-oled.bin
+          if-no-files-found: error
+          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+
       - name: Publish built firmware (elf)
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ matrix.profile }}-${{ matrix.hardware }}.elf
-          path: dbt-build-${{ matrix.profile }}-${{ matrix.hardware }}/Deluge-${{ matrix.profile }}-${{ matrix.hardware }}.elf
+          name: all-elfs
+          path: dbt-build-*/*.elf
           if-no-files-found: error
-          retention-days: 5
+          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}


### PR DESCRIPTION
This should save us about 3 minutes (50%) of total CI runtime by only downloading the toolchain once and building everything in parallel.

All the `.elf`s are now merged in to a single artifact, since they're only needed rarely and only by developers (vs. the .bins, which we want people to test just their own config).