### PR TITLE
Fixed Sticky Shift Conflict with Shift Select Encoder Acceleration

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -650,7 +650,7 @@ ActionResult SoundEditor::horizontalEncoderAction(int32_t offset) {
 
 void SoundEditor::selectEncoderAction(int8_t offset) {
 
-	if (Buttons::isShiftButtonPressed()) {
+	if (Buttons::isButtonPressed(deluge::hid::button::SHIFT)) {
 		offset = offset * 5;
 	}
 


### PR DESCRIPTION
Fixed conflict when Sticky Shift functionality is enabled with the Shift Select Encoder Acceleration that was added in #636

Fixed it by calling isButtonPressed instead of isShiftButtonPressed in order to check if the Shift button is actually being pressed rather than "stickily pressed."