### PR TITLE
Convert uses of static_vector in gui to std::vector

### DIFF
--- a/src/deluge/gui/l10n/l10n.cpp
+++ b/src/deluge/gui/l10n/l10n.cpp
@@ -2,8 +2,6 @@
 #include "gui/l10n/strings.h"
 
 namespace deluge::l10n {
-
-static_vector<Language const*, kMaxNumLanguages> languages = {&built_in::english};
 Language const* chosenLanguage = nullptr;
 
 } // namespace deluge::l10n

--- a/src/deluge/gui/l10n/language.h
+++ b/src/deluge/gui/l10n/language.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "gui/l10n/strings.h"
-#include "util/container/static_vector.hpp"
 #include "util/misc.h"
 #include <array>
 #include <optional>
@@ -12,7 +11,6 @@ namespace deluge::l10n {
 
 class Language;
 constexpr size_t kMaxNumLanguages = 4;
-extern static_vector<Language const*, kMaxNumLanguages> languages;
 extern Language const* chosenLanguage;
 
 class Language {
@@ -21,7 +19,7 @@ class Language {
 public:
 	using map_type = std::array<std::optional<std::string_view>, kNumStrings>;
 
-	Language(std::string name, Language const* fallback = languages[0]) : name_(std::move(name)) {
+	Language(std::string name, Language const* fallback = nullptr) : name_(std::move(name)) {
 		std::copy(fallback->map_.cbegin(), fallback->map_.cend(), this->map_.begin());
 	};
 

--- a/src/deluge/gui/menu_item/arpeggiator/mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/mode.h
@@ -27,7 +27,7 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::arpeggiator {
-class Mode final : public Selection<kNumArpModes> {
+class Mode final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(soundEditor.currentArpSettings->mode); }
@@ -60,7 +60,8 @@ public:
 			bool arpNow = (current_value != ArpMode::OFF); // Uh.... this does nothing...
 		}
 	}
-	static_vector<std::string_view, capacity()> getOptions() override {
+
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_DISABLED), //<

--- a/src/deluge/gui/menu_item/colour.h
+++ b/src/deluge/gui/menu_item/colour.h
@@ -20,7 +20,7 @@
 
 namespace deluge::gui::menu_item {
 
-class Colour final : public Selection<9> {
+class Colour final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(value); }
@@ -28,12 +28,14 @@ public:
 		value = this->getValue();
 		renderingNeededRegardlessOfUI();
 	};
-	static_vector<std::string_view, capacity()> getOptions() override {
-		return {l10n::getView(l10n::String::STRING_FOR_RED),   l10n::getView(l10n::String::STRING_FOR_GREEN),
-		        l10n::getView(l10n::String::STRING_FOR_BLUE),  l10n::getView(l10n::String::STRING_FOR_YELLOW),
-		        l10n::getView(l10n::String::STRING_FOR_CYAN),  l10n::getView(l10n::String::STRING_FOR_MAGENTA),
-		        l10n::getView(l10n::String::STRING_FOR_AMBER), l10n::getView(l10n::String::STRING_FOR_WHITE),
-		        l10n::getView(l10n::String::STRING_FOR_PINK)};
+	std::vector<std::string_view> getOptions() override {
+		return {
+		    l10n::getView(l10n::String::STRING_FOR_RED),   l10n::getView(l10n::String::STRING_FOR_GREEN),
+		    l10n::getView(l10n::String::STRING_FOR_BLUE),  l10n::getView(l10n::String::STRING_FOR_YELLOW),
+		    l10n::getView(l10n::String::STRING_FOR_CYAN),  l10n::getView(l10n::String::STRING_FOR_MAGENTA),
+		    l10n::getView(l10n::String::STRING_FOR_AMBER), l10n::getView(l10n::String::STRING_FOR_WHITE),
+		    l10n::getView(l10n::String::STRING_FOR_PINK),
+		};
 	}
 	void getRGB(uint8_t rgb[3]);
 	uint8_t value;

--- a/src/deluge/gui/menu_item/cv/selection.h
+++ b/src/deluge/gui/menu_item/cv/selection.h
@@ -28,9 +28,9 @@ extern void setCvNumberForTitle(int32_t m);
 extern deluge::gui::menu_item::cv::Submenu cvSubmenu;
 
 namespace deluge::gui::menu_item::cv {
-class Selection final : public menu_item::Selection<2> {
+class Selection final : public menu_item::Selection {
 public:
-	using menu_item::Selection<capacity()>::Selection;
+	using menu_item::Selection::Selection;
 
 	void beginSession(MenuItem* navigatedBackwardFrom) override {
 		if (navigatedBackwardFrom == nullptr) {
@@ -39,7 +39,7 @@ public:
 		else {
 			this->setValue(soundEditor.currentSourceIndex);
 		}
-		menu_item::Selection<2>::beginSession(navigatedBackwardFrom);
+		menu_item::Selection::beginSession(navigatedBackwardFrom);
 	}
 
 	MenuItem* selectButtonPress() override {
@@ -48,7 +48,7 @@ public:
 		return &cvSubmenu;
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		static auto cv1 = l10n::getView(STRING_FOR_CV_OUTPUT_1);
 		static auto cv2 = l10n::getView(STRING_FOR_CV_OUTPUT_2);

--- a/src/deluge/gui/menu_item/cv/submenu.h
+++ b/src/deluge/gui/menu_item/cv/submenu.h
@@ -1,13 +1,15 @@
 #pragma once
 #include "gui/menu_item/formatted_title.h"
+#include "gui/menu_item/menu_item.h"
 #include "gui/menu_item/submenu.h"
+#include <initializer_list>
 #include <string_view>
 
 namespace deluge::gui::menu_item::cv {
-class Submenu : public menu_item::Submenu<2>, public FormattedTitle {
+class Submenu : public menu_item::Submenu, public FormattedTitle {
 public:
-	Submenu(l10n::String newName, MenuItem* const (&newItems)[2])
-	    : menu_item::Submenu<2>::Submenu(newName, newItems), FormattedTitle(newName) {}
+	Submenu(l10n::String newName, std::initializer_list<MenuItem*> newItems)
+	    : menu_item::Submenu::Submenu(newName, newItems), FormattedTitle(newName) {}
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 };

--- a/src/deluge/gui/menu_item/defaults/keyboard_layout.h
+++ b/src/deluge/gui/menu_item/defaults/keyboard_layout.h
@@ -25,12 +25,12 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::defaults {
-class KeyboardLayout final : public Selection<2> {
+class KeyboardLayout final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(FlashStorage::defaultKeyboardLayout); }
 	void writeCurrentValue() override { FlashStorage::defaultKeyboardLayout = this->getValue<KeyboardLayoutType>(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		return {
 		    l10n::getView(l10n::String::STRING_FOR_DEFAULT_UI_KEYBOARD_LAYOUT_ISOMORPHIC),
 		    l10n::getView(l10n::String::STRING_FOR_DEFAULT_UI_KEYBOARD_LAYOUT_INKEY),

--- a/src/deluge/gui/menu_item/defaults/magnitude.h
+++ b/src/deluge/gui/menu_item/defaults/magnitude.h
@@ -21,7 +21,7 @@
 #include "storage/flash_storage.h"
 
 namespace deluge::gui::menu_item::defaults {
-class Magnitude final : public Enumeration<7> {
+class Magnitude final : public Enumeration {
 public:
 	using Enumeration::Enumeration;
 	void readCurrentValue() override { this->setValue(FlashStorage::defaultMagnitude); }
@@ -36,5 +36,6 @@ public:
 	}
 
 	void drawValue() override { display->setTextAsNumber(96 << this->getValue()); }
+	size_t size() override { return 7; }
 };
 } // namespace deluge::gui::menu_item::defaults

--- a/src/deluge/gui/menu_item/defaults/scale.h
+++ b/src/deluge/gui/menu_item/defaults/scale.h
@@ -18,17 +18,16 @@
 #include "gui/menu_item/selection.h"
 #include "gui/ui/sound_editor.h"
 #include "storage/flash_storage.h"
-#include "util/container/static_vector.hpp"
 #include "util/lookuptables/lookuptables.h"
 
 namespace deluge::gui::menu_item::defaults {
-class Scale final : public Selection<NUM_PRESET_SCALES + 2> {
+class Scale final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(FlashStorage::defaultScale); }
 	void writeCurrentValue() override { FlashStorage::defaultScale = this->getValue(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
-		return {presetScaleNames.begin(), presetScaleNames.begin() + capacity()};
+	std::vector<std::string_view> getOptions() override {
+		return {presetScaleNames.begin(), presetScaleNames.begin() + NUM_PRESET_SCALES + 2};
 	}
 };
 } // namespace deluge::gui::menu_item::defaults

--- a/src/deluge/gui/menu_item/defaults/session_layout.h
+++ b/src/deluge/gui/menu_item/defaults/session_layout.h
@@ -25,14 +25,16 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::defaults {
-class SessionLayout final : public Selection<2> {
+class SessionLayout final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(FlashStorage::defaultSessionLayout); }
 	void writeCurrentValue() override { FlashStorage::defaultSessionLayout = this->getValue<SessionLayoutType>(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
-		return {l10n::getView(l10n::String::STRING_FOR_DEFAULT_UI_SONG_LAYOUT_ROWS),
-		        l10n::getView(l10n::String::STRING_FOR_DEFAULT_UI_SONG_LAYOUT_GRID)};
+	std::vector<std::string_view> getOptions() override {
+		return {
+		    l10n::getView(l10n::String::STRING_FOR_DEFAULT_UI_SONG_LAYOUT_ROWS),
+		    l10n::getView(l10n::String::STRING_FOR_DEFAULT_UI_SONG_LAYOUT_GRID),
+		};
 	}
 };
 } // namespace deluge::gui::menu_item::defaults

--- a/src/deluge/gui/menu_item/delay/analog.h
+++ b/src/deluge/gui/menu_item/delay/analog.h
@@ -23,12 +23,12 @@
 
 namespace deluge::gui::menu_item::delay {
 
-class Analog final : public Selection<2> {
+class Analog final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(soundEditor.currentModControllable->delay.analog); }
 	void writeCurrentValue() override { soundEditor.currentModControllable->delay.analog = this->getValue(); }
-	static_vector<std::string_view, 2> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {l10n::getView(STRING_FOR_DIGITAL), l10n::getView(STRING_FOR_ANALOG)};
 	}

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -1,0 +1,44 @@
+#include "enumeration.h"
+
+namespace deluge::gui::menu_item {
+void Enumeration::beginSession(MenuItem* navigatedBackwardFrom) {
+	Value::beginSession(navigatedBackwardFrom);
+#if HAVE_OLED
+	soundEditor.menuCurrentScroll = 0;
+#else
+	drawValue();
+#endif
+}
+
+void Enumeration::selectEncoderAction(int32_t offset) {
+	this->setValue(this->getValue() + offset);
+	int32_t numOptions = size();
+
+#if HAVE_OLED
+	if (this->getValue() >= numOptions) {
+		this->setValue(numOptions - 1);
+	}
+	else if (this->getValue() < 0) {
+		this->setValue(0);
+	}
+#else
+	if (this->getValue() >= numOptions) {
+		this->setValue(this->getValue() - numOptions);
+	}
+	else if (this->getValue() < 0) {
+		this->setValue(this->getValue() + numOptions);
+	}
+#endif
+
+	Value::selectEncoderAction(offset);
+}
+
+void Enumeration::drawValue() {
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+	if (display->have7SEG()) {
+		display->setTextAsNumber(this->getValue());
+	}
+}
+} // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/enumeration.h
+++ b/src/deluge/gui/menu_item/enumeration.h
@@ -9,64 +9,17 @@ namespace deluge::gui::menu_item {
 /**
  * @brief An enumeration has a fixed number of items, with values from 1 to n (exclusive)
  */
-template <size_t n>
 class Enumeration : public Value<int32_t> {
 public:
 	using Value::Value;
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
 	void selectEncoderAction(int32_t offset) override;
 
-	virtual size_t size() { return n; };
+	virtual size_t size() = 0;
 
 protected:
 	virtual void drawPixelsForOled() override = 0;
 	void drawValue() override;
 };
-
-template <size_t n>
-void Enumeration<n>::beginSession(MenuItem* navigatedBackwardFrom) {
-	Value::beginSession(navigatedBackwardFrom);
-	if (display->haveOLED()) {
-		soundEditor.menuCurrentScroll = 0;
-	}
-	else {
-		drawValue();
-	}
-}
-
-template <size_t n>
-void Enumeration<n>::selectEncoderAction(int32_t offset) {
-	this->setValue(this->getValue() + offset);
-	int32_t numOptions = size();
-
-	if (display->haveOLED()) {
-		if (this->getValue() >= numOptions) {
-			this->setValue(numOptions - 1);
-		}
-		else if (this->getValue() < 0) {
-			this->setValue(0);
-		}
-	}
-	else {
-		if (this->getValue() >= numOptions) {
-			this->setValue(this->getValue() - numOptions);
-		}
-		else if (this->getValue() < 0) {
-			this->setValue(this->getValue() + numOptions);
-		}
-	}
-
-	Value::selectEncoderAction(offset);
-}
-
-template <size_t n>
-void Enumeration<n>::drawValue() {
-	if (display->haveOLED()) {
-		renderUIsForOled();
-	}
-	else {
-		display->setTextAsNumber(this->getValue());
-	}
-}
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/filter/hpf_mode.h
+++ b/src/deluge/gui/menu_item/filter/hpf_mode.h
@@ -24,7 +24,7 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::filter {
-class HPFMode final : public Selection<kNumHPFModes> {
+class HPFMode final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override {
@@ -33,7 +33,7 @@ public:
 	void writeCurrentValue() override {
 		soundEditor.currentModControllable->hpfMode = static_cast<FilterMode>(this->getValue() + kFirstHPFMode);
 	}
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_SVF_BAND),

--- a/src/deluge/gui/menu_item/filter/lpf_mode.h
+++ b/src/deluge/gui/menu_item/filter/lpf_mode.h
@@ -24,12 +24,12 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::filter {
-class LPFMode final : public Selection<kNumLPFModes> {
+class LPFMode final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue<::FilterMode>(soundEditor.currentModControllable->lpfMode); }
 	void writeCurrentValue() override { soundEditor.currentModControllable->lpfMode = this->getValue<::FilterMode>(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_12DB_LADDER), l10n::getView(STRING_FOR_24DB_LADDER),

--- a/src/deluge/gui/menu_item/filter_route.h
+++ b/src/deluge/gui/menu_item/filter_route.h
@@ -23,14 +23,14 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item {
-class FilterRouting final : public Selection<kNumFilterRoutes> {
+class FilterRouting final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue<::FilterRoute>(soundEditor.currentModControllable->filterRoute); }
 	void writeCurrentValue() override {
 		soundEditor.currentModControllable->filterRoute = this->getValue<::FilterRoute>();
 	}
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		return {"HPF2LPF", "LPF2HPF", l10n::getView(l10n::String::STRING_FOR_PARALLEL)};
 	}
 	bool isRelevant(Sound* sound, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/flash/status.h
+++ b/src/deluge/gui/menu_item/flash/status.h
@@ -22,7 +22,7 @@
 #include "storage/flash_storage.h"
 
 namespace deluge::gui::menu_item::flash {
-class Status final : public Selection<3> {
+class Status final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(PadLEDs::flashCursor); }
@@ -32,7 +32,7 @@ public:
 		}
 		PadLEDs::flashCursor = this->getValue();
 	}
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_FAST),

--- a/src/deluge/gui/menu_item/gate/mode.h
+++ b/src/deluge/gui/menu_item/gate/mode.h
@@ -26,9 +26,9 @@
 
 namespace deluge::gui::menu_item::gate {
 
-class Mode final : public Selection<3>, public FormattedTitle {
+class Mode final : public Selection, public FormattedTitle {
 
-	static_vector<l10n::String, capacity()> options_ = {
+	std::vector<l10n::String> options_ = {
 	    l10n::String::STRING_FOR_V_TRIGGER,
 	    l10n::String::STRING_FOR_S_TRIGGER,
 	};
@@ -41,8 +41,8 @@ public:
 	void writeCurrentValue() override {
 		cvEngine.setGateType(soundEditor.currentSourceIndex, this->getValue<GateType>());
 	}
-	static_vector<std::string_view, capacity()> getOptions() override {
-		static_vector<std::string_view, capacity()> output;
+	std::vector<std::string_view> getOptions() override {
+		std::vector<std::string_view> output;
 		for (l10n::String str : options_) {
 			output.push_back(l10n::getView(str));
 		}

--- a/src/deluge/gui/menu_item/gate/selection.h
+++ b/src/deluge/gui/menu_item/gate/selection.h
@@ -21,15 +21,14 @@
 #include "hid/display/display.h"
 #include "mode.h"
 #include "off_time.h"
-#include "util/container/static_vector.hpp"
 
 extern deluge::gui::menu_item::gate::OffTime gateOffTimeMenu;
 extern deluge::gui::menu_item::gate::Mode gateModeMenu;
 namespace deluge::gui::menu_item::gate {
 
-class Selection final : public menu_item::Selection<5> {
+class Selection final : public menu_item::Selection {
 public:
-	using menu_item::Selection<capacity()>::Selection;
+	using menu_item::Selection::Selection;
 
 	void beginSession(MenuItem* navigatedBackwardFrom) override {
 		if (navigatedBackwardFrom == nullptr) {
@@ -38,7 +37,7 @@ public:
 		else {
 			this->setValue(soundEditor.currentSourceIndex);
 		}
-		menu_item::Selection<capacity()>::beginSession(navigatedBackwardFrom);
+		menu_item::Selection::beginSession(navigatedBackwardFrom);
 	}
 
 	MenuItem* selectButtonPress() override {
@@ -55,7 +54,7 @@ public:
 		return &gateModeMenu;
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		static auto out1 = l10n::getView(STRING_FOR_GATE_OUTPUT_1);
 		static auto out2 = l10n::getView(STRING_FOR_GATE_OUTPUT_2);

--- a/src/deluge/gui/menu_item/keyboard/layout.h
+++ b/src/deluge/gui/menu_item/keyboard/layout.h
@@ -23,12 +23,12 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::keyboard {
-class Layout final : public Selection<kNumKeyboardLayouts> {
+class Layout final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(FlashStorage::keyboardLayout); }
 	void writeCurrentValue() override { FlashStorage::keyboardLayout = this->getValue<KeyboardLayout>(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		return {
 		    "QWERTY",
 		    "AZERTY",

--- a/src/deluge/gui/menu_item/lfo/shape.h
+++ b/src/deluge/gui/menu_item/lfo/shape.h
@@ -22,11 +22,11 @@
 
 namespace deluge::gui::menu_item::lfo {
 
-class Shape : public Selection<kNumLFOTypes> {
+class Shape : public Selection {
 public:
 	using Selection::Selection;
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_SINE),

--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -17,6 +17,7 @@
 
 #include "menu_item.h"
 #include "hid/display/display.h"
+#include <string_view>
 
 using namespace deluge;
 
@@ -36,4 +37,27 @@ void MenuItem::renderOLED() {
 
 void MenuItem::drawName() {
 	display->setText(getName(), false, shouldDrawDotOnName());
+}
+
+// A couple of our child classes call this - that's all
+void MenuItem::drawItemsForOled(std::span<std::string_view> options, const int32_t selectedOption,
+                                const int32_t offset) {
+	int32_t baseY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 15 : 14;
+	baseY += OLED_MAIN_TOPMOST_PIXEL;
+
+	auto it = std::next(options.begin(), offset); // fast-forward to the first option visible
+	for (int32_t o = 0; o < OLED_HEIGHT_CHARS - 1 && o < options.size() - offset; o++) {
+		int32_t yPixel = o * kTextSpacingY + baseY;
+
+		deluge::hid::display::OLED::drawString(options[o + offset], kTextSpacingX, yPixel,
+		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
+		                                       kTextSpacingX, kTextSpacingY);
+
+		if (o == selectedOption) {
+			deluge::hid::display::OLED::invertArea(0, OLED_MAIN_WIDTH_PIXELS, yPixel, yPixel + 8,
+			                                       &deluge::hid::display::OLED::oledMainImage[0]);
+			deluge::hid::display::OLED::setupSideScroller(0, options[o + offset], kTextSpacingX, OLED_MAIN_WIDTH_PIXELS,
+			                                              yPixel, yPixel + 8, kTextSpacingX, kTextSpacingY, true);
+		}
+	}
 }

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -22,10 +22,10 @@
 #include "gui/l10n/strings.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
-#include "util/container/static_vector.hpp"
 #include "util/sized.h"
-
 #include <cstdint>
+#include <span>
+#include <vector>
 
 enum class MenuPermission {
 	NO,
@@ -99,35 +99,8 @@ public:
 
 	virtual void renderOLED();
 	virtual void drawPixelsForOled() {}
-	void drawItemsForOled(char const** options, int32_t selectedOption);
 
-	template <size_t n>
-	static void drawItemsForOled(deluge::static_vector<std::string_view, n>& options, int32_t selectedOption,
-	                             int32_t offset = 0);
+	static void drawItemsForOled(std::span<std::string_view> options, int32_t selectedOption, int32_t offset = 0);
 	/// Get the title to be used when rendering on OLED. If not overriden, defaults to returning `title`.
 	virtual void drawName();
 };
-
-// A couple of our child classes call this - that's all
-template <size_t n>
-void MenuItem::drawItemsForOled(deluge::static_vector<std::string_view, n>& options, const int32_t selectedOption,
-                                const int32_t offset) {
-	int32_t baseY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 15 : 14;
-	baseY += OLED_MAIN_TOPMOST_PIXEL;
-
-	auto* it = std::next(options.begin(), offset); // fast-forward to the first option visible
-	for (int32_t o = 0; o < OLED_HEIGHT_CHARS - 1 && o < options.size() - offset; o++) {
-		int32_t yPixel = o * kTextSpacingY + baseY;
-
-		deluge::hid::display::OLED::drawString(options[o + offset], kTextSpacingX, yPixel,
-		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-		                                       kTextSpacingX, kTextSpacingY);
-
-		if (o == selectedOption) {
-			deluge::hid::display::OLED::invertArea(0, OLED_MAIN_WIDTH_PIXELS, yPixel, yPixel + 8,
-			                                       &deluge::hid::display::OLED::oledMainImage[0]);
-			deluge::hid::display::OLED::setupSideScroller(0, options[o + offset], kTextSpacingX, OLED_MAIN_WIDTH_PIXELS,
-			                                              yPixel, yPixel + 8, kTextSpacingX, kTextSpacingY, true);
-		}
-	}
-}

--- a/src/deluge/gui/menu_item/midi/device.h
+++ b/src/deluge/gui/menu_item/midi/device.h
@@ -3,8 +3,8 @@
 #include "gui/menu_item/submenu.h"
 #include "io/midi/midi_device.h"
 namespace deluge::gui::menu_item::midi {
-struct Device : Submenu<2> {
-	using Submenu<2>::Submenu;
+struct Device : Submenu {
+	using Submenu::Submenu;
 	[[nodiscard]] std::string_view getTitle() const override { return soundEditor.currentMIDIDevice->getDisplayName(); }
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/midi/takeover.h
+++ b/src/deluge/gui/menu_item/midi/takeover.h
@@ -23,12 +23,12 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::midi {
-class Takeover final : public Selection<kNumMIDITakeoverModes> {
+class Takeover final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(midiEngine.midiTakeover); }
 	void writeCurrentValue() override { midiEngine.midiTakeover = this->getValue<MIDITakeoverMode>(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_JUMP),

--- a/src/deluge/gui/menu_item/mod_fx/type.h
+++ b/src/deluge/gui/menu_item/mod_fx/type.h
@@ -24,7 +24,7 @@
 
 namespace deluge::gui::menu_item::mod_fx {
 
-class Type : public Selection<kNumModFXTypes> {
+class Type : public Selection {
 public:
 	using Selection::Selection;
 
@@ -35,7 +35,7 @@ public:
 		}
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_DISABLED),      //<

--- a/src/deluge/gui/menu_item/modulator/destination.h
+++ b/src/deluge/gui/menu_item/modulator/destination.h
@@ -21,12 +21,12 @@
 #include "processing/sound/sound.h"
 
 namespace deluge::gui::menu_item::modulator {
-class Destination final : public Selection<2> {
+class Destination final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(soundEditor.currentSound->modulator1ToModulator0); }
 	void writeCurrentValue() override { soundEditor.currentSound->modulator1ToModulator0 = this->getValue(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		static auto mod1 = l10n::getView(STRING_FOR_MODULATOR_1);
 		return {

--- a/src/deluge/gui/menu_item/monitor/mode.h
+++ b/src/deluge/gui/menu_item/monitor/mode.h
@@ -23,13 +23,13 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::monitor {
-class Mode final : public Selection<kNumInputMonitoringModes> {
+class Mode final : public Selection {
 public:
 	using Selection::Selection;
 
 	void readCurrentValue() override { this->setValue(AudioEngine::inputMonitoringMode); }
 	void writeCurrentValue() override { AudioEngine::inputMonitoringMode = this->getValue<InputMonitoringMode>(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_CONDITIONAL),

--- a/src/deluge/gui/menu_item/mpe/direction_selector.h
+++ b/src/deluge/gui/menu_item/mpe/direction_selector.h
@@ -23,11 +23,11 @@
 
 namespace deluge::gui::menu_item::mpe {
 
-class DirectionSelector final : public Selection<2> {
+class DirectionSelector final : public Selection {
 public:
 	using Selection::Selection;
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override;
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_IN),

--- a/src/deluge/gui/menu_item/mpe/zone_selector.h
+++ b/src/deluge/gui/menu_item/mpe/zone_selector.h
@@ -22,14 +22,14 @@
 
 namespace deluge::gui::menu_item::mpe {
 
-class ZoneSelector final : public Selection<2> {
+class ZoneSelector final : public Selection {
 public:
 	using Selection::Selection;
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override;
 	void readCurrentValue() override { this->setValue(whichZone); }
 	void writeCurrentValue() override { whichZone = this->getValue(); }
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_LOWER_ZONE),

--- a/src/deluge/gui/menu_item/multi_range.cpp
+++ b/src/deluge/gui/menu_item/multi_range.cpp
@@ -30,8 +30,9 @@
 #include "processing/source.h"
 #include "storage/multi_range/multi_wave_table_range.h"
 #include "storage/multi_range/multisample_range.h"
+#include "util/container/static_vector.hpp"
 #include "util/functions.h"
-#include <string.h>
+#include <cstring>
 
 namespace deluge::gui::menu_item {
 

--- a/src/deluge/gui/menu_item/osc/type.h
+++ b/src/deluge/gui/menu_item/osc/type.h
@@ -27,7 +27,7 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::osc {
-class Type final : public Selection<kNumOscTypes>, public FormattedTitle {
+class Type final : public Selection, public FormattedTitle {
 public:
 	Type(l10n::String name, l10n::String title_format_str) : Selection(name), FormattedTitle(title_format_str){};
 	void beginSession(MenuItem* navigatedBackwardFrom) override { Selection::beginSession(navigatedBackwardFrom); }
@@ -60,9 +60,9 @@ public:
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
-		static_vector<std::string_view, capacity()> options = {
+		std::vector<std::string_view> options = {
 		    l10n::getView(STRING_FOR_SINE),          //<
 		    l10n::getView(STRING_FOR_TRIANGLE),      //<
 		    l10n::getView(STRING_FOR_SQUARE),        //<

--- a/src/deluge/gui/menu_item/patch_cables.cpp
+++ b/src/deluge/gui/menu_item/patch_cables.cpp
@@ -10,7 +10,6 @@
 #include "processing/sound/sound.h"
 #include "source_selection/range.h"
 #include "source_selection/regular.h"
-#include "util/container/static_vector.hpp"
 #include "util/functions.h"
 
 namespace deluge::gui::menu_item {

--- a/src/deluge/gui/menu_item/patch_cables.h
+++ b/src/deluge/gui/menu_item/patch_cables.h
@@ -23,7 +23,7 @@ public:
 	int32_t savedVal = 0;
 	int32_t currentValue = 0;
 
-	static_vector<std::string_view, kMaxNumPatchCables> options;
+	std::vector<std::string_view> options;
 
 	PatchSource blinkSrc = PatchSource::NOT_AVAILABLE;
 	PatchSource blinkSrc2 = PatchSource::NOT_AVAILABLE;

--- a/src/deluge/gui/menu_item/runtime_feature/devSysexSetting.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/devSysexSetting.cpp
@@ -20,7 +20,6 @@
 #include "gui/menu_item/runtime_feature/setting.h"
 #include "gui/ui/sound_editor.h"
 #include "model/settings/runtime_feature_settings.h"
-#include "util/container/static_vector.hpp"
 #include "util/functions.h"
 #include <algorithm>
 #include <iterator>
@@ -54,7 +53,7 @@ void DevSysexSetting::writeCurrentValue() {
 	}
 }
 
-static_vector<std::string_view, 2> DevSysexSetting::getOptions() {
+std::vector<std::string_view> DevSysexSetting::getOptions() {
 	intToHex(onValue, &on_val[5]);
 	return {
 	    l10n::get(l10n::String::STRING_FOR_OFF),

--- a/src/deluge/gui/menu_item/runtime_feature/devSysexSetting.h
+++ b/src/deluge/gui/menu_item/runtime_feature/devSysexSetting.h
@@ -22,13 +22,13 @@
 
 namespace deluge::gui::menu_item::runtime_feature {
 class Settings;
-class DevSysexSetting final : public Selection<2> {
+class DevSysexSetting final : public Selection {
 public:
 	explicit DevSysexSetting(RuntimeFeatureSettingType ty);
 
 	void readCurrentValue() override;
 	void writeCurrentValue() override;
-	static_vector<std::string_view, 2> getOptions() override;
+	std::vector<std::string_view> getOptions() override;
 	[[nodiscard]] std::string_view getName() const override;
 	[[nodiscard]] std::string_view getTitle() const override;
 

--- a/src/deluge/gui/menu_item/runtime_feature/setting.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/setting.cpp
@@ -19,7 +19,6 @@
 #include "gui/menu_item/runtime_feature/setting.h"
 #include "gui/ui/sound_editor.h"
 #include "model/settings/runtime_feature_settings.h"
-#include "util/container/static_vector.hpp"
 #include <algorithm>
 #include <iterator>
 #include <ranges>
@@ -46,8 +45,8 @@ void Setting::writeCurrentValue() {
 	    runtimeFeatureSettings.settings[currentSettingIndex].options[this->getValue()].value;
 }
 
-static_vector<std::string_view, RUNTIME_FEATURE_SETTING_MAX_OPTIONS> Setting::getOptions() {
-	static_vector<std::string_view, capacity()> options;
+std::vector<std::string_view> Setting::getOptions() {
+	std::vector<std::string_view> options;
 	for (const RuntimeFeatureSettingOption& option : runtimeFeatureSettings.settings[currentSettingIndex].options) {
 		options.push_back(option.displayName);
 	}

--- a/src/deluge/gui/menu_item/runtime_feature/setting.h
+++ b/src/deluge/gui/menu_item/runtime_feature/setting.h
@@ -22,13 +22,13 @@
 
 namespace deluge::gui::menu_item::runtime_feature {
 class Settings;
-class Setting : public Selection<RUNTIME_FEATURE_SETTING_MAX_OPTIONS> {
+class Setting : public Selection {
 public:
 	explicit Setting(RuntimeFeatureSettingType ty);
 
 	void readCurrentValue() override;
 	void writeCurrentValue() override;
-	static_vector<std::string_view, RUNTIME_FEATURE_SETTING_MAX_OPTIONS> getOptions() override;
+	std::vector<std::string_view> getOptions() override;
 	[[nodiscard]] std::string_view getName() const override;
 	[[nodiscard]] std::string_view getTitle() const override;
 

--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -69,8 +69,7 @@ std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement - kNonTopLevelSettin
     &menuHighlightIncomingNotes, &menuDisplayNornsLayout, &menuShiftIsSticky,       &menuLightShiftLed,
 };
 
-Settings::Settings(l10n::String name, l10n::String title)
-    : menu_item::Submenu<subMenuEntries.size()>(name, title, subMenuEntries) {
+Settings::Settings(l10n::String name, l10n::String title) : menu_item::Submenu(name, title, subMenuEntries) {
 }
 
 } // namespace deluge::gui::menu_item::runtime_feature

--- a/src/deluge/gui/menu_item/runtime_feature/settings.h
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.h
@@ -25,8 +25,8 @@ namespace deluge::gui::menu_item::runtime_feature {
 
 /// Some runtime feature settings are squirrled away in submenus.
 constexpr size_t kNonTopLevelSettings = 3;
-
-class Settings final : public Submenu<RuntimeFeatureSettingType::MaxElement - kNonTopLevelSettings> {
+// RuntimeFeatureSettingType::MaxElement - kNonTopLevelSettings
+class Settings final : public Submenu {
 public:
 	Settings(l10n::String name, l10n::String title);
 

--- a/src/deluge/gui/menu_item/sample/browser_preview/mode.h
+++ b/src/deluge/gui/menu_item/sample/browser_preview/mode.h
@@ -20,12 +20,12 @@
 #include "storage/flash_storage.h"
 
 namespace deluge::gui::menu_item::sample::browser_preview {
-class Mode final : public Selection<3> {
+class Mode final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(FlashStorage::sampleBrowserPreviewMode); }
 	void writeCurrentValue() override { FlashStorage::sampleBrowserPreviewMode = this->getValue(); }
-	static_vector<std::string_view, 3> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		return {
 		    l10n::getView(l10n::String::STRING_FOR_DISABLED),
 		    l10n::getView(l10n::String::STRING_FOR_CONDITIONAL),

--- a/src/deluge/gui/menu_item/sample/interpolation.h
+++ b/src/deluge/gui/menu_item/sample/interpolation.h
@@ -24,7 +24,7 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::sample {
-class Interpolation final : public Selection<kNumInterpolationModes>, public FormattedTitle {
+class Interpolation final : public Selection, public FormattedTitle {
 public:
 	Interpolation(l10n::String name, l10n::String title_format_str)
 	    : Selection(name), FormattedTitle(title_format_str) {}
@@ -37,7 +37,7 @@ public:
 		soundEditor.currentSampleControls->interpolationMode = this->getValue<InterpolationMode>();
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		return {l10n::getView(l10n::String::STRING_FOR_LINEAR), l10n::getView(l10n::String::STRING_FOR_SINC)};
 	}
 

--- a/src/deluge/gui/menu_item/sample/pitch_speed.h
+++ b/src/deluge/gui/menu_item/sample/pitch_speed.h
@@ -24,7 +24,7 @@
 #include "processing/sound/sound_drum.h"
 
 namespace deluge::gui::menu_item::sample {
-class PitchSpeed final : public Selection<2> {
+class PitchSpeed final : public Selection {
 public:
 	using Selection::Selection;
 
@@ -54,7 +54,7 @@ public:
 		}
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		return {l10n::getView(l10n::String::STRING_FOR_LINKED), l10n::getView(l10n::String::STRING_FOR_INDEPENDENT)};
 	}
 };

--- a/src/deluge/gui/menu_item/sample/repeat.h
+++ b/src/deluge/gui/menu_item/sample/repeat.h
@@ -29,7 +29,7 @@
 
 namespace deluge::gui::menu_item::sample {
 
-class Repeat final : public Selection<kNumRepeatModes>, public FormattedTitle {
+class Repeat final : public Selection, public FormattedTitle {
 public:
 	Repeat(l10n::String name, l10n::String title_format_str) : Selection(name), FormattedTitle(title_format_str) {}
 
@@ -83,9 +83,13 @@ public:
 		// We need to re-render all rows, because this will have changed whether Note tails are displayed. Probably just one row, but we don't know which
 		uiNeedsRendering(&instrumentClipView, 0xFFFFFFFF, 0);
 	}
-	static_vector<std::string_view, capacity()> getOptions() override {
-		return {l10n::getView(l10n::String::STRING_FOR_CUT), l10n::getView(l10n::String::STRING_FOR_ONCE),
-		        l10n::getView(l10n::String::STRING_FOR_LOOP), l10n::getView(l10n::String::STRING_FOR_STRETCH)};
+	std::vector<std::string_view> getOptions() override {
+		return {
+		    l10n::getView(l10n::String::STRING_FOR_CUT),
+		    l10n::getView(l10n::String::STRING_FOR_ONCE),
+		    l10n::getView(l10n::String::STRING_FOR_LOOP),
+		    l10n::getView(l10n::String::STRING_FOR_STRETCH),
+		};
 	}
 };
 

--- a/src/deluge/gui/menu_item/sample/selection.h
+++ b/src/deluge/gui/menu_item/sample/selection.h
@@ -20,9 +20,9 @@
 
 namespace deluge::gui::menu_item::sample {
 template <size_t n>
-class Selection : public menu_item::Selection<n> {
+class Selection : public menu_item::Selection {
 public:
-	using menu_item::Selection<n>::Selection;
+	using menu_item::Selection::Selection;
 	bool isRelevant(Sound* sound, int32_t whichThing) override {
 		if (sound == nullptr) {
 			return true; // For AudioClips

--- a/src/deluge/gui/menu_item/selection.cpp
+++ b/src/deluge/gui/menu_item/selection.cpp
@@ -1,0 +1,32 @@
+#include "selection.h"
+#include "gui/menu_item/menu_item.h"
+#include "gui/ui/sound_editor.h"
+#include "hid/display/display.h"
+
+namespace deluge::gui::menu_item {
+void Selection::drawValue() {
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+	if (display->have7SEG()) {
+		const auto options = this->getOptions();
+		display->setText(options[this->getValue()].data());
+	}
+}
+
+void Selection::drawPixelsForOled() {
+	auto value = this->getValue();
+	// Move scroll
+	if (soundEditor.menuCurrentScroll > value) {
+		soundEditor.menuCurrentScroll = value;
+	}
+	else if (soundEditor.menuCurrentScroll < this->getValue() - kOLEDMenuNumOptionsVisible + 1) {
+		soundEditor.menuCurrentScroll = value - kOLEDMenuNumOptionsVisible + 1;
+	}
+
+	const int32_t selectedOption = value - soundEditor.menuCurrentScroll;
+
+	MenuItem::drawItemsForOled(std::span{getOptions().data(), getOptions().size()}, selectedOption,
+	                           soundEditor.menuCurrentScroll);
+}
+} // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/selection.h
+++ b/src/deluge/gui/menu_item/selection.h
@@ -18,56 +18,19 @@
 #pragma once
 
 #include "gui/menu_item/enumeration.h"
-#include "gui/menu_item/menu_item.h"
-#include "util/container/static_vector.hpp"
-#include "util/sized.h"
-
-#include "gui/ui/sound_editor.h"
-#include "hid/display/display.h"
+#include <span>
+#include <string_view>
 
 namespace deluge::gui::menu_item {
-template <size_t n>
-class Selection : public Enumeration<n> {
+class Selection : public Enumeration {
 public:
-	using Enumeration<n>::Enumeration;
+	using Enumeration::Enumeration;
 
-	virtual static_vector<std::string_view, n> getOptions() = 0;
+	virtual std::vector<std::string_view> getOptions() = 0;
 
 	void drawValue() override;
 
 	void drawPixelsForOled() override;
 	size_t size() override { return this->getOptions().size(); }
-	constexpr static size_t capacity() { return n; }
 };
-
-template <size_t n>
-void Selection<n>::drawValue() {
-	if (display->haveOLED()) {
-		renderUIsForOled();
-	}
-	else {
-		const auto options = getOptions();
-		display->setText(options[this->getValue()].data());
-	}
-}
-
-template <size_t n>
-void Selection<n>::drawPixelsForOled() {
-	// Move scroll
-	if (soundEditor.menuCurrentScroll > this->getValue()) {
-		soundEditor.menuCurrentScroll = this->getValue();
-	}
-	else if (soundEditor.menuCurrentScroll < this->getValue() - kOLEDMenuNumOptionsVisible + 1) {
-		soundEditor.menuCurrentScroll = this->getValue() - kOLEDMenuNumOptionsVisible + 1;
-	}
-
-	const int32_t selectedOption = this->getValue() - soundEditor.menuCurrentScroll;
-
-	deluge::static_vector<std::string_view, n> options;
-	for (auto const& option : getOptions()) {
-		options.push_back(option);
-	}
-	MenuItem::drawItemsForOled(options, selectedOption, soundEditor.menuCurrentScroll);
-}
-
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/sequence/direction.h
+++ b/src/deluge/gui/menu_item/sequence/direction.h
@@ -26,7 +26,7 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::sequence {
-class Direction final : public Selection<kNumSequenceDirections + 1> {
+class Direction final : public Selection {
 public:
 	using Selection::Selection;
 
@@ -68,10 +68,12 @@ public:
 		}
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
-		static_vector<std::string_view, capacity()> sequenceDirectionOptions = {
-		    l10n::getView(l10n::String::STRING_FOR_FORWARD), l10n::getView(l10n::String::STRING_FOR_REVERSED),
-		    l10n::getView(l10n::String::STRING_FOR_PING_PONG)};
+	std::vector<std::string_view> getOptions() override {
+		std::vector<std::string_view> sequenceDirectionOptions = {
+		    l10n::getView(l10n::String::STRING_FOR_FORWARD),
+		    l10n::getView(l10n::String::STRING_FOR_REVERSED),
+		    l10n::getView(l10n::String::STRING_FOR_PING_PONG),
+		};
 
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);

--- a/src/deluge/gui/menu_item/shortcuts/version.h
+++ b/src/deluge/gui/menu_item/shortcuts/version.h
@@ -20,12 +20,12 @@
 #include "gui/ui/sound_editor.h"
 
 namespace deluge::gui::menu_item::shortcuts {
-class Version final : public Selection<NUM_SHORTCUTS_VERSIONS> {
+class Version final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(soundEditor.shortcutsVersion); }
 	void writeCurrentValue() override { soundEditor.setShortcutsVersion(this->getValue()); }
-	static_vector<std::string_view, capacity()> getOptions() override {
+	std::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_SHORTCUTS_VERSION_1),

--- a/src/deluge/gui/menu_item/source_selection.cpp
+++ b/src/deluge/gui/menu_item/source_selection.cpp
@@ -24,6 +24,7 @@
 #include "modulation/patch/patch_cable_set.h"
 #include "patch_cable_strength.h"
 #include "processing/sound/sound.h"
+#include "util/container/static_vector.hpp"
 #include <array>
 
 namespace deluge::gui::menu_item {

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -1,0 +1,143 @@
+#include "submenu.h"
+
+namespace deluge::gui::menu_item {
+void Submenu::beginSession(MenuItem* navigatedBackwardFrom) {
+	current_item_ = items.begin();
+	soundEditor.menuCurrentScroll = 0;
+	soundEditor.currentMultiRange = nullptr;
+	if (navigatedBackwardFrom != nullptr) {
+		for (; *current_item_ != navigatedBackwardFrom; current_item_++) {
+			if (current_item_ == items.end()) { // If desired item not found
+				current_item_ = items.begin();
+				break;
+			}
+		}
+	}
+	while (!(*current_item_)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
+		current_item_++;
+		if (current_item_ == items.end()) { // Not sure we need this since we don't wrap submenu items?
+			current_item_ = items.begin();
+		}
+	}
+	if (display->have7SEG()) {
+		updateDisplay();
+	}
+}
+
+void Submenu::updateDisplay() {
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+	else {
+		(*current_item_)->drawName();
+	}
+}
+
+void Submenu::drawPixelsForOled() {
+	int32_t selectedRow = soundEditor.menuCurrentScroll;
+
+	// This finds the next relevant submenu item
+	static_vector<std::string_view, kOLEDMenuNumOptionsVisible> nextItemNames = {};
+	int32_t idx = selectedRow;
+	for (auto it = current_item_; it != this->items.end() && idx < kOLEDMenuNumOptionsVisible; it++) {
+		if ((*it)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
+			nextItemNames.push_back((*it)->getName());
+			idx++;
+		}
+	}
+
+	static_vector<std::string_view, kOLEDMenuNumOptionsVisible> prevItemNames = {};
+	idx = selectedRow - 1;
+	for (auto it = current_item_ - 1; it != this->items.begin() - 1 && idx >= 0; it--) {
+		if ((*it)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
+			prevItemNames.push_back((*it)->getName());
+			idx--;
+		}
+	}
+	std::reverse(prevItemNames.begin(), prevItemNames.end());
+
+	if (!prevItemNames.empty()) {
+		prevItemNames.insert(prevItemNames.end(), nextItemNames.begin(), nextItemNames.end());
+		drawItemsForOled(prevItemNames, selectedRow);
+	}
+	else {
+		drawItemsForOled(nextItemNames, selectedRow);
+	}
+}
+
+void Submenu::selectEncoderAction(int32_t offset) {
+
+	auto thisSubmenuItem = current_item_;
+
+	do {
+		if (offset >= 0) {
+			thisSubmenuItem++;
+			if (thisSubmenuItem == items.end()) {
+				if (display->haveOLED()) {
+					return;
+				}
+				else {
+					thisSubmenuItem = items.begin();
+				}
+			}
+		}
+		else {
+			if (thisSubmenuItem == items.begin()) {
+				if (display->haveOLED()) {
+					return;
+				}
+				else {
+					thisSubmenuItem = (items.end() - 1);
+				}
+			}
+			else {
+				thisSubmenuItem--;
+			}
+		}
+	} while (!(*thisSubmenuItem)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex));
+
+	current_item_ = thisSubmenuItem;
+
+	if (display->haveOLED()) {
+		soundEditor.menuCurrentScroll += offset;
+		if (soundEditor.menuCurrentScroll < 0) {
+			soundEditor.menuCurrentScroll = 0;
+		}
+		else if (soundEditor.menuCurrentScroll > kOLEDMenuNumOptionsVisible - 1) {
+			soundEditor.menuCurrentScroll = kOLEDMenuNumOptionsVisible - 1;
+		}
+	}
+
+	updateDisplay();
+}
+
+MenuItem* Submenu::selectButtonPress() {
+	return *current_item_;
+}
+
+void Submenu::unlearnAction() {
+	if (soundEditor.getCurrentMenuItem() == this) {
+		(*current_item_)->unlearnAction();
+	}
+}
+
+bool Submenu::allowsLearnMode() {
+	if (soundEditor.getCurrentMenuItem() == this) {
+		return (*current_item_)->allowsLearnMode();
+	}
+	return false;
+}
+
+void Submenu::learnKnob(MIDIDevice* fromDevice, int32_t whichKnob, int32_t modKnobMode, int32_t midiChannel) {
+	if (soundEditor.getCurrentMenuItem() == this) {
+		(*current_item_)->learnKnob(fromDevice, whichKnob, modKnobMode, midiChannel);
+	}
+}
+
+bool Submenu::learnNoteOn(MIDIDevice* fromDevice, int32_t channel, int32_t noteCode) {
+	if (soundEditor.getCurrentMenuItem() == this) {
+		return (*current_item_)->learnNoteOn(fromDevice, channel, noteCode);
+	}
+	return false;
+}
+} // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -31,17 +31,19 @@
 #include "util/container/static_vector.hpp"
 #include <array>
 #include <initializer_list>
+#include <span>
 
 namespace deluge::gui::menu_item {
 
-template <size_t n>
 class Submenu : public MenuItem {
 public:
-	Submenu(l10n::String newName, MenuItem* const (&newItems)[n])
-	    : MenuItem(newName), items{to_static_vector(newItems)} {}
-	Submenu(l10n::String newName, l10n::String title, MenuItem* const (&newItems)[n])
-	    : MenuItem(newName, title), items{to_static_vector(newItems)} {}
-	Submenu(l10n::String newName, l10n::String title, std::array<MenuItem*, n> newItems)
+	Submenu(l10n::String newName, std::initializer_list<MenuItem*> newItems) : MenuItem(newName), items{newItems} {}
+	Submenu(l10n::String newName, std::span<MenuItem*> newItems)
+	    : MenuItem(newName), items{newItems.begin(), newItems.end()} {}
+	Submenu(l10n::String newName, l10n::String title, std::initializer_list<MenuItem*> newItems)
+	    : MenuItem(newName, title), items{newItems} {}
+
+	Submenu(l10n::String newName, l10n::String title, std::span<MenuItem*> newItems)
 	    : MenuItem(newName, title), items{newItems.begin(), newItems.end()} {}
 
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override;
@@ -55,156 +57,8 @@ public:
 	bool learnNoteOn(MIDIDevice* fromDevice, int32_t channel, int32_t noteCode) final;
 	void drawPixelsForOled() override;
 
-	deluge::static_vector<MenuItem*, n> items;
+	std::vector<MenuItem*> items;
 	typename decltype(items)::iterator current_item_;
 };
-
-template <size_t n>
-void Submenu<n>::beginSession(MenuItem* navigatedBackwardFrom) {
-	current_item_ = items.begin();
-	soundEditor.menuCurrentScroll = 0;
-	soundEditor.currentMultiRange = nullptr;
-	if (navigatedBackwardFrom != nullptr) {
-		for (; *current_item_ != navigatedBackwardFrom; current_item_++) {
-			if (current_item_ == items.end()) { // If desired item not found
-				current_item_ = items.begin();
-				break;
-			}
-		}
-	}
-	while (!(*current_item_)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
-		current_item_++;
-		if (current_item_ == items.end()) { // Not sure we need this since we don't wrap submenu items?
-			current_item_ = items.begin();
-		}
-	}
-	if (display->have7SEG()) {
-		updateDisplay();
-	}
-}
-
-template <size_t n>
-void Submenu<n>::updateDisplay() {
-	if (display->haveOLED()) {
-		renderUIsForOled();
-	}
-	else {
-		(*current_item_)->drawName();
-	}
-}
-
-template <size_t n>
-void Submenu<n>::drawPixelsForOled() {
-	int32_t selectedRow = soundEditor.menuCurrentScroll;
-
-	// This finds the next relevant submenu item
-	static_vector<std::string_view, kOLEDMenuNumOptionsVisible> nextItemNames = {};
-	for (auto it = current_item_, idx = selectedRow; it != this->items.end() && idx < kOLEDMenuNumOptionsVisible;
-	     it++) {
-		if ((*it)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
-			nextItemNames.push_back((*it)->getName());
-			idx++;
-		}
-	}
-
-	static_vector<std::string_view, kOLEDMenuNumOptionsVisible> prevItemNames = {};
-	for (auto it = current_item_ - 1, idx = selectedRow - 1; it != this->items.begin() - 1 && idx >= 0; it--) {
-		if ((*it)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
-			prevItemNames.push_back((*it)->getName());
-			idx--;
-		}
-	}
-	std::reverse(prevItemNames.begin(), prevItemNames.end());
-
-	if (!prevItemNames.empty()) {
-		prevItemNames.insert(prevItemNames.end(), nextItemNames.begin(), nextItemNames.end());
-		drawItemsForOled(prevItemNames, selectedRow);
-	}
-	else {
-		drawItemsForOled(nextItemNames, selectedRow);
-	}
-}
-
-template <size_t n>
-void Submenu<n>::selectEncoderAction(int32_t offset) {
-
-	auto thisSubmenuItem = current_item_;
-
-	do {
-		if (offset >= 0) {
-			thisSubmenuItem++;
-			if (thisSubmenuItem == items.end()) {
-				if (display->haveOLED()) {
-					return;
-				}
-				else {
-					thisSubmenuItem = items.begin();
-				}
-			}
-		}
-		else {
-			if (thisSubmenuItem == items.begin()) {
-				if (display->haveOLED()) {
-					return;
-				}
-				else {
-					thisSubmenuItem = &items.back();
-				}
-			}
-			else {
-				thisSubmenuItem--;
-			}
-		}
-	} while (!(*thisSubmenuItem)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex));
-
-	current_item_ = thisSubmenuItem;
-
-	if (display->haveOLED()) {
-		soundEditor.menuCurrentScroll += offset;
-		if (soundEditor.menuCurrentScroll < 0) {
-			soundEditor.menuCurrentScroll = 0;
-		}
-		else if (soundEditor.menuCurrentScroll > kOLEDMenuNumOptionsVisible - 1) {
-			soundEditor.menuCurrentScroll = kOLEDMenuNumOptionsVisible - 1;
-		}
-	}
-
-	updateDisplay();
-}
-
-template <size_t n>
-MenuItem* Submenu<n>::selectButtonPress() {
-	return *current_item_;
-}
-
-template <size_t n>
-void Submenu<n>::unlearnAction() {
-	if (soundEditor.getCurrentMenuItem() == this) {
-		(*current_item_)->unlearnAction();
-	}
-}
-
-template <size_t n>
-bool Submenu<n>::allowsLearnMode() {
-	if (soundEditor.getCurrentMenuItem() == this) {
-		return (*current_item_)->allowsLearnMode();
-	}
-	return false;
-}
-
-template <size_t n>
-void Submenu<n>::learnKnob(MIDIDevice* fromDevice, int32_t whichKnob, int32_t modKnobMode, int32_t midiChannel) {
-	if (soundEditor.getCurrentMenuItem() == this) {
-		(*current_item_)->learnKnob(fromDevice, whichKnob, modKnobMode, midiChannel);
-	}
-}
-
-template <size_t n>
-bool Submenu<n>::learnNoteOn(MIDIDevice* fromDevice, int32_t channel, int32_t noteCode) {
-	if (soundEditor.getCurrentMenuItem() == this) {
-		return (*current_item_)->learnNoteOn(fromDevice, channel, noteCode);
-	}
-	return false;
-}
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/submenu/actual_source.h
+++ b/src/deluge/gui/menu_item/submenu/actual_source.h
@@ -24,15 +24,14 @@
 extern void setOscillatorNumberForTitles(int32_t);
 
 namespace deluge::gui::menu_item::submenu {
-template <size_t n>
-class ActualSource final : public SubmenuReferringToOneThing<n> {
+class ActualSource final : public SubmenuReferringToOneThing {
 public:
-	using SubmenuReferringToOneThing<n>::SubmenuReferringToOneThing;
+	using SubmenuReferringToOneThing::SubmenuReferringToOneThing;
 
 	//OLED Only
 	void beginSession(MenuItem* navigatedBackwardFrom) {
 		setOscillatorNumberForTitles(this->thingIndex);
-		SubmenuReferringToOneThing<n>::beginSession(navigatedBackwardFrom);
+		SubmenuReferringToOneThing::beginSession(navigatedBackwardFrom);
 	}
 
 	// 7seg Only
@@ -44,13 +43,9 @@ public:
 			display->setText(buffer);
 		}
 		else {
-			SubmenuReferringToOneThing<n>::drawName();
+			SubmenuReferringToOneThing::drawName();
 		}
 	}
 };
-
-// Template deduction guide, will not be required with P2582@C++23
-template <size_t n>
-ActualSource(l10n::String, MenuItem* const (&)[n], int32_t) -> ActualSource<n>;
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu/arpeggiator.h
+++ b/src/deluge/gui/menu_item/submenu/arpeggiator.h
@@ -24,20 +24,16 @@
 
 namespace deluge::gui::menu_item::submenu {
 
-template <size_t n>
-class Arpeggiator final : public Submenu<n> {
+class Arpeggiator final : public Submenu {
 public:
-	using Submenu<n>::Submenu;
+	using Submenu::Submenu;
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override {
 
 		soundEditor.currentArpSettings = soundEditor.editingKit()
 		                                     ? &(static_cast<SoundDrum*>(soundEditor.currentSound))->arpSettings
 		                                     : &(static_cast<InstrumentClip*>(currentSong->currentClip))->arpSettings;
-		Submenu<n>::beginSession(navigatedBackwardFrom);
+		Submenu::beginSession(navigatedBackwardFrom);
 	}
 };
 
-// Template deduction guide, will not be required with P2582@C++23
-template <size_t n>
-Arpeggiator(l10n::String, MenuItem* const (&)[n]) -> Arpeggiator<n>;
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu/bend.h
+++ b/src/deluge/gui/menu_item/submenu/bend.h
@@ -21,19 +21,14 @@
 #include "model/song/song.h"
 
 namespace deluge::gui::menu_item::submenu {
-template <size_t n>
-class Bend final : public Submenu<n> {
+class Bend final : public Submenu {
 public:
-	using Submenu<n>::Submenu;
+	using Submenu::Submenu;
 	bool isRelevant(Sound* sound, int32_t whichThing) override {
 		// Drums within a Kit don't need the two-item submenu - they have their own single item.
 		const auto type = currentSong->currentClip->output->type;
 		return (type == InstrumentType::SYNTH || type == InstrumentType::CV);
 	}
 };
-
-// Template deduction guide, will not be required with P2582@C++23
-template <size_t n>
-Bend(l10n::String, MenuItem* const (&)[n]) -> Bend<n>;
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu/compressor.h
+++ b/src/deluge/gui/menu_item/submenu/compressor.h
@@ -21,21 +21,18 @@
 #include "processing/sound/sound.h"
 
 namespace deluge::gui::menu_item::submenu {
-template <size_t n>
-class Compressor final : public Submenu<n> {
+class Compressor final : public Submenu {
 public:
-	Compressor(l10n::String newName, l10n::String title, MenuItem* const (&newItems)[n], bool newForReverbCompressor)
-	    : Submenu<n>(newName, title, newItems), forReverbCompressor(newForReverbCompressor) {}
+	Compressor(l10n::String newName, l10n::String title, std::initializer_list<MenuItem*> newItems,
+	           bool newForReverbCompressor)
+	    : Submenu(newName, title, newItems), forReverbCompressor(newForReverbCompressor) {}
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override {
 		soundEditor.currentCompressor =
 		    forReverbCompressor ? &AudioEngine::reverbCompressor : &soundEditor.currentSound->compressor;
-		Submenu<n>::beginSession(navigatedBackwardFrom);
+		Submenu::beginSession(navigatedBackwardFrom);
 	}
 
 	bool forReverbCompressor;
 };
-// Template deduction guide, will not be required with P2582@C++23
-template <size_t n>
-Compressor(l10n::String, MenuItem* const (&)[n]) -> Compressor<n>;
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu/envelope.h
+++ b/src/deluge/gui/menu_item/submenu/envelope.h
@@ -20,19 +20,14 @@
 extern void setEnvelopeNumberForTitles(int32_t);
 
 namespace deluge::gui::menu_item::submenu {
-template <size_t n>
-class Envelope final : public SubmenuReferringToOneThing<n> {
+class Envelope final : public SubmenuReferringToOneThing {
 public:
-	using SubmenuReferringToOneThing<n>::SubmenuReferringToOneThing;
+	using SubmenuReferringToOneThing::SubmenuReferringToOneThing;
 
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) {
-		SubmenuReferringToOneThing<n>::beginSession(navigatedBackwardFrom);
+		SubmenuReferringToOneThing::beginSession(navigatedBackwardFrom);
 		setEnvelopeNumberForTitles(this->thingIndex);
 	}
 };
-
-// Template deduction guide, will not be required with P2582@C++23
-template <size_t n>
-Envelope(l10n::String, MenuItem* const (&)[n], int32_t) -> Envelope<n>;
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu/filter.h
+++ b/src/deluge/gui/menu_item/submenu/filter.h
@@ -19,15 +19,10 @@
 #include "processing/sound/sound.h"
 
 namespace deluge::gui::menu_item::submenu {
-template <size_t n>
-class Filter final : public Submenu<n> {
+class Filter final : public Submenu {
 public:
-	using Submenu<n>::Submenu;
+	using Submenu::Submenu;
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->synthMode != SynthMode::FM); }
 };
-
-// Template deduction guide, will not be required with P2582@C++23
-template <size_t n>
-Filter(l10n::String, MenuItem* const (&)[n]) -> Filter<n>;
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu/modulator.h
+++ b/src/deluge/gui/menu_item/submenu/modulator.h
@@ -21,21 +21,16 @@
 extern void setModulatorNumberForTitles(int32_t);
 
 namespace deluge::gui::menu_item::submenu {
-template <size_t n>
-class Modulator final : public SubmenuReferringToOneThing<n> {
+class Modulator final : public SubmenuReferringToOneThing {
 public:
-	using SubmenuReferringToOneThing<n>::SubmenuReferringToOneThing;
+	using SubmenuReferringToOneThing::SubmenuReferringToOneThing;
 
 	void beginSession(MenuItem* navigatedBackwardFrom) {
 		setModulatorNumberForTitles(this->thingIndex);
-		SubmenuReferringToOneThing<n>::beginSession(navigatedBackwardFrom);
+		SubmenuReferringToOneThing::beginSession(navigatedBackwardFrom);
 	}
 
 	bool isRelevant(Sound* sound, int32_t whichThing) { return (sound->synthMode == SynthMode::FM); }
 };
-
-// Template deduction guide, will not be required with P2582@C++23
-template <size_t n>
-Modulator(l10n::String, MenuItem* const (&)[n], int32_t) -> Modulator<n>;
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu_referring_to_one_thing.h
+++ b/src/deluge/gui/menu_item/submenu_referring_to_one_thing.h
@@ -20,17 +20,19 @@
 #include "submenu.h"
 
 namespace deluge::gui::menu_item {
-template <size_t n>
-class SubmenuReferringToOneThing : public Submenu<n> {
+class SubmenuReferringToOneThing : public Submenu {
 public:
-	SubmenuReferringToOneThing(l10n::String newName, MenuItem* const (&newItems)[n], int32_t newThingIndex)
-	    : Submenu<n>(newName, newItems), thingIndex(newThingIndex) {}
+	SubmenuReferringToOneThing(l10n::String newName, std::initializer_list<MenuItem*> newItems, int32_t newThingIndex)
+	    : Submenu(newName, newItems), thingIndex(newThingIndex) {}
+
+	SubmenuReferringToOneThing(l10n::String newName, std::span<MenuItem*> newItems, int32_t newThingIndex)
+	    : Submenu(newName, newItems), thingIndex(newThingIndex) {}
 
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override {
 		soundEditor.currentSourceIndex = thingIndex;
 		soundEditor.currentSource = &soundEditor.currentSound->sources[thingIndex];
 		soundEditor.currentSampleControls = &soundEditor.currentSource->sampleControls;
-		Submenu<n>::beginSession(navigatedBackwardFrom);
+		Submenu::beginSession(navigatedBackwardFrom);
 	}
 
 	uint8_t thingIndex;

--- a/src/deluge/gui/menu_item/sync_level.h
+++ b/src/deluge/gui/menu_item/sync_level.h
@@ -23,12 +23,13 @@
 namespace deluge::gui::menu_item {
 
 // This one is "absolute" - if song's insideWorldTickMagnitude changes, such a param's text value will display as a different one, but the music will sound the same
-class SyncLevel : public Enumeration<28> {
+class SyncLevel : public Enumeration {
 public:
 	using Enumeration::Enumeration;
 	SyncType menuOptionToSyncType(int32_t option);
 	::SyncLevel menuOptionToSyncLevel(int32_t option);
 	int32_t syncTypeAndLevelToMenuOption(SyncType type, ::SyncLevel level);
+	size_t size() override { return 28; }
 
 protected:
 	void drawValue() final;

--- a/src/deluge/gui/menu_item/synth_mode.h
+++ b/src/deluge/gui/menu_item/synth_mode.h
@@ -24,7 +24,7 @@
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item {
-class SynthMode final : public Selection<kNumSynthModes> {
+class SynthMode final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(soundEditor.currentSound->synthMode); }
@@ -33,9 +33,12 @@ public:
 		view.setKnobIndicatorLevels();
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
-		return {l10n::getView(l10n::String::STRING_FOR_SUBTRACTIVE), l10n::getView(l10n::String::STRING_FOR_FM),
-		        l10n::getView(l10n::String::STRING_FOR_RINGMOD)};
+	std::vector<std::string_view> getOptions() override {
+		return {
+		    l10n::getView(l10n::String::STRING_FOR_SUBTRACTIVE),
+		    l10n::getView(l10n::String::STRING_FOR_FM),
+		    l10n::getView(l10n::String::STRING_FOR_RINGMOD),
+		};
 	}
 
 	bool isRelevant(Sound* sound, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/voice/polyphony.h
+++ b/src/deluge/gui/menu_item/voice/polyphony.h
@@ -25,11 +25,10 @@
 #include "model/song/song.h"
 #include "processing/sound/sound.h"
 #include "processing/sound/sound_drum.h"
-#include "util/container/static_vector.hpp"
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::voice {
-class Polyphony final : public Selection<kNumPolyphonyModes> {
+class Polyphony final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(soundEditor.currentSound->polyphonic); }
@@ -55,10 +54,13 @@ public:
 		}
 	}
 
-	static_vector<std::string_view, capacity()> getOptions() override {
-		static_vector<std::string_view, capacity()> options = {
-		    l10n::getView(l10n::String::STRING_FOR_AUTO), l10n::getView(l10n::String::STRING_FOR_POLYPHONIC),
-		    l10n::getView(l10n::String::STRING_FOR_MONOPHONIC), l10n::getView(l10n::String::STRING_FOR_LEGATO)};
+	std::vector<std::string_view> getOptions() override {
+		std::vector<std::string_view> options = {
+		    l10n::getView(l10n::String::STRING_FOR_AUTO),
+		    l10n::getView(l10n::String::STRING_FOR_POLYPHONIC),
+		    l10n::getView(l10n::String::STRING_FOR_MONOPHONIC),
+		    l10n::getView(l10n::String::STRING_FOR_LEGATO),
+		};
 
 		if (soundEditor.editingKit()) {
 			options.push_back(l10n::getView(l10n::String::STRING_FOR_CHOKE));

--- a/src/deluge/gui/menu_item/voice/priority.h
+++ b/src/deluge/gui/menu_item/voice/priority.h
@@ -18,18 +18,20 @@
 #include "definitions_cxx.hpp"
 #include "gui/menu_item/selection.h"
 #include "gui/ui/sound_editor.h"
-#include "util/container/static_vector.hpp"
 #include "util/misc.h"
 
 namespace deluge::gui::menu_item::voice {
-class Priority final : public Selection<kNumVoicePriorities> {
+class Priority final : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(*soundEditor.currentPriority); }
 	void writeCurrentValue() override { *soundEditor.currentPriority = this->getValue<VoicePriority>(); }
-	static_vector<std::string_view, capacity()> getOptions() override {
-		return {l10n::getView(l10n::String::STRING_FOR_LOW), l10n::getView(l10n::String::STRING_FOR_MEDIUM),
-		        l10n::getView(l10n::String::STRING_FOR_HIGH)};
+	std::vector<std::string_view> getOptions() override {
+		return {
+		    l10n::getView(l10n::String::STRING_FOR_LOW),
+		    l10n::getView(l10n::String::STRING_FOR_MEDIUM),
+		    l10n::getView(l10n::String::STRING_FOR_HIGH),
+		};
 	}
 };
 } // namespace deluge::gui::menu_item::voice

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -225,7 +225,7 @@ envelope::Segment envDecayMenu{STRING_FOR_DECAY, STRING_FOR_ENV_DECAY_MENU_TITLE
 envelope::Segment envSustainMenu{STRING_FOR_SUSTAIN, STRING_FOR_ENV_SUSTAIN_MENU_TITLE, ::Param::Local::ENV_0_SUSTAIN};
 envelope::Segment envReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_ENV_RELEASE_MENU_TITLE, ::Param::Local::ENV_0_RELEASE};
 
-MenuItem* envMenuItems[] = {
+std::array<MenuItem*, 4> envMenuItems = {
     &envAttackMenu,
     &envDecayMenu,
     &envSustainMenu,
@@ -258,7 +258,7 @@ osc::PulseWidth pulseWidthMenu{STRING_FOR_PULSE_WIDTH, STRING_FOR_OSC_P_WIDTH_ME
 osc::Sync oscSyncMenu{STRING_FOR_OSCILLATOR_SYNC};
 osc::RetriggerPhase oscPhaseMenu{STRING_FOR_RETRIGGER_PHASE, STRING_FOR_OSC_R_PHASE_MENU_TITLE, false};
 
-MenuItem* oscMenuItems[] = {
+std::array<MenuItem*, 17> oscMenuItems = {
     &oscTypeMenu,         &sourceVolumeMenu,     &sourceWaveIndexMenu, &sourceFeedbackMenu, &fileSelectorMenu,
     &audioRecorderMenu,   &sampleReverseMenu,    &sampleRepeatMenu,    &sampleStartMenu,    &sampleEndMenu,
     &sourceTransposeMenu, &samplePitchSpeedMenu, &timeStretchMenu,     &interpolationMenu,  &pulseWidthMenu,
@@ -854,7 +854,7 @@ Submenu defaultsSubmenu{
 // Sound editor menu -----------------------------------------------------------------------------
 
 // FM only
-MenuItem* modulatorMenuItems[] = {
+std::array<MenuItem*, 5> modulatorMenuItems = {
     &modulatorVolume, &modulatorTransposeMenu, &modulatorFeedbackMenu, &modulatorDestMenu, &modulatorPhaseMenu,
 };
 

--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -29,13 +29,13 @@ extern DrumName drumNameMenu;
 
 extern deluge::gui::menu_item::firmware::Version firmwareVersionMenu;
 extern deluge::gui::menu_item::sequence::Direction sequenceDirectionMenu;
-extern deluge::gui::menu_item::Submenu<6> soundEditorRootMenuMIDIOrCV;
-extern deluge::gui::menu_item::Submenu<11> soundEditorRootMenuAudioClip;
-extern deluge::gui::menu_item::Submenu<25> soundEditorRootMenu;
-extern deluge::gui::menu_item::Submenu<12> settingsRootMenu;
+extern deluge::gui::menu_item::Submenu soundEditorRootMenuMIDIOrCV;
+extern deluge::gui::menu_item::Submenu soundEditorRootMenuAudioClip;
+extern deluge::gui::menu_item::Submenu soundEditorRootMenu;
+extern deluge::gui::menu_item::Submenu settingsRootMenu;
 
 namespace deluge::gui::menu_item::runtime_feature {
-extern Submenu<4> subMenuAutomation;
+extern Submenu subMenuAutomation;
 }
 
 extern deluge::gui::menu_item::PatchCables patchCablesMenu;

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -193,7 +193,7 @@ void RuntimeFeatureSettings::readSettingsFromFile() {
 
 			bool found = false;
 			for (auto& setting : settings) {
-				if (strcmp(setting.xmlName.c_str(), currentName.get()) == 0) {
+				if (strcmp(setting.xmlName.data(), currentName.get()) == 0) {
 					found = true;
 					setting.value = currentValue;
 				}
@@ -234,7 +234,7 @@ void RuntimeFeatureSettings::writeSettingsToFile() {
 
 	for (auto& setting : settings) {
 		storageManager.writeOpeningTagBeginning(TAG_RUNTIME_FEATURE_SETTING);
-		storageManager.writeAttribute(TAG_RUNTIME_FEATURE_SETTING_ATTR_NAME, setting.xmlName.c_str(), false);
+		storageManager.writeAttribute(TAG_RUNTIME_FEATURE_SETTING_ATTR_NAME, setting.xmlName.data(), false);
 		storageManager.writeAttribute(TAG_RUNTIME_FEATURE_SETTING_ATTR_VALUE, setting.value, false);
 		storageManager.writeOpeningTagEnd(false);
 		storageManager.writeClosingTag(TAG_RUNTIME_FEATURE_SETTING, false);
@@ -244,7 +244,7 @@ void RuntimeFeatureSettings::writeSettingsToFile() {
 	for (uint32_t idxUnknownSetting = 0; idxUnknownSetting < unknownSettings.getNumElements(); idxUnknownSetting++) {
 		UnknownSetting* unknownSetting = (UnknownSetting*)unknownSettings.getElementAddress(idxUnknownSetting);
 		storageManager.writeOpeningTagBeginning(TAG_RUNTIME_FEATURE_SETTING);
-		storageManager.writeAttribute(TAG_RUNTIME_FEATURE_SETTING_ATTR_NAME, unknownSetting->name.c_str(), false);
+		storageManager.writeAttribute(TAG_RUNTIME_FEATURE_SETTING_ATTR_NAME, unknownSetting->name.data(), false);
 		storageManager.writeAttribute(TAG_RUNTIME_FEATURE_SETTING_ATTR_VALUE, unknownSetting->value, false);
 		storageManager.writeOpeningTagEnd(false);
 		storageManager.writeClosingTag(TAG_RUNTIME_FEATURE_SETTING, false);

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -21,9 +21,8 @@
 #include "hid/display/display.h"
 #include "storage/storage_manager.h"
 #include "util/d_string.h"
-#include <cstdio>
 #include <cstring>
-#include <new>
+#include <string_view>
 
 #define RUNTIME_FEATURE_SETTINGS_FILE "CommunityFeatures.XML"
 #define TAG_RUNTIME_FEATURE_SETTINGS "runtimeFeatureSettings"
@@ -37,13 +36,13 @@ struct UnknownSetting {
 	uint32_t value;
 };
 
-PLACE_SDRAM_BSS RuntimeFeatureSettings runtimeFeatureSettings{};
+RuntimeFeatureSettings runtimeFeatureSettings{};
 
 RuntimeFeatureSettings::RuntimeFeatureSettings() : unknownSettings(sizeof(UnknownSetting)) {
 }
 
-static void SetupOnOffSetting(RuntimeFeatureSetting& setting, const std::string& displayName,
-                              const std::string& xmlName, RuntimeFeatureStateToggle def) {
+static void SetupOnOffSetting(RuntimeFeatureSetting& setting, std::string_view displayName, std::string_view xmlName,
+                              RuntimeFeatureStateToggle def) {
 	setting.displayName = displayName;
 	setting.xmlName = xmlName;
 	setting.value = static_cast<uint32_t>(def);
@@ -60,92 +59,94 @@ static void SetupOnOffSetting(RuntimeFeatureSetting& setting, const std::string&
 	};
 }
 
-static void SetupSyncScalingActionSetting(RuntimeFeatureSetting& setting, char const* const displayName,
-                                          char const* const xmlName, RuntimeFeatureStateSyncScalingAction def) {
+static void SetupSyncScalingActionSetting(RuntimeFeatureSetting& setting, std::string_view displayName,
+                                          std::string_view xmlName, RuntimeFeatureStateSyncScalingAction def) {
 	setting.displayName = displayName;
 	setting.xmlName = xmlName;
 	setting.value = static_cast<uint32_t>(def);
 
-	setting.options = {{
-	                       .displayName = display->haveOLED() ? "Sync Scaling" : "SCAL",
-	                       .value = RuntimeFeatureStateSyncScalingAction::SyncScaling,
-	                   },
-	                   {
-	                       .displayName = display->haveOLED() ? "Fill mode" : "FILL",
-	                       .value = RuntimeFeatureStateSyncScalingAction::Fill,
-	                   }};
+	setting.options = {
+	    {
+	        .displayName = display->haveOLED() ? "Sync Scaling" : "SCAL",
+	        .value = RuntimeFeatureStateSyncScalingAction::SyncScaling,
+	    },
+	    {
+	        .displayName = display->haveOLED() ? "Fill mode" : "FILL",
+	        .value = RuntimeFeatureStateSyncScalingAction::Fill,
+	    },
+	};
 }
 
 void RuntimeFeatureSettings::init() {
+	using enum deluge::l10n::String;
 	// Drum randomizer
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::DrumRandomizer],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_DRUM_RANDOMIZER),
-	                  "drumRandomizer", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_DRUM_RANDOMIZER), "drumRandomizer",
+	                  RuntimeFeatureStateToggle::On);
 	// Master compressor
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::MasterCompressorFx],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_MASTER_COMPRESSOR),
-	                  "masterCompressor", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_MASTER_COMPRESSOR), "masterCompressor",
+	                  RuntimeFeatureStateToggle::On);
 	// Quantize
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::Quantize],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_QUANTIZE), "quantize",
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_QUANTIZE), "quantize",
 	                  RuntimeFeatureStateToggle::On);
 	// FineTempoKnob
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::FineTempoKnob],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_FINE_TEMPO_KNOB),
-	                  "fineTempoKnob", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_FINE_TEMPO_KNOB), "fineTempoKnob",
+	                  RuntimeFeatureStateToggle::On);
 	// PatchCableResolution
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::PatchCableResolution],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_MOD_DEPTH_DECIMALS),
-	                  "modDepthDecimals", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_MOD_DEPTH_DECIMALS), "modDepthDecimals",
+	                  RuntimeFeatureStateToggle::On);
 	// CatchNotes
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::CatchNotes],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_CATCH_NOTES), "catchNotes",
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_CATCH_NOTES), "catchNotes",
 	                  RuntimeFeatureStateToggle::On);
 	// DeleteUnusedKitRows
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::DeleteUnusedKitRows],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_DELETE_UNUSED_KIT_ROWS),
-	                  "deleteUnusedKitRows", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_DELETE_UNUSED_KIT_ROWS), "deleteUnusedKitRows",
+	                  RuntimeFeatureStateToggle::On);
 	// AltGoldenKnobDelayParams
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AltGoldenKnobDelayParams],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_ALT_DELAY_PARAMS),
-	                  "altGoldenKnobDelayParams", RuntimeFeatureStateToggle::Off);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_ALT_DELAY_PARAMS), "altGoldenKnobDelayParams",
+	                  RuntimeFeatureStateToggle::Off);
 	// QuantizedStutterRate
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::QuantizedStutterRate],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_QUANTIZED_STUTTER),
-	                  "quantizedStutterRate", RuntimeFeatureStateToggle::Off);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_QUANTIZED_STUTTER), "quantizedStutterRate",
+	                  RuntimeFeatureStateToggle::Off);
 	// InterpolateAutomation
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AutomationInterpolate],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_INTERPOLATION),
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_INTERPOLATION),
 	                  "automationInterpolate", RuntimeFeatureStateToggle::On);
 	// ClearClipAutomation
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AutomationClearClip],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_CLEAR_CLIP),
-	                  "automationClearClip", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_CLEAR_CLIP), "automationClearClip",
+	                  RuntimeFeatureStateToggle::On);
 	// NudgeNoteAutomation
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AutomationNudgeNote],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_NUDGE_NOTE),
-	                  "automationNudgeNote", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_NUDGE_NOTE), "automationNudgeNote",
+	                  RuntimeFeatureStateToggle::On);
 	// ShiftNoteAutomation
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::AutomationShiftClip],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_SHIFT_CLIP),
-	                  "automationShiftClip", RuntimeFeatureStateToggle::On);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_AUTOMATION_SHIFT_CLIP), "automationShiftClip",
+	                  RuntimeFeatureStateToggle::On);
 	// devSysexAllowed
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::DevSysexAllowed],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_DEV_SYSEX),
-	                  "devSysexAllowed", RuntimeFeatureStateToggle::Off);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_DEV_SYSEX), "devSysexAllowed",
+	                  RuntimeFeatureStateToggle::Off);
 	// SyncScalingAction
-	SetupSyncScalingActionSetting(
-	    settings[RuntimeFeatureSettingType::SyncScalingAction],
-	    deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_SYNC_SCALING_ACTION), "syncScalingAction",
-	    RuntimeFeatureStateSyncScalingAction::SyncScaling);
+	SetupSyncScalingActionSetting(settings[RuntimeFeatureSettingType::SyncScalingAction],
+	                              deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_SYNC_SCALING_ACTION),
+	                              "syncScalingAction", RuntimeFeatureStateSyncScalingAction::SyncScaling);
 	// HighlightIncomingNotes
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::HighlightIncomingNotes],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_HIGHLIGHT_INCOMING_NOTES),
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_HIGHLIGHT_INCOMING_NOTES),
 	                  "highlightIncomingNotes", RuntimeFeatureStateToggle::On);
 	// DisplayNornsLayout
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::DisplayNornsLayout],
-	                  deluge::l10n::get(deluge::l10n::String::STRING_FOR_COMMUNITY_FEATURE_NORNS_LAYOUT),
-	                  "displayNornsLayout", RuntimeFeatureStateToggle::Off);
+	                  deluge::l10n::getView(STRING_FOR_COMMUNITY_FEATURE_NORNS_LAYOUT), "displayNornsLayout",
+	                  RuntimeFeatureStateToggle::Off);
 
 	// ShiftIsSticky
 	SetupOnOffSetting(settings[RuntimeFeatureSettingType::ShiftIsSticky], "Sticky Shift", "stickyShift",

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -33,7 +33,7 @@
 
 /// Unknown Settings container
 struct UnknownSetting {
-	std::string name;
+	std::string_view name;
 	uint32_t value;
 };
 
@@ -208,7 +208,7 @@ void RuntimeFeatureSettings::readSettingsFromFile() {
 				}
 				void* address = unknownSettings.getElementAddress(idx);
 				auto* unknownSetting = new (address) UnknownSetting();
-				unknownSetting->name = std::string(currentName.get());
+				unknownSetting->name = currentName.get();
 				unknownSetting->value = currentValue;
 			}
 		}

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -18,9 +18,11 @@
 #pragma once
 
 #include "util/container/array/resizeable_array.h"
-#include "util/container/static_vector.hpp"
 
+#include <array>
 #include <cstdint>
+#include <string_view>
+#include <vector>
 
 namespace deluge::gui::menu_item::runtime_feature {
 class Setting;
@@ -60,18 +62,18 @@ enum RuntimeFeatureSettingType : uint32_t {
 
 /// Definition for selectable options
 struct RuntimeFeatureSettingOption {
-	std::string displayName;
+	std::string_view displayName;
 	uint32_t value; // Value to be defined as typed Enum above
 };
 
 /// Every setting keeps its metadata and value in here
 struct RuntimeFeatureSetting {
-	std::string displayName;
-	std::string xmlName;
+	std::string_view displayName;
+	std::string_view xmlName;
 	uint32_t value;
 
 	// Limited to safe memory
-	deluge::static_vector<RuntimeFeatureSettingOption, RUNTIME_FEATURE_SETTING_MAX_OPTIONS> options;
+	std::vector<RuntimeFeatureSettingOption> options;
 };
 
 /// Encapsulating class

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -36,7 +36,7 @@ enum RuntimeFeatureStateToggle : uint32_t { Off = 0, On = 1 };
 // Declare additional enums for specific multi state settings (e.g. like RuntimeFeatureStateTrackLaunchStyle)
 enum RuntimeFeatureStateSyncScalingAction : uint32_t { SyncScaling = 0, Fill = 1 };
 
-/// Every setting needs to be delcared in here - Warning - Probably don't use them in the rendering path
+/// Every setting needs to be declared in here
 enum RuntimeFeatureSettingType : uint32_t {
 	DrumRandomizer,
 	MasterCompressorFx,


### PR DESCRIPTION
This reduces the overall memory footprint by reducing the number of template instantiations of static_vector, while the majority of the std::vector uses are simply instances that contain string_views.