### PR TITLE
Svf fixes

### DIFF
--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -364,7 +364,6 @@ SVF_outs SVFilter::doSVF(int32_t input, FilterSetConfig* filterSetConfig) {
 	high = high - 2 * multiply_32x32_rshift32(band, q);
 	band = 2 * multiply_32x32_rshift32(high, f) + band;
 
-
 	//saturate band feedback
 	band = getTanHUnknown(band, 3);
 	notch = high + low;

--- a/src/deluge/dsp/filter/filter_set_config.cpp
+++ b/src/deluge/dsp/filter/filter_set_config.cpp
@@ -134,7 +134,7 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 				    (int32_t)540817); // We really want to keep the frequency from going lower than it has to - it causes problems
 
 				int32_t resonance = ONE_Q31 - (getMin(lpfResonance, resonanceUpperLimit) << 2); // Limits it
-				lpfRawResonance = resonance;
+				lpfRawResonance = lpfResonance;
 				resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
 				processedResonance =
 				    ONE_Q31

--- a/src/deluge/dsp/filter/filter_set_config.cpp
+++ b/src/deluge/dsp/filter/filter_set_config.cpp
@@ -163,7 +163,7 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 			}
 
 			// Full ladder
-			else if ((lpfMode == LPF_MODE_TRANSISTOR_24DB) || (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE)){
+			else if ((lpfMode == LPF_MODE_TRANSISTOR_24DB) || (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE)) {
 				lpf3Feedback = multiply_32x32_rshift32_rounded(divideBy1PlusTannedFrequency, moveability);
 				lpf2Feedback = multiply_32x32_rshift32_rounded(lpf3Feedback, moveability) << 1;
 				lpf1Feedback = multiply_32x32_rshift32_rounded(lpf2Feedback, moveability) << 1;
@@ -196,7 +196,6 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 				filterGain = multiply_32x32_rshift32(filterGain, gainModifier) << 3;
 			}
 
-
 			// Drive filter - increase output amplitude
 			else if (lpfMode == LPF_MODE_TRANSISTOR_24DB_DRIVE) {
 				//overallOscAmplitude <<= 2;
@@ -206,12 +205,11 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 
 				// raw resonance is 0 - 536870896 (2^28ish, don't know where it comes from)
 				// Multiply by 4 to bring it to the q31 0-1 range
-				processedResonance = (ONE_Q31 - 4*(lpfRawResonance));
+				processedResonance = (ONE_Q31 - 4 * (lpfRawResonance));
 				SVFInputScale = (processedResonance >> 1) + (ONE_Q31 >> 1);
 				//squared q is a better match for the ladders
 
 				processedResonance = multiply_32x32_rshift32_rounded(processedResonance, processedResonance) << 1;
-
 			}
 		}
 	}

--- a/src/deluge/dsp/filter/filter_set_config.h
+++ b/src/deluge/dsp/filter/filter_set_config.h
@@ -52,6 +52,7 @@ public:
 	q31_t divideByTotalMoveability; // 1 represented as 268435456
 
 	q31_t lpfRawResonance;
+	q31_t SVFInputScale;
 	q31_t alteredHpfMomentumMultiplier;
 	q31_t thisHpfResonance;
 	bool doLPF;


### PR DESCRIPTION
This enables oversampling to address a stability issue (occasional 22KHz oscillation) that made sample rate reduction incompatible with the SVF

This also increases the cutoff frequency and resonance range on the SVF, bringing them more in line with the ladder filters.

This should close #173 and #179