### PR TITLE
Improve performance of note quantization.

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4663,8 +4663,10 @@ void InstrumentClipView::quantizeNotes(int32_t offset, int32_t nudgeMode) {
 			continue;
 		}
 
-		action->recordNoteArrayChangeDefinitely(currentClip, modelStackWithNoteRow->noteRowId, &thisNoteRow->notes,
-		                                        false);
+		if (action != nullptr) {
+			action->recordNoteArrayChangeDefinitely(currentClip, modelStackWithNoteRow->noteRowId, &thisNoteRow->notes,
+			                                        false);
+		}
 
 		thisNoteRow->quantize(modelStackWithNoteRow, squareSize, quantizeAmount);
 	}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4575,20 +4575,15 @@ void InstrumentClipView::quantizeNotes(int32_t offset, int32_t nudgeMode) {
 
 	if (display->haveOLED()) {
 		char buffer[24];
-		if (nudgeMode == NUDGEMODE_QUANTIZE) {
-			strcpy(buffer, (quantizeAmount >= 0) ? "Quantize " : "Humanize ");
-		}
-		else {
-			strcpy(buffer, (quantizeAmount >= 0) ? "Quantize All " : "Humanize All ");
-		}
-		intToString(abs(quantizeAmount * 10), buffer + strlen(buffer));
-		strcpy(buffer + strlen(buffer), "%");
+		snprintf(buffer, sizeof(buffer), "%s %s%d%%",             //<
+		         (quantizeAmount >= 0) ? "Quantize" : "Humanize", //<
+		         (nudgeMode == NUDGEMODE_QUANTIZE) ? "" : "All ", //<
+		         abs(quantizeAmount * 10));
 		display->popupTextTemporary(buffer);
 	}
 	else {
 		char buffer[5];
-		strcpy(buffer, "");
-		intToString(quantizeAmount * 10, buffer + strlen(buffer)); // Negative means humanize
+		snprintf(buffer, sizeof(buffer), "%d", quantizeAmount * 10); // Negative means humanize
 		display->displayPopup(buffer, 0, true);
 	}
 

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -620,7 +620,7 @@ void SevenSegment::setTextVeryBasicA1(char const* text) {
 	PIC::update7SEG(segments);
 }
 
-// Highest error code used, main branch: E451
+// Highest error code used, main branch: E452
 // Highest error code used, fix branch: i041
 
 void SevenSegment::freezeWithError(char const* text) {

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -175,17 +175,18 @@ public:
 	void complexSetNoteLength(Note* thisNote, uint32_t newLength, ModelStackWithNoteRow* modelStack, Action* action);
 	int32_t changeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
 	                                    int32_t changeType, int32_t changeValue);
-	/// Nude the note at editPos by either +1 (if nudgeOffset > 0) or -1 (if nudgeOffset < 0)
+	/// Nudge the note at editPos by either +1 (if nudgeOffset > 0) or -1 (if nudgeOffset < 0)
 	///
 	/// The caller must call Clip::expectEvent on the clip containing this `NoteRow` after this.
 	int32_t nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
 	                                   uint32_t wrapEditLevel, int32_t nudgeOffset);
-	/// Quantize the notes in this NoteRow so their positions are within `(10 - amount) * increment/10` of the grid
-	/// defined by `n * increment`. If `amount` is negative, the row is instead "humanized" by jittering the note
-	/// positions to `±amount * increment / 10` sequencer ticks of the `n * increment` grid.
+	/// Quantize the notes in this NoteRow so their positions are within `(kQuantizationPrecision - amount) *
+	/// increment/kQuantizationPrecision` of the grid defined by `n * increment`. If `amount` is negative, the row is
+	/// instead "humanized" by jittering the note positions to `±amount * increment / kQuantizationPrecision` sequencer
+	/// ticks of the `n * increment` grid.
 	///
 	/// The caller must call Clip::expectEvent on the clip containing this `NoteRow` after this.
-	int32_t quantize(ModelStackWithNoteRow* modelStack, int32_t increment, int32_t amount );
+	int32_t quantize(ModelStackWithNoteRow* modelStack, int32_t increment, int32_t amount);
 	int32_t editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareWidth, ModelStackWithNoteRow* modelStack,
 	                                       Action* action, uint32_t wrapEditLevel, int32_t newNumNotes);
 	void setLength(ModelStackWithNoteRow* modelStack, int32_t newLength, Action* actionToRecordTo, int32_t oldPos,

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -63,9 +63,20 @@ struct PendingNoteOnList {
 	uint8_t count;
 };
 
+constexpr int32_t kQuantizationPrecision = 10;
+
 #define STATUS_OFF 0
 #define STATUS_SEQUENCED_NOTE 1
 
+/// An ordered list of notes which all share the same nominal y value.
+///
+/// In kits, the y value represents the row within the kit directly. In other types of clips, the y value maps to a MIDI
+/// pitch value.
+///
+/// Notes within the row must not overlap -- the end location of each note (described by note.pos + note.length) must be
+/// strictly less than the start location of the next note. The length of the last note in the row can exceed the loop
+/// length of this NoteRow (either loopLengthIfIndependent if that value is nonzero, or the loop length of the clip
+/// containing this NoteRow).
 class NoteRow {
 public:
 	NoteRow(int16_t newY = -32768);
@@ -164,8 +175,17 @@ public:
 	void complexSetNoteLength(Note* thisNote, uint32_t newLength, ModelStackWithNoteRow* modelStack, Action* action);
 	int32_t changeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
 	                                    int32_t changeType, int32_t changeValue);
+	/// Nude the note at editPos by either +1 (if nudgeOffset > 0) or -1 (if nudgeOffset < 0)
+	///
+	/// The caller must call Clip::expectEvent on the clip containing this `NoteRow` after this.
 	int32_t nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
 	                                   uint32_t wrapEditLevel, int32_t nudgeOffset);
+	/// Quantize the notes in this NoteRow so their positions are within `(10 - amount) * increment/10` of the grid
+	/// defined by `n * increment`. If `amount` is negative, the row is instead "humanized" by jittering the note
+	/// positions to `±amount * increment / 10` sequencer ticks of the `n * increment` grid.
+	///
+	/// The caller must call Clip::expectEvent on the clip containing this `NoteRow` after this.
+	int32_t quantize(ModelStackWithNoteRow* modelStack, int32_t increment, int32_t amount );
 	int32_t editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareWidth, ModelStackWithNoteRow* modelStack,
 	                                       Action* action, uint32_t wrapEditLevel, int32_t newNumNotes);
 	void setLength(ModelStackWithNoteRow* modelStack, int32_t newLength, Action* actionToRecordTo, int32_t oldPos,


### PR DESCRIPTION
The note nudge code is horrendously inefficient and inflexible for the kind of bulk editing quantize requires. It only supports nudging 1 sequencer tick at a time (which the old code worked around by calling the quantize routine multiple times), and has a lot of logic to support cross-screen editing that we don't need here. Said support code does a number of allocations and linear searches through the NoteRow resulting in effectively quadratic or cubic performance in the number of notes in the row. When combined with the allocations this results in noticeable voice drops when quantizing arppegiated chords.

This change reworks the quantize code to use a dedicated bulk edit routine. Despite this new code, the overall implementation is now smaller in terms of code size thanks to the elimination of some botique string formatting, duplicated code, and spurious checks. The new code is hopefully also easier to read and maintain.

This PR is intended to be read 1 commit at a time. I think I handled all the edge cases, but it's possible I missed something so some hammering on this before merging would probably be good.