### PR TITLE
Fix memory unit tests

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -14,7 +14,7 @@ extern void freezeWithError(char const* errmsg);
 #ifdef __cplusplus
 }
 #endif
-
+#if defined(__arm__)
 #define FREEZE_WITH_ERROR(error)                                                                                       \
 	({                                                                                                                 \
 		uint32_t regLR = 0;                                                                                            \
@@ -24,7 +24,9 @@ extern void freezeWithError(char const* errmsg);
 		fault_handler_print_freeze_pointers(0, 0, regLR, regSP);                                                       \
 		freezeWithError(error);                                                                                        \
 	})
-
+#else
+#define FREEZE_WITH_ERROR(error) ({ freezeWithError(error); })
+#endif
 #define TIMER_MIDI_GATE_OUTPUT 2
 #define TIMER_SYSTEM_FAST 0
 #define TIMER_SYSTEM_SLOW 4

--- a/tests/memory_tests.cpp
+++ b/tests/memory_tests.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #define NUM_TEST_ALLOCATIONS 1024
 #define MEM_SIZE 10000000
+
 namespace {
 uint32_t vtableAddress;  // will hold address of the stealable test vtable
 uint32_t nSteals;        //to count steals
@@ -305,7 +306,7 @@ TEST(MemoryAllocation, stealableAllocations) {
 	void* testAllocations[NUM_TEST_ALLOCATIONS];
 	uint32_t actualSize;
 
-	mock().disable(); //disable mocking since number of steals is unpredictable
+	mock().expectNCalls(720, "steal");
 	for (int i = 0; i < NUM_TEST_ALLOCATIONS; i += 1) {
 		uint32_t size = sizes[2];
 		if (i % 10 == 0) {
@@ -327,6 +328,6 @@ TEST(MemoryAllocation, stealableAllocations) {
 	std::cout << "stealable efficiency: " << efficiency << std::endl;
 	//current efficiency is .994
 	CHECK(efficiency > 0.994);
-	mock().enable();
+	mock().checkExpectations();
 };
 } // namespace

--- a/tests/mocks/mock_display.cpp
+++ b/tests/mocks/mock_display.cpp
@@ -54,5 +54,13 @@ public:
 	bool have7SEG() { return false; }
 };
 
+extern "C" void freezeWithError(char const* error) {
+	display->freezeWithError(error);
+}
+
+extern "C" void displayPopup(char const* text) {
+	display->displayPopup(text);
+}
+
 MockDisplay mockdisplay;
 deluge::hid::Display* display = &mockdisplay;

--- a/tests/mocks/version.h
+++ b/tests/mocks/version.h
@@ -1,0 +1,36 @@
+//mock up the version.h that would be made by cmake in the main build
+
+#pragma once
+
+#ifdef __cplusplus
+#include <compare>
+#include <cstdint>
+
+struct SemVer {
+	uint8_t major;
+	uint8_t minor;
+	uint8_t patch;
+
+	auto operator<=>(const SemVer&) const = default;
+};
+
+// clang-format off
+constexpr SemVer kCommunityFirmwareVersion {
+	0,
+	0,
+	0,
+};
+//clang-format on
+
+constexpr char const* kFirmwareVersionString = "TESTS";
+
+#else
+
+#define FIRMWARE_VERSION_MAJOR 0
+#define FIRMWARE_VERSION_MINOR 0
+#define FIRMWARE_VERSION_PATCH 0
+
+#define FIRMWARE_VERSION_STRING "TESTS"
+#define FIRMWARE_COMMIT_SHORT "0000"
+
+#endif


### PR DESCRIPTION
Fix the memory tests after the new freeze function broke them

Puts clusters at the start of the queue so they get stolen first, reducing the number of total steals