### PR TITLE
keyboard-view: use const names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,8 @@ target_compile_options(deluge INTERFACE
     $<$<CONFIG:DEBUG>:-Wnull-dereference>
     $<$<CONFIG:DEBUG>:-Wno-psabi>
 
+    $<$<CONFIG:DEBUG>:-Werror=write-strings>
+
     # Stack usage
     $<$<CONFIG:DEBUG>:-Wstack-usage=100>
     $<$<CONFIG:RELEASE>:-Wstack-usage=1000>

--- a/src/deluge/gui/context_menu/delete_file.cpp
+++ b/src/deluge/gui/context_menu/delete_file.cpp
@@ -31,7 +31,7 @@ namespace deluge::gui::context_menu {
 DeleteFile deleteFile{};
 
 char const* DeleteFile::getTitle() {
-	static char* title;
+	static char const* title;
 	if (getUIUpOneLevel() == &context_menu::saveSongOrInstrument) {
 		title = "Are you sure?";
 	}

--- a/src/deluge/gui/ui/keyboard/layout.h
+++ b/src/deluge/gui/ui/keyboard/layout.h
@@ -80,7 +80,7 @@ public:
 
 	// Properties
 
-	virtual char* name() = 0;
+	virtual char const* name() = 0;
 	/// This currently includes Synth, MIDI and CV
 	virtual bool supportsInstrument() { return false; }
 	virtual bool supportsKit() { return false; }

--- a/src/deluge/gui/ui/keyboard/layout/in_key.h
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void renderPads(uint8_t image[][kDisplayWidth + kSideBarWidth][3]);
 
-	virtual char* name() { return "In-Key"; }
+	virtual char const* name() { return "In-Key"; }
 	virtual bool supportsInstrument() { return true; }
 	virtual bool supportsKit() { return false; }
 	virtual RequiredScaleMode requiredScaleMode() { return RequiredScaleMode::Enabled; }

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.h
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void renderPads(uint8_t image[][kDisplayWidth + kSideBarWidth][3]);
 
-	virtual char* name() { return "Isomorphic"; }
+	virtual char const* name() { return "Isomorphic"; }
 	virtual bool supportsInstrument() { return true; }
 	virtual bool supportsKit() { return false; }
 

--- a/src/deluge/gui/ui/keyboard/layout/velocity_drums.h
+++ b/src/deluge/gui/ui/keyboard/layout/velocity_drums.h
@@ -36,7 +36,7 @@ public:
 
 	virtual void renderPads(uint8_t image[][kDisplayWidth + kSideBarWidth][3]);
 
-	virtual char* name() { return "Drums"; }
+	virtual char const* name() { return "Drums"; }
 	virtual bool supportsInstrument() { return false; }
 	virtual bool supportsKit() { return true; }
 


### PR DESCRIPTION
this avoids a -Wwrite-strings warning

also adds -Wwrite-strings as an error in debug builds, so we don't accidentally commit this particular sin again