### PR TITLE
Bugfix/frunk

### DIFF
--- a/linker_script_rz_a1l.ld
+++ b/linker_script_rz_a1l.ld
@@ -97,8 +97,11 @@ SECTIONS
 	.frunk_bss (NOLOAD) :
 	{
         . = ALIGN(4);
+        PROVIDE(__frunk_bss_start = .);
         *(.frunk_bss .frunk_bss*)
         . = ALIGN(4);
+		KEEP(*(.frunk_bss))
+        PROVIDE(__frunk_bss_end = .);
 	} > RAM012L
 
 	/* L1 translation table must be aligned to 16KB Boundary!           */
@@ -278,6 +281,7 @@ SECTIONS
         PROVIDE(__sdram_text_start = .);
         *(.sdram_text .sdram_text*)
         . = ALIGN(4);
+		KEEP(*(.sdram_text))
         PROVIDE(__sdram_text_end = .);
 	} > SDRAM
 
@@ -287,6 +291,7 @@ SECTIONS
         PROVIDE(__sdram_data_start = .);
         *(.sdram_data .sdram_data*)
         . = ALIGN(4);
+		KEEP(*(.sdram_data))
         PROVIDE(__sdram_data_end = .);
 	} > SDRAM
 
@@ -309,6 +314,7 @@ SECTIONS
         PROVIDE(__sdram_bss_start = .);
         *(.sdram_bss .sdram_bss*)
         . = ALIGN(4);
+		KEEP(*(.sdram_bss))
         PROVIDE(__sdram_bss_end = .);
     } > SDRAM
 

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -40,7 +40,7 @@ extern uint8_t anyUSBSendingStillHappening[];
 //This is supported by GCC and other compilers should error (not warn), so turn off for this file
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
-PLACE_INTERNAL_FRUNK ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES] = { 0 };
+PLACE_INTERNAL_FRUNK ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES];
 
 namespace MIDIDeviceManager {
 

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -40,7 +40,7 @@ extern uint8_t anyUSBSendingStillHappening[];
 //This is supported by GCC and other compilers should error (not warn), so turn off for this file
 #pragma GCC diagnostic ignored "-Winvalid-offsetof"
 
-ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES];
+PLACE_INTERNAL_FRUNK ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES] = { 0 };
 
 namespace MIDIDeviceManager {
 

--- a/src/resetprg.c
+++ b/src/resetprg.c
@@ -81,7 +81,8 @@ extern void __libc_init_array(void);
 #define PLACEMENT_FLASH_START (0x18080000) // Copied from bootloader, start address of firmware image in flash
 
 extern uint32_t __heap_start;
-
+extern uint32_t __frunk_bss_start;
+extern uint32_t __frunk_bss_end;
 extern uint32_t __sdram_bss_start;
 extern uint32_t __sdram_bss_end;
 extern uint32_t __sdram_text_start;
@@ -99,9 +100,7 @@ void _fini(void) {
 	// empty
 }
 
-inline void emptySDRAMSection(uint32_t* start, uint32_t* end) {
-	uint32_t size = (end - start) / sizeof(uint32_t);
-
+inline void emptySection(uint32_t* start, uint32_t* end) {
 	uint32_t* dst = start;
 	while (dst < end) {
 		*dst = 0;
@@ -127,6 +126,8 @@ inline void relocateSDRAMSection(uint32_t* start, uint32_t* end) {
  * Return Value : none
  *******************************************************************************/
 void resetprg(void) {
+	emptySection(&__frunk_bss_start, &__frunk_bss_end);
+
 	// Enable all modules' clocks --------------------------------------------------------------
 	STB_Init();
 	// SDRAM pin mux ------------------------------------------------------------------


### PR DESCRIPTION
Fixes empty placements in the section not advancing the location in the linker script. 
Attempt to fix putting connectedUSBMIDIDevices into frunk.
I did check that all the init otherwise works fine and that the area is not involuntarily overwritten at runtime 