### PR TITLE
Fix options menu indexing and item addition for MIDI devices

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -56,4 +56,5 @@ CheckOptions:
   - { key: readability-identifier-naming.StructCase,          value: CamelCase  }
   - { key: readability-identifier-naming.FunctionCase,        value: camelBack  }
   - { key: readability-identifier-naming.VariableCase,        value: lower_case }
-  - { key: readability-identifier-naming.GlobalConstantCase,  value: UPPER_CASE }
+  - { key: readability-identifier-naming.GlobalConstantCase,  value: camelBack  }
+  - { key: readability-identifier-naming.MacroDefinitionCase, value: UPPER_CASE }


### PR DESCRIPTION
MIDI Device menu item options weren't being setup properly (push_back instead of assignment operator), or accessed properly (passing negative offset to render function).

Fixes #342 