### PR TITLE
Fix: Master compressor behavior when clip pad is pressed in song view

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2349,7 +2349,8 @@ void SessionView::midiLearnFlash() {
 void SessionView::modEncoderAction(int whichModEncoder, int offset) {
 	performActionOnPadRelease = false;
 
-	if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::MasterCompressorFx) == RuntimeFeatureStateToggle::On) {
+	if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::MasterCompressorFx) == RuntimeFeatureStateToggle::On
+	    && currentUIMode != UI_MODE_CLIP_PRESSED_IN_SONG_VIEW) {
 		int modKnobMode = -1;
 		if (view.activeModControllableModelStack.modControllable) {
 			uint8_t* modKnobModePointer = view.activeModControllableModelStack.modControllable->getModKnobMode();


### PR DESCRIPTION
Fixed a bug in the song view that, when the SIDECHAIN knob was turned while holding down a clip pad, the SIDECHAIN value and the Master compressor Threshold would change at the same time.