### PR TITLE
Make format task default to recursive

### DIFF
--- a/scripts/tasks/task-format.py
+++ b/scripts/tasks/task-format.py
@@ -41,10 +41,10 @@ def argparser():
         description="Formats files using clang-format (Assumes .clang-format present in directory structure)",
     )
     parser.add_argument(
-        "-r",
-        "--recursive",
-        help="recursively descend and process files",
-        action="store_true",
+        "-nr",
+        "--no-recursive",
+        help="do not recursively descend and process files",
+        action="store_true"
     )
     parser.add_argument(
         "-q", "--quiet", help="don't show any output", action="store_true"
@@ -60,11 +60,11 @@ def argparser():
 
 def main():
     args = argparser().parse_args()
-    files = get_header_and_source_files(Path(args.directory), args.recursive)
+    files = get_header_and_source_files(Path(args.directory), not args.no_recursive)
     clang_format = get_clang_format()
     if files:
         if args.quiet:
-            util.do_parallel(lambda f: format_file(clang_format, f, False), files)
+            util.do_parallel(partial(format_file, clang_format, False), files)
         elif args.verbose:
             # Single-process for output purposes :/
             for file in files:


### PR DESCRIPTION
This changes the default behavior of the formatting task so that it is recursive by default rather than by flag, and fixes a bug when trying to use the task in quiet mode.

This has no impact on Deluge firmware code.