### PR TITLE
Fix MasterCompressor by considering masterVolumeAdjustment value

### DIFF
--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -61,8 +61,10 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, int32_t
 				r = rawr * (1.0 - wet) + r * wet;
 			}
 
-			thisSample->l = l * adjustmentL * 2147483647;
-			thisSample->r = r * adjustmentR * 2147483647;
+			thisSample->l = l * 2147483647;
+			thisSample->r = r * 2147483647;
+			thisSample->l = multiply_32x32_rshift32(thisSample->l, masterVolumeAdjustmentL);
+			thisSample->r = multiply_32x32_rshift32(thisSample->r, masterVolumeAdjustmentR);
 
 		} while (++thisSample != bufferEnd);
 	}

--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -30,14 +30,21 @@ MasterCompressor::MasterCompressor() {
 	wet = 1.0;
 }
 
-void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples) {
+void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, int32_t masterVolumeAdjustmentL,
+                              int32_t masterVolumeAdjustmentR) {
 
 	StereoSample* thisSample = buffer;
 	StereoSample* bufferEnd = buffer + numSamples;
 	if (compressor.getThresh() < -0.001) {
+		double adjustmentL = (masterVolumeAdjustmentL) / 4294967296.0; //  *2.0 is <<1 from multiply_32x32_rshift32
+		double adjustmentR = (masterVolumeAdjustmentR) / 4294967296.0;
+		if (adjustmentL < 0.000001)
+			adjustmentL = 0.000001;
+		if (adjustmentR < 0.000001)
+			adjustmentR = 0.000001;
 		do {
-			double l = thisSample->l / 2147483648.0;
-			double r = thisSample->r / 2147483648.0;
+			double l = thisSample->l / 2147483648.0 / adjustmentL;
+			double r = thisSample->r / 2147483648.0 / adjustmentR;
 			double rawl = l;
 			double rawr = r;
 			compressor.process(l, r);
@@ -54,8 +61,8 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples) {
 				r = rawr * (1.0 - wet) + r * wet;
 			}
 
-			thisSample->l = l * 2147483647;
-			thisSample->r = r * 2147483647;
+			thisSample->l = l * adjustmentL * 2147483647;
+			thisSample->r = r * adjustmentR * 2147483647;
 
 		} while (++thisSample != bufferEnd);
 	}

--- a/src/deluge/dsp/master_compressor/master_compressor.h
+++ b/src/deluge/dsp/master_compressor/master_compressor.h
@@ -213,7 +213,8 @@ private:
 class MasterCompressor {
 public:
 	MasterCompressor();
-	void render(StereoSample* buffer, uint16_t numSamples);
+	void render(StereoSample* buffer, uint16_t numSamples, int32_t masterVolumeAdjustmentL,
+	            int32_t masterVolumeAdjustmentR);
 	double makeup;
 	double gr;
 	double wet;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -721,10 +721,10 @@ startAgain:
 		}
 	}
 
+	mastercompressor.render(renderingBuffer, numSamples, masterVolumeAdjustmentL, masterVolumeAdjustmentR);
 	masterVolumeAdjustmentL <<= 2;
 	masterVolumeAdjustmentR <<= 2;
 
-	mastercompressor.render(renderingBuffer, numSamples);
 	metronome.render(renderingBuffer, numSamples);
 
 	// Monitoring setup


### PR DESCRIPTION
Fixed master compressor. The masterVolumeAdjustment value is now considered in the process. With this change, threshold value are now displayed correctly.

This modification affects songs that had saved master compressor settings.