### PR TITLE
Consistency / Performance View ~ Update Load and Save shortcut in Performance View

### DIFF
--- a/docs/features/performance_view.md
+++ b/docs/features/performance_view.md
@@ -47,8 +47,8 @@ or
 Value Editing Mode:
 - While in the Value Editor, pressing any pad on the grid will open up the menu corresponding to the parameter for that pad. It will display the current value assigned to that pad when you pressed it.
 - You can edit that pad's value by turning the select encoder while selecting a single pad (so it's highlighted white) or holding down on that pad. The updated value will be reflected on the display.
-- After you have edited a value, the Save button will start flashing to indicate that you have "Unsaved" changes. Press the save button to save your changes. Once saved, the Save button will stop blinking. To avoid being distracting, the save button will only blink when you are in editing mode. If you exit editing mode it will stop blinking and if you re-enter editing mode it will blink again to remind you that you have unsaved changes.
-- You can re-load saved changes using the Load button. This will cause you to lose unsaved changes and the Save button will stop blinking.
+- After you have edited a value, the Save button will start flashing to indicate that you have "Unsaved" changes. Press and hold the save button + press the keyboard button to save your changes. Once saved, the Save button will stop blinking. To avoid being distracting, the save button will only blink when you are in editing mode. If you exit editing mode it will stop blinking and if you re-enter editing mode it will blink again to remind you that you have unsaved changes.
+- You can re-load saved changes by pressing and holding the Load button + press the keyboard button. This will cause you to lose unsaved changes and the Save button will stop blinking.
 - Defaults are saved in an XML file on your SD card called "PerformanceView.XML" - deleting this file will cause the PerformanceView to revert back to its regular default values for each pad.
 - Once you are done with editing mode, repeat the steps above to set editing mode back to "Disabled" and exit out of the menu to use Performance View in its regular state
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -289,34 +289,19 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 
 	// Save button
 	else if (b == SAVE) {
-		if (on && (currentUIMode == UI_MODE_NONE || getRootUI() == &performanceSessionView) && !inSettingsMenu()
-		    && !editingCVOrMIDIClip() && getCurrentClip()->type != CLIP_TYPE_AUDIO) {
+		if (on && (currentUIMode == UI_MODE_NONE) && !inSettingsMenu() && !inSongMenu() && !editingCVOrMIDIClip()
+		    && getCurrentClip()->type != CLIP_TYPE_AUDIO) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
-
-			if (getRootUI() != &performanceSessionView) {
-				if (Buttons::isShiftButtonPressed()) {
-					if (getCurrentMenuItem() == &menu_item::multiRangeMenu) {
-						menu_item::multiRangeMenu.deletePress();
-					}
-				}
-				else {
-					openUI(&saveInstrumentPresetUI);
+			if (Buttons::isShiftButtonPressed()) {
+				if (getCurrentMenuItem() == &menu_item::multiRangeMenu) {
+					menu_item::multiRangeMenu.deletePress();
 				}
 			}
 			else {
-				performanceSessionView.savePerformanceViewLayout();
-				display->displayPopup(l10n::get(l10n::String::STRING_FOR_PERFORM_DEFAULTS_SAVED));
+				openUI(&saveInstrumentPresetUI);
 			}
-		}
-	}
-
-	//Load button
-	else if (b == LOAD) {
-		if (on && (getRootUI() == &performanceSessionView)) {
-			performanceSessionView.loadPerformanceViewLayout();
-			display->displayPopup(l10n::get(l10n::String::STRING_FOR_PERFORM_DEFAULTS_LOADED));
 		}
 	}
 
@@ -1376,6 +1361,11 @@ MenuItem* SoundEditor::getCurrentMenuItem() {
 
 bool SoundEditor::inSettingsMenu() {
 	return (menuItemNavigationRecord[0] == &settingsRootMenu);
+}
+
+bool SoundEditor::inSongMenu() {
+	return ((menuItemNavigationRecord[0] == &soundEditorRootMenuSongView)
+	        || (menuItemNavigationRecord[0] == &soundEditorRootMenuPerformanceView));
 }
 
 bool SoundEditor::isUntransposedNoteWithinRange(int32_t noteCode) {

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -116,6 +116,7 @@ public:
 	bool editingReverbCompressor();
 	MenuItem* getCurrentMenuItem();
 	bool inSettingsMenu();
+	bool inSongMenu();
 	bool setupKitGlobalFXMenu;
 	void exitCompletely();
 	void goUpOneLevel();

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -750,7 +750,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 	}
 
 	//save performance view layout
-	else if (b == SAVE) {
+	else if (b == KEYBOARD && isUIModeActive(UI_MODE_HOLDING_SAVE_BUTTON)) {
 		if (on) {
 			savePerformanceViewLayout();
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_PERFORM_DEFAULTS_SAVED));
@@ -758,7 +758,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 	}
 
 	//load performance view layout
-	else if (b == LOAD) {
+	else if (b == KEYBOARD && isUIModeActive(UI_MODE_HOLDING_LOAD_BUTTON)) {
 		if (on) {
 			loadPerformanceViewLayout();
 			renderViewDisplay();

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -225,7 +225,8 @@ doEndMidiLearnPressSession:
 
 		if (!Buttons::isButtonPressed(deluge::hid::button::SYNTH) && !Buttons::isButtonPressed(deluge::hid::button::KIT)
 		    && !Buttons::isButtonPressed(deluge::hid::button::MIDI)
-		    && !Buttons::isButtonPressed(deluge::hid::button::CV)) {
+		    && !Buttons::isButtonPressed(deluge::hid::button::CV)
+		    && !((getRootUI() == &performanceSessionView) && Buttons::isButtonPressed(deluge::hid::button::KEYBOARD))) {
 			// Press down
 			if (on) {
 				if (currentUIMode == UI_MODE_NONE && !Buttons::isShiftButtonPressed()) {
@@ -269,7 +270,8 @@ doEndMidiLearnPressSession:
 
 		if (!Buttons::isButtonPressed(deluge::hid::button::SYNTH) && !Buttons::isButtonPressed(deluge::hid::button::KIT)
 		    && !Buttons::isButtonPressed(deluge::hid::button::MIDI)
-		    && !Buttons::isButtonPressed(deluge::hid::button::CV)) {
+		    && !Buttons::isButtonPressed(deluge::hid::button::CV)
+		    && !((getRootUI() == &performanceSessionView) && Buttons::isButtonPressed(deluge::hid::button::KEYBOARD))) {
 			// Press down
 			if (on) {
 				if (currentUIMode == UI_MODE_NONE) {


### PR DESCRIPTION
Updated shortcut to load and save default preset in performance view to "Hold Save/Load + Press Keyboard"

Also disabled Load/Saving when in Song/Performance View menu (it wasn't working before - it was trying to save a Synth when in the song menu).