### PR TITLE
Fix quantized stutter LEDs to only apply to sounds params and not midi params

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1121,12 +1121,8 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 	}
 
 	// Quantized Stutter FX
-	if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
-	    && (modelStackWithParam->isParam(Param::Kind::UNPATCHED_SOUND, modelStackWithParam->paramId)
-	        || modelStackWithParam->isParam(Param::Kind::UNPATCHED_GLOBAL, modelStackWithParam->paramId))
-	    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
-	        == RuntimeFeatureStateToggle::On)
-	    && !isUIModeActive(UI_MODE_STUTTERING)) {
+	Param::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+	if (isParamQuantizedStutter(kind, modelStackWithParam->paramId) && !isUIModeActive(UI_MODE_STUTTERING)) {
 		if (knobPos < -39) { // 4ths stutter: no leds turned on
 			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 0);
 		}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1122,6 +1122,8 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 
 	// Quantized Stutter FX
 	if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
+	    && (modelStackWithParam->isParam(Param::Kind::UNPATCHED_SOUND, modelStackWithParam->paramId)
+	        || modelStackWithParam->isParam(Param::Kind::UNPATCHED_GLOBAL, modelStackWithParam->paramId))
 	    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
 	        == RuntimeFeatureStateToggle::On)
 	    && !isUIModeActive(UI_MODE_STUTTERING)) {


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/872