### PR TITLE
Fix bipolar display of pan

### DIFF
--- a/src/deluge/gui/menu_item/param.h
+++ b/src/deluge/gui/menu_item/param.h
@@ -28,8 +28,8 @@ namespace menu_item {
 class Param {
 public:
 	Param(int newP = 0) { p = newP; }
-	int getMaxValue() const { return 50; }
-	int getMinValue() const { return 0; }
+	virtual int getMaxValue() const { return 50; }
+	virtual int getMinValue() const { return 0; }
 	virtual uint8_t getP() { return p; };
 	MenuItem* selectButtonPress();
 	virtual ModelStackWithAutoParam* getModelStack(void* memory) = 0;

--- a/src/deluge/gui/menu_item/patched_param/pan.h
+++ b/src/deluge/gui/menu_item/patched_param/pan.h
@@ -25,12 +25,8 @@ public:
 	void drawValue();
 #endif
 protected:
-	int getMaxValue() {
-		return 32;
-	}
-	int getMinValue() {
-		return -32;
-	}
+	int getMaxValue() const override { return 32; }
+	int getMinValue() const override { return -32; }
 	int32_t getFinalValue();
 	void readCurrentValue();
 };


### PR DESCRIPTION
Pan was being clamped to 0-50 instead of -32 to 32, fixed by marking the base definitions as virtual and the pan definitions as override

Closes #195 