### PR TITLE
Bugfix/volume change clicks

### DIFF
--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -103,13 +103,13 @@ void MasterCompressor::render(StereoSample* buffer, uint16_t numSamples, q31_t v
 	rms = calc_rms(buffer, numSamples);
 }
 
-float MasterCompressor::runEnvelope(float state, float in, float numSamples) {
+float MasterCompressor::runEnvelope(float current, float desired, float numSamples) {
 	float s;
-	if (in > state) {
-		s = in + exp(a_ * numSamples) * (state - in);
+	if (desired > current) {
+		s = desired + exp(a_ * numSamples) * (current - desired);
 	}
 	else {
-		s = in + exp(r_ * numSamples) * (state - in);
+		s = desired + exp(r_ * numSamples) * (current - desired);
 	}
 	return s;
 }

--- a/src/deluge/dsp/master_compressor/master_compressor.cpp
+++ b/src/deluge/dsp/master_compressor/master_compressor.cpp
@@ -33,7 +33,7 @@ MasterCompressor::MasterCompressor() {
 
 	currentVolumeL = 0;
 	currentVolumeR = 0;
-
+	er = 0;
 	setSidechain(sideChainKnobPos);
 }
 //16 is ln(1<<24) - 1, i.e. where we start clipping

--- a/src/deluge/dsp/master_compressor/master_compressor.h
+++ b/src/deluge/dsp/master_compressor/master_compressor.h
@@ -32,7 +32,7 @@ public:
 	void setup(q31_t attack, q31_t release, q31_t threshold, q31_t ratio, q31_t sidechain_fc);
 
 	void render(StereoSample* buffer, uint16_t numSamples, q31_t volAdjustL, q31_t volAdjustR);
-	float runEnvelope(float in, float numSamples);
+	float runEnvelope(float state, float in, float numSamples);
 	//attack/release in range 0 to 2^31
 	inline q31_t getAttack() { return attackKnobPos; }
 	inline int32_t getAttackMS() { return attackMS; }
@@ -56,7 +56,6 @@ public:
 	void setThreshold(q31_t t) {
 		thresholdKnobPos = t;
 		threshold = 1 - 0.8 * (float(thresholdKnobPos) / ONE_Q31f);
-		updateER();
 	}
 	q31_t getRatio() { return ratioKnobPos; }
 	int32_t setRatio(q31_t rat) {
@@ -77,7 +76,7 @@ public:
 		return fc_hz;
 	}
 
-	void updateER();
+	void updateER(float numSamples);
 	float calc_rms(StereoSample* buffer, uint16_t numSamples);
 	uint8_t gainReduction;
 

--- a/src/deluge/dsp/master_compressor/master_compressor.h
+++ b/src/deluge/dsp/master_compressor/master_compressor.h
@@ -32,7 +32,7 @@ public:
 	void setup(q31_t attack, q31_t release, q31_t threshold, q31_t ratio, q31_t sidechain_fc);
 
 	void render(StereoSample* buffer, uint16_t numSamples, q31_t volAdjustL, q31_t volAdjustR);
-	float runEnvelope(float state, float in, float numSamples);
+	float runEnvelope(float current, float desired, float numSamples);
 	//attack/release in range 0 to 2^31
 	inline q31_t getAttack() { return attackKnobPos; }
 	inline int32_t getAttackMS() { return attackMS; }


### PR DESCRIPTION
Filter volume changes so that clicks are less noticeable

Stops all crackling while adjusting compressor or volume knob

Reduces clicks from adjusting modfx or filter

Song filter can still click when first engaged