### PR TITLE
BugFix / MIDI Follow ~ Fix "BBBB" crash in MIDIFollow.XML load parsing routine

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -773,28 +773,27 @@ void MidiFollow::readDefaultMappingsFromFile() {
 		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 			for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 				//let's see if this x, y corresponds to a valid param shortcut
-				if ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-				    || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-				    || (unpatchedGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)) {
-					//if we have a valid param shortcut, let's confirm the tag name corresponds to that shortcut
-					if ((!strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED,
-					                                               patchedParamShortcuts[xDisplay][yDisplay])))
-					    || (!strcmp(tagName, params::paramNameForFile(
-					                             params::Kind::UNPATCHED_SOUND,
-					                             params::UNPATCHED_START
-					                                 + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay])))
-					    || (!strcmp(tagName, params::paramNameForFile(
-					                             params::Kind::UNPATCHED_GLOBAL,
-					                             params::UNPATCHED_START
-					                                 + unpatchedGlobalParamShortcuts[xDisplay][yDisplay])))) {
-						//tag name matches the param shortcut, so we can load the cc mapping for that param
-						//into the paramToCC grid shortcut array which holds the cc value for each param
-						paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
-						//now that we've handled this tag, we need to break out of these for loops
-						//as you can only read from a tag once (otherwise next read will result in a crash "BBBB")
-						foundParam = true;
-						break;
-					}
+				//if we have a valid param shortcut, let's confirm the tag name corresponds to that shortcut
+				if (((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+				     && !strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED,
+				                                                  patchedParamShortcuts[xDisplay][yDisplay])))
+				    || ((unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+				        && !strcmp(tagName,
+				                   params::paramNameForFile(
+				                       params::Kind::UNPATCHED_SOUND,
+				                       params::UNPATCHED_START + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay])))
+				    || ((unpatchedGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+				        && !strcmp(tagName,
+				                   params::paramNameForFile(
+				                       params::Kind::UNPATCHED_GLOBAL,
+				                       params::UNPATCHED_START + unpatchedGlobalParamShortcuts[xDisplay][yDisplay])))) {
+					//tag name matches the param shortcut, so we can load the cc mapping for that param
+					//into the paramToCC grid shortcut array which holds the cc value for each param
+					paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
+					//now that we've handled this tag, we need to break out of these for loops
+					//as you can only read from a tag once (otherwise next read will result in a crash "BBBB")
+					foundParam = true;
+					break;
 				}
 			}
 			//break out of the first for loop if a param was found in the second for loop above

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -769,40 +769,37 @@ void MidiFollow::readDefaultMappingsFromFile() {
 	char const* tagName;
 	bool foundParam;
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
-		//don't even process this tag if the param name is "none" as you can't find a matching param
-		if (strcmp(tagName, "none")) {
-			foundParam = false;
-			for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
-				for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-					//let's see if this x, y corresponds to a valid param shortcut
-					if ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-					    || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-					    || (unpatchedGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)) {
-						//if we have a valid param shortcut, let's confirm the tag name corresponds to that shortcut
-						if ((!strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED,
-						                                               patchedParamShortcuts[xDisplay][yDisplay])))
-						    || (!strcmp(tagName, params::paramNameForFile(
-						                             params::Kind::UNPATCHED_SOUND,
-						                             params::UNPATCHED_START
-						                                 + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay])))
-						    || (!strcmp(tagName, params::paramNameForFile(
-						                             params::Kind::UNPATCHED_GLOBAL,
-						                             params::UNPATCHED_START
-						                                 + unpatchedGlobalParamShortcuts[xDisplay][yDisplay])))) {
-							//tag name matches the param shortcut, so we can load the cc mapping for that param
-							//into the paramToCC grid shortcut array which holds the cc value for each param
-							paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
-							//now that we've handled this tag, we need to break out of these for loops
-							//as you can only read from a tag once (otherwise next read will result in a crash "BBBB")
-							foundParam = true;
-							break;
-						}
+		foundParam = false;
+		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+			for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+				//let's see if this x, y corresponds to a valid param shortcut
+				if ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+				    || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+				    || (unpatchedGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)) {
+					//if we have a valid param shortcut, let's confirm the tag name corresponds to that shortcut
+					if ((!strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED,
+					                                               patchedParamShortcuts[xDisplay][yDisplay])))
+					    || (!strcmp(tagName, params::paramNameForFile(
+					                             params::Kind::UNPATCHED_SOUND,
+					                             params::UNPATCHED_START
+					                                 + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay])))
+					    || (!strcmp(tagName, params::paramNameForFile(
+					                             params::Kind::UNPATCHED_GLOBAL,
+					                             params::UNPATCHED_START
+					                                 + unpatchedGlobalParamShortcuts[xDisplay][yDisplay])))) {
+						//tag name matches the param shortcut, so we can load the cc mapping for that param
+						//into the paramToCC grid shortcut array which holds the cc value for each param
+						paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
+						//now that we've handled this tag, we need to break out of these for loops
+						//as you can only read from a tag once (otherwise next read will result in a crash "BBBB")
+						foundParam = true;
+						break;
 					}
 				}
-				//break out of the first for loop if a param was found in the second for loop above
-				if (foundParam) {
-					break;
-				}
+			}
+			//break out of the first for loop if a param was found in the second for loop above
+			if (foundParam) {
+				break;
 			}
 		}
 		//exit out of this tag so you can check the next tag

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -766,29 +766,46 @@ void MidiFollow::readDefaultsFromFile() {
 /// compares param name tag to the list of params available are midi controllable
 /// if param is found, it loads the CC mapping info for that param into the view
 void MidiFollow::readDefaultMappingsFromFile() {
-	char const* paramName;
 	char const* tagName;
+	bool foundParam;
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
-		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
-			for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-				if (!strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED,
-				                                              patchedParamShortcuts[xDisplay][yDisplay]))) {
-					paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
+		//don't even process this tag if the param name is "none" as you can't find a matching param
+		if (strcmp(tagName, "none")) {
+			foundParam = false;
+			for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+				for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+					//let's see if this x, y corresponds to a valid param shortcut
+					if ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+					    || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+					    || (unpatchedGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)) {
+						//if we have a valid param shortcut, let's confirm the tag name corresponds to that shortcut
+						if ((!strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED,
+						                                               patchedParamShortcuts[xDisplay][yDisplay])))
+						    || (!strcmp(tagName, params::paramNameForFile(
+						                             params::Kind::UNPATCHED_SOUND,
+						                             params::UNPATCHED_START
+						                                 + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay])))
+						    || (!strcmp(tagName, params::paramNameForFile(
+						                             params::Kind::UNPATCHED_GLOBAL,
+						                             params::UNPATCHED_START
+						                                 + unpatchedGlobalParamShortcuts[xDisplay][yDisplay])))) {
+							//tag name matches the param shortcut, so we can load the cc mapping for that param
+							//into the paramToCC grid shortcut array which holds the cc value for each param
+							paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
+							//now that we've handled this tag, we need to break out of these for loops
+							//as you can only read from a tag once (otherwise next read will result in a crash "BBBB")
+							foundParam = true;
+							break;
+						}
+					}
 				}
-				else if (!strcmp(tagName,
-				                 params::paramNameForFile(
-				                     params::Kind::UNPATCHED_SOUND,
-				                     params::UNPATCHED_START + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay]))) {
-					paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
-				}
-				else if (!strcmp(tagName,
-				                 params::paramNameForFile(params::Kind::UNPATCHED_GLOBAL,
-				                                          params::UNPATCHED_START
-				                                              + unpatchedGlobalParamShortcuts[xDisplay][yDisplay]))) {
-					paramToCC[xDisplay][yDisplay] = storageManager.readTagOrAttributeValueInt();
+				//break out of the first for loop if a param was found in the second for loop above
+				if (foundParam) {
+					break;
 				}
 			}
 		}
+		//exit out of this tag so you can check the next tag
 		storageManager.exitTag();
 	}
 }


### PR DESCRIPTION
This fixes: https://github.com/SynthstromAudible/DelugeFirmware/issues/1032

It was reported that MIDI Follow could cause Deluge to crash with error "BBBB" on load whenever the param "none" was entered as a tag in the MIDIFollow.XML file.

This was a symptom of a bigger problem with the XML parsing function in MIDIFollow.

Basically, you cannot parse a tag more than once. This was happening when "none" was entered as a param because the grid loop would loop through multiple params which would return a param name of "none" which would cause a match with the XML tag and cause a re-read of the value within that XML tag.

the Function "readTagOrAttributeValueInt()" does not allow you to re-read the value within that tag and crashes with "BBBB" on the second read.

To fix this, we do a couple things:

1) we check that the x, y position in the loop actually corresponds to a param

2) a param name corresponds to one grid x, y shortcut. So after you've found that param and the corresponding x, y shortcut and after you've loaded the cc number from the XML tag into the paramToCC array, you are now done with the loop. You should exit both for loops and proceed to processing the next XML tag if there is one.