### PR TITLE
Speed up audio rendering by selective interrupt disabling

### DIFF
--- a/src/RZA1/intc/devdrv_intc.h
+++ b/src/RZA1/intc/devdrv_intc.h
@@ -575,6 +575,7 @@ int32_t R_INTC_RegistIntFunc(uint16_t int_id, void (*func)(uint32_t int_sense));
 void R_INTC_Init(void);
 int32_t R_INTC_Enable(uint16_t int_id);
 int32_t R_INTC_Disable(uint16_t int_id);
+uint8_t R_INTC_Enabled(uint16_t int_id);
 int32_t R_INTC_SetPriority(uint16_t int_id, uint8_t priority);
 int32_t R_INTC_SetMaskLevel(uint8_t mask_level);
 void R_INTC_GetMaskLevel(uint8_t* mask_level);

--- a/src/RZA1/intc/intc.c
+++ b/src/RZA1/intc/intc.c
@@ -106,15 +106,15 @@ static uint32_t intc_icdicfrn_table[] = /* Initial value table of Interrupt Conf
 
 /******************************************************************************
 * Function Name: R_INTC_RegistIntFunc
-* Description  : Registers the function specified by the func to the element 
+* Description  : Registers the function specified by the func to the element
 *              : specified by the int_id in the INTC interrupt handler function
 *              : table.
 * Arguments    : uint16_t int_id         : Interrupt ID
 *              : void (* func)(uint32_t) : Function to be registered to INTC
 *              :                         : interrupt hander table
-* Return Value : DEVDRV_SUCCESS          : Success of registration of INTC 
+* Return Value : DEVDRV_SUCCESS          : Success of registration of INTC
 *              :                         : interrupt handler function
-*              : DEVDRV_ERROR            : Failure of registration of INTC 
+*              : DEVDRV_ERROR            : Failure of registration of INTC
 *              :                         : interrupt handler function
 ******************************************************************************/
 int32_t R_INTC_RegistIntFunc(uint16_t int_id, void (*func)(uint32_t int_sense))
@@ -133,7 +133,7 @@ int32_t R_INTC_RegistIntFunc(uint16_t int_id, void (*func)(uint32_t int_sense))
 /******************************************************************************
 * Function Name: R_INTC_Init
 * Description  : Executes initial setting for the INTC.
-*              : The interrupt mask level is set to 31 to receive interrupts 
+*              : The interrupt mask level is set to 31 to receive interrupts
 *              : with the interrupt priority level 0 to 30.
 * Arguments    : none
 * Return Value : none
@@ -263,9 +263,22 @@ int32_t R_INTC_Disable(uint16_t int_id)
     return DEVDRV_SUCCESS;
 }
 
+uint8_t R_INTC_Enabled(uint16_t int_id)
+{
+    if (int_id >= INTC_ID_TOTAL)
+    {
+        return false;
+    }
+
+    volatile uint32_t* addr = (volatile uint32_t*)&INTC.ICDICER0;
+    uint32_t mask           = 1 << (int_id & 31); /* Create mask data */
+
+    return ((*(addr + (int_id >> 5)) & mask) == mask) ? 1 : 0;
+}
+
 /******************************************************************************
 * Function Name: R_INTC_SetPriority
-* Description  : Sets the priority level of the ID specified by the int_id to 
+* Description  : Sets the priority level of the ID specified by the int_id to
 *              : the priority level specified by the priority.
 * Arguments    : uint16_t int_id   : Interrupt ID
 *              : uint8_t  priority : Interrupt priority level (0 to 31)
@@ -332,7 +345,7 @@ int32_t R_INTC_SetMaskLevel(uint8_t mask_level)
 
 /******************************************************************************
 * Function Name: R_INTC_GetMaskLevel
-* Description  : Obtains the setting value of the interrupt mask level, and 
+* Description  : Obtains the setting value of the interrupt mask level, and
 *              : returns the obtained value to the mask_level.
 * Arguments    : uint8_t * mask_level : Interrupt mask level (0 to 31)
 * Return Value : none
@@ -345,10 +358,10 @@ void R_INTC_GetMaskLevel(uint8_t* mask_level)
 
 /******************************************************************************
 * Function Name: R_INTC_GetPendingStatus
-* Description  : Obtains the interrupt state of the interrupt specified by 
+* Description  : Obtains the interrupt state of the interrupt specified by
 *              : int_id, and returns the obtained value to the *icdicpr.
 * Arguments    : uint16_t int_id    : Interrupt ID
-*              : uint32_t * icdicpr : Interrupt state of the interrupt 
+*              : uint32_t * icdicpr : Interrupt state of the interrupt
 *              :                    : specified by int_id
 *              :                    :   1 : Pending or active and pending
 *              :                    :   0 : Not pending
@@ -378,7 +391,7 @@ int32_t R_INTC_GetPendingStatus(uint16_t int_id, uint32_t* icdicpr)
 
 /******************************************************************************
 * Function Name: R_INTC_SetConfiguration
-* Description  : Sets the interrupt detection mode of the ID specified by the 
+* Description  : Sets the interrupt detection mode of the ID specified by the
 *              : int_id to the detection mode specified by the int_sense.
 * Arguments    : uint16_t int_id    : Interrupt ID (INTC_ID_TINT0 to INTC_ID_TINT170)
 *              : uint32_t int_sense : Interrupt detection

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -72,6 +72,17 @@ extern "C" {
 //void *__dso_handle = NULL; // This fixes an insane error.
 }
 
+#define DISABLE_INTERRUPTS_COUNT (sizeof(disableInterrupts) / sizeof(uint32_t))
+uint32_t disableInterrupts[] = {INTC_ID_SPRI0,
+                                INTC_ID_DMAINT0 + PIC_TX_DMA_CHANNEL,
+                                IRQ_INTERRUPT_0 + 6,
+                                INTC_ID_USBI0,
+                                INTC_ID_SDHI1_0,
+                                INTC_ID_SDHI1_3,
+                                INTC_ID_DMAINT0 + OLED_SPI_DMA_CHANNEL,
+                                INTC_ID_DMAINT0 + MIDI_TX_DMA_CHANNEL,
+                                INTC_ID_SDHI1_1};
+
 using namespace deluge;
 
 extern bool inSpamMode;
@@ -618,18 +629,21 @@ startAgain:
 
 	// Render audio for song
 	if (currentSong) {
-		// Paul: Removed again because of MIDI and CV jitter, leaving interrupts enabled costs about 8 Voices
-		// bool interruptsDisabled = false;
-		// if (intc_func_active == 0) {
-		// 	__disable_irq();
-		// 	interruptsDisabled = true;
-		// }
+		uint8_t enabledInterrupts[DISABLE_INTERRUPTS_COUNT] = {0};
+		for (uint32_t idx = 0; idx < DISABLE_INTERRUPTS_COUNT; ++idx) {
+			enabledInterrupts[idx] = R_INTC_Enabled(disableInterrupts[idx]);
+			if (enabledInterrupts[idx]) {
+				R_INTC_Disable(disableInterrupts[idx]);
+			}
+		}
 
 		currentSong->renderAudio(renderingBuffer, numSamples, reverbBuffer, sideChainHitPending);
 
-		// if (interruptsDisabled) {
-		// 	__enable_irq();
-		// }
+		for (uint32_t idx = 0; idx < DISABLE_INTERRUPTS_COUNT; ++idx) {
+			if (enabledInterrupts[idx] != 0) {
+				R_INTC_Enable(disableInterrupts[idx]);
+			}
+		}
 	}
 
 #ifdef REPORT_CPU_USAGE


### PR DESCRIPTION
Selectively disable all interrupts except INTC_ID_TGI2A which is used for MIDI/CV gate timing