### PR TITLE
fix memory leak in cache manager

### DIFF
--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -80,7 +80,7 @@ public:
 	static bool readParamTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager,
 	                                 int32_t readAutomationUpToPos);
 	static void initParams(ParamManager* paramManager);
-	void wontBeRenderedForAWhile();
+	virtual void wontBeRenderedForAWhile();
 	void endStutter(ParamManagerForTimeline* paramManager);
 	virtual bool setModFXType(ModFXType newType);
 	bool offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -4006,7 +4006,7 @@ void Song::setHibernatingMIDIInstrument(MIDIInstrument* newInstrument) {
 void Song::deleteHibernatingMIDIInstrument() {
 	if (hibernatingMIDIInstrument) {
 		void* toDealloc = dynamic_cast<void*>(hibernatingMIDIInstrument);
-		hibernatingMIDIInstrument->~Instrument();
+		hibernatingMIDIInstrument->~MIDIInstrument();
 		delugeDealloc(toDealloc);
 		hibernatingMIDIInstrument = NULL;
 	}


### PR DESCRIPTION
When stealing exactly one stealable, if that was the first stealable run looked at, the longest runs for the queue would be set to 0. This would last until the next time a cluster was marked as stealable in that queue, or a stealable from that queue was reclaimed as neighboring memory from another queue.

Instead set the longest run to 0xFFFFFFFF to indicate that queue needs to be re checked

Fix #643 