### PR TITLE
Pause interrupt processing druing audio rendering

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -609,7 +609,9 @@ startAgain:
 
 	// Render audio for song
 	if (currentSong) {
+		asm("cpsid if");
 		currentSong->renderAudio(renderingBuffer, numSamples, reverbBuffer, sideChainHitPending);
+		asm("cpsie if");
 	}
 
 #ifdef REPORT_CPU_USAGE


### PR DESCRIPTION
This commit pauses interrupts during renderAudio call. We need to watch out for side effects but in my initial testing it yielded 8 additional voices.