### PR TITLE
unison stereo spread

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -808,6 +808,7 @@ constexpr int kCacheByteDepth = 3;
 constexpr int kCacheByteDepthMagnitude = 2; // Invalid / unused for odd numbers of bytes like 3
 
 constexpr int kMaxUnisonDetune = 50;
+constexpr int kMaxUnisonStereoSpread = 50;
 
 // This is about right. Making it smaller didn't help. Tried it as 9, and I'm pretty sure some fast percussive details were lost in the output
 constexpr int kPercBufferReductionMagnitude = 7;

--- a/src/deluge/gui/menu_item/unison/stereoSpread.h
+++ b/src/deluge/gui/menu_item/unison/stereoSpread.h
@@ -15,26 +15,19 @@
  * If not, see <https://www.gnu.org/licenses/>.
 */
 #pragma once
-#include "gui/menu_item/integer.h"
 #include "model/model_stack.h"
+#include "gui/menu_item/integer.h"
 #include "gui/ui/sound_editor.h"
 #include "processing/sound/sound.h"
-#include "stereoSpread.h"
 
 namespace menu_item::unison {
-
-class Count final : public Integer {
+class StereoSpread final : public Integer {
 public:
-	Count(char const* newName = NULL) : Integer(newName) {}
-	void readCurrentValue() { soundEditor.currentValue = soundEditor.currentSound->numUnison; }
-	void writeCurrentValue() {
-		char modelStackMemory[MODEL_STACK_MAX_SIZE];
-		ModelStackWithSoundFlags* modelStack = soundEditor.getCurrentModelStack(modelStackMemory)->addSoundFlags();
-		soundEditor.currentSound->setNumUnison(soundEditor.currentValue, modelStack);
-	}
-	int getMinValue() const { return 1; }
-	int getMaxValue() const { return kMaxNumVoicesUnison; }
-
-	MenuItem* selectButtonPress() override { return &unisonStereoSpreadMenu; }
+	using Integer::Integer;
+	void readCurrentValue() { soundEditor.currentValue = soundEditor.currentSound->unisonStereoSpread; }
+	void writeCurrentValue() { soundEditor.currentSound->setUnisonStereoSpread(soundEditor.currentValue); }
+	int getMaxValue() const { return kMaxUnisonStereoSpread; }
 };
 } // namespace menu_item::unison
+
+extern menu_item::unison::StereoSpread unisonStereoSpreadMenu;

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -149,6 +149,7 @@
 #include "gui/menu_item/trigger/out/ppqn.h"
 #include "gui/menu_item/unison/count.h"
 #include "gui/menu_item/unison/detune.h"
+#include "gui/menu_item/unison/stereoSpread.h"
 #include "gui/menu_item/unpatched_param/pan.h"
 #include "gui/menu_item/unpatched_param/updating_reverb_params.h"
 #include "gui/menu_item/unpatched_param.h"
@@ -292,8 +293,9 @@ submenu::ActualSource source1Menu{HAVE_OLED ? "Oscillator 2" : "OSC2", oscMenuIt
 
 unison::Count numUnisonMenu{HAVE_OLED ? "Unison number" : "NUM"};
 unison::Detune unisonDetuneMenu{HAVE_OLED ? "Unison detune" : "DETUNE"};
+unison::StereoSpread unisonStereoSpreadMenu{HAVE_OLED ? "Unison stereo spread" : "SPREAD"};
 
-MenuItem* unisonMenuItems[] = {&numUnisonMenu, &unisonDetuneMenu, NULL};
+MenuItem* unisonMenuItems[] = {&numUnisonMenu, &unisonDetuneMenu, &unisonStereoSpreadMenu, NULL};
 
 // Arp --------------------------------------------------------------------------------------
 arpeggiator::Mode arpModeMenu{"MODE"};

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -55,7 +55,7 @@ extern "C" {
 #include "RZA1/mtu/mtu.h"
 }
 
-int32_t spareRenderingBuffer[3][SSI_TX_BUFFER_NUM_SAMPLES] __attribute__((aligned(CACHE_LINE_SIZE)));
+int32_t spareRenderingBuffer[4][SSI_TX_BUFFER_NUM_SAMPLES] __attribute__((aligned(CACHE_LINE_SIZE)));
 
 int32_t oscSyncRenderingBuffer[SSI_TX_BUFFER_NUM_SAMPLES + 4]
     __attribute__((aligned(CACHE_LINE_SIZE))); // Hopefully I could make this use the spareRenderingBuffer instead...
@@ -676,6 +676,8 @@ bool Voice::render(ModelStackWithVoice* modelStack, int32_t* soundBuffer, int nu
 	ParamManagerForTimeline* paramManager = (ParamManagerForTimeline*)modelStack->paramManager;
 	Sound* sound = (Sound*)modelStack->modControllable;
 
+	bool didStereoTempBuffer = false;
+
 	// If we've previously ignored a note-off, we need to check that the user hasn't changed the preset so that we're now waiting for a note-off again
 	if (previouslyIgnoredNoteOff && sound->allowNoteTails(modelStack, true)) {
 		noteOff(modelStack);
@@ -1037,6 +1039,9 @@ skipAutoRelease : {}
 		}
 	}
 
+	// whether stereo unison actually is active. if stereo is being vetoed from higher up, don't do it.
+	bool stereoUnison = sound->unisonStereoSpread && sound->numUnison > 1 && soundRenderingInStereo;
+
 	// If various conditions are met, we can cut a corner by rendering directly into the Sound's buffer
 	bool renderingDirectlyIntoSoundBuffer;
 
@@ -1065,7 +1070,7 @@ skipAutoRelease : {}
 				}
 
 				bool renderingSourceInStereo =
-				    sound->sources[s].renderInStereo((SampleHolder*)guides[s].audioFileHolder);
+				    sound->sources[s].renderInStereo(sound, (SampleHolder*)guides[s].audioFileHolder);
 
 				if (renderingSourceInStereo != soundRenderingInStereo) {
 					renderingDirectlyIntoSoundBuffer = false;
@@ -1115,6 +1120,7 @@ decidedWhichBufferRenderingInto:
 
 	// Or if rendering to local Voice buffer, We need to do some other setting up - like wiping the buffer clean first
 	else {
+		// two first indicies are reserved in case we need stereo for unison spread
 		oscBuffer = spareRenderingBuffer[0];
 
 		int32_t const* const oscBufferEnd = oscBuffer + numSamples;
@@ -1144,7 +1150,8 @@ decidedWhichBufferRenderingInto:
 
 		// Otherwise, clear the buffer
 		else {
-			memset(oscBuffer, 0, numSamples * sizeof(int32_t));
+			int channels = stereoUnison ? 2 : 1;
+			memset(oscBuffer, 0, channels * numSamples * sizeof(int32_t));
 		}
 
 		// Even if first rendering into a local Voice buffer, we'll very often still just do panning at the Sound level
@@ -1192,8 +1199,8 @@ decidedWhichBufferRenderingInto:
 				}
 			}
 
-			if (!sound->sources[s].renderInStereo((SampleHolder*)guides[s].audioFileHolder)) {
-				renderBasicSource(sound, paramManager, s, oscBuffer, numSamples, sourceAmplitudesNow[s],
+			if (!sound->sources[s].renderInStereo(sound, (SampleHolder*)guides[s].audioFileHolder)) {
+				renderBasicSource(sound, paramManager, s, oscBuffer, numSamples, false, sourceAmplitudesNow[s],
 				                  &unisonPartBecameInactive, overallPitchAdjust, (s == 1) && doingOscSync, oscSyncPos,
 				                  oscSyncPhaseIncrement, sourceAmplitudeIncrements[s], getPhaseIncrements,
 				                  getOutAfterGettingPhaseIncrements, sourceWaveIndexIncrements[s]);
@@ -1225,7 +1232,7 @@ decidedWhichBufferRenderingInto:
 			// Render each source that's stereo
 			for (int s = 0; s < kNumSources; s++) {
 				if (sourcesToRenderInStereo & (1 << s)) {
-					renderBasicSource(sound, paramManager, s, oscBuffer, numSamples, sourceAmplitudesNow[s],
+					renderBasicSource(sound, paramManager, s, oscBuffer, numSamples, true, sourceAmplitudesNow[s],
 					                  &unisonPartBecameInactive, overallPitchAdjust, false, 0, 0,
 					                  sourceAmplitudeIncrements[s], NULL, false, sourceWaveIndexIncrements[s]);
 				}
@@ -1234,68 +1241,7 @@ decidedWhichBufferRenderingInto:
 			// Output of stereo oscillator buffer (mono gets done elsewhere, below).
 			// If we're here, we also know that the Sound's buffer is also stereo
 			if (!renderingDirectlyIntoSoundBuffer) {
-				int32_t* const oscBufferEnd = oscBuffer + (numSamples << 1);
-
-				// Filters
-				filterSets[0].renderLong(oscBuffer, oscBufferEnd, filterSetConfig, sound->lpfMode, numSamples, 2);
-				filterSets[1].renderLong(oscBuffer + 1, oscBufferEnd, filterSetConfig, sound->lpfMode, numSamples, 2);
-
-				// No clipping
-				if (!sound->clippingAmount) {
-
-					int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
-					StereoSample* __restrict__ outputSample = (StereoSample*)soundBuffer;
-					int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
-
-					do {
-						int32_t outputSampleL = *(oscBufferPos++);
-						int32_t outputSampleR = *(oscBufferPos++);
-
-						overallOscAmplitudeNow += overallOscillatorAmplitudeIncrement;
-						outputSampleL = multiply_32x32_rshift32_rounded(outputSampleL, overallOscAmplitudeNow) << 1;
-						outputSampleR = multiply_32x32_rshift32_rounded(outputSampleR, overallOscAmplitudeNow) << 1;
-
-						// Write to the output buffer, panning or not
-						if (doPanning) {
-							outputSample->addPannedStereo(outputSampleL, outputSampleR, amplitudeL, amplitudeR);
-						}
-						else {
-							outputSample->addStereo(outputSampleL, outputSampleR);
-						}
-
-						outputSample++;
-					} while (oscBufferPos != oscBufferEnd);
-				}
-
-				// Yes clipping
-				else {
-
-					int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
-					StereoSample* __restrict__ outputSample = (StereoSample*)soundBuffer;
-					int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
-
-					do {
-						int32_t outputSampleL = *(oscBufferPos++);
-						int32_t outputSampleR = *(oscBufferPos++);
-
-						overallOscAmplitudeNow += overallOscillatorAmplitudeIncrement;
-						outputSampleL = multiply_32x32_rshift32_rounded(outputSampleL, overallOscAmplitudeNow) << 1;
-						outputSampleR = multiply_32x32_rshift32_rounded(outputSampleR, overallOscAmplitudeNow) << 1;
-
-						sound->saturate(&outputSampleL, &lastSaturationTanHWorkingValue[0]);
-						sound->saturate(&outputSampleR, &lastSaturationTanHWorkingValue[1]);
-
-						// Write to the output buffer, panning or not
-						if (doPanning) {
-							outputSample->addPannedStereo(outputSampleL, outputSampleR, amplitudeL, amplitudeR);
-						}
-						else {
-							outputSample->addStereo(outputSampleL, outputSampleR);
-						}
-
-						outputSample++;
-					} while (oscBufferPos != oscBufferEnd);
-				}
+				didStereoTempBuffer = true;
 			}
 		}
 
@@ -1314,18 +1260,21 @@ decidedWhichBufferRenderingInto:
 				}
 			}
 		}
-
-		// If we rendered sources in stereo, and therefore have already output the osc buffer, skip some stuff
-		if (sourcesToRenderInStereo) {
-			goto renderingDone;
-		}
 	}
 
 	// Otherwise (FM and ringmod) we go through each unison first, and for each one we render both sources together
 	else {
 
+		if (stereoUnison) {
+			// oscBuffer is always a stereo temp buffer
+			didStereoTempBuffer = true;
+		}
+
 		// For each unison part
 		for (int u = 0; u < sound->numUnison; u++) {
+
+			int32_t unisonAmplitudeL, unisonAmplitudeR;
+			shouldDoPanning((stereoUnison ? sound->unisonPan[u] : 0), &unisonAmplitudeL, &unisonAmplitudeR);
 
 			// Work out the phase increments of the two sources. If these are too high, sourceAmplitudes[s] is set to 0. Yes this will affect all unison parts, which seems like it's
 			// not what we want, but since we're traversing the unison parts in ascending frequency, it's fine!
@@ -1384,7 +1333,7 @@ cantBeDoingOscSyncForFirstOsc:
 
 					OscType oscType = sound->sources[s].oscType;
 
-					renderOsc(s, oscType, 0, spareRenderingBuffer[s + 1], spareRenderingBuffer[s + 1] + numSamples,
+					renderOsc(s, oscType, 0, spareRenderingBuffer[s + 2], spareRenderingBuffer[s + 2] + numSamples,
 					          numSamples, phaseIncrements[s], pulseWidth, &unisonParts[u].sources[s].oscPos, false, 0,
 					          doingOscSyncThisOscillator, oscSyncPos[u], phaseIncrements[0],
 					          sound->oscRetriggerPhase[s], sourceWaveIndexIncrements[s]);
@@ -1399,15 +1348,29 @@ cantBeDoingOscSyncForFirstOsc:
 				}
 
 				int32_t* __restrict__ output = oscBuffer;
-				int32_t* __restrict__ input0 = spareRenderingBuffer[1];
-				int32_t* __restrict__ input1 = spareRenderingBuffer[2];
-				int32_t const* const oscBufferEnd = oscBuffer + numSamples;
+				int32_t* __restrict__ input0 = spareRenderingBuffer[2];
+				int32_t* __restrict__ input1 = spareRenderingBuffer[3];
 
-				do {
-					renderRingmodSample(output, amplitudeForRingMod, *input0, *input1);
-					input0++;
-					input1++;
-				} while (++output != oscBufferEnd);
+				if (stereoUnison) {
+					int32_t const* const oscBufferEnd = oscBuffer + 2 * numSamples;
+					do {
+						int32_t out = multiply_32x32_rshift32_rounded(multiply_32x32_rshift32(*input0, *input1),
+						                                              amplitudeForRingMod);
+						*output++ += multiply_32x32_rshift32(out, unisonAmplitudeL) << 2;
+						*output++ += multiply_32x32_rshift32(out, unisonAmplitudeR) << 2;
+						input0++;
+						input1++;
+					} while (output != oscBufferEnd);
+				}
+				else {
+					int32_t const* const oscBufferEnd = oscBuffer + numSamples;
+					do {
+						*output += multiply_32x32_rshift32_rounded(multiply_32x32_rshift32(*input0, *input1),
+						                                           amplitudeForRingMod);
+						input0++;
+						input1++;
+					} while (++output != oscBufferEnd);
+				}
 			}
 
 			// Or if FM
@@ -1442,6 +1405,13 @@ cantBeDoingOscSyncForFirstOsc:
 					}
 				}
 
+				int32_t* fmOscBuffer = oscBuffer;
+				if (stereoUnison) {
+					// buffer 0-1: stereo output, 2: modulators, 3: per-unison carriers
+					fmOscBuffer = spareRenderingBuffer[3];
+					memset(fmOscBuffer, 0, numSamples * sizeof(int32_t));
+				}
+
 				// Modulators
 				if (modulatorsActive[1]) {
 
@@ -1451,7 +1421,7 @@ cantBeDoingOscSyncForFirstOsc:
 					}
 
 					// Render mod1
-					renderSineWaveWithFeedback(spareRenderingBuffer[1], numSamples, &unisonParts[u].modulatorPhase[1],
+					renderSineWaveWithFeedback(spareRenderingBuffer[2], numSamples, &unisonParts[u].modulatorPhase[1],
 					                           modulatorAmplitudeLastTime[1], phaseIncrementModulator[1],
 					                           paramFinalValues[Param::Local::MODULATOR_1_FEEDBACK],
 					                           &unisonParts[u].modulatorFeedback[1], false,
@@ -1460,7 +1430,7 @@ cantBeDoingOscSyncForFirstOsc:
 					// If mod1 is modulating mod0...
 					if (sound->modulator1ToModulator0) {
 						// .. render modulator0, receiving the FM from mod1
-						renderFMWithFeedback(spareRenderingBuffer[1], numSamples, NULL,
+						renderFMWithFeedback(spareRenderingBuffer[2], numSamples, NULL,
 						                     &unisonParts[u].modulatorPhase[0], modulatorAmplitudeLastTime[0],
 						                     phaseIncrementModulator[0],
 						                     paramFinalValues[Param::Local::MODULATOR_0_FEEDBACK],
@@ -1470,7 +1440,7 @@ cantBeDoingOscSyncForFirstOsc:
 					// Otherwise, so long as modulator0 is in fact active, render it separately and add it
 					else if (modulatorsActive[0]) {
 						renderSineWaveWithFeedback(
-						    spareRenderingBuffer[1], numSamples, &unisonParts[u].modulatorPhase[0],
+						    spareRenderingBuffer[2], numSamples, &unisonParts[u].modulatorPhase[0],
 						    modulatorAmplitudeLastTime[0], phaseIncrementModulator[0],
 						    paramFinalValues[Param::Local::MODULATOR_0_FEEDBACK], &unisonParts[u].modulatorFeedback[0],
 						    true, modulatorAmplitudeIncrements[0]);
@@ -1479,7 +1449,7 @@ cantBeDoingOscSyncForFirstOsc:
 				else {
 					if (modulatorsActive[0]) {
 						renderSineWaveWithFeedback(
-						    spareRenderingBuffer[1], numSamples, &unisonParts[u].modulatorPhase[0],
+						    spareRenderingBuffer[2], numSamples, &unisonParts[u].modulatorPhase[0],
 						    modulatorAmplitudeLastTime[0], phaseIncrementModulator[0],
 						    paramFinalValues[Param::Local::MODULATOR_0_FEEDBACK], &unisonParts[u].modulatorFeedback[0],
 						    false, modulatorAmplitudeIncrements[0]);
@@ -1489,7 +1459,7 @@ noModulatorsActive:
 						for (int s = 0; s < kNumSources; s++) {
 							if (sourceAmplitudes[s]) {
 								renderSineWaveWithFeedback(
-								    oscBuffer, numSamples, &unisonParts[u].sources[s].oscPos, sourceAmplitudesNow[s],
+								    fmOscBuffer, numSamples, &unisonParts[u].sources[s].oscPos, sourceAmplitudesNow[s],
 								    phaseIncrements[s], paramFinalValues[Param::Local::CARRIER_0_FEEDBACK + s],
 								    &unisonParts[u].sources[s].carrierFeedback, true, sourceAmplitudeIncrements[s]);
 							}
@@ -1503,7 +1473,7 @@ noModulatorsActive:
 				for (int s = 0; s < kNumSources; s++) {
 					if (sourceAmplitudes[s]) {
 						renderFMWithFeedbackAdd(
-						    oscBuffer, numSamples, spareRenderingBuffer[1], &unisonParts[u].sources[s].oscPos,
+						    fmOscBuffer, numSamples, spareRenderingBuffer[2], &unisonParts[u].sources[s].oscPos,
 						    sourceAmplitudesNow[s], phaseIncrements[s],
 						    paramFinalValues[Param::Local::CARRIER_0_FEEDBACK + s],
 						    &unisonParts[u].sources[s].carrierFeedback, sourceAmplitudeIncrements[s]);
@@ -1511,90 +1481,166 @@ noModulatorsActive:
 				}
 
 carriersDone : {}
+				if (stereoUnison) {
+					// double up the temp buffer
+					for (int i = 0; i < numSamples; i++) {
+						oscBuffer[(i << 1)] += multiply_32x32_rshift32(fmOscBuffer[i], unisonAmplitudeL) << 2;
+						oscBuffer[(i << 1) + 1] += multiply_32x32_rshift32(fmOscBuffer[i], unisonAmplitudeR) << 2;
+					}
+				}
 			}
 		}
 
 skipUnisonPart : {}
 	}
 
-	// Output mono osc buffer. This is skipped (via goto statement above) if we ended up with a stereo buffer.
 	if (!renderingDirectlyIntoSoundBuffer) {
-		/*
-		do {
-			int32_t distanceToGoL = *oscBufferPos - hpfMem;
-			hpfMem += distanceToGoL >> 11;
-			*oscBufferPos -= hpfMem;
+		if (didStereoTempBuffer) {
+			int32_t* const oscBufferEnd = oscBuffer + (numSamples << 1);
 
-		} while (++oscBufferPos != oscBufferEnd);
+			// Filters
+			filterSets[0].renderLong(oscBuffer, oscBufferEnd, filterSetConfig, sound->lpfMode, numSamples, 2);
+			filterSets[1].renderLong(oscBuffer + 1, oscBufferEnd, filterSetConfig, sound->lpfMode, numSamples, 2);
 
-		oscBufferPos = oscBuffer;
-		*/
+			// No clipping
+			if (!sound->clippingAmount) {
 
-		int32_t* const oscBufferEnd = oscBuffer + numSamples;
-		filterSets[0].renderLong(oscBuffer, oscBufferEnd, filterSetConfig, sound->lpfMode, numSamples);
+				int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
+				StereoSample* __restrict__ outputSample = (StereoSample*)soundBuffer;
+				int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
 
-		// No clipping
-		if (!sound->clippingAmount) {
+				do {
+					int32_t outputSampleL = *(oscBufferPos++);
+					int32_t outputSampleR = *(oscBufferPos++);
 
-			int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
-			int32_t* __restrict__ outputSample = soundBuffer;
-			int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
-
-			do {
-				int32_t output = *oscBufferPos;
-
-				if (synthMode != SynthMode::FM) {
 					overallOscAmplitudeNow += overallOscillatorAmplitudeIncrement;
-					output = multiply_32x32_rshift32_rounded(output, overallOscAmplitudeNow) << 1;
-				}
+					if (synthMode != SynthMode::FM) {
+						outputSampleL = multiply_32x32_rshift32_rounded(outputSampleL, overallOscAmplitudeNow) << 1;
+						outputSampleR = multiply_32x32_rshift32_rounded(outputSampleR, overallOscAmplitudeNow) << 1;
+					}
 
-				if (soundRenderingInStereo) {
+					// Write to the output buffer, panning or not
 					if (doPanning) {
-						((StereoSample*)outputSample)->addPannedMono(output, amplitudeL, amplitudeR);
+						outputSample->addPannedStereo(outputSampleL, outputSampleR, amplitudeL, amplitudeR);
 					}
 					else {
-						((StereoSample*)outputSample)->addMono(output);
+						outputSample->addStereo(outputSampleL, outputSampleR);
 					}
-					outputSample += 2;
-				}
-				else {
-					*outputSample += output;
+
 					outputSample++;
-				}
-			} while (++oscBufferPos != oscBufferEnd);
+				} while (oscBufferPos != oscBufferEnd);
+			}
+
+			// Yes clipping
+			else {
+
+				int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
+				StereoSample* __restrict__ outputSample = (StereoSample*)soundBuffer;
+				int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
+
+				do {
+					int32_t outputSampleL = *(oscBufferPos++);
+					int32_t outputSampleR = *(oscBufferPos++);
+
+					overallOscAmplitudeNow += overallOscillatorAmplitudeIncrement;
+					if (synthMode != SynthMode::FM) {
+						outputSampleL = multiply_32x32_rshift32_rounded(outputSampleL, overallOscAmplitudeNow) << 1;
+						outputSampleR = multiply_32x32_rshift32_rounded(outputSampleR, overallOscAmplitudeNow) << 1;
+					}
+
+					sound->saturate(&outputSampleL, &lastSaturationTanHWorkingValue[0]);
+					sound->saturate(&outputSampleR, &lastSaturationTanHWorkingValue[1]);
+
+					// Write to the output buffer, panning or not
+					if (doPanning) {
+						outputSample->addPannedStereo(outputSampleL, outputSampleR, amplitudeL, amplitudeR);
+					}
+					else {
+						outputSample->addStereo(outputSampleL, outputSampleR);
+					}
+
+					outputSample++;
+				} while (oscBufferPos != oscBufferEnd);
+			}
 		}
-
-		// Yes clipping
 		else {
-
-			int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
-			int32_t* __restrict__ outputSample = soundBuffer;
-			int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
-
+			/*
 			do {
-				int32_t output = *oscBufferPos;
+				int32_t distanceToGoL = *oscBufferPos - hpfMem;
+				hpfMem += distanceToGoL >> 11;
+				*oscBufferPos -= hpfMem;
 
-				if (synthMode != SynthMode::FM) {
-					overallOscAmplitudeNow += overallOscillatorAmplitudeIncrement;
-					output = multiply_32x32_rshift32_rounded(output, overallOscAmplitudeNow) << 1;
-				}
+			} while (++oscBufferPos != oscBufferEnd);
 
-				sound->saturate(&output, &lastSaturationTanHWorkingValue[0]);
+			oscBufferPos = oscBuffer;
+			*/
 
-				if (soundRenderingInStereo) {
-					if (doPanning) {
-						((StereoSample*)outputSample)->addPannedMono(output, amplitudeL, amplitudeR);
+			int32_t* const oscBufferEnd = oscBuffer + numSamples;
+			filterSets[0].renderLong(oscBuffer, oscBufferEnd, filterSetConfig, sound->lpfMode, numSamples);
+
+			// No clipping
+			if (!sound->clippingAmount) {
+
+				int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
+				int32_t* __restrict__ outputSample = soundBuffer;
+				int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
+
+				do {
+					int32_t output = *oscBufferPos;
+
+					if (synthMode != SynthMode::FM) {
+						overallOscAmplitudeNow += overallOscillatorAmplitudeIncrement;
+						output = multiply_32x32_rshift32_rounded(output, overallOscAmplitudeNow) << 1;
+					}
+
+					if (soundRenderingInStereo) {
+						if (doPanning) {
+							((StereoSample*)outputSample)->addPannedMono(output, amplitudeL, amplitudeR);
+						}
+						else {
+							((StereoSample*)outputSample)->addMono(output);
+						}
+						outputSample += 2;
 					}
 					else {
-						((StereoSample*)outputSample)->addMono(output);
+						*outputSample += output;
+						outputSample++;
 					}
-					outputSample += 2;
-				}
-				else {
-					*outputSample += output;
-					outputSample++;
-				}
-			} while (++oscBufferPos != oscBufferEnd);
+				} while (++oscBufferPos != oscBufferEnd);
+			}
+
+			// Yes clipping
+			else {
+
+				int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
+				int32_t* __restrict__ outputSample = soundBuffer;
+				int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
+
+				do {
+					int32_t output = *oscBufferPos;
+
+					if (synthMode != SynthMode::FM) {
+						overallOscAmplitudeNow += overallOscillatorAmplitudeIncrement;
+						output = multiply_32x32_rshift32_rounded(output, overallOscAmplitudeNow) << 1;
+					}
+
+					sound->saturate(&output, &lastSaturationTanHWorkingValue[0]);
+
+					if (soundRenderingInStereo) {
+						if (doPanning) {
+							((StereoSample*)outputSample)->addPannedMono(output, amplitudeL, amplitudeR);
+						}
+						else {
+							((StereoSample*)outputSample)->addMono(output);
+						}
+						outputSample += 2;
+					}
+					else {
+						*outputSample += output;
+						outputSample++;
+					}
+				} while (++oscBufferPos != oscBufferEnd);
+			}
 		}
 	}
 
@@ -1939,11 +1985,12 @@ void Voice::renderFMWithFeedbackAdd(int32_t* bufferStart, int numSamples, int32_
 //		and we might as well just apply amplitude while that's happening, which is exactly how it is currently.
 
 void Voice::renderBasicSource(Sound* sound, ParamManagerForTimeline* paramManager, int s,
-                              int32_t* __restrict__ oscBuffer, int numSamples, int32_t sourceAmplitude,
-                              bool* __restrict__ unisonPartBecameInactive, int32_t overallPitchAdjust, bool doOscSync,
-                              uint32_t* __restrict__ oscSyncPos, uint32_t* __restrict__ oscSyncPhaseIncrements,
-                              int32_t amplitudeIncrement, uint32_t* __restrict__ getPhaseIncrements,
-                              bool getOutAfterPhaseIncrements, int32_t waveIndexIncrement) {
+                              int32_t* __restrict__ oscBuffer, int numSamples, bool stereoBuffer,
+                              int32_t sourceAmplitude, bool* __restrict__ unisonPartBecameInactive,
+                              int32_t overallPitchAdjust, bool doOscSync, uint32_t* __restrict__ oscSyncPos,
+                              uint32_t* __restrict__ oscSyncPhaseIncrements, int32_t amplitudeIncrement,
+                              uint32_t* __restrict__ getPhaseIncrements, bool getOutAfterPhaseIncrements,
+                              int32_t waveIndexIncrement) {
 
 	generalMemoryAllocator.checkStack("Voice::renderBasicSource");
 
@@ -1994,6 +2041,11 @@ pitchTooHigh:
 				continue;
 			}
 		}
+
+		bool stereoUnison = sound->unisonStereoSpread && sound->numUnison > 1 && stereoBuffer;
+		int32_t amplitudeL, amplitudeR;
+		shouldDoPanning((stereoUnison ? sound->unisonPan[u] : 0), &amplitudeL, &amplitudeR);
+		// used if mono source but stereoUnison active
 
 		// If sample...
 		if (sound->sources[s].oscType == OscType::SAMPLE) {
@@ -2164,16 +2216,46 @@ dontUseCache : {}
 				}
 			}
 
+			int32_t* renderBuffer = oscBuffer;
+
+			if (stereoUnison) {
+				// TODO: I first wanted to integrate this with voiceSample->render()'s own
+				// amplitude control but it is just too complex - multiple copies of
+				// the amp logic depending if caching is used or not, timestretching or not,
+				// for now settle for "don't pay what you don't use", i e no extra copies/maths
+				// if you don't use unison stereo on a sample - bfredl
+				renderBuffer = spareRenderingBuffer[2]; // note: 2 and 3 are used
+				memset(renderBuffer, 0, 2 * SSI_TX_BUFFER_NUM_SAMPLES * sizeof(int32_t));
+			}
+
 			// We no longer do caching when there's just time stretching with no pitch adjustment, because the time stretching algorithm is so efficient,
 			// playing back the cache is hardly any faster than just doing the time stretching (once perc info has been cached) - and, crucially, creating / writing to the cache in the first place
 			// is quite inefficient when time stretching, because when we're not writing to the cache, that allows us to do a special optimization not otherwise available
 			// (that is, combining the amplitude increments for the hop crossfades with the overall voice ones, and having multiple crossfading hops write directly
 			// to the osc buffer).
 
-			bool stillActive =
-			    voiceSample->render(&guides[s], oscBuffer, numSamples, sample, numChannels, loopingType, phaseIncrement,
-			                        timeStretchRatio, sourceAmplitude, amplitudeIncrement, interpolationBufferSize,
-			                        sound->sources[s].sampleControls.interpolationMode, getPriorityRating());
+			bool stillActive = voiceSample->render(
+			    &guides[s], renderBuffer, numSamples, sample, numChannels, loopingType, phaseIncrement,
+			    timeStretchRatio, sourceAmplitude, amplitudeIncrement, interpolationBufferSize,
+			    sound->sources[s].sampleControls.interpolationMode, getPriorityRating());
+
+			if (stereoUnison) {
+				if (numChannels == 2) {
+					// TODO: society if renderBasicSource() took a StereoSample[] buffer already
+					for (int i = 0; i < numSamples; i++) {
+						oscBuffer[(i << 1)] += multiply_32x32_rshift32(renderBuffer[(i << 1)], amplitudeL) << 2;
+						oscBuffer[(i << 1) + 1] += multiply_32x32_rshift32(renderBuffer[(i << 1) + 1], amplitudeR) << 2;
+					}
+				}
+				else {
+					// TODO: if render buffer was typed we could use addPannedMono()
+					for (int i = 0; i < numSamples; i++) {
+						oscBuffer[(i << 1)] += multiply_32x32_rshift32(renderBuffer[i], amplitudeL) << 2;
+						oscBuffer[(i << 1) + 1] += multiply_32x32_rshift32(renderBuffer[i], amplitudeR) << 2;
+					}
+				}
+			}
+
 			if (!stillActive) {
 				goto instantUnassign;
 			}
@@ -2273,7 +2355,7 @@ dontUseCache : {}
 				// Stereo
 				else {
 
-					int numChannelsAfterCondensing = AudioEngine::renderInStereo ? 2 : 1;
+					int numChannelsAfterCondensing = stereoBuffer ? 2 : 1;
 
 					int32_t const* const oscBufferEnd = oscBuffer + numSamples * numChannelsAfterCondensing;
 
@@ -2285,7 +2367,7 @@ dontUseCache : {}
 						int32_t sampleR = inputReadPos[1];
 
 						// If condensing to mono, do that now
-						if (!AudioEngine::renderInStereo) {
+						if (!stereoBuffer) {
 							sampleL = ((sampleL >> 1) + (sampleR >> 1));
 						}
 
@@ -2293,7 +2375,7 @@ dontUseCache : {}
 						*(oscBufferPos++) += multiply_32x32_rshift32(sampleL, sourceAmplitudeNow) << 4;
 
 						// Right channel
-						if (AudioEngine::renderInStereo) {
+						if (stereoBuffer) {
 							*(oscBufferPos++) += multiply_32x32_rshift32(sampleR, sourceAmplitudeNow) << 4;
 						}
 
@@ -2325,16 +2407,31 @@ dontUseCache : {}
 				oscSyncPhaseIncrementsThisUnison = oscSyncPhaseIncrements[u];
 			}
 
+			int32_t* renderBuffer = oscBuffer;
+
+			if (stereoBuffer) {
+				renderBuffer = spareRenderingBuffer[2];
+				memset(renderBuffer, 0, SSI_TX_BUFFER_NUM_SAMPLES * sizeof(int32_t));
+			}
+
 			int32_t* oscBufferEnd =
-			    oscBuffer + numSamples; // TODO: we don't really want to be calculating this so early do we?
+			    renderBuffer + numSamples; // TODO: we don't really want to be calculating this so early do we?
 
 			// Work out pulse width
 			uint32_t pulseWidth = (uint32_t)lshiftAndSaturate<1>(paramFinalValues[Param::Local::OSC_A_PHASE_WIDTH + s]);
 
-			renderOsc(s, sound->sources[s].oscType, sourceAmplitude, oscBuffer, oscBufferEnd, numSamples,
+			renderOsc(s, sound->sources[s].oscType, sourceAmplitude, renderBuffer, oscBufferEnd, numSamples,
 			          phaseIncrement, pulseWidth, &unisonParts[u].sources[s].oscPos, true, amplitudeIncrement,
 			          doOscSync, oscSyncPosThisUnison, oscSyncPhaseIncrementsThisUnison, oscRetriggerPhase,
 			          waveIndexIncrement);
+
+			if (stereoBuffer) {
+				// TODO: if render buffer was typed we could use addPannedMono()
+				for (int i = 0; i < numSamples; i++) {
+					oscBuffer[(i << 1)] += multiply_32x32_rshift32(renderBuffer[i], amplitudeL) << 2;
+					oscBuffer[(i << 1) + 1] += multiply_32x32_rshift32(renderBuffer[i], amplitudeR) << 2;
+				}
+			}
 		}
 	}
 }

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -109,7 +109,7 @@ private:
 	               int32_t amplitudeIncrement, bool doOscSync, uint32_t resetterPhase, uint32_t resetterPhaseIncrement,
 	               uint32_t retriggerPhase, int32_t waveIndexIncrement);
 	void renderBasicSource(Sound* sound, ParamManagerForTimeline* paramManager, int s, int32_t* oscBuffer,
-	                       int numSamples, int32_t sourceAmplitude, bool* unisonPartBecameInactive,
+	                       int numSamples, bool stereoBuffer, int32_t sourceAmplitude, bool* unisonPartBecameInactive,
 	                       int32_t overallPitchAdjust, bool doOscSync, uint32_t* oscSyncPos,
 	                       uint32_t* oscSyncPhaseIncrements, int32_t amplitudeIncrement, uint32_t* getPhaseIncrements,
 	                       bool getOutAfterPhaseIncrements, int32_t waveIndexIncrement);

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -93,8 +93,8 @@ public:
 	int16_t transpose;
 
 	uint8_t numUnison;
-
 	int8_t unisonDetune;
+	uint8_t unisonStereoSpread;
 
 	int16_t modulatorTranspose[kNumModulators];
 	int8_t modulatorCents[kNumModulators];
@@ -102,6 +102,7 @@ public:
 	PhaseIncrementFineTuner modulatorTransposers[kNumModulators];
 
 	PhaseIncrementFineTuner unisonDetuners[kMaxNumVoicesUnison];
+	int32_t unisonPan[kMaxNumVoicesUnison];
 
 	SynthMode synthMode;
 	bool modulator1ToModulator0;
@@ -170,6 +171,7 @@ public:
 	void sampleZoneChanged(MarkerType markerType, int s, ModelStackWithSoundFlags* modelStack);
 	void setNumUnison(int newNum, ModelStackWithSoundFlags* modelStack);
 	void setUnisonDetune(int newAmount, ModelStackWithSoundFlags* modelStack);
+	void setUnisonStereoSpread(int newAmount);
 	void setModulatorTranspose(int m, int value, ModelStackWithSoundFlags* modelStack);
 	void setModulatorCents(int m, int value, ModelStackWithSoundFlags* modelStack);
 	int readFromFile(ModelStackWithModControllable* modelStack, int32_t readAutomationUpToPos,
@@ -273,6 +275,7 @@ private:
 	uint32_t getGlobalLFOPhaseIncrement();
 	void recalculateModulatorTransposer(uint8_t m, ModelStackWithSoundFlags* modelStack);
 	void setupUnisonDetuners(ModelStackWithSoundFlags* modelStack);
+	void setupUnisonStereoSpread();
 	void calculateEffectiveVolume();
 	void ensureKnobReferencesCorrectVolume(Knob* knob);
 	int readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos,

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -83,9 +83,13 @@ void Source::recalculateFineTuner() {
 }
 
 // This function has to give the same result as Sound::renderingVoicesInStereo(). The duplication is for optimization.
-bool Source::renderInStereo(SampleHolder* sampleHolder) {
+bool Source::renderInStereo(Sound* s, SampleHolder* sampleHolder) {
 	if (!AudioEngine::renderInStereo) {
 		return false;
+	}
+
+	if (s->unisonStereoSpread && s->numUnison > 1) {
+		return true;
 	}
 
 	return (oscType == OscType::SAMPLE && sampleHolder && sampleHolder->audioFile

--- a/src/deluge/processing/source.h
+++ b/src/deluge/processing/source.h
@@ -49,7 +49,7 @@ public:
 
 	int16_t defaultRangeI; // -1 means none yet
 
-	bool renderInStereo(SampleHolder* sampleHolder = NULL);
+	bool renderInStereo(Sound* s, SampleHolder* sampleHolder = NULL);
 	void setCents(int newCents);
 	void recalculateFineTuner();
 	int32_t getLengthInSamplesAtSystemSampleRate(int note, bool forTimeStretching = false);

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1384,6 +1384,8 @@ int random(int upperLimit) {
 
 bool shouldDoPanning(int32_t panAmount, int32_t* amplitudeL, int32_t* amplitudeR) {
 	if (panAmount == 0) {
+		*amplitudeR = 1073741823;
+		*amplitudeL = 1073741823;
 		return false;
 	}
 

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -184,11 +184,6 @@ void getThingFilename(char const* thingName, int16_t currentSlot, int8_t current
 
 int32_t getExp(int32_t presetValue, int32_t adjustment);
 
-inline void renderRingmodSample(int32_t* __restrict__ thisSample, int32_t amplitude, int32_t waveValueA,
-                                int32_t waveValueB) {
-	*thisSample += multiply_32x32_rshift32_rounded(multiply_32x32_rshift32(waveValueA, waveValueB), amplitude);
-}
-
 bool isAudioFilename(char const* filename);
 bool isAiffFilename(char const* filename);
 


### PR DESCRIPTION
only works for basic waves (and wavetables) yet, not samples nor FM/RM. I'm gonna try refactor the mono vs stereo rendering logic, to not duplicate the same panning logic for samples, FM and ringmod.

For now the shortcut is to press SELECT inside the unison number menu, but we could also take the free spot above it (right of decimation).