### PR TITLE
Add nightly builds to Github actions

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   # Build job
-  build:
+  build-pages:
     runs-on: ubuntu-latest
     # Run when we're triggered by something other than a workflow run (i.e.
     # workflow dispatch) or the workflow run is a success
@@ -100,7 +100,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-pages
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,18 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - 'synthstrom-official'
-  pull_request:
-    branches:
-      - 'community'
-  merge_group:
-  workflow_dispatch:
-
-env:
-  FIRMWARE_RETENTION_DAYS: 5
+  workflow_call:
+    inputs:
+      firmware-retention-days:
+        required: true
+        type: number
+      build-type:
+        required: true
+        type: string
 
 jobs:
   build:
-    name: Build ${{ matrix.profile }}-${{ matrix.hardware }}
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: check out repo
@@ -33,6 +30,7 @@ jobs:
             build \
             --verbose \
             --tag-metadata \
+            --type ${{ inputs.build-type }} \
             all
 
       - name: Publish built firmware (7seg-debug) (bin)
@@ -41,28 +39,28 @@ jobs:
           name: debug-7seg.bin
           path: build/Debug/deluge7SEG*.bin
           if-no-files-found: error
-          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+          retention-days: ${{ inputs.firmware-retention-days }}
       - name: Publish built firmware (7seg-release) (bin)
         uses: actions/upload-artifact@v3
         with:
           name: release-7seg.bin
           path: build/Release/deluge7SEG*.bin
           if-no-files-found: error
-          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+          retention-days: ${{ inputs.firmware-retention-days }}
       - name: Publish built firmware (oled-debug) (bin)
         uses: actions/upload-artifact@v3
         with:
           name: debug-oled.bin
           path: build/Debug/delugeOLED*.bin
           if-no-files-found: error
-          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+          retention-days: ${{ inputs.firmware-retention-days }}
       - name: Publish built firmware (oled-release) (bin)
         uses: actions/upload-artifact@v3
         with:
           name: release-oled.bin
           path: build/Release/delugeOLED*.bin
           if-no-files-found: error
-          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+          retention-days: ${{ inputs.firmware-retention-days }}
 
       - name: Publish built firmware (elf)
         uses: actions/upload-artifact@v3
@@ -70,4 +68,4 @@ jobs:
           name: all-elfs
           path: build/*/*.elf
           if-no-files-found: error
-          retention-days: ${{ env.FIRMWARE_RETENTION_DAYS }}
+          retention-days: ${{ inputs.firmware-retention-days }}

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -1,0 +1,23 @@
+name: Nightly Build
+
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '14 0 * * *' # runs daily at 00:14
+
+jobs:
+  nightly-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Required to count the commits
+      - name: Get new commits
+        run: echo "NEW_COMMIT_COUNT=$(git log --oneline --since '24 hours ago' | wc -l)" >> $GITHUB_ENV
+      - name: Build nightly
+        uses: ./.github/workflows/build.yml
+        if: ${{ env.NEW_COMMIT_COUNT > 0 }}
+        with:
+          firmware-retention-days: 30
+          build-type: 'nightly'
+          

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,19 @@
+name: Pull Request Build
+
+on:
+  push:
+    branches:
+      - 'synthstrom-official'
+  pull_request:
+    branches:
+      - 'community'
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  pr-build:
+    name: Build Check
+    uses: ./.github/workflows/build.yml
+    with:
+      firmware-retention-days: 5
+      build-type: 'dev'

--- a/scripts/tasks/task-build.py
+++ b/scripts/tasks/task-build.py
@@ -36,6 +36,12 @@ def argparser() -> argparse.ArgumentParser:
         action="store_true",
     )
     parser.add_argument(
+        "-t",
+        "--type",
+        help="The type of metadata tag (only applicable with -m, see `dbt configure -h` for options)",
+    )
+
+    parser.add_argument(
         "-m",
         "--tag-metadata",
         help="Tag the build with a metadata suffix",
@@ -66,8 +72,11 @@ def main() -> int:
     os.chdir(util.get_git_root())
 
     if args.tag_metadata:
+        configure_args = []
+        if args.type:
+            configure_args += ['-t', args.type]
         # configure with tagging
-        result = importlib.import_module("task-configure").main(["-m"] + unknown_args)
+        result = importlib.import_module("task-configure").main(["-m"] + configure_args + unknown_args)
         if result != 0:
             return result
 


### PR DESCRIPTION
This adds nightly builds to the GitHub actions via a "reuseable workflow". Unfortunately it also currently breaks our merge barrier, so we'll need to change that as well before merge.