### PR TITLE
rescale metronome volume

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -370,8 +370,8 @@ constexpr int32_t kMaxMenuPatchCableValue = kMaxMenuValue * 100;
 constexpr int32_t kMinMenuPatchCableValue = -1 * kMaxMenuPatchCableValue;
 
 //metronome volume menu range : 22 to 27
-constexpr int32_t kMaxMenuMetronomeVolumeValue = 27;
-constexpr int32_t kMinMenuMetronomeVolumeValue = 22;
+constexpr int32_t kMaxMenuMetronomeVolumeValue = 50;
+constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 
 //
 

--- a/src/deluge/gui/menu_item/defaults/metronome_volume.h
+++ b/src/deluge/gui/menu_item/defaults/metronome_volume.h
@@ -16,6 +16,8 @@
 */
 #pragma once
 #include "gui/menu_item/integer.h"
+#include "processing/engines/audio_engine.h"
+#include "processing/metronome/metronome.h"
 #include "storage/flash_storage.h"
 
 namespace deluge::gui::menu_item::defaults {
@@ -25,6 +27,9 @@ public:
 	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuMetronomeVolumeValue; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuMetronomeVolumeValue; }
 	void readCurrentValue() override { this->setValue(FlashStorage::defaultMetronomeVolume); }
-	void writeCurrentValue() override { FlashStorage::defaultMetronomeVolume = this->getValue(); }
+	void writeCurrentValue() override {
+		FlashStorage::defaultMetronomeVolume = this->getValue();
+		AudioEngine::metronome.setVolume(this->getValue());
+	}
 };
 } // namespace deluge::gui::menu_item::defaults

--- a/src/deluge/processing/metronome/metronome.cpp
+++ b/src/deluge/processing/metronome/metronome.cpp
@@ -24,6 +24,7 @@
 
 Metronome::Metronome() {
 	sounding = false;
+	setVolume(25);
 }
 
 void Metronome::trigger(uint32_t newPhaseIncrement) {
@@ -39,17 +40,17 @@ void Metronome::render(StereoSample* buffer, uint16_t numSamples) {
 	}
 	int32_t volumePostFX;
 	if (currentSong) {
-		volumePostFX = getFinalParameterValueVolume(
-		                   1 << FlashStorage::defaultMetronomeVolume,
-		                   cableToLinearParamShortcut(currentSong->paramManager.getUnpatchedParamSet()->getValue(
+		volumePostFX =
+		    getFinalParameterValueVolume(
+		        134217728, cableToLinearParamShortcut(currentSong->paramManager.getUnpatchedParamSet()->getValue(
 		                       Param::Unpatched::GlobalEffectable::VOLUME)))
-		               >> 1;
+		    >> 1;
 	}
 	else {
 		volumePostFX = ONE_Q31;
 	}
 
-	q31_t high = multiply_32x32_rshift32(1 << FlashStorage::defaultMetronomeVolume, volumePostFX);
+	q31_t high = multiply_32x32_rshift32(metronomeVolume, volumePostFX);
 	StereoSample* thisSample = buffer;
 	StereoSample* bufferEnd = buffer + numSamples;
 	do {

--- a/src/deluge/processing/metronome/metronome.h
+++ b/src/deluge/processing/metronome/metronome.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 
 class StereoSample;
@@ -26,9 +27,11 @@ public:
 	Metronome();
 	void trigger(uint32_t newPhaseIncrement);
 	void render(StereoSample* buffer, uint16_t numSamples);
+	void setVolume(int32_t linearParam) { metronomeVolume = (exp(float(linearParam) / 200.0f) - 1.0) * float(1 << 27); }
 
 	uint32_t phase;
 	uint32_t phaseIncrement;
 	uint32_t timeSinceTrigger;
+	uint32_t metronomeVolume;
 	bool sounding;
 };

--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -23,6 +23,7 @@
 #include "io/midi/midi_engine.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/engines/cv_engine.h"
+#include "processing/metronome/metronome.h"
 #include "util/functions.h"
 #include "util/misc.h"
 
@@ -418,6 +419,7 @@ void readSettings() {
 	    || defaultMetronomeVolume < kMinMenuMetronomeVolumeValue) {
 		defaultMetronomeVolume = kMaxMenuMetronomeVolumeValue;
 	}
+	AudioEngine::metronome.setVolume(defaultMetronomeVolume);
 }
 
 void writeSettings() {


### PR DESCRIPTION
Fix #777 

A bug in reading default metronome volume in #683 caused the metronome volume to be squared, making the scaling opposite of what's desired for audio and giving it a small usable range

Range is now 1-50 exponentially scaled