### PR TITLE
Bugfix / invalid modelStackWithParam pointer + refactor modelStackWithParam to Output and Song classes

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -543,7 +543,7 @@ void AutomationView::performActualRender(uint32_t whichRows, RGB* image,
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-		modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip);
+		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 	}
 	int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 
@@ -600,8 +600,8 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 
 			if (patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
 				modelStackWithParam =
-				    getModelStackWithParam(modelStackWithTimelineCounter, clip,
-				                           patchedParamShortcuts[xDisplay][yDisplay], params::Kind::PATCHED);
+				    getModelStackWithParamForClip(modelStackWithTimelineCounter, clip,
+				                                  patchedParamShortcuts[xDisplay][yDisplay], params::Kind::PATCHED);
 			}
 
 			else if (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
@@ -611,9 +611,9 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 					continue;
 				}
 
-				modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip,
-				                                             unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay],
-				                                             params::Kind::UNPATCHED_SOUND);
+				modelStackWithParam = getModelStackWithParamForClip(
+				    modelStackWithTimelineCounter, clip, unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay],
+				    params::Kind::UNPATCHED_SOUND);
 			}
 		}
 
@@ -631,13 +631,13 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 				    performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings, paramID);
 			}
 			else {
-				modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID);
+				modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip, paramID);
 			}
 		}
 
 		else if (outputType == OutputType::MIDI_OUT && midiCCShortcutsForAutomation[xDisplay][yDisplay] != kNoParamID) {
-			modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip,
-			                                             midiCCShortcutsForAutomation[xDisplay][yDisplay]);
+			modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip,
+			                                                    midiCCShortcutsForAutomation[xDisplay][yDisplay]);
 		}
 
 		if (modelStackWithParam && modelStackWithParam->autoParam) {
@@ -890,7 +890,7 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 		else {
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
-			modelStackWithParam = getModelStackWithParam(modelStack, clip);
+			modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
 		}
 
 		char const* isAutomated;
@@ -1083,7 +1083,7 @@ void AutomationView::displayAutomation(bool padSelected, bool updateDisplay) {
 
 			Clip* clip = getCurrentClip();
 
-			modelStackWithParam = getModelStackWithParam(modelStack, clip);
+			modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
 		}
 
 		if (modelStackWithParam && modelStackWithParam->autoParam) {
@@ -1508,7 +1508,7 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 		}
 		else {
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-			modelStackWithParam = getModelStackWithParam(modelStack, clip);
+			modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
 		}
 
 		if (modelStackWithParam && modelStackWithParam->autoParam) {
@@ -1613,7 +1613,7 @@ ActionResult AutomationView::padAction(int32_t x, int32_t y, int32_t velocity) {
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-		modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip);
+		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 	}
 	int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 
@@ -2188,7 +2188,7 @@ ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 		}
 		else {
 			Clip* clip = getCurrentClip();
-			modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip);
+			modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 		}
 
 		int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
@@ -2543,7 +2543,7 @@ void AutomationView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 		Clip* clip = getCurrentClip();
-		modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip);
+		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 	}
 	int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 
@@ -2734,7 +2734,7 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-		modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip);
+		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 	}
 	int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 
@@ -2975,7 +2975,7 @@ void AutomationView::selectEncoderAction(int8_t offset) {
 		}
 		else {
 			modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-			modelStackWithParam = getModelStackWithParam(modelStackWithTimelineCounter, clip);
+			modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 		}
 		int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 		int32_t xScroll = currentSong->xScroll[navSysId];
@@ -3197,139 +3197,17 @@ void AutomationView::initInterpolation() {
 
 // get's the modelstack for the parameters that are being edited
 // the model stack differs for SYNTH's, KIT's, MIDI, and Audio clip's
-ModelStackWithAutoParam* AutomationView::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-                                                                int32_t paramID, params::Kind paramKind) {
+ModelStackWithAutoParam* AutomationView::getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelStack,
+                                                                       Clip* clip, int32_t paramID,
+                                                                       params::Kind paramKind) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	OutputType outputType = clip->output->type;
 
 	if (paramID == kNoParamID) {
 		paramID = clip->lastSelectedParamID;
 		paramKind = clip->lastSelectedParamKind;
 	}
 
-	if (outputType == OutputType::SYNTH) {
-		modelStackWithParam = getModelStackWithParamForSynthClip(modelStack, (InstrumentClip*)clip, paramID, paramKind);
-	}
-
-	else if (outputType == OutputType::KIT) {
-		modelStackWithParam = getModelStackWithParamForKitClip(modelStack, (InstrumentClip*)clip, paramID, paramKind);
-	}
-
-	else if (outputType == OutputType::MIDI_OUT) {
-		modelStackWithParam = getModelStackWithParamForMIDIClip(modelStack, (InstrumentClip*)clip, paramID);
-	}
-
-	else if (outputType == OutputType::AUDIO) {
-		modelStackWithParam = getModelStackWithParamForAudioClip(modelStack, (AudioClip*)clip, paramID);
-	}
-
-	return modelStackWithParam;
-}
-
-ModelStackWithAutoParam* AutomationView::getModelStackWithParamForSynthClip(ModelStackWithTimelineCounter* modelStack,
-                                                                            InstrumentClip* clip, int32_t paramID,
-                                                                            params::Kind paramKind) {
-	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-	    modelStack->addOtherTwoThingsButNoNoteRow(clip->output->toModControllable(), &clip->paramManager);
-
-	if (modelStackWithThreeMainThings) {
-		if (paramKind == params::Kind::PATCHED) {
-			modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
-		}
-
-		else if (paramKind == params::Kind::UNPATCHED_SOUND) {
-			modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
-		}
-	}
-
-	return modelStackWithParam;
-}
-
-ModelStackWithAutoParam* AutomationView::getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* modelStack,
-                                                                          InstrumentClip* clip, int32_t paramID,
-                                                                          params::Kind paramKind) {
-	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	Output* output = clip->output;
-
-	// for a kit we have two types of automation: with Affect Entire and without Affect Entire
-	// for a kit with affect entire off, we are automating information at the noterow level
-	if (!instrumentClipView.getAffectEntire()) {
-		Drum* drum = ((Kit*)output)->selectedDrum;
-
-		if (drum) {
-			if (drum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
-
-				ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowForSelectedDrum(modelStack);
-
-				if (modelStackWithNoteRow) {
-
-					ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-					    modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow();
-
-					if (modelStackWithThreeMainThings) {
-						if (paramKind == params::Kind::PATCHED) {
-							modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
-						}
-
-						else if (paramKind == params::Kind::UNPATCHED_SOUND) {
-							modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
-						}
-					}
-				}
-			}
-		}
-	}
-
-	else { // model stack for automating kit params when "affect entire" is enabled
-
-		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-		    modelStack->addOtherTwoThingsButNoNoteRow(output->toModControllable(), &clip->paramManager);
-
-		if (modelStackWithThreeMainThings) {
-			modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
-		}
-	}
-
-	return modelStackWithParam;
-}
-
-ModelStackWithAutoParam* AutomationView::getModelStackWithParamForMIDIClip(ModelStackWithTimelineCounter* modelStack,
-                                                                           InstrumentClip* clip, int32_t paramID) {
-	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	Output* output = clip->output;
-
-	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-	    modelStack->addOtherTwoThingsButNoNoteRow(output->toModControllable(), &clip->paramManager);
-
-	if (modelStackWithThreeMainThings) {
-		ParamManager* paramManager = modelStackWithThreeMainThings->paramManager;
-
-		if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
-			MIDIInstrument* midiInstrument = (MIDIInstrument*)output;
-
-			modelStackWithParam =
-			    midiInstrument->getParamToControlFromInputMIDIChannel(paramID, modelStackWithThreeMainThings);
-		}
-	}
-
-	return modelStackWithParam;
-}
-
-ModelStackWithAutoParam* AutomationView::getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStack,
-                                                                            AudioClip* clip, int32_t paramID) {
-	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-	    modelStack->addOtherTwoThingsButNoNoteRow(clip->output->toModControllable(), &clip->paramManager);
-
-	if (modelStackWithThreeMainThings) {
-		modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
-	}
+	modelStackWithParam = clip->output->getModelStackWithParam(modelStack, clip, paramID, paramKind);
 
 	return modelStackWithParam;
 }

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -538,8 +538,8 @@ void AutomationView::performActualRender(uint32_t whichRows, RGB* image,
 
 	if (onArrangerView) {
 		modelStackWithThreeMainThings = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-		modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-		                                                                    currentSong->lastSelectedParamID);
+		modelStackWithParam =
+		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -627,8 +627,7 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 				    || (paramID == params::UNPATCHED_SIDECHAIN_VOLUME)) {
 					continue;
 				}
-				modelStackWithParam =
-				    performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings, paramID);
+				modelStackWithParam = currentSong->getModelStackWithParam(modelStackWithThreeMainThings, paramID);
 			}
 			else {
 				modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip, paramID);
@@ -884,8 +883,8 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 			ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
-			modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-			                                                                    currentSong->lastSelectedParamID);
+			modelStackWithParam =
+			    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 		}
 		else {
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -1075,8 +1074,8 @@ void AutomationView::displayAutomation(bool padSelected, bool updateDisplay) {
 			ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
-			modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-			                                                                    currentSong->lastSelectedParamID);
+			modelStackWithParam =
+			    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 		}
 		else {
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -1503,8 +1502,8 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 		if (onArrangerView) {
 			ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-			modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-			                                                                    currentSong->lastSelectedParamID);
+			modelStackWithParam =
+			    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 		}
 		else {
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -1608,8 +1607,8 @@ ActionResult AutomationView::padAction(int32_t x, int32_t y, int32_t velocity) {
 
 	if (onArrangerView) {
 		modelStackWithThreeMainThings = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-		modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-		                                                                    currentSong->lastSelectedParamID);
+		modelStackWithParam =
+		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -2183,8 +2182,8 @@ ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 		int32_t shiftAmount = offset * squareSize;
 
 		if (onArrangerView) {
-			modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-			                                                                    currentSong->lastSelectedParamID);
+			modelStackWithParam =
+			    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 		}
 		else {
 			Clip* clip = getCurrentClip();
@@ -2537,8 +2536,8 @@ void AutomationView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
 	if (onArrangerView) {
 		modelStackWithThreeMainThings = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-		modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-		                                                                    currentSong->lastSelectedParamID);
+		modelStackWithParam =
+		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -2729,8 +2728,8 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 
 	if (onArrangerView) {
 		modelStackWithThreeMainThings = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-		modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-		                                                                    currentSong->lastSelectedParamID);
+		modelStackWithParam =
+		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
@@ -2970,8 +2969,8 @@ void AutomationView::selectEncoderAction(int8_t offset) {
 
 		if (onArrangerView) {
 			modelStackWithThreeMainThings = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-			modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings,
-			                                                                    currentSong->lastSelectedParamID);
+			modelStackWithParam =
+			    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
 		}
 		else {
 			modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -120,22 +120,9 @@ public:
 
 	// public to midi follow can access it
 	ModelStackWithAutoParam*
-	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip, int32_t paramID = 0xFFFFFFFF,
-	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
-	ModelStackWithAutoParam* getModelStackWithParamForSynthClip(
-	    ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip,
-	    int32_t paramID = deluge::modulation::params::kNoParamID,
-	    deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
-	ModelStackWithAutoParam* getModelStackWithParamForKitClip(
-	    ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip,
-	    int32_t paramID = deluge::modulation::params::kNoParamID,
-	    deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
-	ModelStackWithAutoParam*
-	getModelStackWithParamForMIDIClip(ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip,
-	                                  int32_t paramID = deluge::modulation::params::kNoParamID);
-	ModelStackWithAutoParam*
-	getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStack, AudioClip* clip,
-	                                   int32_t paramID = deluge::modulation::params::kNoParamID);
+	getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                              int32_t paramID = deluge::modulation::params::kNoParamID,
+	                              deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
 
 	// public so instrument clip view can access it
 	void initParameterSelection();

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -1192,7 +1192,7 @@ void PerformanceSessionView::releaseStutter(ModelStackWithThreeMainThings* model
 /// in regular performance view, this function will also update the parameter value shown on the display
 bool PerformanceSessionView::setParameterValue(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
                                                int32_t paramID, int32_t xDisplay, int32_t knobPos, bool renderDisplay) {
-	ModelStackWithAutoParam* modelStackWithParam = getModelStackWithParam(modelStack, paramID);
+	ModelStackWithAutoParam* modelStackWithParam = currentSong->getModelStackWithParam(modelStack, paramID);
 
 	if (modelStackWithParam && modelStackWithParam->autoParam) {
 
@@ -1253,7 +1253,7 @@ bool PerformanceSessionView::setParameterValue(ModelStackWithThreeMainThings* mo
 /// update current value stored
 void PerformanceSessionView::getParameterValue(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
                                                int32_t paramID, int32_t xDisplay, bool renderDisplay) {
-	ModelStackWithAutoParam* modelStackWithParam = getModelStackWithParam(modelStack, paramID);
+	ModelStackWithAutoParam* modelStackWithParam = currentSong->getModelStackWithParam(modelStack, paramID);
 
 	if (modelStackWithParam && modelStackWithParam->autoParam) {
 
@@ -1280,18 +1280,6 @@ void PerformanceSessionView::getParameterValue(ModelStackWithThreeMainThings* mo
 			}
 		}
 	}
-}
-
-/// get's the modelstack for the parameters that are being edited
-ModelStackWithAutoParam* PerformanceSessionView::getModelStackWithParam(ModelStackWithThreeMainThings* modelStack,
-                                                                        int32_t paramID) {
-	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	if (modelStack) {
-		modelStackWithParam = modelStack->getUnpatchedAutoParamFromId(paramID);
-	}
-
-	return modelStackWithParam;
 }
 
 /// converts grid pad press yDisplay into a knobPosition value default

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -115,9 +115,6 @@ public:
 	// public so Action Logger can access it
 	FXColumnPress fxPress[kDisplayWidth];
 
-	// public so midi follow can access it
-	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithThreeMainThings* modelStack, int32_t paramID);
-
 	// public so view.modEncoderAction and midi follow can access it
 	PadPress lastPadPress;
 	void renderFXDisplay(deluge::modulation::params::Kind paramKind, int32_t paramID, int32_t knobPos = kNoSelection);

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -165,13 +165,13 @@ MidiFollow::getModelStackWithParam(ModelStackWithThreeMainThings* modelStackWith
 	if (clip) {
 		if (modelStackWithTimelineCounter) {
 			modelStackWithParam =
-			    getModelStackWithParamWithClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
+			    getModelStackWithParamForClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
 		}
 	}
 	// null clip means you're dealing with the song context
 	else {
 		if (modelStackWithThreeMainThings) {
-			modelStackWithParam = getModelStackWithParamWithoutClip(modelStackWithThreeMainThings, xDisplay, yDisplay);
+			modelStackWithParam = getModelStackWithParamForSong(modelStackWithThreeMainThings, xDisplay, yDisplay);
 		}
 	}
 
@@ -184,8 +184,8 @@ MidiFollow::getModelStackWithParam(ModelStackWithThreeMainThings* modelStackWith
 }
 
 ModelStackWithAutoParam*
-MidiFollow::getModelStackWithParamWithoutClip(ModelStackWithThreeMainThings* modelStackWithThreeMainThings,
-                                              int32_t xDisplay, int32_t yDisplay) {
+MidiFollow::getModelStackWithParamForSong(ModelStackWithThreeMainThings* modelStackWithThreeMainThings,
+                                          int32_t xDisplay, int32_t yDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 	int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
@@ -197,34 +197,35 @@ MidiFollow::getModelStackWithParamWithoutClip(ModelStackWithThreeMainThings* mod
 }
 
 ModelStackWithAutoParam*
-MidiFollow::getModelStackWithParamWithClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
-                                           int32_t xDisplay, int32_t yDisplay) {
+MidiFollow::getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
+                                          int32_t xDisplay, int32_t yDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
-	if (clip->type == ClipType::INSTRUMENT) {
-		InstrumentClip* instrumentClip = (InstrumentClip*)clip;
-		OutputType outputType = clip->output->type;
-
-		if (outputType == OutputType::SYNTH) {
+	switch (clip->type) {
+	case ClipType::INSTRUMENT: {
+		switch (clip->output->type) {
+		case OutputType::SYNTH: {
 			modelStackWithParam =
-			    getModelStackWithParamForSynthClip(modelStackWithTimelineCounter, instrumentClip, xDisplay, yDisplay);
+			    getModelStackWithParamForSynthClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
 		}
-		else if (outputType == OutputType::KIT) {
+		case OutputType::KIT: {
 			modelStackWithParam =
-			    getModelStackWithParamForKitClip(modelStackWithTimelineCounter, instrumentClip, xDisplay, yDisplay);
+			    getModelStackWithParamForKitClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
+		}
 		}
 	}
-	else {
+	case ClipType::AUDIO: {
 		modelStackWithParam =
-		    getModelStackWithParamForAudioClip(modelStackWithTimelineCounter, (AudioClip*)clip, xDisplay, yDisplay);
+		    getModelStackWithParamForAudioClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
+	}
 	}
 
 	return modelStackWithParam;
 }
 
 ModelStackWithAutoParam*
-MidiFollow::getModelStackWithParamForSynthClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-                                               InstrumentClip* instrumentClip, int32_t xDisplay, int32_t yDisplay) {
+MidiFollow::getModelStackWithParamForSynthClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
+                                               int32_t xDisplay, int32_t yDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 	params::Kind paramKind = params::Kind::NONE;
 	int32_t paramID = kNoParamID;
@@ -238,16 +239,16 @@ MidiFollow::getModelStackWithParamForSynthClip(ModelStackWithTimelineCounter* mo
 		paramID = unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay];
 	}
 	if ((paramKind != params::Kind::NONE) && (paramID != kNoParamID)) {
-		modelStackWithParam = automationView.getModelStackWithParamForSynthClip(modelStackWithTimelineCounter,
-		                                                                        instrumentClip, paramID, paramKind);
+		modelStackWithParam =
+		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind);
 	}
 
 	return modelStackWithParam;
 }
 
 ModelStackWithAutoParam*
-MidiFollow::getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-                                             InstrumentClip* instrumentClip, int32_t xDisplay, int32_t yDisplay) {
+MidiFollow::getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
+                                             int32_t xDisplay, int32_t yDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 	params::Kind paramKind = params::Kind::NONE;
 	int32_t paramID = kNoParamID;
@@ -272,22 +273,21 @@ MidiFollow::getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* mode
 		}
 	}
 	if ((paramKind != params::Kind::NONE) && (paramID != kNoParamID)) {
-		modelStackWithParam = automationView.getModelStackWithParamForKitClip(modelStackWithTimelineCounter,
-		                                                                      instrumentClip, paramID, paramKind);
+		modelStackWithParam =
+		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind);
 	}
 
 	return modelStackWithParam;
 }
 
 ModelStackWithAutoParam*
-MidiFollow::getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-                                               AudioClip* audioClip, int32_t xDisplay, int32_t yDisplay) {
+MidiFollow::getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
+                                               int32_t xDisplay, int32_t yDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 	int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
 	if (paramID != kNoParamID) {
-		modelStackWithParam =
-		    automationView.getModelStackWithParamForAudioClip(modelStackWithTimelineCounter, audioClip, paramID);
+		modelStackWithParam = clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID);
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -281,10 +281,12 @@ ModelStackWithAutoParam*
 MidiFollow::getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
                                                int32_t xDisplay, int32_t yDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+	params::Kind paramKind = params::Kind::UNPATCHED_GLOBAL;
 	int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
 	if (paramID != kNoParamID) {
-		modelStackWithParam = clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID);
+		modelStackWithParam =
+		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind);
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -190,7 +190,11 @@ MidiFollow::getModelStackWithParamForSong(ModelStackWithThreeMainThings* modelSt
 	int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
 	if (paramID != kNoParamID) {
-		modelStackWithParam = currentSong->getModelStackWithParam(modelStackWithThreeMainThings, paramID);
+		//can't control Pitch or Sidechain params in Song view
+		if ((paramID != params::UNPATCHED_PITCH_ADJUST) && (paramID != params::UNPATCHED_COMPRESSOR_SHAPE)
+		    && (paramID != params::UNPATCHED_SIDECHAIN_VOLUME)) {
+			modelStackWithParam = currentSong->getModelStackWithParam(modelStackWithThreeMainThings, paramID);
+		}
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -190,7 +190,7 @@ MidiFollow::getModelStackWithParamForSong(ModelStackWithThreeMainThings* modelSt
 	int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
 	if (paramID != kNoParamID) {
-		//can't control Pitch or Sidechain params in Song view
+		// can't control Pitch or Sidechain params in Song view
 		if ((paramID != params::UNPATCHED_PITCH_ADJUST) && (paramID != params::UNPATCHED_COMPRESSOR_SHAPE)
 		    && (paramID != params::UNPATCHED_SIDECHAIN_VOLUME)) {
 			modelStackWithParam = currentSong->getModelStackWithParam(modelStackWithThreeMainThings, paramID);

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -190,7 +190,7 @@ MidiFollow::getModelStackWithParamForSong(ModelStackWithThreeMainThings* modelSt
 	int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
 	if (paramID != kNoParamID) {
-		modelStackWithParam = performanceSessionView.getModelStackWithParam(modelStackWithThreeMainThings, paramID);
+		modelStackWithParam = currentSong->getModelStackWithParam(modelStackWithThreeMainThings, paramID);
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -200,24 +200,20 @@ ModelStackWithAutoParam*
 MidiFollow::getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
                                           int32_t xDisplay, int32_t yDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+	OutputType outputType = clip->output->type;
 
-	switch (clip->type) {
-	case ClipType::INSTRUMENT: {
-		switch (clip->output->type) {
-		case OutputType::SYNTH: {
-			modelStackWithParam =
-			    getModelStackWithParamForSynthClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
-		}
-		case OutputType::KIT: {
-			modelStackWithParam =
-			    getModelStackWithParamForKitClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
-		}
-		}
-	}
-	case ClipType::AUDIO: {
+	switch (outputType) {
+	case OutputType::SYNTH:
+		modelStackWithParam =
+		    getModelStackWithParamForSynthClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
+		break;
+	case OutputType::KIT:
+		modelStackWithParam = getModelStackWithParamForKitClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
+		break;
+	case OutputType::AUDIO:
 		modelStackWithParam =
 		    getModelStackWithParamForAudioClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
-	}
+		break;
 	}
 
 	return modelStackWithParam;
@@ -252,8 +248,9 @@ MidiFollow::getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* mode
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 	params::Kind paramKind = params::Kind::NONE;
 	int32_t paramID = kNoParamID;
+	InstrumentClip* instrumentClip = (InstrumentClip*)clip;
 
-	if (!instrumentClipView.getAffectEntire()) {
+	if (!instrumentClip->affectEntire) {
 		if (patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
 			paramKind = params::Kind::PATCHED;
 			paramID = patchedParamShortcuts[xDisplay][yDisplay];

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -67,21 +67,19 @@ private:
 	void initMapping(int32_t mapping[kDisplayWidth][kDisplayHeight]);
 
 	// get model stack with auto param for midi follow cc-param control
+	ModelStackWithAutoParam* getModelStackWithParamForSong(ModelStackWithThreeMainThings* modelStackWithThreeMainThings,
+	                                                       int32_t xDisplay, int32_t yDisplay);
+	ModelStackWithAutoParam* getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+	                                                       Clip* clip, int32_t xDisplay, int32_t yDisplay);
 	ModelStackWithAutoParam*
-	getModelStackWithParamWithoutClip(ModelStackWithThreeMainThings* modelStackWithThreeMainThings, int32_t xDisplay,
-	                                  int32_t yDisplay);
+	getModelStackWithParamForSynthClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
+	                                   int32_t xDisplay, int32_t yDisplay);
 	ModelStackWithAutoParam*
-	getModelStackWithParamWithClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
-	                               int32_t xDisplay, int32_t yDisplay);
+	getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
+	                                 int32_t xDisplay, int32_t yDisplay);
 	ModelStackWithAutoParam*
-	getModelStackWithParamForSynthClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-	                                   InstrumentClip* instrumentClip, int32_t xDisplay, int32_t yDisplay);
-	ModelStackWithAutoParam*
-	getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-	                                 InstrumentClip* instrumentClip, int32_t xDisplay, int32_t yDisplay);
-	ModelStackWithAutoParam*
-	getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-	                                   AudioClip* audioClip, int32_t xDisplay, int32_t yDisplay);
+	getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
+	                                   int32_t xDisplay, int32_t yDisplay);
 	void displayParamControlError(int32_t xDisplay, int32_t yDisplay);
 
 	// handle midi received for midi follow

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1490,3 +1490,50 @@ gotParamManager:
 }
 
 // for (Drum* drum = firstDrum; drum; drum = drum->next) {
+
+ModelStackWithAutoParam* Kit::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+                                                     int32_t paramID, params::Kind paramKind) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	// for a kit we have two types of automation: with Affect Entire and without Affect Entire
+	// for a kit with affect entire off, we are automating information at the noterow level
+	if (!instrumentClipView.getAffectEntire()) {
+		Drum* drum = selectedDrum;
+
+		if (drum) {
+			if (drum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
+
+				ModelStackWithNoteRow* modelStackWithNoteRow =
+				    ((InstrumentClip*)clip)->getNoteRowForSelectedDrum(modelStack);
+
+				if (modelStackWithNoteRow) {
+
+					ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+					    modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow();
+
+					if (modelStackWithThreeMainThings) {
+						if (paramKind == deluge::modulation::params::Kind::PATCHED) {
+							modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
+						}
+
+						else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
+							modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	else { // model stack for automating kit params when "affect entire" is enabled
+
+		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+		    modelStack->addOtherTwoThingsButNoNoteRow(toModControllable(), &clip->paramManager);
+
+		if (modelStackWithThreeMainThings) {
+			modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
+		}
+	}
+
+	return modelStackWithParam;
+}

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1501,24 +1501,22 @@ ModelStackWithAutoParam* Kit::getModelStackWithParam(ModelStackWithTimelineCount
 	if (!instrumentClip->affectEntire) {
 		Drum* drum = selectedDrum;
 
-		if (drum) {
-			if (drum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
+		if (drum && drum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
 
-				ModelStackWithNoteRow* modelStackWithNoteRow = instrumentClip->getNoteRowForSelectedDrum(modelStack);
+			ModelStackWithNoteRow* modelStackWithNoteRow = instrumentClip->getNoteRowForSelectedDrum(modelStack);
 
-				if (modelStackWithNoteRow) {
+			if (modelStackWithNoteRow) {
 
-					ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-					    modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow();
+				ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+				    modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow();
 
-					if (modelStackWithThreeMainThings) {
-						if (paramKind == deluge::modulation::params::Kind::PATCHED) {
-							modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
-						}
+				if (modelStackWithThreeMainThings) {
+					if (paramKind == deluge::modulation::params::Kind::PATCHED) {
+						modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
+					}
 
-						else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
-							modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
-						}
+					else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
+						modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
 					}
 				}
 			}

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1494,17 +1494,17 @@ gotParamManager:
 ModelStackWithAutoParam* Kit::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
                                                      int32_t paramID, params::Kind paramKind) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+	InstrumentClip* instrumentClip = (InstrumentClip*)clip;
 
 	// for a kit we have two types of automation: with Affect Entire and without Affect Entire
 	// for a kit with affect entire off, we are automating information at the noterow level
-	if (!instrumentClipView.getAffectEntire()) {
+	if (!instrumentClip->affectEntire) {
 		Drum* drum = selectedDrum;
 
 		if (drum) {
 			if (drum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
 
-				ModelStackWithNoteRow* modelStackWithNoteRow =
-				    ((InstrumentClip*)clip)->getNoteRowForSelectedDrum(modelStack);
+				ModelStackWithNoteRow* modelStackWithNoteRow = instrumentClip->getNoteRowForSelectedDrum(modelStack);
 
 				if (modelStackWithNoteRow) {
 

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -121,10 +121,8 @@ public:
 
 	OrderedResizeableArrayWith32bitKey drumsWithRenderingActive;
 
-	ModelStackWithAutoParam*
-	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                       int32_t paramID = deluge::modulation::params::kNoParamID,
-	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
 
 protected:
 	bool isKit() { return true; }

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -121,6 +121,11 @@ public:
 
 	OrderedResizeableArrayWith32bitKey drumsWithRenderingActive;
 
+	ModelStackWithAutoParam*
+	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                       int32_t paramID = deluge::modulation::params::kNoParamID,
+	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+
 protected:
 	bool isKit() { return true; }
 

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -698,3 +698,24 @@ void MelodicInstrument::polyphonicExpressionEventPossiblyToRecord(ModelStackWith
 
 	expressionValueChangesMustBeDoneSmoothly = false;
 }
+
+ModelStackWithAutoParam* MelodicInstrument::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack,
+                                                                   Clip* clip, int32_t paramID,
+                                                                   deluge::modulation::params::Kind paramKind) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+	    modelStack->addOtherTwoThingsButNoNoteRow(toModControllable(), &clip->paramManager);
+
+	if (modelStackWithThreeMainThings) {
+		if (paramKind == deluge::modulation::params::Kind::PATCHED) {
+			modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
+		}
+
+		else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
+			modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
+		}
+	}
+
+	return modelStackWithParam;
+}

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -92,6 +92,11 @@ public:
 
 	LearnedMIDI midiInput;
 
+	ModelStackWithAutoParam*
+	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                       int32_t paramID = deluge::modulation::params::kNoParamID,
+	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+
 private:
 	void possiblyRefreshAutomationEditorGrid(int32_t ccNumber);
 };

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -92,10 +92,8 @@ public:
 
 	LearnedMIDI midiInput;
 
-	ModelStackWithAutoParam*
-	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                       int32_t paramID = deluge::modulation::params::kNoParamID,
-	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
 
 private:
 	void possiblyRefreshAutomationEditorGrid(int32_t ccNumber);

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -998,3 +998,23 @@ void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t whichExpressionDi
 		sendMonophonicExpressionEvent(whichExpressionDimension);
 	}
 }
+
+ModelStackWithAutoParam* MIDIInstrument::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+                                                                int32_t paramID,
+                                                                deluge::modulation::params::Kind paramKind) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+	    modelStack->addOtherTwoThingsButNoNoteRow(toModControllable(), &clip->paramManager);
+
+	if (modelStackWithThreeMainThings) {
+		ParamManager* paramManager = modelStackWithThreeMainThings->paramManager;
+
+		if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+
+			modelStackWithParam = getParamToControlFromInputMIDIChannel(paramID, modelStackWithThreeMainThings);
+		}
+	}
+
+	return modelStackWithParam;
+}

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -87,6 +87,11 @@ public:
 	char const* getSlotXMLTag() { return sendsToMPE() ? "zone" : "channel"; }
 	char const* getSubSlotXMLTag() { return "suffix"; }
 
+	ModelStackWithAutoParam*
+	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                       int32_t paramID = deluge::modulation::params::kNoParamID,
+	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+
 protected:
 	void polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,
 	                                              int32_t whichExpressionDimension, ArpNote* arpNote);

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -87,10 +87,8 @@ public:
 	char const* getSlotXMLTag() { return sendsToMPE() ? "zone" : "channel"; }
 	char const* getSubSlotXMLTag() { return "suffix"; }
 
-	ModelStackWithAutoParam*
-	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                       int32_t paramID = deluge::modulation::params::kNoParamID,
-	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
 
 protected:
 	void polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -19,6 +19,7 @@
 
 #include "definitions_cxx.hpp"
 #include "model/clip/clip_instance_vector.h"
+#include "modulation/params/param.h"
 #include "util/d_string.h"
 #include <cstdint>
 
@@ -34,6 +35,7 @@ class ModControllable;
 class GlobalEffectableForClip;
 class ModelStack;
 class ModelStackWithTimelineCounter;
+class ModelStackWithAutoParam;
 class MIDIDevice;
 class LearnedMIDI;
 class ParamManager;
@@ -145,6 +147,11 @@ public:
 	int32_t possiblyBeginArrangementRecording(Song* song, int32_t newPos);
 	void endArrangementPlayback(Song* song, int32_t actualEndPos, uint32_t timeRemainder);
 	bool recordingInArrangement;
+
+	virtual ModelStackWithAutoParam*
+	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                       int32_t paramID = deluge::modulation::params::kNoParamID,
+	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE) = 0;
 
 protected:
 	virtual Clip* createNewClipForArrangementRecording(ModelStack* modelStack) = 0;

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -148,10 +148,9 @@ public:
 	void endArrangementPlayback(Song* song, int32_t actualEndPos, uint32_t timeRemainder);
 	bool recordingInArrangement;
 
-	virtual ModelStackWithAutoParam*
-	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                       int32_t paramID = deluge::modulation::params::kNoParamID,
-	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE) = 0;
+	virtual ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                                                        int32_t paramID,
+	                                                        deluge::modulation::params::Kind paramKind) = 0;
 
 protected:
 	virtual Clip* createNewClipForArrangementRecording(ModelStack* modelStack) = 0;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5758,6 +5758,18 @@ ModelStackWithThreeMainThings* Song::addToModelStack(ModelStack* modelStack) {
 	return modelStack->addTimelineCounter(this)->addOtherTwoThingsButNoNoteRow(&globalEffectable, &paramManager);
 }
 
+// get's the model stack for Song level parameters that are being edited
+// used in performance view and in automation arranger view
+ModelStackWithAutoParam* Song::getModelStackWithParam(ModelStackWithThreeMainThings* modelStack, int32_t paramID) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	if (modelStack) {
+		modelStackWithParam = modelStack->getUnpatchedAutoParamFromId(paramID);
+	}
+
+	return modelStackWithParam;
+}
+
 /*
     // For each Clip in session and arranger
     ClipArray* clipArray = &sessionClips;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5758,8 +5758,6 @@ ModelStackWithThreeMainThings* Song::addToModelStack(ModelStack* modelStack) {
 	return modelStack->addTimelineCounter(this)->addOtherTwoThingsButNoNoteRow(&globalEffectable, &paramManager);
 }
 
-// get's the model stack for Song level parameters that are being edited
-// used in performance view and in automation arranger view
 ModelStackWithAutoParam* Song::getModelStackWithParam(ModelStackWithThreeMainThings* modelStack, int32_t paramID) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -333,6 +333,8 @@ public:
 	ModelStackWithThreeMainThings* setupModelStackWithSongAsTimelineCounter(void* memory);
 	ModelStackWithTimelineCounter* setupModelStackWithCurrentClip(void* memory);
 	ModelStackWithThreeMainThings* addToModelStack(ModelStack* modelStack);
+	/// Gets a modelstack with the song-global unpatched param paramID.
+	/// used in performance view and in automation arranger view
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithThreeMainThings* modelStack, int32_t paramID);
 
 	// Whether this song wants notes/cc/etc from delly midi clips looped back

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -333,6 +333,7 @@ public:
 	ModelStackWithThreeMainThings* setupModelStackWithSongAsTimelineCounter(void* memory);
 	ModelStackWithTimelineCounter* setupModelStackWithCurrentClip(void* memory);
 	ModelStackWithThreeMainThings* addToModelStack(ModelStack* modelStack);
+	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithThreeMainThings* modelStack, int32_t paramID);
 
 	// Whether this song wants notes/cc/etc from delly midi clips looped back
 	bool midiLoopback = false;

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -417,3 +417,17 @@ void AudioOutput::getThingWithMostReverb(Sound** soundWithMostReverb, ParamManag
 	GlobalEffectableForClip::getThingWithMostReverb(activeClip, soundWithMostReverb, paramManagerWithMostReverb,
 	                                                globalEffectableWithMostReverb, highestReverbAmountFound);
 }
+
+ModelStackWithAutoParam* AudioOutput::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+                                                             int32_t paramID, params::Kind paramKind) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+	    modelStack->addOtherTwoThingsButNoNoteRow(toModControllable(), &clip->paramManager);
+
+	if (modelStackWithThreeMainThings) {
+		modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
+	}
+
+	return modelStackWithParam;
+}

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -82,6 +82,11 @@ public:
 	AudioInputChannel inputChannel;
 	bool echoing; // Doesn't get cloned - we wouldn't want that!
 
+	ModelStackWithAutoParam*
+	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                       int32_t paramID = deluge::modulation::params::kNoParamID,
+	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+
 protected:
 	Clip* createNewClipForArrangementRecording(ModelStack* modelStack);
 	bool wantsToBeginArrangementRecording();

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -82,10 +82,8 @@ public:
 	AudioInputChannel inputChannel;
 	bool echoing; // Doesn't get cloned - we wouldn't want that!
 
-	ModelStackWithAutoParam*
-	getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                       int32_t paramID = deluge::modulation::params::kNoParamID,
-	                       deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE);
+	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
 
 protected:
 	Clip* createNewClipForArrangementRecording(ModelStack* modelStack);


### PR DESCRIPTION
This PR closes issue # https://github.com/SynthstromAudible/DelugeFirmware/issues/1135

- Fixed: identified "else" condition where the code would attempt to create a modelStackWithParam for an audio clip when the ClipType may not be an audio clip.

- Refactored getModelStackWithParam for different output types from Automation View class to the various Output classes.
- Refactored getModelStackWithParam for the song from the Performance View class to the Song class.

Left to do:
- [x] Got a bug with midi follow and getting model stack with param for Synth clip / Kit row. Can't control params .. means I'm getting a null modelStackWithParam...on the hunt for it!