### PR TITLE
Refactor/seperate midi matching from receiving in melodic instruments

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -1054,7 +1054,7 @@ constexpr int32_t kMaxImageStoreWidth = kDisplayWidth;
 
 constexpr int32_t kNumExpressionDimensions = 3;
 
-enum class Expression {
+enum Expression {
 	X_PITCH_BEND,
 	Y_SLIDE_TIMBRE,
 	Z_PRESSURE,

--- a/src/deluge/io/midi/learned_midi.h
+++ b/src/deluge/io/midi/learned_midi.h
@@ -25,7 +25,7 @@
 #define MIDI_MESSAGE_CC 2
 
 class MIDIDevice;
-enum MIDIMatchType { NO_MATCH, CHANNEL, MPE_MEMBER, MPE_MASTER };
+enum class MIDIMatchType { NO_MATCH, CHANNEL, MPE_MEMBER, MPE_MASTER };
 class LearnedMIDI {
 public:
 	LearnedMIDI();

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1197,8 +1197,8 @@ void Kit::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevic
 	}
 }
 
-void Kit::offerReceivedPitchBendToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-                                       uint8_t data1, uint8_t data2, int32_t level, bool* doingMidiThru) {
+void Kit::receivedPitchBendForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+                                   uint8_t data1, uint8_t data2, int32_t level, bool* doingMidiThru) {
 	int16_t value16 = (((uint32_t)data1 | ((uint32_t)data2 << 7)) - 8192) << 2;
 	thisDrum->expressionEventPossiblyToRecord(modelStackWithTimelineCounter, value16, 0, level);
 }
@@ -1224,14 +1224,13 @@ void Kit::offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTi
 			}
 			else { // Or, if Drum does not have MPE input, then this is a channel-level message.
 yesThisDrum:
-				offerReceivedPitchBendToDrum(modelStackWithTimelineCounter, thisDrum, data1, data2, level,
-				                             doingMidiThru);
+				receivedPitchBendForDrum(modelStackWithTimelineCounter, thisDrum, data1, data2, level, doingMidiThru);
 			}
 		}
 	}
 }
 
-void Kit::offerMPEYAxisToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+void Kit::receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
                               int32_t level, uint8_t value) {
 	int16_t value16 = (value - 64) << 9;
 	thisDrum->expressionEventPossiblyToRecord(modelStackWithTimelineCounter, value16, 1, level);
@@ -1253,7 +1252,7 @@ void Kit::offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineC
 			bend_range = BEND_RANGE_MAIN;
 			[[fallthrough]];
 		case MPE_MEMBER:
-			offerMPEYAxisToDrum(modelStackWithTimelineCounter, thisDrum, bend_range, value);
+			receivedMPEYForDrum(modelStackWithTimelineCounter, thisDrum, bend_range, value);
 			break;
 		default:
 			continue;

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -61,7 +61,7 @@ public:
 	void receivedPitchBendForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
 	                              uint8_t data1, uint8_t data2, int32_t level, bool* doingMidiThru);
 	void receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                         int32_t level, uint8_t value);
+	                         MIDIMatchType match, uint8_t value);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -67,6 +67,8 @@ public:
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                             int32_t channel, int32_t value, int32_t noteCode, bool* doingMidiThru);
+	void receivedAftertouchForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+	                               int32_t level, uint8_t value);
 
 	void choke();
 	void resyncLFOs();

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -59,9 +59,9 @@ public:
 
 	void offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                            uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
-	void offerReceivedPitchBendToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                                  uint8_t data1, uint8_t data2, int32_t level, bool* doingMidiThru);
-	void offerMPEYAxisToDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+	void receivedPitchBendForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
+	                              uint8_t data1, uint8_t data2, int32_t level, bool* doingMidiThru);
+	void receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
 	                         int32_t level, uint8_t value);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -59,7 +59,7 @@ public:
 	void offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                            uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
 	void receivedPitchBendForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                              uint8_t data1, uint8_t data2, int32_t level, bool* doingMidiThru);
+	                              uint8_t data1, uint8_t data2, MIDIMatchType match, bool* doingMidiThru);
 	void receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
 	                         MIDIMatchType match, uint8_t value);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -21,7 +21,6 @@
 #include "model/global_effectable/global_effectable_for_clip.h"
 #include "model/instrument/instrument.h"
 #include "util/container/array/ordered_resizeable_array.h"
-
 class InstrumentClip;
 class Drum;
 class Sound;
@@ -30,7 +29,7 @@ class NoteRow;
 class GateDrum;
 class ModelStack;
 class ModelStackWithNoteRow;
-
+enum class MIDIMatchType;
 class Kit final : public Instrument, public GlobalEffectableForClip {
 public:
 	Kit();
@@ -68,7 +67,7 @@ public:
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                             int32_t channel, int32_t value, int32_t noteCode, bool* doingMidiThru);
 	void receivedAftertouchForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                               int32_t level, uint8_t value);
+	                               MIDIMatchType match, uint8_t value);
 
 	void choke();
 	void resyncLFOs();

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -98,16 +98,15 @@ bool MelodicInstrument::readTagFromFile(char const* tagName) {
 	return true;
 }
 
-void MelodicInstrument::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
-                                          int32_t midiChannel, int32_t note, int32_t velocity, bool shouldRecordNotes,
-                                          bool* doingMidiThru) {
+void MelodicInstrument::receivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
+                                     int32_t midiChannel, MIDIMatchType match, int32_t note, int32_t velocity,
+                                     bool shouldRecordNotes, bool* doingMidiThru) {
 	int16_t const* mpeValues = zeroMPEValues;
 	int16_t const* mpeValuesOrNull = NULL;
-	MIDIMatchType match = midiInput.checkMatch(fromDevice, midiChannel);
 	int32_t highlightNoteValue = -1;
 	switch (match) {
 	case MIDIMatchType::NO_MATCH:
-		break;
+		return;
 	case MIDIMatchType::MPE_MASTER:
 	case MIDIMatchType::MPE_MEMBER:
 		mpeValues = mpeValuesOrNull = fromDevice->defaultInputMPEValuesPerMIDIChannel[midiChannel];
@@ -292,6 +291,15 @@ justAuditionNote:
 	if (highlightNoteValue != -1) {
 		keyboardScreen.highlightedNotes[note] = highlightNoteValue;
 		keyboardScreen.requestRendering();
+	}
+}
+
+void MelodicInstrument::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
+                                          int32_t midiChannel, int32_t note, int32_t velocity, bool shouldRecordNotes,
+                                          bool* doingMidiThru) {
+	MIDIMatchType match = midiInput.checkMatch(fromDevice, midiChannel);
+	if (match != NO_MATCH) {
+		receivedNote(modelStack, fromDevice, on, midiChannel, match, note, velocity, shouldRecordNotes, doingMidiThru);
 	}
 }
 

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -306,8 +306,17 @@ void MelodicInstrument::offerReceivedNote(ModelStackWithTimelineCounter* modelSt
 void MelodicInstrument::offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                                MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
                                                bool* doingMidiThru) {
+	MIDIMatchType match = midiInput.checkMatch(fromDevice, channel);
+	if (match != NO_MATCH) {
+		receivedPitchBend(modelStackWithTimelineCounter, fromDevice, match, channel, data1, data2, doingMidiThru);
+	}
+}
+
+void MelodicInstrument::receivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+                                          MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
+                                          uint8_t data2, bool* doingMidiThru) {
 	int32_t newValue;
-	switch (midiInput.checkMatch(fromDevice, channel)) {
+	switch (match) {
 
 	case MIDIMatchType::NO_MATCH:
 		return;

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -298,7 +298,7 @@ void MelodicInstrument::offerReceivedNote(ModelStackWithTimelineCounter* modelSt
                                           int32_t midiChannel, int32_t note, int32_t velocity, bool shouldRecordNotes,
                                           bool* doingMidiThru) {
 	MIDIMatchType match = midiInput.checkMatch(fromDevice, midiChannel);
-	if (match != NO_MATCH) {
+	if (match != MIDIMatchType::NO_MATCH) {
 		receivedNote(modelStack, fromDevice, on, midiChannel, match, note, velocity, shouldRecordNotes, doingMidiThru);
 	}
 }
@@ -307,7 +307,7 @@ void MelodicInstrument::offerReceivedPitchBend(ModelStackWithTimelineCounter* mo
                                                MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
                                                bool* doingMidiThru) {
 	MIDIMatchType match = midiInput.checkMatch(fromDevice, channel);
-	if (match != NO_MATCH) {
+	if (match != MIDIMatchType::NO_MATCH) {
 		receivedPitchBend(modelStackWithTimelineCounter, fromDevice, match, channel, data1, data2, doingMidiThru);
 	}
 }
@@ -348,7 +348,7 @@ void MelodicInstrument::offerReceivedCC(ModelStackWithTimelineCounter* modelStac
                                         MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
                                         bool* doingMidiThru) {
 	MIDIMatchType match = midiInput.checkMatch(fromDevice, channel);
-	if (match != NO_MATCH) {
+	if (match != MIDIMatchType::NO_MATCH) {
 		receivedCC(modelStackWithTimelineCounter, fromDevice, match, channel, ccNumber, value, doingMidiThru);
 	}
 }
@@ -401,7 +401,7 @@ void MelodicInstrument::offerReceivedAftertouch(ModelStackWithTimelineCounter* m
                                                 MIDIDevice* fromDevice, int32_t channel, int32_t value,
                                                 int32_t noteCode, bool* doingMidiThru) {
 	MIDIMatchType match = midiInput.checkMatch(fromDevice, channel);
-	if (match != NO_MATCH) {
+	if (match != MIDIMatchType::NO_MATCH) {
 		receivedAftertouch(modelStackWithTimelineCounter, fromDevice, match, channel, value, noteCode, doingMidiThru);
 	}
 }

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -344,13 +344,20 @@ void MelodicInstrument::receivedPitchBend(ModelStackWithTimelineCounter* modelSt
 		break;
 	}
 }
-
 void MelodicInstrument::offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                         MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
                                         bool* doingMidiThru) {
+	MIDIMatchType match = midiInput.checkMatch(fromDevice, channel);
+	if (match != NO_MATCH) {
+		receivedCC(modelStackWithTimelineCounter, fromDevice, match, channel, ccNumber, value, doingMidiThru);
+	}
+}
+void MelodicInstrument::receivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+                                   MIDIMatchType match, uint8_t channel, uint8_t ccNumber, uint8_t value,
+                                   bool* doingMidiThru) {
 	int yCC = 1;
 	int32_t value32 = 0;
-	switch (midiInput.checkMatch(fromDevice, channel)) {
+	switch (match) {
 
 	case MIDIMatchType::NO_MATCH:
 		return;
@@ -390,12 +397,21 @@ void MelodicInstrument::offerReceivedCC(ModelStackWithTimelineCounter* modelStac
 	}
 }
 
-// noteCode -1 means channel-wide, including for MPE input (which then means it could still then just apply to one note).
 void MelodicInstrument::offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                                 MIDIDevice* fromDevice, int32_t channel, int32_t value,
                                                 int32_t noteCode, bool* doingMidiThru) {
+	MIDIMatchType match = midiInput.checkMatch(fromDevice, channel);
+	if (match != NO_MATCH) {
+		receivedAftertouch(modelStackWithTimelineCounter, fromDevice, match, channel, value, noteCode, doingMidiThru);
+	}
+}
+
+// noteCode -1 means channel-wide, including for MPE input (which then means it could still then just apply to one note).
+void MelodicInstrument::receivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+                                           MIDIDevice* fromDevice, MIDIMatchType match, int32_t channel, int32_t value,
+                                           int32_t noteCode, bool* doingMidiThru) {
 	int32_t valueBig = (int32_t)value << 24;
-	switch (midiInput.checkMatch(fromDevice, channel)) {
+	switch (match) {
 
 	case MIDIMatchType::NO_MATCH:
 		return;

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -324,7 +324,7 @@ void MelodicInstrument::receivedPitchBend(ModelStackWithTimelineCounter* modelSt
 		//each of these are 7 bit values but we need them to represent the range +-2^31
 		newValue = (int32_t)(((uint32_t)data1 | ((uint32_t)data2 << 7)) - 8192) << 18;
 		// Unlike for whole-Instrument pitch bend, this per-note kind is a modulation *source*, not the "preset" value for the parameter!
-		polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, newValue, 0, channel,
+		polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, newValue, X_PITCH_BEND, channel,
 		                                          MIDICharacteristic::CHANNEL);
 		break;
 	case MIDIMatchType::MPE_MASTER:
@@ -364,7 +364,7 @@ void MelodicInstrument::receivedCC(ModelStackWithTimelineCounter* modelStackWith
 	case MIDIMatchType::MPE_MEMBER:
 		if (ccNumber == 74) { // All other CCs are not supposed to be used for Member Channels, for anything.
 			int32_t value32 = (value - 64) << 25;
-			polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, value32, 1, channel,
+			polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, value32, Y_SLIDE_TIMBRE, channel,
 			                                          MIDICharacteristic::CHANNEL);
 			return;
 		}
@@ -416,7 +416,7 @@ void MelodicInstrument::receivedAftertouch(ModelStackWithTimelineCounter* modelS
 	case MIDIMatchType::NO_MATCH:
 		return;
 	case MIDIMatchType::MPE_MEMBER:
-		polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, valueBig, 2, channel,
+		polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, valueBig, Z_PRESSURE, channel,
 		                                          MIDICharacteristic::CHANNEL);
 		break;
 	case MIDIMatchType::MPE_MASTER:
@@ -433,7 +433,7 @@ void MelodicInstrument::receivedAftertouch(ModelStackWithTimelineCounter* modelS
 		// MPE should never send poly aftertouch but we might as well handle it anyway
 		// Polyphonic aftertouch gets processed along with MPE
 		if (noteCode != -1) {
-			polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, valueBig, 2, noteCode,
+			polyphonicExpressionEventPossiblyToRecord(modelStackWithTimelineCounter, valueBig, Z_PRESSURE, noteCode,
 			                                          MIDICharacteristic::NOTE);
 			// We wouldn't be here if this was MPE input, so we know this incoming polyphonic aftertouch message is allowed
 		}

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -47,6 +47,8 @@ public:
 	void offerReceivedNote(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                       bool on, int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
 	                       bool* doingMidiThru);
+	void receivedNote(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on, int32_t midiChannel,
+	                  MIDIMatchType match, int32_t note, int32_t velocity, bool shouldRecordNotes, bool* doingMidiThru);
 	void offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                            uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -51,6 +51,8 @@ public:
 	                  MIDIMatchType match, int32_t note, int32_t velocity, bool shouldRecordNotes, bool* doingMidiThru);
 	void offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                            uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
+	void receivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+	                       MIDIMatchType match, uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -55,9 +55,12 @@ public:
 	                       MIDIMatchType match, uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
+	void receivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+	                MIDIMatchType match, uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                             int32_t channel, int32_t value, int32_t noteCode, bool* doingMidiThru);
-
+	void receivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+	                        MIDIMatchType match, int32_t channel, int32_t value, int32_t noteCode, bool* doingMidiThru);
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs);
 	bool isNoteRowStillAuditioningAsLinearRecordingEnded(NoteRow* noteRow) final;
 	void stopAnyAuditioning(ModelStack* modelStack) final;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -103,7 +103,7 @@ int32_t usageTimes[REPORT_AVERAGE_NUM];
 extern "C" uint32_t getAudioSampleTimerMS() {
 	return AudioEngine::audioSampleTimer / 44.1;
 }
-
+// Pitch, Y, Pressure
 int16_t zeroMPEValues[kNumExpressionDimensions] = {0, 0, 0};
 
 namespace AudioEngine {


### PR DESCRIPTION
Breaks out matching and receiving midi to allow midi follow to integrate more easily

Renames drum received functions from offerXtodrum to receivedXForDrum to make it more clear that it must already have been matched