### PR TITLE
Fix for preset browsing freeze/crash

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -1255,8 +1255,8 @@ needToGrabLeftmostButHaveToReadFirst:
 	goto doReturn;
 }
 
-// Caller must call emptyFileItems() at some point after calling this function - unless an error is returned.
-// Caller must remove OLED working animation after calling this too.
+/// Caller must call emptyFileItems() at some point after calling this function - unless an error is returned
+/// Caller must remove OLED working animation after calling this too.
 PresetNavigationResult LoadInstrumentPresetUI::doPresetNavigation(int32_t offset, Instrument* oldInstrument,
                                                                   Availability availabilityRequirement, bool doBlink) {
 
@@ -1389,6 +1389,11 @@ searchFromOneEnd:
 
 doneMoving:
 	toReturn.fileItem = (FileItem*)fileItems.getElementAddress(i);
+
+	bool isAlreadyInSong = toReturn.fileItem->instrument && toReturn.fileItem->instrumentAlreadyInSong;
+	if(availabilityRequirement == Availability::INSTRUMENT_UNUSED && isAlreadyInSong) {
+		goto moveAgain;
+	}
 
 	toReturn.loadedFromFile = false;
 	bool isHibernating = toReturn.fileItem->instrument && !toReturn.fileItem->instrumentAlreadyInSong;

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -1391,7 +1391,7 @@ doneMoving:
 	toReturn.fileItem = (FileItem*)fileItems.getElementAddress(i);
 
 	bool isAlreadyInSong = toReturn.fileItem->instrument && toReturn.fileItem->instrumentAlreadyInSong;
-	if(availabilityRequirement == Availability::INSTRUMENT_UNUSED && isAlreadyInSong) {
+	if (availabilityRequirement == Availability::INSTRUMENT_UNUSED && isAlreadyInSong) {
 		goto moveAgain;
 	}
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2954,12 +2954,12 @@ allDone:
 // Any audio routine calls that happen during the course of this function won't have access to either the old or new Instrument,
 // because neither will be in the master list when they happen
 void Song::replaceInstrument(Instrument* oldOutput, Instrument* newOutput, bool keepNoteRowsWithMIDIInput) {
-    for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
-        if (thisOutput == newOutput) {
-            numericDriver.cancelPopup();
-            numericDriver.freezeWithError("i009");
-        }
-    }
+	for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
+		if (thisOutput == newOutput) {
+			numericDriver.cancelPopup();
+			numericDriver.freezeWithError("i009");
+		}
+	}
 
 	// We don't detach the Instrument's activeClip here anymore. This happens in InstrumentClip::changeInstrument(), called below.
 	// If we changed it here, near-future calls to the audio routine could cause new voices to be sounded, with no later unassignment.

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2954,6 +2954,12 @@ allDone:
 // Any audio routine calls that happen during the course of this function won't have access to either the old or new Instrument,
 // because neither will be in the master list when they happen
 void Song::replaceInstrument(Instrument* oldOutput, Instrument* newOutput, bool keepNoteRowsWithMIDIInput) {
+    for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
+        if (thisOutput == newOutput) {
+            numericDriver.cancelPopup();
+            numericDriver.freezeWithError("i009");
+        }
+    }
 
 	// We don't detach the Instrument's activeClip here anymore. This happens in InstrumentClip::changeInstrument(), called below.
 	// If we changed it here, near-future calls to the audio routine could cause new voices to be sounded, with no later unassignment.


### PR DESCRIPTION
 - [x] Show Error I009 if replaceInstrument is called with an new instrument already in the song
 - [x] Prevent LoadInstrumentPresetUI::doPresetNavigation from generating existing instruments
 - [x] Check if other code paths can also produce I009

Fixes #320