### PR TITLE
print used bytes in stack as well as free

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -943,9 +943,6 @@ enum class LoopType {
 	TIMESTRETCHER_LEVEL_IF_ACTIVE, // Will cause low-level looping if no time-stretching;
 };
 
-constexpr int32_t kInternalMemoryEnd = 0x20300000;
-constexpr int32_t kProgramStackMaxSize = 8192;
-
 enum StealableQueue {
 	STEALABLE_QUEUE_NO_SONG_SAMPLE_DATA,
 	STEALABLE_QUEUE_NO_SONG_SAMPLE_DATA_CONVERTED, // E.g. from floating point file, or wrong endianness AIFF file.

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -35,7 +35,7 @@ char emptySpacesMemoryInternal[sizeof(EmptySpaceRecord) * 1024];
 extern uint32_t __heap_start;
 extern uint32_t __heap_end;
 extern uint32_t program_stack_start;
-
+extern uint32_t program_stack_end;
 GeneralMemoryAllocator::GeneralMemoryAllocator() {
 	lock = false;
 	regions[MEMORY_REGION_SDRAM].setup(emptySpacesMemory, sizeof(emptySpacesMemory), EXTERNAL_MEMORY_BEGIN,
@@ -56,10 +56,11 @@ void GeneralMemoryAllocator::checkStack(char const* caller) {
 
 	char a;
 
-	int32_t distance = (int32_t)&a - (kInternalMemoryEnd - kProgramStackMaxSize);
+	int32_t distance = (int32_t)&a - (uint32_t)&program_stack_start;
 	if (distance < closestDistance) {
 		closestDistance = distance;
-
+		Debug::print((uint32_t)&program_stack_end - (int32_t)&a);
+		Debug::println(" bytes in stack");
 		Debug::print(distance);
 		Debug::print(" free bytes in stack at ");
 		Debug::println(caller);


### PR DESCRIPTION
Minor change, corrects the stack usage debug function and adds a line to print current usage as well as free space