### PR TITLE
Bugfix/global midi overdub

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -738,6 +738,7 @@ enum class PatchCableAcceptance {
 	ALLOWED,
 	YET_TO_BE_DETERMINED,
 };
+enum class OverDubType { Normal, ContinuousLayering };
 
 enum class GlobalMIDICommand {
 	NONE = -1,

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -712,8 +712,8 @@ holdingRecord:
 								session.toggleClipStatus(sourceClip, &clipIndex, false, kInternalButtonPressLatency);
 							}
 
-							int32_t newOverdubNature =
-							    (xDisplay < kDisplayWidth) ? OVERDUB_NORMAL : OVERDUB_CONTINUOUS_LAYERING;
+							OverDubType newOverdubNature =
+							    (xDisplay < kDisplayWidth) ? OverDubType::Normal : OverDubType::ContinuousLayering;
 							Clip* overdub =
 							    currentSong->createPendingNextOverdubBelowClip(sourceClip, clipIndex, newOverdubNature);
 							if (overdub) {

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -218,7 +218,7 @@ void AudioClip::finishLinearRecording(ModelStackWithTimelineCounter* modelStack,
 	recorder = NULL;
 }
 
-Clip* AudioClip::cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStackOldClip, int32_t newOverdubNature) {
+Clip* AudioClip::cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStackOldClip, OverDubType newOverdubNature) {
 
 	// Allocate memory for audio clip
 	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(AudioClip), NULL, false, true);
@@ -253,8 +253,9 @@ ramError:
 	return newClip;
 }
 
-bool AudioClip::cloneOutput(ModelStackWithTimelineCounter* modelStack) {
-	if (!overdubsShouldCloneOutput) {
+bool AudioClip::cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature) {
+	//don't clone for loop commands in red mode
+	if (!(overdubsShouldCloneOutput || overdubNature == OverDubType::ContinuousLayering)) {
 		return false;
 	}
 

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -253,7 +253,7 @@ ramError:
 	return newClip;
 }
 
-bool AudioClip::cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature) {
+bool AudioClip::cloneOutput(ModelStackWithTimelineCounter* modelStack) {
 	//don't clone for loop commands in red mode
 	if (!overdubsShouldCloneOutput) {
 		return false;

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -255,7 +255,7 @@ ramError:
 
 bool AudioClip::cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature) {
 	//don't clone for loop commands in red mode
-	if (!(overdubsShouldCloneOutput || overdubNature == OverDubType::ContinuousLayering)) {
+	if (!overdubsShouldCloneOutput) {
 		return false;
 	}
 

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -107,7 +107,7 @@ public:
 	bool maySetupCache;
 
 protected:
-	bool cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature);
+	bool cloneOutput(ModelStackWithTimelineCounter* modelStack);
 
 private:
 	void detachAudioClipFromOutput(Song* song, bool shouldRetainLinksToOutput, bool shouldTakeParamManagerWith = false);

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -105,7 +105,6 @@ public:
 
 	bool doingLateStart;
 	bool maySetupCache;
-	bool overdubsShouldCloneOutput;
 
 protected:
 	bool cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature);

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -56,7 +56,7 @@ public:
 	void quantizeLengthForArrangementRecording(ModelStackWithTimelineCounter* modelStack, int32_t lengthSoFar,
 	                                           uint32_t timeRemainder, int32_t suggestedLength,
 	                                           int32_t alternativeLongerLength);
-	Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, int32_t newOverdubNature);
+	Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature);
 	int64_t getSamplesFromTicks(int32_t ticks);
 	void unassignVoiceSample();
 	void resumePlayback(ModelStackWithTimelineCounter* modelStack, bool mayMakeSound = true);
@@ -108,7 +108,7 @@ public:
 	bool overdubsShouldCloneOutput;
 
 protected:
-	bool cloneOutput(ModelStackWithTimelineCounter* modelStack);
+	bool cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature);
 
 private:
 	void detachAudioClipFromOutput(Song* song, bool shouldRetainLinksToOutput, bool shouldTakeParamManagerWith = false);

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -56,7 +56,7 @@ Clip::Clip(int32_t newType) : type(newType) {
 	isPendingOverdub = false;
 	isUnfinishedAutoOverdub = false;
 	colourOffset = -60;
-	overdubNature = OVERDUB_NORMAL;
+	overdubNature = OverDubType::Normal;
 	originalLength = 0;
 	armedForRecording = true;
 	launchStyle = LAUNCH_STYLE_DEFAULT;
@@ -92,12 +92,12 @@ void Clip::copyBasicsFrom(Clip* otherClip) {
 	launchStyle = otherClip->launchStyle;
 }
 
-void Clip::setupForRecordingAsAutoOverdub(Clip* existingClip, Song* song, int32_t newOverdubNature) {
+void Clip::setupForRecordingAsAutoOverdub(Clip* existingClip, Song* song, OverDubType newOverdubNature) {
 	copyBasicsFrom(existingClip);
 
 	uint32_t newLength = existingClip->loopLength;
 
-	if (newOverdubNature != OVERDUB_CONTINUOUS_LAYERING) {
+	if (newOverdubNature != OverDubType::ContinuousLayering) {
 		uint32_t currentScreenLength = currentSong->xZoom[NAVIGATION_CLIP] << kDisplayWidthMagnitude;
 
 		// If new length is a multiple of screen length, just use screen length

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -180,6 +180,7 @@ public:
 
 	uint8_t launchStyle;
 	int64_t fillEventAtTickCount;
+	bool overdubsShouldCloneOutput;
 
 protected:
 	virtual void

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -186,11 +186,9 @@ protected:
 	virtual void
 	posReachedEnd(ModelStackWithTimelineCounter*
 	                  modelStack); // May change the TimelineCounter in the modelStack if new Clip got created
-	virtual bool cloneOutput(
-	    ModelStackWithTimelineCounter* modelStack,
-	    OverDubType overdubNature = OverDubType::Normal) = 0; // Returns whether a new Output was in fact created
+	virtual bool
+	cloneOutput(ModelStackWithTimelineCounter* modelStack) = 0; // Returns whether a new Output was in fact created
 	int32_t solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
 	                            Clip* favourClipForCloningParamManager = NULL);
-	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {
-	}
+	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {}
 };

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -25,9 +25,6 @@
 #define CLIP_TYPE_INSTRUMENT 0
 #define CLIP_TYPE_AUDIO 1
 
-#define OVERDUB_NORMAL 0
-#define OVERDUB_CONTINUOUS_LAYERING 1
-
 #define LAUNCH_STYLE_DEFAULT 0
 #define LAUNCH_STYLE_FILL 1
 
@@ -107,7 +104,7 @@ public:
 	                       int32_t imageWidth, TimelineView* editorScreen, bool tripletsOnHere);
 	bool opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounter* modelStack, bool* newOutputCreated,
 	                                              int32_t buttonPressLatency);
-	virtual Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, int32_t newOverdubNature) = 0;
+	virtual Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) = 0;
 	virtual bool getCurrentlyRecordingLinearly() = 0;
 	virtual bool currentlyScrollableAndZoomable() = 0;
 	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack);
@@ -119,7 +116,7 @@ public:
 	void readTagFromFile(char const* tagName, Song* song, int32_t* readAutomationUpToPos);
 
 	virtual void copyBasicsFrom(Clip* otherClip);
-	void setupForRecordingAsAutoOverdub(Clip* existingClip, Song* song, int32_t newOverdubNature);
+	void setupForRecordingAsAutoOverdub(Clip* existingClip, Song* song, OverDubType newOverdubNature);
 	void outputChanged(ModelStackWithTimelineCounter* modelStack, Output* newOutput);
 	virtual bool isAbandonedOverdub() = 0;
 	virtual bool wantsToBeginLinearRecording(Song* song);
@@ -160,7 +157,7 @@ public:
 	bool isUnfinishedAutoOverdub;
 	bool armedForRecording;
 	bool wasWantingToDoLinearRecordingBeforeCountIn; // Only valid during a count-in
-	uint8_t overdubNature;
+	OverDubType overdubNature;
 
 	LearnedMIDI muteMIDICommand;
 
@@ -188,10 +185,10 @@ protected:
 	virtual void
 	posReachedEnd(ModelStackWithTimelineCounter*
 	                  modelStack); // May change the TimelineCounter in the modelStack if new Clip got created
-	virtual bool
-	cloneOutput(ModelStackWithTimelineCounter* modelStack) = 0; // Returns whether a new Output was in fact created
+	virtual bool cloneOutput(
+	    ModelStackWithTimelineCounter* modelStack,
+	    OverDubType overdubNature = OverDubType::Normal) = 0; // Returns whether a new Output was in fact created
 	int32_t solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
 	                            Clip* favourClipForCloningParamManager = NULL);
-	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {
-	}
+	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {}
 };

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -190,5 +190,6 @@ protected:
 	cloneOutput(ModelStackWithTimelineCounter* modelStack) = 0; // Returns whether a new Output was in fact created
 	int32_t solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
 	                            Clip* favourClipForCloningParamManager = NULL);
-	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {}
+	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {
+	}
 };

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -191,5 +191,6 @@ protected:
 	    OverDubType overdubNature = OverDubType::Normal) = 0; // Returns whether a new Output was in fact created
 	int32_t solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
 	                            Clip* favourClipForCloningParamManager = NULL);
-	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {}
+	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {
+	}
 };

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -4033,7 +4033,7 @@ void InstrumentClip::finishLinearRecording(ModelStackWithTimelineCounter* modelS
 	}
 }
 
-Clip* InstrumentClip::cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, int32_t newOverdubNature) {
+Clip* InstrumentClip::cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) {
 
 	// Allocate memory for Clip
 	void* clipMemory = GeneralMemoryAllocator::get().alloc(sizeof(InstrumentClip), NULL, false, true);
@@ -4078,7 +4078,7 @@ ramError:
 	return newInstrumentClip;
 }
 
-bool InstrumentClip::cloneOutput(ModelStackWithTimelineCounter* modelStack) {
+bool InstrumentClip::cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature) {
 	return false;
 }
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -4078,7 +4078,7 @@ ramError:
 	return newInstrumentClip;
 }
 
-bool InstrumentClip::cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubNature) {
+bool InstrumentClip::cloneOutput(ModelStackWithTimelineCounter* modelStack) {
 	return false;
 }
 

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -248,7 +248,7 @@ public:
 protected:
 	void posReachedEnd(ModelStackWithTimelineCounter* modelStack);
 	bool wantsToBeginLinearRecording(Song* song);
-	bool cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubnature);
+	bool cloneOutput(ModelStackWithTimelineCounter* modelStack);
 	void pingpongOccurred(ModelStackWithTimelineCounter* modelStack);
 
 private:

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -226,7 +226,7 @@ public:
 	void finishLinearRecording(ModelStackWithTimelineCounter* modelStack, Clip* nextPendingLoop,
 	                           int32_t buttonLatencyForTempolessRecord);
 	int32_t beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency);
-	Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, int32_t newOverdubNature);
+	Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature);
 	bool isAbandonedOverdub();
 	void quantizeLengthForArrangementRecording(ModelStackWithTimelineCounter* modelStack, int32_t lengthSoFar,
 	                                           uint32_t timeRemainder, int32_t suggestedLength,
@@ -248,7 +248,7 @@ public:
 protected:
 	void posReachedEnd(ModelStackWithTimelineCounter* modelStack);
 	bool wantsToBeginLinearRecording(Song* song);
-	bool cloneOutput(ModelStackWithTimelineCounter* modelStack);
+	bool cloneOutput(ModelStackWithTimelineCounter* modelStack, OverDubType overdubnature);
 	void pingpongOccurred(ModelStackWithTimelineCounter* modelStack);
 
 private:

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5067,7 +5067,7 @@ Clip* Song::getClipWithOutputAboutToBeginLinearRecording(Output* output) {
 	return NULL;
 }
 
-Clip* Song::createPendingNextOverdubBelowClip(Clip* clip, int32_t clipIndex, int32_t newOverdubNature) {
+Clip* Song::createPendingNextOverdubBelowClip(Clip* clip, int32_t clipIndex, OverDubType newOverdubNature) {
 
 	// No automatic overdubs are allowed during soloing, cos that's just too complicated
 	if (anyClipsSoloing) {

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -296,7 +296,7 @@ public:
 	                           bool createConsequencesForOtherLinearlyRecordingClips = false);
 	Clip* getPendingOverdubWithOutput(Output* output);
 	Clip* getClipWithOutputAboutToBeginLinearRecording(Output* output);
-	Clip* createPendingNextOverdubBelowClip(Clip* clip, int32_t clipIndex, int32_t newOverdubNature);
+	Clip* createPendingNextOverdubBelowClip(Clip* clip, int32_t clipIndex, OverDubType newOverdubNature);
 	bool hasAnyPendingNextOverdubs();
 	Output* getNextAudioOutput(int32_t offset, Output* oldOutput, Availability availabilityRequirement);
 	void deleteOutput(Output* output);

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -166,13 +166,14 @@ bool Session::giveClipOpportunityToBeginLinearRecording(Clip* clip, int32_t clip
 			uiNeedsRendering(getCurrentUI());
 		}
 
-		if (clip->overdubNature != OVERDUB_NORMAL && playbackHandler.isEitherClockActive()) {
+		if (clip->overdubNature != OverDubType::Normal && playbackHandler.isEitherClockActive()) {
 			armClipToStopAction(clip);
 
 			// Create new clip if we're continuous-layering
-			if (clip->getCurrentlyRecordingLinearly() && clip->overdubNature == OVERDUB_CONTINUOUS_LAYERING) {
-				currentSong->createPendingNextOverdubBelowClip(clip, clipIndex,
-				                                               OVERDUB_CONTINUOUS_LAYERING); // Make it spawn more too
+			if (clip->getCurrentlyRecordingLinearly() && clip->overdubNature == OverDubType::ContinuousLayering) {
+				currentSong->createPendingNextOverdubBelowClip(
+				    clip, clipIndex,
+				    OverDubType::ContinuousLayering); // Make it spawn more too
 			}
 		}
 	}
@@ -194,10 +195,10 @@ bool Session::giveClipOpportunityToBeginLinearRecording(Clip* clip, int32_t clip
 
 /**
  * doLaunch
- * 
+ *
  * Launches / stops clips at a 'launch event'. This occurs at the end of the current loop in song mode,
  * and additionally to launch fill clips.
- * 
+ *
  * @param isFillLaunch - A non-fill launch acts on the arm states of all clips:
  * 	                        - Regular clips that are:
  * 								- stopping or starting
@@ -211,13 +212,13 @@ bool Session::giveClipOpportunityToBeginLinearRecording(Clip* clip, int32_t clip
  *                       repeat count incread with the select knob, the fill waits until
  *                       the last repeat, whereas doLaunch is called at the end of every
  *                       repeat.
- * 	                    
+ *
  * 	                     A fill launch starts fill clips at the correct time, such
  *                       that they _finish_ at the next launch event. A fill launch
  *                       should leave non-fill clips unaffected. Fills that launch
  *                       may override other fills if they need the same synth/kit/audio
  *                       output, but must not override a non-fill.
- * 
+ *
 */
 void Session::doLaunch(bool isFillLaunch) {
 
@@ -245,7 +246,7 @@ void Session::doLaunch(bool isFillLaunch) {
 		if (isFillLaunch
 		    && (clip->fillEventAtTickCount <= 0
 		        || playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
-			/* This clip needs no action, since it is not a fill clip, 
+			/* This clip needs no action, since it is not a fill clip,
 			   or it is but it's not time to start it, or it's not armed at all. */
 			continue;
 		}
@@ -1694,9 +1695,9 @@ setPosAndStuff:
  *                    usual song mode loop. If there is less time until
  *                    then than the clip is long, start right now mid way
  *                    through. Otherwise schedule for the correct time.
- * 
+ *
  * @param section - the section number to launch fill clips for.
- * 
+ *
 */
 void Session::scheduleFillClip(Clip* clip) {
 
@@ -1761,9 +1762,9 @@ void Session::scheduleFillClip(Clip* clip) {
  * scheduleFillClips - schedules all fill clips in a section. If
  *                     a non-fill clip is already playing on the same output
  *                     that we want to use, we prevent the fill from starting.
- * 
+ *
  * @param section - the section number to launch fill clips for.
- * 
+ *
 */
 void Session::scheduleFillClips(uint8_t section) {
 	for (int32_t c = 0; c < currentSong->sessionClips.getNumElements(); c++) {

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2956,7 +2956,11 @@ doCreateNextOverdub:
 
 					// Or if that Clip was armed to record linearly...
 					else {
-						clipToCreateOverdubFrom->overdubNature = overdubNature;
+						//ensure that audio clips will clone outputs to layer continuously
+						if (overdubNature == OverDubType::ContinuousLayering) {
+							clipToCreateOverdubFrom->overdubsShouldCloneOutput = true;
+						}
+
 						if (!recording) {
 							recording = RECORDING_NORMAL;
 							setLedStates();

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2467,9 +2467,9 @@ bool PlaybackHandler::tryGlobalMIDICommands(MIDIDevice* device, int32_t channel,
 				if (actionLogger.allowedToDoReversion()
 				    || currentUIMode
 				           == UI_MODE_RECORD_COUNT_IN) { // Not quite sure if this describes exactly what we want but it'll do...
-					int32_t overdubNature = (static_cast<GlobalMIDICommand>(c) == GlobalMIDICommand::LOOP)
-					                            ? OVERDUB_NORMAL
-					                            : OVERDUB_CONTINUOUS_LAYERING;
+					OverDubType overdubNature = (static_cast<GlobalMIDICommand>(c) == GlobalMIDICommand::LOOP)
+					                                ? OverDubType::Normal
+					                                : OverDubType::ContinuousLayering;
 					loopCommand(overdubNature);
 				}
 				break;
@@ -2846,8 +2846,7 @@ int32_t PlaybackHandler::getArrangementRecordPosAtLastActionedSwungTick() {
 }
 
 // Warning - this might get called during card routine!
-void PlaybackHandler::loopCommand(int32_t overdubNature) {
-
+void PlaybackHandler::loopCommand(OverDubType overdubNature) {
 	bool anyGotArmedToStop;
 	bool mustEndTempolessRecordingAfter = false;
 
@@ -2883,7 +2882,7 @@ probablyExitRecordMode:
 		mustEndTempolessRecordingAfter = true;
 
 		// And if LAYERING command, make an overdub too
-		if (overdubNature == OVERDUB_CONTINUOUS_LAYERING) {
+		if (overdubNature == OverDubType::ContinuousLayering) {
 			goto doCreateNextOverdub;
 		}
 	}
@@ -2913,7 +2912,7 @@ probablyExitRecordMode:
 		}
 
 		// Or if none were recording, or if it was the LAYERING command, then create a new overdub (potentially in addition to having armed the old one to stop
-		if (!anyGotArmedToStop || overdubNature == OVERDUB_CONTINUOUS_LAYERING) {
+		if (!anyGotArmedToStop || overdubNature == OverDubType::ContinuousLayering) {
 
 doCreateNextOverdub:
 
@@ -2957,7 +2956,7 @@ doCreateNextOverdub:
 
 					// Or if that Clip was armed to record linearly...
 					else {
-
+						clipToCreateOverdubFrom->overdubNature = overdubNature;
 						if (!recording) {
 							recording = RECORDING_NORMAL;
 							setLedStates();
@@ -2983,7 +2982,7 @@ doCreateNextOverdub:
 	}
 
 	if (mustEndTempolessRecordingAfter) {
-		bool shouldExitRecordMode = (overdubNature != OVERDUB_CONTINUOUS_LAYERING);
+		bool shouldExitRecordMode = (overdubNature != OverDubType::ContinuousLayering);
 		finishTempolessRecording(true, kMIDIKeyInputLatency, shouldExitRecordMode);
 	}
 }

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -183,7 +183,7 @@ public:
 	void midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void aftertouchReceived(MIDIDevice* fromDevice, int32_t channel, int32_t value, int32_t noteCode,
 	                        bool* doingMidiThru); // noteCode -1 means channel-wide
-	void loopCommand(int32_t overdubNature);
+	void loopCommand(OverDubType overdubNature);
 	void grabTempoFromClip(Clip* clip);
 	int32_t getTimeLeftInCountIn();
 


### PR DESCRIPTION
Fixes #407

Enable audio output cloning on all continuous layering commands. This fixes a bug where the layer command only worked properly if the clip was magenta

It's still broken on midi clips (as is official), but just punching record in and out does continuous layering for midi anyway. A larger looper overhaul will be done later

Also makes an enum of looper modes to replace the define