### PR TITLE
Fix problem found by macMOE

### DIFF
--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -59,7 +59,9 @@ void ActionLogger::deleteLastActionIfEmpty() {
 	if (firstAction[BEFORE]) {
 
 		// There are probably more cases where we might want to do this, but I've only done it for recording so far
-		while (!firstAction[BEFORE]->firstConsequence) {
+		// Paul: reinstating the original for now because it seems there are broken pointers in this list which lead to crashes, we need to fix after release
+		// while (!firstAction[BEFORE]->firstConsequence) {
+		if (firstAction[BEFORE]->type == ACTION_RECORD && !firstAction[BEFORE]->firstConsequence) {
 
 			deleteLastAction();
 		}


### PR DESCRIPTION
In arranger_view.cpp:1489
```
Action* action = actionLogger.getNewAction(ACTION_CLIP_INSTANCE_EDIT, false);
```
or line 199
```
Action* action = actionLogger.getNewAction(ACTION_ARRANGEMENT_RECORD, false);
```

can trigger a crash because the pointer given to deallocate is not inside any memory region, we need to fix that later and find the source