### PR TITLE
menus: add missing override for reverb sidechain compressor OLED rending

### DIFF
--- a/src/deluge/gui/menu_item/reverb/compressor/volume.h
+++ b/src/deluge/gui/menu_item/reverb/compressor/volume.h
@@ -41,6 +41,18 @@ public:
 			Integer::drawValue();
 		}
 	}
+
+	void drawPixelsForOled() override {
+		if (this->getValue() < 0) {
+			deluge::hid::display::OLED::drawStringCentred(l10n::get(l10n::String::STRING_FOR_AUTO),
+			                                              18 + OLED_MAIN_TOPMOST_PIXEL,
+			                                              deluge::hid::display::OLED::oledMainImage[0],
+			                                              OLED_MAIN_WIDTH_PIXELS, kTextHugeSpacingX, kTextHugeSizeY);
+		}
+		else {
+			Integer::drawPixelsForOled();
+		}
+	}
 };
 
 } // namespace deluge::gui::menu_item::reverb::compressor


### PR DESCRIPTION
Fixes #986