### PR TITLE
Debug printing: refactor and allow USB output

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -192,8 +192,8 @@ void inputRoutine() {
 		batteryMV =
 		    (voltageReadingLastTime)
 		    >> 15; // We only >> by 15 so that we intentionally double the value, because the incoming voltage is halved by a resistive divider already
-		//uartPrint("batt mV: ");
-		//uartPrintNumber(batteryMV);
+		//Uart::print("batt mV: ");
+		//Uart::println(batteryMV);
 
 		// See if we've reached threshold to change verdict on battery level
 

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -74,7 +74,7 @@
 #include "storage/flash_storage.h"
 #include "testing/hardware_testing.h"
 #include "hid/buttons.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "io/midi/midi_device_manager.h"
 #include "model/clip/instrument_clip.h"
 #include "storage/file_item.h"
@@ -153,15 +153,15 @@ void inputRoutine() {
 
 	bool headphoneNow = readInput(HEADPHONE_DETECT_1, HEADPHONE_DETECT_2);
 	if (headphoneNow != AudioEngine::headphonesPluggedIn) {
-		Uart::print("headphone ");
-		Uart::println(headphoneNow);
+		Debug::print("headphone ");
+		Debug::println(headphoneNow);
 		AudioEngine::headphonesPluggedIn = headphoneNow;
 	}
 
 	bool micNow = !readInput(7, 9);
 	if (micNow != AudioEngine::micPluggedIn) {
-		Uart::print("mic ");
-		Uart::println(micNow);
+		Debug::print("mic ");
+		Debug::println(micNow);
 		AudioEngine::micPluggedIn = micNow;
 	}
 
@@ -175,8 +175,8 @@ void inputRoutine() {
 
 	bool lineInNow = readInput(6, 6);
 	if (lineInNow != AudioEngine::lineInPluggedIn) {
-		Uart::print("line in ");
-		Uart::println(lineInNow);
+		Debug::print("line in ");
+		Debug::println(lineInNow);
 		AudioEngine::lineInPluggedIn = lineInNow;
 	}
 
@@ -192,8 +192,8 @@ void inputRoutine() {
 		batteryMV =
 		    (voltageReadingLastTime)
 		    >> 15; // We only >> by 15 so that we intentionally double the value, because the incoming voltage is halved by a resistive divider already
-		//Uart::print("batt mV: ");
-		//Uart::println(batteryMV);
+		//Debug::print("batt mV: ");
+		//Debug::println(batteryMV);
 
 		// See if we've reached threshold to change verdict on battery level
 
@@ -266,9 +266,9 @@ bool readButtonsAndPads() {
 
 	/*
 	if (!inSDRoutine && !closedPeripheral && !anythingInitiallyAttachedAsUSBHost && AudioEngine::audioSampleTimer >= (44100 << 1)) {
-		Uart::println("closing peripheral");
+		Debug::println("closing peripheral");
 		closeUSBPeripheral();
-		Uart::println("switching back to host");
+		Debug::println("switching back to host");
 		openUSBHost();
 		closedPeripheral = true;
 	}
@@ -279,7 +279,7 @@ bool readButtonsAndPads() {
 			return false;
 		}
 		else {
-			Uart::println("got to end of sd routine");
+			Debug::println("got to end of sd routine");
 			waitingForSDRoutineToEnd = false;
 		}
 	}
@@ -298,13 +298,13 @@ bool readButtonsAndPads() {
 	if (!inSDRoutine && (int32_t)(AudioEngine::audioSampleTimer - timeNextSDTestAction) >= 0) {
 		if (playbackHandler.playbackState) {
 
-			Uart::println("");
-			Uart::println("undoing");
+			Debug::println("");
+			Debug::println("undoing");
 			Buttons::buttonAction(hid::button::BACK, true, sdRoutineLock);
 		}
 		else {
-			Uart::println("");
-			Uart::println("beginning playback");
+			Debug::println("");
+			Debug::println("beginning playback");
 			Buttons::buttonAction(hid::button::PLAY, true, sdRoutineLock);
 		}
 
@@ -338,7 +338,7 @@ bool readButtonsAndPads() {
 
 			if (result == ACTION_RESULT_REMIND_ME_OUTSIDE_CARD_ROUTINE) {
 				nextPadPressIsOn = thisPadPressIsOn;
-				Uart::println("putCharBack ---------");
+				Debug::println("putCharBack ---------");
 				uartPutCharBack(UART_ITEM_PIC);
 				waitingForSDRoutineToEnd = true;
 				return false;
@@ -672,8 +672,8 @@ extern "C" int deluge_main(void) {
 			readingFirmwareVersion = false;
 			picFirmwareVersion = value & 127;
 			picSaysOLEDPresent = value & 128;
-			Uart::print("PIC firmware version reported: ");
-			Uart::println(value);
+			Debug::print("PIC firmware version reported: ");
+			Debug::println(value);
 		}
 		else {
 			if (value == 245) {
@@ -715,7 +715,7 @@ resetSettings:
 
 	// If nothing was plugged in to us as host, we'll go peripheral
 	if (!anythingInitiallyAttachedAsUSBHost) {
-		Uart::println("switching from host to peripheral");
+		Debug::println("switching from host to peripheral");
 		closeUSBHost();
 		openUSBPeripheral();
 	}
@@ -806,7 +806,7 @@ resetSettings:
 
 	uiTimerManager.setTimer(TIMER_GRAPHICS_ROUTINE, 50);
 
-	Uart::println("going into main loop");
+	Debug::println("going into main loop");
 	sdRoutineLock = false; // Allow SD routine to start happening
 
 	while (1) {
@@ -1078,11 +1078,11 @@ void spamMode() {
 				if (!sdFileCurrentlyOpen) {
 					result = f_open(&fil, "written.txt", FA_CREATE_ALWAYS | FA_WRITE);
 					if (result) {
-						//Uart::println("couldn't create");
+						//Debug::println("couldn't create");
 					}
 					else {
 						if (spamStates[SPAM_MIDI])
-							Uart::println("writing");
+							Debug::println("writing");
 						sdFileCurrentlyOpen = true;
 					}
 				}
@@ -1092,13 +1092,13 @@ void spamMode() {
 					UINT bytesWritten = 0;
 					char thisByte = getRandom255();
 					result = f_write(&fil, &thisByte, 1, &bytesWritten);
-					//if (result) Uart::println("couldn't write");
+					//if (result) Debug::println("couldn't write");
 
 					sdTotalBytesWritten++;
 
 					if (sdTotalBytesWritten > 1000 * 5) {
 						f_close(&fil);
-						//Uart::println("finished writing");
+						//Debug::println("finished writing");
 						sdReading = true;
 						sdFileCurrentlyOpen = false;
 					}
@@ -1113,12 +1113,12 @@ void spamMode() {
 
 					result = f_open(&fil, "written.txt", FA_READ);
 					if (result) {
-						//Uart::println("file not found");
+						//Debug::println("file not found");
 					}
 
 					else {
 						if (spamStates[SPAM_MIDI])
-							Uart::println("reading");
+							Debug::println("reading");
 						sdFileCurrentlyOpen = true;
 					}
 				}
@@ -1132,7 +1132,7 @@ void spamMode() {
 
 					if (bytesRead <= 0) {
 						f_close(&fil);
-						//Uart::println("finished file");
+						//Debug::println("finished file");
 						sdReading = false;
 						sdFileCurrentlyOpen = false;
 						sdTotalBytesWritten = 0;
@@ -1147,14 +1147,14 @@ void spamMode() {
 			if (timeSince >= 5000) {
 				timeLastPIC = MTU2.TCNT_0;
 
-				Uart::putChar(UART_CHANNEL_PIC, lastCol + 1);
+				Debug::putChar(UART_CHANNEL_PIC, lastCol + 1);
 				for (int i = 0; i < 16; i++) {
 					int whichColour = getRandom255() % 3;
 					for (int colour = 0; colour < 3; colour++) {
 						if (colour == whichColour && (getRandom255() % 3) == 0)
-							Uart::putChar(UART_CHANNEL_PIC, getRandom255());
+							Debug::putChar(UART_CHANNEL_PIC, getRandom255());
 						else
-							Uart::putChar(UART_CHANNEL_PIC, 0);
+							Debug::putChar(UART_CHANNEL_PIC, 0);
 					}
 				}
 
@@ -1221,7 +1221,7 @@ void spamMode() {
 
 				// Disable
 				if (!spamStates[currentSpamThing]) {
-					Uart::putChar(UART_CHANNEL_PIC, 227);
+					Debug::putChar(UART_CHANNEL_PIC, 227);
 				}
 
 				// Enable

--- a/src/deluge/drivers/uart/uart.c
+++ b/src/deluge/drivers/uart/uart.c
@@ -52,14 +52,6 @@ void uartPrintNumber(int number) {
 #endif
 }
 
-void uartPrintNumberSameLine(int number) {
-#if ENABLE_TEXT_OUTPUT
-	char buffer[12];
-	intToString(number, buffer, 1);
-	uartPrint(buffer);
-#endif
-}
-
 void uartPrint(char const* output) {
 #if ENABLE_TEXT_OUTPUT
 #if HAVE_RTT

--- a/src/deluge/dsp/delay/delay.cpp
+++ b/src/deluge/dsp/delay/delay.cpp
@@ -20,7 +20,7 @@
 #include "dsp/stereo_sample.h"
 #include "definitions.h"
 //#include <algorithm>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "playback/playback_handler.h"
 #include "util/functions.h"
 #include "model/song/song.h"
@@ -88,7 +88,7 @@ setupSecondaryBuffer:
 
 				if (idealBufferSize != secondaryBuffer.size) {
 
-					Uart::println("new secondary buffer before writing starts");
+					Debug::println("new secondary buffer before writing starts");
 
 					// Ditch that secondary buffer, make a new one
 					secondaryBuffer.discard();
@@ -214,7 +214,7 @@ void Delay::setTimeToAbandon(DelayWorkingState* workingState) {
 		repeatsUntilAbandon = 255;
 	}
 
-	//if (!getRandom255()) Uart::println(workingState->delayFeedbackAmount);
+	//if (!getRandom255()) Debug::println(workingState->delayFeedbackAmount);
 }
 
 void Delay::hasWrapped() {
@@ -224,7 +224,7 @@ void Delay::hasWrapped() {
 
 	repeatsUntilAbandon--;
 	if (!repeatsUntilAbandon) {
-		//Uart::println("discarding");
+		//Debug::println("discarding");
 		discardBuffers();
 	}
 }

--- a/src/deluge/dsp/filter/filter_set_config.cpp
+++ b/src/deluge/dsp/filter/filter_set_config.cpp
@@ -18,7 +18,7 @@
 #include "processing/engines/audio_engine.h"
 #include "dsp/filter/filter_set_config.h"
 #include "util/functions.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "storage/storage_manager.h"
 
 FilterSetConfig::FilterSetConfig() {

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -32,7 +32,7 @@
 #include "model/sample/sample_holder.h"
 #include "model/sample/sample_playback_guide.h"
 #include "playback/playback_handler.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 #define MEASURE_HOP_END_PERFORMANCE 0
 
@@ -42,7 +42,7 @@ bool TimeStretcher::init(Sample* sample, VoiceSample* voiceSample, SamplePlaybac
 
 	AudioEngine::logAction("TimeStretcher::init");
 
-	//Uart::println("TimeStretcher::init");
+	//Debug::println("TimeStretcher::init");
 
 	for (int l = 0; l < NUM_CLUSTERS_LOADED_AHEAD; l++) {
 		clustersForPercLookahead[l] = NULL;
@@ -252,8 +252,8 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 
 	/*
 	if (numTimesMissedHop) {
-		Uart::print("missed ");
-		Uart::println(numTimesMissedHop);
+		Debug::print("missed ");
+		Debug::println(numTimesMissedHop);
 	}
 	*/
 
@@ -274,8 +274,8 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 
 	int32_t oldHeadBytePos;
 
-	//Uart::println("");
-	//Uart::println("hopEnd ------");
+	//Debug::println("");
+	//Debug::println("hopEnd ------");
 
 	olderHeadReadingFromBuffer = false;
 	oldHeadBytePos = voiceSample->getPlayByteLowLevel(sample, guide, true);
@@ -353,8 +353,8 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 		//lookahead = interpolateTableSigned(position, 27, lookaheadCoarse, 2) >> 16;
 	}
 
-	//Uart::print("maxBeamWidth: ");
-	//Uart::println(maxBeamWidth);
+	//Debug::print("maxBeamWidth: ");
+	//Debug::println(maxBeamWidth);
 
 	/*
 	minBeamWidth = storageManager.devVarA * 10;
@@ -439,8 +439,8 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 
 						hasLoopedBackIntoPreMargin = true;
 
-						//Uart::print("did special crossfade of length ");
-						//Uart::println(crossfadeLengthSamples);
+						//Debug::print("did special crossfade of length ");
+						//Debug::println(crossfadeLengthSamples);
 
 						// If there's a cache, we can't move a bit sideways to phase-align,
 						// cos our new play-head needs to remain perfectly aligned with the start of the cache.
@@ -462,7 +462,7 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 			}
 		}
 		else {
-			//Uart::println("TimeStretcher sees there's no pre-margin");
+			//Debug::println("TimeStretcher sees there's no pre-margin");
 		}
 	}
 
@@ -504,11 +504,11 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 				if (pixellatedBeamWidth) { // It might be zero near the start
 
 					if ((beamFrontEdge - latestPixellatedPos) * playDirection > 0) {
-						//Uart::println("hit front edge");
+						//Debug::println("hit front edge");
 						break;
 					}
 					if ((beamBackEdge - earliestPixellatedPos) * playDirection < 0) {
-						//Uart::println("hit back edge");
+						//Debug::println("hit back edge");
 						break;
 					}
 
@@ -560,7 +560,7 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 		}
 
 		if (!olderPartReader.clusters[0]) {
-			Uart::println("No cluster!!!");
+			Debug::println("No cluster!!!");
 		}
 
 		samplesTilHopEnd =
@@ -658,8 +658,8 @@ skipPercStuff:
 		    (sample->sampleRate / 45)
 		    >> 1; // Allow tracking down to around 45Hz, at input. We >>1 again because this limit is just for searching in one direction, and we're going to do both directions.
 		maxSearchSize = getMin(maxSearchSize, limit);
-		//Uart::print("max search length: ");
-		//Uart::println(maxSearchSize);
+		//Debug::print("max search length: ");
+		//Debug::println(maxSearchSize);
 
 		int numFullDirectionsSearched = 0;
 		int timesSignFlipped = 0;
@@ -853,8 +853,8 @@ stopSearch:
 		// The above is supposed to not go back beyond the start of the waveform, but there must be some bug because it does. Until I fix that,
 		// this check ensures we stay within the waveform
 		if ((newHeadBytePos - waveformStartByte) * playDirection < 0) {
-			Uart::println("avoided going before 0");
-			Uart::println(newHeadBytePos - waveformStartByte);
+			Debug::println("avoided going before 0");
+			Debug::println(newHeadBytePos - waveformStartByte);
 			newHeadBytePos = waveformStartByte;
 		}
 	}
@@ -867,13 +867,13 @@ skipSearch:
 	    && phaseIncrement != 16777216) {
 
 		if (!olderPartReader.clusters[0]) {
-			Uart::println("aaa");
+			Debug::println("aaa");
 		}
 
 		int32_t bytesBehind = (olderPartReader.getPlayByteLowLevel(sample, guide) - newHeadBytePos) * playDirection;
 
-		//Uart::print("bytesBehind: ");
-		//Uart::println(bytesBehind);
+		//Debug::print("bytesBehind: ");
+		//Debug::println(bytesBehind);
 
 		// Only proceed if newer head is earlier than older one
 		if (bytesBehind < 0)
@@ -889,42 +889,42 @@ skipSearch:
 
 		if (bufferSamplesWritten < samplesBehindOnRepitchedWaveform) {
 
-			Uart::println("nope");
+			Debug::println("nope");
 
-			Uart::print("samplesBehindOnRepitchedWaveform: ");
-			Uart::println(samplesBehindOnRepitchedWaveform);
-			Uart::print("bufferSamplesWritten: ");
-			Uart::println(bufferSamplesWritten);
+			Debug::print("samplesBehindOnRepitchedWaveform: ");
+			Debug::println(samplesBehindOnRepitchedWaveform);
+			Debug::print("bufferSamplesWritten: ");
+			Debug::println(bufferSamplesWritten);
 			goto optForDirectReading;
 		}
 
-		//Uart::print("samplesBehindOnRepitchedWaveform: ");
-		//Uart::println(samplesBehindOnRepitchedWaveform);
+		//Debug::print("samplesBehindOnRepitchedWaveform: ");
+		//Debug::println(samplesBehindOnRepitchedWaveform);
 
 		if (!samplesBehindOnRepitchedWaveform) {
-			//Uart::println("new head reading non-buffered and writing to buffer");
+			//Debug::println("new head reading non-buffered and writing to buffer");
 			voiceSample->cloneFrom(&olderPartReader, false);
 			newerHeadReadingFromBuffer = false;
 			olderHeadReadingFromBuffer = true;
 			olderBufferReadPos = bufferWritePos; // TODO: is this right?
 			if (olderBufferReadPos != bufferWritePos)
-				Uart::println("aaaaaaaaaaaa!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+				Debug::println("aaaaaaaaaaaa!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 			bufferFillingMode = BUFFER_FILLING_NEWER;
 		}
 		else {
-			//Uart::println("new head reading buffered");
+			//Debug::println("new head reading buffered");
 			newerBufferReadPos =
 			    (uint32_t)(bufferWritePos - samplesBehindOnRepitchedWaveform) & (TIME_STRETCH_BUFFER_SIZE - 1);
 			newerHeadReadingFromBuffer = true;
-			//Uart::print("samples behind: ");
-			//Uart::println(samplesBehindOnRepitchedWaveform);
+			//Debug::print("samples behind: ");
+			//Debug::println(samplesBehindOnRepitchedWaveform);
 		}
 	}
 
 	// Or, set up reading directly from audio file Clusters
 	else {
 optForDirectReading:
-		//Uart::println("head reading non-buffered");
+		//Debug::println("head reading non-buffered");
 		newerHeadReadingFromBuffer = false;
 #endif
 
@@ -932,7 +932,7 @@ optForDirectReading:
 		    setupNewPlayHead(sample, voiceSample, guide, newHeadBytePos, additionalOscPos, priorityRating, loopingType);
 		if (!success) {
 
-			Uart::println("setupNewPlayHead failed. Sticking with old");
+			Debug::println("setupNewPlayHead failed. Sticking with old");
 
 			voiceSample->cloneFrom(&olderPartReader, true); // Steals all reasons back
 			playHeadStillActive[PLAY_HEAD_NEWER] = playHeadStillActive[PLAY_HEAD_OLDER];
@@ -957,7 +957,7 @@ optForDirectReading:
 	    && !olderHeadReadingFromBuffer) { // olderHeadReadingFromBuffer will always be false - we set it above, at the start
 		generalMemoryAllocator.dealloc(buffer);
 		buffer = NULL;
-		Uart::println("abandoning buffer!!!!!!!!!!!!!!!!");
+		Debug::println("abandoning buffer!!!!!!!!!!!!!!!!");
 	}
 
 #endif
@@ -965,8 +965,8 @@ optForDirectReading:
 #if MEASURE_HOP_END_PERFORMANCE
 	uint16_t endTime = MTU2.TCNT_0;
 	uint16_t timeTaken = endTime - startTime;
-	Uart::print("hop end time: ");
-	Uart::println(timeTaken);
+	Debug::print("hop end time: ");
+	Debug::println(timeTaken);
 #endif
 
 	AudioEngine::logAction("/hopEnd");
@@ -992,7 +992,7 @@ bool TimeStretcher::setupNewPlayHead(Sample* sample, VoiceSample* voiceSample, S
 	voiceSample->oscPos = additionalOscPos;
 	if (!voiceSample->clusters[0]) {
 		playHeadStillActive[PLAY_HEAD_NEWER] = false;
-		Uart::println("new no longer active");
+		Debug::println("new no longer active");
 	}
 
 	return true;
@@ -1014,11 +1014,11 @@ void TimeStretcher::reassessWhetherToBeFillingBuffer(int32_t phaseIncrement, int
 
 				bufferWritePos = 0;
 				bufferSamplesWritten = 0;
-				Uart::println("setting up buffer !!!!!!!!!!!!!!!!");
+				Debug::println("setting up buffer !!!!!!!!!!!!!!!!");
 				if (bufferFillingMode == BUFFER_FILLING_OLDER)
-					Uart::println(" - filling older");
+					Debug::println(" - filling older");
 				else
-					Uart::println(" - filling newer");
+					Debug::println(" - filling newer");
 			}
 		}
 	}
@@ -1031,7 +1031,7 @@ void TimeStretcher::reassessWhetherToBeFillingBuffer(int32_t phaseIncrement, int
 			bufferFillingMode = BUFFER_FILLING_OFF;
 			generalMemoryAllocator.dealloc(buffer);
 			buffer = NULL;
-			Uart::println("abandoning buffer!!!!!!!!!!!!!!!!");
+			Debug::println("abandoning buffer!!!!!!!!!!!!!!!!");
 		}
 	}
 }
@@ -1206,8 +1206,8 @@ void TimeStretcher::setupCrossfadeFromCache(SampleCache* cache, int cacheBytePos
 	crossfadeIncrement = 16777216 / (uint16_t)numSamplesThisCacheRead + 1;
 	crossfadeProgress = 0;
 
-	//Uart::print("doing crossfade from cache, length: ");
-	//Uart::println(numSamplesThisCacheRead);
+	//Debug::print("doing crossfade from cache, length: ");
+	//Debug::println(numSamplesThisCacheRead);
 
 #if TIME_STRETCH_ENABLE_BUFFER
 	bufferWritePos = TIME_STRETCH_BUFFER_SIZE - 1; // To trick it out of trying to do a "normal" thing later

--- a/src/deluge/gui/context_menu/delete_file.cpp
+++ b/src/deluge/gui/context_menu/delete_file.cpp
@@ -18,7 +18,7 @@
 #include "gui/context_menu/delete_file.h"
 #include "gui/ui/browser/browser.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "hid/matrix/matrix_driver.h"
 #include "gui/context_menu/save_song_or_instrument.h"
 

--- a/src/deluge/gui/menu_item/multi_range.cpp
+++ b/src/deluge/gui/menu_item/multi_range.cpp
@@ -25,7 +25,7 @@
 #include "processing/source.h"
 #include <string.h>
 #include "util/functions.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "hid/matrix/matrix_driver.h"
 #include "gui/views/view.h"
 #include "gui/ui/keyboard_screen.h"

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -25,7 +25,7 @@
 #include "processing/sound/sound_drum.h"
 #include "gui/ui/audio_recorder.h"
 #include "storage/storage_manager.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "dsp/stereo_sample.h"
 #include "gui/ui/sound_editor.h"
 #include "hid/display/numeric_driver.h"

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -33,7 +33,7 @@
 #include "model/instrument/instrument.h"
 #include "gui/views/view.h"
 #include "hid/encoders.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "processing/engines/audio_engine.h"
 
 using namespace deluge;
@@ -992,7 +992,7 @@ nonNumeric:
 			scrollPosVertical = 9999;
 
 tryReadingItems:
-			Uart::println("reloading");
+			Debug::println("reloading");
 			error = readFileItemsFromFolderAndMemory(currentSong, instrumentTypeToLoad, filePrefix, enteredText.get(),
 			                                         NULL, true, 0, CATALOG_SEARCH_BOTH);
 			if (error) {
@@ -1017,7 +1017,7 @@ gotErrorAfterAllocating:
 			if (numFileItemsDeletedAtEnd) {
 				newCatalogSearchDirection = CATALOG_SEARCH_LEFT;
 searchFromOneEnd:
-				Uart::println("reloading and wrap");
+				Debug::println("reloading and wrap");
 				error = readFileItemsFromFolderAndMemory(currentSong, instrumentTypeToLoad, filePrefix, NULL, NULL,
 				                                         true, 0, newCatalogSearchDirection); // Load from start
 				if (error) {

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -36,10 +36,6 @@
 #include "io/uart/uart.h"
 #include "processing/engines/audio_engine.h"
 
-extern "C" {
-#include "drivers/uart/uart.h"
-}
-
 using namespace deluge;
 
 String Browser::currentDir{};
@@ -996,7 +992,7 @@ nonNumeric:
 			scrollPosVertical = 9999;
 
 tryReadingItems:
-			uartPrintln("reloading");
+			Uart::println("reloading");
 			error = readFileItemsFromFolderAndMemory(currentSong, instrumentTypeToLoad, filePrefix, enteredText.get(),
 			                                         NULL, true, 0, CATALOG_SEARCH_BOTH);
 			if (error) {
@@ -1021,7 +1017,7 @@ gotErrorAfterAllocating:
 			if (numFileItemsDeletedAtEnd) {
 				newCatalogSearchDirection = CATALOG_SEARCH_LEFT;
 searchFromOneEnd:
-				uartPrintln("reloading and wrap");
+				Uart::println("reloading and wrap");
 				error = readFileItemsFromFolderAndMemory(currentSong, instrumentTypeToLoad, filePrefix, NULL, NULL,
 				                                         true, 0, newCatalogSearchDirection); // Load from start
 				if (error) {

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -24,7 +24,7 @@
 #include "processing/engines/audio_engine.h"
 #include "storage/storage_manager.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <string.h>
 #include "processing/source.h"
 #include "processing/sound/sound.h"
@@ -536,7 +536,7 @@ void SampleBrowser::previewIfPossible(int movementDirection) {
 	/*
 	// Was this in case they've already turned the knob further?
 	if (movementDirection && movementDirection * Encoders::encoders[ENCODER_THIS_CPU_SELECT].detentPos > 0 && numFilesFoundInRightDirection > 1) {
-		Uart::println("returned 1");
+		Debug::println("returned 1");
 		return;
 	}
 	*/
@@ -579,7 +579,7 @@ void SampleBrowser::previewIfPossible(int movementDirection) {
 
 		/*
 		if (movementDirection && movementDirection * Encoders::encoders[ENCODER_THIS_CPU_SELECT].detentPos > 0 && numFilesFoundInRightDirection > 1) {
-			Uart::println("returned 2");
+			Debug::println("returned 2");
 			return;
 		}
 		*/
@@ -1179,8 +1179,8 @@ int getNumTimesIncorrectSampleOrderSeen(int numSamples, Sample** samples) {
 		}
 	}
 
-	Uart::print("timesIncorrectOrderSeen: ");
-	Uart::println(timesIncorrectOrderSeen);
+	Debug::print("timesIncorrectOrderSeen: ");
+	Debug::println(timesIncorrectOrderSeen);
 
 	return timesIncorrectOrderSeen;
 }
@@ -1330,8 +1330,8 @@ removeReasonsFromSamplesAndGetOut:
 
 	// Ok, the samples are now all in memory.
 
-	Uart::print("loaded from folder: ");
-	Uart::println(numSamples);
+	Debug::print("loaded from folder: ");
+	Debug::println(numSamples);
 
 	// If all samples were tagged with the same MIDI note, we get suspicious and delete them.
 	bool discardingMIDINoteFromFile = (numSamples > 1 && commonMIDINote >= 0);
@@ -1377,8 +1377,8 @@ removeReasonsFromSamplesAndGetOut:
 
 	numSamples = sampleI; // In case it's lower now, e.g. due to some samples' pitch detection failing
 
-	Uart::print("successfully detected pitch: ");
-	Uart::println(numSamples);
+	Debug::print("successfully detected pitch: ");
+	Debug::println(numSamples);
 
 	Sample** sortAreas[2];
 	sortAreas[0] = sortArea;
@@ -1423,7 +1423,7 @@ removeReasonsFromSamplesAndGetOut:
 			// But if C is actually bad enough, we might conclude that the filenames are irrelevant
 			if ((badnessRatingFromC * 3) > numSamples) goto justSortByPitch;
 
-			Uart::println("going back to ordering from C");
+			Debug::println("going back to ordering from C");
 			sortSamples(filenameGreaterOrEqual, numSamples, sortAreas, &readArea, &writeArea);
 		}
 
@@ -1436,7 +1436,7 @@ removeReasonsFromSamplesAndGetOut:
 		*/
 
 		// Ok, we're here, the samples are optimally ordered by file, but, the pitch is out.
-		Uart::println("sample order by file finalized");
+		Debug::println("sample order by file finalized");
 
 		float prevNote = sortAreas[readArea][0]->midiNote; // May be MIDI_NOTE_ERROR
 
@@ -1568,10 +1568,10 @@ removeReasonsFromSamplesAndGetOut:
 				continue;
 			}
 
-			Uart::print("redoing, limited to ");
-			Uart::print(minFreqHz);
-			Uart::print(" to ");
-			Uart::println(maxFreqHz);
+			Debug::print("redoing, limited to ");
+			Debug::print(minFreqHz);
+			Debug::print(" to ");
+			Debug::println(maxFreqHz);
 
 			thisSample->workOutMIDINote(doingSingleCycle, minFreqHz, maxFreqHz, false);
 
@@ -1582,7 +1582,7 @@ removeReasonsFromSamplesAndGetOut:
 				minFreqHz *= 2;
 				maxFreqHz *= 2;
 
-				Uart::println("pretending an octave up...");
+				Debug::println("pretending an octave up...");
 
 				thisSample->workOutMIDINote(doingSingleCycle, minFreqHz, maxFreqHz, false);
 
@@ -1646,7 +1646,7 @@ doReturnFalse:
 		return false;
 	}
 
-	Uart::println("loaded and sorted samples");
+	Debug::println("loaded and sorted samples");
 
 	AudioEngine::routineWithClusterLoading(); // --------------------------------------------------
 
@@ -1702,7 +1702,7 @@ doReturnFalse:
 			else {
 				// If there are other intervals of more than a semitone, we can't really take it for granted what's going on, so get out
 				if (noteHere >= prevNote + 1.85) {
-					Uart::println("aaa");
+					Debug::println("aaa");
 					uartPrintlnFloat(noteHere - prevNote);
 					goto skipOctaveCorrection;
 				}
@@ -1712,7 +1712,7 @@ doReturnFalse:
 		}
 
 		if (whichSampleIsAnOctaveUp) {
-			Uart::println("correcting octaves");
+			Debug::println("correcting octaves");
 			// Correct earlier ones?
 			if (whichSampleIsAnOctaveUp * 2 < numSamples) {
 				for (int s = 0; s < whichSampleIsAnOctaveUp; s++) {
@@ -1745,7 +1745,7 @@ skipOctaveCorrection:
 		soundEditor.currentSource->setOscType(OSC_TYPE_SAMPLE);
 	}
 
-	Uart::println("creating ranges");
+	Debug::println("creating ranges");
 
 	for (int s = 0; s < numSamples; s++) {
 
@@ -1756,7 +1756,7 @@ skipOctaveCorrection:
 		Sample* thisSample = sortArea[s];
 
 		if (thisSample->midiNote == MIDI_NOTE_ERROR) {
-			Uart::println("dismissing 1 sample for which pitch couldn't be detected");
+			Debug::println("dismissing 1 sample for which pitch couldn't be detected");
 			// TODO: shouldn't we remove a reason here?
 			continue;
 		}
@@ -1769,10 +1769,10 @@ skipOctaveCorrection:
 			float midPoint = (thisSample->midiNote + nextSample->midiNote) * 0.5;
 			topNote = midPoint; // Round down
 			if (topNote <= lastTopNote) {
-				Uart::print("skipping sample cos ");
-				Uart::print(topNote);
-				Uart::print(" <= ");
-				Uart::println(lastTopNote);
+				Debug::print("skipping sample cos ");
+				Debug::print(topNote);
+				Debug::print(" <= ");
+				Debug::println(lastTopNote);
 				// TODO: shouldn't we remove a reason here?
 				continue;
 			}
@@ -1792,8 +1792,8 @@ skipOctaveCorrection:
 			    rangeIndex); // We know it's gonna succeed
 		}
 
-		Uart::print("top note: ");
-		Uart::println(topNote);
+		Debug::print("top note: ");
+		Debug::println(topNote);
 
 		range->topNote = topNote;
 
@@ -1827,8 +1827,8 @@ skipOctaveCorrection:
 		goto doReturnFalse;
 	}
 
-	Uart::print("distinct ranges: ");
-	Uart::println(numSamples);
+	Debug::print("distinct ranges: ");
+	Debug::println(numSamples);
 
 	generalMemoryAllocator.dealloc(sortArea);
 

--- a/src/deluge/gui/ui/browser/slot_browser.cpp
+++ b/src/deluge/gui/ui/browser/slot_browser.cpp
@@ -23,7 +23,7 @@
 #include "util/functions.h"
 #include "hid/display/numeric_driver.h"
 #include "hid/led/pad_leds.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "storage/file_item.h"
 
 bool SlotBrowser::currentFileHasSuffixFormatNameImplied;

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -26,7 +26,7 @@
 #include "model/instrument/instrument.h"
 #include "hid/display/numeric_driver.h"
 #include "hid/matrix/matrix_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "gui/views/view.h"
 #include "storage/storage_manager.h"
 #include "gui/ui/keyboard_screen.h"
@@ -1360,7 +1360,7 @@ moveAgain:
 			if (numFileItemsDeletedAtEnd) {
 searchFromOneEnd:
 				oldNameString.clear();
-				Uart::println("reloading and wrap");
+				Debug::println("reloading and wrap");
 				goto readAgain;
 			}
 			else {
@@ -1410,7 +1410,7 @@ doneMoving:
 #endif
 
 	if (Encoders::encoders[ENCODER_SELECT].detentPos) {
-		Uart::println("go again 1 --------------------------");
+		Debug::println("go again 1 --------------------------");
 
 doPendingPresetNavigation:
 		offset = Encoders::encoders[ENCODER_SELECT].getLimitedDetentPosAndReset();
@@ -1435,7 +1435,7 @@ doPendingPresetNavigation:
 		toReturn.loadedFromFile = true;
 
 		if (Encoders::encoders[ENCODER_SELECT].detentPos) {
-			Uart::println("go again 2 --------------------------");
+			Debug::println("go again 2 --------------------------");
 			goto doPendingPresetNavigation;
 		}
 	}
@@ -1454,7 +1454,7 @@ doPendingPresetNavigation:
 
 	// If user wants to move on...
 	if (Encoders::encoders[ENCODER_SELECT].detentPos) {
-		Uart::println("go again 3 --------------------------");
+		Debug::println("go again 3 --------------------------");
 		goto doPendingPresetNavigation;
 	}
 

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -43,10 +43,6 @@
 #include "hid/display/oled.h"
 #include "processing/engines/audio_engine.h"
 
-extern "C" {
-#include "drivers/uart/uart.h"
-}
-
 using namespace deluge;
 
 LoadInstrumentPresetUI loadInstrumentPresetUI{};
@@ -1364,7 +1360,7 @@ moveAgain:
 			if (numFileItemsDeletedAtEnd) {
 searchFromOneEnd:
 				oldNameString.clear();
-				uartPrintln("reloading and wrap");
+				Uart::println("reloading and wrap");
 				goto readAgain;
 			}
 			else {

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -22,7 +22,7 @@
 #include "gui/ui/load/load_song_ui.h"
 #include "util/functions.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <string.h>
 #include "gui/views/session_view.h"
 #include "memory/general_memory_allocator.h"

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -21,7 +21,7 @@
 #include "hid/display/numeric_driver.h"
 #include "util/functions.h"
 #include "gui/ui_timer_manager.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "storage/storage_manager.h"
 #include "hid/led/pad_leds.h"
 #include "hid/led/indicator_leds.h"

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -22,7 +22,7 @@
 #include <string.h>
 #include "gui/context_menu/save_song_or_instrument.h"
 #include "model/sample/sample.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "gui/ui/audio_recorder.h"
 #include "gui/views/view.h"
 #include "storage/storage_manager.h"
@@ -208,10 +208,10 @@ gotError:
 						// successful, something's gone wrong
 						anyErrorMovingTempFiles = true;
 						/*
-						Uart::print("rename failed. ");
-						Uart::println(result);
-						Uart::println(((Sample*)sample)->tempFilePathForRecording.get());
-						Uart::println(sample->filePath.get());
+						Debug::print("rename failed. ");
+						Debug::println(result);
+						Debug::println(((Sample*)sample)->tempFilePathForRecording.get());
+						Debug::println(sample->filePath.get());
 						*/
 					}
 				}
@@ -253,8 +253,8 @@ gotError:
 				// Open file to read
 				FRESULT result = f_open(&fileSystemStuff.currentFile, sourceFilePath, FA_READ);
 				if (result != FR_OK) {
-					Uart::println("open fail");
-					Uart::println(sourceFilePath);
+					Debug::println("open fail");
+					Debug::println(sourceFilePath);
 					error = ERROR_UNSPECIFIED;
 					goto gotError;
 				}
@@ -361,7 +361,7 @@ failAfterOpeningSourceFile:
 						result = f_read(&fileSystemStuff.currentFile, storageManager.fileClusterBuffer,
 						                audioFileManager.clusterSize, &bytesRead);
 						if (result) {
-							Uart::println("read fail");
+							Debug::println("read fail");
 fail3:
 							f_close(&recorderFileSystemStuff.currentFile);
 							error = ERROR_UNSPECIFIED;
@@ -375,8 +375,8 @@ fail3:
 						result = f_write(&recorderFileSystemStuff.currentFile, storageManager.fileClusterBuffer,
 						                 bytesRead, &bytesWritten);
 						if (result || bytesWritten != bytesRead) {
-							Uart::println("write fail");
-							Uart::println(result);
+							Debug::println("write fail");
+							Debug::println(result);
 							goto fail3;
 						}
 
@@ -431,8 +431,8 @@ fail3:
 		filePathDuringWrite.set(&filePath);
 	}
 
-	Uart::print("creating: ");
-	Uart::println(filePathDuringWrite.get());
+	Debug::print("creating: ");
+	Debug::println(filePathDuringWrite.get());
 
 	// Write the actual song file
 	error = storageManager.createXMLFile(filePathDuringWrite.get(), false);

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -21,7 +21,7 @@
 #include "hid/matrix/matrix_driver.h"
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_engine.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/action/action_logger.h"
 #include "model/clip/audio_clip.h"
 #include "model/clip/instrument_clip_minder.h"
@@ -1062,7 +1062,7 @@ doMIDIOrCV:
 	}
 	else if (result == MENU_PERMISSION_MUST_SELECT_RANGE) {
 
-		Uart::println("must select range");
+		Debug::println("must select range");
 
 		newRange = NULL;
 		menu_item::multiRangeMenu.menuItemHeadingTo = newItem;

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -21,7 +21,7 @@
 #include "hid/matrix/matrix_driver.h"
 #include "gui/ui_timer_manager.h"
 #include "gui/ui/root_ui.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "hid/led/pad_leds.h"
 #include "hid/display/oled.h"
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -36,7 +36,7 @@
 #include "hid/display/numeric_driver.h"
 #include "model/instrument/instrument.h"
 #include "model/action/action_logger.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "gui/views/view.h"
 #include "playback/mode/arrangement.h"
 #include "gui/ui/keyboard_screen.h"
@@ -1751,7 +1751,7 @@ bool ArrangerView::transitionToArrangementEditor() {
 	int i = output->clipInstances.search(currentSong->lastClipInstanceEnteredStartPos, GREATER_OR_EQUAL);
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
 	if (!clipInstance || clipInstance->clip != currentSong->currentClip) {
-		Uart::println("no go");
+		Debug::println("no go");
 		return false;
 	}
 

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -27,7 +27,7 @@
 #include "playback/playback_handler.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/view.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/sample/sample_recorder.h"
 #include "playback/mode/playback_mode.h"
 #include "playback/mode/session.h"

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -28,7 +28,7 @@
 #include "gui/ui/sound_editor.h"
 #include "util/functions.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "processing/engines/cv_engine.h"
 #include "gui/ui/keyboard_screen.h"
 #include "gui/views/view.h"
@@ -3259,7 +3259,7 @@ void InstrumentClipView::cancelAllAuditioning() {
 
 void InstrumentClipView::enterDrumCreator(ModelStackWithNoteRow* modelStack, bool doRecording) {
 
-	Uart::println("enterDrumCreator");
+	Debug::println("enterDrumCreator");
 
 	char const* prefix;
 	String soundName;
@@ -4435,7 +4435,7 @@ void InstrumentClipView::editNoteRepeat(int offset) {
 
 			modelStackWithNoteRow->getNoteRow()->editNoteRepeatAcrossAllScreens(
 			    squareStart, squareWidth, modelStackWithNoteRow, action, currentClip->getWrapEditLevel(), newNumNotes);
-			Uart::println("did actual note repeat edit");
+			Debug::println("did actual note repeat edit");
 		}
 
 		uiNeedsRendering(this, 0xFFFFFFFF, 0);

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -27,7 +27,7 @@
 #include "gui/views/session_view.h"
 #include "util/functions.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "gui/views/view.h"
 #include "model/note/note_row.h"
 #include "gui/ui/ui.h"

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -40,7 +40,7 @@
 #include "model/drum/drum.h"
 #include "model/instrument/melodic_instrument.h"
 #include "playback/mode/arrangement.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/drum/kit.h"
 #include "model/song/song.h"

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "gui/waveform/waveform_renderer.h"
 #include "model/sample/sample.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "gui/ui/sound_editor.h"
 #include "storage/multi_range/multisample_range.h"
 #include "gui/views/view.h"
@@ -132,10 +132,10 @@ int WaveformRenderer::getColBrightnessForSingleRow(int xDisplay, int32_t maxPeak
 	int32_t peakHere = getMax(peak1, peak2);
 
 	if (false && peakHere >= maxPeakFromZero) {
-		Uart::print("peak: ");
-		Uart::print(peakHere);
-		Uart::print(" but max: ");
-		Uart::println(maxPeakFromZero);
+		Debug::print("peak: ");
+		Debug::print(peakHere);
+		Debug::print(" but max: ");
+		Debug::println(maxPeakFromZero);
 	}
 
 	uint32_t peak16 = ((int64_t)peakHere << 16) / maxPeakFromZero;
@@ -421,7 +421,7 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 			Cluster* cluster = sampleCluster->getCluster(sample, clusterIndexToDo, CLUSTER_LOAD_IMMEDIATELY);
 			if (!cluster) {
 cantReadData:
-				Uart::println("cant read");
+				Debug::println("cant read");
 				data->colStatus[col] = 0;
 				hadAnyTroubleLoading = true;
 				continue;

--- a/src/deluge/hid/display/numeric_driver.cpp
+++ b/src/deluge/hid/display/numeric_driver.cpp
@@ -17,7 +17,7 @@
 
 #include "hid/display/numeric_driver.h"
 #include "gui/ui_timer_manager.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <string.h>
 #include "hid/display/numeric_layer/numeric_layer_scroll_transition.h"
 #include "hid/display/numeric_layer/numeric_layer_basic_text.h"

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -1,6 +1,7 @@
 #include "hid/hid_sysex.h"
 #include "hid/display/oled.h"
 #include "io/midi/midi_device.h"
+#include "io/midi/midi_engine.h"
 #include "util/pack.h"
 #include <cstring>
 
@@ -29,8 +30,6 @@ void HIDSysex::requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int len) {
 	}
 }
 
-static uint8_t big_buffer[1024];
-
 void HIDSysex::sendOLEDData(MIDIDevice* device, bool rle) {
 	// TODO: in the long run, this should not depend on having a physical OLED screen
 #if HAVE_OLED
@@ -38,7 +37,7 @@ void HIDSysex::sendOLEDData(MIDIDevice* device, bool rle) {
 	const int max_packed_size = 922;
 
 	uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, rle ? 0x01 : 0x00};
-	uint8_t* reply = big_buffer;
+	uint8_t* reply = midiEngine.sysex_fmt_buffer;
 	memcpy(reply, reply_hdr, 5);
 	reply[5] = 0; // nominally 32*data[5] is start pos for a delta
 

--- a/src/deluge/hid/matrix/matrix_driver.cpp
+++ b/src/deluge/hid/matrix/matrix_driver.cpp
@@ -24,7 +24,7 @@
 #include "hid/matrix/matrix_driver.h"
 #include "util/functions.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "gui/ui/audio_recorder.h"
 #include <cstring>
 #include "gui/views/session_view.h"

--- a/src/deluge/io/debug/print.cpp
+++ b/src/deluge/io/debug/print.cpp
@@ -15,7 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <math.h>
 #include "util/functions.h"
 #include "io/midi/midi_engine.h"
@@ -24,7 +24,7 @@ extern "C" {
 #include "RZA1/uart/sio_char.h"
 }
 
-namespace Uart {
+namespace Debug {
 
 MIDIDevice* midiDebugDevice = nullptr;
 
@@ -66,4 +66,4 @@ void print(int32_t number) {
 #endif
 }
 
-} // namespace Uart
+} // namespace Debug

--- a/src/deluge/io/debug/print.h
+++ b/src/deluge/io/debug/print.h
@@ -21,7 +21,7 @@
 
 class MIDIDevice;
 
-namespace Uart {
+namespace Debug {
 void print(char const* output);
 void println(char const* output);
 void println(int32_t number);
@@ -30,4 +30,4 @@ void printfloat(float number);
 void print(int32_t number);
 
 extern MIDIDevice* midiDebugDevice;
-} // namespace Uart
+} // namespace Debug

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -19,7 +19,7 @@
 #include "io/midi/midi_engine.h"
 #include "util/functions.h"
 #include "gui/ui/sound_editor.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <string.h>
 #include "playback/mode/playback_mode.h"
 #include "model/song/song.h"
@@ -570,7 +570,7 @@ bool MidiEngine::checkIncomingSerialMidi() {
 	uint8_t thisSerialByte;
 	uint32_t* timer = uartGetCharWithTiming(TIMING_CAPTURE_ITEM_MIDI, (char*)&thisSerialByte);
 	if (timer) {
-		//Uart::println((unsigned int)thisSerialByte);
+		//Debug::println((unsigned int)thisSerialByte);
 		MIDIDevice* dev = &MIDIDeviceManager::dinMIDIPorts;
 
 		// If this is a status byte, then we have to store it as the first byte.
@@ -587,7 +587,7 @@ bool MidiEngine::checkIncomingSerialMidi() {
 			// Or if it's a SysEx start...
 			case 0xF0:
 				currentlyReceivingSysExSerial = true;
-				Uart::println("Sysex start");
+				Debug::println("Sysex start");
 				dev->incomingSysexBuffer[0] = thisSerialByte;
 				dev->incomingSysexPos = 1;
 				//numSerialMidiInput = 0; // This would throw away any running status stuff...
@@ -598,7 +598,7 @@ bool MidiEngine::checkIncomingSerialMidi() {
 
 			// If it was a Sysex stop, that's all we need to do
 			if (thisSerialByte == 0xF7) {
-				Uart::println("Sysex end");
+				Debug::println("Sysex end");
 				if (currentlyReceivingSysExSerial) {
 					currentlyReceivingSysExSerial = false;
 					if (dev->incomingSysexPos < sizeof dev->incomingSysexBuffer) {
@@ -622,8 +622,8 @@ bool MidiEngine::checkIncomingSerialMidi() {
 				if (dev->incomingSysexPos < sizeof dev->incomingSysexBuffer) {
 					dev->incomingSysexBuffer[dev->incomingSysexPos++] = thisSerialByte;
 				}
-				Uart::print("Sysex: ");
-				Uart::println(thisSerialByte);
+				Debug::print("Sysex: ");
+				Debug::println(thisSerialByte);
 				return true;
 			}
 
@@ -731,10 +731,10 @@ void MidiEngine::debugSysexReceived(MIDIDevice* device, uint8_t* data, int len) 
 	switch (data[3]) {
 	case 0:
 		if (data[4] == 1) {
-			Uart::midiDebugDevice = device;
+			Debug::midiDebugDevice = device;
 		}
 		else if (data[4] == 0) {
-			Uart::midiDebugDevice = nullptr;
+			Debug::midiDebugDevice = nullptr;
 		}
 		break;
 	}

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -64,6 +64,10 @@ public:
 	bool midiThru;
 	uint8_t midiTakeover;
 
+	// shared buffer for formatting sysex messages.
+	// Not safe for use in interrupts.
+	uint8_t sysex_fmt_buffer[1024];
+
 private:
 	uint8_t serialMidiInput[3];
 	uint8_t numSerialMidiInput;
@@ -75,11 +79,13 @@ private:
 	void midiMessageReceived(MIDIDevice* fromDevice, uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2,
 	                         uint32_t* timer = NULL);
 
-	// or midi device?? whatever makes sense for a consumer as a reply address.
 	void midiSysexReceived(MIDIDevice* device, uint8_t* data, int len);
 	int getPotentialNumConnectedUSBMIDIDevices(int ip);
+
+	void debugSysexReceived(MIDIDevice* device, uint8_t* data, int len);
 };
 
+void midiDebugPrint(MIDIDevice* device, const char* msg, bool nl);
 uint32_t setupUSBMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
 
 extern MidiEngine midiEngine;

--- a/src/deluge/io/uart/uart.cpp
+++ b/src/deluge/io/uart/uart.cpp
@@ -18,6 +18,7 @@
 #include "io/uart/uart.h"
 #include <math.h>
 #include "util/functions.h"
+#include "io/midi/midi_engine.h"
 
 extern "C" {
 #include "RZA1/uart/sio_char.h"
@@ -25,9 +26,16 @@ extern "C" {
 
 namespace Uart {
 
+MIDIDevice* midiDebugDevice = nullptr;
+
 void println(char const* output) {
 #if ENABLE_TEXT_OUTPUT
-	uartPrintln(output);
+	if (midiDebugDevice) {
+		midiDebugPrint(midiDebugDevice, output, true);
+	}
+	else {
+		uartPrintln(output);
+	}
 #endif
 }
 
@@ -35,13 +43,18 @@ void println(int32_t number) {
 #if ENABLE_TEXT_OUTPUT
 	char buffer[12];
 	intToString(number, buffer);
-	uartPrintln(buffer);
+	println(buffer);
 #endif
 }
 
 void print(char const* output) {
 #if ENABLE_TEXT_OUTPUT
-	uartPrint(output);
+	if (midiDebugDevice) {
+		midiDebugPrint(midiDebugDevice, output, false);
+	}
+	else {
+		uartPrint(output);
+	}
 #endif
 }
 
@@ -49,7 +62,7 @@ void print(int32_t number) {
 #if ENABLE_TEXT_OUTPUT
 	char buffer[12];
 	intToString(number, buffer);
-	uartPrint(buffer);
+	print(buffer);
 #endif
 }
 

--- a/src/deluge/io/uart/uart.h
+++ b/src/deluge/io/uart/uart.h
@@ -20,12 +20,10 @@
 #include "RZA1/system/r_typedefs.h"
 
 namespace Uart {
-void setBaudRate(uint8_t scifID, uint32_t baudRate);
 void print(char const* output);
 void println(char const* output);
 void println(int32_t number);
 void printlnfloat(float number);
 void printfloat(float number);
 void print(int32_t number);
-unsigned int getTxBufferFullness(uint8_t scifID);
 } // namespace Uart

--- a/src/deluge/io/uart/uart.h
+++ b/src/deluge/io/uart/uart.h
@@ -19,6 +19,8 @@
 
 #include "RZA1/system/r_typedefs.h"
 
+class MIDIDevice;
+
 namespace Uart {
 void print(char const* output);
 void println(char const* output);
@@ -26,4 +28,6 @@ void println(int32_t number);
 void printlnfloat(float number);
 void printfloat(float number);
 void print(int32_t number);
+
+extern MIDIDevice* midiDebugDevice;
 } // namespace Uart

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -20,7 +20,7 @@
 #include "storage/cluster/cluster.h"
 #include "memory/general_memory_allocator.h"
 #include <new>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "util/functions.h"
 #include <string.h>
 #include "model/action/action_logger.h"
@@ -61,12 +61,12 @@ void GeneralMemoryAllocator::checkStack(char const* caller) {
 	if (distance < closestDistance) {
 		closestDistance = distance;
 
-		Uart::print(distance);
-		Uart::print(" free bytes in stack at ");
-		Uart::println(caller);
+		Debug::print(distance);
+		Debug::print(" free bytes in stack at ");
+		Debug::println(caller);
 
 		if (distance < 200) {
-			Uart::println("COLLISION");
+			Debug::println("COLLISION");
 			numericDriver.freezeWithError("E338");
 		}
 	}
@@ -110,11 +110,11 @@ void* GeneralMemoryAllocator::alloc(uint32_t requiredSize, uint32_t* getAllocate
 			totalMallocTime += timeTaken;
 			numMallocTimes++;
 
-			Uart::print("average malloc time: ");
-			Uart::println(totalMallocTime / numMallocTimes);
+			Debug::print("average malloc time: ");
+			Debug::println(totalMallocTime / numMallocTimes);
 
-			//Uart::print("total: ");
-			//Uart::println(totalMallocTime);
+			//Debug::print("total: ");
+			//Debug::println(totalMallocTime);
 			*/
 			return address;
 		}
@@ -122,7 +122,7 @@ void* GeneralMemoryAllocator::alloc(uint32_t requiredSize, uint32_t* getAllocate
 
 #if TEST_GENERAL_MEMORY_ALLOCATION
 	if (requiredSize < 1) {
-		Uart::println("alloc too little a bit");
+		Debug::println("alloc too little a bit");
 		while (1) {}
 	}
 #endif
@@ -240,12 +240,12 @@ void testReadingMemory(int i) {
 	uint8_t readValue = *readPos;
 	for (int j = 0; j < sizes[i]; j++) {
 		if (*readPos != readValue) {
-			Uart::println("data corrupted!");
-			Uart::println((int)readPos);
-			Uart::print("allocation total size: ");
-			Uart::println(sizes[i]);
-			Uart::print("num bytes in: ");
-			Uart::println((int)readPos - (int)testAllocations[i]);
+			Debug::println("data corrupted!");
+			Debug::println((int)readPos);
+			Debug::print("allocation total size: ");
+			Debug::println(sizes[i]);
+			Debug::print("num bytes in: ");
+			Debug::println((int)readPos - (int)testAllocations[i]);
 			while (1) {}
 		}
 		readPos++;
@@ -278,20 +278,20 @@ void GeneralMemoryAllocator::checkEverythingOk(char const* errorString) {
 			uint32_t shouldBe = sizes[i] | spaceTypes[i];
 
 			if (*header != shouldBe) {
-				Uart::println("allocation header wrong");
-				Uart::println(errorString);
-				Uart::println(*header);
-				Uart::println(shouldBe);
+				Debug::println("allocation header wrong");
+				Debug::println(errorString);
+				Debug::println(*header);
+				Debug::println(shouldBe);
 				while (1) {}
 			}
 			if (*footer != shouldBe) {
-				Uart::println("allocation footer wrong");
-				Uart::println(errorString);
+				Debug::println("allocation footer wrong");
+				Debug::println(errorString);
 				while (1) {}
 			}
 			if (spaceTypes[i] == SPACE_HEADER_STEALABLE && *(header + 1) != vtableAddress) {
-				Uart::println("vtable address corrupted");
-				Uart::println(errorString);
+				Debug::println("vtable address corrupted");
+				Debug::println(errorString);
 				while (1) {}
 			}
 		}
@@ -306,13 +306,13 @@ void GeneralMemoryAllocator::checkEverythingOk(char const* errorString) {
 		uint32_t shouldBe = record->length | SPACE_HEADER_EMPTY;
 
 		if (*header != shouldBe) {
-			Uart::println("empty space header wrong");
-			Uart::println(errorString);
+			Debug::println("empty space header wrong");
+			Debug::println(errorString);
 			while (1) {}
 		}
 		if (*footer != shouldBe) {
-			Uart::println("empty space footer wrong");
-			Uart::println(errorString);
+			Debug::println("empty space footer wrong");
+			Debug::println(errorString);
 			while (1) {}
 		}
 	}
@@ -332,7 +332,7 @@ void GeneralMemoryAllocator::testShorten(int i) {
 	if (a < 128) {
 
 		if (!getRandom255())
-			Uart::println("shortening left");
+			Debug::println("shortening left");
 		int newSize =
 		    ((uint32_t)getRandom255() << 17) | ((uint32_t)getRandom255() << 9) | ((uint32_t)getRandom255() << 1);
 		while (newSize > sizes[i])
@@ -348,7 +348,7 @@ void GeneralMemoryAllocator::testShorten(int i) {
 	else {
 
 		if (!getRandom255())
-			Uart::println("shortening right");
+			Debug::println("shortening right");
 		int newSize =
 		    ((uint32_t)getRandom255() << 17) | ((uint32_t)getRandom255() << 9) | ((uint32_t)getRandom255() << 1);
 		while (newSize > sizes[i])
@@ -361,7 +361,7 @@ void GeneralMemoryAllocator::testShorten(int i) {
 
 void GeneralMemoryAllocator::test() {
 
-	Uart::println("GeneralMemoryAllocator::test()");
+	Debug::println("GeneralMemoryAllocator::test()");
 
 	// Corrupt the crap out of these two so we know they can take it!
 	sampleManager.clusterSize = 0;
@@ -374,7 +374,7 @@ void GeneralMemoryAllocator::test() {
 	bool goingUp = true;
 
 	while (1) {
-		//if (!(count & 15)) Uart::println("...");
+		//if (!(count & 15)) Debug::println("...");
 		count++;
 
 		for (int i = 0; i < NUM_TEST_ALLOCATIONS; i++) {
@@ -408,7 +408,7 @@ void GeneralMemoryAllocator::test() {
 
 					else {
 						if (!getRandom255())
-							Uart::println("extending");
+							Debug::println("extending");
 						uint32_t amountExtendedLeft, amountExtendedRight;
 
 						uint32_t idealAmountToExtend = ((uint32_t)getRandom255() << 17)
@@ -440,7 +440,7 @@ void GeneralMemoryAllocator::test() {
 
 						if (amountExtended > 0) {
 							if (amountExtended < minAmountToExtend) {
-								Uart::println("extended too little!");
+								Debug::println("extended too little!");
 								while (1) {}
 							}
 						}
@@ -457,18 +457,18 @@ void GeneralMemoryAllocator::test() {
 			}
 
 			if (getRandom255() < 2) {
-				Uart::print("\nfree spaces: ");
-				Uart::println(regions[MEMORY_REGION_SDRAM].emptySpaces.getNumElements());
-				Uart::print("allocations: ");
-				Uart::println(regions[MEMORY_REGION_SDRAM].numAllocations);
+				Debug::print("\nfree spaces: ");
+				Debug::println(regions[MEMORY_REGION_SDRAM].emptySpaces.getNumElements());
+				Debug::print("allocations: ");
+				Debug::println(regions[MEMORY_REGION_SDRAM].numAllocations);
 
 				if (regions[MEMORY_REGION_SDRAM].emptySpaces.getNumElements() == 1) {
 					EmptySpaceRecord* firstRecord =
 					    (EmptySpaceRecord*)regions[MEMORY_REGION_SDRAM].emptySpaces.getElementAddress(0);
-					Uart::print("free space size: ");
-					Uart::println(firstRecord->length);
-					Uart::print("free space address: ");
-					Uart::println(firstRecord->address);
+					Debug::print("free space size: ");
+					Debug::println(firstRecord->length);
+					Debug::print("free space address: ");
+					Debug::println(firstRecord->address);
 				}
 				delayMS(200);
 			}
@@ -495,8 +495,8 @@ void GeneralMemoryAllocator::test() {
 					//if ((uint32_t)testAllocations[i] >= (uint32_t)INTERNAL_MEMORY_BEGIN) actualSize = desiredSize; // If on-chip memory
 
 					if (actualSize < desiredSize) {
-						Uart::println("got too little!!");
-						Uart::println(desiredSize - actualSize);
+						Debug::println("got too little!!");
+						Debug::println(desiredSize - actualSize);
 						while (1) {}
 					}
 

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -18,7 +18,7 @@
 #include "processing/engines/audio_engine.h"
 #include "memory/memory_region.h"
 #include "memory/stealable.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "memory/general_memory_allocator.h"
 #include "drivers/mtu/mtu.h"
 #include "util/functions.h"
@@ -57,13 +57,13 @@ void MemoryRegion::sanityCheck() {
 	}
 
 	if (count > 1) {
-		Uart::println("multiple 0xc0080bc!!!!");
+		Debug::println("multiple 0xc0080bc!!!!");
 		numericDriver.freezeWithError("BBBB");
 	}
 	else if (count == 1) {
 		if (!seenYet) {
 			seenYet = true;
-			Uart::println("seen 0xc0080bc");
+			Debug::println("seen 0xc0080bc");
 		}
 	}
 }
@@ -72,17 +72,17 @@ void MemoryRegion::verifyMemoryNotFree(void* address, uint32_t spaceSize) {
 	for (int i = 0; i < emptySpaces.getNumElements(); i++) {
 		EmptySpaceRecord* emptySpaceRecord = (EmptySpaceRecord*)emptySpaces.getElementAddress(i);
 		if (emptySpaceRecord->address == (uint32_t)address) {
-			Uart::println("Exact address free!");
+			Debug::println("Exact address free!");
 			numericDriver.freezeWithError("dddffffd");
 		}
 		else if (emptySpaceRecord->address <= (uint32_t)address
 		         && (emptySpaceRecord->address + emptySpaceRecord->length > (uint32_t)address)) {
-			Uart::println("free mem overlap on left!");
+			Debug::println("free mem overlap on left!");
 			numericDriver.freezeWithError("dddd");
 		}
 		else if ((uint32_t)address <= (uint32_t)emptySpaceRecord->address
 		         && ((uint32_t)address + spaceSize > emptySpaceRecord->address)) {
-			Uart::println("free mem overlap on right!");
+			Debug::println("free mem overlap on right!");
 			numericDriver.freezeWithError("eeee");
 		}
 	}
@@ -182,8 +182,8 @@ justInsertRecord:
 #if ALPHA_OR_BETA_VERSION
 		if (i
 		    == -1) { // Array might have gotten full. This has to be coped with. Perhaps in a perfect world we should opt to throw away the smallest empty space to make space for this one if this one is bigger?
-			Uart::print("Lost track of empty space in region: ");
-			Uart::println(name);
+			Debug::print("Lost track of empty space in region: ");
+			Debug::println(name);
 		}
 #endif
 	}
@@ -196,8 +196,8 @@ goingToReplaceOldRecord:
 		if (i
 		    == -1) { // The record might not exist because there wasn't room to insert it when the empty space was created.
 #if ALPHA_OR_BETA_VERSION
-			Uart::print("Found orphaned empty space in region: ");
-			Uart::println(name);
+			Debug::print("Found orphaned empty space in region: ");
+			Debug::println(name);
 #endif
 			goto justInsertRecord;
 		}
@@ -315,10 +315,10 @@ moveOn:
 			// If it was in the wrong queue, put it in the right queue and start again with the next one in our queue
 			if (appropriateQueue > q) {
 
-				Uart::print("changing queue from ");
-				Uart::print(q);
-				Uart::print(" to ");
-				Uart::println(appropriateQueue);
+				Debug::print("changing queue from ");
+				Debug::print(q);
+				Debug::print(" to ");
+				Debug::println(appropriateQueue);
 
 				Stealable* next = (Stealable*)stealableClusterQueues[q].getNext(stealable);
 
@@ -369,7 +369,7 @@ moveOn:
 
 		spaceSize += result.amountsExtended[0] + result.amountsExtended[1];
 
-		Uart::println("stole and grabbed neighbouring stuff too...........");
+		Debug::println("stole and grabbed neighbouring stuff too...........");
 		goto stolenIt;
 	}
 
@@ -491,13 +491,13 @@ justUpdateRecord:
 noEmptySpace:
 		allocatedAddress = freeSomeStealableMemory(requiredSize, thingNotToStealFrom, &allocatedSize);
 		if (!allocatedAddress) {
-			//Uart::println("nothing to steal.........................");
+			//Debug::println("nothing to steal.........................");
 			return NULL;
 		}
 
 #if 0 && TEST_GENERAL_MEMORY_ALLOCATION
 		if (allocatedSize < requiredSize) {
-			Uart::println("freeSomeStealableMemory() got too little memory");
+			Debug::println("freeSomeStealableMemory() got too little memory");
 			while (1);
 		}
 #endif
@@ -755,7 +755,7 @@ tryNotStealingFirst:
 #if TEST_GENERAL_MEMORY_ALLOCATION
 							if (!success) {
 								// TODO: actually, this is basically ok - it should be allowed to not find the key, because the empty space might indeed not have a record if there wasn't room to insert one when the empty space was created.
-								Uart::println("fail to delete key");
+								Debug::println("fail to delete key");
 								while (1) {}
 							}
 #endif
@@ -805,11 +805,11 @@ tryNotStealingFirst:
 			// If we somehow grabbed without finding min amount, then that shouldn't have happened!
 #if TEST_GENERAL_MEMORY_ALLOCATION
 			if (actuallyGrabbing) {
-				Uart::println("grabbed extension without reaching min size"); // This happened recently!
+				Debug::println("grabbed extension without reaching min size"); // This happened recently!
 				if (originalSpaceNeedsStealing)
-					Uart::println("during steal");
+					Debug::println("during steal");
 				else
-					Uart::println("during extend");
+					Debug::println("during extend");
 				while (1) {}
 			}
 #endif
@@ -852,7 +852,7 @@ void MemoryRegion::extend(void* address, uint32_t minAmountToExtend, uint32_t id
 
 		if (grabResult.amountsExtended[0] > 8) {
 
-			//Uart::println("extend leaving empty space right");
+			//Debug::println("extend leaving empty space right");
 
 			int amountToCutRightIncludingHeaders = getMax(12, surplusWeGot);
 			amountToCutRightIncludingHeaders = getMin(amountToCutRightIncludingHeaders, grabResult.amountsExtended[0]);
@@ -869,7 +869,7 @@ void MemoryRegion::extend(void* address, uint32_t minAmountToExtend, uint32_t id
 
 			if (grabResult.amountsExtended[1] > 8) {
 
-				//Uart::println("extend leaving empty space left");
+				//Debug::println("extend leaving empty space left");
 
 				int amountToCutLeftIncludingHeaders = getMax(12, surplusWeGot);
 				amountToCutLeftIncludingHeaders =
@@ -920,8 +920,8 @@ void MemoryRegion::dealloc(void* address) {
 	totalDeallocTime += timeTaken;
 	numDeallocTimes++;
 
-	Uart::print("average dealloc time: ");
-	Uart::println(totalDeallocTime / numDeallocTimes);
+	Debug::print("average dealloc time: ");
+	Debug::println(totalDeallocTime / numDeallocTimes);
 	 */
 #if TEST_GENERAL_MEMORY_ALLOCATION
 	numAllocations--;

--- a/src/deluge/model/action/action.cpp
+++ b/src/deluge/model/action/action.cpp
@@ -29,7 +29,7 @@
 #include "model/note/note.h"
 #include "model/action/action_logger.h"
 #include "model/consequence/consequence_note_existence.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <new>
 #include "memory/general_memory_allocator.h"
 #include "model/consequence/consequence_clip_length.h"
@@ -313,7 +313,7 @@ void Action::updateYScrollClipViewAfter(InstrumentClip* clip) {
 		numClipStates = 0;
 		generalMemoryAllocator.dealloc(clipStates);
 		clipStates = NULL;
-		Uart::println("discarded clip states");
+		Debug::println("discarded clip states");
 		return;
 	}
 

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -32,7 +32,7 @@
 #include "model/consequence/consequence_param_change.h"
 #include "model/drum/kit.h"
 #include <new>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <string.h>
 #include "memory/general_memory_allocator.h"
 #include "playback/mode/playback_mode.h"
@@ -129,7 +129,7 @@ Action* ActionLogger::getNewAction(int newActionType, int addToExistingIfPossibl
 		void* actionMemory = generalMemoryAllocator.alloc(sizeof(Action), NULL, true);
 
 		if (!actionMemory) {
-			Uart::println("no ram to create new Action");
+			Debug::println("no ram to create new Action");
 			return NULL;
 		}
 
@@ -205,7 +205,7 @@ void ActionLogger::updateAction(Action* newAction) {
 			newAction->numClipStates = 0;
 			generalMemoryAllocator.dealloc(newAction->clipStates);
 			newAction->clipStates = NULL;
-			Uart::println("discarded clip states");
+			Debug::println("discarded clip states");
 		}
 
 		else {
@@ -301,7 +301,7 @@ void ActionLogger::recordTempoChange(uint64_t timePerBigBefore, uint64_t timePer
 // doNavigation and updateVisually are only false when doing one of those undo-Clip-resize things as part of another Clip resize.
 // You must not call this during the card routine - though I've lost track of the exact reason why not - is it just because we could then be in the middle of executing whichever function accessed the card and we don't know if things will break?
 bool ActionLogger::revert(int time, bool updateVisually, bool doNavigation) {
-	Uart::println("ActionLogger::revert");
+	Debug::println("ActionLogger::revert");
 
 	deleteLastActionIfEmpty();
 
@@ -477,7 +477,7 @@ traverseClips:
 				}
 			}
 			else {
-				Uart::println("clip states wrong number so not restoring");
+				Debug::println("clip states wrong number so not restoring");
 			}
 		}
 
@@ -828,13 +828,13 @@ gotMultipleConsequencesPerNoteRow:
 			} while (thisConsequence->type != CONSEQUENCE_NOTE_ARRAY_CHANGE
 			         || ((ConsequenceNoteArrayChange*)firstConsequence)->noteRowId != firstNoteRowId);
 
-			Uart::println("did secret undo, just one Consequence");
+			Debug::println("did secret undo, just one Consequence");
 		}
 
 		// Or if only one Consequence (per NoteRow), revert whole Action
 		else {
 			revert(BEFORE, true, false);
-			Uart::println("did secret undo, whole Action");
+			Debug::println("did secret undo, whole Action");
 			revertedWholeAction = true;
 		}
 

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -41,7 +41,7 @@
 #include "util/functions.h"
 #include "storage/flash_storage.h"
 #include "model/sample/sample.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/model_stack.h"
 #include "modulation/params/param_set.h"
 
@@ -566,8 +566,8 @@ justDontTimeStretch:
 						goto justDontTimeStretch;
 					}
 					else {
-						//Uart::print("sync: ");
-						//Uart::println(numSamplesDrift);
+						//Debug::print("sync: ");
+						//Debug::println(numSamplesDrift);
 					}
 				}
 			}
@@ -638,8 +638,8 @@ justDontTimeStretch:
 					}
 
 					if (numSamplesOfPreMarginAvailable > 2) {
-						//Uart::println("");
-						//Uart::println("might attempt fudge");
+						//Debug::println("");
+						//Debug::println("might attempt fudge");
 
 						int crossfadeLength = getMin(numSamplesOfPreMarginAvailable, ANTI_CLICK_CROSSFADE_LENGTH);
 
@@ -782,9 +782,9 @@ void AudioClip::posReachedEnd(ModelStackWithTimelineCounter* modelStack) {
 	// If recording from session to arranger...
 	if (playbackHandler.recording == RECORDING_ARRANGEMENT && isArrangementOnlyClip()) {
 
-		Uart::println("");
-		Uart::print("AudioClip::posReachedEnd, at pos: ");
-		Uart::println(playbackHandler.getActualArrangementRecordPos());
+		Debug::println("");
+		Debug::print("AudioClip::posReachedEnd, at pos: ");
+		Debug::println(playbackHandler.getActualArrangementRecordPos());
 
 		if (!modelStack->song->arrangementOnlyClips.ensureEnoughSpaceAllocated(1)) {
 			return;
@@ -933,7 +933,7 @@ bool AudioClip::renderAsSingleRow(ModelStackWithTimelineCounter* modelStack, Tim
                                   bool addUndefinedArea, int noteRowIndexStart, int noteRowIndexEnd, int xStart,
                                   int xEnd, bool allowBlur, bool drawRepeats) {
 
-	//Uart::println("AudioClip::renderAsSingleRow");
+	//Debug::println("AudioClip::renderAsSingleRow");
 
 	Sample* sample;
 	if (recorder) {
@@ -1028,7 +1028,7 @@ someError:
 	int32_t readAutomationUpToPos = MAX_SEQUENCE_LENGTH;
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
-		//Uart::println(tagName); delayMS(30);
+		//Debug::println(tagName); delayMS(30);
 
 		if (!strcmp(tagName, "trackName")) {
 			storageManager.readTagOrAttributeValueString(&outputNameWhileLoading);

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -38,7 +38,7 @@
 #include "model/consequence/consequence_output_existence.h"
 #include <new>
 #include "model/consequence/consequence_clip_begin_linear_record.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/model_stack.h"
 #include "model/clip/audio_clip.h"
 
@@ -789,7 +789,7 @@ void Clip::posReachedEnd(ModelStackWithTimelineCounter* modelStack) {
 			// But, don't do this if this Clips still would get deleted as an "abandoned overdub" (meaning it has no notes), cos if that happened,
 			// we definitely don't want to have a consequence - pointer pointing to it!
 			if (true || type != CLIP_TYPE_AUDIO) {
-				Uart::println("getting new action");
+				Debug::println("getting new action");
 				Action* action = actionLogger.getNewAction(ACTION_RECORD, ACTION_ADDITION_ALLOWED);
 				if (action) {
 					action->recordClipLengthChange(this, oldLength);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -30,7 +30,7 @@
 #include "processing/sound/sound_drum.h"
 #include "processing/sound/sound_instrument.h"
 #include "gui/views/session_view.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "processing/engines/cv_engine.h"
 #include "hid/display/numeric_driver.h"
 #include "model/song/song.h"
@@ -471,7 +471,7 @@ int InstrumentClip::beginLinearRecording(ModelStackWithTimelineCounter* modelSta
 
 					noteRow->attemptNoteAdd(0, 1, velocity, NUM_PROBABILITY_VALUES, modelStackWithNoteRow, action);
 					if (!thisDrum->earlyNoteStillActive) {
-						Uart::println("skipping next note");
+						Debug::println("skipping next note");
 						noteRow->skipNextNote = true;
 					}
 				}
@@ -2300,7 +2300,7 @@ someError:
 	int32_t readAutomationUpToPos = MAX_SEQUENCE_LENGTH;
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
-		//Uart::println(tagName); delayMS(30);
+		//Debug::println(tagName); delayMS(30);
 
 		int temp;
 

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -37,7 +37,7 @@
 #include "model/action/action.h"
 #include <string.h>
 #include "playback/mode/session.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/instrument/cv_instrument.h"
 #include "memory/general_memory_allocator.h"

--- a/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
+++ b/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
@@ -18,7 +18,7 @@
 #include "model/consequence/consequence_audio_clip_set_sample.h"
 #include "model/clip/audio_clip.h"
 #include "playback/playback_handler.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "playback/mode/session.h"
 #include "model/song/song.h"
 #include "model/model_stack.h"

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -27,7 +27,7 @@
 #include "playback/mode/session.h"
 #include "playback/mode/arrangement.h"
 #include "model/output.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/clip/audio_clip.h"
 #include "model/model_stack.h"
 
@@ -85,7 +85,7 @@ int ConsequenceClipExistence::revert(int time, ModelStack* modelStack) {
 		if (shouldBeActiveWhileExistent && !(playbackHandler.playbackState && currentPlaybackMode == &arrangement)) {
 			session.toggleClipStatus(clip, &clipIndex, true, 0);
 			if (!clip->activeIfNoSolo) {
-				Uart::println("still not active!");
+				Debug::println("still not active!");
 			}
 		}
 

--- a/src/deluge/model/drum/kit.cpp
+++ b/src/deluge/model/drum/kit.cpp
@@ -38,7 +38,7 @@
 #include "gui/ui/ui.h"
 #include "playback/mode/session.h"
 #include "model/drum/midi_drum.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "hid/display/numeric_driver.h"
 #include "model/model_stack.h"
 #include "io/midi/midi_device_manager.h"
@@ -163,7 +163,7 @@ bool Kit::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song) {
 
 		// If saving Kit (not song), only save Drums if some other NoteRow in the song has it - in which case, save as "default" the params from that NoteRow
 		if (clipForSavingOutputOnly) {
-			Uart::println("yup, clipForSavingOutputOnly");
+			Debug::println("yup, clipForSavingOutputOnly");
 			NoteRow* noteRow = song->findNoteRowForDrum(this, thisDrum);
 			if (!noteRow) {
 				goto moveOn;
@@ -177,7 +177,7 @@ bool Kit::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song) {
 			// If no activeClip, this means we want to store all Drums
 			// - and for SoundDrums, save as "default" any backedUpParamManagers (if none for a SoundDrum, definitely skip it)
 			if (!activeClip) {
-				Uart::println("nah, !activeClip");
+				Debug::println("nah, !activeClip");
 				if (thisDrum->type == DRUM_TYPE_SOUND) {
 					paramManagerForDrum = song->getBackedUpParamManagerPreferablyWithClip((SoundDrum*)thisDrum, NULL);
 					if (!paramManagerForDrum) {
@@ -682,7 +682,7 @@ ModControllable* Kit::toModControllable() {
 // newName must be allowed to be edited by this function
 int Kit::makeDrumNameUnique(String* name, int startAtNumber) {
 
-	Uart::println("making unique newName:");
+	Debug::println("making unique newName:");
 
 	int originalLength = name->getLength();
 

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -26,7 +26,7 @@
 #include "hid/matrix/matrix_driver.h"
 #include "util/lookuptables/lookuptables.h"
 #include "string.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "playback/mode/playback_mode.h"
 #include "memory/general_memory_allocator.h"
 #include <new>

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -25,7 +25,7 @@
 #include <string.h>
 #include "gui/views/session_view.h"
 #include "playback/playback_handler.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "memory/general_memory_allocator.h"
 #include "gui/views/view.h"
 #include "model/timeline_counter.h"
@@ -297,7 +297,7 @@ void ModControllableAudio::processFX(StereoSample* buffer, int numSamples, int m
 
 				// If delay speed has settled for a split second...
 				if (delay.countCyclesWithoutChange >= (44100 >> 5)) {
-					//Uart::println("settling");
+					//Debug::println("settling");
 					initializeSecondaryDelayBuffer(delayWorkingState->userDelayRate, true);
 				}
 
@@ -930,12 +930,12 @@ void ModControllableAudio::initializeSecondaryDelayBuffer(int32_t newNativeRate,
                                                           bool makeNativeRatePreciseRelativeToOtherBuffer) {
 	uint8_t result = delay.secondaryBuffer.init(newNativeRate, delay.primaryBuffer.size);
 	if (result == NO_ERROR) {
-		//Uart::print("new buffer, size: ");
-		//Uart::println(delay.secondaryBuffer.size);
+		//Debug::print("new buffer, size: ");
+		//Debug::println(delay.secondaryBuffer.size);
 
 		// 2 different options here for different scenarios. I can't very clearly remember how to describe the difference
 		if (makeNativeRatePreciseRelativeToOtherBuffer) {
-			//Uart::println("making precise");
+			//Debug::println("making precise");
 			delay.primaryBuffer.makeNativeRatePreciseRelativeToOtherBuffer(&delay.secondaryBuffer);
 		}
 		else {

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -33,7 +33,7 @@
 #include "model/note/note_vector.h"
 #include "model/action/action.h"
 #include "model/consequence/consequence_note_existence.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <string.h>
 #include "gui/views/timeline_view.h"
 #include "model/note/copied_note_row.h"
@@ -995,8 +995,8 @@ int NoteRow::editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareWidth
 			int32_t areaEndPosThisScreen = areaBeginPosThisScreen + squareWidthThisScreen;
 			if (areaEndPosThisScreen > effectiveLength) {
 				squareWidthThisScreen = effectiveLength - areaBeginPosThisScreen;
-				Uart::print("square width cut short: ");
-				Uart::println(newNumNotesThisScreen);
+				Debug::print("square width cut short: ");
+				Debug::println(newNumNotesThisScreen);
 
 				// If that's ended up 0 or negative, there's nothing for us to do. Though there'd probably be no harm if this check wasn't here, and in a perfect world
 				// maybe we'd check this before deciding how many search terms?
@@ -1177,7 +1177,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 	if (nudgeOffset >= 0 && (numScreens - 1) * wrapEditLevel + editPos + 1 == effectiveLength) {
 		Note* __restrict__ lastSourceNote = notes.getElement(numSourceNotes - 1);
 		if (lastSourceNote->pos == effectiveLength - 1) {
-			Uart::println("wrapping right");
+			Debug::println("wrapping right");
 			destNote = newNotes.getElement(nextIndexToCopyTo);
 			*destNote = *lastSourceNote;
 			destNote->pos = 0;
@@ -1194,7 +1194,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 			if (destNote->length > maxLength) {
 				// But only if that next note won't itself get nudged!
 				if (((uint32_t)nextSourceNote->pos % wrapEditLevel) != editPos) {
-					Uart::println("constraining length in right wrap");
+					Debug::println("constraining length in right wrap");
 					destNote->length = maxLength;
 				}
 			}
@@ -1244,7 +1244,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 
 				if (noteToNudge->pos == preNudgeNotePos) {
 					// Ok, we've got one we'll be nudging left.
-					Uart::println("nudging note left");
+					Debug::println("nudging note left");
 
 					if (preNudgeNotePos == 0) {
 						wrappingLeft = true;
@@ -1258,7 +1258,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 							int32_t postNudgeNotePos = preNudgeNotePos - 1;
 							int32_t maxLength = postNudgeNotePos - destNote->pos;
 							if (destNote->length > maxLength) {
-								Uart::println("constraining length of prev note");
+								Debug::println("constraining length of prev note");
 								destNote->length = maxLength;
 							}
 						}
@@ -1283,7 +1283,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 
 				// If there was a nudge note, it will be the last one we copied. If so...
 				if (destNote->pos == preNudgeNotePos) {
-					Uart::println("nudging note right");
+					Debug::println("nudging note right");
 
 					int32_t postNudgeNotePos = preNudgeNotePos + 1;
 					destNote->pos = postNudgeNotePos; // Nudge it
@@ -1308,11 +1308,11 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 					else { // Or if there's no more Notes, in which case wrap length
 						Note* __restrict__ firstNote = newNotes.getElement(0);
 						maxLength = firstNote->pos + effectiveLength - postNudgeNotePos;
-						Uart::println("potentially wrapping note length");
+						Debug::println("potentially wrapping note length");
 					}
 
 					if (destNote->length > maxLength) {
-						Uart::println("constraining right-nudged note length");
+						Debug::println("constraining right-nudged note length");
 						destNote->length = maxLength;
 					}
 				}
@@ -1340,7 +1340,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 
 	// If a nudged note wrapped around left
 	if (wrappingLeft) {
-		Uart::println("placing left-wrapped nudged note at end");
+		Debug::println("placing left-wrapped nudged note at end");
 
 		int32_t nudgedPos = effectiveLength - 1;
 
@@ -1372,11 +1372,11 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 	}
 	// Or a less extreme case where we just nudged the very first Note left and it didn't wrap - but we still need to check the final Note's length
 	else if (firstNoteGotNudgedLeft) {
-		Uart::println("checking cos first note got nudged left");
+		Debug::println("checking cos first note got nudged left");
 		Note* __restrict__ firstDestNote = newNotes.getElement(0);
 		int32_t maxLength = firstDestNote->pos + effectiveLength - destNote->pos;
 		if (destNote->length > maxLength) {
-			Uart::println("yup, constraining last note's length");
+			Debug::println("yup, constraining last note's length");
 			destNote->length = maxLength;
 		}
 	}
@@ -2048,8 +2048,8 @@ void NoteRow::attemptLateStartOfNextNoteToPlay(ModelStackWithNoteRow* modelStack
 
 	int32_t timeAgo = AudioEngine::audioSampleTimer - noteOnTime;
 
-	Uart::print("timeAgo: ");
-	Uart::println(timeAgo);
+	Debug::print("timeAgo: ");
+	Debug::println(timeAgo);
 
 	if (timeAgo < 0) { // Gregory J got this. And Vinz
 #if ALPHA_OR_BETA_VERSION
@@ -2087,7 +2087,7 @@ void NoteRow::attemptLateStartOfNextNoteToPlay(ModelStackWithNoteRow* modelStack
 	             sound->allowsVeryLateNoteStart(((InstrumentClip*)modelStack->getTimelineCounter()), thisParamManager)))
 	    || timeAgo < noteOnLatenessAllowed) {
 
-		Uart::println("doing late");
+		Debug::println("doing late");
 
 		if (!allows) {
 			swungTicksBeforeLastActionedOne = 0;
@@ -2750,7 +2750,7 @@ int NoteRow::readFromFile(int* minY, InstrumentClip* parentClip, Song* song, int
 	    -1; // Temp variable for this because we can't actually create the expressionParams before we know what kind of Drum (if any) we have.
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
-		//Uart::println(tagName); delayMS(50);
+		//Debug::println(tagName); delayMS(50);
 
 		uint16_t noteHexLength;
 

--- a/src/deluge/model/note/note_vector.cpp
+++ b/src/deluge/model/note/note_vector.cpp
@@ -19,7 +19,7 @@
 #include "RZA1/system/r_typedefs.h"
 #include "model/note/note.h"
 #include <string.h>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 NoteVector::NoteVector() : OrderedResizeableArrayWith32bitKey(sizeof(Note)) {
 }

--- a/src/deluge/model/sample/sample_cache.cpp
+++ b/src/deluge/model/sample/sample_cache.cpp
@@ -18,7 +18,7 @@
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 #include "model/sample/sample_cache.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "hid/display/numeric_driver.h"
 #include "model/sample/sample.h"
 #include "memory/general_memory_allocator.h"
@@ -56,7 +56,7 @@ void SampleCache::clusterStolen(int clusterIndex) {
 	}
 #endif
 
-	Uart::println("cache Cluster stolen");
+	Debug::println("cache Cluster stolen");
 
 	// There's now no point in having any further Clusters
 	unlinkClusters(clusterIndex + 1, false); // Must do this before changing writeBytePos
@@ -136,7 +136,7 @@ void SampleCache::setWriteBytePos(int newWriteBytePos) {
 // Does not move the new Cluster to the appropriate "availability queue", because it's expected that the caller is just about to call getCluster(), to get it,
 // which will call prioritizeNotStealingCluster(), and that'll do it
 bool SampleCache::setupNewCluster(int clusterIndex) {
-	//Uart::println("writing cache to new Cluster");
+	//Debug::println("writing cache to new Cluster");
 
 #if ALPHA_OR_BETA_VERSION
 	if (clusterIndex >= numClusters) {
@@ -150,7 +150,7 @@ bool SampleCache::setupNewCluster(int clusterIndex) {
 	clusters[clusterIndex] = audioFileManager.allocateCluster(
 	    CLUSTER_SAMPLE_CACHE, false, this); // Do not add reasons, and don't steal from this SampleCache
 	if (!clusters[clusterIndex]) {          // If that allocation failed...
-		Uart::println("allocation fail");
+		Debug::println("allocation fail");
 		return false;
 	}
 

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -18,7 +18,7 @@
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 #include "model/sample/sample_cluster.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "util/functions.h"
 #include "model/sample/sample.h"
 #include "hid/display/numeric_driver.h"
@@ -43,8 +43,8 @@ SampleCluster::~SampleCluster() {
 		}
 
 		if (numReasonsToBeLoaded) {
-			Uart::print("uh oh, some reasons left... ");
-			Uart::println(numReasonsToBeLoaded);
+			Debug::print("uh oh, some reasons left... ");
+			Debug::println(numReasonsToBeLoaded);
 
 			numericDriver.freezeWithError(
 			    "E036"); // Bay_Mud got this, and thinks a FlashAir card might have been a catalyst. It still "shouldn't" be able to happen though.
@@ -57,9 +57,9 @@ SampleCluster::~SampleCluster() {
 void SampleCluster::ensureNoReason(Sample* sample) {
 	if (cluster) {
 		if (cluster->numReasonsToBeLoaded) {
-			Uart::print("Cluster has reason! ");
-			Uart::println(cluster->numReasonsToBeLoaded);
-			Uart::println(sample->filePath.get());
+			Debug::print("Cluster has reason! ");
+			Debug::println(cluster->numReasonsToBeLoaded);
+			Debug::println(sample->filePath.get());
 
 			if (cluster->numReasonsToBeLoaded >= 0) {
 				numericDriver.freezeWithError("E068");
@@ -86,18 +86,18 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int lo
 
 		// If the file can no longer be found on the card, we're in trouble
 		if (sample->unloadable) {
-			Uart::println("unloadable");
+			Debug::println("unloadable");
 			if (error) {
 				*error = ERROR_FILE_NOT_FOUND;
 			}
 			return NULL;
 		}
 
-		//Uart::println("loading");
+		//Debug::println("loading");
 		cluster = audioFileManager.allocateCluster(); // Adds 1 reason
 
 		if (!cluster) {
-			Uart::println("couldn't allocate");
+			Debug::println("couldn't allocate");
 			if (error) {
 				*error = ERROR_INSUFFICIENT_RAM;
 			}
@@ -190,8 +190,8 @@ justEnqueue:
 
 			// If it's still not loaded and it was a must-load-now...
 			if (loadInstruction == CLUSTER_LOAD_IMMEDIATELY && !cluster->loaded) {
-				Uart::print("hurrying loading along failed for index: ");
-				Uart::println(clusterIndex);
+				Debug::print("hurrying loading along failed for index: ");
+				Debug::println(clusterIndex);
 				if (error) {
 					*error = ERROR_UNSPECIFIED; // TODO: get actual error
 				}

--- a/src/deluge/model/sample/sample_holder.cpp
+++ b/src/deluge/model/sample/sample_holder.cpp
@@ -22,7 +22,7 @@
 #include "model/sample/sample.h"
 #include "hid/display/numeric_driver.h"
 #include "util/functions.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 SampleHolder::SampleHolder() {
 	startPos = 0;
@@ -207,10 +207,10 @@ void SampleHolder::claimClusterReasonsForMarker(Cluster** clusters, uint32_t sta
 		newClusters[l] = sampleCluster->getCluster(((Sample*)audioFile), clusterIndex, clusterLoadInstruction);
 
 		if (!newClusters[l]) {
-			Uart::println("NULL!!");
+			Debug::println("NULL!!");
 		}
 		else if (clusterLoadInstruction == CLUSTER_LOAD_IMMEDIATELY_OR_ENQUEUE && !newClusters[l]->loaded) {
-			Uart::println("not loaded!!");
+			Debug::println("not loaded!!");
 		}
 
 		clusterIndex += playDirection;

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -21,7 +21,7 @@
 #include "model/sample/sample_low_level_reader.h"
 #include "model/sample/sample.h"
 #include "storage/cluster/cluster.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "storage/audio/audio_file_manager.h"
 #include "hid/display/numeric_driver.h"
 #include "model/voice/voice_sample_playback_guide.h"
@@ -102,7 +102,7 @@ void SampleLowLevelReader::realignPlaybackParameters(Sample* sample) {
 // (though it'd be harmless for "natively" playing Samples). Caller must ensure safety here.
 bool SampleLowLevelReader::reassessReassessmentLocation(SamplePlaybackGuide* guide, Sample* sample,
                                                         int priorityRating) {
-	//Uart::println("reassessing");
+	//Debug::println("reassessing");
 
 	if (!clusters[0]) {
 		return true; // Is this for if we've gone past the end of the audio data, while re-pitching / interpolating?
@@ -116,7 +116,7 @@ bool SampleLowLevelReader::reassessReassessmentLocation(SamplePlaybackGuide* gui
 	// This needs correcting, so "looping" can occur at next render. Must happen before setupReassessmentLocation() is called.
 	int finalClusterIndex = guide->getFinalClusterIndex(sample, shouldObeyMarkers());
 	if ((clusterIndex - finalClusterIndex) * guide->playDirection > 0) {
-		Uart::println("saving from being past finalCluster");
+		Debug::println("saving from being past finalCluster");
 		Cluster* finalCluster = sample->clusters.getElement(finalClusterIndex)->cluster;
 		if (!finalCluster) {
 			return false;
@@ -132,7 +132,7 @@ bool SampleLowLevelReader::reassessReassessmentLocation(SamplePlaybackGuide* gui
 	unassignAllReasons(); // Can only do this after we've done the above stuff, which references clusters, which this will clear
 	bool success = assignClusters(guide, sample, clusterIndex, priorityRating);
 	if (!success) {
-		Uart::println("reassessReassessmentLocation fail");
+		Debug::println("reassessReassessmentLocation fail");
 		return false;
 	}
 	setupReassessmentLocation(guide, sample);
@@ -264,7 +264,7 @@ bool SampleLowLevelReader::setupClusersForInitialPlay(SamplePlaybackGuide* guide
 	bool success = setupClustersForPlayFromByte(guide, sample, startPlaybackAtByte, priorityRating);
 
 	if (!success) {
-		Uart::println("setupClustersForInitialPlay fail");
+		Debug::println("setupClustersForInitialPlay fail");
 	}
 
 	return success;
@@ -288,9 +288,9 @@ bool SampleLowLevelReader::setupClustersForPlayFromByte(SamplePlaybackGuide* gui
 
 	bool success = assignClusters(guide, sample, clusterIndex, priorityRating);
 	if (!success) {
-		Uart::println("setupClustersForPlayFromByte fail");
-		Uart::print("byte: ");
-		Uart::println(startPlaybackAtByte);
+		Debug::println("setupClustersForPlayFromByte fail");
+		Debug::print("byte: ");
+		Debug::println(startPlaybackAtByte);
 		return false;
 	}
 
@@ -356,17 +356,17 @@ bool SampleLowLevelReader::moveOnToNextCluster(SamplePlaybackGuide* guide, Sampl
 
 	// First things first - if there is no next Cluster or it's not loaded...
 	if (!clusters[0]) {
-		Uart::print("reached end of waveform. last Cluster was: ");
-		Uart::println(oldClusterIndex);
+		Debug::print("reached end of waveform. last Cluster was: ");
+		Debug::println(oldClusterIndex);
 		currentPlayPos = 0;
 		return false;
 	}
 
 	if (!clusters[0]->loaded) {
-		Uart::print("late ");
-		Uart::print(clusters[0]->sample->filePath.get());
-		Uart::print(" p ");
-		Uart::println(clusters[0]->clusterIndex);
+		Debug::print("late ");
+		Debug::print(clusters[0]->sample->filePath.get());
+		Debug::print(" p ");
+		Debug::println(clusters[0]->clusterIndex);
 
 		return false;
 	}
@@ -427,7 +427,7 @@ bool SampleLowLevelReader::changeClusterIfNecessary(SamplePlaybackGuide* guide, 
 		if (reassessmentAction == REASSESSMENT_ACTION_NEXT_CLUSTER) {
 			bool success = moveOnToNextCluster(guide, sample, priorityRating);
 			if (!success) {
-				Uart::println("next failed");
+				Debug::println("next failed");
 				return false;
 			}
 		}
@@ -436,7 +436,7 @@ bool SampleLowLevelReader::changeClusterIfNecessary(SamplePlaybackGuide* guide, 
 			if (loopingAtLowLevel) {
 				bool success = setupClusersForInitialPlay(guide, sample, byteOvershoot, true, priorityRating);
 				if (!success) {
-					Uart::println("loop failed");
+					Debug::println("loop failed");
 					// TODO: shouldn't we set currentPlayPos = 0 here too?
 					return false;
 				}
@@ -542,7 +542,7 @@ void SampleLowLevelReader::jumpBackSamples(Sample* sample, int numToJumpBack, in
 
 		// If there was no valid audio data there...
 		if (bytesPastClusterStart < 0) {
-			Uart::println("failed to go back!");
+			Debug::println("failed to go back!");
 			break;
 		}
 
@@ -861,8 +861,8 @@ doZeroes:
 			*numSamples = (uint32_t)bytesLeftWhichMayBeRead / (uint8_t)bytesPerSample;
 
 			if (ALPHA_OR_BETA_VERSION && *numSamples <= 0) {
-				Uart::print("bytesLeftWhichMayBeRead: ");
-				Uart::println(bytesLeftWhichMayBeRead);
+				Debug::print("bytesLeftWhichMayBeRead: ");
+				Debug::println(bytesLeftWhichMayBeRead);
 				numericDriver.freezeWithError(
 				    "E147"); // Crazily, Michael B got in Nov 2022, when "closing" a recorded loop.
 			}
@@ -1238,7 +1238,7 @@ bool SampleLowLevelReader::readSamplesForTimeStretching(int32_t* outputBuffer, S
 				return false;
 			}
 
-			//Uart::println("one head no longer active for timeStretcher");
+			//Debug::println("one head no longer active for timeStretcher");
 			break;
 		}
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -38,7 +38,7 @@
 #include <string.h>
 #include "gui/views/session_view.h"
 #include "playback/playback_handler.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "io/midi/midi_engine.h"
 #include "memory/general_memory_allocator.h"
 #include "playback/mode/session.h"
@@ -1188,8 +1188,8 @@ int Song::readFromFile() {
 
 	outputClipInstanceListIsCurrentlyInvalid = true;
 
-	Uart::println("");
-	Uart::println("loading song!!!!!!!!!!!!!!");
+	Debug::println("");
+	Debug::println("loading song!!!!!!!!!!!!!!");
 
 	char const* tagName;
 
@@ -1200,7 +1200,7 @@ int Song::readFromFile() {
 	uint64_t newTimePerTimerTick = (uint64_t)1 << 32; // TODO: make better!
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
-		//Uart::println(tagName); delayMS(30);
+		//Debug::println(tagName); delayMS(30);
 		switch (*(uint32_t*)tagName) {
 
 		// "reverb"
@@ -1680,8 +1680,8 @@ loadOutput:
 						return result;
 					}
 					if (ALPHA_OR_BETA_VERSION) {
-						Uart::print("unknown tag: ");
-						Uart::println(tagName);
+						Debug::print("unknown tag: ");
+						Debug::println(tagName);
 					}
 					storageManager.exitTag(tagName);
 				}
@@ -1751,7 +1751,7 @@ traverseClips:
 
 	anyOutputsSoloingInArrangement = false;
 
-	Uart::println("aaa1");
+	Debug::println("aaa1");
 
 	// Match all ClipInstances up with their Clip. And while we're at it, check if any Outputs are soloing in arranger
 	for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
@@ -1827,7 +1827,7 @@ skipInstance:
 
 	outputClipInstanceListIsCurrentlyInvalid = false; // All clipInstances are valid now.
 
-	Uart::println("aaa2");
+	Debug::println("aaa2");
 
 	// Ensure no arrangement-only Clips with no ClipInstance
 	// For each Clip in arrangement
@@ -1864,7 +1864,7 @@ skipInstance:
 		setInputTickScaleClip(newInputTickScaleClip);
 	}
 
-	Uart::println("aaa3");
+	Debug::println("aaa3");
 	AudioEngine::logAction("aaa3.1");
 
 	AudioEngine::routineWithClusterLoading(); // -----------------------------------
@@ -4976,7 +4976,7 @@ void Song::cullAudioClipVoice() {
 
 	if (bestClip) {
 		bestClip->unassignVoiceSample();
-		Uart::println("audio clip voice culled!");
+		Debug::println("audio clip voice culled!");
 	}
 }
 

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -40,7 +40,7 @@
 #include <new>
 #include "arm_neon.h"
 #include "util/lookuptables/lookuptables.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/model_stack.h"
 #include "model/sample/sample_holder_for_voice.h"
 #include "processing/render_wave.h"
@@ -630,7 +630,7 @@ bool Voice::sampleZoneChanged(ModelStackWithVoice* modelStack, int s, int marker
 			bool stillActive = voiceUnisonPartSource->voiceSample->sampleZoneChanged(&guides[s], sample, markerType,
 			                                                                         loopingType, getPriorityRating());
 			if (!stillActive) {
-				Uart::println("returned false ---------");
+				Debug::println("returned false ---------");
 				voiceUnisonPartSource->unassign();
 			}
 			else {
@@ -1997,7 +1997,7 @@ pitchTooHigh:
 
 #ifdef TEST_SAMPLE_LOOP_POINTS
 			if (!(getNoise() >> 19)) {
-				//Uart::println("random change");
+				//Debug::println("random change");
 
 				int r = getRandom255();
 
@@ -2020,7 +2020,7 @@ pitchTooHigh:
 					sound->recalculateAllVoicePhaseIncrements(paramManager);
 				}
 
-				//Uart::println("end random change");
+				//Debug::println("end random change");
 			}
 #endif
 
@@ -2196,7 +2196,7 @@ dontUseCache : {}
 
 						if (memory) {
 							source->livePitchShifter = new (memory) LivePitchShifter(inputTypeNow, phaseIncrement);
-							Uart::println("start pitch shifting");
+							Debug::println("start pitch shifting");
 						}
 					}
 				}
@@ -2205,7 +2205,7 @@ dontUseCache : {}
 			// If not pitch shifting and we were previously...
 			else {
 				if (source->livePitchShifter && source->livePitchShifter->mayBeRemovedWithoutClick()) {
-					Uart::println("stop pitch shifting");
+					Debug::println("stop pitch shifting");
 					source->livePitchShifter->~LivePitchShifter();
 					generalMemoryAllocator.dealloc(source->livePitchShifter);
 					source->livePitchShifter = NULL;

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -52,7 +52,6 @@
 extern "C" {
 #include "drivers/ssi/ssi.h"
 #include "RZA1/mtu/mtu.h"
-#include "drivers/uart/uart.h"
 }
 
 int32_t spareRenderingBuffer[3][SSI_TX_BUFFER_NUM_SAMPLES] __attribute__((aligned(CACHE_LINE_SIZE)));

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -37,10 +37,6 @@
 #include "modulation/params/param_collection.h"
 #include "gui/views/view.h"
 
-extern "C" {
-#include "drivers/uart/uart.h"
-}
-
 #define SAMPLES_TO_CLEAR_AFTER_RECORD 8820          // 200ms
 #define SAMPLES_TO_IGNORE_AFTER_BEGIN_OVERRIDE 9200 // 200ms + a bit
 #define TIME_TO_INTERPOLATE_WITHIN 6615             // 150ms

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -18,7 +18,7 @@
 #include "processing/engines/audio_engine.h"
 #include "model/clip/instrument_clip.h"
 #include "modulation/automation/auto_param.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "playback/playback_handler.h"
 #include "util/functions.h"
 #include "modulation/params/param_node.h"
@@ -425,14 +425,14 @@ int32_t AutoParam::processCurrentPos(ModelStackWithAutoParam const* modelStack, 
 	// Ok, if we're here, we just reached the node!
 
 	/*
-		Uart::println("");
-		Uart::print("at node: ");
-		Uart::print(nodeJustReached->pos);
-		Uart::print(", ");
-		Uart::print(nodeJustReached->value);
-		if (nodeJustReached->interpolated) Uart::print(", interp");
-		Uart::println("");
-		if (renewedOverridingAtTime) Uart::println("overriding");
+		Debug::println("");
+		Debug::print("at node: ");
+		Debug::print(nodeJustReached->pos);
+		Debug::print(", ");
+		Debug::print(nodeJustReached->value);
+		if (nodeJustReached->interpolated) Debug::print(", interp");
+		Debug::println("");
+		if (renewedOverridingAtTime) Debug::println("overriding");
 	*/
 
 	// Stop any pre-existing interpolation (though we might set up some more, below)
@@ -517,7 +517,7 @@ int32_t AutoParam::processCurrentPos(ModelStackWithAutoParam const* modelStack, 
 		if (shouldCancelOverridingNow) {
 yesCancelOverriding:
 			renewedOverridingAtTime = 0;
-			Uart::println("cancel overriding, basic way");
+			Debug::println("cancel overriding, basic way");
 		}
 
 		// Otherwise...
@@ -629,12 +629,12 @@ recordOverNodeJustReached:
 								renewedOverridingAtTime = 0xFFFFFFFF;
 							}
 						}
-						Uart::println("cancel latching");
+						Debug::println("cancel latching");
 					}
 				}
 
 adjustNodeJustReached:
-				//Uart::println("adjusting node value");
+				//Debug::println("adjusting node value");
 				if (!didPinpong) {
 					nodeJustReached->value = currentValue;
 				}
@@ -660,10 +660,10 @@ adjustNodeJustReached:
 						nextNodeInOurDirection->interpolated = newNodeShouldBeInterpolated;
 
 						/*
-						Uart::print("new one: ");
-						Uart::print(posOverridingEnds);
-						Uart::print(", ");
-						Uart::println(valueOverridingEnds);
+						Debug::print("new one: ");
+						Debug::print(posOverridingEnds);
+						Debug::print(", ");
+						Debug::println(valueOverridingEnds);
 						*/
 						if (!reversed) {
 							needToReGetNextNode = deleteRedundantNodeInLinearRun(
@@ -1870,7 +1870,7 @@ int AutoParam::readFromFile(int32_t readAutomationUpToPos) {
 
 			// Ensure there isn't some problem where nodes are out of order...
 			if (pos <= prevPos) {
-				Uart::println("Automation nodes out of order");
+				Debug::println("Automation nodes out of order");
 				continue;
 			}
 

--- a/src/deluge/modulation/envelope.cpp
+++ b/src/deluge/modulation/envelope.cpp
@@ -19,7 +19,7 @@
 #include "processing/sound/sound.h"
 #include "modulation/envelope.h"
 #include "model/voice/voice.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 Envelope::Envelope() {
 }

--- a/src/deluge/modulation/params/param_node_vector.cpp
+++ b/src/deluge/modulation/params/param_node_vector.cpp
@@ -19,7 +19,7 @@
 
 #include "RZA1/system/r_typedefs.h"
 #include <string.h>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "modulation/params/param_node.h"
 
 ParamNodeVector::ParamNodeVector() : OrderedResizeableArrayWith32bitKey(sizeof(ParamNode)) {

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -30,10 +30,6 @@
 #include "memory/general_memory_allocator.h"
 #include "io/midi/midi_device.h"
 
-extern "C" {
-#include "drivers/uart/uart.h"
-}
-
 void flagCable(uint32_t* flags, int c) {
 	flags[
 #if NUM_UINTS_TO_REP_PATCH_CABLES > 1

--- a/src/deluge/modulation/patch/patcher.cpp
+++ b/src/deluge/modulation/patch/patcher.cpp
@@ -20,7 +20,7 @@
 #include "processing/sound/sound.h"
 #include "model/voice/voice.h"
 #include "modulation/patch/patch_cable_set.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 extern "C" {
 #include "RZA1/mtu/mtu.h"
@@ -388,7 +388,7 @@ void Patcher::performInitialPatching(Sound* sound, ParamManager* paramManager) {
 
 	uint32_t timePassedUSA = timerCountToUS(duration);
 
-	Uart::print("duration, uSec: ");
-	Uart::println(timePassedUSA);
+	Debug::print("duration, uSec: ");
+	Debug::println(timePassedUSA);
 */
 }

--- a/src/deluge/modulation/patch/patcher.cpp
+++ b/src/deluge/modulation/patch/patcher.cpp
@@ -20,10 +20,10 @@
 #include "processing/sound/sound.h"
 #include "model/voice/voice.h"
 #include "modulation/patch/patch_cable_set.h"
+#include "io/uart/uart.h"
 
 extern "C" {
 #include "RZA1/mtu/mtu.h"
-#include "drivers/uart/uart.h"
 }
 
 Patcher::Patcher(const PatchableInfo* newInfo) : patchableInfo(newInfo) {
@@ -383,14 +383,12 @@ void Patcher::performInitialPatching(Sound* sound, ParamManager* paramManager) {
 		}
 	}
 	/*
-	}
-
 	uint16_t endTime = *TCNT[TIMER_SYSTEM_FAST];
 	uint16_t duration = endTime - startTime;
 
 	uint32_t timePassedUSA = timerCountToUS(duration);
 
-	uartPrint("duration, uSec: ");
-	uartPrintNumber(timePassedUSA);
+	Uart::print("duration, uSec: ");
+	Uart::println(timePassedUSA);
 */
 }

--- a/src/deluge/playback/mode/arrangement.cpp
+++ b/src/deluge/playback/mode/arrangement.cpp
@@ -24,7 +24,7 @@
 #include "playback/mode/arrangement.h"
 #include "model/song/song.h"
 #include "playback/playback_handler.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/instrument/instrument.h"
 #include "gui/ui/ui.h"
 #include "gui/views/view.h"

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -28,7 +28,7 @@
 #include "playback/playback_handler.h"
 #include "gui/views/view.h"
 #include "model/note/note_row.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/drum/drum.h"
 #include "model/action/action_logger.h"
 #include "model/action/action.h"
@@ -1302,7 +1302,7 @@ int Session::investigateSyncedLaunch(Clip* waitForClip, uint32_t* currentPosWith
 
 // Returns whether we are now armed. If not, it means it's just done the swap already in this function
 bool Session::armForSongSwap() {
-	Uart::println("Session::armForSongSwap()");
+	Debug::println("Session::armForSongSwap()");
 
 	Clip* waitForClip = currentSong->getLongestClip(false, true);
 
@@ -1323,8 +1323,8 @@ bool Session::armForSongSwap() {
 		int32_t pos = currentPosWithinQuantization % quantization;
 		int32_t ticksTilSwap = quantization - pos;
 		scheduleLaunchTiming(playbackHandler.getActualSwungTickCount() + ticksTilSwap, 1, quantization);
-		Uart::print("ticksTilSwap: ");
-		Uart::println(ticksTilSwap);
+		Debug::print("ticksTilSwap: ");
+		Debug::println(ticksTilSwap);
 	}
 	else if (launchStatus == LAUNCH_STATUS_LAUNCH_ALONG_WITH_EXISTING_LAUNCHING) {
 		// Nothing to do!

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -53,7 +53,7 @@
 #include "hid/led/indicator_leds.h"
 #include "storage/flash_storage.h"
 #include "hid/buttons.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "processing/metronome/metronome.h"
 #include "model/model_stack.h"
 #include "io/midi/midi_device.h"
@@ -135,7 +135,7 @@ void PlaybackHandler::slowRoutine() {
 	// See if any MIDI commands are pending which couldn't be actioned before (see comments in tryGlobalMIDICommands())
 	if (pendingGlobalMIDICommand != -1 && !currentlyAccessingCard) {
 
-		Uart::println("actioning pending command -----------------------------------------");
+		Debug::println("actioning pending command -----------------------------------------");
 
 		if (actionLogger.allowedToDoReversion()) {
 
@@ -1340,7 +1340,7 @@ void PlaybackHandler::setupPlaybackUsingExternalClock(bool switchingFromInternal
 }
 
 void PlaybackHandler::positionPointerReceived(uint8_t data1, uint8_t data2) {
-	Uart::println("position");
+	Debug::println("position");
 	unsigned int pos = (((unsigned int)data2 << 7) | data1) * 6;
 
 	if (currentSong->insideWorldTickMagnitude >= 0) {
@@ -1371,7 +1371,7 @@ void PlaybackHandler::startMessageReceived() {
 	if (ignoringMidiClockInput || !midiInClockEnabled) {
 		return;
 	}
-	Uart::println("start");
+	Debug::println("start");
 	// If we already are playing
 	if (playbackState) {
 
@@ -1393,7 +1393,7 @@ bool PlaybackHandler::startIgnoringMidiClockInputIfNecessary() {
 
 	if ((playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE)
 	    && (int32_t)(AudioEngine::audioSampleTimer - timeLastMIDIStartOrContinueMessageSent) < 50 * 44) {
-		Uart::println("ignoring midi clock input");
+		Debug::println("ignoring midi clock input");
 		ignoringMidiClockInput = true;
 		return true;
 	}
@@ -1408,7 +1408,7 @@ void PlaybackHandler::continueMessageReceived() {
 		return;
 	}
 
-	Uart::println("continue");
+	Debug::println("continue");
 	// If we already are playing
 	if (playbackState) {
 
@@ -1443,7 +1443,7 @@ void PlaybackHandler::clockMessageReceived(uint32_t time) {
 	if (ignoringMidiClockInput || !midiInClockEnabled) {
 		return;
 	}
-	//Uart::println("clock");
+	//Debug::println("clock");
 
 	if (playbackState) {
 		inputTick(false, time);
@@ -1583,8 +1583,8 @@ void PlaybackHandler::inputTick(bool fromTriggerClock, uint32_t time) {
 			// If we've done this enough times, don't do it again
 			if (lastInputTickReceived >= numInputTicksToAllowTempoTargeting) {
 				tempoMagnitudeMatchingActiveNow = false;
-				Uart::print("finished tempo magnitude matching. magnitude = ");
-				Uart::println(currentSong->insideWorldTickMagnitude);
+				Debug::print("finished tempo magnitude matching. magnitude = ");
+				Debug::println(currentSong->insideWorldTickMagnitude);
 			}
 		}
 	}
@@ -1595,8 +1595,8 @@ void PlaybackHandler::inputTick(bool fromTriggerClock, uint32_t time) {
 	if (lastInputTickReceived != 0) {
 		uint32_t timeLastInputTickTook = timeThisInputTick - timeLastInputTicks[0];
 
-		Uart::print("time since last: ");
-		Uart::println(timeLastInputTickTook);
+		Debug::print("time since last: ");
+		Debug::println(timeLastInputTickTook);
 
 		uint32_t internalTicksPer;
 		uint32_t inputTicksPer;
@@ -1627,8 +1627,8 @@ void PlaybackHandler::inputTick(bool fromTriggerClock, uint32_t time) {
 		// 5% = 1127428915
 		if ((lowpassedTimePerInternalTick >> 2) > multiply_32x32_rshift32(1127428915, stickyTimePerInternalTick)
 		    || (stickyTimePerInternalTick >> 2) > multiply_32x32_rshift32(1127428915, lowpassedTimePerInternalTick)) {
-			//Uart::println("5% tempo jump");
-			//Uart::println(lowpassedTimePerInternalTick);
+			//Debug::println("5% tempo jump");
+			//Debug::println(lowpassedTimePerInternalTick);
 			slowpassedTimePerInternalTick = lowpassedTimePerInternalTick << slowpassedTimePerInternalTickSlowness;
 			stickyTimePerInternalTick = lowpassedTimePerInternalTick;
 
@@ -1638,7 +1638,7 @@ void PlaybackHandler::inputTick(bool fromTriggerClock, uint32_t time) {
 		             > multiply_32x32_rshift32(1084479242, stickyTimePerInternalTick)
 		         || (stickyTimePerInternalTick >> 2) > multiply_32x32_rshift32(
 		                1084479242, slowpassedTimePerInternalTick >> slowpassedTimePerInternalTickSlowness)) {
-			//Uart::println("1% tempo jump");
+			//Debug::println("1% tempo jump");
 			stickyTimePerInternalTick = lowpassedTimePerInternalTick =
 			    slowpassedTimePerInternalTick >> slowpassedTimePerInternalTickSlowness;
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -50,7 +50,7 @@
 #include "dsp/master_compressor/master_compressor.h"
 #include "model/voice/voice_vector.h"
 #include "definitions.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "modulation/patch/patch_cable_set.h"
 #include "modulation/params/param_set.h"
 
@@ -274,8 +274,8 @@ Voice* cullVoice(bool saveVoice, bool justDoFastRelease) {
 				}
 
 #if ALPHA_OR_BETA_VERSION
-				Uart::print("soft-culled 1 voice. voices now: ");
-				Uart::println(getNumVoices());
+				Debug::print("soft-culled 1 voice. voices now: ");
+				Debug::println(getNumVoices());
 #endif
 			}
 			// Otherwise, it's already fast-releasing, so just leave it
@@ -340,7 +340,7 @@ void routine() {
 	bool finishedOutputting = doSomeOutputting();
 	if (!finishedOutputting) {
 		logAction("AudioDriver::still outputting");
-		//Uart::println("still waiting");
+		//Debug::println("still waiting");
 		return;
 	}
 
@@ -426,13 +426,13 @@ void routine() {
 				}
 
 #if ALPHA_OR_BETA_VERSION
-				Uart::print("culled ");
-				Uart::print(numToCull);
-				Uart::print(" voices. numSamples: ");
-				Uart::print(numSamples);
+				Debug::print("culled ");
+				Debug::print(numToCull);
+				Debug::print(" voices. numSamples: ");
+				Debug::print(numSamples);
 
-				Uart::print(". voices left: ");
-				Uart::println(getNumVoices());
+				Debug::print(". voices left: ");
+				Debug::println(getNumVoices());
 #endif
 			}
 
@@ -444,8 +444,8 @@ void routine() {
 		else {
 			int numSamplesOverLimit = numSamples - numSamplesLimit;
 			if (numSamplesOverLimit >= 0) {
-				Uart::print("Won't cull, but numSamples is ");
-				Uart::println(numSamples);
+				Debug::print("Won't cull, but numSamples is ");
+				Debug::println(numSamples);
 			}
 		}
 	}
@@ -459,8 +459,8 @@ void routine() {
 				cpuDireness = 0;
 			}
 			else {
-				//Uart::print("direness: ");
-				//Uart::println(cpuDireness);
+				//Debug::print("direness: ");
+				//Debug::println(cpuDireness);
 			}
 		}
 	}
@@ -602,10 +602,10 @@ startAgain:
 
 		usageTimes[REPORT_AVERAGE_NUM - 1] = value;
 
-		Uart::print("uS per ");
-		Uart::print(NUM_SAMPLES_FOR_CPU_USAGE_REPORT * 10);
-		Uart::print(" samples: ");
-		Uart::println(total / REPORT_AVERAGE_NUM);
+		Debug::print("uS per ");
+		Debug::print(NUM_SAMPLES_FOR_CPU_USAGE_REPORT * 10);
+		Debug::print(" samples: ");
+		Debug::println(total / REPORT_AVERAGE_NUM);
 	}
 #endif
 
@@ -768,10 +768,10 @@ startAgain:
 
 	/*
     if (!getRandom255()) {
-    	Uart::print("samples: ");
-        Uart::print(numSamples);
-    	Uart::print(". voices: ");
-    	Uart::println(getNumVoices());
+    	Debug::print("samples: ");
+        Debug::print(numSamples);
+    	Debug::print(". voices: ");
+    	Debug::println(getNumVoices());
     }
 */
 
@@ -830,17 +830,17 @@ startAgain:
 	uint16_t timePassedA = (uint16_t)currentTime - lastRoutineTime;
 	uint32_t timePassedUSA = fastTimerCountToUS(timePassedA);
 	if (timePassedUSA > storageManager.devVarA * 10) {
-		Uart::println("");
+		Debug::println("");
 		for (int i = 0; i < numAudioLogItems; i++) {
 			uint16_t timePassed = (uint16_t)audioLogTimes[i] - lastRoutineTime;
 			uint32_t timePassedUS = fastTimerCountToUS(timePassed);
-			Uart::print(timePassedUS);
-			Uart::print(": ");
-			Uart::println(audioLogStrings[i]);
+			Debug::print(timePassedUS);
+			Debug::print(": ");
+			Debug::println(audioLogStrings[i]);
 		}
 
-		Uart::print(timePassedUSA);
-		Uart::println(": end");
+		Debug::print(timePassedUSA);
+		Debug::println(": end");
 	}
 
 	lastRoutineTime = *TCNT[TIMER_SYSTEM_FAST];
@@ -1160,7 +1160,7 @@ Voice* solicitVoice(Sound* forSound) {
 
 		numSamplesLastTime -=
 		    10; // Stop this triggering for lots of new voices. We just don't know how they'll weigh up to the ones being culled
-		Uart::println("soliciting via culling");
+		Debug::println("soliciting via culling");
 doCull:
 		newVoice = cullVoice(true);
 	}
@@ -1336,7 +1336,7 @@ void doRecorderCardRoutines() {
 
 		// If complete, discard it
 		if (recorder->status == RECORDER_STATUS_AWAITING_DELETION) {
-			Uart::println("deleting recorder");
+			Debug::println("deleting recorder");
 			*prevPointer = recorder->next;
 			recorder->~SampleRecorder();
 			generalMemoryAllocator.dealloc(recorder);

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -17,7 +17,7 @@
 
 #include "processing/engines/audio_engine.h"
 #include "processing/engines/cv_engine.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <string.h>
 #include <math.h>
 #include "util/functions.h"

--- a/src/deluge/processing/live/live_pitch_shifter.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter.cpp
@@ -22,7 +22,7 @@
 #include "storage/storage_manager.h"
 #include "dsp/timestretch/time_stretcher.h"
 #include <stdlib.h>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "util/functions.h"
 
 //#define MEASURE_HOP_END_PERFORMANCE 1
@@ -141,24 +141,24 @@ startRenderAgain:
 			nextCrossfadeLength = getMin(nextCrossfadeLength, maxTotalPlayable >> 1);
 
 			samplesTilHopEnd = maxPlayableSamplesNewer - nextCrossfadeLength;
-			//Uart::println("shortening hop");
+			//Debug::println("shortening hop");
 
 			if (samplesTilHopEnd < 0) {
 				samplesTilHopEnd = 0;
 				nextCrossfadeLength = getMax(maxPlayableSamplesNewer, 0);
-				//Uart::println("nex");
+				//Debug::println("nex");
 				crossfadeProgress = 16777216;
 			}
 
 			else if (samplesTilHopEnd == 0) {
-				//Uart::println("to zero");
+				//Debug::println("to zero");
 			}
 
 			else if (samplesTilHopEnd > 0 && olderPlayHeadIsCurrentlySounding()) {
 				uint32_t minCrossfadeIncrement = (uint32_t)(16777216 - crossfadeProgress) / samplesTilHopEnd + 1;
 				if (minCrossfadeIncrement > crossfadeIncrement) {
 					crossfadeIncrement = minCrossfadeIncrement;
-					//Uart::println("d");
+					//Debug::println("d");
 				}
 			}
 		}
@@ -171,7 +171,7 @@ startRenderAgain:
 			    0,
 #endif
 			    liveInputBuffer, phaseIncrement);
-			//Uart::println(maxPlayableSamplesOlder);
+			//Debug::println(maxPlayableSamplesOlder);
 			if (!maxPlayableSamplesOlder) {
 				crossfadeIncrement = 16777216;
 			}
@@ -180,7 +180,7 @@ startRenderAgain:
 				//crossfadeIncrement = getMax(crossfadeIncrement, minCrossfadeIncrement);
 				if (minCrossfadeIncrement > crossfadeIncrement) {
 					crossfadeIncrement = minCrossfadeIncrement;
-					//Uart::println("c");
+					//Debug::println("c");
 				}
 			}
 		}
@@ -209,9 +209,9 @@ startRenderAgain:
 
 			if (percLatest >= percNewerPlayHead + percThresholdForCut) {
 				/*
-				Uart::print(percLatest);
-				Uart::print(" vs ");
-				Uart::println(percNewerPlayHead);
+				Debug::print(percLatest);
+				Debug::print(" vs ");
+				Debug::println(percNewerPlayHead);
 				*/
 				samplesTilHopEnd = 0;
 			}
@@ -363,16 +363,16 @@ void LivePitchShifter::hopEnd(int32_t phaseIncrement, LiveInputBuffer* liveInput
 
 	//int numChannelsNow = numChannels;
 
-	//Uart::println("");
-	//Uart::print("hop at ");
-	//Uart::println(numRawSamplesProcessedAtNowTime);
+	//Debug::println("");
+	//Debug::print("hop at ");
+	//Debug::println(numRawSamplesProcessedAtNowTime);
 	if (crossfadeProgress < 16777216) {
-		Uart::println("last crossfade not finished");
+		Debug::println("last crossfade not finished");
 		//if (ALPHA_OR_BETA_VERSION) numericDriver.freezeWithError("FADE");
 	}
-	//Uart::println(phaseIncrement);
+	//Debug::println(phaseIncrement);
 
-	//Uart::println((uint32_t)(liveInputBuffer->numRawSamplesProcessed - playHeads[PLAY_HEAD_NEWER].rawBufferReadPos) & (INPUT_RAW_BUFFER_SIZE - 1)); // How far behind raw buffer is being read
+	//Debug::println((uint32_t)(liveInputBuffer->numRawSamplesProcessed - playHeads[PLAY_HEAD_NEWER].rawBufferReadPos) & (INPUT_RAW_BUFFER_SIZE - 1)); // How far behind raw buffer is being read
 
 	// What was new is now old
 	playHeads[PLAY_HEAD_OLDER] = playHeads[PLAY_HEAD_NEWER];
@@ -770,7 +770,7 @@ stopSearch:
 	if (phaseIncrement == 16777216) {
 		playHeads[PLAY_HEAD_NEWER].mode = PLAY_HEAD_MODE_RAW_DIRECT;
 		playHeads[PLAY_HEAD_NEWER].rawBufferReadPos = numRawSamplesProcessedAtNowTime & (INPUT_RAW_BUFFER_SIZE - 1);
-		Uart::println("raw hop");
+		Debug::println("raw hop");
 	}
 
 	else {
@@ -780,8 +780,8 @@ stopSearch:
 		playHeads[PLAY_HEAD_NEWER].fillInterpolationBuffer(liveInputBuffer, numChannels);
 		playHeads[PLAY_HEAD_NEWER].oscPos = additionalOscPos;
 
-		//Uart::print("playing from: ");
-		//Uart::println(playHeads[PLAY_HEAD_NEWER].rawBufferReadPos);
+		//Debug::print("playing from: ");
+		//Debug::println(playHeads[PLAY_HEAD_NEWER].rawBufferReadPos);
 	}
 
 thatsDone:
@@ -796,8 +796,8 @@ thatsDone:
 		crossfadeProgress = 16777216;
 	}
 
-	//Uart::print("crossfade length: ");
-	//Uart::println(thisCrossfadeLength);
+	//Debug::print("crossfade length: ");
+	//Debug::println(thisCrossfadeLength);
 
 	/*
 	if (phaseIncrement > 16777216) {
@@ -827,8 +827,8 @@ thatsDone:
 #if MEASURE_HOP_END_PERFORMANCE
 	uint16_t endTime = MTU2.TCNT_0;
 	uint16_t timeTaken = endTime - startTime;
-	Uart::print("hop end time: ");
-	Uart::println(timeTaken);
+	Debug::print("hop end time: ");
+	Debug::println(timeTaken);
 #endif
 }
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -55,7 +55,6 @@
 
 extern "C" {
 #include "RZA1/mtu/mtu.h"
-#include "drivers/uart/uart.h"
 }
 
 const PatchableInfo patchableInfoForSound = {

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -22,7 +22,7 @@
 #include "storage/storage_manager.h"
 #include "model/song/song.h"
 #include "gui/views/view.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "memory/general_memory_allocator.h"
 #include "model/action/action_logger.h"
 #include "processing/engines/audio_engine.h"

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -19,7 +19,7 @@
 #include "storage/audio/audio_file_manager.h"
 #include "model/clip/instrument_clip.h"
 #include "processing/sound/sound_instrument.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/song/song.h"
 #include "playback/playback_handler.h"
 #include "gui/views/view.h"

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -21,7 +21,7 @@
 #include "gui/ui/browser/sample_browser.h"
 #include "processing/sound/sound.h"
 #include "processing/source.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "util/functions.h"
 #include "storage/storage_manager.h"
 #include "model/sample/sample.h"

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -26,10 +26,6 @@
 #include "hid/display/numeric_driver.h"
 #include "memory/general_memory_allocator.h"
 
-extern "C" {
-#include "drivers/uart/uart.h"
-}
-
 AudioFile::AudioFile(int newType) : type(newType) {
 	numReasonsToBeLoaded = 0;
 }
@@ -283,8 +279,8 @@ doSetupWaveTable:
 
 					if (number >= 1) {
 						waveTableCycleSize = number;
-						//uartPrint("clm tag num samples per cycle: ");
-						//uartPrintNumber(waveTableNumSamplesPerCycle);
+						//Uart::print("clm tag num samples per cycle: ");
+						//Uart::println(waveTableNumSamplesPerCycle);
 					}
 				}
 

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -19,7 +19,7 @@
 #include "storage/audio/audio_file_manager.h"
 #include "util/functions.h"
 #include <string.h>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "storage/audio/audio_file_reader.h"
 #include "model/sample/sample.h"
 #include "storage/wave_table/wave_table.h"
@@ -205,19 +205,19 @@ doSetupWaveTable:
 					}
 
 					/*
-					Uart::print("unity note: ");
-					Uart::println(midiNote);
+					Debug::print("unity note: ");
+					Debug::println(midiNote);
 
-					Uart::print("num loops: ");
-					Uart::println(numLoops);
+					Debug::print("num loops: ");
+					Debug::println(numLoops);
 					*/
 
 					if (numLoops == 1) {
 
 						// Go through loops
 						for (int l = 0; l < numLoops; l++) {
-							//Uart::print("loop ");
-							//Uart::println(l);
+							//Debug::print("loop ");
+							//Debug::println(l);
 
 							uint32_t loopData[6];
 							error = reader->readBytes((char*)loopData, 4 * 6);
@@ -225,20 +225,20 @@ doSetupWaveTable:
 								goto finishedWhileLoop;
 							}
 
-							//Uart::print("start: ");
-							//Uart::println(loopData[2]);
+							//Debug::print("start: ");
+							//Debug::println(loopData[2]);
 							((Sample*)this)->fileLoopStartSamples = loopData[2];
 
-							//Uart::print("end: ");
-							//Uart::println(loopData[3]);
+							//Debug::print("end: ");
+							//Debug::println(loopData[3]);
 							((Sample*)this)->fileLoopEndSamples = loopData[3];
 
-							//Uart::print("play count: ");
-							//Uart::println(loopData[5]);
+							//Debug::print("play count: ");
+							//Debug::println(loopData[5]);
 						}
 					}
 
-					Uart::println("");
+					Debug::println("");
 				}
 				break;
 			}
@@ -259,8 +259,8 @@ doSetupWaveTable:
 						((Sample*)this)->midiNoteFromFile = (float)midiNote - (float)fineTune * 0.01;
 					}
 
-					Uart::print("unshifted note: ");
-					Uart::println(midiNote);
+					Debug::print("unshifted note: ");
+					Debug::println(midiNote);
 				}
 				break;
 			}
@@ -279,8 +279,8 @@ doSetupWaveTable:
 
 					if (number >= 1) {
 						waveTableCycleSize = number;
-						//Uart::print("clm tag num samples per cycle: ");
-						//Uart::println(waveTableNumSamplesPerCycle);
+						//Debug::print("clm tag num samples per cycle: ");
+						//Debug::println(waveTableNumSamplesPerCycle);
 					}
 				}
 
@@ -371,8 +371,8 @@ doSetupWaveTable:
 				}
 				numMarkers = swapEndianness2x16(numMarkers);
 
-				Uart::print("numMarkers: ");
-				Uart::println(numMarkers);
+				Debug::print("numMarkers: ");
+				Debug::println(numMarkers);
 
 				if (numMarkers > MAX_NUM_MARKERS) {
 					numMarkers = MAX_NUM_MARKERS;
@@ -386,9 +386,9 @@ doSetupWaveTable:
 					}
 					markerIDs[m] = swapEndianness2x16(markerId);
 
-					Uart::println("");
-					Uart::print("markerId: ");
-					Uart::println(markerIDs[m]);
+					Debug::println("");
+					Debug::print("markerId: ");
+					Debug::println(markerIDs[m]);
 
 					uint32_t markerPos;
 					error = reader->readBytes((char*)&markerPos, 4);
@@ -397,8 +397,8 @@ doSetupWaveTable:
 					}
 					markerPositions[m] = swapEndianness32(markerPos);
 
-					Uart::print("markerPos: ");
-					Uart::println(markerPositions[m]);
+					Debug::print("markerPos: ");
+					Debug::println(markerPositions[m]);
 
 					uint8_t stringLength;
 					error = reader->readBytes((char*)&stringLength, 1);
@@ -426,14 +426,14 @@ doSetupWaveTable:
 					int8_t fineTune = data[1];
 					if ((midiNote || fineTune) && midiNote < 128) {
 						((Sample*)this)->midiNoteFromFile = (float)midiNote - (float)fineTune * 0.01;
-						//Uart::print("unshifted note: ");
-						//Uart::printlnfloat(newSample->midiNoteFromFile);
+						//Debug::print("unshifted note: ");
+						//Debug::printlnfloat(newSample->midiNoteFromFile);
 					}
 
 					//for (int l = 0; l < 2; l++) {
 
-					//if (l == 0) Uart::println("sustain loop:");
-					//else Uart::println("release loop:");
+					//if (l == 0) Debug::println("sustain loop:");
+					//else Debug::println("release loop:");
 
 					// Just read the sustain loop, which is first
 
@@ -443,16 +443,16 @@ doSetupWaveTable:
 						break;
 					}
 
-					//Uart::print("play mode: ");
-					//Uart::println(swapEndianness2x16(loopData[0]));
+					//Debug::print("play mode: ");
+					//Debug::println(swapEndianness2x16(loopData[0]));
 
 					sustainLoopBeginMarkerId = swapEndianness2x16(loopData[1]);
-					//Uart::print("begin marker id: ");
-					//Uart::println(sustainLoopBeginMarkerId);
+					//Debug::print("begin marker id: ");
+					//Debug::println(sustainLoopBeginMarkerId);
 
 					sustainLoopEndMarkerId = swapEndianness2x16(loopData[2]);
-					//Uart::print("end marker id: ");
-					//Uart::println(sustainLoopEndMarkerId);
+					//Debug::print("end marker id: ");
+					//Debug::println(sustainLoopEndMarkerId);
 					//}
 				}
 				break;

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -22,7 +22,7 @@
 #include "model/sample/sample.h"
 #include <string.h>
 #include "storage/storage_manager.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include <new>
 #include "util/functions.h"
 #include "hid/display/numeric_driver.h"
@@ -78,10 +78,10 @@ void AudioFileManager::init() {
 	if (!error) {
 		setClusterSize(fileSystemStuff.fileSystem.csize * 512);
 
-		Uart::print("clusterSize ");
-		Uart::println(clusterSize);
-		Uart::print("clusterSizeMagnitude ");
-		Uart::println(clusterSizeMagnitude);
+		Debug::print("clusterSize ");
+		Debug::println(clusterSize);
+		Debug::print("clusterSizeMagnitude ");
+		Debug::println(clusterSizeMagnitude);
 		cardEjected = false;
 	}
 
@@ -122,7 +122,7 @@ void AudioFileManager::cardReinserted() {
 			goto clusterSizeChangedButItsOk;
 		}
 
-		Uart::println("cluster size increased and we're in trouble");
+		Debug::println("cluster size increased and we're in trouble");
 		cardDisabled = true;
 		numericDriver.displayPopup(HAVE_OLED ? "Reboot to use this SD card" : "DIFF");
 	}
@@ -131,7 +131,7 @@ void AudioFileManager::cardReinserted() {
 	else if (fileSystemStuff.fileSystem.csize * 512 < clusterSize) {
 
 clusterSizeChangedButItsOk:
-		Uart::println("cluster size changed, and smaller than original so it's ok");
+		Debug::println("cluster size changed, and smaller than original so it's ok");
 		AudioEngine::unassignAllVoices(); // Will also stop synth voices - too bad.
 
 		for (int e = 0; e < audioFiles.getNumElements(); e++) {
@@ -180,7 +180,7 @@ clusterSizeChangedButItsOk:
 
 					FRESULT result = f_open(&fileSystemStuff.currentFile, filePath, FA_READ);
 					if (result != FR_OK) {
-						Uart::println("couldn't open file");
+						Debug::println("couldn't open file");
 						((Sample*)thisAudioFile)->markAsUnloadable();
 						continue;
 					}
@@ -291,8 +291,8 @@ int AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String* 
 
 	highestUsedAudioRecordingNumber[folderID]++;
 
-	Uart::print("new file: -------------- ");
-	Uart::println(highestUsedAudioRecordingNumber[folderID]);
+	Debug::print("new file: -------------- ");
+	Debug::println(highestUsedAudioRecordingNumber[folderID]);
 
 	error = filePath->set(audioRecordingFolderNames[folderID]);
 	if (error) {
@@ -854,25 +854,25 @@ void AudioFileManager::testQueue() {
 
 		if (loadedSampleChunk->nextAvailableLoadedSampleChunk == &queues[LOADED_SAMPLE_CHUNK_ALLOCATION_QUEUE_NORMAL].endNode
 				&& queues[LOADED_SAMPLE_CHUNK_ALLOCATION_QUEUE_NORMAL].endNode.prevAvailableLoadedSampleChunkPointer != &loadedSampleChunk->nextAvailableLoadedSampleChunk) {
-			Uart::println("error ---------------------------------");
-			Uart::print(loadedSampleChunk->sample->fileName);
-			Uart::print(", part ");
-			Uart::println(loadedSampleChunk->chunkIndex);
+			Debug::println("error ---------------------------------");
+			Debug::print(loadedSampleChunk->sample->fileName);
+			Debug::print(", part ");
+			Debug::println(loadedSampleChunk->chunkIndex);
 			return;
 		}
 
 		if (loadedSampleChunk->nextAvailableLoadedSampleChunk->prevAvailableLoadedSampleChunkPointer != &loadedSampleChunk->nextAvailableLoadedSampleChunk) {
-			Uart::println("abc ---------------------------------");
-			Uart::print(loadedSampleChunk->sample->fileName);
-			Uart::print(", part ");
-			Uart::println(loadedSampleChunk->chunkIndex);
+			Debug::println("abc ---------------------------------");
+			Debug::print(loadedSampleChunk->sample->fileName);
+			Debug::print(", part ");
+			Debug::println(loadedSampleChunk->chunkIndex);
 			return;
 		}
 
 		loadedSampleChunk = loadedSampleChunk->nextAvailableLoadedSampleChunk;
 	}
 
-	Uart::println("queue ok -----------------------");
+	Debug::println("queue ok -----------------------");
 	*/
 }
 
@@ -956,7 +956,7 @@ getOutEarly:
 		uint32_t startByteThisCluster = clusterIndex << clusterSizeMagnitude;
 		int32_t bytesToRead = audioDataEndPosBytes - startByteThisCluster;
 		if (bytesToRead <= 0) {
-			Uart::println("fail thing"); // Shouldn't really still happen
+			Debug::println("fail thing"); // Shouldn't really still happen
 			goto getOutEarly;
 		}
 		if (bytesToRead < clusterSize) {
@@ -967,8 +967,8 @@ getOutEarly:
 
 #if ALPHA_OR_BETA_VERSION
 	if ((uint32_t)cluster->data & 0b11) {
-		Uart::print("SD read address misaligned by ");
-		Uart::println((int32_t)((uint32_t)cluster->data & 0b11));
+		Debug::print("SD read address misaligned by ");
+		Debug::println((int32_t)((uint32_t)cluster->data & 0b11));
 	}
 #endif
 
@@ -996,7 +996,7 @@ getOutEarly:
 	uint16_t duration = endTime - startTime;
 	int uSec = timerCountToUS(duration);
 	if (uSec > 7000) {
-		Uart::println(uSec);
+		Debug::println(uSec);
 	}
 #endif
 
@@ -1268,8 +1268,8 @@ void AudioFileManager::slowRoutine() {
 		}
 
 		if (node) {
-			Uart::print("stealing cluster for fun from queue: ");
-			Uart::println(q);
+			Debug::print("stealing cluster for fun from queue: ");
+			Debug::println(q);
 			Cluster* cluster = (Cluster*)node;
 			cluster->steal();
 			deallocateCluster(cluster);
@@ -1318,8 +1318,8 @@ performActionsAndGetOut:
 	uint16_t awayTime = startTime - timeLastFinish;
 	int uSecAway = timerCountToUS(awayTime);
 	if (uSecAway > 1000) {
-		Uart::print("away ");
-		Uart::println(uSecAway);
+		Debug::print("away ");
+		Debug::println(uSecAway);
 	}
 #endif
 
@@ -1348,7 +1348,7 @@ performActionsAndGetOut:
 
 		// If that didn't work, presumably because the SD card got ejected...
 		if (!success) {
-			Uart::println("load Cluster fail");
+			Debug::println("load Cluster fail");
 
 			// If the Cluster is now down to 0 reasons (i.e. it lost a reason while being loaded), then it's already been made "available" and we don't have a problem
 			if (!cluster->numReasonsToBeLoaded) {}
@@ -1430,8 +1430,8 @@ void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* err
 	else if (cluster->numReasonsToBeLoaded < 0) {
 #if ALPHA_OR_BETA_VERSION
 		if (cluster->sample) { // "Should" always be true...
-			Uart::print("reason remains on cluster of sample: ");
-			Uart::println(cluster->sample->filePath.get());
+			Debug::print("reason remains on cluster of sample: ");
+			Debug::println(cluster->sample->filePath.get());
 		}
 		numericDriver.freezeWithError(errorCode);
 #else

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -18,7 +18,7 @@
 #include "processing/engines/audio_engine.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "model/sample/sample.h"
 #include "util/functions.h"
 #include <string.h>
@@ -140,8 +140,8 @@ void Cluster::convertDataIfNecessary() {
 			uint16_t endTime = MTU2.TCNT_0;
 
 			if (clusterIndex != startCluster) {
-				Uart::print("time to convert: ");
-				Uart::println((uint16_t)(endTime - startTime));
+				Debug::print("time to convert: ");
+				Debug::println((uint16_t)(endTime - startTime));
 			}
 			*/
 		}

--- a/src/deluge/storage/cluster/cluster_priority_queue.cpp
+++ b/src/deluge/storage/cluster/cluster_priority_queue.cpp
@@ -17,7 +17,7 @@
 
 #include "storage/cluster/cluster_priority_queue.h"
 #include "definitions.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 class Cluster;
 

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -27,7 +27,7 @@
 #include "util/functions.h"
 #include "model/song/song.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "processing/engines/cv_engine.h"
 #include "model/instrument/instrument.h"
 #include "model/song/song.h"
@@ -398,9 +398,9 @@ char const* StorageManager::readNextTagOrAttributeName() {
 	if (*toReturn) {
 		/*
     	for (int t = 0; t < tagDepthCaller; t++) {
-    		Uart::print("\t");
+    		Debug::print("\t");
     	}
-    	Uart::println(toReturn);
+    	Debug::println(toReturn);
 		*/
 		tagDepthCaller++;
 		AudioEngine::logAction(toReturn);
@@ -934,8 +934,8 @@ void StorageManager::readMidiCommand(uint8_t* channel, uint8_t* note) {
 }
 
 int StorageManager::checkSpaceOnCard() {
-	Uart::print("free clusters: ");
-	Uart::println(fileSystemStuff.fileSystem.free_clst);
+	Debug::print("free clusters: ");
+	Debug::println(fileSystemStuff.fileSystem.free_clst);
 	return fileSystemStuff.fileSystem.free_clst ? NO_ERROR
 	                                            : ERROR_SD_CARD_FULL; // This doesn't seem to always be 100% accurate...
 }
@@ -1337,7 +1337,7 @@ void StorageManager::openFilePointer(FilePointer* fp) {
 
 	AudioEngine::logAction("openFilePointer");
 
-	Uart::println("openFilePointer");
+	Debug::println("openFilePointer");
 
 	fileSystemStuff.currentFile.obj.sclust = fp->sclust;
 	fileSystemStuff.currentFile.obj.objsize = fp->objsize;

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -30,7 +30,7 @@
 #include "RZA1/mtu/mtu.h"
 #include "processing/render_wave.h"
 #include "processing/engines/audio_engine.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 extern int32_t oscSyncRenderingBuffer[];
 
@@ -123,8 +123,8 @@ void dft_r2c(ne10_fft_cpx_int32_t* __restrict__ out, int32_t const* __restrict__
 	/*
 	uint16_t endTime = *TCNT[TIMER_SYSTEM_SLOW];
 	uint16_t duration = endTime - startTime;
-	Uart::print("dft duration: ");
-	Uart::println(duration);
+	Debug::print("dft duration: ");
+	Debug::println(duration);
 	*/
 }
 
@@ -514,8 +514,8 @@ gotError5:
 		AudioEngine::logAction("analyzing cycle");
 
 		// Ok, we've finished reading one wave cycle (which potentially spanned multiple file clusters).
-		Uart::print("\nCycle: ");
-		Uart::println(cycleIndex);
+		Debug::print("\nCycle: ");
+		Debug::println(cycleIndex);
 
 		// If it wasn't a power-of-two size, we have to do a DFT even just to get the first band's useable time-domain data.
 		if (!rawFileCycleSizeIsAPowerOfTwo) {
@@ -709,8 +709,8 @@ transformBandToTimeDomain:
 	AudioEngine::routineWithClusterLoading();
 	AudioEngine::logAction("finalizing wavetable");
 
-	Uart::print("initial num bands: ");
-	Uart::println(bands.getNumElements());
+	Debug::print("initial num bands: ");
+	Debug::println(bands.getNumElements());
 
 	// Ok, we've now processed all Cycles.
 
@@ -733,20 +733,20 @@ transformBandToTimeDomain:
 	generalMemoryAllocator.dealloc(frequencyDomainData);
 
 	// Printout stats
-	Uart::print("initial band size if all populated: ");
-	Uart::println(numCycles * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE)
-	              * 2);
-	Uart::print("initial band size after trimming: ");
-	Uart::println((initialBand->toCycleNumber - initialBand->fromCycleNumber)
-	              * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE) * 2);
+	Debug::print("initial band size if all populated: ");
+	Debug::println(numCycles * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE)
+	               * 2);
+	Debug::print("initial band size after trimming: ");
+	Debug::println((initialBand->toCycleNumber - initialBand->fromCycleNumber)
+	               * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE) * 2);
 	int total = 0;
 	for (int b = 1; b < bands.getNumElements(); b++) {
 		WaveTableBand* band = (WaveTableBand*)bands.getElementAddress(b);
 		total += (band->toCycleNumber - band->fromCycleNumber)
 		         * (band->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE) * 2;
 	}
-	Uart::print("other bands total size after trimming: ");
-	Uart::println(total);
+	Debug::print("other bands total size after trimming: ");
+	Debug::println(total);
 
 	// Dispose of bands that didn't end up getting used, or such portions of their memory.
 	for (int b = bands.getNumElements() - 1; b >= 0; b--) { // Traverse backwards because we might delete elements.
@@ -756,8 +756,8 @@ transformBandToTimeDomain:
 		if (band->fromCycleNumber >= band->toCycleNumber) {
 			band->~WaveTableBand();
 			bands.deleteAtIndex(b);
-			Uart::print("deleted whole band - ");
-			Uart::println(b);
+			Debug::print("deleted whole band - ");
+			Debug::println(b);
 		}
 
 		// Otherwise, can we shorten the memory?
@@ -766,10 +766,10 @@ transformBandToTimeDomain:
 			// Right-hand side
 			if (band->toCycleNumber < numCycles) {
 				if (!b) {
-					Uart::print("(band 0) ");
+					Debug::print("(band 0) ");
 				}
-				Uart::print("deleting num cycles from right-hand side: ");
-				Uart::println(numCycles - band->toCycleNumber);
+				Debug::print("deleting num cycles from right-hand side: ");
+				Debug::println(numCycles - band->toCycleNumber);
 				int newSize = band->toCycleNumber
 				                  * (band->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE)
 				                  * sizeof(int16_t)
@@ -1010,8 +1010,8 @@ const int16_t* getKernel(int32_t phaseIncrement, int32_t bandMaxPhaseIncrement) 
 	else if (phaseIncrement >= (band->maxPhaseIncrement * 0.354))
 		whichKernel = 1;
 	if (!getRandom255()) {
-		Uart::print("kernel: ");
-		Uart::println(whichKernel);
+		Debug::print("kernel: ");
+		Debug::println(whichKernel);
 	}
 #else
 	uint32_t phaseIncrementHere = phaseIncrement;

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -30,10 +30,7 @@
 #include "RZA1/mtu/mtu.h"
 #include "processing/render_wave.h"
 #include "processing/engines/audio_engine.h"
-
-extern "C" {
-#include "drivers/uart/uart.h"
-}
+#include "io/uart/uart.h"
 
 extern int32_t oscSyncRenderingBuffer[];
 
@@ -126,8 +123,8 @@ void dft_r2c(ne10_fft_cpx_int32_t* __restrict__ out, int32_t const* __restrict__
 	/*
 	uint16_t endTime = *TCNT[TIMER_SYSTEM_SLOW];
 	uint16_t duration = endTime - startTime;
-	uartPrint("dft duration: ");
-	uartPrintNumber(duration);
+	Uart::print("dft duration: ");
+	Uart::println(duration);
 	*/
 }
 
@@ -517,8 +514,8 @@ gotError5:
 		AudioEngine::logAction("analyzing cycle");
 
 		// Ok, we've finished reading one wave cycle (which potentially spanned multiple file clusters).
-		uartPrint("\nCycle: ");
-		uartPrintNumber(cycleIndex);
+		Uart::print("\nCycle: ");
+		Uart::println(cycleIndex);
 
 		// If it wasn't a power-of-two size, we have to do a DFT even just to get the first band's useable time-domain data.
 		if (!rawFileCycleSizeIsAPowerOfTwo) {
@@ -712,8 +709,8 @@ transformBandToTimeDomain:
 	AudioEngine::routineWithClusterLoading();
 	AudioEngine::logAction("finalizing wavetable");
 
-	uartPrint("initial num bands: ");
-	uartPrintNumber(bands.getNumElements());
+	Uart::print("initial num bands: ");
+	Uart::println(bands.getNumElements());
 
 	// Ok, we've now processed all Cycles.
 
@@ -736,20 +733,20 @@ transformBandToTimeDomain:
 	generalMemoryAllocator.dealloc(frequencyDomainData);
 
 	// Printout stats
-	uartPrint("initial band size if all populated: ");
-	uartPrintNumber(numCycles * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE)
-	                * 2);
-	uartPrint("initial band size after trimming: ");
-	uartPrintNumber((initialBand->toCycleNumber - initialBand->fromCycleNumber)
-	                * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE) * 2);
+	Uart::print("initial band size if all populated: ");
+	Uart::println(numCycles * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE)
+	              * 2);
+	Uart::print("initial band size after trimming: ");
+	Uart::println((initialBand->toCycleNumber - initialBand->fromCycleNumber)
+	              * (initialBand->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE) * 2);
 	int total = 0;
 	for (int b = 1; b < bands.getNumElements(); b++) {
 		WaveTableBand* band = (WaveTableBand*)bands.getElementAddress(b);
 		total += (band->toCycleNumber - band->fromCycleNumber)
 		         * (band->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE) * 2;
 	}
-	uartPrint("other bands total size after trimming: ");
-	uartPrintNumber(total);
+	Uart::print("other bands total size after trimming: ");
+	Uart::println(total);
 
 	// Dispose of bands that didn't end up getting used, or such portions of their memory.
 	for (int b = bands.getNumElements() - 1; b >= 0; b--) { // Traverse backwards because we might delete elements.
@@ -759,8 +756,8 @@ transformBandToTimeDomain:
 		if (band->fromCycleNumber >= band->toCycleNumber) {
 			band->~WaveTableBand();
 			bands.deleteAtIndex(b);
-			uartPrint("deleted whole band - ");
-			uartPrintNumber(b);
+			Uart::print("deleted whole band - ");
+			Uart::println(b);
 		}
 
 		// Otherwise, can we shorten the memory?
@@ -769,10 +766,10 @@ transformBandToTimeDomain:
 			// Right-hand side
 			if (band->toCycleNumber < numCycles) {
 				if (!b) {
-					uartPrint("(band 0) ");
+					Uart::print("(band 0) ");
 				}
-				uartPrint("deleting num cycles from right-hand side: ");
-				uartPrintNumber(numCycles - band->toCycleNumber);
+				Uart::print("deleting num cycles from right-hand side: ");
+				Uart::println(numCycles - band->toCycleNumber);
 				int newSize = band->toCycleNumber
 				                  * (band->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE)
 				                  * sizeof(int16_t)
@@ -1013,8 +1010,8 @@ const int16_t* getKernel(int32_t phaseIncrement, int32_t bandMaxPhaseIncrement) 
 	else if (phaseIncrement >= (band->maxPhaseIncrement * 0.354))
 		whichKernel = 1;
 	if (!getRandom255()) {
-		uartPrint("kernel: ");
-		uartPrintNumber(whichKernel);
+		Uart::print("kernel: ");
+		Uart::println(whichKernel);
 	}
 #else
 	uint32_t phaseIncrementHere = phaseIncrement;

--- a/src/deluge/testing/hardware_testing.cpp
+++ b/src/deluge/testing/hardware_testing.cpp
@@ -17,7 +17,7 @@
 
 #include "testing/hardware_testing.h"
 #include "definitions.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "hid/led/indicator_leds.h"
 #include "processing/engines/cv_engine.h"
 #include <string.h>
@@ -48,7 +48,7 @@ void ramTestUart() {
 	while (1) {
 
 		//while (1) {
-		Uart::println("writing to ram");
+		Debug::println("writing to ram");
 		address = (uint32_t*)EXTERNAL_MEMORY_BEGIN;
 		while (address != (uint32_t*)EXTERNAL_MEMORY_END) {
 			*address = (uint32_t)address;
@@ -57,7 +57,7 @@ void ramTestUart() {
 		//}
 
 		//while (1) {
-		Uart::println("reading back from ram. Checking for errors every megabyte");
+		Debug::println("reading back from ram. Checking for errors every megabyte");
 		address = (uint32_t*)EXTERNAL_MEMORY_BEGIN;
 		while (address != (uint32_t*)EXTERNAL_MEMORY_END) {
 			if (*address != (uint32_t)address) {
@@ -67,10 +67,10 @@ void ramTestUart() {
 					while (uartGetTxBufferFullnessByItem(UART_ITEM_MIDI) > 100) {
 						;
 					}
-					Uart::print("error at ");
-					Uart::print((uint32_t)address);
-					Uart::print(". got ");
-					Uart::println(*address);
+					Debug::print("error at ");
+					Debug::print((uint32_t)address);
+					Debug::print(". got ");
+					Debug::println(*address);
 					//while(1);
 					lastErrorAt = errorAtBlockNow;
 				}
@@ -78,7 +78,7 @@ void ramTestUart() {
 			address++;
 		}
 		//}
-		Uart::println("finished checking ram");
+		Debug::println("finished checking ram");
 	}
 }
 

--- a/src/deluge/util/container/array/ordered_resizeable_array.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array.cpp
@@ -22,7 +22,7 @@
 #include "hid/display/numeric_driver.h"
 #include "memory/general_memory_allocator.h"
 #include "drivers/mtu/mtu.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 OrderedResizeableArray::OrderedResizeableArray(int newElementSize, int keyNumBits, int newKeyOffset,
                                                int newMaxNumEmptySpacesToKeep, int newNumExtraSpacesToAllocate)
@@ -189,8 +189,8 @@ void OrderedResizeableArrayWith32bitKey::searchMultiple(int32_t* __restrict__ se
 		searchTerms[t] = rangeEnd;
 	}
 
-	//Uart::print("maxSearchRecord: ");
-	//Uart::println(maxSearchRecord);
+	//Debug::print("maxSearchRecord: ");
+	//Debug::println(maxSearchRecord);
 }
 
 bool OrderedResizeableArrayWith32bitKey::generateRepeats(int32_t wrapPoint, int32_t endPos) {
@@ -311,16 +311,16 @@ void OrderedResizeableArrayWith32bitKey::testSearchMultiple() {
 			while (getKeyAtIndex(i) < searchPos[t]) {
 				if (i >= resultingIndexes[t]) {
 					//numericDriver.freezeWithError("FAIL");
-					Uart::println("fail");
+					Debug::println("fail");
 					goto thatsDone;
 				}
 				i++;
 			}
 		}
 
-		Uart::print("search-multiple success. time taken: ");
+		Debug::print("search-multiple success. time taken: ");
 thatsDone:
-		Uart::println(timeTaken);
+		Debug::println(timeTaken);
 	}
 }
 
@@ -336,7 +336,7 @@ void OrderedResizeableArray::test() {
 
 	while (true) {
 
-		Uart::print("up ");
+		Debug::print("up ");
 
 		// Insert tons of stuff
 		for (int v = 0; v < NUM_TEST_INSERTIONS;) {
@@ -381,12 +381,12 @@ startAgain:
 			if (numToInsert > NUM_TEST_INSERTIONS - v)
 				numToInsert = NUM_TEST_INSERTIONS - v;
 
-			//if (numToInsert == 15) Uart::println("inserting 15");
+			//if (numToInsert == 15) Debug::println("inserting 15");
 
 			int error = insertAtIndex(i, numToInsert);
 
 			if (error) {
-				Uart::println("insert failed");
+				Debug::println("insert failed");
 				while (1) {}
 			}
 
@@ -401,14 +401,14 @@ startAgain:
 		}
 
 		if (numElements != NUM_TEST_INSERTIONS) {
-			Uart::println("wrong size");
+			Debug::println("wrong size");
 			while (1) {}
 			//empty();
 		}
 
-		Uart::println(moveCount);
+		Debug::println(moveCount);
 
-		Uart::print("down ");
+		Debug::print("down ");
 
 		moveCount = 0;
 
@@ -417,11 +417,11 @@ startAgain:
 
 			int i = search(values[v], GREATER_OR_EQUAL);
 			if (i >= numElements) {
-				Uart::println("value no longer there, end");
+				Debug::println("value no longer there, end");
 				while (1) {}
 			}
 			if (getKeyAtIndex(i) != values[v]) {
-				Uart::println("value no longer there, mid");
+				Debug::println("value no longer there, mid");
 				while (1) {}
 			}
 
@@ -441,19 +441,19 @@ startAgain:
 
 				j++;
 				if (j >= numElements) {
-					Uart::println("multi value no longer there, end");
+					Debug::println("multi value no longer there, end");
 					while (1) {}
 				}
 
 				if (getKeyAtIndex(j) != value) {
-					Uart::println("multi value no longer there, mid");
+					Debug::println("multi value no longer there, mid");
 					while (1) {}
 				}
 
 				numToDelete++;
 			}
 
-			//if (numToDelete == 15) Uart::println("deleting 15");
+			//if (numToDelete == 15) Debug::println("deleting 15");
 
 			deleteAtIndex(i, numToDelete);
 
@@ -461,12 +461,12 @@ startAgain:
 		}
 
 		if (numElements) {
-			Uart::println("some elements left");
+			Debug::println("some elements left");
 			while (1) {}
 			//empty();
 		}
 
-		Uart::println(moveCount);
+		Debug::println(moveCount);
 	}
 }
 #endif
@@ -477,7 +477,7 @@ void OrderedResizeableArray::testDuplicates() {
 	int count = 0;
 	while (1) {
 		if (!(count & 31)) {
-			Uart::println("testing duplicate search...");
+			Debug::println("testing duplicate search...");
 		}
 		count++;
 
@@ -499,7 +499,7 @@ void OrderedResizeableArray::testDuplicates() {
 			if (i < numElements) {
 				keyAtSearchResult = getKeyAtIndex(i);
 				if (keyAtSearchResult < searchKey) {
-					Uart::println("key too low");
+					Debug::println("key too low");
 					while (1)
 						;
 				}
@@ -512,7 +512,7 @@ void OrderedResizeableArray::testDuplicates() {
 			// If here, we got a key higher than our search key, so check the next key to the left is lower
 			if (i) {
 				if (getKeyAtIndex(i - 1) >= searchKey) {
-					Uart::println("invalid");
+					Debug::println("invalid");
 					while (1)
 						;
 				}

--- a/src/deluge/util/container/array/ordered_resizeable_array.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array.cpp
@@ -24,10 +24,6 @@
 #include "drivers/mtu/mtu.h"
 #include "io/uart/uart.h"
 
-extern "C" {
-#include "drivers/uart/uart.h"
-}
-
 OrderedResizeableArray::OrderedResizeableArray(int newElementSize, int keyNumBits, int newKeyOffset,
                                                int newMaxNumEmptySpacesToKeep, int newNumExtraSpacesToAllocate)
     : ResizeableArray(newElementSize, newMaxNumEmptySpacesToKeep, newNumExtraSpacesToAllocate),

--- a/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
@@ -16,7 +16,7 @@
  */
 
 #include "util/container/array/ordered_resizeable_array_with_multi_word_key.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 OrderedResizeableArrayWithMultiWordKey::OrderedResizeableArrayWithMultiWordKey(int newElementSize, int newNumWordsInKey)
     : OrderedResizeableArrayWith32bitKey(newElementSize, 16, 15), numWordsInKey(newNumWordsInKey) {
@@ -112,9 +112,9 @@ bool OrderedResizeableArrayWithMultiWordKey::deleteAtKeyMultiWord(uint32_t* __re
 		return true;
 	}
 	else {
-		Uart::println("couldn't find key to delete");
-		Uart::println(keyWords[0]);
-		Uart::println(keyWords[1]);
+		Debug::println("couldn't find key to delete");
+		Debug::println(keyWords[0]);
+		Debug::println(keyWords[1]);
 		return false;
 	}
 }

--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -23,7 +23,7 @@
 #include "util/functions.h"
 #include <string.h>
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 #if RESIZEABLE_ARRAY_DO_LOCKS
 #define LOCK_ENTRY                                                                                                     \
@@ -533,7 +533,7 @@ getBrandNewMemory:
 
 #ifdef TEST_VECTOR
 		if (getRandom255() < 50) {
-			Uart::println("allocation fail for test purpose");
+			Debug::println("allocation fail for test purpose");
 			goto allocationFail;
 		}
 #endif
@@ -563,7 +563,7 @@ allocationFail:
 		uint32_t newMemoryStartIndex = 0;
 
 		if (memoryIncreasedBy) {
-			Uart::println("new memory, already increased");
+			Debug::println("new memory, already increased");
 		}
 
 		// Or if we're here, we got our new memory. Copy the stuff over. Before wrap point...
@@ -1071,7 +1071,7 @@ getBrandNewMemory:
 				return ERROR_INSUFFICIENT_RAM;
 			}
 
-			//Uart::println("getting new memory");
+			//Debug::println("getting new memory");
 
 			// Otherwise, manually get some brand new memory and do a more complex copying process
 			uint32_t desiredSize = (newNum + numExtraSpacesToAllocate) * elementSize;

--- a/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
+++ b/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
@@ -21,7 +21,7 @@
 #include "util/functions.h"
 #include "definitions.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 #define SECONDARY_MEMORY_FUNCTION_NONE 0
 #define SECONDARY_MEMORY_FUNCTION_BEING_INITIALIZED 1
@@ -388,7 +388,7 @@ void OpenAddressingHashTable::test() {
 	while (true) {
 		count++;
 		if (!(count & ((1 << 13) - 1))) {
-			Uart::println("still going");
+			Debug::println("still going");
 		}
 
 		int numElementsAdded = 0;
@@ -405,7 +405,7 @@ void OpenAddressingHashTable::test() {
 			numElementsAdded++;
 
 			if (!result) {
-				Uart::println("couldn't add element");
+				Debug::println("couldn't add element");
 				while (1) {
 					;
 				}
@@ -413,7 +413,7 @@ void OpenAddressingHashTable::test() {
 		}
 
 		if (numElements != NUM_ELEMENTS_TO_ADD) {
-			Uart::println("wrong numElements");
+			Debug::println("wrong numElements");
 			while (1) {
 				;
 			}
@@ -422,7 +422,7 @@ void OpenAddressingHashTable::test() {
 		// See if it'll let us remove an element that doesn't exist
 		bool result = remove(0);
 		if (result) {
-			Uart::println("reported successful removal of nonexistent element");
+			Debug::println("reported successful removal of nonexistent element");
 			while (1) {
 				;
 			}
@@ -431,14 +431,14 @@ void OpenAddressingHashTable::test() {
 		for (int i = 0; i < NUM_ELEMENTS_TO_ADD; i++) {
 			bool result = remove(elementsAdded[i]);
 			if (!result) {
-				Uart::print("remove failed. i == ");
-				Uart::println(i);
-				Uart::print("numBuckets == ");
-				Uart::println(numBuckets);
-				Uart::print("numElements == ");
-				Uart::println(numElements);
-				Uart::print("key == ");
-				Uart::println(elementsAdded[i]);
+				Debug::print("remove failed. i == ");
+				Debug::println(i);
+				Debug::print("numBuckets == ");
+				Debug::println(numBuckets);
+				Debug::print("numElements == ");
+				Debug::println(numElements);
+				Debug::print("key == ");
+				Debug::println(elementsAdded[i]);
 				while (1) {
 					;
 				}
@@ -446,7 +446,7 @@ void OpenAddressingHashTable::test() {
 		}
 
 		if (numElements != 0) {
-			Uart::println("numElements didn't return to 0");
+			Debug::println("numElements didn't return to 0");
 			while (1) {
 				;
 			}
@@ -455,7 +455,7 @@ void OpenAddressingHashTable::test() {
 		// See if it'll let us remove an element that doesn't exist
 		result = remove(0);
 		if (result) {
-			Uart::println("reported successful removal of element when there are no elements at all");
+			Debug::println("reported successful removal of element when there are no elements at all");
 			while (1) {
 				;
 			}

--- a/src/deluge/util/container/list/bidirectional_linked_list.cpp
+++ b/src/deluge/util/container/list/bidirectional_linked_list.cpp
@@ -18,7 +18,7 @@
 #include "storage/cluster/cluster.h"
 #include "util/container/list/bidirectional_linked_list.h"
 #include "hid/display/numeric_driver.h"
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 
 BidirectionalLinkedList::BidirectionalLinkedList() {
 	first = &endNode;
@@ -103,8 +103,8 @@ void BidirectionalLinkedList::test() {
 		thisNode = thisNode->next;
 	}
 
-	Uart::print("list size: ");
-	Uart::println(count);
+	Debug::print("list size: ");
+	Debug::println(count);
 }
 
 BidirectionalLinkedListNode::BidirectionalLinkedListNode() {

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -24,7 +24,7 @@
 #include "gui/ui/sound_editor.h"
 #include "model/action/action_logger.h"
 #include <string.h>
-#include "io/uart/uart.h"
+#include "io/debug/print.h"
 #include "hid/encoders.h"
 #include "gui/ui/qwerty_ui.h"
 #include "hid/display/oled.h"


### PR DESCRIPTION
- Complete the separation of using highlevel c++ functions for debug printing in most high-level code
- Add the option to send debug output to a USB device (this excludes the low-level uartPrintLn calls as these could occur in interrupts where sending USB-MIDI data might not be safe)
- rename the namespace for debug printing to `Debug::` instead of `Uart::`