### PR TITLE
[Ready for Review] Automation View: Resolve Issue #440 - Strange values while editing pitch bend / channel pressure

### DIFF
--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -3083,7 +3083,6 @@ void AutomationInstrumentClipView::handleMultiPadPress(ModelStackWithTimelineCou
 
 			//clear existing nodes from long press range
 			int32_t squareRightEdge = getPosFromSquare(secondPadX + 1);
-			//int32_t clearLength = std::min(effectiveLength, squareRightEdge) - getPosFromSquare(firstPadX);
 
 			//reset interpolation settings to default
 			initInterpolation();

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -17,6 +17,7 @@
 
 #include "modulation/params/param_set.h"
 #include "deluge/model/settings/runtime_feature_settings.h"
+#include "gui/views/automation_instrument_clip_view.h"
 #include "gui/views/view.h"
 #include "io/midi/midi_engine.h"
 #include "model/action/action_logger.h"
@@ -553,16 +554,19 @@ void ExpressionParamSet::notifyParamModifiedInSomeWay(ModelStackWithAutoParam co
 // Displays text number. This will only actually end up getting used/seen on MIDI Clips, at channel/Clip level - not MPE/polyphonic.
 int32_t ExpressionParamSet::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
 
-	char buffer[5];
-	int32_t valueForDisplay = knobPos;
-	if (modelStack->paramId == 2) { // Just for aftertouch
-		valueForDisplay += 64;
-		if (valueForDisplay == 128) {
-			valueForDisplay = 127;
+	if (getCurrentUI()
+	    != &automationInstrumentClipView) { //let the automation instrument clip view handle the drawing of midi cc value
+		char buffer[5];
+		int32_t valueForDisplay = knobPos;
+		if (modelStack->paramId == 2) { // Just for aftertouch
+			valueForDisplay += 64;
+			if (valueForDisplay == 128) {
+				valueForDisplay = 127;
+			}
 		}
+		intToString(valueForDisplay, buffer);
+		display->displayPopup(buffer, 3, true);
 	}
-	intToString(valueForDisplay, buffer);
-	display->displayPopup(buffer, 3, true);
 
 	// Everything but aftertouch gets handled by parent from here
 	if (modelStack->paramId != 2) {


### PR DESCRIPTION
In Issue #440 @trappar identified some weird pop up values being displayed on the screen when editing after touch and pressure. This is because the deluge was displaying pop up values at the same time as I was displaying pop up values in the deluge so it basically giving weird behaviour of overlapping popups and not showing the right value.

I've corrected this by putting a condition in the deluge function that was displaying the popup to say: "if in automation view, let the automation view handle the drawing of popups.

I did the same thing previously in another function called MidiParamCollection::knobPosToParamValue

I didn't realize then that there was another function being used in midi clips to display popups for Pitch Bend and After Touch (ExpressionParamSet::knobPosToParamValue)