### PR TITLE
runtime features: make style of patch cable strength selectable

### DIFF
--- a/src/deluge/gui/menu_item/integer.cpp
+++ b/src/deluge/gui/menu_item/integer.cpp
@@ -73,45 +73,6 @@ void Integer::drawPixelsForOled() {
 	drawInteger(TEXT_HUGE_SPACING_X, TEXT_HUGE_SIZE_Y, 18);
 }
 
-void IntegerContinuous::drawBar(int yTop, int marginL, int marginR) {
-	if (marginR == -1) {
-		marginR = marginL;
-	}
-	int height = 7;
-
-	int leftMost = marginL;
-	int rightMost = OLED_MAIN_WIDTH_PIXELS - marginR - 1;
-
-	int y = OLED_MAIN_TOPMOST_PIXEL + OLED_MAIN_VISIBLE_HEIGHT * 0.78;
-
-	int endLineHalfHeight = 8;
-
-	/*
-	OLED::drawHorizontalLine(y, leftMost, rightMost, OLED::oledMainImage);
-	OLED::drawVerticalLine(leftMost, y, y + endLineHalfHeight, OLED::oledMainImage);
-	OLED::drawVerticalLine(rightMost, y, y + endLineHalfHeight, OLED::oledMainImage);
-*/
-	int minValue = getMinValue();
-	int maxValue = getMaxValue();
-	unsigned int range = maxValue - minValue;
-	float posFractional = (float)(soundEditor.currentValue - minValue) / range;
-	float zeroPosFractional = (float)(-minValue) / range;
-
-	int width = rightMost - leftMost;
-	int posHorizontal = (int)(posFractional * width + 0.5);
-	int zeroPosHorizontal = (int)(zeroPosFractional * width);
-
-	if (posHorizontal <= zeroPosHorizontal) {
-		int xMin = leftMost + posHorizontal;
-		OLED::invertArea(xMin, zeroPosHorizontal - posHorizontal + 1, yTop, yTop + height, OLED::oledMainImage);
-	}
-	else {
-		int xMin = leftMost + zeroPosHorizontal;
-		OLED::invertArea(xMin, posHorizontal - zeroPosHorizontal, yTop, yTop + height, OLED::oledMainImage);
-	}
-	OLED::drawRectangle(leftMost, yTop, rightMost, yTop + height, OLED::oledMainImage);
-}
-
 void IntegerContinuous::drawPixelsForOled() {
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64

--- a/src/deluge/gui/menu_item/integer.h
+++ b/src/deluge/gui/menu_item/integer.h
@@ -50,7 +50,6 @@ public:
 protected:
 #if HAVE_OLED
 	void drawPixelsForOled();
-	void drawBar(int yTop, int marginL, int marginR = -1);
 #endif
 };
 

--- a/src/deluge/gui/menu_item/number.cpp
+++ b/src/deluge/gui/menu_item/number.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+*/
+
+#include "number.h"
+#include "hid/display/numeric_driver.h"
+#include "gui/ui/sound_editor.h"
+
+#if HAVE_OLED
+#include "hid/display/oled.h"
+#endif
+
+namespace menu_item {
+
+#if HAVE_OLED
+void Number::drawBar(int yTop, int marginL, int marginR) {
+	if (marginR == -1) {
+		marginR = marginL;
+	}
+	int height = 7;
+
+	int leftMost = marginL;
+	int rightMost = OLED_MAIN_WIDTH_PIXELS - marginR - 1;
+
+	int y = OLED_MAIN_TOPMOST_PIXEL + OLED_MAIN_VISIBLE_HEIGHT * 0.78;
+
+	int endLineHalfHeight = 8;
+
+	/*
+	OLED::drawHorizontalLine(y, leftMost, rightMost, OLED::oledMainImage);
+	OLED::drawVerticalLine(leftMost, y, y + endLineHalfHeight, OLED::oledMainImage);
+	OLED::drawVerticalLine(rightMost, y, y + endLineHalfHeight, OLED::oledMainImage);
+*/
+	int minValue = getMinValue();
+	int maxValue = getMaxValue();
+	unsigned int range = maxValue - minValue;
+	float posFractional = (float)(soundEditor.currentValue - minValue) / range;
+	float zeroPosFractional = (float)(-minValue) / range;
+
+	int width = rightMost - leftMost;
+	int posHorizontal = (int)(posFractional * width + 0.5);
+	int zeroPosHorizontal = (int)(zeroPosFractional * width);
+
+	if (posHorizontal <= zeroPosHorizontal) {
+		int xMin = leftMost + posHorizontal;
+		OLED::invertArea(xMin, zeroPosHorizontal - posHorizontal + 1, yTop, yTop + height, OLED::oledMainImage);
+	}
+	else {
+		int xMin = leftMost + zeroPosHorizontal;
+		OLED::invertArea(xMin, posHorizontal - zeroPosHorizontal, yTop, yTop + height, OLED::oledMainImage);
+	}
+	OLED::drawRectangle(leftMost, yTop, rightMost, yTop + height, OLED::oledMainImage);
+}
+#endif
+
+} // namespace menu_item

--- a/src/deluge/gui/menu_item/number.h
+++ b/src/deluge/gui/menu_item/number.h
@@ -25,10 +25,15 @@ namespace menu_item {
 class Number : public Value {
 public:
 	using Value::Value;
+#if HAVE_OLED
+	void drawBar(int yTop, int marginL, int marginR = -1);
+#endif
 
 protected:
 	virtual int getMaxValue() const = 0;
-	virtual int getMinValue() const { return 0; }
+	virtual int getMinValue() const {
+		return 0;
+	}
 };
 
 } // namespace menu_item

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -24,6 +24,7 @@ namespace menu_item {
 class PatchCableStrength : public Decimal, public MenuItemWithCCLearning {
 public:
 	using Decimal::Decimal;
+	void beginSession(MenuItem* navigatedBackwardFrom) final;
 	void readCurrentValue() final;
 	void writeCurrentValue();
 	int getMinValue() const final { return -5000; }
@@ -50,6 +51,7 @@ public:
 	};
 
 protected:
+	bool preferBarDrawing = false;
 	ModelStackWithAutoParam* getModelStack(void* memory, bool allowCreation = false);
 };
 

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -35,6 +35,7 @@ enum RuntimeFeatureSettingType : uint32_t {
 	DrumRandomizer,
 	MasterCompressorFx,
 	Quantize,
+	PatchCableResolution,
 	MaxElement // Keep as boundary
 };
 
@@ -106,6 +107,13 @@ protected:
 	                     {.displayName = "On", .value = RuntimeFeatureStateToggle::On},
 	                     {.displayName = NULL, .value = 0}}},
 
+	    [RuntimeFeatureSettingType::PatchCableResolution] =
+	        {.displayName = "Mod. depth decimals",
+	         .xmlName = "patchcableresolution",
+	         .value = RuntimeFeatureStateToggle::On, // Default value
+	         .options = {{.displayName = "Off", .value = RuntimeFeatureStateToggle::Off},
+	                     {.displayName = "On", .value = RuntimeFeatureStateToggle::On},
+	                     {.displayName = NULL, .value = 0}}},
 	};
 
 private:


### PR DESCRIPTION
Fixes #158

`drawBar()` method is moved unmodified from `IntegerContinuous` to `Number` as it only depends of attributes of the `Number` base class.

I think we eventually should have a unified display that fits both the slider bar and potential decimals on the same screen, but for now it gives you the option of either showing the old stock firmware layout or the one implemented in #17 .