### PR TITLE
[DRAFT] feature request: remove default cable: aftertouch -> volume

### DIFF
--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -307,12 +307,6 @@ void Sound::setupDefaultExpressionPatching(ParamManager* paramManager) {
 	if (patchCableSet->numPatchCables >= kMaxNumPatchCables) {
 		return;
 	}
-	patchCableSet->patchCables[patchCableSet->numPatchCables++].setup(
-	    PatchSource::AFTERTOUCH, Param::Local::VOLUME, getParamFromUserValue(Param::Static::PATCH_CABLE, 33));
-
-	if (patchCableSet->numPatchCables >= kMaxNumPatchCables) {
-		return;
-	}
 
 	if (synthMode == SynthMode::FM) {
 		patchCableSet->patchCables[patchCableSet->numPatchCables++].setup(


### PR DESCRIPTION
Since 4.0, the default has been to link aftertouch in to master level, with a strength of 33.  Unfortunately, this overdrives / clips on a lot of patches, and volume on aftertouch is a strange choice on its face.  

(Should pressure affect pitch bend?  Vibrato?  Filter cutoff?  IMO, it shouldn't be a global default.)

And for all the times that you're not actively using aftertouch, it just eats up a patch cable slot.

This is a super simple change, and will make a number of people happy to get rid of it without having to explicitly un-set the volume-pressure cable in every patch.

https://forums.synthstrom.com/discussion/comment/20999
https://forums.synthstrom.com/discussion/comment/23574/#Comment_23574
