### PR TITLE
Seperate receiving midi from matching in kits and synths

### DIFF
--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -658,6 +658,7 @@ void Kit::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel
 	}
 }
 
+//not updated for midi follow, this seems dumb and is just left for backwards compatibility
 bool Kit::offerReceivedPitchBendToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
                                                 ModelStackWithTimelineCounter* modelStack) {
 
@@ -1195,6 +1196,13 @@ void Kit::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevic
 	}
 }
 
+void Kit::offerReceivedPitchBendToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+                                       MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
+                                       int32_t level, bool* doingMidiThru) {
+	int16_t value16 = (((uint32_t)data1 | ((uint32_t)data2 << 7)) - 8192) << 2;
+	thisDrum->expressionEventPossiblyToRecord(modelStackWithTimelineCounter, value16, 0, level);
+}
+
 void Kit::offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
                                  uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru) {
 
@@ -1216,8 +1224,8 @@ void Kit::offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTi
 			}
 			else { // Or, if Drum does not have MPE input, then this is a channel-level message.
 yesThisDrum:
-				int16_t value16 = (((uint32_t)data1 | ((uint32_t)data2 << 7)) - 8192) << 2;
-				thisDrum->expressionEventPossiblyToRecord(modelStackWithTimelineCounter, value16, 0, level);
+				offerReceivedPitchBendToDrum(modelStackWithTimelineCounter, thisDrum, fromDevice, channel, data1, data2,
+				                             level, doingMidiThru);
 			}
 		}
 	}

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -628,13 +628,19 @@ void Kit::renderOutput(ModelStack* modelStack, StereoSample* outputBuffer, Stere
 	                                      shouldLimitDelayFeedback, isClipActive, InstrumentType::KIT, 8);
 }
 
+//offer the CC to kit gold knobs without also offering to all drums
+void Kit::offerReceivedCCToModControllable(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
+                                           ModelStackWithTimelineCounter* modelStack) {
+	ModControllableAudio::offerReceivedCCToLearnedParams(
+	    fromDevice, channel, ccNumber, value,
+	    modelStack); // NOTE: this call may change modelStack->timelineCounter etc!
+}
 void Kit::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
                                          ModelStackWithTimelineCounter* modelStack) {
 
 	// Do it for this whole Kit
-	ModControllableAudio::offerReceivedCCToLearnedParams(
-	    fromDevice, channel, ccNumber, value,
-	    modelStack); // NOTE: this call may change modelStack->timelineCounter etc!
+	offerReceivedCCToModControllable(fromDevice, channel, ccNumber, value,
+	                                 modelStack); // NOTE: this call may change modelStack->timelineCounter etc!
 
 	// Now do it for each NoteRow / Drum
 	if (modelStack

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -994,177 +994,182 @@ void Kit::getThingWithMostReverb(Sound** soundWithMostReverb, ParamManager** par
 	}
 }
 
-void Kit::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on, int32_t channel,
-                            int32_t note, int32_t velocity, bool shouldRecordNotes, bool* doingMidiThru) {
-
+void Kit::receivedNoteForDrum(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
+                              int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
+                              bool* doingMidiThru, Drum* thisDrum) {
 	InstrumentClip* instrumentClip = (InstrumentClip*)modelStack->getTimelineCounterAllowNull(); // Yup it might be NULL
 
 	bool recordingNoteOnEarly = false;
-	bool lookingForFirstDrumForNoteOn = on;
 
 	bool shouldRecordNoteOn =
 	    shouldRecordNotes && instrumentClip
 	    && currentSong->isClipActive(instrumentClip); // Even if this comes out as false here, there are some
 	                                                  // special cases below where we might insist on making
 	                                                  // it true
+	// If MIDIDrum, outputting same note, then don't additionally do thru
+	if (doingMidiThru && thisDrum->type == DrumType::MIDI && ((MIDIDrum*)thisDrum)->channel == channel
+	    && ((MIDIDrum*)thisDrum)->note == note) {
+		*doingMidiThru = false;
+	}
+
+	// Just once, for first Drum we're doing a note-on on, see if we want to switch to a different InstrumentClip, for a couple of reasons
+	// For simplicity we can do this every time, it only matters if you have multiple drums mapped to the same note
+	if (on && instrumentClip && shouldRecordNotes) {
+
+		// Firstly, if recording session to arranger...
+		if (playbackHandler.recording == RECORDING_ARRANGEMENT) {
+
+			instrumentClip->possiblyCloneForArrangementRecording(modelStack);
+
+			instrumentClip = (InstrumentClip*)modelStack->getTimelineCounter(); // Re-get it, cos it might have changed
+
+			if (instrumentClip->isArrangementOnlyClip()) {
+				shouldRecordNoteOn = true;
+			}
+		}
+
+		// If count-in is on, we only got here if it's very nearly finished
+		else if (currentUIMode == UI_MODE_RECORD_COUNT_IN) {
+goingToRecordNoteOnEarly:
+			recordingNoteOnEarly = true;
+			shouldRecordNoteOn = false;
+		}
+
+		// And another special case - if there's a pending overdub beginning really soon,
+		// and activeClip is not linearly recording (and maybe not even active)...
+		else if (currentPlaybackMode == &session && session.launchEventAtSwungTickCount
+		         && !instrumentClip->getCurrentlyRecordingLinearly()) {
+			int32_t ticksTilLaunch = session.launchEventAtSwungTickCount - playbackHandler.getActualSwungTickCount();
+			int32_t samplesTilLaunch = ticksTilLaunch * playbackHandler.getTimePerInternalTick();
+			if (samplesTilLaunch <= kLinearRecordingEarlyFirstNoteAllowance) {
+				Clip* clipAboutToRecord = currentSong->getClipWithOutputAboutToBeginLinearRecording(this);
+				if (clipAboutToRecord) {
+					goto goingToRecordNoteOnEarly;
+				}
+			}
+		}
+	}
+
+	ModelStackWithNoteRow* modelStackWithNoteRow;
+
+	NoteRow* thisNoteRow = NULL; // Will only be set to true if there's a Clip / activeClip
+
+	if (instrumentClip) {
+		modelStackWithNoteRow = instrumentClip->getNoteRowForDrum(modelStack, thisDrum);
+		thisNoteRow = modelStackWithNoteRow->getNoteRowAllowNull();
+		if (!thisNoteRow) {
+			return; // Yeah, we won't even let them sound one with no NoteRow
+		}
+	}
+	else {
+		modelStackWithNoteRow = modelStack->addNoteRow(0, NULL);
+	}
+
+	if (recordingNoteOnEarly) {
+		bool allowingNoteTails = instrumentClip && instrumentClip->allowNoteTails(modelStackWithNoteRow);
+		thisDrum->recordNoteOnEarly(velocity, allowingNoteTails);
+	}
+
+	// Note-on
+	if (on) {
+
+		// If input is MPE, we need to give the Drum the most recent MPE expression values received on the channel on the Device. It doesn't keep track of these when a note isn't on, and
+		// even if it did, this new note might be on a different channel (just same notecode).
+		if (thisDrum->midiInput.isForMPEZone()) {
+			for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
+				thisDrum->lastExpressionInputsReceived[BEND_RANGE_FINGER_LEVEL][i] =
+				    fromDevice->defaultInputMPEValuesPerMIDIChannel[channel][i] >> 8;
+			}
+		}
+
+		// And if non-MPE input, just set those finger-level MPE values to 0. If an MPE instrument had been used just before, it could have left them set to something.
+		else {
+			for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
+				thisDrum->lastExpressionInputsReceived[BEND_RANGE_FINGER_LEVEL][i] = 0;
+			}
+		}
+
+		int16_t mpeValues[kNumExpressionDimensions];
+		thisDrum->getCombinedExpressionInputs(mpeValues);
+
+		// MPE stuff - if editing note, we need to take note of the initial values which might have been sent before this note-on.
+		instrumentClipView.reportMPEInitialValuesForNoteEditing(modelStackWithNoteRow, mpeValues);
+
+		if (!thisNoteRow || !thisNoteRow->soundingStatus) {
+
+			if (thisNoteRow && shouldRecordNoteOn) {
+
+				int16_t const* mpeValuesOrNull = NULL;
+
+				if (fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isChannelPartOfAnMPEZone(channel)) {
+					mpeValuesOrNull = mpeValues;
+				}
+
+				instrumentClip->recordNoteOn(modelStackWithNoteRow, velocity, false, mpeValuesOrNull);
+				if (getRootUI()) {
+					getRootUI()->noteRowChanged(instrumentClip, thisNoteRow);
+				}
+			}
+			// TODO: possibly should change the MPE params' currentValue to the initial values, since that usually does get updated by the
+			// subsequent MPE that will come in. Or does that not matter?
+
+			if (thisNoteRow && thisDrum->type == DrumType::SOUND
+			    && !thisNoteRow->paramManager.containsAnyMainParamCollections()) {
+				FREEZE_WITH_ERROR("E326"); // Trying to catch an E313 that Vinz got
+			}
+
+			beginAuditioningforDrum(modelStackWithNoteRow, thisDrum, velocity, mpeValues, channel);
+		}
+	}
+
+	// Note-off
+	else {
+		if (thisNoteRow) {
+			if (shouldRecordNotes && thisDrum->auditioned
+			    && ((playbackHandler.recording == RECORDING_ARRANGEMENT && instrumentClip->isArrangementOnlyClip())
+			        || currentSong->isClipActive(instrumentClip))) {
+
+				if (playbackHandler.recording == RECORDING_ARRANGEMENT && !instrumentClip->isArrangementOnlyClip()) {}
+				else {
+					instrumentClip->recordNoteOff(modelStackWithNoteRow, velocity);
+					if (getRootUI()) {
+						getRootUI()->noteRowChanged(instrumentClip, thisNoteRow);
+					}
+				}
+			}
+			instrumentClipView.reportNoteOffForMPEEditing(modelStackWithNoteRow);
+
+			// MPE-controlled params are a bit special in that we can see (via this note-off) when the user has removed their finger and won't be sending more
+			// values. So, let's unlatch those params now.
+			ExpressionParamSet* mpeParams = thisNoteRow->paramManager.getExpressionParamSet();
+			if (mpeParams) {
+				mpeParams->cancelAllOverriding();
+			}
+		}
+		endAuditioningForDrum(
+		    modelStackWithNoteRow, thisDrum,
+		    velocity); // Do this even if not marked as auditioned, to avoid stuck notes in cases like if two note-ons were sent
+	}
+}
+
+void Kit::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on, int32_t channel,
+                            int32_t note, int32_t velocity, bool shouldRecordNotes, bool* doingMidiThru) {
+
+	InstrumentClip* instrumentClip = (InstrumentClip*)modelStack->getTimelineCounterAllowNull(); // Yup it might be NULL
+
 	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
 
 		// If this is the "input" command, to sound / audition the Drum...
 		// Returns true if midi channel and note match the learned midi note
+		// We don't need the MPE match because all types of matches should sound the drum
 		if (thisDrum->midiInput.equalsNoteOrCCAllowMPE(fromDevice, channel, note)) {
-
-			// If MIDIDrum, outputting same note, then don't additionally do thru
-			if (doingMidiThru && thisDrum->type == DrumType::MIDI && ((MIDIDrum*)thisDrum)->channel == channel
-			    && ((MIDIDrum*)thisDrum)->note == note) {
-				*doingMidiThru = false;
-			}
-
-			// Just once, for first Drum we're doing a note-on on, see if we want to switch to a different InstrumentClip, for a couple of reasons
-			if (lookingForFirstDrumForNoteOn && instrumentClip && shouldRecordNotes) {
-				lookingForFirstDrumForNoteOn = false;
-
-				// Firstly, if recording session to arranger...
-				if (playbackHandler.recording == RECORDING_ARRANGEMENT) {
-
-					instrumentClip->possiblyCloneForArrangementRecording(modelStack);
-
-					instrumentClip =
-					    (InstrumentClip*)modelStack->getTimelineCounter(); // Re-get it, cos it might have changed
-
-					if (instrumentClip->isArrangementOnlyClip()) {
-						shouldRecordNoteOn = true;
-					}
-				}
-
-				// If count-in is on, we only got here if it's very nearly finished
-				else if (currentUIMode == UI_MODE_RECORD_COUNT_IN) {
-goingToRecordNoteOnEarly:
-					recordingNoteOnEarly = true;
-					shouldRecordNoteOn = false;
-				}
-
-				// And another special case - if there's a pending overdub beginning really soon,
-				// and activeClip is not linearly recording (and maybe not even active)...
-				else if (currentPlaybackMode == &session && session.launchEventAtSwungTickCount
-				         && !instrumentClip->getCurrentlyRecordingLinearly()) {
-					int32_t ticksTilLaunch =
-					    session.launchEventAtSwungTickCount - playbackHandler.getActualSwungTickCount();
-					int32_t samplesTilLaunch = ticksTilLaunch * playbackHandler.getTimePerInternalTick();
-					if (samplesTilLaunch <= kLinearRecordingEarlyFirstNoteAllowance) {
-						Clip* clipAboutToRecord = currentSong->getClipWithOutputAboutToBeginLinearRecording(this);
-						if (clipAboutToRecord) {
-							goto goingToRecordNoteOnEarly;
-						}
-					}
-				}
-			}
-
-			ModelStackWithNoteRow* modelStackWithNoteRow;
-
-			NoteRow* thisNoteRow = NULL; // Will only be set to true if there's a Clip / activeClip
-
-			if (instrumentClip) {
-				modelStackWithNoteRow = instrumentClip->getNoteRowForDrum(modelStack, thisDrum);
-				thisNoteRow = modelStackWithNoteRow->getNoteRowAllowNull();
-				if (!thisNoteRow) {
-					continue; // Yeah, we won't even let them sound one with no NoteRow
-				}
-			}
-			else {
-				modelStackWithNoteRow = modelStack->addNoteRow(0, NULL);
-			}
-
-			if (recordingNoteOnEarly) {
-				bool allowingNoteTails = instrumentClip && instrumentClip->allowNoteTails(modelStackWithNoteRow);
-				thisDrum->recordNoteOnEarly(velocity, allowingNoteTails);
-			}
-
-			// Note-on
-			if (on) {
-
-				// If input is MPE, we need to give the Drum the most recent MPE expression values received on the channel on the Device. It doesn't keep track of these when a note isn't on, and
-				// even if it did, this new note might be on a different channel (just same notecode).
-				if (thisDrum->midiInput.isForMPEZone()) {
-					for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
-						thisDrum->lastExpressionInputsReceived[BEND_RANGE_FINGER_LEVEL][i] =
-						    fromDevice->defaultInputMPEValuesPerMIDIChannel[channel][i] >> 8;
-					}
-				}
-
-				// And if non-MPE input, just set those finger-level MPE values to 0. If an MPE instrument had been used just before, it could have left them set to something.
-				else {
-					for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
-						thisDrum->lastExpressionInputsReceived[BEND_RANGE_FINGER_LEVEL][i] = 0;
-					}
-				}
-
-				int16_t mpeValues[kNumExpressionDimensions];
-				thisDrum->getCombinedExpressionInputs(mpeValues);
-
-				// MPE stuff - if editing note, we need to take note of the initial values which might have been sent before this note-on.
-				instrumentClipView.reportMPEInitialValuesForNoteEditing(modelStackWithNoteRow, mpeValues);
-
-				if (!thisNoteRow || !thisNoteRow->soundingStatus) {
-
-					if (thisNoteRow && shouldRecordNoteOn) {
-
-						int16_t const* mpeValuesOrNull = NULL;
-
-						if (fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isChannelPartOfAnMPEZone(channel)) {
-							mpeValuesOrNull = mpeValues;
-						}
-
-						instrumentClip->recordNoteOn(modelStackWithNoteRow, velocity, false, mpeValuesOrNull);
-						if (getRootUI()) {
-							getRootUI()->noteRowChanged(instrumentClip, thisNoteRow);
-						}
-					}
-					// TODO: possibly should change the MPE params' currentValue to the initial values, since that usually does get updated by the
-					// subsequent MPE that will come in. Or does that not matter?
-
-					if (thisNoteRow && thisDrum->type == DrumType::SOUND
-					    && !thisNoteRow->paramManager.containsAnyMainParamCollections()) {
-						FREEZE_WITH_ERROR("E326"); // Trying to catch an E313 that Vinz got
-					}
-
-					beginAuditioningforDrum(modelStackWithNoteRow, thisDrum, velocity, mpeValues, channel);
-				}
-			}
-
-			// Note-off
-			else {
-				if (thisNoteRow) {
-					if (shouldRecordNotes && thisDrum->auditioned
-					    && ((playbackHandler.recording == RECORDING_ARRANGEMENT
-					         && instrumentClip->isArrangementOnlyClip())
-					        || currentSong->isClipActive(instrumentClip))) {
-
-						if (playbackHandler.recording == RECORDING_ARRANGEMENT
-						    && !instrumentClip->isArrangementOnlyClip()) {}
-						else {
-							instrumentClip->recordNoteOff(modelStackWithNoteRow, velocity);
-							if (getRootUI()) {
-								getRootUI()->noteRowChanged(instrumentClip, thisNoteRow);
-							}
-						}
-					}
-					instrumentClipView.reportNoteOffForMPEEditing(modelStackWithNoteRow);
-
-					// MPE-controlled params are a bit special in that we can see (via this note-off) when the user has removed their finger and won't be sending more
-					// values. So, let's unlatch those params now.
-					ExpressionParamSet* mpeParams = thisNoteRow->paramManager.getExpressionParamSet();
-					if (mpeParams) {
-						mpeParams->cancelAllOverriding();
-					}
-				}
-				endAuditioningForDrum(
-				    modelStackWithNoteRow, thisDrum,
-				    velocity); // Do this even if not marked as auditioned, to avoid stuck notes in cases like if two note-ons were sent
-			}
+			receivedNoteForDrum(modelStack, fromDevice, on, channel, note, velocity, shouldRecordNotes, doingMidiThru,
+			                    thisDrum);
 		}
-
 		// Or if this is the Drum's mute command...
-		if (instrumentClip && on && thisDrum->muteMIDICommand.equalsNoteOrCC(fromDevice, channel, note)) {
+		// changed to else if dec 2023 because the same note should never be both mute and sound, this will save
+		// potential confusion if someone accidentally learns a note to mute as well as audition
+		else if (instrumentClip && on && thisDrum->muteMIDICommand.equalsNoteOrCC(fromDevice, channel, note)) {
 
 			ModelStackWithNoteRow* modelStackWithNoteRow = instrumentClip->getNoteRowForDrum(modelStack, thisDrum);
 

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -59,6 +59,9 @@ public:
 
 	void offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                            uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
+	void offerReceivedPitchBendToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+	                                  MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
+	                                  int32_t level, bool* doingMidiThru);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -60,8 +60,9 @@ public:
 	void offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                            uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
 	void offerReceivedPitchBendToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                                  MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
-	                                  int32_t level, bool* doingMidiThru);
+	                                  uint8_t data1, uint8_t data2, int32_t level, bool* doingMidiThru);
+	void offerMPEYAxisToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+	                         int32_t level, uint8_t value);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -50,6 +50,8 @@ public:
 	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                  bool shouldLimitDelayFeedback, bool isClipActive);
 	void notifySamplesInterruptsSuspended();
+	inline void offerReceivedCCToModControllable(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber,
+	                                             uint8_t value, ModelStackWithTimelineCounter* modelStack);
 	void offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
 	                                    ModelStackWithTimelineCounter* modelStack);
 	bool offerReceivedPitchBendToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -86,6 +86,9 @@ public:
 	void offerReceivedNote(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                       bool on, int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
 	                       bool* doingMidiThru);
+	void receivedNoteForDrum(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
+	                         int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
+	                         bool* doingMidiThru, Drum* thisDrum);
 	bool isNoteRowStillAuditioningAsLinearRecordingEnded(NoteRow* noteRow);
 	bool allowNoteTails(NoteRow* noteRow);
 	void stopAnyAuditioning(ModelStack* modelStack);

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -50,8 +50,8 @@ public:
 	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                  bool shouldLimitDelayFeedback, bool isClipActive);
 	void notifySamplesInterruptsSuspended();
-	inline void offerReceivedCCToModControllable(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber,
-	                                             uint8_t value, ModelStackWithTimelineCounter* modelStack);
+	void offerReceivedCCToModControllable(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
+	                                      ModelStackWithTimelineCounter* modelStack);
 	void offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
 	                                    ModelStackWithTimelineCounter* modelStack);
 	bool offerReceivedPitchBendToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,


### PR DESCRIPTION
Refactor to allow skipping the match section when the ultimate destination for incoming midi is already known