### PR TITLE
Fix implicit casts for min/max/clamp

### DIFF
--- a/src/deluge/drivers/pic/pic.h
+++ b/src/deluge/drivers/pic/pic.h
@@ -243,12 +243,14 @@ public:
 	 */
 	static int32_t read(uint32_t timeout, std::function<int32_t(Response)> handler) {
 		uint16_t timeWaitBegan = *TCNT[TIMER_SYSTEM_FAST];
+		int32_t result = 1; // error with failure by default
 		while ((uint16_t)(*TCNT[TIMER_SYSTEM_FAST] - timeWaitBegan) < timeout) {
-			int32_t result = handler(PIC::read());
+			result = handler(PIC::read());
 			if (result != 0) {
 				return result;
 			}
 		}
+		return result;
 	}
 
 private:

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -431,7 +431,7 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 
 						// Bigger sounds bad. Need to make smaller to match similarly resulting deduction which happens in the "normal" case
 						samplesTilHopEnd = minBeamWidth >> 2;
-						samplesTilHopEnd = std::max<int32_t>(samplesTilHopEnd, crossfadeLengthSamples);
+						samplesTilHopEnd = std::max<int64_t>(samplesTilHopEnd, crossfadeLengthSamples);
 
 						crossfadeIncrement = (uint32_t)(16777215 + crossfadeLengthSamples)
 						                     / (uint32_t)crossfadeLengthSamples; // Round up
@@ -578,8 +578,8 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 		samplesTilHopEnd -= crossfadeLengthSamples;
 
 		// Apply maxHopLength
-		samplesTilHopEnd = std::min<int32_t>(samplesTilHopEnd, maxHopLength);
-		crossfadeLengthSamples = std::min<uint32_t>(samplesTilHopEnd, crossfadeLengthSamples);
+		samplesTilHopEnd = std::min(samplesTilHopEnd, maxHopLength);
+		crossfadeLengthSamples = std::min<int32_t>(samplesTilHopEnd, crossfadeLengthSamples);
 
 		crossfadeIncrement = (uint32_t)16777216 / (uint32_t)crossfadeLengthSamples;
 		crossfadeProgress = 0;
@@ -601,8 +601,8 @@ skipPercStuff:
 	// the beginning play-point of the new play-head, but the point half-way through the crossfade later. Remember that!
 	if (playHeadStillActive[PLAY_HEAD_OLDER]) { // Added condition, Aug 2019. Surely this makes sense...
 		int32_t lengthToAverageEach = ((uint64_t)phaseIncrement * TimeStretch::Crossfade::kMovingAverageLength) >> 24;
-		lengthToAverageEach = std::clamp<int32_t>(
-		    lengthToAverageEach, 1, TimeStretch::Crossfade::kMovingAverageLength * 2); // Keep things sensible
+		lengthToAverageEach = std::clamp(lengthToAverageEach, 1_i32,
+		                                 TimeStretch::Crossfade::kMovingAverageLength * 2); // Keep things sensible
 
 		int32_t crossfadeLengthSamplesSource = ((uint64_t)crossfadeLengthSamples * phaseIncrement) >> 24;
 

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -17,6 +17,7 @@
 
 #include <cmath>
 #include <cstring>
+#include <stdint.h>
 
 #include "decimal.h"
 #include "gui/ui/sound_editor.h"
@@ -114,12 +115,12 @@ void Decimal::scrollToGoodPos() {
 
 	// Negative numbers
 	if (this->getValue() < 0) {
-		soundEditor.numberScrollAmount = std::max<int8_t>(numDigits - 3, soundEditor.numberEditPos - 2);
+		soundEditor.numberScrollAmount = std::max<int32_t>(numDigits - 3, soundEditor.numberEditPos - 2);
 	}
 
 	// Positive numbers
 	else {
-		soundEditor.numberScrollAmount = std::max<int8_t>(numDigits - 4, soundEditor.numberEditPos - 3);
+		soundEditor.numberScrollAmount = std::max<int32_t>(numDigits - 4, soundEditor.numberEditPos - 3);
 	}
 
 	if (soundEditor.numberScrollAmount < 0) {

--- a/src/deluge/gui/menu_item/lfo/shape.h
+++ b/src/deluge/gui/menu_item/lfo/shape.h
@@ -17,6 +17,7 @@
 #pragma once
 #include "definitions_cxx.hpp"
 #include "gui/menu_item/selection.h"
+#include <string>
 
 namespace deluge::gui::menu_item::lfo {
 

--- a/src/deluge/gui/ui/keyboard/layout/in_key.h
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.h
@@ -71,7 +71,7 @@ private:
 		}
 		int32_t octave = (((note + kOctaveSize) - rootNote) / kOctaveSize) - 1;
 		// Make sure we don't go into negative because our root note is lower than C-2
-		return std::max<uint16_t>(0, octave * scaleNoteCount + padScaleOffset);
+		return std::max<int32_t>(octave * scaleNoteCount + padScaleOffset, std::numeric_limits<uint16_t>::min());
 	}
 
 	// inline uint16_t padIndexFromNote(uint16_t note) {

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -21,6 +21,7 @@
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/sound_editor.h"
 #include "util/functions.h"
+#include <limits>
 
 namespace deluge::gui::ui::keyboard::layout {
 
@@ -121,7 +122,7 @@ void KeyboardLayoutIsomorphic::renderPads(uint8_t image[][kDisplayWidth + kSideB
 				if (soundEditor.isUntransposedNoteWithinRange(noteCode)) {
 					for (int32_t colour = 0; colour < 3; colour++) {
 						int32_t value = (int32_t)image[y][x][colour] + 35;
-						image[y][x][colour] = std::min<uint8_t>(value, 255);
+						image[y][x][colour] = std::min<int32_t>(value, std::numeric_limits<uint8_t>::max());
 					}
 				}
 			}

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -3130,7 +3130,7 @@ uint32_t ArrangerView::getMaxLength() {
 	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
 
 		if (thisOutput->recordingInArrangement) {
-			maxEndPos = std::max<uint32_t>(maxEndPos, arrangement.getLivePos());
+			maxEndPos = std::max<int32_t>(maxEndPos, arrangement.getLivePos());
 		}
 
 		int32_t numElements = thisOutput->clipInstances.getNumElements();

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1597,7 +1597,7 @@ void InstrumentClipView::editPadAction(bool state, uint8_t yDisplay, uint8_t xDi
 
 					// Make sure it doesn't eat into the next note
 					int32_t maxLength = noteRow->getDistanceToNextNote(noteStartPos, modelStackWithNoteRow);
-					newLength = std::min<int32_t>(newLength, maxLength);
+					newLength = std::min(newLength, maxLength);
 
 					areaStart = noteStartPos;
 					areaWidth = newLength;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1359,7 +1359,7 @@ Clip* SessionView::createNewInstrumentClip(int32_t yDisplay) {
 	uint32_t oneBar = currentSong->getBarLength();
 
 	// Default Clip length. Default to current zoom, minimum 1 bar
-	int32_t newClipLength = std::max<int32_t>(currentDisplayLength, oneBar);
+	int32_t newClipLength = std::max(currentDisplayLength, oneBar);
 
 	newClip->colourOffset = random(72);
 	newClip->loopLength = newClipLength;
@@ -2178,7 +2178,7 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 		}
 	}
 	currentSong->currentClip = clip;
-	int32_t clipPlaceOnScreen = std::clamp<int32_t>(getClipPlaceOnScreen(clip), -1, kDisplayHeight);
+	int32_t clipPlaceOnScreen = std::clamp(getClipPlaceOnScreen(clip), -1_i32, kDisplayHeight);
 
 	currentSong->xScroll[NAVIGATION_CLIP] =
 	    getClipLocalScroll(clip, currentSong->xScroll[NAVIGATION_CLIP], currentSong->xZoom[NAVIGATION_CLIP]);

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -36,6 +36,7 @@
 #include "model/song/song.h"
 #include "processing/engines/audio_engine.h"
 #include <cstring>
+#include <limits>
 
 extern "C" {
 #include "RZA1/uart/sio_char.h"
@@ -403,7 +404,8 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 						int32_t newColour =
 						    rshift_round((int32_t)squareColours[colour] * progress, 16)
 						    + rshift_round((int32_t)clipMuteSquareColour[colour] * (65536 - progress), 16);
-						thisColour[colour] = std::clamp<int32_t>(newColour, 0, 255);
+						thisColour[colour] = std::clamp<int32_t>(newColour, std::numeric_limits<uint8_t>::min(),
+						                                         std::numeric_limits<uint8_t>::max());
 					}
 					squareColours = thisColour;
 				}
@@ -1163,7 +1165,8 @@ void renderZoomWithProgress(int32_t inImageTimesBiggerThanNative, uint32_t inIma
 				if (drawingAnything) {
 					for (int32_t colour = 0; colour < 3; colour++) {
 						int32_t result = rshift_round(outValue[colour], 16);
-						PadLEDs::image[yDisplay][xDisplay][colour] = std::min<int32_t>(255, result);
+						PadLEDs::image[yDisplay][xDisplay][colour] =
+						    std::min<int32_t>(std::numeric_limits<uint8_t>::max(), result);
 					}
 				}
 				else {

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -374,7 +374,7 @@ noEmptySpace:
 // Returns new size
 uint32_t MemoryRegion::shortenRight(void* address, uint32_t newSize) {
 
-	newSize = std::max<uint32_t>(newSize, 4);
+	newSize = std::max(newSize, 4_u32);
 	newSize = (newSize + 3) & 0b11111111111111111111111111111100; // Round new size up to 4-byte boundary
 
 	uint32_t* __restrict__ header = (uint32_t*)((char*)address - 4);
@@ -417,7 +417,7 @@ uint32_t MemoryRegion::shortenLeft(void* address, uint32_t amountToShorten, uint
 	uint32_t* __restrict__ footer = (uint32_t*)((char*)address + oldAllocatedSize);
 	uint32_t newSize = oldAllocatedSize - amountToShorten;
 
-	newSize = std::max<uint32_t>(newSize, 4);
+	newSize = std::max(newSize, 4_u32);
 	newSize = (newSize + 3) & 0b11111111111111111111111111111100; // Round new size up to 4-byte boundary
 
 	uint32_t* __restrict__ lookLeft =

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2695,7 +2695,7 @@ doReadBendRange:
 		if (!instrumentWasLoadedByReferenceFromClip) {
 			switch (output->type) {
 			case InstrumentType::MIDI_OUT:
-				((MIDIInstrument*)output)->channelSuffix = std::clamp<int32_t>(instrumentPresetSubSlot, -1, 25);
+				((MIDIInstrument*)output)->channelSuffix = std::clamp<int8_t>(instrumentPresetSubSlot, -1, 25);
 				[[fallthrough]];
 				// No break
 

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -665,8 +665,9 @@ doLoading:
 
 	} while (numSamples);
 
-	percCacheZone->samplesAtStartWhichShouldBeReplaced = std::max<int32_t>(
-	    2048, (percCacheZone->endPos - percCacheZone->startPos) * playDirection); // 2048 is fairly arbitrary
+	percCacheZone->samplesAtStartWhichShouldBeReplaced =
+	    std::max<int32_t>(2048, // 2048 is fairly arbitrary
+	                      (percCacheZone->endPos - percCacheZone->startPos) * playDirection);
 
 	// If we connected up to another, later zone...
 	if (willHitNextElement) {
@@ -969,8 +970,8 @@ void Sample::percCacheClusterStolen(Cluster* cluster) {
 
 		if ((zoneLater->endPos - laterBorder) * playDirection > 0) {
 			zoneLater->samplesAtStartWhichShouldBeReplaced =
-			    std::max<int32_t>(0, zoneLater->samplesAtStartWhichShouldBeReplaced
-			                             - (laterBorder - zoneLater->startPos) * playDirection);
+			    std::max(0_i32, zoneLater->samplesAtStartWhichShouldBeReplaced
+			                        - (laterBorder - zoneLater->startPos) * playDirection);
 			zoneLater->startPos = laterBorder;
 		}
 		else {

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -79,7 +79,7 @@ void SampleRecorder::detachSample() {
 	// If we were holding onto the reasons for the first couple of Clusters, release them now
 	if (keepingReasonsForFirstClusters) {
 		int32_t numClustersToRemoveFor = std::min(kNumClustersLoadedAhead, sample->clusters.getNumElements());
-		numClustersToRemoveFor = std::min<int32_t>(numClustersToRemoveFor, firstUnwrittenClusterIndex);
+		numClustersToRemoveFor = std::min(numClustersToRemoveFor, firstUnwrittenClusterIndex);
 
 		for (int32_t l = 0; l < numClustersToRemoveFor; l++) {
 			Cluster* cluster = sample->clusters.getElement(l)->cluster;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1832,7 +1832,7 @@ displayNudge:
 
 	// Otherwise, adjust swing
 	else if (shiftButtonPressed) {
-		int32_t newSwingAmount = std::clamp<int32_t>(currentSong->swingAmount + offset, -49, 49);
+		int32_t newSwingAmount = std::clamp(currentSong->swingAmount + offset, -49, 49);
 
 		if (newSwingAmount != currentSong->swingAmount) {
 			actionLogger.recordSwingChange(currentSong->swingAmount, newSwingAmount);

--- a/src/deluge/processing/live/live_pitch_shifter.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter.cpp
@@ -659,7 +659,7 @@ startSearch:
 		}
 
 		{
-			int32_t searchSizeHere = std::min<int32_t>(searchSize, searchSizeBoundary);
+			int32_t searchSizeHere = std::min(searchSize, searchSizeBoundary);
 			endOffset = searchSizeHere * searchDirection;
 		}
 

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -203,7 +203,7 @@ void Source::doneReadingFromFile(Sound* sound) {
 		oscType = OscType::SINE;
 	}
 	else if (synthMode == SynthMode::RINGMOD) {
-		oscType = std::min<OscType>(oscType, static_cast<OscType>(kLastRingmoddableOscType));
+		oscType = std::min(oscType, kLastRingmoddableOscType);
 	}
 
 	bool isActualSampleOscillator = (synthMode != SynthMode::FM && oscType == OscType::SAMPLE);


### PR DESCRIPTION
This fixes a number of improper implicit casts, primarily by removing the template specification and relying on deduction.