### PR TITLE
Tweak cull smoothing

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -400,9 +400,15 @@ void routine() {
 	int32_t unadjustedNumSamplesBeforeLappingPlayHead = numSamples;
 #else
 
+	if (smoothedSamples < numSamples) {
+		smoothedSamples = (smoothedSamples + numSamples) >> 1;
+	}
+	else {
+		smoothedSamples = numSamples;
+	}
+
 	numSamplesLastTime = numSamples;
 
-	smoothedSamples = (smoothedSamples + numSamples >> 1 + numSamplesLastTime >> 1) >> 1;
 	// Consider direness and culling - before increasing the number of samples
 	int32_t numSamplesLimit = 40; //storageManager.devVarC;
 	int32_t direnessThreshold = numSamplesLimit - 17;
@@ -474,7 +480,7 @@ void routine() {
 
 	// Double the number of samples we're going to do - within some constraints
 	int32_t sampleThreshold = 6; // If too low, it'll lead to bigger audio windows and stuff
-	int32_t maxAdjustedNumSamples = SSI_TX_BUFFER_NUM_SAMPLES >> 1;
+	constexpr int32_t maxAdjustedNumSamples = 0.66 * SSI_TX_BUFFER_NUM_SAMPLES;
 
 	int32_t unadjustedNumSamplesBeforeLappingPlayHead = numSamples;
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -401,13 +401,14 @@ void routine() {
 #else
 
 	if (smoothedSamples < numSamples) {
-		smoothedSamples = (smoothedSamples + numSamples) >> 1;
+		smoothedSamples = (numSamplesLastTime + numSamples) >> 1;
 	}
 	else {
 		smoothedSamples = numSamples;
 	}
-
-	numSamplesLastTime = numSamples;
+	if (!bypassCulling) {
+		numSamplesLastTime = numSamples;
+	}
 
 	// Consider direness and culling - before increasing the number of samples
 	int32_t numSamplesLimit = 40; //storageManager.devVarC;


### PR DESCRIPTION
- Instantly drop when numsamples lowers
- Increase max num samples for larger runway in case of spikes (only applies when numSamples is right around the cull threshold)
- use 2 step average instead of recursive smoothing