### PR TITLE
build: don't do -flto on debug builds

### DIFF
--- a/site_scons/build_opts.scons
+++ b/site_scons/build_opts.scons
@@ -22,7 +22,6 @@ env.AppendUnique(
         "-mfloat-abi=hard",
         "-mthumb-interwork",
         "-mlittle-endian",
-        "-flto",
         "-fdiagnostics-parseable-fixits",
     ],
     ASMPATH=[


### PR DESCRIPTION
assuming this was a mistake. `-flto` is mentioned specifically among the release flags, but got duplicated amongst the shared flags, so it got applied to debug builds as well.

Having `-flto` unconditionaly in LINKFLAGS is fine. If there is no LTO data in the .o files, the linker will just skip it.