### PR TITLE
Documentation / Update change log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Sound Engine
 
-- Added a version of Émilie Gillet's Mutable Instruments Clouds reverb model. Can be enabled via a new `REVERB MODE` sub-menu under the existing Reverb menu. Note: The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the reverb model used with those songs.
+- Added an adapted version of the reverb found in Émilie Gillet's Mutable Instruments Rings module. Can be enabled via a new `REVERB MODEL` sub-menu under the existing Reverb menu. 
+    - The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the reverb model used with those songs.
 - Fixed some bugs around the waveform Loop Lock feature which allowed setting invalid loop points.
 
 ### User Interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `PERFORMANCE VIEW`, accessible in Song Row View by pressing the Keyboard button and in Song Grid View by pressing the Pink Mode pad. Allows quick control of Song Global FX.
 - Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
 - Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the Automation Overview and with the shortcut combos (e.g. Shift + Shortcut Pad).
+- Added Mod Button popups to display the current Mod (Gold) Encoder context (e.g. LPF/HPF Mode, Delay Mode and Type, Reverb Room Size, Compressor Mode, ModFX Type and Param).
 - Added a menu for song parameters, accessible in Song View and Arranger View by pressing on the Select Encoder.
 - Added a `AFFECT ENTIRE GLOBAL FX MENU` to Kits, accessible in Kit Clip View by pressing on the Select Encoder with Affect Entire enabled.
 - Added support for LUMI Keys SYSEX protocol protocol. When hosting a LUMI Keys keyboard, the current scale will automatically be set on the keyboard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 ### User Interface
 
 - Added `PERFORMANCE VIEW`, accessible in Song View by pressing the Keyboard button. Allows quick control of Song Global FX.
-- Added `AUTOMATION VIEW` for Audio Clips.
+- Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
+- Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the Automation Overview and with the shortcut combos (e.g. Shift + Shortcut Pad).
 - Added a menu for song parameters, accessible in Song View and Arranger View by pressing on the Select Encoder.
 - Added a `AFFECT ENTIRE GLOBAL FX MENU` to Kits, accessible in Kit Clip View by pressing on the Select Encoder with Affect Entire enabled.
 - Added support for LUMI Keys SYSEX protocol protocol. When hosting a LUMI Keys keyboard, the current scale will automatically be set on the keyboard.
@@ -23,7 +24,7 @@
 In addition, a number of improvements have been made to how the OLED display is used:
 
 - Added parameter name to Mod (Gold) Encoder popups.
-- "ARRANGER VIEW" and "SONG VIEW" now display the name of the current view on the screen.
+- `ARRANGER VIEW` and `SONG VIEW` now display the name of the current view on the screen.
 - The 12TET note name is now displayed along with the MIDI note number.
 - Added a new community setting which allows emulating the old 7SEG style on the OLED display.
 - Fixed several cases where popups could get stuck open.
@@ -54,7 +55,7 @@ In addition, a number of improvements have been made to how the OLED display is 
 ### MIDI
 
 - Added `MIDI FOLLOW MODE` which causes MIDI data to be directed based on context.
-- Added MIDI feedback, so external MIDI controllers can be made aware of the state of the Deluge synth engine. Configurable via the new global `MIDI > MIDI-FOLLOW > FEEDBACK` menu.
+- Added `MIDI FEEDBACK`, so external MIDI controllers can be made aware of the state of the Deluge synth engine. Configurable via the new global `MIDI > MIDI-FOLLOW > FEEDBACK` menu.
 - Added Loopy Pro and TouchOsc templates for use with MIDI follow/MIDI feedback.
 - Added a `MIDI LOOPBACK` mode, accessible in the SONG menu, which directs MIDI data from internal MIDI clips back to the Deluge input.
 - Added support for learning Program Change methods to most global commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Sound Engine
 
-- Added a version of Émilie Gillet's Mutable Instruments Clouds reverb model. Can be enabled via a new `REVERB MODE` sub-menu under the existing Reverb menu.
+- Added a version of Émilie Gillet's Mutable Instruments Clouds reverb model. Can be enabled via a new `REVERB MODE` sub-menu under the existing Reverb menu. Note: The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the reverb model used with those songs.
 - Fixed some bugs around the waveform Loop Lock feature which allowed setting invalid loop points.
 
 ### User Interface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### User Interface
 
-- Added `PERFORMANCE VIEW`, accessible in Song View by pressing the Keyboard button. Allows quick control of Song Global FX.
+- Added `PERFORMANCE VIEW`, accessible in Song Row View by pressing the Keyboard button and in Song Grid View by pressing the Pink Mode pad. Allows quick control of Song Global FX.
 - Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
 - Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the Automation Overview and with the shortcut combos (e.g. Shift + Shortcut Pad).
 - Added a menu for song parameters, accessible in Song View and Arranger View by pressing on the Select Encoder.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -211,7 +211,7 @@ This mode affects how the Deluge handles MIDI input for learned CC controls.
 - ([#1065]) New reverb models are available for selection inside of the `FX > REVERB > MODEL` menu. These include:
 	- Freeverb (the original Deluge reverb)
 	- Mutable (an adapted version of the reverb found in Mutable Instruments' Rings module)
-		- Note: The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the reverb model used with those songs.
+		- The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the reverb model used with those songs.
 
 ### 4.3 - Instrument Clip View - General Features
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -211,6 +211,7 @@ This mode affects how the Deluge handles MIDI input for learned CC controls.
 - ([#1065]) New reverb models are available for selection inside of the `FX > REVERB > MODEL` menu. These include:
 	- Freeverb (the original Deluge reverb)
 	- Mutable (an adapted version of the reverb found in Mutable Instruments' Rings module)
+		- Note: The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the reverb model used with those songs.
 
 ### 4.3 - Instrument Clip View - General Features
 


### PR DESCRIPTION
Updated change log for changes from these PR's:

Performance View Pink Mode: https://github.com/SynthstromAudible/DelugeFirmware/pull/877
Add Mod Button Popups: https://github.com/SynthstromAudible/DelugeFirmware/pull/888
Automation View for Arranger: https://github.com/SynthstromAudible/DelugeFirmware/pull/1039
Automation View for MIDI Clips: https://github.com/SynthstromAudible/DelugeFirmware/pull/1083
Update default reverb model: https://github.com/SynthstromAudible/DelugeFirmware/pull/1099