### PR TITLE
Improve dbt format and add format-on-save support for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,6 @@
 		"editorconfig.editorconfig",
 		"xaver.clang-format",
 		"marus25.cortex-debug",
-		"jkillian.custom-local-formatters"
+		"webfreak.advanced-local-formatters"
 	]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
 		"ms-vscode.cpptools",
 		"editorconfig.editorconfig",
 		"xaver.clang-format",
-		"marus25.cortex-debug"
+		"marus25.cortex-debug",
+		"jkillian.custom-local-formatters"
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,4 +16,10 @@
         "Synthstrom"
     ],
     "cortex-debug.armToolchainPath.windows": "${workspaceRoot}/toolchain/win32-x86_64/arm-none-eabi-gcc/bin",
+    "customLocalFormatters.formatters": [
+        {
+          "command": "./dbt format --stdio ${file}",
+          "languages": ["cpp"]
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,10 +16,13 @@
         "Synthstrom"
     ],
     "cortex-debug.armToolchainPath.windows": "${workspaceRoot}/toolchain/win32-x86_64/arm-none-eabi-gcc/bin",
-    "customLocalFormatters.formatters": [
+    "advancedLocalFormatters.formatters": [
         {
-          "command": "./dbt format --stdio ${file}",
-          "languages": ["cpp"]
+            "command": {
+                "win32": ["dbt.cmd", "format", "--stdio", "$absoluteFilePath"],
+                "*": ["./dbt", "format", "--stdio", "$absoluteFilePath"]
+            },
+            "languages": ["cpp"]
         }
     ]
 }


### PR DESCRIPTION
This PR does a few things:
* Adds the ability to format files using stdio
* Enables auto format of CPP files on save in VS Code (tested in WSL Ubuntu and native Windows)
* Adds the abilty to pass any number of directories and files to `dbt format`

## format files using stdio

@robmccoll and I collaborated on some changes to `dbt format` which allows it to work with stdin and stdout, to make it able to be used with VS Code (and possibly other editors) as a custom formatter! See `dbt format --help` and `.vscode/extensions.json` for more details on the `--stdio` option.

## auto format of CPP files on save in VS Code

I updated a few VS Code config files to make use of the [Advanced Local Formatters](https://marketplace.visualstudio.com/items?itemName=webfreak.advanced-local-formatters) (webfreak.advanced-local-formatters) extension to auto-format CPP files using `dbt format`.

## pass any number of directories and files to `dbt format`

I updated `dbt format` so that it can be run on an individual file, or directory, or any combination of files and directories. This allows it to be used more surgically, eg. as a git hook of some sort.

The way I tested this was to use the following commands:

```sh
mkdir -p format-test/{a,b}/{,c}
find format-test -type d -exec touch {}/file.{h,cpp} \;
find format-test -type f
```
To create this sample directory structure

```
format-test/file.cpp
format-test/b/file.cpp
format-test/b/c/file.cpp
format-test/b/c/file.h
format-test/b/file.h
format-test/file.h
format-test/a/file.cpp
format-test/a/c/file.cpp
format-test/a/c/file.h
format-test/a/file.h
```

Which I then tested by updating `task-format.py` with the following changes:
* Add `print(); print(args.files_and_directories)` on a new line after `args = argparser().parse_args()` on line 120
* Change `"src"` to `"format-test"` on line 135
* Add `[print(f) for f in sorted(files)]; exit()` on a new line after `files = found_files.union(valid_files)` on line 146

And then ran the following commands to visually inspect that the code was finding the expected files:

```sh
./dbt format
./dbt format format-test
./dbt format format-test/{a,b}
./dbt format format-test format-test/{a,b}
./dbt format format-test/file.cpp
./dbt format format-test/file.{cpp,h}
./dbt format format-test/a/file.cpp format-test/b{,/file.cpp} format-test/file.{cpp,h}
```