### PR TITLE
Bugfixes for fill mode

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -5266,7 +5266,7 @@ justDisplayOldNumNotes:
 						Note* note = newNotes.getElement(n);
 						note->pos = (uint32_t)(n * numStepsAvailable) / (uint32_t)newNumNotes * squareWidth;
 						note->length = squareWidth;
-						note->probability = kNumProbabilityValues;
+						note->probability = noteRow->getDefaultProbability(modelStack);
 						note->velocity = ((Instrument*)clip->output)->defaultVelocity;
 						note->lift = kDefaultLiftValue;
 					}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2068,7 +2068,7 @@ void InstrumentClipView::adjustProbability(int32_t offset) {
 							}
 							else {
 								// See if there's a prev-base
-								if (probabilityValue < kNumProbabilityValues
+								if (probabilityValue > 0 && probabilityValue < kNumProbabilityValues
 								    && getCurrentClip()->doesProbabilityExist(
 								        editPadPresses[i].intendedPos, probabilityValue,
 								        kNumProbabilityValues - probabilityValue)) {
@@ -2090,7 +2090,7 @@ void InstrumentClipView::adjustProbability(int32_t offset) {
 							}
 							else {
 								probabilityValue--;
-								prevBase = (probabilityValue < kNumProbabilityValues
+								prevBase = (probabilityValue > 0 && probabilityValue < kNumProbabilityValues
 								            && getCurrentClip()->doesProbabilityExist(
 								                editPadPresses[i].intendedPos, probabilityValue,
 								                kNumProbabilityValues - probabilityValue));
@@ -2158,7 +2158,7 @@ multiplePresses:
 		// Decide the probability, based on the existing probability of the leftmost note
 		probabilityValue = editPadPresses[leftMostIndex].intendedProbability & 127;
 		probabilityValue += offset;
-		probabilityValue = std::clamp<int32_t>(probabilityValue, 1, kNumProbabilityValues + kNumIterationValues);
+		probabilityValue = std::clamp<int32_t>(probabilityValue, 0, kNumProbabilityValues + kNumIterationValues);
 
 		Action* action = actionLogger.getNewAction(ACTION_NOTE_EDIT, true);
 		if (!action) {
@@ -2201,7 +2201,8 @@ multiplePresses:
 				// Or, just 1 note in square
 				else {
 					// And if not one of the leftmost notes, make it a prev-base one - if we're doing actual percentage probabilities
-					if (probabilityValue < kNumProbabilityValues && editPadPresses[i].intendedPos != leftMostPos) {
+					if (probabilityValue > 0 && probabilityValue < kNumProbabilityValues
+					    && editPadPresses[i].intendedPos != leftMostPos) {
 						editPadPresses[i].intendedProbability |= 128;
 					}
 					noteRow->changeNotesAcrossAllScreens(editPadPresses[i].intendedPos, modelStackWithNoteRow, action,

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -476,8 +476,8 @@ int32_t InstrumentClip::beginLinearRecording(ModelStackWithTimelineCounter* mode
 					}
 
 					ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(noteRowIndex, noteRow);
-
-					noteRow->attemptNoteAdd(0, 1, velocity, kNumProbabilityValues, modelStackWithNoteRow, action);
+					int32_t probability = noteRow->getDefaultProbability(modelStackWithNoteRow);
+					noteRow->attemptNoteAdd(0, 1, velocity, probability, modelStackWithNoteRow, action);
 					if (!thisDrum->earlyNoteStillActive) {
 						Debug::println("skipping next note");
 						noteRow->skipNextNote = true;
@@ -501,9 +501,8 @@ int32_t InstrumentClip::beginLinearRecording(ModelStackWithTimelineCounter* mode
 				    getOrCreateNoteRowForYNote(basicNote->note, modelStack, action, &scaleAltered);
 				NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
 				if (noteRow) {
-
-					noteRow->attemptNoteAdd(0, 1, basicNote->velocity, kNumProbabilityValues, modelStackWithNoteRow,
-					                        action);
+					int32_t probability = noteRow->getDefaultProbability(modelStackWithNoteRow);
+					noteRow->attemptNoteAdd(0, 1, basicNote->velocity, probability, modelStackWithNoteRow, action);
 					if (!basicNote->stillActive) {
 						noteRow->skipNextNote = true;
 					}
@@ -4323,7 +4322,8 @@ doNormal: // Wrap it back to the start.
 	}
 
 	else {
-		distanceToNextNote = noteRow->attemptNoteAdd(quantizedPos, 1, velocity, kNumProbabilityValues, modelStack,
+		int32_t probability = noteRow->getDefaultProbability(modelStack);
+		distanceToNextNote = noteRow->attemptNoteAdd(quantizedPos, 1, velocity, probability, modelStack,
 		                                             NULL); // Don't supply Action, cos we've done our own thing, above
 	}
 

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -511,6 +511,15 @@ addNewNote:
 
 	return NO_ERROR;
 }
+int32_t NoteRow::getDefaultProbability(ModelStackWithNoteRow* ModelStack) {
+
+	if (ModelStack->song->fillModeActive) {
+		return 0;
+	}
+	else {
+		return probabilityValue;
+	}
+}
 
 // This gets called after we've scrolled and attempted to drag notes. And for recording.
 // If you supply an Action, it'll add an individual ConsequenceNoteExistenceChange. Or, you can supply NULL and do something else yourself.

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -223,7 +223,8 @@ addNewNote:
 
 		newNote->setVelocity(((Instrument*)((Clip*)modelStack->getTimelineCounter())->output)->defaultVelocity);
 		newNote->setLift(kDefaultLiftValue);
-		newNote->setProbability(kNumProbabilityValues);
+
+		newNote->setProbability(getDefaultProbability(modelStack));
 
 		if (i + 1 < notes.getNumElements()) {
 			newNote->setLength(std::min(desiredNoteLength, notes.getElement(i + 1)->pos - newNote->pos));
@@ -441,7 +442,7 @@ addNewNote:
 			destNote->pos = posThisScreen;
 			destNote->setVelocity(velocity);
 			destNote->setLift(kDefaultLiftValue);
-			destNote->setProbability(kNumProbabilityValues);
+			destNote->setProbability(getDefaultProbability(modelStack));
 
 			int32_t newLength;
 
@@ -638,7 +639,7 @@ int32_t NoteRow::attemptNoteAddReversed(ModelStackWithNoteRow* modelStack, int32
 	newNote->setLength(1);
 	newNote->setVelocity(velocity);
 	newNote->setLift(kDefaultLiftValue);
-	newNote->setProbability(kNumProbabilityValues);
+	newNote->setProbability(getDefaultProbability(modelStack));
 
 	((InstrumentClip*)modelStack->getTimelineCounter())->expectEvent();
 

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -122,7 +122,7 @@ public:
 
 	bool
 	    skipNextNote; // To be used if we recorded a note which was quantized forwards, and we have to remember not to play it
-
+	int32_t getDefaultProbability(ModelStackWithNoteRow* ModelStack);
 	int32_t attemptNoteAdd(int32_t pos, int32_t length, int32_t velocity, int32_t probability,
 	                       ModelStackWithNoteRow* modelStack, Action* action);
 	int32_t attemptNoteAddReversed(ModelStackWithNoteRow* modelStack, int32_t pos, int32_t velocity,

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2773,9 +2773,15 @@ void PlaybackHandler::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, ui
 			}
 		}
 
-		if (value) {
-			int32_t channelOrZone = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
+		int32_t channelOrZone = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
+
+		if (value > 0) {
 			if (tryGlobalMIDICommands(fromDevice, channelOrZone + IS_A_CC, ccNumber)) {
+				return;
+			}
+		}
+		else {
+			if (tryGlobalMIDICommandsOff(fromDevice, channelOrZone + IS_A_CC, ccNumber)) {
 				return;
 			}
 		}


### PR DESCRIPTION
Fixes #442 
Fixes #451 
Fixes #375
Fixes #385 

Fill notes can no longer have a latching value (it didn't do anything)
Fill notes can now be quickly set by holding fill and adding notes
New notes inherit song fill status or row probability by default 
Fill mode can be properly deactivated over midi CC as well as note on/off