### PR TITLE
Fixing bug reports for Grid for release/1.0

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2406,15 +2406,15 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 	currentSong->currentClip = clip;
 
-	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
-		gridTransitionToViewForClip(clip);
-		return;
-	}
-
 	int32_t clipPlaceOnScreen = std::clamp(getClipPlaceOnScreen(clip), -1_i32, kDisplayHeight);
 
 	currentSong->xScroll[NAVIGATION_CLIP] =
 	    getClipLocalScroll(clip, currentSong->xScroll[NAVIGATION_CLIP], currentSong->xZoom[NAVIGATION_CLIP]);
+
+	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
+		gridTransitionToViewForClip(clip);
+		return;
+	}
 
 	PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3492,7 +3492,7 @@ ActionResult SessionView::gridHandleScroll(int32_t offsetX, int32_t offsetY) {
 
 	// Fix the range
 	currentSong->songGridScrollY =
-	    std::clamp<int32_t>(currentSong->songGridScrollY + offsetY, 0, kMaxNumSections - kGridHeight);
+	    std::clamp<int32_t>(currentSong->songGridScrollY - offsetY, 0, kMaxNumSections - kGridHeight);
 	currentSong->songGridScrollX = std::clamp<int32_t>(currentSong->songGridScrollX + offsetX, 0,
 	                                                   std::max<int32_t>(0, (gridTrackCount() - kDisplayWidth) + 1));
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3489,6 +3489,8 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 
 ActionResult SessionView::gridHandleScroll(int32_t offsetX, int32_t offsetY) {
 	gridResetPresses();
+	gridPreventArm = false;
+	clipPressEnded();
 
 	// Fix the range
 	currentSong->songGridScrollY =

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3432,7 +3432,7 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		// Release
 		else {
 			// End stuttering on any key up for safety
-			if (isUIModeActive(UI_MODE_STUTTERING)) {
+			if (isUIModeActive(UI_MODE_CLIP_PRESSED_IN_SONG_VIEW) && isUIModeActive(UI_MODE_STUTTERING)) {
 				((ModControllableAudio*)view.activeModControllableModelStack.modControllable)
 				    ->endStutter((ParamManagerForTimeline*)view.activeModControllableModelStack.paramManager);
 			}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -255,7 +255,7 @@ doEndMidiLearnPressSession:
 						indicator_leds::setLedState(IndicatorLED::SAVE, false);
 					}
 				}
-				else if(currentUIMode == UI_MODE_NONE) {
+				else if (currentUIMode == UI_MODE_NONE) {
 					indicator_leds::setLedState(IndicatorLED::SAVE, false);
 				}
 			}
@@ -311,7 +311,7 @@ doEndMidiLearnPressSession:
 						indicator_leds::setLedState(IndicatorLED::LOAD, false);
 					}
 				}
-				else if(currentUIMode == UI_MODE_NONE) {
+				else if (currentUIMode == UI_MODE_NONE) {
 					indicator_leds::setLedState(IndicatorLED::LOAD, false);
 				}
 			}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -255,6 +255,9 @@ doEndMidiLearnPressSession:
 						indicator_leds::setLedState(IndicatorLED::SAVE, false);
 					}
 				}
+				else if(currentUIMode == UI_MODE_NONE) {
+					indicator_leds::setLedState(IndicatorLED::SAVE, false);
+				}
 			}
 		}
 	}
@@ -307,6 +310,9 @@ doEndMidiLearnPressSession:
 					else {
 						indicator_leds::setLedState(IndicatorLED::LOAD, false);
 					}
+				}
+				else if(currentUIMode == UI_MODE_NONE) {
+					indicator_leds::setLedState(IndicatorLED::LOAD, false);
 				}
 			}
 		}

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -4314,7 +4314,8 @@ void Song::setParamsInAutomationMode(bool newState) {
 
 bool Song::canOldOutputBeReplaced(Clip* clip, Availability* availabilityRequirement) {
 	// If Clip has an "instance" within its Output in arranger, then we can only change the entire Output to a different Output
-	if (clip->output->clipHasInstance(clip)) {
+	// Same if grid layout is active in session mode since the clips would jump around otherwise
+	if (clip->output->clipHasInstance(clip) || currentSong->sessionLayout == SessionLayoutTypeGrid) {
 		if (availabilityRequirement) {
 			*availabilityRequirement = Availability::INSTRUMENT_UNUSED;
 		}


### PR DESCRIPTION
Issues:

- [x] #382
- [x] #402 
- [x] #413 
- [x] #419

Additional fixes:
* Vertical scroll direction
* If Grid mode is active changing preset in clip mode always replaces whole instrument, same as if arranger contains a clip of that instrument