### PR TITLE
Change tempo knob behavior and stop text scrolling on OLED

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1350,8 +1350,8 @@ oledDrawString:
 		else {
 			OLED::drawString(nameToDraw, 0, yPos, OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, textSpacingX,
 			                 textSpacingY);
-			OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos, yPos + textSpacingY, textSpacingX,
-			                        textSpacingY, false);
+			//OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos, yPos + textSpacingY, textSpacingX,
+			//                        textSpacingY, false);
 		}
 
 #else

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1887,16 +1887,6 @@ displayNudge:
 		if (!(playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE)) {
 
 			if (Buttons::isButtonPressed(hid::button::TEMPO_ENC)) {
-				// Fine tempo adjustment
-				uint32_t tempoBPM = calculateBPM(currentSong->getTimePerTimerTickFloat()) + 0.5;
-				tempoBPM += offset;
-				if (tempoBPM > 0) {
-					currentSong->setBPM(tempoBPM, true);
-					displayTempoBPM(tempoBPM);
-				}
-			}
-
-			else {
 				// Coarse tempo adjustment
 
 				// Get current tempo
@@ -1919,6 +1909,16 @@ displayNudge:
 
 				displayTempoFromParams(magnitude, whichValue);
 			}
+
+			else {
+				// Fine tempo adjustment
+				uint32_t tempoBPM = calculateBPM(currentSong->getTimePerTimerTickFloat()) + 0.5;
+				tempoBPM += offset;
+				if (tempoBPM > 0) {
+					currentSong->setBPM(tempoBPM, true);
+					displayTempoBPM(tempoBPM);
+				}
+			}				
 		}
 	}
 }


### PR DESCRIPTION
Hello everyone...  two things that have bugged me with my Deluge is the tempo knob changing in 4 bpm increments by default, so I switched the tempo knob behavior so it changes in 1 bpm increments by default and changes by 4 when you push in and turn.

I also disabled OLED text scrolling because i find it incredibly distracting.  I simply commented out a line in View.cpp.

I would like to have these both available as options in the community features menu of the community branch but I am not sure how to go about implementing that...  Ideally users could toggle either one of these options on or off.