### PR TITLE
bugfix for MPE CC and global commands

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2745,7 +2745,8 @@ void PlaybackHandler::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, ui
 		}
 
 		if (value) {
-			if (tryGlobalMIDICommands(fromDevice, channel + IS_A_CC, ccNumber)) {
+			int channelOrZone = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
+			if (tryGlobalMIDICommands(fromDevice, channelOrZone + IS_A_CC, ccNumber)) {
 				return;
 			}
 		}


### PR DESCRIPTION
Bug fix for an issue in #147, CC's received on MPE channels could accidentally trigger global commands learned to non MPE channels