### PR TITLE
Show human note name instead of integer note number, refactor

### DIFF
--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -493,7 +493,7 @@ void InstrumentClipMinder::drawActualNoteCode(int16_t noteCode) {
 		display->popupTextTemporary(noteName);
 	}
 	else {
-		uint8_t drawDot =  !isNatural ? 0 : 255;
+		uint8_t drawDot = !isNatural ? 0 : 255;
 		display->setText(noteName, false, drawDot, true);
 	}
 }

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -485,25 +485,15 @@ void InstrumentClipMinder::calculateDefaultRootNote() {
 }
 
 void InstrumentClipMinder::drawActualNoteCode(int16_t noteCode) {
-	int32_t octave = (noteCode) / 12 - 2;
-	int32_t noteCodeWithinOctave = (uint16_t)(noteCode + 120) % (uint8_t)12;
-
 	char noteName[5];
-	noteName[0] = noteCodeToNoteLetter[noteCodeWithinOctave];
-	char* writePos = &noteName[1];
-	if (display->haveOLED()) {
-		if (noteCodeIsSharp[noteCodeWithinOctave]) {
-			*writePos = '#';
-			writePos++;
-		}
-	}
-	intToString(octave, writePos, 1);
+	int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
+	noteCodeToString(noteCode, noteName, &isNatural);
 
 	if (display->haveOLED()) {
 		display->popupTextTemporary(noteName);
 	}
 	else {
-		uint8_t drawDot = noteCodeIsSharp[noteCodeWithinOctave] ? 0 : 255;
+		uint8_t drawDot =  !isNatural ? 0 : 255;
 		display->setText(noteName, false, drawDot, true);
 	}
 }

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -2505,6 +2505,29 @@ void noteCodeToString(int32_t noteCode, char* buffer, int32_t* getLengthWithoutD
 	}
 }
 
+void concatenateLines(const char* lines[], size_t numLines, char* resultString) {
+	const size_t maxCharsPerLine = 19;
+	size_t resultIndex = 0;
+
+	for (size_t i = 0; i < numLines; ++i) {
+		const char* currentLine = lines[i];
+		size_t lineLength = std::strlen(currentLine);
+
+		// Copy the current line to the result string
+		std::strncpy(&resultString[resultIndex], currentLine, lineLength);
+		resultIndex += lineLength;
+
+		// Add a line break after each line except the last one
+		if (i < numLines - 1) {
+			resultString[resultIndex] = '\n';
+			resultIndex++;
+		}
+	}
+
+	// Null-terminate the result string
+	resultString[resultIndex] = '\0';
+}
+
 void seedRandom() {
 	jcong = *TCNT[TIMER_SYSTEM_FAST];
 }

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -520,6 +520,7 @@ inline void colorCopy(uint8_t* dest, uint8_t* src, uint8_t intensity, uint8_t br
 
 int32_t howMuchMoreMagnitude(uint32_t to, uint32_t from);
 void noteCodeToString(int32_t noteCode, char* buffer, int32_t* getLengthWithoutDot = NULL);
+void concatenateLines(const char* lines[], size_t numLines, char* resultString);
 double ConvertFromIeeeExtended(unsigned char* bytes /* LCN */);
 int32_t divide_round_negative(int32_t dividend, int32_t divisor);
 void dissectIterationDependence(int32_t probability, int32_t* getDivisor, int32_t* getWhichIterationWithinDivisor);


### PR DESCRIPTION
We had a function that converted integers into human readable notes e.g. "C#5". We were duplicating that logic in several places where we hadn't leveraged the function in util/functions. The original intent of this was to avoid using integer note values when modifying what note a kit's midi track is linked to. There was discussion around appropriate UX for this and it was discovered that displaying channel and note name on two lines is unideal because the realized vertical hierarchy is incongruent with the physical layout. The gold knobs are farther apart vertically than they are spaced apart horizontally. As a result, the display feels "flipped" because you twist the bottom knob to modify the channel and the top knob to modify the note. 

On the 7seg, the channel and note are horizontal with channel being first then note. This only makes sense because the bottom knob is slightly to the left of the top knob. 

Since compatibility with the paradigms used in the 7seg is a priority, it makes most sense to get the channel/note to fit on the same line – thus closing the gap in presentational consistency across device models. 

To do this, we reasoned that "MIDI " in `"MIDI CHANNEL 5, " is unnecessary. Additionally, "CHANNEL" can be shortened to "CHAN" and could be argued would be worth introducing inconsistency because the alternative is to break the display in two linesl

Discussion: 
https://discord.com/channels/608916579421257728/1107026299945496577/1179913677818839051

QA:

**Before**

https://github.com/SynthstromAudible/DelugeFirmware/assets/809953/5d9b3911-e5cd-4446-83ce-033f1f9a6252



**After**


https://github.com/SynthstromAudible/DelugeFirmware/assets/809953/05a9a003-de65-4289-91fb-e60dcbdeb784


