### PR TITLE
Dedicated nonaudio memory region

### DIFF
--- a/src/deluge/memory/fallback_allocator.h
+++ b/src/deluge/memory/fallback_allocator.h
@@ -24,10 +24,10 @@ public:
 		if (n == 0) {
 			return nullptr;
 		}
-		return static_cast<T*>(delugeAlloc(n * sizeof(T)));
+		return static_cast<T*>(GeneralMemoryAllocator::get().allocNonAudio(n * sizeof(T)));
 	}
 
-	void deallocate(T* p, std::size_t n) { delugeDealloc(p); }
+	void deallocate(T* p, std::size_t n) { GeneralMemoryAllocator::get().deallocNonAudio(p); }
 
 	template <typename U>
 	bool operator==(const deluge::memory::fallback_allocator<U>& o) {

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -84,10 +84,10 @@ int32_t numMallocTimes = 0;
 #endif
 //	void* alloc(uint32_t requiredSize, uint32_t* getAllocatedSize, bool makeStealable, void* thingNotToStealFrom, bool getBiggestAllocationPossible);
 extern "C" void* delugeAlloc(unsigned int requiredSize, bool mayUseOnChipRam) {
-	return GeneralMemoryAllocator::get().allocNonAudio(requiredSize);
+	return GeneralMemoryAllocator::get().alloc(requiredSize, nullptr, false, mayUseOnChipRam);
 }
 extern "C" void delugeDealloc(void* address) {
-	GeneralMemoryAllocator::get().deallocNonAudio(address);
+	GeneralMemoryAllocator::get().dealloc(address);
 }
 void* GeneralMemoryAllocator::allocNonAudio(uint32_t requiredSize) {
 

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -169,11 +169,10 @@ int32_t GeneralMemoryAllocator::getRegion(void* address) {
 	if ((uint32_t)address >= (uint32_t)INTERNAL_MEMORY_BEGIN) {
 		return MEMORY_REGION_INTERNAL;
 	}
-	else if (((uint32_t)address <= EXTERNAL_MEMORY_BEGIN) || (uint32_t)address >= EXTERNAL_MEMORY_END) {
-		numericDriver.freezeWithError("M999");
-		return -1;
+	else if ((uint32_t)address <= EXTERNAL_MEMORY_END - RESERVED_GENERAL_ALLOCATOR) {
+		return MEMORY_REGION_SDRAM;
 	}
-	return MEMORY_REGION_SDRAM;
+	return MEMORY_REGION_GENERAL;
 }
 
 // Returns new size

--- a/src/deluge/memory/general_memory_allocator.h
+++ b/src/deluge/memory/general_memory_allocator.h
@@ -21,9 +21,9 @@
 
 #define MEMORY_REGION_SDRAM 0
 #define MEMORY_REGION_INTERNAL 1
-#define MEMORY_REGION_GENERAL 2
+#define MEMORY_REGION_NONAUDIO 2
 #define NUM_MEMORY_REGIONS 3
-constexpr uint32_t RESERVED_GENERAL_ALLOCATOR = 0x00100000;
+constexpr uint32_t RESERVED_NONAUDIO_ALLOCATOR = 0x00100000;
 class Stealable;
 
 /*
@@ -63,8 +63,8 @@ public:
 	            bool mayUseOnChipRam = false, bool makeStealable = false, void* thingNotToStealFrom = NULL,
 	            bool getBiggestAllocationPossible = false);
 	void dealloc(void* address);
-	void* allocGeneral(uint32_t requiredSize);
-	void deallocGeneral(void* address);
+	void* allocNonAudio(uint32_t requiredSize);
+	void deallocNonAudio(void* address);
 	uint32_t shortenRight(void* address, uint32_t newSize);
 	uint32_t shortenLeft(void* address, uint32_t amountToShorten, uint32_t numBytesToMoveRightIfSuccessful = 0);
 	void extend(void* address, uint32_t minAmountToExtend, uint32_t idealAmountToExtend,

--- a/src/deluge/memory/general_memory_allocator.h
+++ b/src/deluge/memory/general_memory_allocator.h
@@ -21,8 +21,9 @@
 
 #define MEMORY_REGION_SDRAM 0
 #define MEMORY_REGION_INTERNAL 1
-#define NUM_MEMORY_REGIONS 2
-
+#define MEMORY_REGION_GENERAL 2
+#define NUM_MEMORY_REGIONS 3
+constexpr uint32_t RESERVED_GENERAL_ALLOCATOR = 0x00100000;
 class Stealable;
 
 /*
@@ -62,6 +63,8 @@ public:
 	            bool mayUseOnChipRam = false, bool makeStealable = false, void* thingNotToStealFrom = NULL,
 	            bool getBiggestAllocationPossible = false);
 	void dealloc(void* address);
+	void* allocGeneral(uint32_t requiredSize);
+	void deallocGeneral(void* address);
 	uint32_t shortenRight(void* address, uint32_t newSize);
 	uint32_t shortenLeft(void* address, uint32_t amountToShorten, uint32_t numBytesToMoveRightIfSuccessful = 0);
 	void extend(void* address, uint32_t minAmountToExtend, uint32_t idealAmountToExtend,

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -32,7 +32,8 @@ void MemoryRegion::setup(void* emptySpacesMemory, int32_t emptySpacesMemorySize,
                          uint32_t regionEnd) {
 	emptySpaces.setStaticMemory(emptySpacesMemory, emptySpacesMemorySize);
 	start = regionBegin;
-	end = regionEnd;
+	//this is actually the location of the footer but that's better anyway
+	end = regionEnd - 8;
 	uint32_t memorySizeWithoutHeaders = regionEnd - regionBegin - 16;
 
 	*(uint32_t*)regionBegin = SPACE_HEADER_ALLOCATED;
@@ -100,7 +101,7 @@ static EmptySpaceRecord* recordToMergeWith;
 // spaceSize can even be 0 or less if you know it's going to get merged.
 inline void MemoryRegion::markSpaceAsEmpty(uint32_t address, uint32_t spaceSize, bool mayLookLeft, bool mayLookRight) {
 	if ((address <= start) || address >= end) {
-		numericDriver.freezeWithError("M998");
+		//numericDriver.freezeWithError("M998");
 		return;
 	}
 	int32_t biggerRecordSearchFromIndex = 0;

--- a/src/deluge/memory/operators.cpp
+++ b/src/deluge/memory/operators.cpp
@@ -3,7 +3,7 @@
 
 void* operator new(std::size_t n) noexcept(false) {
 	//allocate on external RAM
-	return delugeAlloc(n, false);
+	return GeneralMemoryAllocator::get().allocNonAudio(n);
 }
 
 void operator delete(void* p) {

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -115,7 +115,7 @@ clearAndAllocateNew:
 	}
 
 	{
-		void* newMemory = GeneralMemoryAllocator::get().alloc(newLength + 1 + 4, NULL, false, false);
+		void* newMemory = GeneralMemoryAllocator::get().allocGeneral(newLength + 1 + 4);
 		if (!newMemory) {
 			return ERROR_INSUFFICIENT_RAM;
 		}
@@ -157,7 +157,7 @@ int32_t String::shorten(int32_t newLength) {
 
 		// If reasons, we have to do a clone
 		if (oldNumReasons > 1) {
-			void* newMemory = GeneralMemoryAllocator::get().alloc(newLength + 1 + 4, NULL, false, false);
+			void* newMemory = GeneralMemoryAllocator::get().allocGeneral(newLength + 1 + 4);
 			if (!newMemory) {
 				return ERROR_INSUFFICIENT_RAM;
 			}
@@ -240,7 +240,7 @@ int32_t String::concatenateAtPos(char const* newChars, int32_t pos, int32_t newC
 		// Otherwise, gotta allocate brand new memory
 		else {
 allocateNewMemory:
-			void* newMemory = GeneralMemoryAllocator::get().alloc(requiredSize, NULL, false, false);
+			void* newMemory = GeneralMemoryAllocator::get().allocGeneral(requiredSize);
 			if (!newMemory) {
 				return ERROR_INSUFFICIENT_RAM;
 			}
@@ -284,7 +284,7 @@ int32_t String::setChar(char newChar, int32_t pos) {
 		int32_t length = getLength();
 
 		int32_t requiredSize = length + 4 + 1;
-		void* newMemory = GeneralMemoryAllocator::get().alloc(requiredSize, NULL, false, false);
+		void* newMemory = GeneralMemoryAllocator::get().allocGeneral(requiredSize);
 		if (!newMemory) {
 			return ERROR_INSUFFICIENT_RAM;
 		}

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -115,7 +115,7 @@ clearAndAllocateNew:
 	}
 
 	{
-		void* newMemory = GeneralMemoryAllocator::get().allocGeneral(newLength + 1 + 4);
+		void* newMemory = GeneralMemoryAllocator::get().allocNonAudio(newLength + 1 + 4);
 		if (!newMemory) {
 			return ERROR_INSUFFICIENT_RAM;
 		}
@@ -157,7 +157,7 @@ int32_t String::shorten(int32_t newLength) {
 
 		// If reasons, we have to do a clone
 		if (oldNumReasons > 1) {
-			void* newMemory = GeneralMemoryAllocator::get().allocGeneral(newLength + 1 + 4);
+			void* newMemory = GeneralMemoryAllocator::get().allocNonAudio(newLength + 1 + 4);
 			if (!newMemory) {
 				return ERROR_INSUFFICIENT_RAM;
 			}
@@ -240,7 +240,7 @@ int32_t String::concatenateAtPos(char const* newChars, int32_t pos, int32_t newC
 		// Otherwise, gotta allocate brand new memory
 		else {
 allocateNewMemory:
-			void* newMemory = GeneralMemoryAllocator::get().allocGeneral(requiredSize);
+			void* newMemory = GeneralMemoryAllocator::get().allocNonAudio(requiredSize);
 			if (!newMemory) {
 				return ERROR_INSUFFICIENT_RAM;
 			}
@@ -284,7 +284,7 @@ int32_t String::setChar(char newChar, int32_t pos) {
 		int32_t length = getLength();
 
 		int32_t requiredSize = length + 4 + 1;
-		void* newMemory = GeneralMemoryAllocator::get().allocGeneral(requiredSize);
+		void* newMemory = GeneralMemoryAllocator::get().allocNonAudio(requiredSize);
 		if (!newMemory) {
 			return ERROR_INSUFFICIENT_RAM;
 		}


### PR DESCRIPTION
Creates a third memory region for use by the new operator and explicitly calling gma.allocGeneral. This region is specifically for use by non audio code. The GMA relies on its stealable system to maintain efficient memory behaviour and by moving a portion of the non stealable allocations to their own region the Deluge operates more efficiently overall. Currently this is just used for handling the menu system and all associated strings/d_strings 

The net effect of this is less voice culling, especially when using lots of samples