### PR TITLE
Fixed Midi Mod Encoder bugs

### DIFF
--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2432,10 +2432,8 @@ bool AutomationInstrumentClipView::modEncoderActionForSelectedPad(int32_t whichM
 			//ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
 			//if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a value change gets recorded
 			//if newKnobPos exceeds 127, then it means current knobPos was 127 and it was increased to 128. In which case, ignore value change
-			if (clip->output->type == InstrumentType::MIDI_OUT) {
-				if ((knobPos == 64) || (newKnobPos == 64)) {
-					return true;
-				}
+			if ((clip->output->type == InstrumentType::MIDI_OUT) && (newKnobPos == 64)) {
+				return true;
 			}
 
 			//use default interpolation settings
@@ -2479,10 +2477,8 @@ void AutomationInstrumentClipView::modEncoderActionForUnselectedPad(int32_t whic
 			//ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
 			//if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a value change gets recorded
 			//if newKnobPos exceeds 127, then it means current knobPos was 127 and it was increased to 128. In which case, ignore value change
-			if (clip->output->type == InstrumentType::MIDI_OUT) {
-				if ((knobPos == 64) || (newKnobPos == 64)) {
-					return;
-				}
+			if ((clip->output->type == InstrumentType::MIDI_OUT) && (newKnobPos == 64)) {
+				return;
 			}
 
 			int32_t newValue =

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -874,10 +874,8 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				//if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a value change gets recorded
 				//if newKnobPos exceeds 127, then it means current knobPos was 127 and it was increased to 128. In which case, ignore value change
 				if ((getRootUI() == &instrumentClipView) || (getRootUI() == &automationInstrumentClipView)) {
-					if (clip->output->type == InstrumentType::MIDI_OUT) {
-						if ((knobPos == 64) || (newKnobPos == 64)) {
-							return;
-						}
+					if ((clip->output->type == InstrumentType::MIDI_OUT) && (newKnobPos == 64)) {
+						return;
 					}
 				}
 
@@ -894,7 +892,7 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 					char buffer[5];
 					int32_t valueForDisplay;
 					if (clip->output->type == InstrumentType::MIDI_OUT) {
-						valueForDisplay = newKnobPos = kKnobPosOffset;
+						valueForDisplay = newKnobPos + kKnobPosOffset;
 					}
 					else if ((modelStackWithParam->paramId == Param::Local::PAN)
 					         || (modelStackWithParam->paramId == Param::Unpatched::GlobalEffectable::PAN)) {


### PR DESCRIPTION
Fixed a couple bugs with MIDI Clips and the use of Mod Encoders.

1) Fixed mod encoder setting value to max when assigning midi cc to mod encoder

2) Fixed inability to change midi cc value after it was set to max