### PR TITLE
Bugfix/recall routine when needed

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -914,10 +914,17 @@ startAgain:
 
 	sideChainHitPending = 0;
 	audioSampleTimer += numSamples;
-
-	if (shortenedWindow && (numRoutines < 5)) {
-		numRoutines += 1;
-		routine();
+	//If we shorten the window we need to render again immediately - otherwise
+	//we'll get a click at high CPU loads, and hard cull when we could soft cull
+	//this is basically so that we don't click at normal tempos and still
+	//let Ron go to 10 000 BPM and then play wildly with the tempo knob for
+	//whatever reason
+	if (shortenedWindow) {
+		if (numRoutines < 5) {
+			numRoutines += 1;
+			//this seems to get tail call optimized
+			routine();
+		}
 	}
 	numRoutines = 0;
 	audioRoutineLocked = false;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -504,7 +504,7 @@ void routine() {
 			}
 		}
 	}
-	bypassCulling = false;
+
 	bool shortenedWindow = false;
 	// Double the number of samples we're going to do - within some constraints
 	int32_t sampleThreshold = 6; // If too low, it'll lead to bigger audio windows and stuff
@@ -927,6 +927,7 @@ startAgain:
 		}
 	}
 	numRoutines = 0;
+	bypassCulling = false;
 	audioRoutineLocked = false;
 }
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -342,6 +342,7 @@ int32_t numAudioLogItems = 0;
 
 extern uint16_t g_usb_usbmode;
 
+uint8_t numRoutines = 0;
 void routine() {
 	logAction("AudioDriver::routine");
 
@@ -504,7 +505,7 @@ void routine() {
 		}
 	}
 	bypassCulling = false;
-
+	bool shortenedWindow = false;
 	// Double the number of samples we're going to do - within some constraints
 	int32_t sampleThreshold = 6; // If too low, it'll lead to bigger audio windows and stuff
 	constexpr int32_t maxAdjustedNumSamples = 0.66 * SSI_TX_BUFFER_NUM_SAMPLES;
@@ -575,6 +576,7 @@ startAgain:
 		// If the tick is during this window, shorten the window so we stop right at the tick
 		if (timeTilNextTick < numSamples) {
 			numSamples = timeTilNextTick;
+			shortenedWindow = true;
 		}
 
 		// And now we know how long the window's definitely going to be, see if we want to do any trigger clock or MIDI clock out ticks during it
@@ -604,16 +606,16 @@ startAgain:
 		}
 	}
 
-	//this sets a floor on the number of samples at 16, avoiding the audio DMA catching up to the
-	//output when cutting rendering short for clock at critical times
-	//the max error is 0.3ms. At 100bpm 24ppq it is 25ms per pulse
-	//this works out to a 1% error in the absolute worse case of alternating
-	//no extension and max extension, approximately 10x better than average usb midi accuracy.
-	int32_t minSamples = std::min<int32_t>(unadjustedNumSamplesBeforeLappingPlayHead, MINSAMPLES);
-	if (currentSong) {
-		minSamples = std::min<int32_t>(minSamples, currentSong->timePerTimerTickBig >> 32);
-	}
-	numSamples = std::max<int32_t>(numSamples, minSamples);
+	// //this sets a floor on the number of samples at 16, avoiding the audio DMA catching up to the
+	// //output when cutting rendering short for clock at critical times
+	// //the max error is 0.3ms. At 100bpm 24ppq it is 25ms per pulse
+	// //this works out to a 1% error in the absolute worse case of alternating
+	// //no extension and max extension, approximately 10x better than average usb midi accuracy.
+	// int32_t minSamples = std::min<int32_t>(unadjustedNumSamplesBeforeLappingPlayHead, MINSAMPLES);
+	// if (currentSong) {
+	// 	minSamples = std::min<int32_t>(minSamples, currentSong->timePerTimerTickBig >> 32);
+	// }
+	// numSamples = std::max<int32_t>(numSamples, minSamples);
 	numSamplesLastTime = numSamples;
 	memset(&renderingBuffer, 0, numSamples * sizeof(StereoSample));
 
@@ -913,6 +915,11 @@ startAgain:
 	sideChainHitPending = 0;
 	audioSampleTimer += numSamples;
 
+	if (shortenedWindow && (numRoutines < 5)) {
+		numRoutines += 1;
+		routine();
+	}
+	numRoutines = 0;
 	audioRoutineLocked = false;
 }
 


### PR DESCRIPTION
Instead of a minimum render window, just recall the audio routine if we shortened the render to process a step

This minimizes culling and allows soft culling to work more predictably. It avoids the situation where we would have soft culled, but need to hard cull because we rendered a single sample and then did SD card and UI stuff instead of returning to render

