### PR TITLE
Turn the GeneralMemoryAllocator into a singleton

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -458,7 +458,7 @@ void setUIForLoadedSong(Song* song) {
 }
 
 void setupBlankSong() {
-	void* songMemory = generalMemoryAllocator.alloc(sizeof(Song), NULL, false, true); // TODO: error checking
+	void* songMemory = GeneralMemoryAllocator::get().alloc(sizeof(Song), NULL, false, true); // TODO: error checking
 	preLoadedSong = new (songMemory) Song();
 
 	preLoadedSong->paramManager.setupUnpatched(); // TODO: error checking
@@ -598,7 +598,7 @@ extern "C" int deluge_main(void) {
 	Encoders::init();
 
 #ifdef TEST_GENERAL_MEMORY_ALLOCATION
-	generalMemoryAllocator.test();
+	GeneralMemoryAllocator::get().test();
 #endif
 
 	// Setup for gate output
@@ -931,7 +931,7 @@ void deleteOldSongBeforeLoadingNew() {
 	currentSong = NULL;
 	void* toDealloc = dynamic_cast<void*>(toDelete);
 	toDelete->~Song();
-	generalMemoryAllocator.dealloc(toDelete);
+	GeneralMemoryAllocator::get().dealloc(toDelete);
 }
 
 #if ALLOW_SPAM_MODE

--- a/src/deluge/dsp/delay/delay_buffer.cpp
+++ b/src/deluge/dsp/delay/delay_buffer.cpp
@@ -63,8 +63,8 @@ uint8_t DelayBuffer::init(uint32_t newRate, uint32_t failIfThisSize, bool includ
 	sizeIncludingExtra = size + (includeExtraSpace ? delaySpaceBetweenReadAndWrite : 0);
 	AudioEngine::logAction("DelayBuffer::init before");
 
-	bufferStart =
-	    (StereoSample*)generalMemoryAllocator.alloc(sizeIncludingExtra * sizeof(StereoSample), NULL, false, true);
+	bufferStart = (StereoSample*)GeneralMemoryAllocator::get().alloc(sizeIncludingExtra * sizeof(StereoSample), NULL,
+	                                                                 false, true);
 	AudioEngine::logAction("DelayBuffer::init after");
 	if (bufferStart == 0) {
 		return ERROR_INSUFFICIENT_RAM;
@@ -97,7 +97,7 @@ void DelayBuffer::makeNativeRatePreciseRelativeToOtherBuffer(DelayBuffer* otherB
 
 void DelayBuffer::discard(bool beingDestructed) {
 	if (bufferStart) {
-		generalMemoryAllocator.dealloc(bufferStart);
+		GeneralMemoryAllocator::get().dealloc(bufferStart);
 		if (!beingDestructed) {
 			bufferStart = NULL; // If destructing, writing anything would be a waste of time
 		}

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -168,7 +168,7 @@ void TimeStretcher::beenUnassigned() {
 	unassignAllReasonsForPercCacheClusters();
 	olderPartReader.unassignAllReasons();
 	if (buffer) {
-		generalMemoryAllocator.dealloc(buffer);
+		GeneralMemoryAllocator::get().dealloc(buffer);
 	}
 }
 
@@ -955,7 +955,7 @@ optForDirectReading:
 	// If no one's reading from the buffer anymore, stop filling it
 	if (buffer
 	    && !olderHeadReadingFromBuffer) { // olderHeadReadingFromBuffer will always be false - we set it above, at the start
-		generalMemoryAllocator.dealloc(buffer);
+		GeneralMemoryAllocator::get().dealloc(buffer);
 		buffer = NULL;
 		Debug::println("abandoning buffer!!!!!!!!!!!!!!!!");
 	}
@@ -1030,7 +1030,7 @@ void TimeStretcher::reassessWhetherToBeFillingBuffer(int32_t phaseIncrement, int
 		// If no one's reading from the buffer anymore, stop filling it
 		if (!newerHeadReadingFromBuffer && !olderHeadReadingFromBuffer && bufferFillingMode == BUFFER_FILLING_NEITHER) {
 			bufferFillingMode = BUFFER_FILLING_OFF;
-			generalMemoryAllocator.dealloc(buffer);
+			GeneralMemoryAllocator::get().dealloc(buffer);
 			buffer = NULL;
 			Debug::println("abandoning buffer!!!!!!!!!!!!!!!!");
 		}
@@ -1039,8 +1039,8 @@ void TimeStretcher::reassessWhetherToBeFillingBuffer(int32_t phaseIncrement, int
 #endif
 
 bool TimeStretcher::allocateBuffer(int numChannels) {
-	buffer = (int32_t*)generalMemoryAllocator.alloc(TimeStretch::kBufferSize * sizeof(int32_t) * numChannels, NULL,
-	                                                false, true);
+	buffer = (int32_t*)GeneralMemoryAllocator::get().alloc(TimeStretch::kBufferSize * sizeof(int32_t) * numChannels,
+	                                                       NULL, false, true);
 	return (buffer != NULL);
 }
 
@@ -1164,7 +1164,7 @@ void TimeStretcher::setupCrossfadeFromCache(SampleCache* cache, int cacheBytePos
 
 	// If we're really unlucky, allocating the buffer may have stolen from the cache
 	if (originalCacheWriteBytePos != cache->writeBytePos) {
-		generalMemoryAllocator.dealloc(buffer);
+		GeneralMemoryAllocator::get().dealloc(buffer);
 		buffer = NULL;
 		return;
 	}

--- a/src/deluge/gui/context_menu/clear_song.cpp
+++ b/src/deluge/gui/context_menu/clear_song.cpp
@@ -86,7 +86,7 @@ bool ClearSong::acceptCurrentOption() {
 		AudioEngine::songSwapAboutToHappen();
 	}
 
-	void* songMemory = generalMemoryAllocator.alloc(sizeof(Song), NULL, false, true); // TODO: error checking
+	void* songMemory = GeneralMemoryAllocator::get().alloc(sizeof(Song), NULL, false, true); // TODO: error checking
 	preLoadedSong = new (songMemory) Song();
 	preLoadedSong->paramManager.setupUnpatched(); // TODO: error checking
 	GlobalEffectable::initParams(&preLoadedSong->paramManager);
@@ -100,7 +100,7 @@ bool ClearSong::acceptCurrentOption() {
 	if (toDelete) {
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Song();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 	}
 
 	audioFileManager.deleteAnyTempRecordedSamplesFromMemory();

--- a/src/deluge/gui/context_menu/overwrite_bootloader.cpp
+++ b/src/deluge/gui/context_menu/overwrite_bootloader.cpp
@@ -114,7 +114,7 @@ longError:
 			}
 
 			// Allocate RAM
-			uint8_t* buffer = (uint8_t*)generalMemoryAllocator.alloc(fileSize, NULL, false, true);
+			uint8_t* buffer = (uint8_t*)GeneralMemoryAllocator::get().alloc(fileSize, NULL, false, true);
 			if (!buffer) {
 				error = ERROR_INSUFFICIENT_RAM;
 				goto gotError;
@@ -125,7 +125,7 @@ longError:
 			result = f_open(&currentFile, fno.fname, FA_READ);
 			if (result != FR_OK) {
 gotFresultErrorAfterAllocating:
-				generalMemoryAllocator.dealloc(buffer);
+				GeneralMemoryAllocator::get().dealloc(buffer);
 				goto gotFresultError;
 			}
 
@@ -139,7 +139,7 @@ gotFresultErrorAfterAllocating:
 
 			if (numBytesRead != fileSize) { // Can this happen?
 				error = ERROR_SD_CARD;
-				generalMemoryAllocator.dealloc(buffer);
+				GeneralMemoryAllocator::get().dealloc(buffer);
 				goto gotError;
 			}
 
@@ -200,7 +200,7 @@ gotFlashError:
 				readAddress += FLASH_WRITE_SIZE;
 			}
 
-			generalMemoryAllocator.dealloc(buffer);
+			GeneralMemoryAllocator::get().dealloc(buffer);
 
 #if HAVE_OLED
 			OLED::removeWorkingAnimation();

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -1338,7 +1338,8 @@ removeReasonsFromSamplesAndGetOut:
 	// If all samples were tagged with the same MIDI note, we get suspicious and delete them.
 	bool discardingMIDINoteFromFile = (numSamples > 1 && commonMIDINote >= 0);
 
-	Sample** sortArea = (Sample**)generalMemoryAllocator.alloc(numSamples * sizeof(Sample*) * 2, NULL, false, true);
+	Sample** sortArea =
+	    (Sample**)GeneralMemoryAllocator::get().alloc(numSamples * sizeof(Sample*) * 2, NULL, false, true);
 	if (!sortArea) {
 		error = ERROR_INSUFFICIENT_RAM;
 		goto removeReasonsFromSamplesAndGetOut;
@@ -1666,7 +1667,7 @@ doReturnFalse:
 		AudioEngine::audioRoutineLocked = false;
 
 		if (!success) {
-			generalMemoryAllocator.dealloc(sortArea);
+			GeneralMemoryAllocator::get().dealloc(sortArea);
 			for (int s = 0; s < numSamples; s++) {
 				Sample* thisSample = sortArea[s];
 #if ALPHA_OR_BETA_VERSION
@@ -1832,7 +1833,7 @@ skipOctaveCorrection:
 	Debug::print("distinct ranges: ");
 	Debug::println(numSamples);
 
-	generalMemoryAllocator.dealloc(sortArea);
+	GeneralMemoryAllocator::get().dealloc(sortArea);
 
 	audioFileIsNowSet();
 
@@ -1952,7 +1953,7 @@ getOut:
 					goto getOut;
 				}
 
-				void* drumMemory = generalMemoryAllocator.alloc(sizeof(SoundDrum), NULL, false, true);
+				void* drumMemory = GeneralMemoryAllocator::get().alloc(sizeof(SoundDrum), NULL, false, true);
 				if (!drumMemory) {
 					goto getOut;
 				}
@@ -1963,7 +1964,7 @@ getOut:
 				range = source->getOrCreateFirstRange();
 				if (!range) {
 					drum->~Drum();
-					generalMemoryAllocator.dealloc(drumMemory);
+					GeneralMemoryAllocator::get().dealloc(drumMemory);
 					goto getOut;
 				}
 
@@ -2015,7 +2016,7 @@ skipNameStuff:
 			thisSample->removeReason("E395");
 		}
 
-		generalMemoryAllocator.dealloc(sortArea);
+		GeneralMemoryAllocator::get().dealloc(sortArea);
 	}
 
 	// Make NoteRows for all these new Drums

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -277,7 +277,7 @@ void LoadSongUI::performLoad() {
 		playbackHandler.songSwapShouldPreserveTempo = Buttons::isButtonPressed(hid::button::TEMPO_ENC);
 	}
 
-	void* songMemory = generalMemoryAllocator.alloc(sizeof(Song), NULL, false, true);
+	void* songMemory = GeneralMemoryAllocator::get().alloc(sizeof(Song), NULL, false, true);
 	if (!songMemory) {
 ramError:
 		error = ERROR_INSUFFICIENT_RAM;
@@ -310,7 +310,7 @@ fail:
 gotErrorAfterCreatingSong:
 		void* toDealloc = dynamic_cast<void*>(preLoadedSong);
 		preLoadedSong->~Song(); // Will also delete paramManager
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 		preLoadedSong = NULL;
 		goto someError;
 	}
@@ -432,7 +432,7 @@ swapDone:
 	if (toDelete) {
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Song();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 	}
 
 	audioFileManager.deleteAnyTempRecordedSamplesFromMemory();

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -691,7 +691,7 @@ getOut:
 				goto getOut;
 			}
 
-			void* drumMemory = generalMemoryAllocator.alloc(sizeof(SoundDrum), NULL, false, true);
+			void* drumMemory = GeneralMemoryAllocator::get().alloc(sizeof(SoundDrum), NULL, false, true);
 			if (!drumMemory) {
 ramError:
 				error = ERROR_INSUFFICIENT_RAM;
@@ -704,7 +704,7 @@ ramError:
 			if (!range) {
 ramError2:
 				newDrum->~Drum();
-				generalMemoryAllocator.dealloc(drumMemory);
+				GeneralMemoryAllocator::get().dealloc(drumMemory);
 				goto ramError;
 			}
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1506,7 +1506,7 @@ justGetOut:
 								int size = (output->type == InstrumentType::AUDIO) ? sizeof(AudioClip)
 								                                                   : sizeof(InstrumentClip);
 
-								void* memory = generalMemoryAllocator.alloc(size, NULL, false, true);
+								void* memory = GeneralMemoryAllocator::get().alloc(size, NULL, false, true);
 								if (!memory) {
 									numericDriver.displayError(ERROR_INSUFFICIENT_RAM);
 									goto justGetOut;
@@ -1541,7 +1541,7 @@ justGetOut:
 								if (error) {
 									numericDriver.displayError(error);
 									newClip->~Clip();
-									generalMemoryAllocator.dealloc(memory);
+									GeneralMemoryAllocator::get().dealloc(memory);
 									goto justGetOut;
 								}
 
@@ -2693,7 +2693,8 @@ ActionResult ArrangerView::horizontalEncoderAction(int offset) {
 				        ->addParamCollection(unpatchedParams, unpatchedParamsSummary);
 
 				if (offset >= 0) {
-					void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceArrangerParamsTimeInserted));
+					void* consMemory =
+					    GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceArrangerParamsTimeInserted));
 					if (consMemory) {
 						ConsequenceArrangerParamsTimeInserted* consequence = new (consMemory)
 						    ConsequenceArrangerParamsTimeInserted(currentSong->xScroll[NAVIGATION_ARRANGEMENT],

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -266,7 +266,7 @@ doReRender:
 			action = actionLogger.getNewAction(ACTION_CLIP_HORIZONTAL_SHIFT, ACTION_ADDITION_NOT_ALLOWED);
 			if (action) {
 addConsequenceToAction:
-				void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceClipHorizontalShift));
+				void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceClipHorizontalShift));
 
 				if (consMemory) {
 					ConsequenceClipHorizontalShift* newConsequence =

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -794,7 +794,7 @@ someError:
 discardDrum:
 			void* toDealloc = dynamic_cast<void*>(newDrum);
 			newDrum->~Drum();
-			generalMemoryAllocator.dealloc(toDealloc);
+			GeneralMemoryAllocator::get().dealloc(toDealloc);
 			goto someError;
 		}
 
@@ -852,7 +852,7 @@ void InstrumentClipView::modEncoderButtonAction(uint8_t whichModEncoder, bool on
 
 void InstrumentClipView::copyAutomation(int whichModEncoder) {
 	if (copiedParamAutomation.nodes) {
-		generalMemoryAllocator.dealloc(copiedParamAutomation.nodes);
+		GeneralMemoryAllocator::get().dealloc(copiedParamAutomation.nodes);
 		copiedParamAutomation.nodes = NULL;
 		copiedParamAutomation.numNodes = 0;
 	}
@@ -921,7 +921,7 @@ void InstrumentClipView::copyNotes() {
 
 			if (numNotes > 0) {
 
-				void* copiedNoteRowMemory = generalMemoryAllocator.alloc(sizeof(CopiedNoteRow), NULL, true);
+				void* copiedNoteRowMemory = GeneralMemoryAllocator::get().alloc(sizeof(CopiedNoteRow), NULL, true);
 				if (!copiedNoteRowMemory) {
 ramError:
 					deleteCopiedNoteRows();
@@ -937,7 +937,8 @@ ramError:
 				prevPointer = &newCopiedNoteRow->next;
 
 				// Allocate some memory for the notes
-				newCopiedNoteRow->notes = (Note*)generalMemoryAllocator.alloc(sizeof(Note) * numNotes, NULL, true);
+				newCopiedNoteRow->notes =
+				    (Note*)GeneralMemoryAllocator::get().alloc(sizeof(Note) * numNotes, NULL, true);
 
 				if (!newCopiedNoteRow->notes) {
 					goto ramError;
@@ -980,7 +981,7 @@ void InstrumentClipView::deleteCopiedNoteRows() {
 		CopiedNoteRow* toDelete = firstCopiedNoteRow;
 		firstCopiedNoteRow = firstCopiedNoteRow->next;
 		toDelete->~CopiedNoteRow();
-		generalMemoryAllocator.dealloc(toDelete);
+		GeneralMemoryAllocator::get().dealloc(toDelete);
 	}
 }
 
@@ -1140,7 +1141,7 @@ void InstrumentClipView::doubleClipLengthAction() {
 	// Add the ConsequenceClipMultiply to the Action. This must happen before calling doubleClipLength(), which may add note changes and deletions,
 	// because when redoing, those have to happen after (and they'll have no effect at all, but who cares)
 	if (action) {
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceInstrumentClipMultiply));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceInstrumentClipMultiply));
 
 		if (consMemory) {
 			ConsequenceInstrumentClipMultiply* newConsequence = new (consMemory) ConsequenceInstrumentClipMultiply();
@@ -1896,7 +1897,7 @@ void InstrumentClipView::endEditPadPress(uint8_t i) {
 
 	for (int m = 0; m < kNumExpressionDimensions; m++) {
 		if (editPadPresses[i].stolenMPE[m].num) {
-			generalMemoryAllocator.dealloc(editPadPresses[i].stolenMPE[m].nodes);
+			GeneralMemoryAllocator::get().dealloc(editPadPresses[i].stolenMPE[m].nodes);
 		}
 	}
 }
@@ -3332,7 +3333,7 @@ doDisplayError:
 		return;
 	}
 
-	void* memory = generalMemoryAllocator.alloc(sizeof(SoundDrum), NULL, false, true);
+	void* memory = GeneralMemoryAllocator::get().alloc(sizeof(SoundDrum), NULL, false, true);
 	if (!memory) {
 		error = ERROR_INSUFFICIENT_RAM;
 		goto doDisplayError;
@@ -3341,7 +3342,7 @@ doDisplayError:
 	ParamManagerForTimeline paramManager;
 	error = paramManager.setupWithPatching();
 	if (error) {
-		generalMemoryAllocator.dealloc(memory);
+		GeneralMemoryAllocator::get().dealloc(memory);
 		goto doDisplayError;
 	}
 
@@ -3421,7 +3422,7 @@ void InstrumentClipView::deleteDrum(SoundDrum* drum) {
 	currentSong->deleteBackedUpParamManagersForModControllable(drum);
 	void* toDealloc = dynamic_cast<void*>(drum);
 	drum->~SoundDrum();
-	generalMemoryAllocator.dealloc(toDealloc);
+	GeneralMemoryAllocator::get().dealloc(toDealloc);
 
 	AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 
@@ -5371,7 +5372,7 @@ getNewAction:
 			action = actionLogger.getNewAction(ACTION_NOTEROW_HORIZONTAL_SHIFT, ACTION_ADDITION_NOT_ALLOWED);
 			if (action) {
 addConsequenceToAction:
-				void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceNoteRowHorizontalShift));
+				void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceNoteRowHorizontalShift));
 
 				if (consMemory) {
 					ConsequenceNoteRowHorizontalShift* newConsequence =
@@ -5486,7 +5487,7 @@ ramError:
 			return;
 		}
 
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceNoteRowLength));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceNoteRowLength));
 		if (!consMemory) {
 			goto ramError;
 		}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1339,7 +1339,7 @@ Clip* SessionView::createNewInstrumentClip(int yDisplay) {
 
 	actionLogger.deleteAllLogs();
 
-	void* memory = generalMemoryAllocator.alloc(sizeof(InstrumentClip), NULL, false, true);
+	void* memory = GeneralMemoryAllocator::get().alloc(sizeof(InstrumentClip), NULL, false, true);
 	if (!memory) {
 		numericDriver.displayError(ERROR_INSUFFICIENT_RAM);
 		return NULL;
@@ -1375,7 +1375,7 @@ doGetInstrument:
 			goto doGetInstrument;
 		}
 		newClip->~InstrumentClip();
-		generalMemoryAllocator.dealloc(memory);
+		GeneralMemoryAllocator::get().dealloc(memory);
 		numericDriver.displayError(error);
 		return NULL;
 	}
@@ -1429,7 +1429,7 @@ void SessionView::replaceAudioClipWithInstrumentClip(InstrumentType instrumentTy
 	}
 
 	// Allocate memory for InstrumentClip
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(InstrumentClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(InstrumentClip), NULL, false, true);
 	if (!clipMemory) {
 ramError:
 		numericDriver.displayError(ERROR_INSUFFICIENT_RAM);
@@ -1454,7 +1454,7 @@ gotError:
 			numericDriver.displayError(error);
 gotErrorDontDisplay:
 			newClip->~InstrumentClip();
-			generalMemoryAllocator.dealloc(clipMemory);
+			GeneralMemoryAllocator::get().dealloc(clipMemory);
 			return;
 		}
 	}

--- a/src/deluge/hid/display/numeric_driver.cpp
+++ b/src/deluge/hid/display/numeric_driver.cpp
@@ -80,7 +80,7 @@ void NumericDriver::deleteAllLayers() {
 		NumericLayer* toDelete = topLayer;
 		topLayer = topLayer->next;
 		toDelete->~NumericLayer();
-		generalMemoryAllocator.dealloc(toDelete);
+		GeneralMemoryAllocator::get().dealloc(toDelete);
 	}
 }
 
@@ -93,7 +93,7 @@ void NumericDriver::removeTopLayer() {
 	topLayer = topLayer->next;
 
 	toDelete->~NumericLayer();
-	generalMemoryAllocator.dealloc(toDelete);
+	GeneralMemoryAllocator::get().dealloc(toDelete);
 
 	if (!popupActive) {
 		uiTimerManager.unsetTimer(TIMER_DISPLAY);
@@ -107,7 +107,7 @@ void NumericDriver::setText(char const* newText, bool alignRight, uint8_t drawDo
                             bool blinkImmediately, bool shouldBlinkFast, int scrollPos, uint8_t* encodedAddition,
                             bool justReplaceBottomLayer) {
 #if !HAVE_OLED
-	void* layerSpace = generalMemoryAllocator.alloc(sizeof(NumericLayerBasicText));
+	void* layerSpace = GeneralMemoryAllocator::get().alloc(sizeof(NumericLayerBasicText));
 	if (!layerSpace) {
 		return;
 	}
@@ -156,7 +156,7 @@ void NumericDriver::setText(char const* newText, bool alignRight, uint8_t drawDo
 
 #if !HAVE_OLED
 NumericLayerScrollingText* NumericDriver::setScrollingText(char const* newText, int startAtTextPos, int initialDelay) {
-	void* layerSpace = generalMemoryAllocator.alloc(sizeof(NumericLayerScrollingText));
+	void* layerSpace = GeneralMemoryAllocator::get().alloc(sizeof(NumericLayerScrollingText));
 	if (!layerSpace) {
 		return NULL;
 	}
@@ -187,7 +187,7 @@ void NumericDriver::replaceBottomLayer(NumericLayer* newLayer) {
 	NumericLayer* toDelete = *prevPointer;
 	*prevPointer = newLayer;
 	toDelete->~NumericLayer();
-	generalMemoryAllocator.dealloc(toDelete);
+	GeneralMemoryAllocator::get().dealloc(toDelete);
 
 	if (!popupActive && topLayer == newLayer) {
 		uiTimerManager.unsetTimer(TIMER_DISPLAY);
@@ -204,7 +204,7 @@ void NumericDriver::transitionToNewLayer(NumericLayer* newLayer) {
 	// If transition...
 	if (!popupActive && nextTransitionDirection != 0 && topLayer != NULL) {
 
-		void* layerSpace = generalMemoryAllocator.alloc(sizeof(NumericLayerScrollTransition));
+		void* layerSpace = GeneralMemoryAllocator::get().alloc(sizeof(NumericLayerScrollTransition));
 
 		if (layerSpace) {
 			scrollTransition = new (layerSpace) NumericLayerScrollTransition();
@@ -562,7 +562,7 @@ void NumericDriver::render() {
 
 // Call this to make the loading animation happen
 void NumericDriver::displayLoadingAnimation(bool delayed, bool transparent) {
-	void* layerSpace = generalMemoryAllocator.alloc(sizeof(NumericLayerLoadingAnimation));
+	void* layerSpace = GeneralMemoryAllocator::get().alloc(sizeof(NumericLayerLoadingAnimation));
 	if (!layerSpace) {
 		return;
 	}

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -135,7 +135,7 @@ MIDIDeviceUSBHosted* getOrCreateHostedMIDIDeviceFromDetails(String* name, uint16
 		return NULL;
 	}
 
-	void* memory = generalMemoryAllocator.alloc(sizeof(MIDIDeviceUSBHosted), NULL, false, true);
+	void* memory = GeneralMemoryAllocator::get().alloc(sizeof(MIDIDeviceUSBHosted), NULL, false, true);
 	if (!memory) {
 		return NULL;
 	}

--- a/src/deluge/memory/fallback_allocator.h
+++ b/src/deluge/memory/fallback_allocator.h
@@ -25,10 +25,10 @@ public:
 			return nullptr;
 		}
 		return static_cast<T*>(
-		    generalMemoryAllocator.alloc(n * sizeof(T), nullptr, false, true, false, nullptr, false));
+		    GeneralMemoryAllocator::get().alloc(n * sizeof(T), nullptr, false, true, false, nullptr, false));
 	}
 
-	void deallocate(T* p, std::size_t n) { generalMemoryAllocator.dealloc(p); }
+	void deallocate(T* p, std::size_t n) { GeneralMemoryAllocator::get().dealloc(p); }
 
 	template <typename U>
 	bool operator==(const deluge::memory::fallback_allocator<U>& o) {

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -35,8 +35,6 @@ char emptySpacesMemoryInternal[sizeof(EmptySpaceRecord) * 1024];
 extern uint32_t __heap_start;
 extern uint32_t __heap_end;
 
-GeneralMemoryAllocator generalMemoryAllocator{};
-
 GeneralMemoryAllocator::GeneralMemoryAllocator() {
 	lock = false;
 	regions[MEMORY_REGION_SDRAM].setup(emptySpacesMemory, sizeof(emptySpacesMemory), EXTERNAL_MEMORY_BEGIN,

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -79,7 +79,7 @@ int numMallocTimes = 0;
 #endif
 
 extern "C" void* delugeAlloc(int requiredSize) {
-	return generalMemoryAllocator.alloc(requiredSize, NULL, false, true);
+	return GeneralMemoryAllocator::get().alloc(requiredSize, NULL, false, true);
 }
 
 // Watch the heck out - in the older V3.1 branch, this had one less argument - makeStealable was missing - so in code from there, thingNotToStealFrom could be interpreted as makeStealable!
@@ -176,7 +176,7 @@ uint32_t GeneralMemoryAllocator::extendRightAsMuchAsEasilyPossible(void* address
 }
 
 extern "C" void delugeDealloc(void* address) {
-	generalMemoryAllocator.dealloc(address);
+	GeneralMemoryAllocator::get().dealloc(address);
 }
 
 void GeneralMemoryAllocator::dealloc(void* address) {
@@ -206,7 +206,7 @@ public:
 	void steal() {
 		//Stealable::steal();
 		testAllocations[testIndex] = 0;
-		generalMemoryAllocator.regions[MEMORY_REGION_SDRAM].numAllocations--;
+		GeneralMemoryAllocator::get().regions[MEMORY_REGION_SDRAM].numAllocations--;
 
 		// The steal() function is allowed to deallocate or shorten some other allocations, too
 		int i = getRandom255() % NUM_TEST_ALLOCATIONS;
@@ -219,13 +219,13 @@ public:
 				if (spaceTypes[i] == SPACE_HEADER_STEALABLE) {
 					((Stealable*)testAllocations[i])->~Stealable();
 				}
-				generalMemoryAllocator.dealloc(testAllocations[i]);
+				GeneralMemoryAllocator::get().dealloc(testAllocations[i]);
 				testAllocations[i] = NULL;
 			}
 
 			else {
 				// Shorten
-				generalMemoryAllocator.testShorten(i);
+				GeneralMemoryAllocator::get().testShorten(i);
 			}
 		}
 	}

--- a/src/deluge/memory/general_memory_allocator.h
+++ b/src/deluge/memory/general_memory_allocator.h
@@ -81,8 +81,11 @@ public:
 
 	bool lock;
 
+	static GeneralMemoryAllocator& get() {
+		static GeneralMemoryAllocator generalMemoryAllocator;
+		return generalMemoryAllocator;
+	}
+
 private:
 	void checkEverythingOk(char const* errorString);
 };
-
-extern GeneralMemoryAllocator generalMemoryAllocator;

--- a/src/deluge/model/action/action.cpp
+++ b/src/deluge/model/action/action.cpp
@@ -58,7 +58,7 @@ void Action::prepareForDestruction(int whichQueueActionIn, Song* song) {
 	deleteAllConsequences(whichQueueActionIn, song, true);
 
 	if (clipStates) {
-		generalMemoryAllocator.dealloc(clipStates);
+		GeneralMemoryAllocator::get().dealloc(clipStates);
 	}
 }
 
@@ -70,7 +70,7 @@ void Action::deleteAllConsequences(int whichQueueActionIn, Song* song, bool dest
 		currentConsequence = currentConsequence->next;
 		toDelete->prepareForDestruction(whichQueueActionIn, song);
 		toDelete->~Consequence();
-		generalMemoryAllocator.dealloc(toDelete);
+		GeneralMemoryAllocator::get().dealloc(toDelete);
 	}
 	if (!destructing) {
 		firstConsequence = NULL;
@@ -122,7 +122,7 @@ int Action::revert(TimeType time, ModelStack* modelStack) {
 			    modelStack
 			        ->song); // Have to put AFTER. See the effect this will have in ConsequenceCDelete::prepareForDestruction()
 			thisConsequence->~Consequence();
-			generalMemoryAllocator.dealloc(thisConsequence);
+			GeneralMemoryAllocator::get().dealloc(thisConsequence);
 		}
 
 		// Or, normal case
@@ -174,7 +174,7 @@ void Action::recordParamChangeIfNotAlreadySnapshotted(ModelStackWithAutoParam co
 
 void Action::recordParamChangeDefinitely(ModelStackWithAutoParam const* modelStack, bool stealData) {
 
-	void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceParamChange));
+	void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceParamChange));
 
 	if (consMemory) {
 		ConsequenceParamChange* newCons = new (consMemory) ConsequenceParamChange(modelStack, stealData);
@@ -214,7 +214,7 @@ int Action::recordNoteArrayChangeIfNotAlreadySnapshotted(InstrumentClip* clip, i
 
 int Action::recordNoteArrayChangeDefinitely(InstrumentClip* clip, int noteRowId, NoteVector* noteVector,
                                             bool stealData) {
-	void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceNoteArrayChange));
+	void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceNoteArrayChange));
 
 	if (!consMemory) {
 		return ERROR_INSUFFICIENT_RAM;
@@ -233,7 +233,7 @@ void Action::recordNoteExistenceChange(InstrumentClip* clip, int noteRowId, Note
 		return;
 	}
 
-	void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceNoteExistence));
+	void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceNoteExistence));
 
 	if (consMemory) {
 		ConsequenceNoteExistence* newConsequence =
@@ -244,7 +244,7 @@ void Action::recordNoteExistenceChange(InstrumentClip* clip, int noteRowId, Note
 
 void Action::recordClipInstanceExistenceChange(Output* output, ClipInstance* clipInstance, ExistenceChangeType type) {
 
-	void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceClipInstanceExistence));
+	void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceClipInstanceExistence));
 
 	if (consMemory) {
 		ConsequenceClipInstanceExistence* newConsequence =
@@ -265,7 +265,7 @@ void Action::recordClipLengthChange(Clip* clip, int32_t oldLength) {
 		}
 	}
 
-	void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceClipLength));
+	void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceClipLength));
 
 	if (consMemory) {
 		ConsequenceClipLength* consequenceClipLength = new (consMemory) ConsequenceClipLength(clip, oldLength);
@@ -274,7 +274,7 @@ void Action::recordClipLengthChange(Clip* clip, int32_t oldLength) {
 }
 
 bool Action::recordClipExistenceChange(Song* song, ClipArray* clipArray, Clip* clip, ExistenceChangeType type) {
-	void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceClipExistence));
+	void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceClipExistence));
 	if (!consMemory) {
 		return false;
 	}
@@ -297,7 +297,7 @@ bool Action::recordClipExistenceChange(Song* song, ClipArray* clipArray, Clip* c
 
 // Call this *before* you change the Sample or its filePath
 void Action::recordAudioClipSampleChange(AudioClip* clip) {
-	void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceAudioClipSetSample));
+	void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceAudioClipSetSample));
 	if (consMemory) {
 		ConsequenceAudioClipSetSample* cons = new (consMemory) ConsequenceAudioClipSetSample(clip);
 		addConsequence(cons);
@@ -312,7 +312,7 @@ void Action::updateYScrollClipViewAfter(InstrumentClip* clip) {
 	if (numClipStates
 	    != currentSong->sessionClips.getNumElements() + currentSong->arrangementOnlyClips.getNumElements()) {
 		numClipStates = 0;
-		generalMemoryAllocator.dealloc(clipStates);
+		GeneralMemoryAllocator::get().dealloc(clipStates);
 		clipStates = NULL;
 		Debug::println("discarded clip states");
 		return;

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -73,7 +73,7 @@ void ActionLogger::deleteLastAction() {
 
 	toDelete->prepareForDestruction(BEFORE, currentSong);
 	toDelete->~Action();
-	generalMemoryAllocator.dealloc(toDelete);
+	GeneralMemoryAllocator::get().dealloc(toDelete);
 }
 
 Action* ActionLogger::getNewAction(int newActionType, int addToExistingIfPossible) {
@@ -126,7 +126,7 @@ Action* ActionLogger::getNewAction(int newActionType, int addToExistingIfPossibl
 		}
 
 		// And make a new one
-		void* actionMemory = generalMemoryAllocator.alloc(sizeof(Action), NULL, true);
+		void* actionMemory = GeneralMemoryAllocator::get().alloc(sizeof(Action), NULL, true);
 
 		if (!actionMemory) {
 			Debug::println("no ram to create new Action");
@@ -137,10 +137,10 @@ Action* ActionLogger::getNewAction(int newActionType, int addToExistingIfPossibl
 		int numClips = currentSong->sessionClips.getNumElements() + currentSong->arrangementOnlyClips.getNumElements();
 
 		ActionClipState* clipStates =
-		    (ActionClipState*)generalMemoryAllocator.alloc(numClips * sizeof(ActionClipState), NULL, true);
+		    (ActionClipState*)GeneralMemoryAllocator::get().alloc(numClips * sizeof(ActionClipState), NULL, true);
 
 		if (!clipStates) {
-			generalMemoryAllocator.dealloc(actionMemory);
+			GeneralMemoryAllocator::get().dealloc(actionMemory);
 			return NULL;
 		}
 
@@ -203,7 +203,7 @@ void ActionLogger::updateAction(Action* newAction) {
 		if (newAction->numClipStates
 		    != currentSong->sessionClips.getNumElements() + currentSong->arrangementOnlyClips.getNumElements()) {
 			newAction->numClipStates = 0;
-			generalMemoryAllocator.dealloc(newAction->clipStates);
+			GeneralMemoryAllocator::get().dealloc(newAction->clipStates);
 			newAction->clipStates = NULL;
 			Debug::println("discarded clip states");
 		}
@@ -264,7 +264,7 @@ void ActionLogger::recordSwingChange(int8_t swingBefore, int8_t swingAfter) {
 		consequence->swing[AFTER] = swingAfter;
 	}
 	else {
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceSwingChange));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceSwingChange));
 
 		if (consMemory) {
 			ConsequenceSwingChange* newConsequence = new (consMemory) ConsequenceSwingChange(swingBefore, swingAfter);
@@ -287,7 +287,7 @@ void ActionLogger::recordTempoChange(uint64_t timePerBigBefore, uint64_t timePer
 	}
 	else {
 
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceTempoChange));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceTempoChange));
 
 		if (consMemory) {
 			ConsequenceTempoChange* newConsequence =
@@ -707,7 +707,7 @@ void ActionLogger::deleteLog(int time) {
 
 		toDelete->prepareForDestruction(time, currentSong);
 		toDelete->~Action();
-		generalMemoryAllocator.dealloc(toDelete);
+		GeneralMemoryAllocator::get().dealloc(toDelete);
 	}
 }
 
@@ -823,7 +823,7 @@ gotMultipleConsequencesPerNoteRow:
 
 				firstConsequence->prepareForDestruction(BEFORE, modelStack->song);
 				firstConsequence->~Consequence();
-				generalMemoryAllocator.dealloc(firstConsequence);
+				GeneralMemoryAllocator::get().dealloc(firstConsequence);
 				firstConsequence = firstAction[BEFORE]->firstConsequence;
 			} while (thisConsequence->type != Consequence::NOTE_ARRAY_CHANGE
 			         || ((ConsequenceNoteArrayChange*)firstConsequence)->noteRowId != firstNoteRowId);

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -79,7 +79,7 @@ AudioClip::~AudioClip() {
 // Will replace the Clip in the modelStack, if success.
 int AudioClip::clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing) {
 
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(AudioClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(AudioClip), NULL, false, true);
 	if (!clipMemory) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -90,7 +90,7 @@ int AudioClip::clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlatt
 	int error = newClip->paramManager.cloneParamCollectionsFrom(&paramManager, true);
 	if (error) {
 		newClip->~AudioClip();
-		generalMemoryAllocator.dealloc(clipMemory);
+		GeneralMemoryAllocator::get().dealloc(clipMemory);
 		return error;
 	}
 
@@ -221,7 +221,7 @@ void AudioClip::finishLinearRecording(ModelStackWithTimelineCounter* modelStack,
 Clip* AudioClip::cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStackOldClip, int newOverdubNature) {
 
 	// Allocate memory for audio clip
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(AudioClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(AudioClip), NULL, false, true);
 	if (!clipMemory) {
 ramError:
 		numericDriver.displayError(ERROR_INSUFFICIENT_RAM);
@@ -240,7 +240,7 @@ ramError:
 
 	if (error) {
 		newClip->~AudioClip();
-		generalMemoryAllocator.dealloc(clipMemory);
+		GeneralMemoryAllocator::get().dealloc(clipMemory);
 		goto ramError;
 	}
 

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -380,7 +380,7 @@ bool Clip::opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounte
 				                                  ExistenceChangeType::CREATE);
 
 				if (*newOutputCreated) {
-					void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceOutputExistence));
+					void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceOutputExistence));
 					if (consMemory) {
 						ConsequenceOutputExistence* cons =
 						    new (consMemory) ConsequenceOutputExistence(output, ExistenceChangeType::CREATE);
@@ -391,7 +391,7 @@ bool Clip::opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounte
 		}
 		else {
 			if (action) {
-				void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceClipBeginLinearRecord));
+				void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceClipBeginLinearRecord));
 				if (consMemory) {
 					ConsequenceClipBeginLinearRecord* cons = new (consMemory) ConsequenceClipBeginLinearRecord(this);
 					action->addConsequence(cons);

--- a/src/deluge/model/clip/clip_instance.cpp
+++ b/src/deluge/model/clip/clip_instance.cpp
@@ -39,7 +39,7 @@ void ClipInstance::getColour(uint8_t* colour) {
 
 void ClipInstance::change(Action* action, Output* output, int32_t newPos, int32_t newLength, Clip* newClip) {
 	if (action) {
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceClipInstanceChange));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceClipInstanceChange));
 
 		if (consMemory) {
 			ConsequenceClipInstanceChange* newConsequence =

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -164,7 +164,7 @@ void InstrumentClip::copyBasicsFrom(Clip* otherClip) {
 // Will replace the Clip in the modelStack, if success.
 int InstrumentClip::clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing) {
 
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(InstrumentClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(InstrumentClip), NULL, false, true);
 	if (!clipMemory) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -183,7 +183,7 @@ int InstrumentClip::clone(ModelStackWithTimelineCounter* modelStack, bool should
 	if (error) {
 deleteClipAndGetOut:
 		newClip->~InstrumentClip();
-		generalMemoryAllocator.dealloc(clipMemory);
+		GeneralMemoryAllocator::get().dealloc(clipMemory);
 		return error;
 	}
 
@@ -919,7 +919,7 @@ void InstrumentClip::toggleNoteRowMute(ModelStackWithNoteRow* modelStack) {
 	// Record action
 	Action* action = actionLogger.getNewAction(ACTION_MISC);
 	if (action) {
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceNoteRowMute));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceNoteRowMute));
 
 		if (consMemory) {
 			ConsequenceNoteRowMute* newConsequence =
@@ -1084,7 +1084,7 @@ ModelStackWithNoteRow* InstrumentClip::getOrCreateNoteRowForYNote(int yNote, Mod
 				thisNoteRow->notes.empty(); // Undo our "total hack", above
 
 				if (action) {
-					void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceScaleAddNote));
+					void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceScaleAddNote));
 
 					if (consMemory) {
 						ConsequenceScaleAddNote* newConsequence =
@@ -1798,7 +1798,7 @@ void InstrumentClip::actuallyDeleteEmptyNoteRow(ModelStackWithNoteRow* modelStac
 		noteRow->setDrum(NULL, (Kit*)output, modelStack);
 	}
 	noteRow->~NoteRow();
-	generalMemoryAllocator.dealloc(noteRow);
+	GeneralMemoryAllocator::get().dealloc(noteRow);
 }
 
 // Returns whether to delete it
@@ -2512,7 +2512,8 @@ someError:
 		else if (!strcmp(tagName, "sound") || !strcmp(tagName, "synth")) {
 			if (!output) {
 				{
-					void* instrumentMemory = generalMemoryAllocator.alloc(sizeof(SoundInstrument), NULL, false, true);
+					void* instrumentMemory =
+					    GeneralMemoryAllocator::get().alloc(sizeof(SoundInstrument), NULL, false, true);
 					if (!instrumentMemory) {
 						goto ramError;
 					}
@@ -2545,7 +2546,7 @@ loadInstrument:
 		// For song files from before V2.0, where Instruments were stored within the Clip
 		else if (!strcmp(tagName, "kit")) {
 			if (!output) {
-				void* instrumentMemory = generalMemoryAllocator.alloc(sizeof(Kit), NULL, false, true);
+				void* instrumentMemory = GeneralMemoryAllocator::get().alloc(sizeof(Kit), NULL, false, true);
 				if (!instrumentMemory) {
 					goto ramError;
 				}
@@ -3015,7 +3016,7 @@ bool InstrumentClip::deleteSoundsWhichWontSound(Song* song) {
 
 					void* toDealloc = dynamic_cast<void*>(drum);
 					drum->~Drum();
-					generalMemoryAllocator.dealloc(toDealloc);
+					GeneralMemoryAllocator::get().dealloc(toDealloc);
 				}
 
 				noteRows.deleteNoteRowAtIndex(i);
@@ -3642,7 +3643,7 @@ int InstrumentClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 				thisNoteRow->drum = kit->getGateDrumForChannel(gateChannel);
 
 				if (!thisNoteRow->drum) {
-					void* drumMemory = generalMemoryAllocator.alloc(sizeof(GateDrum), NULL, true);
+					void* drumMemory = GeneralMemoryAllocator::get().alloc(sizeof(GateDrum), NULL, true);
 					if (!drumMemory) {
 						return ERROR_INSUFFICIENT_RAM;
 					}
@@ -3944,7 +3945,7 @@ void InstrumentClip::finishLinearRecording(ModelStackWithTimelineCounter* modelS
 Clip* InstrumentClip::cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, int newOverdubNature) {
 
 	// Allocate memory for Clip
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(InstrumentClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(InstrumentClip), NULL, false, true);
 	if (!clipMemory) {
 ramError:
 		numericDriver.displayError(ERROR_INSUFFICIENT_RAM);

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -197,7 +197,7 @@ gotError:
 	if (error) {
 		void* toDealloc = dynamic_cast<void*>(newInstrument);
 		newInstrument->~Instrument();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 		goto gotError;
 	}
 

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -52,7 +52,7 @@ void ConsequenceClipExistence::prepareForDestruction(int whichQueueActionIn, Son
 #endif
 
 		clip->~Clip();
-		generalMemoryAllocator.dealloc(clip);
+		GeneralMemoryAllocator::get().dealloc(clip);
 	}
 }
 

--- a/src/deluge/model/drum/kit.cpp
+++ b/src/deluge/model/drum/kit.cpp
@@ -63,7 +63,7 @@ Kit::~Kit() {
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 
 		toDelete->~Drum();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 	}
 }
 
@@ -203,7 +203,7 @@ bool Kit::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song) {
 
 					void* toDealloc = dynamic_cast<void*>(thisDrum);
 					thisDrum->~Drum();
-					generalMemoryAllocator.dealloc(toDealloc);
+					GeneralMemoryAllocator::get().dealloc(toDealloc);
 
 					continue;
 				}
@@ -322,7 +322,7 @@ int Kit::readDrumFromFile(Song* song, Clip* clip, DrumType drumType, int32_t rea
 	if (error) {
 		void* toDealloc = dynamic_cast<void*>(newDrum);
 		newDrum->~Drum();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 		return error;
 	}
 	addDrum(newDrum);

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -743,8 +743,8 @@ void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, i
 	if (modFXTypeNow == ModFXType::FLANGER || modFXTypeNow == ModFXType::CHORUS
 	    || modFXTypeNow == ModFXType::CHORUS_STEREO) {
 		if (!modFXBuffer) {
-			modFXBuffer =
-			    (StereoSample*)generalMemoryAllocator.alloc(kModFXBufferSize * sizeof(StereoSample), NULL, false, true);
+			modFXBuffer = (StereoSample*)GeneralMemoryAllocator::get().alloc(kModFXBufferSize * sizeof(StereoSample),
+			                                                                 NULL, false, true);
 			if (!modFXBuffer) {
 				modFXTypeNow = ModFXType::NONE;
 			}
@@ -755,7 +755,7 @@ void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, i
 	}
 	else {
 		if (modFXBuffer) {
-			generalMemoryAllocator.dealloc(modFXBuffer);
+			GeneralMemoryAllocator::get().dealloc(modFXBuffer);
 			modFXBuffer = NULL;
 		}
 	}

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -142,7 +142,7 @@ bool Instrument::readTagFromFile(char const* tagName) {
 Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 
 	// Allocate memory for Clip
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(InstrumentClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(InstrumentClip), NULL, false, true);
 	if (!clipMemory) {
 		return NULL;
 	}
@@ -157,7 +157,7 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 		int error = newParamManager.cloneParamCollectionsFrom(getParamManager(modelStack->song), false, true);
 
 		if (error) {
-			generalMemoryAllocator.dealloc(clipMemory);
+			GeneralMemoryAllocator::get().dealloc(clipMemory);
 			return NULL;
 		}
 	}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -70,7 +70,7 @@ ModControllableAudio::~ModControllableAudio() {
 
 	// Free the mod fx memory
 	if (modFXBuffer) {
-		generalMemoryAllocator.dealloc(modFXBuffer);
+		GeneralMemoryAllocator::get().dealloc(modFXBuffer);
 	}
 }
 
@@ -326,7 +326,7 @@ void ModControllableAudio::processFX(StereoSample* buffer, int numSamples, ModFX
 
 		int32_t* delayWorkingBuffer = spareRenderingBuffer[0];
 
-		generalMemoryAllocator.checkStack("delay");
+		GeneralMemoryAllocator::get().checkStack("delay");
 
 		int32_t* workingBufferEnd = delayWorkingBuffer + numSamples * 2;
 

--- a/src/deluge/model/note/copied_note_row.cpp
+++ b/src/deluge/model/note/copied_note_row.cpp
@@ -25,6 +25,6 @@ CopiedNoteRow::CopiedNoteRow() {
 
 CopiedNoteRow::~CopiedNoteRow() {
 	if (notes) {
-		generalMemoryAllocator.dealloc(notes);
+		GeneralMemoryAllocator::get().dealloc(notes);
 	}
 }

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -81,7 +81,7 @@ void NoteRow::deleteOldDrumNames(bool shouldUpdatePointer) {
 		DrumName* toDelete = oldFirstOldDrumName;
 		oldFirstOldDrumName = oldFirstOldDrumName->next;
 		toDelete->~DrumName();
-		generalMemoryAllocator.dealloc(toDelete);
+		GeneralMemoryAllocator::get().dealloc(toDelete);
 	}
 
 	if (shouldUpdatePointer) {
@@ -362,7 +362,7 @@ int NoteRow::addCorrespondingNotes(int32_t targetPos, int32_t newNotesLength, ui
 
 	// Allocate all the working memory we're going to need for this operation - that's arrays for searchPos and resultingIndexes
 	int32_t* __restrict__ searchTerms =
-	    (int32_t*)generalMemoryAllocator.alloc(numScreensToAddNoteOn * sizeof(int), NULL, false, true);
+	    (int32_t*)GeneralMemoryAllocator::get().alloc(numScreensToAddNoteOn * sizeof(int), NULL, false, true);
 	if (!searchTerms) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -372,7 +372,7 @@ int NoteRow::addCorrespondingNotes(int32_t targetPos, int32_t newNotesLength, ui
 	int newNotesInitialSize = notes.getNumElements() + numScreensToAddNoteOn;
 	int error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
-		generalMemoryAllocator.dealloc(searchTerms);
+		GeneralMemoryAllocator::get().dealloc(searchTerms);
 		return error;
 	}
 
@@ -462,7 +462,7 @@ addNewNote:
 	}
 
 	// Deallocate working memory - no longer needed
-	generalMemoryAllocator.dealloc(searchTerms);
+	GeneralMemoryAllocator::get().dealloc(searchTerms);
 
 	// Copy the final notes too - after the insertion-point on the final screen
 	while (nextIndexToCopyFrom < notes.getNumElements()) {
@@ -651,7 +651,7 @@ int NoteRow::clearArea(int32_t areaStart, int32_t areaWidth, ModelStackWithNoteR
 
 	// Allocate all the working memory we're going to need for this operation - that's arrays for searchPos and resultingIndexes
 	int32_t* __restrict__ searchTerms =
-	    (int32_t*)generalMemoryAllocator.alloc(numScreens * 2 * sizeof(int), NULL, false, true);
+	    (int32_t*)GeneralMemoryAllocator::get().alloc(numScreens * 2 * sizeof(int), NULL, false, true);
 	if (!searchTerms) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -661,7 +661,7 @@ int NoteRow::clearArea(int32_t areaStart, int32_t areaWidth, ModelStackWithNoteR
 	int newNotesInitialSize = notes.getNumElements();
 	int error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
-		generalMemoryAllocator.dealloc(searchTerms);
+		GeneralMemoryAllocator::get().dealloc(searchTerms);
 		return error;
 	}
 
@@ -745,7 +745,7 @@ int NoteRow::clearArea(int32_t areaStart, int32_t areaWidth, ModelStackWithNoteR
 	}
 
 	// Deallocate working memory - no longer needed
-	generalMemoryAllocator.dealloc(searchTerms);
+	GeneralMemoryAllocator::get().dealloc(searchTerms);
 
 	Note* __restrict__ destNote = NULL;
 
@@ -946,7 +946,7 @@ int NoteRow::editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareWidth
 
 	// Allocate all the working memory we're going to need for this operation - that's arrays for searchPos and resultingIndexes
 	int32_t* __restrict__ searchTerms =
-	    (int32_t*)generalMemoryAllocator.alloc(numScreens * 2 * sizeof(int), NULL, false, true);
+	    (int32_t*)GeneralMemoryAllocator::get().alloc(numScreens * 2 * sizeof(int), NULL, false, true);
 	if (!searchTerms) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -958,7 +958,7 @@ int NoteRow::editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareWidth
 	int newNotesInitialSize = numSourceNotes + (newNumNotes - 1) * numScreens;
 	int error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
-		generalMemoryAllocator.dealloc(searchTerms);
+		GeneralMemoryAllocator::get().dealloc(searchTerms);
 		return error;
 	}
 
@@ -1072,7 +1072,7 @@ int NoteRow::editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareWidth
 	}
 
 	// Deallocate working memory - no longer needed
-	generalMemoryAllocator.dealloc(searchTerms);
+	GeneralMemoryAllocator::get().dealloc(searchTerms);
 
 	// Copy the final notes too - after area end on the final screen
 	while (nextIndexToCopyFrom < numSourceNotes) {
@@ -1143,7 +1143,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 
 	// Allocate all the working memory we're going to need for this operation - that's arrays for searchPos and resultingIndexes
 	int32_t* __restrict__ searchTerms =
-	    (int32_t*)generalMemoryAllocator.alloc(numScreens * 2 * sizeof(int), NULL, false, true);
+	    (int32_t*)GeneralMemoryAllocator::get().alloc(numScreens * 2 * sizeof(int), NULL, false, true);
 	if (!searchTerms) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -1155,7 +1155,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 	int newNotesInitialSize = numSourceNotes;
 	int error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
-		generalMemoryAllocator.dealloc(searchTerms);
+		GeneralMemoryAllocator::get().dealloc(searchTerms);
 		return error;
 	}
 
@@ -1325,7 +1325,7 @@ int NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* 
 	}
 
 	// Deallocate working memory - no longer needed
-	generalMemoryAllocator.dealloc(searchTerms);
+	GeneralMemoryAllocator::get().dealloc(searchTerms);
 
 	// Copy the final notes too - after area end on the final screen
 	while (nextIndexToCopyFrom < numSourceNotes) {
@@ -1422,7 +1422,7 @@ int NoteRow::changeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow*
 
 	// Allocate all the working memory we're going to need for this operation - that's arrays for searchPos and resultingIndexes
 	int32_t* __restrict__ searchTerms =
-	    (int32_t*)generalMemoryAllocator.alloc(numScreens * sizeof(int), NULL, false, true);
+	    (int32_t*)GeneralMemoryAllocator::get().alloc(numScreens * sizeof(int), NULL, false, true);
 	if (!searchTerms) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -1468,7 +1468,7 @@ int NoteRow::changeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow*
 	}
 
 	// Deallocate working memory - no longer needed
-	generalMemoryAllocator.dealloc(searchTerms);
+	GeneralMemoryAllocator::get().dealloc(searchTerms);
 
 	return NO_ERROR;
 }
@@ -3294,7 +3294,7 @@ void NoteRow::rememberDrumName() {
 		}
 
 		// If we're here, we're at the end of the list, didn't find an instance of the name, and want to add it to the end of the list now
-		void* drumNameMemory = generalMemoryAllocator.alloc(sizeof(DrumName));
+		void* drumNameMemory = GeneralMemoryAllocator::get().alloc(sizeof(DrumName));
 		if (drumNameMemory) {
 			*prevPointer = new (drumNameMemory) DrumName(&soundDrum->name);
 		}

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -113,7 +113,7 @@ Sample::~Sample() {
 	for (int i = 0; i < caches.getNumElements(); i++) {
 		SampleCacheElement* element = (SampleCacheElement*)caches.getElementAddress(i);
 		element->cache->~SampleCache();
-		generalMemoryAllocator.dealloc(element->cache);
+		GeneralMemoryAllocator::get().dealloc(element->cache);
 	}
 }
 
@@ -121,7 +121,7 @@ void Sample::deletePercCache(bool beingDestructed) {
 
 	for (int reversed = 0; reversed < 2; reversed++) {
 		if (percCacheMemory[reversed]) {
-			generalMemoryAllocator.dealloc(percCacheMemory[reversed]);
+			GeneralMemoryAllocator::get().dealloc(percCacheMemory[reversed]);
 			if (!beingDestructed) {
 				percCacheMemory[reversed] = NULL;
 			}
@@ -142,7 +142,7 @@ void Sample::deletePercCache(bool beingDestructed) {
 				}
 			}
 
-			generalMemoryAllocator.dealloc(percCacheClusters[reversed]);
+			GeneralMemoryAllocator::get().dealloc(percCacheClusters[reversed]);
 			if (!beingDestructed) {
 				percCacheClusters[reversed] = NULL;
 			}
@@ -222,15 +222,15 @@ SampleCache* Sample::getOrCreateCache(SampleHolder* sampleHolder, int32_t phaseI
 	}
 
 	int numClusters = ((lengthInBytesCached - 1) >> audioFileManager.clusterSizeMagnitude) + 1;
-	void* memory =
-	    generalMemoryAllocator.alloc(sizeof(SampleCache) + (numClusters - 1) * sizeof(Cluster*), NULL, false, false);
+	void* memory = GeneralMemoryAllocator::get().alloc(sizeof(SampleCache) + (numClusters - 1) * sizeof(Cluster*), NULL,
+	                                                   false, false);
 	if (!memory) {
 		return NULL;
 	}
 
 	i = caches.insertAtKeyMultiWord(keyWords);
 	if (i == -1) { // If error
-		generalMemoryAllocator.dealloc(memory);
+		GeneralMemoryAllocator::get().dealloc(memory);
 		return NULL;
 	}
 
@@ -305,7 +305,7 @@ int Sample::fillPercCache(TimeStretcher* timeStretcher, int32_t startPosSamples,
 			numPercCacheClusters = ((lengthInSamplesAfterReduction - 1) >> audioFileManager.clusterSizeMagnitude)
 			                       + 1; // Stores this number for the future too
 			int memorySize = numPercCacheClusters * sizeof(Cluster*);
-			percCacheClusters[reversed] = (Cluster**)generalMemoryAllocator.alloc(memorySize, NULL, false, true);
+			percCacheClusters[reversed] = (Cluster**)GeneralMemoryAllocator::get().alloc(memorySize, NULL, false, true);
 			if (!percCacheClusters[reversed]) {
 				LOCK_EXIT
 				return ERROR_INSUFFICIENT_RAM;
@@ -320,7 +320,7 @@ int Sample::fillPercCache(TimeStretcher* timeStretcher, int32_t startPosSamples,
 		if (!percCacheMemory[reversed]) {
 			int percCacheSize = lengthInSamplesAfterReduction;
 
-			percCacheMemory[reversed] = (uint8_t*)generalMemoryAllocator.alloc(percCacheSize);
+			percCacheMemory[reversed] = (uint8_t*)GeneralMemoryAllocator::get().alloc(percCacheSize);
 			if (!percCacheMemory[reversed]) {
 				LOCK_EXIT
 				return ERROR_INSUFFICIENT_RAM;
@@ -1274,8 +1274,8 @@ float Sample::determinePitch(bool doingSingleCycle, float minFreqHz, float maxFr
 	int fftInputSize = kPitchDetectWindowSize * sizeof(int32_t);
 	int fftOutputSize = ((kPitchDetectWindowSize >> 1) + 1) * sizeof(ne10_fft_cpx_int32_t);
 	int floatIndexTableSize = (kPitchDetectWindowSize >> 2) * sizeof(float);
-	int32_t* fftInput =
-	    (int32_t*)generalMemoryAllocator.alloc(fftInputSize + fftOutputSize + floatIndexTableSize, NULL, false, true);
+	int32_t* fftInput = (int32_t*)GeneralMemoryAllocator::get().alloc(
+	    fftInputSize + fftOutputSize + floatIndexTableSize, NULL, false, true);
 	if (!fftInput) {
 		return 0;
 	}
@@ -1328,7 +1328,7 @@ startAgain:
 	if (!cluster) {
 		Debug::println("failed to load first");
 getOut:
-		generalMemoryAllocator.dealloc(fftInput);
+		GeneralMemoryAllocator::get().dealloc(fftInput);
 		return 0;
 	}
 
@@ -1667,7 +1667,7 @@ doneReading:
 		goto startAgain;
 	}
 
-	generalMemoryAllocator.dealloc(fftInput);
+	GeneralMemoryAllocator::get().dealloc(fftInput);
 
 	float freq = freqBeforeAdjustment / (1 << lengthDoublings);
 	Debug::print("freq: ");

--- a/src/deluge/model/sample/sample_cache.cpp
+++ b/src/deluge/model/sample/sample_cache.cpp
@@ -162,7 +162,7 @@ bool SampleCache::setupNewCluster(int clusterIndex) {
 
 void SampleCache::prioritizeNotStealingCluster(int clusterIndex) {
 
-	if (generalMemoryAllocator.getRegion(clusters[clusterIndex]) != MEMORY_REGION_SDRAM) {
+	if (GeneralMemoryAllocator::get().getRegion(clusters[clusterIndex]) != MEMORY_REGION_SDRAM) {
 		return; // Sorta just have to do this
 	}
 
@@ -174,7 +174,7 @@ void SampleCache::prioritizeNotStealingCluster(int clusterIndex) {
 	// First Cluster
 	if (clusterIndex == 0) {
 		const auto q = STEALABLE_QUEUE_CURRENT_SONG_SAMPLE_DATA_REPITCHED_CACHE;
-		CacheManager& cache_manager = generalMemoryAllocator.regions[MEMORY_REGION_SDRAM].cache_manager();
+		CacheManager& cache_manager = GeneralMemoryAllocator::get().regions[MEMORY_REGION_SDRAM].cache_manager();
 		Cluster* cluster = clusters[clusterIndex];
 		if (cluster->list != &cache_manager.queue(q) || !cluster->isLast()) {
 			cluster->remove(); // Remove from old list, if it was already in one (might not have been).
@@ -185,14 +185,14 @@ void SampleCache::prioritizeNotStealingCluster(int clusterIndex) {
 	// Later Clusters
 	else {
 
-		if (generalMemoryAllocator.getRegion(clusters[clusterIndex - 1]) != MEMORY_REGION_SDRAM) {
+		if (GeneralMemoryAllocator::get().getRegion(clusters[clusterIndex - 1]) != MEMORY_REGION_SDRAM) {
 			return; // Sorta just have to do this
 		}
 
 		// In most cases, we'll want to do this thing to alter the ordering - including if the Cluster in question hasn't actually been added to a queue at all yet,
 		// because this functions serves the additional purpose of being what puts Clusters in their queue in the first place.
 		if (clusters[clusterIndex]->list
-		        != &generalMemoryAllocator.regions[MEMORY_REGION_SDRAM].cache_manager().queue(
+		        != &GeneralMemoryAllocator::get().regions[MEMORY_REGION_SDRAM].cache_manager().queue(
 		            STEALABLE_QUEUE_CURRENT_SONG_SAMPLE_DATA_REPITCHED_CACHE)
 		    || clusters[clusterIndex]->next != clusters[clusterIndex - 1]) {
 

--- a/src/deluge/model/sample/sample_playback_guide.cpp
+++ b/src/deluge/model/sample/sample_playback_guide.cpp
@@ -30,7 +30,7 @@ SamplePlaybackGuide::SamplePlaybackGuide() {
 
 int SamplePlaybackGuide::getFinalClusterIndex(Sample* sample, bool obeyMarkers, int32_t* getEndPlaybackAtByte) {
 
-	generalMemoryAllocator.checkStack("SamplePlaybackGuide::getFinalClusterIndex");
+	GeneralMemoryAllocator::get().checkStack("SamplePlaybackGuide::getFinalClusterIndex");
 
 	int32_t endPlaybackAtByteNow;
 	// If cache, go right to the end of the waveform

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -129,8 +129,8 @@ int SampleRecorder::setup(int newNumChannels, AudioInputChannel newMode, bool ne
 	recordingExtraMargins = shouldRecordExtraMargins;
 	folderID = newFolderID;
 
-	void* sampleMemory =
-	    generalMemoryAllocator.alloc(sizeof(Sample)); // Didn't seem to make a difference forcing this into local RAM
+	void* sampleMemory = GeneralMemoryAllocator::get().alloc(
+	    sizeof(Sample)); // Didn't seem to make a difference forcing this into local RAM
 	if (!sampleMemory) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -141,7 +141,7 @@ int SampleRecorder::setup(int newNumChannels, AudioInputChannel newMode, bool ne
 	if (error) {
 gotError:
 		sample->~Sample();
-		generalMemoryAllocator.dealloc(sampleMemory);
+		GeneralMemoryAllocator::get().dealloc(sampleMemory);
 		return error;
 	}
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -211,7 +211,7 @@ void Song::deleteAllOutputs(Output** prevPointer) {
 
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Output();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 	}
 }
 
@@ -285,7 +285,7 @@ bool Song::ensureAtLeastOneSessionClip() {
 	// If no Clips added, make just one blank one - we can't have none!
 	if (!sessionClips.getNumElements()) {
 
-		void* memory = generalMemoryAllocator.alloc(sizeof(InstrumentClip), NULL, false, true);
+		void* memory = GeneralMemoryAllocator::get().alloc(sizeof(InstrumentClip), NULL, false, true);
 		InstrumentClip* firstClip = new (memory) InstrumentClip(this);
 
 		sessionClips.insertClipAtIndex(firstClip, 0);
@@ -1578,7 +1578,7 @@ unknownTag:
 					int error;
 
 					if (!strcmp(tagName, "audioTrack")) {
-						memory = generalMemoryAllocator.alloc(sizeof(AudioOutput), NULL, false, true);
+						memory = GeneralMemoryAllocator::get().alloc(sizeof(AudioOutput), NULL, false, true);
 						if (!memory) {
 							return ERROR_INSUFFICIENT_RAM;
 						}
@@ -1587,7 +1587,7 @@ unknownTag:
 					}
 
 					else if (!strcmp(tagName, "sound")) {
-						memory = generalMemoryAllocator.alloc(sizeof(SoundInstrument), NULL, false, true);
+						memory = GeneralMemoryAllocator::get().alloc(sizeof(SoundInstrument), NULL, false, true);
 						if (!memory) {
 							return ERROR_INSUFFICIENT_RAM;
 						}
@@ -1599,7 +1599,7 @@ setDirPathFirst:
 						if (error) {
 gotError:
 							newOutput->~Output();
-							generalMemoryAllocator.dealloc(memory);
+							GeneralMemoryAllocator::get().dealloc(memory);
 							return error;
 						}
 
@@ -1616,7 +1616,7 @@ loadOutput:
 					}
 
 					else if (!strcmp(tagName, "kit")) {
-						memory = generalMemoryAllocator.alloc(sizeof(Kit), NULL, false, true);
+						memory = GeneralMemoryAllocator::get().alloc(sizeof(Kit), NULL, false, true);
 						if (!memory) {
 							return ERROR_INSUFFICIENT_RAM;
 						}
@@ -1626,7 +1626,7 @@ loadOutput:
 					}
 
 					else if (!strcmp(tagName, "midiChannel") || !strcmp(tagName, "mpeZone")) {
-						memory = generalMemoryAllocator.alloc(sizeof(MIDIInstrument), NULL, false, true);
+						memory = GeneralMemoryAllocator::get().alloc(sizeof(MIDIInstrument), NULL, false, true);
 						if (!memory) {
 							return ERROR_INSUFFICIENT_RAM;
 						}
@@ -1635,7 +1635,7 @@ loadOutput:
 					}
 
 					else if (!strcmp(tagName, "cvChannel")) {
-						memory = generalMemoryAllocator.alloc(sizeof(CVInstrument), NULL, false, true);
+						memory = GeneralMemoryAllocator::get().alloc(sizeof(CVInstrument), NULL, false, true);
 						if (!memory) {
 							return ERROR_INSUFFICIENT_RAM;
 						}
@@ -1908,7 +1908,7 @@ readClip:
 				return ERROR_INSUFFICIENT_RAM;
 			}
 
-			void* memory = generalMemoryAllocator.alloc(allocationSize, NULL, false, true);
+			void* memory = GeneralMemoryAllocator::get().alloc(allocationSize, NULL, false, true);
 			if (!memory) {
 				return ERROR_INSUFFICIENT_RAM;
 			}
@@ -1924,7 +1924,7 @@ readClip:
 			int error = newClip->readFromFile(this);
 			if (error) {
 				newClip->~Clip();
-				generalMemoryAllocator.dealloc(memory);
+				GeneralMemoryAllocator::get().dealloc(memory);
 				return error;
 			}
 
@@ -2751,7 +2751,7 @@ void Song::deleteClipObject(Clip* clip, bool songBeingDestroyedToo, InstrumentRe
 
 	void* toDealloc = dynamic_cast<void*>(clip);
 	clip->~Clip();
-	generalMemoryAllocator.dealloc(toDealloc);
+	GeneralMemoryAllocator::get().dealloc(toDealloc);
 }
 
 int Song::getMaxMIDIChannelSuffix(int channel) {
@@ -3097,7 +3097,7 @@ void Song::deleteOutput(Output* output) {
 	output->deleteBackedUpParamManagers(this);
 	void* toDealloc = dynamic_cast<void*>(output);
 	output->~Output();
-	generalMemoryAllocator.dealloc(toDealloc);
+	GeneralMemoryAllocator::get().dealloc(toDealloc);
 }
 
 void Song::moveInstrumentToHibernationList(Instrument* instrument) {
@@ -3989,7 +3989,7 @@ void Song::deleteHibernatingMIDIInstrument() {
 	if (hibernatingMIDIInstrument) {
 		void* toDealloc = dynamic_cast<void*>(hibernatingMIDIInstrument);
 		hibernatingMIDIInstrument->~Instrument();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 		hibernatingMIDIInstrument = NULL;
 	}
 }
@@ -4550,7 +4550,7 @@ AudioOutput* Song::createNewAudioOutput(Output* replaceOutput) {
 		return NULL;
 	}
 
-	void* outputMemory = generalMemoryAllocator.alloc(sizeof(AudioOutput), NULL, false, true);
+	void* outputMemory = GeneralMemoryAllocator::get().alloc(sizeof(AudioOutput), NULL, false, true);
 	if (!outputMemory) {
 		return NULL;
 	}
@@ -5002,7 +5002,7 @@ int8_t defaultAudioClipOverdubOutputCloning = -1; // -1 means no default set
 Clip* Song::replaceInstrumentClipWithAudioClip(Clip* oldClip, int clipIndex) {
 
 	// Allocate memory for audio clip
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(AudioClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(AudioClip), NULL, false, true);
 	if (!clipMemory) {
 		return NULL;
 	}
@@ -5010,7 +5010,7 @@ Clip* Song::replaceInstrumentClipWithAudioClip(Clip* oldClip, int clipIndex) {
 	// Suss output
 	AudioOutput* newOutput = createNewAudioOutput();
 	if (!newOutput) {
-		generalMemoryAllocator.dealloc(clipMemory);
+		GeneralMemoryAllocator::get().dealloc(clipMemory);
 		return NULL;
 	}
 

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -108,7 +108,7 @@ bool Voice::noteOn(ModelStackWithVoice* modelStack, int newNoteCodeBeforeArpeggi
                    uint8_t velocity, uint32_t newSampleSyncLength, int32_t ticksLate, uint32_t samplesLate,
                    bool resetEnvelopes, int newFromMIDIChannel, const int16_t* mpeValues) {
 
-	generalMemoryAllocator.checkStack("Voice::noteOn");
+	GeneralMemoryAllocator::get().checkStack("Voice::noteOn");
 
 	inputCharacteristics[util::to_underlying(MIDICharacteristic::NOTE)] = newNoteCodeBeforeArpeggiation;
 	inputCharacteristics[util::to_underlying(MIDICharacteristic::CHANNEL)] = newFromMIDIChannel;
@@ -671,7 +671,7 @@ bool Voice::render(ModelStackWithVoice* modelStack, int32_t* soundBuffer, int nu
                    bool applyingPanAtVoiceLevel, uint32_t sourcesChanged, FilterSetConfig* filterSetConfig,
                    int32_t externalPitchAdjust) {
 
-	generalMemoryAllocator.checkStack("Voice::render");
+	GeneralMemoryAllocator::get().checkStack("Voice::render");
 
 	ParamManagerForTimeline* paramManager = (ParamManagerForTimeline*)modelStack->paramManager;
 	Sound* sound = (Sound*)modelStack->modControllable;
@@ -1992,7 +1992,7 @@ void Voice::renderBasicSource(Sound* sound, ParamManagerForTimeline* paramManage
                               uint32_t* __restrict__ getPhaseIncrements, bool getOutAfterPhaseIncrements,
                               int32_t waveIndexIncrement) {
 
-	generalMemoryAllocator.checkStack("Voice::renderBasicSource");
+	GeneralMemoryAllocator::get().checkStack("Voice::renderBasicSource");
 
 	// For each unison part
 	for (int u = 0; u < sound->numUnison; u++) {
@@ -2282,7 +2282,7 @@ dontUseCache : {}
 
 					if (liveInputBuffer) {
 
-						void* memory = generalMemoryAllocator.alloc(sizeof(LivePitchShifter), NULL, false, true);
+						void* memory = GeneralMemoryAllocator::get().alloc(sizeof(LivePitchShifter), NULL, false, true);
 
 						if (memory) {
 							source->livePitchShifter = new (memory) LivePitchShifter(inputTypeNow, phaseIncrement);
@@ -2297,7 +2297,7 @@ dontUseCache : {}
 				if (source->livePitchShifter && source->livePitchShifter->mayBeRemovedWithoutClick()) {
 					Debug::println("stop pitch shifting");
 					source->livePitchShifter->~LivePitchShifter();
-					generalMemoryAllocator.dealloc(source->livePitchShifter);
+					GeneralMemoryAllocator::get().dealloc(source->livePitchShifter);
 					source->livePitchShifter = NULL;
 				}
 			}
@@ -2722,7 +2722,7 @@ Voice::renderOsc(int s, OscType type, int32_t amplitude, int32_t* bufferStart, i
                  uint32_t phaseIncrement, uint32_t pulseWidth, uint32_t* startPhase, bool applyAmplitude,
                  int32_t amplitudeIncrement, bool doOscSync, uint32_t resetterPhase, uint32_t resetterPhaseIncrement,
                  uint32_t retriggerPhase, int32_t waveIndexIncrement) {
-	generalMemoryAllocator.checkStack("renderOsc");
+	GeneralMemoryAllocator::get().checkStack("renderOsc");
 
 	// We save a decent bit of processing power by grabbing a local copy of the phase to work with, and just incrementing the startPhase once
 	uint32_t phase = *startPhase;

--- a/src/deluge/model/voice/voice_sample.cpp
+++ b/src/deluge/model/voice/voice_sample.cpp
@@ -1114,7 +1114,7 @@ readTimestretched:
 			int numSamplesThisTimestretchedRead = numSamplesThisUncachedRead;
 
 			// Now, perform the actual time stretching on the contents of the bands
-			generalMemoryAllocator.checkStack("timestretch");
+			GeneralMemoryAllocator::get().checkStack("timestretch");
 
 			if (timeStretcher->playHeadStillActive[PLAY_HEAD_NEWER]) {
 

--- a/src/deluge/model/voice/voice_unison_part_source.cpp
+++ b/src/deluge/model/voice/voice_unison_part_source.cpp
@@ -82,7 +82,7 @@ void VoiceUnisonPartSource::unassign() {
 	}
 
 	if (livePitchShifter) {
-		generalMemoryAllocator.dealloc(livePitchShifter);
+		GeneralMemoryAllocator::get().dealloc(livePitchShifter);
 		livePitchShifter = NULL;
 	}
 }

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -2101,8 +2101,8 @@ void AutoParam::copy(int32_t startPos, int32_t endPos, CopiedParamAutomation* co
 	if (copiedParamAutomation->numNodes > 0) {
 
 		// Allocate some memory for the nodes
-		copiedParamAutomation->nodes =
-		    (ParamNode*)generalMemoryAllocator.alloc(sizeof(ParamNode) * copiedParamAutomation->numNodes, NULL, true);
+		copiedParamAutomation->nodes = (ParamNode*)GeneralMemoryAllocator::get().alloc(
+		    sizeof(ParamNode) * copiedParamAutomation->numNodes, NULL, true);
 
 		if (!copiedParamAutomation->nodes) {
 			copiedParamAutomation->numNodes = 0;
@@ -2664,7 +2664,8 @@ void AutoParam::stealNodes(ModelStackWithAutoParam const* modelStack, int32_t po
 				action->recordParamChangeIfNotAlreadySnapshotted(modelStack);
 			}
 
-			void* memory = generalMemoryAllocator.alloc(numNodesToStealTotal * sizeof(ParamNode), NULL, false, true);
+			void* memory =
+			    GeneralMemoryAllocator::get().alloc(numNodesToStealTotal * sizeof(ParamNode), NULL, false, true);
 			if (memory) {
 				ParamNode* stolenNodes = (ParamNode*)memory;
 				stolenNodeRecord->nodes = stolenNodes;

--- a/src/deluge/modulation/params/param_manager.cpp
+++ b/src/deluge/modulation/params/param_manager.cpp
@@ -57,7 +57,7 @@ ParamManagerForTimeline* ParamManagerForTimeline::toForTimeline() {
 #endif
 
 int ParamManager::setupMIDI() {
-	void* memory = generalMemoryAllocator.alloc(sizeof(MIDIParamCollection), NULL, false, true);
+	void* memory = GeneralMemoryAllocator::get().alloc(sizeof(MIDIParamCollection), NULL, false, true);
 	if (!memory) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -70,7 +70,7 @@ int ParamManager::setupMIDI() {
 }
 
 int ParamManager::setupUnpatched() {
-	void* memoryUnpatched = generalMemoryAllocator.alloc(sizeof(UnpatchedParamSet), NULL, false, true);
+	void* memoryUnpatched = GeneralMemoryAllocator::get().alloc(sizeof(UnpatchedParamSet), NULL, false, true);
 	if (!memoryUnpatched) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -82,21 +82,21 @@ int ParamManager::setupUnpatched() {
 }
 
 int ParamManager::setupWithPatching() {
-	void* memoryUnpatched = generalMemoryAllocator.alloc(sizeof(UnpatchedParamSet), NULL, false, true);
+	void* memoryUnpatched = GeneralMemoryAllocator::get().alloc(sizeof(UnpatchedParamSet), NULL, false, true);
 	if (!memoryUnpatched) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
 
-	void* memoryPatched = generalMemoryAllocator.alloc(sizeof(PatchedParamSet), NULL, false, true);
+	void* memoryPatched = GeneralMemoryAllocator::get().alloc(sizeof(PatchedParamSet), NULL, false, true);
 	if (!memoryPatched) {
 ramError2:
-		generalMemoryAllocator.dealloc(memoryUnpatched);
+		GeneralMemoryAllocator::get().dealloc(memoryUnpatched);
 		return ERROR_INSUFFICIENT_RAM;
 	}
 
-	void* memoryPatchCables = generalMemoryAllocator.alloc(sizeof(PatchCableSet), NULL, false, true);
+	void* memoryPatchCables = GeneralMemoryAllocator::get().alloc(sizeof(PatchCableSet), NULL, false, true);
 	if (!memoryPatchCables) {
-		generalMemoryAllocator.dealloc(memoryPatched);
+		GeneralMemoryAllocator::get().dealloc(memoryPatched);
 		goto ramError2;
 	}
 
@@ -126,7 +126,7 @@ void ParamManager::stealParamCollectionsFrom(ParamManager* other, bool stealExpr
 		// If "here" has them too, we'll just keep these, and destruct "other"'s ones
 		if (summaries[mpeParamsOffsetHere].paramCollection) {
 			other->summaries[stopAtOther].paramCollection->~ParamCollection();
-			generalMemoryAllocator.dealloc(other->summaries[stopAtOther].paramCollection);
+			GeneralMemoryAllocator::get().dealloc(other->summaries[stopAtOther].paramCollection);
 			other->summaries[stopAtOther] = {0};
 		}
 
@@ -183,7 +183,7 @@ int ParamManager::cloneParamCollectionsFrom(ParamManager* other, bool copyAutoma
 
 	while (otherSummary != otherStopAt) {
 
-		newSummary->paramCollection = (ParamCollection*)generalMemoryAllocator.alloc(
+		newSummary->paramCollection = (ParamCollection*)GeneralMemoryAllocator::get().alloc(
 		    otherSummary->paramCollection->objectSize, NULL, false,
 		    true); // To cut corners, we store this currently blank/undefined memory in our array of type ParamCollectionSummary
 
@@ -191,7 +191,7 @@ int ParamManager::cloneParamCollectionsFrom(ParamManager* other, bool copyAutoma
 		if (!newSummary->paramCollection) {
 			while (newSummary != newSummaries) {
 				newSummary--;
-				generalMemoryAllocator.dealloc(newSummary->paramCollection);
+				GeneralMemoryAllocator::get().dealloc(newSummary->paramCollection);
 			}
 
 			// Mark that there's nothing here
@@ -265,7 +265,7 @@ void ParamManager::destructAndForgetParamCollections() {
 	ParamCollectionSummary* summary = summaries;
 	while (summary->paramCollection) {
 		summary->paramCollection->~ParamCollection();
-		generalMemoryAllocator.dealloc(summary->paramCollection);
+		GeneralMemoryAllocator::get().dealloc(summary->paramCollection);
 		summary++;
 	}
 
@@ -278,7 +278,7 @@ bool ParamManager::ensureExpressionParamSetExists(bool forDrum) {
 	int offset = getExpressionParamSetOffset();
 	if (!summaries[offset].paramCollection) {
 
-		void* memory = generalMemoryAllocator.alloc(sizeof(ExpressionParamSet), NULL, false, true);
+		void* memory = GeneralMemoryAllocator::get().alloc(sizeof(ExpressionParamSet), NULL, false, true);
 		if (!memory) {
 			return false;
 		}

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -58,7 +58,7 @@ void unflagCable(uint32_t* flags, int c) {
 inline void PatchCableSet::freeDestinationMemory(bool destructing) {
 	for (int g = 0; g < 2; g++) {
 		if (destinations[g]) {
-			generalMemoryAllocator.dealloc(destinations[g]);
+			GeneralMemoryAllocator::get().dealloc(destinations[g]);
 			if (!destructing) {
 				destinations[g] = NULL;
 			}
@@ -136,15 +136,15 @@ void PatchCableSet::setupPatching(ModelStackWithParamCollection const* modelStac
 
 	// Allocate new memory - max size we might need
 	for (int g = 0; g < 2; g++) {
-		destinations[g] = (Destination*)generalMemoryAllocator.alloc(sizeof(Destination) * (kMaxNumPatchCables + 1),
-		                                                             NULL, false, true);
+		destinations[g] = (Destination*)GeneralMemoryAllocator::get().alloc(
+		    sizeof(Destination) * (kMaxNumPatchCables + 1), NULL, false, true);
 
 		// If couldn't...
 		if (!destinations[g]) {
 
 			// If we'd got the first one successfully, deallocate it again
 			if (g == 1) {
-				generalMemoryAllocator.dealloc(destinations[0]);
+				GeneralMemoryAllocator::get().dealloc(destinations[0]);
 				destinations[0] = NULL;
 			}
 
@@ -250,7 +250,7 @@ goAgainWithoutIncrement:
 
 		// If no Destinations here at all, free memory
 		if (!numDestinations[globality]) {
-			generalMemoryAllocator.dealloc(destinations[globality]);
+			GeneralMemoryAllocator::get().dealloc(destinations[globality]);
 			destinations[globality] = NULL;
 		}
 
@@ -259,8 +259,8 @@ goAgainWithoutIncrement:
 
 			// Probably shorten memory, from max size which we allocated
 			if (numDestinations[globality] < kMaxNumPatchCables) {
-				generalMemoryAllocator.shortenRight(destinations[globality],
-				                                    sizeof(Destination) * (numDestinations[globality] + 1));
+				GeneralMemoryAllocator::get().shortenRight(destinations[globality],
+				                                           sizeof(Destination) * (numDestinations[globality] + 1));
 			}
 
 			// Write the "end of list" marker
@@ -747,7 +747,7 @@ void PatchCableSet::beenCloned(bool copyAutomation, int32_t reverseDirectionWith
 			continue;
 		}
 
-		newDestinations[g] = (Destination*)generalMemoryAllocator.alloc(
+		newDestinations[g] = (Destination*)GeneralMemoryAllocator::get().alloc(
 		    sizeof(Destination) * (kMaxNumPatchCables + 1), NULL, false,
 		    true); // TODO: this is more than we'll soon realise we need - we should really shorten it again afterwards.
 
@@ -756,7 +756,7 @@ void PatchCableSet::beenCloned(bool copyAutomation, int32_t reverseDirectionWith
 
 			// If we'd got the first one successfully, deallocate it again
 			if (g == 1) {
-				generalMemoryAllocator.dealloc(newDestinations[0]);
+				GeneralMemoryAllocator::get().dealloc(newDestinations[0]);
 				newDestinations[0] = NULL;
 			}
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2243,7 +2243,7 @@ void PlaybackHandler::grabTempoFromClip(Clip* clip) {
 	// Record that change, ourselves. We sent false above because that mechanism of recording it would do all this other stuff
 	if (action) {
 
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceTempoChange));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceTempoChange));
 
 		if (consMemory) {
 			ConsequenceTempoChange* newConsequence =
@@ -2277,7 +2277,7 @@ uint32_t PlaybackHandler::setTempoFromAudioClipLength(uint64_t loopLengthSamples
 	// Record that change, ourselves. We sent false above because that mechanism of recording it would do all this other stuff
 	if (action) {
 
-		void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceTempoChange));
+		void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceTempoChange));
 
 		if (consMemory) {
 			ConsequenceTempoChange* newConsequence =
@@ -2361,7 +2361,7 @@ void PlaybackHandler::finishTempolessRecording(bool shouldStartPlaybackAgain, in
 
 		// And remember that this tempoless-record Action included beginning playback, so undoing / redoing it later will stop and start playback respectively
 		if (action) {
-			void* consMemory = generalMemoryAllocator.alloc(sizeof(ConsequenceBeginPlayback));
+			void* consMemory = GeneralMemoryAllocator::get().alloc(sizeof(ConsequenceBeginPlayback));
 
 			if (consMemory) {
 				ConsequenceBeginPlayback* newConsequence = new (consMemory) ConsequenceBeginPlayback();

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -363,7 +363,7 @@ void AudioOutput::deleteBackedUpParamManagers(Song* song) {
 Clip* AudioOutput::createNewClipForArrangementRecording(ModelStack* modelStack) {
 
 	// Allocate memory for audio clip
-	void* clipMemory = generalMemoryAllocator.alloc(sizeof(AudioClip), NULL, false, true);
+	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(AudioClip), NULL, false, true);
 	if (!clipMemory) {
 		return NULL;
 	}

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -351,7 +351,7 @@ void routine() {
 
 	// At this point, there may be MIDI, including clocks, waiting to be sent.
 
-	generalMemoryAllocator.checkStack("AudioDriver::routine");
+	GeneralMemoryAllocator::get().checkStack("AudioDriver::routine");
 
 	saddr = (uint32_t)(getTxBufferCurrentPlace());
 	uint32_t saddrPosAtStart = saddr >> (2 + NUM_MONO_OUTPUT_CHANNELS_MAGNITUDE);
@@ -1172,7 +1172,7 @@ doCull:
 	}
 
 	else {
-		void* memory = generalMemoryAllocator.alloc(sizeof(Voice), NULL, false, true);
+		void* memory = GeneralMemoryAllocator::get().alloc(sizeof(Voice), NULL, false, true);
 		if (!memory) {
 			if (activeVoices.getNumElements()) {
 				goto doCull;
@@ -1227,7 +1227,7 @@ void disposeOfVoice(Voice* voice) {
 		firstUnassignedVoice = voice;
 	}
 	else {
-		generalMemoryAllocator.dealloc(voice);
+		GeneralMemoryAllocator::get().dealloc(voice);
 	}
 }
 
@@ -1238,7 +1238,7 @@ VoiceSample* solicitVoiceSample() {
 		return toReturn;
 	}
 	else {
-		void* memory = generalMemoryAllocator.alloc(sizeof(VoiceSample), NULL, false, true);
+		void* memory = GeneralMemoryAllocator::get().alloc(sizeof(VoiceSample), NULL, false, true);
 		if (!memory) {
 			return NULL;
 		}
@@ -1253,7 +1253,7 @@ void voiceSampleUnassigned(VoiceSample* voiceSample) {
 		firstUnassignedVoiceSample = voiceSample;
 	}
 	else {
-		generalMemoryAllocator.dealloc(voiceSample);
+		GeneralMemoryAllocator::get().dealloc(voiceSample);
 	}
 }
 
@@ -1266,7 +1266,7 @@ TimeStretcher* solicitTimeStretcher() {
 	}
 
 	else {
-		void* memory = generalMemoryAllocator.alloc(sizeof(TimeStretcher), NULL, false, true);
+		void* memory = GeneralMemoryAllocator::get().alloc(sizeof(TimeStretcher), NULL, false, true);
 		if (!memory) {
 			return NULL;
 		}
@@ -1282,7 +1282,7 @@ void timeStretcherUnassigned(TimeStretcher* timeStretcher) {
 		firstUnassignedTimeStretcher = timeStretcher;
 	}
 	else {
-		generalMemoryAllocator.dealloc(timeStretcher);
+		GeneralMemoryAllocator::get().dealloc(timeStretcher);
 	}
 }
 
@@ -1299,7 +1299,7 @@ LiveInputBuffer* getOrCreateLiveInputBuffer(OscType inputType, bool mayCreate) {
 			size += kInputRawBufferSize * sizeof(int32_t);
 		}
 
-		void* memory = generalMemoryAllocator.alloc(size, NULL, false, true);
+		void* memory = GeneralMemoryAllocator::get().alloc(size, NULL, false, true);
 		if (!memory) {
 			return NULL;
 		}
@@ -1340,7 +1340,7 @@ void doRecorderCardRoutines() {
 			Debug::println("deleting recorder");
 			*prevPointer = recorder->next;
 			recorder->~SampleRecorder();
-			generalMemoryAllocator.dealloc(recorder);
+			GeneralMemoryAllocator::get().dealloc(recorder);
 		}
 
 		// Otherwise, move on
@@ -1379,7 +1379,7 @@ void slowRoutine() {
 		if (liveInputBuffers[i]) {
 			if (liveInputBuffers[i]->upToTime != audioSampleTimer) {
 				liveInputBuffers[i]->~LiveInputBuffer();
-				generalMemoryAllocator.dealloc(liveInputBuffers[i]);
+				GeneralMemoryAllocator::get().dealloc(liveInputBuffers[i]);
 				liveInputBuffers[i] = NULL;
 			}
 		}
@@ -1395,7 +1395,7 @@ SampleRecorder* getNewRecorder(int numChannels, AudioRecordingFolder folderID, A
                                bool keepFirstReasons, bool writeLoopPoints, int buttonPressLatency) {
 	int error;
 
-	void* recorderMemory = generalMemoryAllocator.alloc(sizeof(SampleRecorder), NULL, false, true);
+	void* recorderMemory = GeneralMemoryAllocator::get().alloc(sizeof(SampleRecorder), NULL, false, true);
 	if (!recorderMemory) {
 		return NULL;
 	}
@@ -1405,7 +1405,7 @@ SampleRecorder* getNewRecorder(int numChannels, AudioRecordingFolder folderID, A
 	error = newRecorder->setup(numChannels, mode, keepFirstReasons, writeLoopPoints, folderID, buttonPressLatency);
 	if (error) {
 		newRecorder->~SampleRecorder();
-		generalMemoryAllocator.dealloc(recorderMemory);
+		GeneralMemoryAllocator::get().dealloc(recorderMemory);
 		return NULL;
 	}
 
@@ -1441,7 +1441,7 @@ void discardRecorder(SampleRecorder* recorder) {
 	}
 
 	recorder->~SampleRecorder();
-	generalMemoryAllocator.dealloc(recorder);
+	GeneralMemoryAllocator::get().dealloc(recorder);
 }
 
 bool isAnyInternalRecordingHappening() {

--- a/src/deluge/processing/live/live_pitch_shifter.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter.cpp
@@ -65,7 +65,7 @@ LivePitchShifter::~LivePitchShifter() {
 
 #if INPUT_ENABLE_REPITCHED_BUFFER
 	if (repitchedBuffer) {
-		generalMemoryAllocator.dealloc(repitchedBuffer);
+		GeneralMemoryAllocator::get().dealloc(repitchedBuffer);
 	}
 #endif
 }
@@ -819,7 +819,7 @@ thatsDone:
 	if (repitchedBuffer && !stillWritingToRepitchedBuffer
 	    && playHeads[PLAY_HEAD_NEWER].mode != PLAY_HEAD_MODE_REPITCHED_BUFFER
 	    && playHeads[PLAY_HEAD_OLDER].mode != PLAY_HEAD_MODE_REPITCHED_BUFFER) {
-		generalMemoryAllocator.dealloc(repitchedBuffer);
+		GeneralMemoryAllocator::get().dealloc(repitchedBuffer);
 		repitchedBuffer = NULL;
 	}
 #endif
@@ -839,7 +839,7 @@ void LivePitchShifter::considerRepitchedBuffer(int32_t phaseIncrement) {
 	if (phaseIncrement > 16777216) {
 		if (!repitchedBuffer) {
 
-			repitchedBuffer = (int32_t*)generalMemoryAllocator.alloc(
+			repitchedBuffer = (int32_t*)GeneralMemoryAllocator::get().alloc(
 			    INPUT_REPITCHED_BUFFER_SIZE * sizeof(int32_t) * numChannels, NULL, false, true);
 			if (repitchedBuffer) {
 				repitchedBufferWritePos = 0;

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -341,8 +341,8 @@ bool Sound::setModFXType(ModFXType newType) {
 	if (newType == ModFXType::FLANGER || newType == ModFXType::CHORUS || newType == ModFXType::CHORUS_STEREO) {
 		if (!modFXBuffer) {
 			// TODO: should give an error here if no free ram
-			modFXBuffer =
-			    (StereoSample*)generalMemoryAllocator.alloc(kModFXBufferSize * sizeof(StereoSample), NULL, false, true);
+			modFXBuffer = (StereoSample*)GeneralMemoryAllocator::get().alloc(kModFXBufferSize * sizeof(StereoSample),
+			                                                                 NULL, false, true);
 			if (!modFXBuffer) {
 				return false;
 			}
@@ -350,7 +350,7 @@ bool Sound::setModFXType(ModFXType newType) {
 	}
 	else {
 		if (modFXBuffer) {
-			generalMemoryAllocator.dealloc(modFXBuffer);
+			GeneralMemoryAllocator::get().dealloc(modFXBuffer);
 			modFXBuffer = NULL;
 		}
 	}

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -39,7 +39,7 @@ SoundDrum::SoundDrum() : Drum(DrumType::SOUND), arpeggiator() {
 /*
 // Started but didn't finish this - it's hard!
 Drum* SoundDrum::clone() {
-	void* drumMemory = generalMemoryAllocator.alloc(sizeof(SoundDrum), NULL, false, true);
+	void* drumMemory = GeneralMemoryAllocator::get().alloc(sizeof(SoundDrum), NULL, false, true);
 	if (!drumMemory) return NULL;
 	SoundDrum* newDrum = new (drumMemory) SoundDrum();
 

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -509,7 +509,7 @@ void AudioFile::removeReason(char const* errorCode) {
 	// If it's now zero, it's become unused
 	if (numReasonsToBeLoaded == 0) {
 		numReasonsDecreasedToZero(errorCode);
-		generalMemoryAllocator.putStealableInQueue(this, STEALABLE_QUEUE_NO_SONG_AUDIO_FILE_OBJECTS);
+		GeneralMemoryAllocator::get().putStealableInQueue(this, STEALABLE_QUEUE_NO_SONG_AUDIO_FILE_OBJECTS);
 	}
 
 	else if (numReasonsToBeLoaded < 0) {

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1407,7 +1407,7 @@ deleteInstrumentAndGetOut:
 		newInstrument->deleteBackedUpParamManagers(song);
 		void* toDealloc = dynamic_cast<void*>(newInstrument);
 		newInstrument->~Instrument();
-		generalMemoryAllocator.dealloc(toDealloc);
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
 
 		return error;
 	}
@@ -1473,7 +1473,7 @@ Instrument* StorageManager::createNewInstrument(InstrumentType newInstrumentType
 		instrumentSize = sizeof(Kit);
 	}
 
-	void* instrumentMemory = generalMemoryAllocator.alloc(instrumentSize, NULL, false, true);
+	void* instrumentMemory = GeneralMemoryAllocator::get().alloc(instrumentSize, NULL, false, true);
 	if (!instrumentMemory) {
 		return NULL;
 	}
@@ -1488,7 +1488,7 @@ Instrument* StorageManager::createNewInstrument(InstrumentType newInstrumentType
 			error = paramManager->setupWithPatching();
 			if (error) {
 paramManagerSetupError:
-				generalMemoryAllocator.dealloc(instrumentMemory);
+				GeneralMemoryAllocator::get().dealloc(instrumentMemory);
 				return NULL;
 			}
 			Sound::initParams(paramManager);
@@ -1514,7 +1514,7 @@ paramManagerSetupError:
 
 Instrument* StorageManager::createNewNonAudioInstrument(InstrumentType instrumentType, int slot, int subSlot) {
 	int size = (instrumentType == InstrumentType::MIDI_OUT) ? sizeof(MIDIInstrument) : sizeof(CVInstrument);
-	void* instrumentMemory = generalMemoryAllocator.alloc(size);
+	void* instrumentMemory = GeneralMemoryAllocator::get().alloc(size);
 	if (!instrumentMemory) { // RAM fail
 		return NULL;
 	}
@@ -1545,7 +1545,7 @@ Drum* StorageManager::createNewDrum(DrumType drumType) {
 		memorySize = sizeof(GateDrum);
 	}
 
-	void* drumMemory = generalMemoryAllocator.alloc(memorySize, NULL, false, true);
+	void* drumMemory = GeneralMemoryAllocator::get().alloc(memorySize, NULL, false, true);
 	if (!drumMemory) {
 		return NULL;
 	}

--- a/src/deluge/util/container/array/ordered_resizeable_array.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array.cpp
@@ -281,9 +281,9 @@ void OrderedResizeableArray::testSequentiality(char const* errorCode) {
 void OrderedResizeableArrayWith32bitKey::testSearchMultiple() {
 	insertAtIndex(0, TEST_SEARCH_MULTIPLE_NUM_ITEMS);
 
-	int32_t* searchPos = (int32_t*)generalMemoryAllocator.alloc(TEST_SEARCH_MULTIPLE_NUM_SEARCH_TERMS * sizeof(int32_t),
-	                                                            NULL, false, false);
-	int32_t* resultingIndexes = (int32_t*)generalMemoryAllocator.alloc(
+	int32_t* searchPos = (int32_t*)GeneralMemoryAllocator::get().alloc(
+	    TEST_SEARCH_MULTIPLE_NUM_SEARCH_TERMS * sizeof(int32_t), NULL, false, false);
+	int32_t* resultingIndexes = (int32_t*)GeneralMemoryAllocator::get().alloc(
 	    TEST_SEARCH_MULTIPLE_NUM_SEARCH_TERMS * sizeof(int32_t), NULL, false, false);
 
 	while (true) {

--- a/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
+++ b/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
@@ -45,10 +45,10 @@ OpenAddressingHashTable::~OpenAddressingHashTable() {
 
 void OpenAddressingHashTable::empty(bool destructing) {
 	if (memory) {
-		generalMemoryAllocator.dealloc(memory);
+		GeneralMemoryAllocator::get().dealloc(memory);
 	}
 	if (secondaryMemory) {
-		generalMemoryAllocator.dealloc(secondaryMemory);
+		GeneralMemoryAllocator::get().dealloc(secondaryMemory);
 	}
 
 	if (!destructing) {
@@ -95,7 +95,7 @@ void* OpenAddressingHashTable::insert(uint32_t key, bool* onlyIfNotAlreadyPresen
 	// If no memory, get some
 	if (!memory) {
 		int newNumBuckets = initialNumBuckets;
-		memory = generalMemoryAllocator.alloc(newNumBuckets * elementSize, NULL, false, true);
+		memory = GeneralMemoryAllocator::get().alloc(newNumBuckets * elementSize, NULL, false, true);
 		if (!memory) {
 			return NULL;
 		}
@@ -110,7 +110,7 @@ void* OpenAddressingHashTable::insert(uint32_t key, bool* onlyIfNotAlreadyPresen
 	else if (numElements >= numBuckets - (numBuckets >> 2)) {
 		int newNumBuckets = numBuckets << 1;
 
-		secondaryMemory = generalMemoryAllocator.alloc(newNumBuckets * elementSize, NULL, false, true);
+		secondaryMemory = GeneralMemoryAllocator::get().alloc(newNumBuckets * elementSize, NULL, false, true);
 		if (secondaryMemory) {
 
 			// Initialize
@@ -158,7 +158,7 @@ void* OpenAddressingHashTable::insert(uint32_t key, bool* onlyIfNotAlreadyPresen
 
 			// Discard old stuff
 			secondaryMemoryCurrentFunction = SECONDARY_MEMORY_FUNCTION_NONE;
-			generalMemoryAllocator.dealloc(secondaryMemory);
+			GeneralMemoryAllocator::get().dealloc(secondaryMemory);
 			secondaryMemory = NULL;
 			secondaryMemoryNumBuckets = 0;
 		}
@@ -277,7 +277,7 @@ bool OpenAddressingHashTable::remove(uint32_t key) {
 
 	// If we've hit zero elements, and it's worth getting rid of the memory, just do that
 	if (!numElements && numBuckets > initialNumBuckets) {
-		generalMemoryAllocator.dealloc(memory);
+		GeneralMemoryAllocator::get().dealloc(memory);
 		memory = NULL;
 		numBuckets = 0;
 	}

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -50,7 +50,7 @@ void String::clear(bool destructing) {
 			setNumReasons(numReasons - 1);
 		}
 		else {
-			generalMemoryAllocator.dealloc(stringMemory - 4);
+			GeneralMemoryAllocator::get().dealloc(stringMemory - 4);
 		}
 
 		if (!destructing) {
@@ -85,7 +85,7 @@ int String::set(char const* newChars, int newLength) {
 
 			// If we're here, the memory is exclusively ours (1 reason)
 
-			int allocatedSize = generalMemoryAllocator.getAllocatedSize(stringMemory - 4);
+			int allocatedSize = GeneralMemoryAllocator::get().getAllocatedSize(stringMemory - 4);
 
 			int extraMemoryNeeded = newLength + 1 + 4 - allocatedSize;
 
@@ -97,8 +97,8 @@ int String::set(char const* newChars, int newLength) {
 			else {
 				// Try extending
 				uint32_t amountExtendedLeft, amountExtendedRight;
-				generalMemoryAllocator.extend(stringMemory - 4, extraMemoryNeeded, extraMemoryNeeded,
-				                              &amountExtendedLeft, &amountExtendedRight);
+				GeneralMemoryAllocator::get().extend(stringMemory - 4, extraMemoryNeeded, extraMemoryNeeded,
+				                                     &amountExtendedLeft, &amountExtendedRight);
 
 				stringMemory -= amountExtendedLeft;
 
@@ -115,7 +115,7 @@ clearAndAllocateNew:
 	}
 
 	{
-		void* newMemory = generalMemoryAllocator.alloc(newLength + 1 + 4, NULL, false, false);
+		void* newMemory = GeneralMemoryAllocator::get().alloc(newLength + 1 + 4, NULL, false, false);
 		if (!newMemory) {
 			return ERROR_INSUFFICIENT_RAM;
 		}
@@ -157,7 +157,7 @@ int String::shorten(int newLength) {
 
 		// If reasons, we have to do a clone
 		if (oldNumReasons > 1) {
-			void* newMemory = generalMemoryAllocator.alloc(newLength + 1 + 4, NULL, false, false);
+			void* newMemory = GeneralMemoryAllocator::get().alloc(newLength + 1 + 4, NULL, false, false);
 			if (!newMemory) {
 				return ERROR_INSUFFICIENT_RAM;
 			}
@@ -216,15 +216,15 @@ int String::concatenateAtPos(char const* newChars, int pos, int newCharsLength) 
 		goto allocateNewMemory;
 	}
 
-	extraBytesNeeded = requiredSize - generalMemoryAllocator.getAllocatedSize(stringMemory - 4);
+	extraBytesNeeded = requiredSize - GeneralMemoryAllocator::get().getAllocatedSize(stringMemory - 4);
 
 	// If not enough memory allocated...
 	if (extraBytesNeeded > 0) {
 
 		// See if we can extend
 		uint32_t amountExtendedLeft, amountExtendedRight;
-		generalMemoryAllocator.extend(stringMemory - 4, extraBytesNeeded, extraBytesNeeded, &amountExtendedLeft,
-		                              &amountExtendedRight);
+		GeneralMemoryAllocator::get().extend(stringMemory - 4, extraBytesNeeded, extraBytesNeeded, &amountExtendedLeft,
+		                                     &amountExtendedRight);
 
 		// If that worked...
 		if (amountExtendedLeft || amountExtendedRight) {
@@ -240,7 +240,7 @@ int String::concatenateAtPos(char const* newChars, int pos, int newCharsLength) 
 		// Otherwise, gotta allocate brand new memory
 		else {
 allocateNewMemory:
-			void* newMemory = generalMemoryAllocator.alloc(requiredSize, NULL, false, false);
+			void* newMemory = GeneralMemoryAllocator::get().alloc(requiredSize, NULL, false, false);
 			if (!newMemory) {
 				return ERROR_INSUFFICIENT_RAM;
 			}
@@ -251,7 +251,7 @@ allocateNewMemory:
 			memcpy(newStringMemory, stringMemory, pos);
 
 			if (deallocateAfter) {
-				generalMemoryAllocator.dealloc(stringMemory - 4);
+				GeneralMemoryAllocator::get().dealloc(stringMemory - 4);
 			}
 			stringMemory = newStringMemory;
 			setNumReasons(1);
@@ -284,7 +284,7 @@ int String::setChar(char newChar, int pos) {
 		int length = getLength();
 
 		int requiredSize = length + 4 + 1;
-		void* newMemory = generalMemoryAllocator.alloc(requiredSize, NULL, false, false);
+		void* newMemory = GeneralMemoryAllocator::get().alloc(requiredSize, NULL, false, false);
 		if (!newMemory) {
 			return ERROR_INSUFFICIENT_RAM;
 		}


### PR DESCRIPTION
Unfortunately, with the state of the heaps and the way global variable initialization order is undefined behavior, the only way to guarantee the GMA is up and running the first time it's accessed by any global variables is to make it a singleton.

This does that, though I expect this to eventually be swapped out when the memory allocator overhaul takes place.