### PR TITLE
sysex: add 7SEG over sysex and improve OLED

### DIFF
--- a/src/deluge/hid/display/numeric_driver.cpp
+++ b/src/deluge/hid/display/numeric_driver.cpp
@@ -553,6 +553,7 @@ void NumericDriver::render() {
 	uint8_t segments[NUMERIC_DISPLAY_LENGTH];
 	layer->render(segments);
 
+	memcpy(lastDisplay, segments, NUMERIC_DISPLAY_LENGTH);
 	bufferPICUart(224);
 	for (int whichChar = 0; whichChar < NUMERIC_DISPLAY_LENGTH; whichChar++) {
 		bufferPICUart(segments[whichChar]);

--- a/src/deluge/hid/display/numeric_driver.h
+++ b/src/deluge/hid/display/numeric_driver.h
@@ -48,6 +48,7 @@ public:
 	void render();
 	void displayLoadingAnimation(bool delayed = false, bool transparent = false);
 	bool isLayerCurrentlyOnTop(NumericLayer* layer);
+	uint8_t lastDisplay[NUMERIC_DISPLAY_LENGTH];
 #endif
 
 	bool popupActive;

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -1,7 +1,8 @@
 #include "hid/hid_sysex.h"
 #include "hid/display/oled.h"
 #include "io/midi/midi_device.h"
-#include "util/functions.h"
+#include "util/pack.h"
+#include <cstring>
 
 void HIDSysex::sysexReceived(MIDIDevice* device, uint8_t* data, int len) {
 	if (len < 6) {
@@ -9,8 +10,12 @@ void HIDSysex::sysexReceived(MIDIDevice* device, uint8_t* data, int len) {
 	}
 	// first three bytes are already used, next is command
 	switch (data[3]) {
-	case 0: // request OLED dispaly
+	case 0:
 		requestOLEDDisplay(device, data, len);
+		break;
+
+	case 1:
+		request7SegDisplay(device, data, len);
 		break;
 
 	default:
@@ -29,21 +34,39 @@ static uint8_t big_buffer[1024];
 void HIDSysex::sendOLEDData(MIDIDevice* device, bool rle) {
 	// TODO: in the long run, this should not depend on having a physical OLED screen
 #if HAVE_OLED
-	const int block_size = 768;
-	const int packed_block_size = 878;
+	const int data_size = 768;
+	const int max_packed_size = 922;
 
-	rle = false; // not yet implemented
-
-	uint8_t reply_hdr[5] = {0xf0, 0x7e, 0x02, 0x40, rle ? 0x02 : 0x01};
+	uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, rle ? 0x01 : 0x00};
 	uint8_t* reply = big_buffer;
 	memcpy(reply, reply_hdr, 5);
 	reply[5] = 0; // nominally 32*data[5] is start pos for a delta
 
-	int packed = pack_8bit_to_7bit(reply + 6, packed_block_size, OLED::oledCurrentImage[0], block_size);
-	if (packed != packed_block_size) {
+	int packed;
+	if (rle) {
+		packed = pack_8to7_rle(reply + 6, max_packed_size, OLED::oledCurrentImage[0], data_size);
+	}
+	else {
+		packed = pack_8bit_to_7bit(reply + 6, max_packed_size, OLED::oledCurrentImage[0], data_size);
+	}
+	if (packed < 0) {
 		OLED::popupText("eror: fail");
 	}
-	reply[6 + packed_block_size] = 0xf7; // end of transmission
-	device->sendSysex(reply, packed_block_size + 7);
+	reply[6 + packed] = 0xf7; // end of transmission
+	device->sendSysex(reply, packed + 7);
+#endif
+}
+
+void HIDSysex::request7SegDisplay(MIDIDevice* device, uint8_t* data, int len) {
+#if !HAVE_OLED
+	if (data[4] == 0) {
+		// aschually 8 segments if you count the dot
+		const int data_size = 4;
+		const int packed_data_size = 5;
+		uint8_t reply[11] = {0xf0, 0x7d, 0x02, 0x41, 0x00};
+		pack_8bit_to_7bit(reply + 6, packed_data_size, numericDriver.lastDisplay, data_size);
+		reply[6 + packed_data_size] = 0xf7; // end of transmission
+		device->sendSysex(reply, packed_data_size + 7);
+	}
 #endif
 }

--- a/src/deluge/hid/hid_sysex.h
+++ b/src/deluge/hid/hid_sysex.h
@@ -3,6 +3,7 @@
 
 namespace HIDSysex {
 void requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int len);
+void request7SegDisplay(MIDIDevice* device, uint8_t* data, int len);
 void sysexReceived(MIDIDevice* device, uint8_t* data, int len);
 void sendOLEDData(MIDIDevice* device, bool rle);
 

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -2399,58 +2399,5 @@ int fresultToDelugeErrorCode(FRESULT result) {
 	}
 }
 
-// This is the same packing format as used by Sequential synthesizers
-// See the "Packed Data Format" section of any DSI or sequential manual.
-
-int pack_8bit_to_7bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len) {
-	int packets = (src_len + 6) / 7;
-	int missing = (7 * packets - src_len); // allow incomplete packets
-	int out_len = 8 * packets - missing;
-	if (out_len > dst_size)
-		return 0;
-
-	for (int i = 0; i < packets; i++) {
-		int ipos = 7 * i;
-		int opos = 8 * i;
-		memset(dst + opos, 0, 8);
-		for (int j = 0; j < 7; j++) {
-			// incomplete packet
-			if (!(ipos + j < src_len))
-				break;
-			dst[opos + 1 + j] = src[ipos + j] & 0x7f;
-			if (src[ipos + j] & 0x80) {
-				dst[opos] |= (1 << j);
-			}
-		}
-	}
-	return out_len;
-}
-
-int unpack_7bit_to_8bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len) {
-	int packets = (src_len + 7) / 8;
-	int missing = (8 * packets - src_len);
-	if (missing == 7) { // this would be weird
-		packets--;
-		missing = 0;
-	}
-	int out_len = 7 * packets - missing;
-	if (out_len > dst_size)
-		return 0;
-	for (int i = 0; i < packets; i++) {
-		int ipos = 8 * i;
-		int opos = 7 * i;
-		memset(dst + opos, 0, 7);
-		for (int j = 0; j < 7; j++) {
-			if (!(j + 1 + ipos < src_len))
-				break;
-			dst[opos + j] = src[ipos + 1 + j] & 0x7f;
-			if (src[ipos] & (1 << j)) {
-				dst[opos + j] |= 0x80;
-			}
-		}
-	}
-	return 8 * packets;
-}
-
 char miscStringBuffer[FILENAME_BUFFER_SIZE] __attribute__((aligned(CACHE_LINE_SIZE)));
 char shortStringBuffer[64] __attribute__((aligned(CACHE_LINE_SIZE)));

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -558,8 +558,5 @@ inline void writeInt32(char** address, uint32_t number) {
 	*address += 4;
 }
 
-int pack_8bit_to_7bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len);
-int unpack_7bit_to_8bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len);
-
 extern char miscStringBuffer[];
 extern char shortStringBuffer[];

--- a/src/deluge/util/pack.cpp
+++ b/src/deluge/util/pack.cpp
@@ -1,0 +1,211 @@
+#include "pack.h"
+#include <cstring>
+
+// This is the same packing format as used by Sequential synthesizers
+// See the "Packed Data Format" section of any DSI or sequential manual.
+
+int pack_8bit_to_7bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len) {
+	int packets = (src_len + 6) / 7;
+	int missing = (7 * packets - src_len); // allow incomplete packets
+	int out_len = 8 * packets - missing;
+	if (out_len > dst_size)
+		return 0;
+
+	for (int i = 0; i < packets; i++) {
+		int ipos = 7 * i;
+		int opos = 8 * i;
+		memset(dst + opos, 0, 8);
+		for (int j = 0; j < 7; j++) {
+			// incomplete packet
+			if (!(ipos + j < src_len))
+				break;
+			dst[opos + 1 + j] = src[ipos + j] & 0x7f;
+			if (src[ipos + j] & 0x80) {
+				dst[opos] |= (1 << j);
+			}
+		}
+	}
+	return out_len;
+}
+
+int unpack_7bit_to_8bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len) {
+	int packets = (src_len + 7) / 8;
+	int missing = (8 * packets - src_len);
+	if (missing == 7) { // this would be weird
+		packets--;
+		missing = 0;
+	}
+	int out_len = 7 * packets - missing;
+	if (out_len > dst_size)
+		return 0;
+	for (int i = 0; i < packets; i++) {
+		int ipos = 8 * i;
+		int opos = 7 * i;
+		memset(dst + opos, 0, 7);
+		for (int j = 0; j < 7; j++) {
+			if (!(j + 1 + ipos < src_len))
+				break;
+			dst[opos + j] = src[ipos + 1 + j] & 0x7f;
+			if (src[ipos] & (1 << j)) {
+				dst[opos + j] |= 0x80;
+			}
+		}
+	}
+	return 8 * packets;
+}
+
+const int MAX_DENSE_SIZE = 5;
+const int MAX_REP_SIZE = (31 + 127);
+static int pack_dense(uint8_t* dst, int dst_size, uint8_t* src, int src_len) {
+	if (src_len > dst_size - 1)
+		return -1;
+	int highbits = 0;
+	for (int j = 0; j < src_len; j++) {
+		dst[j + 1] = src[j] & 0x7f;
+		if (src[j] & 0x80) {
+			highbits |= (1 << j);
+		}
+	}
+	int off = 0;
+	switch (src_len) {
+	case 2:
+		off = 0;
+		break;
+	case 3:
+		off = 4;
+		break;
+	case 4:
+		off = 12;
+		break;
+	case 5:
+		off = 28;
+		break;
+	default:
+		return -1;
+	}
+	dst[0] = off + highbits;
+	return src_len + 1;
+}
+
+int pack_8to7_rle(uint8_t* dst, int dst_size, uint8_t* src, int src_len) {
+	int d = 0;
+	int s = 0;
+
+	int i = 0; // start of outer (dense) run
+	while (s < src_len) {
+		// no matter what happens, we are gonna need at least 2 more bytes..
+		if (d > dst_size - 2)
+			return -1;
+		int k = s; // start of inner (repeated) run
+		uint8_t val = src[s++];
+		while (s < src_len && (s - k) < MAX_REP_SIZE) {
+			if (src[s] != val)
+				break;
+			s++;
+		}
+		int dense_size = k - i;
+		int rep_size = s - k;
+		if (rep_size < 2) {
+			dense_size += rep_size;
+			rep_size = 0;
+			if (dense_size < MAX_DENSE_SIZE && s < src_len) {
+				// if there is more data, reconsider after next run
+				continue;
+			}
+		}
+
+		if (dense_size > 0) {
+			if (dense_size == 1) {
+				dst[d++] = 64 + (1 << 1) + ((src[i] & 0x80) ? 1 : 0);
+				dst[d++] = src[i] & 0x7f;
+			}
+			else {
+				int siz = pack_dense(dst + d, dst_size - d, src + i, dense_size);
+				if (siz < 0)
+					return siz;
+				d += siz;
+			}
+		}
+
+		if (rep_size > 0) {
+			if (d > dst_size - 2 - (rep_size >= 31))
+				return -2;
+			int first = 64 + ((val & 0x80) ? 1 : 0);
+			if (rep_size < 31) {
+				dst[d++] = first + (rep_size << 1);
+			}
+			else {
+				dst[d++] = first + (31 << 1);
+				dst[d++] = (rep_size - 31);
+			}
+			dst[d++] = val & 0x7f;
+		}
+
+		i = s;
+	}
+	return d;
+}
+
+int unpack_7to8_rle(uint8_t* dst, int dst_size, uint8_t* src, int src_len) {
+	int d = 0;
+	int s = 0;
+
+	while (s + 1 < src_len) {
+		uint8_t first = src[s++];
+		if (first < 64) {
+			int size = 0, off = 0;
+			if (first < 4) {
+				size = 2;
+				off = 0;
+			}
+			else if (first < 12) {
+				size = 3;
+				off = 4;
+			}
+			else if (first < 28) {
+				size = 4;
+				off = 12;
+			}
+			else if (first < 60) {
+				size = 5;
+				off = 28;
+			}
+			else {
+				return -7;
+			}
+
+			if (size > src_len - s) {
+				return -1;
+			}
+			if (size > dst_size - d)
+				return -11;
+			int highbits = first - off;
+			for (int j = 0; j < size; j++) {
+				dst[d + j] = src[s + j] & 0x7f;
+				if (highbits & (1 << j)) {
+					dst[d + j] |= 0x80;
+				}
+			}
+
+			d += size;
+			s += size;
+		}
+		else {
+			// first = 64 + (runlen<<1) + highbit
+			first = first - 64;
+			int high = (first & 1);
+			int runlen = first >> 1;
+			if (runlen == 31) {
+				runlen = 31 + src[s++];
+				if (s == src_len)
+					return -3;
+			}
+			int byte = src[s++] + 128 * high;
+			if (runlen > dst_size - d)
+				return -12;
+			memset(dst + d, byte, runlen);
+			d += runlen;
+		}
+	}
+	return d;
+}

--- a/src/deluge/util/pack.h
+++ b/src/deluge/util/pack.h
@@ -1,0 +1,7 @@
+#include "definitions.h"
+
+int pack_8bit_to_7bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len);
+int unpack_7bit_to_8bit(uint8_t* dst, int dst_size, uint8_t* src, int src_len);
+
+int pack_8to7_rle(uint8_t* dst, int dst_size, uint8_t* src, int src_len);
+int unpack_7to8_rle(uint8_t* dst, int dst_size, uint8_t* src, int src_len);


### PR DESCRIPTION
Run Length Encoding avoids wasting a lot of bandwidth on large empty regions.
