### PR TITLE
[DRAFT] Bug Fix - Mod Popup for Non-Global Params

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -67,6 +67,9 @@ Here is a list of general improvements that have been made, ordered from newest 
 - ([#683]) The Metronome's volume now respects the song's volume and will increase and decrease in volume together with the Gold Volume Encoder.
 	- In addition, a `DEFAULTS` menu entry was created titled `METRONOME` which enables you to set a value between 1-50 to further adjust the volume of the Metronome. 1 being the lowest metronome volume that can be heard when the Song's volume is at its maximum and 50 being the loudest metronome volume.
 
+#### 3.11 - Mod Button Pop-up
+- ([#888]) Added Mod Button pop-up to display the current Mod (Gold) Encoder context (e.g. LPF/HPF Mode, Delay Mode and Type, Reverb Room Size, Compressor Mode, ModFX Type and Param).
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -516,6 +519,7 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#865]: https://github.com/SynthstromAudible/DelugeFirmware/pull/865
 [#886]: https://github.com/SynthstromAudible/DelugeFirmware/pull/886
 [#887]: https://github.com/SynthstromAudible/DelugeFirmware/pull/887
+[#888]: https://github.com/SynthstromAudible/DelugeFirmware/pull/888
 [#889]: https://github.com/SynthstromAudible/DelugeFirmware/pull/889
 [#934]: https://github.com/SynthstromAudible/DelugeFirmware/pull/934
 [#963]: https://github.com/SynthstromAudible/DelugeFirmware/pull/963

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1174,12 +1174,13 @@ void View::modButtonAction(uint8_t whichButton, bool on) {
 
 	if (activeModControllableModelStack.modControllable) {
 		if (on) {
-
 			if (isUIModeWithinRange(modButtonUIModes) || (getRootUI() == &performanceSessionView)) {
+				//change the button selection before calling mod button action so that mod button action
+				//knows the mod button parameter context
+				*activeModControllableModelStack.modControllable->getModKnobMode() = whichButton;
+
 				activeModControllableModelStack.modControllable->modButtonAction(
 				    whichButton, true, (ParamManagerForTimeline*)activeModControllableModelStack.paramManager);
-
-				*activeModControllableModelStack.modControllable->getModKnobMode() = whichButton;
 
 				setKnobIndicatorLevels();
 				setModLedStates();

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1175,8 +1175,8 @@ void View::modButtonAction(uint8_t whichButton, bool on) {
 	if (activeModControllableModelStack.modControllable) {
 		if (on) {
 			if (isUIModeWithinRange(modButtonUIModes) || (getRootUI() == &performanceSessionView)) {
-				//change the button selection before calling mod button action so that mod button action
-				//knows the mod button parameter context
+				// change the button selection before calling mod button action so that mod button action
+				// knows the mod button parameter context
 				*activeModControllableModelStack.modControllable->getModKnobMode() = whichButton;
 
 				activeModControllableModelStack.modControllable->modButtonAction(


### PR DESCRIPTION
Ok this really fixes: https://github.com/SynthstromAudible/DelugeFirmware/issues/1115

When in a non-global param context (e.g. in a synth clip, or in a kit with affect entire disabled), the mod button's were not displaying a popup when you first switch the mod button from another mod button

This has now been fixed by setting the mod knob mode before calling mod button action