### PR TITLE
Minor bugfixes

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -818,9 +818,10 @@ enum class ExistenceChangeType {
 enum CCNumber {
 	CC_NUMBER_PITCH_BEND = 120,
 	CC_NUMBER_AFTERTOUCH = 121,
-	CC_NUMBER_NONE = 122,
+	CC_NUMBER_Y_AXIS = 122,
+	CC_NUMBER_NONE = 123,
 };
-constexpr int32_t kNumCCNumbersIncludingFake = 123;
+constexpr int32_t kNumCCNumbersIncludingFake = 124;
 constexpr int32_t kNumRealCCNumbers = 120;
 
 enum class InstrumentRemoval {

--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -43,7 +43,8 @@ public:
 	//returns a gain compensation value
 	q31_t configure(q31_t frequency, q31_t resonance, FilterMode lpfMode, q31_t lpfMorph, q31_t filterGain) {
 		//lpfmorph comes in q28 but we want q31
-		return static_cast<T*>(this)->setConfig(frequency, resonance, lpfMode, 4 * lpfMorph, filterGain);
+		return static_cast<T*>(this)->setConfig(frequency, resonance, lpfMode, lshiftAndSaturate<2>(lpfMorph),
+		                                        filterGain);
 	}
 	/**
 	 * Filter a buffer of mono samples from startSample to endSample incrememnting by the increment

--- a/src/deluge/dsp/filter/lpladder.h
+++ b/src/deluge/dsp/filter/lpladder.h
@@ -50,7 +50,7 @@ private:
 			lpfLPF4.reset();
 		}
 	};
-	inline q31_t scaleInput(q31_t input, q31_t feedbacksSum) {
+	[[gnu::always_inline]] inline q31_t scaleInput(q31_t input, q31_t feedbacksSum) {
 		q31_t temp;
 		if (morph > 0 || processedResonance > 510000000) {
 			temp = multiply_32x32_rshift32_rounded(
@@ -72,8 +72,6 @@ private:
 	[[gnu::always_inline]] inline q31_t do24dBLPFOnSample(q31_t input, LpLadderState& state);
 	[[gnu::always_inline]] inline q31_t do12dBLPFOnSample(q31_t input, LpLadderState& state);
 	[[gnu::always_inline]] inline q31_t doDriveLPFOnSample(q31_t input, LpLadderState& state);
-	inline void renderLPLadder(q31_t* startSample, q31_t* endSample, FilterMode lpfMode, int32_t sampleIncrement);
-
 	//all ladders are in this class to share the basic components
 	//this differentiates between them
 	FilterMode lpfMode;

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -80,9 +80,8 @@ bool Browser::opened() {
 	arrivedAtFileByTyping = false;
 	allowedFileExtensions = allowedFileExtensionsXML;
 	allowFoldersSharingNameWithFile = false;
-	if (display->have7SEG()) {
-		numberEditPos = -1;
-	}
+
+	numberEditPos = -1;
 
 	return QwertyUI::opened();
 }

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -803,10 +803,10 @@ void View::midiLearnFlash() {
 }
 
 void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
-
-	if (Buttons::isShiftButtonPressed()) {
-		return;
-	}
+	//this routine used to exit if shift was held, but the shift+encoder combo does not seem used anywhere else either
+	// if (Buttons::isShiftButtonPressed()) {
+	// 	return;
+	// }
 
 	if (activeModControllableModelStack.modControllable) {
 

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -375,7 +375,7 @@ void MelodicInstrument::offerReceivedCC(ModelStackWithTimelineCounter* modelStac
 		if (ccNumber == yCC) {
 			//this also passes CC1 to the instrument, but that's important for midi instruments
 			//or internal synths that have CC1 learnt to a parameter instead of used as modwheel
-			processParamFromInputMIDIChannel(74, value32, modelStackWithTimelineCounter);
+			processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, value32, modelStackWithTimelineCounter);
 		}
 		// If it's a MIDI Clip...
 		if (type == InstrumentType::MIDI_OUT) {
@@ -545,7 +545,7 @@ MelodicInstrument::getParamToControlFromInputMIDIChannel(int32_t cc, ModelStackW
 		paramId = 0;
 		break;
 
-	case 74:
+	case CC_NUMBER_Y_AXIS:
 		paramId = 1;
 		break;
 

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -163,7 +163,7 @@ noParam:
 		paramId = 0;
 		goto expressionParam;
 
-	case 74:
+	case CC_NUMBER_Y_AXIS:
 		paramId = 1;
 		goto expressionParam;
 

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -327,7 +327,7 @@ inline int32_t getTanH(int32_t input) {
 	return interpolateTableSigned(workingValue, 32, tanHSmall, 8) >> (saturationAmount + 2);
 }
 
-inline int32_t getTanHUnknown(int32_t input, uint32_t saturationAmount) {
+[[gnu::always_inline]] inline int32_t getTanHUnknown(int32_t input, uint32_t saturationAmount) {
 	uint32_t workingValue;
 
 	if (saturationAmount)


### PR DESCRIPTION
Slot browser expects numberEditPos to be -1 as default, on oled it's not initialized so is 0. This caused the code to always take the branch at line 932 assuming the user was editing a numeric song file using the pre-folder slot system


The mod encoder action used to not work if shift was held, making sticky shift more annoying than it should be. I've just commented that out so it's easy to find if I've overlooked a conflicting function. This is the root modencoder action that eventually gets called from all other UIs and views if nothing else has claimed the encoder

Fix #581 by saturating morph

Inline lpf scale input, missed when inline-functions was disabled

Define memset to be faster than the nano.specs version

Move y axis to a new enum to stop MPE<->non MPE crossover