### PR TITLE
Fix vertical scroll inversion issue

### DIFF
--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -1328,7 +1328,7 @@ void vertical::renderScroll() {
 	for (int32_t x = 0; x < kDisplayWidth + kSideBarWidth; x++) {
 		colours[x] = prepareColour(x, endSquare, Colour::fromArray(image[endSquare][x]));
 	}
-	PIC::doVerticalScroll(scrollDirection <= 0, colours);
+	PIC::doVerticalScroll(scrollDirection > 0, colours);
 	PIC::flush();
 }
 


### PR DESCRIPTION
Fixes #503.

[Originally](https://github.com/SynthstromAudible/DelugeFirmware/blame/596e38a64842f21da5cbcb23718431b4500dad0d/src/deluge/hid/led/pad_leds.cpp#L1297) the comparison was greater than _anyways_, but somehow got swapped in the PIC refactor. 