### PR TITLE
Integrate SCons and Tasks into unified DBT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
             --user=$(id --user):$(id --group) \
             -v $(pwd):/src \
             ghcr.io/litui/dbt-toolchain:v$(cat toolchain/REQUIRED_VERSION) \
+            build \
             --spew \
             all
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,7 +8,7 @@
 			"windows": {
 				"command": "./dbt.cmd",
 			},
-			"args":["dbt-build-debug-7seg"],
+			"args":["build", "dbt-build-debug-7seg"],
 			"group": { 
 				"kind": "build",
 				"isDefault": true
@@ -21,7 +21,7 @@
 			"windows": {
 				"command": "./dbt.cmd",
 			},
-			"args":["dbt-build-debug-oled"],
+			"args":["build", "dbt-build-debug-oled"],
 			"group": { 
 				"kind": "build",
 				"isDefault": false
@@ -34,7 +34,7 @@
 			"windows": {
 				"command": "./dbt.cmd",
 			},
-			"args":["dbt-build-release-7seg"],
+			"args":["build", "dbt-build-release-7seg"],
 			"group": { 
 				"kind": "build",
 				"isDefault": false
@@ -47,7 +47,7 @@
 			"windows": {
 				"command": "./dbt.cmd",
 			},
-			"args":["dbt-build-release-oled"],
+			"args":["build", "dbt-build-release-oled"],
 			"group": { 
 				"kind": "build",
 				"isDefault": false
@@ -58,9 +58,12 @@
 			"type": "process",
 			"label": "Run JLink GDB Server",
 			"problemMatcher": [],
-			"command": "python",	
+			"command": "./dbt",	
+			"windows": {
+				"command": "./dbt.cmd",
+			},
 			"args": [
-				"scripts/tasks/task-debug.py",
+				"debug",
 				"-j",
 			]
 		},
@@ -68,9 +71,12 @@
 			"type": "process",
 			"label": "Run OpenOCD GDB Server",
 			"problemMatcher": [],
-			"command": "python",
+			"command": "./dbt",
+			"windows": {
+				"command": "./dbt.cmd",
+			},
 			"args": [
-				"scripts/tasks/task-debug.py",
+				"debug",
 			]
 		}
 	]

--- a/SConstruct
+++ b/SConstruct
@@ -1,5 +1,10 @@
 import os
 import multiprocessing
+import sys
+import pathlib
+
+# Remove current directory from search list (dbt package and dbt.py name collision)
+sys.path = [d for d in sys.path if str(pathlib.Path(d)) != os.getcwd()]
 
 from SCons.Action import Action
 from SCons.Platform import TempFileMunge

--- a/dbt
+++ b/dbt
@@ -12,8 +12,7 @@ set -eu;
 # private variables
 N_GIT_THREADS="$(getconf _NPROCESSORS_ONLN)";
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd -P)";
-SCONS_DEFAULT_FLAGS="-Q --warn=target-not-built";
-SCONS_EP="python3 -m SCons";
+DBT_EP="python3 dbt.py";
 
 # public variables
 DBT_NOENV="${DBT_NOENV:-""}";
@@ -44,4 +43,4 @@ $pip_cmd install -q --upgrade pip
 $pip_cmd install -q -f "${pip_wheel_path}" -r "${pip_requirements_path}"
 
 
-$SCONS_EP $SCONS_DEFAULT_FLAGS "$@"
+$DBT_EP "$@"

--- a/dbt.cmd
+++ b/dbt.cmd
@@ -2,7 +2,7 @@
 call "%~dp0scripts\toolchain\dbtenv.cmd" env
 set "SCRIPT_PATH=%DBT_ROOT%"
 
-set SCONS_EP=python -m SCons
+set DBT_EP=python dbt.py
 
 if [%DBT_NO_SYNC%] == [] (
     if exist ".git" (
@@ -11,12 +11,6 @@ if [%DBT_NO_SYNC%] == [] (
         echo Not in a git repo, please clone with "git clone"
         exit /b 1
     )
-)
-
-set "SCONS_DEFAULT_FLAGS=--warn=target-not-built"
-
-if not defined DBT_VERBOSE (
-    set "SCONS_DEFAULT_FLAGS=%SCONS_DEFAULT_FLAGS% -Q"
 )
 
 set PIP_CMD=python -m pip
@@ -30,4 +24,4 @@ for /R %PIP_WHEEL_PATH% %%G in (
 %PIP_CMD% install -q --upgrade pip | find /V "already satisfied"
 %PIP_CMD% install -q -f "%PIP_WHEEL_PATH%" -r "%PIP_REQUIREMENTS_PATH%" | find /V "already satisfied"
 
-%SCONS_EP% %SCONS_DEFAULT_FLAGS% %*
+%DBT_EP% %*

--- a/dbt.py
+++ b/dbt.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+import argparse
+import importlib
+from pathlib import Path
+import sys
+import os
+import textwrap
+
+PROG_NAME = sys.argv[0].split('.')[0]
+
+TASKS_DIR = str(Path(__file__).absolute().parent / "scripts/tasks")
+SCRIPTS_DIR = str(Path(__file__).absolute().parent / "scripts")
+DBT_DEBUG_DIR = str(Path(__file__).absolute().parent / "scripts/debug")
+
+os.environ["DBT_DEBUG_DIR"] = DBT_DEBUG_DIR
+
+def print_tasks_usage(tasks):
+    grouped = {}
+    for name, stem in tasks.items():
+        argparser = importlib.import_module(stem).argparser()
+        try:
+            group = argparser.group
+        except AttributeError:
+            group = "Ungrouped"
+        grouped[group] = grouped.get(group, []) + [argparser]
+        
+    for group, argparsers in sorted(grouped.items()):
+        print(textwrap.indent(group + ':', ' ' * 2))
+        for argparser in argparsers:
+            # get our argparsers (lazy import)
+            usage : str = argparser.format_usage().strip().removeprefix("usage: ")
+            #usage = f"{PROG_NAME} " + usage
+            print(textwrap.indent(usage, ' ' * 4))
+            if argparser.description:
+                print(textwrap.indent(argparser.description, ' ' * 6))
+
+
+def print_help(argparser: argparse.ArgumentParser, tasks: dict):
+    argparser.print_help()
+    print("")
+    print("subcommands: ")
+    print_tasks_usage(tasks)
+    
+
+def main():
+    # Create the main parser
+    parser = argparse.ArgumentParser(
+        prog=f"{PROG_NAME}" or "task",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        add_help=False,
+    )
+    parser.add_argument("subcommand", metavar="<subcommand>")
+
+    # Specify the folder containing the task files
+    task_files = Path(TASKS_DIR).glob("task-*.py")
+
+    sys.path.append(TASKS_DIR)
+    sys.path.insert(0, SCRIPTS_DIR)
+
+    tasks = {}
+    for task_file in task_files:
+        task = task_file.stem
+        task_name = task.replace("task-", "")
+        tasks[task_name] = task
+    
+    # is the subcommand in our list of tasks?
+    if len(sys.argv) > 1 and sys.argv[1] in tasks:
+        task_name = sys.argv[1]
+
+        # Remove our own program name/path from the arguments
+        if sys.argv[1:]:
+            sys.argv = sys.argv[1:]
+
+        # Call out to our task. (lazy import)
+        importlib.import_module(tasks[task_name]).main()
+        sys.exit(0)
+    
+
+    # nothing on the command line
+    if len(sys.argv) == 1:
+        print_help(parser, tasks)
+        exit()
+        
+
+    args = parser.parse_args()
+    
+    if args.subcommand not in tasks:
+      print("{PROG_NAME}: '{}' is not a valid subcommand.".format(args.subcommand))
+      print("")
+      print("Valid tasks:")
+      print_tasks_usage(tasks)
+
+
+if __name__ == '__main__':
+    try:
+        retcode = main()
+        sys.exit(retcode)
+    except KeyboardInterrupt:
+        sys.exit(130)

--- a/scripts/tasks/task-build.py
+++ b/scripts/tasks/task-build.py
@@ -1,0 +1,29 @@
+#! /usr/bin/env python3
+import argparse
+import subprocess
+import sys
+import util
+import os
+
+def argparser():
+    parser = argparse.ArgumentParser(
+        prog="build",
+        description="Run SCons in the current environment",
+    )
+    parser.group = "Building"
+    return parser
+
+
+def main():
+    scons_args = sys.argv[1:]
+    
+    scons_args += ['--warn=target-not-built']
+
+    if not os.environ.get('DBT_VERBOSE'):
+        scons_args += ['-Q']
+
+    os.chdir(util.get_git_root())
+    subprocess.run(['scons'] + scons_args, env=os.environ)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tasks/task-debug.py
+++ b/scripts/tasks/task-debug.py
@@ -44,9 +44,7 @@ def jlink_gdb(cmd, device: str, endian: str, protocol: str, gdb_port: int):
 
 def openocd_gdb(cmd, interface: str, target: str, protocol: str, gdb_port: int):
     if not cmd:
-        cmd = find_cmd_with_fallback(
-            "openocd", absolute_path_str("toolchain/win32-x64/openocd/bin/openocd.exe")
-        )
+        cmd = find_cmd_with_fallback("openocd", "openocd")
 
     # if we haven't gotten an interface with a path already, qualify it
     if len(target.split("/")) == 1:
@@ -67,8 +65,11 @@ def openocd_gdb(cmd, interface: str, target: str, protocol: str, gdb_port: int):
 
 def argparser():
     parser = argparse.ArgumentParser(
-        prog="task debug", formatter_class=argparse.ArgumentDefaultsHelpFormatter
+        prog="debug",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description="Run a debug server (JLink or OpenOCD)",
     )
+    parser.group = "Debugging"
     parser.add_argument(
         "-j", "--jlink", action="store_true", help="Use JLinkGDB instead of OpenOCD"
     )

--- a/scripts/tasks/task-format.py
+++ b/scripts/tasks/task-format.py
@@ -65,9 +65,10 @@ def format_file(clang_format: str, verbose: bool, path: Path):
 
 def argparser():
     parser = argparse.ArgumentParser(
-        prog="task format",
+        prog="format",
         description="Formats files using clang-format (Assumes .clang-format present in directory structure)",
     )
+    parser.group = "Miscellaneous"
     parser.add_argument(
         "-nr",
         "--no-recursive",

--- a/scripts/tasks/task-gdb.py
+++ b/scripts/tasks/task-gdb.py
@@ -1,0 +1,55 @@
+#! /usr/bin/env python3
+import argparse
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+import os
+
+# Based on dbt_tools/gdb.py by litui
+
+
+def argparser():
+    parser = argparse.ArgumentParser(
+        prog="gdb",
+        description="Open a GDB remote for the proper target",
+    )
+    parser.group = "Debugging"
+    parser.add_argument("-nb", "--no-build", action="store_true")
+    parser.add_argument(
+        "target",
+        default="oled",
+        const="oled",
+        nargs="?",
+        choices=["7seg", "oled"],
+    )
+    return parser
+
+
+def main():
+    args = argparser().parse_args()
+
+    scons_target = f"dbt-build-debug-{args.target}"
+
+    if not args.no_build:
+        sys.argv = ["build", scons_target]
+        importlib.import_module("task-build").main()
+
+    elf_path = Path(scons_target) / f"Deluge-debug-{args.target}.elf"
+
+    gdbinit = Path(os.environ['DBT_DEBUG_DIR']) / "gdbinit"
+
+    subprocess.run(
+        [
+            "arm-none-eabi-gdb",
+            "-ex",
+            f"source {str(gdbinit)}",
+            "-ex",
+            "target extended-remote :3333",
+            elf_path,
+        ]
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tasks/task-license.py
+++ b/scripts/tasks/task-license.py
@@ -41,9 +41,10 @@ def license_file(dry_run: bool, verbose: bool, path: Path):
 
 def argparser():
     parser = argparse.ArgumentParser(
-        prog="task license",
+        prog="license",
         description="Add Synthstrom Deluge license prelude to files (if not present)",
     )
+    parser.group = "Miscellaneous"
     parser.add_argument(
         "-r",
         "--recursive",

--- a/scripts/tasks/task-openocd.py
+++ b/scripts/tasks/task-openocd.py
@@ -1,0 +1,118 @@
+#! /usr/bin/env python3
+import argparse
+from pathlib import Path
+import subprocess
+import shutil
+import sys
+import os
+
+# Based on dbt_tools/openocd.py by litui
+from dbt.exit_codes import ExitCodes
+
+__OPENOCD_BIN = shutil.which("openocd")
+
+OPENOCD = __OPENOCD_BIN
+OPENOCD_SCRIPT_DIR = os.path.join(os.environ["DBT_DEBUG_DIR"], "openocd")
+OPENOCD_OPTS = []
+OPENOCD_COMMAND = []
+OPENOCDCOM = "${OPENOCD} ${OPENOCD_OPTS} ${OPENOCD_COMMAND}"
+OPENOCDCOMSTR = ""
+
+
+_oocd_action = [
+    "${OPENOCD} ${OPENOCD_OPTS} ${OPENOCD_COMMAND}",
+    "${OPENOCDCOMSTR}",
+]
+
+# hardware_type -> protocol = filenames
+# Make sure dependencies are sourced within the file
+_OPENOCD_CONFIG_MAP = {
+    "delugeprobe": {
+        "jtag": [os.path.join("interface", "delugeprobe.cfg"), "deluge-swj-jtag.cfg"],
+        "swd": [os.path.join("interface", "delugeprobe.cfg"), "deluge-swj-swd.cfg"],
+    },
+    "esp-prog": {
+        "jtag": [os.path.join("interface", "esp-prog.cfg"), "deluge-jtag.cfg"],
+    },
+}
+
+
+def _get_acceptable_hardware(hardware):
+    if hardware in _OPENOCD_CONFIG_MAP.keys():
+        return hardware
+
+    # Always default to delugeprobe if weird stuff
+    # is entered
+    return "delugeprobe"
+
+
+def _get_acceptable_protocol(hardware, protocol):
+    checked_hw = _get_acceptable_hardware(hardware)
+    protocols = _OPENOCD_CONFIG_MAP[checked_hw]
+
+    if protocol in protocols.keys():
+        return protocol
+
+    # If provided protocol is not in list
+    for k, v in protocols.items():
+        return k
+
+    # If for whatever reason there are no listed protocols
+    return None
+
+
+def exists():
+    if not OPENOCD:
+        raise FileNotFoundError("Could not detect openocd")
+
+    return OPENOCD
+
+
+def argparser():
+    parser = argparse.ArgumentParser(
+        prog="openocd",
+        description="Run OpenOCD with default arguments (CMSIS-DAP/DelugeProbe).\nThese can be changed using the OPENOCD_OPTS variable.",
+    )
+    parser.group = "Debugging"
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="print the command used to call openocd",
+        action="store_true",
+    )
+    return parser
+
+
+def main():
+    args = argparser().parse_args()
+
+    hardware = os.environ.get("DEBUG_HARDWARE") or "delugeprobe"
+    protocol = os.environ.get("DEBUG_PROTOCOL") or "swd"
+
+    if not hardware in _OPENOCD_CONFIG_MAP.keys():
+        print(f"Debugging hardware [{hardware}] is not yet supported.")
+        sys.exit(ExitCodes.OPENOCD_UNSUPPORTED_HARDWARE)
+
+    if not protocol in _OPENOCD_CONFIG_MAP[hardware].keys():
+        better_protocol = _get_acceptable_protocol(hardware, protocol)
+        print(
+            f"Debugging protocol [{protocol}] is not supported on hardware [{hardware}]."
+        )
+        print(f"Trying supported protocol [{better_protocol}] instead.")
+        protocol = better_protocol
+
+    cfg_files = _OPENOCD_CONFIG_MAP[hardware][protocol]
+
+    ocd_cmd = [__OPENOCD_BIN]
+    for cfg_part in cfg_files:
+        ocd_cmd.append("-f")
+        path = os.path.join(OPENOCD_SCRIPT_DIR, cfg_part)
+        ocd_cmd.append(f"{path}")
+
+    if args.verbose:
+        print(" ".join(ocd_cmd))
+    subprocess.run(ocd_cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tasks/task-shell.py
+++ b/scripts/tasks/task-shell.py
@@ -1,0 +1,38 @@
+#! /usr/bin/env python3
+import argparse
+import platform
+import subprocess
+import shutil
+import os
+import sys
+
+# Based on dbt_tools/shell.py by litui
+
+PLATFORM = platform.system().lower()
+
+
+def get_shell():
+    if PLATFORM == "windows":
+        shell_command = shutil.which("cmd.exe")
+    else:
+        shell_command = (
+            os.environ.get("SHELL") or shutil.which("bash") or shutil.which("sh")
+        )
+    return shell_command
+
+
+def argparser():
+    parser = argparse.ArgumentParser(
+        prog="shell",
+        description="Open a shell in the DBT environment",
+    )
+    parser.group = "Development"
+    return parser
+
+
+def main():
+    subprocess.run([get_shell()] + sys.argv[1:] , env=os.environ)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently we have two separate toolsets: tasks for debug and format, DBT (or rather SCons on top of DBT's toolchain) for building and OpenOCD. There's been some efforts at moving features between the two, but they're currently in an awkward position.  At its heart SCons is designed for compilation tasks. However it's complicated, not easy for newcomers to understand, and ultimately makes doing things that should be simple (like calling clang-format) harder than they need to be.

So I'm proposing that rather than relying on bolting functionality onto SCons via ad-hoc target handling and Builders, we invert the point of control and leave SCons to what it does best: compilation, relying on a larger overarching system to handle the day-to-day actions we need, in a way that is portable, easily configurable for arguments, and does not rely on SCons.

The tasks system is very simple at heart: it looks in a predetermined folder for any Python files called `task-*`, and calls the function `main()` in one of these files if they match the subcommand passed in. Each file also has an `argparser()` function that allows the task coordinator to print the usage and information for all tasks at once. 

That's it.

Everything else is handled by the task, in the current environment. Current arguments are naturally maintained across task-calling via `sys.argv`, and the DBT environment is available when called from `dbt.cmd` or `dbt`. Tasks are easily maintainable and extended by others simply by nature of being barebones python programs.

There are currently seven tasks. The `build` task directly calls SCons, and all flags and environment variables that worked previously can be used unaltered, simply by using `dbt build` instead of `dbt` on its own.

The end result is a unified interface for both building and running pre-commit tasks that are not tied to SCons, but instead freestanding, inside of the environment provided by the DBT toolchain. This was how I imagined DBT was going to operate when I first heard about it.

The current state of the output:
```
./dbt.cmd
usage: dbt <subcommand>

positional arguments:
  <subcommand>

subcommands:
  Building:
    build [-h]
      Run SCons in the current environment
  Debugging:
    debug [-h] [-j] [-c COMMAND] [-d TARGET_DEVICE] [-g GDB_PORT] [-v] [-p {swd,jtag}] [-i INTERFACE]
      Run a debug server (JLink or OpenOCD)
    gdb [-h] [-nb] [{7seg,oled}]
      Open a GDB remote for the proper target
    openocd [-h] [-v]
      Run OpenOCD with default arguments (CMSIS-DAP/DelugeProbe).
      These can be changed using the OPENOCD_OPTS variable.
  Development:
    shell [-h]
      Open a shell in the DBT environment
  Miscellaneous:
    format [-h] [-nr] [-q] [-v] directory
      Formats files using clang-format (Assumes .clang-format present in directory structure)
    license [-h] [-r] [-q] [-d] [-v] directory
      Add Synthstrom Deluge license prelude to files (if not present)
 ```