### PR TITLE
fix crash while loading synth to kit row

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -960,9 +960,13 @@ int32_t LoadInstrumentPresetUI::performLoadSynthToKit() {
 	if (currentFileItem->isFolder) {
 		return NO_ERROR;
 	}
-
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(noteRowIndex, noteRow);
+	//make sure the drum isn't currently in use
+	noteRow->stopCurrentlyPlayingNote(modelStackWithNoteRow);
+	kitToLoadFor->drumsWithRenderingActive.deleteAtKey((int32_t)(Drum*)soundDrumToReplace);
+	kitToLoadFor->removeDrum(soundDrumToReplace);
 
 	int32_t error = storageManager.loadSynthToDrum(currentSong, instrumentClipToLoadFor, false, &soundDrumToReplace,
 	                                               &currentFileItem->filePointer, &enteredText, &currentDir);
@@ -972,10 +976,11 @@ int32_t LoadInstrumentPresetUI::performLoadSynthToKit() {
 
 	//soundDrumToReplace->name.set(getCurrentFilenameWithoutExtension());
 	getCurrentFilenameWithoutExtension(&soundDrumToReplace->name);
-	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(noteRowIndex, noteRow);
+
 	ParamManager* paramManager =
 	    currentSong->getBackedUpParamManagerPreferablyWithClip(soundDrumToReplace, instrumentClipToLoadFor);
 	if (paramManager) {
+		kitToLoadFor->addDrum(soundDrumToReplace);
 		noteRow->setDrum(soundDrumToReplace, kitToLoadFor, modelStackWithNoteRow, instrumentClipToLoadFor,
 		                 paramManager);
 		kitToLoadFor->setupPatching(modelStack);

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1467,6 +1467,7 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
                                         SoundDrum** getInstrument, FilePointer* filePointer, String* name,
                                         String* dirPath) {
 	InstrumentType instrumentType = InstrumentType::SYNTH;
+	SoundDrum* newDrum = (SoundDrum*)createNewDrum(DrumType::SOUND);
 
 	AudioEngine::logAction("loadSynthDrumFromFile");
 
@@ -1477,7 +1478,7 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
 
 	AudioEngine::logAction("loadInstrumentFromFile");
 
-	error = (*getInstrument)->readFromFile(song, clip, 0);
+	error = newDrum->readFromFile(song, clip, 0);
 
 	bool fileSuccess = closeFile();
 
@@ -1489,7 +1490,7 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
 			return error;
 		}
 	}
-	//*getInstrument = newInstrument;
+	*getInstrument = newDrum;
 	return error;
 }
 


### PR DESCRIPTION
Replacing the samples while the row was in use lead to freezes. It is now modified to stop the row from starting a new note during the load and to load into a new sounddrum and then replace the previous one, rather than directly modifying the drum which could be playing