### PR TITLE
Use the NAME shortcut in audio clips to rename the audio track.

### DIFF
--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -30,7 +30,7 @@ void RenameUI::displayText(bool blinkImmediately) {
 
 void RenameUI::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 
-	int32_t windowWidth = 100;
+	int32_t windowWidth = 120;
 	int32_t windowHeight = 40;
 
 	int32_t windowMinX = (OLED_MAIN_WIDTH_PIXELS - windowWidth) >> 1;
@@ -46,7 +46,7 @@ void RenameUI::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 	deluge::hid::display::OLED::drawStringCentred(title, windowMinY + 6, image[0], OLED_MAIN_WIDTH_PIXELS,
 	                                              kTextSpacingX, kTextSpacingY);
 
-	int32_t maxNumChars = 12;
+	int32_t maxNumChars = 17; // "RENAME INSTRUMENT" should be the longest title string, so match that, so match that
 	int32_t charsWidthPixels = maxNumChars * kTextSpacingX;
 	int32_t charsStartPixel = (OLED_MAIN_WIDTH_PIXELS - charsWidthPixels) >> 1;
 	int32_t boxStartPixel = charsStartPixel - 3;

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -9,6 +9,7 @@
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/rename/rename_drum_ui.h"
+#include "gui/ui/rename/rename_output_ui.h"
 #include "gui/ui/sample_marker_editor.h"
 #include "gui/ui/save/save_instrument_preset_ui.h"
 #include "gui/ui_timer_manager.h"
@@ -730,7 +731,17 @@ ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool 
 		// AudioClips - there are just a few shortcuts
 		if (currentSong->currentClip->type == CLIP_TYPE_AUDIO) {
 
-			if (x <= 14) {
+			// NAME shortcut
+			if (x == 11 && y == 5) {
+				// Renames the output (track), not the clip
+				Output* output = currentSong->currentClip->output;
+				if (output) {
+					renameOutputUI.output = output;
+					openUI(&renameOutputUI);
+					return ActionResult::DEALT_WITH;
+				}
+			}
+			else if (x <= 14) {
 				item = paramShortcutsForAudioClips[x][y];
 			}
 


### PR DESCRIPTION
Also slightly expands the width of the rename UI window, as it didnt fit the RENAME INSTRUMENT title before

Previously, the only way to rename audio tracks was `ARRANGEMENT VIEW -> AUDITION + NAME`

This problem technically also applies to SYNTH and KIT tracks, but they are usually solved there by saving the sound/kit as a preset. Also, in KIT mode, the NAME shortcut is already used to rename the kit row.

Another option could be to enable the shortcut for all three types, but link it to AFFECT ENTIRE for kits.