### PR TITLE
Fix iterations not displaying

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2863,12 +2863,10 @@ void InstrumentClipView::setRowProbability(int32_t offset) {
 
 void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) {
 	char buffer[(display->haveOLED()) ? 29 : 5];
-	char* displayString;
 
 	// FILL mode
 	if (probability == kFillProbabilityValue) {
 		strcpy(buffer, "FILL");
-		displayString = buffer;
 	}
 
 	// Probability dependence
@@ -2884,7 +2882,6 @@ void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) 
 		if (display->have7SEG()) {
 			intToString(probability * 5, buffer);
 		}
-		displayString = buffer;
 	}
 
 	// Iteration dependence
@@ -2914,10 +2911,10 @@ void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) 
 	}
 
 	if (display->haveOLED()) {
-		display->popupText(displayString, DisplayPopupType::PROBABILITY);
+		display->popupText(buffer, DisplayPopupType::PROBABILITY);
 	}
 	if (display->have7SEG()) {
-		display->displayPopup(displayString, 0, true, prevBase ? 3 : 255, 1, DisplayPopupType::PROBABILITY);
+		display->displayPopup(buffer, 0, true, prevBase ? 3 : 255, 1, DisplayPopupType::PROBABILITY);
 	}
 }
 


### PR DESCRIPTION
displayString variable was unnecesary and not set in the case of iteration when optimizations are on

removed it and just pass buffer to popup instead

Fix #800 