### PR TITLE
Propogate return code, add default build argument

### DIFF
--- a/dbt.py
+++ b/dbt.py
@@ -43,7 +43,7 @@ def print_help(argparser: argparse.ArgumentParser, tasks: dict):
     print_tasks_usage(tasks)
     
 
-def main():
+def main() -> int:
     # Create the main parser
     parser = argparse.ArgumentParser(
         prog=f"{PROG_NAME}" or "task",
@@ -73,8 +73,8 @@ def main():
             sys.argv = sys.argv[1:]
 
         # Call out to our task. (lazy import)
-        importlib.import_module(tasks[task_name]).main()
-        sys.exit(0)
+        retcode = importlib.import_module(tasks[task_name]).main()
+        sys.exit(retcode)
     
 
     # nothing on the command line

--- a/scripts/tasks/task-build.py
+++ b/scripts/tasks/task-build.py
@@ -5,7 +5,7 @@ import sys
 import util
 import os
 
-def argparser():
+def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="build",
         description="Run SCons in the current environment",
@@ -14,8 +14,10 @@ def argparser():
     return parser
 
 
-def main():
+def main() -> int:
     scons_args = sys.argv[1:]
+    if not scons_args:
+        scons_args = ['all']
     
     scons_args += ['--warn=target-not-built']
 
@@ -23,7 +25,8 @@ def main():
         scons_args += ['-Q']
 
     os.chdir(util.get_git_root())
-    subprocess.run(['scons'] + scons_args, env=os.environ)
+    result = subprocess.run(['scons'] + scons_args, env=os.environ)
+    return result.returncode
 
 if __name__ == "__main__":
     main()

--- a/scripts/tasks/task-debug.py
+++ b/scripts/tasks/task-debug.py
@@ -63,7 +63,7 @@ def openocd_gdb(cmd, interface: str, target: str, protocol: str, gdb_port: int):
     ]
 
 
-def argparser():
+def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="debug",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -123,7 +123,7 @@ def get_openocd_target(target: str, protocol: str) -> str:
     return target
 
 
-def main():
+def main() -> int:
     args = argparser().parse_args()
     if args.jlink:
         cmd = jlink_gdb(
@@ -137,7 +137,7 @@ def main():
 
     if args.verbose:
         print(" ".join(cmd))
-    util.run(cmd, False)
+    return util.run(cmd, False)
 
 
 if __name__ == "__main__":

--- a/scripts/tasks/task-format.py
+++ b/scripts/tasks/task-format.py
@@ -63,7 +63,7 @@ def format_file(clang_format: str, verbose: bool, path: Path):
     util.run([clang_format, "--style=file", "-i", path], verbose, verbose)
 
 
-def argparser():
+def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="format",
         description="Formats files using clang-format (Assumes .clang-format present in directory structure)",
@@ -87,7 +87,7 @@ def argparser():
     return parser
 
 
-def main():
+def main() -> int:
     args = argparser().parse_args()
     files = get_header_and_source_files(Path(args.directory), not args.no_recursive)
     excludes = excludes_from_file(".clang-format-ignore")
@@ -104,8 +104,10 @@ def main():
         else:
             util.do_parallel_progressbar(partial(format_file, clang_format, False), files, "Formatting: ")
         print("Done!")
+        return 0
     else:
         print("No files found! Did you mean to add '-r'?")
+        return -1
 
 
 if __name__ == "__main__":

--- a/scripts/tasks/task-gdb.py
+++ b/scripts/tasks/task-gdb.py
@@ -9,7 +9,7 @@ import os
 # Based on dbt_tools/gdb.py by litui
 
 
-def argparser():
+def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="gdb",
         description="Open a GDB remote for the proper target",
@@ -26,7 +26,7 @@ def argparser():
     return parser
 
 
-def main():
+def main() -> int:
     args = argparser().parse_args()
 
     scons_target = f"dbt-build-debug-{args.target}"
@@ -39,7 +39,7 @@ def main():
 
     gdbinit = Path(os.environ['DBT_DEBUG_DIR']) / "gdbinit"
 
-    subprocess.run(
+    result = subprocess.run(
         [
             "arm-none-eabi-gdb",
             "-ex",
@@ -49,6 +49,7 @@ def main():
             elf_path,
         ]
     )
+    return result.returncode
 
 
 if __name__ == "__main__":

--- a/scripts/tasks/task-license.py
+++ b/scripts/tasks/task-license.py
@@ -39,7 +39,7 @@ def license_file(dry_run: bool, verbose: bool, path: Path):
         util.prepend_file(LICENSE_TEMPLATE, Path(path))
 
 
-def argparser():
+def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="license",
         description="Add Synthstrom Deluge license prelude to files (if not present)",
@@ -64,7 +64,7 @@ def argparser():
     return parser
 
 
-def main():
+def main() -> int:
     args = argparser().parse_args()
     files = util.get_header_and_source_files(Path(args.directory), args.recursive)
     if files:
@@ -79,8 +79,10 @@ def main():
                 partial(license_file, args.dry_run, False), files, "Formatting: "
             )
         print("Done!")
+        return 0
     else:
         print("No files found! Did you mean to add '-r'?")
+        return -1
 
 
 if __name__ == "__main__":

--- a/scripts/tasks/task-openocd.py
+++ b/scripts/tasks/task-openocd.py
@@ -68,7 +68,7 @@ def exists():
     return OPENOCD
 
 
-def argparser():
+def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="openocd",
         description="Run OpenOCD with default arguments (CMSIS-DAP/DelugeProbe).\nThese can be changed using the OPENOCD_OPTS variable.",
@@ -83,7 +83,7 @@ def argparser():
     return parser
 
 
-def main():
+def main() -> int:
     args = argparser().parse_args()
 
     hardware = os.environ.get("DEBUG_HARDWARE") or "delugeprobe"
@@ -111,7 +111,8 @@ def main():
 
     if args.verbose:
         print(" ".join(ocd_cmd))
-    subprocess.run(ocd_cmd)
+    result = subprocess.run(ocd_cmd)
+    return result.returncode
 
 
 if __name__ == "__main__":

--- a/scripts/tasks/task-shell.py
+++ b/scripts/tasks/task-shell.py
@@ -21,7 +21,7 @@ def get_shell():
     return shell_command
 
 
-def argparser():
+def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="shell",
         description="Open a shell in the DBT environment",
@@ -30,8 +30,9 @@ def argparser():
     return parser
 
 
-def main():
-    subprocess.run([get_shell()] + sys.argv[1:] , env=os.environ)
+def main() -> int:
+    result = subprocess.run([get_shell()] + sys.argv[1:] , env=os.environ)
+    return result.returncode
 
 
 if __name__ == "__main__":

--- a/scripts/tasks/util.py
+++ b/scripts/tasks/util.py
@@ -1,5 +1,6 @@
 from functools import partial
 import multiprocessing
+import os
 import subprocess
 import sys
 import shutil
@@ -16,6 +17,7 @@ def run(args, redirect_input: bool = True, redirect_output: bool = True):
         stdout=(sys.stdout if redirect_output else None),
         stdin=(sys.stdin if redirect_input else None),
         stderr=(sys.stderr if redirect_output else None),
+        env=os.environ
     )
 
     return process.returncode


### PR DESCRIPTION
This is a bugfix/feature for propagating the return code of executed subprocesses up to the parent process.

It also adds the default argument `all` to all `dbt build` commands so we're not just building an empty target when it's called with no arguments.