### PR TITLE
[Ready for Review] Automation View: Resolve Issues #434 and #435 : Use of Sidebar + Auditioning of last selected value

### DIFF
--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1426,7 +1426,7 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 					knobPos = getParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
 					indicator_leds::setKnobIndicatorLevel(1, knobPos);
 
-					if (!currentSong->isClipActive(clip)) {
+					if (!playbackHandler.isEitherClockActive()) {
 						if (modelStackWithParam->getTimelineCounter()
 						    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
@@ -2235,7 +2235,7 @@ void AutomationInstrumentClipView::modEncoderAction(int32_t whichModEncoder, int
 
 						indicator_leds::setKnobIndicatorLevel(whichModEncoder, newKnobPos + kKnobPosOffset);
 
-						if (!currentSong->isClipActive(clip)) {
+						if (!playbackHandler.isEitherClockActive()) {
 							if (modelStackWithParam->getTimelineCounter()
 							    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
@@ -3034,7 +3034,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 
 			if (modelStackWithParam && modelStackWithParam->autoParam) {
 
-				if (!currentSong->isClipActive(clip)) {
+				if (!playbackHandler.isEitherClockActive()) {
 					if (modelStackWithParam->getTimelineCounter()
 					    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -97,7 +97,7 @@ const uint32_t auditionPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDI
 
 const uint32_t editPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};
 
-const uint32_t mutePadActionUIModes[] = {UI_MODE_AUDITIONING, 0};
+const uint32_t mutePadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};
 
 static const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_RECORD_COUNT_IN,
                                                  0};

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2150,7 +2150,7 @@ void AutomationInstrumentClipView::modEncoderAction(int32_t whichModEncoder, int
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
 
 	//if user holding a node down, we'll adjust the value of the selected parameter being automated
-	if ((currentUIMode == UI_MODE_NOTES_PRESSED) || padSelectionOn) {
+	if (isUIModeActive(UI_MODE_NOTES_PRESSED) || padSelectionOn) {
 
 		if (clip->lastSelectedParamID != kNoLastSelectedParamID
 		    && ((instrumentClipView.numEditPadPresses > 0

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1428,14 +1428,14 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 
 					if (!currentSong->isClipActive(clip)) {
 						if (modelStackWithParam->getTimelineCounter()
-							== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+						    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
 							if (leftPadSelectedX == xDisplay) {
 								squareStart = getPosFromSquare(leftPadSelectedX);
 							}
 
 							view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-								squareStart, &view.activeModControllableModelStack);
+							    squareStart, &view.activeModControllableModelStack);
 						}
 					}
 
@@ -2237,10 +2237,10 @@ void AutomationInstrumentClipView::modEncoderAction(int32_t whichModEncoder, int
 
 						if (!currentSong->isClipActive(clip)) {
 							if (modelStackWithParam->getTimelineCounter()
-								== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+							    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
 								view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-									squareStart, &view.activeModControllableModelStack);
+								    squareStart, &view.activeModControllableModelStack);
 							}
 						}
 
@@ -3036,10 +3036,10 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 
 				if (!currentSong->isClipActive(clip)) {
 					if (modelStackWithParam->getTimelineCounter()
-						== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+					    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
 						view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-							squareStart, &view.activeModControllableModelStack);
+						    squareStart, &view.activeModControllableModelStack);
 					}
 				}
 			}

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -92,8 +92,12 @@ extern "C" {
 
 using namespace deluge::gui;
 
-const uint32_t auditionPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_HORIZONTAL_SCROLL, UI_MODE_RECORD_COUNT_IN,
-                                             UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON, 0};
+const uint32_t auditionPadActionUIModes[] = {UI_MODE_NOTES_PRESSED,
+                                             UI_MODE_AUDITIONING,
+                                             UI_MODE_HORIZONTAL_SCROLL,
+                                             UI_MODE_RECORD_COUNT_IN,
+                                             UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON,
+                                             0};
 
 const uint32_t editPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};
 
@@ -1423,14 +1427,14 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 					indicator_leds::setKnobIndicatorLevel(1, knobPos);
 
 					if (modelStackWithParam->getTimelineCounter()
-						== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {	
+					    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
 						if (leftPadSelectedX == xDisplay) {
 							squareStart = getPosFromSquare(leftPadSelectedX);
 						}
 
 						view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-						squareStart, &view.activeModControllableModelStack);
+						    squareStart, &view.activeModControllableModelStack);
 					}
 
 					//display pad value of second pad pressed
@@ -2230,10 +2234,10 @@ void AutomationInstrumentClipView::modEncoderAction(int32_t whichModEncoder, int
 						indicator_leds::setKnobIndicatorLevel(whichModEncoder, newKnobPos + kKnobPosOffset);
 
 						if (modelStackWithParam->getTimelineCounter()
-							== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {	
+						    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
 							view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-							squareStart, &view.activeModControllableModelStack);
+							    squareStart, &view.activeModControllableModelStack);
 						}
 
 						return;
@@ -3014,11 +3018,10 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 			if (modelStackWithParam && modelStackWithParam->autoParam) {
 
 				if (modelStackWithParam->getTimelineCounter()
-				    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {	
+				    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
 					view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-		    		squareStart, &view.activeModControllableModelStack);
-
+					    squareStart, &view.activeModControllableModelStack);
 				}
 			}
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1426,15 +1426,17 @@ void AutomationInstrumentClipView::editPadAction(bool state, uint8_t yDisplay, u
 					knobPos = getParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
 					indicator_leds::setKnobIndicatorLevel(1, knobPos);
 
-					if (modelStackWithParam->getTimelineCounter()
-					    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+					if (!currentSong->isClipActive(clip)) {
+						if (modelStackWithParam->getTimelineCounter()
+							== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
-						if (leftPadSelectedX == xDisplay) {
-							squareStart = getPosFromSquare(leftPadSelectedX);
+							if (leftPadSelectedX == xDisplay) {
+								squareStart = getPosFromSquare(leftPadSelectedX);
+							}
+
+							view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
+								squareStart, &view.activeModControllableModelStack);
 						}
-
-						view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-						    squareStart, &view.activeModControllableModelStack);
 					}
 
 					//display pad value of second pad pressed
@@ -2233,11 +2235,13 @@ void AutomationInstrumentClipView::modEncoderAction(int32_t whichModEncoder, int
 
 						indicator_leds::setKnobIndicatorLevel(whichModEncoder, newKnobPos + kKnobPosOffset);
 
-						if (modelStackWithParam->getTimelineCounter()
-						    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+						if (!currentSong->isClipActive(clip)) {
+							if (modelStackWithParam->getTimelineCounter()
+								== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
-							view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-							    squareStart, &view.activeModControllableModelStack);
+								view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
+									squareStart, &view.activeModControllableModelStack);
+							}
 						}
 
 						return;
@@ -3030,11 +3034,13 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 
 			if (modelStackWithParam && modelStackWithParam->autoParam) {
 
-				if (modelStackWithParam->getTimelineCounter()
-				    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+				if (!currentSong->isClipActive(clip)) {
+					if (modelStackWithParam->getTimelineCounter()
+						== view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
-					view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-					    squareStart, &view.activeModControllableModelStack);
+						view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
+							squareStart, &view.activeModControllableModelStack);
+					}
 				}
 			}
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -92,7 +92,7 @@ extern "C" {
 
 using namespace deluge::gui;
 
-const uint32_t auditionPadActionUIModes[] = {UI_MODE_AUDITIONING, UI_MODE_HORIZONTAL_SCROLL, UI_MODE_RECORD_COUNT_IN,
+const uint32_t auditionPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_HORIZONTAL_SCROLL, UI_MODE_RECORD_COUNT_IN,
                                              UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON, 0};
 
 const uint32_t editPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2990,7 +2990,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 		    getModelStackWithParam(modelStack, clip, clip->lastSelectedParamID, clip->lastSelectedParamKind);
 
 		if (padSelectionOn) {
-			//display pad's middle value
+			//display pad's value
 
 			int32_t effectiveLength;
 
@@ -3003,9 +3003,22 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 				effectiveLength = clip->loopLength;
 			}
 
-			uint32_t squareStart = getPosFromSquare(xDisplay);
+			uint32_t squareStart = 0;
 
-			if (!multiPadPressSelected) {
+			//if a long press is selected and you're checking value of start or end pad
+			//display value at very first or very last node
+			if (multiPadPressSelected && ((leftPadSelectedX == xDisplay) || (rightPadSelectedX == xDisplay))) {
+				if (leftPadSelectedX == xDisplay) {
+					squareStart = getPosFromSquare(xDisplay);
+				}
+				else {
+					int32_t squareRightEdge = getPosFromSquare(rightPadSelectedX + 1);
+					squareStart = std::min(effectiveLength, squareRightEdge) - kParamNodeWidth;
+				}
+			}
+			//display pad's middle value
+			else {
+				squareStart = getPosFromSquare(xDisplay);
 				uint32_t squareWidth = instrumentClipView.getSquareWidth(xDisplay, effectiveLength);
 				if (squareWidth != 3) {
 					squareStart = squareStart + (squareWidth / 2);


### PR DESCRIPTION
This PR resolves two issues reported by @trappar

#434 : audition pads follow value from last input / selection
#435 : sidebar unusable while holding automation pads first