### PR TITLE
Bring quantized stutter into release branch

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -140,6 +140,10 @@ This mode affects how the deluge handles MIDI input for learned CC controls.
 		- **Preset 4:** 5th and +1 Octave
 		- **Preset 5:** Unison and +1/-1 Octave (Tempo Sync)
 
+#### 4.2.7 - Quantized Stutter
+
+- ([#357]) Ability to set, using the Community Features Menu, the stutterer effect to be quantized to 4th, 8th, 16th, 32nd, and 64th rate when selecting it. Once you have pressed the Stutter knob, then the selected value will be the center value of the knob and you can go up and down with the golden knob and come back to the original rate by centering the knob (LEDs will flash indicating it).
+
 ### 4.3 - Instrument Clip View - General Features
 
 These features were added to the Instrument Clip View and affect Synth, Kit and Midi instrument clip types.
@@ -354,6 +358,7 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#339]: https://github.com/SynthstromAudible/DelugeFirmware/pull/339
 [#347]: https://github.com/SynthstromAudible/DelugeFirmware/pull/347
 [#349]: https://github.com/SynthstromAudible/DelugeFirmware/pull/349
+[#357]: https://github.com/SynthstromAudible/DelugeFirmware/pull/357
 [#360]: https://github.com/SynthstromAudible/DelugeFirmware/pull/360
 [#363]: https://github.com/SynthstromAudible/DelugeFirmware/pull/363
 [#368]: https://github.com/SynthstromAudible/DelugeFirmware/pull/368

--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -39,6 +39,7 @@ Setting menuPatchCableResolution(RuntimeFeatureSettingType::PatchCableResolution
 Setting menuCatchNotes(RuntimeFeatureSettingType::CatchNotes);
 Setting menuDeleteUnusedKitRows(RuntimeFeatureSettingType::DeleteUnusedKitRows);
 Setting menuAltGoldenKnobDelayParams(RuntimeFeatureSettingType::AltGoldenKnobDelayParams);
+Setting menuQuantizedStutterRate(RuntimeFeatureSettingType::QuantizedStutterRate);
 Setting menuAutomationInterpolate(RuntimeFeatureSettingType::AutomationInterpolate);
 Setting menuAutomationClearClip(RuntimeFeatureSettingType::AutomationClearClip);
 Setting menuAutomationNudgeNote(RuntimeFeatureSettingType::AutomationNudgeNote);
@@ -59,10 +60,10 @@ Submenu subMenuAutomation{
 };
 
 std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement - kNonTopLevelSettings> subMenuEntries{
-    &menuDrumRandomizer,       &menuMasterCompressorFx, &menuFineTempo,           &menuQuantize,
-    &menuPatchCableResolution, &menuCatchNotes,         &menuDeleteUnusedKitRows, &menuAltGoldenKnobDelayParams,
-    &subMenuAutomation,        &menuDevSysexAllowed,    &menuSyncScalingAction,   &menuHighlightIncomingNotes,
-    &menuDisplayNornsLayout,
+    &menuDrumRandomizer,         &menuMasterCompressorFx, &menuFineTempo,           &menuQuantize,
+    &menuPatchCableResolution,   &menuCatchNotes,         &menuDeleteUnusedKitRows, &menuAltGoldenKnobDelayParams,
+    &menuQuantizedStutterRate,   &subMenuAutomation,      &menuDevSysexAllowed,     &menuSyncScalingAction,
+    &menuHighlightIncomingNotes, &menuDisplayNornsLayout,
 };
 
 Settings::Settings(l10n::String name, l10n::String title)

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -17,6 +17,7 @@
 
 #include "gui/views/view.h"
 #include "definitions_cxx.hpp"
+#include "deluge/model/settings/runtime_feature_settings.h"
 #include "dsp/reverb/freeverb/revmodel.hpp"
 #include "extern.h"
 #include "gui/colour.h"
@@ -29,6 +30,7 @@
 #include "gui/ui/root_ui.h"
 #include "gui/ui/save/save_song_ui.h"
 #include "gui/ui/sound_editor.h"
+#include "gui/ui/ui.h"
 #include "gui/ui_timer_manager.h"
 #include "gui/views/arranger_view.h"
 #include "gui/views/automation_instrument_clip_view.h"
@@ -1009,7 +1011,30 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 		    modelStackWithParam->modControllable->getKnobPosForNonExistentParam(whichModEncoder, modelStackWithParam);
 	}
 
-	indicator_leds::setKnobIndicatorLevel(whichModEncoder, knobPos + 64);
+	// Quantized Stutter FX
+	if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
+	    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+	        == RuntimeFeatureStateToggle::On)
+	    && !isUIModeActive(UI_MODE_STUTTERING)) {
+		if (knobPos < -39) { // 4ths stutter: no leds turned on
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 0);
+		}
+		else if (knobPos < -14) { // 8ths stutter: 1 led turned on
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 32);
+		}
+		else if (knobPos < 14) { // 16ths stutter: 2 leds turned on
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 64);
+		}
+		else if (knobPos < 39) { // 32nds stutter: 3 leds turned on
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 96);
+		}
+		else { // 64ths stutter: all 4 leds turned on
+			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 128);
+		}
+	}
+	else {
+		indicator_leds::setKnobIndicatorLevel(whichModEncoder, knobPos + 64);
+	}
 }
 
 static const uint32_t modButtonUIModes[] = {UI_MODE_AUDITIONING,

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -17,6 +17,7 @@
 
 #include "model/mod_controllable/mod_controllable_audio.h"
 #include "definitions_cxx.hpp"
+#include "deluge/model/settings/runtime_feature_settings.h"
 #include "gui/l10n/l10n.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
@@ -1027,6 +1028,7 @@ void ModControllableAudio::processStutter(StereoSample* buffer, int32_t numSampl
 	StereoSample* thisSample = buffer;
 
 	DelayBufferSetup delayBufferSetup;
+
 	int32_t rate = getStutterRate(paramManager);
 
 	stutterer.buffer.setupForRender(rate, &delayBufferSetup);
@@ -1131,9 +1133,18 @@ void ModControllableAudio::processStutter(StereoSample* buffer, int32_t numSampl
 
 int32_t ModControllableAudio::getStutterRate(ParamManager* paramManager) {
 	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+	int32_t paramValue = unpatchedParams->getValue(Param::Unpatched::STUTTER_RATE);
+
+	// Quantized Stutter diff
+	// Convert to knobPos (range -64 to 64) for easy operation
+	int32_t knobPos = unpatchedParams->paramValueToKnobPos(paramValue, NULL);
+	// Add diff "lastQuantizedKnobDiff" (this value will be set if Quantized Stutter is On, zero if not so this will be a no-op)
+	knobPos = knobPos + stutterer.lastQuantizedKnobDiff;
+	// Convert back to value range
+	paramValue = unpatchedParams->knobPosToParamValue(knobPos, NULL);
+
 	int32_t rate =
-	    getFinalParameterValueExp(paramNeutralValues[Param::Global::DELAY_RATE],
-	                              cableToExpParamShortcut(unpatchedParams->getValue(Param::Unpatched::STUTTER_RATE)));
+	    getFinalParameterValueExp(paramNeutralValues[Param::Global::DELAY_RATE], cableToExpParamShortcut(paramValue));
 
 	if (stutterer.sync != 0) {
 		rate = multiply_32x32_rshift32(rate, playbackHandler.getTimePerInternalTickInverse());
@@ -1844,6 +1855,36 @@ void ModControllableAudio::beginStutter(ParamManagerForTimeline* paramManager) {
 		return;
 	}
 
+	// Quantized Stutter FX
+	if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate) == RuntimeFeatureStateToggle::On) {
+		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+		int32_t paramValue = unpatchedParams->getValue(Param::Unpatched::STUTTER_RATE);
+		int32_t knobPos = unpatchedParams->paramValueToKnobPos(paramValue, NULL);
+		if (knobPos < -39) {
+			knobPos = -16; // 4ths
+		}
+		else if (knobPos < -14) {
+			knobPos = -8; // 8ths
+		}
+		else if (knobPos < 14) {
+			knobPos = 0; // 16ths
+		}
+		else if (knobPos < 39) {
+			knobPos = 8; // 32nds
+		}
+		else {
+			knobPos = 16; // 64ths
+		}
+		// Save current values for later recovering them
+		stutterer.valueBeforeStuttering = paramValue;
+		stutterer.lastQuantizedKnobDiff = knobPos;
+
+		// When stuttering, we center the value at 0, so the center is the reference for the stutter rate that we selected just before pressing the knob
+		// and we use the lastQuantizedKnobDiff value to calculate the relative (real) value
+		unpatchedParams->params[Param::Unpatched::STUTTER_RATE].setCurrentValueBasicForSetup(0);
+		view.notifyParamAutomationOccurred(paramManager);
+	}
+
 	// You'd think I should apply "false" here, to make it not add extra space to the buffer, but somehow this seems to sound as good if not better (in terms of ticking / crackling)...
 	bool error = stutterer.buffer.init(getStutterRate(paramManager), 0, true);
 	if (error == NO_ERROR) {
@@ -1863,12 +1904,25 @@ void ModControllableAudio::endStutter(ParamManagerForTimeline* paramManager) {
 
 		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 
-		// Normally we shouldn't call this directly, but it's ok because automation isn't allowed for stutter anyway
-		if (unpatchedParams->getValue(Param::Unpatched::STUTTER_RATE) < 0) {
-			unpatchedParams->params[Param::Unpatched::STUTTER_RATE].setCurrentValueBasicForSetup(0);
+		if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+		    == RuntimeFeatureStateToggle::On) {
+			// Quantized Stutter FX (set back the value it had just before stuttering so orange LEDs are redrawn)
+			unpatchedParams->params[Param::Unpatched::STUTTER_RATE].setCurrentValueBasicForSetup(
+			    stutterer.valueBeforeStuttering);
 			view.notifyParamAutomationOccurred(paramManager);
 		}
+		else {
+			// Regular Stutter FX (if below middle value, reset it back to middle)
+			// Normally we shouldn't call this directly, but it's ok because automation isn't allowed for stutter anyway
+			if (unpatchedParams->getValue(Param::Unpatched::STUTTER_RATE) < 0) {
+				unpatchedParams->params[Param::Unpatched::STUTTER_RATE].setCurrentValueBasicForSetup(0);
+				view.notifyParamAutomationOccurred(paramManager);
+			}
+		}
 	}
+	// Reset temporary and diff values for Quantized stutter
+	stutterer.lastQuantizedKnobDiff = 0;
+	stutterer.valueBeforeStuttering = 0;
 }
 
 void ModControllableAudio::switchDelayPingPong() {

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -36,6 +36,8 @@ struct Stutterer {
 	uint8_t status;
 	uint8_t sync;
 	int32_t sizeLeftUntilRecordFinished;
+	int32_t valueBeforeStuttering;
+	int32_t lastQuantizedKnobDiff;
 };
 
 struct Grain {

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -100,6 +100,9 @@ void RuntimeFeatureSettings::init() {
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AltGoldenKnobDelayParams],
 	                  "Alternative Golden Knob Delay Params", "altGoldenKnobDelayParams",
 	                  RuntimeFeatureStateToggle::Off);
+	// QuantizedStutterRate
+	SetupOnOffSetting(settings[RuntimeFeatureSettingType::QuantizedStutterRate], "Stutter Rate Quantize",
+	                  "quantizedStutterRate", RuntimeFeatureStateToggle::Off);
 	// InterpolateAutomation
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AutomationInterpolate], "Interpolation",
 	                  "automationInterpolate", RuntimeFeatureStateToggle::On);

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -44,6 +44,7 @@ enum RuntimeFeatureSettingType : uint32_t {
 	CatchNotes,
 	DeleteUnusedKitRows,
 	AltGoldenKnobDelayParams,
+	QuantizedStutterRate,
 	AutomationClearClip,
 	AutomationNudgeNote,
 	AutomationShiftClip,

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "modulation/params/param_set.h"
+#include "deluge/model/settings/runtime_feature_settings.h"
 #include "gui/views/view.h"
 #include "io/midi/midi_engine.h"
 #include "model/action/action_logger.h"
@@ -376,6 +377,9 @@ void UnpatchedParamSet::beenCloned(bool copyAutomation, int32_t reverseDirection
 bool UnpatchedParamSet::shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) {
 	switch (modelStack->paramId) {
 	case Param::Unpatched::STUTTER_RATE:
+		return runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+		           == RuntimeFeatureStateToggle::Off
+		       || isUIModeActive(UI_MODE_STUTTERING);
 	case Param::Unpatched::BASS:
 	case Param::Unpatched::TREBLE:
 	case Param::Unpatched::GlobalEffectable::DELAY_RATE:
@@ -459,8 +463,9 @@ void PatchedParamSet::notifyParamModifiedInSomeWay(ModelStackWithAutoParam const
 }
 
 int32_t PatchedParamSet::paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack) {
-	if (modelStack->paramId == Param::Local::OSC_A_PHASE_WIDTH
-	    || modelStack->paramId == Param::Local::OSC_B_PHASE_WIDTH) {
+	if (modelStack
+	    && (modelStack->paramId == Param::Local::OSC_A_PHASE_WIDTH
+	        || modelStack->paramId == Param::Local::OSC_B_PHASE_WIDTH)) {
 		return (paramValue >> 24) - 64;
 	}
 	else {
@@ -469,8 +474,9 @@ int32_t PatchedParamSet::paramValueToKnobPos(int32_t paramValue, ModelStackWithA
 }
 
 int32_t PatchedParamSet::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
-	if (modelStack->paramId == Param::Local::OSC_A_PHASE_WIDTH
-	    || modelStack->paramId == Param::Local::OSC_B_PHASE_WIDTH) {
+	if (modelStack
+	    && (modelStack->paramId == Param::Local::OSC_A_PHASE_WIDTH
+	        || modelStack->paramId == Param::Local::OSC_B_PHASE_WIDTH)) {
 		int32_t paramValue = 2147483647;
 		if (knobPos < 64) {
 			paramValue = (knobPos + 64) << 24;


### PR DESCRIPTION
* Quantized Stutter FX

* Fixed bug when knob position is 127 (maximum)

* Fixed formatting

* Change runtime feature name so 7seg display reads STUT

* Improve code to use existing knobPosToParamValue and paramValueToKnobPos functions. Check for modelStack nullity for safety although it won’t ever happen for the STUTTER_RATE param

* Update docs