### PR TITLE
Fixed Song Change MasterComp Setting Issue

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -473,6 +473,7 @@ void setupBlankSong() {
 	preLoadedSong = NULL;
 
 	AudioEngine::getReverbParamsFromSong(currentSong);
+	AudioEngine::getMasterCompressorParamsFromSong(currentSong);
 
 	setUIForLoadedSong(currentSong);
 	AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -133,13 +133,13 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	reverbCompressorShape = -601295438;
 	reverbCompressorSync = SYNC_LEVEL_8TH;
 
-	AudioEngine::mastercompressor.compressor.setAttack(10.0);
-	AudioEngine::mastercompressor.compressor.setRelease(100.0);
-	AudioEngine::mastercompressor.compressor.setThresh(0.0);
-	AudioEngine::mastercompressor.compressor.setRatio(1.0 / 4.0);
-	AudioEngine::mastercompressor.setMakeup(0.0);
+	masterCompressorAttack = 10.0;
+	masterCompressorRelease = 100.0;
+	masterCompressorThresh = 0.0;
+	masterCompressorRatio = 1.0 / 4.0;
+	masterCompressorMakeup = 0.0;
+	masterCompressorWet = 1.0;
 	AudioEngine::mastercompressor.gr = 0.0;
-	AudioEngine::mastercompressor.wet = 1.0;
 
 	dirPath.set("SONGS");
 }
@@ -1457,32 +1457,27 @@ unknownTag:
 				AudioEngine::mastercompressor.gr = 0.0;
 				while (*(tagName = storageManager.readNextTagOrAttributeName())) {
 					if (!strcmp(tagName, "attack")) { //ms
-						AudioEngine::mastercompressor.compressor.setAttack(
-						    (double)storageManager.readTagOrAttributeValueInt() / 100.0);
+						masterCompressorAttack = (double)storageManager.readTagOrAttributeValueInt() / 100.0;
 						storageManager.exitTag("attack");
 					}
 					else if (!strcmp(tagName, "release")) { //ms
-						AudioEngine::mastercompressor.compressor.setRelease(
-						    (double)storageManager.readTagOrAttributeValueInt() / 100.0);
+						masterCompressorRelease = (double)storageManager.readTagOrAttributeValueInt() / 100.0;
 						storageManager.exitTag("release");
 					}
 					else if (!strcmp(tagName, "thresh")) { //db
-						AudioEngine::mastercompressor.compressor.setThresh(
-						    (double)storageManager.readTagOrAttributeValueInt() / 100.0);
+						masterCompressorThresh = (double)storageManager.readTagOrAttributeValueInt() / 100.0;
 						storageManager.exitTag("thresh");
 					}
 					else if (!strcmp(tagName, "ratio")) { //r:1
-						AudioEngine::mastercompressor.compressor.setRatio(
-						    1.0 / ((double)storageManager.readTagOrAttributeValueInt() / 100.0));
+						masterCompressorRatio = 1.0 / ((double)storageManager.readTagOrAttributeValueInt() / 100.0);
 						storageManager.exitTag("ratio");
 					}
 					else if (!strcmp(tagName, "makeup")) { //db
-						AudioEngine::mastercompressor.setMakeup((double)storageManager.readTagOrAttributeValueInt()
-						                                        / 100.0);
+						masterCompressorMakeup = (double)storageManager.readTagOrAttributeValueInt() / 100.0;
 						storageManager.exitTag("makeup");
 					}
 					else if (!strcmp(tagName, "wet")) { //0.0-1.0
-						AudioEngine::mastercompressor.wet = (double)storageManager.readTagOrAttributeValueInt() / 100.0;
+						masterCompressorWet = (double)storageManager.readTagOrAttributeValueInt() / 100.0;
 						storageManager.exitTag("wet");
 					}
 					else {

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -320,6 +320,13 @@ public:
 	int32_t reverbCompressorRelease;
 	SyncLevel reverbCompressorSync;
 
+	double masterCompressorAttack;
+	double masterCompressorRelease;
+	double masterCompressorThresh;
+	double masterCompressorRatio;
+	double masterCompressorMakeup;
+	double masterCompressorWet;
+
 private:
 	void inputTickScalePotentiallyJustChanged(uint32_t oldScale);
 	int32_t readClipsFromFile(ClipArray* clipArray);

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1206,6 +1206,7 @@ void PlaybackHandler::doSongSwap(bool preservePlayPosition) {
 
 	currentSong->sendAllMIDIPGMs();
 	AudioEngine::getReverbParamsFromSong(currentSong);
+	AudioEngine::getMasterCompressorParamsFromSong(currentSong);
 
 	// Some more "if we're playing" stuff - this needs to happen after currentSong is swapped over, because resyncInternalTicksToInputTicks() references it
 	if (isEitherClockActive()) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1152,6 +1152,15 @@ void getReverbParamsFromSong(Song* song) {
 	reverbCompressor.syncLevel = song->reverbCompressorSync;
 }
 
+void getMasterCompressorParamsFromSong(Song* song) {
+	AudioEngine::mastercompressor.compressor.setAttack(song->masterCompressorAttack);
+	AudioEngine::mastercompressor.compressor.setRelease(song->masterCompressorRelease);
+	AudioEngine::mastercompressor.compressor.setThresh(song->masterCompressorThresh);
+	AudioEngine::mastercompressor.compressor.setRatio(song->masterCompressorRatio);
+	AudioEngine::mastercompressor.setMakeup(song->masterCompressorMakeup);
+	AudioEngine::mastercompressor.wet = song->masterCompressorWet;
+}
+
 Voice* solicitVoice(Sound* forSound) {
 
 	Voice* newVoice;

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -135,6 +135,7 @@ void logAction(char const* string);
 void logAction(int32_t number);
 
 void getReverbParamsFromSong(Song* song);
+void getMasterCompressorParamsFromSong(Song* song);
 
 VoiceSample* solicitVoiceSample();
 void voiceSampleUnassigned(VoiceSample* voiceSample);


### PR DESCRIPTION
Fixed the issue where swapping to a different song during playback could lead to unintended changes in the MasterComp settings before the start of the next song's playback.