### PR TITLE
Synth presets sometimes loading incorrectly

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -528,12 +528,15 @@ tryReadingItems:
 		return error;
 	}
 
+	printInstrumentFileList("After readFileItemsForFolder");
 	if (song && instrumentType != InstrumentType::NONE) {
 		error = song->addInstrumentsToFileItems(instrumentType);
 		if (error) {
 			return error;
 		}
 	}
+	printInstrumentFileList("Before sorting");
+
 
 	if (fileItems.getNumElements()) {
 		sortFileItems();

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -528,15 +528,12 @@ tryReadingItems:
 		return error;
 	}
 
-	printInstrumentFileList("After readFileItemsForFolder");
 	if (song && instrumentType != InstrumentType::NONE) {
 		error = song->addInstrumentsToFileItems(instrumentType);
 		if (error) {
 			return error;
 		}
 	}
-	printInstrumentFileList("Before sorting");
-
 
 	if (fileItems.getNumElements()) {
 		sortFileItems();
@@ -550,6 +547,7 @@ tryReadingItems:
 			}
 		}
 	}
+
 	return NO_ERROR;
 }
 

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -934,7 +934,7 @@ void Browser::selectEncoderAction(int8_t offset) {
 				if (thisSlot.slot < 0) {
 					goto nonNumeric;
 				}
-
+				Debug::println("treating as numeric");
 				thisSlot.subSlot = -1;
 				switch (numberEditPosNow) {
 				case 0:
@@ -983,6 +983,7 @@ void Browser::selectEncoderAction(int8_t offset) {
 				if (thisSlot.slot < 0) {
 					goto nonNumeric;
 				}
+				Debug::println("treating as numeric");
 				thisSlot.slot += offset;
 
 				char searchString[9];
@@ -1021,6 +1022,7 @@ tryReadingItems:
 			                                         NULL, true, Availability::ANY, CATALOG_SEARCH_BOTH);
 			if (error) {
 gotErrorAfterAllocating:
+				Debug::println("error while reloading, emptying file items");
 				emptyFileItems();
 				return;
 				// TODO - need to close UI or something?

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -86,6 +86,7 @@ public:
 	int32_t getUnusedSlot(InstrumentType instrumentType, String* newName, char const* thingName);
 	bool opened();
 	void cullSomeFileItems();
+	bool checkFP();
 
 	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
 

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -145,18 +145,18 @@ protected:
 };
 
 #include "io/debug/print.h"
-	inline void printInstrumentFileList(const char* where) {
-		Debug::print("\n");
-		Debug::print(where);
-		Debug::print(" List: \n");
-		for(uint32_t idx = 0; idx < Browser::fileItems.getNumElements(); ++idx) {
-			FileItem* fileItem = (FileItem*)Browser::fileItems.getElementAddress(idx);
-			Debug::print(" - ");
-			Debug::print(fileItem->displayName);
-			Debug::print(" (");
-			Debug::print(fileItem->filePointer.sclust);
-			Debug::print(")\n");
-		}
-
-		Debug::print("\n");
+inline void printInstrumentFileList(const char* where) {
+	Debug::print("\n");
+	Debug::print(where);
+	Debug::print(" List: \n");
+	for (uint32_t idx = 0; idx < Browser::fileItems.getNumElements(); ++idx) {
+		FileItem* fileItem = (FileItem*)Browser::fileItems.getElementAddress(idx);
+		Debug::print(" - ");
+		Debug::print(fileItem->displayName);
+		Debug::print(" (");
+		Debug::print(fileItem->filePointer.sclust);
+		Debug::print(")\n");
 	}
+
+	Debug::print("\n");
+}

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -143,3 +143,20 @@ protected:
 	char const* filePrefix;
 	bool shouldInterpretNoteNamesForThisBrowser;
 };
+
+#include "io/debug/print.h"
+	inline void printInstrumentFileList(const char* where) {
+		Debug::print("\n");
+		Debug::print(where);
+		Debug::print(" List: \n");
+		for(uint32_t idx = 0; idx < Browser::fileItems.getNumElements(); ++idx) {
+			FileItem* fileItem = (FileItem*)Browser::fileItems.getElementAddress(idx);
+			Debug::print(" - ");
+			Debug::print(fileItem->displayName);
+			Debug::print(" (");
+			Debug::print(fileItem->filePointer.sclust);
+			Debug::print(")\n");
+		}
+
+		Debug::print("\n");
+	}

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -260,7 +260,12 @@ void LoadInstrumentPresetUI::enterKeyPress() {
 	else {
 
 		if (currentInstrumentLoadError) {
-			currentInstrumentLoadError = performLoad();
+			if (loadingSynthToKitRow) {
+				currentInstrumentLoadError = performLoadSynthToKit();
+			}
+			else {
+				currentInstrumentLoadError = performLoad();
+			}
 			if (currentInstrumentLoadError) {
 				display->displayError(currentInstrumentLoadError);
 				return;

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -797,10 +797,6 @@ int32_t LoadInstrumentPresetUI::performLoad(bool doClone) {
 		return NO_ERROR; // Happens if navigate over a folder's name (Instrument stays the same),
 	}
 
-	Debug::print("Attempting load of ");
-	Debug::print(currentFileItem->filename.get());
-	Debug::print(" from FP ");
-	Debug::println((int32_t)currentFileItem->filePointer.sclust);
 	// then back onto that neighbouring Instrument - you'd incorrectly get a "USED" error without this line.
 
 	// Work out availabilityRequirement. This can't change as presets are navigated through... I don't think?

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -51,32 +51,6 @@ LoadInstrumentPresetUI loadInstrumentPresetUI{};
 LoadInstrumentPresetUI::LoadInstrumentPresetUI() {
 }
 
-//returns true if the FP for the filepath is correct
-bool LoadInstrumentPresetUI::checkFPs() {
-	FileItem* currentFileItem = getCurrentFileItem();
-	String filePath;
-	int32_t error = getCurrentFilePath(&filePath);
-	if (error != 0) {
-		Debug::println("couldn't get filepath");
-		return false;
-	}
-
-	FilePointer tempfp;
-	bool fileExists = storageManager.fileExists(filePath.get(), &tempfp);
-	if (!fileExists) {
-		Debug::println("couldn't get filepath");
-		return false;
-	}
-	else if (tempfp.sclust != currentFileItem->filePointer.sclust) {
-		Debug::println("FPs don't match");
-#if ALPHA_OR_BETA_VERSION
-		display->freezeWithError("P001");
-#endif
-		return false;
-	}
-	return true;
-}
-
 bool LoadInstrumentPresetUI::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
 	if (showingAuditionPads()) {
 		*cols = 0b10;
@@ -881,7 +855,7 @@ giveUsedError:
 			}
 		}
 		int32_t error;
-		checkFPs();
+		Browser::checkFP();
 		error = storageManager.loadInstrumentFromFile(currentSong, instrumentClipToLoadFor, instrumentTypeToLoad, false,
 		                                              &newInstrument, &currentFileItem->filePointer, &enteredText,
 		                                              &currentDir);

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -51,6 +51,32 @@ LoadInstrumentPresetUI loadInstrumentPresetUI{};
 LoadInstrumentPresetUI::LoadInstrumentPresetUI() {
 }
 
+//returns true if the FP for the filepath is correct
+bool LoadInstrumentPresetUI::checkFPs() {
+	FileItem* currentFileItem = getCurrentFileItem();
+	String filePath;
+	int32_t error = getCurrentFilePath(&filePath);
+	if (error != 0) {
+		Debug::println("couldn't get filepath");
+		return false;
+	}
+
+	FilePointer tempfp;
+	bool fileExists = storageManager.fileExists(filePath.get(), &tempfp);
+	if (!fileExists) {
+		Debug::println("couldn't get filepath");
+		return false;
+	}
+	else if (tempfp.sclust != currentFileItem->filePointer.sclust) {
+		Debug::println("FPs don't match");
+#if ALPHA_OR_BETA_VERSION
+		display->freezeWithError("P001");
+#endif
+		return false;
+	}
+	return true;
+}
+
 bool LoadInstrumentPresetUI::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
 	if (showingAuditionPads()) {
 		*cols = 0b10;
@@ -855,7 +881,7 @@ giveUsedError:
 			}
 		}
 		int32_t error;
-
+		checkFPs();
 		error = storageManager.loadInstrumentFromFile(currentSong, instrumentClipToLoadFor, instrumentTypeToLoad, false,
 		                                              &newInstrument, &currentFileItem->filePointer, &enteredText,
 		                                              &currentDir);

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -796,6 +796,11 @@ int32_t LoadInstrumentPresetUI::performLoad(bool doClone) {
 	if (currentFileItem->instrument == instrumentToReplace && !doClone) {
 		return NO_ERROR; // Happens if navigate over a folder's name (Instrument stays the same),
 	}
+
+	Debug::print("Attempting load of ");
+	Debug::print(currentFileItem->filename.get());
+	Debug::print(" from FP ");
+	Debug::println((int32_t)currentFileItem->filePointer.sclust);
 	// then back onto that neighbouring Instrument - you'd incorrectly get a "USED" error without this line.
 
 	// Work out availabilityRequirement. This can't change as presets are navigated through... I don't think?

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -860,7 +860,8 @@ giveUsedError:
 			}
 		}
 		int32_t error;
-		Browser::checkFP();
+		//check if the file pointer matches the current file item
+		//Browser::checkFP();
 		error = storageManager.loadInstrumentFromFile(currentSong, instrumentClipToLoadFor, instrumentTypeToLoad, false,
 		                                              &newInstrument, &currentFileItem->filePointer, &enteredText,
 		                                              &currentDir);

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.h
@@ -80,6 +80,7 @@ private:
 	void exitAction();
 	bool isInstrumentInList(Instrument* searchInstrument, Output* list);
 	bool findUnusedSlotVariation(String* oldName, String* newName);
+	bool checkFPs();
 
 	uint8_t currentInstrumentLoadError;
 

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.h
@@ -80,7 +80,6 @@ private:
 	void exitAction();
 	bool isInstrumentInList(Instrument* searchInstrument, Output* list);
 	bool findUnusedSlotVariation(String* oldName, String* newName);
-	bool checkFPs();
 
 	uint8_t currentInstrumentLoadError;
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5390,14 +5390,12 @@ doHibernatingInstruments:
 		}
 
 		FileItem* thisItem = loadInstrumentPresetUI.getNewFileItem();
-printInstrumentFileList("after getNewFileItem");
 
 		if (!thisItem) {
 			return ERROR_INSUFFICIENT_RAM;
 		}
 
 		int32_t error = thisItem->setupWithInstrument(thisInstrument, doingHibernatingOnes);
-printInstrumentFileList("after setupWithInstrument");
 
 		if (error) {
 			return error;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5390,11 +5390,15 @@ doHibernatingInstruments:
 		}
 
 		FileItem* thisItem = loadInstrumentPresetUI.getNewFileItem();
+printInstrumentFileList("after getNewFileItem");
+
 		if (!thisItem) {
 			return ERROR_INSUFFICIENT_RAM;
 		}
 
 		int32_t error = thisItem->setupWithInstrument(thisInstrument, doingHibernatingOnes);
+printInstrumentFileList("after setupWithInstrument");
+
 		if (error) {
 			return error;
 		}

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -16,6 +16,7 @@
 */
 #include "storage/file_item.h"
 #include "hid/display/display.h"
+#include "io/debug/print.h"
 #include "model/instrument/instrument.h"
 #include <string.h>
 
@@ -37,6 +38,16 @@ int32_t FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernatin
 	isFolder = false;
 	instrumentAlreadyInSong = !hibernating;
 	displayName = filename.get();
+	String tempFilePath;
+	tempFilePath.set(newInstrument->dirPath.get());
+	tempFilePath.concatenate("/");
+	tempFilePath.concatenate(filename.get());
+	bool fileExists = storageManager.fileExists(tempFilePath.get(), &filePointer);
+	if (!fileExists) {
+		Debug::print("couldn't get filepath for file");
+		Debug::println(filename.get());
+		return false;
+	}
 	return NO_ERROR;
 }
 

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -46,7 +46,6 @@ int32_t FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernatin
 	if (!fileExists) {
 		Debug::print("couldn't get filepath for file");
 		Debug::println(filename.get());
-		return false;
 	}
 	return NO_ERROR;
 }

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -20,6 +20,7 @@
 #include <string.h>
 
 FileItem::FileItem() {
+	filePointer = {0};
 	instrument = NULL;
 	filenameIncludesExtension = true;
 	instrumentAlreadyInSong = false;

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1380,7 +1380,9 @@ int32_t StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip,
 
 	AudioEngine::logAction("loadInstrumentFromFile");
 	Debug::print("opening instrument file - ");
-	Debug::println(name->get());
+	Debug::print(name->get());
+	Debug::print(" from FP ");
+	Debug::println((int32_t)filePointer->sclust);
 	int32_t error = openInstrumentFile(instrumentType, filePointer);
 	if (error) {
 		Debug::print("opening instrument file failed - ");

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1379,9 +1379,12 @@ int32_t StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip,
                                                FilePointer* filePointer, String* name, String* dirPath) {
 
 	AudioEngine::logAction("loadInstrumentFromFile");
-
+	Debug::print("opening instrument file - ");
+	Debug::println(name->get());
 	int32_t error = openInstrumentFile(instrumentType, filePointer);
 	if (error) {
+		Debug::print("opening instrument file failed - ");
+		Debug::println(name->get());
 		return error;
 	}
 
@@ -1390,6 +1393,8 @@ int32_t StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip,
 
 	if (!newInstrument) {
 		closeFile();
+		Debug::print("Allocating instrument file failed - ");
+		Debug::println(name->get());
 		return ERROR_INSUFFICIENT_RAM;
 	}
 
@@ -1399,12 +1404,15 @@ int32_t StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip,
 
 	// If that somehow didn't work...
 	if (error || !fileSuccess) {
-
+		Debug::print("reading instrument file failed - ");
+		Debug::println(name->get());
 		if (!fileSuccess) {
 			error = ERROR_SD_CARD;
 		}
 
 deleteInstrumentAndGetOut:
+		Debug::print("abandoning load - ");
+		Debug::println(name->get());
 		newInstrument->deleteBackedUpParamManagers(song);
 		void* toDealloc = static_cast<void*>(newInstrument);
 		newInstrument->~Instrument();
@@ -1432,6 +1440,8 @@ deleteInstrumentAndGetOut:
 		}
 		else {
 paramManagersMissing:
+			Debug::print("creating param manager failed - ");
+			Debug::println(name->get());
 			error = ERROR_FILE_CORRUPTED;
 			goto deleteInstrumentAndGetOut;
 		}

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1356,7 +1356,9 @@ void StorageManager::openFilePointer(FilePointer* fp) {
 int32_t StorageManager::openInstrumentFile(InstrumentType instrumentType, FilePointer* filePointer) {
 
 	AudioEngine::logAction("openInstrumentFile");
-
+	if (!filePointer->sclust) {
+		return ERROR_FILE_NOT_FOUND;
+	}
 	char const* firstTagName;
 	char const* altTagName = "";
 
@@ -1384,6 +1386,7 @@ int32_t StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip,
 	Debug::print(name->get());
 	Debug::print(" from FP ");
 	Debug::println((int32_t)filePointer->sclust);
+
 	int32_t error = openInstrumentFile(instrumentType, filePointer);
 	if (error) {
 		Debug::print("opening instrument file failed - ");

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1380,6 +1380,7 @@ int32_t StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip,
 
 	AudioEngine::logAction("loadInstrumentFromFile");
 	Debug::print("opening instrument file - ");
+	Debug::print(dirPath->get());
 	Debug::print(name->get());
 	Debug::print(" from FP ");
 	Debug::println((int32_t)filePointer->sclust);


### PR DESCRIPTION
Adds additional logging to synth loads

In some situations a file name/synth preset can become associated with an incorrect file pointer (the underlying location on the card)

![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/7f4ab238-b520-4d82-97b1-a1ca98702f4a)

When this happens the sound loads incorrectly

Fixed by leveraging instrument file path to set fp in file item

Fix 715, 718