### PR TITLE
Fixed Automation Editor Popup Issues when Loading/Saving

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -351,7 +351,7 @@ Also, similar to the Keyboard screen which uses the variable "onKeyboardScreen" 
 
 # De-scoped Items (Future Release)
 
-- Fix Parameter Name pop-up when loading/saving in the Automation Editor. Explore displaying a menu instead of a pop-up.
+- Explore displaying a menu instead of a pop-up.
 - Automation for Audio Clips
 - Key Frames + Parameter value for each frame
 - Automation Shapes

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -923,10 +923,6 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 		// Otherwise, exit.
 		else {
 			exitCompletely();
-
-			if (getRootUI() == &automationInstrumentClipView) {
-				automationInstrumentClipView.setDisplayParameterNameTimer();
-			}
 		}
 	}
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -387,15 +387,6 @@ bool AutomationInstrumentClipView::opened() {
 		clip->lastSelectedInstrumentType = instrument->type;
 	}
 
-	if (clip->lastSelectedParamID != kNoLastSelectedParamID) {
-		displayAutomation(); //update led indicator levels
-		uiTimerManager.setTimer(TIMER_AUTOMATION_VIEW, 700);
-	}
-
-	if (instrument->type == InstrumentType::CV) {
-		displayCVErrorMessage();
-	}
-
 	if (clip->wrapEditing) { //turn led off if it's on
 		indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
 	}
@@ -413,6 +404,18 @@ bool AutomationInstrumentClipView::opened() {
 
 // Initializes some stuff to begin a new editing session
 void AutomationInstrumentClipView::focusRegained() {
+
+	InstrumentClip* clip = getCurrentClip();
+	Instrument* instrument = (Instrument*)clip->output;
+
+	if (clip->lastSelectedParamID != kNoLastSelectedParamID) {
+		displayParameterName(clip->lastSelectedParamID);
+		displayAutomation(); //update led indicator levels
+	}
+
+	if (instrument->type == InstrumentType::CV) {
+		displayCVErrorMessage();
+	}
 
 	ClipView::focusRegained();
 
@@ -1155,7 +1158,13 @@ passToOthers:
 
 		result = ClipView::buttonAction(b, on, inCardRoutine);
 
-		setDisplayParameterNameTimer();
+		if (on && (b == SAVE || b == LOAD)) {
+			display->cancelPopup();
+		}
+
+		if (on && (b != SAVE && b != LOAD)) {
+			setDisplayParameterNameTimer();
+		}
 
 		return result;
 	}
@@ -2586,7 +2595,6 @@ void AutomationInstrumentClipView::tempoEncoderAction(int8_t offset, bool encode
                                                       bool shiftButtonPressed) {
 
 	playbackHandler.tempoEncoderAction(offset, encoderButtonPressed, shiftButtonPressed);
-	setDisplayParameterNameTimer();
 }
 
 //called by melodic_instrument.cpp or kit.cpp


### PR DESCRIPTION
Fixed issue with Parameter Name Popup hiding Load/Save UI.

Also at same time removed some popup code in Sound Editor that wasn't necessary anymore

This resolves issue #392 