### PR TITLE
Revert "Fix quantized stutter LEDs to only apply to sounds params and not midi params"

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1121,8 +1121,10 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 	}
 
 	// Quantized Stutter FX
-	Param::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-	if (isParamQuantizedStutter(kind, modelStackWithParam->paramId) && !isUIModeActive(UI_MODE_STUTTERING)) {
+	if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
+	    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
+	        == RuntimeFeatureStateToggle::On)
+	    && !isUIModeActive(UI_MODE_STUTTERING)) {
 		if (knobPos < -39) { // 4ths stutter: no leds turned on
 			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 0);
 		}


### PR DESCRIPTION
Reverts SynthstromAudible/DelugeFirmware#874

Reverting because there is a possible outcome where the param collection is null which can result in a crash

We need to check that there is a valid param collection