### PR TITLE
Fix popup values displayed on 7SEG

### DIFF
--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -815,8 +815,12 @@ void AutomationInstrumentClipView::renderDisplay(int32_t knobPosLeft, int32_t kn
 
 	//if you're not in a MIDI instrument clip, convert the knobPos to the same range as the menu (0-50)
 	if (instrument->type != InstrumentType::MIDI_OUT) {
-		knobPosLeft = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, knobPosLeft);
-		knobPosRight = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, knobPosRight);
+		if (knobPosLeft != kNoSelection) {
+			knobPosLeft = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, knobPosLeft);
+		}
+		if (knobPosRight != kNoSelection) {
+			knobPosRight = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, knobPosRight);
+		}
 	}
 
 	//OLED Display
@@ -945,7 +949,7 @@ void AutomationInstrumentClipView::renderDisplay7SEG(InstrumentClip* clip, Instr
 				lastPadSelectedKnobPos = knobPosLeft;
 			}
 			else if (lastPadSelectedKnobPos != kNoSelection) {
-				knobPosLeft = lastPadSelectedKnobPos;
+				knobPosLeft = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, lastPadSelectedKnobPos);
 			}
 		}
 
@@ -956,10 +960,10 @@ void AutomationInstrumentClipView::renderDisplay7SEG(InstrumentClip* clip, Instr
 			intToString(knobPosLeft, buffer);
 
 			if (isUIModeActive(UI_MODE_NOTES_PRESSED)) {
-				display->setText(buffer, false, 255, false);
+				display->setText(buffer, true, 255, false);
 			}
 			else if (modEncoderAction || padSelectionOn) {
-				display->displayPopup(buffer);
+				display->displayPopup(buffer, 3, true);
 			}
 		}
 		//display parameter name

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -949,7 +949,8 @@ void AutomationInstrumentClipView::renderDisplay7SEG(InstrumentClip* clip, Instr
 				lastPadSelectedKnobPos = knobPosLeft;
 			}
 			else if (lastPadSelectedKnobPos != kNoSelection) {
-				knobPosLeft = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID, lastPadSelectedKnobPos);
+				knobPosLeft = view.calculateKnobPosForDisplay(instrument->type, clip->lastSelectedParamID,
+				                                              lastPadSelectedKnobPos);
 			}
 		}
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -943,7 +943,7 @@ void View::displayModEncoderValuePopup(InstrumentType instrumentType, int32_t pa
 			valueForDisplay = calculateKnobPosForDisplay(instrumentType, paramID, newKnobPos + kKnobPosOffset);
 		}
 		intToString(valueForDisplay, buffer);
-		display->displayPopup(buffer);
+		display->displayPopup(buffer, 3, true);
 	}
 
 	//if turning stutter mod encoder and stutter quantize is enabled


### PR DESCRIPTION
- Fixed mod encoder value popups to align values to the right of the 7Seg display

- Fixed automation instrument clip view value popups which were not displaying the correct amounts since the change to 0-50. This also fixes a bug that was introduced which wouldn't show the parameter names on 7Seg.