### PR TITLE
Catch Notes setting to allow not catching existing notes.

### DIFF
--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -37,6 +37,7 @@ Setting menuMasterCompressorFx(RuntimeFeatureSettingType::MasterCompressorFx);
 Setting menuFineTempo(RuntimeFeatureSettingType::FineTempoKnob);
 Setting menuQuantize(RuntimeFeatureSettingType::Quantize);
 Setting menuPatchCableResolution(RuntimeFeatureSettingType::PatchCableResolution);
+Setting menuCatchNotes(RuntimeFeatureSettingType::CatchNotes);
 
 std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement + 1> subMenuEntries{
     &menuDrumRandomizer,
@@ -44,6 +45,7 @@ std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement + 1> subMenuEntries{
     &menuFineTempo,
     &menuQuantize,
     &menuPatchCableResolution,
+    &menuCatchNotes,
 
     nullptr,
 };

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -239,8 +239,7 @@ addNewNote:
 		if (clipCurrentlyPlaying && !muted) {
 			((InstrumentClip*)modelStack->getTimelineCounter())->expectEvent();
 
-			if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes)
-					== RuntimeFeatureStateToggle::On)) {
+			if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes) == RuntimeFeatureStateToggle::On)) {
 				// If the play-pos is inside this note, see if we'd like to attempt a late-start of it
 				int actualPlayPos = getLivePos(modelStack);
 
@@ -2691,8 +2690,7 @@ void NoteRow::resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMake
 
 		int32_t effectiveActualCurrentPos = getLivePos(modelStack);
 
-		if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes)
-					== RuntimeFeatureStateToggle::On)) {
+		if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes) == RuntimeFeatureStateToggle::On)) {
 			// See if our play-pos is inside of a note, which we might want to try playing...
 			int i = notes.search(effectiveActualCurrentPos, LESS);
 			bool wrapping = (i == -1);

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -47,6 +47,7 @@
 #include "io/midi/midi_device.h"
 #include "gui/views/view.h"
 #include "gui/views/instrument_clip_view.h"
+#include "model/settings/runtime_feature_settings.h"
 
 extern "C" {
 #include "RZA1/uart/sio_char.h"
@@ -238,15 +239,18 @@ addNewNote:
 		if (clipCurrentlyPlaying && !muted) {
 			((InstrumentClip*)modelStack->getTimelineCounter())->expectEvent();
 
-			// If the play-pos is inside this note, see if we'd like to attempt a late-start of it
-			int actualPlayPos = getLivePos(modelStack);
+			if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes)
+					== RuntimeFeatureStateToggle::On)) {
+				// If the play-pos is inside this note, see if we'd like to attempt a late-start of it
+				int actualPlayPos = getLivePos(modelStack);
 
-			int howFarIntoNote = actualPlayPos - newNote->pos;
-			if (howFarIntoNote < 0) {
-				howFarIntoNote += effectiveLength;
-			}
-			if (howFarIntoNote < newNote->getLength()) {
-				attemptLateStartOfNextNoteToPlay(modelStack, newNote);
+				int howFarIntoNote = actualPlayPos - newNote->pos;
+				if (howFarIntoNote < 0) {
+					howFarIntoNote += effectiveLength;
+				}
+				if (howFarIntoNote < newNote->getLength()) {
+					attemptLateStartOfNextNoteToPlay(modelStack, newNote);
+				}
 			}
 		}
 
@@ -2687,20 +2691,23 @@ void NoteRow::resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMake
 
 		int32_t effectiveActualCurrentPos = getLivePos(modelStack);
 
-		// See if our play-pos is inside of a note, which we might want to try playing...
-		int i = notes.search(effectiveActualCurrentPos, LESS);
-		bool wrapping = (i == -1);
-		if (wrapping) {
-			i = notes.getNumElements() - 1;
-		}
-		Note* note = notes.getElement(i);
-		int noteEnd = note->pos + note->length;
-		if (wrapping) {
-			noteEnd -= modelStack->getLoopLength();
-		}
+		if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes)
+					== RuntimeFeatureStateToggle::On)) {
+			// See if our play-pos is inside of a note, which we might want to try playing...
+			int i = notes.search(effectiveActualCurrentPos, LESS);
+			bool wrapping = (i == -1);
+			if (wrapping) {
+				i = notes.getNumElements() - 1;
+			}
+			Note* note = notes.getElement(i);
+			int noteEnd = note->pos + note->length;
+			if (wrapping) {
+				noteEnd -= modelStack->getLoopLength();
+			}
 
-		if (noteEnd > effectiveActualCurrentPos) {
-			attemptLateStartOfNextNoteToPlay(modelStack, note);
+			if (noteEnd > effectiveActualCurrentPos) {
+				attemptLateStartOfNextNoteToPlay(modelStack, note);
+			}
 		}
 	}
 

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -80,8 +80,8 @@ void RuntimeFeatureSettings::init() {
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::PatchCableResolution], "Mod. depth decimals",
 	                  "ModDepthDecimals", RuntimeFeatureStateToggle::On);
 	// CatchNotes
-	SetupOnOffSetting(settings[RuntimeFeatureSettingType::CatchNotes], "CatchNotes",
-	                  "catchNotes", RuntimeFeatureStateToggle::On);
+	SetupOnOffSetting(settings[RuntimeFeatureSettingType::CatchNotes], "CatchNotes", "catchNotes",
+	                  RuntimeFeatureStateToggle::On);
 }
 
 void RuntimeFeatureSettings::readSettingsFromFile() {

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -79,6 +79,9 @@ void RuntimeFeatureSettings::init() {
 	// PatchCableResolution
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::PatchCableResolution], "Mod. depth decimals",
 	                  "ModDepthDecimals", RuntimeFeatureStateToggle::On);
+	// CatchNotes
+	SetupOnOffSetting(settings[RuntimeFeatureSettingType::CatchNotes], "CatchNotes",
+	                  "catchNotes", RuntimeFeatureStateToggle::On);
 }
 
 void RuntimeFeatureSettings::readSettingsFromFile() {

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -40,6 +40,7 @@ enum RuntimeFeatureSettingType : uint32_t {
 	Quantize,
 	FineTempoKnob,
 	PatchCableResolution,
+	CatchNotes,
 	MaxElement // Keep as boundary
 };
 


### PR DESCRIPTION
Small thing that always bugged me. When shift switching between clips there was code that looked for any notes in the new clip that would've been recently triggered and plays them. For drum clips this was especially noticeable - producing double hits and flams and didn't sound good at all.

This community setting I called Catch Notes is a simple on/off that adds a conditional to the code that finds and plays these 'already triggered' notes. Set to 'off' these notes will not be triggered and shift switching between drum clips now becomes flawless.

It defaults to 'on' which is the current Deluge behavior so no surprises for users.

Again, a video is worth a billion words. In the first half Catch Notes is on (current default behavior) and you'll hear lots of double hits and flamming. After I turn it 'off' switching clips is silky smooth.

_NOTE: I would've called this a bug fix until I found the code that plays these notes. It's very deliberate and intentional code so I wouldn't consider it a bug to fix. Just a behavior to optionally change._

https://github.com/SynthstromAudible/DelugeFirmware/assets/3027787/f14b4985-0c57-4632-860e-af94d4f8e33d

