### PR TITLE
Enhancement / Set default reverb mode to mutable, read/write reverb mode from Song XML, set older firmware song's to Freeverb

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1331,6 +1331,11 @@ int32_t Song::readFromFile() {
 
 	uint64_t newTimePerTimerTick = (uint64_t)1 << 32; // TODO: make better!
 
+	// reverb mode
+	if (storageManager.firmwareVersionOfFileBeingRead < FIRMWARE_4P1P4_ALPHA) {
+		AudioEngine::reverb.setModel(deluge::dsp::Reverb::Model::FREEVERB);
+	}
+
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
 		// D_PRINTLN(tagName); delayMS(30);
 		switch (*(uint32_t*)tagName) {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1348,7 +1348,8 @@ int32_t Song::readFromFile() {
 			}
 			while (*(tagName = storageManager.readNextTagOrAttributeName())) {
 				if (!strcmp(tagName, "model")) {
-					deluge::dsp::Reverb::Model model = static_cast<deluge::dsp::Reverb::Model>(storageManager.readTagOrAttributeValueInt());
+					deluge::dsp::Reverb::Model model =
+					    static_cast<deluge::dsp::Reverb::Model>(storageManager.readTagOrAttributeValueInt());
 					if (model == deluge::dsp::Reverb::Model::FREEVERB) {
 						AudioEngine::reverb.setModel(deluge::dsp::Reverb::Model::FREEVERB);
 					}

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -185,6 +185,8 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	reverbCompressorVolume = getParamFromUserValue(params::STATIC_COMPRESSOR_VOLUME, -1);
 	reverbCompressorShape = -601295438;
 	reverbCompressorSync = SYNC_LEVEL_8TH;
+	AudioEngine::reverb.setModel(deluge::dsp::Reverb::Model::MUTABLE);
+
 
 	masterCompressorAttack = 10 << 24;
 	masterCompressorRelease = 20 << 24;


### PR DESCRIPTION
This PR closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1097 and https://github.com/SynthstromAudible/DelugeFirmware/issues/1082

It does so by doing the following:

1. Mutable reverb is now the default for new songs
2. Song's created/saved before the current firmware version (FIRMWARE_4P1P4_ALPHA) will load the "Freeverb" reverb mode
3. New song's saved with the current firmware version (FIRMWARE_4P1P4_ALPHA) or later firmwares will save the current reverb mode to the Song XML file and will read and set that reverb mode when the song is loaded.

