### PR TITLE
664 Hard crash with shift+scroll in small menus

### DIFF
--- a/src/deluge/gui/context_menu/launch_style.cpp
+++ b/src/deluge/gui/context_menu/launch_style.cpp
@@ -50,9 +50,10 @@ bool LaunchStyle::setupAndCheckAvailability() {
 
 	currentOption = static_cast<int32_t>(valueOption);
 
-#if HAVE_OLED
-	scrollPos = currentOption;
-#endif
+	if (display->haveOLED()) {
+		scrollPos = currentOption;
+	}
+
 	return true;
 }
 

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -3,32 +3,34 @@
 namespace deluge::gui::menu_item {
 void Enumeration::beginSession(MenuItem* navigatedBackwardFrom) {
 	Value::beginSession(navigatedBackwardFrom);
-#if HAVE_OLED
-	soundEditor.menuCurrentScroll = 0;
-#else
-	drawValue();
-#endif
+	if (display->haveOLED()) {
+		soundEditor.menuCurrentScroll = 0;
+	}
+	else {
+		drawValue();
+	}
 }
 
 void Enumeration::selectEncoderAction(int32_t offset) {
 	this->setValue(this->getValue() + offset);
 	int32_t numOptions = size();
 
-#if HAVE_OLED
-	if (this->getValue() >= numOptions) {
-		this->setValue(numOptions - 1);
+	if (display->haveOLED()) {
+		if (this->getValue() >= numOptions) {
+			this->setValue(numOptions - 1);
+		}
+		else if (this->getValue() < 0) {
+			this->setValue(0);
+		}
 	}
-	else if (this->getValue() < 0) {
-		this->setValue(0);
+	else {
+		if (this->getValue() >= numOptions) {
+			this->setValue(this->getValue() - numOptions);
+		}
+		else if (this->getValue() < 0) {
+			this->setValue(this->getValue() + numOptions);
+		}
 	}
-#else
-	if (this->getValue() >= numOptions) {
-		this->setValue(this->getValue() - numOptions);
-	}
-	else if (this->getValue() < 0) {
-		this->setValue(this->getValue() + numOptions);
-	}
-#endif
 
 	Value::selectEncoderAction(offset);
 }

--- a/src/deluge/gui/menu_item/selection.cpp
+++ b/src/deluge/gui/menu_item/selection.cpp
@@ -20,7 +20,7 @@ void Selection::drawPixelsForOled() {
 	if (soundEditor.menuCurrentScroll > value) {
 		soundEditor.menuCurrentScroll = value;
 	}
-	else if (soundEditor.menuCurrentScroll < this->getValue() - kOLEDMenuNumOptionsVisible + 1) {
+	else if (soundEditor.menuCurrentScroll < value - kOLEDMenuNumOptionsVisible + 1) {
 		soundEditor.menuCurrentScroll = value - kOLEDMenuNumOptionsVisible + 1;
 	}
 

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -66,45 +66,50 @@ void Submenu::drawPixelsForOled() {
 }
 
 void Submenu::selectEncoderAction(int32_t offset) {
-
+	int32_t sign = (offset > 0) ? 1 : ((offset < 0) ? -1 : 0);
 	auto thisSubmenuItem = current_item_;
 
-	do {
-		if (offset >= 0) {
-			thisSubmenuItem++;
-			if (thisSubmenuItem == items.end()) {
-				if (display->haveOLED()) {
-					return;
-				}
-				else {
+	int32_t moved = 0;
+	for (; moved < std::abs(offset); moved++) {
+		do {
+			if (offset >= 0) {
+				thisSubmenuItem++;
+				if (thisSubmenuItem >= items.end()) {
+					if (display->haveOLED()) {
+						updateDisplay();
+						return;
+					}
+					// 7SEG wraps
 					thisSubmenuItem = items.begin();
 				}
 			}
-		}
-		else {
-			if (thisSubmenuItem == items.begin()) {
-				if (display->haveOLED()) {
-					return;
-				}
-				else {
+			else {
+				if (thisSubmenuItem <= items.begin()) {
+					if (display->haveOLED()) {
+						updateDisplay();
+						return;
+					}
+					// 7SEG wraps
 					thisSubmenuItem = (items.end() - 1);
 				}
+				else {
+					thisSubmenuItem--;
+				}
 			}
-			else {
-				thisSubmenuItem--;
+		} while (!(*thisSubmenuItem)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex));
+
+
+
+		current_item_ = thisSubmenuItem;
+
+		if (display->haveOLED()) {
+			soundEditor.menuCurrentScroll += sign;
+			if (soundEditor.menuCurrentScroll < 0) {
+				soundEditor.menuCurrentScroll = 0;
 			}
-		}
-	} while (!(*thisSubmenuItem)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex));
-
-	current_item_ = thisSubmenuItem;
-
-	if (display->haveOLED()) {
-		soundEditor.menuCurrentScroll += offset;
-		if (soundEditor.menuCurrentScroll < 0) {
-			soundEditor.menuCurrentScroll = 0;
-		}
-		else if (soundEditor.menuCurrentScroll > kOLEDMenuNumOptionsVisible - 1) {
-			soundEditor.menuCurrentScroll = kOLEDMenuNumOptionsVisible - 1;
+			else if (soundEditor.menuCurrentScroll > kOLEDMenuNumOptionsVisible - 1) {
+				soundEditor.menuCurrentScroll = kOLEDMenuNumOptionsVisible - 1;
+			}
 		}
 	}
 

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -69,8 +69,7 @@ void Submenu::selectEncoderAction(int32_t offset) {
 	int32_t sign = (offset > 0) ? 1 : ((offset < 0) ? -1 : 0);
 	auto thisSubmenuItem = current_item_;
 
-	int32_t moved = 0;
-	for (; moved < std::abs(offset); moved++) {
+	for (size_t i = 0; i < std::abs(offset); ++i) {
 		do {
 			if (offset >= 0) {
 				thisSubmenuItem++;
@@ -97,8 +96,6 @@ void Submenu::selectEncoderAction(int32_t offset) {
 				}
 			}
 		} while (!(*thisSubmenuItem)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex));
-
-
 
 		current_item_ = thisSubmenuItem;
 


### PR DESCRIPTION
https://github.com/SynthstromAudible/DelugeFirmware/issues/664

Somehow I missed, or accidentally didn't stage, or overwrote, or something, enumeration.cpp during the display refactor, so there were still some HAVE_OLED checks that obviously no longer worked. This swaps them for the runtime display check, guaranteeing that an Enumeration MenuItem cannot hold a Value greater than size of its options