### PR TITLE
Automation view  - update pad selection mode display values

### DIFF
--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -814,7 +814,7 @@ void AutomationInstrumentClipView::renderDisplay(int32_t knobPosLeft, int32_t kn
 	Instrument* instrument = (Instrument*)clip->output;
 
 	//if you're not in a MIDI instrument clip, convert the knobPos to the same range as the menu (0-50)
-	if (instrument->type != InstrumentType::MIDI_OUT) {
+	if ((instrument->type != InstrumentType::MIDI_OUT) && (!padSelectionOn)) {
 		knobPosLeft = calculateKnobPosForDisplay(clip, knobPosLeft);
 		knobPosRight = calculateKnobPosForDisplay(clip, knobPosRight);
 	}
@@ -1018,16 +1018,19 @@ void AutomationInstrumentClipView::getParameterName(InstrumentClip* clip, Instru
 
 //for non-MIDI instruments, convert deluge internal knobPos range to same range as used by menu's.
 int32_t AutomationInstrumentClipView::calculateKnobPosForDisplay(InstrumentClip* clip, int32_t knobPos) {
-	int32_t offset = 0;
+	if (knobPos != kNoSelection) {
+		int32_t offset = 0;
 
-	//if the parameter is pan, convert knobPos from 0 - 50 to -25 to +25
-	if ((clip->lastSelectedParamID == Param::Local::PAN)
-	    || (clip->lastSelectedParamID == Param::Unpatched::GlobalEffectable::PAN)) {
-		offset = kMaxMenuPanValue;
+		//if the parameter is pan, convert knobPos from 0 - 50 to -25 to +25
+		if ((clip->lastSelectedParamID == Param::Local::PAN)
+			|| (clip->lastSelectedParamID == Param::Unpatched::GlobalEffectable::PAN)) {
+			offset = kMaxMenuPanValue;
+		}
+
+		//convert knobPos from 0 - 128 to 0 - 50
+		return (((((knobPos << 20) / kMaxKnobPos) * kMaxMenuValue) >> 20) - offset);
 	}
-
-	//convert knobPos from 0 - 128 to 0 - 50
-	return (((((knobPos << 20) / kMaxKnobPos) * kMaxMenuValue) >> 20) - offset);
+	return knobPos;
 }
 
 //adjust the LED meters and update the display


### PR DESCRIPTION
Quick update to show more granular values in pad selection mode

As pad selection mode was intended to be a mode for "fine tuning" automation values, it makes sense to show the user the more granular values which is the 0 - 128 range, instead of the 0 - 50 range.

When you exit pad selection mode the display refreshes to show the 0 - 50 range again.