### PR TITLE
Automation View: Disable mod LED's in Automation Editor

### DIFF
--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2826,6 +2826,7 @@ flashShortcut:
 		displayAutomation(true, !display->have7SEG());
 	}
 	resetShortcutBlinking();
+	view.setModLedStates();
 	uiNeedsRendering(this);
 }
 
@@ -2866,6 +2867,7 @@ void AutomationInstrumentClipView::initParameterSelection() {
 	display->cancelPopup();
 	renderDisplay();
 	view.setKnobIndicatorLevels();
+	view.setModLedStates();
 }
 
 //exit pad selection mode, reset pad press statuses
@@ -3252,6 +3254,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 
 		displayAutomation(true);
 		resetShortcutBlinking();
+		view.setModLedStates();
 	}
 
 	else if (!isOnAutomationOverview()) { //this means you are editing a parameter's value

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1055,6 +1055,12 @@ static const uint32_t modButtonUIModes[] = {UI_MODE_AUDITIONING,
                                             0};
 
 void View::modButtonAction(uint8_t whichButton, bool on) {
+
+	//ignore modButtonAction when in the Automation View Automation Editor
+	if ((getRootUI() == &automationInstrumentClipView) && !automationInstrumentClipView.isOnAutomationOverview()) {
+		return;
+	}
+
 	pretendModKnobsUntouchedForAWhile();
 
 	if (activeModControllableModelStack.modControllable) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1174,7 +1174,7 @@ setNextLED:
 
 	for (int32_t i = 0; i < kNumModButtons; i++) {
 		bool on = (i == modKnobMode);
-		//if you're in the automation editor, turn off mod fx LED's
+		//if you're in the Automation View Automation Editor, turn off Mod LED's
 		if ((getRootUI() == &automationInstrumentClipView) && !automationInstrumentClipView.isOnAutomationOverview()) {
 			indicator_leds::setLedState(indicator_leds::modLed[i], false);
 		}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1168,7 +1168,13 @@ setNextLED:
 
 	for (int32_t i = 0; i < kNumModButtons; i++) {
 		bool on = (i == modKnobMode);
-		indicator_leds::setLedState(indicator_leds::modLed[i], on);
+		//if you're in the automation editor, turn off mod fx LED's
+		if ((getRootUI() == &automationInstrumentClipView) && !automationInstrumentClipView.isOnAutomationOverview()) {
+			indicator_leds::setLedState(indicator_leds::modLed[i], false);
+		}
+		else {
+			indicator_leds::setLedState(indicator_leds::modLed[i], on);
+		}
 	}
 }
 


### PR DESCRIPTION
One of the recommendations from Issue #547 was to disable the mod LED's in the Automation Editor as the buttons are not used for anything in the Automation Editor and lead to confusion about why pressing the buttons doesn't do anything.

This PR achieves this by:

- [x] disabling the Mod LED's when entering the automation editor
- [x] enabling the Mod LED's when exiting the automation editor (e.g. going to the automation overview).
- [x] ignoring Mod LED button presses when in the automation editor