### PR TITLE
Define relwithdebinfo target

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,6 +71,43 @@
       ]
     },
     {
+      "name": "Load/Run OLED RelWithDebInfo",
+      "type": "cppdbg",
+      "preLaunchTask": "Build OLED RelWithDebInfo",
+      "request": "launch",
+      "cwd": "${workspaceRoot}",
+      "program": "${workspaceRoot}/build/RelWithDebInfo/delugeOLED.elf",
+      "MIMode": "gdb",
+      "miDebuggerPath": "arm-none-eabi-gdb",
+      "windows": {
+        "miDebuggerPath": "${workspaceRoot}/toolchain/win32-x86_64/arm-none-eabi-gcc/bin/arm-none-eabi-gdb.exe"
+      },
+      "miDebuggerServerAddress": "localhost:3333",
+      "useExtendedRemote": true,
+      "targetArchitecture": "arm",
+      "svdPath": "${workspaceRoot}/contrib/rza1.svd",
+      "customLaunchSetupCommands": [
+        {
+          "text": "-gdb-set target-async on"
+        },
+        {
+          "text": "-target-select extended-remote localhost:3333"
+        },
+        {
+          "text": "cd ${workspaceRoot}"
+        },
+        {
+          "text": "monitor reset"
+        },
+        {
+          "text": "-file-exec-and-symbols build/RelWithDebInfo/delugeOLED.elf"
+        },
+        {
+          "text": "-target-download"
+        },
+      ]
+    },
+    {
       "name": "Load/Run 7SEG Debug",
       "type": "cppdbg",
       "preLaunchTask": "Build 7SEG Debug",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -87,6 +87,27 @@
 		},
 		{
 			"type": "process",
+			"label": "Build OLED RelWithDebInfo",
+			"command": "./dbt",
+			"windows": {
+				"command": "./dbt.cmd",
+			},
+			"args": [
+				"build",
+				"oled",
+				"relwithdebinfo"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": false
+			},
+			"problemMatcher": {
+				"base": "$gcc",
+				"fileLocation": "absolute"
+			}
+		},
+		{
+			"type": "process",
 			"label": "Build All Debug",
 			"command": "./dbt",
 			"windows": {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT error)
 if(IPO_SUPPORTED)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
         $<$<CONFIG:DEBUG>:OFF>
-        $<$<CONFIG:TEST>:ON>
+        $<$<CONFIG:RELWITHDEBINFO>:ON>
         $<$<CONFIG:RELEASE>:ON>
     )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT error)
 if(IPO_SUPPORTED)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION
         $<$<CONFIG:DEBUG>:OFF>
+        $<$<CONFIG:TEST>:ON>
         $<$<CONFIG:RELEASE>:ON>
     )
 endif()
@@ -167,13 +168,16 @@ add_compile_options(
     # Debug symbols
     $<$<CONFIG:DEBUG>:-g> # Include
     $<$<CONFIG:DEBUG>:-ggdb> # Include
+    $<$<CONFIG:RELWITHDEBINFO>:-g> # Include
     $<$<CONFIG:RELEASE>:-s> # Strip
 
     # Optimization level
     $<$<CONFIG:DEBUG>:-Og>
+    $<$<CONFIG:RELWITHDEBINFO>:-O2>
     $<$<CONFIG:RELEASE>:-O2>
 
     # Link time optimizations
+    $<$<CONFIG:RELWITHDEBINFO>:-flto>
     $<$<CONFIG:RELEASE>:-flto>
     -ffunction-sections
     -fdata-sections
@@ -233,6 +237,7 @@ target_compile_options(deluge INTERFACE
 
     # Stack usage
     $<$<CONFIG:DEBUG>:-Wstack-usage=100>
+    $<$<CONFIG:RELWITHDEBINFO>:-Wstack-usage=1000>
     $<$<CONFIG:RELEASE>:-Wstack-usage=1000>
 )
 

--- a/src/deluge/CMakeLists.txt
+++ b/src/deluge/CMakeLists.txt
@@ -27,11 +27,14 @@ target_link_libraries(deluge INTERFACE
 target_compile_definitions(deluge INTERFACE
     $<$<CONFIG:DEBUG>:IN_HARDWARE_DEBUG=1>
     $<$<CONFIG:DEBUG>:ENABLE_TEXT_OUTPUT=1>
+    $<$<CONFIG:RELWITHDEBINFO>:IN_HARDWARE_DEBUG=1>
+    $<$<CONFIG:RELWITHDEBINFO>:ENABLE_TEXT_OUTPUT=1>
 )
 
 if(ENABLE_RTT)
     message(STATUS "RTT enabled for deluge")
     target_compile_definitions(deluge INTERFACE
         $<$<CONFIG:DEBUG>:HAVE_RTT=1>
+        $<$<CONFIG:RELWITHDEBINFO>:HAVE_RTT=1>
     )
 endif(ENABLE_RTT)


### PR DESCRIPTION
Creates a relwithdebinfo target that enables RTT and LTO compared to the default relwithdebinfo

This avoids a bizarre crash on voice stealing when O2 is used without LTO 