### PR TITLE
Fix the Doxyfile so it looks up recursively for all sources to generate full documentation

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1008,7 +1008,7 @@ FILE_PATTERNS          = *.c \
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a
@@ -1064,7 +1064,7 @@ EXAMPLE_PATTERNS       = *
 # irrespective of the value of the RECURSIVE tag.
 # The default value is: NO.
 
-EXAMPLE_RECURSIVE      = NO
+EXAMPLE_RECURSIVE      = YES
 
 # The IMAGE_PATH tag can be used to specify one or more files or directories
 # that contain images that are to be included in the documentation (see the


### PR DESCRIPTION
When I tried generating the doxygen documentation I realized that it only generated for the source files contained in the root src/ folder. Only after I enabled RECURSIVE I got the full documentation generated with all classes in subdirectories