### PR TITLE
Fix resonance in low pass ladder filters

### DIFF
--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -79,12 +79,12 @@ public:
 
 		//this is 1q31*1q16/(1q16+tan(f)/2)
 		//tan(f) is q17
-		DivideBy1PlusTannedFrequency = (int64_t)ONE_Q31U * ONE_Q16 / (ONE_Q16 + (tannedFrequency >> 1));
-		fc = multiply_32x32_rshift32_rounded(tannedFrequency, DivideBy1PlusTannedFrequency) << 4;
+		divideBy1PlusTannedFrequency = (int64_t)ONE_Q31U * ONE_Q16 / (ONE_Q16 + (tannedFrequency >> 1));
+		fc = multiply_32x32_rshift32_rounded(tannedFrequency, divideBy1PlusTannedFrequency) << 4;
 	}
 	q31_t fc;
 	q31_t tannedFrequency;
-	q31_t DivideBy1PlusTannedFrequency;
+	q31_t divideBy1PlusTannedFrequency;
 };
 
 } // namespace deluge::dsp::filter

--- a/src/deluge/dsp/filter/hpladder.cpp
+++ b/src/deluge/dsp/filter/hpladder.cpp
@@ -49,8 +49,8 @@ q31_t HpLadderFilter::setConfig(q31_t hpfFrequency, q31_t hpfResonance, FilterMo
 	int32_t moveabilitySquaredTimesProcessedResonance =
 	    multiply_32x32_rshift32(moveabilityTimesProcessedResonance, fc); // 1 = 268435456
 
-	hpfHPF3Feedback = -multiply_32x32_rshift32_rounded(fc, DivideBy1PlusTannedFrequency);
-	hpfLPF1Feedback = DivideBy1PlusTannedFrequency >> 1;
+	hpfHPF3Feedback = -multiply_32x32_rshift32_rounded(fc, divideBy1PlusTannedFrequency);
+	hpfLPF1Feedback = divideBy1PlusTannedFrequency >> 1;
 
 	uint32_t toDivideBy =
 	    ((int32_t)268435456 - (moveabilityTimesProcessedResonance >> 1) + moveabilitySquaredTimesProcessedResonance);

--- a/src/deluge/dsp/filter/lpladder.h
+++ b/src/deluge/dsp/filter/lpladder.h
@@ -70,7 +70,6 @@ private:
 
 	//moveability is tan(f)/(1+tan(f))
 	q31_t moveability;
-	q31_t divideBy1PlusTannedFrequency;
 
 	// All feedbacks have 1 represented as 1073741824
 	q31_t lpf1Feedback;


### PR DESCRIPTION
fix 1/(1+tan(f)) result getting set to the wrong variable in LP Ladders