### PR TITLE
Temporarily redirect nightly builds to release branch

### DIFF
--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -6,7 +6,7 @@ name: Deploy Pages site
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["release/1.0"]
+    branches: ["community"]
     paths:
       - 'pages/**'
 
@@ -37,8 +37,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          ref: 'release/1.0'
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/.github/workflows/build-pages.yml
+++ b/.github/workflows/build-pages.yml
@@ -6,7 +6,7 @@ name: Deploy Pages site
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["community"]
+    branches: ["release/1.0"]
     paths:
       - 'pages/**'
 
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: 'release/1.0'
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,8 +15,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: check out repo
+      - name: normal check out repo
+        if: inputs.build-type != 'nightly'
         uses: actions/checkout@v3
+      - name: nightly check out repo
+        if: inputs.build-type == 'nightly'
+        uses: actions/checkout@v3
+        with:
+          ref: 'release/1.0'
       - name: Fetch container image
         run: |
           docker pull ghcr.io/litui/dbt-toolchain:v$(cat toolchain/REQUIRED_VERSION)

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: 'release/1.0'
           fetch-depth: 0 # Required to count the commits
       - name: Get new commits
         id: count-commits


### PR DESCRIPTION
This should work together with #400 and #398 to make current page and nightly releases all work with the release branch. In the long run I aim to have a page that has stable, beta/rc and nightlies together but for this first release having only the nightly pointing to the release branch is the easiest way before we consider it more stable and I have more time to extend the page