### PR TITLE
Fix non-void function does not return a value warning

### DIFF
--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -72,27 +72,20 @@ int32_t FileItem::getDisplayNameWithoutExtension(String* displayNameWithoutExten
 	}
 
 	// 7SEG...
-	if (displayName != filename.get()) {
-		int32_t error = displayNameWithoutExtension->set(displayName);
-		if (error) {
-			return error;
-		}
-		if (filenameIncludesExtension) {
-			char const* chars = displayNameWithoutExtension->get();
-			char const* dotAddress = strrchr(chars, '.');
-			if (dotAddress) {
-				int32_t newLength = (uint32_t)dotAddress - (uint32_t)chars;
-				error = displayNameWithoutExtension->shorten(newLength);
-				if (error) {
-					return error;
-				}
+	int32_t error = displayNameWithoutExtension->set(displayName);
+	if (error) {
+		return error;
+	}
+	if (filenameIncludesExtension) {
+		char const* chars = displayNameWithoutExtension->get();
+		char const* dotAddress = strrchr(chars, '.');
+		if (dotAddress) {
+			int32_t newLength = (uint32_t)dotAddress - (uint32_t)chars;
+			error = displayNameWithoutExtension->shorten(newLength);
+			if (error) {
+				return error;
 			}
 		}
-		return NO_ERROR;
 	}
-	/*
-Warning - not having a return is functional. Whatever is passing through
-is required to reset the display after auditioning. Further debugging required,
-returning 0, 1, filename.get() or (displayName != filename.get()) all cause bugs
-*/
+	return NO_ERROR;
 }


### PR DESCRIPTION
Looking at the disassembly of the function, it seems the second if was optimized away. Since not returning a value is UB, the compiler assumes that one of the two outer if statements must succeed.

For reference, the disassembly of the function before and after this fix. Note, that while the order of the first branch has been inverted, both are equivalent (and the same length. If one did an additional comparison, it should be longer)
```
BEFORE FIX                                                                                    | AFTER FIX
----------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------
200de878 <FileItem::getDisplayNameWithoutExtension(String*)>:                                 | 200de878 <FileItem::getDisplayNameWithoutExtension(String*)>:
200de878:   e300347c    movw    r3, #1148   @ 0x47c                                           | 200de878:   e300347c    movw    r3, #1148   @ 0x47c
200de87c:   e92d4070    push    {r4, r5, r6, lr}                                              | 200de87c:   e92d4070    push    {r4, r5, r6, lr}
200de880:   e3423003    movt    r3, #8195   @ 0x2003                                          | 200de880:   e3423003    movt    r3, #8195   @ 0x2003
200de884:   e1a05000    mov r5, r0                                                            | 200de884:   e1a04000    mov r4, r0
200de888:   e1a04001    mov r4, r1                                                            | 200de888:   e1a05001    mov r5, r1
200de88c:   e5933000    ldr r3, [r3]                                                          | 200de88c:   e5933000    ldr r3, [r3]
200de890:   e5932000    ldr r2, [r3]                                                          | 200de890:   e5932000    ldr r2, [r3]
200de894:   e1a00003    mov r0, r3                                                            | 200de894:   e1a00003    mov r0, r3
200de898:   e5923064    ldr r3, [r2, #100]  @ 0x64                                            | 200de898:   e5923064    ldr r3, [r2, #100]  @ 0x64
200de89c:   e12fff33    blx r3                                                                | 200de89c:   e12fff33    blx r3
200de8a0:   e3500000    cmp r0, #0                                                            | 200de8a0:   e3500000    cmp r0, #0
200de8a4:   1a000016    bne 200de904 <FileItem::getDisplayNameWithoutExtension(String*)+0x8c> | 200de8a4:   0a000003    beq 200de8b8 <FileItem::getDisplayNameWithoutExtension(String*)+0x40>
200de8a8:   e5951000    ldr r1, [r5]                                                          | 200de8a8:   e1a01005    mov r1, r5
200de8ac:   e3e02000    mvn r2, #0                                                            | 200de8ac:   e1a00004    mov r0, r4
200de8b0:   e1a00004    mov r0, r4                                                            | 200de8b0:   e8bd4070    pop {r4, r5, r6, lr}
200de8b4:   ebfffed8    bl  200de41c <String::set(char const*, long)>                         | 200de8b4:   eaffffd8    b   200de81c <FileItem::getFilenameWithoutExtension(String*)>
200de8b8:   e2506000    subs    r6, r0, #0                                                    | 200de8b8:   e5941000    ldr r1, [r4]
200de8bc:   1a00000e    bne 200de8fc <FileItem::getDisplayNameWithoutExtension(String*)+0x84> | 200de8bc:   e3e02000    mvn r2, #0
200de8c0:   e5d53016    ldrb    r3, [r5, #22]                                                 | 200de8c0:   e1a00005    mov r0, r5
200de8c4:   e3530000    cmp r3, #0                                                            | 200de8c4:   ebfffed4    bl  200de41c <String::set(char const*, long)>
200de8c8:   0a00000b    beq 200de8fc <FileItem::getDisplayNameWithoutExtension(String*)+0x84> | 200de8c8:   e2506000    subs    r6, r0, #0
200de8cc:   e5945000    ldr r5, [r4]                                                          | 200de8cc:   1a00000e    bne 200de90c <FileItem::getDisplayNameWithoutExtension(String*)+0x94>
200de8d0:   e3550000    cmp r5, #0                                                            | 200de8d0:   e5d43016    ldrb    r3, [r4, #22]
200de8d4:   0a000008    beq 200de8fc <FileItem::getDisplayNameWithoutExtension(String*)+0x84> | 200de8d4:   e3530000    cmp r3, #0
200de8d8:   e3a0102e    mov r1, #46 @ 0x2e                                                    | 200de8d8:   0a00000b    beq 200de90c <FileItem::getDisplayNameWithoutExtension(String*)+0x94>
200de8dc:   e1a00005    mov r0, r5                                                            | 200de8dc:   e5954000    ldr r4, [r5]
200de8e0:   fb011744    blx 201245fa <strrchr>                                                | 200de8e0:   e3540000    cmp r4, #0
200de8e4:   e2501000    subs    r1, r0, #0                                                    | 200de8e4:   0a000008    beq 200de90c <FileItem::getDisplayNameWithoutExtension(String*)+0x94>
200de8e8:   0a000003    beq 200de8fc <FileItem::getDisplayNameWithoutExtension(String*)+0x84> | 200de8e8:   e3a0102e    mov r1, #46 @ 0x2e
200de8ec:   e0411005    sub r1, r1, r5                                                        | 200de8ec:   e1a00004    mov r0, r4
200de8f0:   e1a00004    mov r0, r4                                                            | 200de8f0:   fb011740    blx 201245fa <strrchr>
200de8f4:   e8bd4070    pop {r4, r5, r6, lr}                                                  | 200de8f4:   e3500000    cmp r0, #0
200de8f8:   eaffff98    b   200de760 <String::shorten(long)>                                  | 200de8f8:   0a000003    beq 200de90c <FileItem::getDisplayNameWithoutExtension(String*)+0x94>
200de8fc:   e1a00006    mov r0, r6                                                            | 200de8fc:   e0401004    sub r1, r0, r4
200de900:   e8bd8070    pop {r4, r5, r6, pc}                                                  | 200de900:   e1a00005    mov r0, r5
200de904:   e1a01004    mov r1, r4                                                            | 200de904:   e8bd4070    pop {r4, r5, r6, lr}
200de908:   e1a00005    mov r0, r5                                                            | 200de908:   eaffff94    b   200de760 <String::shorten(long)>
200de90c:   e8bd4070    pop {r4, r5, r6, lr}                                                  | 200de90c:   e1a00006    mov r0, r6
200de910:   eaffffc1    b   200de81c <FileItem::getFilenameWithoutExtension(String*)>         | 200de910:   e8bd8070    pop {r4, r5, r6, pc}
```