### PR TITLE
Make Alternative Golden Knob Delay params community feature Off by default as it changes default behavior

### DIFF
--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -84,7 +84,7 @@ void RuntimeFeatureSettings::init() {
 	// AltGoldenKnobDelayParams
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AltGoldenKnobDelayParams],
 	                  "Alternative Golden Knob Delay Params", "altGoldenKnobDelayParams",
-	                  RuntimeFeatureStateToggle::On);
+	                  RuntimeFeatureStateToggle::Off);
 }
 
 void RuntimeFeatureSettings::readSettingsFromFile() {


### PR DESCRIPTION
This is a followup to PR https://github.com/SynthstromAudible/DelugeFirmware/pull/282