### PR TITLE
Fix quantized stutter LEDs to only apply to sounds params and not midi params

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1122,6 +1122,8 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 
 	// Quantized Stutter FX
 	if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
+	    && (modelStackWithParam->isParam(Param::Kind::UNPATCHED_SOUND, modelStackWithParam->paramId)
+	        || modelStackWithParam->isParam(Param::Kind::UNPATCHED_GLOBAL, modelStackWithParam->paramId))
 	    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
 	        == RuntimeFeatureStateToggle::On)
 	    && !isUIModeActive(UI_MODE_STUTTERING)) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1121,10 +1121,8 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 	}
 
 	// Quantized Stutter FX
-	if (isParamQuantizedStutter(modelStackWithParam->paramCollection
-	                                ? modelStackWithParam->paramCollection->getParamKind()
-	                                : Param::Kind::NONE,
-	                            modelStackWithParam->paramId)
+	ParamCollection* paramCollection = modelStackWithParam->paramCollection;
+	if (paramCollection && isParamQuantizedStutter(paramCollection->getParamKind(), modelStackWithParam->paramId)
 	    && !isUIModeActive(UI_MODE_STUTTERING)) {
 		if (knobPos < -39) { // 4ths stutter: no leds turned on
 			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 0);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1121,8 +1121,10 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 	}
 
 	// Quantized Stutter FX
-	ParamCollection* paramCollection = modelStackWithParam->paramCollection;
-	if (paramCollection && isParamQuantizedStutter(paramCollection->getParamKind(), modelStackWithParam->paramId)
+	if (isParamQuantizedStutter(modelStackWithParam->paramCollection
+	                                ? modelStackWithParam->paramCollection->getParamKind()
+	                                : Param::Kind::NONE,
+	                            modelStackWithParam->paramId)
 	    && !isUIModeActive(UI_MODE_STUTTERING)) {
 		if (knobPos < -39) { // 4ths stutter: no leds turned on
 			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 0);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1121,11 +1121,8 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 	}
 
 	// Quantized Stutter FX
-	if (modelStackWithParam->paramId == Param::Unpatched::STUTTER_RATE
-	    && (modelStackWithParam->isParam(Param::Kind::UNPATCHED_SOUND, modelStackWithParam->paramId)
-	        || modelStackWithParam->isParam(Param::Kind::UNPATCHED_GLOBAL, modelStackWithParam->paramId))
-	    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate)
-	        == RuntimeFeatureStateToggle::On)
+	ParamCollection* paramCollection = modelStackWithParam->paramCollection;
+	if (paramCollection && isParamQuantizedStutter(paramCollection->getParamKind(), modelStackWithParam->paramId)
 	    && !isUIModeActive(UI_MODE_STUTTERING)) {
 		if (knobPos < -39) { // 4ths stutter: no leds turned on
 			indicator_leds::setKnobIndicatorLevel(whichModEncoder, 0);


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/872
But this time using a code that is protected against NULL pointer exception with the paramCollection being checked before