### PR TITLE
Alternative golden knob delay params (ability to change encoder click behavior)

### DIFF
--- a/Documentation/community_features.md
+++ b/Documentation/community_features.md
@@ -73,6 +73,9 @@ Synchronization modes accessible through the "LFO SYNC" shortcut.
 ### Catch Notes
  - ([#221]) The normal behavior of the Deluge is to try to keep up with 'in progress' notes when instant switching between clips by playing them late. However this leads to glitches with drum clips and other percussive sounds. Changing this setting to OFF will prevent this behavior and *not* try to keep up with those notes, leading to smoother instant switching between clips.
 
+### Alternative Delay Params for golden knobs
+ - ([#281]) Ability to select, using a Community Features Menu, which parameters are controlled when you click the Delay-related golden knobs. The default (for upper and lower knobs) is PingPong On/Off and Type (Digital/Analog), and you can modify it so the knob clicks change the Sync Type (Even, Triplets, Even) and SyncLevel (Off, Whole, 2nd, 4th...) respectively.
+
 <h1 id="runtime-features">Runtime settings aka Community Features Menu</h1>
 
 In the main menu of the deluge (Shift + Pressing selection knob) there is an entry called "Community Features" that allows changing behavior and turning features on and off in comparison to the original and previous community firmwares. Here is a list of all options and what they do:
@@ -91,6 +94,8 @@ In the main menu of the deluge (Shift + Pressing selection knob) there is an ent
 	Enable or disables the 'catch notes' behavior.
 * Delete Unused Kit Rows (DELE)
 	Enable or disables the Delete Unused Kit Rows shortcut (hold KIT then SHIFT+SAVE/DELETE).
+* Alternative Golden Knob Delay Params
+	When On, changes the behaviour of the click action, from the default (PingPong and Type) to the alternative params (SyncType and SyncLevel).
 
 
 # Compiletime settings
@@ -120,3 +125,4 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#170]: https://github.com/SynthstromAudible/DelugeFirmware/pull/170
 [#221]: https://github.com/SynthstromAudible/DelugeFirmware/pull/221
 [#234]: https://github.com/SynthstromAudible/DelugeFirmware/pull/234
+[#281]: https://github.com/SynthstromAudible/DelugeFirmware/pull/281

--- a/Documentation/community_features.md
+++ b/Documentation/community_features.md
@@ -74,7 +74,7 @@ Synchronization modes accessible through the "LFO SYNC" shortcut.
  - ([#221]) The normal behavior of the Deluge is to try to keep up with 'in progress' notes when instant switching between clips by playing them late. However this leads to glitches with drum clips and other percussive sounds. Changing this setting to OFF will prevent this behavior and *not* try to keep up with those notes, leading to smoother instant switching between clips.
 
 ### Alternative Delay Params for golden knobs
- - ([#281]) Ability to select, using a Community Features Menu, which parameters are controlled when you click the Delay-related golden knobs. The default (for upper and lower knobs) is PingPong On/Off and Type (Digital/Analog), and you can modify it so the knob clicks change the Sync Type (Even, Triplets, Even) and SyncLevel (Off, Whole, 2nd, 4th...) respectively.
+ - ([#282]) Ability to select, using a Community Features Menu, which parameters are controlled when you click the Delay-related golden knobs. The default (for upper and lower knobs) is PingPong On/Off and Type (Digital/Analog), and you can modify it so the knob clicks change the Sync Type (Even, Triplets, Even) and SyncLevel (Off, Whole, 2nd, 4th...) respectively.
 
 <h1 id="runtime-features">Runtime settings aka Community Features Menu</h1>
 
@@ -125,4 +125,4 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#170]: https://github.com/SynthstromAudible/DelugeFirmware/pull/170
 [#221]: https://github.com/SynthstromAudible/DelugeFirmware/pull/221
 [#234]: https://github.com/SynthstromAudible/DelugeFirmware/pull/234
-[#281]: https://github.com/SynthstromAudible/DelugeFirmware/pull/281
+[#282]: https://github.com/SynthstromAudible/DelugeFirmware/pull/282

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -571,8 +571,6 @@ enum SyncLevel {
 	SYNC_LEVEL_64TH = 7,
 	SYNC_LEVEL_128TH = 8,
 	SYNC_LEVEL_256TH = 9,
-	// Maximum number of SyncLevel values, update if you add more
-	MAX_NUM = 10,
 };
 
 enum class SynthMode {

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -571,6 +571,8 @@ enum SyncLevel {
 	SYNC_LEVEL_64TH = 7,
 	SYNC_LEVEL_128TH = 8,
 	SYNC_LEVEL_256TH = 9,
+	// Maximum number of SyncLevel values, update if you add more
+	MAX_NUM = 10,
 };
 
 enum class SynthMode {

--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -38,10 +38,11 @@ Setting menuQuantize(RuntimeFeatureSettingType::Quantize);
 Setting menuPatchCableResolution(RuntimeFeatureSettingType::PatchCableResolution);
 Setting menuCatchNotes(RuntimeFeatureSettingType::CatchNotes);
 Setting menuDeleteUnusedKitRows(RuntimeFeatureSettingType::DeleteUnusedKitRows);
+Setting menuAltGoldenKnobDelayParams(RuntimeFeatureSettingType::AltGoldenKnobDelayParams);
 
 std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement> subMenuEntries{
     &menuDrumRandomizer,       &menuMasterCompressorFx, &menuFineTempo,           &menuQuantize,
-    &menuPatchCableResolution, &menuCatchNotes,         &menuDeleteUnusedKitRows,
+    &menuPatchCableResolution, &menuCatchNotes,         &menuDeleteUnusedKitRows, &menuAltGoldenKnobDelayParams,
 };
 
 Settings::Settings(char const* name, char const* title)

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -24,6 +24,7 @@
 #include "memory/general_memory_allocator.h"
 #include "model/action/action_logger.h"
 #include "model/model_stack.h"
+#include "model/settings/runtime_feature_settings.h"
 #include "model/song/song.h"
 #include "modulation/params/param_collection.h"
 #include "modulation/params/param_manager.h"
@@ -213,7 +214,13 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 	else if (modKnobMode == 3) {
 		if (whichModEncoder == 1) {
 			if (on) {
-				switchDelayPingPong();
+				if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
+				    == RuntimeFeatureStateToggle::On) {
+					switchDelaySyncType();
+				}
+				else {
+					switchDelayPingPong();
+				}
 				return true;
 			}
 			else {
@@ -222,7 +229,13 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 		}
 		else {
 			if (on) {
-				switchDelayAnalog();
+				if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
+				    == RuntimeFeatureStateToggle::On) {
+					switchDelaySyncLevel();
+				}
+				else {
+					switchDelayAnalog();
+				}
 				return true;
 			}
 			else {

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1706,7 +1706,8 @@ void ModControllableAudio::switchDelaySyncType() {
 }
 
 void ModControllableAudio::switchDelaySyncLevel() {
-	delay.syncLevel = (SyncLevel)((delay.syncLevel + 1) % SyncLevel::MAX_NUM);
+	// Note: SYNC_LEVEL_NONE (value 0) can't be selected
+	delay.syncLevel = (SyncLevel)((delay.syncLevel) % SyncLevel::SYNC_LEVEL_256TH + 1); //cycle from 1 to 9 (omit 0)
 
 	char const* displayText;
 	switch (delay.syncLevel) {

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1675,6 +1675,73 @@ void ModControllableAudio::switchDelayAnalog() {
 	numericDriver.displayPopup(displayText);
 }
 
+void ModControllableAudio::switchDelaySyncType() {
+	switch (delay.syncType) {
+	case SYNC_TYPE_TRIPLET:
+		delay.syncType = SYNC_TYPE_DOTTED;
+		break;
+	case SYNC_TYPE_DOTTED:
+		delay.syncType = SYNC_TYPE_EVEN;
+		break;
+
+	default: //SYNC_TYPE_EVEN
+		delay.syncType = SYNC_TYPE_TRIPLET;
+		break;
+	}
+
+	char const* displayText;
+	switch (delay.syncType) {
+	case SYNC_TYPE_TRIPLET:
+		displayText = "Triplet";
+		break;
+	case SYNC_TYPE_DOTTED:
+		displayText = "Dotted";
+		break;
+
+	default: //SYNC_TYPE_EVEN
+		displayText = "Even";
+		break;
+	}
+	numericDriver.displayPopup(displayText);
+}
+
+void ModControllableAudio::switchDelaySyncLevel() {
+	delay.syncLevel = (SyncLevel)((delay.syncLevel + 1) % SyncLevel::MAX_NUM);
+
+	char const* displayText;
+	switch (delay.syncLevel) {
+	case SYNC_LEVEL_2ND:
+		displayText = "2nd";
+		break;
+	case SYNC_LEVEL_4TH:
+		displayText = "4th";
+		break;
+	case SYNC_LEVEL_8TH:
+		displayText = "8th";
+		break;
+	case SYNC_LEVEL_16TH:
+		displayText = "16th";
+		break;
+	case SYNC_LEVEL_32ND:
+		displayText = "32nd";
+		break;
+	case SYNC_LEVEL_64TH:
+		displayText = "64th";
+		break;
+	case SYNC_LEVEL_128TH:
+		displayText = "128th";
+		break;
+	case SYNC_LEVEL_256TH:
+		displayText = "256th";
+		break;
+
+	default: //SYNC_LEVEL_WHOLE
+		displayText = "1-bar";
+		break;
+	}
+	numericDriver.displayPopup(displayText);
+}
+
 void ModControllableAudio::switchLPFMode() {
 	lpfMode = static_cast<LPFMode>((util::to_underlying(lpfMode) + 1) % kNumLPFModes);
 

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -134,6 +134,8 @@ protected:
 	void beginStutter(ParamManagerForTimeline* paramManager);
 	void switchDelayPingPong();
 	void switchDelayAnalog();
+	void switchDelaySyncType();
+	void switchDelaySyncLevel();
 	void switchLPFMode();
 	void clearModFXMemory();
 

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -81,6 +81,10 @@ void RuntimeFeatureSettings::init() {
 	// DeleteUnusedKitRows
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::DeleteUnusedKitRows], "Delete Unused Kit Rows",
 	                  "deleteUnusedKitRows", RuntimeFeatureStateToggle::On);
+	// AltGoldenKnobDelayParams
+	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AltGoldenKnobDelayParams],
+	                  "Alternative Golden Knob Delay Params", "altGoldenKnobDelayParams",
+	                  RuntimeFeatureStateToggle::On);
 }
 
 void RuntimeFeatureSettings::readSettingsFromFile() {

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -41,6 +41,7 @@ enum RuntimeFeatureSettingType : uint32_t {
 	PatchCableResolution,
 	CatchNotes,
 	DeleteUnusedKitRows,
+	AltGoldenKnobDelayParams,
 	MaxElement // Keep as boundary
 };
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -33,6 +33,7 @@
 #include "model/drum/kit.h"
 #include "model/model_stack.h"
 #include "model/sample/sample.h"
+#include "model/settings/runtime_feature_settings.h"
 #include "model/song/song.h"
 #include "model/timeline_counter.h"
 #include "model/voice/voice.h"
@@ -3904,7 +3905,13 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 	// Switch delay pingpong
 	else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(Param::Global::DELAY_RATE)) {
 		if (on) {
-			switchDelayPingPong();
+			if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
+			    == RuntimeFeatureStateToggle::On) {
+				switchDelaySyncType();
+			}
+			else {
+				switchDelayPingPong();
+			}
 			return true;
 		}
 		else {
@@ -3915,7 +3922,13 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 	// Switch delay analog sim
 	else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(Param::Global::DELAY_FEEDBACK)) {
 		if (on) {
-			switchDelayAnalog();
+			if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
+			    == RuntimeFeatureStateToggle::On) {
+				switchDelaySyncLevel();
+			}
+			else {
+				switchDelayAnalog();
+			}
 			return true;
 		}
 		else {


### PR DESCRIPTION
Instead of changing PingPong On/Off and Type Analog/Digital, they will change SyncType and SyncLevel.
I have always preferred dotted 8th delays over the even 16th delays, probably because of the music genre. But the global effects from the Deluge (when affect-entire engaged in Kits and Song) default to Even 16th delays.
This PR allows users to change what parameters you change when clicking the golden knob encoders. The default behavior is changing Pingpong/Normal (upper knob) and Analog/Digital (lower knob), but with this "alternative" params mode, the upper and lower knobs will toggle between SyncType and SyncLevel values.

DEMO: https://youtu.be/GbhAAqT3_Bo