### PR TITLE
[Draft] Convert kit's midi row into midi clips, so we can make use of arpeggiator and midi CCs

### DIFF
--- a/src/deluge/model/drum/midi_drum.cpp
+++ b/src/deluge/model/drum/midi_drum.cpp
@@ -26,6 +26,8 @@ extern "C" {
 #include "util/cfunctions.h"
 }
 
+// Start here...
+
 MIDIDrum::MIDIDrum() : NonAudioDrum(DrumType::MIDI) {
 	channel = 0;
 	note = 0;


### PR DESCRIPTION
Midi rows in kits currently are a bit dumb, they just trigger basic midi notes. I have always found myself reaching to the Shift + Arp mode to enable arp and discovered it is not possible.

Tasks

- [ ] Change midi kit rows to be internally a midi clip, unblocking them to be able to edit Arp settings (and capable also of all the other midi clip features like midi CCs for golden knobs)
- [ ] Implement the interface (button shortcuts) to edit Midi CCs on midi rows