### PR TITLE
Bugfix mpe kit handling of CCs, pitch bend, and aftertouch

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,7 @@
+# .git-blame-ignore-revs
+#clang format the tree take 2
+fa39e653c29fccccf826f7f62e19b91f4ea34fc9
+#revert clang format
+10233407e7128673b49038727ff1f8fc6437176a
+#clang format the tree take 1
+df18601b7d9a2aa87cdb514afe82c373b3b878be

--- a/src/deluge/io/midi/learned_midi.cpp
+++ b/src/deluge/io/midi/learned_midi.cpp
@@ -128,12 +128,13 @@ bool LearnedMIDI::equalsChannelAllowMPE(MIDIDevice* newDevice, int newChannel) {
 	if (!device) {
 		return false; // Could we actually be set to MPE but have no device? Maybe if loaded from weird song file?
 	}
-	if (channelOrZone == MIDI_CHANNEL_MPE_LOWER_ZONE) {
-		return (newChannel <= device->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel);
+	if (newChannel <= newDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel) {
+		return (channelOrZone == MIDI_CHANNEL_MPE_LOWER_ZONE);
 	}
-	if (channelOrZone == MIDI_CHANNEL_MPE_UPPER_ZONE) {
-		return (newChannel >= device->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel);
+	else if (newChannel >= newDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel) {
+		return (channelOrZone == MIDI_CHANNEL_MPE_UPPER_ZONE);
 	}
+
 	return (channelOrZone == newChannel);
 }
 
@@ -150,5 +151,15 @@ bool LearnedMIDI::equalsChannelAllowMPEMasterChannels(MIDIDevice* newDevice, int
 	if (channelOrZone > IS_A_CC) {
 		return (channelOrZone == newChannel);
 	}
-	return (newChannel == getMasterChannel());
+
+	if (channelOrZone == MIDI_CHANNEL_MPE_LOWER_ZONE) {
+		if (newChannel <= newDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel) {
+			return (newChannel == getMasterChannel());
+		}
+	}
+	if (channelOrZone == MIDI_CHANNEL_MPE_UPPER_ZONE) {
+		if (newChannel >= newDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel) {
+			return (newChannel == getMasterChannel());
+		}
+	}
 }

--- a/src/deluge/model/drum/kit.cpp
+++ b/src/deluge/model/drum/kit.cpp
@@ -1007,10 +1007,7 @@ void Kit::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevic
 
 		// If this is the "input" command, to sound / audition the Drum...
 		// Returns true if midi channel and note match the learned midi note
-		// Calls equalsChannelAllowMPE to check channel equivalence
-		// Convert channel+device into zone before comparison to stop crossover between MPE and non MPE channels
-		int channelOrZone = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
-		if (thisDrum->midiInput.equalsNoteOrCCAllowMPE(fromDevice, channelOrZone, note)) {
+		if (thisDrum->midiInput.equalsNoteOrCCAllowMPE(fromDevice, channel, note)) {
 
 			// If MIDIDrum, outputting same note, then don't additionally do thru
 			if (doingMidiThru && thisDrum->type == DrumType::MIDI && ((MIDIDrum*)thisDrum)->channel == channel


### PR DESCRIPTION
Fix the function equalsChannelAllowMPE to correctly use the receiving device and not the learnt device to determine MPE ranges. 

Fix the logic in the function to correctly return false if a non-MPE channel is sent to an MPE zone. 

Revert earlier change converting channel to zone on note receives as it's no longer necessary

Also add a git-blame-ignore-revs file to remove the clang format from git blame output to aid in bugfinding