### PR TITLE
Bugfix/toggle between sample markers on column

### DIFF
--- a/src/deluge/gui/ui/sample_marker_editor.cpp
+++ b/src/deluge/gui/ui/sample_marker_editor.cpp
@@ -361,10 +361,14 @@ ActionResult SampleMarkerEditor::padAction(int32_t x, int32_t y, int32_t on) {
 			for (int32_t m = 0; m < kNumMarkerTypes; m++) {
 				if (cols[m].colOnScreen == x) {
 					if (markerPressed != MarkerType::NONE) {
-						// Get out if there are two markers occupying the same col we pressed
-						return ActionResult::DEALT_WITH;
+						// toggle between markers if there's two overlapping columns
+						if (MarkerType{m} != markerType) {
+							markerPressed = MarkerType{m};
+						}
 					}
-					markerPressed = MarkerType{m};
+					else {
+						markerPressed = MarkerType{m};
+					}
 				}
 			}
 


### PR DESCRIPTION
Fix #472 

If sample loop points are very close to the start point then neither can be edited without zooming in. This PR changes the behaviour so that repeated presses toggle between the markers sharing that column. 