### PR TITLE
Fix Tempo popup stuck forever on screen

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2095,7 +2095,7 @@ void PlaybackHandler::displayTempoBPM(float tempoBPM) {
 		else {
 			floatToString(tempoBPM, &buffer[7], 0, 3);
 		}
-		display->popupText(buffer);
+		display->popupTextTemporary(buffer);
 	}
 	else {
 		if (tempoBPM >= 9999.5) {


### PR DESCRIPTION
The tempo popup is shown forever until another popup replaces it. This fixed this by calling popupTemporary instead of popup
This fixes this issue: https://github.com/SynthstromAudible/DelugeFirmware/issues/377