### PR TITLE
POC Sustain Support

### DIFF
--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -935,6 +935,8 @@ void MidiEngine::midiMessageReceived(MIDIDevice* fromDevice, uint8_t statusType,
 		// All these messages, we should only interpret if there's definitely a song loaded
 		if (currentSong) {
 
+		// If the SoundEditor is the active UI, give it first dibs on the message
+
 			switch (statusType) {
 
 			case 0x09: // Note on

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -20,13 +20,16 @@
 #include "io/midi/learned_midi.h"
 #include "model/instrument/instrument.h"
 #include "modulation/arpeggiator.h"
+#include "util/container/array/ordered_resizeable_array.h"
 #include "util/container/array/early_note_array.h"
+#define SUSTAIN_MAX 15
 
 class PostArpTriggerable;
 class NoteRow;
 class ModelStackWithAutoParam;
 class ModelStackWithThreeMainThings;
 class MIDIDevice;
+class OrderedResizeable32bitArray;
 
 class MelodicInstrument : public Instrument {
 public:
@@ -77,11 +80,19 @@ public:
 
 	void offerBendRangeUpdate(ModelStack* modelStack, MIDIDevice* device, int32_t channelOrZone, int32_t whichBendRange,
 	                          int32_t bendSemitones);
+	void sustainPedalOn();
+	void sustainPedalOff();
+	void unsustainNote(int32_t note);
 
 	Arpeggiator arpeggiator;
 
 	EarlyNoteArray earlyNotes;
 	EarlyNoteArray notesAuditioned;
 
+
 	LearnedMIDI midiInput;
+	EarlyNoteArray sustainedNotes;
+	ModelStackWithTimelineCounter* lastModelStack;
+	MIDIDevice* lastDevice;
+	bool sustainPedalPressed = false;
 };

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2751,8 +2751,7 @@ void PlaybackHandler::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, ui
 	}
 	else {
 
-		// If the SoundEditor is the active UI, give it first dibs on the message
-		if (getCurrentUI() == &soundEditor) {
+	if (getCurrentUI() == &soundEditor) {
 			if (soundEditor.midiCCReceived(fromDevice, channel, ccNumber, value)) {
 				return;
 			}


### PR DESCRIPTION
I've finally gotten my sustain pedal to work. It's funny how it's actually a physical mechanism, the hammers are lifted off of the strings so they don't mute when the hammer settles back. This is akin to short circuiting the note-off logic. Once the sustain pedal is lifted, all the notes on the piano get muted. We are only sending note-offs for the ones we've tracked are being sustained.

Any way you could try it out and try to figure out where the hole in my logic is that's causing the occasional hung note?

TODO: 
- [ ] Figure out why some notes still hang
- [ ] Consider a max sustain length
- [ ] Figure out why note offs don't record when using sustain
- [ ] Determine highest CPU usage samples for sustain
- [ ] Implement community feature menu