### PR TITLE
hid::Button is now an enum class

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -308,12 +308,12 @@ bool readButtonsAndPads() {
 
 			Uart::println("");
 			Uart::println("undoing");
-			Buttons::buttonAction(hid::button::BACK, true, sdRoutineLock);
+			Buttons::buttonAction(hid::Button::BACK, true, sdRoutineLock);
 		}
 		else {
 			Uart::println("");
 			Uart::println("beginning playback");
-			Buttons::buttonAction(hid::button::PLAY, true, sdRoutineLock);
+			Buttons::buttonAction(hid::Button::PLAY, true, sdRoutineLock);
 		}
 
 		int random = getRandom255();
@@ -378,8 +378,8 @@ bool readButtonsAndPads() {
 
 	if (playbackHandler.currentlyPlaying) {
 		if (getCurrentUI()->isViewScreen()) {
-			Buttons::buttonAction(hid::button::LOAD, true);
-			Buttons::buttonAction(hid::button::LOAD, false);
+			Buttons::buttonAction(hid::Button::LOAD, true);
+			Buttons::buttonAction(hid::Button::LOAD, false);
 			alreadyDoneScroll = false;
 		}
 		else if (getCurrentUI() == &loadSongUI && currentUIMode == noSubMode) {
@@ -388,8 +388,8 @@ bool readButtonsAndPads() {
 				alreadyDoneScroll = true;
 			}
 			else {
-				Buttons::buttonAction(hid::button::LOAD, true);
-				Buttons::buttonAction(hid::button::LOAD, false);
+				Buttons::buttonAction(hid::Button::LOAD, true);
+				Buttons::buttonAction(hid::Button::LOAD, false);
 			}
 		}
 	}

--- a/src/deluge/gui/context_menu/context_menu.cpp
+++ b/src/deluge/gui/context_menu/context_menu.cpp
@@ -163,7 +163,7 @@ void ContextMenu::selectEncoderAction(int8_t offset) {
 int ContextMenu::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
-	if (b == BACK) {
+	if (b == Button::BACK) {
 		if (on && !currentUIMode) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -174,7 +174,7 @@ getOut:
 		}
 	}
 
-	else if (b == SELECT_ENC) {
+	else if (b == Button::SELECT_ENC) {
 probablyAcceptCurrentOption:
 		if (on && !currentUIMode) {
 			if (inCardRoutine) {

--- a/src/deluge/gui/context_menu/context_menu.h
+++ b/src/deluge/gui/context_menu/context_menu.h
@@ -42,7 +42,7 @@ public:
 	int padAction(int x, int y, int velocity) override;
 	bool setupAndCheckAvailability();
 
-	virtual hid::Button getAcceptButton() { return hid::button::SELECT_ENC; }
+	virtual hid::Button getAcceptButton() { return hid::Button::SELECT_ENC; }
 
 	int currentOption; // Don't make static. We'll have multiple nested ContextMenus open at the same time
 
@@ -57,13 +57,13 @@ class ContextMenuForSaving : public ContextMenu {
 public:
 	ContextMenuForSaving() = default;
 	void focusRegained() final;
-	hid::Button getAcceptButton() final { return hid::button::SAVE; }
+	hid::Button getAcceptButton() final { return hid::Button::SAVE; }
 };
 
 class ContextMenuForLoading : public ContextMenu {
 public:
 	ContextMenuForLoading() = default;
 	void focusRegained() override;
-	hid::Button getAcceptButton() final { return hid::button::LOAD; }
+	hid::Button getAcceptButton() final { return hid::Button::LOAD; }
 };
 } // namespace deluge::gui

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -273,7 +273,7 @@ int AudioRecorder::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// We don't actually wrap up recording here, because this could be in fact called from the SD writing routines as they wait - that'd be a tangle.
-	if ((b == BACK) || (b == SELECT_ENC) || (b == RECORD)) {
+	if ((b == Button::BACK) || (b == Button::SELECT_ENC) || (b == Button::RECORD)) {
 
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1439,12 +1439,12 @@ int Browser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Select encoder
-	if (b == SELECT_ENC) {
+	if (b == Button::SELECT_ENC) {
 		return mainButtonAction(on);
 	}
 
 	// Save button, to delete file
-	else if (b == SAVE && Buttons::isShiftButtonPressed()) {
+	else if (b == Button::SAVE && Buttons::isShiftButtonPressed()) {
 		if (!currentUIMode && on) {
 			FileItem* currentFileItem = getCurrentFileItem();
 			if (currentFileItem) {
@@ -1462,7 +1462,7 @@ int Browser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Back button
-	else if (b == BACK) {
+	else if (b == Button::BACK) {
 		if (on && !currentUIMode) {
 			return backButtonAction();
 		}

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -410,7 +410,7 @@ int SampleBrowser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Save button, to delete audio file
-	if (b == SAVE && Buttons::isShiftButtonPressed()) {
+	if (b == Button::SAVE && Buttons::isShiftButtonPressed()) {
 		if (!currentUIMode && on) {
 			FileItem* currentFileItem = getCurrentFileItem();
 			if (currentFileItem) {
@@ -450,7 +450,7 @@ int SampleBrowser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Horizontal encoder button
-	else if (b == X_ENC) {
+	else if (b == Button::X_ENC) {
 		if (on) {
 			if (isNoUIModeActive()) {
 				enterUIMode(UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON);
@@ -466,7 +466,8 @@ int SampleBrowser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 	// Record button
-	else if (b == RECORD && !audioRecorder.recordingSource && currentSong->currentClip->type != CLIP_TYPE_AUDIO) {
+	else if (b == Button::RECORD && !audioRecorder.recordingSource
+	         && currentSong->currentClip->type != CLIP_TYPE_AUDIO) {
 		if (!on || currentUIMode != UI_MODE_NONE) {
 			return ACTION_RESULT_DEALT_WITH;
 		}
@@ -2104,7 +2105,7 @@ doNormal:
 
 int SampleBrowser::verticalEncoderAction(int offset, bool inCardRoutine) {
 	if (getRootUI() == &instrumentClipView) {
-		if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::X_ENC)) {
+		if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::X_ENC)) {
 			return ACTION_RESULT_DEALT_WITH;
 		}
 		return instrumentClipView.verticalEncoderAction(offset, inCardRoutine);

--- a/src/deluge/gui/ui/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard_screen.cpp
@@ -180,7 +180,7 @@ int KeyboardScreen::padAction(int x, int y, int velocity) {
 			enterUIMode(UI_MODE_AUDITIONING);
 
 			// Begin resampling - yup this is even allowed if we're in the card routine!
-			if (Buttons::isButtonPressed(hid::button::RECORD) && !audioRecorder.recordingSource) {
+			if (Buttons::isButtonPressed(hid::Button::RECORD) && !audioRecorder.recordingSource) {
 				audioRecorder.beginOutputRecording();
 				Buttons::recordButtonPressUsedUp = true;
 			}
@@ -321,7 +321,7 @@ int KeyboardScreen::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Scale mode button
-	if (b == SCALE_MODE) {
+	if (b == Button::SCALE_MODE) {
 		if (currentSong->currentClip->output->type == INSTRUMENT_TYPE_KIT) {
 			return ACTION_RESULT_DEALT_WITH; // Kits can't do scales!
 		}
@@ -376,10 +376,10 @@ int KeyboardScreen::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 
 #if DELUGE_MODEL == DELUGE_MODEL_40_PAD
 	// Clip view button - exit mode
-	else if (b == CLIP_VIEW) {
+	else if (b == Button::CLIP_VIEW) {
 #else
 	// Keyboard button - exit mode
-	else if (b == KEYBOARD) {
+	else if (b == Button::KEYBOARD) {
 #endif
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
@@ -390,7 +390,7 @@ int KeyboardScreen::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Song view button
-	else if (b == SESSION_VIEW) {
+	else if (b == Button::SESSION_VIEW) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -424,7 +424,7 @@ doOther:
 	}
 
 	// Kit button
-	else if (b == KIT && currentUIMode == UI_MODE_NONE) {
+	else if (b == Button::KIT && currentUIMode == UI_MODE_NONE) {
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 		if (on) {
 			IndicatorLEDs::indicateAlertOnLed(keyboardLedX, keyboardLedX);

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -276,12 +276,12 @@ int LoadInstrumentPresetUI::buttonAction(hid::Button b, bool on, bool inCardRout
 	int newInstrumentType;
 
 	// Load button
-	if (b == LOAD) {
+	if (b == Button::LOAD) {
 		return mainButtonAction(on);
 	}
 
 	// Synth button
-	else if (b == SYNTH) {
+	else if (b == Button::SYNTH) {
 		newInstrumentType = INSTRUMENT_TYPE_SYNTH;
 doChangeInstrumentType:
 		if (on && currentUIMode == UI_MODE_NONE) {
@@ -294,7 +294,7 @@ doChangeInstrumentType:
 	}
 
 	// Kit button
-	else if (b == KIT) {
+	else if (b == Button::KIT) {
 		if (instrumentClipToLoadFor && instrumentClipToLoadFor->onKeyboardScreen) {
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 			IndicatorLEDs::indicateAlertOnLed(keyboardLedX, keyboardLedX);
@@ -307,13 +307,13 @@ doChangeInstrumentType:
 	}
 
 	// MIDI button
-	else if (b == MIDI) {
+	else if (b == Button::MIDI) {
 		newInstrumentType = INSTRUMENT_TYPE_MIDI_OUT;
 		goto doChangeInstrumentType;
 	}
 
 	// CV button
-	else if (b == CV) {
+	else if (b == Button::CV) {
 		newInstrumentType = INSTRUMENT_TYPE_CV;
 		goto doChangeInstrumentType;
 	}
@@ -999,7 +999,7 @@ potentiallyExit:
 
 int LoadInstrumentPresetUI::verticalEncoderAction(int offset, bool inCardRoutine) {
 	if (showingAuditionPads()) {
-		if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::X_ENC)) {
+		if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::X_ENC)) {
 			return ACTION_RESULT_DEALT_WITH;
 		}
 

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -189,7 +189,7 @@ int LoadSongUI::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	// Load button or select encoder press. Unlike most (all?) other children of Browser, we override this and don't just call mainButtonAction(),
 	// because unlike all the others, we need to action the load immediately on down-press rather than waiting for press-release, because of that special
 	// action where you hold the button down until you want to "launch" the new song.
-	if ((b == LOAD) || (b == SELECT_ENC)) {
+	if ((b == Button::LOAD) || (b == Button::SELECT_ENC)) {
 		if (on) {
 			if (!currentUIMode) {
 				if (inCardRoutine) {
@@ -276,7 +276,7 @@ void LoadSongUI::performLoad() {
 		AudioEngine::logAction("a");
 		AudioEngine::songSwapAboutToHappen();
 		AudioEngine::logAction("b");
-		playbackHandler.songSwapShouldPreserveTempo = Buttons::isButtonPressed(hid::button::TEMPO_ENC);
+		playbackHandler.songSwapShouldPreserveTempo = Buttons::isButtonPressed(hid::Button::TEMPO_ENC);
 	}
 
 	void* songMemory = generalMemoryAllocator.alloc(sizeof(Song), NULL, false, true);
@@ -378,7 +378,7 @@ gotErrorAfterCreatingSong:
 	if (playbackHandler.isEitherClockActive()) {
 
 		// If load button was already released while that loading was happening, arm for song-swap now
-		if (!Buttons::isButtonPressed(hid::button::LOAD)) {
+		if (!Buttons::isButtonPressed(hid::Button::LOAD)) {
 			bool result = session.armForSongSwap();
 
 			// If arming couldn't really be done, e.g. because current song had no Clips currently playing, swap has already occurred
@@ -698,7 +698,7 @@ goAgain:
 }
 
 int LoadSongUI::verticalEncoderAction(int offset, bool inCardRoutine) {
-	if (!currentUIMode && !Buttons::isButtonPressed(hid::button::Y_ENC) && !Buttons::isShiftButtonPressed()
+	if (!currentUIMode && !Buttons::isButtonPressed(hid::Button::Y_ENC) && !Buttons::isShiftButtonPressed()
 	    && offset < 0) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -69,7 +69,7 @@ int RenameDrumUI::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Back button
-	if (b == BACK) {
+	if (b == Button::BACK) {
 		if (on && !currentUIMode) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -79,7 +79,7 @@ int RenameDrumUI::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Select encoder button
-	else if (b == SELECT_ENC) {
+	else if (b == Button::SELECT_ENC) {
 		if (on && !currentUIMode) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -144,7 +144,7 @@ int RenameDrumUI::padAction(int x, int y, int on) {
 }
 
 int RenameDrumUI::verticalEncoderAction(int offset, bool inCardRoutine) {
-	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::X_ENC)) {
+	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::X_ENC)) {
 		return ACTION_RESULT_DEALT_WITH;
 	}
 	return instrumentClipView.verticalEncoderAction(offset, inCardRoutine);

--- a/src/deluge/gui/ui/rename/rename_output_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_output_ui.cpp
@@ -63,7 +63,7 @@ int RenameOutputUI::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Back button
-	if (b == BACK) {
+	if (b == Button::BACK) {
 		if (on && !currentUIMode) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -73,7 +73,7 @@ int RenameOutputUI::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Select encoder button
-	else if (b == SELECT_ENC) {
+	else if (b == Button::SELECT_ENC) {
 		if (on && !currentUIMode) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -133,7 +133,7 @@ int RenameOutputUI::padAction(int x, int y, int on) {
 }
 
 int RenameOutputUI::verticalEncoderAction(int offset, bool inCardRoutine) {
-	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::X_ENC)) {
+	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::X_ENC)) {
 		return ACTION_RESULT_DEALT_WITH;
 	}
 	return arrangerView.verticalEncoderAction(offset, inCardRoutine);

--- a/src/deluge/gui/ui/sample_marker_editor.cpp
+++ b/src/deluge/gui/ui/sample_marker_editor.cpp
@@ -573,7 +573,7 @@ int SampleMarkerEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine)
 	using namespace hid::button;
 
 	// Back button
-	if (b == BACK) {
+	if (b == Button::BACK) {
 		if (on && !currentUIMode) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -583,7 +583,7 @@ int SampleMarkerEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine)
 	}
 
 	// Horizontal encoder button
-	else if (b == X_ENC) {
+	else if (b == Button::X_ENC) {
 		if (on) {
 			if (isNoUIModeActive() || isUIModeActiveExclusively(UI_MODE_AUDITIONING)) {
 				currentUIMode |= UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON;
@@ -680,7 +680,7 @@ int SampleMarkerEditor::timerCallback() {
 }
 
 int SampleMarkerEditor::verticalEncoderAction(int offset, bool inCardRoutine) {
-	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::X_ENC)
+	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::X_ENC)
 	    || currentSong->currentClip->type == CLIP_TYPE_AUDIO) {
 		return ACTION_RESULT_DEALT_WITH;
 	}

--- a/src/deluge/gui/ui/save/save_ui.cpp
+++ b/src/deluge/gui/ui/save/save_ui.cpp
@@ -110,12 +110,12 @@ int SaveUI::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	FileItem* currentFileItem = getCurrentFileItem();
 
 	// Save button
-	if (b == SAVE && !Buttons::isShiftButtonPressed()) {
+	if (b == Button::SAVE && !Buttons::isShiftButtonPressed()) {
 		return mainButtonAction(on);
 	}
 
 	// Select encoder button - we want to override default behaviour here and potentially do nothing, so user doesn't save over something by accident.
-	else if (b == SELECT_ENC && currentFileItem && !currentFileItem->isFolder) {}
+	else if (b == Button::SELECT_ENC && currentFileItem && !currentFileItem->isFolder) {}
 
 	else {
 		return SlotBrowser::buttonAction(b, on, inCardRoutine);

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -118,14 +118,14 @@ int Slicer::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 		return ACTION_RESULT_NOT_DEALT_WITH;
 	}
 
-	if (b == SELECT_ENC) {
+	if (b == Button::SELECT_ENC) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
 		doSlice();
 	}
 
-	else if (b == BACK) {
+	else if (b == Button::BACK) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -201,7 +201,7 @@ int SoundEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Encoder button
-	if (b == SELECT_ENC) {
+	if (b == Button::SELECT_ENC) {
 		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING) {
 			if (on) {
 				if (inCardRoutine) {
@@ -237,7 +237,7 @@ int SoundEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Back button
-	else if (b == BACK) {
+	else if (b == Button::BACK) {
 		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING) {
 			if (on) {
 				if (inCardRoutine) {
@@ -255,7 +255,7 @@ int SoundEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Save button
-	else if (b == SAVE) {
+	else if (b == Button::SAVE) {
 		if (on && currentUIMode == UI_MODE_NONE && !inSettingsMenu() && !editingCVOrMIDIClip()
 		    && currentSong->currentClip->type != CLIP_TYPE_AUDIO) {
 			if (inCardRoutine) {
@@ -274,7 +274,7 @@ int SoundEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// MIDI learn button
-	else if (b == LEARN) {
+	else if (b == Button::LEARN) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -309,13 +309,13 @@ int SoundEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 #if DELUGE_MODEL == DELUGE_MODEL_40_PAD
-	else if (b == CLIP_VIEW && getRootUI() == &instrumentClipView) {
+	else if (b == Button::CLIP_VIEW && getRootUI() == &instrumentClipView) {
 		return instrumentClipView.buttonAction(b, on, inCardRoutine);
 	}
 #else
 
 	// Affect-entire button
-	else if (b == AFFECT_ENTIRE && getRootUI() == &instrumentClipView) {
+	else if (b == Button::AFFECT_ENTIRE && getRootUI() == &instrumentClipView) {
 		if (getCurrentMenuItem()->usesAffectEntire() && editingKit()) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -339,7 +339,7 @@ int SoundEditor::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Keyboard button
-	else if (b == KEYBOARD) {
+	else if (b == Button::KEYBOARD) {
 		if (on && currentUIMode == UI_MODE_NONE && !editingKit()) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -901,7 +901,7 @@ int SoundEditor::padAction(int x, int y, int on) {
 }
 
 int SoundEditor::verticalEncoderAction(int offset, bool inCardRoutine) {
-	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::X_ENC)) {
+	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::X_ENC)) {
 		return ACTION_RESULT_DEALT_WITH;
 	}
 	return getRootUI()->verticalEncoderAction(offset, inCardRoutine);

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -165,7 +165,7 @@ int ArrangerView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	int newInstrumentType;
 
 	// Song button
-	if (b == SESSION_VIEW) {
+	if (b == Button::SESSION_VIEW) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -181,7 +181,7 @@ int ArrangerView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 	// Affect-entire button
-	else if (b == AFFECT_ENTIRE) {
+	else if (b == Button::AFFECT_ENTIRE) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -194,7 +194,7 @@ int ArrangerView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 #endif
 
 	// Cross-screen button
-	else if (b == CROSS_SCREEN_EDIT) {
+	else if (b == Button::CROSS_SCREEN_EDIT) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			currentSong->arrangerAutoScrollModeActive = !currentSong->arrangerAutoScrollModeActive;
 			IndicatorLEDs::setLedState(crossScreenEditLedX, crossScreenEditLedY,
@@ -210,7 +210,7 @@ int ArrangerView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Record button - adds to what MatrixDriver does with it
-	else if (b == RECORD) {
+	else if (b == Button::RECORD) {
 		if (on) {
 			uiTimerManager.setTimer(TIMER_UI_SPECIFIC, 500);
 			blinkOn = true;
@@ -226,7 +226,7 @@ int ArrangerView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Save/delete button with row held
-	else if (b == SAVE
+	else if (b == Button::SAVE
 	         && (currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION
 	             || currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW)) {
 		if (inCardRoutine) {
@@ -238,7 +238,7 @@ int ArrangerView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Select encoder button
-	else if (b == SELECT_ENC && !Buttons::isShiftButtonPressed()) {
+	else if (b == Button::SELECT_ENC && !Buttons::isShiftButtonPressed()) {
 		if (on && currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -248,7 +248,7 @@ int ArrangerView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Which-instrument-type buttons
-	else if (b == SYNTH) {
+	else if (b == Button::SYNTH) {
 		newInstrumentType = INSTRUMENT_TYPE_SYNTH;
 
 doChangeInstrumentType:
@@ -269,7 +269,7 @@ doChangeInstrumentType:
 			else {
 
 				// If load button held, go into LoadInstrumentPresetUI
-				if (Buttons::isButtonPressed(hid::button::LOAD)) {
+				if (Buttons::isButtonPressed(hid::Button::LOAD)) {
 
 					// Can't do that for MIDI or CV tracks though
 					if (newInstrumentType == INSTRUMENT_TYPE_MIDI_OUT || newInstrumentType == INSTRUMENT_TYPE_CV) {
@@ -300,23 +300,23 @@ doActualSimpleChange:
 		}
 	}
 
-	else if (b == KIT) {
+	else if (b == Button::KIT) {
 		newInstrumentType = INSTRUMENT_TYPE_KIT;
 		goto doChangeInstrumentType;
 	}
 
-	else if (b == MIDI) {
+	else if (b == Button::MIDI) {
 		newInstrumentType = INSTRUMENT_TYPE_MIDI_OUT;
 		goto doChangeInstrumentType;
 	}
 
-	else if (b == CV) {
+	else if (b == Button::CV) {
 		newInstrumentType = INSTRUMENT_TYPE_CV;
 		goto doChangeInstrumentType;
 	}
 
 	// Back button with <> button held
-	else if (b == BACK && currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) {
+	else if (b == Button::BACK && currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -1021,7 +1021,7 @@ doUnsolo:
 
 			case UI_MODE_NONE:
 				// If the user was just quick and is actually holding the record button but the submode just hasn't changed yet...
-				if (velocity && Buttons::isButtonPressed(hid::button::RECORD)) {
+				if (velocity && Buttons::isButtonPressed(hid::Button::RECORD)) {
 					output->armedForRecording = !output->armedForRecording;
 					timerCallback();                 // Get into UI_MODE_VIEWING_RECORD_ARMING
 					return ACTION_RESULT_DEALT_WITH; // No need to draw anything
@@ -2246,7 +2246,7 @@ int ArrangerView::timerCallback() {
 		break;
 
 	case UI_MODE_NONE:
-		if (Buttons::isButtonPressed(hid::button::RECORD)) {
+		if (Buttons::isButtonPressed(hid::Button::RECORD)) {
 			currentUIMode = UI_MODE_VIEWING_RECORD_ARMING;
 			PadLEDs::reassessGreyout(false);
 		case UI_MODE_VIEWING_RECORD_ARMING:
@@ -2949,7 +2949,7 @@ static const uint32_t verticalEncoderUIModes[] = {UI_MODE_HOLDING_ARRANGEMENT_RO
 
 int ArrangerView::verticalEncoderAction(int offset, bool inCardRoutine) {
 
-	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::Y_ENC)) {
+	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::Y_ENC)) {
 		return ACTION_RESULT_DEALT_WITH;
 	}
 
@@ -3068,7 +3068,7 @@ static const uint32_t autoScrollPlaybackEndUIModes[] = {UI_MODE_HOLDING_ARRANGEM
 void ArrangerView::autoScrollOnPlaybackEnd() {
 
 	if (doingAutoScrollNow && isUIModeWithinRange(autoScrollPlaybackEndUIModes)
-	    && !Buttons::isButtonPressed(ENCODER_SCROLL_X)) {
+	    && !Buttons::isButtonPressed(hid::Button::X_ENC)) {
 		// Don't do it if they're instantly restarting playback again
 
 		uint32_t xZoom = currentSong->xZoom[NAVIGATION_ARRANGEMENT];

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -296,7 +296,7 @@ int AudioClipView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	int result;
 
 	// Song view button
-	if (b == SESSION_VIEW) {
+	if (b == Button::SESSION_VIEW) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -318,25 +318,25 @@ doOther:
 		}
 	}
 
-	else if (b == PLAY) {
+	else if (b == Button::PLAY) {
 dontDeactivateMarker:
 		return ClipView::buttonAction(b, on, inCardRoutine);
 	}
 
-	else if (b == RECORD) {
+	else if (b == Button::RECORD) {
 		goto dontDeactivateMarker;
 	}
 
-	else if (b == SHIFT) {
+	else if (b == Button::SHIFT) {
 		goto dontDeactivateMarker;
 	}
 
-	else if (b == X_ENC) {
+	else if (b == Button::X_ENC) {
 		goto dontDeactivateMarker;
 	}
 
 	// Select button, without shift
-	else if (b == SELECT_ENC && !Buttons::isShiftButtonPressed()) {
+	else if (b == Button::SELECT_ENC && !Buttons::isShiftButtonPressed()) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -353,7 +353,7 @@ dontDeactivateMarker:
 	}
 
 	// Back button to clear Clip
-	else if (b == BACK && currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) {
+	else if (b == Button::BACK && currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -402,7 +402,7 @@ int AudioClipView::padAction(int x, int y, int on) {
 	// Edit pad action...
 	if (x < displayWidth) {
 
-		if (Buttons::isButtonPressed(hid::button::TEMPO_ENC)) {
+		if (Buttons::isButtonPressed(hid::Button::TEMPO_ENC)) {
 			if (on) {
 				playbackHandler.grabTempoFromClip(getClip());
 			}
@@ -615,7 +615,7 @@ void AudioClipView::selectEncoderAction(int8_t offset) {
 }
 
 int AudioClipView::verticalEncoderAction(int offset, bool inCardRoutine) {
-	if (!currentUIMode && Buttons::isShiftButtonPressed() && !Buttons::isButtonPressed(hid::button::Y_ENC)) {
+	if (!currentUIMode && Buttons::isShiftButtonPressed() && !Buttons::isButtonPressed(hid::Button::Y_ENC)) {
 		if (inCardRoutine && !allowSomeUserActionsEvenWhenInCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE; // Allow sometimes.
 		}

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -56,7 +56,7 @@ int ClipView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Horizontal encoder button press-down - don't let it do its zoom level thing if zooming etc not currently accessible
-	if (b == X_ENC && on && !getCurrentClip()->currentlyScrollableAndZoomable()) {}
+	if (b == Button::X_ENC && on && !getCurrentClip()->currentlyScrollableAndZoomable()) {}
 
 #ifdef BUTTON_SEQUENCE_DIRECTION_X
 	else if (x == BUTTON_SEQUENCE_DIRECTION_X && y == BUTTON_SEQUENCE_DIRECTION_Y) {
@@ -141,8 +141,8 @@ Action* ClipView::shortenClip(int32_t newLength) {
 int ClipView::horizontalEncoderAction(int offset) {
 
 	// Shift button pressed - edit length
-	if (isNoUIModeActive() && !Buttons::isButtonPressed(hid::button::Y_ENC)
-	    && (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::button::CLIP_VIEW))) {
+	if (isNoUIModeActive() && !Buttons::isButtonPressed(hid::Button::Y_ENC)
+	    && (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(hid::Button::CLIP_VIEW))) {
 
 		// If tempoless recording, don't allow
 		if (!getCurrentClip()->currentlyScrollableAndZoomable()) {
@@ -223,9 +223,9 @@ doReRender:
 	}
 
 	// Or, maybe shift everything horizontally
-	else if ((isNoUIModeActive() && Buttons::isButtonPressed(hid::button::Y_ENC))
+	else if ((isNoUIModeActive() && Buttons::isButtonPressed(hid::Button::Y_ENC))
 	         || (isUIModeActiveExclusively(UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON)
-	             && Buttons::isButtonPressed(hid::button::CLIP_VIEW))) {
+	             && Buttons::isButtonPressed(hid::Button::CLIP_VIEW))) {
 		if (sdRoutineLock)
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE; // Just be safe - maybe not necessary
 		int squareSize = getPosFromSquare(1) - getPosFromSquare(0);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -165,7 +165,7 @@ int InstrumentClipView::buttonAction(hid::Button b, bool on, bool inCardRoutine)
 	using namespace hid::button;
 
 	// Scale mode button
-	if (b == SCALE_MODE) {
+	if (b == Button::SCALE_MODE) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -225,7 +225,7 @@ int InstrumentClipView::buttonAction(hid::Button b, bool on, bool inCardRoutine)
 	}
 
 	// Song view button
-	else if (b == SESSION_VIEW) {
+	else if (b == Button::SESSION_VIEW) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -247,7 +247,7 @@ doOther:
 
 #if DELUGE_MODEL == DELUGE_MODEL_40_PAD
 	// Clip view button
-	else if (b == CLIP_VIEW) {
+	else if (b == Button::CLIP_VIEW) {
 		if (on && Buttons::isShiftButtonPressed() && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine)
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -266,7 +266,7 @@ doOther:
 #else
 
 	// Keyboard button
-	else if (b == KEYBOARD) {
+	else if (b == Button::KEYBOARD) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -278,7 +278,7 @@ doOther:
 #endif
 
 	// Wrap edit button
-	else if (b == CROSS_SCREEN_EDIT) {
+	else if (b == Button::CROSS_SCREEN_EDIT) {
 		if (on) {
 			if (currentUIMode == UI_MODE_NONE) {
 				if (inCardRoutine) {
@@ -303,7 +303,8 @@ doOther:
 
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 	// Record button if holding audition pad
-	else if (b == RECORD && (currentUIMode == UI_MODE_ADDING_DRUM_NOTEROW || currentUIMode == UI_MODE_AUDITIONING)) {
+	else if (b == Button::RECORD
+	         && (currentUIMode == UI_MODE_ADDING_DRUM_NOTEROW || currentUIMode == UI_MODE_AUDITIONING)) {
 		if (on && currentSong->currentClip->output->type == INSTRUMENT_TYPE_KIT && !audioRecorder.recordingSource
 		    && (!playbackHandler.isEitherClockActive() || !playbackHandler.ticksLeftInCountIn)) {
 
@@ -350,7 +351,7 @@ doOther:
 #endif
 
 	// Back button if adding Drum
-	else if (b == BACK && currentUIMode == UI_MODE_ADDING_DRUM_NOTEROW) {
+	else if (b == Button::BACK && currentUIMode == UI_MODE_ADDING_DRUM_NOTEROW) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -365,7 +366,7 @@ doOther:
 	}
 
 	// Load / Kit button if creating new NoteRow for Drum
-	else if (currentUIMode == UI_MODE_ADDING_DRUM_NOTEROW && ((b == LOAD) || (b == KIT))) {
+	else if (currentUIMode == UI_MODE_ADDING_DRUM_NOTEROW && ((b == Button::LOAD) || (b == Button::KIT))) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -393,7 +394,7 @@ doOther:
 	}
 
 	// Load / kit button if auditioning
-	else if (currentUIMode == UI_MODE_AUDITIONING && ((b == LOAD) || (b == KIT))
+	else if (currentUIMode == UI_MODE_AUDITIONING && ((b == Button::LOAD) || (b == Button::KIT))
 	         && (!playbackHandler.isEitherClockActive() || !playbackHandler.ticksLeftInCountIn)) {
 
 		if (on) {
@@ -433,7 +434,7 @@ doOther:
 	}
 
 	// Kit button. Unlike the other instrument-type buttons, whose code is in InstrumentClipMinder, this one is only allowed in the InstrumentClipView
-	else if (b == KIT && currentUIMode == UI_MODE_NONE) {
+	else if (b == Button::KIT && currentUIMode == UI_MODE_NONE) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -448,7 +449,7 @@ doOther:
 		}
 	}
 
-	else if (b == SYNTH && currentUIMode != UI_MODE_HOLDING_SAVE_BUTTON
+	else if (b == Button::SYNTH && currentUIMode != UI_MODE_HOLDING_SAVE_BUTTON
 	         && currentUIMode != UI_MODE_HOLDING_LOAD_BUTTON) {
 		if (on) {
 			if (inCardRoutine) {
@@ -469,7 +470,7 @@ doOther:
 		}
 	}
 
-	else if (b == MIDI) {
+	else if (b == Button::MIDI) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -484,7 +485,7 @@ doOther:
 		}
 	}
 
-	else if (b == CV) {
+	else if (b == Button::CV) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -500,7 +501,7 @@ doOther:
 	}
 
 	// Save / delete button if NoteRow held down
-	else if (b == SAVE && currentUIMode == UI_MODE_NOTES_PRESSED) {
+	else if (b == Button::SAVE && currentUIMode == UI_MODE_NOTES_PRESSED) {
 		InstrumentClip* clip = getCurrentClip();
 
 		if (on && numEditPadPresses == 1 && currentSong->currentClip->output->type == INSTRUMENT_TYPE_KIT
@@ -575,7 +576,7 @@ doOther:
 	}
 
 	// Horizontal encoder button if learn button pressed. Make sure you let the "off" action slide past to the Editor
-	else if (b == X_ENC && on && Buttons::isButtonPressed(hid::button::LEARN)) {
+	else if (b == Button::X_ENC && on && Buttons::isButtonPressed(hid::Button::LEARN)) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -588,12 +589,12 @@ doOther:
 		}
 	}
 
-	else if (b == TEMPO_ENC && isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)
+	else if (b == Button::TEMPO_ENC && isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)
 	         && runtimeFeatureSettings.get(RuntimeFeatureSettingType::Quantize) == RuntimeFeatureStateToggle::On) {
 		//prevent Tempo pop-up , when note is pressed
 	}
 	// Horizontal encoder button
-	else if (b == X_ENC) {
+	else if (b == Button::X_ENC) {
 
 		// If user wants to "multiple" Clip contents
 		if (on && Buttons::isShiftButtonPressed() && !isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)) {
@@ -637,7 +638,7 @@ doCancelPopup:
 	}
 
 	// Vertical encoder button
-	else if (b == Y_ENC) {
+	else if (b == Button::Y_ENC) {
 
 		// If holding notes down...
 		if (isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)) {
@@ -814,7 +815,7 @@ discardDrum:
 void InstrumentClipView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 
 	// If they want to copy or paste automation...
-	if (Buttons::isButtonPressed(hid::button::LEARN)) {
+	if (Buttons::isButtonPressed(hid::Button::LEARN)) {
 		if (on && currentSong->currentClip->output->type != INSTRUMENT_TYPE_CV) {
 			if (Buttons::isShiftButtonPressed()) {
 				pasteAutomation(whichModEncoder);
@@ -1179,7 +1180,7 @@ void InstrumentClipView::selectEncoderAction(int8_t offset) {
 
 	// User may be trying to edit noteCode...
 	if (currentUIMode == UI_MODE_AUDITIONING) {
-		if (Buttons::isButtonPressed(hid::button::SELECT_ENC)) {
+		if (Buttons::isButtonPressed(hid::Button::SELECT_ENC)) {
 
 			if (playbackHandler.isEitherClockActive() && playbackHandler.ticksLeftInCountIn) {
 				return;
@@ -1192,7 +1193,7 @@ void InstrumentClipView::selectEncoderAction(int8_t offset) {
 
 	// Or set / create a new Drum
 	else if (currentUIMode == UI_MODE_ADDING_DRUM_NOTEROW) {
-		if (Buttons::isButtonPressed(hid::button::SELECT_ENC)) {
+		if (Buttons::isButtonPressed(hid::Button::SELECT_ENC)) {
 			drumForNewNoteRow = flipThroughAvailableDrums(offset, drumForNewNoteRow, true);
 			//setSelectedDrum(drumForNewNoteRow); // Can't - it doesn't have a NoteRow, and so we don't really know where its ParamManager is!
 			drawDrumName(drumForNewNoteRow);
@@ -3206,7 +3207,7 @@ maybeRenderRow:
 			}
 
 			// If won't be actually sounding Instrument...
-			if (shiftButtonDown || Buttons::isButtonPressed(hid::button::Y_ENC)) {
+			if (shiftButtonDown || Buttons::isButtonPressed(hid::Button::Y_ENC)) {
 
 				fileBrowserShouldNotPreview = true;
 doSilentAudition:
@@ -3236,7 +3237,7 @@ doSilentAudition:
 			lastAuditionedYDisplay = yDisplay;
 
 			// Begin resampling / output-recording
-			if (Buttons::isButtonPressed(hid::button::RECORD) && !audioRecorder.recordingSource) {
+			if (Buttons::isButtonPressed(hid::Button::RECORD) && !audioRecorder.recordingSource) {
 				audioRecorder.beginOutputRecording();
 				Buttons::recordButtonPressUsedUp = true;
 			}
@@ -3964,7 +3965,7 @@ int InstrumentClipView::verticalEncoderAction(int offset, bool inCardRoutine) {
 	}
 
 	// If encoder button pressed
-	if (Buttons::isButtonPressed(hid::button::Y_ENC)) {
+	if (Buttons::isButtonPressed(hid::Button::Y_ENC)) {
 		// User may be trying to move a noteCode...
 		if (isUIModeActiveExclusively(UI_MODE_AUDITIONING)) {
 			/*

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -152,7 +152,7 @@ int SessionView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 		}
 		const char* paramLabels[] = {"THRE", "MAKE", "ATTK", "REL", "RATI", "MIX"};
 
-		if (modKnobMode == 4 && b == MOD_ENCODER_1 && on) {
+		if (modKnobMode == 4 && b == Button::MOD_ENCODER_1 && on) {
 			masterCompEditMode++;
 			masterCompEditMode = masterCompEditMode % 6; //toggle master compressor setting
 
@@ -169,7 +169,7 @@ int SessionView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	int newInstrumentType;
 
 	// Clip-view button
-	if (b == CLIP_VIEW) {
+	if (b == Button::CLIP_VIEW) {
 		if (on && currentUIMode == UI_MODE_NONE && playbackHandler.recording != RECORDING_ARRANGEMENT) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -184,7 +184,7 @@ int SessionView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 #ifdef arrangerViewButtonX
 	else if (b == arrangerView) {
 #else
-	else if (b == SESSION_VIEW && !Buttons::isShiftButtonPressed()) {
+	else if (b == Button::SESSION_VIEW && !Buttons::isShiftButtonPressed()) {
 #endif
 		if (on) {
 			if (inCardRoutine) {
@@ -192,7 +192,7 @@ int SessionView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 			}
 
 			// If holding record button...
-			if (Buttons::isButtonPressed(hid::button::RECORD)) {
+			if (Buttons::isButtonPressed(hid::Button::RECORD)) {
 				Buttons::recordButtonPressUsedUp = true;
 
 				// Make sure we weren't already playing...
@@ -319,7 +319,7 @@ moveAfterClipInstance:
 
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 	// Affect-entire button
-	else if (b == AFFECT_ENTIRE) {
+	else if (b == Button::AFFECT_ENTIRE) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			currentSong->affectEntire = !currentSong->affectEntire;
 			view.setActiveModControllableTimelineCounter(currentSong);
@@ -328,7 +328,7 @@ moveAfterClipInstance:
 #endif
 
 	// Record button - adds to what MatrixDriver does with it
-	else if (b == RECORD) {
+	else if (b == Button::RECORD) {
 		if (on) {
 			if (isNoUIModeActive()) {
 				uiTimerManager.setTimer(TIMER_UI_SPECIFIC, 500);
@@ -352,7 +352,7 @@ moveAfterClipInstance:
 	}
 
 	// If save / delete button pressed, delete the Clip!
-	else if (b == SAVE && currentUIMode == UI_MODE_CLIP_PRESSED_IN_SONG_VIEW) {
+	else if (b == Button::SAVE && currentUIMode == UI_MODE_CLIP_PRESSED_IN_SONG_VIEW) {
 		if (on) {
 
 			if (playbackHandler.recording == RECORDING_ARRANGEMENT) {
@@ -373,7 +373,7 @@ moveAfterClipInstance:
 	}
 
 	// Select encoder button
-	else if (b == SELECT_ENC && !Buttons::isShiftButtonPressed()) {
+	else if (b == Button::SELECT_ENC && !Buttons::isShiftButtonPressed()) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -412,7 +412,7 @@ moveAfterClipInstance:
 	}
 
 	// Which-instrument-type buttons
-	else if (b == SYNTH) {
+	else if (b == Button::SYNTH) {
 		newInstrumentType = INSTRUMENT_TYPE_SYNTH;
 
 changeInstrumentType:
@@ -442,7 +442,7 @@ changeInstrumentType:
 
 				InstrumentClip* instrumentClip = (InstrumentClip*)clip;
 				// If load button held, go into LoadInstrumentPresetUI
-				if (Buttons::isButtonPressed(hid::button::LOAD)) {
+				if (Buttons::isButtonPressed(hid::Button::LOAD)) {
 
 					// Can't do that for MIDI or CV Clips though
 					if (newInstrumentType == INSTRUMENT_TYPE_MIDI_OUT || newInstrumentType == INSTRUMENT_TYPE_CV) {
@@ -476,15 +476,15 @@ doActualSimpleChange:
 			uiNeedsRendering(this, 1 << selectedClipYDisplay, 0);
 		}
 	}
-	else if (b == KIT) {
+	else if (b == Button::KIT) {
 		newInstrumentType = INSTRUMENT_TYPE_KIT;
 		goto changeInstrumentType;
 	}
-	else if (b == MIDI) {
+	else if (b == Button::MIDI) {
 		newInstrumentType = INSTRUMENT_TYPE_MIDI_OUT;
 		goto changeInstrumentType;
 	}
-	else if (b == CV) {
+	else if (b == Button::CV) {
 		newInstrumentType = INSTRUMENT_TYPE_CV;
 		goto changeInstrumentType;
 	}
@@ -572,7 +572,7 @@ int SessionView::padAction(int xDisplay, int yDisplay, int on) {
 				if (currentUIMode == UI_MODE_NONE) {
 
 					// If they're holding down the record button...
-					if (Buttons::isButtonPressed(hid::button::RECORD)) {
+					if (Buttons::isButtonPressed(hid::Button::RECORD)) {
 
 holdingRecord:
 						// If doing recording stuff, create a "pending overdub".
@@ -645,7 +645,7 @@ holdingRecord:
 					else if (clip) {
 
 						// If holding down tempo knob...
-						if (Buttons::isButtonPressed(hid::button::TEMPO_ENC)) {
+						if (Buttons::isButtonPressed(hid::Button::TEMPO_ENC)) {
 							playbackHandler.grabTempoFromClip(clip);
 						}
 
@@ -680,7 +680,7 @@ startHoldingDown:
 					// Otherwise, try and create one
 					else {
 
-						if (Buttons::isButtonPressed(hid::button::RECORD)) {
+						if (Buttons::isButtonPressed(hid::Button::RECORD)) {
 							return ACTION_RESULT_DEALT_WITH;
 						}
 						if (sdRoutineLock) {
@@ -854,7 +854,7 @@ justEndClipPress:
 			// Section pad
 			else if (xDisplay == displayWidth + 1) {
 
-				if (on && Buttons::isButtonPressed(hid::button::RECORD)
+				if (on && Buttons::isButtonPressed(hid::Button::RECORD)
 				    && (!currentUIMode || currentUIMode == UI_MODE_VIEWING_RECORD_ARMING)) {
 					Buttons::recordButtonPressUsedUp = true;
 					goto holdingRecord;
@@ -993,7 +993,7 @@ int SessionView::timerCallback() {
 		break;
 
 	case UI_MODE_NONE:
-		if (Buttons::isButtonPressed(hid::button::RECORD)) {
+		if (Buttons::isButtonPressed(hid::Button::RECORD)) {
 			enterUIMode(UI_MODE_VIEWING_RECORD_ARMING);
 			PadLEDs::reassessGreyout(false);
 		case UI_MODE_VIEWING_RECORD_ARMING:

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -66,7 +66,7 @@ int TimelineView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	using namespace hid::button;
 
 	// Horizontal encoder button
-	if (b == X_ENC) {
+	if (b == Button::X_ENC) {
 		if (on) {
 			// Show current zoom level
 			if (isNoUIModeActive()) {
@@ -86,7 +86,7 @@ int TimelineView::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Triplets button
-	else if (b == TRIPLETS) {
+	else if (b == Button::TRIPLETS) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -127,7 +127,7 @@ int View::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 
 	// Tap tempo button. Shouldn't move this to MatrixDriver, because this code can put us in tapTempo mode, and other UIs aren't built to
 	// handle this
-	if (b == TAP_TEMPO) {
+	if (b == Button::TAP_TEMPO) {
 
 		if (currentUIMode == UI_MODE_MIDI_LEARN) {
 			if (inCardRoutine) {
@@ -163,7 +163,7 @@ doEndMidiLearnPressSession:
 	}
 
 	// MIDI learn button
-	else if (b == LEARN) {
+	else if (b == Button::LEARN) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -185,7 +185,7 @@ doEndMidiLearnPressSession:
 	}
 
 	// Play button for MIDI learn
-	else if (b == PLAY && currentUIMode == UI_MODE_MIDI_LEARN) {
+	else if (b == Button::PLAY && currentUIMode == UI_MODE_MIDI_LEARN) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -201,7 +201,7 @@ doEndMidiLearnPressSession:
 	}
 
 	// Record button for MIDI learn
-	else if (b == RECORD && currentUIMode == UI_MODE_MIDI_LEARN) {
+	else if (b == Button::RECORD && currentUIMode == UI_MODE_MIDI_LEARN) {
 		if (inCardRoutine) {
 			return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -217,10 +217,10 @@ doEndMidiLearnPressSession:
 	}
 
 	// Save button
-	else if (b == SAVE) {
+	else if (b == Button::SAVE) {
 
-		if (!Buttons::isButtonPressed(hid::button::SYNTH) && !Buttons::isButtonPressed(hid::button::KIT)
-		    && !Buttons::isButtonPressed(hid::button::MIDI) && !Buttons::isButtonPressed(hid::button::CV)) {
+		if (!Buttons::isButtonPressed(hid::Button::SYNTH) && !Buttons::isButtonPressed(hid::Button::KIT)
+		    && !Buttons::isButtonPressed(hid::Button::MIDI) && !Buttons::isButtonPressed(hid::Button::CV)) {
 			// Press down
 			if (on) {
 				if (currentUIMode == UI_MODE_NONE && !Buttons::isShiftButtonPressed()) {
@@ -256,10 +256,10 @@ doEndMidiLearnPressSession:
 	}
 
 	// Load button
-	else if (b == LOAD) {
+	else if (b == Button::LOAD) {
 
-		if (!Buttons::isButtonPressed(hid::button::SYNTH) && !Buttons::isButtonPressed(hid::button::KIT)
-		    && !Buttons::isButtonPressed(hid::button::MIDI) && !Buttons::isButtonPressed(hid::button::CV)) {
+		if (!Buttons::isButtonPressed(hid::Button::SYNTH) && !Buttons::isButtonPressed(hid::Button::KIT)
+		    && !Buttons::isButtonPressed(hid::Button::MIDI) && !Buttons::isButtonPressed(hid::Button::CV)) {
 			// Press down
 			if (on) {
 				if (currentUIMode == UI_MODE_NONE) {
@@ -308,7 +308,7 @@ doEndMidiLearnPressSession:
 	}
 
 	// Sync-scaling button
-	else if (b == SYNC_SCALING) {
+	else if (b == Button::SYNC_SCALING) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 
 			if (playbackHandler.recording == RECORDING_ARRANGEMENT) {
@@ -354,7 +354,7 @@ cant:
 	}
 
 	// Back button
-	else if (b == BACK) {
+	else if (b == Button::BACK) {
 
 		if (on) {
 #ifndef undoButtonX
@@ -403,7 +403,7 @@ possiblyRevert:
 #endif
 
 	// Select button with shift - go to settings menu
-	else if (b == SELECT_ENC && Buttons::isShiftButtonPressed()) {
+	else if (b == Button::SELECT_ENC && Buttons::isShiftButtonPressed()) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 
 			if (playbackHandler.recording == RECORDING_ARRANGEMENT) {
@@ -910,7 +910,7 @@ void View::instrumentBeenEdited() {
 void View::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 
 	// If the learn button is pressed, user is trying to copy or paste, and the fact that we've ended up here means they can't
-	if (Buttons::isButtonPressed(hid::button::LEARN)) {
+	if (Buttons::isButtonPressed(hid::Button::LEARN)) {
 #if !HAVE_OLED
 		if (on) {
 			numericDriver.displayPopup("CANT");
@@ -1935,7 +1935,7 @@ int View::clipStatusPadAction(Clip* clip, bool on, int yDisplayIfInSessionView) 
 
 	case UI_MODE_NONE:
 		// If the user was just quick and is actually holding the record button but the submode just hasn't changed yet...
-		if (on && Buttons::isButtonPressed(hid::button::RECORD)) {
+		if (on && Buttons::isButtonPressed(hid::Button::RECORD)) {
 			clip->armedForRecording = !clip->armedForRecording;
 			sessionView
 			    .timerCallback(); // Get into UI_MODE_VIEWING_RECORD_ARMING. TODO: this needs doing properly - what if we're in a Clip view?

--- a/src/deluge/hid/button.cpp
+++ b/src/deluge/hid/button.cpp
@@ -7,12 +7,12 @@ namespace button {
 
 struct xy toXY(Button b) {
 #if DELUGE_MODEL == DELUGE_MODEL_40_PAD
-	int x = (unsigned int)b % 10;
-	int y = ((unsigned int)b % 70) / 10;
+	int x = static_cast<unsigned int>(b) % 10;
+	int y = (static_cast<unsigned int>(b) % 70) / 10;
 	y -= displayHeight;
 #else
-	int y = (unsigned int)b / 9;
-	int x = b - y * 9;
+	int y = static_cast<unsigned int>(b) / 9;
+	int x = static_cast<unsigned int>(b) - y * 9;
 	y -= displayHeight * 2;
 #endif
 	return {x, y};

--- a/src/deluge/hid/button.h
+++ b/src/deluge/hid/button.h
@@ -14,10 +14,8 @@ constexpr uint8_t fromXY(int x, int y) {
 #endif
 }
 
-typedef uint8_t Button;
-
 // clang-format off
-enum KnownButtons : Button {
+enum class Button : uint8_t {
 	AFFECT_ENTIRE     = fromXY(affectEntireButtonX, affectEntireButtonY),
 	SESSION_VIEW      = fromXY(sessionViewButtonX, sessionViewButtonY),
 	CLIP_VIEW         = fromXY(clipViewButtonX, clipViewButtonY),
@@ -45,8 +43,33 @@ enum KnownButtons : Button {
 	MOD_ENCODER_1     = fromXY(modEncoder1ButtonX, modEncoder1ButtonY),
 	SELECT_ENC        = fromXY(selectEncButtonX, selectEncButtonY),
 	TEMPO_ENC         = fromXY(tempoEncButtonX, tempoEncButtonY),
+
+#if DELUGE_MODEL == DELUGE_MODEL_40_PAD
+	MOD_0 = fromXY(0,1),
+	MOD_1 = fromXY(0,0),
+	MOD_2 = fromXY(1,0),
+	MOD_3 = fromXY(1,1),
+	MOD_4 = fromXY(2,1),
+	MOD_5 = fromXY(3,1),
+#else
+	MOD_0 = fromXY(1,0),
+	MOD_1 = fromXY(1,1),
+	MOD_2 = fromXY(1,2),
+	MOD_3 = fromXY(1,3),
+	MOD_4 = fromXY(2,0),
+	MOD_5 = fromXY(2,1),
+	MOD_6 = fromXY(2,2),
+	MOD_7 = fromXY(2,3),
+#endif
 };
 // clang-format on
+
+#if DELUGE_MODEL == DELUGE_MODEL_40_PAD
+const Button modButton[6] = {Button::MOD_0, Button::MOD_1, Button::MOD_2, Button::MOD_3, Button::MOD_4, Button::MOD_5};
+#else
+const Button modButton[8] = {Button::MOD_0, Button::MOD_1, Button::MOD_2, Button::MOD_3,
+                             Button::MOD_4, Button::MOD_5, Button::MOD_6, Button::MOD_7};
+#endif
 
 constexpr uint8_t fromChar(uint8_t c) {
 	return static_cast<uint8_t>(c);

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -41,7 +41,7 @@ int buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	buttonStates[xy.x][xy.y] = on;
 
 #if ALLOW_SPAM_MODE
-	if (b == X_ENC) {
+	if (b == Button::X_ENC) {
 		spamMode();
 		return;
 	}
@@ -77,10 +77,10 @@ int buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Play button
-	if (b == PLAY) {
+	if (b == Button::PLAY) {
 		if (on) {
 
-			if (audioRecorder.recordingSource && isButtonPressed(RECORD)) {
+			if (audioRecorder.recordingSource && isButtonPressed(Button::RECORD)) {
 				// Stop output-recording at end of loop
 				if (!recordButtonPressUsedUp && playbackHandler.isEitherClockActive()) {
 					currentPlaybackMode->stopOutputRecordingAtLoopEnd();
@@ -93,7 +93,7 @@ int buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 				playbackHandler.playButtonPressed(INTERNAL_BUTTON_PRESS_LATENCY);
 
 				// Begin output-recording simultaneously with playback
-				if (isButtonPressed(RECORD) && playbackHandler.playbackState && !recordButtonPressUsedUp) {
+				if (isButtonPressed(Button::RECORD) && playbackHandler.playbackState && !recordButtonPressUsedUp) {
 					audioRecorder.beginOutputRecording();
 				}
 			}
@@ -103,7 +103,7 @@ int buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Record button
-	else if (b == RECORD) {
+	else if (b == Button::RECORD) {
 		// Press on
 		if (on) {
 			timeRecordButtonPressed = AudioEngine::audioSampleTimer;
@@ -134,7 +134,7 @@ int buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 	// Tempo encoder button
-	else if (b == TEMPO_ENC) {
+	else if (b == Button::TEMPO_ENC) {
 		if (on) {
 			if (isShiftButtonPressed()) {
 				playbackHandler.displaySwingAmount();
@@ -148,7 +148,7 @@ int buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	}
 
 #if ALLOW_SPAM_MODE
-	else if (b == SELECT_ENC)
+	else if (b == Button::SELECT_ENC)
 		     && isButtonPressed(shiftButtonX, shiftButtonY)) {
 			     spamMode();
 		     }
@@ -156,10 +156,10 @@ int buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 	// Mod encoder buttons
-	else if (b == MOD_ENCODER_0) {
+	else if (b == Button::MOD_ENCODER_0) {
 		getCurrentUI()->modEncoderButtonAction(0, on);
 	}
-	else if (b == MOD_ENCODER_1) {
+	else if (b == Button::MOD_ENCODER_1) {
 		getCurrentUI()->modEncoderButtonAction(1, on);
 	}
 #endif
@@ -191,7 +191,7 @@ void noPressesHappening(bool inCardRoutine) {
 	for (int x = 0; x < NUM_BUTTON_COLS; x++) {
 		for (int y = 0; y < NUM_BUTTON_ROWS; y++) {
 			if (buttonStates[x][y]) {
-				buttonAction(hid::button::fromXY(x, y), false, inCardRoutine);
+				buttonAction(static_cast<hid::button::Button>(hid::button::fromXY(x, y)), false, inCardRoutine);
 			}
 		}
 	}

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -136,7 +136,7 @@ checkResult:
 				break;
 
 			case ENCODER_SCROLL_Y:
-				if (Buttons::isShiftButtonPressed() && Buttons::isButtonPressed(hid::button::LEARN)) {
+				if (Buttons::isShiftButtonPressed() && Buttons::isButtonPressed(hid::Button::LEARN)) {
 					changeDimmerInterval(limitedDetentPos);
 				}
 				else {
@@ -150,19 +150,19 @@ checkResult:
 				    && runtimeFeatureSettings.get(RuntimeFeatureSettingType::Quantize)
 				           == RuntimeFeatureStateToggle::On) {
 					instrumentClipView.tempoEncoderAction(limitedDetentPos,
-					                                      Buttons::isButtonPressed(hid::button::TEMPO_ENC),
+					                                      Buttons::isButtonPressed(hid::Button::TEMPO_ENC),
 					                                      Buttons::isShiftButtonPressed());
 				}
 				else {
 					playbackHandler.tempoEncoderAction(limitedDetentPos,
-					                                   Buttons::isButtonPressed(hid::button::TEMPO_ENC),
+					                                   Buttons::isButtonPressed(hid::Button::TEMPO_ENC),
 					                                   Buttons::isShiftButtonPressed());
 				}
 
 				break;
 
 			case ENCODER_SELECT:
-				if (Buttons::isButtonPressed(hid::button::CLIP_VIEW)) {
+				if (Buttons::isButtonPressed(hid::Button::CLIP_VIEW)) {
 					changeRefreshTime(limitedDetentPos);
 				}
 				else {

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -88,7 +88,7 @@ void InstrumentClipMinder::selectEncoderAction(int offset) {
 
 			int newCC;
 
-			if (!Buttons::isButtonPressed(hid::button::SELECT_ENC)) {
+			if (!Buttons::isButtonPressed(hid::Button::SELECT_ENC)) {
 				newCC = instrument->changeControlNumberForModKnob(offset, editingMIDICCForWhichModKnob,
 				                                                  instrument->modKnobMode);
 				view.setKnobIndicatorLevels();
@@ -328,14 +328,14 @@ int InstrumentClipMinder::buttonAction(hid::Button b, bool on, bool inCardRoutin
 		currentUIMode = UI_MODE_NONE;
 		IndicatorLEDs::setLedState(saveLedX, saveLedY, false);
 
-		if (b == SYNTH) {
+		if (b == Button::SYNTH) {
 			if (getCurrentClip()->output->type == INSTRUMENT_TYPE_SYNTH) {
 yesSaveInstrument:
 				openUI(&saveInstrumentPresetUI);
 			}
 		}
 
-		else if (b == KIT) {
+		else if (b == Button::KIT) {
 			if (getCurrentClip()->output->type == INSTRUMENT_TYPE_KIT) {
 				goto yesSaveInstrument;
 			}
@@ -350,7 +350,7 @@ yesSaveInstrument:
 		currentUIMode = UI_MODE_NONE;
 		IndicatorLEDs::setLedState(loadLedX, loadLedY, false);
 
-		if (b == SYNTH) {
+		if (b == Button::SYNTH) {
 			Browser::instrumentTypeToLoad = INSTRUMENT_TYPE_SYNTH;
 
 yesLoadInstrument:
@@ -359,7 +359,7 @@ yesLoadInstrument:
 			openUI(&loadInstrumentPresetUI);
 		}
 
-		else if (b == KIT) {
+		else if (b == Button::KIT) {
 			if (getCurrentClip()->onKeyboardScreen) {
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 				IndicatorLEDs::indicateAlertOnLed(keyboardLedX, keyboardLedX);
@@ -373,7 +373,7 @@ yesLoadInstrument:
 	}
 
 	// Select button, without shift
-	else if (b == SELECT_ENC && !Buttons::isShiftButtonPressed()) {
+	else if (b == Button::SELECT_ENC && !Buttons::isShiftButtonPressed()) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -387,7 +387,7 @@ yesLoadInstrument:
 
 #if DELUGE_MODEL != DELUGE_MODEL_40_PAD
 	// Affect-entire
-	else if (b == AFFECT_ENTIRE) {
+	else if (b == Button::AFFECT_ENTIRE) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (getCurrentClip()->output->type == INSTRUMENT_TYPE_KIT) {
 				if (inCardRoutine) {
@@ -402,7 +402,7 @@ yesLoadInstrument:
 #endif
 
 	// Back button to clear Clip
-	else if (b == BACK && currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) {
+	else if (b == Button::BACK && currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) {
 		if (on) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -424,7 +424,7 @@ yesLoadInstrument:
 	}
 
 	// Which-instrument-type buttons
-	else if (b == SYNTH) {
+	else if (b == Button::SYNTH) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -439,7 +439,7 @@ yesLoadInstrument:
 		}
 	}
 
-	else if (b == MIDI) {
+	else if (b == Button::MIDI) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -448,7 +448,7 @@ yesLoadInstrument:
 		}
 	}
 
-	else if (b == CV) {
+	else if (b == Button::CV) {
 		if (on && currentUIMode == UI_MODE_NONE) {
 			if (inCardRoutine) {
 				return ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -167,7 +167,7 @@ void PlaybackHandler::playButtonPressed(int buttonPressLatency) {
 	else {
 
 		// If holding <> encoder down...
-		if (Buttons::isButtonPressed(hid::button::X_ENC)) {
+		if (Buttons::isButtonPressed(hid::Button::X_ENC)) {
 
 			// If wanting to switch into arranger...
 			if (currentPlaybackMode == &session && getCurrentUI() == &arrangerView) {
@@ -266,7 +266,7 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int buttonPressLatency, bo
 
 	// Allow playback to start from current scroll if holding down <> knob
 	int32_t newPos = 0;
-	if (Buttons::isButtonPressed(hid::button::X_ENC)
+	if (Buttons::isButtonPressed(hid::Button::X_ENC)
 	    || (getRootUI() == &arrangerView && recording == RECORDING_NORMAL)) {
 
 		int navSys;
@@ -1794,7 +1794,7 @@ void PlaybackHandler::tempoEncoderAction(int8_t offset, bool encoderButtonPresse
 	offset = getMax((int8_t)-1, getMin((int8_t)1, offset));
 
 	// Nudging sync
-	if (Buttons::isButtonPressed(hid::button::X_ENC)) {
+	if (Buttons::isButtonPressed(hid::Button::X_ENC)) {
 
 		// If Deluge is using internal clock
 		if (playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
@@ -1837,7 +1837,7 @@ displayNudge:
 	}
 
 	// If MIDI learn button down, change clock out scale
-	else if (Buttons::isButtonPressed(hid::button::LEARN)) {
+	else if (Buttons::isButtonPressed(hid::Button::LEARN)) {
 
 		// If playing synced, double or halve our own playing speed relative to the outside world
 		if (playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE) {
@@ -1886,7 +1886,7 @@ displayNudge:
 	else {
 		if (!(playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE)) {
 
-			if (Buttons::isButtonPressed(hid::button::TEMPO_ENC)) {
+			if (Buttons::isButtonPressed(hid::Button::TEMPO_ENC)) {
 				// Fine tempo adjustment
 				uint32_t tempoBPM = calculateBPM(currentSong->getTimePerTimerTickFloat()) + 0.5;
 				tempoBPM += offset;


### PR DESCRIPTION
> > [This comment](https://github.com/SynthstromAudible/DelugeFirmware/pull/153#issuecomment-1624226635) 

> @topisani I think there was a permutation of this code that used an `enum class` but it never made it into a commit since I wasn't sure how to access the underlying type. There's probably room for a follow-up PR that changes this and adds `static_cast` where necessary.