### PR TITLE
Fix crash on returning loop markers to start/end with loop lock engaged

### DIFF
--- a/src/deluge/gui/ui/sample_marker_editor.h
+++ b/src/deluge/gui/ui/sample_marker_editor.h
@@ -60,6 +60,9 @@ public:
 	int8_t pressX;
 	int8_t pressY;
 
+	int32_t loopLength = 0;
+	bool loopLocked = false;
+
 private:
 	void writeValue(uint32_t value, MarkerType markerTypeNow = MarkerType::NOT_AVAILABLE);
 	void exitUI();

--- a/src/deluge/gui/ui/sample_marker_editor.h
+++ b/src/deluge/gui/ui/sample_marker_editor.h
@@ -53,6 +53,11 @@ public:
 	// 7SEG
 	void displayText();
 
+	/// Unlock the loop, allowing the ends to be moved independently
+	void loopUnlock();
+	/// Lock the loop so the start and end are always the same number of samples apart
+	void loopLock();
+
 	MarkerType markerType;
 
 	bool blinkInvisible;


### PR DESCRIPTION
This does the simplest thing (disabling loop lock and then running the normal return code) but a more elegant solution would retain the loop lock state for when the loop markers are next pulled out.