### PR TITLE
remove note offs from the active notes array

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -379,6 +379,9 @@ void MidiFollow::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t ch
 				if (on) {
 					clipForLastNoteReceived[note] = clip;
 				}
+				else {
+					clipForLastNoteReceived[note] = nullptr;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix #913 