### PR TITLE
Restore usb midi functionality

### DIFF
--- a/linker_script_rz_a1l.ld
+++ b/linker_script_rz_a1l.ld
@@ -97,10 +97,8 @@ SECTIONS
 	.frunk_bss (NOLOAD) :
 	{
         . = ALIGN(4);
-        PROVIDE(__frunk_bss_start = .);
         *(.frunk_bss .frunk_bss*)
         . = ALIGN(4);
-        PROVIDE(__frunk_bss_end = .);
 	} > RAM012L
 
 	/* L1 translation table must be aligned to 16KB Boundary!           */

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -40,7 +40,7 @@ extern uint8_t anyUSBSendingStillHappening[];
 //This is supported by GCC and other compilers should error (not warn), so turn off for this file
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
-PLACE_INTERNAL_FRUNK ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES];
+ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES];
 
 namespace MIDIDeviceManager {
 


### PR DESCRIPTION
Move the usb array out of the frunk

Remove the linkerscript provides for the frunk - they don't seem to get set and are a potential source of future bugs