### PR TITLE
Chore/build warnings

### DIFF
--- a/src/c_lib_alternatives.S
+++ b/src/c_lib_alternatives.S
@@ -707,6 +707,8 @@ END (memcpy)
 #define src2		r1
 #define result		r0	/* Overlaps src1.  */
 
+#undef tmp1
+#undef tmp2
 /* Internal variables.  */
 #define tmp1		r4
 #define tmp2		r5

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2928,6 +2928,10 @@ void InstrumentClipView::setRowProbability(int32_t offset) {
 	displayProbability(probabilityValue, false);
 }
 
+// GCC is fine with 29 or 5 for the size, but does not like that it could be either
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
 void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) {
 	char buffer[(display->haveOLED()) ? 29 : 5];
 
@@ -2968,6 +2972,7 @@ void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) 
 		display->displayPopup(buffer, 0, true, prevBase ? 3 : 255, 1, DisplayPopupType::PROBABILITY);
 	}
 }
+#pragma gcc pop
 
 void InstrumentClipView::offsetNoteCodeAction(int32_t newOffset) {
 
@@ -4679,6 +4684,10 @@ void InstrumentClipView::editNoteRepeat(int32_t offset) {
 	}
 }
 
+// GCC doesn't like the MODEL_STACK_MAX_SIZE on the stack
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
 // Supply offset as 0 to just popup number, not change anything
 void InstrumentClipView::nudgeNotes(int32_t offset) {
 
@@ -5006,6 +5015,7 @@ abandonModRegion:
 		currentClip->reGetParameterAutomation(modelStackWithTimelineCounter);
 	}
 }
+#pragma GCC pop
 
 void InstrumentClipView::graphicsRoutine() {
 	if (!currentSong) {

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -120,6 +120,9 @@ void InstrumentClipMinder::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 	view.displayOutputName(getCurrentOutput(), false);
 }
 
+// GCC is fine with 29 or 5 for the size, but does not like that it could be either
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wstack-usage="
 void InstrumentClipMinder::drawMIDIControlNumber(int32_t controlNumber, bool automationExists) {
 
 	char buffer[display->haveOLED() ? 30 : 5];
@@ -156,7 +159,7 @@ void InstrumentClipMinder::drawMIDIControlNumber(int32_t controlNumber, bool aut
 		display->setText(buffer, true, automationExists ? 3 : 255, false);
 	}
 }
-
+#pragma GCC pop
 void InstrumentClipMinder::createNewInstrument(OutputType newOutputType) {
 	int32_t error;
 

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -50,7 +50,7 @@ MIDIInstrument::MIDIInstrument() : NonAudioInstrument(OutputType::MIDI_OUT) {
 		mpeOutputMemberChannels[c].lastNoteCode = 32767;
 		mpeOutputMemberChannels[c].noteOffOrder = 0;
 	}
-	for (int32_t i = 0; i <= kNumExpressionDimensions; i++) {
+	for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
 		lastMonoExpression[i] = 0;
 		lastCombinedPolyExpression[i] = 0;
 	}

--- a/src/deluge/util/algorithm/quick_sorter.cpp
+++ b/src/deluge/util/algorithm/quick_sorter.cpp
@@ -31,6 +31,10 @@ void* QuickSorter::getElementAddress(int32_t i) {
 	return (void*)((uint32_t)memory + i * elementSize);
 }
 
+// GCC doesn't like that workingMemory would be unbounded if elementSize is unbounded
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wstack-usage="
+
 // A utility function to swap two elements
 void QuickSorter::swap(int32_t i, int32_t j) {
 	void* addressI = getElementAddress(i);
@@ -40,7 +44,7 @@ void QuickSorter::swap(int32_t i, int32_t j) {
 	memcpy(addressI, addressJ, elementSize);
 	memcpy(addressJ, temp, elementSize);
 }
-
+#pragma GCC pop
 int32_t QuickSorter::getKey(int32_t i) {
 	return *(uint32_t*)getElementAddress(i) & keyMask;
 }

--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -1160,6 +1160,10 @@ getBrandNewMemoryAgain:
 	LOCK_EXIT
 	return NO_ERROR;
 }
+// swapElements and repositionElements are fine - GCC doesn't like that workingMemory
+// would be unbounded if elementSize is unbounded, but it is so it's all ok
+#pragma GCC push
+#pragma GCC diagnostic ignored "-Wstack-usage="
 
 void ResizeableArray::swapElements(int32_t i1, int32_t i2) {
 	LOCK_ENTRY
@@ -1190,3 +1194,4 @@ void ResizeableArray::repositionElement(int32_t iFrom, int32_t iTo) {
 
 	LOCK_EXIT
 }
+#pragma GCC pop

--- a/src/lib/printf.c
+++ b/src/lib/printf.c
@@ -144,7 +144,7 @@ static inline void _out_char(char character, void* buffer, size_t idx, size_t ma
 	(void)idx;
 	(void)maxlen;
 	if (character) {
-		_putchar(character);
+		putchar_(character);
 	}
 }
 


### PR DESCRIPTION
Fix the build warnings (except the redefinition from the thumb code)

Turns off stack usage warning in spots where GCC couldn't parse it correctly, adds some undefs to stop the warning about redefinitions, fixes an error in the strformat lib, and fixes UB in initializing midi instruments