### PR TITLE
Automation View: Fix clearing all automation for audio clips

### DIFF
--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -985,7 +985,8 @@ void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
 			else {
 				if (getCurrentUI() == &automationInstrumentClipView
 				    || runtimeFeatureSettings.get(RuntimeFeatureSettingType::AutomationClearClip)
-				           == RuntimeFeatureStateToggle::Off) {
+				           == RuntimeFeatureStateToggle::Off
+				    || type == CLIP_TYPE_AUDIO) {
 					summary->paramCollection->deleteAllAutomation(action, modelStackWithParamCollection);
 				}
 			}


### PR DESCRIPTION
As there is no automation view for audio clips yet, the clearing clip action should always delete all automation.

This commit fixes an issue whereby when Automation Community Feature "Clear Clip" was On, it would not be possible to clear all clip automation in an audio clip.

This PR partially addresses Issue #530 