### PR TITLE
Bugfix - render fx if sound rendered

### DIFF
--- a/src/deluge/model/drum/kit.cpp
+++ b/src/deluge/model/drum/kit.cpp
@@ -482,12 +482,12 @@ void Kit::cutAllSound() {
 }
 
 // Beware - unlike usual, modelStack, a ModelStackWithThreeMainThings*,  might have a NULL timelineCounter
-void Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
+bool Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
                                         int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,
                                         int32_t reverbAmountAdjust, int32_t sideChainHitPending,
                                         bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,
                                         int32_t amplitudeAtStart, int32_t amplitudeAtEnd) {
-
+	bool rendered = false;
 	// Render Drums. Traverse backwards, in case one stops rendering (removing itself from the list) as we render it
 	for (int32_t d = drumsWithRenderingActive.getNumElements() - 1; d >= 0; d--) {
 		Drum* thisDrum = (Drum*)drumsWithRenderingActive.getKeyAtIndex(d);
@@ -528,6 +528,7 @@ void Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStac
 		soundDrum->render(modelStackWithThreeMainThings, globalEffectableBuffer, numSamples, reverbBuffer,
 		                  sideChainHitPending, reverbAmountAdjust, shouldLimitDelayFeedback,
 		                  pitchAdjust); // According to our volume, we tell Drums to send less reverb
+		rendered = true;
 	}
 
 	// Tick ParamManagers
@@ -610,6 +611,7 @@ yesTickParamManager:
 			}
 		}
 	}
+	return rendered;
 }
 
 void Kit::renderOutput(ModelStack* modelStack, StereoSample* outputBuffer, StereoSample* outputBufferEnd,

--- a/src/deluge/model/drum/kit.h
+++ b/src/deluge/model/drum/kit.h
@@ -96,7 +96,7 @@ public:
 	void offerBendRangeUpdate(ModelStack* modelStack, MIDIDevice* device, int32_t channelOrZone, int32_t whichBendRange,
 	                          int32_t bendSemitones);
 
-	void renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
+	bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
 	                                   int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,
 	                                   int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                                   bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -167,7 +167,7 @@ doNormal:
 			} while (++currentSample != bufferEnd);
 		}
 		//otherwise we can run a bunch of processing on an empty buffer
-		if (rendered) {
+		if (isClipActive | rendered) {
 
 			// Render filters
 			processFilters(globalEffectableBuffer, numSamples);

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -59,7 +59,7 @@ protected:
 	                  int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive,
 	                  InstrumentType instrumentType, int32_t analogDelaySaturationAmount);
 
-	virtual void renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
+	virtual bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
 	                                           StereoSample* globalEffectableBuffer, int32_t* bufferToTransferTo,
 	                                           int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
 	                                           int32_t sideChainHitPending, bool shouldLimitDelayFeedback,

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -60,8 +60,6 @@ void AudioOutput::renderOutput(ModelStack* modelStack, StereoSample* outputBuffe
 
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(activeClip);
 
-	//audio clips are also effectively active if they're monitoring and turned on in arranger
-	isClipActive |= echoing && modelStack->song->isOutputActiveInArrangement(this);
 	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, outputBuffer, numSamples,
 	                                      reverbBuffer, reverbAmountAdjust, sideChainHitPending,
 	                                      shouldLimitDelayFeedback, isClipActive, InstrumentType::AUDIO, 5);

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -79,11 +79,12 @@ void AudioOutput::resetEnvelope() {
 }
 
 // Beware - unlike usual, modelStack, a ModelStackWithThreeMainThings*,  might have a NULL timelineCounter
-void AudioOutput::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* renderBuffer,
+bool AudioOutput::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* renderBuffer,
                                                 int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,
                                                 int32_t reverbAmountAdjust, int32_t sideChainHitPending,
                                                 bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,
                                                 int32_t amplitudeAtStart, int32_t amplitudeAtEnd) {
+	bool rendered = false;
 	//audio outputs can have an activeClip while being muted
 	if (isClipActive) {
 		AudioClip* activeAudioClip = (AudioClip*)activeClip;
@@ -123,7 +124,7 @@ renderEnvelope:
 				int32_t* intBuffer = (int32_t*)renderBuffer;
 				activeAudioClip->render(modelStack, intBuffer, numSamples, amplitudeEffectiveStart,
 				                        amplitudeIncrementEffective, pitchAdjust);
-
+				rendered = true;
 				amplitudeLastTime = amplitudeLocal;
 
 				// If we need to duplicate mono to stereo...
@@ -210,6 +211,7 @@ renderEnvelope:
 	}
 
 	if (echoing && modelStack->song->isOutputActiveInArrangement(this)) {
+		rendered = true;
 		StereoSample* __restrict__ outputPos = bufferToTransferTo ? (StereoSample*)bufferToTransferTo : renderBuffer;
 		StereoSample const* const outputPosEnd = outputPos + numSamples;
 

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -34,7 +34,7 @@ public:
 	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                  bool shouldLimitDelayFeedback, bool isClipActive);
 
-	void renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
+	bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
 	                                   int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,
 	                                   int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                                   bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,


### PR DESCRIPTION
Instead of relying on clip active status, have renderOutputForGlobalEffectable return a bool for whether it actually rendered anything. This captures using the keyboard in muted tracks and live input monitoring.

Reverts the live input monitoring change - now handled via returning whether something was rendered

Fix #575 