### PR TITLE
Bugfix/synth kit e073 s001

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -74,7 +74,13 @@ bool LoadInstrumentPresetUI::opened() {
 
 	if (loadingSynthToKitRow) {
 		initialInstrumentType = instrumentTypeToLoad = InstrumentType::SYNTH;
-		initialName.set(&soundDrumToReplace->name);
+		if (soundDrumToReplace) {
+			initialName.set(&soundDrumToReplace->name);
+		}
+		else {
+			initialName.set("");
+		}
+
 		initialDirPath.set("SYNTHS");
 	}
 

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -147,7 +147,7 @@ int32_t LoadInstrumentPresetUI::setupForInstrumentType() {
 	// call confirmPresetOrNextUnlaunchedOne() to skip any which aren't "available".
 
 	// If same Instrument type as we already had...
-	if (instrumentToReplace->type == instrumentTypeToLoad) {
+	if (instrumentToReplace && instrumentToReplace->type == instrumentTypeToLoad) {
 
 		// Then we can start by just looking at the existing Instrument, cos they're the same type...
 		currentDir.set(&instrumentToReplace->dirPath);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -795,40 +795,51 @@ someError:
 		reassessAuditionStatus(lastAuditionedYDisplay);
 	}
 
-	Drum* newDrum = storageManager.createNewDrum(drumType);
-
-	if (!newDrum) {
-		goto ramError;
-	}
-
 	Kit* kit = (Kit*)currentSong->currentClip->output;
-
-	ParamManager paramManager;
-	//add sound loading code here
 	if (drumType == DrumType::SOUND) {
 		Browser::instrumentTypeToLoad = InstrumentType::SYNTH;
 		loadInstrumentPresetUI.loadingSynthToKitRow = true;
+		loadInstrumentPresetUI.instrumentToReplace = nullptr;
+
 		loadInstrumentPresetUI.instrumentClipToLoadFor = nullptr;
-		loadInstrumentPresetUI.soundDrumToReplace = (SoundDrum*)newDrum;
+		if (noteRow->drum->type == drumType) {
+			loadInstrumentPresetUI.soundDrumToReplace = (SoundDrum*)noteRow->drum;
+		}
+		else {
+			loadInstrumentPresetUI.soundDrumToReplace = nullptr;
+		}
+
 		loadInstrumentPresetUI.kitToLoadFor = kit;
 		loadInstrumentPresetUI.noteRow = noteRow;
 		loadInstrumentPresetUI.noteRowIndex = noteRowIndex;
 		openUI(&loadInstrumentPresetUI);
 	}
 
-	kit->addDrum(newDrum);
+	else {
 
-	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(noteRowIndex, noteRow);
+		Drum* newDrum = storageManager.createNewDrum(drumType);
 
-	noteRow->setDrum(newDrum, kit, modelStackWithNoteRow, NULL, &paramManager);
+		if (!newDrum) {
+			goto ramError;
+		}
 
-	kit->beenEdited();
+		ParamManager paramManager;
+		//add sound loading code here
 
-	drawDrumName(newDrum);
+		kit->addDrum(newDrum);
+
+		ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(noteRowIndex, noteRow);
+
+		noteRow->setDrum(newDrum, kit, modelStackWithNoteRow, NULL, &paramManager);
+
+		kit->beenEdited();
+		drawDrumName(newDrum);
+		setSelectedDrum(newDrum, true);
+	}
 
 	auditionPadIsPressed[lastAuditionedYDisplay] = true;
 	reassessAuditionStatus(lastAuditionedYDisplay);
-	setSelectedDrum(newDrum, true);
+
 	// uiNeedsRendering(this, 0, 1 << lastAuditionedNoteOnScreen);
 }
 

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3157,9 +3157,8 @@ void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack
 		modelStack->song->backUpParamManager(
 		    (SoundDrum*)drum, (Clip*)modelStack->getTimelineCounter(), &paramManager,
 		    false); // Don't steal expression params - we'll keep them here with this NoteRow.
-
-		paramManager.forgetParamCollections();
 	}
+	paramManager.forgetParamCollections();
 
 	drum = (SoundDrum*)
 	    newDrum; // Better set this temporarily for this call. See comment above for why we can't set it permanently yet

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1406,7 +1406,7 @@ int32_t StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip,
 
 deleteInstrumentAndGetOut:
 		newInstrument->deleteBackedUpParamManagers(song);
-		void* toDealloc = dynamic_cast<void*>(newInstrument);
+		void* toDealloc = static_cast<void*>(newInstrument);
 		newInstrument->~Instrument();
 		GeneralMemoryAllocator::get().dealloc(toDealloc);
 
@@ -1488,7 +1488,7 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
 	// If that somehow didn't work...
 	if (error || !fileSuccess) {
 
-		void* toDealloc = dynamic_cast<void*>(newDrum);
+		void* toDealloc = static_cast<void*>(newDrum);
 		newDrum->~Drum();
 		GeneralMemoryAllocator::get().dealloc(toDealloc);
 		return error;
@@ -1502,7 +1502,7 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
 	if (*getInstrument) {
 		song->deleteBackedUpParamManagersForModControllable(*getInstrument);
 		(*getInstrument)->wontBeRenderedForAWhile();
-		void* toDealloc = dynamic_cast<void*>(*getInstrument);
+		void* toDealloc = static_cast<void*>(*getInstrument);
 		(*getInstrument)->~Drum();
 		GeneralMemoryAllocator::get().dealloc(toDealloc);
 	}

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1488,13 +1488,25 @@ int32_t StorageManager::loadSynthToDrum(Song* song, InstrumentClip* clip, bool m
 	// If that somehow didn't work...
 	if (error || !fileSuccess) {
 
+		void* toDealloc = dynamic_cast<void*>(newDrum);
+		newDrum->~Drum();
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
+		return error;
+
 		if (!fileSuccess) {
 			error = ERROR_SD_CARD;
 			return error;
 		}
 	}
-	song->deleteBackedUpParamManagersForModControllable(*getInstrument);
-	(*getInstrument)->wontBeRenderedForAWhile();
+	//these have to get cleared, otherwise we keep creating drums that aren't attached to note rows
+	if (*getInstrument) {
+		song->deleteBackedUpParamManagersForModControllable(*getInstrument);
+		(*getInstrument)->wontBeRenderedForAWhile();
+		void* toDealloc = dynamic_cast<void*>(*getInstrument);
+		(*getInstrument)->~Drum();
+		GeneralMemoryAllocator::get().dealloc(toDealloc);
+	}
+
 	*getInstrument = newDrum;
 	return error;
 }


### PR DESCRIPTION
Fixes a null pointer de reference if not replacing an instrument

Fixes the first load getting over written by default drum

Fixes lingering drums in memory without note rows

Fix #582 


I believe there is a memory leak in the sound->readFromFile method and memory gets full after ~300 preset loads. That's not fixed by this PR but I'll hopefully get it with expanded cpputest coverage 