### PR TITLE
Display Mod Encoder Values with Popup, Update Value Ranges in Menu's, Update Midi CC Value Range, Bug Fix for Midi CC Assignment in Automation Overview

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -42,7 +42,7 @@ Here is a list of general improvements that have been made, ordered from newest 
 - ([#636]) Changing parameter values with Mod (Gold) Encoders now displays a pop-up with the current value of the Parameter. The Menu's for Parameters and Patch Cables have also been adjusted to show the same value range as displayed with the Mod Encoders.
 	- This allows for better fine-tuning of values. 
 	- The value range displayed is 0-128 for non-MIDI parameters and 0-127 for MIDI parameters.
-	- Note: In the Menu, turning the Select Encoder will now, by default, change values by an increment of +/- 2. This allows you to scroll through the entire value range in an accelerated manner. To better fine tune values using the select encoder (e.g. +/- 1), Hold Shift while turning the Select Encoder and the values will change by an increment of +/- 1.
+	- Note: In the Menu, if you wish to scroll through the parameter value range faster at an accelerated rate of +/- 2, hold Shift while turning the Select Encoder.
 
 ## 4. New Features Added
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -41,7 +41,7 @@ Here is a list of general improvements that have been made, ordered from newest 
 #### 3.8 - Visual Feedback on Value Changes with Mod Encoders and Increased Resolution for Value's in Menu's
 - ([#636]) Changing parameter values with Mod (Gold) Encoders now displays a pop-up with the current value of the Parameter. The Menu's for Parameters and Patch Cables have also been adjusted to show the same value range as displayed with the Mod Encoders.
 	- This allows for better fine-tuning of values. 
-	- The value range displayed is 0-128 for non-MIDI parameters and 0-127 for MIDI parameters.
+	- The value range displayed is 0-50 for non-MIDI parameters and 0-127 for MIDI parameters.
 	- Note: In the Menu, if you wish to scroll through the parameter value range faster at an accelerated rate of +/- 5, hold Shift while turning the Select Encoder.
 
 ## 4. New Features Added
@@ -63,7 +63,6 @@ Here is a list of features that have been added to the firmware as a list, group
  - ([#196]) Holding the status pad (mute pad) for a clip and pressing select brings up a clip type selection menu. The options are:
     - Default (DEFA) - the default Deluge clip type.
 	- Fill (FILL) - Fill clip. It appears orange/cyan on the status pads, and when triggered it will schedule itself to start at such a time that it _finishes_ at the start of the next loop. If the fill clip is longer than the remaining time, it is triggered immediately at a point midway through. The loop length is set by the longest playing clip, or by the total length of a section times the repeat count set for that section. **Limitation**: a fill clip is still subject to the one clip per instrument behavior of the Deluge. Fill clips can steal an output from another fill, but they cannot steal from a non-fill. This can lead to some fills never starting since a default type clip has the needed instrument. This can be worked around by cloning the instrument to an independent copy.
-
 
 #### 4.1.4 - Catch Notes
 
@@ -203,6 +202,7 @@ Synchronization modes accessible through the "LFO SYNC" shortcut.
  - Follow-up PR's: 
 	- ([#347]) Added new automatable parameters
  	- ([#360]) Fixed interpolation bugs, added fine tuning for long presses, and added pad selection mode
+	- ([#636]) Updated Parameter Values displayed in Automation View to match Parameter Value Ranges displayed in the Menu's. E.g. instead of 0 - 128, it now displays 0 - 50 (except for Pan which now displays -25 to +25 and MIDI instrument clips which now display 0 - 127).
 
 #### 4.3.6 - Set Probability By Row
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -38,6 +38,12 @@ Here is a list of general improvements that have been made, ordered from newest 
 #### 3.7 - Mod Wheel
 - ([#512]) Incoming mod wheel on non-MPE synths now maps to y axis
 
+#### 3.8 - Visual Feedback on Value Changes with Mod Encoders and Increased Resolution for Value's in Menu's
+- ([#636]) Changing parameter values with Mod (Gold) Encoders now displays a pop-up with the current value of the Parameter. The Menu's for Parameters and Patch Cables have also been adjusted to show the same value range as displayed with the Mod Encoders.
+	- This allows for better fine-tuning of values. 
+	- The value range displayed is 0-128 for non-MIDI parameters and 0-127 for MIDI parameters.
+	- Note: In the Menu, turning the Select Encoder will now, by default, change values by an increment of +/- 2. This allows you to scroll through the entire value range in an accelerated manner. To better fine tune values using the select encoder (e.g. +/- 1), Hold Shift while turning the Select Encoder and the values will change by an increment of +/- 1.
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -390,4 +396,5 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#368]: https://github.com/SynthstromAudible/DelugeFirmware/pull/368
 [#395]: https://github.com/SynthstromAudible/DelugeFirmware/pull/395
 [#512]: https://github.com/SynthstromAudible/DelugeFirmware/pull/512
+[#636]: https://github.com/SynthstromAudible/DelugeFirmware/pull/636
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -42,7 +42,7 @@ Here is a list of general improvements that have been made, ordered from newest 
 - ([#636]) Changing parameter values with Mod (Gold) Encoders now displays a pop-up with the current value of the Parameter. The Menu's for Parameters and Patch Cables have also been adjusted to show the same value range as displayed with the Mod Encoders.
 	- This allows for better fine-tuning of values. 
 	- The value range displayed is 0-128 for non-MIDI parameters and 0-127 for MIDI parameters.
-	- Note: In the Menu, if you wish to scroll through the parameter value range faster at an accelerated rate of +/- 2, hold Shift while turning the Select Encoder.
+	- Note: In the Menu, if you wish to scroll through the parameter value range faster at an accelerated rate of +/- 5, hold Shift while turning the Select Encoder.
 
 ## 4. New Features Added
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -146,7 +146,9 @@ The Automation Editor **will:**
 - enable you to quickly change parameters in focus for editing by turning select or using shift + shortcut pad
 - enable you to view the current parameter value setting for the parameters that are currently automatable.
 - illuminate each pad row according to the current value within the range of 0-128. E.g. bottom pad = 0-16, then 17-32, 33-48, 49-64, 65-80, 81-96, 97-112, 113-128) 
+> **Update** The values displayed in automation view have been updated to display the same value range displayed in the menu's for consistency across the Deluge UI. So instead of displaying 0 - 128, it now displays 0 - 50. Calculations in automation view are still being done based on the 0 - 128 range, but the display converts it to the 0 - 50 range.
 - edit new or existing parameter automations on a per step basis, at any zoom level across the entire timeline. Each row in a step column corresponds to a range of values in the parameter value range (0-128) (see above). If you press the bottom row, the value will be set to 0. if you press the top row, the value will be set to 128. Pressing the rows in between increments/decrements the value by 18 (e.g. 0, 18, 36, 54, 72, 90, 108, 128). 
+> **Update** The values displayed in automation view have been updated to display the same value range displayed in the menu's for consistency across the Deluge UI. So instead of displaying 0 - 128, it now displays 0 - 50. Calculations in automation view are still being done based on the 0 - 128 range, but the display converts it to the 0 - 50 range.
 
 ![image](https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/8cc7befa-9071-4bd3-ac3c-15049f69b250)
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -358,16 +358,16 @@ constexpr PatchSource kFirstLocalSource = PatchSource::ENVELOPE_0;
 
 //Menu Min Max Values
 
-//regular menu range e.g. 0 - 50 or 0 - 128
-constexpr int32_t kMaxMenuValue = 128;
+//regular menu range e.g. 0 - 50
+constexpr int32_t kMaxMenuValue = 50;
 constexpr int32_t kMinMenuValue = 0;
 constexpr int32_t kMidMenuValue = kMinMenuValue + ((kMaxMenuValue - kMinMenuValue) / 2);
 
-//pan menu range e.g. -32 to +32 or -64 to +64
+//pan menu range e.g. -25 to +25
 constexpr int32_t kMaxMenuPanValue = kMaxMenuValue / 2;
 constexpr int32_t kMinMenuPanValue = -1 * kMaxMenuPanValue;
 
-//patch cable menu range e.g. -50 to 50 or -128 to +128
+//patch cable menu range e.g. -5000 to 5000
 constexpr int32_t kMaxMenuPatchCableValue = kMaxMenuValue * 100;
 constexpr int32_t kMinMenuPatchCableValue = -1 * kMaxMenuPatchCableValue;
 //

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -358,11 +358,19 @@ constexpr PatchSource kFirstLocalSource = PatchSource::ENVELOPE_0;
 
 //Menu Min Max Values
 
-constexpr int32_t kMinMenuPanValue = -64;
-constexpr int32_t kMaxMenuPanValue = 64;
-constexpr int32_t kMinMenuValue = 0;
+//regular menu range e.g. 0 - 50 or 0 - 128
 constexpr int32_t kMaxMenuValue = 128;
+constexpr int32_t kMinMenuValue = 0;
 constexpr int32_t kMidMenuValue = kMinMenuValue + ((kMaxMenuValue - kMinMenuValue) / 2);
+
+//pan menu range e.g. -32 to +32 or -64 to +64
+constexpr int32_t kMaxMenuPanValue = kMaxMenuValue / 2;
+constexpr int32_t kMinMenuPanValue = -1 * kMaxMenuPanValue;
+
+//patch cable menu range e.g. -50 to 50 or -128 to +128
+constexpr int32_t kMaxMenuPatchCableValue = kMaxMenuValue * 100;
+constexpr int32_t kMinMenuPatchCableValue = -1 * kMaxMenuPatchCableValue;
+//
 
 //Automation View constants
 constexpr int32_t kNoSelection = 255;

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -356,7 +356,15 @@ constexpr int32_t kNumPatchSources = static_cast<int32_t>(kLastPatchSource);
 constexpr PatchSource kFirstLocalSource = PatchSource::ENVELOPE_0;
 //constexpr PatchSource kFirstUnchangeableSource = PatchSource::VELOCITY;
 
-//Automation Instrument Clip View constants
+//Menu Min Max Values
+
+constexpr int32_t kMinMenuPanValue = -64;
+constexpr int32_t kMaxMenuPanValue = 64;
+constexpr int32_t kMinMenuValue = 0;
+constexpr int32_t kMaxMenuValue = 128;
+constexpr int32_t kMidMenuValue = kMinMenuValue + ((kMaxMenuValue - kMinMenuValue) / 2);
+
+//Automation View constants
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kNumNonKitAffectEntireParamsForAutomation = 55;
 constexpr int32_t kNumKitAffectEntireParamsForAutomation = 24;

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
@@ -27,13 +27,13 @@ public:
 	void readCurrentValue() override {
 		auto* current_clip = static_cast<InstrumentClip*>(currentSong->currentClip);
 		int64_t arp_gate = (int64_t)current_clip->arpeggiatorGate + 2147483648;
-		this->setValue((arp_gate * 50 + 2147483648) >> 32);
+		this->setValue((arp_gate * kMaxMenuValue + 2147483648) >> 32);
 	}
 	void writeCurrentValue() override {
 		(static_cast<InstrumentClip*>(currentSong->currentClip))->arpeggiatorGate =
 		    (uint32_t)this->getValue() * 85899345 - 2147483648;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return soundEditor.editingCVOrMIDIClip(); }
 };
 } // namespace deluge::gui::menu_item::arpeggiator::midi_cv

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
@@ -26,12 +26,12 @@ public:
 	using Integer::Integer;
 	void readCurrentValue() override {
 		this->setValue(
-		    (((int64_t)(static_cast<InstrumentClip*>(currentSong->currentClip))->arpeggiatorRate + 2147483648) * 50
+		    (((int64_t)(static_cast<InstrumentClip*>(currentSong->currentClip))->arpeggiatorRate + 2147483648) * kMaxMenuValue
 		     + 2147483648)
 		    >> 32);
 	}
 	void writeCurrentValue() override {
-		if (this->getValue() == 25) {
+		if (this->getValue() == kMidMenuValue) {
 			(static_cast<InstrumentClip*>(currentSong->currentClip))->arpeggiatorRate = 0;
 		}
 		else {
@@ -39,7 +39,7 @@ public:
 			    (uint32_t)this->getValue() * 85899345 - 2147483648;
 		}
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return soundEditor.editingCVOrMIDIClip(); }
 };
 } // namespace deluge::gui::menu_item::arpeggiator::midi_cv

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
@@ -26,7 +26,8 @@ public:
 	using Integer::Integer;
 	void readCurrentValue() override {
 		this->setValue(
-		    (((int64_t)(static_cast<InstrumentClip*>(currentSong->currentClip))->arpeggiatorRate + 2147483648) * kMaxMenuValue
+		    (((int64_t)(static_cast<InstrumentClip*>(currentSong->currentClip))->arpeggiatorRate + 2147483648)
+		         * kMaxMenuValue
 		     + 2147483648)
 		    >> 32);
 	}

--- a/src/deluge/gui/menu_item/audio_clip/attack.h
+++ b/src/deluge/gui/menu_item/audio_clip/attack.h
@@ -27,7 +27,8 @@ public:
 
 	void readCurrentValue() override {
 		this->setValue(
-		    (((int64_t)(static_cast<AudioClip*>(currentSong->currentClip))->attack + 2147483648) * kMaxMenuValue + 2147483648)
+		    (((int64_t)(static_cast<AudioClip*>(currentSong->currentClip))->attack + 2147483648) * kMaxMenuValue
+		     + 2147483648)
 		    >> 32);
 	}
 	void writeCurrentValue() override {

--- a/src/deluge/gui/menu_item/audio_clip/attack.h
+++ b/src/deluge/gui/menu_item/audio_clip/attack.h
@@ -27,13 +27,13 @@ public:
 
 	void readCurrentValue() override {
 		this->setValue(
-		    (((int64_t)(static_cast<AudioClip*>(currentSong->currentClip))->attack + 2147483648) * 50 + 2147483648)
+		    (((int64_t)(static_cast<AudioClip*>(currentSong->currentClip))->attack + 2147483648) * kMaxMenuValue + 2147483648)
 		    >> 32);
 	}
 	void writeCurrentValue() override {
 		(static_cast<AudioClip*>(currentSong->currentClip))->attack =
 		    (uint32_t)this->getValue() * 85899345 - 2147483648;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };
 } // namespace deluge::gui::menu_item::audio_clip

--- a/src/deluge/gui/menu_item/audio_clip/hpf_freq.h
+++ b/src/deluge/gui/menu_item/audio_clip/hpf_freq.h
@@ -25,7 +25,7 @@ public:
 
 	// 7SEG ONLY
 	void drawValue() override {
-		if (this->getValue() == 0) {
+		if (this->getValue() == kMinMenuValue) {
 			display->setText(l10n::get(l10n::String::STRING_FOR_DISABLED));
 		}
 		else {

--- a/src/deluge/gui/menu_item/audio_clip/lpf_freq.h
+++ b/src/deluge/gui/menu_item/audio_clip/lpf_freq.h
@@ -25,7 +25,7 @@ public:
 
 	// 7Seg ONLY
 	void drawValue() override {
-		if (this->getValue() == 50) {
+		if (this->getValue() == kMaxMenuValue) {
 			display->setText(l10n::get(l10n::String::STRING_FOR_DISABLED));
 		}
 		else {

--- a/src/deluge/gui/menu_item/compressor/attack.h
+++ b/src/deluge/gui/menu_item/compressor/attack.h
@@ -31,7 +31,7 @@ public:
 		soundEditor.currentCompressor->attack = attackRateTable[this->getValue()] << 2;
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override {
 		return !soundEditor.editingReverbCompressor() || AudioEngine::reverbCompressorVolume >= 0;
 	}

--- a/src/deluge/gui/menu_item/compressor/attack.h
+++ b/src/deluge/gui/menu_item/compressor/attack.h
@@ -31,7 +31,7 @@ public:
 		soundEditor.currentCompressor->attack = attackRateTable[this->getValue()] << 2;
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
+	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override {
 		return !soundEditor.editingReverbCompressor() || AudioEngine::reverbCompressorVolume >= 0;
 	}

--- a/src/deluge/gui/menu_item/compressor/release.h
+++ b/src/deluge/gui/menu_item/compressor/release.h
@@ -31,7 +31,7 @@ public:
 		soundEditor.currentCompressor->release = releaseRateTable[this->getValue()] << 3;
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
+	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override {
 		return !soundEditor.editingReverbCompressor() || AudioEngine::reverbCompressorVolume >= 0;
 	}

--- a/src/deluge/gui/menu_item/compressor/release.h
+++ b/src/deluge/gui/menu_item/compressor/release.h
@@ -31,7 +31,7 @@ public:
 		soundEditor.currentCompressor->release = releaseRateTable[this->getValue()] << 3;
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override {
 		return !soundEditor.editingReverbCompressor() || AudioEngine::reverbCompressorVolume >= 0;
 	}

--- a/src/deluge/gui/menu_item/filter/hpf_freq.h
+++ b/src/deluge/gui/menu_item/filter/hpf_freq.h
@@ -27,7 +27,7 @@ public:
 
 	// 7Seg ONLY
 	void drawValue() override {
-		if (this->getValue() == 0
+		if (this->getValue() == kMinMenuValue
 		    && !soundEditor.currentParamManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(
 		        ::Param::Local::HPF_FREQ)) {
 			display->setText(l10n::get(l10n::String::STRING_FOR_DISABLED));

--- a/src/deluge/gui/menu_item/filter/lpf_freq.h
+++ b/src/deluge/gui/menu_item/filter/lpf_freq.h
@@ -26,7 +26,7 @@ public:
 
 	// 7Seg ONLY
 	void drawValue() override {
-		if (this->getValue() == 50
+		if (this->getValue() == kMaxMenuValue
 		    && !soundEditor.currentParamManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(
 		        ::Param::Local::LPF_FREQ)) {
 			display->setText(l10n::get(l10n::String::STRING_FOR_DISABLED));

--- a/src/deluge/gui/menu_item/midi/default_velocity_to_level.h
+++ b/src/deluge/gui/menu_item/midi/default_velocity_to_level.h
@@ -26,7 +26,8 @@ public:
 	using IntegerWithOff::IntegerWithOff;
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	void readCurrentValue() override {
-		this->setValue(((int64_t)soundEditor.currentMIDIDevice->defaultVelocityToLevel * kMaxMenuValue + 536870912) >> 30);
+		this->setValue(((int64_t)soundEditor.currentMIDIDevice->defaultVelocityToLevel * kMaxMenuValue + 536870912)
+		               >> 30);
 	}
 	void writeCurrentValue() override {
 		soundEditor.currentMIDIDevice->defaultVelocityToLevel = this->getValue() * (2147483648 / (kMaxMenuValue * 2));

--- a/src/deluge/gui/menu_item/midi/default_velocity_to_level.h
+++ b/src/deluge/gui/menu_item/midi/default_velocity_to_level.h
@@ -24,12 +24,12 @@ namespace deluge::gui::menu_item::midi {
 class DefaultVelocityToLevel final : public IntegerWithOff {
 public:
 	using IntegerWithOff::IntegerWithOff;
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	void readCurrentValue() override {
-		this->setValue(((int64_t)soundEditor.currentMIDIDevice->defaultVelocityToLevel * 50 + 536870912) >> 30);
+		this->setValue(((int64_t)soundEditor.currentMIDIDevice->defaultVelocityToLevel * kMaxMenuValue + 536870912) >> 30);
 	}
 	void writeCurrentValue() override {
-		soundEditor.currentMIDIDevice->defaultVelocityToLevel = this->getValue() * 21474836;
+		soundEditor.currentMIDIDevice->defaultVelocityToLevel = this->getValue() * (2147483648 / (kMaxMenuValue * 2));
 		currentSong->grabVelocityToLevelFromMIDIDeviceAndSetupPatchingForEverything(soundEditor.currentMIDIDevice);
 		MIDIDeviceManager::anyChangesToSave = true;
 	}

--- a/src/deluge/gui/menu_item/osc/pulse_width.h
+++ b/src/deluge/gui/menu_item/osc/pulse_width.h
@@ -43,7 +43,8 @@ public:
 
 	void readCurrentValue() override {
 		this->setValue(
-		    ((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * (kMaxMenuValue * 2) + 2147483648)
+		    ((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * (kMaxMenuValue * 2)
+		     + 2147483648)
 		    >> 32);
 	}
 

--- a/src/deluge/gui/menu_item/osc/pulse_width.h
+++ b/src/deluge/gui/menu_item/osc/pulse_width.h
@@ -29,11 +29,21 @@ public:
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
-	int32_t getFinalValue() override { return (uint32_t)this->getValue() * (85899345 >> 1); }
+	int32_t getFinalValue() override {
+		if (this->getValue() == kMaxMenuValue) {
+			return 2147483647;
+		}
+		else if (this->getValue() == kMinMenuValue) {
+			return 0;
+		}
+		else {
+			return (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
+		}
+	}
 
 	void readCurrentValue() override {
 		this->setValue(
-		    ((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * 100 + 2147483648)
+		    ((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * (kMaxMenuValue * 2) + 2147483648)
 		    >> 32);
 	}
 

--- a/src/deluge/gui/menu_item/param.h
+++ b/src/deluge/gui/menu_item/param.h
@@ -28,8 +28,8 @@ namespace deluge::gui::menu_item {
 class Param {
 public:
 	Param(int32_t newP = 0) : p(newP) {}
-	[[nodiscard]] virtual int32_t getMaxValue() const { return 50; }
-	[[nodiscard]] virtual int32_t getMinValue() const { return 0; }
+	[[nodiscard]] virtual int32_t getMaxValue() const { return kMaxMenuValue; }
+	[[nodiscard]] virtual int32_t getMinValue() const { return kMinMenuValue; }
 	virtual uint8_t getP() { return p; };
 	MenuItem* selectButtonPress();
 	virtual ModelStackWithAutoParam* getModelStack(void* memory) = 0;

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -27,8 +27,8 @@ public:
 	void beginSession(MenuItem* navigatedBackwardFrom) final;
 	void readCurrentValue() final;
 	void writeCurrentValue() override;
-	[[nodiscard]] int32_t getMinValue() const final { return -5000; }
-	[[nodiscard]] int32_t getMaxValue() const final { return 5000; }
+	[[nodiscard]] int32_t getMinValue() const final { return kMinMenuPatchCableValue; }
+	[[nodiscard]] int32_t getMaxValue() const final { return kMaxMenuPatchCableValue; }
 	[[nodiscard]] int32_t getNumDecimalPlaces() const final { return 2; }
 	virtual int32_t getDefaultEditPos() { return 2; }
 	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) override;

--- a/src/deluge/gui/menu_item/patch_cables.cpp
+++ b/src/deluge/gui/menu_item/patch_cables.cpp
@@ -79,7 +79,7 @@ void PatchCables::renderOptions() {
 		}
 
 		int32_t param_value = cable->param.getCurrentValue();
-		int32_t level = ((int64_t)param_value * 5000 + (1 << 29)) >> 30;
+		int32_t level = ((int64_t)param_value * kMaxMenuPatchCableValue + (1 << 29)) >> 30;
 
 		floatToString((float)level / 100, buf + off + 5, 2, 2);
 		//fmt::vformat_to_n(buf + off + 5, 5, "{:4}", fmt::make_format_args();

--- a/src/deluge/gui/menu_item/patched_param/integer.cpp
+++ b/src/deluge/gui/menu_item/patched_param/integer.cpp
@@ -21,9 +21,10 @@
 
 namespace deluge::gui::menu_item::patched_param {
 void Integer::readCurrentValue() {
-	this->setValue((((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) + 2147483648) * kMaxMenuValue
-	                + 2147483648)
-	               >> 32);
+	this->setValue(
+	    (((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) + 2147483648) * kMaxMenuValue
+	     + 2147483648)
+	    >> 32);
 }
 
 void Integer::writeCurrentValue() {

--- a/src/deluge/gui/menu_item/patched_param/integer.cpp
+++ b/src/deluge/gui/menu_item/patched_param/integer.cpp
@@ -21,7 +21,7 @@
 
 namespace deluge::gui::menu_item::patched_param {
 void Integer::readCurrentValue() {
-	this->setValue((((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) + 2147483648) * 50
+	this->setValue((((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) + 2147483648) * kMaxMenuValue
 	                + 2147483648)
 	               >> 32);
 }
@@ -35,10 +35,15 @@ void Integer::writeCurrentValue() {
 }
 
 int32_t Integer::getFinalValue() {
-	if (this->getValue() == 25) {
-		return 0;
+	if (this->getValue() == kMaxMenuValue) {
+		return 2147483647;
 	}
-	return (uint32_t)this->getValue() * 85899345 - 2147483648;
+	else if (this->getValue() == kMinMenuValue) {
+		return -2147483648;
+	}
+	else {
+		return (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) - 2147483648;
+	}
 }
 
 } // namespace deluge::gui::menu_item::patched_param

--- a/src/deluge/gui/menu_item/patched_param/pan.cpp
+++ b/src/deluge/gui/menu_item/patched_param/pan.cpp
@@ -47,17 +47,19 @@ void Pan::drawValue() {
 }
 
 int32_t Pan::getFinalValue() {
-	if (this->getValue() == 32) {
+	if (this->getValue() == kMaxMenuPanValue) {
 		return 2147483647;
 	}
-	if (this->getValue() == -32) {
+	else if (this->getValue() == kMinMenuPanValue) {
 		return -2147483648;
 	}
-	return ((int32_t)this->getValue() * 33554432 * 2);
+	else {
+		return ((int32_t)this->getValue() * (2147483648 / (kMaxMenuPanValue * 2)) * 2);
+	}
 }
 
 void Pan::readCurrentValue() {
-	this->setValue(((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * 64 + 2147483648)
+	this->setValue(((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * (kMaxMenuPanValue * 2) + 2147483648)
 	               >> 32);
 }
 } // namespace deluge::gui::menu_item::patched_param

--- a/src/deluge/gui/menu_item/patched_param/pan.cpp
+++ b/src/deluge/gui/menu_item/patched_param/pan.cpp
@@ -59,7 +59,9 @@ int32_t Pan::getFinalValue() {
 }
 
 void Pan::readCurrentValue() {
-	this->setValue(((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * (kMaxMenuPanValue * 2) + 2147483648)
-	               >> 32);
+	this->setValue(
+	    ((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * (kMaxMenuPanValue * 2)
+	     + 2147483648)
+	    >> 32);
 }
 } // namespace deluge::gui::menu_item::patched_param

--- a/src/deluge/gui/menu_item/patched_param/pan.h
+++ b/src/deluge/gui/menu_item/patched_param/pan.h
@@ -24,8 +24,8 @@ public:
 	void drawValue() override;
 
 protected:
-	[[nodiscard]] int32_t getMaxValue() const override { return 32; }
-	[[nodiscard]] int32_t getMinValue() const override { return -32; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuPanValue; }
+	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuPanValue; }
 	int32_t getFinalValue() override;
 	void readCurrentValue() override;
 };

--- a/src/deluge/gui/menu_item/reverb/compressor/shape.h
+++ b/src/deluge/gui/menu_item/reverb/compressor/shape.h
@@ -26,13 +26,13 @@ class Shape final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		this->setValue((((int64_t)AudioEngine::reverbCompressorShape + 2147483648) * 50 + 2147483648) >> 32);
+		this->setValue((((int64_t)AudioEngine::reverbCompressorShape + 2147483648) * kMaxMenuValue + 2147483648) >> 32);
 	}
 	void writeCurrentValue() override {
 		AudioEngine::reverbCompressorShape = (uint32_t)this->getValue() * 85899345 - 2147483648;
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return (AudioEngine::reverbCompressorVolume >= 0); }
 };
 } // namespace deluge::gui::menu_item::reverb::compressor

--- a/src/deluge/gui/menu_item/reverb/compressor/volume.h
+++ b/src/deluge/gui/menu_item/reverb/compressor/volume.h
@@ -30,7 +30,7 @@ public:
 		AudioEngine::reverbCompressorVolume = this->getValue() * 21474836;
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	[[nodiscard]] int32_t getMinValue() const override { return -1; }
 
 	void drawValue() override {

--- a/src/deluge/gui/menu_item/reverb/dampening.h
+++ b/src/deluge/gui/menu_item/reverb/dampening.h
@@ -25,8 +25,8 @@ namespace deluge::gui::menu_item::reverb {
 class Dampening final : public Integer {
 public:
 	using Integer::Integer;
-	void readCurrentValue() override { this->setValue(std::round(AudioEngine::reverb.getdamp() * 50)); }
-	void writeCurrentValue() override { AudioEngine::reverb.setdamp((float)this->getValue() / 50); }
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	void readCurrentValue() override { this->setValue(std::round(AudioEngine::reverb.getdamp() * kMaxMenuValue)); }
+	void writeCurrentValue() override { AudioEngine::reverb.setdamp((float)this->getValue() / kMaxMenuValue); }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };
 } // namespace deluge::gui::menu_item::reverb

--- a/src/deluge/gui/menu_item/reverb/pan.h
+++ b/src/deluge/gui/menu_item/reverb/pan.h
@@ -43,7 +43,9 @@ public:
 
 	void writeCurrentValue() override { AudioEngine::reverbPan = ((int32_t)this->getValue() * 33554432); }
 
-	void readCurrentValue() override { this->setValue(((int64_t)AudioEngine::reverbPan * (kMaxMenuPanValue * 4) + 2147483648) >> 32); }
+	void readCurrentValue() override {
+		this->setValue(((int64_t)AudioEngine::reverbPan * (kMaxMenuPanValue * 4) + 2147483648) >> 32);
+	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuPanValue; }
 	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuPanValue; }
 };

--- a/src/deluge/gui/menu_item/reverb/pan.h
+++ b/src/deluge/gui/menu_item/reverb/pan.h
@@ -43,8 +43,8 @@ public:
 
 	void writeCurrentValue() override { AudioEngine::reverbPan = ((int32_t)this->getValue() * 33554432); }
 
-	void readCurrentValue() override { this->setValue(((int64_t)AudioEngine::reverbPan * 128 + 2147483648) >> 32); }
-	[[nodiscard]] int32_t getMaxValue() const override { return 32; }
-	[[nodiscard]] int32_t getMinValue() const override { return -32; }
+	void readCurrentValue() override { this->setValue(((int64_t)AudioEngine::reverbPan * (kMaxMenuPanValue * 4) + 2147483648) >> 32); }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuPanValue; }
+	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuPanValue; }
 };
 } // namespace deluge::gui::menu_item::reverb

--- a/src/deluge/gui/menu_item/reverb/room_size.h
+++ b/src/deluge/gui/menu_item/reverb/room_size.h
@@ -25,8 +25,8 @@ namespace deluge::gui::menu_item::reverb {
 class RoomSize final : public Integer {
 public:
 	using Integer::Integer;
-	void readCurrentValue() override { this->setValue(std::round(AudioEngine::reverb.getroomsize() * 50)); }
-	void writeCurrentValue() override { AudioEngine::reverb.setroomsize((float)this->getValue() / 50); }
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	void readCurrentValue() override { this->setValue(std::round(AudioEngine::reverb.getroomsize() * kMaxMenuValue)); }
+	void writeCurrentValue() override { AudioEngine::reverb.setroomsize((float)this->getValue() / kMaxMenuValue); }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };
 } // namespace deluge::gui::menu_item::reverb

--- a/src/deluge/gui/menu_item/reverb/width.h
+++ b/src/deluge/gui/menu_item/reverb/width.h
@@ -25,8 +25,8 @@ namespace deluge::gui::menu_item::reverb {
 class Width final : public Integer {
 public:
 	using Integer::Integer;
-	void readCurrentValue() override { this->setValue(std::round(AudioEngine::reverb.getwidth() * 50)); }
-	void writeCurrentValue() override { AudioEngine::reverb.setwidth((float)this->getValue() / 50); }
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	void readCurrentValue() override { this->setValue(std::round(AudioEngine::reverb.getwidth() * kMaxMenuValue)); }
+	void writeCurrentValue() override { AudioEngine::reverb.setwidth((float)this->getValue() / kMaxMenuValue); }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };
 } // namespace deluge::gui::menu_item::reverb

--- a/src/deluge/gui/menu_item/sidechain/send.h
+++ b/src/deluge/gui/menu_item/sidechain/send.h
@@ -24,17 +24,17 @@ class Send final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		this->setValue(((uint64_t)soundEditor.currentSound->sideChainSendLevel * 50 + 1073741824) >> 31);
+		this->setValue(((uint64_t)soundEditor.currentSound->sideChainSendLevel * kMaxMenuValue + 1073741824) >> 31);
 	}
 	void writeCurrentValue() override {
-		if (this->getValue() == 50) {
+		if (this->getValue() == kMaxMenuValue) {
 			soundEditor.currentSound->sideChainSendLevel = 2147483647;
 		}
 		else {
 			soundEditor.currentSound->sideChainSendLevel = this->getValue() * 42949673;
 		}
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(Sound* sound, int32_t whichThing) override { return (soundEditor.editingKit()); }
 };
 } // namespace deluge::gui::menu_item::sidechain

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -31,10 +31,10 @@ extern "C" {
 namespace deluge::gui::menu_item {
 
 void UnpatchedParam::readCurrentValue() {
-	this->setValue(
-	    (((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) + 2147483648) * kMaxMenuValue
-	     + 2147483648)
-	    >> 32);
+	this->setValue((((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) + 2147483648)
+	                    * kMaxMenuValue
+	                + 2147483648)
+	               >> 32);
 }
 
 ModelStackWithAutoParam* UnpatchedParam::getModelStack(void* memory) {

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -32,7 +32,7 @@ namespace deluge::gui::menu_item {
 
 void UnpatchedParam::readCurrentValue() {
 	this->setValue(
-	    (((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) + 2147483648) * 50
+	    (((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) + 2147483648) * kMaxMenuValue
 	     + 2147483648)
 	    >> 32);
 }
@@ -52,11 +52,14 @@ void UnpatchedParam::writeCurrentValue() {
 }
 
 int32_t UnpatchedParam::getFinalValue() {
-	if (this->getValue() == 25) {
-		return 0;
+	if (this->getValue() == kMaxMenuValue) {
+		return 2147483647;
+	}
+	else if (this->getValue() == kMinMenuValue) {
+		return -2147483648;
 	}
 	else {
-		return (uint32_t)this->getValue() * 85899345 - 2147483648;
+		return (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) - 2147483648;
 	}
 }
 

--- a/src/deluge/gui/menu_item/unpatched_param/pan.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param/pan.cpp
@@ -55,7 +55,9 @@ int32_t Pan::getFinalValue() {
 
 void Pan::readCurrentValue() {
 	this->setValue(
-	    ((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) * (kMaxMenuPanValue * 2) + 2147483648) >> 32);
+	    ((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) * (kMaxMenuPanValue * 2)
+	     + 2147483648)
+	    >> 32);
 }
 
 } // namespace deluge::gui::menu_item::unpatched_param

--- a/src/deluge/gui/menu_item/unpatched_param/pan.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param/pan.cpp
@@ -42,20 +42,20 @@ void Pan::drawValue() {    // TODO: should really combine this with the "patched
 }
 
 int32_t Pan::getFinalValue() {
-	if (this->getValue() == 32) {
+	if (this->getValue() == kMaxMenuPanValue) {
 		return 2147483647;
 	}
-	else if (this->getValue() == -32) {
+	else if (this->getValue() == kMinMenuPanValue) {
 		return -2147483648;
 	}
 	else {
-		return ((int32_t)this->getValue() * 33554432 * 2);
+		return ((int32_t)this->getValue() * (2147483648 / (kMaxMenuPanValue * 2)) * 2);
 	}
 }
 
 void Pan::readCurrentValue() {
 	this->setValue(
-	    ((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) * 64 + 2147483648) >> 32);
+	    ((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) * (kMaxMenuPanValue * 2) + 2147483648) >> 32);
 }
 
 } // namespace deluge::gui::menu_item::unpatched_param

--- a/src/deluge/gui/menu_item/unpatched_param/pan.h
+++ b/src/deluge/gui/menu_item/unpatched_param/pan.h
@@ -26,8 +26,8 @@ public:
 	virtual void drawValue();
 
 protected:
-	[[nodiscard]] int32_t getMaxValue() const override { return 32; }
-	[[nodiscard]] int32_t getMinValue() const override { return -32; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuPanValue; }
+	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuPanValue; }
 	int32_t getFinalValue() override;
 	void readCurrentValue() override;
 };

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -651,7 +651,7 @@ ActionResult SoundEditor::horizontalEncoderAction(int32_t offset) {
 void SoundEditor::selectEncoderAction(int8_t offset) {
 
 	if (Buttons::isShiftButtonPressed()) {
-		offset = offset * 2;
+		offset = offset * 5;
 	}
 
 	if (currentUIMode != UI_MODE_NONE && currentUIMode != UI_MODE_AUDITIONING

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -650,6 +650,10 @@ ActionResult SoundEditor::horizontalEncoderAction(int32_t offset) {
 
 void SoundEditor::selectEncoderAction(int8_t offset) {
 
+	if (!Buttons::isShiftButtonPressed()) {
+		offset = offset * 2;
+	}
+
 	if (currentUIMode != UI_MODE_NONE && currentUIMode != UI_MODE_AUDITIONING
 	    && currentUIMode != UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR) {
 		return;

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -650,7 +650,7 @@ ActionResult SoundEditor::horizontalEncoderAction(int32_t offset) {
 
 void SoundEditor::selectEncoderAction(int8_t offset) {
 
-	if (!Buttons::isShiftButtonPressed()) {
+	if (Buttons::isShiftButtonPressed()) {
 		offset = offset * 2;
 	}
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2420,7 +2420,7 @@ bool AutomationInstrumentClipView::modEncoderActionForSelectedPad(int32_t whichM
 				if ((knobPos == 64) || (newKnobPos == 64)) {
 					return true;
 				}
-			}			
+			}
 
 			//use default interpolation settings
 			initInterpolation();

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2416,6 +2416,12 @@ bool AutomationInstrumentClipView::modEncoderActionForSelectedPad(int32_t whichM
 
 			int32_t newKnobPos = calculateKnobPosForModEncoderTurn(knobPos, offset);
 
+			if (clip->output->type == InstrumentType::MIDI_OUT) {
+				if ((knobPos == 64) || (newKnobPos == 64)) {
+					return true;
+				}
+			}			
+
 			//use default interpolation settings
 			initInterpolation();
 
@@ -2453,6 +2459,12 @@ void AutomationInstrumentClipView::modEncoderActionForUnselectedPad(int32_t whic
 			int32_t knobPos = getParameterKnobPos(modelStackWithParam, view.modPos);
 
 			int32_t newKnobPos = calculateKnobPosForModEncoderTurn(knobPos, offset);
+
+			if (clip->output->type == InstrumentType::MIDI_OUT) {
+				if ((knobPos == 64) || (newKnobPos == 64)) {
+					return;
+				}
+			}
 
 			int32_t newValue =
 			    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
@@ -3301,7 +3313,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 				//use default interpolation settings
 				initInterpolation();
 
-				int32_t newKnobPos = calculateKnobPosForSinglePadPress(yDisplay);
+				int32_t newKnobPos = calculateKnobPosForSinglePadPress(clip, yDisplay);
 				setParameterAutomationValue(modelStackWithParam, newKnobPos, squareStart, xDisplay, effectiveLength);
 			}
 		}
@@ -3311,7 +3323,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 }
 
 //calculates what the new parameter value is when you press a single pad
-int32_t AutomationInstrumentClipView::calculateKnobPosForSinglePadPress(int32_t yDisplay) {
+int32_t AutomationInstrumentClipView::calculateKnobPosForSinglePadPress(InstrumentClip* clip, int32_t yDisplay) {
 
 	int32_t newKnobPos = 0;
 
@@ -3321,7 +3333,12 @@ int32_t AutomationInstrumentClipView::calculateKnobPosForSinglePadPress(int32_t 
 	}
 	//if you are pressing the top pad, set the value to max (128)
 	else {
-		newKnobPos = kMaxKnobPos;
+		if (clip->output->type == InstrumentType::MIDI_OUT) {
+			newKnobPos = kMaxKnobPos - 1;
+		}
+		else {
+			newKnobPos = kMaxKnobPos;
+		}
 	}
 
 	//in the deluge knob positions are stored in the range of -64 to + 64, so need to adjust newKnobPos set above.
@@ -3361,8 +3378,8 @@ void AutomationInstrumentClipView::handleMultiPadPress(ModelStackWithTimelineCou
 
 			//otherwise if it's a regular long press, calculate values from the y position of the pads pressed
 			else {
-				firstPadValue = calculateKnobPosForSinglePadPress(firstPadY) + kKnobPosOffset;
-				secondPadValue = calculateKnobPosForSinglePadPress(secondPadY) + kKnobPosOffset;
+				firstPadValue = calculateKnobPosForSinglePadPress(clip, firstPadY) + kKnobPosOffset;
+				secondPadValue = calculateKnobPosForSinglePadPress(clip, secondPadY) + kKnobPosOffset;
 			}
 
 			//converting variables to float for more accurate interpolation calculation

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -810,21 +810,27 @@ DisplayParameterValue
 DisplayParameterName */
 
 void AutomationInstrumentClipView::renderDisplay(int32_t knobPosLeft, int32_t knobPosRight, bool modEncoderAction) {
-	//OLED Display
-	if (display->haveOLED()) {
-		renderDisplayOLED(knobPosLeft, knobPosRight);
-	}
-	//7SEG Display
-	else {
-		renderDisplay7SEG(knobPosLeft, modEncoderAction);
-	}
-}
-
-void AutomationInstrumentClipView::renderDisplayOLED(int32_t knobPosLeft, int32_t knobPosRight) {
-
 	InstrumentClip* clip = getCurrentClip();
 	Instrument* instrument = (Instrument*)clip->output;
 
+	//if you're not in a MIDI instrument clip, convert the knobPos to the same range as the menu (0-50)
+	if (instrument->type != InstrumentType::MIDI_OUT) {
+		knobPosLeft = calculateKnobPosForDisplay(clip, knobPosLeft);
+		knobPosRight = calculateKnobPosForDisplay(clip, knobPosRight);
+	}
+
+	//OLED Display
+	if (display->haveOLED()) {
+		renderDisplayOLED(clip, instrument, knobPosLeft, knobPosRight);
+	}
+	//7SEG Display
+	else {
+		renderDisplay7SEG(clip, instrument, knobPosLeft, modEncoderAction);
+	}
+}
+
+void AutomationInstrumentClipView::renderDisplayOLED(InstrumentClip* clip, Instrument* instrument, int32_t knobPosLeft,
+                                                     int32_t knobPosRight) {
 	deluge::hid::display::OLED::clearMainImage();
 
 	if (isOnAutomationOverview() || (instrument->type == InstrumentType::CV)) {
@@ -852,7 +858,7 @@ void AutomationInstrumentClipView::renderDisplayOLED(int32_t knobPosLeft, int32_
 	else if (instrument->type != InstrumentType::CV) {
 		//display parameter name
 		char parameterName[30];
-		getParameterName(parameterName);
+		getParameterName(clip, instrument, parameterName);
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -917,11 +923,8 @@ void AutomationInstrumentClipView::renderDisplayOLED(int32_t knobPosLeft, int32_
 	deluge::hid::display::OLED::sendMainImage();
 }
 
-void AutomationInstrumentClipView::renderDisplay7SEG(int32_t knobPosLeft, bool modEncoderAction) {
-
-	InstrumentClip* clip = getCurrentClip();
-	Instrument* instrument = (Instrument*)clip->output;
-
+void AutomationInstrumentClipView::renderDisplay7SEG(InstrumentClip* clip, Instrument* instrument, int32_t knobPosLeft,
+                                                     bool modEncoderAction) {
 	//display OVERVIEW or CANT
 	if (isOnAutomationOverview() || (instrument->type == InstrumentType::CV)) {
 		if (instrument->type != InstrumentType::CV) {
@@ -962,18 +965,14 @@ void AutomationInstrumentClipView::renderDisplay7SEG(int32_t knobPosLeft, bool m
 		//display parameter name
 		else {
 			char parameterName[30];
-			getParameterName(parameterName);
+			getParameterName(clip, instrument, parameterName);
 			display->setScrollingText(parameterName);
 		}
 	}
 }
 
 //get's the name of the Parameter being edited so it can be displayed on the screen
-void AutomationInstrumentClipView::getParameterName(char* parameterName) {
-
-	InstrumentClip* clip = getCurrentClip();
-	Instrument* instrument = (Instrument*)clip->output;
-
+void AutomationInstrumentClipView::getParameterName(InstrumentClip* clip, Instrument* instrument, char* parameterName) {
 	if (instrument->type == InstrumentType::SYNTH || instrument->type == InstrumentType::KIT) {
 		if (clip->lastSelectedParamKind == Param::Kind::PATCHED) {
 			strncpy(parameterName, getPatchedParamDisplayName(clip->lastSelectedParamID), 29);
@@ -1015,6 +1014,20 @@ void AutomationInstrumentClipView::getParameterName(char* parameterName) {
 			}
 		}
 	}
+}
+
+//for non-MIDI instruments, convert deluge internal knobPos range to same range as used by menu's.
+int32_t AutomationInstrumentClipView::calculateKnobPosForDisplay(InstrumentClip* clip, int32_t knobPos) {
+	int32_t offset = 0;
+
+	//if the parameter is pan, convert knobPos from 0 - 50 to -25 to +25
+	if ((clip->lastSelectedParamID == Param::Local::PAN)
+	    || (clip->lastSelectedParamID == Param::Unpatched::GlobalEffectable::PAN)) {
+		offset = kMaxMenuPanValue;
+	}
+
+	//convert knobPos from 0 - 128 to 0 - 50
+	return (((((knobPos << 20) / kMaxKnobPos) * kMaxMenuValue) >> 20) - offset);
 }
 
 //adjust the LED meters and update the display
@@ -3325,7 +3338,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 				//use default interpolation settings
 				initInterpolation();
 
-				int32_t newKnobPos = calculateKnobPosForSinglePadPress(clip, yDisplay);
+				int32_t newKnobPos = calculateKnobPosForSinglePadPress(instrument, yDisplay);
 				setParameterAutomationValue(modelStackWithParam, newKnobPos, squareStart, xDisplay, effectiveLength);
 			}
 		}
@@ -3335,7 +3348,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 }
 
 //calculates what the new parameter value is when you press a single pad
-int32_t AutomationInstrumentClipView::calculateKnobPosForSinglePadPress(InstrumentClip* clip, int32_t yDisplay) {
+int32_t AutomationInstrumentClipView::calculateKnobPosForSinglePadPress(Instrument* instrument, int32_t yDisplay) {
 
 	int32_t newKnobPos = 0;
 
@@ -3346,7 +3359,7 @@ int32_t AutomationInstrumentClipView::calculateKnobPosForSinglePadPress(Instrume
 	//if you are pressing the top pad, set the value to max (128)
 	else {
 		//for Midi Clips, maxKnobPos = 127
-		if (clip->output->type == InstrumentType::MIDI_OUT) {
+		if (instrument->type == InstrumentType::MIDI_OUT) {
 			newKnobPos = kMaxKnobPos - 1; //128 - 1 = 127
 		}
 		else {
@@ -3391,8 +3404,8 @@ void AutomationInstrumentClipView::handleMultiPadPress(ModelStackWithTimelineCou
 
 			//otherwise if it's a regular long press, calculate values from the y position of the pads pressed
 			else {
-				firstPadValue = calculateKnobPosForSinglePadPress(clip, firstPadY) + kKnobPosOffset;
-				secondPadValue = calculateKnobPosForSinglePadPress(clip, secondPadY) + kKnobPosOffset;
+				firstPadValue = calculateKnobPosForSinglePadPress(instrument, firstPadY) + kKnobPosOffset;
+				secondPadValue = calculateKnobPosForSinglePadPress(instrument, secondPadY) + kKnobPosOffset;
 			}
 
 			//converting variables to float for more accurate interpolation calculation

--- a/src/deluge/gui/views/automation_instrument_clip_view.h
+++ b/src/deluge/gui/views/automation_instrument_clip_view.h
@@ -62,8 +62,6 @@ public:
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
 	void renderDisplay(int32_t knobPosLeft = kNoSelection, int32_t knobPosRight = kNoSelection,
 	                   bool modEncoderAction = false);
-	void renderDisplayOLED(int32_t knobPosLeft = kNoSelection, int32_t knobPosRight = kNoSelection);
-	void renderDisplay7SEG(int32_t knobPosLeft = kNoSelection, bool modEncoderAction = false);
 	void displayAutomation(bool padSelected = false, bool updateDisplay = true);
 
 	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) { InstrumentClipMinder::renderOLED(image); }
@@ -129,6 +127,10 @@ private:
 	void renderRow(ModelStackWithTimelineCounter* modelStack, ModelStackWithAutoParam* modelStackWithParam,
 	               uint8_t* image, uint8_t occupancyMask[], int32_t yDisplay = 0, bool isAutomated = false);
 	void renderLove(uint8_t* image, uint8_t occupancyMask[], int32_t yDisplay = 0);
+	void renderDisplayOLED(InstrumentClip* clip, Instrument* instrument, int32_t knobPosLeft = kNoSelection,
+	                       int32_t knobPosRight = kNoSelection);
+	void renderDisplay7SEG(InstrumentClip* clip, Instrument* instrument, int32_t knobPosLeft = kNoSelection,
+	                       bool modEncoderAction = false);
 
 	//Enter/Exit Scale Mode
 	void enterScaleMode(uint8_t yDisplay = 255);
@@ -151,7 +153,7 @@ private:
 	int32_t getEffectiveLength(ModelStackWithTimelineCounter* modelStack);
 	uint32_t getMiddlePosFromSquare(ModelStackWithTimelineCounter* modelStack, int32_t xDisplay);
 
-	void getParameterName(char* parameterName);
+	void getParameterName(InstrumentClip* clip, Instrument* instrument, char* parameterName);
 	int32_t getParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t pos);
 
 	bool getNodeInterpolation(ModelStackWithAutoParam* modelStack, int32_t pos, bool reversed);
@@ -164,7 +166,7 @@ private:
 	bool recordSinglePadPress(int32_t xDisplay, int32_t yDisplay);
 	void handleSinglePadPress(ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip, int32_t xDisplay,
 	                          int32_t yDisplay, bool shortcutPress = false);
-	int32_t calculateKnobPosForSinglePadPress(InstrumentClip* clip, int32_t yDisplay);
+	int32_t calculateKnobPosForSinglePadPress(Instrument* instrument, int32_t yDisplay);
 
 	void handleMultiPadPress(ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip, int32_t firstPadX,
 	                         int32_t firstPadY, int32_t secondPadX, int32_t secondPadY, bool modEncoderAction = false);
@@ -172,6 +174,7 @@ private:
 	                                   int32_t xDisplay = kNoSelection, bool modEncoderAction = false);
 
 	int32_t calculateKnobPosForModEncoderTurn(int32_t knobPos, int32_t offset);
+	int32_t calculateKnobPosForDisplay(InstrumentClip* clip, int32_t knobPos);
 	void displayCVErrorMessage();
 	void resetShortcutBlinking();
 

--- a/src/deluge/gui/views/automation_instrument_clip_view.h
+++ b/src/deluge/gui/views/automation_instrument_clip_view.h
@@ -164,7 +164,7 @@ private:
 	bool recordSinglePadPress(int32_t xDisplay, int32_t yDisplay);
 	void handleSinglePadPress(ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip, int32_t xDisplay,
 	                          int32_t yDisplay, bool shortcutPress = false);
-	int32_t calculateKnobPosForSinglePadPress(int32_t yDisplay);
+	int32_t calculateKnobPosForSinglePadPress(InstrumentClip* clip, int32_t yDisplay);
 
 	void handleMultiPadPress(ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip, int32_t firstPadX,
 	                         int32_t firstPadY, int32_t secondPadX, int32_t secondPadY, bool modEncoderAction = false);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -877,7 +877,15 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				newKnobPos = std::clamp(newKnobPos, lowerLimit, 64_i32);
 
 				char buffer[5];
-				intToString(newKnobPos + kKnobPosOffset, buffer);
+				int32_t valueForDisplay;
+				if ((modelStackWithParam->paramId == Param::Local::PAN)
+					|| (modelStackWithParam->paramId == Param::Unpatched::GlobalEffectable::PAN)) {
+						valueForDisplay = newKnobPos;
+					}
+				else {
+					valueForDisplay = newKnobPos + kKnobPosOffset;
+				}
+				intToString(valueForDisplay, buffer);
 				display->displayPopup(buffer);
 
 				if (newKnobPos == knobPos) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -859,17 +859,6 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
 			// Or, if normal case - an actual param
 			else {
-
-				char newModelStackMemory[MODEL_STACK_MAX_SIZE];
-
-				// Hack to make it so stutter can't be automated
-				if (modelStackWithParam->timelineCounterIsSet()
-				    && !modelStackWithParam->paramCollection->doesParamIdAllowAutomation(modelStackWithParam)) {
-					copyModelStack(newModelStackMemory, modelStackWithParam, sizeof(ModelStackWithAutoParam));
-					modelStackWithParam = (ModelStackWithAutoParam*)newModelStackMemory;
-					modelStackWithParam->setTimelineCounter(NULL);
-				}
-
 				int32_t value = modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
 				int32_t knobPos = modelStackWithParam->paramCollection->paramValueToKnobPos(value, modelStackWithParam);
 				int32_t lowerLimit = std::min(-64_i32, knobPos);
@@ -914,6 +903,16 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
 				if (newKnobPos == knobPos) {
 					return;
+				}
+
+				char newModelStackMemory[MODEL_STACK_MAX_SIZE];
+
+				// Hack to make it so stutter can't be automated
+				if (modelStackWithParam->timelineCounterIsSet()
+				    && !modelStackWithParam->paramCollection->doesParamIdAllowAutomation(modelStackWithParam)) {
+					copyModelStack(newModelStackMemory, modelStackWithParam, sizeof(ModelStackWithAutoParam));
+					modelStackWithParam = (ModelStackWithAutoParam*)newModelStackMemory;
+					modelStackWithParam->setTimelineCounter(NULL);
 				}
 
 				int32_t newValue =

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -879,9 +879,9 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				char buffer[5];
 				int32_t valueForDisplay;
 				if ((modelStackWithParam->paramId == Param::Local::PAN)
-					|| (modelStackWithParam->paramId == Param::Unpatched::GlobalEffectable::PAN)) {
-						valueForDisplay = newKnobPos;
-					}
+				    || (modelStackWithParam->paramId == Param::Unpatched::GlobalEffectable::PAN)) {
+					valueForDisplay = newKnobPos;
+				}
 				else {
 					valueForDisplay = newKnobPos + kKnobPosOffset;
 				}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -907,23 +907,23 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				//if turning stutter mod encoder and stutter quantize is enabled
 				//display stutter quantization instead of knob position
 				if ((modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
-				         && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
-				             == RuntimeFeatureStateToggle::On))) {
+				     && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+				         == RuntimeFeatureStateToggle::On))) {
 					char buffer[10];
 					if (newKnobPos < -39) { // 4ths stutter: no leds turned on
-						strncpy (buffer, "4ths", 10);
+						strncpy(buffer, "4ths", 10);
 					}
 					else if (newKnobPos < -14) { // 8ths stutter: 1 led turned on
-						strncpy (buffer, "8ths", 10);
+						strncpy(buffer, "8ths", 10);
 					}
 					else if (newKnobPos < 14) { // 16ths stutter: 2 leds turned on
-						strncpy (buffer, "16ths", 10);
+						strncpy(buffer, "16ths", 10);
 					}
 					else if (newKnobPos < 39) { // 32nds stutter: 3 leds turned on
-						strncpy (buffer, "32nds", 10);
+						strncpy(buffer, "32nds", 10);
 					}
 					else { // 64ths stutter: all 4 leds turned on
-						strncpy (buffer, "64ths", 10);
+						strncpy(buffer, "64ths", 10);
 					}
 					display->displayPopup(buffer);
 				}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -875,6 +875,11 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				int32_t lowerLimit = std::min(-64_i32, knobPos);
 				int32_t newKnobPos = knobPos + offset;
 				newKnobPos = std::clamp(newKnobPos, lowerLimit, 64_i32);
+
+				char buffer[5];
+				intToString(newKnobPos + kKnobPosOffset, buffer);
+				display->displayPopup(buffer);
+
 				if (newKnobPos == knobPos) {
 					return;
 				}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -889,7 +889,8 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				         && (soundEditor.getCurrentMenuItem()->getPatchedParamIndex() != modelStackWithParam->paramId)))
 				    && !(modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
 				         && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
-				             == RuntimeFeatureStateToggle::On))) {
+				             == RuntimeFeatureStateToggle::On)
+				         && !isUIModeActive(UI_MODE_STUTTERING))) {
 
 					char buffer[5];
 					int32_t valueForDisplay;
@@ -906,9 +907,10 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
 				//if turning stutter mod encoder and stutter quantize is enabled
 				//display stutter quantization instead of knob position
-				if ((modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
-				     && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
-				         == RuntimeFeatureStateToggle::On))) {
+				if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
+				    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+				        == RuntimeFeatureStateToggle::On)
+				    && !isUIModeActive(UI_MODE_STUTTERING)) {
 					char buffer[10];
 					if (newKnobPos < -39) { // 4ths stutter: no leds turned on
 						strncpy(buffer, "4ths", 10);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -876,17 +876,24 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				int32_t newKnobPos = knobPos + offset;
 				newKnobPos = std::clamp(newKnobPos, lowerLimit, 64_i32);
 
-				char buffer[5];
-				int32_t valueForDisplay;
-				if ((modelStackWithParam->paramId == Param::Local::PAN)
-				    || (modelStackWithParam->paramId == Param::Unpatched::GlobalEffectable::PAN)) {
-					valueForDisplay = newKnobPos;
+				//don't display pop-up while in soundEditor as values are displayed on the menu screen
+				//unless you're turning a mod encoder for a different param than the menu displayed
+				if ((getCurrentUI() != &soundEditor)
+				    || ((getCurrentUI() == &soundEditor)
+				        && (soundEditor.getCurrentMenuItem()->getPatchedParamIndex()
+				            != modelStackWithParam->paramId))) {
+					char buffer[5];
+					int32_t valueForDisplay;
+					if ((modelStackWithParam->paramId == Param::Local::PAN)
+					    || (modelStackWithParam->paramId == Param::Unpatched::GlobalEffectable::PAN)) {
+						valueForDisplay = newKnobPos;
+					}
+					else {
+						valueForDisplay = newKnobPos + kKnobPosOffset;
+					}
+					intToString(valueForDisplay, buffer);
+					display->displayPopup(buffer);
 				}
-				else {
-					valueForDisplay = newKnobPos + kKnobPosOffset;
-				}
-				intToString(valueForDisplay, buffer);
-				display->displayPopup(buffer);
 
 				if (newKnobPos == knobPos) {
 					return;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -884,10 +884,13 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
 				//don't display pop-up while in soundEditor as values are displayed on the menu screen
 				//unless you're turning a mod encoder for a different param than the menu displayed
-				if ((getCurrentUI() != &soundEditor)
-				    || ((getCurrentUI() == &soundEditor)
-				        && (soundEditor.getCurrentMenuItem()->getPatchedParamIndex()
-				            != modelStackWithParam->paramId))) {
+				if (((getCurrentUI() != &soundEditor)
+				     || ((getCurrentUI() == &soundEditor)
+				         && (soundEditor.getCurrentMenuItem()->getPatchedParamIndex() != modelStackWithParam->paramId)))
+				    && !(modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
+				         && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+				             == RuntimeFeatureStateToggle::On))) {
+
 					char buffer[5];
 					int32_t valueForDisplay;
 					if ((modelStackWithParam->paramId == Param::Local::PAN)
@@ -898,6 +901,30 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 						valueForDisplay = newKnobPos + kKnobPosOffset;
 					}
 					intToString(valueForDisplay, buffer);
+					display->displayPopup(buffer);
+				}
+
+				//if turning stutter mod encoder and stutter quantize is enabled
+				//display stutter quantization instead of knob position
+				if ((modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
+				         && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+				             == RuntimeFeatureStateToggle::On))) {
+					char buffer[10];
+					if (newKnobPos < -39) { // 4ths stutter: no leds turned on
+						strncpy (buffer, "4ths", 10);
+					}
+					else if (newKnobPos < -14) { // 8ths stutter: 1 led turned on
+						strncpy (buffer, "8ths", 10);
+					}
+					else if (newKnobPos < 14) { // 16ths stutter: 2 leds turned on
+						strncpy (buffer, "16ths", 10);
+					}
+					else if (newKnobPos < 39) { // 32nds stutter: 3 leds turned on
+						strncpy (buffer, "32nds", 10);
+					}
+					else { // 64ths stutter: all 4 leds turned on
+						strncpy (buffer, "64ths", 10);
+					}
 					display->displayPopup(buffer);
 				}
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -883,8 +883,8 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 					char modelStackTempMemory[MODEL_STACK_MAX_SIZE];
 					copyModelStack(modelStackTempMemory, modelStackWithParam, sizeof(ModelStackWithThreeMainThings));
 					ModelStackWithThreeMainThings* tempModelStack =
-					    (ModelStackWithThreeMainThings*)modelStackTempMemory;					
-					
+					    (ModelStackWithThreeMainThings*)modelStackTempMemory;
+
 					InstrumentClip* clip = (InstrumentClip*)tempModelStack->getTimelineCounter();
 					if (clip->output->type == InstrumentType::MIDI_OUT) {
 						if ((knobPos == 64) || (newKnobPos == 64)) {

--- a/src/deluge/modulation/midi/midi_param_collection.cpp
+++ b/src/deluge/modulation/midi/midi_param_collection.cpp
@@ -279,19 +279,6 @@ bool MIDIParamCollection::mayParamInterpolate(int32_t paramId) {
 }
 
 int32_t MIDIParamCollection::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
-
-	if (getCurrentUI()
-	    != &automationInstrumentClipView) { //let the automation instrument clip view handle the drawing of midi cc value
-		char buffer[5];
-		int32_t valueForDisplay = knobPos;
-		valueForDisplay += 64;
-		if (valueForDisplay == 128) {
-			valueForDisplay = 127;
-		}
-		intToString(valueForDisplay, buffer);
-		display->displayPopup(buffer, 3, true);
-	}
-
 	return ParamCollection::knobPosToParamValue(knobPos, modelStack);
 }
 

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -553,21 +553,6 @@ void ExpressionParamSet::notifyParamModifiedInSomeWay(ModelStackWithAutoParam co
 
 // Displays text number. This will only actually end up getting used/seen on MIDI Clips, at channel/Clip level - not MPE/polyphonic.
 int32_t ExpressionParamSet::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
-
-	if (getCurrentUI()
-	    != &automationInstrumentClipView) { //let the automation instrument clip view handle the drawing of midi cc value
-		char buffer[5];
-		int32_t valueForDisplay = knobPos;
-		if (modelStack->paramId == 2) { // Just for aftertouch
-			valueForDisplay += 64;
-			if (valueForDisplay == 128) {
-				valueForDisplay = 127;
-			}
-		}
-		intToString(valueForDisplay, buffer);
-		display->displayPopup(buffer, 3, true);
-	}
-
 	// Everything but aftertouch gets handled by parent from here
 	if (modelStack->paramId != 2) {
 		return ParamSet::knobPosToParamValue(knobPos, modelStack);


### PR DESCRIPTION
1. Mod Encoders now display a pop-up showing the current value of the parameter being changed

> Added code to view.cpp to display new value corresponding to the parameter that the mod encoder being turned is assigned to.
> 
> Removed display popup code from MidiParamCollection and ExpressionParamSet as its no longer required.
> 
> Works in Arranger, Song, Audio and Instrument Clips
> 
> Does not work for Master Compressor as the Master Compressor uses Non-Existent Params
>
>When in soundEditor, if you turn a modEncoder, it will only display a pop up when you're turning a modEncoder that is mapped to a parameter that is different from the parameter being edited in the soundEditor menu

2. Updated Param Menu Value Range to match value range displayed by Mod Encoder pop-up's (e.g. change from 0-50 to 0-128)

> Factored out the +/- 50 constants for Param's
>
> Updated the Value Adjustment range in the menu from 0 - 50 to 0 - 128.
> 
> For Pan, the range changed from -32 to +32 to -64 to + 64

3. Updated Patch Cable Value Range to align to values displayed with Mod Encoders and Param Menu's. (eg. change from -50 to + 50 to -128 to +128).

> Factored out the +/- 5000 constants for Patch Cables
> 
> Updated range from -50 to.+50 to -128 to +128 to align with the +128 range displayed for params in the regular menu's

4. Ignore modEncoder turns for Midi above 127

> Currently there is a bug where turning the knob to the 128th position acts as sending 127 twice.
> 
> Instead of doing that, I have set it to ignore modEncoderActions for MIDI Instrument Clips that result in the knob turning to 128 or turning from 128 to 127.
>
> Applied this change in the Automation Instrument Clip View too.

5. Fix bug with Midi CC clips in Automation Instrument Clip View when in the Automation Overview

> There was a bug where you could not assign Midi CC's to a Mod Encoder when in the Automation Overview.
> 
> This has been fixed with an addition to selectEncoderAction to check if the CurrentUIMode is UI_MODE_SELECTING_MIDI_CC

6. Added ability to increase scrolling speed for adjusting values in menu's with Select Encoder by holding Shift

> By default, turning the select encoder will change the value by +/- 1
> To change value by +/- 5 (e.g. accelerated), hold shift while turning the select encoder

7. Stutter Quantization

> When turning mod encoder for stutter and stutter quantization community feature is enabled, a pop up is displayed showing the stutter quantization instead of the knob position.

Addresses: https://github.com/SynthstromAudible/DelugeFirmware/discussions/554