### PR TITLE
Bugfix/quantize shortcut

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3092,7 +3092,10 @@ void InstrumentClipView::setSelectedDrum(Drum* drum, bool shouldRedrawStuff) {
 }
 
 void InstrumentClipView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool shiftButtonDown) {
-
+	if (editedAnyPerNoteRowStuffSinceAuditioningBegan && !velocity) {
+		//in case we were editing quantize/humanize
+		actionLogger.closeAction(ACTION_NOTE_NUDGE);
+	}
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
 
@@ -4482,6 +4485,7 @@ void InstrumentClipView::quantizeNotes(int32_t offset, int32_t nudgeMode) {
 			modelStack->song->currentClip->reGetParameterAutomation(modelStack);
 		}
 	}
+	editedAnyPerNoteRowStuffSinceAuditioningBegan = true;
 	return;
 }
 

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -59,7 +59,7 @@ void ActionLogger::deleteLastActionIfEmpty() {
 	if (firstAction[BEFORE]) {
 
 		// There are probably more cases where we might want to do this, but I've only done it for recording so far
-		if (firstAction[BEFORE]->type == ACTION_RECORD && !firstAction[BEFORE]->firstConsequence) {
+		while (!firstAction[BEFORE]->firstConsequence) {
 
 			deleteLastAction();
 		}

--- a/src/deluge/model/action/action_logger.h
+++ b/src/deluge/model/action/action_logger.h
@@ -32,6 +32,8 @@ class ModelStack;
 class ActionLogger {
 public:
 	ActionLogger();
+
+	//warning - super not thread safe
 	Action* getNewAction(int32_t newActionType, int32_t addToExistingIfPossible = ACTION_ADDITION_NOT_ALLOWED);
 	void recordUnautomatedParamChange(ModelStackWithAutoParam const* modelStack,
 	                                  int32_t actionType = ACTION_PARAM_UNAUTOMATED_VALUE_CHANGE);


### PR DESCRIPTION
Moves quantize/humanize row to audition pad.

Leaves quantize/humanize whole song on any audition pad and push+turn tempo

Fixes a bug in action logger that led to empty actions in the action list