### PR TITLE
only convert cc74 to y axis if saved from old firmware

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2688,7 +2688,7 @@ createNewParamManager:
 			}
 		}
 
-		// These next 3 - only created by alpha testers for a few weeks. Could eventually remove.
+		// These are the expression params for MPE
 		else if (!strcmp(tagName, "pitchBend")) {
 			temp = 0;
 doReadExpressionParam:
@@ -2900,8 +2900,11 @@ expressionParam:
 						paramId = stringToInt(contents);
 						if (paramId < kNumRealCCNumbers) {
 							if (paramId == 74) {
-								paramId = 1;
-								goto expressionParam;
+								if (storageManager.firmwareVersionOfFileBeingRead
+								    < FirmwareVersion::FIRMWARE_3P2P0_ALPHA) {
+									paramId = 1;
+									goto expressionParam;
+								}
 							}
 							MIDIParam* midiParam =
 							    paramManager.getMIDIParamCollection()->params.getOrCreateParamFromCC(paramId, 0);


### PR DESCRIPTION
On old firmware CC74 was converted to y expression on load, but this was ok because y expression would send CC74 even in non-MPE situations. Now that there's differentiation between non-MPE CC74 and MPE y axis, only do the conversion if the file came from prior to expression params (firmware 3.2 per Rohan's comment)

fix #762 