### PR TITLE
[Ready for Review] MIDI Takeover Mode: Resolve issue #427 : Pickup Hanging

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -760,6 +760,7 @@ enum class MIDITakeoverMode : uint8_t {
 	SCALE,
 };
 constexpr auto kNumMIDITakeoverModes = util::to_underlying(MIDITakeoverMode::SCALE) + 1;
+constexpr int32_t kMIDITakeoverKnobSyncThreshold = 3;
 
 constexpr int32_t kNumClustersLoadedAhead = 2;
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -760,7 +760,7 @@ enum class MIDITakeoverMode : uint8_t {
 	SCALE,
 };
 constexpr auto kNumMIDITakeoverModes = util::to_underlying(MIDITakeoverMode::SCALE) + 1;
-constexpr int32_t kMIDITakeoverKnobSyncThreshold = 3;
+constexpr int32_t kMIDITakeoverKnobSyncThreshold = 5;
 
 constexpr int32_t kNumClustersLoadedAhead = 2;
 

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1712,8 +1712,8 @@ bool ModControllableAudio::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice
 
 						//Here is where we check if the Knob/Fader on the Midi Controller is out of sync with the Deluge Knob Position
 
-						//First we check if the Midi Knob/Fader is sending a Value that is greater than or less than the current Deluge Knob Position by a max difference of +/- 3
-						//If the difference is greater than 3, ignore the CC value change (or scale it if value scaling is on)
+						//First we check if the Midi Knob/Fader is sending a Value that is greater than or less than the current Deluge Knob Position by a max difference of +/- kMIDITakeoverKnobSyncThreshold
+						//If the difference is greater than kMIDITakeoverKnobSyncThreshold, ignore the CC value change (or scale it if value scaling is on)
 						int32_t midiKnobMinPos = knobPos - kMIDITakeoverKnobSyncThreshold;
 						int32_t midiKnobMaxPos = knobPos + kMIDITakeoverKnobSyncThreshold;
 

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1712,21 +1712,16 @@ bool ModControllableAudio::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice
 
 						//Here is where we check if the Knob/Fader on the Midi Controller is out of sync with the Deluge Knob Position
 
-						//First we check if the Midi Knob/Fader is sending a Value that is less the current Deluge Knob Position
-						//If less, check by how much its less. If the difference is greater than 1, ignore the CC value change (or scale it if value scaling is on)
-						if (midiKnobPos == (knobPos - 1)) {
-							newKnobPos = knobPos - 1;
-						}
+						//First we check if the Midi Knob/Fader is sending a Value that is greater than or less than the current Deluge Knob Position by a max difference of +/- 3
+						//If the difference is greater than 3, ignore the CC value change (or scale it if value scaling is on)
+						int32_t midiKnobMinPos = knobPos - kMIDITakeoverKnobSyncThreshold;
+						int32_t midiKnobMaxPos = knobPos + kMIDITakeoverKnobSyncThreshold;
 
-						//Next we check if the Midi Knob/Fader is sending a Value that is greater than the current Deluge Knob Position
-						//If greater, check by how much its greater. If the difference is greater than 1, ignore the CC value change (or scale it if value scaling is on)
-						else if (midiKnobPos == (knobPos + 1)) {
-							newKnobPos = knobPos + 1;
+						if ((midiKnobMinPos <= midiKnobPos) && (midiKnobPos <= midiKnobMaxPos)) {
+							newKnobPos = knobPos + (midiKnobPos - knobPos);
 						}
-
 						else {
-
-							//if the first two conditions fail and pickup mode is enabled, then the Deluge Knob Position (and therefore the Parameter Value with it) remains unchanged
+							//if the above conditions fail and pickup mode is enabled, then the Deluge Knob Position (and therefore the Parameter Value with it) remains unchanged
 							if (midiEngine.midiTakeover == MIDITakeoverMode::PICKUP) { //Midi Pickup Mode On
 								newKnobPos = knobPos;
 							}


### PR DESCRIPTION
For MIDI Takeover modes Pickup and Scale, an adjustment is required to allow for fast value changes resulting from fast midi controller actions.

Currently the Deluge goes out of sync with the controller if the controller changes the value too fast.

To resolve this, the previous threshold of +/- 1 was increased to +/- 5.

A global constant was defined for this threshold amount to allow for easy future tweaking if it necessary.

The code was also tidied up a bit as part of this change.

This resolves issue #427 reported by @PaulFreund 