### PR TITLE
remove aliases for bufferPICUart and restructure some LEDs stuff

### DIFF
--- a/src/RZA1/uart/sio_char.h
+++ b/src/RZA1/uart/sio_char.h
@@ -94,10 +94,6 @@ extern char_t midiTxBuffer[];
         uartItems[UART_ITEM_MIDI].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);                                        \
     } while (0)
 
-// Aliases
-#define bufferPICIndicatorsUart(charToSend) bufferPICUart(charToSend)
-#define bufferPICPadsUart(charToSend)       bufferPICUart(charToSend)
-
 /* SIO_CHAR_H */
 #endif
 

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -26,6 +26,7 @@
 #include "modulation/params/param_manager.h"
 #include "gui/ui/browser/sample_browser.h"
 #include "RZA1/system/iodefine.h"
+#include "hid/led/pad_leds.h"
 
 #include <stdlib.h>
 #include <new>
@@ -493,7 +494,7 @@ extern "C" int deluge_main(void) {
 	bufferPICUart(18); // Set debounce time (mS) to...
 	bufferPICUart(20);
 
-	setRefreshTime(23);
+	PadLEDs::setRefreshTime(23);
 
 	bufferPICUart(244); // Set min interrupt interval
 	bufferPICUart(8);
@@ -502,8 +503,8 @@ extern "C" int deluge_main(void) {
 	bufferPICUart(6);
 
 	int newSpeedNumber = 4000000.0f / UART_FULL_SPEED_PIC_PADS_HZ - 0.5f;
-	bufferPICPadsUart(225);            // Set UART speed
-	bufferPICPadsUart(newSpeedNumber); // Speed is 4MHz / (x + 1)
+	bufferPICUart(225);            // Set UART speed
+	bufferPICUart(newSpeedNumber); // Speed is 4MHz / (x + 1)
 	uartFlushIfNotSending(UART_ITEM_PIC_PADS);
 
 	// Setup SDRAM. Have to do this before setting up AudioEngine
@@ -651,8 +652,8 @@ extern "C" int deluge_main(void) {
 	setPinMux(4, 7, 2);
 	initSPIBSC(); // This will run the audio routine! Ideally, have external RAM set up by now.
 
-	bufferPICIndicatorsUart(245);                          // Request PIC firmware version
-	bufferPICIndicatorsUart(RESEND_BUTTON_STATES_MESSAGE); // Tell PIC to re-send button states
+	bufferPICUart(245);                          // Request PIC firmware version
+	bufferPICUart(RESEND_BUTTON_STATES_MESSAGE); // Tell PIC to re-send button states
 	uartFlushIfNotSending(UART_ITEM_PIC_INDICATORS);
 
 	// Check if the user is holding down the select knob to do a factory reset

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -243,7 +243,7 @@ void SampleBrowser::currentFileChanged(int movementDirection) {
 		uiTimerManager.unsetTimer(TIMER_SHORTCUT_BLINK);
 
 		memset(PadLEDs::transitionTakingPlaceOnRow, 1, sizeof(PadLEDs::transitionTakingPlaceOnRow));
-		PadLEDs::setupScroll(movementDirection, displayWidth, true);
+		PadLEDs::horizontal::setupScroll(movementDirection, displayWidth, true);
 		currentUIMode = UI_MODE_HORIZONTAL_SCROLL;
 	}
 
@@ -603,7 +603,7 @@ void SampleBrowser::previewIfPossible(int movementDirection) {
 					                                  waveformBasicNavigator.xZoom, PadLEDs::imageStore,
 					                                  &waveformBasicNavigator.renderData);
 					memset(PadLEDs::transitionTakingPlaceOnRow, 1, sizeof(PadLEDs::transitionTakingPlaceOnRow));
-					PadLEDs::setupScroll(movementDirection, displayWidth);
+					PadLEDs::horizontal::setupScroll(movementDirection, displayWidth);
 
 					currentUIMode = UI_MODE_HORIZONTAL_SCROLL;
 				}
@@ -646,7 +646,7 @@ void SampleBrowser::previewIfPossible(int movementDirection) {
 					PadLEDs::reassessGreyout(true);
 				}
 				memset(PadLEDs::transitionTakingPlaceOnRow, 1, sizeof(PadLEDs::transitionTakingPlaceOnRow));
-				PadLEDs::setupScroll(movementDirection, displayWidth);
+				PadLEDs::horizontal::setupScroll(movementDirection, displayWidth);
 				currentUIMode = UI_MODE_HORIZONTAL_SCROLL;
 			}
 

--- a/src/deluge/gui/ui/load/load_song_ui.h
+++ b/src/deluge/gui/ui/load/load_song_ui.h
@@ -49,9 +49,6 @@ private:
 	void displayArmedPopup();
 #endif
 
-	uint8_t squaresScrolled;
-	int8_t scrollDirection;
-	bool scrollingToNothing;
 	bool scrollingIntoSlot;
 	//int findNextFile(int offset);
 	void exitThisUI();

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -572,7 +572,7 @@ void SoundEditor::blinkShortcut() {
 	if (shortcutBlinkCounter & 1) {
 		// Blink param
 		if ((counterForNow & paramShortcutBlinkFrequency) == 0) {
-			bufferPICPadsUart(24 + currentParamShorcutY + (currentParamShorcutX * displayHeight));
+			PadLEDs::flashMainPad(currentParamShorcutX, currentParamShorcutY);
 		}
 		uiTimerManager.setTimer(TIMER_SHORTCUT_BLINK, 180);
 	}
@@ -583,10 +583,7 @@ void SoundEditor::blinkShortcut() {
 			for (int y = 0; y < displayHeight; y++) {
 				if (sourceShortcutBlinkFrequencies[x][y] != 255
 				    && (counterForNow & sourceShortcutBlinkFrequencies[x][y]) == 0) {
-					if (sourceShortcutBlinkColours[x][y]) {
-						bufferPICPadsUart(10 + sourceShortcutBlinkColours[x][y]);
-					}
-					bufferPICPadsUart(24 + y + ((x + 14) * displayHeight));
+					PadLEDs::flashMainPad(x + 14, y, sourceShortcutBlinkColours[x][y]);
 				}
 			}
 		}

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1723,7 +1723,7 @@ void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 	PadLEDs::explodeAnimationXWidthBig = ((uint32_t)(end - start) / currentSong->xZoom[NAVIGATION_ARRANGEMENT]) << 16;
 
 	PadLEDs::recordTransitionBegin(clipCollapseSpeed);
-	PadLEDs::animationDirection = 1;
+	PadLEDs::explodeAnimationDirection = 1;
 	if (clip->type == CLIP_TYPE_AUDIO) {
 		PadLEDs::renderAudioClipExplodeAnimation(0);
 	}
@@ -1823,7 +1823,7 @@ bool ArrangerView::transitionToArrangementEditor() {
 	PadLEDs::explodeAnimationXWidthBig = ((end - start) / currentSong->xZoom[NAVIGATION_ARRANGEMENT]) << 16;
 
 	PadLEDs::recordTransitionBegin(clipCollapseSpeed);
-	PadLEDs::animationDirection = -1;
+	PadLEDs::explodeAnimationDirection = -1;
 
 	if (getCurrentUI() == &instrumentClipView) {
 		PadLEDs::clearSideBar();

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -304,7 +304,7 @@ void TimelineView::initiateXScroll(uint32_t newXScroll, int numSquaresToScroll) 
 	if (anyAnimationToDo) {
 		currentUIMode |=
 		    UI_MODE_HORIZONTAL_SCROLL; // Must set this before calling PadLEDs::setupScroll(), which might then unset it
-		PadLEDs::setupScroll(scrollDirection, displayWidth, false, numSquaresToScroll);
+		PadLEDs::horizontal::setupScroll(scrollDirection, displayWidth, false, numSquaresToScroll);
 	}
 }
 

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -27,6 +27,7 @@
 #include "util/functions.h"
 #include "gui/views/instrument_clip_view.h"
 #include "model/settings/runtime_feature_settings.h"
+#include "hid/led/pad_leds.h"
 
 namespace Encoders {
 
@@ -128,7 +129,7 @@ checkResult:
 
 			case ENCODER_SCROLL_Y:
 				if (Buttons::isShiftButtonPressed() && Buttons::isButtonPressed(hid::button::LEARN)) {
-					changeDimmerInterval(limitedDetentPos);
+					PadLEDs::changeDimmerInterval(limitedDetentPos);
 				}
 				else {
 					result = getCurrentUI()->verticalEncoderAction(limitedDetentPos, inCardRoutine);
@@ -154,7 +155,7 @@ checkResult:
 
 			case ENCODER_SELECT:
 				if (Buttons::isButtonPressed(hid::button::CLIP_VIEW)) {
-					changeRefreshTime(limitedDetentPos);
+					PadLEDs::changeRefreshTime(limitedDetentPos);
 				}
 				else {
 					getCurrentUI()->selectEncoderAction(limitedDetentPos);

--- a/src/deluge/hid/led/indicator_leds.cpp
+++ b/src/deluge/hid/led/indicator_leds.cpp
@@ -45,7 +45,7 @@ void setLedState(LED led, bool newState, bool allowContinuedBlinking) {
 	uint8_t l = static_cast<int>(led);
 	ledStates[l] = newState;
 
-	bufferPICIndicatorsUart(uartBase + l + (newState ? 36 : 0));
+	bufferPICUart(uartBase + l + (newState ? 36 : 0));
 }
 
 void blinkLed(LED led, uint8_t numBlinks, uint8_t blinkingType, bool initialState) {
@@ -168,7 +168,7 @@ void setKnobIndicatorLevel(uint8_t whichKnob, uint8_t level) {
 		}
 	}
 
-	bufferPICIndicatorsUart(20 + whichKnob);
+	bufferPICUart(20 + whichKnob);
 
 	int numIndicatorLedsFullyOn = level >> 5;
 
@@ -184,7 +184,7 @@ void setKnobIndicatorLevel(uint8_t whichKnob, uint8_t level) {
 		else if (i == numIndicatorLedsFullyOn) {
 			brightnessOutputValue = brightness;
 		}
-		bufferPICIndicatorsUart(brightnessOutputValue);
+		bufferPICUart(brightnessOutputValue);
 	}
 
 	knobIndicatorLevels[whichKnob] = level;

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -34,6 +34,7 @@
 #include "model/sample/sample.h"
 #include "gui/views/view.h"
 #include "model/clip/instrument_clip.h"
+#include "hid/display/oled.h"
 
 extern "C" {
 #include "RZA1/uart/sio_char.h"
@@ -49,11 +50,20 @@ bool zoomingIn;
 int8_t zoomMagnitude;
 int zoomPinSquare[displayHeight];
 bool transitionTakingPlaceOnRow[displayHeight];
+int8_t explodeAnimationDirection;
 
+namespace horizontal {
 uint8_t areaToScroll;
 uint8_t squaresScrolled;
-int8_t animationDirection;
+int8_t scrollDirection;
 bool scrollingIntoNothing; // Means we're scrolling into a black screen
+} // namespace horizontal
+
+namespace vertical {
+uint8_t squaresScrolled;
+int8_t scrollDirection;
+bool scrollingToNothing;
+} // namespace vertical
 
 int16_t animatedRowGoingTo[MAX_NUM_ANIMATED_ROWS];
 int16_t animatedRowGoingFrom[MAX_NUM_ANIMATED_ROWS];
@@ -163,25 +173,21 @@ void setTickSquares(const uint8_t* squares, const uint8_t* colours) {
 		for (int y = 0; y < displayHeight; y++) {
 			if (squares[y] != slowFlashSquares[y] && squares[y] != 255) {
 
-				int colourMessage;
+				int colour = 0;
 				if (colours[y] == 1) { // "Muted" colour
-					colourMessage = 10;
 					uint8_t mutedColour[3];
 					menu_item::mutedColourMenu.getRGB(mutedColour);
 					for (int c = 0; c < 3; c++) {
 						if (mutedColour[c] >= 64) {
-							colourMessage += (1 << c);
+							colour += (1 << c);
 						}
 					}
-sendColourMessage:
-					bufferPICPadsUart(colourMessage);
 				}
 				else if (colours[y] == 2) { // Red
-					colourMessage = 10 + 0b00000001;
-					goto sendColourMessage;
+					colour = 0b00000001;
 				}
 
-				bufferPICPadsUart(24 + y + (squares[y] * displayHeight));
+				PadLEDs::flashMainPad(squares[y], y, colour);
 			}
 		}
 	}
@@ -228,7 +234,7 @@ void sortLedsForCol(int x) {
 	AudioEngine::logAction("MatrixDriver::sortLedsForCol");
 
 	x &= 0b11111110;
-	bufferPICPadsUart((x >> 1) + 1);
+	bufferPICUart((x >> 1) + 1);
 	sendRGBForOneCol(x);
 	sendRGBForOneCol(x + 1);
 }
@@ -263,15 +269,15 @@ void sendRGBForOnePadFast(int x, int y, const uint8_t* colourSource) {
 	    && ((greyoutRows & (1 << y)) || (greyoutCols & (1 << (displayWidth + sideBarWidth - 1 - x))))) {
 		uint8_t greyedOutColour[3];
 		greyColourOut(colourSource, greyedOutColour, greyProportion);
-		bufferPICPadsUart(greyedOutColour[0]);
-		bufferPICPadsUart(greyedOutColour[1]);
-		bufferPICPadsUart(greyedOutColour[2]);
+		bufferPICUart(greyedOutColour[0]);
+		bufferPICUart(greyedOutColour[1]);
+		bufferPICUart(greyedOutColour[2]);
 	}
 
 	else {
-		bufferPICPadsUart(colourSource[0]);
-		bufferPICPadsUart(colourSource[1]);
-		bufferPICPadsUart(colourSource[2]);
+		bufferPICUart(colourSource[0]);
+		bufferPICUart(colourSource[1]);
+		bufferPICUart(colourSource[2]);
 	}
 }
 
@@ -685,6 +691,65 @@ void setGreyoutAmount(float newAmount) {
 	greyProportion = newAmount * 6500000;
 }
 
+int refreshTime;
+int dimmerInterval = 0;
+
+void setRefreshTime(int newTime) {
+	refreshTime = newTime;
+	bufferPICUart(PIC_MESSAGE_REFRESH_TIME); // Set refresh rate inverse
+	bufferPICUart(refreshTime);
+}
+
+void changeRefreshTime(int offset) {
+	int newTime = refreshTime + offset;
+	if (newTime > 255 || newTime < 1) {
+		return;
+	}
+	setRefreshTime(newTime);
+	char buffer[12];
+	intToString(refreshTime, buffer);
+	numericDriver.displayPopup(buffer);
+}
+
+void changeDimmerInterval(int offset) {
+	int newInterval = dimmerInterval - offset;
+	if (newInterval > 25 || newInterval < 0) {}
+	else {
+		setDimmerInterval(newInterval);
+	}
+
+#if HAVE_OLED
+	char text[20];
+	strcpy(text, "Brightness: ");
+	char* pos = strchr(text, 0);
+	intToString((25 - dimmerInterval) << 2, pos);
+	pos = strchr(text, 0);
+	*(pos++) = '%';
+	*pos = 0;
+	OLED::popupText(text);
+#endif
+}
+
+void setDimmerInterval(int newInterval) {
+	//Uart::print("dimmerInterval: ");
+	//Uart::println(newInterval);
+	dimmerInterval = newInterval;
+
+	int newRefreshTime = 23 - newInterval;
+	while (newRefreshTime < 6) {
+		newRefreshTime++;
+		newInterval *= 1.2;
+	}
+
+	//Uart::print("newInterval: ");
+	//Uart::println(newInterval);
+
+	setRefreshTime(newRefreshTime);
+
+	bufferPICUart(243); // Set dimmer interval
+	bufferPICUart(newInterval);
+}
+
 void timerRoutine() {
 	// If output buffer is too full, come back in a little while instead
 	if (uartGetTxBufferSpace(UART_ITEM_PIC_PADS) <= NUM_BYTES_IN_MAIN_PAD_REDRAW + NUM_BYTES_IN_SIDEBAR_REDRAW) {
@@ -699,7 +764,7 @@ void timerRoutine() {
 	}
 
 	else if (isUIModeActive(UI_MODE_HORIZONTAL_SCROLL)) {
-		renderScroll();
+		horizontal::renderScroll();
 	}
 
 	else if (isUIModeActive(UI_MODE_AUDIO_CLIP_EXPANDING) || isUIModeActive(UI_MODE_AUDIO_CLIP_COLLAPSING)) {
@@ -719,7 +784,7 @@ void timerRoutine() {
 		if (progress >= 65536) { // If finished transitioning...
 
 			// If going to keyboard screen, no sidebar or anything to fade in
-			if (animationDirection == 1 && currentSong->currentClip->type == CLIP_TYPE_INSTRUMENT
+			if (explodeAnimationDirection == 1 && currentSong->currentClip->type == CLIP_TYPE_INSTRUMENT
 			    && ((InstrumentClip*)currentSong->currentClip)->onKeyboardScreen) {
 				currentUIMode = UI_MODE_NONE;
 				changeRootUI(&keyboardScreen);
@@ -727,7 +792,7 @@ void timerRoutine() {
 
 			// Otherwise, there's stuff we want to fade in / to
 			else {
-				int explodedness = (animationDirection == 1) ? 65536 : 0;
+				int explodedness = (explodeAnimationDirection == 1) ? 65536 : 0;
 				if (currentSong->currentClip->type == CLIP_TYPE_INSTRUMENT) {
 					renderExplodeAnimation(explodedness, false);
 				}
@@ -737,7 +802,7 @@ void timerRoutine() {
 				memcpy(PadLEDs::imageStore, PadLEDs::image, (displayWidth + sideBarWidth) * displayHeight * 3);
 
 				currentUIMode = UI_MODE_ANIMATION_FADE;
-				if (animationDirection == 1) {
+				if (explodeAnimationDirection == 1) {
 					if (currentSong->currentClip->type == CLIP_TYPE_INSTRUMENT) {
 						changeRootUI(&instrumentClipView); // We want to fade the sidebar in
 					}
@@ -759,8 +824,8 @@ void timerRoutine() {
 			}
 		}
 		else {
-			int explodedness = (animationDirection == 1) ? 0 : 65536;
-			explodedness += progress * animationDirection;
+			int explodedness = (explodeAnimationDirection == 1) ? 0 : 65536;
+			explodedness += progress * explodeAnimationDirection;
 
 			if (currentSong->currentClip->type == CLIP_TYPE_INSTRUMENT) {
 				renderExplodeAnimation(explodedness);
@@ -1149,17 +1214,17 @@ void renderZoomedSquare(int32_t outputSquareStartOnSourceImage, int32_t outputSq
 	}
 }
 
-void renderScroll() {
+void horizontal::renderScroll() {
 
 	squaresScrolled++;
-	int copyCol = (animationDirection > 0) ? squaresScrolled - 1 : areaToScroll - squaresScrolled;
-	int startSquare = (animationDirection > 0) ? 0 : areaToScroll - 1;
-	int endSquare = (animationDirection > 0) ? areaToScroll - 1 : 0;
+	int copyCol = (scrollDirection > 0) ? squaresScrolled - 1 : areaToScroll - squaresScrolled;
+	int startSquare = (scrollDirection > 0) ? 0 : areaToScroll - 1;
+	int endSquare = (scrollDirection > 0) ? areaToScroll - 1 : 0;
 	for (int row = 0; row < displayHeight; row++) {
 		if (transitionTakingPlaceOnRow[row]) {
 			for (int colour = 0; colour < 3; colour++) {
-				for (int x = startSquare; x != endSquare; x += animationDirection) {
-					PadLEDs::image[row][x][colour] = PadLEDs::image[row][x + animationDirection][colour];
+				for (int x = startSquare; x != endSquare; x += scrollDirection) {
+					PadLEDs::image[row][x][colour] = PadLEDs::image[row][x + scrollDirection][colour];
 				}
 				// And, bring in a col from the temp image
 				if (scrollingIntoNothing) {
@@ -1170,12 +1235,12 @@ void renderScroll() {
 				}
 			}
 
-			bufferPICPadsUart(228 + row);
+			bufferPICUart(228 + row);
 			sendRGBForOnePadFast(endSquare, row, image[row][endSquare]);
 		}
 	}
 
-	bufferPICPadsUart(240);
+	bufferPICUart(240);
 	uartFlushIfNotSending(UART_ITEM_PIC_PADS);
 	if (squaresScrolled >= areaToScroll) {
 		getCurrentUI()->scrollFinished();
@@ -1185,8 +1250,9 @@ void renderScroll() {
 	}
 }
 
-void setupScroll(int8_t thisScrollDirection, uint8_t thisAreaToScroll, bool scrollIntoNothing, int numSquaresToScroll) {
-	animationDirection = thisScrollDirection;
+void horizontal::setupScroll(int8_t thisScrollDirection, uint8_t thisAreaToScroll, bool scrollIntoNothing,
+                             int numSquaresToScroll) {
+	scrollDirection = thisScrollDirection;
 	areaToScroll = thisAreaToScroll;
 	squaresScrolled = thisAreaToScroll - numSquaresToScroll;
 	scrollingIntoNothing = scrollIntoNothing;
@@ -1198,9 +1264,42 @@ void setupScroll(int8_t thisScrollDirection, uint8_t thisAreaToScroll, bool scro
 	if (thisAreaToScroll == displayWidth + sideBarWidth) {
 		flags |= 2;
 	}
-	bufferPICPadsUart(236 + flags);
+	bufferPICUart(236 + flags);
 
 	renderScroll();
+}
+
+void vertical::renderScroll() {
+	squaresScrolled++;
+	int copyRow = (scrollDirection > 0) ? squaresScrolled - 1 : displayHeight - squaresScrolled;
+	int startSquare = (scrollDirection > 0) ? 0 : 1;
+	int endSquare = (scrollDirection > 0) ? displayHeight - 1 : 0;
+
+	//matrixDriver.greyoutMinYDisplay = (scrollDirection > 0) ? displayHeight - squaresScrolled : squaresScrolled;
+
+	// Move the scrolling region
+	memmove(image[startSquare], image[1 - startSquare], (displayWidth + sideBarWidth) * (displayHeight - 1) * 3);
+
+	// And, bring in a row from the temp image (or from nowhere)
+	if (scrollingToNothing) {
+		memset(image[endSquare], 0, (displayWidth + sideBarWidth) * 3);
+	}
+	else {
+		memcpy(image[endSquare], imageStore[copyRow], (displayWidth + sideBarWidth) * 3);
+	}
+
+	bufferPICUart((scrollDirection > 0) ? 241 : 242);
+
+	for (int x = 0; x < displayWidth + sideBarWidth; x++) {
+		sendRGBForOnePadFast(x, endSquare, image[endSquare][x]);
+	}
+	uartFlushIfNotSending(UART_ITEM_PIC_PADS);
+}
+
+void vertical::setupScroll(int8_t thisScrollDirection, bool scrollIntoNothing) {
+	scrollDirection = thisScrollDirection;
+	scrollingToNothing = scrollIntoNothing;
+	squaresScrolled = 0;
 }
 
 void renderFade(int progress) {

--- a/src/deluge/hid/led/pad_leds.h
+++ b/src/deluge/hid/led/pad_leds.h
@@ -24,6 +24,10 @@
 #define FLASH_CURSOR_OFF 1
 #define FLASH_CURSOR_SLOW 2
 
+extern "C" {
+#include "RZA1/uart/sio_char.h"
+}
+
 class AudioClip;
 
 namespace PadLEDs {
@@ -38,7 +42,7 @@ extern int explodeAnimationYOriginBig;
 extern int explodeAnimationXStartBig;
 extern int explodeAnimationXWidthBig;
 
-extern int8_t animationDirection;
+extern int8_t explodeAnimationDirection;
 extern bool renderingLock;
 extern uint8_t flashCursor;
 
@@ -68,14 +72,31 @@ void skipGreyoutFade();
 void reassessGreyout(bool doInstantly = false);
 void doGreyoutInstantly();
 
+void setRefreshTime(int newTime);
+void changeRefreshTime(int offset);
+void changeDimmerInterval(int offset);
+void setDimmerInterval(int newInterval);
+
 void renderZoom();
 void renderZoomWithProgress(int inImageTimesBiggerThanNative, uint32_t inImageFadeAmount, uint8_t* innerImage,
                             uint8_t* outerImage, int innerImageLeftEdge, int outerImageLeftEdge,
                             int innerImageRightEdge, int outerImageRightEdge, int innerImageTotalWidth,
                             int outerImageTotalWidth);
-void renderScroll();
+
+namespace horizontal {
 void setupScroll(int8_t thisScrollDirection, uint8_t thisAreaToScroll, bool scrollIntoNothing = false,
                  int numSquaresToScroll = displayWidth);
+void renderScroll();
+} // namespace horizontal
+
+namespace vertical {
+void setupScroll(int8_t thisScrollDirection, bool scrollIntoNothing = false);
+void renderScroll();
+
+extern uint8_t squaresScrolled;
+extern int8_t scrollDirection;
+extern bool scrollingToNothing;
+} // namespace vertical
 
 void sendRGBForOnePadFast(int x, int y, const uint8_t* colourSource);
 void clearTickSquares(bool shouldSend = true);
@@ -91,6 +112,14 @@ void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder);
 void setupAudioClipCollapseOrExplodeAnimation(AudioClip* clip);
 
 void setGreyoutAmount(float newAmount);
+
+static inline void flashMainPad(int x, int y, int color = 0) {
+	if (color > 0) {
+		bufferPICUart(10 + color);
+	}
+
+	bufferPICUart(24 + y + (x * displayHeight));
+}
 
 inline void sendRGBForOneCol(int x);
 void setTimerForSoon();

--- a/src/deluge/testing/hardware_testing.cpp
+++ b/src/deluge/testing/hardware_testing.cpp
@@ -106,7 +106,7 @@ int hardwareTestWhichColour = 0;
 
 void sendColoursForHardwareTest(bool testButtonStates[9][16]) {
 	for (int x = 0; x < 9; x++) {
-		bufferPICPadsUart(x + 1);
+		bufferPICUart(x + 1);
 		for (int y = 0; y < 16; y++) {
 			for (int c = 0; c < 3; c++) {
 				int value;
@@ -116,7 +116,7 @@ void sendColoursForHardwareTest(bool testButtonStates[9][16]) {
 				else {
 					value = (c == hardwareTestWhichColour) ? 64 : 0;
 				}
-				bufferPICPadsUart(value);
+				bufferPICUart(value);
 			}
 		}
 	}
@@ -252,8 +252,8 @@ void ramTestLED(bool stuffAlreadySetUp) {
 		setupSquareWave();
 	}
 
-	bufferPICPadsUart(23); // Set flash length
-	bufferPICPadsUart(100);
+	bufferPICUart(23); // Set flash length
+	bufferPICUart(100);
 
 	// Switch on numeric display
 	bufferPICUart(224);
@@ -272,7 +272,7 @@ void ramTestLED(bool stuffAlreadySetUp) {
 			continue; // Skip icecube LEDs
 		}
 		for (int y = 0; y < 4; y++) {
-			bufferPICIndicatorsUart(152 + x + y * 9 + 36);
+			bufferPICUart(152 + x + y * 9 + 36);
 		}
 	}
 

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -247,65 +247,6 @@ int32_t cableToExpParamShortcut(int32_t sourceValue) {
 	return sourceValue >> 2;
 }
 
-int refreshTime;
-int dimmerInterval = 0;
-
-void setRefreshTime(int newTime) {
-	refreshTime = newTime;
-	bufferPICPadsUart(PIC_MESSAGE_REFRESH_TIME); // Set refresh rate inverse
-	bufferPICPadsUart(refreshTime);
-}
-
-void changeRefreshTime(int offset) {
-	int newTime = refreshTime + offset;
-	if (newTime > 255 || newTime < 1) {
-		return;
-	}
-	setRefreshTime(newTime);
-	char buffer[12];
-	intToString(refreshTime, buffer);
-	numericDriver.displayPopup(buffer);
-}
-
-void changeDimmerInterval(int offset) {
-	int newInterval = dimmerInterval - offset;
-	if (newInterval > 25 || newInterval < 0) {}
-	else {
-		setDimmerInterval(newInterval);
-	}
-
-#if HAVE_OLED
-	char text[20];
-	strcpy(text, "Brightness: ");
-	char* pos = strchr(text, 0);
-	intToString((25 - dimmerInterval) << 2, pos);
-	pos = strchr(text, 0);
-	*(pos++) = '%';
-	*pos = 0;
-	OLED::popupText(text);
-#endif
-}
-
-void setDimmerInterval(int newInterval) {
-	//Uart::print("dimmerInterval: ");
-	//Uart::println(newInterval);
-	dimmerInterval = newInterval;
-
-	int newRefreshTime = 23 - newInterval;
-	while (newRefreshTime < 6) {
-		newRefreshTime++;
-		newInterval *= 1.2;
-	}
-
-	//Uart::print("newInterval: ");
-	//Uart::println(newInterval);
-
-	setRefreshTime(newRefreshTime);
-
-	bufferPICPadsUart(243); // Set dimmer interval
-	bufferPICPadsUart(newInterval);
-}
-
 char const* sourceToString(uint8_t source) {
 
 	switch (source) {

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -241,11 +241,6 @@ int32_t getFinalParameterValueExpWithDumbEnvelopeHack(int32_t paramNeutralValue,
 
 void addAudio(StereoSample* inputBuffer, StereoSample* outputBuffer, int numSamples);
 
-void setRefreshTime(int newTime);
-void changeRefreshTime(int offset);
-void changeDimmerInterval(int offset);
-void setDimmerInterval(int newInterval);
-
 #if HAVE_OLED
 char const* getSourceDisplayNameForOLED(int s);
 char const* getPatchedParamDisplayNameForOled(int p);


### PR DESCRIPTION
These aliases were likely meant as a declaration of intention but in many cases they are just used in a way that doesn't match the alias name. Plus its confusing that it looks like we have four different UART:s when only two exists.

Intention is better being communicated by using wrapper functions in the PadLEDs and IndicatorLEDs namespaces, to separate the high level UI code from effectively hardware driver code.

Draft as there is more cases to fix.