### PR TITLE
General cleanup while bughunting

### DIFF
--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -63,6 +63,11 @@ int32_t numUIsOpen = 0; // Will be 0 again during song load / swap
 
 UI* lastUIBeforeNullifying = nullptr;
 
+/**
+ * @brief Get the greyout rows and columns for the current UI
+ *
+ * @return std::pair<uint32_t, uint32_t> a pair with [rows, columns]
+ */
 std::pair<uint32_t, uint32_t> getUIGreyoutRowsAndCols() {
 	uint32_t cols = 0;
 	uint32_t rows = 0;

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -24,6 +24,7 @@
 #include "hid/led/pad_leds.h"
 #include "hid/matrix/matrix_driver.h"
 #include "io/debug/print.h"
+#include <utility>
 
 extern "C" {
 #include "RZA1/uart/sio_char.h"
@@ -55,23 +56,23 @@ void UI::close() {
 	closeUI(this);
 }
 
-#define UI_NAVIGATION_HISTORY_LENGTH 16
-UI* uiNavigationHierarchy[UI_NAVIGATION_HISTORY_LENGTH];
+constexpr size_t kUiNavigationHistoryLength = 16;
+static std::array<UI*, kUiNavigationHistoryLength> uiNavigationHierarchy;
 
-int8_t numUIsOpen = 0; // Will be 0 again during song load / swap
+int32_t numUIsOpen = 0; // Will be 0 again during song load / swap
 
-UI* lastUIBeforeNullifying = NULL;
+UI* lastUIBeforeNullifying = nullptr;
 
-void getUIGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
-	*cols = 0;
-	*rows = 0;
-
+std::pair<uint32_t, uint32_t> getUIGreyoutRowsAndCols() {
+	uint32_t cols = 0;
+	uint32_t rows = 0;
 	for (int32_t u = numUIsOpen - 1; u >= 0; u--) {
-		bool useThis = uiNavigationHierarchy[u]->getGreyoutRowsAndCols(cols, rows);
+		bool useThis = uiNavigationHierarchy[u]->getGreyoutRowsAndCols(&cols, &rows);
 		if (useThis) {
-			return;
+			return std::make_pair(rows, cols);
 		}
 	}
+	return std::make_pair(0, 0);
 }
 
 bool changeUIAtLevel(UI* newUI, int32_t level) {

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -159,7 +159,7 @@ void swapOutRootUILowLevel(UI* newUI);
 void nullifyUIs();
 bool rootUIIsTimelineView();
 bool rootUIIsClipMinderScreen();
-void getUIGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+std::pair<uint32_t, uint32_t> getUIGreyoutRowsAndCols();
 
 void uiNeedsRendering(UI* ui, uint32_t whichMainRows = 0xFFFFFFFF, uint32_t whichSideRows = 0xFFFFFFFF);
 void renderingNeededRegardlessOfUI(uint32_t whichMainRows = 0xFFFFFFFF, uint32_t whichSideRows = 0xFFFFFFFF);

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1717,7 +1717,7 @@ void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 		// If going to KeyboardView...
 		if (((InstrumentClip*)clip)->onKeyboardScreen) {
 			keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
-			memset(PadLEDs::occupancyMaskStore[0], 0, kDisplayWidth + kSideBarWidth);
+			memset(PadLEDs::occupancyMaskStore, 0, kDisplayWidth + kSideBarWidth);
 			memset(PadLEDs::occupancyMaskStore[kDisplayHeight], 0, kDisplayWidth + kSideBarWidth);
 		}
 

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -39,50 +39,50 @@ class ModelStackWithNoteRow;
 class ArrangerView final : public TimelineView {
 public:
 	ArrangerView();
-	bool opened();
-	void focusRegained();
+	bool opened() override;
+	void focusRegained() override;
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	void selectEncoderAction(int8_t offset);
-	void modEncoderAction(int32_t whichModEncoder, int32_t offset);
+	void selectEncoderAction(int8_t offset) override;
+	void modEncoderAction(int32_t whichModEncoder, int32_t offset) override;
 
 	void repopulateOutputsOnScreen(bool doRender = true);
 	bool renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
-	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
+	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) override;
 	void drawMuteSquare(int32_t yDisplay, RGB thisImage[]);
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
-	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true);
+	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true) override;
 	bool renderRow(ModelStack* modelStack, int32_t yDisplay, int32_t xScroll, uint32_t xZoom, RGB* thisImage,
 	               uint8_t thisOccupancyMask[], int32_t renderWidth);
 	void editPadAction(int32_t x, int32_t y, bool on);
 	ActionResult horizontalEncoderAction(int32_t offset) override;
-	uint32_t getMaxLength();
-	uint32_t getMaxZoom();
-	void graphicsRoutine();
-	int32_t getNavSysId() { return NAVIGATION_ARRANGEMENT; }
+	uint32_t getMaxLength() override;
+	uint32_t getMaxZoom() override;
+	void graphicsRoutine() override;
+	int32_t getNavSysId() override { return NAVIGATION_ARRANGEMENT; }
 	void navigateThroughPresets(int32_t offset);
 	void notifyActiveClipChangedOnOutput(Output* output);
 	ActionResult timerCallback() override;
 	void reassessWhetherDoingAutoScroll(int32_t pos = -1);
 	void autoScrollOnPlaybackEnd();
 	bool initiateXScroll(int32_t newScrollPos);
-	bool supportsTriplets() { return false; }
+	bool supportsTriplets() override { return false; }
 	bool putDraggedClipInstanceInNewPosition(Output* output);
-	void tellMatrixDriverWhichRowsContainSomethingZoomable();
-	void scrollFinished();
-	void notifyPlaybackBegun();
-	uint32_t getGreyedOutRowsNotRepresentingOutput(Output* output);
-	void playbackEnded();
-	void clipNeedsReRendering(Clip* clip);
+	void tellMatrixDriverWhichRowsContainSomethingZoomable() override;
+	void scrollFinished() override;
+	void notifyPlaybackBegun() override;
+	uint32_t getGreyedOutRowsNotRepresentingOutput(Output* output) override;
+	void playbackEnded() override;
+	void clipNeedsReRendering(Clip* clip) override;
 	void exitSubModeWithoutAction();
 	bool transitionToArrangementEditor();
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) override;
 	void setLedStates();
 	ActionResult verticalScrollOneSquare(int32_t direction);
 	ActionResult horizontalScrollOneSquare(int32_t direction);
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override;
 
 	Output* outputsOnScreen[kDisplayHeight];
 	int8_t yPressedEffective;

--- a/src/deluge/gui/views/clip_navigation_timeline_view.h
+++ b/src/deluge/gui/views/clip_navigation_timeline_view.h
@@ -23,8 +23,8 @@
 class ClipNavigationTimelineView : public TimelineView {
 public:
 	ClipNavigationTimelineView() = default;
-	void focusRegained();
-	ActionResult horizontalEncoderAction(int32_t offset);
+	void focusRegained() override;
+	ActionResult horizontalEncoderAction(int32_t offset) override;
 
 protected:
 	void horizontalScrollForLinearRecording(int32_t newXScroll);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -5228,10 +5228,8 @@ void InstrumentClipView::fillOffScreenImageStores() {
 
 	// Clear sidebar pads from offscreen image stores
 	for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
-		for (int32_t colour = 0; colour < 3; colour++) {
-			PadLEDs::imageStore[0][x][colour] = 0;
-			PadLEDs::imageStore[kDisplayHeight][x][colour] = 0;
-		}
+		PadLEDs::imageStore[0][x] = colours::black;
+		PadLEDs::imageStore[kDisplayHeight][x] = colours::black;
 		PadLEDs::occupancyMaskStore[0][x] = 0;
 		PadLEDs::occupancyMaskStore[kDisplayHeight][x] = 0;
 	}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -1074,7 +1074,7 @@ bool PerformanceSessionView::isPadShortcut(int32_t xDisplay, int32_t yDisplay) {
 void PerformanceSessionView::backupPerformanceLayout() {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		if (successfullyReadDefaultsFromFile) {
-			memcpy(&backupFXPress[xDisplay], &fxPress[xDisplay], sizeFXPress);
+			memcpy(&backupFXPress[xDisplay], &fxPress[xDisplay], sizeof(FXColumnPress));
 		}
 	}
 	performanceLayoutBackedUp = true;
@@ -1563,7 +1563,8 @@ void PerformanceSessionView::writeDefaultFXParamToFile(int32_t xDisplay) {
 	//<param>
 	storageManager.writeTag(PERFORM_DEFAULTS_PARAM_TAG, paramName);
 
-	memcpy(&backupXMLDefaultLayoutForPerformance[xDisplay], &layoutForPerformance[xDisplay], sizeParamsForPerformance);
+	memcpy(&backupXMLDefaultLayoutForPerformance[xDisplay], &layoutForPerformance[xDisplay],
+	       sizeof(ParamsForPerformance));
 }
 
 /// creates "8 - 1 row # tags within a "row" tag"
@@ -1599,7 +1600,7 @@ void PerformanceSessionView::writeDefaultFXHoldStatusToFile(int32_t xDisplay) {
 		storageManager.writeTag(PERFORM_DEFAULTS_HOLD_RESETVALUE_TAG,
 		                        fxPress[xDisplay].previousKnobPosition + kKnobPosOffset);
 
-		memcpy(&backupXMLDefaultFXPress[xDisplay], &fxPress[xDisplay], sizeFXPress);
+		memcpy(&backupXMLDefaultFXPress[xDisplay], &fxPress[xDisplay], sizeof(FXColumnPress));
 	}
 	else {
 		//<status>
@@ -1637,9 +1638,9 @@ void PerformanceSessionView::loadPerformanceViewLayout() {
 void PerformanceSessionView::readDefaultsFromBackedUpFile() {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		memcpy(&layoutForPerformance[xDisplay], &backupXMLDefaultLayoutForPerformance[xDisplay],
-		       sizeParamsForPerformance);
+		       sizeof(ParamsForPerformance));
 
-		memcpy(&fxPress[xDisplay], &backupXMLDefaultFXPress[xDisplay], sizeFXPress);
+		memcpy(&fxPress[xDisplay], &backupXMLDefaultFXPress[xDisplay], sizeof(FXColumnPress));
 
 		for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 			defaultFXValues[xDisplay][yDisplay] = backupXMLDefaultFXValues[xDisplay][yDisplay];
@@ -1688,9 +1689,9 @@ void PerformanceSessionView::readDefaultsFromFile() {
 /// if no XML file exists, load default layout (paramKind, paramID, xDisplay, yDisplay, rowColour, rowTailColour)
 void PerformanceSessionView::loadDefaultLayout() {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
-		memcpy(&layoutForPerformance[xDisplay], &defaultLayoutForPerformance[xDisplay], sizeParamsForPerformance);
+		memcpy(&layoutForPerformance[xDisplay], &defaultLayoutForPerformance[xDisplay], sizeof(ParamsForPerformance));
 		memcpy(&backupXMLDefaultLayoutForPerformance[xDisplay], &defaultLayoutForPerformance[xDisplay],
-		       sizeParamsForPerformance);
+		       sizeof(ParamsForPerformance));
 		for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 			if (params::isParamQuantizedStutter(layoutForPerformance[xDisplay].paramKind,
 			                                    layoutForPerformance[xDisplay].paramID)) {
@@ -1754,10 +1755,10 @@ void PerformanceSessionView::readDefaultFXParamFromFile(int32_t xDisplay) {
 		paramName = params::paramNameForFile(songParamsForPerformance[i].paramKind,
 		                                     params::UNPATCHED_START + songParamsForPerformance[i].paramID);
 		if (!strcmp(tagName, paramName)) {
-			memcpy(&layoutForPerformance[xDisplay], &songParamsForPerformance[i], sizeParamsForPerformance);
+			memcpy(&layoutForPerformance[xDisplay], &songParamsForPerformance[i], sizeof(ParamsForPerformance));
 
 			memcpy(&backupXMLDefaultLayoutForPerformance[xDisplay], &layoutForPerformance[xDisplay],
-			       sizeParamsForPerformance);
+			       sizeof(ParamsForPerformance));
 			break;
 		}
 	}

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -56,53 +56,49 @@ struct ParamsForPerformance {
 	RGB rowTailColour = deluge::gui::colours::black;
 };
 
-const int32_t sizePadPress = sizeof(PadPress);
-const int32_t sizeFXPress = sizeof(FXColumnPress);
-const int32_t sizeParamsForPerformance = sizeof(ParamsForPerformance);
-
 class PerformanceSessionView final : public ClipNavigationTimelineView {
 public:
 	PerformanceSessionView();
-	bool opened();
-	void focusRegained();
+	bool opened() override;
+	void focusRegained() override;
 
-	void graphicsRoutine();
-	ActionResult timerCallback();
+	void graphicsRoutine() override;
+	ActionResult timerCallback() override;
 
 	// rendering
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
-	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true);
+	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true) override;
 	bool renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
-	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
+	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) override;
 	void renderViewDisplay();
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override;
 	// 7SEG only
 	void redrawNumericDisplay();
 	void setLedStates();
 
 	// button action
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 
 	// pad action
-	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
+	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
 
 	// horizontal encoder action
-	ActionResult horizontalEncoderAction(int32_t offset);
+	ActionResult horizontalEncoderAction(int32_t offset) override;
 
 	// vertical encoder action
-	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine);
+	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
 
 	// mod encoder action
-	void modEncoderAction(int32_t whichModEncoder, int32_t offset);
-	void modEncoderButtonAction(uint8_t whichModEncoder, bool on);
-	void modButtonAction(uint8_t whichButton, bool on);
+	void modEncoderAction(int32_t whichModEncoder, int32_t offset) override;
+	void modEncoderButtonAction(uint8_t whichModEncoder, bool on) override;
+	void modButtonAction(uint8_t whichButton, bool on) override;
 
 	// select encoder action
-	void selectEncoderAction(int8_t offset);
+	void selectEncoderAction(int8_t offset) override;
 
 	// not sure why we need these...
-	uint32_t getMaxZoom();
-	uint32_t getMaxLength();
+	uint32_t getMaxZoom() override;
+	uint32_t getMaxLength() override;
 
 	// public so soundEditor can access it
 	void savePerformanceViewLayout();

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -630,9 +630,7 @@ void renderExplodeAnimation(int32_t explodedness, bool shouldSendOut) {
 }
 
 void reassessGreyout(bool doInstantly) {
-	uint32_t newCols, newRows;
-
-	getUIGreyoutRowsAndCols(&newCols, &newRows);
+	auto [newCols, newRows] = getUIGreyoutRowsAndCols();
 
 	// If same as before, get out
 	if (newCols == greyoutCols && newRows == greyoutRows) {

--- a/src/deluge/model/consequence/consequence_performance_view_press.cpp
+++ b/src/deluge/model/consequence/consequence_performance_view_press.cpp
@@ -22,14 +22,14 @@ ConsequencePerformanceViewPress::ConsequencePerformanceViewPress(FXColumnPress f
                                                                  FXColumnPress fxPressAfter[kDisplayWidth],
                                                                  int32_t xDisplay) {
 
-	memcpy(&fxPress[BEFORE], &fxPressBefore[xDisplay], sizeFXPress);
-	memcpy(&fxPress[AFTER], &fxPressAfter[xDisplay], sizeFXPress);
+	memcpy(&fxPress[BEFORE], &fxPressBefore[xDisplay], sizeof(FXColumnPress));
+	memcpy(&fxPress[AFTER], &fxPressAfter[xDisplay], sizeof(FXColumnPress));
 
 	xDisplayChanged = xDisplay;
 }
 
 int32_t ConsequencePerformanceViewPress::revert(TimeType time, ModelStack* modelStack) {
-	memcpy(&performanceSessionView.fxPress[xDisplayChanged], &fxPress[time], sizeFXPress);
+	memcpy(&performanceSessionView.fxPress[xDisplayChanged], &fxPress[time], sizeof(FXColumnPress));
 
 	return NO_ERROR;
 }


### PR DESCRIPTION
Just some little QoL things:
- override in places
- not storing a `sizeof()` result (for compiler optimizations)
- returning a pair using std::pair
- simplified zeroing of sidebar data using the new colours instead of per-channel