### PR TITLE
Enhancement / Grid View ~ Add pink mode to grid view for performance view

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -133,7 +133,7 @@ Here is a list of features that have been added to the firmware as a list, group
 
 #### 4.1.6 - New Performance View
 - For a detailed description of this feature as well the button shortcuts/combos, please refer to the feature documentation: [Performance View Documentation]
-- ([#711]) Adds a new performance view, accessible from Song and Arranger View's using the Keyboard button.
+- ([#711]) Adds a new performance view, accessible from Song Row View and Arranger View's using the Keyboard button or the Song Grid View using the Pink Grid Mode pad in the bottom right hand corner of the sidebar.
 	- Each column on the grid represents a different "FX" and each pad/row in the column corresponds to a different FX value.
 	- Specifications:
 		- Perform FX menu to edit Song level parameters and enable/disable editing mode.

--- a/docs/features/performance_view.md
+++ b/docs/features/performance_view.md
@@ -24,7 +24,7 @@ Specifications:
 
 ## Usage:
 
-#### 1) Enter performance view from song view / grid view / arranger view by pressing keyboard button
+#### 1) Enter performance view from song row view / arranger view by pressing the keyboard button / Enter performance view from song grid view by pressing the pink grid mode pad in the bottom right hand corner of the sidebar
 
 #### 2) Short press a pad in the columns to hold that pad's value (parameter and held value is displayed on the screen)
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -1003,6 +1003,18 @@ enum GridDefaultActiveMode : uint8_t {
 	GridDefaultActiveModeMaxElement // Keep as boundary
 };
 
+// mapping of grid modes to y axis
+enum GridMode : uint8_t {
+	PINK,
+	Unassigned1,
+	Unassigned2,
+	Unassigned3,
+	Unassigned4,
+	Unassigned5,
+	BLUE,
+	GREEN,
+};
+
 enum class ClipType {
 	INSTRUMENT,
 	AUDIO,

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -837,6 +837,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				else {
 					changeRootUI(&sessionView);
 				}
+				gridModeActive = false;
 			}
 		}
 	}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -335,7 +335,7 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 	memset(image, 0, sizeof(RGB) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
 	// erase current occupancy mask as it will be refreshed
-	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth));
+	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
 	// render performance view
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -191,6 +191,9 @@ PerformanceSessionView::PerformanceSessionView() {
 
 	justExitedSoundEditor = false;
 
+	gridModeActive = false;
+	timeGridModePress = 0;
+
 	initPadPress(firstPadPress);
 	initPadPress(lastPadPress);
 
@@ -434,14 +437,10 @@ bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisp
 		return true;
 	}
 
-	if (sessionView.gridModeActive == SessionGridModePerformanceView) {
-		int32_t yDisplay = 0;
-		int32_t xDisplay = kDisplayWidth + 1;
-
-		image[yDisplay][xDisplay][0] = 128;
-		image[yDisplay][xDisplay][1] = 0;
-		image[yDisplay][xDisplay][2] = 128;
-		occupancyMask[yDisplay][xDisplay] = 64;
+	if (gridModeActive) {
+		for (int32_t y = (kGridHeight - 1); y >= 0; --y) {
+			sessionView.gridRenderActionModes(y, image, occupancyMask);
+		}
 	}
 
 	return true;
@@ -837,6 +836,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				else {
 					changeRootUI(&sessionView);
 				}
+				gridModeActive = false;
 			}
 		}
 	}
@@ -900,9 +900,11 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 			}
 			uiNeedsRendering(this); // re-render pads
 		}
+		//if
 		else if ((xDisplay == 17) && (yDisplay == 0)) {
-			if (sessionView.gridModeActive == SessionGridModePerformanceView) {
+			if (!on && gridModeActive && ((AudioEngine::audioSampleTimer - timeGridModePress) >= kHoldTime)) {
 				changeRootUI(&sessionView);
+				gridModeActive = false;
 			}
 		}
 	}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -435,10 +435,13 @@ bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisp
 	}
 
 	if (sessionView.gridModeActive == SessionGridModePerformanceView) {
-		image[0][kDisplayWidth + kSideBarWidth - 1][0] = 128;
-		image[0][kDisplayWidth + kSideBarWidth - 1][1] = 0;
-		image[0][kDisplayWidth + kSideBarWidth - 1][2] = 128;
-		occupancyMask[0][kDisplayWidth + kSideBarWidth - 1] = 64;
+		int32_t yDisplay = 0;
+		int32_t xDisplay = kDisplayWidth + 2;
+
+		image[yDisplay][xDisplay][0] = 128;
+		image[yDisplay][xDisplay][1] = 0;
+		image[yDisplay][xDisplay][2] = 128;
+		occupancyMask[yDisplay][xDisplay] = 64;
 	}
 
 	return true;

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -332,7 +332,7 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 	memset(image, 0, sizeof(RGB) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
 	// erase current occupancy mask as it will be refreshed
-	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth));
+	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
 	// render performance view
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
@@ -423,11 +423,18 @@ bool PerformanceSessionView::isParamAssignedToFXColumn(params::Kind paramKind, i
 	return false;
 }
 
-/// nothing to render in sidebar (yet)
+/// if entered performance view using pink grid mode pad, render the pink pad
 bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
 	if (!image) {
 		return true;
+	}
+
+	if (sessionView.gridModeActive == SessionGridModePerformanceView) {
+		image[0][kDisplayWidth + kSideBarWidth - 1][0] = 128;
+		image[0][kDisplayWidth + kSideBarWidth - 1][1] = 0;
+		image[0][kDisplayWidth + kSideBarWidth - 1][2] = 128;
+		occupancyMask[0][kDisplayWidth + kSideBarWidth - 1] = 64;
 	}
 
 	return true;
@@ -886,7 +893,7 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 			}
 			uiNeedsRendering(this); // re-render pads
 		}
-		else if (xDisplay == (kDisplayWidth + kSideBarWidth - 1)) {
+		else if ((xDisplay == 17) && (yDisplay == 0)) {
 			if (sessionView.gridModeActive == SessionGridModePerformanceView) {
 				changeRootUI(&sessionView);
 			}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -335,7 +335,7 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 	memset(image, 0, sizeof(RGB) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
 	// erase current occupancy mask as it will be refreshed
-	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
+	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth));
 
 	// render performance view
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -900,7 +900,7 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 			}
 			uiNeedsRendering(this); // re-render pads
 		}
-		//if
+		// if you're using grid song view and you pressed / released a pad in the grid mode launcher column
 		else if (gridModeActive && (xDisplay == (kDisplayWidth + 1))) {
 			if (yDisplay == 0) {
 				if (!on && ((AudioEngine::audioSampleTimer - timeGridModePress) >= kHoldTime)) {

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -837,7 +837,6 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				else {
 					changeRootUI(&sessionView);
 				}
-				gridModeActive = false;
 			}
 		}
 	}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -430,6 +430,10 @@ bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisp
 		return true;
 	}
 
+	if (!occupancyMask) {
+		return true;
+	}
+
 	if (sessionView.gridModeActive == SessionGridModePerformanceView) {
 		image[0][kDisplayWidth + kSideBarWidth - 1][0] = 128;
 		image[0][kDisplayWidth + kSideBarWidth - 1][1] = 0;

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -436,7 +436,7 @@ bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisp
 
 	if (sessionView.gridModeActive == SessionGridModePerformanceView) {
 		int32_t yDisplay = 0;
-		int32_t xDisplay = kDisplayWidth + 2;
+		int32_t xDisplay = kDisplayWidth + 1;
 
 		image[yDisplay][xDisplay][0] = 128;
 		image[yDisplay][xDisplay][1] = 0;

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -829,6 +829,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				uiNeedsRendering(this);
 			}
 			else {
+				gridModeActive = false;
 				releaseStutter(modelStack);
 				if (currentSong->lastClipInstanceEnteredStartPos != -1) {
 					changeRootUI(&arrangerView);
@@ -836,7 +837,6 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				else {
 					changeRootUI(&sessionView);
 				}
-				gridModeActive = false;
 			}
 		}
 	}
@@ -901,10 +901,17 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 			uiNeedsRendering(this); // re-render pads
 		}
 		//if
-		else if ((xDisplay == 17) && (yDisplay == 0)) {
-			if (!on && gridModeActive && ((AudioEngine::audioSampleTimer - timeGridModePress) >= kHoldTime)) {
-				changeRootUI(&sessionView);
+		else if (gridModeActive && (xDisplay == (kDisplayWidth + 1))) {
+			if (yDisplay == 0) {
+				if (!on && ((AudioEngine::audioSampleTimer - timeGridModePress) >= kHoldTime)) {
+					gridModeActive = false;
+					changeRootUI(&sessionView);
+				}
+			}
+			else if ((yDisplay == 7) || (yDisplay == 6)) {
 				gridModeActive = false;
+				changeRootUI(&sessionView);
+				return sessionView.gridHandlePads(xDisplay, yDisplay, on);
 			}
 		}
 	}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -332,7 +332,7 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 	memset(image, 0, sizeof(RGB) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
 	// erase current occupancy mask as it will be refreshed
-	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
+	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth));
 
 	// render performance view
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
@@ -885,6 +885,11 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 				paramEditorPadAction(modelStack, xDisplay, yDisplay, on);
 			}
 			uiNeedsRendering(this); // re-render pads
+		}
+		else if (xDisplay == (kDisplayWidth + kSideBarWidth - 1)) {
+			if (sessionView.gridModeActive == SessionGridModePerformanceView) {
+				changeRootUI(&sessionView);
+			}
 		}
 	}
 	else if (!on) {

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -120,6 +120,10 @@ public:
 	void renderFXDisplay(deluge::modulation::params::Kind paramKind, int32_t paramID, int32_t knobPos = kNoSelection);
 	bool onFXDisplay;
 
+	//public so Grid View can access it
+	bool gridModeActive;
+	uint32_t timeGridModePress;
+
 private:
 	// initialize
 	void initPadPress(PadPress& padPress);

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -120,7 +120,7 @@ public:
 	void renderFXDisplay(deluge::modulation::params::Kind paramKind, int32_t paramID, int32_t knobPos = kNoSelection);
 	bool onFXDisplay;
 
-	//public so Grid View can access it
+	// public so Grid View can access it
 	bool gridModeActive;
 	uint32_t timeGridModePress;
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3332,11 +3332,6 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 			modeHandleResult = gridHandlePadsLaunch(x, y, on, clip);
 			break;
 		}
-		case SessionGridModePerformanceView: {
-			changeRootUI(&performanceSessionView);
-			uiNeedsRendering(&performanceSessionView);
-			return ActionResult::DEALT_WITH;
-		}
 		}
 
 		if (modeHandleResult == ActionResult::DEALT_WITH) {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2835,17 +2835,17 @@ void SessionView::gridRenderActionModes(int32_t y, RGB image[][kDisplayWidth + k
 	bool modeActive = false;
 	RGB modeColour = colours::black;
 	switch (y) {
-	case 7: {
+	case GridMode::GREEN: {
 		modeActive = (gridModeActive == SessionGridModeLaunch);
 		modeColour = colours::green; // Green
 		break;
 	}
-	case 6: {
+	case GridMode::BLUE: {
 		modeActive = (gridModeActive == SessionGridModeEdit);
 		modeColour = colours::blue; // Blue
 		break;
 	}
-	case 0: {
+	case GridMode::PINK: {
 		modeActive = performanceSessionView.gridModeActive;
 		modeColour = colours::magenta; // Pink
 	}
@@ -3288,15 +3288,15 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		if (on) {
 			gridActiveModeUsed = false;
 			switch (y) {
-			case 7: {
+			case GridMode::GREEN: {
 				gridModeActive = SessionGridModeLaunch;
 				break;
 			}
-			case 6: {
+			case GridMode::BLUE: {
 				gridModeActive = SessionGridModeEdit;
 				break;
 			}
-			case 0: {
+			case GridMode::PINK: {
 				performanceSessionView.gridModeActive = true;
 				performanceSessionView.timeGridModePress = AudioEngine::audioSampleTimer;
 				changeRootUI(&performanceSessionView);

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3307,7 +3307,7 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		}
 		else {
 			if (FlashStorage::defaultGridActiveMode == GridDefaultActiveModeSelection) {
-				if (!gridActiveModeUsed) {
+				if (!gridActiveModeUsed && (gridModeActive != SessionGridModePerformanceView)) {
 					gridModeSelected = gridModeActive;
 				}
 			}
@@ -3331,6 +3331,11 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		case SessionGridModeLaunch: {
 			modeHandleResult = gridHandlePadsLaunch(x, y, on, clip);
 			break;
+		}
+		case SessionGridModePerformanceView: {
+			changeRootUI(&performanceSessionView);
+			uiNeedsRendering(&performanceSessionView);
+			return ActionResult::DEALT_WITH;
 		}
 		}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3307,7 +3307,7 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		}
 		else {
 			if (FlashStorage::defaultGridActiveMode == GridDefaultActiveModeSelection) {
-				if (!gridActiveModeUsed && (gridModeActive != SessionGridModePerformanceView)) {
+				if (!gridActiveModeUsed) {
 					gridModeSelected = gridModeActive;
 				}
 			}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3294,7 +3294,9 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 			}
 			case 0: {
 				gridModeActive = SessionGridModePerformanceView;
-				break;
+				changeRootUI(&performanceSessionView);
+				uiNeedsRendering(&performanceSessionView);
+				return ActionResult::DEALT_WITH;
 			}
 			}
 		}
@@ -3324,11 +3326,6 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		case SessionGridModeLaunch: {
 			modeHandleResult = gridHandlePadsLaunch(x, y, on, clip);
 			break;
-		}
-		case SessionGridModePerformanceView: {
-			changeRootUI(&performanceSessionView);
-			uiNeedsRendering(&performanceSessionView);
-			return ActionResult::DEALT_WITH;
 		}
 		}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2846,7 +2846,7 @@ void SessionView::gridRenderActionModes(int32_t y, RGB image[][kDisplayWidth + k
 		break;
 	}
 	case 0: {
-		modeActive = (gridModeActive == SessionGridModePerformanceView);
+		modeActive = performanceSessionView.gridModeActive;
 		modeColour = colours::magenta; // Pink
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -587,7 +587,8 @@ doActualSimpleChange:
 		goto changeOutputType;
 	}
 	else if (b == KEYBOARD) {
-		if (on && currentUIMode == UI_MODE_NONE) {
+		if (on && (currentUIMode == UI_MODE_NONE)
+		    && (currentSong->sessionLayout != SessionLayoutType::SessionLayoutTypeGrid)) {
 			changeRootUI(&performanceSessionView);
 		}
 	}
@@ -2820,6 +2821,14 @@ bool SessionView::gridRenderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 			}
 		}
 
+		gridRenderActionModes(y, image, occupancyMask);
+	}
+
+	return true;
+}
+
+void SessionView::gridRenderActionModes(int32_t y, RGB image[][kDisplayWidth + kSideBarWidth],
+                                        uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
 		// Action modes column
 		uint32_t actionModeColumnIndex = kDisplayWidth + 1;
 		bool modeExists = true;
@@ -2838,9 +2847,7 @@ bool SessionView::gridRenderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 		}
 		case 0: {
 			modeActive = (gridModeActive == SessionGridModePerformanceView);
-			modeColour[0] = 128; //Pink
-			modeColour[1] = 0;
-			modeColour[2] = 128;
+			modeColour = colours::magenta; // Pink
 		}
 
 		default: {
@@ -2850,9 +2857,6 @@ bool SessionView::gridRenderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 		}
 		occupancyMask[y][actionModeColumnIndex] = (modeExists ? 1 : 0);
 		image[y][actionModeColumnIndex] = modeColour.adjust(255, (modeActive ? 1 : 8));
-	}
-
-	return true;
 }
 
 bool SessionView::gridRenderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
@@ -3293,7 +3297,8 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 				break;
 			}
 			case 0: {
-				gridModeActive = SessionGridModePerformanceView;
+				performanceSessionView.gridModeActive = true;
+				performanceSessionView.timeGridModePress = AudioEngine::audioSampleTimer;
 				changeRootUI(&performanceSessionView);
 				uiNeedsRendering(&performanceSessionView);
 				return ActionResult::DEALT_WITH;
@@ -3302,7 +3307,7 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		}
 		else {
 			if (FlashStorage::defaultGridActiveMode == GridDefaultActiveModeSelection) {
-				if (!gridActiveModeUsed && (gridModeActive != SessionGridModePerformanceView)) {
+				if (!gridActiveModeUsed) {
 					gridModeSelected = gridModeActive;
 				}
 			}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2829,34 +2829,34 @@ bool SessionView::gridRenderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 
 void SessionView::gridRenderActionModes(int32_t y, RGB image[][kDisplayWidth + kSideBarWidth],
                                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
-		// Action modes column
-		uint32_t actionModeColumnIndex = kDisplayWidth + 1;
-		bool modeExists = true;
-		bool modeActive = false;
-		RGB modeColour = colours::black;
-		switch (y) {
-		case 7: {
-			modeActive = (gridModeActive == SessionGridModeLaunch);
-			modeColour = colours::green; // Green
-			break;
-		}
-		case 6: {
-			modeActive = (gridModeActive == SessionGridModeEdit);
-			modeColour = colours::blue; // Blue
-			break;
-		}
-		case 0: {
-			modeActive = (gridModeActive == SessionGridModePerformanceView);
-			modeColour = colours::magenta; // Pink
-		}
+	// Action modes column
+	uint32_t actionModeColumnIndex = kDisplayWidth + 1;
+	bool modeExists = true;
+	bool modeActive = false;
+	RGB modeColour = colours::black;
+	switch (y) {
+	case 7: {
+		modeActive = (gridModeActive == SessionGridModeLaunch);
+		modeColour = colours::green; // Green
+		break;
+	}
+	case 6: {
+		modeActive = (gridModeActive == SessionGridModeEdit);
+		modeColour = colours::blue; // Blue
+		break;
+	}
+	case 0: {
+		modeActive = (gridModeActive == SessionGridModePerformanceView);
+		modeColour = colours::magenta; // Pink
+	}
 
-		default: {
-			modeExists = false;
-			break;
-		}
-		}
-		occupancyMask[y][actionModeColumnIndex] = (modeExists ? 1 : 0);
-		image[y][actionModeColumnIndex] = modeColour.adjust(255, (modeActive ? 1 : 8));
+	default: {
+		modeExists = false;
+		break;
+	}
+	}
+	occupancyMask[y][actionModeColumnIndex] = (modeExists ? 1 : 0);
+	image[y][actionModeColumnIndex] = modeColour.adjust(255, (modeActive ? 1 : 8));
 }
 
 bool SessionView::gridRenderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2836,6 +2836,12 @@ bool SessionView::gridRenderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 			modeColour = colours::blue; // Blue
 			break;
 		}
+		case 0: {
+			modeActive = (gridModeActive == SessionGridModePerformanceView);
+			modeColour[0] = 128; //Pink
+			modeColour[1] = 0;
+			modeColour[2] = 128;
+		}
 
 		default: {
 			modeExists = false;
@@ -3286,11 +3292,15 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 				gridModeActive = SessionGridModeEdit;
 				break;
 			}
+			case 0: {
+				gridModeActive = SessionGridModePerformanceView;
+				break;
+			}
 			}
 		}
 		else {
 			if (FlashStorage::defaultGridActiveMode == GridDefaultActiveModeSelection) {
-				if (!gridActiveModeUsed) {
+				if (!gridActiveModeUsed && (gridModeActive != SessionGridModePerformanceView)) {
 					gridModeSelected = gridModeActive;
 				}
 			}
@@ -3314,6 +3324,11 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		case SessionGridModeLaunch: {
 			modeHandleResult = gridHandlePadsLaunch(x, y, on, clip);
 			break;
+		}
+		case SessionGridModePerformanceView: {
+			changeRootUI(&performanceSessionView);
+			uiNeedsRendering(&performanceSessionView);
+			return ActionResult::DEALT_WITH;
 		}
 		}
 

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -30,6 +30,7 @@ class ModelStack;
 enum SessionGridMode : uint8_t {
 	SessionGridModeEdit,
 	SessionGridModeLaunch,
+	SessionGridModePerformanceView,
 	SessionGridModeMaxElement // Keep as boundary
 };
 
@@ -160,7 +161,6 @@ private:
 	void gridTransitionToViewForClip(Clip* clip);
 
 	SessionGridMode gridModeSelected = SessionGridModeEdit;
-	SessionGridMode gridModeActive = SessionGridModeEdit;
 	bool gridActiveModeUsed = false;
 
 	int32_t gridFirstPressedX = -1;

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -30,7 +30,6 @@ class ModelStack;
 enum SessionGridMode : uint8_t {
 	SessionGridModeEdit,
 	SessionGridModeLaunch,
-	SessionGridModePerformanceView,
 	SessionGridModeMaxElement // Keep as boundary
 };
 
@@ -161,6 +160,7 @@ private:
 	void gridTransitionToViewForClip(Clip* clip);
 
 	SessionGridMode gridModeSelected = SessionGridModeEdit;
+	SessionGridMode gridModeActive = SessionGridModeEdit;
 	bool gridActiveModeUsed = false;
 
 	int32_t gridFirstPressedX = -1;

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -30,7 +30,6 @@ class ModelStack;
 enum SessionGridMode : uint8_t {
 	SessionGridModeEdit,
 	SessionGridModeLaunch,
-	SessionGridModePerformanceView,
 	SessionGridModeMaxElement // Keep as boundary
 };
 
@@ -115,7 +114,8 @@ public:
 
 	// Members for grid layout
 	inline bool gridFirstPadActive() { return (gridFirstPressedX != -1 && gridFirstPressedY != -1); }
-	SessionGridMode gridModeActive = SessionGridModeEdit;
+	void gridRenderActionModes(int32_t y, uint8_t image[][kDisplayWidth + kSideBarWidth][3],
+	                           uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
 
 private:
 	void renderViewDisplay(char const* viewString);
@@ -160,6 +160,7 @@ private:
 	void gridTransitionToViewForClip(Clip* clip);
 
 	SessionGridMode gridModeSelected = SessionGridModeEdit;
+	SessionGridMode gridModeActive = SessionGridModeEdit;
 	bool gridActiveModeUsed = false;
 
 	int32_t gridFirstPressedX = -1;

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -114,7 +114,7 @@ public:
 
 	// Members for grid layout
 	inline bool gridFirstPadActive() { return (gridFirstPressedX != -1 && gridFirstPressedY != -1); }
-	void gridRenderActionModes(int32_t y, uint8_t image[][kDisplayWidth + kSideBarWidth][3],
+	void gridRenderActionModes(int32_t y, RGB image[][kDisplayWidth + kSideBarWidth],
 	                           uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
 	ActionResult gridHandlePads(int32_t x, int32_t y, int32_t on);
 

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -30,6 +30,7 @@ class ModelStack;
 enum SessionGridMode : uint8_t {
 	SessionGridModeEdit,
 	SessionGridModeLaunch,
+	SessionGridModePerformanceView,
 	SessionGridModeMaxElement // Keep as boundary
 };
 
@@ -114,6 +115,7 @@ public:
 
 	// Members for grid layout
 	inline bool gridFirstPadActive() { return (gridFirstPressedX != -1 && gridFirstPressedY != -1); }
+	SessionGridMode gridModeActive = SessionGridModeEdit;
 
 private:
 	void renderViewDisplay(char const* viewString);
@@ -158,7 +160,6 @@ private:
 	void gridTransitionToViewForClip(Clip* clip);
 
 	SessionGridMode gridModeSelected = SessionGridModeEdit;
-	SessionGridMode gridModeActive = SessionGridModeEdit;
 	bool gridActiveModeUsed = false;
 
 	int32_t gridFirstPressedX = -1;

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -116,6 +116,7 @@ public:
 	inline bool gridFirstPadActive() { return (gridFirstPressedX != -1 && gridFirstPressedY != -1); }
 	void gridRenderActionModes(int32_t y, uint8_t image[][kDisplayWidth + kSideBarWidth][3],
 	                           uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
+	ActionResult gridHandlePads(int32_t x, int32_t y, int32_t on);
 
 private:
 	void renderViewDisplay(char const* viewString);
@@ -147,7 +148,6 @@ private:
 
 	RGB gridRenderClipColor(Clip* clip);
 
-	ActionResult gridHandlePads(int32_t x, int32_t y, int32_t on);
 	ActionResult gridHandlePadsEdit(int32_t x, int32_t y, int32_t on, Clip* clip);
 	ActionResult gridHandlePadsLaunch(int32_t x, int32_t y, int32_t on, Clip* clip);
 	ActionResult gridHandlePadsLaunchImmediate(int32_t x, int32_t y, int32_t on, Clip* clip);


### PR DESCRIPTION
Pink Mode: Grid View Performance View Launcher

- From grid view, a new pink mode has been created in the sidebar in the very bottom right hand corner.
- When you press the pink pad, performance view will appear. 
  - if you tap the pink pad (momentary press), it will switch from grid view to performance view
  - if you hold the pink pad (long press), it will switch to performance view only while you are holding the pad and when you let go it will go back to grid view
- If you have entered performance view from grid mode, you can exit back out by pressing the pink pad or pressing one of the other mode pads (e.g. green, blue). Optionally you can still exit the old way as well by pressing the keyboard button.
- Note: When in grid mode, the keyboard button will no longer enter into performance view. Only the pink pad will get you into performance view.

To do:

- [x] Disable keyboard entry to performance view while in grid mode
- [x] Add short/long press entry to performance view (short = enter performance view, long = peak performance view)
- [x] Render last column as per grid view (e.g. show all the modes) - factor out the renderSideBar code in grid view so performance view can call it
- [x] Add bool in performance view for grid view to write to to indicate that you've entered performance view from grid mode