### PR TITLE
Add Fill iteration mode for the whole Note row (which previously only reached till 5% probability)

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2839,7 +2839,7 @@ void InstrumentClipView::setRowProbability(int32_t offset) {
 	uint8_t probabilityValue = noteRow->probabilityValue;
 	bool prevBase = false;
 	// Covers the probabilities and iterations
-	probabilityValue = std::clamp<int32_t>((int32_t)probabilityValue + offset, (int32_t)1, kNumProbabilityValues + 35);
+	probabilityValue = std::clamp<int32_t>((int32_t)probabilityValue + offset, (int32_t)0, kNumProbabilityValues + 35);
 
 	noteRow->probabilityValue = probabilityValue;
 


### PR DESCRIPTION
Now you can set a whole kit row with probability 0% and have all notes be Fill notes