### PR TITLE
Incorporated changes according to spec from recent Renesas RZA1LU_Bli…

### DIFF
--- a/src/RZA1/compiler/asm/irqfiq_handler.S
+++ b/src/RZA1/compiler/asm/irqfiq_handler.S
@@ -35,9 +35,67 @@
 
 /* Standard definitions of mode bits and interrupt (I & F) flags in PSRs */
     .equ    SYS_MODE          , 0x1F
+    .equ    IRQ_MODE          , 0x12
+    .equ    INTC_ICCIAR_MASK  , 0x3FF
     .equ    INTC_ICCIAR_ADDR  , 0xE820200C
     .equ    INTC_ICCEOIR_ADDR , 0xE8202010
+    .equ    INTC_ICCHPIR_ADDR , 0xE8202018
+    .equ    INTC_ICDIPR0_ADDR , 0xE8201400
 
+.align 4
+read_intc_icciar_addr:
+	PUSH	{r0-r1, r12}
+	PUSH	{r3-r4, r12}
+
+    /*; ++REE_SS Addressing ARM Errata 801120 */
+    /*; Perform a dummy read to - ensure subsequent ICCIAR data */
+    /*; will be correct */
+    LDR     r2, =INTC_ICCHPIR_ADDR
+    LDR     r2, [r2]
+
+    /*; Attempt to activate interrupt and get its ID */
+    /*; Load in to R3 - if valid it will be used later as ICCIAR */
+    LDR     r2, =INTC_ICCIAR_ADDR
+    LDR     r3, [r2]
+
+    /*; Extract the interrupt ID (removing the SGI source CPU ID) */
+    LDR     r1, =INTC_ICCIAR_MASK
+    AND     r3, r3, r1
+
+    /*; Read data of 0x0 (SGI ID0 from CPU0) is possibly affected by 733075 */
+    CMP     r3, #0
+    BEQ     errata_733075_workaround
+
+    /*; Interrupt IDs 0x3FE and 0x3FF are also possibly affected */
+    LDR     r1, =1022
+    CMP     r3, r1
+    BGE     errata_733075_workaround
+
+    B       post_733075_workaround
+
+errata_733075_workaround:
+    /*; Perform a read from ulICDIPR0 and write value back */
+    /*; It is sufficient to write the value that is already in the register. */
+    /*; You can obtain the value to be written to the ICDIPR0 register by */
+    /*; reading from it, or through other means" */
+    LDR     r2, =INTC_ICDIPR0_ADDR
+    LDR     r0, [r2]
+    STR     r0, [r2]
+    DSB
+
+    LDR     r2, =INTC_ICCHPIR_ADDR
+    LDR     r2, [r2]
+
+    /*; Attempt to activate interrupt and get its ID */
+    /*; Load in to R3 - if valid it will be used later as ICCIAR */
+    LDR     r2, =INTC_ICCIAR_ADDR
+    LDR     r3, [r2]
+
+post_733075_workaround:
+    //MOV     r0, r3
+	POP		{r3-r4, r12}
+	POP		{r0-r1, r12}
+	B       icciar_read_complete
 
 /* ================================================================== */
 /* Entry point for the FIQ handler */
@@ -73,25 +131,58 @@ fiq_handler_end:
 /* ================================================================== */
     .func irq_handler
 irq_handler:
-    SUB        lr, lr, #4
-    SRSDB    sp!, #SYS_MODE
+    
+    SUB        lr, lr, #4                   // Make sure interrupted instruction gets executed after returining
+
+    //SRSDB    sp!, #SYS_MODE
+	/* Push the return address and SPSR. */
+	PUSH	{lr}
+	MRS		lr, SPSR
+	PUSH	{lr}
+
     CPS        #SYS_MODE
+
     PUSH    {r0-r3, r12}
+
     LDR     r2, =INTC_ICCIAR_ADDR
     LDR        r0, [r2]
     PUSH    {r0}
+
+    B		read_intc_icciar_addr  
+icciar_read_complete:
+
+    /* Ensure bit 2 of the stack pointer is clear.  r2 holds the bit 2 value for
+	future use.  Guard against the start of the stack not being 8-byte aligned */
     MOV        r1, sp
     AND        r1, r1, #4
     SUB        sp, sp, r1
-    PUSH    {r1, lr}
+
+    //PUSH    {r1, lr} (previous version)
+    PUSH	{r0-r4, lr}  /* Call the interrupt handler.  r4 pushed to maintain alignment. */
     BL        INTC_Handler_Interrupt
-    POP        {r1, lr}
+    //POP        {r1, lr} (previous version)
+    POP		{r0-r4, lr} 
     ADD        sp, sp, r1
     POP        {r0}
+
+    // Newer example has barriers here
+	CPSID	i
+	DSB
+	ISB
+
     LDR     r2, =INTC_ICCEOIR_ADDR
     STR        r0, [r2]
+
     POP        {r0-r3, r12}
-    RFEIA    sp!
+
+    //RFEIA    sp!
+
+    /* Restore used registers, LR_irq and SPSR before returning. */
+    CPS		#IRQ_MODE
+	POP		{LR}
+	MSR		SPSR_cxsf, LR
+	POP		{LR}
+	MOVS	PC, LR
 
 Literals3:
 

--- a/src/RZA1/compiler/asm/irqfiq_handler.S
+++ b/src/RZA1/compiler/asm/irqfiq_handler.S
@@ -44,7 +44,7 @@
 
 .align 4
 read_intc_icciar_addr:
-	PUSH	{r0-r1, r12}
+	PUSH	{r1, r12}
 	PUSH	{r3-r4, r12}
 
     /*; ++REE_SS Addressing ARM Errata 801120 */
@@ -92,9 +92,9 @@ errata_733075_workaround:
     LDR     r3, [r2]
 
 post_733075_workaround:
-    //MOV     r0, r3
+    MOV     r0, r3
 	POP		{r3-r4, r12}
-	POP		{r0-r1, r12}
+	POP		{r1, r12}
 	B       icciar_read_complete
 
 /* ================================================================== */
@@ -143,11 +143,7 @@ irq_handler:
     CPS        #SYS_MODE
 
     PUSH    {r0-r3, r12}
-
-    LDR     r2, =INTC_ICCIAR_ADDR
-    LDR        r0, [r2]
-    PUSH    {r0}
-
+    
     B		read_intc_icciar_addr  
 icciar_read_complete:
 
@@ -163,7 +159,6 @@ icciar_read_complete:
     //POP        {r1, lr} (previous version)
     POP		{r0-r4, lr} 
     ADD        sp, sp, r1
-    POP        {r0}
 
     // Newer example has barriers here
 	CPSID	i

--- a/src/RZA1/intc/intc_handler.c
+++ b/src/RZA1/intc/intc_handler.c
@@ -97,9 +97,9 @@ void INTC_Handler_Interrupt(uint32_t icciar)
      * writing the same value as the setting value to the interrupt priority
      * register 0 (ICDIPR0).
      */
-    if (int_id >= 0x3fe)    /* In case of unsupported interrupt ID */
+    if (int_id >= 0x3fe) /* In case of unsupported interrupt ID */
     {
-        addr = (volatile uint32_t *)&INTC.ICDIPR0;
+        addr = (volatile uint32_t*)&INTC.ICDIPR0;
 
         *addr = icciar;
         return;

--- a/src/RZA1/intc/intc_userdef.c
+++ b/src/RZA1/intc/intc_userdef.c
@@ -728,12 +728,6 @@ static void Userdef_INTC_Dummy_Interrupt(uint32_t int_sense)
 ******************************************************************************/
 void Userdef_INTC_HandlerExe(uint16_t int_id, uint32_t int_sense)
 {
-	if(intc_func_active != 0) {
-		volatile int j = int_id;
-		++j;
-		++j;
-		//__asm__ __volatile__("bkpt");
-	}
 
     intc_func_active = int_id;
     intc_func_table[int_id](int_sense);

--- a/src/RZA1/intc/intc_userdef.c
+++ b/src/RZA1/intc/intc_userdef.c
@@ -57,7 +57,7 @@ Imported global variables and functions (from other files)
 /******************************************************************************
 Exported global variables and functions (to be accessed by other files)
 ******************************************************************************/
-volatile uint32_t intc_func_active = false;
+volatile uint32_t intc_func_active = 0;
 
 /******************************************************************************
 Private global variables and functions
@@ -728,9 +728,16 @@ static void Userdef_INTC_Dummy_Interrupt(uint32_t int_sense)
 ******************************************************************************/
 void Userdef_INTC_HandlerExe(uint16_t int_id, uint32_t int_sense)
 {
-    intc_func_active = true;
+	if(intc_func_active != 0) {
+		volatile int j = int_id;
+		++j;
+		++j;
+		//__asm__ __volatile__("bkpt");
+	}
+
+    intc_func_active = int_id;
     intc_func_table[int_id](int_sense);
-    intc_func_active = false;
+    intc_func_active = 0;
 }
 
 /******************************************************************************

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -839,7 +839,7 @@ extern "C" void logAudioAction(char const* string) {
 
 extern "C" void routineForSD(void) {
 
-	if(intc_func_active != 0) {
+	if (intc_func_active != 0) {
 		return;
 	}
 

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -119,15 +119,12 @@ Song* currentSong = NULL;
 Song* preLoadedSong = NULL;
 
 bool sdRoutineLock = true;
-bool inInterrupt = false;
 
 bool allowSomeUserActionsEvenWhenInCardRoutine = false;
 
 extern "C" void timerGoneOff(void) {
-	inInterrupt = true;
 	cvEngine.updateGateOutputs();
 	midiEngine.flushMIDI();
-	inInterrupt = false;
 }
 
 uint32_t timeNextGraphicsTick = 0;
@@ -842,7 +839,7 @@ extern "C" void logAudioAction(char const* string) {
 
 extern "C" void routineForSD(void) {
 
-	if (inInterrupt) {
+	if(intc_func_active != 0) {
 		return;
 	}
 

--- a/src/deluge/drivers/uart/uart.c
+++ b/src/deluge/drivers/uart/uart.c
@@ -153,7 +153,9 @@ int32_t uartFlush(int32_t item) {
 	uartItems[item].shouldDoConsecutiveTransferAfter = false; // Only actually applies to MIDI
 
 	DMACn(txDmaChannels[item]).N0TB_n = num;
-	DMACn(txDmaChannels[item]).N0SA_n = (uint32_t)&txBuffers[item][prevReadPos];
+	uint32_t dataAddress = (uint32_t)&txBuffers[item][prevReadPos];
+	DMACn(txDmaChannels[item]).N0SA_n = dataAddress;
+	v7_dma_flush_range(dataAddress, dataAddress + num);
 
 	return 1;
 }

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -50,7 +50,7 @@ uint8_t OLED::oledMainConsoleImage[kConsoleImageNumRows][OLED_MAIN_WIDTH_PIXELS]
 uint8_t OLED::oledMainPopupImage[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS]
     __attribute__((aligned(alignof(int32_t))));
 
-uint8_t (*OLED::oledCurrentImage)[OLED_MAIN_WIDTH_PIXELS] = oledMainImage;
+uint8_t (*OLED::oledCurrentImage)[OLED_MAIN_WIDTH_PIXELS] __attribute__((aligned(CACHE_LINE_SIZE))) = oledMainImage;
 
 int32_t workingAnimationCount;
 char const* workingAnimationText; // NULL means animation not active

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -316,7 +316,7 @@ void routineWithClusterLoading(bool mayProcessUserActionsBetween) {
 	}
 }
 
-#define DO_AUDIO_LOG 1 // For advavnced debugging printouts.
+#define DO_AUDIO_LOG 0 // For advavnced debugging printouts.
 #define AUDIO_LOG_SIZE 64
 
 #if DO_AUDIO_LOG

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -608,7 +608,7 @@ startAgain:
 	// Render audio for song
 	if (currentSong) {
 		bool interruptsDisabled = false;
-		if (!intc_func_active) {
+		if (intc_func_active == 0) {
 			__disable_irq();
 			interruptsDisabled = true;
 		}


### PR DESCRIPTION
Fixes #564,

Changes:
* Updated interrupt controller interrupt handler assembly and user handler function according to Renesas RZA1LU_BlinkySample. Update: After doing this correctly it seems to solve the problem
* Make sure cache is flushed before DMA is accessing data
* Prevent routineForSD to run from interrupt to prevent possible unlocked data access
* Disabled AUDIO_LOG
* Original Problem can be detected by checking if INTC.ICCRPR != 255 (equalling idle priority)

see also https://github.com/SynthstromAudible/DelugeFirmware/wiki/Interrupts
and https://github.com/SynthstromAudible/DelugeFirmware/wiki/DMA-channels