### PR TITLE
Only run pages deploy on community branch

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -36,7 +36,7 @@ jobs:
     # workflow dispatch) or the workflow run is a success
     if: |
       !github.event.workflow_run ||
-      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success')
+      (github.event.workflow_run && github.event.workflow_run.conclusion == 'success' && github.ref == 'refs/heads/community')
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Currently pages tries to deploy every time build runs. This is a problem since:
* The build workflow currently runs on each commit
* The GH API has rate limiting
* We run more builds than would be allowed by rate limiting

This PR resolves this problem by only allowing the deploy pages job to execute on build workflow completion when the branch is "community"