### PR TITLE
Bugfix/remove sneaky optimization and replace with virtual functions

### DIFF
--- a/src/deluge/storage/multi_range/multi_range.cpp
+++ b/src/deluge/storage/multi_range/multi_range.cpp
@@ -25,7 +25,7 @@ MultiRange::MultiRange() {
 MultiRange::~MultiRange() {
 }
 
-AudioFileHolder* MultiRange::getAudioFileHolder() {
-	return &((MultisampleRange*)this)
-	            ->sampleHolder; // Very sneaky optimization. Relies on both of this class's children having an AudioFileHolder at the same position.
-}
+// AudioFileHolder* MultiRange::getAudioFileHolder() {
+// 	return &((MultisampleRange*)this)
+// 	            ->sampleHolder; // Very sneaky optimization. Relies on both of this class's children having an AudioFileHolder at the same position.
+// }

--- a/src/deluge/storage/multi_range/multi_range.cpp
+++ b/src/deluge/storage/multi_range/multi_range.cpp
@@ -24,8 +24,3 @@ MultiRange::MultiRange() {
 
 MultiRange::~MultiRange() {
 }
-
-// AudioFileHolder* MultiRange::getAudioFileHolder() {
-// 	return &((MultisampleRange*)this)
-// 	            ->sampleHolder; // Very sneaky optimization. Relies on both of this class's children having an AudioFileHolder at the same position.
-// }

--- a/src/deluge/storage/multi_range/multi_range.h
+++ b/src/deluge/storage/multi_range/multi_range.h
@@ -26,7 +26,7 @@ public:
 	MultiRange();
 	virtual ~MultiRange();
 
-	AudioFileHolder* getAudioFileHolder();
+	virtual AudioFileHolder* getAudioFileHolder() = 0;
 
 	int16_t topNote;
 };

--- a/src/deluge/storage/multi_range/multi_wave_table_range.cpp
+++ b/src/deluge/storage/multi_range/multi_wave_table_range.cpp
@@ -19,3 +19,7 @@
 
 MultiWaveTableRange::MultiWaveTableRange() {
 }
+
+AudioFileHolder* MultiWaveTableRange::getAudioFileHolder() {
+	return static_cast<AudioFileHolder*>(&waveTableHolder);
+}

--- a/src/deluge/storage/multi_range/multi_wave_table_range.h
+++ b/src/deluge/storage/multi_range/multi_wave_table_range.h
@@ -23,6 +23,7 @@
 class MultiWaveTableRange final : public MultiRange {
 public:
 	MultiWaveTableRange();
+	AudioFileHolder* getAudioFileHolder();
 
 	WaveTableHolder
 	    waveTableHolder; // Has to be first variable, cos I do a sneaky optimization between both of MultiRange's children.

--- a/src/deluge/storage/multi_range/multi_wave_table_range.h
+++ b/src/deluge/storage/multi_range/multi_wave_table_range.h
@@ -23,8 +23,7 @@
 class MultiWaveTableRange final : public MultiRange {
 public:
 	MultiWaveTableRange();
-	AudioFileHolder* getAudioFileHolder();
+	AudioFileHolder* getAudioFileHolder() override;
 
-	WaveTableHolder
-	    waveTableHolder; // Has to be first variable, cos I do a sneaky optimization between both of MultiRange's children.
+	WaveTableHolder waveTableHolder;
 };

--- a/src/deluge/storage/multi_range/multisample_range.cpp
+++ b/src/deluge/storage/multi_range/multisample_range.cpp
@@ -30,3 +30,7 @@
 
 MultisampleRange::MultisampleRange() {
 }
+
+AudioFileHolder* MultisampleRange::getAudioFileHolder() {
+	return static_cast<AudioFileHolder*>(&sampleHolder);
+}

--- a/src/deluge/storage/multi_range/multisample_range.h
+++ b/src/deluge/storage/multi_range/multisample_range.h
@@ -29,8 +29,7 @@ class Cluster;
 class MultisampleRange final : public MultiRange {
 public:
 	MultisampleRange();
-	AudioFileHolder* getAudioFileHolder();
+	AudioFileHolder* getAudioFileHolder() override;
 
-	SampleHolderForVoice
-	    sampleHolder; // Has to be first variable, cos I do a sneaky optimization between both of MultiRange's children.
+	SampleHolderForVoice sampleHolder;
 };

--- a/src/deluge/storage/multi_range/multisample_range.h
+++ b/src/deluge/storage/multi_range/multisample_range.h
@@ -29,6 +29,7 @@ class Cluster;
 class MultisampleRange final : public MultiRange {
 public:
 	MultisampleRange();
+	AudioFileHolder* getAudioFileHolder();
 
 	SampleHolderForVoice
 	    sampleHolder; // Has to be first variable, cos I do a sneaky optimization between both of MultiRange's children.


### PR DESCRIPTION
The sneaky optimization seems to have resulted in issues around multi samples (which I think is actually all samples internally)

With this fix I can no longer reproduce the following bugs:

Fix #610 
Fix #492
~~Fix #472~~ still happens sometimes 
