### PR TITLE
Fixes for SYSEX behavior

### DIFF
--- a/src/deluge/CMakeLists.txt
+++ b/src/deluge/CMakeLists.txt
@@ -32,6 +32,6 @@ if(ENABLE_RTT)
 endif(ENABLE_RTT)
 
 if(ENABLE_SYSEX_LOAD)
-  message(STATUS "Sysex firmware loading enabled for deluge")
-    target_compile_definitions(deluge INTERFACE ENABLE_SYSEX_LOAD=1)
+    message(STATUS "Sysex firmware loading enabled for deluge")
+    target_compile_definitions(deluge PUBLIC ENABLE_SYSEX_LOAD=1)
 endif(ENABLE_SYSEX_LOAD)

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -632,6 +632,10 @@ void KeyboardScreen::focusRegained() {
 	selectLayout(0); // Make sure we get a valid layout from the loaded file
 }
 
+void KeyboardScreen::displayOrLanguageChanged() {
+	InstrumentClipMinder::displayOrLanguageChanged();
+}
+
 void KeyboardScreen::openedInBackground() {
 	getCurrentClip()->onKeyboardScreen = true;
 

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.h
@@ -57,6 +57,7 @@ public:
 private:
 	bool opened();
 	void focusRegained();
+	void displayOrLanguageChanged() final;
 
 	void evaluateActiveNotes();
 	void updateActiveNotes();

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -191,6 +191,10 @@ void SoundEditor::focusRegained() {
 	setLedStates();
 }
 
+void SoundEditor::displayOrLanguageChanged() {
+	getCurrentMenuItem()->readValueAgain();
+}
+
 void SoundEditor::setLedStates() {
 	indicator_leds::setLedState(IndicatorLED::SAVE, false); // In case we came from the save-Instrument UI
 

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -54,6 +54,7 @@ public:
 	SoundEditor();
 	bool opened();
 	void focusRegained();
+	void displayOrLanguageChanged() final;
 	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
 	Sound* currentSound;
 	ModControllableAudio* currentModControllable;

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -102,7 +102,10 @@ public:
 		focusRegained();
 		return true;
 	}
+
 	virtual void focusRegained() {}
+	// the `display` and/or `chosenLanguage` object changed. redraw accordingly.
+	virtual void displayOrLanguageChanged() {}
 	virtual bool canSeeViewUnderneath() { return false; }
 	virtual ClipMinder* toClipMinder() { return NULL; }
 	virtual void scrollFinished() {}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -157,6 +157,10 @@ void InstrumentClipView::focusRegained() {
 	setLedStates();
 }
 
+void InstrumentClipView::displayOrLanguageChanged() {
+	InstrumentClipMinder::displayOrLanguageChanged();
+}
+
 void InstrumentClipView::setLedStates() {
 	indicator_leds::setLedState(IndicatorLED::KEYBOARD, false);
 	InstrumentClipMinder::setLedStates();

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -67,6 +67,7 @@ public:
 	InstrumentClipView();
 	bool opened();
 	void focusRegained();
+	void displayOrLanguageChanged() final;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	uint8_t getEditPadPressXDisplayOnScreen(uint8_t yDisplay);

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -1,4 +1,5 @@
 #include "hid/hid_sysex.h"
+#include "gui/l10n/l10n.h"
 #include "gui/ui_timer_manager.h"
 #include "hid/display/oled.h"
 #include "hid/display/seven_segment.h"
@@ -64,6 +65,7 @@ void HIDSysex::requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int32_t len
 			display = new deluge::hid::display::SevenSegment;
 		}
 		else {
+			deluge::l10n::chosenLanguage = nullptr;
 			display = new deluge::hid::display::OLED;
 		}
 	}

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -1,5 +1,6 @@
 #include "hid/hid_sysex.h"
 #include "gui/l10n/l10n.h"
+#include "gui/ui/ui.h"
 #include "gui/ui_timer_manager.h"
 #include "hid/display/oled.h"
 #include "hid/display/seven_segment.h"
@@ -67,6 +68,11 @@ void HIDSysex::requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int32_t len
 		else {
 			deluge::l10n::chosenLanguage = nullptr;
 			display = new deluge::hid::display::OLED;
+			oledDeltaForce = true;
+		}
+		UI* ui = getCurrentUI();
+		if (ui) {
+			ui->displayOrLanguageChanged();
 		}
 	}
 }

--- a/src/deluge/io/debug/sysex.cpp
+++ b/src/deluge/io/debug/sysex.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "io/debug/sysex.h"
+#include "gui/l10n/l10n.h"
 #include "hid/display/oled.h"
 #include "io/debug/print.h"
 #include "io/midi/midi_device.h"
@@ -157,14 +158,14 @@ void Debug::loadCheckAndRun(uint8_t* data, int32_t len) {
 	}
 
 	if (load_codesize != fields[1]) {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_WRONG_SIZE));
+		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_WRONG_SIZE));
 		return;
 	}
 
 	uint32_t checksum = get_crc(load_buf, load_codesize);
 
 	if (checksum != fields[2]) {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_CHECKSUM_FAIL));
+		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHECKSUM_FAIL));
 		return;
 	}
 

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -273,6 +273,15 @@ gotError:
 	}
 }
 
+void InstrumentClipMinder::displayOrLanguageChanged() {
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+	else {
+		redrawNumericDisplay();
+	}
+}
+
 void InstrumentClipMinder::setLedStates() {
 	indicator_leds::setLedState(IndicatorLED::SYNTH, getCurrentClip()->output->type == InstrumentType::SYNTH);
 	indicator_leds::setLedState(IndicatorLED::KIT, getCurrentClip()->output->type == InstrumentType::KIT);

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -32,6 +32,7 @@ class InstrumentClipMinder : public ClipMinder {
 public:
 	InstrumentClipMinder();
 	static void redrawNumericDisplay();
+	void displayOrLanguageChanged();
 	void createNewInstrument(InstrumentType newInstrumentType);
 	void setLedStates();
 	void focusRegained();


### PR DESCRIPTION
- `ENABLE_SYSEX_LOAD` did not take effect due to wrong cmake target type (no longer an `INTERFACE`)
- language got stuck on `seven_segment` after switching from `seven_segment` to `OLED` display type.