### PR TITLE
Add generic container specializations

### DIFF
--- a/src/deluge/memory/fallback_allocator.h
+++ b/src/deluge/memory/fallback_allocator.h
@@ -15,7 +15,10 @@ class fallback_allocator {
 public:
 	using value_type = T;
 
-	fallback_allocator() = default;
+	constexpr fallback_allocator() noexcept = default;
+
+	template <typename U>
+	constexpr fallback_allocator(const fallback_allocator<U>&) noexcept {};
 
 	[[nodiscard]] T* allocate(std::size_t n) noexcept {
 		if (n == 0) {

--- a/src/deluge/util/containers.h
+++ b/src/deluge/util/containers.h
@@ -1,0 +1,52 @@
+#pragma once
+#include "memory/fallback_allocator.h"
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <map>
+#include <queue>
+#include <stack>
+#include <unordered_map>
+#include <vector>
+
+namespace deluge {
+// For most purposes containers relying on a fallback allocation strategy should be fine.
+// At some point this will probably move to a priority-based allocation system, so default template arguments
+// are used instead of hardcoded allocator selection.
+//
+// If we decide to require explicit allocation choice in the future, we can also remove the default argument and
+// fix any broken container uses, adding fallback_allocator to their template arguments or a different allocator
+// if appropriate.
+
+// Vector (resizeable variable-length array, unknown size)
+template <typename T, typename Alloc = memory::fallback_allocator<T>>
+using vector = std::vector<T, Alloc>;
+
+// Doubly-ended queue
+template <typename T, typename Alloc = memory::fallback_allocator<T>>
+using deque = std::deque<T, Alloc>;
+
+// Singly linked list
+template <typename T, typename Alloc = memory::fallback_allocator<T>>
+using forward_list = std::forward_list<T, Alloc>;
+
+// Doubly-linked list
+template <typename T, typename Alloc = memory::fallback_allocator<T>>
+using list = std::list<T, Alloc>;
+
+// Tree map
+template <typename Key, typename T, typename Alloc = memory::fallback_allocator<std::pair<const Key, T>>>
+using map = std::map<Key, T, std::less<Key>, Alloc>;
+
+// Hash map
+template <typename Key, typename T, typename Alloc = memory::fallback_allocator<std::pair<const Key, T>>>
+using unordered_map = std::unordered_map<Key, T, std::hash<Key>, std::equal_to<Key>, Alloc>;
+
+// Stack
+template <typename T, typename Alloc = memory::fallback_allocator<T>>
+using stack = std::stack<T, deque<T, Alloc>>;
+
+// Stack
+template <typename T, typename Alloc = memory::fallback_allocator<T>>
+using queue = std::queue<T, deque<T, Alloc>>;
+} // namespace deluge

--- a/src/deluge/util/containers.h
+++ b/src/deluge/util/containers.h
@@ -46,7 +46,7 @@ using unordered_map = std::unordered_map<Key, T, std::hash<Key>, std::equal_to<K
 template <typename T, typename Alloc = memory::fallback_allocator<T>>
 using stack = std::stack<T, deque<T, Alloc>>;
 
-// Stack
+// Queue
 template <typename T, typename Alloc = memory::fallback_allocator<T>>
 using queue = std::queue<T, deque<T, Alloc>>;
 } // namespace deluge


### PR DESCRIPTION
This adds the specializations required to use the STL containers with fallback_allocator, as well as adds a copy constructor for fallback_allocator which is required for std::map