### PR TITLE
Kit bugfix: Only match MPE member channels if received on last channel auditioned

### DIFF
--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1226,9 +1226,9 @@ void Kit::offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTi
 }
 
 void Kit::receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-                              MIDIMatchType match, uint8_t value) {
+                              MIDIMatchType match, uint8_t channel, uint8_t value) {
 
-	int32_t level = BEND_RANGE_MAIN;
+	int32_t level;
 	switch (match) {
 		using enum MIDIMatchType;
 	case NO_MATCH:
@@ -1239,6 +1239,9 @@ void Kit::receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimel
 	case CHANNEL:
 		return;
 	case MPE_MEMBER:
+		if (channel != thisDrum->lastMIDIChannelAuditioned) {
+			return;
+		}
 		level = BEND_RANGE_FINGER_LEVEL;
 		break;
 	case MPE_MASTER:
@@ -1261,7 +1264,7 @@ void Kit::offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineC
 	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
 		MIDIMatchType match = thisDrum->midiInput.checkMatch(fromDevice, channel);
 		if (match == MIDIMatchType::MPE_MASTER || match == MIDIMatchType::MPE_MEMBER) {
-			receivedMPEYForDrum(modelStackWithTimelineCounter, thisDrum, match, value);
+			receivedMPEYForDrum(modelStackWithTimelineCounter, thisDrum, match, channel, value);
 		}
 	}
 }

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -59,7 +59,8 @@ public:
 	void offerReceivedPitchBend(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                            uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru);
 	void receivedPitchBendForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                              uint8_t data1, uint8_t data2, MIDIMatchType match, bool* doingMidiThru);
+	                              uint8_t data1, uint8_t data2, MIDIMatchType match, uint8_t channel,
+	                              bool* doingMidiThru);
 	void receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
 	                         MIDIMatchType match, uint8_t channel, uint8_t value);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
@@ -67,7 +68,7 @@ public:
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                             int32_t channel, int32_t value, int32_t noteCode, bool* doingMidiThru);
 	void receivedAftertouchForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                               MIDIMatchType match, uint8_t value);
+	                               MIDIMatchType match, uint8_t channel, uint8_t value);
 
 	void choke();
 	void resyncLFOs();

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -61,7 +61,7 @@ public:
 	void receivedPitchBendForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
 	                              uint8_t data1, uint8_t data2, MIDIMatchType match, bool* doingMidiThru);
 	void receivedMPEYForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
-	                         MIDIMatchType match, uint8_t value);
+	                         MIDIMatchType match, uint8_t channel, uint8_t value);
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru);
 	void offerReceivedAftertouch(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,


### PR DESCRIPTION
Otherwise all drums respond to MPE params on their zone, changes to only respond if channel matches last auditioned channel