### PR TITLE
Create a q31 fixed point alias for int32_t in DSP code

### DIFF
--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -31,7 +31,7 @@ void FilterSet::renderHPF(q31_t* outputSample, FilterSetConfig* filterSetConfig,
 	q31_t firstHPFOutput = input - hpfHPF1.doFilter(input, filterSetConfig->hpfMoveability);
 
 	q31_t feedbacksValue = hpfHPF3.getFeedbackOutput(filterSetConfig->hpfHPF3Feedback)
-	                         + hpfLPF1.getFeedbackOutput(filterSetConfig->hpfLPF1Feedback);
+	                       + hpfLPF1.getFeedbackOutput(filterSetConfig->hpfLPF1Feedback);
 
 	q31_t a =
 	    multiply_32x32_rshift32_rounded(filterSetConfig->divideByTotalMoveability, firstHPFOutput + feedbacksValue)
@@ -57,8 +57,8 @@ void FilterSet::renderHPF(q31_t* outputSample, FilterSetConfig* filterSetConfig,
 
 #define HPF_LONG_SATURATION 3
 
-void FilterSet::renderHPFLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig,
-                              int numSamples, int sampleIncrement) {
+void FilterSet::renderHPFLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig, int numSamples,
+                              int sampleIncrement) {
 
 	bool needToFixSaturation = false;
 
@@ -85,8 +85,7 @@ void FilterSet::renderHPFLong(q31_t* outputSample, q31_t* endSample, FilterSetCo
 
 	q31_t hpfDivideByProcessedResonanceNow = hpfDivideByProcessedResonanceLastTime;
 	q31_t hpfDivideByProcessedResonanceIncrement =
-	    (q31_t)(filterSetConfig->hpfDivideByProcessedResonance - hpfDivideByProcessedResonanceNow)
-	    / (q31_t)numSamples;
+	    (q31_t)(filterSetConfig->hpfDivideByProcessedResonance - hpfDivideByProcessedResonanceNow) / (q31_t)numSamples;
 	hpfDivideByProcessedResonanceLastTime = filterSetConfig->hpfDivideByProcessedResonance;
 
 	do {
@@ -96,11 +95,11 @@ void FilterSet::renderHPFLong(q31_t* outputSample, q31_t* endSample, FilterSetCo
 		q31_t firstHPFOutput = input - hpfHPF1.doFilter(input, filterSetConfig->hpfMoveability);
 
 		q31_t feedbacksValue = hpfHPF3.getFeedbackOutput(filterSetConfig->hpfHPF3Feedback)
-		                         + hpfLPF1.getFeedbackOutput(filterSetConfig->hpfLPF1Feedback);
+		                       + hpfLPF1.getFeedbackOutput(filterSetConfig->hpfLPF1Feedback);
 
 		hpfDivideByTotalMoveabilityNow += hpfDivideByTotalMoveabilityIncrement;
 		q31_t a = multiply_32x32_rshift32_rounded(hpfDivideByTotalMoveabilityNow, firstHPFOutput + feedbacksValue)
-		            << (4 + 1);
+		          << (4 + 1);
 
 		// Only saturate / anti-alias if lots of resonance
 		if (hpfDoingAntialiasingNow) { // 890551738
@@ -136,19 +135,19 @@ inline q31_t FilterSet::do24dBLPFOnSample(q31_t input, FilterSetConfig* filterSe
 	    filterSetConfig->moveability + multiply_32x32_rshift32(filterSetConfig->moveability, noiseLastValue);
 
 	q31_t feedbacksSum = (lpfLPF1.getFeedbackOutputWithoutLshift(filterSetConfig->lpf1Feedback)
-	                        + lpfLPF2.getFeedbackOutputWithoutLshift(filterSetConfig->lpf2Feedback)
-	                        + lpfLPF3.getFeedbackOutputWithoutLshift(filterSetConfig->lpf3Feedback)
-	                        + lpfLPF4.getFeedbackOutputWithoutLshift(filterSetConfig->divideBy1PlusTannedFrequency))
-	                       << 2;
+	                      + lpfLPF2.getFeedbackOutputWithoutLshift(filterSetConfig->lpf2Feedback)
+	                      + lpfLPF3.getFeedbackOutputWithoutLshift(filterSetConfig->lpf3Feedback)
+	                      + lpfLPF4.getFeedbackOutputWithoutLshift(filterSetConfig->divideBy1PlusTannedFrequency))
+	                     << 2;
 
 	// Note: in the line above, we "should" halve filterSetConfig->divideBy1plusg to get it into the 1=1073741824 range. But it doesn't sound as good.
 	// Primarily it stops us getting to full resonance. But even if we allow further resonance increase, the sound just doesn't quite compare.
 	// Lucky I discovered this by mistake
 
 	q31_t x = multiply_32x32_rshift32_rounded(
-	                (input - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
-	                filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
-	            << 2;
+	              (input - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
+	              filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
+	          << 2;
 
 	// Only saturate if resonance is high enough. Surprisingly, saturation makes no audible difference until very near the point of feedback
 	if (saturationLevel) {
@@ -171,10 +170,10 @@ inline q31_t FilterSet::doDriveLPFOnSample(q31_t input, FilterSetConfig* filterS
 	    filterSetConfig->moveability + multiply_32x32_rshift32(filterSetConfig->moveability, noiseLastValue);
 
 	q31_t feedbacksSum = (lpfLPF1.getFeedbackOutputWithoutLshift(filterSetConfig->lpf1Feedback)
-	                        + lpfLPF2.getFeedbackOutputWithoutLshift(filterSetConfig->lpf2Feedback)
-	                        + lpfLPF3.getFeedbackOutputWithoutLshift(filterSetConfig->lpf3Feedback)
-	                        + lpfLPF4.getFeedbackOutputWithoutLshift(filterSetConfig->divideBy1PlusTannedFrequency))
-	                       << 2;
+	                      + lpfLPF2.getFeedbackOutputWithoutLshift(filterSetConfig->lpf2Feedback)
+	                      + lpfLPF3.getFeedbackOutputWithoutLshift(filterSetConfig->lpf3Feedback)
+	                      + lpfLPF4.getFeedbackOutputWithoutLshift(filterSetConfig->divideBy1PlusTannedFrequency))
+	                     << 2;
 
 	// Note: in the line above, we "should" halve filterSetConfig->divideBy1plusg to get it into the 1=1073741824 range. But it doesn't sound as good.
 	// Primarily it stops us getting to full resonance. But even if we allow further resonance increase, the sound just doesn't quite compare.
@@ -185,9 +184,9 @@ inline q31_t FilterSet::doDriveLPFOnSample(q31_t input, FilterSetConfig* filterS
 
 	// We don't saturate the input anymore, because that's the place where we'd get the most aliasing!
 	q31_t x = multiply_32x32_rshift32_rounded(
-	                (input - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
-	                filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
-	            << 2;
+	              (input - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
+	              filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
+	          << 2;
 
 	q31_t a = lpfLPF1.doFilter(x, moveability);
 
@@ -200,8 +199,8 @@ inline q31_t FilterSet::doDriveLPFOnSample(q31_t input, FilterSetConfig* filterS
 	return d;
 }
 
-void FilterSet::renderLPFLong(q31_t* startSample, q31_t* endSample, FilterSetConfig* filterSetConfig,
-                              uint8_t lpfMode, int sampleIncrement, int extraSaturation, int extraSaturationDrive) {
+void FilterSet::renderLPFLong(q31_t* startSample, q31_t* endSample, FilterSetConfig* filterSetConfig, uint8_t lpfMode,
+                              int sampleIncrement, int extraSaturation, int extraSaturationDrive) {
 
 	// This should help get rid of crackling on start / stop - but doesn't
 	if (!lpfOnLastTime) {
@@ -227,14 +226,13 @@ void FilterSet::renderLPFLong(q31_t* startSample, q31_t* endSample, FilterSetCon
 			    filterSetConfig->moveability + multiply_32x32_rshift32(filterSetConfig->moveability, noiseLastValue);
 
 			q31_t feedbacksSum = lpfLPF1.getFeedbackOutput(filterSetConfig->lpf1Feedback)
-			                       + lpfLPF2.getFeedbackOutput(filterSetConfig->lpf2Feedback)
-			                       + lpfLPF3.getFeedbackOutput(filterSetConfig->divideBy1PlusTannedFrequency);
-			q31_t x =
-			    multiply_32x32_rshift32_rounded(
-			        (*currentSample
-			         - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
-			        filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
-			    << 2;
+			                     + lpfLPF2.getFeedbackOutput(filterSetConfig->lpf2Feedback)
+			                     + lpfLPF3.getFeedbackOutput(filterSetConfig->divideBy1PlusTannedFrequency);
+			q31_t x = multiply_32x32_rshift32_rounded(
+			              (*currentSample
+			               - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
+			              filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
+			          << 2;
 
 			// Only saturate if resonance is high enough. Surprisingly, saturation makes no audible difference until very near the point of feedback
 			if (true || filterSetConfig->processedResonance > 510000000) { // Re-check this?

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -25,15 +25,15 @@
 FilterSet::FilterSet() {
 }
 
-void FilterSet::renderHPF(int32_t* outputSample, FilterSetConfig* filterSetConfig, int extraSaturation) {
-	int32_t input = *outputSample;
+void FilterSet::renderHPF(q31_t* outputSample, FilterSetConfig* filterSetConfig, int extraSaturation) {
+	q31_t input = *outputSample;
 
-	int32_t firstHPFOutput = input - hpfHPF1.doFilter(input, filterSetConfig->hpfMoveability);
+	q31_t firstHPFOutput = input - hpfHPF1.doFilter(input, filterSetConfig->hpfMoveability);
 
-	int32_t feedbacksValue = hpfHPF3.getFeedbackOutput(filterSetConfig->hpfHPF3Feedback)
+	q31_t feedbacksValue = hpfHPF3.getFeedbackOutput(filterSetConfig->hpfHPF3Feedback)
 	                         + hpfLPF1.getFeedbackOutput(filterSetConfig->hpfLPF1Feedback);
 
-	int32_t a =
+	q31_t a =
 	    multiply_32x32_rshift32_rounded(filterSetConfig->divideByTotalMoveability, firstHPFOutput + feedbacksValue)
 	    << (4 + 1);
 
@@ -57,7 +57,7 @@ void FilterSet::renderHPF(int32_t* outputSample, FilterSetConfig* filterSetConfi
 
 #define HPF_LONG_SATURATION 3
 
-void FilterSet::renderHPFLong(int32_t* outputSample, int32_t* endSample, FilterSetConfig* filterSetConfig,
+void FilterSet::renderHPFLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig,
                               int numSamples, int sampleIncrement) {
 
 	bool needToFixSaturation = false;
@@ -78,28 +78,28 @@ void FilterSet::renderHPFLong(int32_t* outputSample, int32_t* endSample, FilterS
 		hpfHPF3.reset();
 	}
 
-	int32_t hpfDivideByTotalMoveabilityNow = hpfDivideByTotalMoveabilityLastTime;
-	int32_t hpfDivideByTotalMoveabilityIncrement =
-	    (int32_t)(filterSetConfig->divideByTotalMoveability - hpfDivideByTotalMoveabilityNow) / (int32_t)numSamples;
+	q31_t hpfDivideByTotalMoveabilityNow = hpfDivideByTotalMoveabilityLastTime;
+	q31_t hpfDivideByTotalMoveabilityIncrement =
+	    (q31_t)(filterSetConfig->divideByTotalMoveability - hpfDivideByTotalMoveabilityNow) / (q31_t)numSamples;
 	hpfDivideByTotalMoveabilityLastTime = filterSetConfig->divideByTotalMoveability;
 
-	int32_t hpfDivideByProcessedResonanceNow = hpfDivideByProcessedResonanceLastTime;
-	int32_t hpfDivideByProcessedResonanceIncrement =
-	    (int32_t)(filterSetConfig->hpfDivideByProcessedResonance - hpfDivideByProcessedResonanceNow)
-	    / (int32_t)numSamples;
+	q31_t hpfDivideByProcessedResonanceNow = hpfDivideByProcessedResonanceLastTime;
+	q31_t hpfDivideByProcessedResonanceIncrement =
+	    (q31_t)(filterSetConfig->hpfDivideByProcessedResonance - hpfDivideByProcessedResonanceNow)
+	    / (q31_t)numSamples;
 	hpfDivideByProcessedResonanceLastTime = filterSetConfig->hpfDivideByProcessedResonance;
 
 	do {
 
-		int32_t input = *outputSample;
+		q31_t input = *outputSample;
 
-		int32_t firstHPFOutput = input - hpfHPF1.doFilter(input, filterSetConfig->hpfMoveability);
+		q31_t firstHPFOutput = input - hpfHPF1.doFilter(input, filterSetConfig->hpfMoveability);
 
-		int32_t feedbacksValue = hpfHPF3.getFeedbackOutput(filterSetConfig->hpfHPF3Feedback)
+		q31_t feedbacksValue = hpfHPF3.getFeedbackOutput(filterSetConfig->hpfHPF3Feedback)
 		                         + hpfLPF1.getFeedbackOutput(filterSetConfig->hpfLPF1Feedback);
 
 		hpfDivideByTotalMoveabilityNow += hpfDivideByTotalMoveabilityIncrement;
-		int32_t a = multiply_32x32_rshift32_rounded(hpfDivideByTotalMoveabilityNow, firstHPFOutput + feedbacksValue)
+		q31_t a = multiply_32x32_rshift32_rounded(hpfDivideByTotalMoveabilityNow, firstHPFOutput + feedbacksValue)
 		            << (4 + 1);
 
 		// Only saturate / anti-alias if lots of resonance
@@ -126,16 +126,16 @@ void FilterSet::renderHPFLong(int32_t* outputSample, int32_t* endSample, FilterS
 	} while (outputSample < endSample);
 }
 
-inline int32_t FilterSet::do24dBLPFOnSample(int32_t input, FilterSetConfig* filterSetConfig, int saturationLevel) {
+inline q31_t FilterSet::do24dBLPFOnSample(q31_t input, FilterSetConfig* filterSetConfig, int saturationLevel) {
 
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
-	int32_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
-	int32_t distanceToGo = noise - noiseLastValue;
+	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
+	q31_t distanceToGo = noise - noiseLastValue;
 	noiseLastValue += distanceToGo >> 7; //storageManager.devVarB;
-	int32_t moveability =
+	q31_t moveability =
 	    filterSetConfig->moveability + multiply_32x32_rshift32(filterSetConfig->moveability, noiseLastValue);
 
-	int32_t feedbacksSum = (lpfLPF1.getFeedbackOutputWithoutLshift(filterSetConfig->lpf1Feedback)
+	q31_t feedbacksSum = (lpfLPF1.getFeedbackOutputWithoutLshift(filterSetConfig->lpf1Feedback)
 	                        + lpfLPF2.getFeedbackOutputWithoutLshift(filterSetConfig->lpf2Feedback)
 	                        + lpfLPF3.getFeedbackOutputWithoutLshift(filterSetConfig->lpf3Feedback)
 	                        + lpfLPF4.getFeedbackOutputWithoutLshift(filterSetConfig->divideBy1PlusTannedFrequency))
@@ -145,7 +145,7 @@ inline int32_t FilterSet::do24dBLPFOnSample(int32_t input, FilterSetConfig* filt
 	// Primarily it stops us getting to full resonance. But even if we allow further resonance increase, the sound just doesn't quite compare.
 	// Lucky I discovered this by mistake
 
-	int32_t x = multiply_32x32_rshift32_rounded(
+	q31_t x = multiply_32x32_rshift32_rounded(
 	                (input - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
 	                filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
 	            << 2;
@@ -161,16 +161,16 @@ inline int32_t FilterSet::do24dBLPFOnSample(int32_t input, FilterSetConfig* filt
 	       << 1;
 }
 
-inline int32_t FilterSet::doDriveLPFOnSample(int32_t input, FilterSetConfig* filterSetConfig, int extraSaturation) {
+inline q31_t FilterSet::doDriveLPFOnSample(q31_t input, FilterSetConfig* filterSetConfig, int extraSaturation) {
 
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
-	int32_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
-	int32_t distanceToGo = noise - noiseLastValue;
+	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
+	q31_t distanceToGo = noise - noiseLastValue;
 	noiseLastValue += distanceToGo >> 7; //storageManager.devVarB;
-	int32_t moveability =
+	q31_t moveability =
 	    filterSetConfig->moveability + multiply_32x32_rshift32(filterSetConfig->moveability, noiseLastValue);
 
-	int32_t feedbacksSum = (lpfLPF1.getFeedbackOutputWithoutLshift(filterSetConfig->lpf1Feedback)
+	q31_t feedbacksSum = (lpfLPF1.getFeedbackOutputWithoutLshift(filterSetConfig->lpf1Feedback)
 	                        + lpfLPF2.getFeedbackOutputWithoutLshift(filterSetConfig->lpf2Feedback)
 	                        + lpfLPF3.getFeedbackOutputWithoutLshift(filterSetConfig->lpf3Feedback)
 	                        + lpfLPF4.getFeedbackOutputWithoutLshift(filterSetConfig->divideBy1PlusTannedFrequency))
@@ -184,23 +184,23 @@ inline int32_t FilterSet::doDriveLPFOnSample(int32_t input, FilterSetConfig* fil
 	feedbacksSum = getTanHUnknown(feedbacksSum, 6 + extraSaturation);
 
 	// We don't saturate the input anymore, because that's the place where we'd get the most aliasing!
-	int32_t x = multiply_32x32_rshift32_rounded(
+	q31_t x = multiply_32x32_rshift32_rounded(
 	                (input - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
 	                filterSetConfig->divideByTotalMoveabilityAndProcessedResonance)
 	            << 2;
 
-	int32_t a = lpfLPF1.doFilter(x, moveability);
+	q31_t a = lpfLPF1.doFilter(x, moveability);
 
-	int32_t b = lpfLPF2.doFilter(a, moveability);
+	q31_t b = lpfLPF2.doFilter(a, moveability);
 
-	int32_t c = lpfLPF3.doFilter(b, moveability);
+	q31_t c = lpfLPF3.doFilter(b, moveability);
 
-	int32_t d = lpfLPF4.doFilter(c, moveability) << 1;
+	q31_t d = lpfLPF4.doFilter(c, moveability) << 1;
 
 	return d;
 }
 
-void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSetConfig* filterSetConfig,
+void FilterSet::renderLPFLong(q31_t* startSample, q31_t* endSample, FilterSetConfig* filterSetConfig,
                               uint8_t lpfMode, int sampleIncrement, int extraSaturation, int extraSaturationDrive) {
 
 	// This should help get rid of crackling on start / stop - but doesn't
@@ -216,20 +216,20 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 	// Half ladder
 	if (lpfMode == LPF_MODE_12DB) {
 
-		int32_t* currentSample = startSample;
+		q31_t* currentSample = startSample;
 		do {
 
 			// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
-			int32_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
-			int32_t distanceToGo = noise - noiseLastValue;
+			q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
+			q31_t distanceToGo = noise - noiseLastValue;
 			noiseLastValue += distanceToGo >> 7; //storageManager.devVarB;
-			int32_t moveability =
+			q31_t moveability =
 			    filterSetConfig->moveability + multiply_32x32_rshift32(filterSetConfig->moveability, noiseLastValue);
 
-			int32_t feedbacksSum = lpfLPF1.getFeedbackOutput(filterSetConfig->lpf1Feedback)
+			q31_t feedbacksSum = lpfLPF1.getFeedbackOutput(filterSetConfig->lpf1Feedback)
 			                       + lpfLPF2.getFeedbackOutput(filterSetConfig->lpf2Feedback)
 			                       + lpfLPF3.getFeedbackOutput(filterSetConfig->divideBy1PlusTannedFrequency);
-			int32_t x =
+			q31_t x =
 			    multiply_32x32_rshift32_rounded(
 			        (*currentSample
 			         - (multiply_32x32_rshift32_rounded(feedbacksSum, filterSetConfig->processedResonance) << 3)),
@@ -254,7 +254,7 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 		// Only saturate if resonance is high enough
 		if (filterSetConfig->processedResonance
 		    > 900000000) { // Careful - pushing this too high leads to crackling, only at the highest frequencies, and at the top of the non-saturating resonance range
-			int32_t* currentSample = startSample;
+			q31_t* currentSample = startSample;
 			do {
 				*currentSample = do24dBLPFOnSample(*currentSample, filterSetConfig, 1 + extraSaturation);
 
@@ -263,7 +263,7 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 		}
 
 		else {
-			int32_t* currentSample = startSample;
+			q31_t* currentSample = startSample;
 			do {
 				*currentSample = do24dBLPFOnSample(*currentSample, filterSetConfig, 0);
 
@@ -276,7 +276,7 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 	else if (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE) {
 
 		if (filterSetConfig->doOversampling) {
-			int32_t* currentSample = startSample;
+			q31_t* currentSample = startSample;
 			do {
 				// Linear interpolation works surprisingly well here - it doesn't lead to audible aliasing. But its big problem is that it kills the highest frequencies,
 				// which is especially noticeable when resonance is low. This is because it'll turn all your high sine waves into triangles whose fundamental is lower in amplitude.
@@ -292,7 +292,7 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 				doDriveLPFOnSample(*currentSample, filterSetConfig, extraSaturationDrive);
 
 				// Crude downsampling - just take every second sample, with no anti-aliasing filter. Works fine cos the ladder LPF filter takes care of lots of those high harmonics!
-				int32_t outputSampleToKeep = doDriveLPFOnSample(*currentSample, filterSetConfig, extraSaturationDrive);
+				q31_t outputSampleToKeep = doDriveLPFOnSample(*currentSample, filterSetConfig, extraSaturationDrive);
 
 				// Only perform the final saturation stage on this one sample, which we want to keep
 				*currentSample = getTanHUnknown(outputSampleToKeep, 3 + extraSaturationDrive);
@@ -302,9 +302,9 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 		}
 
 		else {
-			int32_t* currentSample = startSample;
+			q31_t* currentSample = startSample;
 			do {
-				int32_t outputSampleToKeep = doDriveLPFOnSample(*currentSample, filterSetConfig, extraSaturationDrive);
+				q31_t outputSampleToKeep = doDriveLPFOnSample(*currentSample, filterSetConfig, extraSaturationDrive);
 				*currentSample = getTanHUnknown(outputSampleToKeep, 3 + extraSaturationDrive);
 
 				currentSample += sampleIncrement;
@@ -313,7 +313,7 @@ void FilterSet::renderLPFLong(int32_t* startSample, int32_t* endSample, FilterSe
 	}
 	else if (lpfMode == LPF_MODE_SVF) {
 
-		int32_t* currentSample = startSample;
+		q31_t* currentSample = startSample;
 		do {
 			SVF_outs outs = svf.doSVF(*currentSample, filterSetConfig);
 			*currentSample = outs.lpf << 1;
@@ -341,16 +341,16 @@ void FilterSet::reset() {
 }
 
 SVF_outs SVFilter::doSVF(int32_t input, FilterSetConfig* filterSetConfig) {
-	int32_t high;
-	int32_t notch;
-	int32_t f = filterSetConfig->moveability;
+	q31_t high;
+	q31_t notch;
+	q31_t f = filterSetConfig->moveability;
 	//raw resonance is 0-2, e.g. 1 is 1073741824
-	int32_t q = filterSetConfig->lpfRawResonance;
+	q31_t q = filterSetConfig->lpfRawResonance;
 	f = add_saturation(f, (f >> 2)); //arbitrary to adjust range on gold knob
 	f = add_saturation(f, 26508640); //slightly under the cutoff for C0
 	//processed resonance is 2-rawresonance^2
 	//compensate for resonance by lowering input level
-	int32_t in = 2147483647 - filterSetConfig->processedResonance;
+	q31_t in = ONE_Q31 - filterSetConfig->processedResonance;
 
 	low = low + multiply_32x32_rshift32(f, band);
 

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -26,68 +26,68 @@ class Sound;
 class FilterSetConfig;
 
 struct SVF_outs {
-	int32_t lpf;
-	int32_t bpf;
-	int32_t hpf;
-	int32_t notch;
+	q31_t lpf;
+	q31_t bpf;
+	q31_t hpf;
+	q31_t notch;
 };
 
 class SVFilter {
 public:
 	//input f is actually filter 'moveability', tan(f)/(1+tan(f)) and falls between 0 and 1. 1 represented by 2147483648
 	//resonance is 2147483647 - rawResonance2 Always between 0 and 2. 1 represented as 1073741824
-	SVF_outs doSVF(int32_t input, FilterSetConfig* filterSetConfig);
+	SVF_outs doSVF(q31_t input, FilterSetConfig* filterSetConfig);
 	void reset() {
 		low = 0;
 		band = 0;
 	}
 
-	int32_t low;
-	int32_t band;
+	q31_t low;
+	q31_t band;
 };
 
 class BasicFilterComponent {
 public:
 	//moveability is tan(f)/(1+tan(f))
-	inline int32_t doFilter(int32_t input, int32_t moveability) {
-		int32_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
-		int32_t b = a + memory;
+	inline q31_t doFilter(q31_t input, q31_t moveability) {
+		q31_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
+		q31_t b = a + memory;
 		memory = b + a;
 		return b;
 	}
 
-	inline int32_t doAPF(int32_t input, int32_t moveability) {
-		int32_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
-		int32_t b = a + memory;
+	inline int32_t doAPF(q31_t input, int32_t moveability) {
+		q31_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
+		q31_t b = a + memory;
 		memory = a + b;
 		return b * 2 - input;
 	}
 
-	inline void affectFilter(int32_t input, int32_t moveability) {
+	inline void affectFilter(q31_t input, int32_t moveability) {
 		memory += multiply_32x32_rshift32_rounded(input - memory, moveability) << 2;
 	}
 
 	inline void reset() { memory = 0; }
 
-	inline int32_t getFeedbackOutput(int32_t feedbackAmount) {
+	inline q31_t getFeedbackOutput(int32_t feedbackAmount) {
 		return multiply_32x32_rshift32_rounded(memory, feedbackAmount) << 2;
 	}
 
-	inline int32_t getFeedbackOutputWithoutLshift(int32_t feedbackAmount) {
+	inline q31_t getFeedbackOutputWithoutLshift(int32_t feedbackAmount) {
 		return multiply_32x32_rshift32_rounded(memory, feedbackAmount);
 	}
 
-	int32_t memory;
+	q31_t memory;
 };
 
 class FilterSet {
 public:
 	FilterSet();
-	void renderLPFLong(int32_t* outputSample, int32_t* endSample, FilterSetConfig* filterSetConfig, uint8_t lpfMode,
+	void renderLPFLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig, uint8_t lpfMode,
 	                   int sampleIncrement = 1, int extraSaturation = 0, int extraSaturationDrive = 0);
-	void renderHPFLong(int32_t* outputSample, int32_t* endSample, FilterSetConfig* filterSetConfig, int numSamples,
+	void renderHPFLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig, int numSamples,
 	                   int sampleIncrement = 1);
-	void renderHPF(int32_t* outputSample, FilterSetConfig* filterSetConfig, int extraSaturation = 0);
+	void renderHPF(q31_t* outputSample, FilterSetConfig* filterSetConfig, int extraSaturation = 0);
 	void reset();
 	BasicFilterComponent lpfLPF1;
 	BasicFilterComponent lpfLPF2;
@@ -107,7 +107,7 @@ public:
 	bool hpfOnLastTime;
 	bool lpfOnLastTime;
 
-	inline void renderLong(int32_t* outputSample, int32_t* endSample, FilterSetConfig* filterSetConfig, uint8_t lpfMode,
+	inline void renderLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig, uint8_t lpfMode,
 	                       int numSamples, int sampleIncrememt = 1) {
 
 		// Do HPF, if it's on
@@ -126,8 +126,8 @@ public:
 	}
 
 private:
-	int32_t noiseLastValue;
+	q31_t noiseLastValue;
 
-	int32_t do24dBLPFOnSample(int32_t input, FilterSetConfig* filterSetConfig, int saturationLevel);
-	int32_t doDriveLPFOnSample(int32_t input, FilterSetConfig* filterSetConfig, int extraSaturation = 0);
+	q31_t do24dBLPFOnSample(q31_t input, FilterSetConfig* filterSetConfig, int saturationLevel);
+	q31_t doDriveLPFOnSample(q31_t input, FilterSetConfig* filterSetConfig, int extraSaturation = 0);
 };

--- a/src/deluge/dsp/filter/filter_set_config.cpp
+++ b/src/deluge/dsp/filter/filter_set_config.cpp
@@ -80,8 +80,8 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 		// Hot transistor ladder - needs oversampling and stuff
 		if (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE) {
 
-			int32_t resonance = 2147483647 - (lpfResonance << 2); // Limits it
-			processedResonance = 2147483647 - resonance;          // Always between 0 and 2. 1 represented as 1073741824
+			int32_t resonance = ONE_Q31 - (lpfResonance << 2); // Limits it
+			processedResonance = ONE_Q31 - resonance;          // Always between 0 and 2. 1 represented as 1073741824
 
 			int32_t logFreq = quickLog(lpfFrequency);
 
@@ -126,19 +126,19 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 					howMuchTooLow = 6000000 - tannedFrequency;
 				}
 
-				int32_t howMuchToKeep = 2147483647 - howMuchTooLow * 33;
+				int32_t howMuchToKeep = ONE_Q31 - howMuchTooLow * 33;
 
 				int32_t resonanceUpperLimit = 510000000; // Prone to feeding back lots
 				tannedFrequency = getMax(
 				    tannedFrequency,
 				    (int32_t)540817); // We really want to keep the frequency from going lower than it has to - it causes problems
 
-				int32_t resonance = 2147483647 - (getMin(lpfResonance, resonanceUpperLimit) << 2); // Limits it
+				int32_t resonance = ONE_Q31 - (getMin(lpfResonance, resonanceUpperLimit) << 2); // Limits it
 				lpfRawResonance = resonance;
 				resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
 				processedResonance =
-				    2147483647
-				    - resonance; //2147483647 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
+				    ONE_Q31
+				    - resonance; //ONE_Q31 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
 				processedResonance = multiply_32x32_rshift32_rounded(processedResonance, howMuchToKeep) << 1;
 			}
 
@@ -213,7 +213,7 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 	int32_t squared;
 
 	// Adjust volume for LPF resonance
-	rawResonance = getMin(lpfResonance, (int32_t)2147483647 >> 2) << 2;
+	rawResonance = getMin(lpfResonance, (int32_t)ONE_Q31 >> 2) << 2;
 	squared = multiply_32x32_rshift32(rawResonance, rawResonance) << 1;
 	squared = (multiply_32x32_rshift32(squared, squared) >> 4)
 	          * 19; // Make bigger to have more of a volume cut happen at high resonance
@@ -234,11 +234,11 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 		    / (134217728 + (tannedFrequency >> 1)); // Between ~0.1 and 1. 1 represented by 2147483648
 
 		int32_t resonanceUpperLimit = 536870911;
-		int32_t resonance = 2147483647 - (getMin(hpfResonance, resonanceUpperLimit) << 2); // Limits it
+		int32_t resonance = ONE_Q31 - (getMin(hpfResonance, resonanceUpperLimit) << 2); // Limits it
 
 		resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
 		hpfProcessedResonance =
-		    2147483647 - resonance; //2147483647 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
+		    ONE_Q31 - resonance; //ONE_Q31 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
 
 		hpfProcessedResonance = getMax(hpfProcessedResonance, (int32_t)134217728); // Set minimum resonance amount
 
@@ -268,11 +268,11 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 
 	if (adjustVolumeForHPFResonance) {
 		// Adjust volume for HPF resonance
-		rawResonance = getMin(hpfResonance, (int32_t)2147483647 >> 2) << 2;
+		rawResonance = getMin(hpfResonance, (int32_t)ONE_Q31 >> 2) << 2;
 		squared = multiply_32x32_rshift32(rawResonance, rawResonance) << 1;
 		squared = (multiply_32x32_rshift32(squared, squared) >> 4)
 		          * 19; // Make bigger to have more of a volume cut happen at high resonance
-		filterGain = multiply_32x32_rshift32(filterGain, 2147483647 - squared) << 1;
+		filterGain = multiply_32x32_rshift32(filterGain, ONE_Q31 - squared) << 1;
 	}
 	return filterGain;
 }

--- a/src/deluge/dsp/filter/filter_set_config.h
+++ b/src/deluge/dsp/filter/filter_set_config.h
@@ -24,9 +24,8 @@ class FilterSetConfig {
 
 public:
 	FilterSetConfig();
-	q31_t init(q31_t lpfFrequency, q31_t lpfResonance, q31_t hpfFrequency, q31_t hpfResonance,
-	             uint8_t lpfMode, q31_t filterGain, bool adjustVolumeForHPFResonance = true,
-	             q31_t* overallOscAmplitude = NULL);
+	q31_t init(q31_t lpfFrequency, q31_t lpfResonance, q31_t hpfFrequency, q31_t hpfResonance, uint8_t lpfMode,
+	           q31_t filterGain, bool adjustVolumeForHPFResonance = true, q31_t* overallOscAmplitude = NULL);
 
 	q31_t processedResonance;                            // 1 represented as 1073741824
 	q31_t divideByTotalMoveabilityAndProcessedResonance; // 1 represented as 1073741824

--- a/src/deluge/dsp/filter/filter_set_config.h
+++ b/src/deluge/dsp/filter/filter_set_config.h
@@ -18,42 +18,43 @@
 #pragma once
 
 #include "definitions.h"
+#include "util/fixedpoint.h"
 
 class FilterSetConfig {
 
 public:
 	FilterSetConfig();
-	int32_t init(int32_t lpfFrequency, int32_t lpfResonance, int32_t hpfFrequency, int32_t hpfResonance,
-	             uint8_t lpfMode, int32_t filterGain, bool adjustVolumeForHPFResonance = true,
-	             int32_t* overallOscAmplitude = NULL);
+	q31_t init(q31_t lpfFrequency, q31_t lpfResonance, q31_t hpfFrequency, q31_t hpfResonance,
+	             uint8_t lpfMode, q31_t filterGain, bool adjustVolumeForHPFResonance = true,
+	             q31_t* overallOscAmplitude = NULL);
 
-	int32_t processedResonance;                            // 1 represented as 1073741824
-	int32_t divideByTotalMoveabilityAndProcessedResonance; // 1 represented as 1073741824
+	q31_t processedResonance;                            // 1 represented as 1073741824
+	q31_t divideByTotalMoveabilityAndProcessedResonance; // 1 represented as 1073741824
 
 	//moveability is tan(f)/(1+tan(f))
-	int32_t moveability;                  // 1 represented by 2147483648
-	int32_t divideBy1PlusTannedFrequency; // 1 represented by 2147483648
+	q31_t moveability;                  // 1 represented by 2147483648
+	q31_t divideBy1PlusTannedFrequency; // 1 represented by 2147483648
 
 	// All feedbacks have 1 represented as 1073741824
-	int32_t lpf1Feedback;
-	int32_t lpf2Feedback;
-	int32_t lpf3Feedback;
+	q31_t lpf1Feedback;
+	q31_t lpf2Feedback;
+	q31_t lpf3Feedback;
 
-	int32_t hpfMoveability; // 1 represented by 2147483648
+	q31_t hpfMoveability; // 1 represented by 2147483648
 
 	// All feedbacks have 1 represented as 1073741824
-	int32_t hpfLPF1Feedback;
-	int32_t hpfHPF3Feedback;
+	q31_t hpfLPF1Feedback;
+	q31_t hpfHPF3Feedback;
 
-	int32_t hpfProcessedResonance; // 1 represented as 1073741824
+	q31_t hpfProcessedResonance; // 1 represented as 1073741824
 	bool hpfDoAntialiasing;
-	int32_t hpfDivideByProcessedResonance;
+	q31_t hpfDivideByProcessedResonance;
 
-	int32_t divideByTotalMoveability; // 1 represented as 268435456
+	q31_t divideByTotalMoveability; // 1 represented as 268435456
 
-	int32_t lpfRawResonance;
-	int32_t alteredHpfMomentumMultiplier;
-	int32_t thisHpfResonance;
+	q31_t lpfRawResonance;
+	q31_t alteredHpfMomentumMultiplier;
+	q31_t thisHpfResonance;
 	bool doLPF;
 	bool doHPF;
 

--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -43,13 +43,8 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, int32_t
 		if (adjustmentR < 0.000001)
 			adjustmentR = 0.000001;
 		do {
-<<<<<<< HEAD
-			double l = thisSample->l / 2147483648.0 / adjustmentL;
-			double r = thisSample->r / 2147483648.0 / adjustmentR;
-=======
-			double l = thisSample->l / (double) ONE_Q31;
-			double r = thisSample->r / (double) ONE_Q31;
->>>>>>> 003be83 (replace magic number with constant)
+			double l = thisSample->l / (double)ONE_Q31 / adjustmentL;
+			double r = thisSample->r / (double)ONE_Q31 / adjustmentR;
 			double rawl = l;
 			double rawr = r;
 			compressor.process(l, r);

--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -43,8 +43,13 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, int32_t
 		if (adjustmentR < 0.000001)
 			adjustmentR = 0.000001;
 		do {
+<<<<<<< HEAD
 			double l = thisSample->l / 2147483648.0 / adjustmentL;
 			double r = thisSample->r / 2147483648.0 / adjustmentR;
+=======
+			double l = thisSample->l / (double) ONE_Q31;
+			double r = thisSample->r / (double) ONE_Q31;
+>>>>>>> 003be83 (replace magic number with constant)
 			double rawl = l;
 			double rawr = r;
 			compressor.process(l, r);
@@ -61,8 +66,8 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, int32_t
 				r = rawr * (1.0 - wet) + r * wet;
 			}
 
-			thisSample->l = l * 2147483647;
-			thisSample->r = r * 2147483647;
+			thisSample->l = l * ONE_Q31;
+			thisSample->r = r * ONE_Q31;
 			thisSample->l = multiply_32x32_rshift32(thisSample->l, masterVolumeAdjustmentL);
 			thisSample->r = multiply_32x32_rshift32(thisSample->r, masterVolumeAdjustmentR);
 

--- a/src/deluge/dsp/stereo_sample.h
+++ b/src/deluge/dsp/stereo_sample.h
@@ -24,26 +24,28 @@
 class StereoSample {
 public:
 	StereoSample() {}
-	inline void addMono(int32_t sampleValue) {
+	inline void addMono(q31_t sampleValue) {
 		l += sampleValue;
 		r += sampleValue;
 	}
 
-	inline void addPannedMono(int32_t sampleValue, int32_t amplitudeL, int32_t amplitudeR) {
+	//Amplitude is probably Q2.29?
+	inline void addPannedMono(q31_t sampleValue, int32_t amplitudeL, int32_t amplitudeR) {
 		l += (multiply_32x32_rshift32(sampleValue, amplitudeL) << 2);
 		r += (multiply_32x32_rshift32(sampleValue, amplitudeR) << 2);
 	}
 
-	inline void addStereo(int32_t sampleValueL, int32_t sampleValueR) {
+	inline void addStereo(q31_t sampleValueL, q31_t sampleValueR) {
 		l += sampleValueL;
 		r += sampleValueR;
 	}
 
-	inline void addPannedStereo(int32_t sampleValueL, int32_t sampleValueR, int32_t amplitudeL, int32_t amplitudeR) {
+	//Amplitude is probably Q2.29?
+	inline void addPannedStereo(q31_t sampleValueL, q31_t sampleValueR, int32_t amplitudeL, int32_t amplitudeR) {
 		l += (multiply_32x32_rshift32(sampleValueL, amplitudeL) << 2);
 		r += (multiply_32x32_rshift32(sampleValueR, amplitudeR) << 2);
 	}
 
-	int32_t l;
-	int32_t r;
+	q31_t l;
+	q31_t r;
 };

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -20,7 +20,7 @@
 //signed 31 fractional bits (e.g. one would be 1<<31 but can't be represented)
 typedef int32_t q31_t;
 
-#define ONE_Q31 2147483647;
+#define ONE_Q31 2147483647
 
 // This multiplies two numbers in signed Q31 fixed point and truncates the result
 static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) __attribute__((always_inline, unused));

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+*/
+#pragma once
+#include "math.h"
+
+//signed 31 fractional bits (e.g. one would be 1<<31 but can't be represented)
+typedef int32_t q31_t;
+
+#define ONE_Q31 2147483647;
+
+// computes (((int64_t)a[31:0] * (int64_t)b[31:0]) >> 32)
+static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) __attribute__((always_inline, unused));
+static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) {
+	q31_t out;
+	asm("smmul %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
+	return out;
+}
+
+// computes (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
+static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) __attribute__((always_inline, unused));
+static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
+	q31_t out;
+	asm("smmulr %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
+	return out;
+}
+
+// computes sum + (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
+static inline q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
+    __attribute__((always_inline, unused));
+static inline q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
+	q31_t out;
+	asm("smmlar %0, %2, %3, %1" : "=r"(out) : "r"(sum), "r"(a), "r"(b));
+	return out;
+}
+
+// computes sum - (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
+static inline q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
+    __attribute__((always_inline, unused));
+static inline q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
+	q31_t out;
+	asm("smmlsr %0, %2, %3, %1" : "=r"(out) : "r"(sum), "r"(a), "r"(b));
+	return out;
+}

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -22,7 +22,7 @@ typedef int32_t q31_t;
 
 #define ONE_Q31 2147483647;
 
-// computes (((int64_t)a[31:0] * (int64_t)b[31:0]) >> 32)
+// This multiplies two numbers in signed Q31 fixed point and truncates the result
 static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) __attribute__((always_inline, unused));
 static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) {
 	q31_t out;
@@ -30,7 +30,7 @@ static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) {
 	return out;
 }
 
-// computes (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
+// This multiplies two numbers in signed Q31 fixed point and rounds the result
 static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) __attribute__((always_inline, unused));
 static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
 	q31_t out;
@@ -38,20 +38,20 @@ static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
 	return out;
 }
 
-// computes sum + (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
+// Multiplies A and B, adds to sum, and returns output
 static inline q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
     __attribute__((always_inline, unused));
 static inline q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
 	q31_t out;
-	asm("smmlar %0, %2, %3, %1" : "=r"(out) : "r"(sum), "r"(a), "r"(b));
+	asm("smmlar %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
 	return out;
 }
 
-// computes sum - (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
+// Multiplies A and B, subtracts from sum, and returns output
 static inline q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
     __attribute__((always_inline, unused));
 static inline q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
 	q31_t out;
-	asm("smmlsr %0, %2, %3, %1" : "=r"(out) : "r"(sum), "r"(a), "r"(b));
+	asm("smmlsr %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
 	return out;
 }

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -22,7 +22,7 @@
 #include <cstring>
 #include "ff.h"
 #include "definitions.h"
-#include "fixedpoint.h"
+#include "util/fixedpoint.h"
 extern "C" {
 #include "util/cfunctions.h"
 }

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -22,7 +22,7 @@
 #include <cstring>
 #include "ff.h"
 #include "definitions.h"
-
+#include "fixedpoint.h"
 extern "C" {
 #include "util/cfunctions.h"
 }
@@ -56,40 +56,6 @@ uint32_t hexToIntFixedLength(char const* __restrict__ hexChars, int length);
 
 void byteToHex(uint8_t number, char* buffer);
 uint8_t hexToByte(char const* firstChar);
-
-// computes (((int64_t)a[31:0] * (int64_t)b[31:0]) >> 32)
-static inline int32_t multiply_32x32_rshift32(int32_t a, int32_t b) __attribute__((always_inline, unused));
-static inline int32_t multiply_32x32_rshift32(int32_t a, int32_t b) {
-	int32_t out;
-	asm("smmul %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
-	return out;
-}
-
-// computes (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
-static inline int32_t multiply_32x32_rshift32_rounded(int32_t a, int32_t b) __attribute__((always_inline, unused));
-static inline int32_t multiply_32x32_rshift32_rounded(int32_t a, int32_t b) {
-	int32_t out;
-	asm("smmulr %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
-	return out;
-}
-
-// computes sum + (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
-static inline int32_t multiply_accumulate_32x32_rshift32_rounded(int32_t sum, int32_t a, int32_t b)
-    __attribute__((always_inline, unused));
-static inline int32_t multiply_accumulate_32x32_rshift32_rounded(int32_t sum, int32_t a, int32_t b) {
-	int32_t out;
-	asm("smmlar %0, %2, %3, %1" : "=r"(out) : "r"(sum), "r"(a), "r"(b));
-	return out;
-}
-
-// computes sum - (((int64_t)a[31:0] * (int64_t)b[31:0] + 0x8000000) >> 32)
-static inline int32_t multiply_subtract_32x32_rshift32_rounded(int32_t sum, int32_t a, int32_t b)
-    __attribute__((always_inline, unused));
-static inline int32_t multiply_subtract_32x32_rshift32_rounded(int32_t sum, int32_t a, int32_t b) {
-	int32_t out;
-	asm("smmlsr %0, %2, %3, %1" : "=r"(out) : "r"(sum), "r"(a), "r"(b));
-	return out;
-}
 
 static inline int32_t add_saturation(int32_t a, int32_t b) __attribute__((always_inline, unused));
 static inline int32_t add_saturation(int32_t a, int32_t b) {


### PR DESCRIPTION
This change is aimed at improving maintainability of the DSP code. It creates a typedef q31 for int32 to indicate variables that represent a signed fixed point number between -1 and 1 (e.g. 31 fractional bits). This type is now used where I could verify that q31 format is in use. Places where I believe it is another fixed point format are left as int32_t for now.

It also defines a ONE_Q31 constant to replace the usage of 2147483647 in DSP code. I have not replaced all occurences, only spots where it is used as a q31 value. 

The q31 type and the associated asm functions are moved into their own file. This can be extended to include in place multiplications and vectorization code over time. 

q31_t should probably become a fixed point class eventually but there are no easy solutions that will still output the single cycle SMMUL function and avoid impacting the filter code execution time. 