### PR TITLE
bug fix - community features crash due to additional automation sub menu

### DIFF
--- a/src/deluge/gui/menu_item/runtime_feature/settings.h
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.h
@@ -24,7 +24,7 @@
 namespace deluge::gui::menu_item::runtime_feature {
 
 /// Some runtime feature settings are squirrled away in submenus.
-constexpr size_t kNonTopLevelSettings = 3;
+constexpr size_t kNonTopLevelSettings = 4;
 // RuntimeFeatureSettingType::MaxElement - kNonTopLevelSettings
 class Settings final : public Submenu {
 public:


### PR DESCRIPTION
Incremented count of non top level constant by 1 to accommodate additional automation sub menu added