### PR TITLE
Bugfix - midi fixes

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -880,7 +880,7 @@ enum CCNumber {
 constexpr int32_t kNumCCNumbersIncludingFake = 124;
 constexpr int32_t kNumRealCCNumbers = 120;
 constexpr int32_t kMaxMIDIValue = 127;
-
+constexpr int32_t ALL_NOTES_OFF = -32768;
 enum class InstrumentRemoval {
 	NONE,
 	DELETE_OR_HIBERNATE_IF_UNUSED,

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -360,14 +360,14 @@ void MidiFollow::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t ch
 				clip = clipForLastNoteReceived[note];
 			}
 
-			sendnoteToClip(fromDevice, clip, match, on, channel, note, velocity, doingMidiThru, shouldRecordNotesNowNow,
+			sendNoteToClip(fromDevice, clip, match, on, channel, note, velocity, doingMidiThru, shouldRecordNotesNowNow,
 			               modelStack);
 		}
 		//all notes off
 		else if (note == ALL_NOTES_OFF) {
 			for (int32_t i = 0; i <= 127; i++) {
 				if (clipForLastNoteReceived[i]) {
-					sendnoteToClip(fromDevice, clipForLastNoteReceived[i], match, on, channel, i, velocity,
+					sendNoteToClip(fromDevice, clipForLastNoteReceived[i], match, on, channel, i, velocity,
 					               doingMidiThru, shouldRecordNotesNowNow, modelStack);
 				}
 			}
@@ -375,7 +375,7 @@ void MidiFollow::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t ch
 	}
 }
 
-void MidiFollow::sendnoteToClip(MIDIDevice* fromDevice, Clip* clip, MIDIMatchType match, bool on, int32_t channel,
+void MidiFollow::sendNoteToClip(MIDIDevice* fromDevice, Clip* clip, MIDIMatchType match, bool on, int32_t channel,
                                 int32_t note, int32_t velocity, bool* doingMidiThru, bool shouldRecordNotesNowNow,
                                 ModelStack* modelStack) {
 

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -380,7 +380,9 @@ void MidiFollow::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t ch
 					clipForLastNoteReceived[note] = clip;
 				}
 				else {
-					clipForLastNoteReceived[note] = nullptr;
+					if (note > 0 && note <= 127) {
+						clipForLastNoteReceived[note] = nullptr;
+					}
 				}
 			}
 		}

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -42,7 +42,7 @@ public:
 	                                                bool displayError = true);
 	void noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note, int32_t velocity,
 	                         bool* doingMidiThru, bool shouldRecordNotesNowNow, ModelStack* modelStack);
-	void sendnoteToClip(MIDIDevice* fromDevice, Clip* clip, MIDIMatchType match, bool on, int32_t channel, int32_t note,
+	void sendNoteToClip(MIDIDevice* fromDevice, Clip* clip, MIDIMatchType match, bool on, int32_t channel, int32_t note,
 	                    int32_t velocity, bool* doingMidiThru, bool shouldRecordNotesNowNow, ModelStack* modelStack);
 	void midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru,
 	                    ModelStack* modelStack);

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -42,6 +42,8 @@ public:
 	                                                bool displayError = true);
 	void noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note, int32_t velocity,
 	                         bool* doingMidiThru, bool shouldRecordNotesNowNow, ModelStack* modelStack);
+	void sendnoteToClip(MIDIDevice* fromDevice, Clip* clip, MIDIMatchType match, bool on, int32_t channel, int32_t note,
+	                    int32_t velocity, bool* doingMidiThru, bool shouldRecordNotesNowNow, ModelStack* modelStack);
 	void midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru,
 	                    ModelStack* modelStack);
 	void pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru,

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -369,11 +369,7 @@ void MelodicInstrument::receivedCC(ModelStackWithTimelineCounter* modelStackWith
 			return;
 		}
 	case MIDIMatchType::MPE_MASTER:
-		yCC = 74;
-		if (ccNumber == 74) {
-			value32 = (value - 64) << 25;
-		}
-		//no break
+		[[fallthrough]];
 	case MIDIMatchType::CHANNEL:
 		if (ccNumber == 1) {
 			value32 = (value) << 24;

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -148,7 +148,8 @@ void CVEngine::sendNote(bool on, uint8_t channel, int16_t note) {
 
 		// Switch off, unless the note that's playing is a different one (i.e. if a new one had already cut short this one that we're now saying we wanted to stop)
 		if (gateChannels[channel].on
-		    && (channel >= NUM_CV_CHANNELS || note == -32768 || cvChannels[channel].noteCurrentlyPlaying == note)) {
+		    && (channel >= NUM_CV_CHANNELS || note == ALL_NOTES_OFF
+		        || cvChannels[channel].noteCurrentlyPlaying == note)) {
 
 			// Physically switch it right now, to get a head-start before it turns back on
 			switchGateOff(channel);
@@ -161,7 +162,7 @@ void CVEngine::sendNote(bool on, uint8_t channel, int16_t note) {
 		int32_t voltage;
 
 		// If it's not a gate-only note-on...
-		if (note != -32768) {
+		if (note != ALL_NOTES_OFF) {
 
 			// Calculate the voltage
 			voltage = calculateVoltage(note, channel);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -1573,7 +1573,7 @@ void Sound::noteOffPostArpeggiator(ModelStackWithSoundFlags* modelStack, int32_t
 	AudioEngine::activeVoices.getRangeForSound(this, ends);
 	for (int32_t v = ends[0]; v < ends[1]; v++) {
 		Voice* thisVoice = AudioEngine::activeVoices.getVoice(v);
-		if ((thisVoice->noteCodeAfterArpeggiation == noteCode || noteCode == -32768)
+		if ((thisVoice->noteCodeAfterArpeggiation == noteCode || noteCode == ALL_NOTES_OFF)
 		    && thisVoice->envelopes[0].state < EnvelopeStage::RELEASE) { // Don't bother if it's already "releasing"
 
 			ArpeggiatorSettings* arpSettings = getArpSettings();

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -370,7 +370,7 @@ void SoundInstrument::sendNote(ModelStackWithThreeMainThings* modelStack, bool i
 
 		arpeggiator.noteOff(arpSettings, noteCode, &instruction);
 
-		if (instruction.noteCodeOffPostArp != ARP_NOTE_NONE) {
+		if (instruction.noteCodeOffPostArp != ARP_NOTE_NONE || noteCode == -32768) {
 
 #if ALPHA_OR_BETA_VERSION
 			if (!modelStack->paramManager) {

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -370,7 +370,7 @@ void SoundInstrument::sendNote(ModelStackWithThreeMainThings* modelStack, bool i
 
 		arpeggiator.noteOff(arpSettings, noteCode, &instruction);
 
-		if (instruction.noteCodeOffPostArp != ARP_NOTE_NONE || noteCode == -32768) {
+		if (instruction.noteCodeOffPostArp != ARP_NOTE_NONE) {
 
 #if ALPHA_OR_BETA_VERSION
 			if (!modelStack->paramManager) {


### PR DESCRIPTION
Fix CC74 on MPE master channel being treated as an expression event, fall through so it behaves like normal midi channels

Fix all notes off crashing in midi follow (proper behaviour not implemented yet)