### PR TITLE
Bugfix: stop all voices instead of just detaching when loading synth to kit row

### DIFF
--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1494,7 +1494,7 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
 		}
 	}
 	song->deleteBackedUpParamManagersForModControllable(*getInstrument);
-	(*getInstrument)->detachSourcesFromAudioFiles();
+	(*getInstrument)->wontBeRenderedForAWhile();
 	*getInstrument = newDrum;
 	return error;
 }


### PR DESCRIPTION
Avoids a freeze if a multi sampled instrument has a left over reason by explicitly stopping and unassigning all active note rows

Does not fix the underlying cause but this is safer regardless