### PR TITLE
Fix compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,10 +207,15 @@ target_compile_options(deluge PUBLIC
 
     $<$<CONFIG:DEBUG>:-Werror=write-strings>
 
+    # Offsetof for non standard types is supported in GCC, 
+    # if another compiler does not support it they are obligated to error
+
     # Stack usage
-    $<$<CONFIG:DEBUG>:-Wstack-usage=100>
-    $<$<CONFIG:RELWITHDEBINFO>:-Wstack-usage=1000>
-    $<$<CONFIG:RELEASE>:-Wstack-usage=1000>
+    # tracked for diagnostic usage. We have a 32k stack so it's not that important
+    # primarily concerned with unbounded stack use
+    $<$<CONFIG:DEBUG>:-Wstack-usage=2000>
+    $<$<CONFIG:RELWITHDEBINFO>:-Wstack-usage=2000>
+    $<$<CONFIG:RELEASE>:-Wstack-usage=2000>
 )
 
 set_target_properties(deluge

--- a/src/deluge/drivers/pic/pic.h
+++ b/src/deluge/drivers/pic/pic.h
@@ -294,8 +294,9 @@ private:
 	 * @brief Send a byte. This was originally bufferPICUart()
 	 */
 	inline static void send(uint8_t msg) {
-		intptr_t writePos = uartItems[UART_ITEM_PIC].txBufferWritePos + UNCACHED_MIRROR_OFFSET;
-		picTxBuffer[writePos] = msg;
+		intptr_t writePos = uartItems[UART_ITEM_PIC].txBufferWritePos;
+		volatile char* uncached_tx_buf = (volatile char*)(picTxBuffer + UNCACHED_MIRROR_OFFSET);
+		uncached_tx_buf[writePos] = msg;
 		uartItems[UART_ITEM_PIC].txBufferWritePos += 1;
 		uartItems[UART_ITEM_PIC].txBufferWritePos &= (PIC_TX_BUFFER_SIZE - 1);
 	}

--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -30,7 +30,7 @@ extern DrumName drumNameMenu;
 extern deluge::gui::menu_item::firmware::Version firmwareVersionMenu;
 extern deluge::gui::menu_item::sequence::Direction sequenceDirectionMenu;
 extern deluge::gui::menu_item::Submenu<6> soundEditorRootMenuMIDIOrCV;
-extern deluge::gui::menu_item::Submenu<10> soundEditorRootMenuAudioClip;
+extern deluge::gui::menu_item::Submenu<11> soundEditorRootMenuAudioClip;
 extern deluge::gui::menu_item::Submenu<25> soundEditorRootMenu;
 extern deluge::gui::menu_item::Submenu<12> settingsRootMenu;
 

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -138,8 +138,8 @@ void HIDSysex::send7SegData(MIDIDevice* device) {
 		auto data = display->getLast();
 		const int32_t packed_data_size = 5;
 		uint8_t reply[11] = {0xf0, 0x7d, 0x02, 0x41, 0x00};
-		pack_8bit_to_7bit(reply + 6, packed_data_size, data.data(), data.size());
-		reply[6 + packed_data_size] = 0xf7; // end of transmission
+		pack_8bit_to_7bit(reply + 5, packed_data_size, data.data(), data.size());
+		reply[5 + packed_data_size] = 0xf7; // end of transmission
 		device->sendSysex(reply, packed_data_size + 7);
 	}
 }

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -104,7 +104,7 @@ void HIDSysex::sendOLEDData(MIDIDevice* device, bool rle) {
 		const int32_t data_size = 768;
 		const int32_t max_packed_size = 922;
 
-		uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, rle ? 0x01 : 0x00};
+		uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, rle ? 0x01_u8 : 0x00_u8};
 		uint8_t* reply = midiEngine.sysex_fmt_buffer;
 		memcpy(reply, reply_hdr, 5);
 		reply[5] = 0; // nominally 32*data[5] is start pos for a delta

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -36,6 +36,9 @@ extern "C" {
 
 extern uint8_t anyUSBSendingStillHappening[];
 }
+#pragma GCC diagnostic push
+//This is supported by GCC and other compilers should error (not warn), so turn off for this file
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
 ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES];
 
@@ -619,3 +622,4 @@ void ConnectedUSBMIDIDevice::setup() {
 
 	}
  */
+#pragma GCC diagnostic pop

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -55,6 +55,10 @@ extern "C" {
 #include "drivers/ssi/ssi.h"
 }
 
+#pragma GCC diagnostic push
+//This is supported by GCC and other compilers should error (not warn), so turn off for this file
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+
 int32_t spareRenderingBuffer[4][SSI_TX_BUFFER_NUM_SAMPLES] __attribute__((aligned(CACHE_LINE_SIZE)));
 
 int32_t oscSyncRenderingBuffer[SSI_TX_BUFFER_NUM_SAMPLES + 4]
@@ -2628,7 +2632,9 @@ void renderPDWave(const int16_t* table, const int16_t* secondTable, int32_t numB
 void getTableNumber(uint32_t phaseIncrementForCalculations, int32_t* tableNumber, int32_t* tableSize) {
 
 	if (phaseIncrementForCalculations <= 1247086) {
-		{ *tableNumber = 0; }
+		{
+			*tableNumber = 0;
+		}
 		*tableSize = 13;
 	}
 	else if (phaseIncrementForCalculations <= 2494173) {
@@ -3228,3 +3234,4 @@ uint32_t Voice::getPriorityRating() {
 	    // Bits  0-23 - time entered
 	    + ((uint32_t)(-envelopes[0].timeEnteredState) & (0xFFFFFFFF >> 8));
 }
+#pragma GCC diagnostic pop

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -2632,9 +2632,7 @@ void renderPDWave(const int16_t* table, const int16_t* secondTable, int32_t numB
 void getTableNumber(uint32_t phaseIncrementForCalculations, int32_t* tableNumber, int32_t* tableSize) {
 
 	if (phaseIncrementForCalculations <= 1247086) {
-		{
-			*tableNumber = 0;
-		}
+		{ *tableNumber = 0; }
 		*tableSize = 13;
 	}
 	else if (phaseIncrementForCalculations <= 2494173) {

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3030,6 +3030,12 @@ void Sound::compensateVolumeForResonance(ModelStackWithThreeMainThings* modelSta
 }
 
 // paramManager only required for old old song files
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+/**
+ * Reads the parameters from the storageManager's current file into paramManager
+ * stack usage would be unbounded if file contained infinite tags
+*/
 int32_t Sound::readSourceFromFile(int32_t s, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos) {
 
 	Source* source = &sources[s];
@@ -3275,6 +3281,7 @@ gotError:
 
 	return NO_ERROR;
 }
+#pragma GCC diagnostic pop
 
 void Sound::writeSourceToFile(int32_t s, char const* tagName) {
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -60,6 +60,9 @@
 extern "C" {
 #include "RZA1/mtu/mtu.h"
 }
+#pragma GCC diagnostic push
+//This is supported by GCC and other compilers should error (not warn), so turn off for this file
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
 const PatchableInfo patchableInfoForSound = {
     (int32_t)(offsetof(Sound, paramFinalValues) - offsetof(Sound, patcher) - (Param::Global::FIRST * sizeof(int32_t))),
@@ -4456,3 +4459,4 @@ for (int32_t v = startV; v < endV; v++) {
 
 for (int32_t s = 0; s < NUM_SOURCES; s++) {
 */
+#pragma GCC diagnostic pop

--- a/src/deluge/storage/audio/audio_file_vector.cpp
+++ b/src/deluge/storage/audio/audio_file_vector.cpp
@@ -19,6 +19,10 @@
 #include "hid/display/display.h"
 #include "storage/audio/audio_file.h"
 
+#pragma GCC diagnostic push
+//This is supported by GCC and other compilers should error (not warn), so turn off for this file
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+
 AudioFileVector::AudioFileVector() : NamedThingVector(__builtin_offsetof(AudioFile, filePath)) {
 }
 
@@ -56,3 +60,4 @@ int32_t AudioFileVector::searchForExactObject(AudioFile* audioFile) {
 gotIt:
 	return i;
 }
+#pragma GCC diagnostic pop

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -88,6 +88,6 @@ int32_t FileItem::getDisplayNameWithoutExtension(String* displayNameWithoutExten
 				}
 			}
 		}
-		return NO_ERROR;
 	}
+	return NO_ERROR;
 }

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -88,6 +88,11 @@ int32_t FileItem::getDisplayNameWithoutExtension(String* displayNameWithoutExten
 				}
 			}
 		}
+		return NO_ERROR;
 	}
-	return NO_ERROR;
+	/*
+Warning - not having a return is functional. Whatever is passing through
+is required to reset the display after auditioning. Further debugging required,
+returning 0, 1, filename.get() or (displayName != filename.get()) all cause bugs
+*/
 }

--- a/src/deluge/storage/multi_range/multi_range_array.cpp
+++ b/src/deluge/storage/multi_range/multi_range_array.cpp
@@ -21,9 +21,14 @@
 #include "storage/multi_range/multisample_range.h"
 #include <new>
 
+#pragma GCC diagnostic push
+//This is supported by GCC and other compilers should error (not warn), so turn off for this
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+
 MultiRangeArray::MultiRangeArray()
     : OrderedResizeableArray(sizeof(MultisampleRange), 16, __builtin_offsetof(MultiRange, topNote), 0, 0) {
 }
+#pragma GCC diagnostic pop
 
 // This function could sorta be done without...
 MultiRange* MultiRangeArray::getElement(int32_t i) {


### PR DESCRIPTION
Fixes compiler warnings

1. Fix an ODR violation in menus - templated extern size didn't match declaration
2. Explicitly mark some ints as U8 in sysex code and fix an off by one error
3. Ignore unbounded stack on readsourcefromfile (it's bounded by number of tags in file, which I don't see as a reasonable attack vector)
4. Restructure send to avoid string pop overflow (caused by usage of large constant offset, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578)
5. Suppress warnings for conditionally supported offsetof. It's supported by GCC and per the standard should generate an error if compiled by a compiler which doesn't support this usage. 

There is one remaining warning for reaching end of non void function (FileItem::getDisplayNameWithoutExtension). Unfortunately we're relying on the UB and I haven't been able to fix it, all options lead to the last pressed note remaining on 7seg indefinitely in init patches. I've left a comment for future fixes