### PR TITLE
Improve 7seg text scroll and edit behaviour

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1390,7 +1390,6 @@ void Browser::displayText(bool blinkImmediately) {
 	renderUIsForOled();
 #else
 	if (arrivedAtFileByTyping) {
-doQWERTYDisplay:
 		QwertyUI::displayText(blinkImmediately);
 	}
 	else {
@@ -1412,13 +1411,12 @@ doQWERTYDisplay:
 
 			else {
 nonNumeric:
-				goto doQWERTYDisplay; // Abandon the below for now.
 				numberEditPos = -1;
 				if (qwertyVisible) {
-					goto doQWERTYDisplay;
+					QwertyUI::displayText(blinkImmediately);
 				}
 				else {
-					scrollingText = numericDriver.setScrollingText(enteredText.get(), numCharsInPrefix);
+					scrollingText = numericDriver.setScrollingText(enteredText.get(), enteredTextEditPos);
 				}
 			}
 		}

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1389,7 +1389,13 @@ void Browser::displayText(bool blinkImmediately) {
 #if HAVE_OLED
 	renderUIsForOled();
 #else
-	if (arrivedAtFileByTyping) {
+	if (arrivedAtFileByTyping || qwertyVisible) {
+		if (!arrivedAtFileByTyping) {
+			//This means a key has been hit while browsing
+			//to bring up the keyboard, so set position to -1
+			//this might not be neccesary?
+			numberEditPos = -1;
+		}
 		QwertyUI::displayText(blinkImmediately);
 	}
 	else {
@@ -1401,24 +1407,20 @@ void Browser::displayText(bool blinkImmediately) {
 			if (filePrefix) {
 
 				Slot thisSlot = getSlot(enteredText.get());
-				if (thisSlot.slot < 0) {
-					goto nonNumeric;
-				}
-
-				numericDriver.setTextAsSlot(thisSlot.slot, thisSlot.subSlot, (fileIndexSelected != -1), true,
-				                            numberEditPos, blinkImmediately);
-			}
-
-			else {
-nonNumeric:
-				numberEditPos = -1;
-				if (qwertyVisible) {
-					QwertyUI::displayText(blinkImmediately);
-				}
-				else {
-					scrollingText = numericDriver.setScrollingText(enteredText.get(), enteredTextEditPos);
+				if (thisSlot.slot >= 0) {
+					numericDriver.setTextAsSlot(thisSlot.slot, thisSlot.subSlot, (fileIndexSelected != -1), true,
+					                            numberEditPos, blinkImmediately);
+					return;
 				}
 			}
+			int16_t scrollStart = enteredTextEditPos;
+			//if the first difference would be visible on
+			//screen anyway, start scroll from the beginning
+			if (enteredTextEditPos < 4) {
+				scrollStart = 0;
+			}
+
+			scrollingText = numericDriver.setScrollingText(enteredText.get(), scrollStart);
 		}
 	}
 #endif

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1419,6 +1419,9 @@ void Browser::displayText(bool blinkImmediately) {
 			if (enteredTextEditPos < 4) {
 				scrollStart = 0;
 			}
+			else {
+				scrollStart = enteredTextEditPos - 3;
+			}
 
 			scrollingText = numericDriver.setScrollingText(enteredText.get(), scrollStart);
 		}

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1416,11 +1416,12 @@ void Browser::displayText(bool blinkImmediately) {
 			int16_t scrollStart = enteredTextEditPos;
 			//if the first difference would be visible on
 			//screen anyway, start scroll from the beginning
-			if (enteredTextEditPos < 4) {
+			if (enteredTextEditPos < 3) {
 				scrollStart = 0;
 			}
 			else {
-				scrollStart = enteredTextEditPos - 3;
+				//provide some context in case the post-fix is long
+				scrollStart = enteredTextEditPos - 2;
 			}
 
 			scrollingText = numericDriver.setScrollingText(enteredText.get(), scrollStart);

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -110,10 +110,8 @@ protected:
 	ActionResult mainButtonAction(bool on);
 	virtual void exitAction();
 	virtual ActionResult backButtonAction();
-	virtual void folderContentsReady(int entryDirection) {
-	}
-	virtual void currentFileChanged(int movementDirection) {
-	}
+	virtual void folderContentsReady(int entryDirection) {}
+	virtual void currentFileChanged(int movementDirection) {}
 	void displayText(bool blinkImmediately = false);
 	static Slot getSlot(char const* displayName);
 	int readFileItemsFromFolderAndMemory(Song* song, InstrumentType instrumentType, char const* filePrefixHere,
@@ -139,6 +137,7 @@ protected:
 #endif
 	bool mayDefaultToBrandNewNameOnEntry;
 	bool qwertyAlwaysVisible;
+	//filePrefix is SONG/SYNT/SAMP etc., signifying the portion of the filesystem you're in
 	char const* filePrefix;
 	bool shouldInterpretNoteNamesForThisBrowser;
 };

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -110,8 +110,10 @@ protected:
 	ActionResult mainButtonAction(bool on);
 	virtual void exitAction();
 	virtual ActionResult backButtonAction();
-	virtual void folderContentsReady(int entryDirection) {}
-	virtual void currentFileChanged(int movementDirection) {}
+	virtual void folderContentsReady(int entryDirection) {
+	}
+	virtual void currentFileChanged(int movementDirection) {
+	}
 	void displayText(bool blinkImmediately = false);
 	static Slot getSlot(char const* displayName);
 	int readFileItemsFromFolderAndMemory(Song* song, InstrumentType instrumentType, char const* filePrefixHere,

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -36,6 +36,8 @@
 
 bool QwertyUI::predictionInterrupted;
 String QwertyUI::enteredText{};
+//entered text edit position is the first difference from
+//the previously seen name while browsing/editing
 int16_t QwertyUI::enteredTextEditPos;
 int QwertyUI::scrollPosHorizontal;
 

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -92,8 +92,6 @@ gotError:
 
 	// TODO: create folder if doesn't exist.
 
-	enteredTextEditPos = 0; //enteredText.getLength();
-
 	indicator_leds::setLedState(IndicatorLED::SYNTH, false);
 	indicator_leds::setLedState(IndicatorLED::KIT, false);
 	indicator_leds::setLedState(IndicatorLED::MIDI, false);
@@ -105,6 +103,9 @@ gotError:
 	indicator_leds::blinkLed(IndicatorLED::SESSION_VIEW);
 
 	focusRegained();
+	//do this after focus regained, otherwise the first scroll starts
+	//from the beginning instead of showing the incremented number
+	enteredTextEditPos = 0; //enteredText.getLength();
 	return true;
 }
 

--- a/src/deluge/io/midi/learned_midi.cpp
+++ b/src/deluge/io/midi/learned_midi.cpp
@@ -162,4 +162,5 @@ bool LearnedMIDI::equalsChannelAllowMPEMasterChannels(MIDIDevice* newDevice, int
 			return (newChannel == getMasterChannel());
 		}
 	}
+	return false; //should never happen
 }


### PR DESCRIPTION
Changes the 7seg browsing UI to the following logic:
- If we arrived at the file by typing:
    - Show the typed in text and the deluge prediction without scroling
- Else
    - Check first different character from previous filename
    - If the first difference is less than 3:
        - Scroll from beginning
    - Else:
        - Scroll from first difference -2

This fixes #99, #217, and #101 

Sets the save UI edit position to zero after setting scrolling text, allowing the automatically added _number postfix to appear first. Typing at this point still starts from nothing instead of appending to the end.

This fixes #98. 

Additionally #97 and #100 were fixed by @rohanhill's commit 4500701