### PR TITLE
Bugfix/midi mpe zone matching

### DIFF
--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -350,6 +350,7 @@ void MelodicInstrument::offerReceivedCC(ModelStackWithTimelineCounter* modelStac
                                         MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
                                         bool* doingMidiThru) {
 	int yCC = 1;
+	int32_t value32 = 0;
 	switch (checkMatch(fromDevice, channel)) {
 
 	case MIDIMatchType::NO_MATCH:
@@ -363,10 +364,15 @@ void MelodicInstrument::offerReceivedCC(ModelStackWithTimelineCounter* modelStac
 		}
 	case MIDIMatchType::MPE_MASTER:
 		yCC = 74;
+		if (ccNumber == 74) {
+			value32 = (value - 64) << 25;
+		}
 		//no break
 	case MIDIMatchType::CHANNEL:
-		if (yCC == ccNumber) {
-			int32_t value32 = (value - 64) << 25;
+		if (ccNumber == 1) {
+			value32 = (value) << 24;
+		}
+		if (ccNumber == yCC) {
 			//this also passes CC1 to the instrument, but that's important for midi instruments
 			//or internal synths that have CC1 learnt to a parameter instead of used as modwheel
 			processParamFromInputMIDIChannel(74, value32, modelStackWithTimelineCounter);

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -28,6 +28,8 @@ class ModelStackWithAutoParam;
 class ModelStackWithThreeMainThings;
 class MIDIDevice;
 
+enum MIDIMatchType { NO_MATCH, CHANNEL, MPE_MEMBER, MPE_MASTER };
+
 class MelodicInstrument : public Instrument {
 public:
 	MelodicInstrument(InstrumentType newType) : Instrument(newType) {}
@@ -43,7 +45,7 @@ public:
 	bool writeMelodicInstrumentAttributesToFile(Clip* clipForSavingOutputOnly, Song* song);
 	void writeMelodicInstrumentTagsToFile(Clip* clipForSavingOutputOnly, Song* song);
 	bool readTagFromFile(char const* tagName);
-
+	MIDIMatchType checkMatch(MIDIDevice* fromDevice, int32_t channel);
 	void offerReceivedNote(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                       bool on, int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
 	                       bool* doingMidiThru);


### PR DESCRIPTION
Fixes issues I found while attempting to reproduce #555 

Breaks out the device/midi channel/MPE matching code to its own function, notes/ccs/aftertouch/pitch bend now use that and a switch on the result instead of nested if/else/gotos