### PR TITLE
Fix Cortex-Debug launch

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,10 +20,28 @@
       "servertype": "jlink",
       "device": "R7S721020",
       "interface": "swd",
-      "runToEntryPoint": "main",
+      //"runToEntryPoint": "main",
       "svdFile": "${workspaceRoot}/contrib/rza1.svd",
+      "overrideLaunchCommands": [
+        "load"
+      ],
+      "overrideResetCommands": [
+        "monitor reset",
+        "load"
+      ],
+      "overrideRestartCommands": [
+        "jump start"
+      ],
       "rttConfig": {
         "enabled": true,
+        "address": "auto",
+        "decoders": [
+          {
+            "port": 0,
+            "timestamp": true,
+            "type": "console"
+          }
+        ]
       },
     },
     {
@@ -160,7 +178,7 @@
       "type": "lldb",
       "request": "launch",
       "targetCreateCommands": [
-        "target create ${workspaceFolder}/build/debug/deluge7SEG.elf"
+        "target create ${workspaceFolder}/build/Debug/deluge.elf"
       ],
       "processCreateCommands": [
         "gdb-remote localhost:3333"


### PR DESCRIPTION
This fixes long-standing issues using Cortex Debug for debugging in VSCode. I've been using this patch locally for weeks and it's been working well.

Pairs with #690 for proper RTT output in VSCode.