### PR TITLE
dbt: only do python setup if the toolchain is freshly unpacked

### DIFF
--- a/dbt
+++ b/dbt
@@ -33,16 +33,4 @@ if [ -z "$DBT_NO_SYNC" ]; then
     git submodule update --init --depth 1 --jobs "$N_GIT_THREADS";
 fi
 
-if [ -z "$DBT_NO_PYTHON_UPGRADE" ]; then
-    # Install python wheels if not already installed, upgrade pip
-    # afterward (needs certifi in place).
-    pip_cmd="python3 -m pip";
-    pip_requirements_path="${SCRIPT_PATH}/scripts/toolchain/requirements.txt"
-    pip_wheel_path="${TOOLCHAIN_ARCH_DIR}/python/wheel";
-    pip_certifi_wheel=$(find $pip_wheel_path/certifi*)
-    $pip_cmd install -q "${pip_certifi_wheel}"
-    $pip_cmd install -q --upgrade pip
-    $pip_cmd install -q -f "${pip_wheel_path}" -r "${pip_requirements_path}"
-fi
-
 $DBT_EP "$@"

--- a/dbt.cmd
+++ b/dbt.cmd
@@ -16,18 +16,4 @@ if [%DBT_NO_SYNC%] == [] (
 set PIP_CMD=python -m pip
 set "PIP_REQUIREMENTS_PATH=%SCRIPT_PATH%\scripts\toolchain\requirements.txt"
 
-if [%DBT_NO_PYTHON_UPGRADE%] == [] (
-    python -c "import wheel"
-    if %ERRORLEVEL% NEQ 0 (
-        set "PIP_WHEEL_PATH=%DBT_TOOLCHAIN_ROOT%\python\wheel"
-        for /R %PIP_WHEEL_PATH% %%G in (
-            certifi*.whl
-        ) do (
-            %PIP_CMD% install -q "%%G"
-        )
-    )
-    %PIP_CMD% install -q --upgrade pip | find /V "already satisfied"
-    %PIP_CMD% install -q -f "%PIP_WHEEL_PATH%" -r "%PIP_REQUIREMENTS_PATH%" | find /V "already satisfied"
-)
-
 %DBT_EP% %*

--- a/scripts/toolchain/dbtenv.cmd
+++ b/scripts/toolchain/dbtenv.cmd
@@ -24,12 +24,16 @@ set "DBT_TOOLCHAIN_ROOT=%DBT_TOOLCHAIN_PATH%\toolchain\win32-x86_64"
 
 set "DBT_TOOLCHAIN_VERSION_FILE=%DBT_TOOLCHAIN_ROOT%\VERSION"
 
+set "DBT_TOOLCHAIN_INSTALLED=0"
+
 if not exist "%DBT_TOOLCHAIN_ROOT%" (
     powershell -ExecutionPolicy Bypass -File "%DBT_ROOT%\scripts\toolchain\windows-toolchain-download.ps1" %DBT_TOOLCHAIN_VERSION% "%DBT_TOOLCHAIN_ROOT%"
+    set "DBT_TOOLCHAIN_INSTALLED=1"
 )
 
 if not exist "%DBT_TOOLCHAIN_VERSION_FILE%" (
     powershell -ExecutionPolicy Bypass -File "%DBT_ROOT%\scripts\toolchain\windows-toolchain-download.ps1" %DBT_TOOLCHAIN_VERSION% "%DBT_TOOLCHAIN_ROOT%"
+    set "DBT_TOOLCHAIN_INSTALLED=1"
 )
 
 set /p REAL_TOOLCHAIN_VERSION=<"%DBT_TOOLCHAIN_VERSION_FILE%"
@@ -37,6 +41,7 @@ if not "%REAL_TOOLCHAIN_VERSION%" == "%DBT_TOOLCHAIN_VERSION%" (
     echo DBT: starting toolchain upgrade process..
     powershell -ExecutionPolicy Bypass -File "%DBT_ROOT%\scripts\toolchain\windows-toolchain-download.ps1" %DBT_TOOLCHAIN_VERSION% "%DBT_TOOLCHAIN_ROOT%"
     set /p REAL_TOOLCHAIN_VERSION=<"%DBT_TOOLCHAIN_VERSION_FILE%"
+    set "DBT_TOOLCHAIN_INSTALLED=1"
 )
 
 if defined DBT_VERBOSE (
@@ -50,6 +55,25 @@ set "PYTHONPATH=%DBT_ROOT%\scripts;%PYTHONPATH%"
 set "PYTHONNOUSERSITE=1"
 set "PATH=%DBT_TOOLCHAIN_ROOT%\python;%DBT_TOOLCHAIN_ROOT%\python\Scripts;%DBT_TOOLCHAIN_ROOT%\arm-none-eabi-gcc\bin;%DBT_TOOLCHAIN_ROOT%\openocd\bin;%DBT_TOOLCHAIN_ROOT%\cmake\bin;%DBT_TOOLCHAIN_ROOT%\ninja-build\bin;%PATH%"
 set "PROMPT=(dbt) %PROMPT%"
+
+if "%DBT_TOOLCHAIN_INSTALLED%" == "1" (
+    if [%DBT_NO_PYTHON_UPGRADE%] == [] (
+        echo DBT: Toolchain freshly installed, running python setup
+        set "PIP_CMD=python -m pip"
+        set "PIP_REQUIREMENTS_PATH=%SCRIPT_PATH%\scripts\toolchain\requirements.txt"
+        python -c "import wheel"
+        if %ERRORLEVEL% NEQ 0 (
+            set "PIP_WHEEL_PATH=%DBT_TOOLCHAIN_ROOT%\python\wheel"
+            for /R %PIP_WHEEL_PATH% %%G in (
+                certifi*.whl
+            ) do (
+                %PIP_CMD% install -q "%%G"
+            )
+        )
+        %PIP_CMD% install -q --upgrade pip | find /V "already satisfied"
+        %PIP_CMD% install -q -f "%PIP_WHEEL_PATH%" -r "%PIP_REQUIREMENTS_PATH%" | find /V "already satisfied"
+    )
+)
 
 :already_set
 


### PR DESCRIPTION
This has significant performance benefits to DBT startup time (>1 second to <45ms) which is especially helpful when using DBT as a proxy for `clang-format` in an editor's autoformat configuration.