### PR TITLE
Randomization & Randomization Variants

### DIFF
--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -21,6 +21,7 @@
 
 #include "decimal.h"
 #include "gui/ui/sound_editor.h"
+#include "hid/buttons.h"
 #include "hid/display/numeric_driver.h"
 #include "hid/display/oled.h"
 #include "hid/led/indicator_leds.h"
@@ -56,6 +57,20 @@ void Decimal::drawValue() {
 #else
 	drawActualValue();
 #endif
+}
+
+void Decimal::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
+	if (b == hid::button::Y_ENC) {
+		numericDriver.displayPopup("Soon");
+		if (on && false) {
+			int32_t maxValue = getMaxValue() > 100 ? 100 : getMaxValue();
+			int32_t newValue = rand() * (maxValue - getMinValue() + 1) + getMinValue();
+			int32_t derivedOffset = newValue - this->getValue();
+			this->setValue(newValue);
+			scrollToGoodPos();
+			Number::selectEncoderAction(derivedOffset);
+		}
+	}
 }
 
 void Decimal::selectEncoderAction(int32_t offset) {

--- a/src/deluge/gui/menu_item/decimal.h
+++ b/src/deluge/gui/menu_item/decimal.h
@@ -28,6 +28,7 @@ public:
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override;
 	void selectEncoderAction(int32_t offset) final;
 	void horizontalEncoderAction(int32_t offset) override;
+	void buttonAction(hid::Button b, bool on, bool inCardRoutine) override;
 
 protected:
 	virtual void drawValue();

--- a/src/deluge/gui/menu_item/enumeration.h
+++ b/src/deluge/gui/menu_item/enumeration.h
@@ -21,6 +21,7 @@ public:
 	using Value::Value;
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
 	void selectEncoderAction(int32_t offset) override;
+	void buttonAction(hid::Button b, bool on, bool inCardRoutine) override;
 
 	virtual size_t size() { return n; };
 
@@ -41,6 +42,18 @@ void Enumeration<n>::beginSession(MenuItem* navigatedBackwardFrom) {
 #else
 	drawValue();
 #endif
+}
+
+template <size_t n>
+void Enumeration<n>::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
+	if (b == hid::button::Y_ENC) {
+		if (on) {
+			int32_t numOptions = size();
+			int32_t randomOption = (random() % numOptions - 1);
+			int32_t derivedOffset = randomOption - this->getValue();
+			selectEncoderAction(derivedOffset);
+		}
+	}
 }
 
 template <size_t n>

--- a/src/deluge/gui/menu_item/integer.cpp
+++ b/src/deluge/gui/menu_item/integer.cpp
@@ -18,6 +18,7 @@
 #include "integer.h"
 #include "gui/ui/sound_editor.h"
 #include "hid/display/numeric_driver.h"
+#include "hid/buttons.h"
 #include <cstring>
 
 #if HAVE_OLED
@@ -29,6 +30,28 @@ extern "C" {
 }
 
 namespace deluge::gui::menu_item {
+
+void Integer::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
+	if (b == hid::button::Y_ENC) {
+		if (on) {
+			int32_t newValue = rand() % (getMaxValue() - getMinValue() + 1) + getMinValue();
+			int32_t derivedOffset = newValue - this->getValue();
+			this->setValue(newValue);
+			Number::selectEncoderAction(derivedOffset);
+		}
+	}
+
+	// handle revert to value when beginSession was called NON-WORKING {
+	if (b == hid::button::X_ENC) {
+		if (on) {
+			int32_t derivedOffset = this->getOriginalValue() - this->getValue();
+			this->resetToOriginalValue();
+			Number::selectEncoderAction(derivedOffset);
+		}
+	}
+	// }
+
+}
 
 void Integer::selectEncoderAction(int32_t offset) {
 	this->setValue(this->getValue() + offset);

--- a/src/deluge/gui/menu_item/integer.h
+++ b/src/deluge/gui/menu_item/integer.h
@@ -25,6 +25,7 @@ class Integer : public Number {
 public:
 	using Number::Number;
 	void selectEncoderAction(int32_t offset) override;
+	void buttonAction(hid::Button b, bool on, bool inCardRoutine) override;
 
 protected:
 #if HAVE_OLED

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -20,6 +20,7 @@
 #include "definitions_cxx.hpp"
 #include "util/container/static_vector.hpp"
 #include "util/sized.h"
+#include "hid/buttons.h"
 
 #include <cstdint>
 
@@ -58,6 +59,7 @@ public:
 
 	virtual void horizontalEncoderAction(int32_t offset) {}
 	virtual void selectEncoderAction(int32_t offset) {}
+	virtual void buttonAction(hid::Button b, bool on, bool inCardRoutine) {}
 	virtual void beginSession(MenuItem* navigatedBackwardFrom = nullptr){};
 	virtual bool isRelevant(Sound* sound, int32_t whichThing) { return true; }
 	virtual MenuItem* selectButtonPress() { return nullptr; }

--- a/src/deluge/gui/menu_item/value.h
+++ b/src/deluge/gui/menu_item/value.h
@@ -40,6 +40,7 @@ public:
 	}
 
 	T getValue() { return value_; }
+	T getOriginalValue() { return originalValue_;}
 
 	template <util::enumeration E>
 	E getValue() {
@@ -55,10 +56,23 @@ protected:
 
 private:
 	T value_;
+	T originalValue_;
 };
 
 template <typename T>
 void Value<T>::beginSession(MenuItem* navigatedBackwardFrom) {
+#if HAVE_OLED
+	readCurrentValue();
+#else
+	readValueAgain();
+#endif
+	originalValue_ = value_;
+
+}
+
+template <typename T>
+void Value<T>::resetToOriginalValue() {
+	setValue(originalValue_);
 #if HAVE_OLED
 	readCurrentValue();
 #else

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1474,49 +1474,9 @@ ActionResult Browser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 		}
 	} else if (b == X_ENC) {
 		if (on && currentUIMode == UI_MODE_NONE) {
-			fileIndexSelected = floor((random() * fileItems.getNumElements()) - 1);
-
-
-	if (scrollPosVertical > fileIndexSelected) {
-		scrollPosVertical = fileIndexSelected;
-	}
-	else if (scrollPosVertical < fileIndexSelected - NUM_FILES_ON_SCREEN + 1) {
-		scrollPosVertical = fileIndexSelected - NUM_FILES_ON_SCREEN + 1;
-	}
-
-	enteredTextEditPos = 0;
-#if HAVE_OLED
-	scrollPosHorizontal = 0;
-#else
-	char const* oldCharAddress = enteredText.get();
-	char const* newCharAddress = getCurrentFileItem()->displayName; // Will have file extension, so beware...
-	while (true) {
-		char oldChar = *oldCharAddress;
-		char newChar = *newCharAddress;
-
-		if (oldChar >= 'A' && oldChar <= 'Z') {
-			oldChar += 32;
-		}
-		if (newChar >= 'A' && newChar <= 'Z') {
-			newChar += 32;
-		}
-
-		if (oldChar != newChar) {
-			break;
-		}
-		oldCharAddress++;
-		newCharAddress++;
-		enteredTextEditPos++;
-	}
-#endif
-
-	error = setEnteredTextFromCurrentFilename();
-	if (error) {
-		numericDriver.displayError(error);
-		return;
-	}
-			displayText();
-			currentFileChanged(0);
+			int32_t nextIndexSelected = floor((random() * fileItems.getNumElements()) - 1);
+			int32_t offset = nextIndexSelected - fileIndexSelected;
+			selectEncoderAction(offset);
 		}
 	} else {
 		return ActionResult::NOT_DEALT_WITH;

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1472,13 +1472,59 @@ ActionResult Browser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 		if (on && !currentUIMode) {
 			return backButtonAction();
 		}
+	} else if (b == X_ENC) {
+		if (on && currentUIMode == UI_MODE_NONE) {
+			fileIndexSelected = floor((random() * fileItems.getNumElements()) - 1);
+
+
+	if (scrollPosVertical > fileIndexSelected) {
+		scrollPosVertical = fileIndexSelected;
 	}
-	else {
+	else if (scrollPosVertical < fileIndexSelected - NUM_FILES_ON_SCREEN + 1) {
+		scrollPosVertical = fileIndexSelected - NUM_FILES_ON_SCREEN + 1;
+	}
+
+	enteredTextEditPos = 0;
+#if HAVE_OLED
+	scrollPosHorizontal = 0;
+#else
+	char const* oldCharAddress = enteredText.get();
+	char const* newCharAddress = getCurrentFileItem()->displayName; // Will have file extension, so beware...
+	while (true) {
+		char oldChar = *oldCharAddress;
+		char newChar = *newCharAddress;
+
+		if (oldChar >= 'A' && oldChar <= 'Z') {
+			oldChar += 32;
+		}
+		if (newChar >= 'A' && newChar <= 'Z') {
+			newChar += 32;
+		}
+
+		if (oldChar != newChar) {
+			break;
+		}
+		oldCharAddress++;
+		newCharAddress++;
+		enteredTextEditPos++;
+	}
+#endif
+
+	error = setEnteredTextFromCurrentFilename();
+	if (error) {
+		numericDriver.displayError(error);
+		return;
+	}
+			displayText();
+			currentFileChanged(0);
+		}
+	} else {
 		return ActionResult::NOT_DEALT_WITH;
 	}
 
 	return ActionResult::DEALT_WITH;
 }
+
 
 ActionResult Browser::mainButtonAction(bool on) {
 	// Press down

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1474,7 +1474,7 @@ ActionResult Browser::buttonAction(hid::Button b, bool on, bool inCardRoutine) {
 		}
 	} else if (b == X_ENC) {
 		if (on && currentUIMode == UI_MODE_NONE) {
-			int32_t nextIndexSelected = floor((random() * fileItems.getNumElements()) - 1);
+			int32_t nextIndexSelected = random() % (fileItems.getNumElements() - 1);
 			int32_t offset = nextIndexSelected - fileIndexSelected;
 			selectEncoderAction(offset);
 		}

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -95,6 +95,7 @@ public:
 	static CStringArray fileItems;
 	static int32_t numFileItemsDeletedAtStart;
 	static int32_t numFileItemsDeletedAtEnd;
+	static int32_t validFileItemsCount;
 	static char const* firstFileItemRemaining;
 	static char const* lastFileItemRemaining;
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -367,7 +367,19 @@ ActionResult SoundEditor::buttonAction(hid::Button b, bool on, bool inCardRoutin
 			indicator_leds::setLedState(IndicatorLED::KEYBOARD, getRootUI() == &keyboardScreen);
 		}
 	}
-
+	else if (b == Y_ENC) {
+			if (inCardRoutine) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			}
+			numericDriver.displayPopup(HAVE_OLED ? "Randomizing" : "RND");
+			getCurrentMenuItem()->buttonAction(b, on, inCardRoutine);
+	} else if (b == X_ENC) {
+			if (inCardRoutine) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			}
+			numericDriver.displayPopup(HAVE_OLED ? "Original Value" : "RND");
+			getCurrentMenuItem()->buttonAction(b, on, inCardRoutine);
+	}
 	else {
 		return ActionResult::NOT_DEALT_WITH;
 	}


### PR DESCRIPTION
This PR introduces randomization for several experiences in the Deluge.

- Synth Browser: Press `Y_ENC`, you'll jump a random number of spots ahead. This breaks up the monotony of hearing the same sequence of presets over and over again. I only get to around 40% of my library of presets because of this.
- Any integer control: e.g. Saturation, Env1Attack. Pressing Y_ENC once the control is on the screen jumps to a random value within the valid range of the control.
- Any list control: e.g. LFO1 Type, jumps to a random element in the list

**Not Implemented**
- Reset to original value. This is tricky, I just tried to make it reset to the original value at the beginning of the session (when beginSession) is called, and can't seem to get that to work. 
- Decimal control randomization. This one is tricky for some reason.
- There's some debug code still laying around somewhere

https://github.com/SynthstromAudible/DelugeFirmware/assets/809953/db7ec804-52a3-4d0e-8e32-f58fc3c7cbaf


