### PR TITLE
Fix auto-merge error in displayModEncoderValuePopup

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -940,10 +940,6 @@ void View::displayModEncoderValuePopup(Param::Kind kind, int32_t paramID, int32_
 			popupMsg.append(name);
 			popupMsg.append(": ");
 		}
-		else {
-			int valueForDisplay = calculateKnobPosForDisplay(kind, paramID, newKnobPos + kKnobPosOffset);
-			popupMsg.appendInt(valueForDisplay);
-		}
 	}
 
 	//if turning stutter mod encoder and stutter quantize is enabled


### PR DESCRIPTION
Not sure how this happened, may have been me a bit late at night or an auto merge, but that else branch is not supposed to be there. Results in any parameter with no known display name (such as midi CCs) being shown twice