### PR TITLE
[DRAFT] MIDI follow should prefer clip armed for linear recording

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -108,6 +108,18 @@ Clip* getSelectedClip(bool useActiveClip) {
 	//if you're in session view, check if you're pressing a clip to control that clip
 	if (rootUI == &sessionView) {
 		clip = sessionView.getClipForLayout();
+
+		// If not pressing a clip, find the first clip armed for linear recording (if one exists)
+		if (clip == nullptr) {
+			// Is this even remotely correct? (parts nabbed from Session::doLaunch)
+			for (int32_t c = currentSong->sessionClips.getNumElements() - 1; c >= 0; c--) {
+				clip = currentSong->sessionClips.getClipAtIndex(c);
+				if (clip->armState == ArmState::ON_NORMAL && !currentSong->isClipActive(clip)
+				    && clip->getCurrentlyRecordingLinearly()) {
+					break;
+				}
+			}
+		}
 	}
 	//if you're in arranger view, check if you're pressing a clip or holding audition pad to control that clip
 	else if (rootUI == &arrangerView) {


### PR DESCRIPTION
Preamble: It's my understanding that "linear recording" is the name for an empty clip which is being recorded into such that its length is automatically extended, and "arming" is the mode a clip is in when it's flashing, before it has started playing. If these are not the right names, or there are better names, LMK!

I was running into a problem with MIDI follow, whereby I'd create a clip and linear record into it, and then create a second clip and linear record into it... but when I went to record into the second clip, I would play on the downbeat _slightly_ early and it would play into the first clip. This was actually happening a lot. Oops!

I propose that, for the purpose of MIDI follow, when in session view and not holding a clip, as soon as a clip is armed for linear recording, that clip should be returned by `getSelectedClip()`, instead of having to wait for arming to complete for that clip to become selected.

I'm operating under the assumption that, once someone creates a new clip and arms it for linear recording, they're basically done recording into the previous clip or playing the previous clip's instrument, and would like to move on to the newly created clip.

However, I'm just not sure I've written this in the best way. It seems to work here, but I have a very limited understanding of the internals, and want to get this right. Thoughts?

Notes
* Multiple clips can simultaneously be armed for linear recording. MIDI follow works with one clip at a time. In this case, we assume that the user knows this, and is only recording into one clip at a time.