### PR TITLE
fix: allow load+synth and save+synth again in keyboard view

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -403,8 +403,8 @@ ActionResult KeyboardScreen::buttonAction(hid::Button b, bool on, bool inCardRou
 	}
 
 	// Kit button
-	else if (b == KIT) {
-		if (on && currentUIMode == UI_MODE_NONE) {
+	else if (b == KIT && currentUIMode == UI_MODE_NONE) {
+		if (on) {
 			if (Buttons::isNewOrShiftButtonPressed()) {
 				createNewInstrument(InstrumentType::KIT);
 			}
@@ -415,8 +415,8 @@ ActionResult KeyboardScreen::buttonAction(hid::Button b, bool on, bool inCardRou
 		}
 	}
 
-	else if (b == SYNTH) {
-		if (on && currentUIMode == UI_MODE_NONE) {
+	else if (b == SYNTH && currentUIMode == UI_MODE_NONE) {
+		if (on) {
 			if (Buttons::isNewOrShiftButtonPressed()) {
 				createNewInstrument(InstrumentType::SYNTH);
 			}
@@ -610,11 +610,12 @@ void KeyboardScreen::focusRegained() {
 	keyboardButtonUsed = true; // Ensure we don't leave the mode on button up
 	InstrumentClipMinder::focusRegained();
 	setLedStates();
+
+	selectLayout(0); // Make sure we get a valid layout from the loaded file
 }
 
 void KeyboardScreen::openedInBackground() {
 	getCurrentClip()->onKeyboardScreen = true;
-	selectLayout(0); // Make sure we get a valid layout from the loaded file
 
 	// Ensure scroll values are calculated in bounds
 	layoutList[getCurrentClip()->keyboardState.currentLayout]->handleHorizontalEncoder(0, false);


### PR DESCRIPTION
Enable load+synth and save+synth shortcuts also in KeyboardScreen.

I haven't actually checked back but I believe this is a minor regression from some of the recent keyboard refactors.