### PR TITLE
Bugfixes - mpe channel handling and mono expression downgrading (#512)

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -15,7 +15,9 @@ Here is a list of general improvements that have been made, ordered from newest 
 - ([#17]) Increase the resolution of "patch cables" between mod sources and destinations.
 
 #### 3.2 - MPE
-- ([#29]) Bugfix to respect MPE zones in kit rows. In the official firmware kit rows with midi learned to a channel would be triggered by an MPE zone which uses that channel. With this change they respect zones in the same way as synth and midi clips.
+- ([#29]) Bugfix to respect MPE zones in kit rows. In the official firmware kit rows with midi learned to a channel would be triggered by an MPE zone which uses that channel. With this change they respect zones in the same way as synth and midi clips. ([#512]) adds further fixes related to channels 0 and 15 always getting received as MPE.
+
+-([#512]) Change handling of MPE expression when collapsed to a single midi channel. Previously y axis would still be sent as CC74 on single midi channels. This changes it to send CC1 instead, allowing for controllable behaviour on more non-MPE synths. Future work will make a menu to set this per device. 
 
 #### 3.3 - MIDI
 - ([#47]) Extra MIDI ports on the USB interface for MPE. Port 2 shows in the midi device menu, and improves the usability of MPE-capable devices through the USB interface by allowing MPE zones to be sent to port 2 and non-MPE to be sent to port 1 (or vice versa). A third port is added for future use such as a desktop/mobile companion app, DAW control or Mackie HUI emulation.
@@ -27,6 +29,14 @@ Here is a list of general improvements that have been made, ordered from newest 
 #### 3.5 - Kits
 
 - ([#395]) Load synth presets into kit rows by holding the audition pad and pressing synth. Saving kit rows to synth presets is not yet implemented.
+
+#### 3.6 - Global Interface
+
+- ([#118]) Sticky Shift - When enabled, tapping shift will lock shift on unless another button is also pressed during the short press duration.
+- ([#118]) Shift LED feedback can now be toggled manually.
+
+#### 3.7 - Mod Wheel
+- ([#512]) Incoming mod wheel on non-MPE synths now maps to y axis
 
 ## 4. New Features Added
 
@@ -381,5 +391,5 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#363]: https://github.com/SynthstromAudible/DelugeFirmware/pull/363
 [#368]: https://github.com/SynthstromAudible/DelugeFirmware/pull/368
 [#395]: https://github.com/SynthstromAudible/DelugeFirmware/pull/395
-
+[#512]: https://github.com/SynthstromAudible/DelugeFirmware/pull/512
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -224,6 +224,16 @@ int32_t MIDIPort::channelToZone(int32_t inputChannel) {
 	return inputChannel;
 }
 
+bool MIDIPort::isMasterChannel(int32_t inputChannel) {
+	if (mpeLowerZoneLastMemberChannel && inputChannel == 0) {
+		return true;
+	}
+	if (mpeUpperZoneLastMemberChannel < 15 && inputChannel == 15) {
+		return true;
+	}
+	return false;
+}
+
 void MIDIPort::moveUpperZoneOutOfWayOfLowerZone() {
 	if (mpeLowerZoneLastMemberChannel >= 14) {
 		mpeUpperZoneLastMemberChannel = 15;

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -48,7 +48,7 @@ public:
 	void readFromFile(MIDIDevice* deviceToSendMCMsOn);
 	void moveUpperZoneOutOfWayOfLowerZone();
 	void moveLowerZoneOutOfWayOfUpperZone();
-
+	bool isMasterChannel(int32_t inputChannel);
 	inline bool isChannelPartOfAnMPEZone(int32_t channel) {
 		return (channel >= 1 && channel <= 14
 		        && (mpeLowerZoneLastMemberChannel >= channel || mpeUpperZoneLastMemberChannel <= channel));

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -979,6 +979,10 @@ void MidiEngine::midiMessageReceived(MIDIDevice* fromDevice, uint8_t statusType,
 						fromDevice->dataEntryMessageReceived(modelStack, channel, data2);
 						break;
 					}
+					default: { //not an rpn - let's reset the msb/lsb
+						fromDevice->inputChannels[channel].rpnLSB = 0x7F;
+						fromDevice->inputChannels[channel].rpnMSB = 0x7F;
+					}
 					}
 
 					playbackHandler.midiCCReceived(fromDevice, channel, data1, data2, &shouldDoMidiThruNow);

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -107,13 +107,18 @@ void MelodicInstrument::offerReceivedNote(ModelStackWithTimelineCounter* modelSt
 		return;
 	}
 
+	int32_t corz = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(midiChannel);
+
 	int16_t const* mpeValues = zeroMPEValues;
 	int16_t const* mpeValuesOrNull = NULL;
+	if (corz >= MIDI_CHANNEL_MPE_LOWER_ZONE) {
+		mpeValues = mpeValuesOrNull = fromDevice->defaultInputMPEValuesPerMIDIChannel[midiChannel];
+	}
 
 	// -1 means no change
 	int32_t highlightNoteValue = -1;
 
-	if (midiInput.channelOrZone == midiChannel) {
+	if (midiInput.channelOrZone == corz) {
 yupItsForUs:
 		InstrumentClip* instrumentClip = (InstrumentClip*)activeClip;
 
@@ -279,20 +284,6 @@ justAuditionNote:
 			                      note, velocity);
 		}
 	}
-	//Handles MPE inputs for melodic instruments - duplicate of MPE check in playback
-	//handler, however playback handler does not pass on MPE info
-	else if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_LOWER_ZONE) {
-		if (midiChannel <= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel) {
-gotMPEInput:
-			mpeValues = mpeValuesOrNull = fromDevice->defaultInputMPEValuesPerMIDIChannel[midiChannel];
-			goto yupItsForUs;
-		}
-	}
-	else if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_UPPER_ZONE) {
-		if (midiChannel >= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel) {
-			goto gotMPEInput;
-		}
-	}
 
 	// In case Norns layout is active show
 	InstrumentClip* instrumentClip = (InstrumentClip*)activeClip;
@@ -329,27 +320,19 @@ forMasterChannel:
 			int32_t newValue = (int32_t)(((uint32_t)data1 | ((uint32_t)data2 << 7)) - 8192) << 18; // Was 16... why?
 			processParamFromInputMIDIChannel(CC_NUMBER_PITCH_BEND, newValue, modelStackWithTimelineCounter);
 		}
-
-		else if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_LOWER_ZONE) {
-			if (channel <= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel) {
-				if (channel == 0) {
+		else {
+			uint8_t corz = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
+			if (midiInput.channelOrZone == corz) {
+				bool master = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isMasterChannel(channel);
+				if (master) {
 					goto forMasterChannel;
 				}
-mpeX:
 				int16_t value16 = (((uint32_t)data1 | ((uint32_t)data2 << 7)) - 8192) << 2;
 				int32_t value32 =
 				    (int32_t)value16
 				    << 16; // Unlike for whole-Instrument pitch bend, this per-note kind is a modulation *source*, not the "preset" value for the parameter!
 				polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, value32, 0, channel,
 				                                          MIDICharacteristic::CHANNEL);
-			}
-		}
-		else if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_UPPER_ZONE) {
-			if (channel >= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel) {
-				if (channel == 15) {
-					goto forMasterChannel;
-				}
-				goto mpeX;
 			}
 		}
 	}
@@ -362,6 +345,11 @@ void MelodicInstrument::offerReceivedCC(ModelStackWithTimelineCounter* modelStac
 	if (midiInput.equalsDevice(fromDevice)) {
 
 		if (midiInput.channelOrZone == channel) {
+			//map non MPE mod wheel to y expression
+			if (ccNumber == 1) {
+				int32_t value32 = (value - 64) << 25;
+				processParamFromInputMIDIChannel(74, value32, modelStackWithTimelineCounter);
+			}
 forMasterChannel:
 			// If it's a MIDI Clip...
 			if (type == InstrumentType::MIDI_OUT) {
@@ -374,9 +362,11 @@ forMasterChannel:
 			// Still send the cc even if the Output is muted. MidiInstruments will check for and block this themselves
 			ccReceivedFromInputMIDIChannel(ccNumber, value, modelStackWithTimelineCounter);
 		}
-		else if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_LOWER_ZONE) {
-			if (channel <= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel) {
-				if (channel == 0) {
+		else {
+			uint8_t corz = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
+			if (midiInput.channelOrZone == corz) {
+				bool master = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isMasterChannel(channel);
+				if (master) {
 mpeMasterChannel:
 					if (ccNumber == 74) {
 						int32_t value32 = (value - 64) << 25;
@@ -390,14 +380,6 @@ mpeY:
 					polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, value32, 1, channel,
 					                                          MIDICharacteristic::CHANNEL);
 				}
-			}
-		}
-		else if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_UPPER_ZONE) {
-			if (channel >= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel) {
-				if (channel == 15) {
-					goto mpeMasterChannel;
-				}
-				goto mpeY;
 			}
 		}
 	}
@@ -444,23 +426,14 @@ forMasterChannel:
 			// Only if a "channel pressure" message (which with MPE of course refers to ideally just one key).
 			// Non-MPE "polyphonic key pressure" messages are not allowed in MPE currently.
 			if (noteCode == -1) {
-				if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_LOWER_ZONE) {
-					if (channel <= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel) {
-						if (channel == 0) {
-							goto forMasterChannel;
-						}
-processPolyphonicZ:
-						polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, valueBig, 2, channel,
-						                                          MIDICharacteristic::CHANNEL);
+				uint8_t corz = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
+				if (midiInput.channelOrZone == corz) {
+					bool master = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isMasterChannel(channel);
+					if (master) {
+						goto forMasterChannel;
 					}
-				}
-				else if (midiInput.channelOrZone == MIDI_CHANNEL_MPE_UPPER_ZONE) {
-					if (channel >= fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel) {
-						if (channel == 15) {
-							goto forMasterChannel;
-						}
-						goto processPolyphonicZ;
-					}
+					polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, valueBig, 2, channel,
+					                                          MIDICharacteristic::CHANNEL);
 				}
 			}
 		}

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -226,7 +226,8 @@ void MIDIInstrument::monophonicExpressionEvent(int32_t newValue, int32_t whichEx
 	}
 
 	case 1:
-		midiEngine.sendCC(masterChannel, 74, (newValue >> 25) + 64, channel);
+		//send CC1 for monophonic expression - monophonic synths won't do anything useful with CC74
+		midiEngine.sendCC(masterChannel, 1, (newValue >> 25) + 64, channel);
 		break;
 
 	case 2:


### PR DESCRIPTION
* use port method to test MPE zone (#507)

* set rpn msb&lsb to 0 if non nrpn received

* properly unset rpn

* comment with reasoning

* prevent all channel 0 and 15 CCs from going to MPE zones

* cherry pick action

* fix mpe zone check in melodic instrument

* specify permissions

* fix zone check in pitch bend

* fix zone check on aftertouch

* update community features

* fix links