### PR TITLE
Fix for i008 in latest community

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -512,7 +512,8 @@ static_assert(std::max<ParamType>(Unpatched::GlobalEffectable::MAX_NUM, Unpatche
 
 } // namespace Param
 
-constexpr ParamType kNumParams = util::to_underlying(Param::Global::NONE) - 1; // Not including the "none" param
+//None is the last global param, 0 indexed so it's also the number of real params
+constexpr ParamType kNumParams = util::to_underlying(Param::Global::NONE);
 constexpr ParamType kMaxNumUnpatchedParams = Param::Unpatched::GlobalEffectable::MAX_NUM;
 
 enum class OscType {

--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -26,13 +26,22 @@
 #include "io/debug/print.h"
 
 #if RESIZEABLE_ARRAY_DO_LOCKS
-#define LOCK_ENTRY                                                                                                     \
-	if (lock) {                                                                                                        \
-		numericDriver.freezeWithError("i008");                                                                         \
-	}                                                                                                                  \
-	lock =                                                                                                             \
-	    true; // Bay_Mud got this error around V4.0.1 (must have been a beta), and thinks a FlashAir card might have been a catalyst. It still "shouldn't" be able to happen though.
-#define LOCK_EXIT lock = false;
+#define LOCK_ENTRY freezeOnLock();
+// Bay_Mud got this error around V4.0.1 (must have been a beta), and thinks a FlashAir card might have been a catalyst.
+//It still "shouldn't" be able to happen though.
+#define LOCK_EXIT exitLock();
+void ResizeableArray::freezeOnLock() {
+	if (lock) {
+		numericDriver.freezeWithError("i008");
+	}
+	lock = true;
+}
+void ResizeableArray::exitLock() {
+	if (!lock) {
+		numericDriver.freezeWithError("i008");
+	}
+	lock = false;
+}
 #else
 #define LOCK_ENTRY                                                                                                     \
 	{}

--- a/src/deluge/util/container/array/resizeable_array.h
+++ b/src/deluge/util/container/array/resizeable_array.h
@@ -69,6 +69,8 @@ protected:
 
 #if RESIZEABLE_ARRAY_DO_LOCKS
 	bool lock;
+	void freezeOnLock();
+	void exitLock();
 #endif
 
 private:


### PR DESCRIPTION
Error i008 is being triggered when browsing synth presets with latest community, this breaks out the error macro into a function to allow breakpoints for debugging.

Bug is narrowed down to a call to nodes.empty() on parameter automation when the preset is loaded for preview