### PR TITLE
Bugfix: handle case of indexed params

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -437,15 +437,14 @@ bool SoundEditor::findPatchedParam(int32_t paramLookingFor, int32_t* xout, int32
 		for (int32_t y = 0; y < kDisplayHeight; y++) {
 			if (paramShortcutsForSounds[x][y] && paramShortcutsForSounds[x][y] != comingSoonMenu
 			    && ((MenuItem*)paramShortcutsForSounds[x][y])->getPatchedParamIndex() == paramLookingFor) {
-				if ((x & 1) && currentSourceIndex == 0) {
-					//this means we're on osc2/env2/lfo2 but wanted osc1
-					return true;
-				}
+
 				*xout = x;
 				*yout = y;
 
-				//can't return yet in case we're on an indexed param and want the second one
-				found = true;
+				if ((x & 1) == currentSourceIndex) {
+					//check we're on the corretc index
+					return true;
+				}
 			}
 		}
 	}

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -432,18 +432,24 @@ void SoundEditor::exitCompletely() {
 }
 
 bool SoundEditor::findPatchedParam(int32_t paramLookingFor, int32_t* xout, int32_t* yout) {
+	bool found = false;
 	for (int32_t x = 0; x < 15; x++) {
 		for (int32_t y = 0; y < kDisplayHeight; y++) {
 			if (paramShortcutsForSounds[x][y] && paramShortcutsForSounds[x][y] != comingSoonMenu
 			    && ((MenuItem*)paramShortcutsForSounds[x][y])->getPatchedParamIndex() == paramLookingFor) {
-
+				if ((x & 1) && currentSourceIndex == 0) {
+					//this means we're on osc2/env2/lfo2 but wanted osc1
+					return true;
+				}
 				*xout = x;
 				*yout = y;
-				return true;
+
+				//can't return yet in case we're on an indexed param and want the second one
+				found = true;
 			}
 		}
 	}
-	return false;
+	return found;
 }
 
 void SoundEditor::updateSourceBlinks(MenuItem* currentItem) {


### PR DESCRIPTION
Fix #593 

In the code for the mod matrix a check was lost to make sure we highlight the correct version of indexed menus (e.g. osc, env, lfo)