### PR TITLE
Bugfix/xml parser sanity check

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1535,7 +1535,15 @@ int32_t Song::readFromFile() {
 
 		default:
 unknownTag:
-			if (!strcmp(tagName, "sessionLayout")) {
+			if (!strcmp(tagName, "firmwareVersion") || !strcmp(tagName, "earliestCompatibleFirmware")) {
+				storageManager.tryReadingFirmwareTagFromFile(tagName);
+				storageManager.exitTag(tagName);
+			}
+			else if (!strcmp(tagName, "preview") || !strcmp(tagName, "previewNumPads")) {
+				storageManager.tryReadingFirmwareTagFromFile(tagName);
+				storageManager.exitTag(tagName);
+			}
+			else if (!strcmp(tagName, "sessionLayout")) {
 				sessionLayout = (SessionLayoutType)storageManager.readTagOrAttributeValueInt();
 				storageManager.exitTag("sessionLayout");
 			}
@@ -1842,7 +1850,7 @@ loadOutput:
 						goto loadOutput;
 					}
 
-					storageManager.exitTag();
+					storageManager.exitTag(tagName);
 				}
 				storageManager.exitTag("instruments");
 			}
@@ -1880,7 +1888,7 @@ loadOutput:
 						return result;
 					}
 					if (ALPHA_OR_BETA_VERSION) {
-						D_PRINTLN("unknown tag:  %d", tagName);
+						D_PRINTLN("unknown tag:  %s", tagName);
 					}
 					storageManager.exitTag(tagName);
 				}

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -879,7 +879,7 @@ uint32_t StorageManager::readCharXML(char* thisChar) {
 }
 
 void StorageManager::exitTag(char const* exitTagName) {
-	//back out the file depth to one less than the caller depth
+	// back out the file depth to one less than the caller depth
 	while (tagDepthFile >= tagDepthCaller) {
 
 		if (xmlReachedEnd) {
@@ -919,12 +919,11 @@ void StorageManager::exitTag(char const* exitTagName) {
 			__builtin_unreachable();
 		}
 	}
-	//It is possible for caller and file tag depths to get out of sync due to faulty error handling
-	//On exit reset the caller depth to match tag depth. File depth represents the parsers view of
-	//where we are in the xml parsing, caller depth represents the callers view. The caller can be shallower
-	//as the file will open past empty or unused tags, but should never be deeper.
+	// It is possible for caller and file tag depths to get out of sync due to faulty error handling
+	// On exit reset the caller depth to match tag depth. File depth represents the parsers view of
+	// where we are in the xml parsing, caller depth represents the callers view. The caller can be shallower
+	// as the file will open past empty or unused tags, but should never be deeper.
 	tagDepthCaller = tagDepthFile;
-
 }
 
 void StorageManager::readMidiCommand(uint8_t* channel, uint8_t* note) {

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -527,7 +527,6 @@ void StorageManager::xmlReadDone() {
 void StorageManager::skipUntilChar(char endChar) {
 
 	readXMLFileClusterIfNecessary(); // Does this need to be here? Originally I didn't have it...
-
 	do {
 		while (fileBufferCurrentPos < currentReadBufferEndPos && fileClusterBuffer[fileBufferCurrentPos] != endChar) {
 			fileBufferCurrentPos++;
@@ -880,7 +879,7 @@ uint32_t StorageManager::readCharXML(char* thisChar) {
 }
 
 void StorageManager::exitTag(char const* exitTagName) {
-
+	//back out the file depth to one less than the caller depth
 	while (tagDepthFile >= tagDepthCaller) {
 
 		if (xmlReachedEnd) {
@@ -920,8 +919,12 @@ void StorageManager::exitTag(char const* exitTagName) {
 			__builtin_unreachable();
 		}
 	}
+	//It is possible for caller and file tag depths to get out of sync due to faulty error handling
+	//On exit reset the caller depth to match tag depth. File depth represents the parsers view of
+	//where we are in the xml parsing, caller depth represents the callers view. The caller can be shallower
+	//as the file will open past empty or unused tags, but should never be deeper.
+	tagDepthCaller = tagDepthFile;
 
-	tagDepthCaller--;
 }
 
 void StorageManager::readMidiCommand(uint8_t* channel, uint8_t* note) {


### PR DESCRIPTION
In song.cpp -> checks the firmware version so that FIRMWARE_VERSION_BEING_LOADED is correct while loading synths/kits within it

In storage_manager.cpp -> backs out caller depth to match file depth. This should never be necessary, but entering tags without properly exiting them can cause this to happen, since the file parser will back out its own level on hitting a closing tag. The caller depth cannot be updated there as the file depth may be greater, and decrementing the caller depth on ever closing tag found would be incorrect

The fact that this is necessary indicates that there is likely a remaining bug in the kit or midi parser - in both parsers it is possible to end up with a call depth greater than the file depth otherwise. 