### PR TITLE
bypass effects if clip is not active

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -166,22 +166,25 @@ doNormal:
 				saturate(&currentSample->r, &lastSaturationTanHWorkingValue[1]);
 			} while (++currentSample != bufferEnd);
 		}
+		//otherwise we can run a bunch of processing on an empty buffer
+		if (isClipActive) {
 
-		// Render filters
-		processFilters(globalEffectableBuffer, numSamples);
+			// Render filters
+			processFilters(globalEffectableBuffer, numSamples);
 
-		// Render FX
-		processSRRAndBitcrushing(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip);
-		processFXForGlobalEffectable(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip,
-		                             &delayWorkingState, analogDelaySaturationAmount);
-		processStutter(globalEffectableBuffer, numSamples, paramManagerForClip);
+			// Render FX
+			processSRRAndBitcrushing(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip);
+			processFXForGlobalEffectable(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip,
+			                             &delayWorkingState, analogDelaySaturationAmount);
+			processStutter(globalEffectableBuffer, numSamples, paramManagerForClip);
 
-		int32_t postReverbSendVolumeIncrement = (int32_t)(postReverbVolume - postReverbVolumeLastTime) / numSamples;
+			int32_t postReverbSendVolumeIncrement = (int32_t)(postReverbVolume - postReverbVolumeLastTime) / numSamples;
 
-		processReverbSendAndVolume(globalEffectableBuffer, numSamples, reverbBuffer, volumePostFX,
-		                           postReverbVolumeLastTime, reverbSendAmount, pan, true,
-		                           postReverbSendVolumeIncrement);
-		addAudio(globalEffectableBuffer, outputBuffer, numSamples);
+			processReverbSendAndVolume(globalEffectableBuffer, numSamples, reverbBuffer, volumePostFX,
+			                           postReverbVolumeLastTime, reverbSendAmount, pan, true,
+			                           postReverbSendVolumeIncrement);
+			addAudio(globalEffectableBuffer, outputBuffer, numSamples);
+		}
 	}
 
 	postReverbVolumeLastTime = postReverbVolume;

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -82,8 +82,8 @@ void AudioOutput::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* m
                                                 int32_t reverbAmountAdjust, int32_t sideChainHitPending,
                                                 bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,
                                                 int32_t amplitudeAtStart, int32_t amplitudeAtEnd) {
-
-	if (activeClip) {
+	//audio outputs can have an activeClip while being muted
+	if (isClipActive) {
 		AudioClip* activeAudioClip = (AudioClip*)activeClip;
 		if (activeAudioClip->voiceSample) {
 


### PR DESCRIPTION
For kits and audio outputs effects would be rendered even if the clip is not active. In the case of grain fx this leads to a significant slowdown

Limits #538 to only affect clips that are playing