### PR TITLE
Show name of parameter in MOD knob popup

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -399,11 +399,15 @@ using ParamType = uint8_t;
 namespace Param {
 
 enum Kind : int32_t {
-	PATCHED,
-	UNPATCHED,
-	GLOBAL_EFFECTABLE,
-
 	NONE,
+
+	PATCHED,
+	UNPATCHED_SOUND,
+	UNPATCHED_GLOBAL,
+	STATIC,
+	MIDI,
+	PATCH_CABLE,
+	EXPRESSION,
 };
 
 namespace Local {

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -118,17 +118,17 @@ const std::array<std::pair<Param::Kind, ParamType>, kNumNonKitAffectEntireParams
         {Param::Kind::PATCHED, Param::Local::HPF_FREQ}, //HPF Cutoff, Resonance, Morph
         {Param::Kind::PATCHED, Param::Local::HPF_RESONANCE},
         {Param::Kind::PATCHED, Param::Local::HPF_MORPH},
-        {Param::Kind::UNPATCHED, Param::Unpatched::BASS}, //Bass, Bass Freq
-        {Param::Kind::UNPATCHED, Param::Unpatched::BASS_FREQ},
-        {Param::Kind::UNPATCHED, Param::Unpatched::TREBLE}, //Treble, Treble Freq
-        {Param::Kind::UNPATCHED, Param::Unpatched::TREBLE_FREQ},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BASS}, //Bass, Bass Freq
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BASS_FREQ},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::TREBLE}, //Treble, Treble Freq
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::TREBLE_FREQ},
         {Param::Kind::PATCHED, Param::Global::REVERB_AMOUNT}, //Reverb Amount
         {Param::Kind::PATCHED, Param::Global::DELAY_RATE},    //Delay Rate, Amount
         {Param::Kind::PATCHED, Param::Global::DELAY_FEEDBACK},
         {Param::Kind::PATCHED, Param::Global::VOLUME_POST_REVERB_SEND}, //Sidechain Send, Shape
-        {Param::Kind::UNPATCHED, Param::Unpatched::COMPRESSOR_SHAPE},
-        {Param::Kind::UNPATCHED, Param::Unpatched::SAMPLE_RATE_REDUCTION}, //Decimation, Bitcrush, Wavefolder
-        {Param::Kind::UNPATCHED, Param::Unpatched::BITCRUSHING},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::COMPRESSOR_SHAPE},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::SAMPLE_RATE_REDUCTION}, //Decimation, Bitcrush, Wavefolder
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BITCRUSHING},
         {Param::Kind::PATCHED, Param::Local::FOLD},
         {Param::Kind::PATCHED,
          Param::Local::OSC_A_VOLUME}, //OSC 1 Volume, Pitch, Phase Width, Carrier Feedback, Wave Index
@@ -156,47 +156,47 @@ const std::array<std::pair<Param::Kind, ParamType>, kNumNonKitAffectEntireParams
         {Param::Kind::PATCHED, Param::Local::ENV_1_DECAY},
         {Param::Kind::PATCHED, Param::Local::ENV_1_SUSTAIN},
         {Param::Kind::PATCHED, Param::Local::ENV_1_RELEASE},
-        {Param::Kind::PATCHED, Param::Global::LFO_FREQ},           //LFO 1 Freq
-        {Param::Kind::PATCHED, Param::Local::LFO_LOCAL_FREQ},      //LFO 2 Freq
-        {Param::Kind::UNPATCHED, Param::Unpatched::MOD_FX_OFFSET}, //Mod FX Offset, Feedback, Depth, Rate
-        {Param::Kind::UNPATCHED, Param::Unpatched::MOD_FX_FEEDBACK},
+        {Param::Kind::PATCHED, Param::Global::LFO_FREQ},                 //LFO 1 Freq
+        {Param::Kind::PATCHED, Param::Local::LFO_LOCAL_FREQ},            //LFO 2 Freq
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::MOD_FX_OFFSET}, //Mod FX Offset, Feedback, Depth, Rate
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::MOD_FX_FEEDBACK},
         {Param::Kind::PATCHED, Param::Global::MOD_FX_DEPTH},
         {Param::Kind::PATCHED, Param::Global::MOD_FX_RATE},
         {Param::Kind::PATCHED, Param::Global::ARP_RATE}, //Arp Rate, Gate
-        {Param::Kind::UNPATCHED, Param::Unpatched::Sound::ARP_GATE},
-        {Param::Kind::PATCHED, Param::Local::NOISE_VOLUME},            //Noise
-        {Param::Kind::UNPATCHED, Param::Unpatched::Sound::PORTAMENTO}, //Portamento
-        {Param::Kind::UNPATCHED, Param::Unpatched::STUTTER_RATE},      //Stutter Rate
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::Sound::ARP_GATE},
+        {Param::Kind::PATCHED, Param::Local::NOISE_VOLUME},                  //Noise
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::Sound::PORTAMENTO}, //Portamento
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::STUTTER_RATE},      //Stutter Rate
     }};
 
 //kit affect entire FX - sorted in the order that Parameters are scrolled through on the display
 const std::array<std::pair<Param::Kind, ParamType>, kNumKitAffectEntireParamsForAutomation>
     kitAffectEntireParamsForAutomation{{
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::VOLUME}, //Master Volume, Pitch, Pan
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::PITCH_ADJUST},
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::PAN},
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::LPF_FREQ}, //LPF Cutoff, Resonance
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::LPF_RES},
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::HPF_FREQ}, //HPF Cutoff, Resonance
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::HPF_RES},
-        {Param::Kind::UNPATCHED, Param::Unpatched::BASS}, //Bass, Bass Freq
-        {Param::Kind::UNPATCHED, Param::Unpatched::BASS_FREQ},
-        {Param::Kind::UNPATCHED, Param::Unpatched::TREBLE}, //Treble, Treble Freq
-        {Param::Kind::UNPATCHED, Param::Unpatched::TREBLE_FREQ},
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::REVERB_SEND_AMOUNT}, //Reverb Amount
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::DELAY_RATE},         //Delay Rate, Amount
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::DELAY_AMOUNT},
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::SIDECHAIN_VOLUME}, //Sidechain Send, Shape
-        {Param::Kind::UNPATCHED, Param::Unpatched::COMPRESSOR_SHAPE},
-        {Param::Kind::UNPATCHED, Param::Unpatched::SAMPLE_RATE_REDUCTION}, //Decimation, Bitcrush
-        {Param::Kind::UNPATCHED, Param::Unpatched::BITCRUSHING},
-        {Param::Kind::UNPATCHED, Param::Unpatched::MOD_FX_OFFSET}, //Mod FX Offset, Feedback, Depth, Rate
-        {Param::Kind::UNPATCHED, Param::Unpatched::MOD_FX_FEEDBACK},
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::MOD_FX_DEPTH},
-        {Param::Kind::GLOBAL_EFFECTABLE, Param::Unpatched::GlobalEffectable::MOD_FX_RATE},
-        {Param::Kind::UNPATCHED, Param::Unpatched::Sound::ARP_GATE},   //Arp Gate
-        {Param::Kind::UNPATCHED, Param::Unpatched::Sound::PORTAMENTO}, //Portamento
-        {Param::Kind::UNPATCHED, Param::Unpatched::STUTTER_RATE},      //Stutter Rate
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::VOLUME}, //Master Volume, Pitch, Pan
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::PITCH_ADJUST},
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::PAN},
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::LPF_FREQ}, //LPF Cutoff, Resonance
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::LPF_RES},
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::HPF_FREQ}, //HPF Cutoff, Resonance
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::HPF_RES},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BASS}, //Bass, Bass Freq
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BASS_FREQ},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::TREBLE}, //Treble, Treble Freq
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::TREBLE_FREQ},
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::REVERB_SEND_AMOUNT}, //Reverb Amount
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::DELAY_RATE},         //Delay Rate, Amount
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::DELAY_AMOUNT},
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::SIDECHAIN_VOLUME}, //Sidechain Send, Shape
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::COMPRESSOR_SHAPE},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::SAMPLE_RATE_REDUCTION}, //Decimation, Bitcrush
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BITCRUSHING},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::MOD_FX_OFFSET}, //Mod FX Offset, Feedback, Depth, Rate
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::MOD_FX_FEEDBACK},
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::MOD_FX_DEPTH},
+        {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::MOD_FX_RATE},
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::Sound::ARP_GATE},   //Arp Gate
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::Sound::PORTAMENTO}, //Portamento
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::STUTTER_RATE},      //Stutter Rate
     }};
 
 //grid sized arrays to assign automatable parameters to the grid
@@ -646,8 +646,9 @@ void AutomationInstrumentClipView::renderAutomationOverview(ModelStackWithTimeli
 
 			else if (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
 
-				modelStackWithParam = getModelStackWithParam(
-				    modelStack, clip, unpatchedParamShortcutsForAutomation[xDisplay][yDisplay], Param::Kind::UNPATCHED);
+				modelStackWithParam =
+				    getModelStackWithParam(modelStack, clip, unpatchedParamShortcutsForAutomation[xDisplay][yDisplay],
+				                           Param::Kind::UNPATCHED_SOUND);
 			}
 		}
 
@@ -815,11 +816,9 @@ void AutomationInstrumentClipView::renderDisplay(int32_t knobPosLeft, int32_t kn
 	InstrumentClip* clip = getCurrentClip();
 	Instrument* instrument = (Instrument*)clip->output;
 
-	//if you're not in a MIDI instrument clip, convert the knobPos to the same range as the menu (0-50)
-	if (instrument->type != InstrumentType::MIDI_OUT) {
-		knobPosLeft = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, knobPosLeft);
-		knobPosRight = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, knobPosRight);
-	}
+	knobPosLeft = view.calculateKnobPosForDisplay(clip->lastSelectedParamKind, clip->lastSelectedParamID, knobPosLeft);
+	knobPosRight =
+	    view.calculateKnobPosForDisplay(clip->lastSelectedParamKind, clip->lastSelectedParamID, knobPosRight);
 
 	//OLED Display
 	if (display->haveOLED()) {
@@ -976,15 +975,7 @@ void AutomationInstrumentClipView::renderDisplay7SEG(InstrumentClip* clip, Instr
 //get's the name of the Parameter being edited so it can be displayed on the screen
 void AutomationInstrumentClipView::getParameterName(InstrumentClip* clip, Instrument* instrument, char* parameterName) {
 	if (instrument->type == InstrumentType::SYNTH || instrument->type == InstrumentType::KIT) {
-		if (clip->lastSelectedParamKind == Param::Kind::PATCHED) {
-			strncpy(parameterName, getPatchedParamDisplayName(clip->lastSelectedParamID), 29);
-		}
-		else if (clip->lastSelectedParamKind == Param::Kind::UNPATCHED) {
-			strncpy(parameterName, getUnpatchedParamDisplayName(clip->lastSelectedParamID), 29);
-		}
-		else if (clip->lastSelectedParamKind == Param::Kind::GLOBAL_EFFECTABLE) {
-			strncpy(parameterName, getGlobalEffectableParamDisplayName(clip->lastSelectedParamID), 29);
-		}
+		strncpy(parameterName, getParamDisplayName(clip->lastSelectedParamKind, clip->lastSelectedParamID), 29);
 	}
 	else if (instrument->type == InstrumentType::MIDI_OUT) {
 		if (clip->lastSelectedParamID == CC_NUMBER_NONE) {
@@ -2795,16 +2786,14 @@ void AutomationInstrumentClipView::selectEncoderAction(int8_t offset) {
 		else {
 			for (int32_t x = 0; x < kDisplayWidth; x++) {
 				for (int32_t y = 0; y < kDisplayHeight; y++) {
-
 					if ((clip->lastSelectedParamKind == Param::Kind::PATCHED
 					     && patchedParamShortcutsForAutomation[x][y] == clip->lastSelectedParamID)
-					    || (clip->lastSelectedParamKind == Param::Kind::UNPATCHED
+					    || (clip->lastSelectedParamKind == Param::Kind::UNPATCHED_SOUND
 					        && unpatchedParamShortcutsForAutomation[x][y] == clip->lastSelectedParamID)
-					    || (clip->lastSelectedParamKind == Param::Kind::GLOBAL_EFFECTABLE
+					    || (clip->lastSelectedParamKind == Param::Kind::UNPATCHED_GLOBAL
 					        && globalEffectableParamShortcutsForAutomation[x][y] == clip->lastSelectedParamID)) {
 						clip->lastSelectedParamShortcutX = x;
 						clip->lastSelectedParamShortcutY = y;
-
 						goto flashShortcut;
 					}
 				}
@@ -2938,7 +2927,7 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 				summary = modelStackWithThreeMainThings->paramManager->getPatchedParamSetSummary();
 			}
 
-			else if (paramKind == Param::Kind::UNPATCHED) {
+			else if (paramKind == Param::Kind::UNPATCHED_SOUND) {
 				summary = modelStackWithThreeMainThings->paramManager->getUnpatchedParamSetSummary();
 			}
 
@@ -2975,7 +2964,7 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 								summary = modelStackWithThreeMainThings->paramManager->getPatchedParamSetSummary();
 							}
 
-							else if (paramKind == Param::Kind::UNPATCHED) {
+							else if (paramKind == Param::Kind::UNPATCHED_SOUND) {
 								summary = modelStackWithThreeMainThings->paramManager->getUnpatchedParamSetSummary();
 							}
 
@@ -3224,7 +3213,7 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 			}
 
 			else if (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
-				clip->lastSelectedParamKind = Param::Kind::UNPATCHED;
+				clip->lastSelectedParamKind = Param::Kind::UNPATCHED_SOUND;
 				//if you are in a synth or a kit clip and the shortcut is valid, set current selected ParamID
 				clip->lastSelectedParamID = unpatchedParamShortcutsForAutomation[xDisplay][yDisplay];
 			}
@@ -3245,13 +3234,13 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 		             || (globalEffectableParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF))) {
 
 			if (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
-				clip->lastSelectedParamKind = Param::Kind::UNPATCHED;
+				clip->lastSelectedParamKind = Param::Kind::UNPATCHED_SOUND;
 				//if you are in a kit clip with affect entire enabled and the shortcut is valid, set current selected ParamID
 				clip->lastSelectedParamID = unpatchedParamShortcutsForAutomation[xDisplay][yDisplay];
 			}
 
 			else if (globalEffectableParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
-				clip->lastSelectedParamKind = Param::Kind::GLOBAL_EFFECTABLE;
+				clip->lastSelectedParamKind = Param::Kind::UNPATCHED_GLOBAL;
 				//if you are in a kit clip with affect entire enabled and the shortcut is valid, set current selected ParamID
 				clip->lastSelectedParamID = globalEffectableParamShortcutsForAutomation[xDisplay][yDisplay];
 			}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -864,23 +864,21 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				copyModelStack(modelStackTempMemory, modelStackWithParam, sizeof(ModelStackWithThreeMainThings));
 				ModelStackWithThreeMainThings* tempModelStack = (ModelStackWithThreeMainThings*)modelStackTempMemory;
 
-				InstrumentClip* clip = (InstrumentClip*)tempModelStack->getTimelineCounter();
-
 				int32_t value = modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
 				int32_t knobPos = modelStackWithParam->paramCollection->paramValueToKnobPos(value, modelStackWithParam);
 				int32_t lowerLimit = std::min(-64_i32, knobPos);
 				int32_t newKnobPos = knobPos + offset;
 				newKnobPos = std::clamp(newKnobPos, lowerLimit, 64_i32);
+
+				Param::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+
 				//ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
 				//if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a value change gets recorded
 				//if newKnobPos exceeds 127, then it means current knobPos was 127 and it was increased to 128. In which case, ignore value change
-				if ((getRootUI() == &instrumentClipView) || (getRootUI() == &automationInstrumentClipView)) {
-					if ((clip->output->type == InstrumentType::MIDI_OUT) && (newKnobPos == 64)) {
-						return;
-					}
+				if (kind == Param::Kind::MIDI && (newKnobPos == 64)) {
+					return;
 				}
 
-				Param::Kind kind = modelStackWithParam->paramCollection->getParamKind();
 				displayModEncoderValuePopup(kind, modelStackWithParam->paramId, newKnobPos);
 
 				if (newKnobPos == knobPos) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -28,6 +28,7 @@
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/load/load_instrument_preset_ui.h"
 #include "gui/ui/load/load_song_ui.h"
+#include "gui/ui/menus.h"
 #include "gui/ui/root_ui.h"
 #include "gui/ui/save/save_song_ui.h"
 #include "gui/ui/sound_editor.h"
@@ -879,7 +880,8 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 					}
 				}
 
-				displayModEncoderValuePopup(clip->output->type, modelStackWithParam->paramId, newKnobPos);
+				Param::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+				displayModEncoderValuePopup(kind, modelStackWithParam->paramId, newKnobPos);
 
 				if (newKnobPos == knobPos) {
 					return;
@@ -913,7 +915,7 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 					}
 				}
 
-				if (!newKnobPos
+				if (newKnobPos == 0
 				    && modelStackWithParam->paramCollection->shouldParamIndicateMiddleValue(modelStackWithParam)) {
 					indicator_leds::blinkKnobIndicator(whichModEncoder);
 
@@ -930,47 +932,51 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 	}
 }
 
-void View::displayModEncoderValuePopup(InstrumentType instrumentType, int32_t paramID, int32_t newKnobPos) {
-	//check if param is quantized stutter with stuttering enabled
-	if (!(isParamQuantizedStutter(paramID) && !isUIModeActive(UI_MODE_STUTTERING))) {
+void View::displayModEncoderValuePopup(Param::Kind kind, int32_t paramID, int32_t newKnobPos) {
+	DEF_STACK_STRING_BUF(popupMsg, 40);
 
-		char buffer[5];
-		int32_t valueForDisplay;
-		if (instrumentType == InstrumentType::MIDI_OUT) {
-			valueForDisplay = newKnobPos + kKnobPosOffset;
+	// On OLED, display the name of the parameter on the first line of the popup
+	if (display->haveOLED()) {
+		const char* name = getParamDisplayName(kind, paramID);
+		if (name != l10n::get(l10n::String::STRING_FOR_NONE)) {
+			popupMsg.append(name);
+			popupMsg.append(": ");
 		}
-		else {
-			valueForDisplay = calculateKnobPosForDisplay(instrumentType, paramID, newKnobPos + kKnobPosOffset);
-		}
-		intToString(valueForDisplay, buffer);
-		display->displayPopup(buffer);
 	}
 
 	//if turning stutter mod encoder and stutter quantize is enabled
 	//display stutter quantization instead of knob position
-	if (isParamQuantizedStutter(paramID) && !isUIModeActive(UI_MODE_STUTTERING)) {
+	if (isParamQuantizedStutter(kind, paramID) && !isUIModeActive(UI_MODE_STUTTERING)) {
 		char buffer[10];
 		if (newKnobPos < -39) { // 4ths stutter: no leds turned on
-			strncpy(buffer, "4ths", 10);
+			popupMsg.append("4ths");
 		}
 		else if (newKnobPos < -14) { // 8ths stutter: 1 led turned on
-			strncpy(buffer, "8ths", 10);
+			popupMsg.append("8ths");
 		}
 		else if (newKnobPos < 14) { // 16ths stutter: 2 leds turned on
-			strncpy(buffer, "16ths", 10);
+			popupMsg.append("16ths");
 		}
 		else if (newKnobPos < 39) { // 32nds stutter: 3 leds turned on
-			strncpy(buffer, "32nds", 10);
+			popupMsg.append("32nds");
 		}
 		else { // 64ths stutter: all 4 leds turned on
-			strncpy(buffer, "64ths", 10);
+			popupMsg.append("64ths");
 		}
-		display->displayPopup(buffer);
 	}
+	else {
+		int valueForDisplay = calculateKnobPosForDisplay(kind, paramID, newKnobPos + kKnobPosOffset);
+		popupMsg.appendInt(valueForDisplay);
+	}
+	display->displayPopup(popupMsg.c_str());
 }
 
 //convert deluge internal knobPos range to same range as used by menu's.
-int32_t View::calculateKnobPosForDisplay(InstrumentType instrumentType, int32_t paramID, int32_t knobPos) {
+int32_t View::calculateKnobPosForDisplay(Param::Kind kind, int32_t paramID, int32_t knobPos) {
+	if (kind == Param::Kind::MIDI) {
+		return knobPos;
+	}
+
 	float knobPosFloat = static_cast<float>(knobPos);
 	float knobPosOffsetFloat = static_cast<float>(kKnobPosOffset);
 	float maxKnobPosFloat = static_cast<float>(kMaxKnobPos);
@@ -982,7 +988,7 @@ int32_t View::calculateKnobPosForDisplay(InstrumentType instrumentType, int32_t 
 	valueForDisplayFloat = (knobPosFloat / maxKnobPosFloat) * maxMenuValueFloat;
 
 	//check if parameter is pan, in which case, further adjust range from 0 - 50 to -25 to +25
-	if (isParamPan(instrumentType, paramID)) {
+	if (isParamPan(kind, paramID)) {
 		valueForDisplayFloat = valueForDisplayFloat - maxMenuPanValueFloat;
 	}
 
@@ -991,33 +997,26 @@ returnValue:
 }
 
 //check if Parameter is Stutter Rate and if Quantized Stutter Community Feature is enabled
-bool View::isParamQuantizedStutter(int32_t paramID) {
-	if (((Param::Unpatched::START + paramID) == (Param::Unpatched::START + Param::Unpatched::STUTTER_RATE))
-	    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
-	        == RuntimeFeatureStateToggle::On)) {
+bool View::isParamQuantizedStutter(Param::Kind kind, int32_t paramID) {
+	if (!runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate) == RuntimeFeatureStateToggle::On) {
+		return false;
+	}
+	if ((kind == Param::Kind::UNPATCHED_GLOBAL || kind == Param::Kind::UNPATCHED_SOUND)
+	    && paramID == Param::Unpatched::Shared::STUTTER_RATE) {
 		return true;
 	}
 	return false;
 }
 
-bool View::isParamPan(InstrumentType instrumentType, int32_t paramID) {
-	bool isPan = false;
-
-	//in a synth or a kit (with affect entire disabled), check if it is the patched Pan parameter
-	if ((instrumentType == InstrumentType::SYNTH)
-	    || ((instrumentType == InstrumentType::KIT) && !instrumentClipView.getAffectEntire())) {
-		if (paramID == Param::Local::PAN) {
-			isPan = true;
-		}
+bool View::isParamPan(Param::Kind kind, int32_t paramID) {
+	if (kind == Param::Kind::PATCHED && paramID == Param::Local::PAN) {
+		return true;
 	}
-	//elsewhere (song, performance, audio clip, kit with affect entire enabled)
-	// only global effectable pan is used - check for it)
-	else if ((Param::Unpatched::START + paramID)
-	         == (Param::Unpatched::START + Param::Unpatched::GlobalEffectable::PAN)) {
-		isPan = true;
+	if (kind == Param::Kind::UNPATCHED_GLOBAL && paramID == Param::Unpatched::GlobalEffectable::PAN) {
+		return true;
 	}
 
-	return isPan;
+	return false;
 }
 
 void View::instrumentBeenEdited() {

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -122,15 +122,15 @@ public:
 	// == activeModControllableTimelineCounter
 	uint32_t modLength;
 
-	bool isParamPan(InstrumentType instrumentType, int32_t paramID);
-	int32_t calculateKnobPosForDisplay(InstrumentType instrumentType, int32_t paramID, int32_t knobPos);
+	bool isParamPan(Param::Kind kind, int32_t paramID);
+	int32_t calculateKnobPosForDisplay(Param::Kind kind, int32_t paramID, int32_t knobPos);
 
 private:
 	void pretendModKnobsUntouchedForAWhile();
 	void instrumentBeenEdited();
 	void clearMelodicInstrumentMonoExpressionIfPossible();
-	void displayModEncoderValuePopup(InstrumentType instrumentType, int32_t paramID, int32_t newKnobPos);
-	bool isParamQuantizedStutter(int32_t paramID);
+	void displayModEncoderValuePopup(Param::Kind kind, int32_t paramID, int32_t newKnobPos);
+	bool isParamQuantizedStutter(Param::Kind kind, int32_t paramID);
 };
 
 extern View view;

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -63,6 +63,7 @@ void GlobalEffectable::initParams(ParamManager* paramManager) {
 	ModControllableAudio::initParams(paramManager);
 
 	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+	unpatchedParams->kind = Param::Kind::UNPATCHED_GLOBAL;
 
 	unpatchedParams->params[Param::Unpatched::GlobalEffectable::MOD_FX_RATE].setCurrentValueBasicForSetup(-536870912);
 	unpatchedParams->params[Param::Unpatched::MOD_FX_FEEDBACK].setCurrentValueBasicForSetup(-2147483648);

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -185,6 +185,10 @@ ModelStackWithThreeMainThings* ModelStackWithNoteRow::addOtherTwoThingsAutomatic
 	return toReturn;
 }
 
+bool ModelStackWithParamId::isParam(Param::Kind kind, ParamType id) {
+	return paramCollection && paramCollection->getParamKind() == kind && paramId == id;
+}
+
 bool ModelStackWithSoundFlags::checkSourceEverActiveDisregardingMissingSample(int32_t s) {
 	int32_t flagValue = soundFlags[SOUND_FLAG_SOURCE_0_ACTIVE_DISREGARDING_MISSING_SAMPLE + s];
 	if (flagValue == FLAG_TBD) {

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -265,6 +265,8 @@ public:
 	int32_t paramId;
 
 	ModelStackWithAutoParam* addAutoParam(AutoParam* newAutoParam) const;
+
+	bool isParam(Param::Kind kind, ParamType id);
 };
 
 class ModelStackWithAutoParam : public ModelStackWithParamId {

--- a/src/deluge/modulation/midi/midi_param_collection.h
+++ b/src/deluge/modulation/midi/midi_param_collection.h
@@ -61,6 +61,8 @@ public:
 	void writeToFile();
 	int32_t moveAutomationToDifferentCC(int32_t oldCC, int32_t newCC, ModelStackWithParamCollection* modelStack);
 
+	Param::Kind getParamKind() { return Param::Kind::MIDI; }
+
 	MIDIParamVector params;
 
 private:

--- a/src/deluge/modulation/params/param_collection.h
+++ b/src/deluge/modulation/params/param_collection.h
@@ -18,6 +18,8 @@
 #pragma once
 #include <cstdint>
 
+#include "definitions_cxx.hpp"
+
 class ParamManagerForTimeline;
 class Sound;
 class InstrumentClip;
@@ -67,12 +69,14 @@ public:
 	    ModelStackWithParamId* modelStack,
 	    bool allowCreation =
 	        false) = 0; // You must not pass this any child class of ModelStackWithThreeMoreThings (wait why again?). May return NULL
+
 	virtual bool mayParamInterpolate(int32_t paramId);
 	virtual bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) { return false; }
 	virtual bool doesParamIdAllowAutomation(ModelStackWithParamId const* modelStack) { return true; }
 	virtual int32_t paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack);
 	virtual int32_t knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack);
 	virtual void notifyPingpongOccurred(ModelStackWithParamCollection* modelStack);
+	virtual Param::Kind getParamKind() = 0;
 
 	const int32_t objectSize;
 	int32_t ticksTilNextEvent;

--- a/src/deluge/modulation/params/param_set.h
+++ b/src/deluge/modulation/params/param_set.h
@@ -101,6 +101,9 @@ public:
 	void beenCloned(bool copyAutomation, int32_t reverseDirectionWithLength);
 	bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack);
 	bool doesParamIdAllowAutomation(ModelStackWithParamId const* modelStack);
+	Param::Kind getParamKind() { return kind; }
+
+	Param::Kind kind = Param::Kind::NONE;
 
 private:
 	std::array<AutoParam, kMaxNumUnpatchedParams> params_;
@@ -115,6 +118,7 @@ public:
 	int32_t paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack);
 	int32_t knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack);
 	bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack);
+	Param::Kind getParamKind() { return Param::Kind::PATCHED; }
 
 private:
 	std::array<AutoParam, kNumParams> params_;
@@ -136,6 +140,7 @@ public:
 	void clearValues(ModelStackWithParamCollection const* modelStack);
 	void cancelAllOverriding();
 	void deleteAllAutomation(Action* action, ModelStackWithParamCollection* modelStack);
+	Param::Kind getParamKind() { return Param::Kind::EXPRESSION; }
 
 	// bendRanges being stored here in ExpressionParamSet still seems like the best option. I was thinking storing them in the ParamManager would make more sense, except for one thing
 	// - persistence when preset/Instrument changes. ExpressionParamSets do this unique thing where they normally aren't "stolen" or "backed up" - unless the last Clip is being deleted,

--- a/src/deluge/modulation/patch/patch_cable_set.h
+++ b/src/deluge/modulation/patch/patch_cable_set.h
@@ -101,6 +101,8 @@ public:
 
 	Destination* getDestinationForParam(int32_t p);
 
+	Param::Kind getParamKind() { return Param::Kind::PATCH_CABLE; }
+
 	uint32_t sourcesPatchedToAnything[2]; // Only valid after setupPatching()
 
 	PatchCable patchCables[kMaxNumPatchCables]; // TODO: store these in dynamic memory.

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -164,6 +164,8 @@ void Sound::initParams(ParamManager* paramManager) {
 	ModControllableAudio::initParams(paramManager);
 
 	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+	unpatchedParams->kind = Param::Kind::UNPATCHED_SOUND;
+
 	unpatchedParams->params[Param::Unpatched::Sound::ARP_GATE].setCurrentValueBasicForSetup(0);
 	unpatchedParams->params[Param::Unpatched::MOD_FX_FEEDBACK].setCurrentValueBasicForSetup(0);
 	unpatchedParams->params[Param::Unpatched::Sound::PORTAMENTO].setCurrentValueBasicForSetup(-2147483648);

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include "functions.h"
 #include <cstdint>
+#include <cstring>
 
 extern const char nothing;
 
@@ -72,3 +74,40 @@ private:
 
 	char* stringMemory;
 };
+
+/// A string buffer with utility functions to append and format contents.
+/// does not handle allocation
+class StringBuf {
+	// Not templated to optimize binary size.
+public:
+	StringBuf(char* buf, size_t capacity) : capacity_(capacity), buf_(buf) {}
+
+	void append(const char* str) { ::strncat(buf_, str, capacity_ - size()); }
+	void append(char c) { ::strncat(buf_, &c, 1); }
+	void clear() { buf_[0] = 0; }
+
+	// TODO: Validate buffer size. This will overflow
+	void appendInt(int i, int minChars = 1) { intToString(i, buf_ + size(), minChars); }
+	void appendHex(int i, int minChars = 1) { intToHex(i, buf_ + size(), minChars); }
+
+	[[nodiscard]] char* data() { return buf_; }
+	[[nodiscard]] const char* data() const { return buf_; }
+	[[nodiscard]] const char* c_str() const { return buf_; }
+
+	[[nodiscard]] std::size_t capacity() const { return capacity_; }
+	[[nodiscard]] std::size_t size() const { return ::strlen(buf_); }
+
+	[[nodiscard]] bool empty() const { return buf_[0] == 0; }
+
+	bool operator==(const char* rhs) const { return strcmp(buf_, rhs) == 0; }
+	bool operator==(StringBuf const& rhs) const { return strcmp(buf_, rhs.c_str()) == 0; }
+
+private:
+	size_t capacity_;
+	char* buf_;
+};
+
+/// Define a `StringBuf` that uses an array placed on the stack.
+#define DEF_STACK_STRING_BUF(name, capacity)                                                                           \
+	char name##__buf[capacity] = {0};                                                                                  \
+	StringBuf name = {name##__buf, capacity}

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -501,116 +501,113 @@ char const* getPatchedParamDisplayName(int32_t p) {
 	}
 }
 
-char const* getUnpatchedParamDisplayName(int32_t p) {
+char const* getParamDisplayName(Param::Kind kind, int32_t p) {
 	using enum l10n::String;
-
-	// These can basically be 13 chars long, or 14 if the last one is a dot.
-	switch (p) {
-
-	//Bass, Bass Freq
-	case Param::Unpatched::BASS:
-		return l10n::get(STRING_FOR_BASS);
-
-	case Param::Unpatched::BASS_FREQ:
-		return l10n::get(STRING_FOR_BASS_FREQUENCY);
-
-	//Treble, Treble Freq
-	case Param::Unpatched::TREBLE:
-		return l10n::get(STRING_FOR_TREBLE);
-
-	case Param::Unpatched::TREBLE_FREQ:
-		return l10n::get(STRING_FOR_TREBLE_FREQUENCY);
-
-	//Sidechain Shape
-	case Param::Unpatched::COMPRESSOR_SHAPE:
-		return l10n::get(STRING_FOR_SIDECHAIN_SHAPE);
-
-	//Decimation, Bitcrush
-	case Param::Unpatched::SAMPLE_RATE_REDUCTION:
-		return l10n::get(STRING_FOR_DECIMATION);
-
-	case Param::Unpatched::BITCRUSHING:
-		return l10n::get(STRING_FOR_BITCRUSH);
-
-	//Mod FX Offset, Feedback
-	case Param::Unpatched::MOD_FX_OFFSET:
-		return l10n::get(STRING_FOR_MODFX_OFFSET);
-
-	case Param::Unpatched::MOD_FX_FEEDBACK:
-		return l10n::get(STRING_FOR_MODFX_FEEDBACK);
-
-	//Arp Gate
-	case Param::Unpatched::Sound::ARP_GATE:
-		return l10n::get(STRING_FOR_ARP_GATE_MENU_TITLE);
-
-	//Portamento
-	case Param::Unpatched::Sound::PORTAMENTO:
-		return l10n::get(STRING_FOR_PORTAMENTO);
-
-	//Stutter
-	case Param::Unpatched::STUTTER_RATE:
-		return l10n::get(STRING_FOR_STUTTER_RATE);
-
-	default:
-		return l10n::get(STRING_FOR_NONE);
+	if (kind == Param::Kind::PATCHED) {
+		return getPatchedParamDisplayName(p);
 	}
-}
 
-char const* getGlobalEffectableParamDisplayName(int32_t p) {
-	using enum l10n::String;
+	if (kind == Param::Kind::UNPATCHED_SOUND || kind == Param::Kind::UNPATCHED_GLOBAL) {
+		// These can basically be 13 chars long, or 14 if the last one is a dot.
+		switch (p) {
 
-	// These can basically be 13 chars long, or 14 if the last one is a dot.
-	switch (p) {
+		//Bass, Bass Freq
+		case Param::Unpatched::BASS:
+			return l10n::get(STRING_FOR_BASS);
 
-	//Master Volume, Pitch, Pan
-	case Param::Unpatched::GlobalEffectable::VOLUME:
-		return l10n::get(STRING_FOR_MASTER_LEVEL);
+		case Param::Unpatched::BASS_FREQ:
+			return l10n::get(STRING_FOR_BASS_FREQUENCY);
 
-	case Param::Unpatched::GlobalEffectable::PITCH_ADJUST:
-		return l10n::get(STRING_FOR_MASTER_PITCH);
+		//Treble, Treble Freq
+		case Param::Unpatched::TREBLE:
+			return l10n::get(STRING_FOR_TREBLE);
 
-	case Param::Unpatched::GlobalEffectable::PAN:
-		return l10n::get(STRING_FOR_MASTER_PAN);
+		case Param::Unpatched::TREBLE_FREQ:
+			return l10n::get(STRING_FOR_TREBLE_FREQUENCY);
 
-	//LPF Cutoff, Resonance
-	case Param::Unpatched::GlobalEffectable::LPF_FREQ:
-		return l10n::get(STRING_FOR_LPF_FREQUENCY);
+		//Sidechain Shape
+		case Param::Unpatched::COMPRESSOR_SHAPE:
+			return l10n::get(STRING_FOR_SIDECHAIN_SHAPE);
 
-	case Param::Unpatched::GlobalEffectable::LPF_RES:
-		return l10n::get(STRING_FOR_LPF_RESONANCE);
+		//Decimation, Bitcrush
+		case Param::Unpatched::SAMPLE_RATE_REDUCTION:
+			return l10n::get(STRING_FOR_DECIMATION);
 
-	//HPF Cutoff, Resonance
-	case Param::Unpatched::GlobalEffectable::HPF_FREQ:
-		return l10n::get(STRING_FOR_HPF_FREQUENCY);
+		case Param::Unpatched::BITCRUSHING:
+			return l10n::get(STRING_FOR_BITCRUSH);
 
-	case Param::Unpatched::GlobalEffectable::HPF_RES:
-		return l10n::get(STRING_FOR_HPF_RESONANCE);
+		//Mod FX Offset, Feedback
+		case Param::Unpatched::MOD_FX_OFFSET:
+			return l10n::get(STRING_FOR_MODFX_OFFSET);
 
-	//Reverb Amount
-	case Param::Unpatched::GlobalEffectable::REVERB_SEND_AMOUNT:
-		return l10n::get(STRING_FOR_REVERB_AMOUNT);
+		case Param::Unpatched::MOD_FX_FEEDBACK:
+			return l10n::get(STRING_FOR_MODFX_FEEDBACK);
 
-	//Delay Rate, Amount
-	case Param::Unpatched::GlobalEffectable::DELAY_RATE:
-		return l10n::get(STRING_FOR_DELAY_RATE);
-
-	case Param::Unpatched::GlobalEffectable::DELAY_AMOUNT:
-		return l10n::get(STRING_FOR_DELAY_AMOUNT);
-
-	//Sidechain Send
-	case Param::Unpatched::GlobalEffectable::SIDECHAIN_VOLUME:
-		return l10n::get(STRING_FOR_SIDECHAIN_LEVEL);
-
-	//Mod FX Depth, Rate
-	case Param::Unpatched::GlobalEffectable::MOD_FX_DEPTH:
-		return l10n::get(STRING_FOR_MODFX_DEPTH);
-
-	case Param::Unpatched::GlobalEffectable::MOD_FX_RATE:
-		return l10n::get(STRING_FOR_MODFX_RATE);
-
-	default:
-		return l10n::get(STRING_FOR_NONE);
+		case Param::Unpatched::STUTTER_RATE:
+			return l10n::get(STRING_FOR_STUTTER_RATE);
+		}
 	}
+
+	if (kind == Param::Kind::UNPATCHED_SOUND) {
+		switch (p) {
+		case Param::Unpatched::Sound::ARP_GATE:
+			return l10n::get(STRING_FOR_ARP_GATE_MENU_TITLE);
+		case Param::Unpatched::Sound::PORTAMENTO:
+			return l10n::get(STRING_FOR_PORTAMENTO);
+		}
+	}
+
+	if (kind == Param::Kind::UNPATCHED_GLOBAL) {
+		// These can basically be 13 chars long, or 14 if the last one is a dot.
+		switch (p) {
+		//Master Volume, Pitch, Pan
+		case Param::Unpatched::GlobalEffectable::VOLUME:
+			return l10n::get(STRING_FOR_MASTER_LEVEL);
+
+		case Param::Unpatched::GlobalEffectable::PITCH_ADJUST:
+			return l10n::get(STRING_FOR_MASTER_PITCH);
+
+		case Param::Unpatched::GlobalEffectable::PAN:
+			return l10n::get(STRING_FOR_MASTER_PAN);
+
+		//LPF Cutoff, Resonance
+		case Param::Unpatched::GlobalEffectable::LPF_FREQ:
+			return l10n::get(STRING_FOR_LPF_FREQUENCY);
+
+		case Param::Unpatched::GlobalEffectable::LPF_RES:
+			return l10n::get(STRING_FOR_LPF_RESONANCE);
+
+		//HPF Cutoff, Resonance
+		case Param::Unpatched::GlobalEffectable::HPF_FREQ:
+			return l10n::get(STRING_FOR_HPF_FREQUENCY);
+
+		case Param::Unpatched::GlobalEffectable::HPF_RES:
+			return l10n::get(STRING_FOR_HPF_RESONANCE);
+
+		//Reverb Amount
+		case Param::Unpatched::GlobalEffectable::REVERB_SEND_AMOUNT:
+			return l10n::get(STRING_FOR_REVERB_AMOUNT);
+
+		//Delay Rate, Amount
+		case Param::Unpatched::GlobalEffectable::DELAY_RATE:
+			return l10n::get(STRING_FOR_DELAY_RATE);
+
+		case Param::Unpatched::GlobalEffectable::DELAY_AMOUNT:
+			return l10n::get(STRING_FOR_DELAY_AMOUNT);
+
+		//Sidechain Send
+		case Param::Unpatched::GlobalEffectable::SIDECHAIN_VOLUME:
+			return l10n::get(STRING_FOR_SIDECHAIN_LEVEL);
+
+		//Mod FX Depth, Rate
+		case Param::Unpatched::GlobalEffectable::MOD_FX_DEPTH:
+			return l10n::get(STRING_FOR_MODFX_DEPTH);
+
+		case Param::Unpatched::GlobalEffectable::MOD_FX_RATE:
+			return l10n::get(STRING_FOR_MODFX_RATE);
+		}
+	}
+	return l10n::get(STRING_FOR_NONE);
 }
 
 PatchSource stringToSource(char const* string) {

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -215,8 +215,7 @@ void addAudio(StereoSample* inputBuffer, StereoSample* outputBuffer, int32_t num
 
 char const* getSourceDisplayNameForOLED(PatchSource s);
 char const* getPatchedParamDisplayName(int32_t p);
-char const* getUnpatchedParamDisplayName(int32_t p);
-char const* getGlobalEffectableParamDisplayName(int32_t p);
+char const* getParamDisplayName(Param::Kind kind, int32_t p);
 
 char const* sourceToString(PatchSource source);
 PatchSource stringToSource(char const* string);


### PR DESCRIPTION
Required a refactor of param kinds. This should make mapping from `paramID` to parameter label (or even the entire menuitem) easier in other cases as well, such as the automation view.

![20231110_114452](https://github.com/SynthstromAudible/DelugeFirmware/assets/3133596/870cdf96-7d7f-428c-8d79-275a9f74455d)
