### PR TITLE
use signed int to avoid tempo wrapping

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1938,7 +1938,7 @@ displayNudge:
 			case 2:
 				// Fine tempo adjustment
 
-				uint32_t tempoBPM = calculateBPM(currentSong->getTimePerTimerTickFloat()) + 0.5;
+				int32_t tempoBPM = calculateBPM(currentSong->getTimePerTimerTickFloat()) + 0.5;
 				tempoBPM += offset;
 				if (tempoBPM > 0) {
 					currentSong->setBPM(tempoBPM, true);


### PR DESCRIPTION
Overflow can't happen since the max BPM is 9999

Fix #827