### PR TITLE
Automation View: Resolve Issue #411 : Pad selection mode enhancement to switch between short and long presses

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -197,6 +197,8 @@ The Automation Editor **will:**
 > When two pads are selected, two cursors are displayed on the grid and the lower led indicator shows the value of the left pad (left cursor), and the upper led indicator shows the value of the right pad (right cursor).
 > 
 > With this mode you can also press on each pad to see its current value without changing its value.
+>
+> Note: if you entered a long press in pad selection mode and wish to switch back to a single press, you can do so by entering a long press on a single column (press one and hold one pad and then press another pad above or below it).
 
 - enable you to lay down longer automations with interpolation 
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -198,7 +198,7 @@ The Automation Editor **will:**
 > 
 > With this mode you can also press on each pad to see its current value without changing its value.
 >
-> Note: if you entered a long press in pad selection mode and wish to switch back to a single press, you can do so by entering a long press on a single column (press one and hold one pad and then press another pad above or below it).
+> Note: if you entered a long press in pad selection mode and wish to switch back to a single press, you can do so by entering a long press on a single column (press and hold one pad and then press another pad above or below it).
 
 - enable you to lay down longer automations with interpolation 
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -198,7 +198,9 @@ The Automation Editor **will:**
 > 
 > With this mode you can also press on each pad to see its current value without changing its value.
 >
-> Note: if you entered a long press in pad selection mode and wish to switch back to a single press, you can do so by entering a long press on a single column (press and hold one pad and then press another pad above or below it).
+> ** Note 1:** if you've entered a long press and wish to see the value of each pad in the long press, you will need to press and hold the pad.
+>
+> ** Note 2:** if you've entered a long press and wish to switch back to a single press, you can do by quickly pressing a pad in any column (e.g. don't hold it).
 
 - enable you to lay down longer automations with interpolation 
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1478,8 +1478,8 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 		}
 		//switch from long press selection to short press selection in pad selection mode
 		else if ((clip->lastSelectedParamID != kNoLastSelectedParamID) && padSelectionOn && multiPadPressSelected
-			&& !multiPadPressActive
-			&& ((AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress) < kShortPressTime)) {
+		         && !multiPadPressActive
+		         && ((AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress) < kShortPressTime)) {
 
 			multiPadPressSelected = false;
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1375,16 +1375,7 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 				}
 			}
 
-			if (padSelectionOn && firstPadX != 255 && firstPadX == xDisplay) {
-				leftPadSelectedX = firstPadX;
-				leftPadSelectedY = kNoLastSelectedPad;;
-				rightPadSelectedX = kNoLastSelectedPad;
-				rightPadSelectedY = kNoLastSelectedPad;
-
-				multiPadPressSelected = false;
-				uiNeedsRendering(this);
-			}
-			else if (firstPadX != 255 && firstPadY != 255 && firstPadX != xDisplay) {
+			if (firstPadX != 255 && firstPadY != 255 && firstPadX != xDisplay) {
 				multiPadPressSelected = true;
 
 				//the long press logic calculates and renders the interpolation as if the press was entered in a forward fashion
@@ -1476,9 +1467,22 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 		}
 
 		//exit multi pad press once you've let go of the first pad in the long press
-		if (!padSelectionOn && (currentUIMode != UI_MODE_NOTES_PRESSED)) {
+		if ((clip->lastSelectedParamID != kNoLastSelectedParamID) && !padSelectionOn && multiPadPressSelected
+		    && (currentUIMode != UI_MODE_NOTES_PRESSED)) {
 			initPadSelection();
 			displayAutomation();
+		}
+		else if ((clip->lastSelectedParamID != kNoLastSelectedParamID) && padSelectionOn && multiPadPressSelected
+		    && (currentUIMode != UI_MODE_NOTES_PRESSED)
+		    && (AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress < kShortPressTime)) {
+
+			leftPadSelectedX = xDisplay;
+			leftPadSelectedY = kNoLastSelectedPad;
+			rightPadSelectedX = kNoLastSelectedPad;
+			rightPadSelectedY = kNoLastSelectedPad;
+
+			multiPadPressSelected = false;
+			uiNeedsRendering(this);
 		}
 	}
 }

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -356,6 +356,7 @@ AutomationInstrumentClipView::AutomationInstrumentClipView() {
 	//used to enter pad selection mode
 	padSelectionOn = false;
 	multiPadPressSelected = false;
+	multiPadPressActive = false;
 	leftPadSelectedX = kNoLastSelectedPad;
 	leftPadSelectedY = kNoLastSelectedPad;
 	rightPadSelectedX = kNoLastSelectedPad;
@@ -1377,6 +1378,7 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 
 			if (firstPadX != 255 && firstPadY != 255 && firstPadX != xDisplay) {
 				multiPadPressSelected = true;
+				multiPadPressActive = true;
 
 				//the long press logic calculates and renders the interpolation as if the press was entered in a forward fashion
 				//(where the first pad is to the left of the second pad). if the user happens to enter a long press backwards
@@ -1458,17 +1460,23 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 
 				//switch from long press selection to short press selection in pad selection mode
 				if ((clip->lastSelectedParamID != kNoLastSelectedParamID) && padSelectionOn && multiPadPressSelected
-				    && (leftPadSelectedX != xDisplay) && (rightPadSelectedX != xDisplay)
+					&& (currentUIMode != UI_MODE_NOTES_PRESSED)
 				    && (AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress < kShortPressTime)) {
 
-					multiPadPressSelected = false;
+					if (multiPadPressActive && (leftPadSelectedX == xDisplay || rightPadSelectedX == xDisplay)) {
+						multiPadPressActive = false;
+					}
+					else if (!multiPadPressActive) {
 
-					leftPadSelectedX = xDisplay;
-					leftPadSelectedY = kNoLastSelectedPad;
-					rightPadSelectedX = kNoLastSelectedPad;
-					rightPadSelectedY = kNoLastSelectedPad;
+						multiPadPressSelected = false;
 
-					uiNeedsRendering(this);
+						leftPadSelectedX = xDisplay;
+						leftPadSelectedY = kNoLastSelectedPad;
+						rightPadSelectedX = kNoLastSelectedPad;
+						rightPadSelectedY = kNoLastSelectedPad;
+
+						uiNeedsRendering(this);
+					}
 				}
 
 				break;

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1455,6 +1455,22 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 			if (instrumentClipView.editPadPresses[i].isActive
 			    && instrumentClipView.editPadPresses[i].yDisplay == yDisplay
 			    && instrumentClipView.editPadPresses[i].xDisplay == xDisplay) {
+
+				//switch from long press selection to short press selection in pad selection mode
+				if ((clip->lastSelectedParamID != kNoLastSelectedParamID) && padSelectionOn && multiPadPressSelected
+				    && (leftPadSelectedX != xDisplay) && (rightPadSelectedX != xDisplay)
+				    && (AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress < kShortPressTime)) {
+
+					multiPadPressSelected = false;
+
+					leftPadSelectedX = xDisplay;
+					leftPadSelectedY = kNoLastSelectedPad;
+					rightPadSelectedX = kNoLastSelectedPad;
+					rightPadSelectedY = kNoLastSelectedPad;
+
+					uiNeedsRendering(this);
+				}
+
 				break;
 			}
 		}
@@ -1471,18 +1487,6 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 		    && (currentUIMode != UI_MODE_NOTES_PRESSED)) {
 			initPadSelection();
 			displayAutomation();
-		}
-		else if ((clip->lastSelectedParamID != kNoLastSelectedParamID) && padSelectionOn && multiPadPressSelected
-		    && (currentUIMode != UI_MODE_NOTES_PRESSED)
-		    && (AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress < kShortPressTime)) {
-
-			leftPadSelectedX = xDisplay;
-			leftPadSelectedY = kNoLastSelectedPad;
-			rightPadSelectedX = kNoLastSelectedPad;
-			rightPadSelectedY = kNoLastSelectedPad;
-
-			multiPadPressSelected = false;
-			uiNeedsRendering(this);
 		}
 	}
 }

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1375,7 +1375,16 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 				}
 			}
 
-			if (firstPadX != 255 && firstPadY != 255 && firstPadX != xDisplay) {
+			if (padSelectionOn && firstPadX != 255 && firstPadX == xDisplay) {
+				leftPadSelectedX = firstPadX;
+				leftPadSelectedY = kNoLastSelectedPad;;
+				rightPadSelectedX = kNoLastSelectedPad;
+				rightPadSelectedY = kNoLastSelectedPad;
+
+				multiPadPressSelected = false;
+				uiNeedsRendering(this);
+			}
+			else if (firstPadX != 255 && firstPadY != 255 && firstPadX != xDisplay) {
 				multiPadPressSelected = true;
 
 				//the long press logic calculates and renders the interpolation as if the press was entered in a forward fashion

--- a/src/deluge/gui/views/automation_instrument_clip_view.h
+++ b/src/deluge/gui/views/automation_instrument_clip_view.h
@@ -169,6 +169,7 @@ private:
 
 	bool padSelectionOn;
 	bool multiPadPressSelected;
+	bool multiPadPressActive;
 	int32_t leftPadSelectedX;
 	int32_t leftPadSelectedY;
 	int32_t rightPadSelectedX;


### PR DESCRIPTION
Per Issue #411 I have enhanced the Pad Selection Mode to permit you to switch back and forth between a Single and Long Press by simply pressing quickly on another column. This is a follow-up to PR #360 which introduced Pad Selection Mode.

If you press and hold another column while a Long Press is selected, it allows you to peak the value of that column.

FYI @trappar 