### PR TITLE
Bugfix - allow midi CCs to properly trigger launch commands

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2531,7 +2531,7 @@ void PlaybackHandler::programChangeReceived(MIDIDevice* fromDevice, int32_t chan
 	}
 	else {
 		// we build ontop of the CC hack
-		tryGlobalMIDICommands(fromDevice, channel + IS_A_PC, program);
+		offerNoteToLearnedThings(fromDevice, true, channel + IS_A_PC, program);
 	}
 }
 bool PlaybackHandler::offerNoteToLearnedThings(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note) {

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2534,21 +2534,7 @@ void PlaybackHandler::programChangeReceived(MIDIDevice* fromDevice, int32_t chan
 		tryGlobalMIDICommands(fromDevice, channel + IS_A_PC, program);
 	}
 }
-
-void PlaybackHandler::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note,
-                                          int32_t velocity, bool* doingMidiThru) {
-	// If user assigning/learning MIDI commands, do that
-	if (currentUIMode == UI_MODE_MIDI_LEARN && on) {
-		// Checks velocity to let note-offs pass through,
-		// so no risk of stuck note if they pressed learn while holding a note
-		int32_t channelOrZone = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
-
-		if (getCurrentUI()->noteOnReceivedForMidiLearn(fromDevice, channelOrZone, note, velocity)) {}
-		else {
-			view.noteOnReceivedForMidiLearn(fromDevice, channelOrZone, note, velocity);
-		}
-		return;
-	}
+bool PlaybackHandler::offerNoteToLearnedThings(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note) {
 
 	// Otherwise, enact the relevant MIDI command, if it can be found
 
@@ -2595,7 +2581,27 @@ void PlaybackHandler::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32
 		}
 	}
 
-	if (foundAnything) {
+	return foundAnything;
+}
+
+void PlaybackHandler::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note,
+                                          int32_t velocity, bool* doingMidiThru) {
+	// If user assigning/learning MIDI commands, do that
+	if (currentUIMode == UI_MODE_MIDI_LEARN && on) {
+		// Checks velocity to let note-offs pass through,
+		// so no risk of stuck note if they pressed learn while holding a note
+		int32_t channelOrZone = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(channel);
+
+		if (getCurrentUI()->noteOnReceivedForMidiLearn(fromDevice, channelOrZone, note, velocity)) {}
+		else {
+			view.noteOnReceivedForMidiLearn(fromDevice, channelOrZone, note, velocity);
+		}
+		return;
+	}
+
+	// Otherwise, enact the relevant MIDI command, if it can be found
+
+	if (offerNoteToLearnedThings(fromDevice, on, channel, note)) {
 		return;
 	}
 
@@ -2754,7 +2760,7 @@ void PlaybackHandler::pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel,
 
 void PlaybackHandler::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
                                      bool* doingMidiThru) {
-
+	//true only if it's an MPE member channel, and therefore only used for per note expression
 	bool isMPE = fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isChannelPartOfAnMPEZone(channel);
 
 	if (isMPE) {
@@ -2768,23 +2774,15 @@ void PlaybackHandler::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, ui
 				return;
 			}
 		}
-
-		else {
-			if (currentUIMode == UI_MODE_MIDI_LEARN) {
-				view.ccReceivedForMIDILearn(fromDevice, channelOrZone, ccNumber, value);
-				return;
-			}
+		// then midi learn is second priority
+		else if (currentUIMode == UI_MODE_MIDI_LEARN) {
+			view.ccReceivedForMIDILearn(fromDevice, channelOrZone, ccNumber, value);
+			// we don't want this learn to immediately trigger the thing it was learnt to so just return
+			return;
 		}
-
-		if (value > 0) {
-			if (tryGlobalMIDICommands(fromDevice, channelOrZone + IS_A_CC, ccNumber)) {
-				return;
-			}
-		}
-		else {
-			if (tryGlobalMIDICommandsOff(fromDevice, channelOrZone + IS_A_CC, ccNumber)) {
-				return;
-			}
+		// check if it was learned to on/off commands (loop, drums, section launch etc.)
+		else if (offerNoteToLearnedThings(fromDevice, value > 0, channelOrZone + IS_A_CC, ccNumber)) {
+			return;
 		}
 	}
 

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -238,6 +238,7 @@ private:
 	//void scheduleNextTimerTick();
 	bool startIgnoringMidiClockInputIfNecessary();
 	uint32_t setTempoFromAudioClipLength(uint64_t loopLengthSamples, Action* action);
+	bool offerNoteToLearnedThings(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note);
 	bool tryGlobalMIDICommands(MIDIDevice* device, int32_t channel, int32_t note);
 	bool tryGlobalMIDICommandsOff(MIDIDevice* device, int32_t channel, int32_t note);
 	void decideOnCurrentPlaybackMode();


### PR DESCRIPTION
Midi CCs could be learnt to drums/sections/clips but not actually trigger them. This refactors note on received to seperate commands from real notes, then offers CCs to commands so that it works properly