### PR TITLE
Resolved Audition Pad Illumination Issue on Drum Keyboard Screen

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -713,8 +713,8 @@ void KeyboardScreen::unscrolledPadAudition(int32_t velocity, int32_t note, bool 
 	// but this refactor needs to wait for another day.
 	// Until then we set the scroll to 0 during the auditioning
 	int32_t yScrollBackup = getCurrentClip()->yScroll;
-	getCurrentClip()->yScroll = 0;
-	instrumentClipView.auditionPadAction(velocity, note, shiftButtonDown);
+	getCurrentClip()->yScroll = trunc(note / 8) * 8;
+	instrumentClipView.auditionPadAction(velocity, note % 8, shiftButtonDown);
 	getCurrentClip()->yScroll = yScrollBackup;
 }
 


### PR DESCRIPTION
In the Drum Keyboard screen, I have fixed the issue where audition pads would remain illuminated after pressing pads 9 to 16 and then returning to the clip view.
https://youtu.be/TkzCt-VDFt4