### PR TITLE
Fix sysex loader - Version 2 (final) (Really Final) (FINAL FINAL)

### DIFF
--- a/src/deluge/io/debug/sysex.cpp
+++ b/src/deluge/io/debug/sysex.cpp
@@ -3,16 +3,18 @@
  *
  * This file is part of The Synthstrom Audible Deluge Firmware.
  *
- * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
- * terms of the GNU General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "io/debug/sysex.h"
@@ -69,7 +71,8 @@ void Debug::sysexDebugPrint(MIDIDevice* device, const char* msg, bool nl) {
 	if (!msg) {
 		return; // Do not do that
 	}
-	// data[4]: reserved, could serve as a message identifier to filter messages per category
+	// data[4]: reserved, could serve as a message identifier to filter messages
+	// per category
 	uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x03, 0x40, 0x00};
 	uint8_t* reply = midiEngine.sysex_fmt_buffer;
 	memcpy(reply, reply_hdr, 5);
@@ -151,9 +154,8 @@ void Debug::loadPacketReceived(uint8_t* data, int32_t len) {
 		uint32_t pad = (18 * 8 * pos) / load_bufsize;
 		uint8_t col = pad % 18;
 		uint8_t row = pad / 18;
-		PadLEDs::image[row][col][0] = (255 / 7) * row;
-		PadLEDs::image[row][col][1] = 0;
-		PadLEDs::image[row][col][2] = 255 - (255 / 7) * row;
+		PadLEDs::image[row][col] = {static_cast<RGB::channel_type>(255 / 7 * row), 0,
+		                            static_cast<RGB::channel_type>(255 - (255 / 7) * row)};
 		PadLEDs::sendOutMainPadColours();
 		PadLEDs::sendOutSidebarColours();
 	}

--- a/src/deluge/util/chainload.S
+++ b/src/deluge/util/chainload.S
@@ -87,7 +87,7 @@ chainloader_copy_start:
   add       r6, r6, #4
   b         chainloader_copy_start
 chainloader_copy_done:
-  // Reload arguments and jump to the new code
+  // Reload arguments and jump to the second-stage chainloader
   ldr       r0, [sp, #0x00]
   ldr       r1, [sp, #0x04]
   ldr       r2, [sp, #0x08]
@@ -98,6 +98,7 @@ chainloader_copy_done:
   // Ensure instruction alignment
   .align 2
   // Start of the second-stage chainloder
+  // Expects r0, r1, r2, and r3 to be set as described in the arugments
 chainload_code_start:
   // Copy the new image to $r0
   // r4 is scratch storage (the data being copied)
@@ -125,7 +126,6 @@ buffer_copy_done:
   dsb
   isb
   // Jump to the new firmware image
-  ldr       r2, [sp, #0x08]
   bx        r2
 
   // Align to a full instruction so the first-stage chainloader copies enough bytes

--- a/src/deluge/util/chainload.S
+++ b/src/deluge/util/chainload.S
@@ -1,0 +1,134 @@
+/*
+ * Copyright © 2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+// Chainload routine
+//
+// Accepts 5 arguments in registers:
+//  - r0, the code start address
+//  - r1, the code size
+//  - r2, the code execution start address
+//  - r3, the buffer containing the new firmware
+//  - r4, the location we should copy the second-stage chainloader in memory
+//
+// Because the ARMv7 ABI is annoying and I prototyped this with more C code
+// involved, `deluge_chainload` can't be called as a regular C function and
+// must instead be called via inline assembly. See `chainload.cpp` for how this
+// is done.
+//
+// This is a 2-stage chainloader, which first copies its second stage to RAM
+// and then copies the new firmware image over the old. The second stage code
+// is implicitly position-independent because all jumps (except `bx/blx` to
+// registers) in armv7a are relative.
+//
+// All of this work needs to be done with the MMU and caches disabled because
+// the RZ/A1L cache is extremely broken, and doesn't respect most of the cache
+// maintenance operations. This includes CP15 MCRs, the usual DMB/IMB
+// instructions, and the ARM-recommended L1$ flush logic.
+//
+// It's possible all of this actually works and it's the L2$ misbehaving -- We
+// haven't tried flushing that cache instead yet. But disabling the MMU is
+// easy, doesn't cost meaningful performance here, and seems to work (mostly)
+// reliably.
+  .align 4
+  .text
+  .arm
+  .func
+  .global deluge_chainload
+deluge_chainload:
+  // Switch to system mode so we can poke MCRs without fear of faults, and so
+  // the new firmware starts in system mode as it expects.
+  cps       #0x1f
+
+  // Disable MMU and caches
+  mrc       p15, 0, r5, c1, c0, 0       /* Read CP15 System Control register */
+  bic       r5, r5, #(0x1 << 12)        /* Clear I bit 12 to disable I Cache */
+  bic       r5, r5, #(0x1 <<  2)        /* Clear C bit  2 to disable D Cache */
+  bic       r5, r5, #0x2   /* Clear A bit 1 to disable alignment fault check */
+  bic       r5, r5, #0x1 /* Set M bit 0 to enable MMU before scatter loading */
+  mcr       p15, 0, r5, c1, c0, 0      /* Write CP15 System Control register */
+
+  // Save arguments
+  sub       sp, #0x20
+  str       r0, [sp, #0x00]
+  str       r1, [sp, #0x04]
+  str       r2, [sp, #0x08]
+  str       r3, [sp, #0x0c]
+  str       r4, [sp, #0x10]
+
+  // Copy the second stage to $r4
+  mov       r5, r4
+  ldr       r6, =chainload_code_start
+  ldr       r7, =chainload_code_end
+  mov       r8,r7
+chainloader_copy_start:
+  cmp       r6, r8
+  bgt       chainloader_copy_done
+  ldr       r7, [r6] @;; # =0xe320f000
+  str       r7, [r5]
+  // From DDI0406C (ARMv7AR ARM), section A3.5.4 -- everything required to flush instructions
+  mcr       p15, 0, r5, c7, c11, 1      @;; DCCMVAU, Flush D$ to point of unification by MVA
+  dmb                                   @;; Make that write visible
+  mcr       p15, 0, r5, c7, c5 , 1      @;; ICIMVAU, Flush I$ to point of unification by MVA
+  mcr       p15, 0, r5, c7, c5 , 7      @;; BPIMVA , Invalidate branch predictor by MVA
+  add       r5, r5, #4
+  add       r6, r6, #4
+  b         chainloader_copy_start
+chainloader_copy_done:
+  // Reload arguments and jump to the new code
+  ldr       r0, [sp, #0x00]
+  ldr       r1, [sp, #0x04]
+  ldr       r2, [sp, #0x08]
+  ldr       r3, [sp, #0x0c]
+  ldr       r4, [sp, #0x10]
+  bx        r4
+
+  // Ensure instruction alignment
+  .align 2
+  // Start of the second-stage chainloder
+chainload_code_start:
+  // Copy the new image to $r0
+  // r4 is scratch storage (the data being copied)
+  // r5 is the copy end address
+  mov       r5, r0
+  add       r5, r5, r1
+buffer_copy:
+  cmp       r0, r5
+  bgt       buffer_copy_done
+  ldr       r4,[r3]
+  str       r4,[r0]
+  // From DDI0406C (ARMv7AR ARM), section A3.5.4 -- everything required to flush instructions
+  mcr       p15, 0, r0, c7, c11, 1     @;; DCCMVAU, Flush D$ to point of unification by MVA
+  dmb                                  @;; Make that write visible
+  mcr       p15, 0, r0, c7, c5 , 1     @;; ICIMVAU, Flush I$ to point of unification by MVA
+  mcr       p15, 0, r0, c7, c5 , 7     @;; BPIMVA , Invalidate branch predictor by MVA
+  add       r3, r3, #4
+  add       r0, r0, #4
+  b         buffer_copy
+buffer_copy_done:
+  // flush L1I$
+  mov       r0, #0
+  mcr       p15, 0, r0, c7, c5, 0      @;; ICIALLU
+  // Issue memory barriers
+  dsb
+  isb
+  // Jump to the new firmware image
+  ldr       r2, [sp, #0x08]
+  bx        r2
+
+  // Align to a full instruction so the first-stage chainloader copies enough bytes
+  .align 2
+chainload_code_end:
+

--- a/src/deluge/util/chainload.cpp
+++ b/src/deluge/util/chainload.cpp
@@ -3,36 +3,27 @@
  *
  * This file is part of The Synthstrom Audible Deluge Firmware.
  *
- * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
- * terms of the GNU General Public License as published by the Free Software Foundation,
- * either version 3 of the License, or (at your option) any later version.
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute
+ * it and/or modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the License,
+ * or (at your option) any later version.
  *
- * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
  *
- * You should have received a copy of the GNU General Public License along with this program.
- * If not, see <https://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
 #include "chainload.h"
+#include "RZA1/intc/devdrv_intc.h"
 #include "RZA1/mtu/mtu.h"
 #include "definitions_cxx.hpp"
+#include <cstddef>
 
-static void chainloader(uint32_t code_start, uint32_t code_size, uint32_t code_exec, char* buf) {
-	int32_t loop_num = (((uint32_t)code_size + 3) / (sizeof(uint32_t)));
-
-	uint32_t* psrc = (uint32_t*)buf;
-	uint32_t* pdst = (uint32_t*)code_start;
-	uint32_t* pdst2 = (uint32_t*)(code_start + UNCACHED_MIRROR_OFFSET);
-
-	for (int32_t i = 0; i < loop_num; i++) {
-		pdst[i] = psrc[i];
-		pdst2[i] = psrc[i];
-	}
-
-	((void (*)(void))code_exec)(); // lessgo
-}
+extern uint32_t spareRenderingBuffer[][SSI_TX_BUFFER_NUM_SAMPLES];
 
 void chainload_from_buf(uint8_t* buffer, int buf_size) {
 	uint32_t user_code_start = *(uint32_t*)(buffer + OFF_USER_CODE_START);
@@ -44,17 +35,27 @@ void chainload_from_buf(uint8_t* buffer, int buf_size) {
 		return;
 	}
 
-	char* funcbuf = (char*)user_code_end; // this should be a nice spot
-	char* from = (char*)chainloader;
-	for (int i = 0; i < 128; i++) {
-		(funcbuf + UNCACHED_MIRROR_OFFSET)[i] = from[i];
-	}
-
+	// Disable interrupts so we don't get interrupted during the chainload
+#if defined(__arm__)
+	asm volatile("CPSID   i");
+#endif
+	// Disable timers
 	disableTimer(TIMER_MIDI_GATE_OUTPUT);
 	disableTimer(TIMER_SYSTEM_SLOW);
 	disableTimer(TIMER_SYSTEM_FAST);
 	disableTimer(TIMER_SYSTEM_SUPERFAST);
+	uint8_t* funcbuf = reinterpret_cast<uint8_t*>(spareRenderingBuffer);
 
-	auto ptr = (void (*)(uint32_t, uint32_t, uint32_t, char*))funcbuf;
-	ptr(user_code_start, code_size, user_code_exec, (char*)buffer);
+#if defined(__arm__)
+	// Jump to the chainloader
+	asm volatile("mov r0,%0\n\t"
+	             "mov r1,%1\n\t"
+	             "mov r2,%2\n\t"
+	             "mov r3,%3\n\t"
+	             "mov r4,%4\n\t"
+	             "blx deluge_chainload"
+	             :
+	             : "r"(user_code_start), "r"(code_size), "r"(user_code_exec), "r"(buffer), "r"(funcbuf)
+	             : "r0", "r1", "r2", "r3", "r4");
+#endif
 }

--- a/src/deluge/util/chainload.h
+++ b/src/deluge/util/chainload.h
@@ -5,4 +5,7 @@
 #define OFF_USER_CODE_EXECUTE 0x28
 #define OFF_USER_SIGNATURE 0x2c
 
+/// Chainload from a buffer.
+///
+/// Currently only implemented for ARM.
 void chainload_from_buf(uint8_t* buffer, int buf_size);

--- a/src/deluge/util/chainload.h
+++ b/src/deluge/util/chainload.h
@@ -7,5 +7,10 @@
 
 /// Chainload from a buffer.
 ///
+/// The buffer is expected to be in the same format as a Deluge firmware .bin. Namely:
+///   - The code start address is located at buffer + OFF_USER_CODE_START
+///   - The code end address (inclusive) is at buffer + OFF_USER_CODE_END
+///   - The entrypoint address is at a buffer + OFF_USER_CODE_EXECUTE
+///
 /// Currently only implemented for ARM.
 void chainload_from_buf(uint8_t* buffer, int buf_size);


### PR DESCRIPTION
Fixes the sysex chainload logic by porting it to assembly and disabling the MMU.