### PR TITLE
bump to 1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/scripts/cmake/CMakeToolchainD
 
 project(Deluge
     LANGUAGES CXX C ASM
-    VERSION 1.0.0
+    VERSION 1.1.0
 )
 
 include(ProcessorCount)


### PR DESCRIPTION
Now that 1.0.0 is released we should bump the nightly version to avoid confusion