### PR TITLE
Bugfix for freezes when loading another synth after using load synth to kit row

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -72,6 +72,7 @@ bool LoadInstrumentPresetUI::opened() {
 	initialDirPath.set(&instrumentToReplace->dirPath);
 	if (loadingSynthToKitRow) {
 		instrumentTypeToLoad = InstrumentType::SYNTH;
+		initialDirPath.set("SYNTHS");
 	}
 
 	switch (instrumentToReplace->type) {

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -284,6 +284,7 @@ doChangeInstrumentType:
 					Browser::instrumentTypeToLoad = newInstrumentType;
 					loadInstrumentPresetUI.instrumentToReplace = (Instrument*)output;
 					loadInstrumentPresetUI.instrumentClipToLoadFor = NULL;
+					loadInstrumentPresetUI.loadingSynthToKitRow = false;
 					openUI(&loadInstrumentPresetUI);
 				}
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -802,6 +802,7 @@ someError:
 	ParamManager paramManager;
 	//add sound loading code here
 	if (drumType == DrumType::SOUND) {
+		Browser::instrumentTypeToLoad = InstrumentType::SYNTH;
 		loadInstrumentPresetUI.loadingSynthToKitRow = true;
 		loadInstrumentPresetUI.soundDrumToReplace = (SoundDrum*)newDrum;
 		loadInstrumentPresetUI.kitToLoadFor = kit;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -804,6 +804,7 @@ someError:
 	if (drumType == DrumType::SOUND) {
 		Browser::instrumentTypeToLoad = InstrumentType::SYNTH;
 		loadInstrumentPresetUI.loadingSynthToKitRow = true;
+		loadInstrumentPresetUI.instrumentClipToLoadFor = nullptr;
 		loadInstrumentPresetUI.soundDrumToReplace = (SoundDrum*)newDrum;
 		loadInstrumentPresetUI.kitToLoadFor = kit;
 		loadInstrumentPresetUI.noteRow = noteRow;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -529,7 +529,7 @@ changeInstrumentType:
 							break;
 						}
 						}
-
+						loadInstrumentPresetUI.loadingSynthToKitRow = false;
 						openUI(&loadInstrumentPresetUI);
 					}
 

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -342,6 +342,7 @@ yesSaveInstrument:
 yesLoadInstrument:
 			loadInstrumentPresetUI.instrumentToReplace = (Instrument*)getCurrentClip()->output;
 			loadInstrumentPresetUI.instrumentClipToLoadFor = getCurrentClip();
+			loadInstrumentPresetUI.loadingSynthToKitRow = false;
 			openUI(&loadInstrumentPresetUI);
 		}
 


### PR DESCRIPTION
Resets the loading synth to kit row flag at other calls which open the preset UI

Sets the browser to synth mode in case it wasn't already there

Fix for #403 