### PR TITLE
save correct values

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1125,8 +1125,8 @@ weAreInArrangementEditorOrInClipInstance:
 	storageManager.writeOpeningTagBeginning("masterCompressor");
 	int32_t attack = AudioEngine::mastercompressor.attack;
 	int32_t release = AudioEngine::mastercompressor.release;
-	int32_t thresh = AudioEngine::mastercompressor.threshold;
-	int32_t ratio = AudioEngine::mastercompressor.ratio;
+	int32_t thresh = AudioEngine::mastercompressor.rawThreshold;
+	int32_t ratio = AudioEngine::mastercompressor.rawRatio;
 
 	storageManager.writeAttribute("attack", attack);
 	storageManager.writeAttribute("release", release);


### PR DESCRIPTION
Incorrect values were being saved post transition to use standard deluge parameter ranges