### PR TITLE
Convert contents of deluge/ to #pragma once

### DIFF
--- a/src/deluge/deluge.h
+++ b/src/deluge/deluge.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DELUGE_H_
-#define DELUGE_H_
+#pragma once
 
 #ifdef __cplusplus
 extern "C" {
@@ -44,5 +43,3 @@ extern void setTimeUSBInitializationEnds(int timeFromNow);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* DELUGE_H_ */

--- a/src/deluge/drivers/dmac/dmac.h
+++ b/src/deluge/drivers/dmac/dmac.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_ALL_CPUS_DMAC_DMAC_H_
-#define DRIVERS_ALL_CPUS_DMAC_DMAC_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "RZA1/system/iodefines/dmac_iodefine.h"
@@ -28,5 +27,3 @@
 void setDMARS(int dmaChannel, uint32_t dmarsValue);
 void initDMAWithLinkDescriptor(int dma_channel, const uint32_t* linkDescriptor, uint32_t dmarsValue);
 void dmaChannelStart(const uint32_t dma_channel);
-
-#endif /* DRIVERS_ALL_CPUS_DMAC_DMAC_H_ */

--- a/src/deluge/drivers/mtu/mtu.h
+++ b/src/deluge/drivers/mtu/mtu.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_ALL_CPUS_MTU_ALL_CPUS_H_
-#define DRIVERS_ALL_CPUS_MTU_ALL_CPUS_H_
+#pragma once
 
 #include "RZA1/mtu/mtu.h"
 
@@ -27,5 +26,3 @@ static inline void timerEnableInterruptsTGRA(int timerNo) {
 static inline void timerDisableInterruptsTGRA(int timerNo) {
 	*TIER[timerNo] = 0;
 }
-
-#endif /* DRIVERS_ALL_CPUS_MTU_ALL_CPUS_H_ */

--- a/src/deluge/drivers/oled/oled.h
+++ b/src/deluge/drivers/oled/oled.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_H_
-#define DRIVERS_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_H_
+#pragma once
 
 #define SPI_TRANSFER_QUEUE_SIZE 32
 
@@ -35,5 +34,3 @@ struct SpiTransferQueueItem {
 };
 
 extern struct SpiTransferQueueItem spiTransferQueue[SPI_TRANSFER_QUEUE_SIZE];
-
-#endif /* DRIVERS_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_H_ */

--- a/src/deluge/drivers/rspi/rspi.h
+++ b/src/deluge/drivers/rspi/rspi.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_ALL_CPUS_RSPI_ALL_CPUS_RSPI_ALL_CPUS_H_
-#define DRIVERS_ALL_CPUS_RSPI_ALL_CPUS_RSPI_ALL_CPUS_H_
+#pragma once
 
 #include "RZA1/system/iodefine.h"
 #include "RZA1/system/r_typedefs.h"
@@ -25,5 +24,3 @@ void R_RSPI_SendBasic8(uint8_t channel, uint8_t data);
 void R_RSPI_SendBasic32(uint8_t channel, uint32_t data);
 void R_RSPI_WaitEnd(uint8_t channel);
 int R_RSPI_HasEnded(uint8_t channel);
-
-#endif /* DRIVERS_ALL_CPUS_RSPI_ALL_CPUS_RSPI_ALL_CPUS_H_ */

--- a/src/deluge/drivers/ssi/ssi.h
+++ b/src/deluge/drivers/ssi/ssi.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_ALL_CPUS_SSI_ALL_CPUS_SSI_ALL_CPUS_H_
-#define DRIVERS_ALL_CPUS_SSI_ALL_CPUS_SSI_ALL_CPUS_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -31,5 +30,3 @@ int32_t* getTxBufferStart();
 int32_t* getTxBufferEnd();
 int32_t* getRxBufferStart();
 int32_t* getRxBufferEnd();
-
-#endif /* DRIVERS_ALL_CPUS_SSI_ALL_CPUS_SSI_ALL_CPUS_H_ */

--- a/src/deluge/drivers/uart/uart.h
+++ b/src/deluge/drivers/uart/uart.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_ALL_CPUS_UART_ALL_CPUS_UART_ALL_CPUS_H_
-#define DRIVERS_ALL_CPUS_UART_ALL_CPUS_UART_ALL_CPUS_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -64,5 +63,3 @@ int uartGetTxBufferFullnessByItem(int item);
 int uartGetTxBufferSpace(int item);
 
 extern void tx_interrupt(int item);
-
-#endif /* DRIVERS_ALL_CPUS_UART_ALL_CPUS_UART_ALL_CPUS_H_ */

--- a/src/deluge/drivers/usb/userdef/r_usb_pmidi_config.h
+++ b/src/deluge/drivers/usb/userdef/r_usb_pmidi_config.h
@@ -15,11 +15,8 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef R_USB_MIDI_CONFIG_H
-#define R_USB_MIDI_CONFIG_H
+#pragma once
 
 // Let's just keep these two pipes as not the same as the send-pipe for USB MIDI hosting (PIPE1)
 #define USB_CFG_PMIDI_BULK_IN (USB_PIPE2)
 #define USB_CFG_PMIDI_BULK_OUT (USB_PIPE3)
-
-#endif /* R_USB_MIDI_CONFIG_H */

--- a/src/deluge/dsp/compressor/compressor.h
+++ b/src/deluge/dsp/compressor/compressor.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef COMPRESSOR_H
-#define COMPRESSOR_H
+#pragma once
 
 #include "definitions.h"
 #include "RZA1/system/r_typedefs.h"
@@ -50,5 +49,3 @@ private:
 	int32_t getActualAttackRate();
 	int32_t getActualReleaseRate();
 };
-
-#endif // COMPRESSOR_H

--- a/src/deluge/dsp/convolution/impulse_response_processor.h
+++ b/src/deluge/dsp/convolution/impulse_response_processor.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef IMPULSERESPONSEPROCESSOR_H_
-#define IMPULSERESPONSEPROCESSOR_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "dsp/stereo_sample.h"
@@ -46,5 +45,3 @@ public:
 		buffer[IR_BUFFER_SIZE - 1].r = multiply_32x32_rshift32_rounded(inputR, ir[IR_BUFFER_SIZE]);
 	}
 };
-
-#endif /* IMPULSERESPONSEPROCESSOR_H_ */

--- a/src/deluge/dsp/delay/delay.h
+++ b/src/deluge/dsp/delay/delay.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DELAY_H_
-#define DELAY_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "dsp/stereo_sample.h"
@@ -66,5 +65,3 @@ private:
 	void prepareToBeginWriting();
 	int getAmountToWriteBeforeReadingBegins();
 };
-
-#endif /* DELAY_H_ */

--- a/src/deluge/dsp/delay/delay_buffer.h
+++ b/src/deluge/dsp/delay/delay_buffer.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DELAYBUFFER_H_
-#define DELAYBUFFER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include <math.h>
@@ -302,5 +301,3 @@ public:
 	uint32_t sizeIncludingExtra;
 	bool isResampling;
 };
-
-#endif /* DELAYBUFFER_H_ */

--- a/src/deluge/dsp/fft/fft_config_manager.h
+++ b/src/deluge/dsp/fft/fft_config_manager.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef FFTCONFIGMANAGER_H_
-#define FFTCONFIGMANAGER_H_
+#pragma once
 
 #include "NE10.h"
 
@@ -25,5 +24,3 @@ namespace FFTConfigManager {
 ne10_fft_r2c_cfg_int32_t getConfig(int magnitude);
 
 }
-
-#endif /* FFTCONFIGMANAGER_H_ */

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef FILTERSET_H_
-#define FILTERSET_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "util/functions.h"
@@ -132,5 +131,3 @@ private:
 	int32_t do24dBLPFOnSample(int32_t input, FilterSetConfig* filterSetConfig, int saturationLevel);
 	int32_t doDriveLPFOnSample(int32_t input, FilterSetConfig* filterSetConfig, int extraSaturation = 0);
 };
-
-#endif /* FILTERSET_H_ */

--- a/src/deluge/dsp/filter/filter_set_config.h
+++ b/src/deluge/dsp/filter/filter_set_config.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef FILTERSETCONFIG_H_
-#define FILTERSETCONFIG_H_
+#pragma once
 
 #include "definitions.h"
 
@@ -60,5 +59,3 @@ public:
 
 	bool doOversampling;
 };
-
-#endif /* FILTERSETCONFIG_H_ */

--- a/src/deluge/dsp/master_compressor/master_compressor.h
+++ b/src/deluge/dsp/master_compressor/master_compressor.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef MASTERCOMPRESSOR_H_
-#define MASTERCOMPRESSOR_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -231,5 +230,3 @@ public:
 
 	chunkware_simple::SimpleComp compressor;
 };
-
-#endif /* MASTERCOMPRESSOR_H_ */

--- a/src/deluge/dsp/reverb/freeverb/allpass.hpp
+++ b/src/deluge/dsp/reverb/freeverb/allpass.hpp
@@ -21,8 +21,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _allpass_
-#define _allpass_
+#pragma once
 #include "RZA1/system/r_typedefs.h"
 #include "util/functions.h"
 
@@ -57,7 +56,5 @@ inline int32_t allpass::process(int32_t input) {
 
 	return output;
 }
-
-#endif //_allpass
 
 //ends

--- a/src/deluge/dsp/reverb/freeverb/comb.hpp
+++ b/src/deluge/dsp/reverb/freeverb/comb.hpp
@@ -21,8 +21,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef _comb_
-#define _comb_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "util/functions.h"
@@ -65,7 +64,5 @@ inline int32_t comb::process(int32_t input) {
 
 	return output;
 }
-
-#endif //_comb_
 
 //ends

--- a/src/deluge/dsp/reverb/freeverb/revmodel.hpp
+++ b/src/deluge/dsp/reverb/freeverb/revmodel.hpp
@@ -21,8 +21,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef _revmodel_
-#define _revmodel_
+#pragma once
 
 #include "dsp/reverb/freeverb/comb.hpp"
 #include "dsp/reverb/freeverb/allpass.hpp"
@@ -122,7 +121,5 @@ private:
 	int32_t bufallpassL4[allpasstuningL4];
 	int32_t bufallpassR4[allpasstuningR4];
 };
-
-#endif //_revmodel_
 
 //ends

--- a/src/deluge/dsp/reverb/freeverb/tuning.h
+++ b/src/deluge/dsp/reverb/freeverb/tuning.h
@@ -21,8 +21,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef _tuning_
-#define _tuning_
+#pragma once
 
 const int numcombs = 8;
 const int numallpasses = 4;
@@ -70,7 +69,5 @@ const int allpasstuningL3 = 341;
 const int allpasstuningR3 = 341 + stereospread;
 const int allpasstuningL4 = 225;
 const int allpasstuningR4 = 225 + stereospread;
-
-#endif //_tuning_
 
 //ends

--- a/src/deluge/dsp/stereo_sample.h
+++ b/src/deluge/dsp/stereo_sample.h
@@ -17,8 +17,7 @@
 
 // Ok, creating a class for this is absolutely stupid, but I was a noob at the time! It doesn't add any performance overhead though.
 
-#ifndef AUDIOSAMPLE_H
-#define AUDIOSAMPLE_H
+#pragma once
 
 #include "util/functions.h"
 
@@ -48,5 +47,3 @@ public:
 	int32_t l;
 	int32_t r;
 };
-
-#endif // AUDIOSAMPLE_H

--- a/src/deluge/dsp/timestretch/time_stretcher.h
+++ b/src/deluge/dsp/timestretch/time_stretcher.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SRC_TIMESTRETCHER_H_
-#define SRC_TIMESTRETCHER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -126,5 +125,3 @@ inline int32_t getTotalChange(int32_t* totals1, int32_t* totals2) {
 	}
 	return totalChange;
 }
-
-#endif /* SRC_TIMESTRETCHER_H_ */

--- a/src/deluge/extern.h
+++ b/src/deluge/extern.h
@@ -17,12 +17,9 @@
 
 // Was I going to expand this file to have more stuff?
 
-#ifndef EXTERN_H_
-#define EXTERN_H_
+#pragma once
 
 extern bool sdRoutineLock;
 extern int16_t zeroMPEValues[];
 extern bool allowSomeUserActionsEvenWhenInCardRoutine;
 extern bool readButtonsAndPads();
-
-#endif /* EXTERN_H_ */

--- a/src/deluge/gui/context_menu/audio_input_selector.h
+++ b/src/deluge/gui/context_menu/audio_input_selector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOINPUTSELECTOR_H_
-#define AUDIOINPUTSELECTOR_H_
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -34,5 +33,3 @@ public:
 };
 
 extern AudioInputSelector audioInputSelector;
-
-#endif /* AUDIOINPUTSELECTOR_H_ */

--- a/src/deluge/gui/context_menu/context_menu.h
+++ b/src/deluge/gui/context_menu/context_menu.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONTEXTMENU_H_
-#define CONTEXTMENU_H_
+#pragma once
 
 #include "gui/ui/ui.h"
 #include "hid/button.h"
@@ -63,5 +62,3 @@ public:
 	void focusRegained();
 	virtual hid::Button getAcceptButton() final { return hid::button::LOAD; }
 };
-
-#endif /* CONTEXTMENU_H_ */

--- a/src/deluge/gui/context_menu/context_menu_delete_file.h
+++ b/src/deluge/gui/context_menu/context_menu_delete_file.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONTEXTMENUDELETEFILE_H_
-#define CONTEXTMENUDELETEFILE_H_
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -29,5 +28,3 @@ public:
 };
 
 extern ContextMenuDeleteFile contextMenuDeleteFile;
-
-#endif /* CONTEXTMENUDELETEFILE_H_ */

--- a/src/deluge/gui/context_menu/context_menu_load_instrument_preset.h
+++ b/src/deluge/gui/context_menu/context_menu_load_instrument_preset.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONTEXTMENULOADINSTRUMENTPRESET_H_
-#define CONTEXTMENULOADINSTRUMENTPRESET_H_
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -28,5 +27,3 @@ public:
 };
 
 extern ContextMenuLoadInstrumentPreset contextMenuLoadInstrumentPreset;
-
-#endif /* CONTEXTMENULOADINSTRUMENTPRESET_H_ */

--- a/src/deluge/gui/context_menu/context_menu_overwrite_bootloader.h
+++ b/src/deluge/gui/context_menu/context_menu_overwrite_bootloader.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONTEXTMENUOVERWRITEBOOTLOADER_H_
-#define CONTEXTMENUOVERWRITEBOOTLOADER_H_
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -29,5 +28,3 @@ public:
 };
 
 extern ContextMenuOverwriteBootloader contextMenuOverwriteBootloader;
-
-#endif /* CONTEXTMENUOVERWRITEBOOTLOADER_H_ */

--- a/src/deluge/gui/context_menu/context_menu_overwrite_file.h
+++ b/src/deluge/gui/context_menu/context_menu_overwrite_file.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONTEXTMENUOVERWRITEFILE_H_
-#define CONTEXTMENUOVERWRITEFILE_H_
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -33,5 +32,3 @@ public:
 };
 
 extern ContextMenuOverwriteFile contextMenuOverwriteFile;
-
-#endif /* CONTEXTMENUOVERWRITEFILE_H_ */

--- a/src/deluge/gui/context_menu/context_menu_sample_browser_kit.h
+++ b/src/deluge/gui/context_menu/context_menu_sample_browser_kit.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONTEXTMENUSAMPLEBROWSERKIT_H_
-#define CONTEXTMENUSAMPLEBROWSERKIT_H_
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -34,5 +33,3 @@ public:
 };
 
 extern ContextMenuSampleBrowserKit contextMenuFileBrowserKit;
-
-#endif /* CONTEXTMENUSAMPLEBROWSERKIT_H_ */

--- a/src/deluge/gui/context_menu/context_menu_sample_browser_synth.h
+++ b/src/deluge/gui/context_menu/context_menu_sample_browser_synth.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONTEXTMENUSAMPLEBROWSERSYNTH_H_
-#define CONTEXTMENUSAMPLEBROWSERSYNTH_H_
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -34,5 +33,3 @@ public:
 };
 
 extern ContextMenuSampleBrowserSynth contextMenuFileBrowserSynth;
-
-#endif /* CONTEXTMENUSAMPLEBROWSERSYNTH_H_ */

--- a/src/deluge/gui/context_menu/contextmenuclearsong.h
+++ b/src/deluge/gui/context_menu/contextmenuclearsong.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLEARSONGUI_H
-#define CLEARSONGUI_H
+#pragma once
 
 #include "gui/context_menu/context_menu.h"
 
@@ -31,5 +30,3 @@ public:
 };
 
 extern ContextMenuClearSong contextMenuClearSong;
-
-#endif // CLEARSONGUI_H

--- a/src/deluge/gui/context_menu/save_song_or_instrument_context_menu.h
+++ b/src/deluge/gui/context_menu/save_song_or_instrument_context_menu.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAVESONGORINSTRUMENTCONTEXTMENU_H_
-#define SAVESONGORINSTRUMENTCONTEXTMENU_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "gui/context_menu/context_menu.h"
@@ -34,5 +33,3 @@ public:
 };
 
 extern SaveSongOrInstrumentContextMenu saveSongOrInstrumentContextMenu;
-
-#endif /* SAVESONGORINSTRUMENTCONTEXTMENU_H_ */

--- a/src/deluge/gui/fonts/fonts.h
+++ b/src/deluge/gui/fonts/fonts.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_FONTS_H_
-#define DRIVERS_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_FONTS_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -36,5 +35,3 @@ extern const lv_font_glyph_dsc_t font_apple_desc[];
 
 extern const uint8_t font_metric_bold_13px[];
 extern const lv_font_glyph_dsc_t font_metric_bold_13px_desc[];
-
-#endif /* DRIVERS_ALL_CPUS_OLED_LOW_LEVEL_ALL_CPUS_FONTS_H_ */

--- a/src/deluge/gui/positionable.h
+++ b/src/deluge/gui/positionable.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef POSITIONABLE_H_
-#define POSITIONABLE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -26,5 +25,3 @@ public:
 
 	int32_t pos;
 };
-
-#endif /* POSITIONABLE_H_ */

--- a/src/deluge/gui/ui/audio_recorder.h
+++ b/src/deluge/gui/ui/audio_recorder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIORECORDER_H_
-#define AUDIORECORDER_H_
+#pragma once
 
 #include "gui/ui/ui.h"
 #include "hid/button.h"
@@ -62,5 +61,3 @@ private:
 };
 
 extern AudioRecorder audioRecorder;
-
-#endif /* AUDIORECORDER_H_ */

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef BROWSER_H_
-#define BROWSER_H_
+#pragma once
 
 #include "util/container/array/c_string_array.h"
 #include "storage/file_item.h"
@@ -142,5 +141,3 @@ protected:
 	char const* filePrefix;
 	bool shouldInterpretNoteNamesForThisBrowser;
 };
-
-#endif /* BROWSER_H_ */

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef FILEBROWSER_H
-#define FILEBROWSER_H
+#pragma once
 
 #include "gui/ui/browser/browser.h"
 #include "hid/button.h"
@@ -85,5 +84,3 @@ private:
 };
 
 extern SampleBrowser sampleBrowser;
-
-#endif // FILEBROWSER_H

--- a/src/deluge/gui/ui/browser/slot_browser.h
+++ b/src/deluge/gui/ui/browser/slot_browser.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SLOTBROWSER_H_
-#define SLOTBROWSER_H_
+#pragma once
 
 #include "gui/ui/browser/browser.h"
 
@@ -51,5 +50,3 @@ protected:
 	                       // We do need this, separate from the current FileItem, because if user moves onto a folder,
 	                       // the currentInstrument needs to remain the same.
 };
-
-#endif /* SLOTBROWSER_H_ */

--- a/src/deluge/gui/ui/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard_screen.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KEYBOARDSCREEN_H_
-#define KEYBOARDSCREEN_H_
+#pragma once
 
 #include "gui/ui/root_ui.h"
 #include "gui/ui/ui.h"
@@ -78,4 +77,3 @@ private:
 };
 
 extern KeyboardScreen keyboardScreen;
-#endif /* KEYBOARDSCREEN_H_ */

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LOADINSTRUMENTPRESETUI_H_
-#define LOADINSTRUMENTPRESETUI_H_
+#pragma once
 
 #include "gui/ui/load/load_ui.h"
 #include "hid/button.h"
@@ -82,5 +81,3 @@ private:
 };
 
 extern LoadInstrumentPresetUI loadInstrumentPresetUI;
-
-#endif /* LOADINSTRUMENTPRESETUI_H_ */

--- a/src/deluge/gui/ui/load/load_song_ui.h
+++ b/src/deluge/gui/ui/load/load_song_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LOADSONGUI_H
-#define LOADSONGUI_H
+#pragma once
 
 #include "gui/ui/load/load_ui.h"
 #include "hid/button.h"
@@ -59,5 +58,3 @@ private:
 	void exitActionWithError();
 };
 extern LoadSongUI loadSongUI;
-
-#endif // LOADSONGUI_H

--- a/src/deluge/gui/ui/load/load_ui.h
+++ b/src/deluge/gui/ui/load/load_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LOADUI_H_
-#define LOADUI_H_
+#pragma once
 
 #include "gui/ui/browser/slot_browser.h"
 
@@ -29,5 +28,3 @@ public:
 protected:
 	virtual void searchMemoryForBetterFile(int offset, char* bestFilenameFound) {}
 };
-
-#endif /* LOADUI_H_ */

--- a/src/deluge/gui/ui/qwerty_ui.h
+++ b/src/deluge/gui/ui/qwerty_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef QWERTYUI_H_
-#define QWERTYUI_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "gui/ui/ui.h"
@@ -58,5 +57,3 @@ protected:
 
 private:
 };
-
-#endif /* QWERTYUI_H_ */

--- a/src/deluge/gui/ui/rename/rename_drum_ui.h
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef RENAMEDRUMUI_H_
-#define RENAMEDRUMUI_H_
+#pragma once
 
 #include "gui/ui/rename/rename_ui.h"
 #include "hid/button.h"
@@ -41,5 +40,3 @@ private:
 };
 
 extern RenameDrumUI renameDrumUI;
-
-#endif /* RENAMEDRUMUI_H_ */

--- a/src/deluge/gui/ui/rename/rename_output_ui.h
+++ b/src/deluge/gui/ui/rename/rename_output_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef RENAMEOUTPUTUI_H_
-#define RENAMEOUTPUTUI_H_
+#pragma once
 
 #include "gui/ui/rename/rename_ui.h"
 #include "hid/button.h"
@@ -42,5 +41,3 @@ private:
 };
 
 extern RenameOutputUI renameOutputUI;
-
-#endif /* RENAMEOUTPUTUI_H_ */

--- a/src/deluge/gui/ui/rename/rename_ui.h
+++ b/src/deluge/gui/ui/rename/rename_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef RENAMEUI_H_
-#define RENAMEUI_H_
+#pragma once
 
 #include "gui/ui/qwerty_ui.h"
 
@@ -29,5 +28,3 @@ public:
 	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
 #endif
 };
-
-#endif /* RENAMEUI_H_ */

--- a/src/deluge/gui/ui/root_ui.h
+++ b/src/deluge/gui/ui/root_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef ROOTUI_H_
-#define ROOTUI_H_
+#pragma once
 
 #include "gui/ui/ui.h"
 class Output;
@@ -40,5 +39,3 @@ public:
 	virtual void sampleNeedsReRendering(Sample* sample) {}
 	virtual void midiLearnFlash() {}
 };
-
-#endif /* ROOTUI_H_ */

--- a/src/deluge/gui/ui/sample_marker_editor.h
+++ b/src/deluge/gui/ui/sample_marker_editor.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEMARKEREDITOR_H_
-#define SAMPLEMARKEREDITOR_H_
+#pragma once
 
 #include "gui/ui/ui.h"
 #include "RZA1/system/r_typedefs.h"
@@ -77,5 +76,3 @@ private:
 };
 
 extern SampleMarkerEditor sampleMarkerEditor;
-
-#endif /* SAMPLEMARKEREDITOR_H_ */

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAVESYNTHPRESETUI_H
-#define SAVESYNTHPRESETUI_H
+#pragma once
 #include "gui/ui/save/save_ui.h"
 
 class Song;
@@ -42,5 +41,3 @@ protected:
 };
 
 extern SaveInstrumentPresetUI saveInstrumentPresetUI;
-
-#endif // SAVESYNTHPRESETUI_H

--- a/src/deluge/gui/ui/save/save_song_ui.h
+++ b/src/deluge/gui/ui/save/save_song_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SaveSongUI_h
-#define SaveSongUI_h
+#pragma once
 
 #include "gui/ui/save/save_ui.h"
 
@@ -41,5 +40,3 @@ protected:
 };
 
 extern SaveSongUI saveSongUI;
-
-#endif

--- a/src/deluge/gui/ui/save/save_ui.h
+++ b/src/deluge/gui/ui/save/save_ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAVEUI_H_
-#define SAVEUI_H_
+#pragma once
 
 #include "gui/ui/browser/slot_browser.h"
 #include "hid/button.h"
@@ -48,5 +47,3 @@ protected:
 	void enterKeyPress() final;
 	static bool currentFolderIsEmpty;
 };
-
-#endif /* SAVEUI_H_ */

--- a/src/deluge/gui/ui/slicer.h
+++ b/src/deluge/gui/ui/slicer.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SLICER_H_
-#define SLICER_H_
+#pragma once
 
 #include "gui/ui/ui.h"
 #include "hid/button.h"
@@ -43,5 +42,3 @@ private:
 };
 
 extern Slicer slicer;
-
-#endif /* SLICER_H_ */

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SOUNDEDITOR_H
-#define SOUNDEDITOR_H
+#pragma once
 
 #include "gui/ui/ui.h"
 #include "gui/menu_item/menu_item.h"
@@ -144,5 +143,3 @@ private:
 };
 
 extern SoundEditor soundEditor;
-
-#endif // SOUNDEDITOR_H

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef UI_h
-#define UI_h
+#pragma once
 
 #include "hid/button.h"
 #include "definitions.h"
@@ -169,5 +168,3 @@ bool isUIModeWithinRange(const uint32_t* modes);
 bool isNoUIModeActive();
 void exitUIMode(uint32_t uiMode);
 void enterUIMode(uint32_t uiMode);
-
-#endif

--- a/src/deluge/gui/ui_timer_manager.h
+++ b/src/deluge/gui/ui_timer_manager.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef UITIMERMANAGER_H
-#define UITIMERMANAGER_H
+#pragma once
 
 #include "definitions.h"
 
@@ -71,5 +70,3 @@ private:
 };
 
 extern UITimerManager uiTimerManager;
-
-#endif // UITIMERMANAGER_H

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ARRANGERVIEW_H_
-#define ARRANGERVIEW_H_
+#pragma once
 
 #include "gui/views/timeline_view.h"
 #include "hid/button.h"
@@ -143,5 +142,3 @@ private:
 };
 
 extern ArrangerView arrangerView;
-
-#endif /* ARRANGERVIEW_H_ */

--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOCLIPVIEW_H_
-#define AUDIOCLIPVIEW_H_
+#pragma once
 
 #include "gui/views/clip_view.h"
 #include "hid/button.h"
@@ -66,5 +65,3 @@ private:
 };
 
 extern AudioClipView audioClipView;
-
-#endif /* AUDIOCLIPVIEW_H_ */

--- a/src/deluge/gui/views/clip_navigation_timeline_view.h
+++ b/src/deluge/gui/views/clip_navigation_timeline_view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLIPNAVIGATIONTIMELINEVIEW_H_
-#define CLIPNAVIGATIONTIMELINEVIEW_H_
+#pragma once
 
 #include "gui/views/timeline_view.h"
 #include "RZA1/system/r_typedefs.h"
@@ -32,5 +31,3 @@ protected:
 
 	static int32_t xScrollBeforeFollowingAutoExtendingLinearRecording; // -1 means none
 };
-
-#endif /* CLIPNAVIGATIONTIMELINEVIEW_H_ */

--- a/src/deluge/gui/views/clip_view.h
+++ b/src/deluge/gui/views/clip_view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLIPVIEW_H_
-#define CLIPVIEW_H_
+#pragma once
 
 #include "gui/views/clip_navigation_timeline_view.h"
 #include "hid/button.h"
@@ -42,5 +41,3 @@ private:
 	Action* lengthenClip(int32_t newLength);
 	Action* shortenClip(int32_t newLength);
 };
-
-#endif /* CLIPVIEW_H_ */

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef EditModeUI_h
-#define EditModeUI_h
+#pragma once
 
 #include "gui/views/clip_view.h"
 #include "hid/button.h"
@@ -233,5 +232,3 @@ private:
 };
 
 extern InstrumentClipView instrumentClipView;
-
-#endif

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef OverviewModeUI_h
-#define OverviewModeUI_h
+#pragma once
 
 #include "gui/views/clip_navigation_timeline_view.h"
 #include "hid/button.h"
@@ -113,5 +112,3 @@ private:
 };
 
 extern SessionView sessionView;
-
-#endif

--- a/src/deluge/gui/views/timeline_view.h
+++ b/src/deluge/gui/views/timeline_view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef EDITORSCREEN_H
-#define EDITORSCREEN_H
+#pragma once
 
 #include "gui/ui/root_ui.h"
 #include "hid/button.h"
@@ -69,5 +68,3 @@ public:
 
 	bool inTripletsView();
 };
-
-#endif // EDITORSCREEN_H

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef VIEW_H_
-#define VIEW_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "hid/button.h"
@@ -127,5 +126,3 @@ private:
 };
 
 extern View view;
-
-#endif /* VIEW_H_ */

--- a/src/deluge/gui/waveform/waveform_basic_navigator.h
+++ b/src/deluge/gui/waveform/waveform_basic_navigator.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WAVEFORMBASICNAVIGATOR_H_
-#define WAVEFORMBASICNAVIGATOR_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -49,5 +48,3 @@ public:
 };
 
 extern WaveformBasicNavigator waveformBasicNavigator;
-
-#endif /* WAVEFORMBASICNAVIGATOR_H_ */

--- a/src/deluge/gui/waveform/waveform_render_data.h
+++ b/src/deluge/gui/waveform/waveform_render_data.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WAVEFORMRENDERDATA_H_
-#define WAVEFORMRENDERDATA_H_
+#pragma once
 
 #include "definitions.h"
 #include "RZA1/system/r_typedefs.h"
@@ -31,5 +30,3 @@ struct WaveformRenderData {
 	int32_t minPerCol[displayWidth];
 	uint8_t colStatus[displayWidth];
 };
-
-#endif // WAVEFORMRENDERDATA_H_

--- a/src/deluge/gui/waveform/waveform_renderer.h
+++ b/src/deluge/gui/waveform/waveform_renderer.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WAVEFORMRENDERER_H_
-#define WAVEFORMRENDERER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -72,5 +71,3 @@ private:
 };
 
 extern WaveformRenderer waveformRenderer;
-
-#endif /* WAVEFORMRENDERER_H_ */

--- a/src/deluge/hid/buttons.h
+++ b/src/deluge/hid/buttons.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef BUTTONS_H_
-#define BUTTONS_H_
+#pragma once
 
 #include <stddef.h>
 
@@ -32,5 +31,3 @@ void noPressesHappening(bool inCardRoutine);
 
 extern bool recordButtonPressUsedUp;
 } // namespace Buttons
-
-#endif /* BUTTONS_H_ */

--- a/src/deluge/hid/display/numeric_driver.h
+++ b/src/deluge/hid/display/numeric_driver.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NUMERICDRIVER_H
-#define NUMERICDRIVER_H
+#pragma once
 
 #include "definitions.h"
 
@@ -80,5 +79,3 @@ void displayPopupIfAllBootedUp(char const* text);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // NUMERICDRIVER_H

--- a/src/deluge/hid/display/numeric_layer/numeric_layer.h
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NUMERICLAYER_H_
-#define NUMERICLAYER_H_
+#pragma once
 
 #include "definitions.h"
 #include "RZA1/system/r_typedefs.h"
@@ -32,5 +31,3 @@ public:
 
 	NumericLayer* next;
 };
-
-#endif /* NUMERICLAYER_H_ */

--- a/src/deluge/hid/display/numeric_layer/numeric_layer_basic_text.h
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer_basic_text.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NUMERICLAYERBASICTEXT_H_
-#define NUMERICLAYERBASICTEXT_H_
+#pragma once
 
 #include "hid/display/numeric_layer/numeric_layer.h"
 
@@ -39,5 +38,3 @@ public:
 
 	int8_t blinkSpeed;
 };
-
-#endif /* NUMERICLAYERBASICTEXT_H_ */

--- a/src/deluge/hid/display/numeric_layer/numeric_layer_loading_animation.h
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer_loading_animation.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NUMERICLAYERLOADINGANIMATION_H_
-#define NUMERICLAYERLOADINGANIMATION_H_
+#pragma once
 
 #include "hid/display/numeric_layer/numeric_layer.h"
 
@@ -31,5 +30,3 @@ public:
 	int8_t loadingAnimationPos;
 	bool animationIsTransparent;
 };
-
-#endif /* NUMERICLAYERLOADINGANIMATION_H_ */

--- a/src/deluge/hid/display/numeric_layer/numeric_layer_scroll_transition.h
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer_scroll_transition.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NUMERICLAYERSCROLLTRANSITION_H_
-#define NUMERICLAYERSCROLLTRANSITION_H_
+#pragma once
 
 #include "hid/display/numeric_layer/numeric_layer.h"
 
@@ -33,5 +32,3 @@ public:
 	int8_t transitionDirection;
 	int8_t transitionProgress;
 };
-
-#endif /* NUMERICLAYERSCROLLTRANSITION_H_ */

--- a/src/deluge/hid/display/numeric_layer/numeric_layer_scrolling_text.h
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer_scrolling_text.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NUMERICLAYERSCROLLINGTEXT_H_
-#define NUMERICLAYERSCROLLINGTEXT_H_
+#pragma once
 
 #include "hid/display/numeric_layer/numeric_layer.h"
 
@@ -34,5 +33,3 @@ public:
 	int8_t currentPos;
 	int16_t initialDelay;
 };
-
-#endif /* NUMERICLAYERSCROLLINGTEXT_H_ */

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef DRIVERS_RZA2_OLED_OLED_H_
-#define DRIVERS_RZA2_OLED_OLED_H_
+#pragma once
 
 #include "definitions.h"
 
@@ -102,5 +101,3 @@ void consoleTextIfAllBootedUp(char const* text);
 #endif
 
 #endif /* HAVE_OLED */
-
-#endif /* DRIVERS_RZA2_OLED_OLED_H_ */

--- a/src/deluge/hid/encoder.h
+++ b/src/deluge/hid/encoder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef Encoder_h
-#define Encoder_h
+#pragma once
 
 #define encMinBacktrackTime (20 * 44) // In milliseconds/44
 #include "RZA1/system/r_typedefs.h"
@@ -44,5 +43,3 @@ private:
 	bool doDetents;
 	bool valuesNow[2];
 };
-
-#endif

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ENCODERS_H_
-#define ENCODERS_H_
+#pragma once
 
 #include "hid/encoder.h"
 
@@ -29,5 +28,3 @@ void init();
 void readEncoders();
 bool interpretEncoders(bool inCardRoutine = false);
 } // namespace Encoders
-
-#endif /* ENCODERS_H_ */

--- a/src/deluge/hid/led/indicator_leds.h
+++ b/src/deluge/hid/led/indicator_leds.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef INDICATORLEDS_H_
-#define INDICATORLEDS_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -51,5 +50,3 @@ bool updateBlinkingLedStates(uint8_t blinkingType);
 bool isKnobIndicatorBlinking(int whichKnob);
 
 } // namespace IndicatorLEDs
-
-#endif /* INDICATORLEDS_H_ */

--- a/src/deluge/hid/led/pad_leds.h
+++ b/src/deluge/hid/led/pad_leds.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PADLEDS_H_
-#define PADLEDS_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -106,5 +105,3 @@ void copyBetweenImageStores(uint8_t* dest, uint8_t* source, int destWidth, int s
 void moveBetweenImageStores(uint8_t* dest, uint8_t* source, int destWidth, int sourceWidth, int copyWidth);
 
 } // namespace PadLEDs
-
-#endif /* PADLEDS_H_ */

--- a/src/deluge/hid/matrix/matrix_driver.h
+++ b/src/deluge/hid/matrix/matrix_driver.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DISPLAYMANAGER_H
-#define DISPLAYMANAGER_H
+#pragma once
 
 #include "definitions.h"
 #include "RZA1/system/r_typedefs.h"
@@ -41,4 +40,3 @@ public:
 extern char* matrixDriverDisplayWritePos;
 
 extern MatrixDriver matrixDriver;
-#endif // DISPLAYMANAGER_H

--- a/src/deluge/io/midi/learned_midi.h
+++ b/src/deluge/io/midi/learned_midi.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LEARNEDMIDI_H_
-#define LEARNEDMIDI_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "io/midi/midi_device_manager.h"
@@ -85,5 +84,3 @@ public:
 	                   // Channels 18-36 signify CCs on channels 1-16+MPE respectively. Check with the constant IS_A_CC
 	uint8_t noteOrCC;
 };
-
-#endif /* LEARNEDMIDI_H_ */

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIDEVICE_H_
-#define MIDIDEVICE_H_
+#pragma once
 
 #include "util/d_string.h"
 #include "definitions.h"
@@ -173,5 +172,3 @@ public:
 	char const* getDisplayName();
 	void sendMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
 };
-
-#endif /* MIDIDEVICE_H_ */

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIDEVICEMANAGER_H_
-#define MIDIDEVICEMANAGER_H_
+#pragma once
 #include "definitions.h"
 
 #ifdef __cplusplus
@@ -104,5 +103,3 @@ extern bool anyChangesToSave;
 #endif
 
 extern struct ConnectedUSBMIDIDevice connectedUSBMIDIDevices[][MAX_NUM_USB_MIDI_DEVICES];
-
-#endif /* MIDIDEVICEMANAGER_H_ */

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIENGINE_H
-#define MIDIENGINE_H
+#pragma once
 
 #ifdef __cplusplus
 
@@ -94,5 +93,3 @@ void usbSendComplete(int ip);
 #ifdef __cplusplus
 }
 #endif
-
-#endif // MIDIENGINE_H

--- a/src/deluge/io/uart/uart.h
+++ b/src/deluge/io/uart/uart.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef UART_H_
-#define UART_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -30,5 +29,3 @@ void printfloat(float number);
 void print(int32_t number);
 unsigned int getTxBufferFullness(uint8_t scifID);
 } // namespace Uart
-
-#endif /* UART_H_ */

--- a/src/deluge/memory/general_memory_allocator.h
+++ b/src/deluge/memory/general_memory_allocator.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef GENERALMEMORYALLOCATOR_H_
-#define GENERALMEMORYALLOCATOR_H_
+#pragma once
 
 #include "memory/memory_region.h"
 
@@ -87,5 +86,3 @@ private:
 };
 
 extern GeneralMemoryAllocator generalMemoryAllocator;
-
-#endif /* GENERALMEMORYALLOCATOR_H_ */

--- a/src/deluge/memory/memory_region.h
+++ b/src/deluge/memory/memory_region.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef MEMORYREGION_H_
-#define MEMORYREGION_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array_with_multi_word_key.h"
 #include "util/container/list/bidirectional_linked_list.h"
@@ -76,5 +75,3 @@ private:
 	void writeTempHeadersBeforeASteal(uint32_t newStartAddress, uint32_t newSize);
 	void sanityCheck();
 };
-
-#endif /* MEMORYREGION_H_ */

--- a/src/deluge/memory/stealable.h
+++ b/src/deluge/memory/stealable.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef STEALABLE_H_
-#define STEALABLE_H_
+#pragma once
 
 #include "util/container/list/bidirectional_linked_list.h"
 
@@ -31,5 +30,3 @@ public:
 
 	uint32_t lastTraversalNo;
 };
-
-#endif /* STEALABLE_H_ */

--- a/src/deluge/model/action/action.h
+++ b/src/deluge/model/action/action.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ACTION_H_
-#define ACTION_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -139,5 +138,3 @@ public:
 
 private:
 };
-
-#endif /* ACTION_H_ */

--- a/src/deluge/model/action/action_clip_state.h
+++ b/src/deluge/model/action/action_clip_state.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ACTIONCLIPSTATE_H_
-#define ACTIONCLIPSTATE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -35,5 +34,3 @@ public:
 	uint32_t wrapEditLevel;
 	int selectedDrumIndex; // -1 means none
 };
-
-#endif /* ACTIONCLIPSTATE_H_ */

--- a/src/deluge/model/action/action_logger.h
+++ b/src/deluge/model/action/action_logger.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ACTIONLOGGER_H_
-#define ACTIONLOGGER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "model/action/action.h"
@@ -58,5 +57,3 @@ private:
 };
 
 extern ActionLogger actionLogger;
-
-#endif /* ACTIONLOGGER_H_ */

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOCLIP_H_
-#define AUDIOCLIP_H_
+#pragma once
 
 #include "model/clip/clip.h"
 #include "model/sample/sample_holder_for_clip.h"
@@ -114,5 +113,3 @@ private:
 	void detachAudioClipFromOutput(Song* song, bool shouldRetainLinksToOutput, bool shouldTakeParamManagerWith = false);
 	int getLoopingType(ModelStackWithTimelineCounter const* modelStack);
 };
-
-#endif /* AUDIOCLIP_H_ */

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLIP_H_
-#define CLIP_H_
+#pragma once
 
 #include "model/timeline_counter.h"
 #include "RZA1/system/r_typedefs.h"
@@ -189,5 +188,3 @@ protected:
 	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {
 	}
 };
-
-#endif /* CLIP_H_ */

--- a/src/deluge/model/clip/clip_array.h
+++ b/src/deluge/model/clip/clip_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLIPARRAY_H_
-#define CLIPARRAY_H_
+#pragma once
 
 #include "util/container/array/resizeable_pointer_array.h"
 
@@ -29,5 +28,3 @@ public:
 	Clip* getClipAtIndex(int index);
 	int getIndexForClip(Clip* clip);
 };
-
-#endif /* CLIPARRAY_H_ */

--- a/src/deluge/model/clip/clip_instance.h
+++ b/src/deluge/model/clip/clip_instance.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLIPINSTANCE_H_
-#define CLIPINSTANCE_H_
+#pragma once
 
 #include "gui/positionable.h"
 #include "RZA1/system/r_typedefs.h"
@@ -35,5 +34,3 @@ public:
 	int32_t length;
 	Clip* clip;
 };
-
-#endif /* CLIPINSTANCE_H_ */

--- a/src/deluge/model/clip/clip_instance_vector.h
+++ b/src/deluge/model/clip/clip_instance_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLIPINSTANCEVECTOR_H_
-#define CLIPINSTANCEVECTOR_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -28,5 +27,3 @@ public:
 
 	ClipInstance* getElement(int index); // Plz deprecate.
 };
-
-#endif /* CLIPINSTANCEVECTOR_H_ */

--- a/src/deluge/model/clip/clip_minder.h
+++ b/src/deluge/model/clip/clip_minder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLIPMINDER_H_
-#define CLIPMINDER_H_
+#pragma once
 
 #include "hid/button.h"
 #include "definitions.h"
@@ -25,5 +24,3 @@ class ClipMinder {
 public:
 	int buttonAction(hid::Button b, bool on);
 };
-
-#endif /* CLIPMINDER_H_ */

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef INSTRUMENTCLIP_H
-#define INSTRUMENTCLIP_H
+#pragma once
 
 #include "model/clip/clip.h"
 #include "model/timeline_counter.h"
@@ -256,5 +255,3 @@ private:
 	int32_t lastProbabiltyPos[NUM_PROBABILITY_VALUES];
 	bool currentlyRecordingLinearly;
 };
-
-#endif

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef INSTRUMENTCLIPMINDER_H_
-#define INSTRUMENTCLIPMINDER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "hid/button.h"
@@ -58,5 +57,3 @@ public:
 
 	static uint8_t editingMIDICCForWhichModKnob;
 };
-
-#endif /* INSTRUMENTCLIPMINDER_H_ */

--- a/src/deluge/model/consequence/consequence.h
+++ b/src/deluge/model/consequence/consequence.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCE_H_
-#define CONSEQUENCE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -39,5 +38,3 @@ public:
 	Consequence* next;
 	uint8_t type;
 };
-
-#endif /* CONSEQUENCE_H_ */

--- a/src/deluge/model/consequence/consequence_arranger_params_time_inserted.h
+++ b/src/deluge/model/consequence/consequence_arranger_params_time_inserted.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCEARRANGERPARAMSTIMEINSERTED_H_
-#define CONSEQUENCEARRANGERPARAMSTIMEINSERTED_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -28,5 +27,3 @@ public:
 	int32_t pos;
 	int32_t length;
 };
-
-#endif /* CONSEQUENCEARRANGERPARAMSTIMEINSERTED_H_ */

--- a/src/deluge/model/consequence/consequence_audio_clip_set_sample.h
+++ b/src/deluge/model/consequence/consequence_audio_clip_set_sample.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCEAUDIOCLIPSETSAMPLE_H_
-#define CONSEQUENCEAUDIOCLIPSETSAMPLE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "util/d_string.h"
@@ -32,5 +31,3 @@ public:
 	String filePathToRevertTo;
 	uint64_t endPosToRevertTo;
 };
-
-#endif /* CONSEQUENCEAUDIOCLIPSETSAMPLE_H_ */

--- a/src/deluge/model/consequence/consequence_begin_playback.h
+++ b/src/deluge/model/consequence/consequence_begin_playback.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCEBEGINPLAYBACK_H_
-#define CONSEQUENCEBEGINPLAYBACK_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 
@@ -25,5 +24,3 @@ public:
 	ConsequenceBeginPlayback();
 	int revert(int time, ModelStack* modelStack);
 };
-
-#endif /* CONSEQUENCEBEGINPLAYBACK_H_ */

--- a/src/deluge/model/consequence/consequence_clip_begin_linear_record.h
+++ b/src/deluge/model/consequence/consequence_clip_begin_linear_record.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCECLIPBEGINLINEARRECORD_H_
-#define CONSEQUENCECLIPBEGINLINEARRECORD_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 
@@ -30,5 +29,3 @@ public:
 
 	Clip* clip;
 };
-
-#endif /* CONSEQUENCECLIPBEGINLINEARRECORD_H_ */

--- a/src/deluge/model/consequence/consequence_clip_existence.h
+++ b/src/deluge/model/consequence/consequence_clip_existence.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCECLIPEXISTENCE_H_
-#define CONSEQUENCECLIPEXISTENCE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -36,5 +35,3 @@ public:
 	uint8_t type;
 	bool shouldBeActiveWhileExistent;
 };
-
-#endif /* CONSEQUENCECLIPEXISTENCE_H_ */

--- a/src/deluge/model/consequence/consequence_clip_horizontal_shift.h
+++ b/src/deluge/model/consequence/consequence_clip_horizontal_shift.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCECLIPHORIZONTALSHIFT_H_
-#define CONSEQUENCECLIPHORIZONTALSHIFT_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -28,5 +27,3 @@ public:
 
 	int32_t amount;
 };
-
-#endif /* CONSEQUENCECLIPHORIZONTALSHIFT_H_ */

--- a/src/deluge/model/consequence/consequence_clip_instance_change.h
+++ b/src/deluge/model/consequence/consequence_clip_instance_change.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCECLIPINSTANCECHANGE_H_
-#define CONSEQUENCECLIPINSTANCECHANGE_H_
+#pragma once
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
 
@@ -35,5 +34,3 @@ public:
 	int32_t length[2];
 	Clip* clip[2];
 };
-
-#endif /* CONSEQUENCECLIPINSTANCECHANGE_H_ */

--- a/src/deluge/model/consequence/consequence_clip_instance_existence.h
+++ b/src/deluge/model/consequence/consequence_clip_instance_existence.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCECLIPINSTANCEEXISTENCE_H_
-#define CONSEQUENCECLIPINSTANCEEXISTENCE_H_
+#pragma once
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
 
@@ -37,5 +36,3 @@ public:
 
 	uint8_t type;
 };
-
-#endif /* CONSEQUENCECLIPINSTANCEEXISTENCE_H_ */

--- a/src/deluge/model/consequence/consequence_clip_length.h
+++ b/src/deluge/model/consequence/consequence_clip_length.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCECLIPLENGTH_H_
-#define CONSEQUENCECLIPLENGTH_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -34,5 +33,3 @@ public:
 	uint64_t* pointerToMarkerValue;
 	uint64_t markerValueToRevertTo;
 };
-
-#endif /* CONSEQUENCECLIPLENGTH_H_ */

--- a/src/deluge/model/consequence/consequence_instrument_clip_multiply.h
+++ b/src/deluge/model/consequence/consequence_instrument_clip_multiply.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCEINSTRUMENTCLIPMULTIPLY_H_
-#define CONSEQUENCEINSTRUMENTCLIPMULTIPLY_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -27,5 +26,3 @@ public:
 
 	int revert(int time, ModelStack* modelStack);
 };
-
-#endif /* CONSEQUENCEINSTRUMENTCLIPMULTIPLY_H_ */

--- a/src/deluge/model/consequence/consequence_note_array_change.h
+++ b/src/deluge/model/consequence/consequence_note_array_change.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCENOTEARRAYCHANGE_H_
-#define CONSEQUENCENOTEARRAYCHANGE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -34,5 +33,3 @@ public:
 
 	NoteVector backedUpNoteVector;
 };
-
-#endif /* CONSEQUENCENOTEARRAYCHANGE_H_ */

--- a/src/deluge/model/consequence/consequence_note_existence.h
+++ b/src/deluge/model/consequence/consequence_note_existence.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCENOTEEXISTENCE_H_
-#define CONSEQUENCENOTEEXISTENCE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -38,5 +37,3 @@ public:
 
 	uint8_t type;
 };
-
-#endif /* CONSEQUENCENOTEEXISTENCE_H_ */

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.h
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCENOTEROWHORIZONTALSHIFT_H_
-#define CONSEQUENCENOTEROWHORIZONTALSHIFT_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -29,5 +28,3 @@ public:
 	int noteRowId;
 	int32_t amount;
 };
-
-#endif /* CONSEQUENCENOTEROWHORIZONTALSHIFT_H_ */

--- a/src/deluge/model/consequence/consequence_note_row_length.h
+++ b/src/deluge/model/consequence/consequence_note_row_length.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCENOTEROWLENGTH_H_
-#define CONSEQUENCENOTEROWLENGTH_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 
@@ -32,5 +31,3 @@ public:
 	int32_t backedUpLength;
 	int noteRowId;
 };
-
-#endif /* CONSEQUENCENOTEROWLENGTH_H_ */

--- a/src/deluge/model/consequence/consequence_note_row_mute.h
+++ b/src/deluge/model/consequence/consequence_note_row_mute.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCENOTEROWMUTE_H_
-#define CONSEQUENCENOTEROWMUTE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 
@@ -28,5 +27,3 @@ public:
 	int noteRowId;
 	InstrumentClip* clip;
 };
-
-#endif /* CONSEQUENCENOTEROWMUTE_H_ */

--- a/src/deluge/model/consequence/consequence_output_existence.h
+++ b/src/deluge/model/consequence/consequence_output_existence.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCEOUTPUTEXISTENCE_H_
-#define CONSEQUENCEOUTPUTEXISTENCE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 
@@ -31,5 +30,3 @@ public:
 	int outputIndex;
 	uint8_t type;
 };
-
-#endif /* CONSEQUENCEOUTPUTEXISTENCE_H_ */

--- a/src/deluge/model/consequence/consequence_param_change.h
+++ b/src/deluge/model/consequence/consequence_param_change.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCEPARAMAUTOMATIONRECORD_H_
-#define CONSEQUENCEPARAMAUTOMATIONRECORD_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "modulation/automation/auto_param.h"
@@ -34,5 +33,3 @@ public:
 	};
 	AutoParamState state;
 };
-
-#endif /* CONSEQUENCEPARAMAUTOMATIONRECORD_H_ */

--- a/src/deluge/model/consequence/consequence_scale_add_note.h
+++ b/src/deluge/model/consequence/consequence_scale_add_note.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCESCALEADDNOTE_H_
-#define CONSEQUENCESCALEADDNOTE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -28,5 +27,3 @@ public:
 
 	uint8_t noteWithinOctave;
 };
-
-#endif /* CONSEQUENCESCALEADDNOTE_H_ */

--- a/src/deluge/model/consequence/consequence_swing_change.h
+++ b/src/deluge/model/consequence/consequence_swing_change.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCESWINGCHANGE_H_
-#define CONSEQUENCESWINGCHANGE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -28,5 +27,3 @@ public:
 
 	int8_t swing[2];
 };
-
-#endif /* CONSEQUENCESWINGCHANGE_H_ */

--- a/src/deluge/model/consequence/consequence_tempo_change.h
+++ b/src/deluge/model/consequence/consequence_tempo_change.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CONSEQUENCETEMPOCHANGE_H_
-#define CONSEQUENCETEMPOCHANGE_H_
+#pragma once
 
 #include "model/consequence/consequence.h"
 #include "RZA1/system/r_typedefs.h"
@@ -28,5 +27,3 @@ public:
 
 	uint64_t timePerBig[2];
 };
-
-#endif /* CONSEQUENCETEMPOCHANGE_H_ */

--- a/src/deluge/model/drum/drum.h
+++ b/src/deluge/model/drum/drum.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DRUM_H
-#define DRUM_H
+#pragma once
 
 #include "definitions.h"
 #include "RZA1/system/r_typedefs.h"
@@ -92,5 +91,3 @@ public:
 
 	virtual ModControllable* toModControllable() { return NULL; }
 };
-
-#endif // DRUM_H

--- a/src/deluge/model/drum/drum_name.h
+++ b/src/deluge/model/drum/drum_name.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DRUMNAME_H_
-#define DRUMNAME_H_
+#pragma once
 
 #include "util/d_string.h"
 
@@ -28,5 +27,3 @@ public:
 	String name;
 	DrumName* next;
 };
-
-#endif /* DRUMNAME_H_ */

--- a/src/deluge/model/drum/gate_drum.h
+++ b/src/deluge/model/drum/gate_drum.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef GATEDRUM_H_
-#define GATEDRUM_H_
+#pragma once
 
 #include "model/drum/non_audio_drum.h"
 #include "RZA1/system/r_typedefs.h"
@@ -38,5 +37,3 @@ public:
 	void getName(char* buffer);
 	int getNumChannels();
 };
-
-#endif /* GATEDRUM_H_ */

--- a/src/deluge/model/drum/kit.h
+++ b/src/deluge/model/drum/kit.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KIT_H
-#define KIT_H
+#pragma once
 
 #include "model/global_effectable/global_effectable_for_clip.h"
 #include "model/instrument/instrument.h"
@@ -119,5 +118,3 @@ private:
 	void removeDrumFromLinkedList(Drum* drum);
 	void drumRemoved(Drum* drum);
 };
-
-#endif // KIT_H

--- a/src/deluge/model/drum/midi_drum.h
+++ b/src/deluge/model/drum/midi_drum.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIDRUM_H_
-#define MIDIDRUM_H_
+#pragma once
 
 #include "model/drum/non_audio_drum.h"
 
@@ -44,5 +43,3 @@ public:
 	uint8_t note;
 	int8_t noteEncoderCurrentOffset;
 };
-
-#endif /* MIDIDRUM_H_ */

--- a/src/deluge/model/drum/non_audio_drum.h
+++ b/src/deluge/model/drum/non_audio_drum.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NONAUDIODRUM_H_
-#define NONAUDIODRUM_H_
+#pragma once
 
 #include "model/drum/drum.h"
 #include "model/mod_controllable/mod_controllable.h"
@@ -48,5 +47,3 @@ protected:
 	void modChange(ModelStackWithThreeMainThings* modelStack, int offset, int8_t* encoderOffset, uint8_t* value,
 	               int numValues);
 };
-
-#endif /* NONAUDIODRUM_H_ */

--- a/src/deluge/model/global_effectable/global_effectable.h
+++ b/src/deluge/model/global_effectable/global_effectable.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef GLOBALEFFECTABLE_H_
-#define GLOBALEFFECTABLE_H_
+#pragma once
 
 #include "model/mod_controllable/mod_controllable_audio.h"
 #include "dsp/filter/filter_set.h"
@@ -66,5 +65,3 @@ protected:
 private:
 	void ensureModFXParamIsValid();
 };
-
-#endif /* GLOBALEFFECTABLE_H_ */

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef GLOBALEFFECTABLEFORCLIP_H_
-#define GLOBALEFFECTABLEFORCLIP_H_
+#pragma once
 
 #include "definitions.h"
 #include "model/global_effectable/global_effectable.h"
@@ -69,5 +68,3 @@ protected:
 
 	virtual bool willRenderAsOneChannelOnlyWhichWillNeedCopying() { return false; }
 };
-
-#endif /* GLOBALEFFECTABLEFORCLIP_H_ */

--- a/src/deluge/model/global_effectable/global_effectable_for_song.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_song.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef GLOBALEFFECTABLEFORSONG_H_
-#define GLOBALEFFECTABLEFORSONG_H_
+#pragma once
 
 #include "model/global_effectable/global_effectable.h"
 
@@ -28,5 +27,3 @@ public:
 
 	uint8_t modKnobMode;
 };
-
-#endif /* GLOBALEFFECTABLEFORSONG_H_ */

--- a/src/deluge/model/instrument/cv_instrument.h
+++ b/src/deluge/model/instrument/cv_instrument.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CVINSTRUMENT_H_
-#define CVINSTRUMENT_H_
+#pragma once
 
 #include "model/instrument/cv_instrument.h"
 #include "model/instrument/non_audio_instrument.h"
@@ -49,5 +48,3 @@ public:
 private:
 	void updatePitchBendOutput(bool outputToo = true);
 };
-
-#endif /* CVINSTRUMENT_H_ */

--- a/src/deluge/model/instrument/instrument.h
+++ b/src/deluge/model/instrument/instrument.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef INSTRUMENT_H
-#define INSTRUMENT_H
+#pragma once
 
 #include "model/clip/clip_instance_vector.h"
 #include "definitions.h"
@@ -77,5 +76,3 @@ protected:
 	Clip* createNewClipForArrangementRecording(ModelStack* modelStack) final;
 	int setupDefaultAudioFileDir();
 };
-
-#endif // INSTRUMENT_H

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef MELODICINSTRUMENT_H_
-#define MELODICINSTRUMENT_H_
+#pragma once
 
 #include "util/container/array/early_note_array.h"
 #include "io/midi/learned_midi.h"
@@ -84,5 +83,3 @@ public:
 
 	LearnedMIDI midiInput;
 };
-
-#endif /* MELODICINSTRUMENT_H_ */

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIINSTRUMENT_H_
-#define MIDIINSTRUMENT_H_
+#pragma once
 
 #include "model/instrument/non_audio_instrument.h"
 
@@ -87,5 +86,3 @@ protected:
 private:
 	void outputAllMPEValuesOnMemberChannel(int16_t const* mpeValuesToUse, int outputMemberChannel);
 };
-
-#endif /* MIDIINSTRUMENT_H_ */

--- a/src/deluge/model/instrument/non_audio_instrument.h
+++ b/src/deluge/model/instrument/non_audio_instrument.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NONAUDIOINSTRUMENT_H_
-#define NONAUDIOINSTRUMENT_H_
+#pragma once
 
 #include "model/instrument/melodic_instrument.h"
 #include "modulation/arpeggiator.h"
@@ -59,5 +58,3 @@ protected:
 	virtual void polyphonicExpressionEventPostArpeggiator(int newValue, int noteCodeAfterArpeggiation,
 	                                                      int whichExpressionDimension, ArpNote* arpNote) = 0;
 };
-
-#endif /* NONAUDIOINSTRUMENT_H_ */

--- a/src/deluge/model/mod_controllable/mod_controllable.h
+++ b/src/deluge/model/mod_controllable/mod_controllable.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MODCONTROLLABLE_H_
-#define MODCONTROLLABLE_H_
+#pragma once
 #include "definitions.h"
 
 class ParamManagerForTimeline;
@@ -60,5 +59,3 @@ public:
 	                                                      int channelOrNoteNumber, int whichCharacteristic) {}
 	virtual void monophonicExpressionEvent(int newValue, int whichExpressionDimension) {}
 };
-
-#endif /* MODCONTROLLABLE_H_ */

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MODCONTROLLABLEAUDIO_H_
-#define MODCONTROLLABLEAUDIO_H_
+#pragma once
 
 #include "model/mod_controllable/mod_controllable.h"
 #include "dsp/stereo_sample.h"
@@ -142,5 +141,3 @@ private:
 	void doEQ(bool doBass, bool doTreble, int32_t* inputL, int32_t* inputR, int32_t bassAmount, int32_t trebleAmount);
 	ModelStackWithThreeMainThings* addNoteRowIndexAndStuff(ModelStackWithTimelineCounter* modelStack, int noteRowIndex);
 };
-
-#endif /* MODCONTROLLABLEAUDIO_H_ */

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MODELSTACK_H_
-#define MODELSTACK_H_
+#pragma once
 
 #include "modulation/params/param_manager.h"
 #include "hid/display/numeric_driver.h"
@@ -501,5 +500,3 @@ ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurr
 
 
  */
-
-#endif /* MODELSTACK_H_ */

--- a/src/deluge/model/note/copied_note_row.h
+++ b/src/deluge/model/note/copied_note_row.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef COPIEDNOTEROW_H_
-#define COPIEDNOTEROW_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 class Note;
@@ -32,5 +31,3 @@ public:
 	CopiedNoteRow* next;
 	int16_t yNote;
 };
-
-#endif /* COPIEDNOTEROW_H_ */

--- a/src/deluge/model/note/note.h
+++ b/src/deluge/model/note/note.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef Note_h
-#define Note_h
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -52,5 +51,3 @@ public:
 	// Understanding the probability field: the first bit says whether it's based on a previous one.
 	// So take the rightmost 7 bits. If that's greater than NUM_PROBABILITY_VALUES (20),
 };
-
-#endif

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NoteRow_h
-#define NoteRow_h
+#pragma once
 
 #include "modulation/params/param_manager.h"
 #include "definitions.h"
@@ -186,5 +185,3 @@ private:
 	void drawTail(int32_t startTail, int32_t endTail, uint8_t squareColour[], bool overwriteExisting,
 	              uint8_t image[][3], uint8_t occupancyMask[]);
 };
-
-#endif

--- a/src/deluge/model/note/note_row_vector.h
+++ b/src/deluge/model/note/note_row_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NOTEROWVECTOR_H_
-#define NOTEROWVECTOR_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -32,5 +31,3 @@ public:
 	NoteRow* insertNoteRowAtY(int y, int* getIndex = NULL);
 	void deleteNoteRowAtIndex(int index, int numToDelete = 1);
 };
-
-#endif /* NOTEROWVECTOR_H_ */

--- a/src/deluge/model/note/note_vector.h
+++ b/src/deluge/model/note/note_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NOTEVECTOR_H_
-#define NOTEVECTOR_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -33,5 +32,3 @@ public:
 
 private:
 };
-
-#endif /* NOTEVECTOR_H_ */

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef OUTPUT_H_
-#define OUTPUT_H_
+#pragma once
 
 #include "model/clip/clip_instance_vector.h"
 #include "RZA1/system/r_typedefs.h"
@@ -148,5 +147,3 @@ public:
 protected:
 	virtual Clip* createNewClipForArrangementRecording(ModelStack* modelStack) = 0;
 };
-
-#endif /* OUTPUT_H_ */

--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLE_H_
-#define SAMPLE_H_
+#pragma once
 
 #include "model/sample/sample_cluster.h"
 #include "util/functions.h"
@@ -152,5 +151,3 @@ private:
 	                                uint64_t* sumTable, float* floatIndexTable, float* getFreq, int numDoublings,
 	                                bool doPrimeTest);
 };
-
-#endif /* SAMPLE_H_ */

--- a/src/deluge/model/sample/sample_cache.h
+++ b/src/deluge/model/sample/sample_cache.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEPITCHADJUSTMENT_H_
-#define SAMPLEPITCHADJUSTMENT_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -52,5 +51,3 @@ private:
 	// This has to be last!!!
 	Cluster* clusters[1]; // These are not initialized, and are only "valid" as far as writeBytePos dictates
 };
-
-#endif /* SAMPLEPITCHADJUSTMENT_H_ */

--- a/src/deluge/model/sample/sample_cluster.h
+++ b/src/deluge/model/sample/sample_cluster.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLECLUSTER_H_
-#define SAMPLECLUSTER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -40,5 +39,3 @@ public:
 	int8_t maxValue;
 	bool investigatedWholeLength;
 };
-
-#endif /* SAMPLECLUSTER_H_ */

--- a/src/deluge/model/sample/sample_cluster_array.h
+++ b/src/deluge/model/sample/sample_cluster_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLECLUSTERARRAY_H_
-#define SAMPLECLUSTERARRAY_H_
+#pragma once
 
 #include "util/container/array/resizeable_array.h"
 
@@ -28,5 +27,3 @@ public:
 	int insertSampleClustersAtEnd(int numToInsert);
 	SampleCluster* getElement(int i);
 };
-
-#endif /* SAMPLECLUSTERARRAY_H_ */

--- a/src/deluge/model/sample/sample_controls.h
+++ b/src/deluge/model/sample/sample_controls.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLECONTROLS_H_
-#define SAMPLECONTROLS_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -29,5 +28,3 @@ public:
 	bool pitchAndSpeedAreIndependent;
 	bool reversed;
 };
-
-#endif /* SAMPLECONTROLS_H_ */

--- a/src/deluge/model/sample/sample_holder.h
+++ b/src/deluge/model/sample/sample_holder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEHOLDER_H_
-#define SAMPLEHOLDER_H_
+#pragma once
 
 #include "definitions.h"
 #include "util/d_string.h"
@@ -58,5 +57,3 @@ protected:
 	                                  int clusterLoadInstruction);
 	virtual void sampleBeenSet(bool reversed, bool manuallySelected) {}
 };
-
-#endif /* SAMPLEHOLDER_H_ */

--- a/src/deluge/model/sample/sample_holder_for_clip.h
+++ b/src/deluge/model/sample/sample_holder_for_clip.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEHOLDERFORCLIP_H_
-#define SAMPLEHOLDERFORCLIP_H_
+#pragma once
 
 #include "model/sample/sample_holder.h"
 
@@ -36,5 +35,3 @@ public:
 protected:
 	void sampleBeenSet(bool reversed, bool manuallySelected);
 };
-
-#endif /* SAMPLEHOLDERFORCLIP_H_ */

--- a/src/deluge/model/sample/sample_holder_for_voice.h
+++ b/src/deluge/model/sample/sample_holder_for_voice.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEHOLDERFORVOICE_H_
-#define SAMPLEHOLDERFORVOICE_H_
+#pragma once
 
 #include "model/sample/sample_holder.h"
 #include "util/phase_increment_fine_tuner.h"
@@ -52,5 +51,3 @@ public:
 protected:
 	void sampleBeenSet(bool reversed, bool manuallySelected);
 };
-
-#endif /* SAMPLEHOLDERFORVOICE_H_ */

--- a/src/deluge/model/sample/sample_low_level_reader.h
+++ b/src/deluge/model/sample/sample_low_level_reader.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEREADER_H_
-#define SAMPLEREADER_H_
+#pragma once
 
 #include "definitions.h"
 #include "hid/display/numeric_driver.h"
@@ -105,5 +104,3 @@ private:
 	bool fillInterpolationBufferForward(SamplePlaybackGuide* guide, Sample* sample, int interpolationBufferSize,
 	                                    bool loopingAtLowLevel, int numSpacesToFill, int priorityRating);
 };
-
-#endif /* SAMPLEREADER_H_ */

--- a/src/deluge/model/sample/sample_perc_cache_zone.h
+++ b/src/deluge/model/sample/sample_perc_cache_zone.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEPERCCACHEZONE_H_
-#define SAMPLEPERCCACHEZONE_H_
+#pragma once
 
 #include "definitions.h"
 
@@ -36,5 +35,3 @@ public:
 	int32_t lastSampleRead;
 	int32_t angleLPFMem[DIFFERENCE_LPF_POLES];
 };
-
-#endif /* SAMPLEPERCCACHEZONE_H_ */

--- a/src/deluge/model/sample/sample_playback_guide.h
+++ b/src/deluge/model/sample/sample_playback_guide.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEPLAYBACKGUIDE_H_
-#define SAMPLEPLAYBACKGUIDE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -56,5 +55,3 @@ public:
 	int32_t sequenceSyncStartedAtTick;
 	uint32_t sequenceSyncLengthTicks; // When 0, means no syncing happening
 };
-
-#endif /* SAMPLEPLAYBACKGUIDE_H_ */

--- a/src/deluge/model/sample/sample_reader.h
+++ b/src/deluge/model/sample/sample_reader.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEREADER_H_
-#define SAMPLEREADER_H_
+#pragma once
 
 #include "storage/audio/audio_file_reader.h"
 
@@ -30,5 +29,3 @@ public:
 
 	Cluster* currentCluster;
 };
-
-#endif /* SAMPLEREADER_H_ */

--- a/src/deluge/model/sample/sample_recorder.h
+++ b/src/deluge/model/sample/sample_recorder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLERECORDER_H_
-#define SAMPLERECORDER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "util/d_string.h"
@@ -129,5 +128,3 @@ private:
 	int truncateFileDownToSize(uint32_t newFileSize);
 	int writeOneCompletedCluster();
 };
-
-#endif /* SAMPLERECORDER_H_ */

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef RUNTIMEFEATURESETTINGS_H_
-#define RUNTIMEFEATURESETTINGS_H_
+#pragma once
 
 #include <cstdint>
 #include "gui/menu_item/runtime_feature/setting.h"
@@ -119,5 +118,3 @@ public:
 
 /// Static instance for external access
 extern RuntimeFeatureSettings runtimeFeatureSettings;
-
-#endif /* RUNTIMEFEATURESETTINGS_H_ */

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SONG_H
-#define SONG_H
+#pragma once
 
 #include "model/clip/clip_array.h"
 #include "model/global_effectable/global_effectable_for_song.h"
@@ -330,5 +329,3 @@ private:
 
 extern Song* currentSong;
 extern Song* preLoadedSong;
-
-#endif // SONG_H

--- a/src/deluge/model/timeline_counter.h
+++ b/src/deluge/model/timeline_counter.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef TIMELINECOUNTER_H_
-#define TIMELINECOUNTER_H_
+#pragma once
 
 #include "modulation/params/param_manager.h"
 #include "RZA1/system/r_typedefs.h"
@@ -48,5 +47,3 @@ public:
 
 	ParamManagerForTimeline paramManager;
 };
-
-#endif /* TIMELINECOUNTER_H_ */

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef VOICE_H
-#define VOICE_H
+#pragma once
 
 #include "modulation/patch/patcher.h"
 #include "model/voice/voice_sample_playback_guide.h"
@@ -127,5 +126,3 @@ private:
 	void setupPorta(Sound* sound);
 	int32_t combineExpressionValues(Sound* sound, int whichExpressionDimension);
 };
-
-#endif // VOICE_H

--- a/src/deluge/model/voice/voice_sample.h
+++ b/src/deluge/model/voice/voice_sample.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef VOICESAMPLE_H_
-#define VOICESAMPLE_H_
+#pragma once
 
 #include "model/sample/sample_low_level_reader.h"
 
@@ -92,5 +91,3 @@ private:
 	void switchToReadingCacheFromWriting();
 	bool stopReadingFromCache();
 };
-
-#endif /* VOICESAMPLE_H_ */

--- a/src/deluge/model/voice/voice_sample_playback_guide.h
+++ b/src/deluge/model/voice/voice_sample_playback_guide.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef VOICE_SOURCE_H
-#define VOICE_SOURCE_H
+#pragma once
 
 #include "definitions.h"
 #include "model/sample/sample_playback_guide.h"
@@ -44,5 +43,3 @@ public:
 
 	bool noteOffReceived;
 };
-
-#endif

--- a/src/deluge/model/voice/voice_unison_part.h
+++ b/src/deluge/model/voice/voice_unison_part.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef VOICE_UNISON_PART_H
-#define VOICE_UNISON_PART_H
+#pragma once
 
 #include "definitions.h"
 #include "model/voice/voice_unison_part_source.h"
@@ -31,5 +30,3 @@ public:
 
 	VoiceUnisonPartSource sources[NUM_SOURCES];
 };
-
-#endif // VOICE_H

--- a/src/deluge/model/voice/voice_unison_part_source.h
+++ b/src/deluge/model/voice/voice_unison_part_source.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef VOICE_UNISON_PART_SOURCE_H
-#define VOICE_UNISON_PART_SOURCE_H
+#pragma once
 
 #include "definitions.h"
 #include "model/sample/sample.h"
@@ -47,5 +46,3 @@ public:
 	VoiceSample* voiceSample;
 	LivePitchShifter* livePitchShifter;
 };
-
-#endif

--- a/src/deluge/model/voice/voice_vector.h
+++ b/src/deluge/model/voice/voice_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef VOICEVECTOR_H_
-#define VOICEVECTOR_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array_with_multi_word_key.h"
 
@@ -37,5 +36,3 @@ public:
 
 	inline Voice* getVoice(int index) { return ((VoiceVectorElement*)getElementAddress(index))->voice; }
 };
-
-#endif /* VOICEVECTOR_H_ */

--- a/src/deluge/modulation/arpeggiator.h
+++ b/src/deluge/modulation/arpeggiator.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ARPEGGIATOR_H_
-#define ARPEGGIATOR_H_
+#pragma once
 
 #include "definitions.h"
 #include "util/container/array/ordered_resizeable_array.h"
@@ -125,5 +124,3 @@ public:
 protected:
 	void switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstruction* instruction);
 };
-
-#endif /* ARPEGGIATOR_H_ */

--- a/src/deluge/modulation/automation/auto_param.h
+++ b/src/deluge/modulation/automation/auto_param.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUTOPARAM_H_
-#define AUTOPARAM_H_
+#pragma once
 #include "RZA1/system/r_typedefs.h"
 #include "modulation/params/param_node_vector.h"
 #include "model/action/action.h"
@@ -128,5 +127,3 @@ private:
 	                                 bool interpolateEnd);
 	void deleteNodesBeyondPos(int32_t pos);
 };
-
-#endif /* AUTOPARAM_H_ */

--- a/src/deluge/modulation/automation/copied_param_automation.h
+++ b/src/deluge/modulation/automation/copied_param_automation.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef COPIEDPARAMAUTOMATION_H_
-#define COPIEDPARAMAUTOMATION_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -31,5 +30,3 @@ public:
 	ParamNode* nodes;
 	int numNodes;
 };
-
-#endif /* COPIEDPARAMAUTOMATION_H_ */

--- a/src/deluge/modulation/envelope.h
+++ b/src/deluge/modulation/envelope.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ENVELOPE_H
-#define ENVELOPE_H
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -47,5 +46,3 @@ public:
 private:
 	void setState(uint8_t newState);
 };
-
-#endif // ENVELOPE_H

--- a/src/deluge/modulation/knob.h
+++ b/src/deluge/modulation/knob.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef KNOB_H_
-#define KNOB_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "io/midi/learned_midi.h"
@@ -48,5 +47,3 @@ public:
 	bool is14Bit() { return false; }
 	bool topValueIs127() { return false; }
 };
-
-#endif /* KNOB_H_ */

--- a/src/deluge/modulation/lfo.h
+++ b/src/deluge/modulation/lfo.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LFO_H
-#define LFO_H
+#pragma once
 
 #include "definitions.h"
 
@@ -28,5 +27,3 @@ public:
 	int32_t render(int numSamples, int waveType, uint32_t phaseIncrement);
 	void tick(int numSamples, uint32_t phaseIncrement);
 };
-
-#endif // LFO_H

--- a/src/deluge/modulation/midi/midi_knob_array.h
+++ b/src/deluge/modulation/midi/midi_knob_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIKNOBVECTOR_H_
-#define MIDIKNOBVECTOR_H_
+#pragma once
 
 #include "util/container/array/resizeable_array.h"
 
@@ -29,5 +28,3 @@ public:
 	MIDIKnob* getElement(int i);
 	MIDIKnob* insertKnobAtEnd();
 };
-
-#endif /* MIDIKNOBVECTOR_H_ */

--- a/src/deluge/modulation/midi/midi_param.h
+++ b/src/deluge/modulation/midi/midi_param.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIPARAM_H_
-#define MIDIPARAM_H_
+#pragma once
 
 #include "modulation/automation/auto_param.h"
 
@@ -27,5 +26,3 @@ public:
 	uint8_t cc;
 	AutoParam param;
 };
-
-#endif /* MIDIPARAM_H_ */

--- a/src/deluge/modulation/midi/midi_param_collection.h
+++ b/src/deluge/modulation/midi/midi_param_collection.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIPARAMCOLLECTION_H_
-#define MIDIPARAMCOLLECTION_H_
+#pragma once
 
 #include "modulation/params/param_collection.h"
 #include "modulation/midi/midi_param_vector.h"
@@ -67,5 +66,3 @@ public:
 private:
 	void deleteAllParams(Action* action = NULL, bool deleteStorateToo = true);
 };
-
-#endif /* MIDIPARAMCOLLECTION_H_ */

--- a/src/deluge/modulation/midi/midi_param_vector.h
+++ b/src/deluge/modulation/midi/midi_param_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MIDIPARAMVECTOR_H_
-#define MIDIPARAMVECTOR_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -30,5 +29,3 @@ public:
 	MIDIParam* insertParam(int i);
 	MIDIParam* getOrCreateParamFromCC(int cc, int32_t defaultValue = 0, bool allowCreation = true);
 };
-
-#endif /* MIDIPARAMVECTOR_H_ */

--- a/src/deluge/modulation/params/param_collection.h
+++ b/src/deluge/modulation/params/param_collection.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PARAMCOLLECTION_H_
-#define PARAMCOLLECTION_H_
+#pragma once
 #include "RZA1/system/r_typedefs.h"
 
 class ParamManagerForTimeline;
@@ -78,5 +77,3 @@ public:
 	const int objectSize;
 	int32_t ticksTilNextEvent;
 };
-
-#endif /* PARAMCOLLECTION_H_ */

--- a/src/deluge/modulation/params/param_collection_summary.h
+++ b/src/deluge/modulation/params/param_collection_summary.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PARAMCOLLECTIONSUMMARY_H_
-#define PARAMCOLLECTIONSUMMARY_H_
+#pragma once
 
 #include "definitions.h"
 
@@ -60,5 +59,3 @@ public:
 
 	// The list of these ParamCollectionSummarys, in ParamManager, must be terminated by one whose values are *all* zero. This helps because if we know this, we can check for stuff faster.
 };
-
-#endif /* PARAMCOLLECTIONSUMMARY_H_ */

--- a/src/deluge/modulation/params/param_descriptor.h
+++ b/src/deluge/modulation/params/param_descriptor.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PARAMDESCRIPTOR_H_
-#define PARAMDESCRIPTOR_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -97,5 +96,3 @@ inline bool operator==(const ParamDescriptor& lhs, const ParamDescriptor& rhs) {
 inline bool operator!=(const ParamDescriptor& lhs, const ParamDescriptor& rhs) {
 	return !(lhs == rhs);
 }
-
-#endif /* PARAMDESCRIPTOR_H_ */

--- a/src/deluge/modulation/params/param_manager.h
+++ b/src/deluge/modulation/params/param_manager.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PARAMMANAGER_H_
-#define PARAMMANAGER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -202,5 +201,3 @@ public:
 	int32_t ticksTilNextEvent;
 	int32_t ticksSkipped;
 };
-
-#endif /* PARAMMANAGER_H_ */

--- a/src/deluge/modulation/params/param_node.h
+++ b/src/deluge/modulation/params/param_node.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PARAMNODE_H_
-#define PARAMNODE_H_
+#pragma once
 #include "RZA1/system/r_typedefs.h"
 
 #include "gui/positionable.h"
@@ -33,5 +32,3 @@ struct StolenParamNodes {
 	int num;
 	ParamNode* nodes;
 };
-
-#endif /* PARAMNODE_H_ */

--- a/src/deluge/modulation/params/param_node_vector.h
+++ b/src/deluge/modulation/params/param_node_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PARAMNODEVECTOR_H_
-#define PARAMNODEVECTOR_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -30,5 +29,3 @@ public:
 	ParamNode* getFirst();
 	ParamNode* getLast();
 };
-
-#endif /* PARAMNODEVECTOR_H_ */

--- a/src/deluge/modulation/params/param_set.h
+++ b/src/deluge/modulation/params/param_set.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PARAMSET_H_
-#define PARAMSET_H_
+#pragma once
 
 #include "modulation/automation/auto_param.h"
 #include "definitions.h"
@@ -140,5 +139,3 @@ public:
 	// in which case they do move to the backedUpParamManager. This is exactly the persistence we want for bendRanges too.
 	uint8_t bendRanges[2];
 };
-
-#endif /* PARAMSET_H_ */

--- a/src/deluge/modulation/patch/patch_cable.h
+++ b/src/deluge/modulation/patch/patch_cable.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PATCHCABLE_H_
-#define PATCHCABLE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "modulation/automation/auto_param.h"
@@ -38,4 +37,3 @@ public:
 	AutoParam param; // Amounts have to be within +1073741824 and -1073741824
 	int32_t const* rangeAdjustmentPointer;
 };
-#endif /* PATCHCABLE_H_ */

--- a/src/deluge/modulation/patch/patch_cable_set.h
+++ b/src/deluge/modulation/patch/patch_cable_set.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PATCHCABLESET_H_
-#define PATCHCABLESET_H_
+#pragma once
 #include "modulation/params/param_collection.h"
 #include "definitions.h"
 #include "modulation/patch/patch_cable.h"
@@ -112,5 +111,3 @@ private:
 	void swapCables(int c1, int c2);
 	void freeDestinationMemory(bool destructing);
 };
-
-#endif /* PATCHCABLESET_H_ */

--- a/src/deluge/modulation/patch/patcher.h
+++ b/src/deluge/modulation/patch/patcher.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PATCHABLE_H
-#define PATCHABLE_H
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -69,5 +68,3 @@ private:
 
 	const PatchableInfo* const patchableInfo;
 };
-
-#endif // PATCHABLE_H

--- a/src/deluge/playback/mode/arrangement.h
+++ b/src/deluge/playback/mode/arrangement.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef ARRANGEMENT_H_
-#define ARRANGEMENT_H_
+#pragma once
 
 #include "playback/mode/playback_mode.h"
 
@@ -58,5 +57,3 @@ public:
 };
 
 extern Arrangement arrangement;
-
-#endif /* ARRANGEMENT_H_ */

--- a/src/deluge/playback/mode/playback_mode.h
+++ b/src/deluge/playback/mode/playback_mode.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PLAYBACKMODE_H_
-#define PLAYBACKMODE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -61,5 +60,3 @@ public:
 };
 
 extern PlaybackMode* currentPlaybackMode;
-
-#endif /* PLAYBACKMODE_H_ */

--- a/src/deluge/playback/mode/session.h
+++ b/src/deluge/playback/mode/session.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SESSION_H_
-#define SESSION_H_
+#pragma once
 #include "playback/mode/playback_mode.h"
 #include "definitions.h"
 
@@ -99,5 +98,3 @@ private:
 };
 
 extern Session session;
-
-#endif /* SESSION_H_ */

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PLAYBACKHANDLER_H
-#define PLAYBACKHANDLER_H
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -247,4 +246,3 @@ private:
 };
 
 extern PlaybackHandler playbackHandler;
-#endif // PLAYBACKHANDLER_H

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOOUTPUT_H_
-#define AUDIOOUTPUT_H_
+#pragma once
 
 #include "model/global_effectable/global_effectable_for_clip.h"
 #include "model/output.h"
@@ -86,5 +85,3 @@ protected:
 	bool wantsToBeginArrangementRecording();
 	bool willRenderAsOneChannelOnlyWhichWillNeedCopying();
 };
-
-#endif /* AUDIOOUTPUT_H_ */

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIODRIVER_H
-#define AUDIODRIVER_H
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -197,5 +196,3 @@ extern MasterCompressor mastercompressor;
 extern uint32_t timeLastSideChainHit;
 extern int32_t sizeLastSideChainHit;
 } // namespace AudioEngine
-
-#endif // AUDIODRIVER_H

--- a/src/deluge/processing/engines/cv_engine.h
+++ b/src/deluge/processing/engines/cv_engine.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CVENGINE_H_
-#define CVENGINE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "model/drum/gate_drum.h"
@@ -112,5 +111,3 @@ private:
 };
 
 extern CVEngine cvEngine;
-
-#endif /* CVENGINE_H_ */

--- a/src/deluge/processing/live/live_input_buffer.h
+++ b/src/deluge/processing/live/live_input_buffer.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef INPUTPERCBUFFER_H_
-#define INPUTPERCBUFFER_H_
+#pragma once
 
 #include "definitions.h"
 #include "RZA1/system/r_typedefs.h"
@@ -41,5 +40,3 @@ public:
 	int32_t rawBuffer
 	    [INPUT_RAW_BUFFER_SIZE]; // Must be last!!! Cos we're gonna allocate and access it double-length for stereo
 };
-
-#endif /* INPUTPERCBUFFER_H_ */

--- a/src/deluge/processing/live/live_pitch_shifter.h
+++ b/src/deluge/processing/live/live_pitch_shifter.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIVEPITCHSHIFTER_H_
-#define LIVEPITCHSHIFTER_H_
+#pragma once
 
 #include "definitions.h"
 #include "processing/live/live_pitch_shifter_play_head.h"
@@ -62,5 +61,3 @@ private:
 	void considerRepitchedBuffer(int32_t phaseIncrement);
 	bool olderPlayHeadIsCurrentlySounding();
 };
-
-#endif /* LIVEPITCHSHIFTER_H_ */

--- a/src/deluge/processing/live/live_pitch_shifter_play_head.h
+++ b/src/deluge/processing/live/live_pitch_shifter_play_head.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LIVEPITCHSHIFTERPLAYHEAD_H_
-#define LIVEPITCHSHIFTERPLAYHEAD_H_
+#pragma once
 
 #include "definitions.h"
 
@@ -58,5 +57,3 @@ private:
 	void interpolate(int32_t* sampleRead, int numChannelsNow, int whichKernel);
 	void interpolateLinear(int32_t* sampleRead, int numChannelsNow, int whichKernel);
 };
-
-#endif /* LIVEPITCHSHIFTERPLAYHEAD_H_ */

--- a/src/deluge/processing/metronome/metronome.h
+++ b/src/deluge/processing/metronome/metronome.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef METRONOME_H_
-#define METRONOME_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -33,5 +32,3 @@ public:
 	uint32_t timeSinceTrigger;
 	bool sounding;
 };
-
-#endif /* METRONOME_H_ */

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SOUND_H
-#define SOUND_H
+#pragma once
 
 #include "modulation/patch/patcher.h"
 #include "definitions.h"
@@ -293,5 +292,3 @@ private:
 	                                                      ModelStackWithThreeMainThings* modelStack,
 	                                                      bool allowCreation = true);
 };
-
-#endif // SOUND_H

--- a/src/deluge/processing/sound/sound_drum.h
+++ b/src/deluge/processing/sound/sound_drum.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SOUNDDRUM_H
-#define SOUNDDRUM_H
+#pragma once
 
 #include "processing/sound/sound.h"
 #include "definitions.h"
@@ -63,5 +62,3 @@ public:
 	ArpeggiatorBase* getArp();
 	ArpeggiatorSettings* getArpSettings(InstrumentClip* clip = NULL) { return &arpSettings; }
 };
-
-#endif // SOUNDDRUM_H

--- a/src/deluge/processing/sound/sound_instrument.h
+++ b/src/deluge/processing/sound/sound_instrument.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SOUNDINSTRUMENT_H
-#define SOUNDINSTRUMENT_H
+#pragma once
 
 #include "processing/sound/sound.h"
 #include "model/instrument/melodic_instrument.h"
@@ -84,5 +83,3 @@ public:
 
 	ArpeggiatorSettings defaultArpSettings;
 };
-
-#endif

--- a/src/deluge/processing/source.h
+++ b/src/deluge/processing/source.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SOURCE_H
-#define SOURCE_H
+#pragma once
 
 #include "storage/multi_range/multi_range_array.h"
 #include "util/phase_increment_fine_tuner.h"
@@ -67,5 +66,3 @@ public:
 private:
 	void destructAllMultiRanges();
 };
-
-#endif

--- a/src/deluge/storage/audio/audio_file.h
+++ b/src/deluge/storage/audio/audio_file.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOFILE_H_
-#define AUDIOFILE_H_
+#pragma once
 
 #include "memory/stealable.h"
 #include "util/d_string.h"
@@ -50,5 +49,3 @@ protected:
 	virtual void numReasonsIncreasedFromZero() {}
 	virtual void numReasonsDecreasedToZero(char const* errorCode) {}
 };
-
-#endif /* AUDIOFILE_H_ */

--- a/src/deluge/storage/audio/audio_file_holder.h
+++ b/src/deluge/storage/audio/audio_file_holder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOFILEHOLDER_H_
-#define AUDIOFILEHOLDER_H_
+#pragma once
 
 #include "definitions.h"
 #include "util/d_string.h"
@@ -43,5 +42,3 @@ public:
 	AudioFile* audioFile;
 	uint8_t audioFileType;
 };
-
-#endif /* AUDIOFILEHOLDER_H_ */

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef SAMPLEMANAGER_H_
-#define SAMPLEMANAGER_H_
+#pragma once
 #include "storage/audio/audio_file_vector.h"
 #include "storage/cluster/cluster_priority_queue.h"
 #include "RZA1/system/r_typedefs.h"
@@ -136,5 +135,3 @@ private:
 };
 
 extern AudioFileManager audioFileManager;
-
-#endif /* SAMPLEMANAGER_H_ */

--- a/src/deluge/storage/audio/audio_file_reader.h
+++ b/src/deluge/storage/audio/audio_file_reader.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOFILEREADER_H_
-#define AUDIOFILEREADER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -39,5 +38,3 @@ public:
 	uint32_t fileSize;
 	AudioFile* audioFile;
 };
-
-#endif /* AUDIOFILEREADER_H_ */

--- a/src/deluge/storage/audio/audio_file_vector.h
+++ b/src/deluge/storage/audio/audio_file_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUDIOFILEVECTOR_H_
-#define AUDIOFILEVECTOR_H_
+#pragma once
 
 #include "util/container/vector/named_thing_vector.h"
 
@@ -27,5 +26,3 @@ public:
 	AudioFileVector();
 	int searchForExactObject(AudioFile* audioFile);
 };
-
-#endif /* AUDIOFILEVECTOR_H_ */

--- a/src/deluge/storage/cluster/cluster.h
+++ b/src/deluge/storage/cluster/cluster.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLUSTER_H_
-#define CLUSTER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -51,5 +50,3 @@ public:
 
 	char data[CACHE_LINE_SIZE];
 };
-
-#endif /* CLUSTER_H_ */

--- a/src/deluge/storage/cluster/cluster_priority_queue.h
+++ b/src/deluge/storage/cluster/cluster_priority_queue.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CLUSTERPRIORITYQUEUE_H_
-#define CLUSTERPRIORITYQUEUE_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -36,5 +35,3 @@ public:
 	bool removeIfPresent(Cluster* cluster);
 	bool checkPresent(Cluster* cluster);
 };
-
-#endif /* CLUSTERPRIORITYQUEUE_H_ */

--- a/src/deluge/storage/file_item.h
+++ b/src/deluge/storage/file_item.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef FILEITEM_H_
-#define FILEITEM_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "util/d_string.h"
@@ -41,5 +40,3 @@ public:
 	bool instrumentAlreadyInSong; // Only valid if instrument is set to something.
 	bool filenameIncludesExtension;
 };
-
-#endif /* FILEITEM_H_ */

--- a/src/deluge/storage/flash_storage.h
+++ b/src/deluge/storage/flash_storage.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef FLASHSTORAGE_H_
-#define FLASHSTORAGE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -42,5 +41,3 @@ void writeSettings();
 void resetSettings();
 
 } // namespace FlashStorage
-
-#endif /* FLASHSTORAGE_H_ */

--- a/src/deluge/storage/multi_range/multi_range.h
+++ b/src/deluge/storage/multi_range/multi_range.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MULTIRANGE_H_
-#define MULTIRANGE_H_
+#pragma once
 
 #include "definitions.h"
 
@@ -31,5 +30,3 @@ public:
 
 	int16_t topNote;
 };
-
-#endif /* MULTIRANGE_H_ */

--- a/src/deluge/storage/multi_range/multi_range_array.h
+++ b/src/deluge/storage/multi_range/multi_range_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MULTIRANGEARRAY_H_
-#define MULTIRANGEARRAY_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -31,5 +30,3 @@ public:
 	MultiRange* insertMultiRange(int i);
 	int changeType(int newSize);
 };
-
-#endif /* MULTIRANGEARRAY_H_ */

--- a/src/deluge/storage/multi_range/multi_wave_table_range.h
+++ b/src/deluge/storage/multi_range/multi_wave_table_range.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MULTIWAVETABLERANGE_H_
-#define MULTIWAVETABLERANGE_H_
+#pragma once
 
 #include "storage/multi_range/multi_range.h"
 #include "storage/wave_table/wave_table_holder.h"
@@ -28,5 +27,3 @@ public:
 	WaveTableHolder
 	    waveTableHolder; // Has to be first variable, cos I do a sneaky optimization between both of MultiRange's children.
 };
-
-#endif /* MULTIWAVETABLERANGE_H_ */

--- a/src/deluge/storage/multi_range/multisample_range.h
+++ b/src/deluge/storage/multi_range/multisample_range.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef MULTISAMPLERANGE_H_
-#define MULTISAMPLERANGE_H_
+#pragma once
 
 #include "definitions.h"
 #include "util/d_string.h"
@@ -34,5 +33,3 @@ public:
 	SampleHolderForVoice
 	    sampleHolder; // Has to be first variable, cos I do a sneaky optimization between both of MultiRange's children.
 };
-
-#endif /* MULTISAMPLERANGE_H_ */

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef STORAGEMANAGER_H
-#define STORAGEMANAGER_H
+#pragma once
 
 #include "definitions.h"
 #include "RZA1/system/r_typedefs.h"
@@ -156,5 +155,3 @@ private:
 extern StorageManager storageManager;
 extern FILINFO staticFNO;
 extern DIR staticDIR;
-
-#endif // STORAGEMANAGER_H

--- a/src/deluge/storage/wave_table/wave_table.h
+++ b/src/deluge/storage/wave_table/wave_table.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WAVETABLE_H_
-#define WAVETABLE_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "util/container/array/ordered_resizeable_array.h"
@@ -76,5 +75,3 @@ private:
 	                                WaveTableBand* __restrict__ bandHere, uint32_t phase, uint32_t phaseIncrement,
 	                                const int16_t* __restrict__ kernel);
 };
-
-#endif /* WAVETABLE_H_ */

--- a/src/deluge/storage/wave_table/wave_table_band_data.h
+++ b/src/deluge/storage/wave_table/wave_table_band_data.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WAVETABLEBANDDATA_H_
-#define WAVETABLEBANDDATA_H_
+#pragma once
 
 #include "memory/stealable.h"
 
@@ -32,5 +31,3 @@ public:
 
 	WaveTable* waveTable;
 };
-
-#endif /* WAVETABLEBANDDATA_H_ */

--- a/src/deluge/storage/wave_table/wave_table_holder.h
+++ b/src/deluge/storage/wave_table/wave_table_holder.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WAVETABLEHOLDER_H_
-#define WAVETABLEHOLDER_H_
+#pragma once
 
 #include "storage/audio/audio_file_holder.h"
 
@@ -26,5 +25,3 @@ class WaveTableHolder final : public AudioFileHolder {
 public:
 	WaveTableHolder();
 };
-
-#endif /* WAVETABLEHOLDER_H_ */

--- a/src/deluge/storage/wave_table/wave_table_reader.h
+++ b/src/deluge/storage/wave_table/wave_table_reader.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef WAVETABLEREADER_H_
-#define WAVETABLEREADER_H_
+#pragma once
 
 #include "storage/audio/audio_file_reader.h"
 
@@ -26,5 +25,3 @@ public:
 	int readBytesPassedErrorChecking(char* outputBuffer, int num);
 	int readNewCluster();
 };
-
-#endif /* WAVETABLEREADER_H_ */

--- a/src/deluge/testing/automated_tester.h
+++ b/src/deluge/testing/automated_tester.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef AUTOMATEDTESTER_H_
-#define AUTOMATEDTESTER_H_
+#pragma once
 
 namespace AutomatedTester {
 void init();
@@ -25,5 +24,3 @@ void doMomentaryButtonPress(int x, int y);
 void possiblyDoSomething();
 
 } // namespace AutomatedTester
-
-#endif /* AUTOMATEDTESTER_H_ */

--- a/src/deluge/testing/hardware_testing.h
+++ b/src/deluge/testing/hardware_testing.h
@@ -15,11 +15,8 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef HARDWARETESTING_H_
-#define HARDWARETESTING_H_
+#pragma once
 
 void ramTestUart();
 void ramTestLED(bool stuffAlreadySetUp = false);
 void autoPilotStuff();
-
-#endif /* HARDWARETESTING_H_ */

--- a/src/deluge/util/algorithm/quick_sorter.h
+++ b/src/deluge/util/algorithm/quick_sorter.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef QUICKSORTER_H_
-#define QUICKSORTER_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -36,5 +35,3 @@ private:
 	const uint32_t keyMask;
 	void* const memory;
 };
-
-#endif /* QUICKSORTER_H_ */

--- a/src/deluge/util/cfunctions.h
+++ b/src/deluge/util/cfunctions.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CFUNCTIONS_H_
-#define CFUNCTIONS_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -36,5 +35,3 @@ uint32_t superfastTimerCountToNS(uint32_t timerCount);
 
 void delayMS(uint32_t ms);
 void delayUS(uint32_t us);
-
-#endif /* CFUNCTIONS_H_ */

--- a/src/deluge/util/container/array/c_string_array.h
+++ b/src/deluge/util/container/array/c_string_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef CSTRINGARRAY_H_
-#define CSTRINGARRAY_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "util/container/array/resizeable_array.h"
@@ -31,5 +30,3 @@ private:
 	int partitionForStrings(int low, int high);
 	void quickSortForStrings(int low, int high);
 };
-
-#endif /* CSTRINGARRAY_H_ */

--- a/src/deluge/util/container/array/early_note_array.h
+++ b/src/deluge/util/container/array/early_note_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef EARLYNOTEARRAY_H_
-#define EARLYNOTEARRAY_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -33,5 +32,3 @@ public:
 	int insertElementIfNonePresent(int note, int velocity, bool newStillActive = true);
 	void noteNoLongerActive(int note);
 };
-
-#endif /* EARLYNOTEARRAY_H_ */

--- a/src/deluge/util/container/array/ordered_resizeable_array.h
+++ b/src/deluge/util/container/array/ordered_resizeable_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef ORDEREDRESIZEABLEARRAY_H_
-#define ORDEREDRESIZEABLEARRAY_H_
+#pragma once
 
 #include "util/container/array/resizeable_array.h"
 
@@ -81,5 +80,3 @@ protected:
 	// Shadows - doesn't override
 	inline void setKeyAtMemoryLocation(int32_t key, void* address) { *(int32_t*)address = key; }
 };
-
-#endif /* ORDEREDRESIZEABLEARRAY_H_ */

--- a/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.h
+++ b/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef ORDEREDRESIZEABLEARRAYWITHMULTIWORDKEY_H_
-#define ORDEREDRESIZEABLEARRAYWITHMULTIWORDKEY_H_
+#pragma once
 
 #include "util/container/array/ordered_resizeable_array.h"
 
@@ -32,5 +31,3 @@ public:
 
 	int numWordsInKey;
 };
-
-#endif /* ORDEREDRESIZEABLEARRAYWITHMULTIWORDKEY_H_ */

--- a/src/deluge/util/container/array/resizeable_array.h
+++ b/src/deluge/util/container/array/resizeable_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef RESIZEABLEARRAY_H_
-#define RESIZEABLEARRAY_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "definitions.h"
@@ -88,5 +87,3 @@ private:
 	const int maxNumEmptySpacesToKeep;  // Can go down to 0
 	const int numExtraSpacesToAllocate; // Can go down to 0
 };
-
-#endif /* RESIZEABLEARRAY_H_ */

--- a/src/deluge/util/container/array/resizeable_pointer_array.h
+++ b/src/deluge/util/container/array/resizeable_pointer_array.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef RESIZEABLEPOINTERARRAY_H_
-#define RESIZEABLEPOINTERARRAY_H_
+#pragma once
 
 #include "util/container/array/resizeable_array.h"
 
@@ -27,5 +26,3 @@ public:
 	void* getPointerAtIndex(int index);
 	void setPointerAtIndex(void* pointer, int index);
 };
-
-#endif /* RESIZEABLEPOINTERARRAY_H_ */

--- a/src/deluge/util/container/hashtable/open_addressing_hash_table.h
+++ b/src/deluge/util/container/hashtable/open_addressing_hash_table.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef OPENADDRESSINGHASHTABLE_H_
-#define OPENADDRESSINGHASHTABLE_H_
+#pragma once
 #include "RZA1/system/r_typedefs.h"
 
 class OpenAddressingHashTable {
@@ -72,5 +71,3 @@ public:
 	void setKeyAtAddress(uint32_t key, void* address);
 	bool doesKeyIndicateEmptyBucket(uint32_t key);
 };
-
-#endif /* OPENADDRESSINGHASHTABLE_H_ */

--- a/src/deluge/util/container/list/bidirectional_linked_list.h
+++ b/src/deluge/util/container/list/bidirectional_linked_list.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef BIDIRECTIONALLINKEDLIST_H_
-#define BIDIRECTIONALLINKEDLIST_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -48,5 +47,3 @@ public:
 	BidirectionalLinkedListNode endNode;
 	BidirectionalLinkedListNode* first;
 };
-
-#endif /* BIDIRECTIONALLINKEDLIST_H_ */

--- a/src/deluge/util/container/vector/named_thing_vector.h
+++ b/src/deluge/util/container/vector/named_thing_vector.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef NAMEDTHINGVECTOR_H_
-#define NAMEDTHINGVECTOR_H_
+#pragma once
 
 #include "util/container/array/resizeable_array.h"
 
@@ -47,5 +46,3 @@ private:
 	NamedThingVectorElement* getMemory(int index);
 	String* getName(void* namedThing);
 };
-
-#endif /* NAMEDTHINGVECTOR_H_ */

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef DSTRING_H_
-#define DSTRING_H_
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -73,5 +72,3 @@ private:
 
 	char* stringMemory;
 };
-
-#endif /* DSTRING_H_ */

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef FUNCTIONS_H
-#define FUNCTIONS_H
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 #include "util/lookuptables/lookuptables.h"
@@ -573,5 +572,3 @@ inline void writeInt32(char** address, uint32_t number) {
 
 extern char miscStringBuffer[];
 extern char shortStringBuffer[];
-
-#endif // FUNCTIONS_H

--- a/src/deluge/util/lookuptables/lookuptables.h
+++ b/src/deluge/util/lookuptables/lookuptables.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 
-#ifndef LOOKUPTABLES_H
-#define LOOKUPTABLES_H
+#pragma once
 
 #include "RZA1/system/r_typedefs.h"
 
@@ -143,5 +142,3 @@ extern const uint8_t defaultClipGroupColours[];
 
 extern const uint8_t noteCodeToNoteLetter[];
 extern const bool noteCodeIsSharp[];
-
-#endif // LOOKUPTABLES_H

--- a/src/deluge/util/phase_increment_fine_tuner.h
+++ b/src/deluge/util/phase_increment_fine_tuner.h
@@ -15,8 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#ifndef PHASEINCREMENTFINETUNER_H
-#define PHASEINCREMENTFINETUNER_H
+#pragma once
 
 #include "definitions.h"
 #include "util/lookuptables/lookuptables.h"
@@ -32,5 +31,3 @@ public:
 private:
 	int32_t multiplier;
 };
-
-#endif // PHASEINCREMENTFINETUNER_H


### PR DESCRIPTION
This follows the discussion on Discord re: maintainability of the include guards in such a way that they can be checked using linters/external tools, and the conversion of most of the Deluge source to use `#pragma once`

clang-tidy's auto-include-guard system only works for headers with an "/include" somewhere in their absolute path, which the deluge source does not have.

Part of the pre-commit hook that I assume dbt will eventually have should perform a sub-task to check all header files for `#pragma once`, except those that are whitelisted (currently embedded function fragments: 
```
.\src\deluge\dsp\interpolation\interpolate.h
.\src\deluge\dsp\interpolation\interpolate_linear.h
.\src\deluge\processing\render_wave.h
.\src\deluge\processing\vector_rendering_function.h
```