### PR TITLE
Updated Community Features link to Release 1.0 branch

### DIFF
--- a/pages/public/index.html
+++ b/pages/public/index.html
@@ -120,7 +120,7 @@
         <a class="btn" target="_blank"
             href="https://github.com/SynthstromAudible/DelugeFirmware/releases/download/nightly/deluge-nightly.zip">I
             backed up my SD card &check;<br>download todays nightly build</a>
-        <a class="btn" target="_blank" href="https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/community_features.md">List of changes and new features</a>
+        <a class="btn" target="_blank" href="https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/community_features.md">List of changes and new features</a>
         <a class="btn" target="_blank" href="https://github.com/SynthstromAudible/DelugeFirmware/issues">Feedback and
             issues</a>
         <a class="btn" target="_blank" href="https://discord.com/channels/608916579421257728/1138924035657449482">Join


### PR DESCRIPTION
Community Firmware website was pointing to the Community Branch version of Community_Features.md. As the website is pointing to the Release 1.0 Nightly Build, it should also point to the Release 1.0 Community Documentation.

FYI: @PaulFreund 