### PR TITLE
workflows: run less often

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -4,15 +4,8 @@
 name: Deploy Pages site
 
 on:
-  # Runs on pushes targeting the default branch that modify the pages directory
-  push:
-    branches:
-      - 'community'
-    paths:
-      - '.github/workflows/build-pages.yml'
-      - 'pages/**'
-
-  # And automatically runs after the build workflow
+  # Automatically run after the build workflow completes, since that workflow
+  # must *always* run to get PRs approved.
   workflow_run:
     workflows: [Build]
     types:
@@ -39,9 +32,10 @@ jobs:
   # Build job
   build:
     runs-on: ubuntu-latest
+    # Run when we're triggered by something other than a workflow run (i.e.
+    # workflow dispatch) or the workflow run is a success
     if: |
-      github.event.push ||
-      github.event.workflow_dispatch ||
+      !github.event.workflow_run ||
       (github.event.workflow_run && github.event.workflow_run.conclusion == 'success')
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ name: Build
 on:
   push:
     branches:
-      - 'community'
       - 'synthstrom-official'
   pull_request:
     branches:


### PR DESCRIPTION
This should prevent the double-run of workflows when the merge queue kicks code in to `community`. Requires some modification of the "gather all runs for community commits" logic in the pages build.

It should also fix the bug where it's not possible to manually run the pages deploy.