### PR TITLE
Improve synth to kit row performance

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -66,10 +66,12 @@ bool LoadInstrumentPresetUI::opened() {
 	if (getRootUI() == &keyboardScreen) {
 		PadLEDs::skipGreyoutFade();
 	}
+	if (instrumentToReplace) {
+		initialInstrumentType = instrumentToReplace->type;
+		initialName.set(&instrumentToReplace->name);
+		initialDirPath.set(&instrumentToReplace->dirPath);
+	}
 
-	initialInstrumentType = instrumentToReplace->type;
-	initialName.set(&instrumentToReplace->name);
-	initialDirPath.set(&instrumentToReplace->dirPath);
 	if (loadingSynthToKitRow) {
 		instrumentTypeToLoad = InstrumentType::SYNTH;
 		initialDirPath.set("SYNTHS");

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -73,7 +73,8 @@ bool LoadInstrumentPresetUI::opened() {
 	}
 
 	if (loadingSynthToKitRow) {
-		instrumentTypeToLoad = InstrumentType::SYNTH;
+		initialInstrumentType = instrumentTypeToLoad = InstrumentType::SYNTH;
+		initialName.set(&soundDrumToReplace->name);
 		initialDirPath.set("SYNTHS");
 	}
 
@@ -972,6 +973,9 @@ int32_t LoadInstrumentPresetUI::performLoadSynthToKit() {
 
 	int32_t error = storageManager.loadSynthToDrum(currentSong, instrumentClipToLoadFor, false, &soundDrumToReplace,
 	                                               &currentFileItem->filePointer, &enteredText, &currentDir);
+	if (error) {
+		return error;
+	}
 	//kitToLoadFor->addDrum(soundDrumToReplace);
 	display->displayLoadingAnimationText("Loading", false, true);
 	soundDrumToReplace->loadAllAudioFiles(true);
@@ -983,9 +987,9 @@ int32_t LoadInstrumentPresetUI::performLoadSynthToKit() {
 	    currentSong->getBackedUpParamManagerPreferablyWithClip(soundDrumToReplace, instrumentClipToLoadFor);
 	if (paramManager) {
 		kitToLoadFor->addDrum(soundDrumToReplace);
-		noteRow->setDrum(soundDrumToReplace, kitToLoadFor, modelStackWithNoteRow, instrumentClipToLoadFor,
-		                 paramManager);
-		kitToLoadFor->setupPatching(modelStack);
+		//don't back up the param manager since we can't use the backup anyway
+		noteRow->setDrum(soundDrumToReplace, kitToLoadFor, modelStackWithNoteRow, instrumentClipToLoadFor, paramManager,
+		                 false);
 		kitToLoadFor->beenEdited();
 	}
 	else {

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -101,7 +101,7 @@ static EmptySpaceRecord* recordToMergeWith;
 // spaceSize can even be 0 or less if you know it's going to get merged.
 inline void MemoryRegion::markSpaceAsEmpty(uint32_t address, uint32_t spaceSize, bool mayLookLeft, bool mayLookRight) {
 	if ((address <= start) || address >= end) {
-		//display->freezeWithError("M998");
+		display->freezeWithError("M998");
 		return;
 	}
 	int32_t biggerRecordSearchFromIndex = 0;
@@ -373,6 +373,12 @@ noEmptySpace:
 	numAllocations++;
 #endif
 
+#if ALPHA_OR_BETA_VERSION
+	if (allocatedAddress < start || allocatedAddress > end) {
+		//trying to allocate outside our region
+		display->freezeWithError("M002");
+	}
+#endif
 	return (void*)allocatedAddress;
 }
 
@@ -759,7 +765,12 @@ void MemoryRegion::dealloc(void* address) {
 	uint32_t spaceSize = (*header & SPACE_SIZE_MASK);
 
 #if ALPHA_OR_BETA_VERSION
+	if ((uint32_t)address < start || (uint32_t)address > end) {
+		//deallocating outside our region
+		display->freezeWithError("M001");
+	}
 	if ((*header & SPACE_TYPE_MASK) == SPACE_HEADER_EMPTY) {
+		//double free
 		display->freezeWithError("M000");
 	}
 #endif

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -152,13 +152,9 @@ public:
 		return timelineCounter;
 	}
 
-	inline TimelineCounter* getTimelineCounterAllowNull() const {
-		return timelineCounter;
-	}
+	inline TimelineCounter* getTimelineCounterAllowNull() const { return timelineCounter; }
 
-	inline void setTimelineCounter(TimelineCounter* newTimelineCounter) {
-		timelineCounter = newTimelineCounter;
-	}
+	inline void setTimelineCounter(TimelineCounter* newTimelineCounter) { timelineCounter = newTimelineCounter; }
 
 protected:
 	TimelineCounter* timelineCounter; // Allowed to be NULL
@@ -205,13 +201,9 @@ public:
 		return noteRow;
 	}
 
-	inline NoteRow* getNoteRowAllowNull() const {
-		return noteRow;
-	}
+	inline NoteRow* getNoteRowAllowNull() const { return noteRow; }
 
-	inline void setNoteRow(NoteRow* newNoteRow) {
-		noteRow = newNoteRow;
-	}
+	inline void setNoteRow(NoteRow* newNoteRow) { noteRow = newNoteRow; }
 
 	ModelStackWithThreeMainThings* addOtherTwoThings(ModControllable* newModControllable,
 	                                                 ParamManager* newParamManager) const;
@@ -382,6 +374,9 @@ ModelStackWithNoteRow::addModControllable(ModControllable* newModControllable) c
 	return toReturn;
 }
 
+/**
+ * adds a modcontrollable and a param manager
+*/
 inline ModelStackWithThreeMainThings* ModelStackWithNoteRow::addOtherTwoThings(ModControllable* newModControllable,
                                                                                ParamManager* newParamManager) const {
 	ModelStackWithThreeMainThings* toReturn = (ModelStackWithThreeMainThings*)this;

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -152,9 +152,13 @@ public:
 		return timelineCounter;
 	}
 
-	inline TimelineCounter* getTimelineCounterAllowNull() const { return timelineCounter; }
+	inline TimelineCounter* getTimelineCounterAllowNull() const {
+		return timelineCounter;
+	}
 
-	inline void setTimelineCounter(TimelineCounter* newTimelineCounter) { timelineCounter = newTimelineCounter; }
+	inline void setTimelineCounter(TimelineCounter* newTimelineCounter) {
+		timelineCounter = newTimelineCounter;
+	}
 
 protected:
 	TimelineCounter* timelineCounter; // Allowed to be NULL
@@ -201,9 +205,13 @@ public:
 		return noteRow;
 	}
 
-	inline NoteRow* getNoteRowAllowNull() const { return noteRow; }
+	inline NoteRow* getNoteRowAllowNull() const {
+		return noteRow;
+	}
 
-	inline void setNoteRow(NoteRow* newNoteRow) { noteRow = newNoteRow; }
+	inline void setNoteRow(NoteRow* newNoteRow) {
+		noteRow = newNoteRow;
+	}
 
 	ModelStackWithThreeMainThings* addOtherTwoThings(ModControllable* newModControllable,
 	                                                 ParamManager* newParamManager) const;

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3150,9 +3150,10 @@ void NoteRow::setDrumToNull(ModelStackWithTimelineCounter const* modelStack) {
 // song not required if setting to NULL
 // Can handle NULL newParamManager.
 void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack,
-                      InstrumentClip* favourClipForCloningParamManager, ParamManager* newParamManager) {
+                      InstrumentClip* favourClipForCloningParamManager, ParamManager* newParamManager,
+                      bool backupOldParamManager) {
 
-	if (paramManager.containsAnyMainParamCollections()) {
+	if (backupOldParamManager && paramManager.containsAnyMainParamCollections()) {
 		modelStack->song->backUpParamManager(
 		    (SoundDrum*)drum, (Clip*)modelStack->getTimelineCounter(), &paramManager,
 		    false); // Don't steal expression params - we'll keep them here with this NoteRow.
@@ -3164,8 +3165,7 @@ void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack
 	    newDrum; // Better set this temporarily for this call. See comment above for why we can't set it permanently yet
 
 	if (newParamManager) {
-		paramManager.stealParamCollectionsFrom(
-		    newParamManager); // Don't bother stealing expression/MPE params - newParamManager is actually literally brand new in the one case that it gets supplied.
+		paramManager.stealParamCollectionsFrom(newParamManager, true);
 		if (paramManager.containsAnyParamCollectionsIncludingExpression()) {
 			trimParamManager(modelStack);
 		}

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -87,7 +87,8 @@ public:
 	void readFromFlash(InstrumentClip* parentClip);
 	uint32_t getNumNotes();
 	void setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack,
-	             InstrumentClip* favourClipForCloningParamManager = NULL, ParamManager* paramManager = NULL);
+	             InstrumentClip* favourClipForCloningParamManager = NULL, ParamManager* paramManager = NULL,
+	             bool backupOldParamManager = true);
 
 	int32_t getDistanceToNextNote(int32_t pos, ModelStackWithNoteRow const* modelStack, bool reversed = false);
 

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1468,6 +1468,9 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
                                         String* dirPath) {
 	InstrumentType instrumentType = InstrumentType::SYNTH;
 	SoundDrum* newDrum = (SoundDrum*)createNewDrum(DrumType::SOUND);
+	if (!newDrum) {
+		return ERROR_INSUFFICIENT_RAM;
+	}
 
 	AudioEngine::logAction("loadSynthDrumFromFile");
 

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -17,6 +17,7 @@
 
 #include "util/d_string.h"
 #include "definitions_cxx.hpp"
+#include "hid/display/display.h"
 #include "memory/general_memory_allocator.h"
 #include "util/functions.h"
 #include <string.h>
@@ -133,6 +134,13 @@ doCopy:
 void String::set(String* otherString) {
 	clear();
 	stringMemory = otherString->stringMemory;
+
+#if ALPHA_OR_BETA_VERSION
+	if (stringMemory && !GeneralMemoryAllocator::get().getAllocatedSize(stringMemory)) {
+		//string set to non allocated address
+		display->freezeWithError("S001");
+	}
+#endif
 	beenCloned();
 }
 

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -132,15 +132,24 @@ doCopy:
 
 // This one can't fail!
 void String::set(String* otherString) {
-	clear();
-	stringMemory = otherString->stringMemory;
-
+	char* sm = otherString->stringMemory;
 #if ALPHA_OR_BETA_VERSION
-	if (stringMemory && !GeneralMemoryAllocator::get().getAllocatedSize(stringMemory)) {
-		//string set to non allocated address
-		display->freezeWithError("S001");
+	//if the other string has memory and it's not in the non audio region
+	if (sm) {
+		if (!(EXTERNAL_MEMORY_END - RESERVED_NONAUDIO_ALLOCATOR < (uint32_t)sm && (uint32_t)sm < EXTERNAL_MEMORY_END)) {
+			display->freezeWithError("S001");
+			return;
+		}
+		//or if it doesn't have an allocation
+		else if (!GeneralMemoryAllocator::get().getAllocatedSize(sm)) {
+			display->freezeWithError("S002");
+			return;
+		}
 	}
 #endif
+	clear();
+	stringMemory = sm;
+
 	beenCloned();
 }
 


### PR DESCRIPTION
Fixes a null pointer dereference in load_instrument_preset_ui

Adds more safety checks in d_string and memory_region (only for alpha/beta) 

Reduces memory usage for the load synth preset to kit row function