### PR TITLE
c1.0.1 Bugfix / Invalid Param Collection in getModelStackWithParam for Automation View

### DIFF
--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2939,9 +2939,14 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 			}
 
 			if (summary) {
-				ParamSet* paramSet = (ParamSet*)summary->paramCollection;
-				modelStackWithParam =
-				    modelStackWithThreeMainThings->addParam(paramSet, summary, paramID, &paramSet->params[paramID]);
+				ModelStackWithParamCollection* modelStackWithParamCollection =
+				    modelStackWithThreeMainThings->addParamCollectionSummary(summary);
+				if (modelStackWithParamCollection) {
+					ModelStackWithParamId* ModelStackWithParamId = modelStackWithParamCollection->addParamId(paramID);
+					if (ModelStackWithParamId) {
+						modelStackWithParam = summary->paramCollection->getAutoParamFromId(ModelStackWithParamId, true);
+					}
+				}
 			}
 		}
 	}
@@ -2976,9 +2981,16 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 							}
 
 							if (summary) {
-								ParamSet* paramSet = (ParamSet*)summary->paramCollection;
-								modelStackWithParam = modelStackWithThreeMainThings->addParam(
-								    paramSet, summary, paramID, &paramSet->params[paramID]);
+								ModelStackWithParamCollection* modelStackWithParamCollection =
+								    modelStackWithThreeMainThings->addParamCollectionSummary(summary);
+								if (modelStackWithParamCollection) {
+									ModelStackWithParamId* ModelStackWithParamId =
+									    modelStackWithParamCollection->addParamId(paramID);
+									if (ModelStackWithParamId) {
+										modelStackWithParam =
+										    summary->paramCollection->getAutoParamFromId(ModelStackWithParamId, true);
+									}
+								}
 							}
 						}
 					}
@@ -2998,9 +3010,16 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 				summary = modelStackWithThreeMainThings->paramManager->getUnpatchedParamSetSummary();
 
 				if (summary) {
-					ParamSet* paramSet = (ParamSet*)summary->paramCollection;
-					modelStackWithParam =
-					    modelStackWithThreeMainThings->addParam(paramSet, summary, paramID, &paramSet->params[paramID]);
+					ModelStackWithParamCollection* modelStackWithParamCollection =
+					    modelStackWithThreeMainThings->addParamCollectionSummary(summary);
+					if (modelStackWithParamCollection) {
+						ModelStackWithParamId* ModelStackWithParamId =
+						    modelStackWithParamCollection->addParamId(paramID);
+						if (ModelStackWithParamId) {
+							modelStackWithParam =
+							    summary->paramCollection->getAutoParamFromId(ModelStackWithParamId, true);
+						}
+					}
 				}
 			}
 		}

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -1023,7 +1023,7 @@ void AutomationInstrumentClipView::getParameterName(InstrumentClip* clip, Instru
 
 //adjust the LED meters and update the display
 
-/*updated function for displaying automation when playback is enabled (called from ui_timer_manager). 
+/*updated function for displaying automation when playback is enabled (called from ui_timer_manager).
 Also used internally in the automation instrument clip view for updating the display and led indicators.*/
 
 void AutomationInstrumentClipView::displayAutomation(bool padSelected, bool updateDisplay) {
@@ -2942,7 +2942,7 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 				ModelStackWithParamCollection* modelStackWithParamCollection =
 				    modelStackWithThreeMainThings->addParamCollectionSummary(summary);
 				if (modelStackWithParamCollection) {
-					ModelStackWithParamId* ModelStackWithParamId = modelStackWithParamCollection->addParamId(paramID);
+					ModelStackWithParamId* modelStackWithParamId = modelStackWithParamCollection->addParamId(paramID);
 					if (ModelStackWithParamId) {
 						modelStackWithParam = summary->paramCollection->getAutoParamFromId(ModelStackWithParamId, true);
 					}
@@ -2984,7 +2984,7 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 								ModelStackWithParamCollection* modelStackWithParamCollection =
 								    modelStackWithThreeMainThings->addParamCollectionSummary(summary);
 								if (modelStackWithParamCollection) {
-									ModelStackWithParamId* ModelStackWithParamId =
+									ModelStackWithParamId* modelStackWithParamId =
 									    modelStackWithParamCollection->addParamId(paramID);
 									if (ModelStackWithParamId) {
 										modelStackWithParam =
@@ -3013,7 +3013,7 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 					ModelStackWithParamCollection* modelStackWithParamCollection =
 					    modelStackWithThreeMainThings->addParamCollectionSummary(summary);
 					if (modelStackWithParamCollection) {
-						ModelStackWithParamId* ModelStackWithParamId =
+						ModelStackWithParamId* modelStackWithParamId =
 						    modelStackWithParamCollection->addParamId(paramID);
 						if (ModelStackWithParamId) {
 							modelStackWithParam =

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2943,8 +2943,8 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 				    modelStackWithThreeMainThings->addParamCollectionSummary(summary);
 				if (modelStackWithParamCollection) {
 					ModelStackWithParamId* modelStackWithParamId = modelStackWithParamCollection->addParamId(paramID);
-					if (ModelStackWithParamId) {
-						modelStackWithParam = summary->paramCollection->getAutoParamFromId(ModelStackWithParamId, true);
+					if (modelStackWithParamId) {
+						modelStackWithParam = summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
 					}
 				}
 			}
@@ -2986,9 +2986,9 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 								if (modelStackWithParamCollection) {
 									ModelStackWithParamId* modelStackWithParamId =
 									    modelStackWithParamCollection->addParamId(paramID);
-									if (ModelStackWithParamId) {
+									if (modelStackWithParamId) {
 										modelStackWithParam =
-										    summary->paramCollection->getAutoParamFromId(ModelStackWithParamId, true);
+										    summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
 									}
 								}
 							}
@@ -3015,9 +3015,9 @@ ModelStackWithAutoParam* AutomationInstrumentClipView::getModelStackWithParam(Mo
 					if (modelStackWithParamCollection) {
 						ModelStackWithParamId* modelStackWithParamId =
 						    modelStackWithParamCollection->addParamId(paramID);
-						if (ModelStackWithParamId) {
+						if (modelStackWithParamId) {
 							modelStackWithParam =
-							    summary->paramCollection->getAutoParamFromId(ModelStackWithParamId, true);
+							    summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
 						}
 					}
 				}


### PR DESCRIPTION
We have received a few bug reports of crashes when entering automation view.

This may have been due to a possible scenario where getModelStackWithParam was returned with an invalid Param Collection.

To resolve this, I have modified the code to getModelStackWithParam to first get the modelStackWithParamCollection and check that it is valid before getting the modelStackWithParamId from the Param Collection and then finally getting the modelStackWithParam from the modelStackWithParamId.