### PR TITLE
Hotfix for when dbt format is called without args

### DIFF
--- a/scripts/tasks/task-format.py
+++ b/scripts/tasks/task-format.py
@@ -11,12 +11,13 @@ from functools import partial
 
 EXEC_EXT = ".exe" if os.name == "nt" else ""
 
+
 def excludes_from_file(ignore_file):
     excludes = []
     try:
-        with io.open(ignore_file, 'r', encoding='utf-8') as f:
+        with io.open(ignore_file, "r", encoding="utf-8") as f:
             for line in f:
-                if line.startswith('#'):
+                if line.startswith("#"):
                     # ignore comments
                     continue
                 pattern = line.rstrip()
@@ -29,14 +30,14 @@ def excludes_from_file(ignore_file):
             raise
     return excludes
 
+
 def exclude(files, excludes):
     out = []
     fpaths = [f for f in files]
     for pattern in excludes:
-        fpaths = [
-            x for x in fpaths if not fnmatch.fnmatch(x, pattern)
-        ]
+        fpaths = [x for x in fpaths if not fnmatch.fnmatch(x, pattern)]
     return fpaths
+
 
 def get_clang_format():
     git_path = util.get_git_root()
@@ -73,7 +74,7 @@ def argparser() -> argparse.ArgumentParser:
         "-nr",
         "--no-recursive",
         help="do not recursively descend and process files",
-        action="store_true"
+        action="store_true",
     )
     parser.add_argument(
         "-q", "--quiet", help="don't show any output", action="store_true"
@@ -82,16 +83,20 @@ def argparser() -> argparse.ArgumentParser:
         "-v", "--verbose", help="print the changes happening", action="store_true"
     )
     parser.add_argument(
-        "directory", 
-        nargs='?',
-        help="the directory of source files to format (defaults to whole project)"
+        "directory",
+        nargs="?",
+        help="the directory of source files to format (defaults to whole project)",
     )
     return parser
 
 
 def main() -> int:
     args = argparser().parse_args()
-    directory = Path(args.directory) or (util.get_git_root().absolute() / 'src')
+    directory = (
+        Path(args.directory)
+        if args.directory is not None
+        else (util.get_git_root().absolute() / "src")
+    )
     files = get_header_and_source_files(directory, not args.no_recursive)
     excludes = excludes_from_file(".clang-format-ignore")
     files = exclude(files, excludes)
@@ -105,11 +110,12 @@ def main() -> int:
             format_file(clang_format, True, file)
             print(f"Formatting {file}")
     else:
-        util.do_parallel_progressbar(partial(format_file, clang_format, False), files, "Formatting: ")
-    
+        util.do_parallel_progressbar(
+            partial(format_file, clang_format, False), files, "Formatting: "
+        )
+
     print("Done!")
     return 0
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a bug introduced by attempting to fix a bug when calling `dbt format` without any explicit arguments.