### PR TITLE
Operator New Alloc to external only

### DIFF
--- a/src/NE10/inc/NE10_macros.h
+++ b/src/NE10/inc/NE10_macros.h
@@ -35,7 +35,7 @@
 
 #ifndef NE10_MACROS_H
 #define NE10_MACROS_H
-
+#include <stdbool.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -50,10 +50,10 @@ extern "C" {
 // some external macro definitions to be exposed to the users
 /////////////////////////////////////////////////////////
 
-void* delugeAlloc(unsigned int requiredSize);
+void* delugeAlloc(unsigned int requiredSize, bool mayUseOnChipRam);
 void delugeDealloc(void* address);
 
-#define NE10_MALLOC delugeAlloc
+#define NE10_MALLOC(p) delugeAlloc(p, true)
 #define NE10_FREE(p) \
     do { \
     	delugeDealloc(p); \

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -506,9 +506,6 @@ extern "C" int32_t deluge_main(void) {
 	PIC::setUARTSpeed();
 	PIC::flush();
 
-	// Setup SDRAM. Have to do this before setting up AudioEngine
-	userdef_bsc_cs2_init(0); // 64MB, hardcoded
-
 	functionsInit();
 
 #if AUTOMATED_TESTER_ENABLED

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -145,11 +145,10 @@ int32_t GeneralMemoryAllocator::getRegion(void* address) {
 		return MEMORY_REGION_INTERNAL;
 	}
 	else if (((uint32_t)address <= EXTERNAL_MEMORY_BEGIN) || (uint32_t)address >= EXTERNAL_MEMORY_END) {
-		numericDriver.freezeWithError("e999");
+		numericDriver.freezeWithError("M999");
 		return -1;
 	}
 	return MEMORY_REGION_SDRAM;
-	//return ((uint32_t)address >= (uint32_t)INTERNAL_MEMORY_BEGIN) ? MEMORY_REGION_INTERNAL : MEMORY_REGION_SDRAM;
 }
 
 // Returns new size

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -38,6 +38,7 @@ extern uint32_t program_stack_start;
 extern uint32_t program_stack_end;
 GeneralMemoryAllocator::GeneralMemoryAllocator() {
 	lock = false;
+
 	regions[MEMORY_REGION_SDRAM].setup(emptySpacesMemory, sizeof(emptySpacesMemory), EXTERNAL_MEMORY_BEGIN,
 	                                   EXTERNAL_MEMORY_END);
 	regions[MEMORY_REGION_INTERNAL].setup(emptySpacesMemoryInternal, sizeof(emptySpacesMemoryInternal),
@@ -140,7 +141,15 @@ uint32_t GeneralMemoryAllocator::getAllocatedSize(void* address) {
 }
 
 int32_t GeneralMemoryAllocator::getRegion(void* address) {
-	return ((uint32_t)address >= (uint32_t)INTERNAL_MEMORY_BEGIN) ? MEMORY_REGION_INTERNAL : MEMORY_REGION_SDRAM;
+	if ((uint32_t)address >= (uint32_t)INTERNAL_MEMORY_BEGIN) {
+		return MEMORY_REGION_INTERNAL;
+	}
+	else if (((uint32_t)address <= EXTERNAL_MEMORY_BEGIN) || (uint32_t)address >= EXTERNAL_MEMORY_END) {
+		numericDriver.freezeWithError("e999");
+		return -1;
+	}
+	return MEMORY_REGION_SDRAM;
+	//return ((uint32_t)address >= (uint32_t)INTERNAL_MEMORY_BEGIN) ? MEMORY_REGION_INTERNAL : MEMORY_REGION_SDRAM;
 }
 
 // Returns new size

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -78,8 +78,8 @@ uint32_t totalMallocTime = 0;
 int32_t numMallocTimes = 0;
 #endif
 
-extern "C" void* delugeAlloc(unsigned int requiredSize) {
-	return GeneralMemoryAllocator::get().alloc(requiredSize, NULL, false, true);
+extern "C" void* delugeAlloc(unsigned int requiredSize, bool mayUseOnChipRam) {
+	return GeneralMemoryAllocator::get().alloc(requiredSize, NULL, false, mayUseOnChipRam);
 }
 
 // Watch the heck out - in the older V3.1 branch, this had one less argument - makeStealable was missing - so in code from there, thingNotToStealFrom could be interpreted as makeStealable!

--- a/src/deluge/memory/general_memory_allocator.h
+++ b/src/deluge/memory/general_memory_allocator.h
@@ -91,6 +91,6 @@ private:
 };
 
 extern "C" {
-void* delugeAlloc(unsigned int requiredSize);
+void* delugeAlloc(unsigned int requiredSize, bool mayUseOnChipRam = true);
 void delugeDealloc(void* address);
 }

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -100,7 +100,7 @@ static EmptySpaceRecord* recordToMergeWith;
 // spaceSize can even be 0 or less if you know it's going to get merged.
 inline void MemoryRegion::markSpaceAsEmpty(uint32_t address, uint32_t spaceSize, bool mayLookLeft, bool mayLookRight) {
 	if ((address <= start) || address >= end) {
-		numericDriver.freezeWithError("e999");
+		numericDriver.freezeWithError("M998");
 		return;
 	}
 	int32_t biggerRecordSearchFromIndex = 0;

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -44,6 +44,7 @@ void MemoryRegion::setup(void* emptySpacesMemory, int32_t emptySpacesMemorySize,
 	EmptySpaceRecord* firstRecord = (EmptySpaceRecord*)emptySpaces.getElementAddress(0);
 	firstRecord->length = memorySizeWithoutHeaders;
 	firstRecord->address = regionBegin + 8;
+	memset((void*)firstRecord->address, 0, firstRecord->length);
 }
 
 bool seenYet = false;

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -44,7 +44,10 @@ void MemoryRegion::setup(void* emptySpacesMemory, int32_t emptySpacesMemorySize,
 	EmptySpaceRecord* firstRecord = (EmptySpaceRecord*)emptySpaces.getElementAddress(0);
 	firstRecord->length = memorySizeWithoutHeaders;
 	firstRecord->address = regionBegin + 8;
+//reset to zero in case we loaded via debugger
+#if IN_HARDWARE_DEBUG == 1
 	memset((void*)firstRecord->address, 0, firstRecord->length);
+#endif
 }
 
 bool seenYet = false;

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -31,7 +31,8 @@ MemoryRegion::MemoryRegion() : emptySpaces(sizeof(EmptySpaceRecord)) {
 void MemoryRegion::setup(void* emptySpacesMemory, int32_t emptySpacesMemorySize, uint32_t regionBegin,
                          uint32_t regionEnd) {
 	emptySpaces.setStaticMemory(emptySpacesMemory, emptySpacesMemorySize);
-
+	start = regionBegin;
+	end = regionEnd;
 	uint32_t memorySizeWithoutHeaders = regionEnd - regionBegin - 16;
 
 	*(uint32_t*)regionBegin = SPACE_HEADER_ALLOCATED;
@@ -44,10 +45,6 @@ void MemoryRegion::setup(void* emptySpacesMemory, int32_t emptySpacesMemorySize,
 	EmptySpaceRecord* firstRecord = (EmptySpaceRecord*)emptySpaces.getElementAddress(0);
 	firstRecord->length = memorySizeWithoutHeaders;
 	firstRecord->address = regionBegin + 8;
-//reset to zero in case we loaded via debugger
-#if IN_HARDWARE_DEBUG == 1
-	memset((void*)firstRecord->address, 0, firstRecord->length);
-#endif
 }
 
 bool seenYet = false;
@@ -102,7 +99,10 @@ static EmptySpaceRecord* recordToMergeWith;
 // Specify the address and size of the actual memory region not including its headers, which this function will write and don't have to contain valid data yet.
 // spaceSize can even be 0 or less if you know it's going to get merged.
 inline void MemoryRegion::markSpaceAsEmpty(uint32_t address, uint32_t spaceSize, bool mayLookLeft, bool mayLookRight) {
-
+	if ((address <= start) || address >= end) {
+		numericDriver.freezeWithError("e999");
+		return;
+	}
 	int32_t biggerRecordSearchFromIndex = 0;
 	int32_t insertRangeBegin;
 

--- a/src/deluge/memory/memory_region.h
+++ b/src/deluge/memory/memory_region.h
@@ -38,7 +38,7 @@ struct NeighbouringMemoryGrabAttemptResult {
 #define SPACE_HEADER_ALLOCATED 0x80000000
 
 #define SPACE_TYPE_MASK 0xC0000000
-#define SPACE_SIZE_MASK 0x3FFFFFFF
+#define SPACE_SIZE_MASK 0x3FFFFFFFu
 
 class MemoryRegion {
 public:
@@ -54,7 +54,7 @@ public:
 	void dealloc(void* address);
 	void verifyMemoryNotFree(void* address, uint32_t spaceSize);
 
-	OrderedResizeableArrayWithMultiWordKey emptySpaces;
+	//OrderedResizeableArrayWithMultiWordKey emptySpaces;
 	int32_t numAllocations;
 
 	CacheManager& cache_manager() { return cache_manager_; }
@@ -64,6 +64,7 @@ public:
 #endif
 
 private:
+	OrderedResizeableArrayWithMultiWordKey emptySpaces;
 	friend class CacheManager;
 	CacheManager cache_manager_;
 
@@ -74,4 +75,6 @@ private:
 	                                uint32_t markWithTraversalNo = 0, bool originalSpaceNeedsStealing = false);
 	void writeTempHeadersBeforeASteal(uint32_t newStartAddress, uint32_t newSize);
 	void sanityCheck();
+	uint32_t start;
+	uint32_t end;
 };

--- a/src/deluge/memory/memory_region.h
+++ b/src/deluge/memory/memory_region.h
@@ -37,7 +37,7 @@ struct NeighbouringMemoryGrabAttemptResult {
 #define SPACE_HEADER_STEALABLE 0x40000000
 #define SPACE_HEADER_ALLOCATED 0x80000000
 
-#define SPACE_TYPE_MASK 0xC0000000
+#define SPACE_TYPE_MASK 0xC0000000u
 #define SPACE_SIZE_MASK 0x3FFFFFFFu
 
 class MemoryRegion {
@@ -54,7 +54,6 @@ public:
 	void dealloc(void* address);
 	void verifyMemoryNotFree(void* address, uint32_t spaceSize);
 
-	//OrderedResizeableArrayWithMultiWordKey emptySpaces;
 	int32_t numAllocations;
 
 	CacheManager& cache_manager() { return cache_manager_; }

--- a/src/deluge/memory/operators.cpp
+++ b/src/deluge/memory/operators.cpp
@@ -2,7 +2,8 @@
 #include <new>
 
 void* operator new(std::size_t n) noexcept(false) {
-	return delugeAlloc(n);
+	//allocate on external RAM
+	return delugeAlloc(n, false);
 }
 
 void operator delete(void* p) {

--- a/src/resetprg.c
+++ b/src/resetprg.c
@@ -144,14 +144,14 @@ void resetprg(void) {
 
 	__enable_irq();
 	__enable_fiq();
-       // Setup SDRAM. Have to do this before we init global objects
-       userdef_bsc_cs2_init(0); // 64MB, hardcoded
+	// Setup SDRAM. Have to do this before we init global objects
+	userdef_bsc_cs2_init(0); // 64MB, hardcoded
 #if !defined(NDEBUG)
-const uint32_t SDRAM_SIZE = EXTERNAL_MEMORY_END - EXTERNAL_MEMORY_BEGIN;
-       uint16_t *sdram = (uint16_t*)EXTERNAL_MEMORY_BEGIN;
-       for (size_t i = 0; i < SDRAM_SIZE; i++) {
-               sdram[i] = 0x0000;
-       }
+	const uint32_t SDRAM_SIZE = EXTERNAL_MEMORY_END - EXTERNAL_MEMORY_BEGIN;
+	uint16_t* sdram = (uint16_t*)EXTERNAL_MEMORY_BEGIN;
+	for (size_t i = 0; i < SDRAM_SIZE; i++) {
+		sdram[i] = 0x0000;
+	}
 #endif
 
 	__libc_init_array();

--- a/src/resetprg.c
+++ b/src/resetprg.c
@@ -144,6 +144,15 @@ void resetprg(void) {
 
 	__enable_irq();
 	__enable_fiq();
+       // Setup SDRAM. Have to do this before we init global objects
+       userdef_bsc_cs2_init(0); // 64MB, hardcoded
+#if !defined(NDEBUG)
+const uint32_t SDRAM_SIZE = EXTERNAL_MEMORY_END - EXTERNAL_MEMORY_BEGIN;
+       uint16_t *sdram = (uint16_t*)EXTERNAL_MEMORY_BEGIN;
+       for (size_t i = 0; i < SDRAM_SIZE; i++) {
+               sdram[i] = 0x0000;
+       }
+#endif
 
 	__libc_init_array();
 

--- a/src/resetprg.c
+++ b/src/resetprg.c
@@ -53,13 +53,13 @@
 
 #include "RZA1/system/r_typedefs.h"
 
+#include "RZA1/bsc/bsc_userdef.h" //sdram init
 #include "RZA1/compiler/asm/inc/asm.h"
 #include "RZA1/gpio/gpio.h"
 #include "RZA1/stb/stb.h"
 #include "RZA1/uart/sio_char.h"
 #include "definitions.h"
 #include "deluge/deluge.h"
-#include "RZA1/bsc/bsc_userdef.h" //sdram init
 #include <string.h> //memset
 
 #if defined(__thumb2__) || (defined(__thumb__) && defined(__ARM_ARCH_6M__))
@@ -150,7 +150,7 @@ void resetprg(void) {
 	userdef_bsc_cs2_init(0); // 64MB, hardcoded
 #if !defined(NDEBUG)
 	const uint32_t SDRAM_SIZE = EXTERNAL_MEMORY_END - EXTERNAL_MEMORY_BEGIN;
-	memset((void*) EXTERNAL_MEMORY_BEGIN,0, SDRAM_SIZE );
+	memset((void*)EXTERNAL_MEMORY_BEGIN, 0, SDRAM_SIZE);
 #endif
 
 	__libc_init_array();

--- a/src/resetprg.c
+++ b/src/resetprg.c
@@ -59,6 +59,8 @@
 #include "RZA1/uart/sio_char.h"
 #include "definitions.h"
 #include "deluge/deluge.h"
+#include "RZA1/bsc/bsc_userdef.h" //sdram init
+#include <string.h> //memset
 
 #if defined(__thumb2__) || (defined(__thumb__) && defined(__ARM_ARCH_6M__))
 #define THUMB_V7_V6M
@@ -148,10 +150,7 @@ void resetprg(void) {
 	userdef_bsc_cs2_init(0); // 64MB, hardcoded
 #if !defined(NDEBUG)
 	const uint32_t SDRAM_SIZE = EXTERNAL_MEMORY_END - EXTERNAL_MEMORY_BEGIN;
-	uint16_t* sdram = (uint16_t*)EXTERNAL_MEMORY_BEGIN;
-	for (size_t i = 0; i < SDRAM_SIZE; i++) {
-		sdram[i] = 0x0000;
-	}
+	memset((void*) EXTERNAL_MEMORY_BEGIN,0, SDRAM_SIZE );
 #endif
 
 	__libc_init_array();


### PR DESCRIPTION
Changes the new operator to allocate in external RAM. This frees a significant amount of internal RAM and regains some of our lost performance 

Note that with this change any performance critical objects must be manually allocated and initialized since new would place them on slower SDRAM. Luckily the audio related code already does this.

I believe this fixes  #350 