### PR TITLE
514 (OLED) Parameter titles are missing parts of their title.

### DIFF
--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -95,7 +95,7 @@ public:
 	///
 	/// The returned pointer must live long enough for us to draw the title, which for practical purposes means "the
 	/// lifetime of this menu item"
-	[[nodiscard]] virtual std::string_view getTitle() const { return deluge::l10n::getView(name); }
+	[[nodiscard]] virtual std::string_view getTitle() const { return deluge::l10n::getView(title); }
 
 	virtual void renderOLED();
 	virtual void drawPixelsForOled() {}


### PR DESCRIPTION
https://github.com/SynthstromAudible/DelugeFirmware/issues/514

Single variable fix.