### PR TITLE
Bugfix / Ensure valid param collection exists

### DIFF
--- a/src/deluge/gui/views/automation_clip_view.cpp
+++ b/src/deluge/gui/views/automation_clip_view.cpp
@@ -2886,11 +2886,14 @@ AutomationClipView::getModelStackWithParamForMIDIClip(ModelStackWithTimelineCoun
 	    modelStack->addOtherTwoThingsButNoNoteRow(output->toModControllable(), &clip->paramManager);
 
 	if (modelStackWithThreeMainThings) {
+		ParamManager* paramManager = modelStackWithThreeMainThings->paramManager;
 
-		MIDIInstrument* midiInstrument = (MIDIInstrument*)output;
+		if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+			MIDIInstrument* midiInstrument = (MIDIInstrument*)output;
 
-		modelStackWithParam =
-		    midiInstrument->getParamToControlFromInputMIDIChannel(paramID, modelStackWithThreeMainThings);
+			modelStackWithParam =
+			    midiInstrument->getParamToControlFromInputMIDIChannel(paramID, modelStackWithThreeMainThings);
+		}
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -224,32 +224,26 @@ void copyModelStack(void* newMemory, void const* oldMemory, int32_t size) {
 
 ModelStackWithAutoParam* ModelStackWithThreeMainThings::getUnpatchedAutoParamFromId(int32_t newParamId) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-	ParamCollectionSummary* summary = nullptr;
+	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+		ParamCollectionSummary* summary = paramManager->getUnpatchedParamSetSummary();
 
-	summary = paramManager->getUnpatchedParamSetSummary();
-
-	if (summary) {
 		ModelStackWithParamId* modelStackWithParamId =
 		    addParamCollectionAndId(summary->paramCollection, summary, newParamId);
-		if (modelStackWithParamId) {
-			modelStackWithParam = summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
-		}
+
+		modelStackWithParam = summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
 	}
 	return modelStackWithParam;
 }
 
 ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchedAutoParamFromId(int32_t newParamId) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-	ParamCollectionSummary* summary = nullptr;
+	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+		ParamCollectionSummary* summary = paramManager->getPatchedParamSetSummary();
 
-	summary = paramManager->getPatchedParamSetSummary();
-
-	if (summary) {
 		ModelStackWithParamId* modelStackWithParamId =
 		    addParamCollectionAndId(summary->paramCollection, summary, newParamId);
-		if (modelStackWithParamId) {
-			modelStackWithParam = summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
-		}
+
+		modelStackWithParam = summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
 	}
 	return modelStackWithParam;
 }


### PR DESCRIPTION
Adjusted code for getting model stack with param to ensure that the param manager contains a param collection