### PR TITLE
Bugfix - use single note value if one exists for mono MPE conversion

### DIFF
--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -964,7 +964,7 @@ void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t whichExpressionDi
 		}
 
 		// If there in fact are multiple notes sharing the channel, to combine...
-		if (numNotesFound > 1) {
+		if (numNotesFound >= 1) {
 			int32_t averageValue16;
 			if (whichExpressionDimension == 0) {
 				averageValue16 = mpeValuesSum / numNotesFound;


### PR DESCRIPTION
Stops a bug where releasing one note while exactly one other note was held would reset x/y/z to zero