### PR TITLE
Fix: Stop audio preview from the sample browser when entering Manual slicing

### DIFF
--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -331,6 +331,8 @@ int Slicer::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 	if (b == X_ENC && on) {
 		slicerMode++;
 		slicerMode %= 2;
+		if (slicerMode == SLICER_MODE_MANUAL)
+			AudioEngine::stopAnyPreviewing();
 #if HAVE_OLED
 		renderUIsForOled();
 #else


### PR DESCRIPTION
Changed to stop audio preview (played by the sample browser) when entering manual slicer mode.
https://github.com/SynthstromAudible/DelugeFirmware/pull/198#issuecomment-1640987706