### PR TITLE
Fix for missing menu items on 7seg

### DIFF
--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -26,8 +26,6 @@ extern menu_item::Submenu midiDeviceMenu;
 
 namespace menu_item::midi {
 
-extern Devices devicesMenu{"Devices"};
-
 static const int lowestDeviceNum = -3;
 
 void Devices::beginSession(MenuItem* navigatedBackwardFrom) {

--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -26,7 +26,7 @@ extern menu_item::Submenu midiDeviceMenu;
 
 namespace menu_item::midi {
 
-Devices devicesMenu{"Devices"};
+extern Devices devicesMenu{"Devices"};
 
 static const int lowestDeviceNum = -3;
 

--- a/src/deluge/gui/menu_item/mpe/direction_selector.cpp
+++ b/src/deluge/gui/menu_item/mpe/direction_selector.cpp
@@ -22,7 +22,7 @@
 
 namespace menu_item::mpe {
 
-DirectionSelector directionSelectorMenu{"MPE"};
+extern DirectionSelector directionSelectorMenu{"MPE"};
 
 void DirectionSelector::beginSession(MenuItem* navigatedBackwardFrom) {
 	if (!navigatedBackwardFrom) {

--- a/src/deluge/gui/menu_item/mpe/direction_selector.cpp
+++ b/src/deluge/gui/menu_item/mpe/direction_selector.cpp
@@ -22,8 +22,6 @@
 
 namespace menu_item::mpe {
 
-extern DirectionSelector directionSelectorMenu{"MPE"};
-
 void DirectionSelector::beginSession(MenuItem* navigatedBackwardFrom) {
 	if (!navigatedBackwardFrom) {
 		whichDirection = MIDI_DIRECTION_INPUT_TO_DELUGE;

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -611,6 +611,10 @@ tempo::MagnitudeMatching tempoMagnitudeMatchingMenu{HAVE_OLED ? "Tempo magnitude
 MenuItem* midiClockMenuItems[] = {&midiClockInStatusMenu, &midiClockOutStatusMenu, &tempoMagnitudeMatchingMenu, NULL};
 Submenu midiClockMenu{"CLOCK", midiClockMenuItems};
 
+//Midi devices menu
+midi::Devices devicesMenu{"Devices"};
+mpe::DirectionSelector directionSelectorMenu{"MPE"};
+
 //MIDI menu
 MenuItem* midiMenuItems[] = {
     &midiClockMenu,     &midiThruMenu, &midiTakeoverMenu, &midiCommandsMenu, &midiInputDifferentiationMenu,

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -612,8 +612,8 @@ MenuItem* midiClockMenuItems[] = {&midiClockInStatusMenu, &midiClockOutStatusMen
 Submenu midiClockMenu{"CLOCK", midiClockMenuItems};
 
 //Midi devices menu
-midi::Devices devicesMenu{"Devices"};
-mpe::DirectionSelector directionSelectorMenu{"MPE"};
+midi::Devices midi::devicesMenu{"Devices"};
+mpe::DirectionSelector mpe::directionSelectorMenu{"MPE"};
 
 //MIDI menu
 MenuItem* midiMenuItems[] = {


### PR DESCRIPTION
The midi devices menu and MPE zone menu weren't properly showing on 7seg due to what seems to be initialization order bugs. This moves their declarations into menus.cpp 