### PR TITLE
Add velocity on sidebar pads in isomorphic keyboard view

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -32,9 +32,17 @@ void KeyboardLayoutIsomorphic::evaluatePads(PressedPad presses[kMaxNumKeyboardPa
 	currentNotesState = NotesState{}; // Erase active notes
 
 	for (int32_t idxPress = 0; idxPress < kMaxNumKeyboardPadPresses; ++idxPress) {
-		if (presses[idxPress].active && presses[idxPress].x < kDisplayWidth) {
-			currentNotesState.enableNote(noteFromCoords(presses[idxPress].x, presses[idxPress].y),
-			                             getDefaultVelocity());
+		if (presses[idxPress].active) {
+			// in note columns
+			if (presses[idxPress].x < kDisplayWidth) {
+				currentNotesState.enableNote(noteFromCoords(presses[idxPress].x, presses[idxPress].y), velocity);
+			}
+			else { // in velocity columns (audition pads)
+				velocity = 7 + (presses[idxPress].x - kDisplayWidth) * 8 + presses[idxPress].y * 16;
+				char velocityStr[4] = {0};
+				intToString(velocity, velocityStr, 1);
+				display->displayPopup(velocityStr);
+			}
 		}
 	}
 }
@@ -137,6 +145,22 @@ void KeyboardLayoutIsomorphic::renderPads(uint8_t image[][kDisplayWidth + kSideB
 			++noteCode;
 			++normalizedPadOffset;
 			noteWithinOctave = (noteWithinOctave + 1) % kOctaveSize;
+		}
+	}
+}
+
+void KeyboardLayoutIsomorphic::renderSidebarPads(uint8_t image[][kDisplayWidth + kSideBarWidth][3]) {
+	// Iterate over velocity pads in sidebar
+	uint8_t brightness = 1;
+	uint8_t velocity_val = 7;
+	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+		for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; ++x) {
+			uint8_t selection_brightness = (velocity >= velocity_val - 7 && velocity <= velocity_val) ? 0xf0 : 0;
+			image[y][x][0] = brightness + 0x04;
+			image[y][x][1] = selection_brightness;
+			image[y][x][2] = selection_brightness;
+			brightness += 10;
+			velocity_val += 8;
 		}
 	}
 }

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.h
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.h
@@ -35,6 +35,7 @@ public:
 	void precalculate() override;
 
 	void renderPads(uint8_t image[][kDisplayWidth + kSideBarWidth][3]) override;
+	void renderSidebarPads(uint8_t image[][kDisplayWidth + kSideBarWidth][3]) override;
 
 	char const* name() override { return "Isomorphic"; }
 	bool supportsInstrument() override { return true; }
@@ -46,6 +47,7 @@ private:
 	}
 
 	uint8_t noteColours[kDisplayHeight * kMaxIsomorphicRowInterval + kDisplayWidth][3];
+	uint8_t velocity = 64;
 };
 
 }; // namespace deluge::gui::ui::keyboard::layout


### PR DESCRIPTION
Inspired by the velocity drums keyboard, this change adds a way to adjust note velocity in the isometric layout. 

- Sidebar pads set velocity from 7 (bottom left) to 127 (top right)
- Moving right increases by 8, moving up increases by 16
- The selected velocity is used for all new notes until another velocity key is pressed
- Selected velocity is flashed as a popup on selection
- Pads range in color from dim red to bright red
- Selected pad has other channels set to 0xFF creating a range of cyan to white

Thoughts for improvements:

- Make min / max adjustable and use a linear range between current min / max (press top right or bottom left and use the encoder?)
- Allow changing what sidebar pads set / modulate (maybe a keyboard shortcut of holding any sidebar pad and then pressing another pad)