### PR TITLE
Change preset for whole instrument track

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -462,19 +462,19 @@ void LoadInstrumentPresetUI::revertToInitialPreset() {
 	}
 
 	Availability availabilityRequirement;
-	bool oldInstrumentCanBeReplaced;
+	bool oldInstrumentShouldBeReplaced;
 	if (instrumentClipToLoadFor) {
-		oldInstrumentCanBeReplaced =
-		    currentSong->canOldOutputBeReplaced(instrumentClipToLoadFor, &availabilityRequirement);
+		oldInstrumentShouldBeReplaced =
+		    currentSong->shouldOldOutputBeReplaced(instrumentClipToLoadFor, &availabilityRequirement);
 	}
 
 	else {
-		oldInstrumentCanBeReplaced = true;
+		oldInstrumentShouldBeReplaced = true;
 		availabilityRequirement = Availability::INSTRUMENT_UNUSED;
 	}
 
 	// If we're looking to replace the whole Instrument, but we're not allowed, that's obviously a no-go
-	if (replacedWholeInstrument && !oldInstrumentCanBeReplaced) {
+	if (replacedWholeInstrument && !oldInstrumentShouldBeReplaced) {
 		return;
 	}
 
@@ -805,14 +805,14 @@ int32_t LoadInstrumentPresetUI::performLoad(bool doClone) {
 
 	// Work out availabilityRequirement. This can't change as presets are navigated through... I don't think?
 	Availability availabilityRequirement;
-	bool oldInstrumentCanBeReplaced;
+	bool oldInstrumentShouldBeReplaced;
 	if (instrumentClipToLoadFor) {
-		oldInstrumentCanBeReplaced =
-		    currentSong->canOldOutputBeReplaced(instrumentClipToLoadFor, &availabilityRequirement);
+		oldInstrumentShouldBeReplaced =
+		    currentSong->shouldOldOutputBeReplaced(instrumentClipToLoadFor, &availabilityRequirement);
 	}
 
 	else {
-		oldInstrumentCanBeReplaced = true;
+		oldInstrumentShouldBeReplaced = true;
 		availabilityRequirement = Availability::INSTRUMENT_UNUSED;
 	}
 
@@ -843,7 +843,9 @@ giveUsedError:
 		}
 
 		// Ok, we can have it!
-		shouldReplaceWholeInstrument = (oldInstrumentCanBeReplaced && newInstrumentWasHibernating);
+		//this can only happen when changing a clip that is the only instance of its instrument to another instrument
+		//that has an inactive clip already
+		shouldReplaceWholeInstrument = (oldInstrumentShouldBeReplaced && newInstrumentWasHibernating);
 		needToAddInstrumentToSong = newInstrumentWasHibernating;
 	}
 
@@ -869,7 +871,7 @@ giveUsedError:
 			return error;
 		}
 
-		shouldReplaceWholeInstrument = oldInstrumentCanBeReplaced;
+		shouldReplaceWholeInstrument = oldInstrumentShouldBeReplaced;
 		needToAddInstrumentToSong = true;
 		loadedFromFile = true;
 

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -1417,6 +1417,7 @@ notFound:	if (offset < 0) {
 		}
 	}
 */
+	int32_t wrapped = 0;
 	if (false) {
 moveAgain:
 		// Move along list
@@ -1429,6 +1430,7 @@ moveAgain:
 			goto readAgain;
 		}
 		else { // Wrap to end
+			wrapped += 1;
 			if (numFileItemsDeletedAtEnd) {
 searchFromOneEnd:
 				oldNameString.clear();
@@ -1447,6 +1449,7 @@ searchFromOneEnd:
 			goto readAgain;
 		}
 		else { // Wrap to start
+			wrapped += 1;
 			if (numFileItemsDeletedAtStart) {
 				goto searchFromOneEnd;
 			}
@@ -1460,7 +1463,8 @@ doneMoving:
 	toReturn.fileItem = (FileItem*)fileItems.getElementAddress(i);
 
 	bool isAlreadyInSong = toReturn.fileItem->instrument && toReturn.fileItem->instrumentAlreadyInSong;
-	if (availabilityRequirement == Availability::INSTRUMENT_UNUSED && isAlreadyInSong) {
+	//wrapped is here to prevent an infinite loop
+	if (availabilityRequirement == Availability::INSTRUMENT_UNUSED && isAlreadyInSong && wrapped < 2) {
 		goto moveAgain;
 	}
 
@@ -1500,7 +1504,7 @@ doPendingPresetNavigation:
 	}
 
 	// Unlike in ClipMinder, there's no need to check whether we came back to the same Instrument, cos we've specified that we were looking for "unused" ones only
-
+	// TODO: This isn't true, it's an argument so that must have changed at some point. This logic will create a clone if anything other than unused is passed in
 	if (!toReturn.fileItem->instrument) {
 		toReturn.error =
 		    storageManager.loadInstrumentFromFile(currentSong, NULL, outputType, false, &toReturn.fileItem->instrument,

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1693,7 +1693,7 @@ void View::navigateThroughAudioOutputsForAudioClip(int32_t offset, AudioClip* cl
 
 	// Work out availabilityRequirement. But we don't in this case need to think about whether the Output can be "replaced" - that's for InstrumentClips
 	Availability availabilityRequirement;
-	currentSong->canOldOutputBeReplaced(clip, &availabilityRequirement);
+	currentSong->shouldOldOutputBeReplaced(clip, &availabilityRequirement);
 
 	if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CLIP_HAS_INSTANCES_IN_ARRANGER));
@@ -1743,7 +1743,7 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 
 	// Work out availabilityRequirement. This can't change as presets are navigated through... I don't think?
 	Availability availabilityRequirement;
-	bool oldInstrumentCanBeReplaced = modelStack->song->canOldOutputBeReplaced(clip, &availabilityRequirement);
+	bool oldInstrumentCanBeReplaced = modelStack->song->shouldOldOutputBeReplaced(clip, &availabilityRequirement);
 
 	bool shouldReplaceWholeInstrument;
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2999,7 +2999,7 @@ void InstrumentClip::prepNoteRowsForExitingKitMode(Song* song) {
 				chosenNoteRowIndex = i;
 				break;
 			}
-noteRowFailed: {}
+noteRowFailed : {}
 		}
 	}
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2999,7 +2999,7 @@ void InstrumentClip::prepNoteRowsForExitingKitMode(Song* song) {
 				chosenNoteRowIndex = i;
 				break;
 			}
-noteRowFailed : {}
+noteRowFailed: {}
 		}
 	}
 
@@ -3539,7 +3539,7 @@ Instrument* InstrumentClip::changeOutputType(ModelStackWithTimelineCounter* mode
 	actionLogger.deleteAllLogs(); // Can't undo past this!
 
 	Availability availabilityRequirement;
-	bool canReplaceWholeInstrument = modelStack->song->canOldOutputBeReplaced(this, &availabilityRequirement);
+	bool canReplaceWholeInstrument = modelStack->song->shouldOldOutputBeReplaced(this, &availabilityRequirement);
 
 	bool shouldReplaceWholeInstrument;
 

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -165,7 +165,7 @@ void InstrumentClipMinder::createNewInstrument(OutputType newOutputType) {
 
 	OutputType oldOutputType = getCurrentOutputType();
 
-	bool shouldReplaceWholeInstrument = currentSong->canOldOutputBeReplaced(getCurrentInstrumentClip());
+	bool shouldReplaceWholeInstrument = currentSong->shouldOldOutputBeReplaced(getCurrentInstrumentClip());
 
 	String newName;
 	char const* thingName = (newOutputType == OutputType::SYNTH) ? "SYNT" : "KIT";

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2731,7 +2731,7 @@ int32_t Song::getCurrentPresetScale() {
 		// If we're here, must be this one!
 		return p;
 
-notThisOne : {}
+notThisOne: {}
 	}
 
 	return 255;
@@ -4365,10 +4365,13 @@ void Song::setParamsInAutomationMode(bool newState) {
 	view.notifyParamAutomationOccurred(&paramManager, true);
 }
 
-bool Song::canOldOutputBeReplaced(Clip* clip, Availability* availabilityRequirement) {
+// returns true if the whole instrument should be replaced, and not just the instrument for the given clip
+// returns false iff in clip view for a clip that does not have an instance in arranger
+// availability will be unused in session or arranger view, available in session for active clips in clip view, and any for inactive clips
+bool Song::shouldOldOutputBeReplaced(Clip* clip, Availability* availabilityRequirement) {
 	// If Clip has an "instance" within its Output in arranger, then we can only change the entire Output to a different Output
-	// Same if grid layout is active in session mode since the clips would jump around otherwise
-	if (clip->output->clipHasInstance(clip) || currentSong->sessionLayout == SessionLayoutTypeGrid) {
+	// If in session view, change the whole instrument
+	if (clip->output->clipHasInstance(clip) || getRootUI() != &instrumentClipView) {
 		if (availabilityRequirement) {
 			*availabilityRequirement = Availability::INSTRUMENT_UNUSED;
 		}
@@ -4619,7 +4622,7 @@ Instrument* Song::changeOutputType(Instrument* oldInstrument, OutputType newOutp
 			return NULL;
 		}
 
-gotAnInstrument : {}
+gotAnInstrument: {}
 	}
 
 	// Synth or Kit

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2731,7 +2731,7 @@ int32_t Song::getCurrentPresetScale() {
 		// If we're here, must be this one!
 		return p;
 
-notThisOne: {}
+notThisOne : {}
 	}
 
 	return 255;
@@ -4366,12 +4366,12 @@ void Song::setParamsInAutomationMode(bool newState) {
 }
 
 // returns true if the whole instrument should be replaced, and not just the instrument for the given clip
-// returns false iff in clip view for a clip that does not have an instance in arranger
+// returns false iff in clip view for a clip that does not have an instance in arranger. Or if called with no clip which could happen from the arranger audition pad
 // availability will be unused in session or arranger view, available in session for active clips in clip view, and any for inactive clips
 bool Song::shouldOldOutputBeReplaced(Clip* clip, Availability* availabilityRequirement) {
 	// If Clip has an "instance" within its Output in arranger, then we can only change the entire Output to a different Output
 	// If in session view, change the whole instrument
-	if (clip->output->clipHasInstance(clip) || getRootUI() != &instrumentClipView) {
+	if (!clip || clip->output->clipHasInstance(clip) || getRootUI() == &sessionView) {
 		if (availabilityRequirement) {
 			*availabilityRequirement = Availability::INSTRUMENT_UNUSED;
 		}
@@ -4622,7 +4622,7 @@ Instrument* Song::changeOutputType(Instrument* oldInstrument, OutputType newOutp
 			return NULL;
 		}
 
-gotAnInstrument: {}
+gotAnInstrument : {}
 	}
 
 	// Synth or Kit

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -296,7 +296,7 @@ public:
 	TimelineCounter* getTimelineCounterToRecordTo();
 	int32_t getLastProcessedPos();
 	void setParamsInAutomationMode(bool newState);
-	bool canOldOutputBeReplaced(Clip* clip, Availability* availabilityRequirement = NULL);
+	bool shouldOldOutputBeReplaced(Clip* clip, Availability* availabilityRequirement = NULL);
 	Output* navigateThroughPresetsForInstrument(Output* output, int32_t offset);
 	void instrumentSwapped(Instrument* newInstrument);
 	Instrument* changeOutputType(Instrument* oldInstrument, OutputType newOutputType);


### PR DESCRIPTION
Changes the name of canOldOutputBeReplaced to shouldOldOutputBeReplaced to better reflect it's function. It's really !canJustClipOutputBeChanged but it's called in a lot of places so inverting the logic would be a larger refactor

Changes the logic of this function to make it consistent between views. Now

- When changing instrument presets from session or arranger view, all clips using that preset will be changed
- When changing instrument presets from within clip view, only that clip will be changed (if possible)

This serves two purposes. For rows mode, it now matches the behaviour with and without your clips existing within the arranger. For grid mode it returns the option to change the preset of a single clip, without changing the entire track 