### PR TITLE
Bugfix / Midi Follow ~ Add getModelStackWithParam call for Audio Clips

### DIFF
--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -145,6 +145,11 @@ public:
 	//public so midi follow can access it
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithThreeMainThings* modelStack, int32_t paramID);
 
+	//public so view.modEncoderAction and midi follow can access it
+	PadPress lastPadPress;
+	void renderFXDisplay(Param::Kind paramKind, int32_t paramID, int32_t knobPos = kNoSelection);
+	bool onFXDisplay;
+
 private:
 	//initialize
 	void initPadPress(PadPress& padPress);
@@ -155,8 +160,6 @@ private:
 	//rendering
 	void renderRow(uint8_t* image, uint8_t occupancyMask[], int32_t yDisplay = 0);
 	bool isParamAssignedToFXColumn(Param::Kind paramKind, int32_t paramID);
-	void renderFXDisplay(Param::Kind paramKind, int32_t paramID, int32_t knobPos = kNoSelection);
-	bool onFXDisplay;
 	void setCentralLEDStates();
 
 	//pad action
@@ -206,7 +209,6 @@ private:
 	int32_t adjustKnobPosForQuantizedStutter(int32_t yDisplay);
 
 	PadPress firstPadPress;
-	PadPress lastPadPress;
 	ParamsForPerformance layoutForPerformance[kDisplayWidth];
 	int32_t defaultFXValues[kDisplayWidth][kDisplayHeight];
 	int32_t layoutBank;    //A or B (assign a layout to the bank for cross fader action)

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -884,7 +884,24 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 					return;
 				}
 
-				displayModEncoderValuePopup(kind, modelStackWithParam->paramId, newKnobPos);
+				//if you had selected a parameter in performance view and the parameter name
+				//and current value is displayed on the screen, don't show pop-up as the display
+				//already shows it
+				//this checks that the param displayed on the screen in performance view
+				//is the same param currently being edited with mod encoder
+				bool editingParamInPerformanceView = false;
+				if (getRootUI() == &performanceSessionView) {
+					if (!performanceSessionView.defaultEditingMode && performanceSessionView.lastPadPress.isActive) {
+						if ((kind == performanceSessionView.lastPadPress.paramKind)
+						    && (modelStackWithParam->paramId == performanceSessionView.lastPadPress.paramID)) {
+							editingParamInPerformanceView = true;
+						}
+					}
+				}
+
+				if (!editingParamInPerformanceView) {
+					displayModEncoderValuePopup(kind, modelStackWithParam->paramId, newKnobPos);
+				}
 
 				if (newKnobPos == knobPos) {
 					return;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -103,10 +103,14 @@ void MidiFollow::initMapping(int32_t mapping[kDisplayWidth][kDisplayHeight]) {
 /// 3) entering a clip
 Clip* MidiFollow::getClipForMidiFollow(bool useActiveClip) {
 	Clip* clip = nullptr;
-	if (getRootUI() == &sessionView) {
+	RootUI* rootUI = getRootUI();
+
+	//if you're in session view, check if you're pressing a clip to control that clip
+	if (rootUI == &sessionView) {
 		clip = sessionView.getClipForLayout();
 	}
-	else if ((getRootUI() == &arrangerView)) {
+	//if you're in arranger view, check if you're pressing a clip or holding audition pad to control that clip
+	else if (rootUI == &arrangerView) {
 		if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW) && arrangerView.lastInteractedClipInstance) {
 			clip = arrangerView.lastInteractedClipInstance->clip;
 		}
@@ -115,7 +119,9 @@ Clip* MidiFollow::getClipForMidiFollow(bool useActiveClip) {
 			clip = currentSong->getClipWithOutput(output);
 		}
 	}
-	else {
+	//if you're in performance view, no clip will be selected for param control
+	//if you're not in sessionView, arrangerView, or performanceView, then you're in a clip
+	else if (rootUI != &performanceSessionView) {
 		clip = getCurrentClip();
 	}
 	//special case for instruments where you want to let notes and MPE through to the active clip

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -287,6 +287,10 @@ MidiFollow::getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* mo
 		paramKind = Param::Kind::UNPATCHED_GLOBAL;
 		paramID = globalEffectableParamShortcuts[xDisplay][yDisplay];
 	}
+	if ((paramKind != Param::Kind::NONE) && (paramID != kNoParamID)) {
+		modelStackWithParam = automationInstrumentClipView.getModelStackWithParam(modelStackWithTimelineCounter,
+		                                                                          instrumentClip, paramID, paramKind);
+	}
 
 	return modelStackWithParam;
 }

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -2055,7 +2055,7 @@ int32_t ModControllableAudio::calculateKnobPosForMidiTakeover(ModelStackWithAuto
 // if you're in automation view and editing the same parameter that was just updated
 // by a learned midi knob, then re-render the pads on the automation editor grid
 bool ModControllableAudio::renderAutomationEditorGrid(Param::Kind kind, int32_t id) {
-	InstrumentClip* clip = (InstrumentClip*)currentSong->currentClip;
+	InstrumentClip* clip = getCurrentInstrumentClip();
 	if ((clip->lastSelectedParamID == id) && (clip->lastSelectedParamKind == kind)) {
 		uiNeedsRendering(&automationInstrumentClipView);
 		return true;

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -20,6 +20,7 @@
 #include "deluge/model/settings/runtime_feature_settings.h"
 #include "gui/l10n/l10n.h"
 #include "gui/views/automation_instrument_clip_view.h"
+#include "gui/views/performance_session_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/display/display.h"
@@ -1792,21 +1793,48 @@ void ModControllableAudio::receivedCCFromMidiFollow(ModelStack* modelStack, Clip
 
 								//check if you should display name of the parameter that was changed and the value that has been set
 								if (midiEngine.midiFollowDisplayParam) {
-									bool editingParamInAutomationView = false;
-									//if you're in automation view and editing the same parameter that was just updated
-									//by a learned midi knob, then re-render the pads on the automation editor grid
-									if (getRootUI() == &automationInstrumentClipView) {
-										InstrumentClip* clip = (InstrumentClip*)currentSong->currentClip;
+									bool editingParamInAutomationOrPerformanceView = false;
+									RootUI* rootUI = getRootUI();
+									if (rootUI == &automationInstrumentClipView || rootUI == &performanceSessionView) {
 										int32_t id = modelStackWithParam->paramId;
 										Param::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-										if ((clip->lastSelectedParamID == id)
-										    && (clip->lastSelectedParamKind == kind)) {
-											uiNeedsRendering(&automationInstrumentClipView);
-											editingParamInAutomationView = true;
+										//if you're in automation view and editing the same parameter that was just updated
+										//by a learned midi knob, then re-render the pads on the automation editor grid
+										if (rootUI == &automationInstrumentClipView) {
+											InstrumentClip* clip = (InstrumentClip*)currentSong->currentClip;
+											if ((clip->lastSelectedParamID == id)
+											    && (clip->lastSelectedParamKind == kind)) {
+												uiNeedsRendering(&automationInstrumentClipView);
+												editingParamInAutomationOrPerformanceView = true;
+											}
+										}
+										//if you had selected a parameter in performance view and the parameter name
+										//and current value is displayed on the screen, don't show pop-up as the display
+										//already shows it
+										//this checks that the param displayed on the screen in performance view
+										//is the same param currently being edited with mod encoder
+										else {
+											//check if you're not in editing mode
+											//and a param hold press is currently active
+											if (!performanceSessionView.defaultEditingMode
+											    && performanceSessionView.lastPadPress.isActive) {
+												if ((kind == performanceSessionView.lastPadPress.paramKind)
+												    && (id == performanceSessionView.lastPadPress.paramID)) {
+													int32_t valueForDisplay = view.calculateKnobPosForDisplay(
+													    kind, id, newKnobPos + kKnobPosOffset);
+													performanceSessionView.renderFXDisplay(kind, id, valueForDisplay);
+													editingParamInAutomationOrPerformanceView = true;
+												}
+											}
+											//if a specific param is not active, reset display
+											else if (performanceSessionView.onFXDisplay) {
+												performanceSessionView.renderViewDisplay();
+											}
 										}
 									}
-									//if you're in the automation view editor, don't display popup if you're currently editing the same param
-									if (!editingParamInAutomationView) {
+									//if you're in the automation view editor or performance view non-editing mode
+									//don't display popup if you're currently editing the same param
+									if (!editingParamInAutomationOrPerformanceView) {
 										Param::Kind kind = modelStackWithParam->paramCollection->getParamKind();
 										view.displayModEncoderValuePopup(kind, modelStackWithParam->paramId,
 										                                 newKnobPos);

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -168,6 +168,8 @@ private:
 	int32_t calculateKnobPosForMidiTakeover(ModelStackWithAutoParam* modelStackWithParam, int32_t knobPos,
 	                                        int32_t value, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
 	                                        int32_t ccNumber = MIDI_CC_NONE);
+	bool renderAutomationEditorGrid(Param::Kind kind, int32_t id);
+	bool renderPerformanceViewDisplay(Param::Kind kind, int32_t id, int32_t newKnobPos);
 
 protected:
 	void processFX(StereoSample* buffer, int32_t numSamples, ModFXType modFXType, int32_t modFXRate, int32_t modFXDepth,


### PR DESCRIPTION
Forgot to add call to get the model stack with param for audio clips. As a result MIDI Follow CC param control was not working for audio clips