### PR TITLE
Add black box pointer output to freeze handler

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,9 @@
       "request": "launch",
       "cwd": "${workspaceRoot}",
       "executable": "${workspaceRoot}/build/Debug/deluge.elf",
+      "windows": {
+        "serverpath": "C:\\Program Files\\SEGGER\\JLink\\JLinkGDBServerCL.exe", 
+      },
       "servertype": "jlink",
       "device": "R7S721020",
       "interface": "swd",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,5 @@
         "SDRAM",
         "Synthstrom"
     ],
+    "cortex-debug.armToolchainPath.windows": "${workspaceRoot}/toolchain/win32-x86_64/arm-none-eabi-gcc/bin",
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,7 @@ execute_process(
 string(TIMESTAMP DATE_TODAY "%Y.%m.%d")
 
 # Build our version string
+set(BUILD_COMMIT_SHORT "${GIT_COMMIT_SHORT}") # Used in firmware
 set(BUILD_VERSION_STRING "${PROJECT_VERSION}${SEMVER_PRERELEASE_ID}-${GIT_COMMIT_SHORT}") # Used in firmware
 set(BUILD_VERSION_SUFFIX "-v${PROJECT_VERSION}${SEMVER_PRERELEASE_ID}+${DATE_TODAY}-${GIT_COMMIT_SHORT}") # Used for filename
 

--- a/src/RTT/SEGGER_RTT.c
+++ b/src/RTT/SEGGER_RTT.c
@@ -248,13 +248,13 @@ static unsigned char _aTerminalId[16] = {'0', '1', '2', '3', '4', '5', '6', '7',
 //
 // RTT Control Block and allocate buffers for channel 0
 //
-SEGGER_RTT_PUT_CB_SECTION(SEGGER_RTT_CB_ALIGN(SEGGER_RTT_CB _SEGGER_RTT_REAL));
+SEGGER_RTT_PUT_CB_SECTION(SEGGER_RTT_CB_ALIGN(SEGGER_RTT_CB _SEGGER_RTT));
 
 SEGGER_RTT_PUT_BUFFER_SECTION(SEGGER_RTT_BUFFER_ALIGN(static char _acUpBufferReal[BUFFER_SIZE_UP]));
 SEGGER_RTT_PUT_BUFFER_SECTION(SEGGER_RTT_BUFFER_ALIGN(static char _acDownBufferReal[BUFFER_SIZE_DOWN]));
 
 // Stuff ingeniously messed with by Rohan to get around cache, which would stop RTT from working
-#define _SEGGER_RTT (*(SEGGER_RTT_CB*)((char*)&_SEGGER_RTT_REAL + UNCACHED_MIRROR_OFFSET))
+#define _SEGGER_RTT_UNCACHED (*(SEGGER_RTT_CB*)((char*)&_SEGGER_RTT + UNCACHED_MIRROR_OFFSET))
 #define _acUpBuffer ((char*)_acUpBufferReal + UNCACHED_MIRROR_OFFSET)
 #define _acDownBuffer ((char*)_acDownBufferReal + UNCACHED_MIRROR_OFFSET)
 
@@ -278,7 +278,7 @@ static unsigned char _ActiveTerminal;
 */
 #define INIT()                                                                                                         \
 	do {                                                                                                               \
-		if (_SEGGER_RTT.acID[0] == '\0') {                                                                             \
+		if (_SEGGER_RTT_UNCACHED.acID[0] == '\0') {                                                                    \
 			_DoInit();                                                                                                 \
 		}                                                                                                              \
 	} while (0)
@@ -287,7 +287,7 @@ static void _DoInit(void) {
 	//
 	// Initialize control block
 	//
-	p = &_SEGGER_RTT;
+	p = &_SEGGER_RTT_UNCACHED;
 	p->MaxNumUpBuffers = SEGGER_RTT_MAX_NUM_UP_BUFFERS;
 	p->MaxNumDownBuffers = SEGGER_RTT_MAX_NUM_DOWN_BUFFERS;
 	//
@@ -314,7 +314,7 @@ static void _DoInit(void) {
 	// in initializer memory (usually flash) by J-Link
 	//
 	// GCC gets deeply confused by the UNCACHED_MIRROR_OFFSET trickery
-	// happening inside _SEGGER_RTT. It's not easy to explain what we're doing
+	// happening inside _SEGGER_RTT_UNCACHED. It's not easy to explain what we're doing
 	// here either, so simply silence the warning for now.
 #pragma GCC push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
@@ -556,7 +556,7 @@ unsigned SEGGER_RTT_ReadUpBufferNoLock(unsigned BufferIndex, void* pData, unsign
 #endif
 	//
 	INIT();
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	pBuffer = (unsigned char*)pData;
 	RdOff = pRing->RdOff;
 	WrOff = pRing->WrOff;
@@ -650,7 +650,7 @@ unsigned SEGGER_RTT_ReadNoLock(unsigned BufferIndex, void* pData, unsigned Buffe
 #endif
 	//
 	INIT();
-	pRing = &_SEGGER_RTT.aDown[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aDown[BufferIndex];
 	pBuffer = (unsigned char*)pData;
 	RdOff = pRing->RdOff;
 	WrOff = pRing->WrOff;
@@ -820,7 +820,7 @@ void SEGGER_RTT_WriteWithOverwriteNoLock(unsigned BufferIndex, const void* pBuff
 	//
 	// Get "to-host" ring buffer and copy some elements into local variables.
 	//
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	//
 	// Check if we will overwrite data and need to adjust the RdOff.
 	//
@@ -929,7 +929,7 @@ unsigned SEGGER_RTT_WriteSkipNoLock(unsigned BufferIndex, const void* pBuffer, u
 	// 1) is the most common case for large buffers and assuming that J-Link reads the data fast enough
 	//
 	pData = (const char*)pBuffer;
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	RdOff = pRing->RdOff;
 	WrOff = pRing->WrOff;
 	if (RdOff <= WrOff) { // Case 1), 2) or 3)
@@ -1008,7 +1008,7 @@ unsigned SEGGER_RTT_WriteDownBufferNoLock(unsigned BufferIndex, const void* pBuf
 	// Get "to-target" ring buffer.
 	// It is save to cast that to a "to-host" buffer. Up and Down buffer differ in volatility of offsets that might be modified by J-Link.
 	//
-	pRing = (SEGGER_RTT_BUFFER_UP*)&_SEGGER_RTT.aDown[BufferIndex];
+	pRing = (SEGGER_RTT_BUFFER_UP*)&_SEGGER_RTT_UNCACHED.aDown[BufferIndex];
 	//
 	// How we output depends upon the mode...
 	//
@@ -1084,7 +1084,7 @@ unsigned SEGGER_RTT_WriteNoLock(unsigned BufferIndex, const void* pBuffer, unsig
 	//
 	// Get "to-host" ring buffer.
 	//
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	//
 	// How we output depends upon the mode...
 	//
@@ -1262,7 +1262,7 @@ unsigned SEGGER_RTT_PutCharSkipNoLock(unsigned BufferIndex, char c) {
 	//
 	// Get "to-host" ring buffer.
 	//
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	//
 	// Get write position and handle wrap-around if necessary
 	//
@@ -1315,7 +1315,7 @@ unsigned SEGGER_RTT_PutCharSkip(unsigned BufferIndex, char c) {
 	//
 	// Get "to-host" ring buffer.
 	//
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	//
 	// Get write position and handle wrap-around if necessary
 	//
@@ -1372,7 +1372,7 @@ unsigned SEGGER_RTT_PutChar(unsigned BufferIndex, char c) {
 	//
 	// Get "to-host" ring buffer.
 	//
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	//
 	// Get write position and handle wrap-around if necessary
 	//
@@ -1479,8 +1479,8 @@ int SEGGER_RTT_HasKey(void) {
 	int r;
 
 	INIT();
-	RdOff = _SEGGER_RTT.aDown[0].RdOff;
-	if (RdOff != _SEGGER_RTT.aDown[0].WrOff) {
+	RdOff = _SEGGER_RTT_UNCACHED.aDown[0].RdOff;
+	if (RdOff != _SEGGER_RTT_UNCACHED.aDown[0].WrOff) {
 		r = 1;
 	}
 	else {
@@ -1505,7 +1505,7 @@ unsigned SEGGER_RTT_HasData(unsigned BufferIndex) {
 	SEGGER_RTT_BUFFER_DOWN* pRing;
 	unsigned v;
 
-	pRing = &_SEGGER_RTT.aDown[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aDown[BufferIndex];
 	v = pRing->WrOff;
 	return v - pRing->RdOff;
 }
@@ -1526,7 +1526,7 @@ unsigned SEGGER_RTT_HasDataUp(unsigned BufferIndex) {
 	SEGGER_RTT_BUFFER_UP* pRing;
 	unsigned v;
 
-	pRing = &_SEGGER_RTT.aUp[BufferIndex];
+	pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
 	v = pRing->RdOff;
 	return pRing->WrOff - v;
 }
@@ -1557,18 +1557,18 @@ int SEGGER_RTT_AllocDownBuffer(const char* sName, void* pBuffer, unsigned Buffer
 	SEGGER_RTT_LOCK();
 	BufferIndex = 0;
 	do {
-		if (_SEGGER_RTT.aDown[BufferIndex].pBuffer == NULL) {
+		if (_SEGGER_RTT_UNCACHED.aDown[BufferIndex].pBuffer == NULL) {
 			break;
 		}
 		BufferIndex++;
-	} while (BufferIndex < _SEGGER_RTT.MaxNumDownBuffers);
-	if (BufferIndex < _SEGGER_RTT.MaxNumDownBuffers) {
-		_SEGGER_RTT.aDown[BufferIndex].sName = sName;
-		_SEGGER_RTT.aDown[BufferIndex].pBuffer = (char*)pBuffer;
-		_SEGGER_RTT.aDown[BufferIndex].SizeOfBuffer = BufferSize;
-		_SEGGER_RTT.aDown[BufferIndex].RdOff = 0u;
-		_SEGGER_RTT.aDown[BufferIndex].WrOff = 0u;
-		_SEGGER_RTT.aDown[BufferIndex].Flags = Flags;
+	} while (BufferIndex < _SEGGER_RTT_UNCACHED.MaxNumDownBuffers);
+	if (BufferIndex < _SEGGER_RTT_UNCACHED.MaxNumDownBuffers) {
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].sName = sName;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].pBuffer = (char*)pBuffer;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].SizeOfBuffer = BufferSize;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].RdOff = 0u;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].WrOff = 0u;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].Flags = Flags;
 	}
 	else {
 		BufferIndex = -1;
@@ -1603,18 +1603,18 @@ int SEGGER_RTT_AllocUpBuffer(const char* sName, void* pBuffer, unsigned BufferSi
 	SEGGER_RTT_LOCK();
 	BufferIndex = 0;
 	do {
-		if (_SEGGER_RTT.aUp[BufferIndex].pBuffer == NULL) {
+		if (_SEGGER_RTT_UNCACHED.aUp[BufferIndex].pBuffer == NULL) {
 			break;
 		}
 		BufferIndex++;
-	} while (BufferIndex < _SEGGER_RTT.MaxNumUpBuffers);
-	if (BufferIndex < _SEGGER_RTT.MaxNumUpBuffers) {
-		_SEGGER_RTT.aUp[BufferIndex].sName = sName;
-		_SEGGER_RTT.aUp[BufferIndex].pBuffer = (char*)pBuffer;
-		_SEGGER_RTT.aUp[BufferIndex].SizeOfBuffer = BufferSize;
-		_SEGGER_RTT.aUp[BufferIndex].RdOff = 0u;
-		_SEGGER_RTT.aUp[BufferIndex].WrOff = 0u;
-		_SEGGER_RTT.aUp[BufferIndex].Flags = Flags;
+	} while (BufferIndex < _SEGGER_RTT_UNCACHED.MaxNumUpBuffers);
+	if (BufferIndex < _SEGGER_RTT_UNCACHED.MaxNumUpBuffers) {
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].sName = sName;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].pBuffer = (char*)pBuffer;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].SizeOfBuffer = BufferSize;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].RdOff = 0u;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].WrOff = 0u;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].Flags = Flags;
 	}
 	else {
 		BufferIndex = -1;
@@ -1653,16 +1653,16 @@ int SEGGER_RTT_ConfigUpBuffer(unsigned BufferIndex, const char* sName, void* pBu
 	int r;
 
 	INIT();
-	if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumUpBuffers) {
+	if (BufferIndex < (unsigned)_SEGGER_RTT_UNCACHED.MaxNumUpBuffers) {
 		SEGGER_RTT_LOCK();
 		if (BufferIndex > 0u) {
-			_SEGGER_RTT.aUp[BufferIndex].sName = sName;
-			_SEGGER_RTT.aUp[BufferIndex].pBuffer = (char*)pBuffer;
-			_SEGGER_RTT.aUp[BufferIndex].SizeOfBuffer = BufferSize;
-			_SEGGER_RTT.aUp[BufferIndex].RdOff = 0u;
-			_SEGGER_RTT.aUp[BufferIndex].WrOff = 0u;
+			_SEGGER_RTT_UNCACHED.aUp[BufferIndex].sName = sName;
+			_SEGGER_RTT_UNCACHED.aUp[BufferIndex].pBuffer = (char*)pBuffer;
+			_SEGGER_RTT_UNCACHED.aUp[BufferIndex].SizeOfBuffer = BufferSize;
+			_SEGGER_RTT_UNCACHED.aUp[BufferIndex].RdOff = 0u;
+			_SEGGER_RTT_UNCACHED.aUp[BufferIndex].WrOff = 0u;
 		}
-		_SEGGER_RTT.aUp[BufferIndex].Flags = Flags;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].Flags = Flags;
 		SEGGER_RTT_UNLOCK();
 		r = 0;
 	}
@@ -1702,16 +1702,16 @@ int SEGGER_RTT_ConfigDownBuffer(unsigned BufferIndex, const char* sName, void* p
 	int r;
 
 	INIT();
-	if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumDownBuffers) {
+	if (BufferIndex < (unsigned)_SEGGER_RTT_UNCACHED.MaxNumDownBuffers) {
 		SEGGER_RTT_LOCK();
 		if (BufferIndex > 0u) {
-			_SEGGER_RTT.aDown[BufferIndex].sName = sName;
-			_SEGGER_RTT.aDown[BufferIndex].pBuffer = (char*)pBuffer;
-			_SEGGER_RTT.aDown[BufferIndex].SizeOfBuffer = BufferSize;
-			_SEGGER_RTT.aDown[BufferIndex].RdOff = 0u;
-			_SEGGER_RTT.aDown[BufferIndex].WrOff = 0u;
+			_SEGGER_RTT_UNCACHED.aDown[BufferIndex].sName = sName;
+			_SEGGER_RTT_UNCACHED.aDown[BufferIndex].pBuffer = (char*)pBuffer;
+			_SEGGER_RTT_UNCACHED.aDown[BufferIndex].SizeOfBuffer = BufferSize;
+			_SEGGER_RTT_UNCACHED.aDown[BufferIndex].RdOff = 0u;
+			_SEGGER_RTT_UNCACHED.aDown[BufferIndex].WrOff = 0u;
 		}
-		_SEGGER_RTT.aDown[BufferIndex].Flags = Flags;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].Flags = Flags;
 		SEGGER_RTT_UNLOCK();
 		r = 0;
 	}
@@ -1741,9 +1741,9 @@ int SEGGER_RTT_SetNameUpBuffer(unsigned BufferIndex, const char* sName) {
 	int r;
 
 	INIT();
-	if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumUpBuffers) {
+	if (BufferIndex < (unsigned)_SEGGER_RTT_UNCACHED.MaxNumUpBuffers) {
 		SEGGER_RTT_LOCK();
-		_SEGGER_RTT.aUp[BufferIndex].sName = sName;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].sName = sName;
 		SEGGER_RTT_UNLOCK();
 		r = 0;
 	}
@@ -1773,9 +1773,9 @@ int SEGGER_RTT_SetNameDownBuffer(unsigned BufferIndex, const char* sName) {
 	int r;
 
 	INIT();
-	if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumDownBuffers) {
+	if (BufferIndex < (unsigned)_SEGGER_RTT_UNCACHED.MaxNumDownBuffers) {
 		SEGGER_RTT_LOCK();
-		_SEGGER_RTT.aDown[BufferIndex].sName = sName;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].sName = sName;
 		SEGGER_RTT_UNLOCK();
 		r = 0;
 	}
@@ -1805,9 +1805,9 @@ int SEGGER_RTT_SetFlagsUpBuffer(unsigned BufferIndex, unsigned Flags) {
 	int r;
 
 	INIT();
-	if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumUpBuffers) {
+	if (BufferIndex < (unsigned)_SEGGER_RTT_UNCACHED.MaxNumUpBuffers) {
 		SEGGER_RTT_LOCK();
-		_SEGGER_RTT.aUp[BufferIndex].Flags = Flags;
+		_SEGGER_RTT_UNCACHED.aUp[BufferIndex].Flags = Flags;
 		SEGGER_RTT_UNLOCK();
 		r = 0;
 	}
@@ -1837,9 +1837,9 @@ int SEGGER_RTT_SetFlagsDownBuffer(unsigned BufferIndex, unsigned Flags) {
 	int r;
 
 	INIT();
-	if (BufferIndex < (unsigned)_SEGGER_RTT.MaxNumDownBuffers) {
+	if (BufferIndex < (unsigned)_SEGGER_RTT_UNCACHED.MaxNumDownBuffers) {
 		SEGGER_RTT_LOCK();
-		_SEGGER_RTT.aDown[BufferIndex].Flags = Flags;
+		_SEGGER_RTT_UNCACHED.aDown[BufferIndex].Flags = Flags;
 		SEGGER_RTT_UNLOCK();
 		r = 0;
 	}
@@ -1888,7 +1888,8 @@ int SEGGER_RTT_SetTerminal(unsigned char TerminalId) {
 	ac[0] = 0xFFu;
 	if (TerminalId < sizeof(_aTerminalId)) { // We only support a certain number of channels
 		ac[1] = _aTerminalId[TerminalId];
-		pRing = &_SEGGER_RTT.aUp[0]; // Buffer 0 is always reserved for terminal I/O, so we can use index 0 here, fixed
+		pRing = &_SEGGER_RTT_UNCACHED
+		             .aUp[0]; // Buffer 0 is always reserved for terminal I/O, so we can use index 0 here, fixed
 		SEGGER_RTT_LOCK(); // Lock to make sure that no other task is writing into buffer, while we are and number of free bytes in buffer does not change downwards after checking and before writing
 		if ((pRing->Flags & SEGGER_RTT_MODE_MASK) == SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL) {
 			_ActiveTerminal = TerminalId;
@@ -1943,7 +1944,7 @@ int SEGGER_RTT_TerminalOut(unsigned char TerminalId, const char* s) {
 		//
 		// Get "to-host" ring buffer.
 		//
-		pRing = &_SEGGER_RTT.aUp[0];
+		pRing = &_SEGGER_RTT_UNCACHED.aUp[0];
 		//
 		// Need to be able to change terminal, write data, change back.
 		// Compute the fixed and variable sizes.
@@ -2021,7 +2022,7 @@ int SEGGER_RTT_TerminalOut(unsigned char TerminalId, const char* s) {
 *    Number of bytes that are free in the selected up buffer.
 */
 unsigned SEGGER_RTT_GetAvailWriteSpace(unsigned BufferIndex) {
-	return _GetAvailWriteSpace(&_SEGGER_RTT.aUp[BufferIndex]);
+	return _GetAvailWriteSpace(&_SEGGER_RTT_UNCACHED.aUp[BufferIndex]);
 }
 
 /*********************************************************************
@@ -2045,13 +2046,13 @@ unsigned SEGGER_RTT_GetBytesInBuffer(unsigned BufferIndex) {
 	// Avoid warnings regarding volatile access order.  It's not a problem
 	// in this case, but dampen compiler enthusiasm.
 	//
-	RdOff = _SEGGER_RTT.aUp[BufferIndex].RdOff;
-	WrOff = _SEGGER_RTT.aUp[BufferIndex].WrOff;
+	RdOff = _SEGGER_RTT_UNCACHED.aUp[BufferIndex].RdOff;
+	WrOff = _SEGGER_RTT_UNCACHED.aUp[BufferIndex].WrOff;
 	if (RdOff <= WrOff) {
 		r = WrOff - RdOff;
 	}
 	else {
-		r = _SEGGER_RTT.aUp[BufferIndex].SizeOfBuffer - (WrOff - RdOff);
+		r = _SEGGER_RTT_UNCACHED.aUp[BufferIndex].SizeOfBuffer - (WrOff - RdOff);
 	}
 	return r;
 }

--- a/src/RTT/SEGGER_RTT.h
+++ b/src/RTT/SEGGER_RTT.h
@@ -49,7 +49,7 @@
 ---------------------------END-OF-HEADER------------------------------
 File    : SEGGER_RTT.h
 Purpose : Implementation of SEGGER real-time transfer which allows
-          real-time communication on targets which support debugger 
+          real-time communication on targets which support debugger
           memory accesses while the CPU is running.
 Revision: $Rev: 17697 $
 ----------------------------------------------------------------------
@@ -225,7 +225,7 @@ unsigned SEGGER_RTT_GetBytesInBuffer(unsigned BufferIndex);
 //
 // Function macro for performance optimization
 //
-#define SEGGER_RTT_HASDATA(n) (_SEGGER_RTT.aDown[n].WrOff - _SEGGER_RTT.aDown[n].RdOff)
+#define SEGGER_RTT_HASDATA(n) (_SEGGER_RTT_UNCACHED.aDown[n].WrOff - _SEGGER_RTT_UNCACHED.aDown[n].RdOff)
 
 #if RTT_USE_ASM
 #define SEGGER_RTT_WriteSkipNoLock SEGGER_RTT_ASM_WriteSkipNoLock
@@ -242,7 +242,7 @@ unsigned SEGGER_RTT_ReadUpBufferNoLock(unsigned BufferIndex, void* pData, unsign
 unsigned SEGGER_RTT_WriteDownBuffer(unsigned BufferIndex, const void* pBuffer, unsigned NumBytes);
 unsigned SEGGER_RTT_WriteDownBufferNoLock(unsigned BufferIndex, const void* pBuffer, unsigned NumBytes);
 
-#define SEGGER_RTT_HASDATA_UP(n) (_SEGGER_RTT.aUp[n].WrOff - _SEGGER_RTT.aUp[n].RdOff)
+#define SEGGER_RTT_HASDATA_UP(n) (_SEGGER_RTT_UNCACHED.aUp[n].WrOff - _SEGGER_RTT_UNCACHED.aUp[n].RdOff)
 
 /*********************************************************************
 *

--- a/src/RTT/SEGGER_RTT_ASM_ARMv7M.S
+++ b/src/RTT/SEGGER_RTT_ASM_ARMv7M.S
@@ -148,7 +148,7 @@ SEGGER_RTT_ASM_WriteSkipNoLock:   // unsigned SEGGER_RTT_WriteSkipNoLock(unsigne
         //
         PUSH     {R4-R7}
         ADD      R3,R0,R0, LSL #+1
-        LDR.W    R0,=_SEGGER_RTT                 // pRing = &_SEGGER_RTT.aUp[BufferIndex];
+        LDR.W    R0,=_SEGGER_RTT_UNCACHED                 // pRing = &_SEGGER_RTT_UNCACHED.aUp[BufferIndex];
         ADD      R0,R0,R3, LSL #+3
         ADD      R6,R0,#+24
         LDR      R0,[R6, #+16]                   // RdOff = pRing->RdOff;

--- a/src/RZA1/diskio.c
+++ b/src/RZA1/diskio.c
@@ -202,12 +202,14 @@ DRESULT disk_read_without_streaming_first(BYTE pdrv, /* Physical drive nmuber to
 
     BYTE err;
 
-    if (currentlyAccessingCard) {
-		if (ALPHA_OR_BETA_VERSION) {
-			// Operatricks got! But I think I fixed.
-        	FREEZE_WITH_ERROR("E259");
-		}
-	}
+    if (currentlyAccessingCard)
+    {
+        if (ALPHA_OR_BETA_VERSION)
+        {
+            // Operatricks got! But I think I fixed.
+            FREEZE_WITH_ERROR("E259");
+        }
+    }
 
     //uint16_t startTime = MTU2.TCNT_0;
 
@@ -250,11 +252,13 @@ DRESULT disk_write(BYTE pdrv, /* Physical drive nmuber to identify the drive */
 
     BYTE err;
 
-    if (currentlyAccessingCard) {
-		if (ALPHA_OR_BETA_VERSION) {
-	        FREEZE_WITH_ERROR("E258");
-		}
-	}
+    if (currentlyAccessingCard)
+    {
+        if (ALPHA_OR_BETA_VERSION)
+        {
+            FREEZE_WITH_ERROR("E258");
+        }
+    }
 
     currentlyAccessingCard = 1;
 

--- a/src/RZA1/diskio.c
+++ b/src/RZA1/diskio.c
@@ -202,8 +202,12 @@ DRESULT disk_read_without_streaming_first(BYTE pdrv, /* Physical drive nmuber to
 
     BYTE err;
 
-    if (currentlyAccessingCard)
-        freezeWithError("E259"); // Operatricks got! But I think I fixed.
+    if (currentlyAccessingCard) {
+		if (ALPHA_OR_BETA_VERSION) {
+			// Operatricks got! But I think I fixed.
+        	FREEZE_WITH_ERROR("E259");
+		}
+	}
 
     //uint16_t startTime = MTU2.TCNT_0;
 
@@ -246,8 +250,11 @@ DRESULT disk_write(BYTE pdrv, /* Physical drive nmuber to identify the drive */
 
     BYTE err;
 
-    if (currentlyAccessingCard)
-        freezeWithError("E258");
+    if (currentlyAccessingCard) {
+		if (ALPHA_OR_BETA_VERSION) {
+	        FREEZE_WITH_ERROR("E258");
+		}
+	}
 
     currentlyAccessingCard = 1;
 

--- a/src/RZA1/intc/intc_handler.c
+++ b/src/RZA1/intc/intc_handler.c
@@ -108,7 +108,7 @@ void INTC_Handler_Interrupt(uint32_t icciar)
     if (int_id >= INTC_ID_TOTAL) /* In case of unsupported interrupt ID */
     {
         // Insane thing that keeps happening - we get here somehow, with int_id 1023.
-        //freezeWithError("i029");
+        //FREEZE_WITH_ERROR("i029");
         uartPrintln("i029 ----------------------------------------------------!!");
         return; // Just keep running - it seems to work at least most of the time?
         //Userdef_INTC_UndefId(int_id); // Previously, it'd just go in here and freeze.

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -15,15 +15,15 @@ extern void freezeWithError(char const* errmsg);
 }
 #endif
 
-#define FREEZE_WITH_ERROR(error) ({\
-	uint32_t regLR = 0; \
-	uint32_t regSP = 0; \
-  	asm volatile ("MOV %0, LR\n" : "=r" (regLR)); \
-  	asm volatile ("MOV %0, SP\n" : "=r" (regSP)); \
-	fault_handler_print_freeze_pointers(0, 0, regLR, regSP); \
-	freezeWithError(error); \
-})
-
+#define FREEZE_WITH_ERROR(error)                                                                                       \
+	({                                                                                                                 \
+		uint32_t regLR = 0;                                                                                            \
+		uint32_t regSP = 0;                                                                                            \
+		asm volatile("MOV %0, LR\n" : "=r"(regLR));                                                                    \
+		asm volatile("MOV %0, SP\n" : "=r"(regSP));                                                                    \
+		fault_handler_print_freeze_pointers(0, 0, regLR, regSP);                                                       \
+		freezeWithError(error);                                                                                        \
+	})
 
 #define TIMER_MIDI_GATE_OUTPUT 2
 #define TIMER_SYSTEM_FAST 0

--- a/src/definitions.h
+++ b/src/definitions.h
@@ -1,7 +1,29 @@
 #pragma once
 
+#define ALPHA_OR_BETA_VERSION 1 // Whether to compile with additional error-checking
+
 #include "RZA1/cpu_specific.h"
 #include "RZA1/system/r_typedefs.h"
+#include "fault_handler.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// This is defined in display.cpp
+extern void freezeWithError(char const* errmsg);
+#ifdef __cplusplus
+}
+#endif
+
+#define FREEZE_WITH_ERROR(error) ({\
+	uint32_t regLR = 0; \
+	uint32_t regSP = 0; \
+  	asm volatile ("MOV %0, LR\n" : "=r" (regLR)); \
+  	asm volatile ("MOV %0, SP\n" : "=r" (regSP)); \
+	fault_handler_print_freeze_pointers(0, 0, regLR, regSP); \
+	freezeWithError(error); \
+})
+
 
 #define TIMER_MIDI_GATE_OUTPUT 2
 #define TIMER_SYSTEM_FAST 0

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -24,8 +24,6 @@
 #include <cstddef>
 #include <cstdint>
 
-#define ALPHA_OR_BETA_VERSION 1 // Whether to compile with additional error-checking
-
 #define HARDWARE_TEST_MODE 0
 
 #define AUTOMATED_TESTER_ENABLED (0 && ALPHA_OR_BETA_VERSION)

--- a/src/deluge/deluge.h
+++ b/src/deluge/deluge.h
@@ -33,8 +33,6 @@ extern void loadAnyEnqueuedClustersRoutine(void);
 
 extern void logAudioAction(char const* string);
 
-// This is defined in display.cpp
-extern void freezeWithError(char const* errmsg);
 extern void consoleTextIfAllBootedUp(char const* text);
 
 extern void routineForSD(void);

--- a/src/deluge/drivers/uart/uart.c
+++ b/src/deluge/drivers/uart/uart.c
@@ -192,6 +192,14 @@ int32_t uartGetTxBufferSpace(int32_t item) {
 	return txBufferSizes[item] - uartGetTxBufferFullnessByItem(item);
 }
 
+void uartDrain(uint32_t item) {
+	char value;
+	bool charReceived = true;
+	while (charReceived) {
+		charReceived = uartGetChar(item, (char*)&value);
+	}
+}
+
 void uartPutCharBack(int32_t item) {
 	int32_t readPos = (uint32_t)rxBufferReadAddr[item] - ((uint32_t)rxBuffers[item]);
 	readPos = (readPos - 1) & (rxBufferSizes[item] - 1);

--- a/src/deluge/drivers/uart/uart.h
+++ b/src/deluge/drivers/uart/uart.h
@@ -60,5 +60,6 @@ void uartPrintFloat(float number);
 void uartFlushIfNotSending(int32_t item);
 int32_t uartGetTxBufferFullnessByItem(int32_t item);
 int32_t uartGetTxBufferSpace(int32_t item);
+void uartDrain(uint32_t item);
 
 extern void tx_interrupt(int32_t item);

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -247,7 +247,7 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 	// Trying to track down Steven's E133 - percCacheClusterNearby pointing to things with no reasons left
 	for (int32_t l = 0; l < 2; l++) {
 		if (percCacheClustersNearby[l] && !percCacheClustersNearby[l]->numReasonsToBeLoaded) {
-			display->freezeWithError("i036");
+			FREEZE_WITH_ERROR("i036");
 		}
 	}
 #endif
@@ -621,7 +621,7 @@ skipPercStuff:
 
 		int32_t newHeadTotals[TimeStretch::Crossfade::kNumMovingAverages];
 		if (ALPHA_OR_BETA_VERSION && newHeadBytePos < (int32_t)sample->audioDataStartPosBytes) {
-			display->freezeWithError("E285");
+			FREEZE_WITH_ERROR("E285");
 		}
 		success = sample->getAveragesForCrossfade(newHeadTotals, newHeadBytePos, crossfadeLengthSamplesSource,
 		                                          playDirection, lengthToAverageEach);
@@ -1154,7 +1154,7 @@ void TimeStretcher::setupCrossfadeFromCache(SampleCache* cache, int32_t cacheByt
 
 	Cluster* cacheCluster = cache->getCluster(cachedClusterIndex);
 	if (ALPHA_OR_BETA_VERSION && !cacheCluster) { // If it got stolen - but we should have already detected this above
-		display->freezeWithError("E178");
+		FREEZE_WITH_ERROR("E178");
 	}
 	int32_t* __restrict__ readPos = (int32_t*)&cacheCluster->data[bytePosWithinCluster - 4 + kCacheByteDepth];
 
@@ -1198,7 +1198,7 @@ void TimeStretcher::setupCrossfadeFromCache(SampleCache* cache, int32_t cacheByt
 	}
 
 	if (ALPHA_OR_BETA_VERSION && numSamplesThisCacheRead <= 0) {
-		display->freezeWithError("E179");
+		FREEZE_WITH_ERROR("E179");
 	}
 
 	for (int32_t i = 0; i < numSamplesThisCacheRead; i++) {

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -147,7 +147,7 @@ bool AudioRecorder::setupRecordingToFile(AudioInputChannel newMode, int32_t newN
                                          AudioRecordingFolder folderID) {
 
 	if (ALPHA_OR_BETA_VERSION && recordingSource > AudioInputChannel::NONE) {
-		display->freezeWithError("E242");
+		FREEZE_WITH_ERROR("E242");
 	}
 
 	recorder = AudioEngine::getNewRecorder(newNumChannels, folderID, newMode, kInternalButtonPressLatency);

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -720,7 +720,7 @@ noNumberYet:
 			int32_t searchResult = fileItems.search(endSearchString.get());
 #if ALPHA_OR_BETA_VERSION
 			if (searchResult <= 0) {
-				display->freezeWithError("E448");
+				FREEZE_WITH_ERROR("E448");
 				error = ERROR_BUG;
 				goto gotErrorAfterAllocating;
 			}

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -838,7 +838,7 @@ doLoadAsWaveTable:
 			if (soundEditor.currentSource->ranges.getNumElements() > 1
 					&& soundEditor.currentSource->oscType == OscType::SAMPLE) {
 #if ALPHA_OR_BETA_VERSION
-				if (mayDoWaveTable == 2) display->freezeWithError("E425");
+				if (mayDoWaveTable == 2) FREEZE_WITH_ERROR("E425");
 #endif
 				goto doLoadAsSample;
 			}
@@ -900,7 +900,7 @@ doLoadAsSample:
 			if (soundEditor.currentSource->ranges.getNumElements() > 1
 					&& soundEditor.currentSource->oscType == OscType::WAVETABLE) {
 #if ALPHA_OR_BETA_VERSION
-				if (!mayDoWaveTable) display->freezeWithError("E426");
+				if (!mayDoWaveTable) FREEZE_WITH_ERROR("E426");
 #endif
 				goto doLoadAsWaveTable;
 			}
@@ -1214,7 +1214,7 @@ removeReasonsFromSamplesAndGetOut:
 					thisSample->partOfFolderBeingLoaded = false;
 #if ALPHA_OR_BETA_VERSION
 					if (thisSample->numReasonsToBeLoaded <= 0) {
-						display->freezeWithError("E213"); // I put this here to try and catch an E004 Luc got
+						FREEZE_WITH_ERROR("E213"); // I put this here to try and catch an E004 Luc got
 					}
 #endif
 					thisSample->removeReason("E392"); // Remove that temporary reason we added
@@ -1644,7 +1644,7 @@ doReturnFalse:
 				Sample* thisSample = sortArea[s];
 #if ALPHA_OR_BETA_VERSION
 				if (thisSample->numReasonsToBeLoaded <= 0) {
-					display->freezeWithError("E215"); // I put this here to try and catch an E004 Luc got
+					FREEZE_WITH_ERROR("E215"); // I put this here to try and catch an E004 Luc got
 				}
 #endif
 				thisSample->removeReason("E393"); // Remove that temporary reason we added above
@@ -1760,7 +1760,7 @@ skipOctaveCorrection:
 		else {
 #if ALPHA_OR_BETA_VERSION
 			if (soundEditor.currentSource->ranges.elementSize != sizeof(MultisampleRange)) {
-				display->freezeWithError("E431");
+				FREEZE_WITH_ERROR("E431");
 			}
 #endif
 			range = (MultisampleRange*)soundEditor.currentSource->ranges.insertMultiRange(
@@ -1787,7 +1787,7 @@ skipOctaveCorrection:
 		}
 
 		if (ALPHA_OR_BETA_VERSION && thisSample->numReasonsToBeLoaded <= 0) {
-			display->freezeWithError("E216"); // I put this here to try and catch an E004 Luc got
+			FREEZE_WITH_ERROR("E216"); // I put this here to try and catch an E004 Luc got
 		}
 		thisSample->removeReason("E394"); // Remove that temporary reason we added above
 
@@ -1975,7 +1975,7 @@ skipNameStuff:
 
 #if ALPHA_OR_BETA_VERSION
 			if (thisSample->numReasonsToBeLoaded <= 0) {
-				display->freezeWithError("E217"); // I put this here to try and catch an E004 Luc got
+				FREEZE_WITH_ERROR("E217"); // I put this here to try and catch an E004 Luc got
 			}
 #endif
 			thisSample->removeReason("E395");

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -127,7 +127,7 @@ gotError:
 	indicator_leds::setLedState(IndicatorLED::SCALE_MODE, false);
 
 	if (ALPHA_OR_BETA_VERSION && currentUIMode == UI_MODE_WAITING_FOR_NEXT_FILE_TO_LOAD) {
-		display->freezeWithError("E188");
+		FREEZE_WITH_ERROR("E188");
 	}
 
 	return true;

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -166,7 +166,7 @@ void QwertyUI::displayText(bool blinkImmediately) {
 	memset(encodedAddition, 0, kNumericDisplayLength);
 	if (totalTextLength == enteredTextEditPos || enteredText.get()[enteredTextEditPos] == ' ') {
 		if (ALPHA_OR_BETA_VERSION && (editPosOnscreen < 0 || editPosOnscreen >= kNumericDisplayLength)) {
-			display->freezeWithError("E292");
+			FREEZE_WITH_ERROR("E292");
 		}
 		encodedAddition[editPosOnscreen] = 0x08;
 		encodedEditPosAndAHalf =

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -112,7 +112,7 @@ void SaveSongUI::focusRegained() {
 bool SaveSongUI::performSave(bool mayOverwrite) {
 
 	if (ALPHA_OR_BETA_VERSION && currentlyAccessingCard) {
-		display->freezeWithError("E316");
+		FREEZE_WITH_ERROR("E316");
 	}
 
 	if (currentSong->hasAnyPendingNextOverdubs()) {

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -658,7 +658,7 @@ getOut:
 
 #if 1 || ALPHA_OR_BETA_VERSION
 		if (!firstRange->sampleHolder.audioFile) {
-			display->freezeWithError("i032"); // Trying to narrow down E368 that Kevin F got
+			FREEZE_WITH_ERROR("i032"); // Trying to narrow down E368 that Kevin F got
 		}
 #endif
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -425,6 +425,7 @@ void ArrangerView::setLedStates() {
 }
 
 void ArrangerView::focusRegained() {
+	FREEZE_WITH_ERROR("EPAUL");
 
 	view.focusRegained();
 
@@ -649,7 +650,7 @@ void ArrangerView::beginAudition(Output* output) {
 			if (noteRow) {
 				drum = noteRow->drum;
 				if (drum && drum->type == DrumType::SOUND && !noteRow->paramManager.containsAnyMainParamCollections()) {
-					display->freezeWithError("E324"); // Vinz got this! I may have since fixed.
+					FREEZE_WITH_ERROR("E324"); // Vinz got this! I may have since fixed.
 				}
 			}
 			else {
@@ -1177,7 +1178,7 @@ void ArrangerView::editPadAction(int32_t x, int32_t y, bool on) {
 			int32_t squareEnd = getPosFromSquare(x + 1, xScroll);
 
 			if (squareStart >= squareEnd) {
-				display->freezeWithError("E210");
+				FREEZE_WITH_ERROR("E210");
 			}
 
 			// No previous press
@@ -1243,7 +1244,7 @@ makeNewInstance:
 						int32_t j = output->clipInstances.search(squareStart, GREATER_OR_EQUAL);
 						ClipInstance* nextClipInstance = output->clipInstances.getElement(j);
 						if (nextClipInstance && nextClipInstance->pos == squareStart) {
-							display->freezeWithError("E233"); // Yes, this happened to someone. Including me!!
+							FREEZE_WITH_ERROR("E233"); // Yes, this happened to someone. Including me!!
 						}
 					}
 
@@ -1297,7 +1298,7 @@ getItFromSection:
 						ClipInstance* nextInstance = output->clipInstances.getElement(pressedClipInstanceIndex + 1);
 						if (nextInstance) {
 							if (nextInstance->pos == squareStart) {
-								display->freezeWithError("E232");
+								FREEZE_WITH_ERROR("E232");
 							}
 						}
 					}
@@ -1318,21 +1319,21 @@ getItFromSection:
 					}
 
 					if (clipInstance->length < 1) {
-						display->freezeWithError("E049");
+						FREEZE_WITH_ERROR("E049");
 					}
 
 					ClipInstance* nextInstance = output->clipInstances.getElement(pressedClipInstanceIndex + 1);
 					if (nextInstance) {
 
 						if (nextInstance->pos == squareStart) {
-							display->freezeWithError("E209");
+							FREEZE_WITH_ERROR("E209");
 						}
 
 						int32_t maxLength = nextInstance->pos - squareStart;
 						if (clipInstance->length > maxLength) {
 							clipInstance->length = maxLength;
 							if (clipInstance->length < 1) {
-								display->freezeWithError("E048");
+								FREEZE_WITH_ERROR("E048");
 							}
 						}
 					}
@@ -1340,7 +1341,7 @@ getItFromSection:
 					if (clipInstance->length > kMaxSequenceLength - clipInstance->pos) {
 						clipInstance->length = kMaxSequenceLength - clipInstance->pos;
 						if (clipInstance->length < 1) {
-							display->freezeWithError("E045");
+							FREEZE_WITH_ERROR("E045");
 						}
 					}
 
@@ -2454,7 +2455,7 @@ cant:
 	if (instrumentClip) {
 		int32_t clipIndex = currentSong->sessionClips.getIndexForClip(instrumentClip);
 		if (ALPHA_OR_BETA_VERSION && clipIndex == -1) {
-			display->freezeWithError("E266");
+			FREEZE_WITH_ERROR("E266");
 		}
 		newClip = currentSong->replaceInstrumentClipWithAudioClip(instrumentClip, clipIndex);
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -425,8 +425,6 @@ void ArrangerView::setLedStates() {
 }
 
 void ArrangerView::focusRegained() {
-	FREEZE_WITH_ERROR("EPAUL");
-
 	view.focusRegained();
 
 	repopulateOutputsOnScreen(false);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -519,7 +519,7 @@ doOther:
 
 					if (ALPHA_OR_BETA_VERSION
 					    && (noteRowIndex < 0 || noteRowIndex >= clip->noteRows.getNumElements())) {
-						display->freezeWithError("E323");
+						FREEZE_WITH_ERROR("E323");
 					}
 
 					if (clip->isActiveOnOutput()) {
@@ -2750,7 +2750,7 @@ void InstrumentClipView::sendAuditionNote(bool on, uint8_t yDisplay, uint8_t vel
 				if (on) {
 					if (drum->type == DrumType::SOUND
 					    && !modelStackWithNoteRow->getNoteRow()->paramManager.containsAnyMainParamCollections()) {
-						display->freezeWithError("E325"); // Trying to catch an E313 that Vinz got
+						FREEZE_WITH_ERROR("E325"); // Trying to catch an E313 that Vinz got
 					}
 					((Kit*)instrument)->beginAuditioningforDrum(modelStackWithNoteRow, drum, velocity, zeroMPEValues);
 				}
@@ -5184,7 +5184,7 @@ void InstrumentClipView::modEncoderAction(int32_t whichModEncoder, int32_t offse
 		if (kit->selectedDrum && kit->selectedDrum->type != DrumType::SOUND) {
 
 			if (ALPHA_OR_BETA_VERSION && !kit->activeClip) {
-				display->freezeWithError("E381");
+				FREEZE_WITH_ERROR("E381");
 			}
 
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter =

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1860,14 +1860,14 @@ getOut:
 						        kit, soundDrum)) { // If no ParamManager with a NoteRow somewhere...
 
 							if (results.loadedFromFile) {
-								display->freezeWithError("E103");
+								FREEZE_WITH_ERROR("E103");
 							}
 							else if (instrumentAlreadyInSong) {
-								display->freezeWithError("E104");
+								FREEZE_WITH_ERROR("E104");
 							}
 							else {
 								// Sven got - very rare! This means Kit was hibernating, I guess.
-								display->freezeWithError("E105");
+								FREEZE_WITH_ERROR("E105");
 							}
 						}
 					}

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -394,7 +394,7 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 		SampleCluster* sampleCluster = sample->clusters.getElement(clusterIndexToDo);
 
 		if (sampleCluster->cluster && sampleCluster->cluster->numReasonsToBeLoaded < 0) {
-			display->freezeWithError("E449"); // Trying to catch errer before i028, which users have gotten.
+			FREEZE_WITH_ERROR("E449"); // Trying to catch errer before i028, which users have gotten.
 		}
 
 		// If we're wanting to investigate the whole length of one Cluster, and that's already actually been done previously, we can just reuse those findings!
@@ -429,8 +429,8 @@ cantReadData:
 			}
 
 			if (cluster->numReasonsToBeLoaded <= 0) {
-				display->freezeWithError(
-				    errorCode); // Branko V got this. Trying to catch E340 below, which Ron R got while recording
+				// Branko V got this. Trying to catch E340 below, which Ron R got while recording
+				FREEZE_WITH_ERROR(errorCode);
 			}
 
 			uint32_t numBytesToRead = endByteWithinCluster - startByteWithinCluster;
@@ -445,12 +445,12 @@ cantReadData:
 				endByteWithinCluster += overshoot;
 				SampleCluster* nextSampleCluster = sample->clusters.getElement(clusterIndexToDo + 1);
 				if (nextSampleCluster->cluster && nextSampleCluster->cluster->numReasonsToBeLoaded < 0) {
-					display->freezeWithError("E450"); // Trying to catch errer before i028, which users have gotten.
+					FREEZE_WITH_ERROR("E450"); // Trying to catch errer before i028, which users have gotten.
 				}
 				nextCluster = nextSampleCluster->getCluster(sample, clusterIndexToDo, CLUSTER_LOAD_IMMEDIATELY);
 
 				if (cluster->numReasonsToBeLoaded <= 0) {
-					display->freezeWithError("E342"); // Trying to catch E340 below, which Ron R got while recording
+					FREEZE_WITH_ERROR("E342"); // Trying to catch E340 below, which Ron R got while recording
 				}
 
 				if (!nextCluster) {

--- a/src/deluge/hid/display/display.cpp
+++ b/src/deluge/hid/display/display.cpp
@@ -80,9 +80,7 @@ std::string_view getErrorMessage(int32_t error) {
 } // namespace deluge::hid::display
 
 extern "C" void freezeWithError(char const* error) {
-	if (ALPHA_OR_BETA_VERSION) {
-		display->freezeWithError(error);
-	}
+	display->freezeWithError(error);
 }
 
 extern "C" void displayPopup(char const* text) {

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -1231,12 +1231,12 @@ void OLED::freezeWithError(char const* text) {
 	// Wait for existing DMA transfer to finish
 	uint16_t startTime = *TCNT[TIMER_SYSTEM_SLOW];
 	while (!(DMACn(OLED_SPI_DMA_CHANNEL).CHSTAT_n & DMAC0_CHSTAT_n_TC)
-	       && (uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(10)) {}
+	       && (uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(50)) {}
 
 	// Wait for PIC to de-select OLED, if it's been doing that.
 	if (oledWaitingForMessage != 256) {
 		startTime = *TCNT[TIMER_SYSTEM_SLOW];
-		while ((uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(10)) {
+		while ((uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(50)) {
 			uint8_t value;
 			bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
 			if (anything && value == oledWaitingForMessage) {
@@ -1254,7 +1254,7 @@ void OLED::freezeWithError(char const* text) {
 
 	// Wait for selection to be done
 	startTime = *TCNT[TIMER_SYSTEM_SLOW];
-	while ((uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(10)) {
+	while ((uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(50)) {
 		uint8_t value;
 		bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
 		if (anything && value == 248) {

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -438,7 +438,7 @@ void setupAudioClipCollapseOrExplodeAnimation(AudioClip* clip) {
 	Sample* sample = (Sample*)clip->sampleHolder.audioFile;
 
 	if (ALPHA_OR_BETA_VERSION && !sample) {
-		display->freezeWithError("E311");
+		FREEZE_WITH_ERROR("E311");
 	}
 
 	sampleMaxPeakFromZero = sample->getMaxPeakFromZero();

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -153,7 +153,7 @@ MIDIDeviceUSBHosted* getOrCreateHostedMIDIDeviceFromDetails(String* name, uint16
 	int32_t error = hostedMIDIDevices.insertElement(device, i); // We made sure, above, that there's space
 #if ALPHA_OR_BETA_VERSION
 	if (error) {
-		display->freezeWithError("E405");
+		FREEZE_WITH_ERROR("E405");
 	}
 #endif
 
@@ -240,7 +240,7 @@ extern "C" void hostedDeviceDetached(int32_t ip, int32_t midiDeviceNum) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (midiDeviceNum == MAX_NUM_USB_MIDI_DEVICES) {
-		display->freezeWithError("E367");
+		FREEZE_WITH_ERROR("E367");
 	}
 #endif
 

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -954,7 +954,7 @@ void MidiEngine::midiMessageReceived(MIDIDevice* fromDevice, uint8_t statusType,
 				                                    &shouldDoMidiThruNow);
 #if MISSING_MESSAGE_CHECK
 				if (lastWasNoteOn == (bool)(statusType & 1))
-					display->freezeWithError("MISSED!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
+					FREEZE_WITH_ERROR("MISSED!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
 				lastWasNoteOn = statusType & 1;
 #endif
 				break;

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -68,7 +68,7 @@ void GeneralMemoryAllocator::checkStack(char const* caller) {
 		Debug::println(caller);
 
 		if (distance < 200) {
-			display->freezeWithError("E338");
+			FREEZE_WITH_ERROR("E338");
 			Debug::println("COLLISION");
 		}
 	}
@@ -99,7 +99,7 @@ void* GeneralMemoryAllocator::allocExternal(uint32_t requiredSize) {
 	void* address = regions[MEMORY_REGION_EXTERNAL].alloc(requiredSize, false, NULL);
 	lock = false;
 	if (!address) {
-		//numericDriver.freezeWithError("M998");
+		//FREEZE_WITH_ERROR("M998");
 		return nullptr;
 	}
 	return address;
@@ -190,7 +190,7 @@ int32_t GeneralMemoryAllocator::getRegion(void* address) {
 		return MEMORY_REGION_EXTERNAL;
 	}
 
-	display->freezeWithError("E339");
+	FREEZE_WITH_ERROR("E339");
 	return 0;
 }
 

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -83,7 +83,7 @@ void MemoryRegion::sanityCheck() {
 	}
 
 	if (count > 1) {
-		display->freezeWithError("BBBB");
+		FREEZE_WITH_ERROR("BBBB");
 		Debug::println("multiple 0xc0080bc!!!!");
 	}
 	else if (count == 1) {
@@ -99,16 +99,16 @@ void MemoryRegion::verifyMemoryNotFree(void* address, uint32_t spaceSize) {
 		EmptySpaceRecord* emptySpaceRecord = (EmptySpaceRecord*)emptySpaces.getElementAddress(i);
 		if (emptySpaceRecord->address == (uint32_t)address) {
 			Debug::println("Exact address free!");
-			display->freezeWithError("dddffffd");
+			FREEZE_WITH_ERROR("dddffffd");
 		}
 		else if (emptySpaceRecord->address <= (uint32_t)address
 		         && (emptySpaceRecord->address + emptySpaceRecord->length > (uint32_t)address)) {
-			display->freezeWithError("dddd");
+			FREEZE_WITH_ERROR("dddd");
 			Debug::println("free mem overlap on left!");
 		}
 		else if ((uint32_t)address <= (uint32_t)emptySpaceRecord->address
 		         && ((uint32_t)address + spaceSize > emptySpaceRecord->address)) {
-			display->freezeWithError("eeee");
+			FREEZE_WITH_ERROR("eeee");
 			Debug::println("free mem overlap on right!");
 		}
 	}
@@ -124,7 +124,7 @@ static EmptySpaceRecord* recordToMergeWith;
 // spaceSize can even be 0 or less if you know it's going to get merged.
 inline void MemoryRegion::markSpaceAsEmpty(uint32_t address, uint32_t spaceSize, bool mayLookLeft, bool mayLookRight) {
 	if ((address < start) || address > end) {
-		display->freezeWithError("M998");
+		FREEZE_WITH_ERROR("M998");
 		return;
 	}
 	int32_t biggerRecordSearchFromIndex = 0;
@@ -209,7 +209,7 @@ justInsertRecord:
 		newRecord.address = address;
 		int32_t i = emptySpaces.searchMultiWordExact((uint32_t*)&newRecord);
 		if (i != -1) {
-			display->freezeWithError("M123");
+			FREEZE_WITH_ERROR("M123");
 		}
 		i = emptySpaces.insertAtKeyMultiWord((uint32_t*)&newRecord, insertRangeBegin);
 #if ALPHA_OR_BETA_VERSION
@@ -298,7 +298,7 @@ gotEmptySpace:
 
 		int32_t extraSpaceSizeWithoutItsHeaders = allocatedSize - requiredSize - 8;
 		if (extraSpaceSizeWithoutItsHeaders < -8) {
-			display->freezeWithError("M003");
+			FREEZE_WITH_ERROR("M003");
 		}
 		else {
 			if (extraSpaceSizeWithoutItsHeaders <= minAlign) {
@@ -403,7 +403,7 @@ noEmptySpace:
 			markSpaceAsEmpty(allocatedAddress + allocatedSize + 8, extraSpaceSizeWithoutItsHeaders, false, false);
 		}
 		else if (extraSpaceSizeWithoutItsHeaders < -8) {
-			display->freezeWithError("M004");
+			FREEZE_WITH_ERROR("M004");
 		}
 	}
 
@@ -421,7 +421,7 @@ noEmptySpace:
 #if ALPHA_OR_BETA_VERSION
 	if (allocatedAddress < start || allocatedAddress > end) {
 		//trying to allocate outside our region
-		display->freezeWithError("M002");
+		FREEZE_WITH_ERROR("M002");
 	}
 #endif
 	return (void*)allocatedAddress;
@@ -821,11 +821,11 @@ void MemoryRegion::dealloc(void* address) {
 #if ALPHA_OR_BETA_VERSION
 	if ((uint32_t)address < start || (uint32_t)address > end) {
 		//deallocating outside our region
-		display->freezeWithError("M001");
+		FREEZE_WITH_ERROR("M001");
 	}
 	if ((*header & SPACE_TYPE_MASK) == SPACE_HEADER_EMPTY) {
 		//double free
-		display->freezeWithError("M000");
+		FREEZE_WITH_ERROR("M000");
 	}
 #endif
 

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -67,7 +67,7 @@ AudioClip::AudioClip() : Clip(CLIP_TYPE_AUDIO) {
 
 AudioClip::~AudioClip() {
 	if (recorder) {
-		display->freezeWithError("E278");
+		FREEZE_WITH_ERROR("E278");
 	}
 
 	// Sirhc actually got this in a V3.0.5 RC! No idea how. Also Qui got around V3.1.3.
@@ -246,7 +246,7 @@ ramError:
 
 #if ALPHA_OR_BETA_VERSION
 	if (!newClip->paramManager.summaries[0].paramCollection) {
-		display->freezeWithError("E421"); // Trying to diversify Leo's E410
+		FREEZE_WITH_ERROR("E421"); // Trying to diversify Leo's E410
 	}
 #endif
 
@@ -388,7 +388,7 @@ void AudioClip::resumePlayback(ModelStackWithTimelineCounter* modelStack, bool m
 
 #if ALPHA_OR_BETA_VERSION
 	if (!playbackHandler.isEitherClockActive() || !modelStack->song->isClipActive(this)) {
-		display->freezeWithError("E430");
+		FREEZE_WITH_ERROR("E430");
 	}
 #endif
 
@@ -417,7 +417,7 @@ void AudioClip::resumePlayback(ModelStackWithTimelineCounter* modelStack, bool m
 	int32_t sequenceSyncStartedNumTicksAgo = currentInternalTickCount - sequenceSyncStartedAtTickTrivialValue;
 	if (sequenceSyncStartedNumTicksAgo < 0) { // Shouldn't happen
 		if (ALPHA_OR_BETA_VERSION) {
-			display->freezeWithError("nofg"); // Ron got, Nov 2021. Wait no, he didn't have playback on!
+			FREEZE_WITH_ERROR("nofg"); // Ron got, Nov 2021. Wait no, he didn't have playback on!
 		}
 		sequenceSyncStartedNumTicksAgo = 0; // The show must go on
 	}

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -552,7 +552,7 @@ int32_t Clip::undoDetachmentFromOutput(ModelStackWithTimelineCounter* modelStack
 
 	if (!success) {
 		if (ALPHA_OR_BETA_VERSION) {
-			display->freezeWithError("E245");
+			FREEZE_WITH_ERROR("E245");
 		}
 		return ERROR_BUG;
 	}
@@ -938,13 +938,13 @@ trimFoundParamManager:
 				int32_t error = paramManager.cloneParamCollectionsFrom(&otherClip->paramManager, false, true);
 
 				if (error) {
-					display->freezeWithError("E050");
+					FREEZE_WITH_ERROR("E050");
 					return error;
 				}
 			}
 			// Unless I've done something wrong, there *has* to be another Clip if the Output didn't have a backed-up ParamManager. But, just in case
 			else {
-				display->freezeWithError("E051");
+				FREEZE_WITH_ERROR("E051");
 				return ERROR_UNSPECIFIED;
 			}
 		}

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1095,7 +1095,7 @@ ModelStackWithNoteRow* InstrumentClip::getOrCreateNoteRowForYNote(int32_t yNote,
 
 				thisNoteRow = getNoteRowForYNote(yNote); // Must re-get it
 				if (ALPHA_OR_BETA_VERSION && !thisNoteRow) {
-					display->freezeWithError("E -1");
+					FREEZE_WITH_ERROR("E -1");
 				}
 
 				thisNoteRow->notes.empty(); // Undo our "total hack", above
@@ -1492,7 +1492,7 @@ int32_t InstrumentClip::setNonAudioInstrument(Instrument* newInstrument, Song* s
 			int32_t error = paramManager.setupMIDI();
 			if (error) {
 				if (ALPHA_OR_BETA_VERSION) {
-					display->freezeWithError("E052");
+					FREEZE_WITH_ERROR("E052");
 				}
 				return error;
 			}
@@ -1606,7 +1606,7 @@ int32_t InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelSta
 	    newInstrument, modelStack->song, newParamManager,
 	    favourClipForCloningParamManager); // Tell it not to setup patching - this will happen back here in changeInstrumentPreset() after all Drums matched up
 	if (error) {
-		display->freezeWithError("E039");
+		FREEZE_WITH_ERROR("E039");
 		return error; // TODO: we'll need to get the old Instrument back...
 	}
 
@@ -2034,7 +2034,7 @@ int32_t InstrumentClip::undoUnassignmentOfAllNoteRowsFromDrums(ModelStackWithTim
 
 			if (!success) {
 				if (ALPHA_OR_BETA_VERSION) {
-					display->freezeWithError("E229");
+					FREEZE_WITH_ERROR("E229");
 				}
 				return ERROR_BUG;
 			}
@@ -2125,7 +2125,7 @@ int32_t InstrumentClip::undoDetachmentFromOutput(ModelStackWithTimelineCounter* 
 
 		if (!paramManager.containsAnyMainParamCollections()) {
 			if (ALPHA_OR_BETA_VERSION) {
-				display->freezeWithError("E230");
+				FREEZE_WITH_ERROR("E230");
 			}
 			return ERROR_BUG;
 		}
@@ -3066,7 +3066,7 @@ bool InstrumentClip::deleteSoundsWhichWontSound(Song* song) {
 
 					if (ALPHA_OR_BETA_VERSION && noteRow->drum->type == DrumType::SOUND
 					    && ((SoundDrum*)noteRow->drum)->hasAnyVoices()) {
-						display->freezeWithError("E176");
+						FREEZE_WITH_ERROR("E176");
 					}
 
 					Drum* drum = noteRow->drum;
@@ -3236,7 +3236,7 @@ int32_t InstrumentClip::getDistanceToNextNote(Note* givenNote, ModelStackWithNot
 int32_t InstrumentClip::getNoteRowId(NoteRow* noteRow, int32_t noteRowIndex) {
 #if ALPHA_OR_BETA_VERSION
 	if (!noteRow) {
-		display->freezeWithError("E380");
+		FREEZE_WITH_ERROR("E380");
 	}
 #endif
 	if (output->type == InstrumentType::KIT) {
@@ -3250,7 +3250,7 @@ int32_t InstrumentClip::getNoteRowId(NoteRow* noteRow, int32_t noteRowIndex) {
 NoteRow* InstrumentClip::getNoteRowFromId(int32_t id) {
 	if (output->type == InstrumentType::KIT) {
 		if (id < 0 || id >= noteRows.getNumElements()) {
-			display->freezeWithError("E177");
+			FREEZE_WITH_ERROR("E177");
 		}
 		return noteRows.getElement(id);
 	}
@@ -3801,7 +3801,7 @@ int32_t InstrumentClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 
 						// If wasn't enough RAM, we're really in trouble
 						if (error) {
-							display->freezeWithError("E011");
+							FREEZE_WITH_ERROR("E011");
 haveNoDrum:
 							thisNoteRow->drum = NULL;
 						}

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -46,7 +46,7 @@ void ConsequenceClipExistence::prepareForDestruction(int32_t whichQueueActionIn,
 #if ALPHA_OR_BETA_VERSION
 		if (clip->type == CLIP_TYPE_AUDIO) {
 			if (((AudioClip*)clip)->recorder) {
-				display->freezeWithError("i002"); // Trying to diversify Qui's E278
+				FREEZE_WITH_ERROR("i002"); // Trying to diversify Qui's E278
 			}
 		}
 #endif
@@ -68,14 +68,14 @@ int32_t ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) 
 		int32_t error = clip->undoDetachmentFromOutput(modelStackWithTimelineCounter);
 		if (error) { // This shouldn't actually happen, but if it does...
 #if ALPHA_OR_BETA_VERSION
-			display->freezeWithError("E046");
+			FREEZE_WITH_ERROR("E046");
 #endif
 			return error; // Run away. This and the Clip(?) will get destructed, and everything should be ok!
 		}
 
 #if ALPHA_OR_BETA_VERSION
 		if (clip->type == CLIP_TYPE_AUDIO && !clip->paramManager.summaries[0].paramCollection) {
-			display->freezeWithError("E419"); // Trying to diversify Leo's E410
+			FREEZE_WITH_ERROR("E419"); // Trying to diversify Leo's E410
 		}
 #endif
 
@@ -116,7 +116,7 @@ int32_t ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) 
 
 		clipIndex = clipArray->getIndexForClip(clip);
 		if (clipIndex == -1) {
-			display->freezeWithError("E244");
+			FREEZE_WITH_ERROR("E244");
 		}
 
 		if (clipArray == &modelStackWithTimelineCounter->song->sessionClips) {
@@ -143,14 +143,14 @@ int32_t ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) 
 #if ALPHA_OR_BETA_VERSION
 		if (clip->type == CLIP_TYPE_AUDIO) {
 			if (((AudioClip*)clip)->recorder) {
-				display->freezeWithError("i003"); // Trying to diversify Qui's E278
+				FREEZE_WITH_ERROR("i003"); // Trying to diversify Qui's E278
 			}
 		}
 #endif
 
 #if ALPHA_OR_BETA_VERSION
 		if (clip->type == CLIP_TYPE_AUDIO && !clip->paramManager.summaries[0].paramCollection) {
-			display->freezeWithError("E420"); // Trying to diversify Leo's E410
+			FREEZE_WITH_ERROR("E420"); // Trying to diversify Leo's E410
 		}
 #endif
 

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
@@ -42,7 +42,7 @@ int32_t ConsequenceNoteRowHorizontalShift::revert(TimeType time, ModelStack* mod
 
 	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
 #if ALPHA_OR_BETA_VERSION
-		display->freezeWithError("E377");
+		FREEZE_WITH_ERROR("E377");
 #endif
 		return ERROR_BUG;
 	}

--- a/src/deluge/model/consequence/consequence_output_existence.cpp
+++ b/src/deluge/model/consequence/consequence_output_existence.cpp
@@ -39,7 +39,7 @@ int32_t ConsequenceOutputExistence::revert(TimeType time, ModelStack* modelStack
 
 		outputIndex = modelStack->song->removeOutputFromMainList(output);
 		if (ALPHA_OR_BETA_VERSION && outputIndex == -1) {
-			display->freezeWithError("E263");
+			FREEZE_WITH_ERROR("E263");
 		}
 
 		output->prepareForHibernationOrDeletion();

--- a/src/deluge/model/drum/kit.cpp
+++ b/src/deluge/model/drum/kit.cpp
@@ -425,7 +425,7 @@ void Kit::drumRemoved(Drum* drum) {
 #if ALPHA_OR_BETA_VERSION
 	int32_t i = drumsWithRenderingActive.searchExact((int32_t)drum);
 	if (i != -1) {
-		display->freezeWithError("E321");
+		FREEZE_WITH_ERROR("E321");
 	}
 #endif
 }
@@ -493,13 +493,13 @@ bool Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStac
 		Drum* thisDrum = (Drum*)drumsWithRenderingActive.getKeyAtIndex(d);
 
 		if (ALPHA_OR_BETA_VERSION && thisDrum->type != DrumType::SOUND) {
-			display->freezeWithError("E253");
+			FREEZE_WITH_ERROR("E253");
 		}
 
 		SoundDrum* soundDrum = (SoundDrum*)thisDrum;
 
 		if (ALPHA_OR_BETA_VERSION && soundDrum->skippingRendering) {
-			display->freezeWithError("E254");
+			FREEZE_WITH_ERROR("E254");
 		}
 
 		ParamManager* drumParamManager;
@@ -738,7 +738,7 @@ void Kit::setupWithoutActiveClip(ModelStack* modelStack) {
 			ParamManager* paramManager = modelStackWithTimelineCounter->song->getBackedUpParamManagerPreferablyWithClip(
 			    (ModControllableAudio*)soundDrum, NULL);
 			if (!paramManager) {
-				display->freezeWithError("E174");
+				FREEZE_WITH_ERROR("E174");
 			}
 
 			soundDrum->patcher.performInitialPatching(soundDrum, (ParamManagerForTimeline*)paramManager);
@@ -795,7 +795,7 @@ void Kit::setupPatching(ModelStackWithTimelineCounter* modelStack) {
 				ParamManager* paramManager =
 				    modelStack->song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)soundDrum, NULL);
 				if (!paramManager) {
-					display->freezeWithError("E172");
+					FREEZE_WITH_ERROR("E172");
 				}
 
 				soundDrum->ensureInaccessibleParamPresetValuesWithoutKnobsAreZeroWithMinimalDetails(
@@ -1124,7 +1124,7 @@ goingToRecordNoteOnEarly:
 
 					if (thisNoteRow && thisDrum->type == DrumType::SOUND
 					    && !thisNoteRow->paramManager.containsAnyMainParamCollections()) {
-						display->freezeWithError("E326"); // Trying to catch an E313 that Vinz got
+						FREEZE_WITH_ERROR("E326"); // Trying to catch an E313 that Vinz got
 					}
 
 					beginAuditioningforDrum(modelStackWithNoteRow, thisDrum, velocity, mpeValues, channel);
@@ -1355,15 +1355,15 @@ void Kit::beginAuditioningforDrum(ModelStackWithNoteRow* modelStack, Drum* drum,
 	if (modelStack->getNoteRowAllowNull()) {
 		paramManagerForDrum = &modelStack->getNoteRow()->paramManager;
 		if (!paramManagerForDrum->containsAnyMainParamCollections() && drum->type == DrumType::SOUND) {
-			display->freezeWithError("E313"); // Vinz got this!
+			FREEZE_WITH_ERROR("E313"); // Vinz got this!
 		}
 	}
 	else {
 		if (drum->type == DrumType::SOUND) {
 			paramManagerForDrum = modelStack->song->getBackedUpParamManagerPreferablyWithClip((SoundDrum*)drum, NULL);
 			if (!paramManagerForDrum) {
-				display->freezeWithError(
-				    "E314"); // Ron got this, June 2020, while "dragging" a row vertically in arranger
+				// Ron got this, June 2020, while "dragging" a row vertically in arranger
+				FREEZE_WITH_ERROR("E314");
 			}
 		}
 	}
@@ -1402,7 +1402,7 @@ void Kit::endAuditioningForDrum(ModelStackWithNoteRow* modelStack, Drum* drum, i
 		// If still here, haven't found paramManager yet
 		paramManagerForDrum = modelStack->song->getBackedUpParamManagerPreferablyWithClip((SoundDrum*)drum, NULL);
 		if (!paramManagerForDrum) {
-			display->freezeWithError("E312"); // Should make ALPHA_OR_BETA_VERSION after V3.0.0 release
+			FREEZE_WITH_ERROR("E312"); // Should make ALPHA_OR_BETA_VERSION after V3.0.0 release
 		}
 	}
 

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -439,10 +439,10 @@ int32_t MIDIInstrument::moveAutomationToDifferentCC(int32_t oldCC, int32_t newCC
 	else {
 #if ALPHA_OR_BETA_VERSION
 		if (modelStackWithAutoParam->paramCollection != modelStack->paramManager->getExpressionParamSet()) {
-			display->freezeWithError("E415");
+			FREEZE_WITH_ERROR("E415");
 		}
 		if (modelStackWithAutoParam->paramId >= kNumExpressionDimensions) {
-			display->freezeWithError("E416");
+			FREEZE_WITH_ERROR("E416");
 		}
 #endif
 		((ExpressionParamSet*)modelStackWithAutoParam->paramCollection)

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1574,7 +1574,7 @@ ModelStackWithThreeMainThings* ModControllableAudio::addNoteRowIndexAndStuff(Mod
 		InstrumentClip* clip = (InstrumentClip*)modelStack->getTimelineCounter();
 #if ALPHA_OR_BETA_VERSION
 		if (noteRowIndex >= clip->noteRows.getNumElements()) {
-			display->freezeWithError("E406");
+			FREEZE_WITH_ERROR("E406");
 		}
 #endif
 		noteRow = clip->noteRows.getElement(noteRowIndex);

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -32,7 +32,7 @@ ModelStackWithThreeMainThings* ModelStackWithTimelineCounter::addNoteRowAndExtra
 
 #if ALPHA_OR_BETA_VERSION
 	if (!newNoteRow->paramManager.containsAnyParamCollectionsIncludingExpression()) {
-		display->freezeWithError("E389");
+		FREEZE_WITH_ERROR("E389");
 	}
 #endif
 

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -146,7 +146,7 @@ public:
 	inline TimelineCounter* getTimelineCounter() const {
 #if ALPHA_OR_BETA_VERSION
 		if (!timelineCounter) {
-			display->freezeWithError("E369");
+			FREEZE_WITH_ERROR("E369");
 		}
 #endif
 		return timelineCounter;
@@ -199,7 +199,7 @@ public:
 	inline NoteRow* getNoteRow() const {
 #if ALPHA_OR_BETA_VERSION
 		if (!noteRow) {
-			display->freezeWithError("E379");
+			FREEZE_WITH_ERROR("E379");
 		}
 #endif
 		return noteRow;

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -1104,7 +1104,7 @@ int32_t NoteRow::editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareW
 	}
 #if ALPHA_OR_BETA_VERSION
 	else if (numToDelete < 0) { // If we overshot somehow
-		display->freezeWithError("E329");
+		FREEZE_WITH_ERROR("E329");
 	}
 #endif
 
@@ -3210,7 +3210,7 @@ void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack
 
 						// If there also was no RAM...
 						if (!paramManager.containsAnyMainParamCollections()) {
-							display->freezeWithError("E101");
+							FREEZE_WITH_ERROR("E101");
 						}
 					}
 
@@ -3218,7 +3218,7 @@ void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack
 					else {
 						int32_t error = paramManager.setupWithPatching();
 						if (error) {
-							display->freezeWithError("E010"); // If there also was no RAM, we're really in trouble.
+							FREEZE_WITH_ERROR("E010"); // If there also was no RAM, we're really in trouble.
 						}
 						Sound::initParams(&paramManager);
 

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -171,7 +171,7 @@ ParamManager* Output::getParamManager(Song* song) {
 		ParamManager* paramManager =
 		    song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)toModControllable(), NULL);
 		if (!paramManager) {
-			display->freezeWithError("E170");
+			FREEZE_WITH_ERROR("E170");
 		}
 		return paramManager;
 	}
@@ -426,11 +426,11 @@ void Output::endAnyArrangementRecording(Song* song, int32_t actualEndPosInternal
 		int32_t i = clipInstances.search(actualEndPosInternalTicks, LESS);
 		ClipInstance* clipInstance = clipInstances.getElement(i);
 		if (ALPHA_OR_BETA_VERSION && !clipInstance) {
-			display->freezeWithError("E261");
+			FREEZE_WITH_ERROR("E261");
 		}
 		if (ALPHA_OR_BETA_VERSION && clipInstance->clip != activeClip) {
 			// Michael B got, in 3.2.0-alpha10. Possibly a general memory corruption thing?
-			display->freezeWithError("E262");
+			FREEZE_WITH_ERROR("E262");
 		}
 
 		int32_t lengthSoFarInternalTicks = actualEndPosInternalTicks - clipInstance->pos;

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -44,7 +44,7 @@ extern "C" {
 #if SAMPLE_DO_LOCKS
 #define LOCK_ENTRY                                                                                                     \
 	if (lock) {                                                                                                        \
-		FREEZE_WITH_ERROR("i024");                                                                              \
+		FREEZE_WITH_ERROR("i024");                                                                                     \
 	}                                                                                                                  \
 	lock = true;
 #define LOCK_EXIT lock = false;

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -44,7 +44,7 @@ extern "C" {
 #if SAMPLE_DO_LOCKS
 #define LOCK_ENTRY                                                                                                     \
 	if (lock) {                                                                                                        \
-		display->freezeWithError("i024");                                                                              \
+		FREEZE_WITH_ERROR("i024");                                                                              \
 	}                                                                                                                  \
 	lock = true;
 #define LOCK_EXIT lock = false;
@@ -134,7 +134,7 @@ void Sample::deletePercCache(bool beingDestructed) {
 
 					// If any of them still has a "reason", well, it shouldn't
 					if (ALPHA_OR_BETA_VERSION && percCacheClusters[reversed][c]->numReasonsToBeLoaded) {
-						display->freezeWithError("E137");
+						FREEZE_WITH_ERROR("E137");
 					}
 
 					audioFileManager.deallocateCluster(percCacheClusters[reversed][c]);
@@ -383,7 +383,7 @@ doReturnNoError:
 				percClusterIndexStart = (uint32_t)startPosSamples
 				                        >> (audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude);
 				if (ALPHA_OR_BETA_VERSION && percClusterIndexStart >= numPercCacheClusters) {
-					display->freezeWithError("E138");
+					FREEZE_WITH_ERROR("E138");
 				}
 				Cluster* clusterHere = percCacheClusters[reversed][percClusterIndexStart];
 #if ALPHA_OR_BETA_VERSION
@@ -394,7 +394,7 @@ doReturnNoError:
 					    & ((1 << audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude) - 1)) {
 						// If Cluster has been stolen, the zones should have been updated, so we shouldn't be here
 						Debug::println(startPosSamples);
-						display->freezeWithError("E139");
+						FREEZE_WITH_ERROR("E139");
 					}
 				}
 #endif
@@ -419,11 +419,11 @@ doReturnNoError:
 					if (percClusterIndexEnd != percClusterIndexStart) {
 #if ALPHA_OR_BETA_VERSION
 						if (percClusterIndexEnd >= numPercCacheClusters) {
-							display->freezeWithError("E140");
+							FREEZE_WITH_ERROR("E140");
 						}
 						if (!percCacheClusters[reversed][percClusterIndexEnd]) {
-							display->freezeWithError(
-							    "E141"); // If Cluster has been stolen, the zones should have been updated, so we shouldn't be here
+							// If Cluster has been stolen, the zones should have been updated, so we shouldn't be here
+							FREEZE_WITH_ERROR("E141");
 						}
 #endif
 						timeStretcher->rememberPercCacheCluster(percCacheClusters[reversed][percClusterIndexEnd]);
@@ -528,7 +528,7 @@ doLoading:
 			int32_t percClusterIndex =
 			    startPosSamples >> (audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude);
 			if (ALPHA_OR_BETA_VERSION && percClusterIndex >= numPercCacheClusters) {
-				display->freezeWithError("E136");
+				FREEZE_WITH_ERROR("E136");
 			}
 			if (!percCacheClusters[reversed][percClusterIndex]) {
 				//Debug::println("allocating perc cache Cluster!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
@@ -725,7 +725,7 @@ bool Sample::getAveragesForCrossfade(int32_t* totals, int32_t startBytePos, int3
 
 	// This can happen. Not 100% sure if it should, but we'll return false just below in this case anyway, so I think it's ok
 	if (ALPHA_OR_BETA_VERSION && startBytePos < (int32_t)audioDataStartPosBytes) {
-		display->freezeWithError("E283");
+		FREEZE_WITH_ERROR("E283");
 	}
 
 	int32_t startSamplePos = (uint32_t)(startBytePos - audioDataStartPosBytes) / (uint8_t)bytesPerSample;
@@ -765,7 +765,7 @@ bool Sample::getAveragesForCrossfade(int32_t* totals, int32_t startBytePos, int3
 
 		if (ALPHA_OR_BETA_VERSION
 		    && (readByte < audioDataStartPosBytes - 1 || readByte >= audioDataStartPosBytes + audioDataLengthBytes)) {
-			display->freezeWithError("FFFF");
+			FREEZE_WITH_ERROR("FFFF");
 		}
 
 		do {
@@ -773,14 +773,14 @@ bool Sample::getAveragesForCrossfade(int32_t* totals, int32_t startBytePos, int3
 			if (ALPHA_OR_BETA_VERSION
 			    && (readByte < audioDataStartPosBytes - 1
 			        || readByte >= audioDataStartPosBytes + audioDataLengthBytes)) {
-				display->freezeWithError("E432"); // Was "GGGG". Sven may have gotten.
+				FREEZE_WITH_ERROR("E432"); // Was "GGGG". Sven may have gotten.
 			}
 
 			int32_t whichCluster = readByte >> audioFileManager.clusterSizeMagnitude;
 			if (ALPHA_OR_BETA_VERSION
 			    && (whichCluster < getFirstClusterIndexWithAudioData()
 			        || whichCluster >= getFirstClusterIndexWithNoAudioData())) {
-				display->freezeWithError("EEEE");
+				FREEZE_WITH_ERROR("EEEE");
 			}
 
 			Cluster* cluster = clusters.getElement(whichCluster)->cluster;
@@ -815,7 +815,7 @@ bool Sample::getAveragesForCrossfade(int32_t* totals, int32_t startBytePos, int3
 			readByte += numSamplesThisRead * bytesPerSample * playDirection;
 			numSamplesLeftThisAverage -= numSamplesThisRead;
 			if (ALPHA_OR_BETA_VERSION && numSamplesLeftThisAverage < 0) {
-				display->freezeWithError("DDDD");
+				FREEZE_WITH_ERROR("DDDD");
 			}
 		} while (numSamplesLeftThisAverage);
 	}
@@ -853,7 +853,7 @@ uint8_t* Sample::prepareToReadPercCache(int32_t pixellatedPos, int32_t playDirec
 	else {
 		int32_t ourCluster = pixellatedPos >> audioFileManager.clusterSizeMagnitude;
 		if (ALPHA_OR_BETA_VERSION && !percCacheClusters[reversed][ourCluster]) {
-			display->freezeWithError("E142");
+			FREEZE_WITH_ERROR("E142");
 		}
 
 		int32_t earliestCluster = *earliestPixellatedPos >> audioFileManager.clusterSizeMagnitude;
@@ -890,19 +890,19 @@ void Sample::percCacheClusterStolen(Cluster* cluster) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (cluster->type != ClusterType::PERC_CACHE_FORWARDS && cluster->type != ClusterType::PERC_CACHE_REVERSED) {
-		display->freezeWithError("E149");
+		FREEZE_WITH_ERROR("E149");
 	}
 	if (!percCacheClusters[reversed]) {
-		display->freezeWithError("E134");
+		FREEZE_WITH_ERROR("E134");
 	}
 	if (cluster->clusterIndex >= numPercCacheClusters) {
-		display->freezeWithError("E135");
+		FREEZE_WITH_ERROR("E135");
 	}
 	if (!percCacheClusters[reversed][cluster->clusterIndex]) {
-		display->freezeWithError("i034"); // Trying to track down Steven G's E133 (Feb 2021).
+		FREEZE_WITH_ERROR("i034"); // Trying to track down Steven G's E133 (Feb 2021).
 	}
 	if (percCacheClusters[reversed][cluster->clusterIndex]->numReasonsToBeLoaded) {
-		display->freezeWithError("i035"); // Trying to track down Steven G's E133 (Feb 2021).
+		FREEZE_WITH_ERROR("i035"); // Trying to track down Steven G's E133 (Feb 2021).
 	}
 #endif
 
@@ -1744,11 +1744,11 @@ void Sample::numReasonsDecreasedToZero(char const* errorCode) {
 
 			if (cluster->clusterIndex != c) {
 				// Leo got! Aug 2020. Suspect some sort of memory corruption... And then Michael got, Feb 2021
-				display->freezeWithError(errorCode);
+				FREEZE_WITH_ERROR(errorCode);
 			}
 
 			if (cluster->numReasonsToBeLoaded < 0) {
-				display->freezeWithError("E076");
+				FREEZE_WITH_ERROR("E076");
 			}
 
 			numClusterReasons += cluster->numReasonsToBeLoaded;
@@ -1784,8 +1784,8 @@ void Sample::numReasonsDecreasedToZero(char const* errorCode) {
 		}
 		Debug::println("/reason dump---");
 
-		display->freezeWithError(
-		    "E078"); // LegsMechanical got, V4.0.0-beta2. https://forums.synthstrom.com/discussion/4106/v4-0-beta2-e078-crash-when-recording-audio-clip
+		// LegsMechanical got, V4.0.0-beta2. https://forums.synthstrom.com/discussion/4106/v4-0-beta2-e078-crash-when-recording-audio-clip
+		FREEZE_WITH_ERROR("E078");
 	}
 }
 #endif

--- a/src/deluge/model/sample/sample_cache.cpp
+++ b/src/deluge/model/sample/sample_cache.cpp
@@ -49,10 +49,10 @@ void SampleCache::clusterStolen(int32_t clusterIndex) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (clusterIndex < 0) {
-		display->freezeWithError("E296");
+		FREEZE_WITH_ERROR("E296");
 	}
 	else if (clusterIndex >= numClusters) {
-		display->freezeWithError("E297");
+		FREEZE_WITH_ERROR("E297");
 	}
 #endif
 
@@ -71,16 +71,16 @@ void SampleCache::clusterStolen(int32_t clusterIndex) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (writeBytePos < 0) {
-		display->freezeWithError("E298");
+		FREEZE_WITH_ERROR("E298");
 	}
 	else if (writeBytePos >= waveformLengthBytes) {
-		display->freezeWithError("E299");
+		FREEZE_WITH_ERROR("E299");
 	}
 
 	int32_t numExistentClusters = getNumExistentClusters(writeBytePos);
 
 	if (numExistentClusters != clusterIndex) {
-		display->freezeWithError("E295");
+		FREEZE_WITH_ERROR("E295");
 	}
 	clusters[clusterIndex] =
 	    NULL; // No need to remove this first Cluster from a queue or anything - that's already all done by the thing that's stealing it
@@ -92,7 +92,7 @@ void SampleCache::unlinkClusters(int32_t startAtIndex, bool beingDestructed) {
 	int32_t numExistentClusters = getNumExistentClusters(writeBytePos);
 	for (int32_t i = startAtIndex; i < numExistentClusters; i++) {
 		if (ALPHA_OR_BETA_VERSION && !clusters[i]) {
-			display->freezeWithError("E167");
+			FREEZE_WITH_ERROR("E167");
 		}
 
 		audioFileManager.deallocateCluster(clusters[i]);
@@ -108,15 +108,15 @@ void SampleCache::setWriteBytePos(int32_t newWriteBytePos) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (newWriteBytePos < 0) {
-		display->freezeWithError("E300");
+		FREEZE_WITH_ERROR("E300");
 	}
 	if (newWriteBytePos > waveformLengthBytes) {
-		display->freezeWithError("E301");
+		FREEZE_WITH_ERROR("E301");
 	}
 
 	uint32_t bytesPerSample = sample->numChannels * kCacheByteDepth;
 	if (newWriteBytePos != (uint32_t)newWriteBytePos / bytesPerSample * bytesPerSample) {
-		display->freezeWithError("E302");
+		FREEZE_WITH_ERROR("E302");
 	}
 #endif
 
@@ -129,7 +129,7 @@ void SampleCache::setWriteBytePos(int32_t newWriteBytePos) {
 	writeBytePos = newWriteBytePos;
 
 	if (ALPHA_OR_BETA_VERSION && getNumExistentClusters(writeBytePos) != newNumExistentClusters) {
-		display->freezeWithError("E294");
+		FREEZE_WITH_ERROR("E294");
 	}
 }
 
@@ -140,10 +140,10 @@ bool SampleCache::setupNewCluster(int32_t clusterIndex) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (clusterIndex >= numClusters) {
-		display->freezeWithError("E126");
+		FREEZE_WITH_ERROR("E126");
 	}
 	if (clusterIndex > getNumExistentClusters(writeBytePos)) {
-		display->freezeWithError("E293");
+		FREEZE_WITH_ERROR("E293");
 	}
 #endif
 
@@ -164,7 +164,7 @@ void SampleCache::prioritizeNotStealingCluster(int32_t clusterIndex) {
 
 	if (GeneralMemoryAllocator::get().getRegion(clusters[clusterIndex]) != MEMORY_REGION_STEALABLE) {
 		//clusters not in external
-		display->freezeWithError("C002");
+		FREEZE_WITH_ERROR("C002");
 		return; // Sorta just have to do this
 	}
 
@@ -174,7 +174,7 @@ void SampleCache::prioritizeNotStealingCluster(int32_t clusterIndex) {
 	// Remember, cache clusters never have "reasons", so we can assume these are already in one of the stealableClusterQueues, ready to be "stolen".
 #if ALPHA_OR_BETA_VERSION
 	if (clusters[clusterIndex]->numReasonsToBeLoaded != 0) {
-		display->freezeWithError("C003"); //let's just check to make sure
+		FREEZE_WITH_ERROR("C003"); //let's just check to make sure
 	}
 #endif
 	// First Cluster
@@ -193,7 +193,7 @@ void SampleCache::prioritizeNotStealingCluster(int32_t clusterIndex) {
 
 		if (GeneralMemoryAllocator::get().getRegion(clusters[clusterIndex - 1]) != MEMORY_REGION_STEALABLE) {
 			//clusters not in external
-			display->freezeWithError("C001");
+			FREEZE_WITH_ERROR("C001");
 			return; // Sorta just have to do this
 		}
 
@@ -225,10 +225,10 @@ int32_t SampleCache::getNumExistentClusters(int32_t thisWriteBytePos) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (numExistentClusters < 0) {
-		display->freezeWithError("E303");
+		FREEZE_WITH_ERROR("E303");
 	}
 	if (numExistentClusters > numClusters) {
-		display->freezeWithError("E304");
+		FREEZE_WITH_ERROR("E304");
 	}
 #endif
 

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -46,8 +46,8 @@ SampleCluster::~SampleCluster() {
 			Debug::print("uh oh, some reasons left... ");
 			Debug::println(numReasonsToBeLoaded);
 
-			display->freezeWithError(
-			    "E036"); // Bay_Mud got this, and thinks a FlashAir card might have been a catalyst. It still "shouldn't" be able to happen though.
+			// Bay_Mud got this, and thinks a FlashAir card might have been a catalyst. It still "shouldn't" be able to happen though.
+			FREEZE_WITH_ERROR("E036");
 		}
 #endif
 		audioFileManager.deallocateCluster(cluster);
@@ -62,10 +62,10 @@ void SampleCluster::ensureNoReason(Sample* sample) {
 			Debug::println(sample->filePath.get());
 
 			if (cluster->numReasonsToBeLoaded >= 0) {
-				display->freezeWithError("E068");
+				FREEZE_WITH_ERROR("E068");
 			}
 			else {
-				display->freezeWithError("E069");
+				FREEZE_WITH_ERROR("E069");
 			}
 			delayMS(50);
 		}
@@ -106,10 +106,10 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
 		if (cluster->numReasonsToBeLoaded != 1) {
-			display->freezeWithError("i005"); // Diversifying Qui's E341. It should actually be exactly 1
+			FREEZE_WITH_ERROR("i005"); // Diversifying Qui's E341. It should actually be exactly 1
 		}
 		if (cluster->type != ClusterType::Sample) {
-			display->freezeWithError("E256"); // Cos I got E236
+			FREEZE_WITH_ERROR("E256"); // Cos I got E236
 		}
 #endif
 
@@ -126,14 +126,14 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 justEnqueue:
 
 			if (ALPHA_OR_BETA_VERSION && cluster->type != ClusterType::Sample) {
-				display->freezeWithError("E236"); // Cos Chris F got an E205
+				FREEZE_WITH_ERROR("E236"); // Cos Chris F got an E205
 			}
 
 			audioFileManager.enqueueCluster(
 			    cluster, priorityRating); // TODO: If that fails, it'll just get awkwardly forgotten about
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
 			if (cluster && cluster->numReasonsToBeLoaded <= 0) {
-				display->freezeWithError("i027"); // Diversifying Ron R's i004, which was diversifying Qui's E341
+				FREEZE_WITH_ERROR("i027"); // Diversifying Ron R's i004, which was diversifying Qui's E341
 			}
 #endif
 		}
@@ -144,7 +144,7 @@ justEnqueue:
 			// cluster has (at least?) one reason - added above
 
 			if (ALPHA_OR_BETA_VERSION && cluster->type != ClusterType::Sample) {
-				display->freezeWithError("E234"); // Cos Chris F got an E205
+				FREEZE_WITH_ERROR("E234"); // Cos Chris F got an E205
 			}
 			bool result = audioFileManager.loadCluster(cluster, 1);
 
@@ -168,7 +168,7 @@ justEnqueue:
 			}
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
 			if (cluster && cluster->numReasonsToBeLoaded <= 0) {
-				display->freezeWithError("i026"); // Michael B got - insane.
+				FREEZE_WITH_ERROR("i026"); // Michael B got - insane.
 			}
 #endif
 		}
@@ -179,7 +179,7 @@ justEnqueue:
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on V4.1.3 have been getting E341.
 		if (cluster && cluster->numReasonsToBeLoaded < 0) {
-			display->freezeWithError("i028"); // bnhrsch got this!!
+			FREEZE_WITH_ERROR("i028"); // bnhrsch got this!!
 		}
 #endif
 
@@ -203,14 +203,14 @@ justEnqueue:
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on V4.0.x have been getting E341.
 		if (cluster && cluster->numReasonsToBeLoaded <= 0) {
-			display->freezeWithError("i025"); // Diversifying Ron R's i004, which was diversifying Qui's E341
+			FREEZE_WITH_ERROR("i025"); // Diversifying Ron R's i004, which was diversifying Qui's E341
 		}
 #endif
 	}
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on V4.0.x have been getting E341.
 	if (cluster && cluster->numReasonsToBeLoaded <= 0) {
-		display->freezeWithError("i004"); // Ron R got this! Diversifying Qui's E341
+		FREEZE_WITH_ERROR("i004"); // Ron R got this! Diversifying Qui's E341
 	}
 #endif
 

--- a/src/deluge/model/sample/sample_holder.cpp
+++ b/src/deluge/model/sample/sample_holder.cpp
@@ -43,7 +43,7 @@ SampleHolder::~SampleHolder() {
 		unassignAllClusterReasons(true);
 #if ALPHA_OR_BETA_VERSION
 		if (audioFile->numReasonsToBeLoaded <= 0) {
-			display->freezeWithError("E219"); // I put this here to try and catch an E004 Luc got
+			FREEZE_WITH_ERROR("E219"); // I put this here to try and catch an E004 Luc got
 		}
 #endif
 		audioFile->removeReason("E396");
@@ -130,7 +130,7 @@ void SampleHolder::setAudioFile(AudioFile* newSample, bool reversed, bool manual
 
 #if 1 || ALPHA_OR_BETA_VERSION
 		if (!audioFile) {
-			display->freezeWithError("i031"); // Trying to narrow down E368 that Kevin F got
+			FREEZE_WITH_ERROR("i031"); // Trying to narrow down E368 that Kevin F got
 		}
 #endif
 
@@ -145,7 +145,7 @@ constexpr int32_t kMarkerSamplesBeforeToClaim = 150;
 void SampleHolder::claimClusterReasons(bool reversed, int32_t clusterLoadInstruction) {
 
 	if (ALPHA_OR_BETA_VERSION && !audioFile) {
-		display->freezeWithError("E368");
+		FREEZE_WITH_ERROR("E368");
 	}
 
 	//unassignAllReasons(); // This now happens as part of reassessPosForMarker(), called below

--- a/src/deluge/model/sample/sample_holder_for_voice.cpp
+++ b/src/deluge/model/sample/sample_holder_for_voice.cpp
@@ -67,7 +67,7 @@ void SampleHolderForVoice::claimClusterReasons(bool reversed, int32_t clusterLoa
 
 #if ALPHA_OR_BETA_VERSION
 	if (!audioFile) {
-		display->freezeWithError("i030"); // Trying to narrow down E368 that Kevin F got
+		FREEZE_WITH_ERROR("i030"); // Trying to narrow down E368 that Kevin F got
 	}
 #endif
 

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -76,7 +76,7 @@ void SampleLowLevelReader::setupForPlayPosMovedIntoNewCluster(SamplePlaybackGuid
 
 #if ALPHA_OR_BETA_VERSION
 	if (!clusters[0]) {
-		display->freezeWithError("i022");
+		FREEZE_WITH_ERROR("i022");
 	}
 #endif
 
@@ -146,7 +146,7 @@ void SampleLowLevelReader::setupReassessmentLocation(SamplePlaybackGuide* guide,
 
 #if ALPHA_OR_BETA_VERSION
 	if (!clusters[0]) {
-		display->freezeWithError("i021");
+		FREEZE_WITH_ERROR("i021");
 	}
 #endif
 
@@ -195,7 +195,7 @@ void SampleLowLevelReader::setupReassessmentLocation(SamplePlaybackGuide* guide,
 			if ((endPosWithinCurrentCluster + currentClusterIndex * audioFileManager.clusterSize
 			     - sample->audioDataStartPosBytes)
 			    % bytesPerSample) {
-				display->freezeWithError("E163");
+				FREEZE_WITH_ERROR("E163");
 			}
 #endif
 			reassessmentLocation = clusters[0]->data + endPosWithinCurrentCluster;
@@ -339,7 +339,7 @@ bool SampleLowLevelReader::moveOnToNextCluster(SamplePlaybackGuide* guide, Sampl
 
 #if ALPHA_OR_BETA_VERSION
 	if (!clusters[0]) {
-		display->freezeWithError("i019");
+		FREEZE_WITH_ERROR("i019");
 	}
 #endif
 
@@ -451,7 +451,7 @@ bool SampleLowLevelReader::changeClusterIfNecessary(SamplePlaybackGuide* guide, 
 		count++;
 		if (count >= 1024) {
 			// This happened one time! When stopping AudioClips from playing back, after recording and mucking around with SD card reaching full
-			display->freezeWithError("E227");
+			FREEZE_WITH_ERROR("E227");
 		}
 #endif
 	}
@@ -566,7 +566,7 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
                                                   int32_t priorityRating) {
 
 	if (ALPHA_OR_BETA_VERSION && phaseIncrement < 0) {
-		display->freezeWithError("E228");
+		FREEZE_WITH_ERROR("E228");
 	}
 
 	int32_t bytesPerSample = sample->numChannels * sample->byteDepth;
@@ -595,7 +595,7 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 				int32_t bytesLeftWhichMayBeRead =
 				    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 				if (bytesLeftWhichMayBeRead < 0) {
-					display->freezeWithError("E222");
+					FREEZE_WITH_ERROR("E222");
 				}
 			}
 		}
@@ -610,7 +610,7 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 					int32_t bytesLeftWhichMayBeRead =
 					    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 					if (bytesLeftWhichMayBeRead < 0) {
-						display->freezeWithError("E305");
+						FREEZE_WITH_ERROR("E305");
 					}
 				}
 
@@ -630,7 +630,7 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 					int32_t bytesLeftWhichMayBeRead =
 					    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 					if (bytesLeftWhichMayBeRead < 0) {
-						display->freezeWithError("E306");
+						FREEZE_WITH_ERROR("E306");
 					}
 				}
 			}
@@ -642,7 +642,7 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 					int32_t bytesLeftWhichMayBeRead =
 					    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 					if (bytesLeftWhichMayBeRead < 0) {
-						display->freezeWithError("E308");
+						FREEZE_WITH_ERROR("E308");
 					}
 				}
 
@@ -675,7 +675,7 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 					int32_t bytesLeftWhichMayBeRead =
 					    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 					if (bytesLeftWhichMayBeRead < 0) {
-						display->freezeWithError("E221");
+						FREEZE_WITH_ERROR("E221");
 					}
 				}
 			}
@@ -723,13 +723,13 @@ doZeroes:
 
 					if (ALPHA_OR_BETA_VERSION) {
 						if (!clusters[0]) {
-							display->freezeWithError("E225");
+							FREEZE_WITH_ERROR("E225");
 						}
 
 						int32_t bytesLeftWhichMayBeRead =
 						    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 						if (bytesLeftWhichMayBeRead <= 0) {
-							display->freezeWithError("E226");
+							FREEZE_WITH_ERROR("E226");
 						}
 					}
 
@@ -744,7 +744,7 @@ doZeroes:
 						int32_t bytesLeftWhichMayBeRead =
 						    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 						if (bytesLeftWhichMayBeRead < 0) {
-							display->freezeWithError("E185");
+							FREEZE_WITH_ERROR("E185");
 						}
 					}
 				}
@@ -759,7 +759,7 @@ doZeroes:
 				int32_t bytesLeftWhichMayBeRead =
 				    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 				if (bytesLeftWhichMayBeRead < 0) {
-					display->freezeWithError("E223");
+					FREEZE_WITH_ERROR("E223");
 				}
 			}
 		}
@@ -789,7 +789,7 @@ doZeroes:
 				int32_t bytesLeftWhichMayBeRead =
 				    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 				if (ALPHA_OR_BETA_VERSION && bytesLeftWhichMayBeRead < 0) {
-					display->freezeWithError("E148");
+					FREEZE_WITH_ERROR("E148");
 				}
 
 				int32_t bytesWeWantToRead = samplesWeWantToReadThisWindow * bytesPerSample;
@@ -810,10 +810,10 @@ doZeroes:
 				// This really really should never happen.
 				if (ALPHA_OR_BETA_VERSION && phaseIncrementingLeftWhichMayBeDone < 0) {
 					if (!clusters[0]) {
-						display->freezeWithError("E143");
+						FREEZE_WITH_ERROR("E143");
 					}
 					else {
-						display->freezeWithError("E000");
+						FREEZE_WITH_ERROR("E000");
 					}
 				}
 
@@ -853,7 +853,7 @@ doZeroes:
 		    (int32_t)((uint32_t)reassessmentLocation - (uint32_t)currentPlayPos) * guide->playDirection;
 
 		if (ALPHA_OR_BETA_VERSION && bytesLeftWhichMayBeRead <= 0) {
-			display->freezeWithError("E001");
+			FREEZE_WITH_ERROR("E001");
 		}
 
 		// If there are actually less bytes remaining than we ideally wanted for this window...
@@ -863,7 +863,7 @@ doZeroes:
 			if (ALPHA_OR_BETA_VERSION && *numSamples <= 0) {
 				Debug::print("bytesLeftWhichMayBeRead: ");
 				Debug::println(bytesLeftWhichMayBeRead);
-				display->freezeWithError("E147"); // Crazily, Michael B got in Nov 2022, when "closing" a recorded loop.
+				FREEZE_WITH_ERROR("E147"); // Crazily, Michael B got in Nov 2022, when "closing" a recorded loop.
 			}
 		}
 	}

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -86,7 +86,7 @@ void SampleRecorder::detachSample() {
 
 			// Some bug-hunting
 			if (!cluster->numReasonsHeldBySampleRecorder) {
-				display->freezeWithError("E345");
+				FREEZE_WITH_ERROR("E345");
 			}
 			cluster->numReasonsHeldBySampleRecorder--;
 
@@ -103,12 +103,12 @@ void SampleRecorder::detachSample() {
 		Cluster* cluster = sample->clusters.getElement(firstUnwrittenClusterIndex)->cluster;
 
 		if (!cluster) {
-			display->freezeWithError("E363");
+			FREEZE_WITH_ERROR("E363");
 		}
 
 		// Some bug-hunting
 		if (!cluster->numReasonsHeldBySampleRecorder) {
-			display->freezeWithError("E346");
+			FREEZE_WITH_ERROR("E346");
 		}
 		cluster->numReasonsHeldBySampleRecorder--;
 
@@ -156,7 +156,7 @@ gotError:
 
 	// Bug hunting - newly gotten Cluster
 	if (currentRecordCluster->numReasonsHeldBySampleRecorder) {
-		display->freezeWithError("E360");
+		FREEZE_WITH_ERROR("E360");
 	}
 	currentRecordCluster->numReasonsHeldBySampleRecorder++;
 
@@ -330,7 +330,7 @@ aborted:
 			// It should be impossible that anyone else still holds a "reason" to this Sample, as we can only be "aborted"
 			// before AudioClip::finishLinearRecording() is called, and it's only then at the AudioClip becomes a "reason".
 			if (sample->numReasonsToBeLoaded) {
-				display->freezeWithError("E282");
+				FREEZE_WITH_ERROR("E282");
 			}
 #endif
 
@@ -502,7 +502,7 @@ int32_t SampleRecorder::writeOneCompletedCluster() {
 	// Trying to pin down E347 which Leo got, below
 	Cluster* cluster = sample->clusters.getElement(writingClusterIndex)->cluster;
 	if (!cluster->numReasonsHeldBySampleRecorder) {
-		display->freezeWithError("E374");
+		FREEZE_WITH_ERROR("E374");
 	}
 #endif
 
@@ -517,7 +517,7 @@ int32_t SampleRecorder::writeOneCompletedCluster() {
 		// Some bug-hunting
 		if (!cluster->numReasonsHeldBySampleRecorder) {
 			// Leo got!!! And Vinz, and keyman. May be solved now that fixed so detachSample() doesn't get called during card routine.
-			display->freezeWithError("E347");
+			FREEZE_WITH_ERROR("E347");
 		}
 		cluster->numReasonsHeldBySampleRecorder--;
 
@@ -531,7 +531,7 @@ int32_t SampleRecorder::writeOneCompletedCluster() {
 int32_t SampleRecorder::finalizeRecordedFile() {
 
 	if (ALPHA_OR_BETA_VERSION && (status == RECORDER_STATUS_ABORTED || hadCardError)) {
-		display->freezeWithError("E273");
+		FREEZE_WITH_ERROR("E273");
 	}
 
 	Debug::println("finalizing");
@@ -575,7 +575,7 @@ int32_t SampleRecorder::finalizeRecordedFile() {
 
 			// Some bug-hunting
 			if (!currentRecordCluster->numReasonsHeldBySampleRecorder) {
-				display->freezeWithError("E348");
+				FREEZE_WITH_ERROR("E348");
 			}
 			currentRecordCluster->numReasonsHeldBySampleRecorder--;
 
@@ -677,11 +677,11 @@ int32_t SampleRecorder::finalizeRecordedFile() {
 
 				// Do a last-ditch check that the SD address doesn't look invalid
 				if (firstSampleCluster->sdAddress == 0) {
-					display->freezeWithError("E268");
+					FREEZE_WITH_ERROR("E268");
 				}
 				if ((firstSampleCluster->sdAddress - fileSystemStuff.fileSystem.database)
 				    & (fileSystemStuff.fileSystem.csize - 1)) {
-					display->freezeWithError("E269");
+					FREEZE_WITH_ERROR("E269");
 				}
 
 				audioDataLengthBytesAsWrittenToFile = sample->audioDataLengthBytes;
@@ -695,7 +695,7 @@ int32_t SampleRecorder::finalizeRecordedFile() {
 
 				// Some bug-hunting
 				if (!cluster->numReasonsHeldBySampleRecorder) {
-					display->freezeWithError("E349");
+					FREEZE_WITH_ERROR("E349");
 				}
 				cluster->numReasonsHeldBySampleRecorder--;
 
@@ -800,7 +800,7 @@ int32_t SampleRecorder::createNextCluster() {
 
 	// Bug hunting - newly gotten Cluster
 	if (currentRecordCluster->numReasonsHeldBySampleRecorder) {
-		display->freezeWithError("E362");
+		FREEZE_WITH_ERROR("E362");
 	}
 	currentRecordCluster->numReasonsHeldBySampleRecorder++;
 
@@ -835,7 +835,7 @@ void SampleRecorder::feedAudio(int32_t* __restrict__ inputAddress, int32_t numSa
 	do {
 		int32_t numSamplesThisCycle = numSamples;
 		if (ALPHA_OR_BETA_VERSION && numSamplesThisCycle <= 0) {
-			display->freezeWithError("cccc");
+			FREEZE_WITH_ERROR("cccc");
 		}
 
 		// If haven't actually started recording yet cos we're compensating for lag...
@@ -860,7 +860,7 @@ doFinishCapturing:
 				numSamplesThisCycle = std::min(numSamplesThisCycle, samplesLeft);
 			}
 			if (ALPHA_OR_BETA_VERSION && numSamplesThisCycle <= 0) {
-				display->freezeWithError("bbbb");
+				FREEZE_WITH_ERROR("bbbb");
 			}
 
 			int32_t bytesPerSample = recordingNumChannels * 3;
@@ -890,7 +890,7 @@ doFinishCapturing:
 			}
 
 			if (ALPHA_OR_BETA_VERSION && numSamplesThisCycle <= 0) {
-				display->freezeWithError("aaaa");
+				FREEZE_WITH_ERROR("aaaa");
 			}
 
 			int32_t* endInputNow = inputAddress + (numSamplesThisCycle << NUM_MONO_INPUT_CHANNELS_MAGNITUDE);
@@ -1031,19 +1031,19 @@ doFinishCapturing:
 void SampleRecorder::endSyncedRecording(int32_t buttonLatencyForTempolessRecording) {
 #if ALPHA_OR_BETA_VERSION
 	if (status == RECORDER_STATUS_CAPTURING_DATA_WAITING_TO_STOP) {
-		display->freezeWithError("E272");
+		FREEZE_WITH_ERROR("E272");
 	}
 	else if (status == RECORDER_STATUS_FINISHED_CAPTURING_BUT_STILL_WRITING) {
-		display->freezeWithError("E288");
+		FREEZE_WITH_ERROR("E288");
 	}
 	else if (status == RECORDER_STATUS_COMPLETE) {
-		display->freezeWithError("E289");
+		FREEZE_WITH_ERROR("E289");
 	}
 	else if (status == RECORDER_STATUS_ABORTED) {
-		display->freezeWithError("E290");
+		FREEZE_WITH_ERROR("E290");
 	}
 	else if (status == RECORDER_STATUS_AWAITING_DELETION) {
-		display->freezeWithError("E291");
+		FREEZE_WITH_ERROR("E291");
 	}
 #endif
 
@@ -1087,7 +1087,7 @@ void SampleRecorder::totalSampleLengthNowKnown(uint32_t totalLengthSamples, uint
 		Cluster* cluster =
 		    firstSampleCluster->cluster; // It should still be there, cos it hasn't been written to card yet
 		if (ALPHA_OR_BETA_VERSION && !cluster) {
-			display->freezeWithError("E274");
+			FREEZE_WITH_ERROR("E274");
 		}
 
 		audioDataLengthBytesAsWrittenToFile = sample->audioDataLengthBytes;
@@ -1138,7 +1138,7 @@ int32_t SampleRecorder::alterFile(int32_t action, int32_t lshiftAmount, uint32_t
 	int32_t numClustersBeforeAction =
 	    ((idealFileSizeBeforeAction - 1) >> audioFileManager.clusterSizeMagnitude) + 1; // Rounds up
 	if (ALPHA_OR_BETA_VERSION && numClustersBeforeAction > sample->clusters.getNumElements()) {
-		display->freezeWithError("E286");
+		FREEZE_WITH_ERROR("E286");
 	}
 
 	Cluster* nextReadCluster = NULL;
@@ -1150,7 +1150,7 @@ int32_t SampleRecorder::alterFile(int32_t action, int32_t lshiftAmount, uint32_t
 
 			// Some bug-hunting
 			if (!currentReadCluster->numReasonsHeldBySampleRecorder) {
-				display->freezeWithError("E350");
+				FREEZE_WITH_ERROR("E350");
 			}
 			currentReadCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1251,10 +1251,10 @@ int32_t SampleRecorder::alterFile(int32_t action, int32_t lshiftAmount, uint32_t
 
 			// Do a last-ditch check that the SD address doesn't look invalid
 			if (sdAddress == 0) {
-				display->freezeWithError("E268");
+				FREEZE_WITH_ERROR("E268");
 			}
 			if ((sdAddress - fileSystemStuff.fileSystem.database) & (fileSystemStuff.fileSystem.csize - 1)) {
-				display->freezeWithError("E275");
+				FREEZE_WITH_ERROR("E275");
 			}
 
 			// Write the Cluster we just finished processing to card
@@ -1274,7 +1274,7 @@ int32_t SampleRecorder::alterFile(int32_t action, int32_t lshiftAmount, uint32_t
 
 			// Some bug-hunting
 			if (!currentWriteCluster->numReasonsHeldBySampleRecorder) {
-				display->freezeWithError("E351");
+				FREEZE_WITH_ERROR("E351");
 			}
 			currentWriteCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1288,7 +1288,7 @@ writeFailed:
 
 				// Some bug-hunting
 				if (!currentReadCluster->numReasonsHeldBySampleRecorder) {
-					display->freezeWithError("E352");
+					FREEZE_WITH_ERROR("E352");
 				}
 				currentReadCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1297,7 +1297,7 @@ writeFailed:
 				if (nextReadCluster) {
 					// Some bug-hunting
 					if (!nextReadCluster->numReasonsHeldBySampleRecorder) {
-						display->freezeWithError("E353");
+						FREEZE_WITH_ERROR("E353");
 					}
 					nextReadCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1347,7 +1347,7 @@ writeFailed:
 
 			// Some bug-hunting
 			if (!currentReadCluster->numReasonsHeldBySampleRecorder) {
-				display->freezeWithError("E354");
+				FREEZE_WITH_ERROR("E354");
 			}
 			currentReadCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1366,7 +1366,7 @@ writeFailed:
 
 					// Some bug-hunting
 					if (!currentReadCluster->numReasonsHeldBySampleRecorder) {
-						display->freezeWithError("E355");
+						FREEZE_WITH_ERROR("E355");
 					}
 					currentReadCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1374,7 +1374,7 @@ writeFailed:
 
 					// Some bug-hunting
 					if (!currentWriteCluster->numReasonsHeldBySampleRecorder) {
-						display->freezeWithError("E356");
+						FREEZE_WITH_ERROR("E356");
 					}
 					currentWriteCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1398,7 +1398,7 @@ writeFailed:
 
 	// Some bug-hunting
 	if (!currentReadCluster->numReasonsHeldBySampleRecorder) {
-		display->freezeWithError("E357");
+		FREEZE_WITH_ERROR("E357");
 	}
 	currentReadCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1416,24 +1416,24 @@ writeFailed:
 
 		uint32_t numSectorsToWrite = ((bytesToWriteFinalCluster - 1) >> 9) + 1;
 		if (numSectorsToWrite > (audioFileManager.clusterSize >> 9)) {
-			display->freezeWithError("E239");
+			FREEZE_WITH_ERROR("E239");
 		}
 
 		uint32_t sdAddress = sample->clusters.getElement(currentWriteClusterIndex)->sdAddress;
 
 		// Do a last-ditch check that the SD address doesn't look invalid
 		if (sdAddress == 0) {
-			display->freezeWithError("E268");
+			FREEZE_WITH_ERROR("E268");
 		}
 		if ((sdAddress - fileSystemStuff.fileSystem.database) & (fileSystemStuff.fileSystem.csize - 1)) {
-			display->freezeWithError("E276");
+			FREEZE_WITH_ERROR("E276");
 		}
 
 		DRESULT result = disk_write(0, (BYTE*)currentWriteCluster->data, sdAddress, numSectorsToWrite);
 
 		// Some bug-hunting
 		if (!currentWriteCluster->numReasonsHeldBySampleRecorder) {
-			display->freezeWithError("E358");
+			FREEZE_WITH_ERROR("E358");
 		}
 		currentWriteCluster->numReasonsHeldBySampleRecorder--;
 
@@ -1467,7 +1467,7 @@ writeFailed:
 
 		// Some bug-hunting
 		if (!currentWriteCluster->numReasonsHeldBySampleRecorder) {
-			display->freezeWithError("E359");
+			FREEZE_WITH_ERROR("E359");
 		}
 		currentWriteCluster->numReasonsHeldBySampleRecorder--;
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2756,7 +2756,7 @@ void Song::deleteClipObject(Clip* clip, bool songBeingDestroyedToo, InstrumentRe
 #if ALPHA_OR_BETA_VERSION
 	if (clip->type == CLIP_TYPE_AUDIO) {
 		if (((AudioClip*)clip)->recorder) {
-			display->freezeWithError("i001"); // Trying to diversify Qui's E278
+			FREEZE_WITH_ERROR("i001"); // Trying to diversify Qui's E278
 		}
 	}
 #endif
@@ -2971,7 +2971,7 @@ void Song::replaceInstrument(Instrument* oldOutput, Instrument* newOutput, bool 
 	for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
 		if (thisOutput == newOutput) {
 			display->cancelPopup();
-			display->freezeWithError("i009");
+			FREEZE_WITH_ERROR("i009");
 		}
 	}
 
@@ -3563,15 +3563,15 @@ void Song::deleteBackedUpParamManagersForClip(Clip* clip) {
 		if (i >= 1) {
 
 			if (backedUp->modControllable < lastModControllable) {
-				display->freezeWithError("E053");
+				FREEZE_WITH_ERROR("E053");
 			}
 
 			else if (backedUp->modControllable == lastModControllable) {
 				if (backedUp->clip < lastClip) {
-					display->freezeWithError("E054");
+					FREEZE_WITH_ERROR("E054");
 				}
 				else if (backedUp->clip == lastClip) {
-					display->freezeWithError("E055");
+					FREEZE_WITH_ERROR("E055");
 				}
 			}
 		}
@@ -3903,7 +3903,7 @@ void Song::sortOutWhichClipsAreActiveWithoutSendingPGMs(ModelStack* modelStack,
 					if (!getBackedUpParamManagerPreferablyWithClip(soundDrum, NULL)) { // If no backedUpParamManager...
 						if (!findParamManagerForDrum(kit,
 						                             soundDrum)) { // If no ParamManager with a NoteRow somewhere...
-							display->freezeWithError("E102");
+							FREEZE_WITH_ERROR("E102");
 						}
 					}
 				}
@@ -4081,7 +4081,7 @@ void Song::ensureAllInstrumentsHaveAClipOrBackedUpParamManager(char const* error
 		else {
 			if (!getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)thisOutput->toModControllable(),
 			                                               NULL)) {
-				display->freezeWithError(errorMessageNormal);
+				FREEZE_WITH_ERROR(errorMessageNormal);
 			}
 		}
 	}
@@ -4097,14 +4097,14 @@ void Song::ensureAllInstrumentsHaveAClipOrBackedUpParamManager(char const* error
 
 		// If has Clip, it shouldn't!
 		if (getClipWithOutput(thisInstrument)) {
-			display->freezeWithError(
-			    "E056"); // gtridr got, V4.0.0-beta2. Before I fixed memory corruption issues, so hopefully could just be that.
+			// gtridr got, V4.0.0-beta2. Before I fixed memory corruption issues, so hopefully could just be that.
+			FREEZE_WITH_ERROR("E056");
 		}
 
 		else {
 			if (!getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)thisInstrument->toModControllable(),
 			                                               NULL)) {
-				display->freezeWithError(errorMessageHibernating);
+				FREEZE_WITH_ERROR(errorMessageHibernating);
 			}
 		}
 	}

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -2018,7 +2018,7 @@ void Voice::renderBasicSource(Sound* sound, ParamManagerForTimeline* paramManage
 instantUnassign:
 
 #ifdef TEST_SAMPLE_LOOP_POINTS
-			display->freezeWithError("YEP");
+			FREEZE_WITH_ERROR("YEP");
 #endif
 
 			*unisonPartBecameInactive = true;

--- a/src/deluge/model/voice/voice_sample.cpp
+++ b/src/deluge/model/voice/voice_sample.cpp
@@ -122,7 +122,7 @@ void VoiceSample::setupCacheLoopPoints(SamplePlaybackGuide* guide, Sample* sampl
 		if (ALPHA_OR_BETA_VERSION && cacheEndPointBytes > cache->waveformLengthBytes) {
 			Debug::println(cacheEndPointBytes);
 			Debug::println(cache->waveformLengthBytes);
-			display->freezeWithError("E128");
+			FREEZE_WITH_ERROR("E128");
 		}
 	}
 
@@ -182,7 +182,7 @@ int32_t VoiceSample::attemptLateSampleStart(SamplePlaybackGuide* voiceSource, Sa
 	}
 
 	if ((int64_t)(startAtByte - voiceSource->startPlaybackAtByte) * voiceSource->playDirection < 0) {
-		display->freezeWithError("E439"); // Chasing "E366".
+		FREEZE_WITH_ERROR("E439"); // Chasing "E366".
 	}
 
 	uint32_t startAtClusterIndex = startAtByte >> audioFileManager.clusterSizeMagnitude;
@@ -192,7 +192,7 @@ int32_t VoiceSample::attemptLateSampleStart(SamplePlaybackGuide* voiceSource, Sa
 		// This was a problem around V3.1.0 release, so currently keeping this check
 		// even outside of ALPHA_OR_BETA_VERSION.
 		// Sven got! 4.0.0-beta4.
-		display->freezeWithError("E366");
+		FREEZE_WITH_ERROR("E366");
 	}
 
 	int32_t finalClusterIndex = voiceSource->getFinalClusterIndex(sample, cache); // Think this is right...
@@ -631,10 +631,10 @@ readCachedWindow:
 
 			// If we're here, then timeStretchRatio should be 16777216, and phaseIncrement should *not*
 			if (ALPHA_OR_BETA_VERSION && timeStretchRatio != 16777216) {
-				display->freezeWithError("E240"); // This should have been caught and dealt with above
+				FREEZE_WITH_ERROR("E240"); // This should have been caught and dealt with above
 			}
 			if (ALPHA_OR_BETA_VERSION && phaseIncrement == 16777216) {
-				display->freezeWithError("E241"); // If this were the case, there'd be no reason to have a cache
+				FREEZE_WITH_ERROR("E241"); // If this were the case, there'd be no reason to have a cache
 			}
 
 			if (!stopReadingFromCache()) {
@@ -674,7 +674,7 @@ readCachedWindow:
 
 		// This shouldn't happen - it gets checked for up at the start
 		else if (ALPHA_OR_BETA_VERSION && bytesTilCacheEnd < 0) {
-			display->freezeWithError("E164");
+			FREEZE_WITH_ERROR("E164");
 		}
 
 		int32_t cachedClusterIndex = cacheBytePos >> audioFileManager.clusterSizeMagnitude;
@@ -683,7 +683,7 @@ readCachedWindow:
 		Cluster* cacheCluster = cache->getCluster(cachedClusterIndex);
 		if (ALPHA_OR_BETA_VERSION
 		    && !cacheCluster) { // If it got stolen - but we should have already detected this above
-			display->freezeWithError("E157");
+			FREEZE_WITH_ERROR("E157");
 		}
 		int32_t* __restrict__ readPos = (int32_t*)&cacheCluster->data[bytePosWithinCluster - 4 + kCacheByteDepth];
 
@@ -716,7 +716,7 @@ readCachedWindow:
 		}
 
 		if (ALPHA_OR_BETA_VERSION && numSamplesThisCacheRead <= 0) {
-			display->freezeWithError("E156");
+			FREEZE_WITH_ERROR("E156");
 		}
 
 		// Ok, now we know how many samples we can read from the cache right now. Do it.
@@ -897,7 +897,7 @@ uncachedPlayback:
 			Cluster* cacheCluster = cache->getCluster(cacheClusterIndex);
 			if (ALPHA_OR_BETA_VERSION && !cacheCluster) {
 				// Check that the Cluster hasn't been stolen - but this should have been detected right at the start
-				display->freezeWithError("E166");
+				FREEZE_WITH_ERROR("E166");
 			}
 			cacheWritePos = &cacheCluster->data[bytePosWithinCluster];
 
@@ -925,7 +925,7 @@ uncachedPlayback:
 			}
 
 			if (ALPHA_OR_BETA_VERSION && numSamplesThisUncachedRead <= 0) {
-				display->freezeWithError("E155");
+				FREEZE_WITH_ERROR("E155");
 			}
 		}
 
@@ -992,7 +992,7 @@ assessLoopPointAgainTimestretched:
 
 #if ALPHA_OR_BETA_VERSION
 							if (count >= 1024) {
-								display->freezeWithError("E169");
+								FREEZE_WITH_ERROR("E169");
 							}
 							count++;
 #endif
@@ -1011,7 +1011,7 @@ assessLoopPointAgainTimestretched:
 						    (uint64_t)combinedIncrementingLeftToDoAbsolute / combinedIncrement;
 						if (ALPHA_OR_BETA_VERSION && combinedIncrementsLeft > numSamplesThisUncachedRead) {
 							Debug::println(combinedIncrementsLeft);
-							display->freezeWithError("E151");
+							FREEZE_WITH_ERROR("E151");
 						}
 						numSamplesThisUncachedRead = combinedIncrementsLeft;
 					}

--- a/src/deluge/model/voice/voice_vector.cpp
+++ b/src/deluge/model/voice/voice_vector.cpp
@@ -31,7 +31,7 @@ void VoiceVector::checkVoiceExists(Voice* voice, Sound* sound, char const* error
 		int32_t i = searchMultiWordExact(searchWords);
 
 		if (i == -1) {
-			display->freezeWithError(errorCode);
+			FREEZE_WITH_ERROR(errorCode);
 		}
 	}
 }

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -409,7 +409,7 @@ void Arpeggiator::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstructi
 
 #if ALPHA_OR_BETA_VERSION
 	if (whichNoteCurrentlyOnPostArp < 0 || whichNoteCurrentlyOnPostArp >= notes.getNumElements()) {
-		display->freezeWithError("E404");
+		FREEZE_WITH_ERROR("E404");
 	}
 #endif
 

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -262,7 +262,7 @@ skipThat : {}
 			if (nodes.getNumElements()) {
 				ParamNode* rightmostNode = nodes.getElement(nodes.getNumElements() - 1);
 				if (rightmostNode->pos >= effectiveLength) {
-					display->freezeWithError("llll");
+					FREEZE_WITH_ERROR("llll");
 				}
 			}
 #endif
@@ -705,7 +705,7 @@ adjustNodeJustReached:
 		// we still contain automation, which I think we have to... Let's just verify that.
 #if ALPHA_OR_BETA_VERSION
 		if (!isAutomated()) {
-			display->freezeWithError("E372");
+			FREEZE_WITH_ERROR("E372");
 		}
 #endif
 		modelStack->paramCollection->notifyParamModifiedInSomeWay(modelStack, oldValue, false, true, true);
@@ -733,7 +733,7 @@ getOut:
 		ParamNode* rightmostNode = nodes.getElement(i);
 		if (rightmostNode->pos >= effectiveLength) {
 			nodes.deleteAtIndex(i);
-			//display->freezeWithError("jjjj"); // drbourbon got! And Quixotic7, on V4.0.0-beta8.
+			//FREEZE_WITH_ERROR("jjjj"); // drbourbon got! And Quixotic7, on V4.0.0-beta8.
 		}
 	}
 
@@ -1012,14 +1012,14 @@ int32_t AutoParam::homogenizeRegion(ModelStackWithAutoParam const* modelStack, i
 #if ALPHA_OR_BETA_VERSION
 	// Chasing "E433" / "GGGG" error (probably now largely solved - except got E435, see below).
 	if (length <= 0) {
-		display->freezeWithError("E427");
+		FREEZE_WITH_ERROR("E427");
 	}
 	if (startPos < 0) {
-		display->freezeWithError("E437");
+		FREEZE_WITH_ERROR("E437");
 	}
 	// nodes.testSequentiality("E435"); // drbourbon got! March 2022. Now moved check to each caller.
 	if (nodes.getNumElements() && nodes.getFirst()->pos < 0) {
-		display->freezeWithError("E436");
+		FREEZE_WITH_ERROR("E436");
 	}
 	// Should probably also check that stuff doesn't exist too far right - but that's a bit more complicated.
 #endif
@@ -1037,7 +1037,7 @@ int32_t AutoParam::homogenizeRegion(ModelStackWithAutoParam const* modelStack, i
 			length = maxLength;
 #if ALPHA_OR_BETA_VERSION
 			if (length <= 0) {
-				display->freezeWithError("E428"); // Chasing Leo's GGGG error (probably now solved).
+				FREEZE_WITH_ERROR("E428"); // Chasing Leo's GGGG error (probably now solved).
 			}
 #endif
 			interpolateRightNode = false;
@@ -1070,7 +1070,7 @@ int32_t AutoParam::homogenizeRegion(ModelStackWithAutoParam const* modelStack, i
 	else {
 		if constexpr (ALPHA_OR_BETA_VERSION || kCurrentFirmwareVersion <= FIRMWARE_4P0P0) {
 			if (startPos < posAtWhichClipWillCut) {
-				display->freezeWithError("E445");
+				FREEZE_WITH_ERROR("E445");
 			}
 		}
 		edgePositions[REGION_EDGE_RIGHT] = startPos;
@@ -1082,7 +1082,7 @@ int32_t AutoParam::homogenizeRegion(ModelStackWithAutoParam const* modelStack, i
 			length = edgePositions[REGION_EDGE_RIGHT] - edgePositions[REGION_EDGE_LEFT];
 			if constexpr (ALPHA_OR_BETA_VERSION) {
 				if (edgePositions[REGION_EDGE_LEFT] >= edgePositions[REGION_EDGE_RIGHT]) {
-					display->freezeWithError("HHHH");
+					FREEZE_WITH_ERROR("HHHH");
 				}
 			}
 
@@ -1217,7 +1217,7 @@ getValueNormalWay:
 	if (nodes.getNumElements()) {
 		ParamNode* rightmostNode = nodes.getElement(nodes.getNumElements() - 1);
 		if (rightmostNode->pos >= effectiveLength) {
-			display->freezeWithError("iiii");
+			FREEZE_WITH_ERROR("iiii");
 		}
 	}
 #endif
@@ -1237,24 +1237,24 @@ void AutoParam::homogenizeRegionTestSuccess(int32_t pos, int32_t regionEnd, int3
 		// Fine
 	}
 	else {
-		display->freezeWithError("E119");
+		FREEZE_WITH_ERROR("E119");
 	}
 
 	ParamNode* startNode = nodes.getElement(startI);
 	ParamNode* endNode = nodes.getElement(endI);
 
 	if (!startNode || !endNode) {
-		display->freezeWithError("E118");
+		FREEZE_WITH_ERROR("E118");
 	}
 
 	if (startNode->value != startValue) {
-		display->freezeWithError("E120");
+		FREEZE_WITH_ERROR("E120");
 	}
 	if (startNode->interpolated != interpolateStart) {
-		display->freezeWithError("E121");
+		FREEZE_WITH_ERROR("E121");
 	}
 	if (endNode->interpolated != interpolateEnd) {
-		display->freezeWithError("E122");
+		FREEZE_WITH_ERROR("E122");
 	}
 }
 
@@ -1714,7 +1714,7 @@ void AutoParam::trimToLength(uint32_t newLength, Action* action, ModelStackWithA
 	int32_t newNumNodes = nodes.search(newLength, GREATER_OR_EQUAL);
 
 	if (ALPHA_OR_BETA_VERSION && newNumNodes >= nodes.getNumElements()) {
-		display->freezeWithError("E315");
+		FREEZE_WITH_ERROR("E315");
 	}
 
 	// If still at least 2 nodes afterwards (1 is not allowed, actually wait it is now but let's keep this safe for now)...
@@ -2566,7 +2566,7 @@ void AutoParam::nudgeNonInterpolatingNodesAtPos(int32_t pos, int32_t offset, int
 doWrap:
 				// There should never be just one node
 				if (ALPHA_OR_BETA_VERSION && nodes.getNumElements() == 1) {
-					display->freezeWithError("E335");
+					FREEZE_WITH_ERROR("E335");
 				}
 				int32_t ourValue = node->value; // Grab this before deleting stuff
 
@@ -2596,7 +2596,7 @@ doWrap:
 						int32_t error = nodes.insertAtIndex(
 						    nextNodeI); // This shouldn't be able to fail, cos we just deleted a node
 						if (ALPHA_OR_BETA_VERSION && error) {
-							display->freezeWithError("E333");
+							FREEZE_WITH_ERROR("E333");
 						}
 					}
 

--- a/src/deluge/modulation/params/param_manager.cpp
+++ b/src/deluge/modulation/params/param_manager.cpp
@@ -48,7 +48,7 @@ ParamManager::~ParamManager() {
 
 #if ALPHA_OR_BETA_VERSION
 ParamManagerForTimeline* ParamManager::toForTimeline() {
-	display->freezeWithError("E407");
+	FREEZE_WITH_ERROR("E407");
 	return NULL;
 }
 
@@ -113,7 +113,7 @@ ramError2:
 void ParamManager::stealParamCollectionsFrom(ParamManager* other, bool stealExpressionParams) {
 #if ALPHA_OR_BETA_VERSION
 	if (!other) {
-		display->freezeWithError("E413");
+		FREEZE_WITH_ERROR("E413");
 	}
 #endif
 
@@ -300,7 +300,7 @@ ExpressionParamSet* ParamManager::getOrCreateExpressionParamSet(bool forDrum) {
 ModelStackWithParamCollection* ParamManager::getPatchCableSet(ModelStackWithThreeMainThings const* modelStack) {
 #if ALPHA_OR_BETA_VERSION
 	if (!summaries[2].paramCollection) {
-		display->freezeWithError("E412");
+		FREEZE_WITH_ERROR("E412");
 	}
 #endif
 	return modelStack->addParamCollection(summaries[2].paramCollection, &summaries[2]);
@@ -315,7 +315,7 @@ ParamManagerForTimeline::ParamManagerForTimeline() {
 void ParamManagerForTimeline::ensureSomeParamCollections() {
 #if ALPHA_OR_BETA_VERSION
 	if (!summaries[0].paramCollection) {
-		display->freezeWithError("E408");
+		FREEZE_WITH_ERROR("E408");
 	}
 #endif
 }

--- a/src/deluge/modulation/params/param_manager.h
+++ b/src/deluge/modulation/params/param_manager.h
@@ -80,7 +80,7 @@ public:
 	inline MIDIParamCollection* getMIDIParamCollection() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[0].paramCollection) {
-			display->freezeWithError("E409");
+			FREEZE_WITH_ERROR("E409");
 		}
 #endif
 		return (MIDIParamCollection*)summaries[0].paramCollection;
@@ -89,7 +89,7 @@ public:
 	inline ParamCollectionSummary* getMIDIParamCollectionSummary() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[0].paramCollection) {
-			display->freezeWithError("E409");
+			FREEZE_WITH_ERROR("E409");
 		}
 #endif
 		return &summaries[0];
@@ -98,7 +98,7 @@ public:
 	inline UnpatchedParamSet* getUnpatchedParamSet() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[0].paramCollection) {
-			display->freezeWithError("E410");
+			FREEZE_WITH_ERROR("E410");
 		}
 #endif
 		return (UnpatchedParamSet*)summaries[0].paramCollection;
@@ -107,7 +107,7 @@ public:
 	inline ParamCollectionSummary* getUnpatchedParamSetSummary() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[0].paramCollection) {
-			display->freezeWithError("E410");
+			FREEZE_WITH_ERROR("E410");
 		}
 #endif
 		return &summaries[0];
@@ -116,7 +116,7 @@ public:
 	inline PatchedParamSet* getPatchedParamSet() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[1].paramCollection) {
-			display->freezeWithError("E411");
+			FREEZE_WITH_ERROR("E411");
 		}
 #endif
 		return (PatchedParamSet*)summaries[1].paramCollection;
@@ -125,7 +125,7 @@ public:
 	inline ParamCollectionSummary* getPatchedParamSetSummary() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[1].paramCollection) {
-			display->freezeWithError("E411");
+			FREEZE_WITH_ERROR("E411");
 		}
 #endif
 		return &summaries[1];
@@ -134,7 +134,7 @@ public:
 	inline ParamCollectionSummary* getPatchCableSetSummary() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[2].paramCollection) {
-			display->freezeWithError("E412");
+			FREEZE_WITH_ERROR("E412");
 		}
 #endif
 		return &summaries[2];
@@ -143,7 +143,7 @@ public:
 	inline PatchCableSet* getPatchCableSet() {
 #if ALPHA_OR_BETA_VERSION
 		if (!summaries[2].paramCollection) {
-			display->freezeWithError("E412");
+			FREEZE_WITH_ERROR("E412");
 		}
 #endif
 		return (PatchCableSet*)summaries[2].paramCollection;

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -303,7 +303,7 @@ goAgainWithoutIncrement:
 					// If getting crashes here, well I previously fixed a bug where sometimes the range-adjust*ed* cable was not "allowed", so
 					// was not present here, but the adjust*ing* cable still was here, which this code can't handle. So check that again?
 					if (thatDestination >= (&destinations[globality][numDestinations[globality]])) {
-						display->freezeWithError("E434");
+						FREEZE_WITH_ERROR("E434");
 					}
 #endif
 				}

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -1861,7 +1861,7 @@ int32_t Session::getCurrentSection() {
 		}
 		else {
 			if (ALPHA_OR_BETA_VERSION && clip->section > kMaxNumSections) {
-				display->freezeWithError("E243");
+				FREEZE_WITH_ERROR("E243");
 			}
 			anyUnlaunchedLoopablesInSection[clip->section] = true;
 		}

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1047,7 +1047,7 @@ int64_t PlaybackHandler::getCurrentInternalTickCount(uint32_t* timeRemainder) {
 #if ALPHA_OR_BETA_VERSION
 	if (internalTickCount < 0) {
 		// Trying to narrow down "nofg" error, which Ron got most recently (Nov 2021). Wait no, he didn't have playback on!
-		display->freezeWithError("E429");
+		FREEZE_WITH_ERROR("E429");
 	}
 #endif
 
@@ -1095,7 +1095,7 @@ goAgain:
 
 		// Should now be impossible for them to be at the same time, since we should be looking at one in the future and one not
 		if (ALPHA_OR_BETA_VERSION && timeBetweenInputTicks <= 0) {
-			display->freezeWithError("E337");
+			FREEZE_WITH_ERROR("E337");
 		}
 
 		currentInputTick =

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -376,7 +376,7 @@ Clip* AudioOutput::createNewClipForArrangementRecording(ModelStack* modelStack) 
 
 #if ALPHA_OR_BETA_VERSION
 	if (!newClip->paramManager.summaries[0].paramCollection) {
-		display->freezeWithError("E422"); // Trying to diversify Leo's E410
+		FREEZE_WITH_ERROR("E422"); // Trying to diversify Leo's E410
 	}
 #endif
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1244,7 +1244,7 @@ doCull:
 
 	int32_t i = activeVoices.insertAtKeyMultiWord(keyWords);
 	if (i == -1) {
-		// if (ALPHA_OR_BETA_VERSION) display->freezeWithError("E193"); // No, having run out of RAM here isn't a reason to not continue.
+		// if (ALPHA_OR_BETA_VERSION) FREEZE_WITH_ERROR("E193"); // No, having run out of RAM here isn't a reason to not continue.
 		disposeOfVoice(newVoice);
 		return NULL;
 	}
@@ -1479,7 +1479,7 @@ void discardRecorder(SampleRecorder* recorder) {
 
 		count++;
 		if (ALPHA_OR_BETA_VERSION && !*prevPointer) {
-			display->freezeWithError("E264");
+			FREEZE_WITH_ERROR("E264");
 		}
 		if (*prevPointer == recorder) {
 			*prevPointer = recorder->next;

--- a/src/deluge/processing/live/live_pitch_shifter.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter.cpp
@@ -77,7 +77,7 @@ void LivePitchShifter::render(int32_t* __restrict__ outputBuffer, int32_t numSam
 
 	LiveInputBuffer* liveInputBuffer = AudioEngine::getOrCreateLiveInputBuffer(inputType, false);
 	if (ALPHA_OR_BETA_VERSION && !liveInputBuffer) {
-		display->freezeWithError("E165");
+		FREEZE_WITH_ERROR("E165");
 	}
 
 	liveInputBuffer->giveInput(numSamplesThisFunctionCall, AudioEngine::audioSampleTimer, inputType);
@@ -371,7 +371,7 @@ void LivePitchShifter::hopEnd(int32_t phaseIncrement, LiveInputBuffer* liveInput
 	//Debug::println(numRawSamplesProcessedAtNowTime);
 	if (crossfadeProgress < 16777216) {
 		Debug::println("last crossfade not finished");
-		//if (ALPHA_OR_BETA_VERSION) display->freezeWithError("FADE");
+		//if (ALPHA_OR_BETA_VERSION) FREEZE_WITH_ERROR("FADE");
 	}
 	//Debug::println(phaseIncrement);
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -1552,7 +1552,7 @@ void Sound::allNotesOff(ModelStackWithThreeMainThings* modelStack, ArpeggiatorBa
 #if ALPHA_OR_BETA_VERSION
 	if (!modelStack->paramManager) {
 		// Previously we were allowed to receive a NULL paramManager, then would just crudely do an unassignAllVoices(). But I'm pretty sure this doesn't exist anymore?
-		display->freezeWithError("E403");
+		FREEZE_WITH_ERROR("E403");
 	}
 #endif
 
@@ -2366,11 +2366,11 @@ void Sound::unassignAllVoices() {
 	if (ALPHA_OR_BETA_VERSION) {
 		if (numVoicesAssigned > 0) {
 			// ronronsen got error! https://forums.synthstrom.com/discussion/4090/e203-by-changing-a-drum-kit#latest
-			display->freezeWithError("E070");
+			FREEZE_WITH_ERROR("E070");
 		}
 		else if (numVoicesAssigned < 0) {
 			// ronronsen got error! https://forums.synthstrom.com/discussion/4090/e203-by-changing-a-drum-kit#latest
-			display->freezeWithError("E071");
+			FREEZE_WITH_ERROR("E071");
 		}
 	}
 
@@ -2405,7 +2405,7 @@ void Sound::confirmNumVoices(char const* error) {
 		Uart::print(numVoicesAssigned);
 		Uart::print(", but actually ");
 		Uart::println(voiceCount);
-		display->freezeWithError(error);
+		FREEZE_WITH_ERROR(error);
 	}
 
 	int32_t reasonCountSources = 0;
@@ -2433,7 +2433,7 @@ void Sound::confirmNumVoices(char const* error) {
 			char buffer[5];
 			strcpy(buffer, error);
 			buffer[0] = 'F';
-			display->freezeWithError(buffer);
+			FREEZE_WITH_ERROR(buffer);
 		}
 	}
 	*/
@@ -4145,7 +4145,7 @@ void Sound::wontBeRenderedForAWhile() {
 
 	// If it still thinks it's meant to be rendering, we did something wrong
 	if (ALPHA_OR_BETA_VERSION && !skippingRendering) {
-		display->freezeWithError("E322");
+		FREEZE_WITH_ERROR("E322");
 	}
 }
 

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -275,7 +275,7 @@ void SoundInstrument::setupWithoutActiveClip(ModelStack* modelStack) {
 	ParamManager* paramManager =
 	    modelStackWithTimelineCounter->song->getBackedUpParamManagerPreferablyWithClip(this, NULL);
 	if (!paramManager) {
-		display->freezeWithError("E173");
+		FREEZE_WITH_ERROR("E173");
 	}
 	patcher.performInitialPatching(this, paramManager);
 
@@ -375,7 +375,7 @@ void SoundInstrument::sendNote(ModelStackWithThreeMainThings* modelStack, bool i
 #if ALPHA_OR_BETA_VERSION
 			if (!modelStack->paramManager) {
 				// Previously we were allowed to receive a NULL paramManager, then would just crudely do an unassignAllVoices(). But I'm pretty sure this doesn't exist anymore?
-				display->freezeWithError("E402");
+				FREEZE_WITH_ERROR("E402");
 			}
 #endif
 			ModelStackWithSoundFlags* modelStackWithSoundFlags = modelStack->addSoundFlags();

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -514,7 +514,7 @@ void AudioFile::removeReason(char const* errorCode) {
 
 	else if (numReasonsToBeLoaded < 0) {
 #if ALPHA_OR_BETA_VERSION
-		display->freezeWithError("E004"); // Luc got this! And Paolo. (Must have been years ago :D)
+		FREEZE_WITH_ERROR("E004"); // Luc got this! And Paolo. (Must have been years ago :D)
 #endif
 		numReasonsToBeLoaded = 0; // Save it from crashing
 	}

--- a/src/deluge/storage/audio/audio_file_holder.cpp
+++ b/src/deluge/storage/audio/audio_file_holder.cpp
@@ -65,7 +65,7 @@ void AudioFileHolder::setAudioFile(AudioFile* newAudioFile, bool reversed, bool 
 		unassignAllClusterReasons();
 #if ALPHA_OR_BETA_VERSION
 		if (audioFile->numReasonsToBeLoaded <= 0) {
-			display->freezeWithError("E220"); // I put this here to try and catch an E004 Luc got
+			FREEZE_WITH_ERROR("E220"); // I put this here to try and catch an E004 Luc got
 		}
 #endif
 		audioFile->removeReason("E391");

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -228,7 +228,7 @@ void AudioFileManager::deleteAnyTempRecordedSamplesFromMemory() {
 			// If it's a temp-recorded one
 			if (!((Sample*)audioFile)->tempFilePathForRecording.isEmpty()) {
 
-				//if (ALPHA_OR_BETA_VERSION && audioFile->numReasons) display->freezeWithError("E281"); // It definitely shouldn't still have any reasons
+				//if (ALPHA_OR_BETA_VERSION && audioFile->numReasons) FREEZE_WITH_ERROR("E281"); // It definitely shouldn't still have any reasons
 				// No - it could still have a reason - the reason of its SampleRecorder. Scenario where this happened was: recording AudioClip (instance)
 				// into Arranger when loading a new song, first causes Arranger playback to switch to Session playback, which causes
 				// finishLinearRecording() on AudioClip, so when song-swap does happen, the AudioClip no longer has a recorder, so the recorder doesn't clear stuff,
@@ -367,7 +367,7 @@ void AudioFileManager::deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile* au
 	int32_t i = audioFiles.searchForExactObject(audioFile);
 	if (i < 0) {
 #if ALPHA_OR_BETA_VERSION
-		display->freezeWithError("E401"); // Leo got. And me! But now I've solved.
+		FREEZE_WITH_ERROR("E401"); // Leo got. And me! But now I've solved.
 #endif
 	}
 	else {
@@ -926,17 +926,17 @@ bool AudioFileManager::loadCluster(Cluster* cluster, int32_t minNumReasonsAfter)
 	Sample* sample = cluster->sample;
 
 	if (cluster->type != ClusterType::Sample) {
-		display->freezeWithError("E205"); // Chris F got this, so gonna leave checking in release build
+		FREEZE_WITH_ERROR("E205"); // Chris F got this, so gonna leave checking in release build
 	}
 
 #if ALPHA_OR_BETA_VERSION
 	if (cluster->numReasonsToBeLoaded <= 0) {
 		// Ok, I think we know there's at least 1 reason at the point this function's called, because
-		display->freezeWithError("E204");
+		FREEZE_WITH_ERROR("E204");
 	}
 	// it'd only be in the loading queue if it had a "reason".
 	if (!sample) {
-		display->freezeWithError("E206");
+		FREEZE_WITH_ERROR("E206");
 	}
 #endif
 
@@ -984,11 +984,11 @@ getOutEarly:
 
 #if ALPHA_OR_BETA_VERSION
 	if (cluster->type != ClusterType::Sample) {
-		display->freezeWithError("i023"); // Happened to me while thrash testing with reduced RAM
+		FREEZE_WITH_ERROR("i023"); // Happened to me while thrash testing with reduced RAM
 	}
 
 	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter + 1) {
-		display->freezeWithError("i039"); // It's +1 because we haven't removed this function's "reason" yet.
+		FREEZE_WITH_ERROR("i039"); // It's +1 because we haven't removed this function's "reason" yet.
 	}
 #endif
 
@@ -1006,14 +1006,14 @@ getOutEarly:
 
 #if ALPHA_OR_BETA_VERSION
 	if (cluster->type != ClusterType::Sample) {
-		display->freezeWithError("E207");
+		FREEZE_WITH_ERROR("E207");
 	}
 	if (!cluster->sample) {
-		display->freezeWithError("E208");
+		FREEZE_WITH_ERROR("E208");
 	}
 
 	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter + 1) {
-		display->freezeWithError("i038"); // It's +1 because we haven't removed this function's "reason" yet.
+		FREEZE_WITH_ERROR("i038"); // It's +1 because we haven't removed this function's "reason" yet.
 	}
 #endif
 
@@ -1026,7 +1026,7 @@ getOutEarly:
 
 #if ALPHA_OR_BETA_VERSION
 	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter + 1) {
-		display->freezeWithError("i040"); // It's +1 because we haven't removed this function's "reason" yet.
+		FREEZE_WITH_ERROR("i040"); // It's +1 because we haven't removed this function's "reason" yet.
 	}
 #endif
 
@@ -1208,10 +1208,10 @@ copy7ToMe:
 
 #if ALPHA_OR_BETA_VERSION
 	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter) {
-		display->freezeWithError("i037");
+		FREEZE_WITH_ERROR("i037");
 	}
 	if (cluster->sample->clusters.getElement(cluster->clusterIndex)->cluster != cluster) {
-		display->freezeWithError("E438");
+		FREEZE_WITH_ERROR("E438");
 	}
 #endif
 
@@ -1307,7 +1307,7 @@ performActionsAndGetOut:
 
 		// Do the actual loading
 		if (cluster->type != ClusterType::Sample) {
-			display->freezeWithError("E235"); // Cos Chris F got an E205
+			FREEZE_WITH_ERROR("E235"); // Cos Chris F got an E205
 		}
 
 		allowSomeUserActionsEvenWhenInCardRoutine = true; // Sorry!!
@@ -1326,7 +1326,7 @@ performActionsAndGetOut:
 			else {
 
 				if (cluster->type != ClusterType::Sample) {
-					display->freezeWithError("E237"); // Cos Chris F got an E205
+					FREEZE_WITH_ERROR("E237"); // Cos Chris F got an E205
 				}
 
 				enqueueCluster(cluster); // TODO: If that fails, it'll just get awkwardly forgotten about
@@ -1366,7 +1366,7 @@ void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* err
 	cluster->numReasonsToBeLoaded--;
 
 	if (cluster == clusterBeingLoaded && cluster->numReasonsToBeLoaded < minNumReasonsForClusterBeingLoaded) {
-		display->freezeWithError("E041"); // Sven got this!
+		FREEZE_WITH_ERROR("E041"); // Sven got this!
 	}
 
 	// If it's now zero, it's become available
@@ -1374,7 +1374,7 @@ void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* err
 
 		// Bug hunting
 		if (ALPHA_OR_BETA_VERSION && cluster->numReasonsHeldBySampleRecorder) {
-			display->freezeWithError("E364");
+			FREEZE_WITH_ERROR("E364");
 		}
 
 		// If it's still in the load queue, remove it from there. (We know that it isn't in the process of being loaded right now
@@ -1401,7 +1401,7 @@ void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* err
 			Debug::print("reason remains on cluster of sample: ");
 			Debug::println(cluster->sample->filePath.get());
 		}
-		display->freezeWithError(errorCode);
+		FREEZE_WITH_ERROR(errorCode);
 #else
 		display->displayPopup(errorCode);  // For non testers, just display the error code without freezing
 		cluster->numReasonsToBeLoaded = 0; // Save it from crashing or anything

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -183,14 +183,14 @@ void Cluster::steal(char const* errorCode) {
 
 	case ClusterType::Sample:
 		if (ALPHA_OR_BETA_VERSION && !sample) {
-			display->freezeWithError("E181");
+			FREEZE_WITH_ERROR("E181");
 		}
 		sample->clusters.getElement(clusterIndex)->cluster = NULL;
 		break;
 
 	case ClusterType::SAMPLE_CACHE:
 		if (ALPHA_OR_BETA_VERSION && !sampleCache) {
-			display->freezeWithError("E183");
+			FREEZE_WITH_ERROR("E183");
 		}
 		sampleCache->clusterStolen(clusterIndex);
 
@@ -205,7 +205,7 @@ void Cluster::steal(char const* errorCode) {
 	case ClusterType::PERC_CACHE_FORWARDS:
 	case ClusterType::PERC_CACHE_REVERSED:
 		if (ALPHA_OR_BETA_VERSION && !sample) {
-			display->freezeWithError("E184");
+			FREEZE_WITH_ERROR("E184");
 		}
 		sample->percCacheClusterStolen(this);
 		break;

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -366,8 +366,8 @@ char const* StorageManager::readNextTagOrAttributeName() {
 
 	default:
 #if ALPHA_OR_BETA_VERSION
-		display->freezeWithError(
-		    "E365"); // Can happen with invalid files, though I'm implementing error checks whenever a user alerts me to a scenario. Fraser got this, Nov 2021.
+		// Can happen with invalid files, though I'm implementing error checks whenever a user alerts me to a scenario. Fraser got this, Nov 2021.
+		FREEZE_WITH_ERROR("E365");
 #else
 		__builtin_unreachable();
 #endif
@@ -742,7 +742,7 @@ char const* StorageManager::readTagOrAttributeValue() {
 		return "";
 
 	default:
-		display->freezeWithError("BBBB");
+		FREEZE_WITH_ERROR("BBBB");
 		__builtin_unreachable();
 	}
 }
@@ -763,7 +763,7 @@ int32_t StorageManager::readTagOrAttributeValueInt() {
 		return 0;
 
 	default:
-		display->freezeWithError("BBBB");
+		FREEZE_WITH_ERROR("BBBB");
 		__builtin_unreachable();
 	}
 }
@@ -799,7 +799,7 @@ int32_t StorageManager::readTagOrAttributeValueString(String* string) {
 
 	default:
 		if (ALPHA_OR_BETA_VERSION) {
-			display->freezeWithError("BBBB");
+			FREEZE_WITH_ERROR("BBBB");
 		}
 		__builtin_unreachable();
 	}
@@ -830,7 +830,7 @@ bool StorageManager::prepareToReadTagOrAttributeValueOneCharAtATime() {
 
 	default:
 		if (ALPHA_OR_BETA_VERSION) {
-			display->freezeWithError("CCCC");
+			FREEZE_WITH_ERROR("CCCC");
 		}
 		__builtin_unreachable();
 	}
@@ -907,7 +907,7 @@ void StorageManager::exitTag(char const* exitTagName) {
 
 		default:
 			if (ALPHA_OR_BETA_VERSION) {
-				display->freezeWithError("AAAA"); // Really shouldn't be possible anymore, I feel fairly certain...
+				FREEZE_WITH_ERROR("AAAA"); // Really shouldn't be possible anymore, I feel fairly certain...
 			}
 			__builtin_unreachable();
 		}

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -672,7 +672,7 @@ transformBandToTimeDomain:
 			if (!fftCFGThisBand) {
 #if ALPHA_OR_BETA_VERSION
 				if (!b) {
-					display->freezeWithError("E390");
+					FREEZE_WITH_ERROR("E390");
 				}
 #endif
 				band->~WaveTableBand();
@@ -1083,7 +1083,7 @@ startRenderingACycle:
 			    numIncrementsWeCanDoNow
 			    + 1; // +1 because we can only have to increment *between* the samples we're rendering. If can only do 1 increment, we can still render 2 samples.
 			if (ALPHA_OR_BETA_VERSION && numSamplesThisCycle > numSamplesLeftToDo) {
-				display->freezeWithError("E386");
+				FREEZE_WITH_ERROR("E386");
 			}
 		}
 
@@ -1166,7 +1166,7 @@ void WaveTable::numReasonsDecreasedToZero(char const* errorCode) {
 		if (band->data) {
 #if ALPHA_OR_BETA_VERSION
 			if (band->data->list) {
-				display->freezeWithError("E388");
+				FREEZE_WITH_ERROR("E388");
 			}
 #endif
 			GeneralMemoryAllocator::get().putStealableInQueue(band->data, STEALABLE_QUEUE_NO_SONG_WAVETABLE_BAND_DATA);

--- a/src/deluge/storage/wave_table/wave_table_band_data.cpp
+++ b/src/deluge/storage/wave_table/wave_table_band_data.cpp
@@ -35,7 +35,7 @@ bool WaveTableBandData::mayBeStolen(void* thingNotToStealFrom) {
 void WaveTableBandData::steal(char const* errorCode) {
 #if ALPHA_OR_BETA_VERSION
 	if (!waveTable || waveTable->numReasonsToBeLoaded) {
-		display->freezeWithError("E387");
+		FREEZE_WITH_ERROR("E387");
 	}
 #endif
 

--- a/src/deluge/util/algorithm/quick_sorter.cpp
+++ b/src/deluge/util/algorithm/quick_sorter.cpp
@@ -90,7 +90,7 @@ void QuickSorter::sort(int32_t numElements) {
 	for (int32_t i = 1; i < numElements; i++) {
 		int32_t keyHere = getKey(i);
 		if (keyHere < lastKey) {
-			display->freezeWithError("SORT");
+			FREEZE_WITH_ERROR("SORT");
 		}
 		lastKey = keyHere;
 	}

--- a/src/deluge/util/container/array/ordered_resizeable_array.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array.cpp
@@ -268,7 +268,7 @@ void OrderedResizeableArray::testSequentiality(char const* errorCode) {
 	for (int32_t i = 0; i < getNumElements(); i++) {
 		int32_t key = getKeyAtIndex(i);
 		if (key <= lastKey) {
-			display->freezeWithError(errorCode);
+			FREEZE_WITH_ERROR(errorCode);
 		}
 
 		lastKey = key;
@@ -310,7 +310,7 @@ void OrderedResizeableArrayWith32bitKey::testSearchMultiple() {
 		for (int32_t t = 0; t < TEST_SEARCH_MULTIPLE_NUM_SEARCH_TERMS; t++) {
 			while (getKeyAtIndex(i) < searchPos[t]) {
 				if (i >= resultingIndexes[t]) {
-					//display->freezeWithError("FAIL");
+					//FREEZE_WITH_ERROR("FAIL");
 					Debug::println("fail");
 					goto thatsDone;
 				}

--- a/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
@@ -131,12 +131,12 @@ void OrderedResizeableArrayWithMultiWordKey::testSequentiality(char const* error
 		for (int j = 0; j < numWordsInKey; j++) {
 			int32_t difference = wordsHere[j] - lastWords[j];
 			if (difference < 0) {
-				display->freezeWithError(errorCode);
+				FREEZE_WITH_ERROR(errorCode);
 			}
 			if (difference == 0) {
 				if (j == numWordsInKey - 1) {
 					//if we got here it's a duplicate key
-					display->freezeWithError(errorCode);
+					FREEZE_WITH_ERROR(errorCode);
 				}
 			}
 			else {

--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -32,13 +32,13 @@
 #define LOCK_EXIT exitLock();
 void ResizeableArray::freezeOnLock() {
 	if (lock) {
-		display->freezeWithError("i008");
+		FREEZE_WITH_ERROR("i008");
 	}
 	lock = true;
 }
 void ResizeableArray::exitLock() {
 	if (!lock) {
-		display->freezeWithError("i008");
+		FREEZE_WITH_ERROR("i008");
 	}
 	lock = false;
 }
@@ -892,7 +892,7 @@ void ResizeableArray::setStaticMemory(void* newMemory, int32_t newMemorySize) {
 int32_t ResizeableArray::insertAtIndex(int32_t i, int32_t numToInsert, void* thingNotToStealFrom) {
 
 	if (ALPHA_OR_BETA_VERSION && (i < 0 || i > numElements || numToInsert < 1)) {
-		display->freezeWithError("E280");
+		FREEZE_WITH_ERROR("E280");
 	}
 
 	LOCK_ENTRY
@@ -919,7 +919,7 @@ int32_t ResizeableArray::insertAtIndex(int32_t i, int32_t numToInsert, void* thi
 		}
 
 		if (ALPHA_OR_BETA_VERSION && allocatedMemorySize < newMemorySize * elementSize) {
-			display->freezeWithError("FFFF");
+			FREEZE_WITH_ERROR("FFFF");
 		}
 
 		setMemory(newMemory, allocatedMemorySize);

--- a/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
+++ b/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
@@ -88,7 +88,7 @@ void* OpenAddressingHashTable::insert(uint32_t key, bool* onlyIfNotAlreadyPresen
 
 #if ALPHA_OR_BETA_VERSION
 	if (doesKeyIndicateEmptyBucket(key)) {
-		display->freezeWithError("E330");
+		FREEZE_WITH_ERROR("E330");
 	}
 #endif
 
@@ -197,7 +197,7 @@ void* OpenAddressingHashTable::lookup(uint32_t key) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (doesKeyIndicateEmptyBucket(key)) {
-		display->freezeWithError("E331");
+		FREEZE_WITH_ERROR("E331");
 	}
 #endif
 
@@ -238,7 +238,7 @@ bool OpenAddressingHashTable::remove(uint32_t key) {
 
 #if ALPHA_OR_BETA_VERSION
 	if (doesKeyIndicateEmptyBucket(key)) {
-		display->freezeWithError("E332");
+		FREEZE_WITH_ERROR("E332");
 	}
 #endif
 

--- a/src/deluge/util/container/list/bidirectional_linked_list.cpp
+++ b/src/deluge/util/container/list/bidirectional_linked_list.cpp
@@ -71,7 +71,7 @@ BidirectionalLinkedListNode* BidirectionalLinkedList::getNext(BidirectionalLinke
 void BidirectionalLinkedList::test() {
 
 	if (first == NULL) {
-		display->freezeWithError("E005");
+		FREEZE_WITH_ERROR("E005");
 	}
 
 	int32_t count = 0;
@@ -80,7 +80,7 @@ void BidirectionalLinkedList::test() {
 	BidirectionalLinkedListNode** prevPointer = &first;
 	while (true) {
 		if (thisNode->prevPointer != prevPointer) {
-			display->freezeWithError("E006");
+			FREEZE_WITH_ERROR("E006");
 		}
 
 		if (thisNode == &endNode) {
@@ -89,14 +89,14 @@ void BidirectionalLinkedList::test() {
 
 		// Check the node references its list correctly
 		if (thisNode->list != this) {
-			display->freezeWithError("E007");
+			FREEZE_WITH_ERROR("E007");
 		}
 
 		count++;
 
 		// Check we're not spiralling around forever
 		if (count > 2048) {
-			display->freezeWithError("E008");
+			FREEZE_WITH_ERROR("E008");
 		}
 
 		prevPointer = &thisNode->next;
@@ -136,7 +136,7 @@ void BidirectionalLinkedListNode::insertOtherNodeBefore(BidirectionalLinkedListN
 	if constexpr (ALPHA_OR_BETA_VERSION || kCurrentFirmwareVersion <= FIRMWARE_4P0P0) {
 		// If we're not already in a list, that means we also don't have a valid prevPointer, so everything's about to break. This happened!
 		if (!list) {
-			display->freezeWithError("E443");
+			FREEZE_WITH_ERROR("E443");
 		}
 	}
 	otherNode->list = list;
@@ -152,7 +152,7 @@ void BidirectionalLinkedListNode::insertOtherNodeBefore(BidirectionalLinkedListN
 bool BidirectionalLinkedListNode::isLast() {
 	if constexpr (ALPHA_OR_BETA_VERSION || kCurrentFirmwareVersion <= FIRMWARE_4P0P0) {
 		if (!list) {
-			display->freezeWithError("E444");
+			FREEZE_WITH_ERROR("E444");
 		}
 	}
 	return (next == &list->endNode);

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -137,12 +137,12 @@ void String::set(String* otherString) {
 	//if the other string has memory and it's not in the non audio region
 	if (sm) {
 		if (!(EXTERNAL_MEMORY_END - RESERVED_EXTERNAL_ALLOCATOR < (uint32_t)sm && (uint32_t)sm < EXTERNAL_MEMORY_END)) {
-			display->freezeWithError("S001");
+			FREEZE_WITH_ERROR("S001");
 			return;
 		}
 		//or if it doesn't have an allocation
 		else if (!GeneralMemoryAllocator::get().getAllocatedSize(sm)) {
-			display->freezeWithError("S002");
+			FREEZE_WITH_ERROR("S002");
 			return;
 		}
 	}

--- a/src/deluge/version.h.in
+++ b/src/deluge/version.h.in
@@ -1,4 +1,6 @@
 #pragma once
+
+#ifdef __cplusplus
 #include <compare>
 #include <cstdint>
 
@@ -19,3 +21,14 @@ constexpr SemVer kCommunityFirmwareVersion {
 //clang-format on
 
 constexpr char const* kFirmwareVersionString = "@BUILD_VERSION_STRING@";
+
+#else
+
+#define FIRMWARE_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+#define FIRMWARE_VERSION_MINOR @PROJECT_VERSION_MINOR@
+#define FIRMWARE_VERSION_PATCH @PROJECT_VERSION_PATCH@
+
+#define FIRMWARE_VERSION_STRING "@BUILD_VERSION_STRING@"
+#define FIRMWARE_COMMIT_SHORT "@BUILD_COMMIT_SHORT@"
+
+#endif

--- a/src/fault_handler.c
+++ b/src/fault_handler.c
@@ -102,6 +102,8 @@ extern uint32_t program_code_end;
 	drawByte(pointerValue >> 8, r, g, b);
 	drawByte(pointerValue, r, g, b);
 
+	//@TODO: Debug print pointers in debug version
+
 	return idxColumnPairStart;
 }
 
@@ -121,7 +123,8 @@ extern uint32_t program_code_end;
 	return false;
 }
 
-[[gnu::always_inline]] inline void printPointers(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR, uint32_t addrUSRSP, bool hardFault) {
+[[gnu::always_inline]] inline void printPointers(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR,
+                                                 uint32_t addrUSRSP, bool hardFault) {
 	uint32_t currentColumnPairIndex = 0;
 
 	// Print LR from USR mode if it is valid
@@ -187,7 +190,7 @@ extern uint32_t program_code_end;
 	sendToPIC(1 + currentColumnPairIndex);
 	bool lightActive = true;
 	for (uint32_t idxColumnPairBuffer = 0; idxColumnPairBuffer < 16; ++idxColumnPairBuffer) {
-		if(lightActive) {
+		if (lightActive) {
 			sendColor(255, (hardFault ? 0 : 255), 0);
 		}
 		else {
@@ -205,7 +208,8 @@ extern uint32_t program_code_end;
 }
 
 //@TODO: Pointers seem to be wrong right now and we will need to filter out the SP call to fault_handler_print_freeze_pointers (we can't inline, otherwise that would be huge)
-extern void fault_handler_print_freeze_pointers(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR, uint32_t addrUSRSP) {
+extern void fault_handler_print_freeze_pointers(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR,
+                                                uint32_t addrUSRSP) {
 	printPointers(addrSYSLR, addrSYSSP, addrUSRLR, addrUSRSP, false);
 }
 

--- a/src/fault_handler.h
+++ b/src/fault_handler.h
@@ -59,7 +59,8 @@
 extern "C" {
 #endif
 
-extern void fault_handler_print_freeze_pointers(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR, uint32_t addrUSRSP);
+extern void fault_handler_print_freeze_pointers(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR,
+                                                uint32_t addrUSRSP);
 extern void handle_cpu_fault(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR, uint32_t addrUSRSP);
 
 #ifdef __cplusplus

--- a/src/fault_handler.h
+++ b/src/fault_handler.h
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * DISCLAIMER
+ * This software is supplied by Renesas Electronics Corporation and is only
+ * intended for use with Renesas products. No other uses are authorized. This
+ * software is owned by Renesas Electronics Corporation and is protected under
+ * all applicable laws, including copyright laws.
+ * THIS SOFTWARE IS PROVIDED "AS IS" AND RENESAS MAKES NO WARRANTIES REGARDING
+ * THIS SOFTWARE, WHETHER EXPRESS, IMPLIED OR STATUTORY, INCLUDING BUT NOT
+ * LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+ * AND NON-INFRINGEMENT. ALL SUCH WARRANTIES ARE EXPRESSLY DISCLAIMED.
+ * TO THE MAXIMUM EXTENT PERMITTED NOT PROHIBITED BY LAW, NEITHER RENESAS
+ * ELECTRONICS CORPORATION NOR ANY OF ITS AFFILIATED COMPANIES SHALL BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES FOR
+ * ANY REASON RELATED TO THIS SOFTWARE, EVEN IF RENESAS OR ITS AFFILIATES HAVE
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ * Renesas reserves the right, without notice, to make changes to this software
+ * and to discontinue the availability of this software. By using this software,
+ * you agree to the additional terms and conditions found by accessing the
+ * following link:
+ * http://www.renesas.com/disclaimer
+ *
+ * Copyright (C) 2014 Renesas Electronics Corporation. All rights reserved.
+ *******************************************************************************/
+/*******************************************************************************
+ * File Name     : resetprg.c
+ * Device(s)     : RZ/A1H (R7S721001)
+ * Tool-Chain    : GNUARM-NONEv14.02-EABI
+ * H/W Platform  : RSK+RZA1H CPU Board
+ * Description   : Sample Program - C library entry point
+ *               : Variants of this file must be created for each compiler
+ *******************************************************************************/
+/*******************************************************************************
+ * History       : DD.MM.YYYY Version Description
+ *               : 21.10.2014 1.00
+ *******************************************************************************/
+
+/*
+ * Copyright © 2021-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern void fault_handler_print_freeze_pointers(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR, uint32_t addrUSRSP);
+extern void handle_cpu_fault(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR, uint32_t addrUSRSP);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
* Fixes _SEGGER_RTT address not being visible in ELF
* Blackbox
    * Fixed stack pointer extraction
    * Added first 4 chars of commit ID in sidebar
    * Added blackbox to freeze handler (yellow sidebar instead of red)
    * Added address output via RTT in RelWithDebInfo build
* Fault handler: Switch to user mode before capture loop to help debugger see stack frames

Implements #688