### PR TITLE
build: use THUMB code for UI components

### DIFF
--- a/src/deluge/CMakeLists.txt
+++ b/src/deluge/CMakeLists.txt
@@ -1,5 +1,18 @@
 configure_file(version.h.in version.h @ONLY)
 
+# Ask GCC to generate thumb-mode code for all the GUI code.
+file(GLOB_RECURSE deluge_THUMB_SOURCES
+  CONFIGURE_DEPENDS
+  ${CMAKE_CURRENT_LIST_DIR}/gui/*.c
+  ${CMAKE_CURRENT_LIST_DIR}/gui/*.cpp
+)
+
+set_source_files_properties(${deluge_THUMB_SOURCES}
+  TARGET_DIRECTORY deluge
+  PROPERTIES COMPILE_OPTIONS "-mthumb"
+)
+
+# Add the sources to the target
 file(GLOB_RECURSE deluge_SOURCES CONFIGURE_DEPENDS *.S *.c *.h *.cpp *.hpp)
 target_sources(deluge PUBLIC ${deluge_SOURCES})
 


### PR DESCRIPTION
This code doesn't need to execute at maximum possible speed and a huge amount of it is tiny functions that just build some structure and then return. That makes it well-matched to THUMB code, where we trade some general purpose registers and complex instructions for more compact code. This saves ~100k bytes in the firmware:

```
   text	   data	    bss	    dec	    hex	filename
1391632	  19328	 313532	1724492	 1a504c	baseline.elf
1287496	  19328	 313532	1620356	 18b984	use-thumb-gui.elf
```