### PR TITLE
Fine tempo knob

### DIFF
--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -35,6 +35,7 @@ enum RuntimeFeatureSettingType : uint32_t {
 	DrumRandomizer,
 	MasterCompressorFx,
 	Quantize,
+	FineTempoKnob,
 	MaxElement // Keep as boundary
 };
 
@@ -105,6 +106,14 @@ protected:
 	         .options = {{.displayName = "Off", .value = RuntimeFeatureStateToggle::Off},
 	                     {.displayName = "On", .value = RuntimeFeatureStateToggle::On},
 	                     {.displayName = NULL, .value = 0}}},
+
+		[RuntimeFeatureSettingType::FineTempoKnob] =
+			{.displayName = "Fine Tempo Knob",
+			 .xmlName = "fineTempoknob",
+			 .value = RuntimeFeatureStateToggle::On, // Default value
+			 .options = {{.displayName = "Off", .value = RuntimeFeatureStateToggle::Off},
+						 {.displayName = "On", .value = RuntimeFeatureStateToggle::On},
+						 {.displayName = NULL, .value = 0}}},
 
 	};
 


### PR DESCRIPTION
Hello everyone, I'm trying this again...  This build allows the user to switch the tempo knob behavior.  New default behavior is that turning the tempo knob changed BPM in increments of 1.  Pushing and turning the knob increments like the old default (typically by 4).  This can be enabled/disabled in the runtime features menu (finally figured out how to do this after taking some good advice and checking out how @alter-alter added features to that menu... great community here).  Please let me know your thoughts...  