### PR TITLE
menus: clamp to avoid overflow on shift+scroll

### DIFF
--- a/src/deluge/gui/menu_item/audio_clip/mod_fx/type.h
+++ b/src/deluge/gui/menu_item/audio_clip/mod_fx/type.h
@@ -27,14 +27,12 @@ public:
 	// We override this to set min value to 1. We don't inherit any getMinValue() function to override more easily
 	void selectEncoderAction(int32_t offset) override {
 		auto current = this->getValue() + offset;
-		int32_t numOptions = getOptions().size();
+		int32_t numOptions = getOptions().size() - 1;
 
-		if (current >= numOptions) {
-			current -= (numOptions - 1);
-		}
-		else if (current < 1) {
-			current += (numOptions - 1);
-		}
+		// Shift current down by 1, clamp it (with wrapping) to the legal range, and then shift it back up
+		current -= 1;
+		current = ((current % numOptions) + numOptions) % numOptions;
+		current += 1;
 
 		this->setValue(static_cast<ModFXType>(current));
 		Value::selectEncoderAction(offset);

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -14,6 +14,28 @@ void Enumeration::beginSession(MenuItem* navigatedBackwardFrom) {
 void Enumeration::selectEncoderAction(int32_t offset) {
 	this->setValue(this->getValue() + offset);
 	int32_t numOptions = size();
+	int32_t sign = (offset < 0) ? -1 : ((offset > 0) ? 1 : 0);
+
+	switch (numOptions) {
+	case 0:
+		[[fallthrough]];
+	case 1:
+		[[fallthrough]];
+	case 2:
+		offset = 1 * sign;
+		break;
+	case 3:
+		offset = std::min<int32_t>(offset * sign, 2) * sign;
+		break;
+	case 4:
+		offset = 1 * sign;
+		break;
+	case 5:
+		offset = std::min<int32_t>(offset * sign, 4) * sign;
+		break;
+	default:
+		break;
+	}
 
 	if (display->haveOLED()) {
 		if (this->getValue() >= numOptions) {

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -28,7 +28,7 @@ void Enumeration::selectEncoderAction(int32_t offset) {
 		offset = std::min<int32_t>(offset * sign, 2) * sign;
 		break;
 	case 4:
-		offset = 1 * sign;
+		offset = std::min<int32_t>(offset * sign, 3) * sign;
 		break;
 	case 5:
 		offset = std::min<int32_t>(offset * sign, 4) * sign;

--- a/src/deluge/gui/menu_item/integer_range.cpp
+++ b/src/deluge/gui/menu_item/integer_range.cpp
@@ -43,47 +43,20 @@ void IntegerRange::selectEncoderAction(int32_t offset) {
 
 		// Editing lower
 		if (soundEditor.editingRangeEdge == RangeEdit::LEFT) {
-			if (offset == 1) {
-				if (lower == upper) {
-					if (upper >= maxValue) {
-						goto justDrawRange;
-					}
-					else {
-						upper++;
-					}
-				}
+			lower = std::clamp(lower + offset, minValue, maxValue);
+			if (upper < lower) {
+				upper = lower;
 			}
-			else {
-				if (lower <= minValue) {
-					goto justDrawRange;
-				}
-			}
-
-			lower += offset;
 		}
 
 		// Editing upper
 		else {
-			if (offset == 1) {
-				if (upper >= maxValue) {
-					goto justDrawRange;
-				}
+			upper = std::clamp(upper + offset, minValue, maxValue);
+			if (upper < lower) {
+				lower = upper;
 			}
-			else {
-				if (upper == lower) {
-					if (lower <= minValue) {
-						goto justDrawRange;
-					}
-					else {
-						lower--;
-					}
-				}
-			}
-
-			upper += offset;
 		}
 
-justDrawRange:
 		drawValueForEditingRange(false);
 	}
 
@@ -92,18 +65,7 @@ justDrawRange:
 			return;
 		}
 
-		if (offset == 1) {
-			if (lower == maxValue) {
-				goto justDrawOneNumber;
-			}
-		}
-		else {
-			if (lower == minValue) {
-				goto justDrawOneNumber;
-			}
-		}
-
-		lower += offset;
+		lower = std::clamp(lower + offset, minValue, maxValue);
 		upper = lower;
 
 justDrawOneNumber:

--- a/src/deluge/gui/menu_item/key_range.cpp
+++ b/src/deluge/gui/menu_item/key_range.cpp
@@ -24,61 +24,22 @@
 namespace deluge::gui::menu_item {
 
 void KeyRange::selectEncoderAction(int32_t offset) {
+	int32_t const KEY_MIN = 0;
+	int32_t const KEY_MAX = 11;
 
 	// If editing the range
 	if (soundEditor.editingRangeEdge != RangeEdit::OFF) {
 
 		// Editing lower
 		if (soundEditor.editingRangeEdge == RangeEdit::LEFT) {
-
-			int32_t newValue = lower + offset;
-			if (newValue < 0) {
-				newValue += 12;
-			}
-			else if (newValue >= 12) {
-				newValue -= 12;
-			}
-
-			if (offset == 1) {
-				if (lower == upper) {
-					goto justDrawRange;
-				}
-			}
-			else {
-				if (newValue == upper) {
-					goto justDrawRange;
-				}
-			}
-
-			lower = newValue;
+			// Do not allow lower to pass upper
+			lower = std::clamp(lower + offset, KEY_MIN, upper);
 		}
-
 		// Editing upper
 		else {
-
-			int32_t newValue = upper + offset;
-			if (newValue < 0) {
-				newValue += 12;
-			}
-			else if (newValue >= 12) {
-				newValue -= 12;
-			}
-
-			if (offset == 1) {
-				if (newValue == lower) {
-					goto justDrawRange;
-				}
-			}
-			else {
-				if (upper == lower) {
-					goto justDrawRange;
-				}
-			}
-
-			upper = newValue;
+			upper = std::clamp(upper + offset, lower, KEY_MAX);
 		}
 
-justDrawRange:
 		drawValueForEditingRange(false);
 	}
 
@@ -87,14 +48,7 @@ justDrawRange:
 			return;
 		}
 
-		lower += offset;
-		if (lower < 0) {
-			lower += 12;
-		}
-		else if (lower >= 12) {
-			lower -= 12;
-		}
-
+		lower = std::clamp(lower + offset, KEY_MIN, KEY_MAX);
 		upper = lower;
 
 		drawValue();

--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -57,6 +57,8 @@ void Devices::beginSession(MenuItem* navigatedBackwardFrom) {
 }
 
 void Devices::selectEncoderAction(int32_t offset) {
+	offset = std::clamp<int32_t>(offset, -1, 1);
+
 	do {
 		int32_t newValue = this->getValue() + offset;
 

--- a/src/deluge/gui/menu_item/patch_cables.cpp
+++ b/src/deluge/gui/menu_item/patch_cables.cpp
@@ -118,10 +118,10 @@ void PatchCables::selectEncoderAction(int32_t offset) {
 	}
 	else {
 		if (newValue >= set->numPatchCables) {
-			newValue -= set->numPatchCables;
+			newValue %= set->numPatchCables;
 		}
 		else if (newValue < 0) {
-			newValue += set->numPatchCables;
+			newValue = (newValue % set->numPatchCables + set->numPatchCables) % set->numPatchCables;
 		}
 	}
 

--- a/src/deluge/gui/menu_item/source_selection.cpp
+++ b/src/deluge/gui/menu_item/source_selection.cpp
@@ -199,10 +199,7 @@ void SourceSelection::selectEncoderAction(int32_t offset) {
 			}
 		}
 		else {
-			if (newValue >= kNumPatchSources)
-				newValue -= kNumPatchSources;
-			else if (newValue < 0)
-				newValue += kNumPatchSources;
+			newValue = ((newValue % kNumPatchSources) + kNumPatchSources) % kNumPatchSources;
 		}
 
 		s = sourceMenuContents[newValue];


### PR DESCRIPTION
this change is the result of auditing all menu items that override selectEncoderAction to ensure none of them can go out-of-bounds if abs(offset) > 1

Fixes #871