### PR TITLE
view: fix stutter param detection

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1052,7 +1052,8 @@ bool View::isParamPitch(Param::Kind kind, int32_t paramID) {
 }
 
 bool View::isParamStutter(Param::Kind kind, int32_t paramID) {
-	if (kind == Param::Kind::UNPATCHED_SOUND && paramID == Param::Unpatched::STUTTER_RATE) {
+	if ((kind == Param::Kind::UNPATCHED_GLOBAL || kind == Param::Kind::UNPATCHED_SOUND)
+	    && paramID == Param::Unpatched::STUTTER_RATE) {
 		return true;
 	}
 	return false;


### PR DESCRIPTION
Stutter can be UNPATCHED_GLOBAL in the context of the song, which broke detection of quantized stutter on the song/arranger.