### PR TITLE
Enable Stutter Automation

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -38,6 +38,9 @@ Here is a list of general improvements that have been made, ordered from newest 
 #### 3.7 - Mod Wheel
 - ([#512]) Incoming mod wheel on non-MPE synths now maps to y axis
 
+#### 3.9 - Enable Stutter Automation
+- ([#653]) Enabled ability to record stutter automation with mod (gold) encoder.
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -390,4 +393,5 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#368]: https://github.com/SynthstromAudible/DelugeFirmware/pull/368
 [#395]: https://github.com/SynthstromAudible/DelugeFirmware/pull/395
 [#512]: https://github.com/SynthstromAudible/DelugeFirmware/pull/512
+[#653]: https://github.com/SynthstromAudible/DelugeFirmware/pull/653
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -859,17 +859,6 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
 			// Or, if normal case - an actual param
 			else {
-
-				char newModelStackMemory[MODEL_STACK_MAX_SIZE];
-
-				// Hack to make it so stutter can't be automated
-				if (modelStackWithParam->timelineCounterIsSet()
-				    && !modelStackWithParam->paramCollection->doesParamIdAllowAutomation(modelStackWithParam)) {
-					copyModelStack(newModelStackMemory, modelStackWithParam, sizeof(ModelStackWithAutoParam));
-					modelStackWithParam = (ModelStackWithAutoParam*)newModelStackMemory;
-					modelStackWithParam->setTimelineCounter(NULL);
-				}
-
 				int32_t value = modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
 				int32_t knobPos = modelStackWithParam->paramCollection->paramValueToKnobPos(value, modelStackWithParam);
 				int32_t lowerLimit = std::min(-64_i32, knobPos);


### PR DESCRIPTION
Removed code that disabled ability to record stutter with mod encoder.

Note: we do not know what impact enabling this will have. There must have been a reason it was disabled previously. But let's test and find out!