### PR TITLE
ensure clip is an instrument before setting edited flag

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -687,12 +687,14 @@ extern "C" int32_t deluge_main(void) {
 	FlashStorage::readSettings();
 
 	runtimeFeatureSettings.init();
-	runtimeFeatureSettings.readSettingsFromFile();
 
 	usbLock = 1;
 	openUSBHost();
 
 	// If nothing was plugged in to us as host, we'll go peripheral
+	// Ideally I'd like to repeatedly switch between host and peripheral mode anytime there's no USB connection.
+	// To do that, I'd really need to know at any point in time whether the user had just made a connection, just then, that hadn't fully
+	// initialized yet. I think I sorta have that for host, but not for peripheral yet.
 	if (!anythingInitiallyAttachedAsUSBHost) {
 		Debug::println("switching from host to peripheral");
 		closeUSBHost();
@@ -701,11 +703,9 @@ extern "C" int32_t deluge_main(void) {
 
 	usbLock = 0;
 
-	// Ideally I'd like to repeatedly switch between host and peripheral mode anytime there's no USB connection.
-	// To do that, I'd really need to know at any point in time whether the user had just made a connection, just then, that hadn't fully
-	// initialized yet. I think I sorta have that for host, but not for peripheral yet.
-
-	MIDIDeviceManager::readDevicesFromFile(); // Hopefully we can read this file now.
+	// Hopefully we can read these files now
+	runtimeFeatureSettings.readSettingsFromFile();
+	MIDIDeviceManager::readDevicesFromFile();
 	midiFollow.readDefaultsFromFile();
 
 	setupBlankSong(); // Can only happen after settings, which includes default settings, have been read

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -638,7 +638,7 @@ doSetupBlinkingForAudioClip:
 				}
 			}
 
-stopThat : {}
+stopThat: {}
 
 			if (currentParamShorcutX != 255) {
 				updateSourceBlinks(currentItem);
@@ -792,7 +792,10 @@ ActionResult SoundEditor::timerCallback() {
 
 void SoundEditor::markInstrumentAsEdited() {
 	if (!inSettingsMenu()) {
-		getCurrentInstrument()->beenEdited();
+		Instrument* inst = getCurrentInstrumentOrNull();
+		if (inst) {
+			getCurrentInstrument()->beenEdited();
+		}
 	}
 }
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -638,7 +638,7 @@ doSetupBlinkingForAudioClip:
 				}
 			}
 
-stopThat: {}
+stopThat : {}
 
 			if (currentParamShorcutX != 255) {
 				updateSourceBlinks(currentItem);

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -360,3 +360,11 @@ private:
 extern Song* currentSong;
 extern Song* preLoadedSong;
 extern int8_t defaultAudioClipOverdubOutputCloning;
+
+inline Instrument* getCurrentInstrumentOrNull() {
+	Output* out = currentSong->currentClip->output;
+	if (out->type != InstrumentType::AUDIO) {
+		return (Instrument*)out;
+	}
+	return nullptr;
+}


### PR DESCRIPTION
Fix #587 

Also move the community settings read to after the usb initialization, the extra time makes the read more consistent when flashing via a debugger. This was required to troubleshoot the grain fx