### PR TITLE
Bugfix/duplicate midi clocks

### DIFF
--- a/src/deluge/gui/menu_item/midi/device_send_clock.h
+++ b/src/deluge/gui/menu_item/midi/device_send_clock.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+*/
+#pragma once
+#include "gui/menu_item/toggle.h"
+#include "gui/ui/sound_editor.h"
+#include "io/midi/midi_device_manager.h"
+
+namespace deluge::gui::menu_item::midi {
+class SendClock final : public Toggle {
+public:
+	using Toggle::Toggle;
+	void readCurrentValue() override { this->setValue(soundEditor.currentMIDIDevice->sendClock); }
+	void writeCurrentValue() override {
+		soundEditor.currentMIDIDevice->sendClock = this->getValue();
+		MIDIDeviceManager::anyChangesToSave = true;
+	}
+};
+} // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -67,6 +67,7 @@
 #include "gui/menu_item/midi/command.h"
 #include "gui/menu_item/midi/default_velocity_to_level.h"
 #include "gui/menu_item/midi/device.h"
+#include "gui/menu_item/midi/device_send_clock.h"
 #include "gui/menu_item/midi/devices.h"
 #include "gui/menu_item/midi/input_differentiation.h"
 #include "gui/menu_item/midi/pgm.h"
@@ -735,11 +736,13 @@ Submenu midiCommandsMenu{
 // MIDI device submenu - for after we've selected which device we want it for
 
 midi::DefaultVelocityToLevel defaultVelocityToLevelMenu{STRING_FOR_VELOCITY};
+midi::SendClock sendClockMenu{STRING_FOR_CLOCK};
 midi::Device midiDeviceMenu{
     EMPTY_STRING,
     {
         &mpe::directionSelectorMenu,
         &defaultVelocityToLevelMenu,
+        &sendClockMenu,
     },
 };
 

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -172,7 +172,8 @@ void MIDIDevice::sendAllMCMs() {
 
 bool MIDIDevice::worthWritingToFile() {
 	return (ports[MIDI_DIRECTION_INPUT_TO_DELUGE].worthWritingToFile()
-	        || ports[MIDI_DIRECTION_OUTPUT_FROM_DELUGE].worthWritingToFile() || hasDefaultVelocityToLevelSet());
+	        || ports[MIDI_DIRECTION_OUTPUT_FROM_DELUGE].worthWritingToFile() || hasDefaultVelocityToLevelSet()
+	        || !sendClock);
 }
 
 void MIDIDevice::writePorts() {

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -31,6 +31,7 @@ extern "C" {
 
 MIDIDevice::MIDIDevice() {
 	connectionFlags = 0;
+	sendClock = true;
 	defaultVelocityToLevel = 0; // Means none set.
 	memset(defaultInputMPEValuesPerMIDIChannel, 0, sizeof(defaultInputMPEValuesPerMIDIChannel));
 
@@ -92,8 +93,7 @@ setMPEBendRange:
 				ports[MIDI_DIRECTION_INPUT_TO_DELUGE]
 				    .moveUpperZoneOutOfWayOfLowerZone(); // Move other zone out of the way if necessary (MPE spec says to do this).
 
-resetBendRanges
-    : // Have to reset pitch bend range for zone, according to MPE spec. Unless we just deactivated the MPE zone...
+resetBendRanges: // Have to reset pitch bend range for zone, according to MPE spec. Unless we just deactivated the MPE zone...
 				if (msb) {
 					mpeZoneBendRanges[zone][BEND_RANGE_MAIN] = 2;
 					mpeZoneBendRanges[zone][BEND_RANGE_FINGER_LEVEL] = 48;
@@ -194,6 +194,9 @@ void MIDIDevice::readFromFile() {
 		else if (!strcmp(tagName, "defaultVolumeVelocitySensitivity")) {
 			defaultVelocityToLevel = storageManager.readTagOrAttributeValueInt();
 		}
+		else if (!strcmp(tagName, "sendClock")) {
+			sendClock = storageManager.readTagOrAttributeValueInt();
+		}
 
 		storageManager.exitTag();
 	}
@@ -203,6 +206,7 @@ void MIDIDevice::writeDefinitionAttributesToFile() { // These only go into MIDID
 	if (hasDefaultVelocityToLevelSet()) {
 		storageManager.writeAttribute("defaultVolumeVelocitySensitivity", defaultVelocityToLevel);
 	}
+	storageManager.writeAttribute("sendClock", sendClock);
 }
 
 void MIDIDevice::writeToFile(char const* tagName) {

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -93,7 +93,8 @@ setMPEBendRange:
 				ports[MIDI_DIRECTION_INPUT_TO_DELUGE]
 				    .moveUpperZoneOutOfWayOfLowerZone(); // Move other zone out of the way if necessary (MPE spec says to do this).
 
-resetBendRanges: // Have to reset pitch bend range for zone, according to MPE spec. Unless we just deactivated the MPE zone...
+resetBendRanges
+    : // Have to reset pitch bend range for zone, according to MPE spec. Unless we just deactivated the MPE zone...
 				if (msb) {
 					mpeZoneBendRanges[zone][BEND_RANGE_MAIN] = 2;
 					mpeZoneBendRanges[zone][BEND_RANGE_FINGER_LEVEL] = 48;

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -127,7 +127,7 @@ public:
 	// 0 if not connected. For USB devices, the bits signal a connection of the corresponding connectedUSBMIDIDevices[].
 	// Of course there'll usually just be one bit set, unless two of the same device are connected.
 	uint8_t connectionFlags;
-
+	bool sendClock; //whether to send clocks to this device
 	uint8_t incomingSysexBuffer[1024];
 	int32_t incomingSysexPos = 0;
 

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -393,7 +393,7 @@ void MidiEngine::flushUSBMIDIOutput() {
 
 			flushUSBMIDIToHostedDevice(ip, midiDeviceNumToSendTo);
 		}
-getOut: {}
+getOut : {}
 	}
 
 	usbLock = 0;

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -393,7 +393,7 @@ void MidiEngine::flushUSBMIDIOutput() {
 
 			flushUSBMIDIToHostedDevice(ip, midiDeviceNumToSendTo);
 		}
-getOut : {}
+getOut: {}
 	}
 
 	usbLock = 0;
@@ -512,7 +512,6 @@ void MidiEngine::sendUsbMidi(uint8_t statusType, uint8_t channel, uint8_t data1,
 
 	//formats message per USB midi spec on virtual cable 0
 	uint32_t fullMessage = setupUSBMessage(statusType, channel, data1, data2);
-
 	for (int32_t ip = 0; ip < USB_NUM_USBIP; ip++) {
 		int32_t potentialNumDevices = getPotentialNumConnectedUSBMIDIDevices(ip);
 
@@ -523,15 +522,20 @@ void MidiEngine::sendUsbMidi(uint8_t statusType, uint8_t channel, uint8_t data1,
 			}
 			int32_t maxPort = connectedDevice->maxPortConnected;
 			for (int32_t p = 0; p <= maxPort; p++) {
+				//if device exists, it's not port 3 (for sysex)
 				if (connectedDevice->device[p]
-				    && connectedDevice->device[p] != &MIDIDeviceManager::upstreamUSBMIDIDevice_port3
-				    && (statusType == 0x0F
-				        || connectedDevice->device[p]->wantsToOutputMIDIOnChannel(channel, filter))) {
+				    && connectedDevice->device[p] != &MIDIDeviceManager::upstreamUSBMIDIDevice_port3) {
+					//if it's a clock (or sysex technically but we don't send that to this function)
+					//or if it's a message that this channel wants
+					if ((statusType == 0x0F && connectedDevice->device[p]->sendClock)
+					    || (statusType != 0x0F
+					        && connectedDevice->device[p]->wantsToOutputMIDIOnChannel(channel, filter))) {
 
-					//Or with the port to add the cable number to the full message. This
-					//is a bit hacky but it works
-					uint32_t channeled_message = fullMessage | (p << 4);
-					connectedDevice->bufferMessage(channeled_message);
+						//Or with the port to add the cable number to the full message. This
+						//is a bit hacky but it works
+						uint32_t channeled_message = fullMessage | (p << 4);
+						connectedDevice->bufferMessage(channeled_message);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fix #490 

Creates a per midi device setting to choose whether to send clocks on that device