### PR TITLE
Add clangd completion engine to VSCode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
 		"editorconfig.editorconfig",
 		"xaver.clang-format",
 		"marus25.cortex-debug",
-		"webfreak.advanced-local-formatters"
+		"webfreak.advanced-local-formatters",
+		"llvm-vs-code-extensions.vscode-clangd",
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,14 @@
         "initializer_list": "cpp",
         "utility": "cpp"
     },
+    "C_Cpp.intelliSenseEngine": "disabled",
+    "C_Cpp.autocomplete": "disabled",
     "C_Cpp.errorSquiggles": "disabled",
+    "clangd.arguments": [
+        "-pretty",
+        "--background-index",
+        "--query-driver=*arm-none-eabi-*",
+    ],
     "cSpell.words": [
         "SDRAM",
         "Synthstrom"


### PR DESCRIPTION
This also sets clangd as the default engine.