### PR TITLE
Sidechain HPF for master compressor

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -745,6 +745,8 @@ enum class CompParam {
 	RATIO,
 	ATTACK,
 	RELEASE,
+	SIDECHAIN,
+	LAST,
 };
 
 constexpr auto kNumModFXParams = util::to_underlying(ModFXParam::OFFSET) + 1;

--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -94,8 +94,8 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, q31_t v
 
 	} while (++thisSample != bufferEnd);
 	//for LEDs
-	//9 converts to dB, quadrupled for display range since a 30db reduction is basically killing the signal
-	gainReduction = std::clamp<int32_t>(-(reduction) * 9 * 4, 0, 127);
+	//4 converts to dB, then quadrupled for display range since a 30db reduction is basically killing the signal
+	gainReduction = std::clamp<int32_t>(-(reduction)*4 * 4, 0, 127);
 	//calc compression for next round (feedback compressor)
 	rms = calc_rms(buffer, numSamples);
 }

--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -27,7 +27,7 @@ MasterCompressor::MasterCompressor() {
 	//an appropriate range is 0-50*one q 15
 
 	thresholdKnobPos = 0;
-
+	sideChainKnobPos = ONE_Q31 >> 1;
 	//this is 2:1
 	ratioKnobPos = 0;
 
@@ -35,6 +35,7 @@ MasterCompressor::MasterCompressor() {
 	currentVolumeR = 0;
 	//auto make up gain
 	updateER();
+	setSidechain(sideChainKnobPos);
 }
 //16 is ln(1<<24) - 1, i.e. where we start clipping
 //since this applies to output
@@ -55,7 +56,7 @@ void MasterCompressor::updateER() {
 	}
 	threshdb = songVolume * threshold;
 	//16 is about the level of a single synth voice at max volume
-	er = std::max<float>((songVolume - threshdb - 2) * ratio, 0);
+	er = std::max<float>((songVolume - threshdb - 1) * ratio, 0);
 }
 
 void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, q31_t volAdjustL, q31_t volAdjustR) {
@@ -94,7 +95,7 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, q31_t v
 	} while (++thisSample != bufferEnd);
 	//for LEDs
 	//9 converts to dB, quadrupled for display range since a 30db reduction is basically killing the signal
-	gainReduction = std::clamp<int32_t>(-(reduction)*9 * 4, 0, 127);
+	gainReduction = std::clamp<int32_t>(-(reduction) * 9 * 4, 0, 127);
 	//calc compression for next round (feedback compressor)
 	rms = calc_rms(buffer, numSamples);
 }
@@ -118,7 +119,9 @@ float MasterCompressor::calc_rms(StereoSample* buffer, uint16_t numSamples) {
 	q31_t offset = 0; //to remove dc offset
 	float lastMean = mean;
 	do {
-		q31_t s = std::max(std::abs(thisSample->l), std::abs(thisSample->r));
+		q31_t l = thisSample->l - hpfL.doFilter(thisSample->l, a);
+		q31_t r = thisSample->r - hpfL.doFilter(thisSample->r, a);
+		q31_t s = std::max(std::abs(l), std::abs(r));
 		sum += multiply_32x32_rshift32(s, s) << 1;
 
 	} while (++thisSample != bufferEnd);
@@ -136,10 +139,11 @@ float MasterCompressor::calc_rms(StereoSample* buffer, uint16_t numSamples) {
 
 	return logmean;
 }
-
-void MasterCompressor::setup(int32_t a, int32_t r, int32_t t, int32_t rat) {
+//takes in knob positions in the range 0-ONE_Q31
+void MasterCompressor::setup(q31_t a, q31_t r, q31_t t, q31_t rat, q31_t fc) {
 	setAttack(a);
 	setRelease(r);
 	setThreshold(t);
 	setRatio(rat);
+	setSidechain(fc);
 }

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -276,7 +276,7 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				else {
 					currentCompParam =
 					    static_cast<CompParam>((util::to_underlying(currentCompParam) + 1) % maxCompParam);
-					const char* params[3] = {"ratio", "attack", "release"};
+					const char* params[util::to_underlying(CompParam::LAST)] = {"ratio", "attack", "release", "hpf"};
 					display->popupTextTemporary(params[int(currentCompParam)]);
 				}
 			}
@@ -318,6 +318,10 @@ int32_t GlobalEffectable::getKnobPosForNonExistentParam(int32_t whichModEncoder,
 			case CompParam::RELEASE:
 				current = AudioEngine::mastercompressor.getRelease() >> 24;
 
+				break;
+
+			case CompParam::SIDECHAIN:
+				current = AudioEngine::mastercompressor.getSidechain() >> 24;
 				break;
 			}
 		}
@@ -371,6 +375,15 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				ledLevel = (64 + current);
 
 				displayLevel = AudioEngine::mastercompressor.setRelease(lshiftAndSaturate<24>(current + 64));
+				break;
+
+			case CompParam::SIDECHAIN:
+				current = (AudioEngine::mastercompressor.getSidechain() >> 24) - 64;
+				current += offset;
+				current = std::clamp(current, -64, 64);
+				ledLevel = (64 + current);
+
+				displayLevel = AudioEngine::mastercompressor.setSidechain(lshiftAndSaturate<24>(current + 64));
 				break;
 			}
 			indicator_leds::setKnobIndicatorLevel(0, ledLevel);

--- a/src/deluge/model/global_effectable/global_effectable_for_song.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_song.cpp
@@ -19,6 +19,6 @@
 
 GlobalEffectableForSong::GlobalEffectableForSong() {
 	modKnobMode = 1;
-	//attack and release can't go in the param manager so this keeps them from changing in clip comps
-	maxCompParam = 3;
+	//UI for kit compressors is TBD so they can only be accessed in song
+	maxCompParam = util::to_underlying(CompParam::LAST);
 }

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2671,7 +2671,7 @@ int32_t Song::getCurrentPresetScale() {
 		// If we're here, must be this one!
 		return p;
 
-notThisOne: {}
+notThisOne : {}
 	}
 
 	return 255;
@@ -4560,7 +4560,7 @@ Instrument* Song::changeInstrumentType(Instrument* oldInstrument, InstrumentType
 			return NULL;
 		}
 
-gotAnInstrument: {}
+gotAnInstrument : {}
 	}
 
 	// Synth or Kit

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1128,12 +1128,12 @@ weAreInArrangementEditorOrInClipInstance:
 	int32_t release = AudioEngine::mastercompressor.getRelease();
 	int32_t thresh = AudioEngine::mastercompressor.getThreshold();
 	int32_t ratio = AudioEngine::mastercompressor.getRatio();
-
+	int32_t hpf = AudioEngine::mastercompressor.getSidechain();
 	storageManager.writeAttribute("attack", attack);
 	storageManager.writeAttribute("release", release);
 	storageManager.writeAttribute("thresh", thresh);
 	storageManager.writeAttribute("ratio", ratio);
-
+	storageManager.writeAttribute("compHPF", hpf);
 	storageManager.closeTag();
 
 	globalEffectable.writeTagsToFile(NULL, false);
@@ -1479,21 +1479,25 @@ unknownTag:
 
 			else if (!strcmp(tagName, "songCompressor")) {
 				while (*(tagName = storageManager.readNextTagOrAttributeName())) {
-					if (!strcmp(tagName, "attack")) { //ms
+					if (!strcmp(tagName, "attack")) {
 						masterCompressorAttack = storageManager.readTagOrAttributeValueInt();
 						storageManager.exitTag("attack");
 					}
-					else if (!strcmp(tagName, "release")) { //ms
+					else if (!strcmp(tagName, "release")) {
 						masterCompressorRelease = storageManager.readTagOrAttributeValueInt();
 						storageManager.exitTag("release");
 					}
-					else if (!strcmp(tagName, "thresh")) { //db
+					else if (!strcmp(tagName, "thresh")) {
 						masterCompressorThresh = storageManager.readTagOrAttributeValueInt();
 						storageManager.exitTag("thresh");
 					}
-					else if (!strcmp(tagName, "ratio")) { //r:1
+					else if (!strcmp(tagName, "ratio")) {
 						masterCompressorRatio = storageManager.readTagOrAttributeValueInt();
 						storageManager.exitTag("ratio");
+					}
+					else if (!strcmp(tagName, "compHPF")) {
+						masterCompressorSidechainFC = storageManager.readTagOrAttributeValueInt();
+						storageManager.exitTag("compHPF");
 					}
 					else {
 						storageManager.exitTag(tagName);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -140,7 +140,7 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	masterCompressorRelease = 20 << 24;
 	masterCompressorThresh = 0;
 	masterCompressorRatio = 0;
-	masterCompressorSidechainFC = ONE_Q31 >> 1;
+	masterCompressorSidechain = ONE_Q31 >> 1;
 	AudioEngine::mastercompressor.gainReduction = 0.0;
 
 	dirPath.set("SONGS");
@@ -1496,7 +1496,7 @@ unknownTag:
 						storageManager.exitTag("ratio");
 					}
 					else if (!strcmp(tagName, "compHPF")) {
-						masterCompressorSidechainFC = storageManager.readTagOrAttributeValueInt();
+						masterCompressorSidechain = storageManager.readTagOrAttributeValueInt();
 						storageManager.exitTag("compHPF");
 					}
 					else {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -140,6 +140,7 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	masterCompressorRelease = 20 << 24;
 	masterCompressorThresh = 0;
 	masterCompressorRatio = 0;
+	masterCompressorSidechainFC = ONE_Q31 >> 1;
 	AudioEngine::mastercompressor.gainReduction = 0.0;
 
 	dirPath.set("SONGS");
@@ -2670,7 +2671,7 @@ int32_t Song::getCurrentPresetScale() {
 		// If we're here, must be this one!
 		return p;
 
-notThisOne : {}
+notThisOne: {}
 	}
 
 	return 255;
@@ -4559,7 +4560,7 @@ Instrument* Song::changeInstrumentType(Instrument* oldInstrument, InstrumentType
 			return NULL;
 		}
 
-gotAnInstrument : {}
+gotAnInstrument: {}
 	}
 
 	// Synth or Kit

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -330,7 +330,7 @@ public:
 	int32_t masterCompressorRelease;
 	int32_t masterCompressorThresh;
 	int32_t masterCompressorRatio;
-	int32_t masterCompressorSidechainFC;
+	int32_t masterCompressorSidechain;
 
 private:
 	bool fillModeActive;

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -330,6 +330,7 @@ public:
 	int32_t masterCompressorRelease;
 	int32_t masterCompressorThresh;
 	int32_t masterCompressorRatio;
+	int32_t masterCompressorSidechainFC;
 
 private:
 	bool fillModeActive;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1216,7 +1216,7 @@ void getMasterCompressorParamsFromSong(Song* song) {
 	q31_t r = song->masterCompressorRelease;
 	q31_t t = song->masterCompressorThresh;
 	q31_t rat = song->masterCompressorRatio;
-	q31_t fc = song->masterCompressorSidechainFC;
+	q31_t fc = song->masterCompressorSidechain;
 	mastercompressor.setup(a, r, t, rat, fc);
 }
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1212,12 +1212,12 @@ void getReverbParamsFromSong(Song* song) {
 }
 
 void getMasterCompressorParamsFromSong(Song* song) {
-	int32_t a = song->masterCompressorAttack;
-	int32_t r = song->masterCompressorRelease;
-	int32_t t = song->masterCompressorThresh;
-	int32_t rat = song->masterCompressorRatio;
-
-	mastercompressor.setup(a, r, t, rat);
+	q31_t a = song->masterCompressorAttack;
+	q31_t r = song->masterCompressorRelease;
+	q31_t t = song->masterCompressorThresh;
+	q31_t rat = song->masterCompressorRatio;
+	q31_t fc = song->masterCompressorSidechainFC;
+	mastercompressor.setup(a, r, t, rat, fc);
 }
 
 Voice* solicitVoice(Sound* forSound) {


### PR DESCRIPTION
Adds a sidechain HPF to the compressor, 6dB with an adjustable cutoff range of 0-102 Hz. This allows more bass through the compressor by removing it from the RMS level calculation