### PR TITLE
Switch to format_string, decrease fmtlib compiled size

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -10,3 +10,6 @@ FetchContent_Declare(
   URL_HASH MD5=fa629bc1178918b7af4b2ea6b6a271dc
 )
 FetchContent_MakeAvailable(fmt)
+
+target_compile_options(fmt PRIVATE -Oz)
+target_compile_definitions(fmt PUBLIC FMT_STATIC_THOUSANDS_SEPARATOR)

--- a/src/deluge/gui/menu_item/cv/transpose.h
+++ b/src/deluge/gui/menu_item/cv/transpose.h
@@ -23,7 +23,8 @@
 namespace deluge::gui::menu_item::cv {
 class Transpose final : public Decimal, public FormattedTitle {
 public:
-	Transpose(const string& name, const string& title_format_str) : Decimal(name), FormattedTitle(title_format_str) {}
+	Transpose(const string& name, const fmt::format_string<int32_t>& title_format_str)
+	    : Decimal(name), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 

--- a/src/deluge/gui/menu_item/cv/volts.h
+++ b/src/deluge/gui/menu_item/cv/volts.h
@@ -24,8 +24,8 @@
 namespace deluge::gui::menu_item::cv {
 class Volts final : public Decimal, public FormattedTitle {
 public:
-	using Decimal::Decimal;
-	Volts(const string& name, const string& title_format_str) : Decimal(name), FormattedTitle(title_format_str) {}
+	Volts(const string& name, const fmt::format_string<int32_t>& title_format_str)
+	    : Decimal(name), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 

--- a/src/deluge/gui/menu_item/envelope/segment.h
+++ b/src/deluge/gui/menu_item/envelope/segment.h
@@ -22,7 +22,7 @@
 namespace deluge::gui::menu_item::envelope {
 class Segment : public source::PatchedParam, public FormattedTitle {
 public:
-	Segment(const string& name, const string& title_format_str, int32_t newP)
+	Segment(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/formatted_title.h
+++ b/src/deluge/gui/menu_item/formatted_title.h
@@ -7,16 +7,13 @@
 // Mixin for a formatted title
 class FormattedTitle {
 public:
-	FormattedTitle(deluge::string format_str) : format_str_(std::move(format_str)) {}
+	FormattedTitle(const fmt::format_string<int32_t>& format_str) : format_str_(format_str) {}
 
-	template <class... Args>
-	void format(Args&&... args) {
-		title_ = fmt::format(fmt::runtime(format_str_), args...);
-	}
+	void format(int32_t arg) { title_ = fmt::vformat(format_str_.get(), fmt::make_format_args(arg)); }
 
 	[[nodiscard]] std::string_view title() const { return title_; }
 
 private:
-	deluge::string format_str_;
+	fmt::format_string<int32_t> format_str_;
 	deluge::string title_;
 };

--- a/src/deluge/gui/menu_item/modulator/transpose.h
+++ b/src/deluge/gui/menu_item/modulator/transpose.h
@@ -23,7 +23,7 @@ namespace deluge::gui::menu_item::modulator {
 
 class Transpose final : public source::Transpose, public FormattedTitle {
 public:
-	Transpose(const string& name, const string& title_format_str, int32_t newP)
+	Transpose(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : source::Transpose(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/osc/pulse_width.h
+++ b/src/deluge/gui/menu_item/osc/pulse_width.h
@@ -24,8 +24,7 @@
 namespace deluge::gui::menu_item::osc {
 class PulseWidth final : public menu_item::source::PatchedParam, public FormattedTitle {
 public:
-	using menu_item::source::PatchedParam::PatchedParam;
-	PulseWidth(const string& name, const string& title_format_str, int32_t newP)
+	PulseWidth(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : source::PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/osc/retrigger_phase.h
+++ b/src/deluge/gui/menu_item/osc/retrigger_phase.h
@@ -24,8 +24,9 @@
 namespace deluge::gui::menu_item::osc {
 class RetriggerPhase final : public Decimal, public FormattedTitle {
 public:
-	RetriggerPhase(const string& newName, const deluge::string& title, bool newForModulator = false)
-	    : Decimal(newName), FormattedTitle(title), forModulator(newForModulator) {}
+	RetriggerPhase(const string& newName, const fmt::format_string<int32_t>& title_format_str,
+	               bool newForModulator = false)
+	    : Decimal(newName), FormattedTitle(title_format_str), forModulator(newForModulator) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 

--- a/src/deluge/gui/menu_item/osc/source/feedback.h
+++ b/src/deluge/gui/menu_item/osc/source/feedback.h
@@ -22,7 +22,7 @@
 namespace deluge::gui::menu_item::osc::source {
 class Feedback final : public menu_item::source::PatchedParam, public FormattedTitle {
 public:
-	Feedback(const string& name, const string& title_format_str, int32_t newP)
+	Feedback(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/osc/source/volume.h
+++ b/src/deluge/gui/menu_item/osc/source/volume.h
@@ -23,7 +23,7 @@ namespace deluge::gui::menu_item::osc::source {
 
 class Volume final : public menu_item::source::PatchedParam, public FormattedTitle {
 public:
-	Volume(const string& name, const string& title_format_str, int32_t newP)
+	Volume(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/osc/source/wave_index.h
+++ b/src/deluge/gui/menu_item/osc/source/wave_index.h
@@ -22,7 +22,7 @@
 namespace deluge::gui::menu_item::osc::source {
 class WaveIndex final : public menu_item::source::PatchedParam, public FormattedTitle {
 public:
-	WaveIndex(const string& name, const string& title_format_str, int32_t newP)
+	WaveIndex(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/osc/type.h
+++ b/src/deluge/gui/menu_item/osc/type.h
@@ -29,7 +29,8 @@
 namespace deluge::gui::menu_item::osc {
 class Type final : public TypedSelection<OscType, kNumOscTypes>, public FormattedTitle {
 public:
-	Type(const string& name, const string& title_format_str) : TypedSelection(name), FormattedTitle(title_format_str){};
+	Type(const string& name, const fmt::format_string<int32_t>& title_format_str)
+	    : TypedSelection(name), FormattedTitle(title_format_str){};
 #if HAVE_OLED
 	void beginSession(MenuItem* navigatedBackwardFrom) override {
 		TypedSelection::beginSession(navigatedBackwardFrom);

--- a/src/deluge/gui/menu_item/sample/interpolation.h
+++ b/src/deluge/gui/menu_item/sample/interpolation.h
@@ -26,7 +26,7 @@
 namespace deluge::gui::menu_item::sample {
 class Interpolation final : public TypedSelection<InterpolationMode, kNumInterpolationModes>, public FormattedTitle {
 public:
-	Interpolation(const string& name, const string& title_format_str)
+	Interpolation(const string& name, const fmt::format_string<int32_t>& title_format_str)
 	    : TypedSelection(name), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/sample/repeat.h
+++ b/src/deluge/gui/menu_item/sample/repeat.h
@@ -31,7 +31,7 @@ namespace deluge::gui::menu_item::sample {
 
 class Repeat final : public TypedSelection<SampleRepeatMode, kNumRepeatModes>, public FormattedTitle {
 public:
-	Repeat(const string& name, const string& title_format_str)
+	Repeat(const string& name, const fmt::format_string<int32_t>& title_format_str)
 	    : TypedSelection(name), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/sample/reverse.h
+++ b/src/deluge/gui/menu_item/sample/reverse.h
@@ -26,7 +26,8 @@
 namespace deluge::gui::menu_item::sample {
 class Reverse final : public Toggle, public FormattedTitle {
 public:
-	Reverse(const string& name, const string& title_format_str) : Toggle(name), FormattedTitle(title_format_str) {}
+	Reverse(const string& name, const fmt::format_string<int32_t>& title_format_str)
+	    : Toggle(name), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 

--- a/src/deluge/gui/menu_item/sample/time_stretch.h
+++ b/src/deluge/gui/menu_item/sample/time_stretch.h
@@ -27,7 +27,8 @@
 namespace deluge::gui::menu_item::sample {
 class TimeStretch final : public Integer, public FormattedTitle {
 public:
-	TimeStretch(const string& name, const string& title_format_str) : Integer(name), FormattedTitle(title_format_str) {}
+	TimeStretch(const string& name, const fmt::format_string<int32_t>& title_format_str)
+	    : Integer(name), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -23,7 +23,7 @@
 namespace deluge::gui::menu_item::sample {
 class Transpose final : public source::Transpose, public FormattedTitle {
 public:
-	Transpose(const string& name, const string& title_format_str, int32_t newP)
+	Transpose(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : source::Transpose(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/menu_item/source/patched_param/fm.h
+++ b/src/deluge/gui/menu_item/source/patched_param/fm.h
@@ -22,7 +22,7 @@
 namespace deluge::gui::menu_item::source::patched_param {
 class FM final : public source::PatchedParam, public FormattedTitle {
 public:
-	FM(const string& name, const string& title_format_str, int32_t newP)
+	FM(const string& name, const fmt::format_string<int32_t>& title_format_str, int32_t newP)
 	    : source::PatchedParam(name, newP), FormattedTitle(title_format_str) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -218,19 +218,19 @@ submenu::Envelope env1Menu{HAVE_OLED ? "Envelope 2" : "ENV2", envMenuItems, 1};
 // Osc menu -------------------------------------------------------------------------------------------------------
 
 osc::Type oscTypeMenu{"TYPE", "Osc{} type"};
-osc::source::WaveIndex sourceWaveIndexMenu{"Wave-index", "Osc{} wave-ind.", Param::Local::OSC_A_WAVE_INDEX};
-osc::source::Volume sourceVolumeMenu{HAVE_OLED ? "Level" : "VOLUME", "Osc{} level", Param::Local::OSC_A_VOLUME};
-osc::source::Feedback sourceFeedbackMenu{"FEEDBACK", "Carrier{} feed.", Param::Local::CARRIER_0_FEEDBACK};
+osc::source::WaveIndex sourceWaveIndexMenu{"Wave-index", "Osc{} wave-ind.", ::Param::Local::OSC_A_WAVE_INDEX};
+osc::source::Volume sourceVolumeMenu{HAVE_OLED ? "Level" : "VOLUME", "Osc{} level", ::Param::Local::OSC_A_VOLUME};
+osc::source::Feedback sourceFeedbackMenu{"FEEDBACK", "Carrier{} feed.", ::Param::Local::CARRIER_0_FEEDBACK};
 osc::AudioRecorder audioRecorderMenu{"Record audio"};
 sample::Reverse sampleReverseMenu{"REVERSE", "Samp{} reverse"};
 sample::Repeat sampleRepeatMenu{HAVE_OLED ? "Repeat mode" : "MODE", "Samp{} repeat"};
 sample::Start sampleStartMenu{"Start-point"};
 sample::End sampleEndMenu{"End-point"};
-sample::Transpose sourceTransposeMenu{"TRANSPOSE", "Osc{} transpose", Param::Local::OSC_A_PITCH_ADJUST};
+sample::Transpose sourceTransposeMenu{"TRANSPOSE", "Osc{} transpose", ::Param::Local::OSC_A_PITCH_ADJUST};
 sample::PitchSpeed samplePitchSpeedMenu{HAVE_OLED ? "Pitch/speed" : "PISP"};
 sample::TimeStretch timeStretchMenu{"SPEED", "Samp{} speed"};
 sample::Interpolation interpolationMenu{"INTERPOLATION", "Samp{} interp."};
-osc::PulseWidth pulseWidthMenu{"PULSE WIDTH", "Osc{} p. width", Param::Local::OSC_A_PHASE_WIDTH};
+osc::PulseWidth pulseWidthMenu{"PULSE WIDTH", "Osc{} p. width", ::Param::Local::OSC_A_PHASE_WIDTH};
 osc::Sync oscSyncMenu{HAVE_OLED ? "Oscillator sync" : "SYNC"};
 osc::RetriggerPhase oscPhaseMenu{"Retrigger phase", "Osc{} r. phase", false};
 


### PR DESCRIPTION
This changes all title_format_str references to instead be of type fmt::format_string (instead of string), and adds two compile-time optimizations to bring the size of the static libfmt down (`-Oz` and FMT_STATIC_THOUSANDS_SEPARATOR)