### PR TITLE
MPE can take all channels so channel 1 can be a member of upper zone and channel 16 a member of lower zone

### DIFF
--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -62,7 +62,7 @@ void MIDIDevice::dataEntryMessageReceived(ModelStack* modelStack, int32_t channe
 		if (zone >= 0) { // If it *is* MPE-related...
 
 			// If it's on the "main" channel
-			if (channel == 0 || channel == 15) {
+			if (ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isMasterChannel(channel)) {
 setMPEBendRange:
 				mpeZoneBendRanges[zone][whichBendRange] = msb;
 			}
@@ -88,8 +88,8 @@ setMPEBendRange:
 		if (msb < 16) {
 			int32_t zone;
 
-			// Lower zone
-			if (channel == 0) {
+			// Master Channel of Lower zone
+			if (ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel && channel == 0) {
 				zone = MPE_ZONE_LOWER_NUMBERED_FROM_0;
 				ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel = msb;
 				ports[MIDI_DIRECTION_INPUT_TO_DELUGE]
@@ -117,8 +117,8 @@ resetBendRanges
 				soundEditor.mpeZonesPotentiallyUpdated();
 			}
 
-			// Upper zone
-			else if (channel == 15) {
+			// Master Channel of Upper zone
+			else if (ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel < 15 && channel == 15) {
 				zone = MPE_ZONE_UPPER_NUMBERED_FROM_0;
 				ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel = 15 - msb;
 				ports[MIDI_DIRECTION_INPUT_TO_DELUGE]


### PR DESCRIPTION
In case you set up your MPE Lower Zone to take all channels you will have channel 0 as main channel and channels 1 to 15 as member channels. On the other hand if you set up MPE Upper Zone to take all channels, channel 0 will be a member channel.

So I think we need to modify the logic to take into account channels 0 and 15 only as Main channels if the selected zone is Lower and Upper respectively


@m-m-adams 