### PR TITLE
Hot Fix: Clip button LED stays on when in Song mode

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1052,7 +1052,13 @@ void View::setModLedStates() {
 	}
 	indicator_leds::setLedState(IndicatorLED::AFFECT_ENTIRE, affectEntire);
 
-	indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, !itsTheSong);
+
+	if (!itsTheSong) { //if in clip view, turn on clip button led
+		indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, true);
+	}
+	else { //if not in clip view, turn off clip button led
+		indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, false);
+	}
 
 	// Sort out the session/arranger view LEDs
 	if (itsTheSong) {


### PR DESCRIPTION
Quick fix to resolve a bug with the Clip LED button on the Deluge.

Currently when you switch to Song mode from Clip view mode, the Clip button led stays on. This is contrast to the behaviour of the Song button LED which turns off when you switch from Song mode to Clip view mode.

The fix turns the Clip button LED off when in Song mode.

Code change is simple:

**File **change: \src\Deluge\gui\views\view.cpp  (line 1054)****

**Before**

`indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, !itsTheSong);`

**After**

```
if (!itsTheSong) { //if in clip view, turn on clip button led
	indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, true);
}

else { //if not in clip view, turn off clip button led
	indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, false);
}
```