### PR TITLE
[Draft] Quantized Stutter effect

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -995,7 +995,23 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 		    modelStackWithParam->modControllable->getKnobPosForNonExistentParam(whichModEncoder, modelStackWithParam);
 	}
 
-	indicator_leds::setKnobIndicatorLevel(whichModEncoder, knobPos + 64);
+	if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE) {
+		int32_t knobPosAbs = knobPos + 64;
+		if (knobPosAbs < 25) {
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 0);
+		} else if (knobPosAbs < 50) {
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 32);
+		} else if (knobPosAbs < 78) {
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 64);
+		} else if (knobPosAbs < 103) {
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 96);
+		} else {
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 128);
+		}
+	} else {
+		indicator_leds::setKnobIndicatorLevel(whichModEncoder, knobPos + 64);
+	}
+
 }
 
 static const uint32_t modButtonUIModes[] = {UI_MODE_AUDITIONING,

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1631,16 +1631,16 @@ void ModControllableAudio::endStutter(ParamManagerForTimeline* paramManager) {
 	stutterer.status = STUTTERER_STATUS_OFF;
 	exitUIMode(UI_MODE_STUTTERING);
 
-	if (paramManager) {
+	// if (paramManager) {
 
-		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+	// 	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 
-		// Normally we shouldn't call this directly, but it's ok because automation isn't allowed for stutter anyway
-		if (unpatchedParams->getValue(Param::Unpatched::STUTTER_RATE) < 0) {
-			unpatchedParams->params[Param::Unpatched::STUTTER_RATE].setCurrentValueBasicForSetup(0);
-			view.notifyParamAutomationOccurred(paramManager);
-		}
-	}
+	// 	// Normally we shouldn't call this directly, but it's ok because automation isn't allowed for stutter anyway
+	// 	if (unpatchedParams->getValue(Param::Unpatched::STUTTER_RATE) < 0) {
+	// 		unpatchedParams->params[Param::Unpatched::STUTTER_RATE].setCurrentValueBasicForSetup(0);
+	// 		view.notifyParamAutomationOccurred(paramManager);
+	// 	}
+	// }
 }
 
 void ModControllableAudio::switchDelayPingPong() {

--- a/src/deluge/modulation/midi/midi_param_collection.cpp
+++ b/src/deluge/modulation/midi/midi_param_collection.cpp
@@ -279,14 +279,14 @@ bool MIDIParamCollection::mayParamInterpolate(int32_t paramId) {
 
 int32_t MIDIParamCollection::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
 
-	char buffer[5];
-	int32_t valueForDisplay = knobPos;
-	valueForDisplay += 64;
-	if (valueForDisplay == 128) {
-		valueForDisplay = 127;
-	}
-	intToString(valueForDisplay, buffer);
-	numericDriver.displayPopup(buffer, 3, true);
+	// char buffer[5]; 64 32 16 8 4
+	// int32_t valueForDisplay = knobPos;
+	// valueForDisplay += 64;
+	// if (valueForDisplay == 128) {
+	// 	valueForDisplay = 127;
+	// }
+	// intToString(valueForDisplay, buffer);
+	// numericDriver.displayPopup(buffer, 3, true);
 
 	return ParamCollection::knobPosToParamValue(knobPos, modelStack);
 }

--- a/src/deluge/modulation/params/param_collection.cpp
+++ b/src/deluge/modulation/params/param_collection.cpp
@@ -20,6 +20,7 @@
 #include "model/model_stack.h"
 #include "modulation/automation/auto_param.h"
 #include "modulation/params/param_manager.h"
+#include "util/functions.h"
 
 ParamCollection::ParamCollection(int32_t newObjectSize, ParamCollectionSummary* summary) : objectSize(newObjectSize) {
 	for (int32_t i = 0; i < kMaxNumUnsignedIntegerstoRepAllParams; i++) { // Just do both even if we're only using one.
@@ -60,6 +61,15 @@ int32_t ParamCollection::paramValueToKnobPos(int32_t paramValue, ModelStackWithA
 }
 
 int32_t ParamCollection::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
+	char buffer[5];
+	int valueForDisplay = knobPos;
+	valueForDisplay += 64;
+	if (valueForDisplay == 128) {
+		valueForDisplay = 127;
+	}
+	intToString(valueForDisplay, buffer);
+	numericDriver.displayPopup(buffer, 3, true);
+
 	int32_t paramValue = 2147483647;
 	if (knobPos < 64) {
 		paramValue = knobPos << 25;

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -364,7 +364,6 @@ UnpatchedParamSet::UnpatchedParamSet(ParamCollectionSummary* summary) : ParamSet
 
 bool UnpatchedParamSet::shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) {
 	switch (modelStack->paramId) {
-	case Param::Unpatched::STUTTER_RATE:
 	case Param::Unpatched::BASS:
 	case Param::Unpatched::TREBLE:
 	case Param::Unpatched::GlobalEffectable::DELAY_RATE:


### PR DESCRIPTION
Stutter effect makes a good effect for happy accidents but sometimes you want to have more control with a more musical output. This PR is to allow for a community feature toggle that sets the stutter to discrete (quantized) values

Tasks:
- [ ] Add community feature item to menu
- [ ] Quantize the selection of stutter rate (5 possible values that matches the orange leds) (4th, 8th, **16th**, 32th, and 64th... or maybe 2nd, 4th, **8th**, 16th, 32th?)
- [ ] Once the golden knob is pressed, reset value and Led indicator to center to allow for up and down movements in a wider range, to play with the recorded sample
- [ ] Make the flashing indicator when knob centered only flash while stutter knob is pressed

Bonus:
- [ ] Option to also quantize while holding the knob? Maybe the menu option instead of On/Off it could be: Off, Quantize record only, Quantize record & play
- [ ] Instead of the just the 5 possible led values (all off, 1 on, 2 on, 3 on and 4 on) add also half points (with semilighted leds) for triplets between the even values