### PR TITLE
Batch delete all “unused” kit rows (the ones with no notes)

### DIFF
--- a/CommunityFeatures.md
+++ b/CommunityFeatures.md
@@ -44,6 +44,7 @@ Synchronization modes accessible through the "LFO SYNC" shortcut.
 
 ### Kit Clip View
  - ([#122]) Pressing "AUDITION + RANDOM" on a drum kit row will load a random sample from the same folder as the currently enabled sample and load it as the sound for that row. Currently limited to 25 files for performance reasons. This feature can be toggled in the [runtime features menu](#runtime-features).
+  - ([#234]) While you can delete a kit row by holding a Note in a row and pressing SAVE/DELETE, the "Delete Unused Kit Rows" feature allows you to batch delete kit rows which does not contain any notes, freeing kits from unused sounds (which take some precious RAM). While inside a kit, hold "KIT" and press "Shift + SAVE/DELETE". A confirmation message will appear: "Deleted unused rows". This command is not executed if there are no notes at all in the kit. This feature can be toggled in the [runtime features menu](#runtime-features).
 
 ### Kit Keyboard View
  - ([#112]) All-new use for the "keyboard" button in kit clips, uses the main pad grid for MPC-style 16 level playing. Horizonatal encoder scrolls by one pad at a time, allowing positioning drums left to right, and vertical encoder jumps vertically by rows.
@@ -97,3 +98,4 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#122]: https://github.com/SynthstromAudible/DelugeFirmware/pull/122
 [#141]: https://github.com/SynthstromAudible/DelugeFirmware/pull/141
 [#163]: https://github.com/SynthstromAudible/DelugeFirmware/pull/163
+[#234]: https://github.com/SynthstromAudible/DelugeFirmware/pull/234

--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -38,6 +38,7 @@ Setting menuFineTempo(RuntimeFeatureSettingType::FineTempoKnob);
 Setting menuQuantize(RuntimeFeatureSettingType::Quantize);
 Setting menuPatchCableResolution(RuntimeFeatureSettingType::PatchCableResolution);
 Setting menuCatchNotes(RuntimeFeatureSettingType::CatchNotes);
+Setting menuDeleteUnusedKitRows(RuntimeFeatureSettingType::DeleteUnusedKitRows);
 
 std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement + 1> subMenuEntries{
     &menuDrumRandomizer,
@@ -46,6 +47,7 @@ std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement + 1> subMenuEntries{
     &menuQuantize,
     &menuPatchCableResolution,
     &menuCatchNotes,
+    &menuDeleteUnusedKitRows,
 
     nullptr,
 };

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -590,6 +590,9 @@ doOther:
 
 				recalculateColours();
 				uiNeedsRendering(this);
+
+				// Show popup to make it clear what just happened
+				numericDriver.displayPopup(HAVE_OLED ? "Deleted unused rows" : "DELETED");
 			}
 		}
 	}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -582,7 +582,7 @@ doOther:
 					}
 				}
 
-				clip->yScroll = 0; // Reset yScroll
+				clip->yScroll = 0; // Reset scroll position
 
 				actionLogger.deleteAllLogs(); // Can't undo past this
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -488,11 +488,87 @@ doOther:
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
 
-			if (Buttons::isButtonPressed(AFFECT_ENTIRE)
-			    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::DeleteUnusedKitRows)
-			        == RuntimeFeatureStateToggle::On)) {
-				// Community feature: Batch delete unused rows
+			int i;
+			for (i = 0; i < kEditPadPressBufferSize; i++) {
+				if (editPadPresses[i].isActive) {
 
+					int yDisplay = editPadPresses[i].yDisplay;
+
+					endEditPadPress(i);
+					checkIfAllEditPadPressesEnded(false);
+					reassessAuditionStatus(yDisplay);
+
+					int noteRowIndex = yDisplay + clip->yScroll;
+
+					if (ALPHA_OR_BETA_VERSION
+					    && (noteRowIndex < 0 || noteRowIndex >= clip->noteRows.getNumElements())) {
+						numericDriver.freezeWithError("E323");
+					}
+
+					if (clip->isActiveOnOutput()) {
+						NoteRow* noteRow = clip->noteRows.getElement(noteRowIndex);
+						if (noteRow->drum) {
+							noteRow->drum->drumWontBeRenderedForAWhile();
+						}
+					}
+
+					char modelStackMemory[MODEL_STACK_MAX_SIZE];
+					ModelStackWithTimelineCounter* modelStack =
+					    currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+					clip->deleteNoteRow(modelStack, noteRowIndex);
+
+					// Note: I should fix this - if deleting a NoteRow of a MIDI drum that we're auditioning via MIDI, this will leave a stuck note...
+
+					// If NoteRow was bottom half of screen...
+					if (yDisplay < (kDisplayHeight >> 1)) {
+						if (!noteRowIndex || clip->noteRows.getNumElements() >= (kDisplayHeight >> 1)) {
+							clip->yScroll--;
+						}
+					}
+
+					// Or top half of screen...
+					else {
+						if (!noteRowIndex && clip->noteRows.getNumElements() < (kDisplayHeight >> 1)) {
+							clip->yScroll--;
+						}
+					}
+
+					actionLogger.deleteAllLogs(); // Can't undo past this
+
+					setSelectedDrum(NULL, true);
+
+					recalculateColours();
+					uiNeedsRendering(this);
+
+					// Can't remember why repopulateNoteRowsOnScreen() doesn't do the sidebar automatically?
+
+					currentUIMode = UI_MODE_NONE;
+
+					AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
+
+					break;
+				}
+			}
+		}
+	}
+
+	// Kit + Shift + Save/Delete: shorcut that will delete all Kit rows that does not contain notes
+	// (instead of pressing Note + Delete to do it one by one)
+	else if (b == SAVE && currentUIMode != UI_MODE_NOTES_PRESSED && Buttons::isShiftButtonPressed()
+	         && Buttons::isButtonPressed(KIT) && currentSong->currentClip->output->type == InstrumentType::KIT
+	         && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::DeleteUnusedKitRows)
+	             == RuntimeFeatureStateToggle::On)) {
+		if (inCardRoutine) {
+			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+		}
+
+		if (on) {
+			InstrumentClip* clip = getCurrentClip();
+
+			if (!clip->containsAnyNotes()) {
+				numericDriver.displayPopup(HAVE_OLED ? "At least one row needs to have notes" : "CANT");
+			}
+			else {
 				char modelStackMemory[MODEL_STACK_MAX_SIZE];
 				ModelStackWithTimelineCounter* modelStack =
 				    currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -514,73 +590,6 @@ doOther:
 
 				recalculateColours();
 				uiNeedsRendering(this);
-
-				numericDriver.displayPopup(HAVE_OLED ? "Deleted unused rows" : "DELETED");
-			}
-			else {
-				// Delete the selected row
-
-				int i;
-				for (i = 0; i < kEditPadPressBufferSize; i++) {
-					if (editPadPresses[i].isActive) {
-
-						int yDisplay = editPadPresses[i].yDisplay;
-
-						endEditPadPress(i);
-						checkIfAllEditPadPressesEnded(false);
-						reassessAuditionStatus(yDisplay);
-
-						int noteRowIndex = yDisplay + clip->yScroll;
-
-						if (ALPHA_OR_BETA_VERSION
-						    && (noteRowIndex < 0 || noteRowIndex >= clip->noteRows.getNumElements())) {
-							numericDriver.freezeWithError("E323");
-						}
-
-						if (clip->isActiveOnOutput()) {
-							NoteRow* noteRow = clip->noteRows.getElement(noteRowIndex);
-							if (noteRow->drum) {
-								noteRow->drum->drumWontBeRenderedForAWhile();
-							}
-						}
-
-						char modelStackMemory[MODEL_STACK_MAX_SIZE];
-						ModelStackWithTimelineCounter* modelStack =
-						    currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-						clip->deleteNoteRow(modelStack, noteRowIndex);
-
-						// Note: I should fix this - if deleting a NoteRow of a MIDI drum that we're auditioning via MIDI, this will leave a stuck note...
-
-						// If NoteRow was bottom half of screen...
-						if (yDisplay < (kDisplayHeight >> 1)) {
-							if (!noteRowIndex || clip->noteRows.getNumElements() >= (kDisplayHeight >> 1)) {
-								clip->yScroll--;
-							}
-						}
-
-						// Or top half of screen...
-						else {
-							if (!noteRowIndex && clip->noteRows.getNumElements() < (kDisplayHeight >> 1)) {
-								clip->yScroll--;
-							}
-						}
-
-						actionLogger.deleteAllLogs(); // Can't undo past this
-
-						setSelectedDrum(NULL, true);
-
-						recalculateColours();
-						uiNeedsRendering(this);
-
-						// Can't remember why repopulateNoteRowsOnScreen() doesn't do the sidebar automatically?
-
-						currentUIMode = UI_MODE_NONE;
-
-						AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
-
-						break;
-					}
-				}
 			}
 		}
 	}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -552,10 +552,10 @@ doOther:
 		}
 	}
 
-	// Shift + Save/Delete: shorcut that will delete all Kit rows that does not contain notes
+	// Kit + Shift + Save/Delete: shorcut that will delete all Kit rows that does not contain notes
 	// (instead of pressing Note + Delete to do it one by one)
 	else if (b == SAVE && currentUIMode != UI_MODE_NOTES_PRESSED && Buttons::isShiftButtonPressed()
-	         && currentSong->currentClip->output->type == InstrumentType::KIT
+	         && Buttons::isButtonPressed(KIT) && currentSong->currentClip->output->type == InstrumentType::KIT
 	         && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::DeleteUnusedKitRows)
 	             == RuntimeFeatureStateToggle::On)) {
 		if (inCardRoutine) {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -566,7 +566,7 @@ doOther:
 			InstrumentClip* clip = getCurrentClip();
 
 			if (!clip->containsAnyNotes()) {
-				numericDriver.displayPopup(HAVE_OLED ? "No unused kit rows to delete" : "CANT");
+				numericDriver.displayPopup(HAVE_OLED ? "At least one row needs to have notes" : "CANT");
 			}
 			else {
 				char modelStackMemory[MODEL_STACK_MAX_SIZE];

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -555,7 +555,8 @@ doOther:
 	// Shift + Save/Delete: shorcut that will delete all Kit rows that does not contain notes
 	// (instead of pressing Note + Delete to do it one by one)
 	else if (b == SAVE && currentUIMode != UI_MODE_NOTES_PRESSED && Buttons::isShiftButtonPressed()
-	         && currentSong->currentClip->output->type == InstrumentType::KIT) {
+	         && currentSong->currentClip->output->type == InstrumentType::KIT
+	         && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::DeleteUnusedKitRows) == RuntimeFeatureStateToggle::On)) {
 		if (inCardRoutine) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -82,6 +82,9 @@ void RuntimeFeatureSettings::init() {
 	// CatchNotes
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::CatchNotes], "CatchNotes", "catchNotes",
 	                  RuntimeFeatureStateToggle::On);
+	// DeleteUnusedKitRows
+	SetupOnOffSetting(settings[RuntimeFeatureSettingType::DeleteUnusedKitRows], "Delete Unused Kit Rows",
+	                  "deleteUnusedKitRows", RuntimeFeatureStateToggle::On);
 }
 
 void RuntimeFeatureSettings::readSettingsFromFile() {

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -41,6 +41,7 @@ enum RuntimeFeatureSettingType : uint32_t {
 	FineTempoKnob,
 	PatchCableResolution,
 	CatchNotes,
+	DeleteUnusedKitRows,
 	MaxElement // Keep as boundary
 };
 


### PR DESCRIPTION
This is a big deal for me when I load an entire folder of percussion samples, play around with them till I find maybe a few that I like and create a sequence. Then later I want to quickly delete all the other rows that I didn’t use.
[https://www.youtube.com/watch?v=R7WwzryMg4c](https://www.youtube.com/watch?v=R7WwzryMg4c)
UPDATE:
Changed the key combo to: Kit + Shift + Save/Delete