### PR TITLE
Bin size/less inlining

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ add_compile_options(
     $<$<CONFIG:DEBUG>:-Og>
     $<$<CONFIG:RELWITHDEBINFO>:-O2>
     $<$<CONFIG:RELEASE>:-O2>
-
+    -fno-inline-functions
     # Link time optimizations
     $<$<CONFIG:RELWITHDEBINFO>:-flto>
     $<$<CONFIG:RELEASE>:-flto>

--- a/src/deluge/dsp/filter/hpladder.cpp
+++ b/src/deluge/dsp/filter/hpladder.cpp
@@ -85,7 +85,7 @@ void HpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
 		currentSample += 1;
 	} while (currentSample < endSample);
 }
-inline q31_t __attribute__((always_inline)) HpLadderFilter::doHPF(q31_t input, HPLadderState& state) {
+[[gcc::always_inline]] inline q31_t HpLadderFilter::doHPF(q31_t input, HPLadderState& state) {
 	//inputs are only 16 bit so this is pretty small
 	//this limit was found experimentally as about the lowest fc can get without sounding broken
 	q31_t constexpr lower_limit = -(ONE_Q31 >> 8);

--- a/src/deluge/dsp/filter/hpladder.cpp
+++ b/src/deluge/dsp/filter/hpladder.cpp
@@ -85,7 +85,7 @@ void HpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
 		currentSample += 1;
 	} while (currentSample < endSample);
 }
-inline q31_t HpLadderFilter::doHPF(q31_t input, HPLadderState& state) {
+inline q31_t __attribute__((always_inline)) HpLadderFilter::doHPF(q31_t input, HPLadderState& state) {
 	//inputs are only 16 bit so this is pretty small
 	//this limit was found experimentally as about the lowest fc can get without sounding broken
 	q31_t constexpr lower_limit = -(ONE_Q31 >> 8);

--- a/src/deluge/dsp/filter/hpladder.h
+++ b/src/deluge/dsp/filter/hpladder.h
@@ -48,7 +48,7 @@ private:
 			hpfHPF3.reset();
 		}
 	};
-	inline q31_t doHPF(q31_t input, HPLadderState& state);
+	inline q31_t __attribute__((always_inline)) doHPF(q31_t input, HPLadderState& state);
 
 	//config
 	uint32_t hpfLastWorkingValue;

--- a/src/deluge/dsp/filter/hpladder.h
+++ b/src/deluge/dsp/filter/hpladder.h
@@ -48,7 +48,7 @@ private:
 			hpfHPF3.reset();
 		}
 	};
-	inline q31_t __attribute__((always_inline)) doHPF(q31_t input, HPLadderState& state);
+	[[gcc::always_inline]] inline q31_t doHPF(q31_t input, HPLadderState& state);
 
 	//config
 	uint32_t hpfLastWorkingValue;

--- a/src/deluge/dsp/filter/ladder_components.h
+++ b/src/deluge/dsp/filter/ladder_components.h
@@ -24,31 +24,26 @@ namespace deluge::dsp::filter {
 class BasicFilterComponent {
 public:
 	//moveability is tan(f)/(1+tan(f))
-	inline q31_t __attribute__((always_inline)) doFilter(q31_t input, q31_t moveability) {
+	[[gcc::always_inline]] inline q31_t doFilter(q31_t input, q31_t moveability) {
 		q31_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
 		q31_t b = a + memory;
 		memory = b + a;
 		return b;
 	}
-
-	inline int32_t __attribute__((always_inline)) doAPF(q31_t input, int32_t moveability) {
+	[[gcc::always_inline]] inline int32_t doAPF(q31_t input, int32_t moveability) {
 		q31_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
 		q31_t b = a + memory;
 		memory = a + b;
 		return b * 2 - input;
 	}
-
-	inline void __attribute__((always_inline)) affectFilter(q31_t input, int32_t moveability) {
+	[[gcc::always_inline]] inline void affectFilter(q31_t input, int32_t moveability) {
 		memory += multiply_32x32_rshift32_rounded(input - memory, moveability) << 2;
 	}
-
-	inline void reset() { memory = 0; }
-
-	inline q31_t __attribute__((always_inline)) getFeedbackOutput(int32_t feedbackAmount) {
+	[[gcc::always_inline]] inline void reset() { memory = 0; }
+	[[gcc::always_inline]] inline q31_t getFeedbackOutput(int32_t feedbackAmount) {
 		return multiply_32x32_rshift32_rounded(memory, feedbackAmount) << 2;
 	}
-
-	inline q31_t __attribute__((always_inline)) getFeedbackOutputWithoutLshift(int32_t feedbackAmount) {
+	[[gcc::always_inline]] inline q31_t getFeedbackOutputWithoutLshift(int32_t feedbackAmount) {
 		return multiply_32x32_rshift32_rounded(memory, feedbackAmount);
 	}
 

--- a/src/deluge/dsp/filter/ladder_components.h
+++ b/src/deluge/dsp/filter/ladder_components.h
@@ -24,31 +24,31 @@ namespace deluge::dsp::filter {
 class BasicFilterComponent {
 public:
 	//moveability is tan(f)/(1+tan(f))
-	inline q31_t doFilter(q31_t input, q31_t moveability) {
+	inline q31_t __attribute__((always_inline)) doFilter(q31_t input, q31_t moveability) {
 		q31_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
 		q31_t b = a + memory;
 		memory = b + a;
 		return b;
 	}
 
-	inline int32_t doAPF(q31_t input, int32_t moveability) {
+	inline int32_t __attribute__((always_inline)) doAPF(q31_t input, int32_t moveability) {
 		q31_t a = multiply_32x32_rshift32_rounded(input - memory, moveability) << 1;
 		q31_t b = a + memory;
 		memory = a + b;
 		return b * 2 - input;
 	}
 
-	inline void affectFilter(q31_t input, int32_t moveability) {
+	inline void __attribute__((always_inline)) affectFilter(q31_t input, int32_t moveability) {
 		memory += multiply_32x32_rshift32_rounded(input - memory, moveability) << 2;
 	}
 
 	inline void reset() { memory = 0; }
 
-	inline q31_t getFeedbackOutput(int32_t feedbackAmount) {
+	inline q31_t __attribute__((always_inline)) getFeedbackOutput(int32_t feedbackAmount) {
 		return multiply_32x32_rshift32_rounded(memory, feedbackAmount) << 2;
 	}
 
-	inline q31_t getFeedbackOutputWithoutLshift(int32_t feedbackAmount) {
+	inline q31_t __attribute__((always_inline)) getFeedbackOutputWithoutLshift(int32_t feedbackAmount) {
 		return multiply_32x32_rshift32_rounded(memory, feedbackAmount);
 	}
 

--- a/src/deluge/dsp/filter/lpladder.cpp
+++ b/src/deluge/dsp/filter/lpladder.cpp
@@ -311,7 +311,7 @@ void LpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
 		}
 	}
 }
-inline q31_t LpLadderFilter::do12dBLPFOnSample(q31_t input, LpLadderState& state) {
+inline q31_t __attribute__((always_inline)) LpLadderFilter::do12dBLPFOnSample(q31_t input, LpLadderState& state) {
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
 	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
 	q31_t distanceToGo = noise - state.noiseLastValue;
@@ -330,7 +330,7 @@ inline q31_t LpLadderFilter::do12dBLPFOnSample(q31_t input, LpLadderState& state
 	return state.lpfLPF3.doAPF(state.lpfLPF2.doFilter(state.lpfLPF1.doFilter(x, noisy_m), noisy_m), noisy_m) << 1;
 }
 
-inline q31_t LpLadderFilter::do24dBLPFOnSample(q31_t input, LpLadderState& state) {
+inline q31_t __attribute__((always_inline)) LpLadderFilter::do24dBLPFOnSample(q31_t input, LpLadderState& state) {
 
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
 	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
@@ -362,7 +362,7 @@ inline q31_t LpLadderFilter::do24dBLPFOnSample(q31_t input, LpLadderState& state
 	       << 1;
 }
 
-inline q31_t LpLadderFilter::doDriveLPFOnSample(q31_t input, LpLadderState& state) {
+inline q31_t __attribute__((always_inline)) LpLadderFilter::doDriveLPFOnSample(q31_t input, LpLadderState& state) {
 
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
 	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;

--- a/src/deluge/dsp/filter/lpladder.cpp
+++ b/src/deluge/dsp/filter/lpladder.cpp
@@ -311,7 +311,7 @@ void LpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
 		}
 	}
 }
-inline q31_t __attribute__((always_inline)) LpLadderFilter::do12dBLPFOnSample(q31_t input, LpLadderState& state) {
+[[gcc::always_inline]] inline q31_t LpLadderFilter::do12dBLPFOnSample(q31_t input, LpLadderState& state) {
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
 	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
 	q31_t distanceToGo = noise - state.noiseLastValue;
@@ -329,8 +329,7 @@ inline q31_t __attribute__((always_inline)) LpLadderFilter::do12dBLPFOnSample(q3
 
 	return state.lpfLPF3.doAPF(state.lpfLPF2.doFilter(state.lpfLPF1.doFilter(x, noisy_m), noisy_m), noisy_m) << 1;
 }
-
-inline q31_t __attribute__((always_inline)) LpLadderFilter::do24dBLPFOnSample(q31_t input, LpLadderState& state) {
+[[gcc::always_inline]] inline q31_t LpLadderFilter::do24dBLPFOnSample(q31_t input, LpLadderState& state) {
 
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
 	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;
@@ -362,7 +361,7 @@ inline q31_t __attribute__((always_inline)) LpLadderFilter::do24dBLPFOnSample(q3
 	       << 1;
 }
 
-inline q31_t __attribute__((always_inline)) LpLadderFilter::doDriveLPFOnSample(q31_t input, LpLadderState& state) {
+[[gcc::always_inline]] inline q31_t LpLadderFilter::doDriveLPFOnSample(q31_t input, LpLadderState& state) {
 
 	// For drive filter, apply some heavily lowpassed noise to the filter frequency, to add analog-ness
 	q31_t noise = getNoise() >> 2; //storageManager.devVarA;// 2;

--- a/src/deluge/dsp/filter/lpladder.h
+++ b/src/deluge/dsp/filter/lpladder.h
@@ -69,9 +69,9 @@ private:
 
 		return temp;
 	}
-	inline q31_t do24dBLPFOnSample(q31_t input, LpLadderState& state);
-	inline q31_t do12dBLPFOnSample(q31_t input, LpLadderState& state);
-	inline q31_t doDriveLPFOnSample(q31_t input, LpLadderState& state);
+	inline q31_t __attribute__((always_inline)) do24dBLPFOnSample(q31_t input, LpLadderState& state);
+	inline q31_t __attribute__((always_inline)) do12dBLPFOnSample(q31_t input, LpLadderState& state);
+	inline q31_t __attribute__((always_inline)) doDriveLPFOnSample(q31_t input, LpLadderState& state);
 	inline void renderLPLadder(q31_t* startSample, q31_t* endSample, FilterMode lpfMode, int32_t sampleIncrement);
 
 	//all ladders are in this class to share the basic components

--- a/src/deluge/dsp/filter/lpladder.h
+++ b/src/deluge/dsp/filter/lpladder.h
@@ -69,9 +69,9 @@ private:
 
 		return temp;
 	}
-	inline q31_t __attribute__((always_inline)) do24dBLPFOnSample(q31_t input, LpLadderState& state);
-	inline q31_t __attribute__((always_inline)) do12dBLPFOnSample(q31_t input, LpLadderState& state);
-	inline q31_t __attribute__((always_inline)) doDriveLPFOnSample(q31_t input, LpLadderState& state);
+	[[gcc::always_inline]] inline q31_t do24dBLPFOnSample(q31_t input, LpLadderState& state);
+	[[gcc::always_inline]] inline q31_t do12dBLPFOnSample(q31_t input, LpLadderState& state);
+	[[gcc::always_inline]] inline q31_t doDriveLPFOnSample(q31_t input, LpLadderState& state);
 	inline void renderLPLadder(q31_t* startSample, q31_t* endSample, FilterMode lpfMode, int32_t sampleIncrement);
 
 	//all ladders are in this class to share the basic components

--- a/src/deluge/dsp/filter/svf.cpp
+++ b/src/deluge/dsp/filter/svf.cpp
@@ -81,7 +81,7 @@ q31_t SVFilter::setConfig(q31_t freq, q31_t res, FilterMode lpfMode, q31_t lpfMo
 	return filterGain;
 }
 
-inline q31_t __attribute__((always_inline)) SVFilter::doSVF(int32_t input, SVFState& state) {
+[[gcc::always_inline]] inline q31_t SVFilter::doSVF(int32_t input, SVFState& state) {
 	q31_t high = 0;
 	q31_t notch = 0;
 	q31_t lowi;

--- a/src/deluge/dsp/filter/svf.cpp
+++ b/src/deluge/dsp/filter/svf.cpp
@@ -81,7 +81,7 @@ q31_t SVFilter::setConfig(q31_t freq, q31_t res, FilterMode lpfMode, q31_t lpfMo
 	return filterGain;
 }
 
-inline q31_t SVFilter::doSVF(int32_t input, SVFState& state) {
+inline q31_t __attribute__((always_inline)) SVFilter::doSVF(int32_t input, SVFState& state) {
 	q31_t high = 0;
 	q31_t notch = 0;
 	q31_t lowi;

--- a/src/deluge/dsp/filter/svf.h
+++ b/src/deluge/dsp/filter/svf.h
@@ -40,7 +40,7 @@ private:
 		q31_t low;
 		q31_t band;
 	};
-	inline q31_t __attribute__((always_inline)) doSVF(q31_t input, SVFState& state);
+	[[gcc::always_inline]] inline q31_t doSVF(q31_t input, SVFState& state);
 	SVFState l;
 	SVFState r;
 

--- a/src/deluge/dsp/filter/svf.h
+++ b/src/deluge/dsp/filter/svf.h
@@ -40,7 +40,7 @@ private:
 		q31_t low;
 		q31_t band;
 	};
-	inline q31_t doSVF(q31_t input, SVFState& state);
+	inline q31_t __attribute__((always_inline)) doSVF(q31_t input, SVFState& state);
 	SVFState l;
 	SVFState r;
 


### PR DESCRIPTION
GCC9 didn't inline by default and it is a major cause of the binary size change

LTO in combination with inlining can lead to massive size gains without an associated performance increase since the inlining thresholds are based on the number of inlinable functions (which is almost all of them with lto)

This disables inlining and then restores some performance by always inlining the filter code. Small functions and functions called once will still be inlined