### PR TITLE
ui: use string_view for title

### DIFF
--- a/src/deluge/gui/menu_item/cv/transpose.h
+++ b/src/deluge/gui/menu_item/cv/transpose.h
@@ -25,7 +25,7 @@ class Transpose final : public Decimal, public FormattedTitle {
 public:
 	Transpose(const string& name, const string& title_format_str) : Decimal(name), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	[[nodiscard]] int32_t getMinValue() const override { return -9600; }
 	[[nodiscard]] int32_t getMaxValue() const override { return 9600; }

--- a/src/deluge/gui/menu_item/cv/volts.h
+++ b/src/deluge/gui/menu_item/cv/volts.h
@@ -27,7 +27,7 @@ public:
 	using Decimal::Decimal;
 	Volts(const string& name, const string& title_format_str) : Decimal(name), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	[[nodiscard]] int32_t getMinValue() const override { return 0; }
 	[[nodiscard]] int32_t getMaxValue() const override { return 200; }

--- a/src/deluge/gui/menu_item/envelope/segment.h
+++ b/src/deluge/gui/menu_item/envelope/segment.h
@@ -25,6 +25,6 @@ public:
 	Segment(const string& name, const string& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 };
 } // namespace deluge::gui::menu_item::envelope

--- a/src/deluge/gui/menu_item/formatted_title.h
+++ b/src/deluge/gui/menu_item/formatted_title.h
@@ -14,7 +14,7 @@ public:
 		title_ = fmt::format(fmt::runtime(format_str_), args...);
 	}
 
-	[[nodiscard]] const deluge::string& title() const { return title_; }
+	[[nodiscard]] std::string_view title() const { return title_; }
 
 private:
 	deluge::string format_str_;

--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -32,14 +32,14 @@ void MenuItem::learnCC(MIDIDevice* fromDevice, int32_t channel, int32_t ccNumber
 #if HAVE_OLED
 
 void MenuItem::renderOLED() {
-	OLED::drawScreenTitle(getTitle().c_str());
+	OLED::drawScreenTitle(getTitle());
 	drawPixelsForOled();
 }
 
 #else
 
 void MenuItem::drawName() {
-	numericDriver.setText(getName().c_str(), false, shouldDrawDotOnName());
+	numericDriver.setText(getName(), false, shouldDrawDotOnName());
 }
 
 #endif

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -45,8 +45,16 @@ public:
 		}
 	}
 
-	deluge::string name; // As viewed in a menu list. For OLED, up to 20 chars.
-	[[nodiscard]] virtual const deluge::string& getName() const { return name; }
+	MenuItem(const MenuItem& other) = delete;
+	MenuItem(const MenuItem&& other) = delete;
+	MenuItem& operator=(const MenuItem& other) = delete;
+	MenuItem& operator=(const MenuItem&& other) = delete;
+
+	virtual ~MenuItem() = default;
+
+	/// As viewed in a menu list. For OLED, up to 20 chars.
+	deluge::string name;
+	[[nodiscard]] virtual std::string_view getName() const { return name; }
 
 	virtual void horizontalEncoderAction(int32_t offset) {}
 	virtual void selectEncoderAction(int32_t offset) {}
@@ -76,10 +84,14 @@ public:
 	virtual bool isRangeDependent() { return false; }
 	virtual bool usesAffectEntire() { return false; }
 
-	deluge::string title; // Can get overridden by getTitle(). Actual max num chars for OLED display is 14.
+	/// Can get overridden by getTitle(). Actual max num chars for OLED display is 14.
+	deluge::string title;
 
 	/// Get the title to be used when rendering on OLED. If not overriden, defaults to returning `title`.
-	[[nodiscard]] virtual const deluge::string& getTitle() const { return title; }
+	///
+	/// The returned pointer must live long enough for us to draw the title, which for practical purposes means "the
+	/// lifetime of this menu item"
+	[[nodiscard]] virtual std::string_view getTitle() const { return title; }
 
 #if HAVE_OLED
 	virtual void renderOLED();

--- a/src/deluge/gui/menu_item/modulator/transpose.h
+++ b/src/deluge/gui/menu_item/modulator/transpose.h
@@ -26,7 +26,7 @@ public:
 	Transpose(const string& name, const string& title_format_str, int32_t newP)
 	    : source::Transpose(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	void readCurrentValue() override {
 		this->value_ = (int32_t)soundEditor.currentSound->modulatorTranspose[soundEditor.currentSourceIndex] * 100

--- a/src/deluge/gui/menu_item/mpe/direction_selector.h
+++ b/src/deluge/gui/menu_item/mpe/direction_selector.h
@@ -32,7 +32,7 @@ public:
 	MenuItem* selectButtonPress() override;
 	uint8_t whichDirection;
 #if HAVE_OLED
-	[[nodiscard]] const string& getTitle() const override {
+	[[nodiscard]] std::string_view getTitle() const override {
 		return whichDirection ? "MPE output" : "MPE input";
 	}
 #endif

--- a/src/deluge/gui/menu_item/mpe/zone_num_member_channels.h
+++ b/src/deluge/gui/menu_item/mpe/zone_num_member_channels.h
@@ -37,7 +37,7 @@ public:
 	//char nameChars[16];
 
 #if HAVE_OLED
-	[[nodiscard]] const string& getTitle() const override {
+	[[nodiscard]] std::string_view getTitle() const override {
 		return "Num member ch.";
 	}
 #endif

--- a/src/deluge/gui/menu_item/multi_range.h
+++ b/src/deluge/gui/menu_item/multi_range.h
@@ -40,7 +40,7 @@ protected:
 	bool mayEditRangeEdge(RangeEdit whichEdge) override;
 
 #if HAVE_OLED
-	const string& getTitle() const override {
+	[[nodiscard]] std::string_view getTitle() const override {
 		return "Note range";
 	};
 	void drawPixelsForOled() override;

--- a/src/deluge/gui/menu_item/osc/pulse_width.h
+++ b/src/deluge/gui/menu_item/osc/pulse_width.h
@@ -28,7 +28,7 @@ public:
 	PulseWidth(const string& name, const string& title_format_str, int32_t newP)
 	    : source::PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	int32_t getFinalValue() override { return (uint32_t)this->value_ * (85899345 >> 1); }
 

--- a/src/deluge/gui/menu_item/osc/retrigger_phase.h
+++ b/src/deluge/gui/menu_item/osc/retrigger_phase.h
@@ -27,7 +27,7 @@ public:
 	RetriggerPhase(const string& newName, const deluge::string& title, bool newForModulator = false)
 	    : Decimal(newName), FormattedTitle(title), forModulator(newForModulator) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	[[nodiscard]] int32_t getMinValue() const override { return -soundEditor.numberEditSize; }
 	[[nodiscard]] int32_t getMaxValue() const override { return 360; }

--- a/src/deluge/gui/menu_item/osc/source/feedback.h
+++ b/src/deluge/gui/menu_item/osc/source/feedback.h
@@ -25,7 +25,7 @@ public:
 	Feedback(const string& name, const string& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() == SynthMode::FM); }
 };

--- a/src/deluge/gui/menu_item/osc/source/volume.h
+++ b/src/deluge/gui/menu_item/osc/source/volume.h
@@ -26,7 +26,7 @@ public:
 	Volume(const string& name, const string& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() != SynthMode::RINGMOD); }
 };

--- a/src/deluge/gui/menu_item/osc/source/wave_index.h
+++ b/src/deluge/gui/menu_item/osc/source/wave_index.h
@@ -25,7 +25,7 @@ public:
 	WaveIndex(const string& name, const string& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool isRelevant(Sound* sound, int32_t whichThing) override {
 		Source* source = &sound->sources[whichThing];

--- a/src/deluge/gui/menu_item/osc/type.h
+++ b/src/deluge/gui/menu_item/osc/type.h
@@ -58,7 +58,7 @@ public:
 		}
 	}
 
-	[[nodiscard]] const string& getTitle() const override {
+	[[nodiscard]] std::string_view getTitle() const override {
 		return FormattedTitle::title();
 	}
 

--- a/src/deluge/gui/menu_item/runtime_feature/setting.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/setting.cpp
@@ -54,11 +54,11 @@ static_vector<string, RUNTIME_FEATURE_SETTING_MAX_OPTIONS> Setting::getOptions()
 	return options;
 }
 
-const string& Setting::getName() const {
+std::string_view Setting::getName() const {
 	return runtimeFeatureSettings.settings[currentSettingIndex].displayName;
 }
 
-const string& Setting::getTitle() const {
+std::string_view Setting::getTitle() const {
 	return runtimeFeatureSettings.settings[currentSettingIndex].displayName;
 }
 

--- a/src/deluge/gui/menu_item/runtime_feature/setting.h
+++ b/src/deluge/gui/menu_item/runtime_feature/setting.h
@@ -29,8 +29,8 @@ public:
 	void readCurrentValue() override;
 	void writeCurrentValue() override;
 	static_vector<string, RUNTIME_FEATURE_SETTING_MAX_OPTIONS> getOptions() override;
-	[[nodiscard]] const string& getName() const override;
-	[[nodiscard]] const string& getTitle() const override;
+	[[nodiscard]] std::string_view getName() const override;
+	[[nodiscard]] std::string_view getTitle() const override;
 
 private:
 	friend class Settings;

--- a/src/deluge/gui/menu_item/sample/interpolation.h
+++ b/src/deluge/gui/menu_item/sample/interpolation.h
@@ -29,7 +29,7 @@ public:
 	Interpolation(const string& name, const string& title_format_str)
 	    : TypedSelection(name), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	void readCurrentValue() override { this->value_ = soundEditor.currentSampleControls->interpolationMode; }
 

--- a/src/deluge/gui/menu_item/sample/repeat.h
+++ b/src/deluge/gui/menu_item/sample/repeat.h
@@ -34,7 +34,7 @@ public:
 	Repeat(const string& name, const string& title_format_str)
 	    : TypedSelection(name), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool usesAffectEntire() override { return true; }
 	void readCurrentValue() override { this->value_ = soundEditor.currentSource->repeatMode; }

--- a/src/deluge/gui/menu_item/sample/reverse.h
+++ b/src/deluge/gui/menu_item/sample/reverse.h
@@ -28,7 +28,7 @@ class Reverse final : public Toggle, public FormattedTitle {
 public:
 	Reverse(const string& name, const string& title_format_str) : Toggle(name), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool usesAffectEntire() override { return true; }
 

--- a/src/deluge/gui/menu_item/sample/time_stretch.h
+++ b/src/deluge/gui/menu_item/sample/time_stretch.h
@@ -29,7 +29,7 @@ class TimeStretch final : public Integer, public FormattedTitle {
 public:
 	TimeStretch(const string& name, const string& title_format_str) : Integer(name), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool usesAffectEntire() override { return true; }
 

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -26,7 +26,7 @@ public:
 	Transpose(const string& name, const string& title_format_str, int32_t newP)
 	    : source::Transpose(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	void readCurrentValue() override {
 		int32_t transpose = 0;

--- a/src/deluge/gui/menu_item/source/patched_param/fm.h
+++ b/src/deluge/gui/menu_item/source/patched_param/fm.h
@@ -25,7 +25,7 @@ public:
 	FM(const string& name, const string& title_format_str, int32_t newP)
 	    : source::PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
-	[[nodiscard]] const string& getTitle() const override { return FormattedTitle::title(); }
+	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() == SynthMode::FM); }
 };

--- a/src/deluge/gui/menu_item/source_selection/range.h
+++ b/src/deluge/gui/menu_item/source_selection/range.h
@@ -25,7 +25,7 @@ public:
 	MenuItem* selectButtonPress() override;
 	MenuItem* patchingSourceShortcutPress(PatchSource newS, bool previousPressStillActive) override;
 #if HAVE_OLED
-	const string& getTitle() const override {
+	std::string_view getTitle() const override {
 		return "Modulate depth";
 	};
 #endif

--- a/src/deluge/gui/menu_item/source_selection/regular.h
+++ b/src/deluge/gui/menu_item/source_selection/regular.h
@@ -27,7 +27,7 @@ public:
 	MenuItem* selectButtonPress() override;
 	MenuItem* patchingSourceShortcutPress(PatchSource newS, bool previousPressStillActive) override;
 #if HAVE_OLED
-	const string& getTitle() const override {
+	std::string_view getTitle() const override {
 		return "Modulate with";
 	};
 #endif

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -16,8 +16,10 @@
  */
 
 #include "definitions_cxx.hpp"
-#define _GNU_SOURCE     // Wait why?
+#define _GNU_SOURCE // Wait why?
+#undef __GNU_VISIBLE
 #define __GNU_VISIBLE 1 // Makes strcasestr visible. Might already be the reason for the define above
+
 #include "extern.h"
 #include "gui/context_menu/delete_file.h"
 #include "gui/context_menu/sample_browser/kit.h"

--- a/src/deluge/hid/display/numeric_driver.cpp
+++ b/src/deluge/hid/display/numeric_driver.cpp
@@ -26,8 +26,8 @@
 #include "memory/general_memory_allocator.h"
 #include "model/action/action_logger.h"
 #include "util/functions.h"
+#include <cstring>
 #include <new>
-#include <string.h>
 #if HAVE_OLED
 #include "hid/display/oled.h"
 #endif
@@ -103,9 +103,9 @@ void NumericDriver::removeTopLayer() {
 }
 #endif
 
-void NumericDriver::setText(char const* newText, bool alignRight, uint8_t drawDot, bool doBlink, uint8_t* newBlinkMask,
-                            bool blinkImmediately, bool shouldBlinkFast, int32_t scrollPos, uint8_t* encodedAddition,
-                            bool justReplaceBottomLayer) {
+void NumericDriver::setText(std::string_view newText, bool alignRight, uint8_t drawDot, bool doBlink,
+                            uint8_t* newBlinkMask, bool blinkImmediately, bool shouldBlinkFast, int32_t scrollPos,
+                            uint8_t* encodedAddition, bool justReplaceBottomLayer) {
 #if !HAVE_OLED
 	void* layerSpace = GeneralMemoryAllocator::get().alloc(sizeof(NumericLayerBasicText));
 	if (!layerSpace) {
@@ -270,7 +270,7 @@ int32_t NumericDriver::getEncodedPosFromLeft(int32_t textPos, char const* text, 
 
 // Returns encoded length
 // scrollPos may only be set when aligning left
-int32_t NumericDriver::encodeText(char const* newText, uint8_t* destination, bool alignRight, uint8_t drawDot,
+int32_t NumericDriver::encodeText(std::string_view newText, uint8_t* destination, bool alignRight, uint8_t drawDot,
                                   bool limitToDisplayLength, int32_t scrollPos) {
 
 	int32_t writePos;
@@ -282,7 +282,7 @@ int32_t NumericDriver::encodeText(char const* newText, uint8_t* destination, boo
 	}
 	else {
 		writePos = kNumericDisplayLength - 1;
-		readPos = strlen(newText) - 1;
+		readPos = newText.length() - 1;
 	}
 
 	bool carryingDot = false;

--- a/src/deluge/hid/display/numeric_driver.h
+++ b/src/deluge/hid/display/numeric_driver.h
@@ -20,13 +20,15 @@
 #ifdef __cplusplus
 #include "definitions_cxx.hpp"
 #include "hid/display/numeric_layer/numeric_layer_basic_text.h"
+
+#include <string>
 class NumericLayerScrollingText;
 
 class NumericDriver {
 public:
 	NumericDriver();
 
-	void setText(char const* newText, bool alignRight = false, uint8_t drawDot = 255, bool doBlink = false,
+	void setText(std::string_view newText, bool alignRight = false, uint8_t drawDot = 255, bool doBlink = false,
 	             uint8_t* newBlinkMask = NULL, bool blinkImmediately = false, bool shouldBlinkFast = false,
 	             int32_t scrollPos = 0, uint8_t* blinkAddition = NULL, bool justReplaceBottomLayer = false);
 	void setNextTransitionDirection(int8_t thisDirection);
@@ -61,7 +63,7 @@ private:
 	void deleteAllLayers();
 
 #if !HAVE_OLED
-	int32_t encodeText(char const* newText, uint8_t* destination, bool alignRight, uint8_t drawDot = 255,
+	int32_t encodeText(std::string_view newText, uint8_t* destination, bool alignRight, uint8_t drawDot = 255,
 	                   bool limitToDisplayLength = true, int32_t scrollPos = 0);
 	void replaceBottomLayer(NumericLayer* newLayer);
 	void setTopLayer(NumericLayer* newTopLayer);

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -313,27 +313,26 @@ void drawHorizontalLine(int32_t pixelY, int32_t startX, int32_t endX, uint8_t im
 	} while (currentPos <= lastPos);
 }
 
-void drawString(char const* string, int32_t pixelX, int32_t pixelY, uint8_t* image, int32_t imageWidth,
+void drawString(std::string_view string, int32_t pixelX, int32_t pixelY, uint8_t* image, int32_t imageWidth,
                 int32_t textWidth, int32_t textHeight, int32_t scrollPos, int32_t endX) {
 	if (scrollPos) {
 		int32_t numCharsToChopOff = (uint16_t)scrollPos / (uint8_t)textWidth;
 		if (numCharsToChopOff) {
-			if (numCharsToChopOff >= strlen(string)) {
+			if (numCharsToChopOff >= string.length()) {
 				return;
 			}
 
-			string += numCharsToChopOff;
+			string = string.substr(numCharsToChopOff);
 			scrollPos -= numCharsToChopOff * textWidth;
 		}
 	}
-	while (*string) {
-		drawChar(*string, pixelX, pixelY, image, imageWidth, textWidth, textHeight, scrollPos, endX);
+	for (char const c : string) {
+		drawChar(c, pixelX, pixelY, image, imageWidth, textWidth, textHeight, scrollPos, endX);
 		pixelX += textWidth - scrollPos;
 		if (pixelX >= endX) {
 			break;
 		}
 		scrollPos = 0;
-		string++;
 	}
 }
 
@@ -474,7 +473,7 @@ void drawChar(uint8_t theChar, int32_t pixelX, int32_t pixelY, uint8_t* image, i
 	                     textHeight, bytesPerCol);
 }
 
-void drawScreenTitle(char const* title) {
+void drawScreenTitle(std::string_view title) {
 	int32_t extraY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 0 : 1;
 
 	int32_t startY = extraY + OLED_MAIN_TOPMOST_PIXEL;

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -20,10 +20,10 @@
 #if HAVE_OLED
 #ifdef __cplusplus
 #include "definitions_cxx.hpp"
+#include <string>
 
 namespace OLED {
 
-void mainPutText(char const* text);
 void drawOnePixel(int32_t x, int32_t y);
 void clearMainImage();
 void clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
@@ -31,8 +31,8 @@ void clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, uint
 void drawRectangle(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
 void drawVerticalLine(int32_t pixelX, int32_t startY, int32_t endY, uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
 void drawHorizontalLine(int32_t pixelY, int32_t startX, int32_t endX, uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
-void drawString(char const* string, int32_t pixelX, int32_t pixelY, uint8_t* image, int32_t imageWidth,
-                int32_t textWidth, int32_t textHeight, int32_t scrollPos = 0, int32_t endX = OLED_MAIN_WIDTH_PIXELS);
+void drawString(std::string_view, int32_t pixelX, int32_t pixelY, uint8_t* image, int32_t imageWidth, int32_t textWidth,
+                int32_t textHeight, int32_t scrollPos = 0, int32_t endX = OLED_MAIN_WIDTH_PIXELS);
 void drawStringFixedLength(char const* string, int32_t length, int32_t pixelX, int32_t pixelY, uint8_t* image,
                            int32_t imageWidth, int32_t textWidth, int32_t textHeight);
 void drawStringCentred(char const* string, int32_t pixelY, uint8_t* image, int32_t imageWidth, int32_t textWidth,
@@ -45,7 +45,7 @@ void drawChar(uint8_t theChar, int32_t pixelX, int32_t pixelY, uint8_t* image, i
               int32_t textHeight, int32_t scrollPos = 0, int32_t endX = OLED_MAIN_WIDTH_PIXELS);
 void drawGraphicMultiLine(uint8_t const* graphic, int32_t startX, int32_t startY, int32_t width, uint8_t* image,
                           int32_t height = 8, int32_t numBytesTall = 1);
-void drawScreenTitle(char const* title);
+void drawScreenTitle(std::string_view text);
 
 void setupBlink(int32_t minX, int32_t width, int32_t minY, int32_t maxY, bool shouldBlinkImmediately);
 void stopBlink();


### PR DESCRIPTION
this fixes a warning where we were returning a reference to a temporary which is generally no good.

The total firmware cost is ~10k additional bytes but that's probably because the optimizer was stripping important code away