### PR TITLE
Run Black formatter on save of python files

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,11 @@
 {
 	"recommendations": [
-		"ms-vscode.cpptools",
 		"editorconfig.editorconfig",
-		"xaver.clang-format",
-		"marus25.cortex-debug",
-		"webfreak.advanced-local-formatters",
 		"llvm-vs-code-extensions.vscode-clangd",
+		"marus25.cortex-debug",
 		"ms-python.black-formatter",
+		"ms-vscode.cpptools",
+		"webfreak.advanced-local-formatters",
+		"xaver.clang-format",
 	]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -6,5 +6,6 @@
 		"marus25.cortex-debug",
 		"webfreak.advanced-local-formatters",
 		"llvm-vs-code-extensions.vscode-clangd",
+		"ms-python.black-formatter",
 	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
     "files.encoding": "utf8",
     "cmake.generator": "Ninja Multi-Config",
     "[python]": {
-        "editor.defaultFormatter": "ms-python.black-formatter"
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
     },
     "files.associations": {
         "*.scons": "python",


### PR DESCRIPTION
Also adds the Black Formatter extension to the recommended extensions list.

Should help us with less footguns of running back and forth fixing formatting problems now that the formatting check also does Python.