### PR TITLE
Bugfix/param to string midi learn

### DIFF
--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -4291,8 +4291,11 @@ char const* Sound::paramToString(uint8_t param) {
 	case Param::Local::LPF_FREQ:
 		return "lpfFrequency";
 
+	case Param::Local::LPF_MORPH:
+		return "lpfMorph";
+
 	case Param::Local::HPF_MORPH:
-		return "HPFMorph";
+		return "hpfMorph";
 
 	case Param::Local::PITCH_ADJUST:
 		return "pitch";


### PR DESCRIPTION
Fix lpf morph not having a tag for use in midi learn and patch cables

Fix hpf morph having an incorrect case