### PR TITLE
Bugfix / update global param kind definitions in performance view / midi follow / automation view

### DIFF
--- a/src/deluge/gui/views/automation_clip_view.cpp
+++ b/src/deluge/gui/views/automation_clip_view.cpp
@@ -168,7 +168,7 @@ const std::array<std::pair<Param::Kind, ParamType>, kNumNonGlobalParamsForAutoma
     {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::STUTTER_RATE},      //Stutter Rate
 }};
 
-//kit affect entire FX - sorted in the order that Parameters are scrolled through on the display
+//audio clip / kit affect entire FX - sorted in the order that Parameters are scrolled through on the display
 const std::array<std::pair<Param::Kind, ParamType>, kNumGlobalParamsForAutomation> globalParamsForAutomation{{
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::VOLUME}, //Master Volume, Pitch, Pan
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::PITCH_ADJUST},
@@ -177,22 +177,22 @@ const std::array<std::pair<Param::Kind, ParamType>, kNumGlobalParamsForAutomatio
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::LPF_RES},
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::HPF_FREQ}, //HPF Cutoff, Resonance
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::HPF_RES},
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BASS}, //Bass, Bass Freq
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BASS_FREQ},
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::TREBLE}, //Treble, Treble Freq
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::TREBLE_FREQ},
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::BASS}, //Bass, Bass Freq
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::BASS_FREQ},
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::TREBLE}, //Treble, Treble Freq
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::TREBLE_FREQ},
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::REVERB_SEND_AMOUNT}, //Reverb Amount
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::DELAY_RATE},         //Delay Rate, Amount
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::DELAY_AMOUNT},
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::SIDECHAIN_VOLUME}, //Sidechain Send, Shape
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::COMPRESSOR_SHAPE},
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::SAMPLE_RATE_REDUCTION}, //Decimation, Bitcrush
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::BITCRUSHING},
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::MOD_FX_OFFSET}, //Mod FX Offset, Feedback, Depth, Rate
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::MOD_FX_FEEDBACK},
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::COMPRESSOR_SHAPE},
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::SAMPLE_RATE_REDUCTION}, //Decimation, Bitcrush
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::BITCRUSHING},
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::MOD_FX_OFFSET}, //Mod FX Offset, Feedback, Depth, Rate
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::MOD_FX_FEEDBACK},
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::MOD_FX_DEPTH},
     {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::GlobalEffectable::MOD_FX_RATE},
-    {Param::Kind::UNPATCHED_SOUND, Param::Unpatched::STUTTER_RATE}, //Stutter Rate
+    {Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::STUTTER_RATE}, //Stutter Rate
 }};
 
 //grid sized array to assign midi cc values to each pad on the grid
@@ -2683,6 +2683,8 @@ void AutomationClipView::getLastSelectedParamShortcut(Clip* clip, OutputType out
 				    || (clip->lastSelectedParamKind == Param::Kind::UNPATCHED_SOUND
 				        && unpatchedNonGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)
 				    || (clip->lastSelectedParamKind == Param::Kind::UNPATCHED_GLOBAL
+				        && unpatchedNonGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)
+				    || (clip->lastSelectedParamKind == Param::Kind::UNPATCHED_GLOBAL
 				        && unpatchedGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)) {
 					clip->lastSelectedParamShortcutX = x;
 					clip->lastSelectedParamShortcutY = y;
@@ -3118,7 +3120,7 @@ void AutomationClipView::handleSinglePadPress(ModelStackWithTimelineCounter* mod
 
 			//if you are in a kit instrumentClip with affect entire enabled and the shortcut is valid, set current selected ParamID
 			if (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
-				clip->lastSelectedParamKind = Param::Kind::UNPATCHED_SOUND;
+				clip->lastSelectedParamKind = Param::Kind::UNPATCHED_GLOBAL;
 				clip->lastSelectedParamID = unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay];
 			}
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -106,18 +106,18 @@ const ParamsForPerformance songParamsForPerformance[kNumParamsForPerformance] = 
     {ParamsForPerformance(UNPATCHED_GLOBAL, LPF_RES, 8, 6, rowColourRed, rowTailColourRed)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, HPF_FREQ, 9, 7, rowColourPastelOrange, rowTailColourPastelOrange)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, HPF_RES, 9, 6, rowColourPastelOrange, rowTailColourPastelOrange)},
-    {ParamsForPerformance(UNPATCHED_SOUND, BASS, 10, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
-    {ParamsForPerformance(UNPATCHED_SOUND, TREBLE, 11, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, BASS, 10, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, TREBLE, 11, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, REVERB_SEND_AMOUNT, 13, 3, rowColourPastelGreen, rowTailColourPastelGreen)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, DELAY_AMOUNT, 14, 3, rowColourPastelBlue, rowTailColourPastelBlue)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, DELAY_RATE, 14, 0, rowColourPastelBlue, rowTailColourPastelBlue)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_RATE, 12, 7, rowColourPastelPink, rowTailColourPastelPink)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_DEPTH, 12, 6, rowColourPastelPink, rowTailColourPastelPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, MOD_FX_FEEDBACK, 12, 5, rowColourPastelPink, rowTailColourPastelPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, MOD_FX_OFFSET, 12, 4, rowColourPastelPink, rowTailColourPastelPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, SAMPLE_RATE_REDUCTION, 6, 5, rowColourPink, rowTailColourPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, BITCRUSHING, 6, 6, rowColourPink, rowTailColourPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, STUTTER_RATE, 5, 7, rowColourBlue, rowTailColourBlue)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_FEEDBACK, 12, 5, rowColourPastelPink, rowTailColourPastelPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_OFFSET, 12, 4, rowColourPastelPink, rowTailColourPastelPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, SAMPLE_RATE_REDUCTION, 6, 5, rowColourPink, rowTailColourPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, BITCRUSHING, 6, 6, rowColourPink, rowTailColourPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, STUTTER_RATE, 5, 7, rowColourBlue, rowTailColourBlue)},
 };
 
 const ParamsForPerformance defaultLayoutForPerformance[kDisplayWidth] = {
@@ -125,18 +125,18 @@ const ParamsForPerformance defaultLayoutForPerformance[kDisplayWidth] = {
     {ParamsForPerformance(UNPATCHED_GLOBAL, LPF_RES, 8, 6, rowColourRed, rowTailColourRed)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, HPF_FREQ, 9, 7, rowColourPastelOrange, rowTailColourPastelOrange)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, HPF_RES, 9, 6, rowColourPastelOrange, rowTailColourPastelOrange)},
-    {ParamsForPerformance(UNPATCHED_SOUND, BASS, 10, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
-    {ParamsForPerformance(UNPATCHED_SOUND, TREBLE, 11, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, BASS, 10, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, TREBLE, 11, 6, rowColourPastelYellow, rowTailColourPastelYellow)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, REVERB_SEND_AMOUNT, 13, 3, rowColourPastelGreen, rowTailColourPastelGreen)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, DELAY_AMOUNT, 14, 3, rowColourPastelBlue, rowTailColourPastelBlue)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, DELAY_RATE, 14, 0, rowColourPastelBlue, rowTailColourPastelBlue)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_RATE, 12, 7, rowColourPastelPink, rowTailColourPastelPink)},
     {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_DEPTH, 12, 6, rowColourPastelPink, rowTailColourPastelPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, MOD_FX_FEEDBACK, 12, 5, rowColourPastelPink, rowTailColourPastelPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, MOD_FX_OFFSET, 12, 4, rowColourPastelPink, rowTailColourPastelPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, SAMPLE_RATE_REDUCTION, 6, 5, rowColourPink, rowTailColourPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, BITCRUSHING, 6, 6, rowColourPink, rowTailColourPink)},
-    {ParamsForPerformance(UNPATCHED_SOUND, STUTTER_RATE, 5, 7, rowColourBlue, rowTailColourBlue)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_FEEDBACK, 12, 5, rowColourPastelPink, rowTailColourPastelPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, MOD_FX_OFFSET, 12, 4, rowColourPastelPink, rowTailColourPastelPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, SAMPLE_RATE_REDUCTION, 6, 5, rowColourPink, rowTailColourPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, BITCRUSHING, 6, 6, rowColourPink, rowTailColourPink)},
+    {ParamsForPerformance(UNPATCHED_GLOBAL, STUTTER_RATE, 5, 7, rowColourBlue, rowTailColourBlue)},
 };
 
 //mapping shortcuts to paramKind
@@ -146,14 +146,14 @@ const Param::Kind paramKindShortcutsForPerformanceView[kDisplayWidth][kDisplayHe
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
-    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_SOUND},
-    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_SOUND, UNPATCHED_SOUND, Kind::NONE},
+    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL},
+    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, UNPATCHED_GLOBAL, Kind::NONE},
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, UNPATCHED_GLOBAL},
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, UNPATCHED_GLOBAL},
-    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_SOUND, Kind::NONE},
-    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_SOUND, Kind::NONE},
-    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_SOUND, UNPATCHED_SOUND, UNPATCHED_GLOBAL,
+    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, Kind::NONE},
+    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, Kind::NONE},
+    {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, UNPATCHED_GLOBAL, UNPATCHED_GLOBAL,
      UNPATCHED_GLOBAL},
     {Kind::NONE, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
     {UNPATCHED_GLOBAL, Kind::NONE, Kind::NONE, UNPATCHED_GLOBAL, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
@@ -1164,7 +1164,7 @@ void PerformanceSessionView::resetFXColumn(ModelStackWithThreeMainThings* modelS
 /// check if stutter is active and release it if it is
 void PerformanceSessionView::releaseStutter(ModelStackWithThreeMainThings* modelStack) {
 	if (isUIModeActive(UI_MODE_STUTTERING)) {
-		padReleaseAction(modelStack, Param::Kind::UNPATCHED_SOUND, Param::Unpatched::STUTTER_RATE,
+		padReleaseAction(modelStack, Param::Kind::UNPATCHED_GLOBAL, Param::Unpatched::STUTTER_RATE,
 		                 lastPadPress.xDisplay, false);
 	}
 }
@@ -1186,7 +1186,7 @@ bool PerformanceSessionView::setParameterValue(ModelStackWithThreeMainThings* mo
 
 			//if switching to a new pad in the stutter column and stuttering is already active
 			//e.g. it means a pad was held before, end previous stutter before starting stutter again
-			if ((paramKind == Param::Kind::UNPATCHED_SOUND) && (paramID == Param::Unpatched::STUTTER_RATE)
+			if ((paramKind == Param::Kind::UNPATCHED_GLOBAL) && (paramID == Param::Unpatched::STUTTER_RATE)
 			    && (isUIModeActive(UI_MODE_STUTTERING))) {
 				((ModControllableAudio*)view.activeModControllableModelStack.modControllable)
 				    ->endStutter((ParamManagerForTimeline*)view.activeModControllableModelStack.paramManager);
@@ -1205,7 +1205,7 @@ bool PerformanceSessionView::setParameterValue(ModelStackWithThreeMainThings* mo
 			modelStackWithParam->autoParam->setValuePossiblyForRegion(newParameterValue, modelStackWithParam,
 			                                                          view.modPos, view.modLength);
 
-			if (!defaultEditingMode && (paramKind == Param::Kind::UNPATCHED_SOUND)
+			if (!defaultEditingMode && (paramKind == Param::Kind::UNPATCHED_GLOBAL)
 			    && (paramID == Param::Unpatched::STUTTER_RATE) && (fxPress[xDisplay].previousKnobPosition != knobPos)) {
 				((ModControllableAudio*)view.activeModControllableModelStack.modControllable)
 				    ->beginStutter((ParamManagerForTimeline*)view.activeModControllableModelStack.paramManager);
@@ -1562,10 +1562,6 @@ void PerformanceSessionView::writeDefaultFXParamToFile(int32_t xDisplay) {
 	if (layoutForPerformance[xDisplay].paramKind == Param::Kind::UNPATCHED_GLOBAL) {
 		paramName = GlobalEffectable::paramToString(Param::Unpatched::START + layoutForPerformance[xDisplay].paramID);
 	}
-	else if (layoutForPerformance[xDisplay].paramKind == Param::Kind::UNPATCHED_SOUND) {
-		paramName =
-		    ModControllableAudio::paramToString(Param::Unpatched::START + layoutForPerformance[xDisplay].paramID);
-	}
 	else {
 		paramName = PERFORM_DEFAULTS_NO_PARAM;
 	}
@@ -1761,10 +1757,6 @@ void PerformanceSessionView::readDefaultFXParamFromFile(int32_t xDisplay) {
 	for (int32_t i = 0; i < kNumParamsForPerformance; i++) {
 		if (songParamsForPerformance[i].paramKind == Param::Kind::UNPATCHED_GLOBAL) {
 			paramName = GlobalEffectable::paramToString(Param::Unpatched::START + songParamsForPerformance[i].paramID);
-		}
-		else if (songParamsForPerformance[i].paramKind == Param::Kind::UNPATCHED_SOUND) {
-			paramName =
-			    ModControllableAudio::paramToString(Param::Unpatched::START + songParamsForPerformance[i].paramID);
 		}
 		if (!strcmp(tagName, paramName)) {
 			memcpy(&layoutForPerformance[xDisplay], &songParamsForPerformance[i], sizeParamsForPerformance);

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -255,7 +255,7 @@ MidiFollow::getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* mode
 			//don't allow control of Portamento or Arp Gate in Kit Affect Entire
 			if ((unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != Param::Unpatched::Sound::PORTAMENTO)
 			    && (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != Param::Unpatched::Sound::ARP_GATE)) {
-				paramKind = Param::Kind::UNPATCHED_SOUND;
+				paramKind = Param::Kind::UNPATCHED_GLOBAL;
 				paramID = unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay];
 			}
 		}
@@ -280,7 +280,7 @@ MidiFollow::getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* mo
 	int32_t paramID = kNoParamID;
 
 	if (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
-		paramKind = Param::Kind::UNPATCHED_SOUND;
+		paramKind = Param::Kind::UNPATCHED_GLOBAL;
 		paramID = unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay];
 	}
 	else if (unpatchedGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
@@ -336,7 +336,7 @@ int32_t MidiFollow::getCCFromParam(Param::Kind paramKind, int32_t paramID) {
 		for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 			bool foundParamShortcut =
 			    (((paramKind == Param::Kind::PATCHED) && (patchedParamShortcuts[xDisplay][yDisplay] == paramID))
-			     || ((paramKind == Param::Kind::UNPATCHED_SOUND)
+			     || (((paramKind == Param::Kind::UNPATCHED_SOUND) || (paramKind == Param::Kind::UNPATCHED_GLOBAL))
 			         && (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] == paramID))
 			     || ((paramKind == Param::Kind::UNPATCHED_GLOBAL)
 			         && (unpatchedGlobalParamShortcuts[xDisplay][yDisplay] == paramID)));


### PR DESCRIPTION
I discovered that I was not properly assigning the right param kind in global param contexts (song, arranger, audio clips, kit affect entire).

I also noticed that midi follow feedback for global effectible param's mod fx depth and mod fx rate were incorrectly getting sent for the CC mapped to arp gate and portamento because those params share the same ID.

I fixed all these things by assigning the right param kind's and excluding arp gate and portamento from the global param context logic.