### PR TITLE
re enable monitoring for unmuted audio clips in arranger

### DIFF
--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -60,6 +60,8 @@ void AudioOutput::renderOutput(ModelStack* modelStack, StereoSample* outputBuffe
 
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(activeClip);
 
+	//audio clips are also effectively active if they're monitoring and turned on in arranger
+	isClipActive |= echoing && modelStack->song->isOutputActiveInArrangement(this);
 	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, outputBuffer, numSamples,
 	                                      reverbBuffer, reverbAmountAdjust, sideChainHitPending,
 	                                      shouldLimitDelayFeedback, isClipActive, InstrumentType::AUDIO, 5);


### PR DESCRIPTION
Fix #558 

Sets audio clips to active if monitoring and un muted in arranger view