### PR TITLE
refactor filter configs into seperate classes

### DIFF
--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -36,7 +36,7 @@ class SVFilter {
 public:
 	//input f is actually filter 'moveability', tan(f)/(1+tan(f)) and falls between 0 and 1. 1 represented by 2147483648
 	//resonance is 2147483647 - rawResonance2 Always between 0 and 2. 1 represented as 1073741824
-	SVF_outs doSVF(q31_t input, FilterSetConfig* filterSetConfig);
+	SVF_outs doSVF(q31_t input, LPSVFConfig* filterSetConfig);
 	void reset() {
 		low = 0;
 		band = 0;
@@ -87,7 +87,7 @@ public:
 	                   int sampleIncrement = 1, int extraSaturation = 0, int extraSaturationDrive = 0);
 	void renderHPFLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig, int numSamples,
 	                   int sampleIncrement = 1);
-	void renderHPF(q31_t* outputSample, FilterSetConfig* filterSetConfig, int extraSaturation = 0);
+	void renderLadderHPF(q31_t* outputSample, HPLadderConfig* filterSetConfig, int extraSaturation = 0);
 	void reset();
 	BasicFilterComponent lpfLPF1;
 	BasicFilterComponent lpfLPF2;
@@ -106,7 +106,9 @@ public:
 
 	bool hpfOnLastTime;
 	bool lpfOnLastTime;
-
+	inline void renderLPLadder(q31_t* startSample, q31_t* endSample, LPLadderConfig* filterSetConfig, LPFMode lpfMode,
+	                           int sampleIncrement, int extraSaturation, int extraSaturationDrive);
+	inline void renderLPSVF(q31_t* startSample, q31_t* endSample, LPSVFConfig* filterSetConfig, int sampleIncrement);
 	inline void renderLong(q31_t* outputSample, q31_t* endSample, FilterSetConfig* filterSetConfig, LPFMode lpfMode,
 	                       int numSamples, int sampleIncrememt = 1) {
 
@@ -128,6 +130,6 @@ public:
 private:
 	q31_t noiseLastValue;
 
-	q31_t do24dBLPFOnSample(q31_t input, FilterSetConfig* filterSetConfig, int saturationLevel);
-	q31_t doDriveLPFOnSample(q31_t input, FilterSetConfig* filterSetConfig, int extraSaturation = 0);
+	q31_t do24dBLPFOnSample(q31_t input, LPLadderConfig* filterSetConfig, int saturationLevel);
+	q31_t doDriveLPFOnSample(q31_t input, LPLadderConfig* filterSetConfig, int extraSaturation = 0);
 };

--- a/src/deluge/dsp/filter/filter_set_config.cpp
+++ b/src/deluge/dsp/filter/filter_set_config.cpp
@@ -21,9 +21,6 @@
 #include "io/debug/print.h"
 #include "storage/storage_manager.h"
 
-FilterSetConfig::FilterSetConfig() {
-}
-
 const int16_t resonanceThresholdsForOversampling[] = {
     16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384,
     16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384, 16384,
@@ -56,18 +53,210 @@ const int16_t resonanceLimitTable[] = {
     17000, 17000, 17000, 17000, 17000, 17000, 17000, 17000,
 };
 
-/*
- * 		32767, // 48
-		32767, // 49
-		32767, // 50
-		32767,
-		32767, //30000, // 52
-		32767, //23900,
-		28415, //19000, // 54
-		20000, //19000,
-		17000, //19000, // 56
- */
+LPLadderConfig::LPLadderConfig() = default;
+q31_t LPLadderConfig::init(q31_t lpfFrequency, q31_t lpfResonance, LPFMode lpfMode, q31_t filterGain) {
 
+	// Hot transistor ladder - needs oversampling and stuff
+	if (lpfMode == LPFMode::TRANSISTOR_24DB_DRIVE) {
+
+		int32_t resonance = ONE_Q31 - (lpfResonance << 2); // Limits it
+		processedResonance = ONE_Q31 - resonance;          // Always between 0 and 2. 1 represented as 1073741824
+
+		int32_t logFreq = quickLog(lpfFrequency);
+
+		doOversampling = false; //storageManager.devVarA;
+
+		logFreq = getMin(logFreq, (int32_t)63 << 24);
+
+		if (AudioEngine::cpuDireness < 14 && (logFreq >> 24) > 51) {
+			int32_t resonanceThreshold = interpolateTableSigned(logFreq, 30, resonanceThresholdsForOversampling, 6);
+			doOversampling = (processedResonance > resonanceThreshold);
+		}
+
+		if (doOversampling) {
+
+			lpfFrequency >>= 1;
+
+			logFreq -= 33554432;
+
+			// Adjustment for how the oversampling shifts the frequency just slightly
+			lpfFrequency -= (multiply_32x32_rshift32_rounded(logFreq, lpfFrequency) >> 8)
+			                * 34; // + (lpfFrequency >> 8) * storageManager.devVarB;
+
+			// Enforce a max frequency. Otherwise we'll generate stuff which will cause problems for down-sampling again.
+			// But only if resonance is high. If it's low, we need to be able to get the freq high, to let all the HF through that we want to hear
+			lpfFrequency = getMin((int32_t)39056384, lpfFrequency);
+
+			int32_t resonanceLimit = interpolateTableSigned(logFreq, 30, resonanceLimitTable, 6);
+
+			processedResonance = getMin(processedResonance, resonanceLimit);
+		}
+	}
+
+	// Between 0 and 8, by my making. 1 represented by 268435456
+	int32_t tannedFrequency = instantTan(lshiftAndSaturate<5>(lpfFrequency));
+
+	// Cold transistor ladder
+	if ((lpfMode == LPFMode::TRANSISTOR_24DB) || (lpfMode == LPFMode::TRANSISTOR_12DB)) {
+		// Some long-winded stuff to make it so if frequency goes really low, resonance goes down. This is tuned a bit, but isn't perfect
+		int32_t howMuchTooLow = 0;
+		if (tannedFrequency < 6000000) {
+			howMuchTooLow = 6000000 - tannedFrequency;
+		}
+
+		int32_t howMuchToKeep = ONE_Q31 - 1 * 33;
+
+		int32_t resonanceUpperLimit = 510000000; // Prone to feeding back lots
+		tannedFrequency = getMax(
+		    tannedFrequency,
+		    (int32_t)540817); // We really want to keep the frequency from going lower than it has to - it causes problems
+
+		int32_t resonance = ONE_Q31 - (getMin(lpfResonance, resonanceUpperLimit) << 2); // Limits it
+		resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
+		processedResonance =
+		    ONE_Q31 - resonance; //ONE_Q31 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
+		processedResonance = multiply_32x32_rshift32_rounded(processedResonance, howMuchToKeep) << 1;
+	}
+
+	divideBy1PlusTannedFrequency =
+	    (int64_t)2147483648u * 134217728
+	    / (134217728 + (tannedFrequency >> 1)); // Between ~0.1 and 1. 1 represented by 2147483648
+	moveability = multiply_32x32_rshift32_rounded(tannedFrequency, divideBy1PlusTannedFrequency)
+	              << 4; // Between 0 and 1. 1 represented by 2147483648 I'm pretty sure
+
+	// Half ladder
+	if (lpfMode == LPFMode::TRANSISTOR_12DB) {
+		int32_t moveabilityNegative = moveability - 1073741824; // Between -2 and 0. 1 represented as 1073741824
+		lpf2Feedback = multiply_32x32_rshift32_rounded(moveabilityNegative, divideBy1PlusTannedFrequency) << 1;
+		lpf1Feedback = multiply_32x32_rshift32_rounded(lpf2Feedback, moveability) << 1;
+		divideByTotalMoveabilityAndProcessedResonance =
+		    (int64_t)67108864 * 1073741824
+		    / (67108864
+		       + multiply_32x32_rshift32_rounded(
+		           processedResonance,
+		           multiply_32x32_rshift32_rounded(moveabilityNegative,
+		                                           multiply_32x32_rshift32_rounded(moveability, moveability))));
+	}
+
+	// Full ladder
+	else {
+		lpf3Feedback = multiply_32x32_rshift32_rounded(divideBy1PlusTannedFrequency, moveability);
+		lpf2Feedback = multiply_32x32_rshift32_rounded(lpf3Feedback, moveability) << 1;
+		lpf1Feedback = multiply_32x32_rshift32_rounded(lpf2Feedback, moveability) << 1;
+		int32_t onePlusThing =
+		    67108864
+		    + (multiply_32x32_rshift32_rounded(
+		        moveability,
+		        multiply_32x32_rshift32_rounded(
+		            moveability, multiply_32x32_rshift32_rounded(
+		                             moveability, multiply_32x32_rshift32_rounded(
+		                                              moveability, processedResonance))))); // 1 represented as 67108864
+		divideByTotalMoveabilityAndProcessedResonance = (int64_t)67108864 * 1073741824 / onePlusThing;
+	}
+
+	if (lpfMode != LPFMode::TRANSISTOR_24DB_DRIVE) { // Cold transistor ladder only
+		// Extra feedback - but only if freq isn't too high. Otherwise we get aliasing
+		if (tannedFrequency <= 304587486) {
+			processedResonance = multiply_32x32_rshift32_rounded(processedResonance, 1150000000) << 1;
+		}
+		else {
+			processedResonance >>= 1;
+		}
+
+		int32_t a = getMin(lpfResonance, (int32_t)536870911);
+		a = 536870912 - a;
+		a = multiply_32x32_rshift32(a, a) << 3;
+		a = 536870912 - a;
+		int32_t gainModifier = 268435456 + a;
+		filterGain = multiply_32x32_rshift32(filterGain, gainModifier) << 3;
+	}
+
+	// Drive filter - increase output amplitude
+	else {
+		//overallOscAmplitude <<= 2;
+		filterGain *= 0.8;
+	}
+	return filterGain;
+}
+
+LPSVFConfig::LPSVFConfig() = default;
+q31_t LPSVFConfig::init(q31_t lpfFrequency, q31_t lpfResonance, LPFMode lpfMode, q31_t filterGain) {
+	int32_t tannedFrequency = instantTan(lshiftAndSaturate<5>(lpfFrequency));
+	int32_t divideBy1PlusTannedFrequency =
+	    (int64_t)2147483648u * 134217728
+	    / (134217728 + (tannedFrequency >> 1)); // Between ~0.1 and 1. 1 represented by 2147483648
+	moveability = multiply_32x32_rshift32_rounded(tannedFrequency, divideBy1PlusTannedFrequency)
+	              << 4; // Between 0 and 1. 1 represented by 2147483648 I'm pretty sure
+	// raw resonance is 0 - 536870896 (2^28ish, don't know where it comes from)
+	// Multiply by 4 to bring it to the q31 0-1 range
+	processedResonance = (ONE_Q31 - 4 * (lpfResonance));
+	SVFInputScale = (processedResonance >> 1) + (ONE_Q31 >> 1);
+	//squared q is a better match for the ladders
+	//also the input scale needs to be sqrt(q) for the level compensation to work so it's a win win
+	processedResonance = multiply_32x32_rshift32_rounded(processedResonance, processedResonance) << 1;
+	return filterGain;
+}
+
+HPLadderConfig::HPLadderConfig() = default;
+q31_t HPLadderConfig::init(q31_t hpfFrequency, q31_t hpfResonance, bool adjustVolumeForHPFResonance, q31_t filterGain) {
+	int32_t extraFeedback = 1200000000;
+
+	int32_t tannedFrequency =
+	    instantTan(lshiftAndSaturate<5>(hpfFrequency)); // Between 0 and 8, by my making. 1 represented by 268435456
+
+	int32_t hpfDivideBy1PlusTannedFrequency =
+	    (int64_t)2147483648u * 134217728
+	    / (134217728 + (tannedFrequency >> 1)); // Between ~0.1 and 1. 1 represented by 2147483648
+
+	int32_t resonanceUpperLimit = 536870911;
+	int32_t resonance = ONE_Q31 - (getMin(hpfResonance, resonanceUpperLimit) << 2); // Limits it
+
+	resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
+	hpfProcessedResonance =
+	    ONE_Q31 - resonance; //ONE_Q31 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
+
+	hpfProcessedResonance = getMax(hpfProcessedResonance, (int32_t)134217728); // Set minimum resonance amount
+
+	int32_t hpfProcessedResonanceUnaltered = hpfProcessedResonance;
+
+	// Extra feedback
+	hpfProcessedResonance = multiply_32x32_rshift32(hpfProcessedResonance, extraFeedback) << 1;
+
+	hpfDivideByProcessedResonance = 2147483648u / (hpfProcessedResonance >> (23));
+
+	hpfMoveability = multiply_32x32_rshift32_rounded(tannedFrequency, hpfDivideBy1PlusTannedFrequency) << 4;
+
+	int32_t moveabilityTimesProcessedResonance =
+	    multiply_32x32_rshift32(hpfProcessedResonanceUnaltered, hpfMoveability); // 1 = 536870912
+	int32_t moveabilitySquaredTimesProcessedResonance =
+	    multiply_32x32_rshift32(moveabilityTimesProcessedResonance, hpfMoveability); // 1 = 268435456
+
+	hpfHPF3Feedback = -multiply_32x32_rshift32_rounded(hpfMoveability, hpfDivideBy1PlusTannedFrequency);
+	hpfLPF1Feedback = hpfDivideBy1PlusTannedFrequency >> 1;
+
+	uint32_t toDivideBy =
+	    ((int32_t)268435456 - (moveabilityTimesProcessedResonance >> 1) + moveabilitySquaredTimesProcessedResonance);
+	divideByTotalMoveability = (int32_t)((uint64_t)hpfProcessedResonance * 67108864 / toDivideBy);
+
+	hpfDoAntialiasing = (hpfProcessedResonance > 900000000);
+
+	if (adjustVolumeForHPFResonance) {
+		// Adjust volume for HPF resonance
+		q31_t rawResonance = getMin(hpfResonance, (q31_t)ONE_Q31 >> 2) << 2;
+		q31_t squared = multiply_32x32_rshift32(rawResonance, rawResonance) << 1;
+		squared = (multiply_32x32_rshift32(squared, squared) >> 4)
+		          * 19; // Make bigger to have more of a volume cut happen at high resonance
+		filterGain = multiply_32x32_rshift32(filterGain, ONE_Q31 - squared) << 1;
+	}
+
+	return filterGain;
+}
+
+FilterSetConfig::FilterSetConfig() {
+	lpsvfconfig = LPSVFConfig();
+	lpladderconfig = LPLadderConfig();
+	hpladderconfig = HPLadderConfig();
+}
 int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_t hpfFrequency, int32_t hpfResonance,
                               LPFMode lpfMode, int32_t filterGain, bool adjustVolumeForHPFResonance,
                               int32_t* overallOscAmplitude) {
@@ -76,208 +265,22 @@ int32_t FilterSetConfig::init(int32_t lpfFrequency, int32_t lpfResonance, int32_
 	    (hpfResonance >> 21) << 21; // Insanely, having changes happen in the small bytes too often causes rustling
 
 	if (doLPF) {
-
-		// Hot transistor ladder - needs oversampling and stuff
-		if (lpfMode == LPFMode::TRANSISTOR_24DB_DRIVE) {
-
-			int32_t resonance = ONE_Q31 - (lpfResonance << 2); // Limits it
-			processedResonance = ONE_Q31 - resonance;          // Always between 0 and 2. 1 represented as 1073741824
-
-			int32_t logFreq = quickLog(lpfFrequency);
-
-			doOversampling = false; //storageManager.devVarA;
-
-			logFreq = getMin(logFreq, (int32_t)63 << 24);
-
-			if (AudioEngine::cpuDireness < 14 && (logFreq >> 24) > 51) {
-				int32_t resonanceThreshold = interpolateTableSigned(logFreq, 30, resonanceThresholdsForOversampling, 6);
-				doOversampling = (processedResonance > resonanceThreshold);
-			}
-
-			if (doOversampling) {
-
-				lpfFrequency >>= 1;
-
-				logFreq -= 33554432;
-
-				// Adjustment for how the oversampling shifts the frequency just slightly
-				lpfFrequency -= (multiply_32x32_rshift32_rounded(logFreq, lpfFrequency) >> 8)
-				                * 34; // + (lpfFrequency >> 8) * storageManager.devVarB;
-
-				// Enforce a max frequency. Otherwise we'll generate stuff which will cause problems for down-sampling again.
-				// But only if resonance is high. If it's low, we need to be able to get the freq high, to let all the HF through that we want to hear
-				lpfFrequency = getMin((int32_t)39056384, lpfFrequency);
-
-				int32_t resonanceLimit = interpolateTableSigned(logFreq, 30, resonanceLimitTable, 6);
-
-				processedResonance = getMin(processedResonance, resonanceLimit);
-			}
+		if (lpfMode == LPFMode::SVF) {
+			filterGain = lpsvfconfig.init(lpfFrequency, lpfResonance, lpfMode, filterGain);
 		}
-
-		int32_t tannedFrequency =
-		    instantTan(lshiftAndSaturate<5>(lpfFrequency)); // Between 0 and 8, by my making. 1 represented by 268435456
-		{
-
-			// Cold transistor ladder
-			if (lpfMode != LPFMode::TRANSISTOR_24DB_DRIVE) {
-				// Some long-winded stuff to make it so if frequency goes really low, resonance goes down. This is tuned a bit, but isn't perfect
-				int32_t howMuchTooLow = 0;
-				if (tannedFrequency < 6000000) {
-					howMuchTooLow = 6000000 - tannedFrequency;
-				}
-
-				int32_t howMuchToKeep = ONE_Q31 - 1 * 33;
-
-				int32_t resonanceUpperLimit = 510000000; // Prone to feeding back lots
-				tannedFrequency = getMax(
-				    tannedFrequency,
-				    (int32_t)540817); // We really want to keep the frequency from going lower than it has to - it causes problems
-
-				int32_t resonance = ONE_Q31 - (getMin(lpfResonance, resonanceUpperLimit) << 2); // Limits it
-				lpfRawResonance = lpfResonance;
-				resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
-				processedResonance =
-				    ONE_Q31
-				    - resonance; //ONE_Q31 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
-				processedResonance = multiply_32x32_rshift32_rounded(processedResonance, howMuchToKeep) << 1;
-			}
-
-			divideBy1PlusTannedFrequency =
-			    (int64_t)2147483648u * 134217728
-			    / (134217728 + (tannedFrequency >> 1)); // Between ~0.1 and 1. 1 represented by 2147483648
-			moveability = multiply_32x32_rshift32_rounded(tannedFrequency, divideBy1PlusTannedFrequency)
-			              << 4; // Between 0 and 1. 1 represented by 2147483648 I'm pretty sure
-
-			// Half ladder
-			if (lpfMode == LPFMode::TRANSISTOR_12DB) {
-				int32_t moveabilityNegative = moveability - 1073741824; // Between -2 and 0. 1 represented as 1073741824
-				lpf2Feedback = multiply_32x32_rshift32_rounded(moveabilityNegative, divideBy1PlusTannedFrequency) << 1;
-				lpf1Feedback = multiply_32x32_rshift32_rounded(lpf2Feedback, moveability) << 1;
-				divideByTotalMoveabilityAndProcessedResonance =
-				    (int64_t)67108864 * 1073741824
-				    / (67108864
-				       + multiply_32x32_rshift32_rounded(
-				           processedResonance,
-				           multiply_32x32_rshift32_rounded(moveabilityNegative,
-				                                           multiply_32x32_rshift32_rounded(moveability, moveability))));
-			}
-
-			// Full ladder
-			else if ((lpfMode == LPFMode::TRANSISTOR_24DB) || (lpfMode == LPFMode::TRANSISTOR_24DB_DRIVE)) {
-				lpf3Feedback = multiply_32x32_rshift32_rounded(divideBy1PlusTannedFrequency, moveability);
-				lpf2Feedback = multiply_32x32_rshift32_rounded(lpf3Feedback, moveability) << 1;
-				lpf1Feedback = multiply_32x32_rshift32_rounded(lpf2Feedback, moveability) << 1;
-				int32_t onePlusThing =
-				    67108864
-				    + (multiply_32x32_rshift32_rounded(
-				        moveability,
-				        multiply_32x32_rshift32_rounded(
-				            moveability,
-				            multiply_32x32_rshift32_rounded(
-				                moveability, multiply_32x32_rshift32_rounded(
-				                                 moveability, processedResonance))))); // 1 represented as 67108864
-				divideByTotalMoveabilityAndProcessedResonance = (int64_t)67108864 * 1073741824 / onePlusThing;
-			}
-
-			if (lpfMode != LPFMode::TRANSISTOR_24DB_DRIVE) { // Cold transistor ladder only
-				// Extra feedback - but only if freq isn't too high. Otherwise we get aliasing
-				if (tannedFrequency <= 304587486) {
-					processedResonance = multiply_32x32_rshift32_rounded(processedResonance, 1150000000) << 1;
-				}
-				else {
-					processedResonance >>= 1;
-				}
-
-				int32_t a = getMin(lpfResonance, (int32_t)536870911);
-				a = 536870912 - a;
-				a = multiply_32x32_rshift32(a, a) << 3;
-				a = 536870912 - a;
-				int32_t gainModifier = 268435456 + a;
-				filterGain = multiply_32x32_rshift32(filterGain, gainModifier) << 3;
-			}
-
-			// Drive filter - increase output amplitude
-			else if (lpfMode == LPFMode::TRANSISTOR_24DB_DRIVE) {
-				//overallOscAmplitude <<= 2;
-				filterGain *= 0.8;
-			}
-			if (lpfMode == LPFMode::SVF) {
-
-				// raw resonance is 0 - 536870896 (2^28ish, don't know where it comes from)
-				// Multiply by 4 to bring it to the q31 0-1 range
-				processedResonance = (ONE_Q31 - 4 * (lpfRawResonance));
-				SVFInputScale = (processedResonance >> 1) + (ONE_Q31 >> 1);
-				//squared q is a better match for the ladders
-
-				processedResonance = multiply_32x32_rshift32_rounded(processedResonance, processedResonance) << 1;
-			}
+		else {
+			filterGain = lpladderconfig.init(lpfFrequency, lpfResonance, lpfMode, filterGain);
 		}
 	}
 
-	int32_t rawResonance;
-	int32_t squared;
-
-	// Adjust volume for LPF resonance
-	rawResonance = getMin(lpfResonance, (int32_t)ONE_Q31 >> 2) << 2;
-	squared = multiply_32x32_rshift32(rawResonance, rawResonance) << 1;
-	squared = (multiply_32x32_rshift32(squared, squared) >> 4)
-	          * 19; // Make bigger to have more of a volume cut happen at high resonance
 	filterGain =
 	    multiply_32x32_rshift32(filterGain, 1720000000)
 	    << 1; // This changes the overall amplitude so that, with resonance on 50%, the amplitude is the same as it was pre June 2017
 
 	// HPF
 	if (doHPF) {
-
-		int32_t extraFeedback = 1200000000;
-
-		int32_t tannedFrequency =
-		    instantTan(lshiftAndSaturate<5>(hpfFrequency)); // Between 0 and 8, by my making. 1 represented by 268435456
-
-		int32_t hpfDivideBy1PlusTannedFrequency =
-		    (int64_t)2147483648u * 134217728
-		    / (134217728 + (tannedFrequency >> 1)); // Between ~0.1 and 1. 1 represented by 2147483648
-
-		int32_t resonanceUpperLimit = 536870911;
-		int32_t resonance = ONE_Q31 - (getMin(hpfResonance, resonanceUpperLimit) << 2); // Limits it
-
-		resonance = multiply_32x32_rshift32_rounded(resonance, resonance) << 1;
-		hpfProcessedResonance =
-		    ONE_Q31 - resonance; //ONE_Q31 - rawResonance2; // Always between 0 and 2. 1 represented as 1073741824
-
-		hpfProcessedResonance = getMax(hpfProcessedResonance, (int32_t)134217728); // Set minimum resonance amount
-
-		int32_t hpfProcessedResonanceUnaltered = hpfProcessedResonance;
-
-		// Extra feedback
-		hpfProcessedResonance = multiply_32x32_rshift32(hpfProcessedResonance, extraFeedback) << 1;
-
-		hpfDivideByProcessedResonance = 2147483648u / (hpfProcessedResonance >> (23));
-
-		hpfMoveability = multiply_32x32_rshift32_rounded(tannedFrequency, hpfDivideBy1PlusTannedFrequency) << 4;
-
-		int32_t moveabilityTimesProcessedResonance =
-		    multiply_32x32_rshift32(hpfProcessedResonanceUnaltered, hpfMoveability); // 1 = 536870912
-		int32_t moveabilitySquaredTimesProcessedResonance =
-		    multiply_32x32_rshift32(moveabilityTimesProcessedResonance, hpfMoveability); // 1 = 268435456
-
-		hpfHPF3Feedback = -multiply_32x32_rshift32_rounded(hpfMoveability, hpfDivideBy1PlusTannedFrequency);
-		hpfLPF1Feedback = hpfDivideBy1PlusTannedFrequency >> 1;
-
-		uint32_t toDivideBy = ((int32_t)268435456 - (moveabilityTimesProcessedResonance >> 1)
-		                       + moveabilitySquaredTimesProcessedResonance);
-		divideByTotalMoveability = (int32_t)((uint64_t)hpfProcessedResonance * 67108864 / toDivideBy);
-
-		hpfDoAntialiasing = (hpfProcessedResonance > 900000000);
+		filterGain = hpladderconfig.init(hpfFrequency, hpfResonance, adjustVolumeForHPFResonance, filterGain);
 	}
 
-	if (adjustVolumeForHPFResonance) {
-		// Adjust volume for HPF resonance
-		rawResonance = getMin(hpfResonance, (int32_t)ONE_Q31 >> 2) << 2;
-		squared = multiply_32x32_rshift32(rawResonance, rawResonance) << 1;
-		squared = (multiply_32x32_rshift32(squared, squared) >> 4)
-		          * 19; // Make bigger to have more of a volume cut happen at high resonance
-		filterGain = multiply_32x32_rshift32(filterGain, ONE_Q31 - squared) << 1;
-	}
 	return filterGain;
 }

--- a/src/deluge/dsp/filter/filter_set_config.h
+++ b/src/deluge/dsp/filter/filter_set_config.h
@@ -20,12 +20,11 @@
 #include "definitions_cxx.hpp"
 #include "util/fixedpoint.h"
 
-class FilterSetConfig {
+class LPLadderConfig {
 
 public:
-	FilterSetConfig();
-	q31_t init(q31_t lpfFrequency, q31_t lpfResonance, q31_t hpfFrequency, q31_t hpfResonance, LPFMode lpfMode,
-	           q31_t filterGain, bool adjustVolumeForHPFResonance = true, q31_t* overallOscAmplitude = NULL);
+	LPLadderConfig();
+	q31_t init(q31_t lpfFrequency, q31_t lpfResonance, LPFMode lpfMode, q31_t filterGain);
 
 	q31_t processedResonance;                            // 1 represented as 1073741824
 	q31_t divideByTotalMoveabilityAndProcessedResonance; // 1 represented as 1073741824
@@ -39,6 +38,13 @@ public:
 	q31_t lpf2Feedback;
 	q31_t lpf3Feedback;
 
+	bool doOversampling;
+};
+
+class HPLadderConfig {
+public:
+	HPLadderConfig();
+	q31_t init(q31_t hpfFrequency, q31_t hpfResonance, bool adjustVolumeForHPFResonance, q31_t filterGain);
 	q31_t hpfMoveability; // 1 represented by 2147483648
 
 	// All feedbacks have 1 represented as 1073741824
@@ -51,10 +57,32 @@ public:
 
 	q31_t divideByTotalMoveability; // 1 represented as 268435456
 
-	q31_t lpfRawResonance;
-	q31_t SVFInputScale;
 	q31_t alteredHpfMomentumMultiplier;
 	q31_t thisHpfResonance;
+};
+
+class LPSVFConfig {
+
+public:
+	LPSVFConfig();
+	q31_t init(q31_t lpfFrequency, q31_t lpfResonance, LPFMode lpfMode, q31_t filterGain);
+
+	q31_t moveability;
+	q31_t processedResonance;
+	q31_t SVFInputScale;
+};
+
+class FilterSetConfig {
+
+public:
+	FilterSetConfig();
+	q31_t init(q31_t lpfFrequency, q31_t lpfResonance, q31_t hpfFrequency, q31_t hpfResonance, LPFMode lpfMode,
+	           q31_t filterGain, bool adjustVolumeForHPFResonance = true, q31_t* overallOscAmplitude = NULL);
+
+	LPLadderConfig lpladderconfig;
+	HPLadderConfig hpladderconfig;
+	LPSVFConfig lpsvfconfig;
+
 	bool doLPF;
 	bool doHPF;
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -406,8 +406,8 @@ void GlobalEffectable::processFilters(StereoSample* buffer, int numSamples, Filt
 		StereoSample* bufferEnd = buffer + numSamples;
 
 		do {
-			filterSets[0].renderHPF(&thisSample->l, filterSetConfig, 2);
-			filterSets[1].renderHPF(&thisSample->r, filterSetConfig, 2);
+			filterSets[0].renderLadderHPF(&thisSample->l, &filterSetConfig->hpladderconfig, 2);
+			filterSets[1].renderLadderHPF(&thisSample->r, &filterSetConfig->hpladderconfig, 2);
 		} while (++thisSample != bufferEnd);
 	}
 

--- a/src/deluge/util/fast_fixed_math.h
+++ b/src/deluge/util/fast_fixed_math.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+*/
+#include "fixedpoint.h"
+#include "util/functions.h"
+//This is a very very rough approximation
+static inline q31_t crappy_square_root(q31_t input) {
+	int leading = clz(input);
+	return ONE_Q31 >> (leading / 2);
+}
+static inline q31_t approximate_inverse_square_root(q31_t raw) {
+	q31_t var1, temp, x_squared, in;
+
+	in = raw >> 1; //better range for function
+	//2 rounds of newtons method for isqrt
+	//start at one power of two larger than the input
+	//for an approximate first guess
+
+	//update is x_nxt = x*(3-input(x^2)/2
+	var1 = crappy_square_root(in);
+
+	x_squared = multiply_32x32_rshift32_rounded(var1, var1) << 1;
+	temp = multiply_32x32_rshift32_rounded(in, x_squared) << 1;
+	temp = 0x30000000 - temp;
+	var1 = multiply_32x32_rshift32_rounded(var1, temp) << 2;
+
+	x_squared = multiply_32x32_rshift32_rounded(var1, var1) << 1;
+	temp = multiply_32x32_rshift32_rounded(in, x_squared) << 1;
+	temp = 0x30000000 - temp;
+	var1 = multiply_32x32_rshift32_rounded(var1, temp) << 2;
+
+	x_squared = multiply_32x32_rshift32_rounded(var1, var1) << 1;
+	temp = multiply_32x32_rshift32_rounded(in, x_squared) << 1;
+	temp = 0x30000000 - temp;
+	var1 = multiply_32x32_rshift32_rounded(var1, temp) << 2;
+
+	return (var1 << 2);
+}
+
+//This is off by almost a factor of two for in close to 1 but somewhat accurate for
+//small inputs
+static inline q31_t approximate_square_root(q31_t in) {
+	q31_t isqrt = approximate_inverse_square_root(in);
+	return multiply_32x32_rshift32_rounded(in, isqrt) << 1;
+}

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -16,7 +16,7 @@
 */
 #pragma once
 #include "math.h"
-
+#include "RZA1/system/r_typedefs.h"
 //signed 31 fractional bits (e.g. one would be 1<<31 but can't be represented)
 typedef int32_t q31_t;
 


### PR DESCRIPTION
No logic changes - this breaks the filter configuration setups out into their own class to aid in refactoring in support of #105 

This also adds some integer square root functions to fast_fixed_math.c, I ended up avoiding their use but they're left here in case they are useful to someone else