### PR TITLE
Add style recommendations to clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,3 +46,14 @@ CheckOptions:
     value: google
   - key: modernize-replace-auto-ptr.IncludeStyle
     value: google
+  - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
+  - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
+  - { key: readability-identifier-naming.ClassMemberCase,     value: lower_case }
+  - { key: readability-identifier-naming.ClassMethodCase,     value: camelBack  }
+  - { key: readability-identifier-naming.EnumCase,            value: CamelCase  }
+  - { key: readability-identifier-naming.EnumConstantCase,    value: UPPER_CASE }
+  - { key: readability-identifier-naming.PrivateMemberSuffix, value: _          }
+  - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
+  - { key: readability-identifier-naming.FunctionCase,        value: camelBack  }
+  - { key: readability-identifier-naming.VariableCase,        value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }


### PR DESCRIPTION
This is to push us towards a common style recommendation set. Having everything be camelCase is not good (esp. variables/functions both).

The key points:
classes are PascalCase
functions are camelCase
variables are snake_case