### PR TITLE
backport switchable sysex screen to release

### DIFF
--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -24,6 +24,7 @@
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/display/display.h"
+#include "hid/hid_sysex.h"
 #include "hid/led/indicator_leds.h"
 #include "hid/led/pad_leds.h"
 #include "model/clip/clip_minder.h"
@@ -183,6 +184,10 @@ void UITimerManager::routine() {
 					if (display->haveOLED()) {
 						deluge::hid::display::OLED::scrollingAndBlinkingTimerEvent();
 					}
+					break;
+
+				case TIMER_SYSEX_DISPLAY:
+					HIDSysex::sendDisplayIfChanged();
 					break;
 				}
 			}

--- a/src/deluge/gui/ui_timer_manager.h
+++ b/src/deluge/gui/ui_timer_manager.h
@@ -39,7 +39,8 @@
 #define TIMER_OLED_LOW_LEVEL 16
 #define TIMER_OLED_CONSOLE 17
 #define TIMER_OLED_SCROLLING_AND_BLINKING 18
-#define NUM_TIMERS 19
+#define TIMER_SYSEX_DISPLAY 19
+#define NUM_TIMERS 20
 
 struct Timer {
 	bool active;

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -22,6 +22,8 @@
 #include "drivers/pic/pic.h"
 #include "gui/ui_timer_manager.h"
 #include "hid/display/display.h"
+#include "hid/display/oled.h"
+#include "hid/hid_sysex.h"
 #include "processing/engines/audio_engine.h"
 #include "util/d_string.h"
 #include <string.h>
@@ -41,9 +43,12 @@ extern uint8_t usbInitializationPeriodComplete;
 
 namespace deluge::hid::display {
 
-uint8_t OLED::oledMainImage[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS];
-uint8_t OLED::oledMainConsoleImage[kConsoleImageNumRows][OLED_MAIN_WIDTH_PIXELS];
-uint8_t OLED::oledMainPopupImage[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS];
+uint8_t OLED::oledMainImage[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS]
+    __attribute__((aligned(alignof(int32_t))));
+uint8_t OLED::oledMainConsoleImage[kConsoleImageNumRows][OLED_MAIN_WIDTH_PIXELS]
+    __attribute__((aligned(alignof(int32_t))));
+uint8_t OLED::oledMainPopupImage[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS]
+    __attribute__((aligned(alignof(int32_t))));
 
 uint8_t (*OLED::oledCurrentImage)[OLED_MAIN_WIDTH_PIXELS] = oledMainImage;
 
@@ -710,6 +715,7 @@ void OLED::sendMainImage() {
 #endif
 
 	enqueueSPITransfer(0, oledCurrentImage[0]);
+	HIDSysex::sendDisplayIfChanged();
 }
 
 #define TEXT_MAX_NUM_LINES 8

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -23,6 +23,7 @@
 #include "hid/display/numeric_layer/numeric_layer_loading_animation.h"
 #include "hid/display/numeric_layer/numeric_layer_scroll_transition.h"
 #include "hid/display/numeric_layer/numeric_layer_scrolling_text.h"
+#include "hid/hid_sysex.h"
 #include "hid/led/indicator_leds.h"
 #include "io/debug/print.h"
 #include "memory/general_memory_allocator.h"
@@ -534,6 +535,7 @@ void SevenSegment::render() {
 	lastDisplay_ = segments;
 
 	PIC::update7SEG(segments);
+	HIDSysex::sendDisplayIfChanged();
 }
 
 // Call this to make the loading animation happen

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -1,9 +1,18 @@
 #include "hid/hid_sysex.h"
+#include "gui/ui_timer_manager.h"
 #include "hid/display/oled.h"
+#include "hid/display/seven_segment.h"
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_engine.h"
+#include "memory/general_memory_allocator.h"
+#include "processing/engines/audio_engine.h"
 #include "util/pack.h"
 #include <cstring>
+
+MIDIDevice* midiDisplayDevice = nullptr;
+int32_t midiDisplayUntil = 0;
+uint8_t* oledDeltaImage = nullptr;
+bool oledDeltaForce = true;
 
 void HIDSysex::sysexReceived(MIDIDevice* device, uint8_t* data, int32_t len) {
 	if (len < 6) {
@@ -28,10 +37,61 @@ void HIDSysex::requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int32_t len
 	if (data[4] == 0 or data[4] == 1) {
 		sendOLEDData(device, (data[4] == 1));
 	}
+	else if (data[4] == 2 || data[4] == 3) {
+		bool force = (data[4] == 3);
+		midiDisplayDevice = device;
+		// two seconds
+		midiDisplayUntil = AudioEngine::audioSampleTimer + 2 * 44100;
+		if (display->haveOLED()) {
+			if (force) {
+				oledDeltaForce = true;
+			}
+
+			if (oledDeltaImage == nullptr) {
+				oledDeltaImage = (uint8_t*)GeneralMemoryAllocator::get().alloc(
+				    sizeof(uint8_t[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS]), NULL, false, true);
+			}
+		}
+		sendDisplayIfChanged();
+		if (force && display->have7SEG()) {
+			send7SegData(device);
+		}
+	}
+	else if (data[4] == 4) { // SWAP
+		bool was_oled = display->haveOLED();
+		delete display;
+		if (was_oled) {
+			display = new deluge::hid::display::SevenSegment;
+		}
+		else {
+			display = new deluge::hid::display::OLED;
+		}
+	}
+}
+
+void HIDSysex::sendDisplayIfChanged() {
+	// NB: timer is only used for throttling, under good conditions sending
+	// is driven by the display subsystem only
+	uiTimerManager.unsetTimer(TIMER_SYSEX_DISPLAY);
+	if (midiDisplayDevice == nullptr || AudioEngine::audioSampleTimer > midiDisplayUntil) {
+		return;
+	}
+	// not exact, but if more than half than the serial buffer is still full,
+	// we need to slow down a little. (USB buffer is larger and should be consumed much quicker)
+	if (midiDisplayDevice->sendBufferSpace() < 512) {
+		uiTimerManager.setTimer(TIMER_SYSEX_DISPLAY, 100);
+		return;
+	}
+
+	if (display->haveOLED()) {
+		sendOLEDDataDelta(midiDisplayDevice, false);
+	}
+	if (display->have7SEG()) {
+		send7SegData(midiDisplayDevice);
+	}
 }
 
 void HIDSysex::sendOLEDData(MIDIDevice* device, bool rle) {
-	// TODO: in the long run, this should not depend on having a physical OLED screen
 	if (display->haveOLED()) {
 		const int32_t data_size = 768;
 		const int32_t max_packed_size = 922;
@@ -59,15 +119,70 @@ void HIDSysex::sendOLEDData(MIDIDevice* device, bool rle) {
 }
 
 void HIDSysex::request7SegDisplay(MIDIDevice* device, uint8_t* data, int32_t len) {
+	if (data[4] == 0) {
+		send7SegData(device);
+	}
+}
+
+void HIDSysex::send7SegData(MIDIDevice* device) {
 	if (display->have7SEG()) {
-		if (data[4] == 0) {
-			// aschually 8 segments if you count the dot
-			auto data = display->getLast();
-			const int32_t packed_data_size = 5;
-			uint8_t reply[11] = {0xf0, 0x7d, 0x02, 0x41, 0x00};
-			pack_8bit_to_7bit(reply + 6, packed_data_size, data.data(), data.size());
-			reply[6 + packed_data_size] = 0xf7; // end of transmission
-			device->sendSysex(reply, packed_data_size + 7);
+		// aschually 8 segments if you count the dot
+		auto data = display->getLast();
+		const int32_t packed_data_size = 5;
+		uint8_t reply[11] = {0xf0, 0x7d, 0x02, 0x41, 0x00};
+		pack_8bit_to_7bit(reply + 6, packed_data_size, data.data(), data.size());
+		reply[6 + packed_data_size] = 0xf7; // end of transmission
+		device->sendSysex(reply, packed_data_size + 7);
+	}
+}
+
+void HIDSysex::sendOLEDDataDelta(MIDIDevice* device, bool force) {
+	const int32_t data_size = 768;
+	const int32_t max_packed_size = 922;
+
+	uint8_t* current = deluge::hid::display::OLED::oledCurrentImage[0];
+
+	int32_t first_change = 9000;
+	int32_t last_change = 0;
+	int32_t* blkdata_new = (int32_t*)current;
+	int32_t* blkdata_old = (int32_t*)oledDeltaImage;
+
+	const int32_t word_size = data_size >> 2;
+
+	if (force || oledDeltaForce) {
+		first_change = 0;
+		last_change = word_size - 1;
+	}
+	else {
+		for (int32_t blk = 0; blk < word_size; blk++) {
+			if (blkdata_new[blk] != blkdata_old[blk]) {
+				if (first_change > blk) {
+					first_change = blk;
+				}
+				last_change = blk;
+			}
 		}
 	}
+
+	if (first_change > word_size) {
+		return;
+	}
+
+	int start = first_change / 2;
+	int len = (last_change / 2) - start + 1;
+
+	uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, 0x02};
+	uint8_t* reply = midiEngine.sysex_fmt_buffer;
+	memcpy(reply, reply_hdr, 5);
+	reply[5] = start;
+	reply[6] = len;
+
+	int32_t packed = pack_8to7_rle(reply + 7, max_packed_size, current + 8 * start, 8 * len);
+	if (packed <= 0) {
+		return;
+	}
+	memcpy(oledDeltaImage + (8 * start), current + (8 * start), 8 * len);
+	oledDeltaForce = false;
+	reply[7 + packed] = 0xf7; // end of transmission
+	device->sendSysex(reply, packed + 8);
 }

--- a/src/deluge/hid/hid_sysex.h
+++ b/src/deluge/hid/hid_sysex.h
@@ -6,5 +6,7 @@ void requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int32_t len);
 void request7SegDisplay(MIDIDevice* device, uint8_t* data, int32_t len);
 void sysexReceived(MIDIDevice* device, uint8_t* data, int32_t len);
 void sendOLEDData(MIDIDevice* device, bool rle);
-
+void sendOLEDDataDelta(MIDIDevice* device, bool force);
+void send7SegData(MIDIDevice* device);
+void sendDisplayIfChanged();
 } // namespace HIDSysex

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -354,6 +354,26 @@ void MIDIDeviceUSB::sendMessage(uint8_t statusType, uint8_t channel, uint8_t dat
 	}
 }
 
+int32_t MIDIDeviceUSB::sendBufferSpace() {
+	int32_t ip = 0;
+	ConnectedUSBMIDIDevice* connectedDevice = NULL;
+
+	// find the connected device for this specific device. Note that virtual
+	// port number is specified as part of the message, implemented below.
+	for (int32_t d = 0; d < MAX_NUM_USB_MIDI_DEVICES; d++) {
+		if (connectionFlags & (1 << d)) {
+			connectedDevice = &connectedUSBMIDIDevices[ip][d];
+			break;
+		}
+	}
+
+	if (!connectedDevice) {
+		return 0;
+	}
+
+	return connectedDevice->sendBufferSpace();
+}
+
 void MIDIDeviceUSB::sendSysex(uint8_t* data, int32_t len) {
 	if (len < 3 || data[0] != 0xf0 || data[len - 1] != 0xf7) {
 		return;
@@ -454,6 +474,10 @@ char const* MIDIDeviceDINPorts::getDisplayName() {
 
 void MIDIDeviceDINPorts::sendMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2) {
 	midiEngine.sendSerialMidi(statusType, channel, data1, data2);
+}
+
+int32_t MIDIDeviceDINPorts::sendBufferSpace() {
+	return uartGetTxBufferSpace(UART_ITEM_MIDI);
 }
 
 void MIDIDeviceDINPorts::sendSysex(uint8_t* data, int32_t len) {

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -100,6 +100,8 @@ public:
 	// data should be a complete message with data[0] = 0xf0, data[len-1] = 0xf7
 	virtual void sendSysex(uint8_t* data, int32_t len) = 0;
 
+	virtual int32_t sendBufferSpace() = 0;
+
 	void sendRPN(int32_t channel, int32_t rpnMSB, int32_t rpnLSB, int32_t valueMSB);
 
 	inline bool hasDefaultVelocityToLevelSet() { return defaultVelocityToLevel; }
@@ -143,6 +145,7 @@ public:
 	}
 	void sendMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
 	void sendSysex(uint8_t* data, int32_t len) override;
+	int32_t sendBufferSpace() override;
 	void connectedNow(int32_t midiDeviceNum);
 	void sendMCMsNowIfNeeded();
 	uint8_t needsToSendMCMs;
@@ -180,4 +183,5 @@ public:
 	char const* getDisplayName();
 	void sendMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
 	void sendSysex(uint8_t* data, int32_t len) override;
+	int32_t sendBufferSpace() override;
 };

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -565,9 +565,16 @@ void ConnectedUSBMIDIDevice::bufferMessage(uint32_t fullMessage) {
 }
 
 bool ConnectedUSBMIDIDevice::hasBufferedSendData() {
-	// must me the same unsigned type as ringBufWriteIdx/ringBufReadIdx
+	// must be the same unsigned type as ringBufWriteIdx/ringBufReadIdx
 	uint32_t queued = ringBufWriteIdx - ringBufReadIdx;
 	return queued > 0;
+}
+
+int ConnectedUSBMIDIDevice::sendBufferSpace() {
+	// must be the same unsigned type as ringBufWriteIdx/ringBufReadIdx
+	uint32_t queued = ringBufWriteIdx - ringBufReadIdx;
+	// each 4-byte MIDI-USB message contains 3 bytes of serial MIDI data
+	return (MIDI_SEND_BUFFER_LEN_RING - queued) * 3;
 }
 
 // This tries to read data from the ring buffer, and

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -64,6 +64,7 @@ public:
 	// move data from ring buffer to dataSendingNow, assuming it is free
 	bool consumeSendData();
 	bool hasBufferedSendData();
+	int sendBufferSpace();
 #else
 //warning - accessed as a C struct from usb driver
 struct ConnectedUSBMIDIDevice {


### PR DESCRIPTION
Backport of #374 to release/1.0 .

While the feature is primarily intended for developers, there still are gonna be users which will want to try it, and it would be simpler if the latest version of the client could be used for either branch. Then I will look into upstreaming the updated client into the main repo (so it could live somewhere under the main community web page). Also, while not strictly a bug fix, the updated version should have significantly less CPU overhead on the deluge when using the virtual OLED screen.