### PR TITLE
Automatically cherry pick PRs tagged as release-1.0 into release/1.0

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -1,0 +1,26 @@
+name: Cherry pick
+
+on:
+  pull_request_target:
+    branches:
+      - community
+    types: ["closed"]
+
+jobs:
+  cherry_pick_release_v1_0:
+    runs-on: ubuntu-latest
+    name: Cherry pick into release-v1.0
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-1.0') && github.event.pull_request.merged == true }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into release/1.0
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        with:
+          branch: release/1.0
+          labels: |
+            cherry-pick
+          reviewers: |
+            m-m-adams

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -6,6 +6,12 @@ on:
       - community
     types: ["closed"]
 
+permissions:
+  issues: read
+  pull-requests: write
+  contents: write
+
+
 jobs:
   cherry_pick_release_v1_0:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Uses a github action to cherry pick closed PRs labelled as release/1.0 on community and open PRs against release/1.0 branch