### PR TITLE
Fix crash attempting to open LFO Shape menu

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -547,7 +547,7 @@ enum class LFOType {
 	RANDOM_WALK,
 };
 
-constexpr int32_t kNumLFOTypes = util::to_underlying(LFOType::RANDOM_WALK);
+constexpr int32_t kNumLFOTypes = util::to_underlying(LFOType::RANDOM_WALK) + 1;
 
 // SyncType values correspond to the index of the first option of the specific
 // type in the selection menu. There are 9 different levels for each type (see


### PR DESCRIPTION
Noted by @ok-reza

This bug is fixed in the display merge PR, but considering the severity of the break now that we know the scope of what it affects, the patch is worth submitting as a hotfix now.