### PR TITLE
Bugfix / MIDI Follow ~ Crash in arranger due to deleted clip instance

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1496,6 +1496,8 @@ justGetOut:
 
 						// If pressed head, delete
 						if (pressedHead) {
+							//set lastInteractedClipInstance to null so you don't send midi follow feedback for a deleted clip
+							lastInteractedClipInstance = nullptr;
 							view.setActiveModControllableTimelineCounter(currentSong);
 
 							arrangement.rowEdited(output, clipInstance->pos, clipInstance->pos + clipInstance->length,


### PR DESCRIPTION
Discovered bug where deluge would crash in arranger if you deleted a clip with midi follow feedback on.

This is because midi follow feedback would try to get the model stack for a clip that no longer exists.

To fix this, need to set the lastInteractedClipInstance pointer to null in arrangerView when you are about to delete a clip.