### PR TITLE
C++ Allocator-compliant allocator and string

### DIFF
--- a/src/deluge/memory/fallback_allocator.h
+++ b/src/deluge/memory/fallback_allocator.h
@@ -1,0 +1,39 @@
+#pragma once
+#include "memory/general_memory_allocator.h"
+#include <cstddef>
+
+namespace deluge::memory {
+
+/**
+ * @brief A simple GMA wrapper that conforms to the C++ Allocator trait spec
+ * (see: https://en.cppreference.com/w/cpp/named_req/Allocator)
+ *
+ * @tparam T The type to allocate for
+ */
+template <typename T>
+class fallback_allocator {
+public:
+	using value_type = T;
+
+	fallback_allocator() = default;
+
+	[[nodiscard]] T* allocate(std::size_t n) noexcept {
+		if (n == 0) {
+			return nullptr;
+		}
+		return static_cast<T*>(generalMemoryAllocator.alloc(n * sizeof(T), nullptr, false, true, false, nullptr, false));
+	}
+
+	void deallocate(T* p, std::size_t n) { generalMemoryAllocator.dealloc(p); }
+
+	template <typename U>
+	bool operator==(const deluge::memory::fallback_allocator<U>& o) {
+		return true;
+	}
+
+	template <typename U>
+	bool operator!=(const deluge::memory::fallback_allocator<U>& o) {
+		return false;
+	}
+};
+} // namespace deluge::memory

--- a/src/deluge/memory/fallback_allocator.h
+++ b/src/deluge/memory/fallback_allocator.h
@@ -21,7 +21,8 @@ public:
 		if (n == 0) {
 			return nullptr;
 		}
-		return static_cast<T*>(generalMemoryAllocator.alloc(n * sizeof(T), nullptr, false, true, false, nullptr, false));
+		return static_cast<T*>(
+		    generalMemoryAllocator.alloc(n * sizeof(T), nullptr, false, true, false, nullptr, false));
 	}
 
 	void deallocate(T* p, std::size_t n) { generalMemoryAllocator.dealloc(p); }

--- a/src/deluge/util/string.h
+++ b/src/deluge/util/string.h
@@ -11,4 +11,4 @@ using wstring = std::basic_string<wchar_t, std::char_traits<wchar_t>, memory::fa
 
 using u16string = std::basic_string<char16_t, std::char_traits<char16_t>, memory::fallback_allocator<char16_t>>;
 using u32string = std::basic_string<char32_t, std::char_traits<char32_t>, memory::fallback_allocator<char32_t>>;
-}
+} // namespace deluge

--- a/src/deluge/util/string.h
+++ b/src/deluge/util/string.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "memory/fallback_allocator.h"
+#include <string>
+
+namespace deluge {
+using string = std::basic_string<char, std::char_traits<char>, memory::fallback_allocator<char>>;
+using wstring = std::basic_string<wchar_t, std::char_traits<wchar_t>, memory::fallback_allocator<wchar_t>>;
+
+// Needs C++20
+//using std::u8string = std::basic_string<char8_t, std::char_traits<char8_t>, memory::fallback_allocator<char8_t>>;
+
+using u16string = std::basic_string<char16_t, std::char_traits<char16_t>, memory::fallback_allocator<char16_t>>;
+using u32string = std::basic_string<char32_t, std::char_traits<char32_t>, memory::fallback_allocator<char32_t>>;
+}


### PR DESCRIPTION
This adds a C++-standard compliant allocator that is a very simple wrapper for the GMA, and a set of aliases for string classes that use it as `deluge::[..]string`.

This _should_ just be working, nothing is currently using it, but I'm planning on moving the runtime-formatted titles to std::vformat ASAP.

This should also allow us to begin moving parts that use the custom deluge `String` (aka d_string) to this representation instead, and also alias a `deluge::vector` using this allocator as well to replace some the custom containers with standardized ones in places where appropriate.