### PR TITLE
Make C lookup of l10n strings depend on C++ enum

### DIFF
--- a/src/RZA1/usb/r_usb_basic/src/driver/r_usb_hhubsys.c
+++ b/src/RZA1/usb/r_usb_basic/src/driver/r_usb_hhubsys.c
@@ -933,9 +933,9 @@ static void usb_hhub_init_down_port(usb_utr_t* ptr, uint16_t hubaddr, usb_clsinf
                 USB_PRINTF0("HHHHHHHHHHHHHHHHHHHHHHHHH\n\n");
                 g_usb_shhub_init_seq[ptr->ip]  = USB_SEQ_1; /* Next Sequence */
                 g_usb_shhub_init_port[ptr->ip] = USB_HUB_P1;
-                usb_hhub_specified_path(mess);                                   /* Next Process Selector */
-                consoleTextIfAllBootedUp(l10n_get(STRING_FOR_USB_HUB_ATTACHED)); // By Rohan
-                setTimeUSBInitializationEnds(44100 << 1);                        // No more popups for 2 seconds
+                usb_hhub_specified_path(mess);                                        /* Next Process Selector */
+                consoleTextIfAllBootedUp(l10n_get(l10n_STRING_FOR_USB_HUB_ATTACHED)); // By Rohan
+                setTimeUSBInitializationEnds(44100 << 1);                             // No more popups for 2 seconds
 
                 break;
 
@@ -1480,7 +1480,7 @@ noPortConnection:
                             {
                                 usb_hhub_port_detach(ptr, hubaddr, g_usb_shhub_event_port[ptr->ip]);
                                 USB_PRINTF1(" Hubport disconnect address%d\n", devaddr);
-                                consoleTextIfAllBootedUp(l10n_get(STRING_FOR_USB_DEVICE_DETACHED)); // By Rohan
+                                consoleTextIfAllBootedUp(l10n_get(l10n_STRING_FOR_USB_DEVICE_DETACHED)); // By Rohan
                                 g_usb_shhub_info_data[ptr->ip][devaddr].up_addr     = 0; /* Up-address clear */
                                 g_usb_shhub_info_data[ptr->ip][devaddr].up_port_num = 0; /* Up-port num clear */
                                 g_usb_shhub_info_data[ptr->ip][devaddr].port_num    = 0; /* Port number clear */
@@ -2832,7 +2832,7 @@ static void usb_hhub_new_connect(usb_utr_t* ptr, uint16_t hubaddr, uint16_t port
     else
     {
         USB_PRINTF0("### device count over !\n");
-        consoleTextIfAllBootedUp(l10n_get(STRING_FOR_USB_DEVICES_MAX));
+        consoleTextIfAllBootedUp(l10n_get(l10n_STRING_FOR_USB_DEVICES_MAX));
     }
 } /* End of function usb_hhub_new_connect() */
 

--- a/src/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
+++ b/src/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
@@ -283,7 +283,7 @@ static uint16_t usb_hstd_enumeration(usb_utr_t* ptr)
                             if (1 != flg)
                             {
                                 // By Rohan. Means couldn't find an available "driver" for this device. It could be a 2nd hub.
-                                consoleTextIfAllBootedUp(l10n_get(STRING_FOR_USB_DEVICE_NOT_RECOGNIZED));
+                                consoleTextIfAllBootedUp(l10n_get(l10n_STRING_FOR_USB_DEVICE_NOT_RECOGNIZED));
                                 ctrl.address = g_usb_hstd_device_addr[ptr->ip]; /* USB Device address */
                                 ctrl.module  = ptr->ip;                         /* Module number setting */
                                 usb_set_event(USB_STS_NOT_SUPPORT, &ctrl);      /* Set Event()  */

--- a/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
+++ b/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
@@ -592,7 +592,7 @@ uint16_t usb_hmidi_pipe_info(usb_utr_t* ptr, uint8_t* table, uint16_t speed, uin
 
                     // If still here, we didn't find a pipe
                     uartPrintln("no free pipe");
-                    consoleTextIfAllBootedUp(l10n_get(STRING_FOR_USB_DEVICES_MAX));
+                    consoleTextIfAllBootedUp(l10n_get(l10n_STRING_FOR_USB_DEVICES_MAX));
                     goto moveOnToNextDescriptor;
 
 pickedReceivePipe:

--- a/src/deluge/deluge.h
+++ b/src/deluge/deluge.h
@@ -16,6 +16,7 @@
 */
 
 #pragma once
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -44,14 +45,12 @@ extern void setTimeUSBInitializationEnds(int32_t timeFromNow);
 
 // The following is for use by RZA1, based on gui/l10n/strings.h
 // THIS MUST MATCH THE VALUES OF THESE ENTRIES IN deluge::l10n::String
-enum l10n_string {
-	STRING_FOR_USB_DEVICES_MAX = 256,
-	STRING_FOR_USB_DEVICE_DETACHED,
-	STRING_FOR_USB_HUB_ATTACHED,
-	STRING_FOR_USB_DEVICE_NOT_RECOGNIZED,
-};
+extern const size_t l10n_STRING_FOR_USB_DEVICES_MAX;
+extern const size_t l10n_STRING_FOR_USB_DEVICE_DETACHED;
+extern const size_t l10n_STRING_FOR_USB_HUB_ATTACHED;
+extern const size_t l10n_STRING_FOR_USB_DEVICE_NOT_RECOGNIZED;
 
-char const* l10n_get(enum l10n_string s);
+char const* l10n_get(size_t s);
 
 #ifdef __cplusplus
 }

--- a/src/deluge/gui/l10n/l10n.cpp
+++ b/src/deluge/gui/l10n/l10n.cpp
@@ -1,5 +1,6 @@
 #include "gui/l10n/l10n.h"
 #include "gui/l10n/strings.h"
+#include "util/misc.h"
 
 namespace deluge::l10n {
 Language const* chosenLanguage = nullptr;
@@ -8,7 +9,15 @@ Language const* chosenLanguage = nullptr;
 
 extern "C" {
 #include "deluge.h"
-char const* l10n_get(l10n_string string) {
+
+const size_t l10n_STRING_FOR_USB_DEVICES_MAX = util::to_underlying(deluge::l10n::String::STRING_FOR_USB_DEVICES_MAX);
+const size_t l10n_STRING_FOR_USB_DEVICE_DETACHED =
+    util::to_underlying(deluge::l10n::String::STRING_FOR_USB_DEVICE_DETACHED);
+const size_t l10n_STRING_FOR_USB_HUB_ATTACHED = util::to_underlying(deluge::l10n::String::STRING_FOR_USB_HUB_ATTACHED);
+const size_t l10n_STRING_FOR_USB_DEVICE_NOT_RECOGNIZED =
+    util::to_underlying(deluge::l10n::String::STRING_FOR_USB_DEVICE_NOT_RECOGNIZED);
+
+char const* l10n_get(size_t string) {
 	return deluge::l10n::get(static_cast<deluge::l10n::String>(string));
 }
 }

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -1,6 +1,4 @@
 #pragma once
-#include "gui/l10n/strings.h"
-#include <array>
 #include <cstddef>
 
 namespace deluge::l10n {


### PR DESCRIPTION
This fixes the footgun we have deluge.h of needing certain strings used in the C code to match the indices of their counterparts in the C++ enum.