### PR TITLE
Prevent crash when recording MPE note on

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -4244,7 +4244,7 @@ doNormal: // Wrap it back to the start.
 	    modelStack->addOtherTwoThingsAutomaticallyGivenNoteRow()->addParamCollection(mpeParams, mpeParamsSummary);
 
 	for (int m = 0; m < kNumExpressionDimensions; m++) {
-		AutoParam* param = &mpeParams->params[m];
+		AutoParam* param = (m == 0 ? &mpeParams->params[m] : &mpeParams->fakeParams[m - 1]);
 		ModelStackWithAutoParam* modelStackWithAutoParam = modelStackWithParamCollection->addAutoParam(m, param);
 
 		Action* action = actionLogger.getNewAction(ACTION_RECORD, true);


### PR DESCRIPTION
When compiled with O2 using DBT accessing past the end of params is undefined and this block of code gets optimized out. This causes a crash when an MPE note is recorded. This is a quick fix by explicitly accessing the fake params parameter instead to prevent crashes while we find a better solution.