### PR TITLE
Remove Some Params from Global FX Menu's and from Automation View

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -43,8 +43,6 @@ Automatable Parameters are broken down into two categories for Automation Instru
 > - **Sidechain** Level, Shape
 > - **Distortion** Decimation, Bitcrush
 > - **Mod FX** Offset, Feedback, Depth, Rate
-> - **Arp** Gate
-> - **Portamento**
 > - **Stutter** Rate
 
 It can be thought of as a layer sitting on top of the Instrument Clip View for Synths, Kits and Midi instrument clip types. This PR does not address automation for audio clips.

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -379,7 +379,7 @@ constexpr uint32_t kNoParamID = 0xFFFFFFFF;
 //Automation View constants
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kNumNonKitAffectEntireParamsForAutomation = 56;
-constexpr int32_t kNumKitAffectEntireParamsForAutomation = 25;
+constexpr int32_t kNumKitAffectEntireParamsForAutomation = 23;
 constexpr int32_t kLastMidiCCForAutomation = 121;
 constexpr int32_t kKnobPosOffset = 64;
 constexpr int32_t kMaxKnobPos = 128;

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -627,16 +627,6 @@ Submenu globalDistortionMenu{
     },
 };
 
-submenu::Arpeggiator globalArpMenu{
-    STRING_FOR_ARPEGGIATOR,
-    {
-        &arpModeMenu,
-        &arpSyncMenu,
-        &arpOctavesMenu,
-        &arpGateMenu,
-    },
-};
-
 // Stutter Menu
 
 UnpatchedParam globalStutterRateMenu{
@@ -1040,7 +1030,6 @@ menu_item::Submenu soundEditorRootMenuPerformanceView{
         &globalDelayMenu,
         &globalModFXMenu,
         &globalDistortionMenu,
-        &globalStutterRateMenu,
     },
 };
 
@@ -1057,7 +1046,6 @@ menu_item::Submenu soundEditorRootMenuSongView{
         &globalDelayMenu,
         &globalModFXMenu,
         &globalDistortionMenu,
-        &globalStutterRateMenu,
     },
 };
 
@@ -1076,9 +1064,6 @@ menu_item::Submenu soundEditorRootMenuKitGlobalFX{
         &globalCompressorMenu,
         &globalModFXMenu,
         &globalDistortionMenu,
-        &globalArpMenu,
-        &portaMenu,
-        &globalStutterRateMenu,
     },
 };
 
@@ -1165,13 +1150,13 @@ MenuItem* paramShortcutsForKitGlobalFX[][8] = {
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                nullptr,                  nullptr                            },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                nullptr,                  nullptr                            },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                nullptr,                  nullptr                            },
-    {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                nullptr,                  &globalStutterRateMenu             },
+    {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                nullptr,                  nullptr             				  },
     {&globalLevelMenu,        nullptr,                 &globalVibratoMenu,             &globalPanMenu,                 nullptr,              &srrMenu,               &bitcrushMenu,            nullptr                            },
-    {&portaMenu,              nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                nullptr,                  nullptr                            },
+    {nullptr,              	  nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                nullptr,                  nullptr                            },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              &lpfModeMenu,           &globalLPFResMenu,        &globalLPFFreqMenu                 },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              &hpfModeMenu,           &globalHPFResMenu,        &globalHPFFreqMenu                 },
     {&compressorReleaseMenu,  &sidechainSyncMenu,      &globalCompressorVolumeMenu,    &compressorAttackMenu,          &compressorShapeMenu, nullptr,                &bassMenu,                &bassFreqMenu                      },
-    {nullptr,                 &arpSyncMenu,            &arpGateMenu,                   &arpOctavesMenu,                &arpModeMenu,         nullptr,                &trebleMenu,              &trebleFreqMenu                    },
+    {nullptr,                 nullptr,            	   nullptr,                        nullptr,                		   nullptr,         	 nullptr,                &trebleMenu,              &trebleFreqMenu                    },
     {nullptr,                 nullptr,                 nullptr,                        &modFXTypeMenu,                 &modFXOffsetMenu,     &modFXFeedbackMenu,     &globalModFXDepthMenu,    &globalModFXRateMenu               },
     {nullptr,                 nullptr,                 nullptr,                        &globalReverbSendAmountMenu,    &reverbPanMenu,       &reverbWidthMenu,       &reverbDampeningMenu,     &reverbRoomSizeMenu                },
     {&globalDelayRateMenu,    &delaySyncMenu,          &delayAnalogMenu,               &globalDelayFeedbackMenu,       &delayPingPongMenu,   nullptr,                nullptr,                  nullptr                            },

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2746,7 +2746,7 @@ void AutomationInstrumentClipView::selectEncoderAction(int8_t offset) {
 						offset += 1;
 					}
 					idx = getNextSelectedParamArrayPosition(offset, clip->lastSelectedParamArrayPosition,
-															kNumNonKitAffectEntireParamsForAutomation);
+					                                        kNumNonKitAffectEntireParamsForAutomation);
 				}
 			}
 			auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -194,9 +194,7 @@ const std::array<std::pair<Param::Kind, ParamType>, kNumKitAffectEntireParamsFor
         {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::MOD_FX_FEEDBACK},
         {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::MOD_FX_DEPTH},
         {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::MOD_FX_RATE},
-        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::Sound::ARP_GATE},   //Arp Gate
-        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::Sound::PORTAMENTO}, //Portamento
-        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::STUTTER_RATE},      //Stutter Rate
+        {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::STUTTER_RATE}, //Stutter Rate
     }};
 
 //grid sized arrays to assign automatable parameters to the grid
@@ -646,6 +644,13 @@ void AutomationInstrumentClipView::renderAutomationOverview(ModelStackWithTimeli
 
 			else if (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
 
+				//don't make portamento available for automation in kit rows
+				if ((instrument->type == InstrumentType::KIT)
+				    && (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay]
+				        == Param::Unpatched::Sound::PORTAMENTO)) {
+					continue;
+				}
+
 				modelStackWithParam =
 				    getModelStackWithParam(modelStack, clip, unpatchedParamShortcutsForAutomation[xDisplay][yDisplay],
 				                           Param::Kind::UNPATCHED_SOUND);
@@ -657,6 +662,13 @@ void AutomationInstrumentClipView::renderAutomationOverview(ModelStackWithTimeli
 		             || (globalEffectableParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF))) {
 
 			if (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
+
+				//don't make portamento and arp gate available for automation in kit affect entire
+				if ((unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] == Param::Unpatched::Sound::PORTAMENTO)
+				    || (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay]
+				        == Param::Unpatched::Sound::ARP_GATE)) {
+					continue;
+				}
 
 				modelStackWithParam =
 				    getModelStackWithParam(modelStack, clip, unpatchedParamShortcutsForAutomation[xDisplay][yDisplay]);
@@ -2752,6 +2764,7 @@ void AutomationInstrumentClipView::selectEncoderAction(int8_t offset) {
 		else if (instrument->type == InstrumentType::SYNTH
 		         || (instrument->type == InstrumentType::KIT && ((Kit*)instrument)->selectedDrum)) {
 
+obtainNextParam:
 			//if you haven't selected a parameter yet, start at the beginning of the list
 			if (isOnAutomationOverview()) {
 				auto idx = 0;
@@ -2784,6 +2797,17 @@ void AutomationInstrumentClipView::selectEncoderAction(int8_t offset) {
 				clip->lastSelectedParamID = id;
 				clip->lastSelectedParamKind = kind;
 				clip->lastSelectedParamArrayPosition = idx;
+			}
+			//don't make portamento available for automation in kit rows
+			if ((instrument->type == InstrumentType::KIT)
+			    && (clip->lastSelectedParamID == Param::Unpatched::Sound::PORTAMENTO)) {
+				if (offset < 0) {
+					offset -= 1;
+				}
+				else if (offset > 0) {
+					offset += 1;
+				}
+				goto obtainNextParam;
 			}
 		}
 
@@ -3198,6 +3222,12 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 		    && ((patchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF)
 		        || (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF))) {
 
+			//don't allow automation of portamento in kit's
+			if ((instrument->type == InstrumentType::KIT)
+			    && (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] == Param::Unpatched::Sound::PORTAMENTO)) {
+				return;
+			}
+
 			if (patchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
 				clip->lastSelectedParamKind = Param::Kind::PATCHED;
 				//if you are in a synth or a kit clip and the shortcut is valid, set current selected ParamID
@@ -3224,6 +3254,12 @@ void AutomationInstrumentClipView::handleSinglePadPress(ModelStackWithTimelineCo
 		else if (instrument->type == InstrumentType::KIT && instrumentClipView.getAffectEntire()
 		         && ((unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF)
 		             || (globalEffectableParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF))) {
+
+			//don't allow automation of arp gate or portamento in kit affect entire
+			if ((unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] == Param::Unpatched::Sound::PORTAMENTO)
+			    || (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] == Param::Unpatched::Sound::ARP_GATE)) {
+				return;
+			}
 
 			if (unpatchedParamShortcutsForAutomation[xDisplay][yDisplay] != 0xFFFFFFFF) {
 				clip->lastSelectedParamKind = Param::Kind::UNPATCHED_SOUND;

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2722,93 +2722,69 @@ void AutomationInstrumentClipView::selectEncoderAction(int8_t offset) {
 		InstrumentClipMinder::selectEncoderAction(offset);
 	}
 	else if (instrument->type == InstrumentType::SYNTH || instrument->type == InstrumentType::KIT) {
+		int32_t idx;
 
 		//if you're a kit with affect entire enabled
 		if (instrument->type == InstrumentType::KIT && instrumentClipView.getAffectEntire()) {
-
 			//if you haven't selected a parameter yet, start at the beginning of the list
 			if (isOnAutomationOverview()) {
-				auto idx = 0;
-				auto [kind, id] = kitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
+				idx = 0;
 			}
 			//if you are scrolling left and are at the beginning of the list, go to the end of the list
 			else if ((clip->lastSelectedParamArrayPosition + offset) < 0) {
-				auto idx = kNumKitAffectEntireParamsForAutomation - 1;
-				auto [kind, id] = kitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
+				idx = kNumKitAffectEntireParamsForAutomation - 1;
 			}
 			//if you are scrolling right and are at the end of the list, go to the beginning of the list
 			else if ((clip->lastSelectedParamArrayPosition + offset) > (kNumKitAffectEntireParamsForAutomation - 1)) {
-				auto idx = 0;
-				auto [kind, id] = kitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
+				idx = 0;
 			}
 			//otherwise scrolling left/right within the list
 			else {
-				auto idx = clip->lastSelectedParamArrayPosition + offset;
-				auto [kind, id] = kitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
+				idx = clip->lastSelectedParamArrayPosition + offset;
 			}
+			auto [kind, id] = kitAffectEntireParamsForAutomation[idx];
+			clip->lastSelectedParamID = id;
+			clip->lastSelectedParamKind = kind;
+			clip->lastSelectedParamArrayPosition = idx;
 		}
 
 		//if you're a synth or a kit (with affect entire off and a drum selected)
 		else if (instrument->type == InstrumentType::SYNTH
 		         || (instrument->type == InstrumentType::KIT && ((Kit*)instrument)->selectedDrum)) {
-
-obtainNextParam:
-			//if you haven't selected a parameter yet, start at the beginning of the list
-			if (isOnAutomationOverview()) {
-				auto idx = 0;
-				auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
-			}
-			//if you are scrolling left and are at the beginning of the list, go to the end of the list
-			else if ((clip->lastSelectedParamArrayPosition + offset) < 0) {
-				auto idx = kNumNonKitAffectEntireParamsForAutomation - 1;
-				auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
-			}
-			//if you are scrolling right and are at the end of the list, go to the beginning of the list
-			else if ((clip->lastSelectedParamArrayPosition + offset)
-			         > (kNumNonKitAffectEntireParamsForAutomation - 1)) {
-				auto idx = 0;
-				auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
-			}
-			//otherwise scrolling left/right within the list
-			else {
-				auto idx = clip->lastSelectedParamArrayPosition + offset;
-				auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
-				clip->lastSelectedParamID = id;
-				clip->lastSelectedParamKind = kind;
-				clip->lastSelectedParamArrayPosition = idx;
-			}
-			//don't make portamento available for automation in kit rows
-			if ((instrument->type == InstrumentType::KIT)
-			    && (clip->lastSelectedParamID == Param::Unpatched::Sound::PORTAMENTO)) {
-				if (offset < 0) {
-					offset -= 1;
+			do {
+				//if you haven't selected a parameter yet, start at the beginning of the list
+				if (isOnAutomationOverview()) {
+					idx = 0;
 				}
-				else if (offset > 0) {
-					offset += 1;
+				//if you are scrolling left and are at the beginning of the list, go to the end of the list
+				else if ((clip->lastSelectedParamArrayPosition + offset) < 0) {
+					idx = kNumNonKitAffectEntireParamsForAutomation - 1;
 				}
-				goto obtainNextParam;
-			}
+				//if you are scrolling right and are at the end of the list, go to the beginning of the list
+				else if ((clip->lastSelectedParamArrayPosition + offset)
+				         > (kNumNonKitAffectEntireParamsForAutomation - 1)) {
+					idx = 0;
+				}
+				//otherwise scrolling left/right within the list
+				else {
+					idx = clip->lastSelectedParamArrayPosition + offset;
+				}
+				auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
+				if ((instrument->type == InstrumentType::KIT) && (id == Param::Unpatched::Sound::PORTAMENTO)) {
+					if (offset < 0) {
+						offset -= 1;
+					}
+					else if (offset > 0) {
+						offset += 1;
+					}
+				}
+				else {
+					clip->lastSelectedParamID = id;
+					clip->lastSelectedParamKind = kind;
+					clip->lastSelectedParamArrayPosition = idx;
+					break;
+				}
+			} while (true);
 		}
 
 		//no shortcut to flash for Stutter, so no need to search for the Shortcut X,Y

--- a/src/deluge/gui/views/automation_instrument_clip_view.cpp
+++ b/src/deluge/gui/views/automation_instrument_clip_view.cpp
@@ -2736,17 +2736,20 @@ void AutomationInstrumentClipView::selectEncoderAction(int8_t offset) {
 		         || (instrument->type == InstrumentType::KIT && ((Kit*)instrument)->selectedDrum)) {
 			auto idx = getNextSelectedParamArrayPosition(offset, clip->lastSelectedParamArrayPosition,
 			                                             kNumNonKitAffectEntireParamsForAutomation);
-			auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
-			if ((instrument->type == InstrumentType::KIT) && (id == Param::Unpatched::Sound::PORTAMENTO)) {
-				if (offset < 0) {
-					offset -= 1;
+			{
+				auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
+				if ((instrument->type == InstrumentType::KIT) && (id == Param::Unpatched::Sound::PORTAMENTO)) {
+					if (offset < 0) {
+						offset -= 1;
+					}
+					else if (offset > 0) {
+						offset += 1;
+					}
+					idx = getNextSelectedParamArrayPosition(offset, clip->lastSelectedParamArrayPosition,
+															kNumNonKitAffectEntireParamsForAutomation);
 				}
-				else if (offset > 0) {
-					offset += 1;
-				}
-				idx = getNextSelectedParamArrayPosition(offset, clip->lastSelectedParamArrayPosition,
-				                                        kNumNonKitAffectEntireParamsForAutomation);
 			}
+			auto [kind, id] = nonKitAffectEntireParamsForAutomation[idx];
 			clip->lastSelectedParamID = id;
 			clip->lastSelectedParamKind = kind;
 			clip->lastSelectedParamArrayPosition = idx;

--- a/src/deluge/gui/views/automation_instrument_clip_view.h
+++ b/src/deluge/gui/views/automation_instrument_clip_view.h
@@ -143,6 +143,10 @@ private:
 	void copyAutomation();
 	void pasteAutomation();
 
+	//Select Encoder Action
+	int32_t getNextSelectedParamArrayPosition(int32_t offset, int32_t lastSelectedParamArrayPosition,
+	                                          int32_t numParams);
+
 	//Automation Lanes Functions
 	void initParameterSelection();
 	void initPadSelection();


### PR DESCRIPTION
Addressing issue #875 reported by @soymonitus 

- Removed Stutter Rate from menu's (Song, Performance View, Kit Affect Entire)
- Removed Arp and Portamento from Kit Affect Entire menu
- Removed Arp and Portamento from Kit Affect Entire in Automation View
- Removed Portamento from Kit Rows in Automation View