### PR TITLE
Fix Lumi scale support

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -405,7 +405,7 @@ This is largely on the development side and created the start of a system of mod
 
 ### 4.8.1 Lumi Keys Studio Edition
 
-- ([#812]) When using the Deluge as a USB Midi Host and attaching a Lumi Keys Studio Edition, the keys will go dark until it is learned to a clip. Once learned to a clip, the keys will match the colour of the currently visible octave.
+- ([#812]) When using the Deluge as a USB Midi Host and attaching a Lumi Keys Studio Edition, the keys will go dark until it is learned to a clip. Once learned to a clip, the keys will match the colour of the currently visible octave (compatible Deluge scales that will match Lumi scales are Major, Minor, Dorian, Phrygian, Lydian, Mixolydian, Locrian, Harmonic Minor, Arabian, Whole Tone, Blues, and Pentatonic Minor).
 	- The lit and darkened keys will be aligned with the selected root and scale, so long as the selected scale is one of the builtin scales supported by the Lumi.
 	- While Lumi has limited options for MPE separation, it will be configured to align with the dominant MPE range defined on the Deluge (upper or lower dominant).
 

--- a/src/deluge/io/midi/device_specific/midi_device_lumi_keys.cpp
+++ b/src/deluge/io/midi/device_specific/midi_device_lumi_keys.cpp
@@ -38,8 +38,7 @@ void MIDIDeviceLumiKeys::hookOnConnected() {
 	uint8_t upperZoneLastChannel = this->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel;
 	uint8_t lowerZoneLastChannel = this->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel;
 
-	std::pair<MIDIDeviceLumiKeys::Scale, int16_t> scaleAndRootNoteOffset =
-	    determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes, currentSong->numModeNotes);
+	Scale currentScale = determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes, currentSong->numModeNotes);
 
 	if (lowerZoneLastChannel != 0 || upperZoneLastChannel != 15) {
 		setMIDIMode(MIDIMode::MPE);
@@ -62,8 +61,8 @@ void MIDIDeviceLumiKeys::hookOnConnected() {
 	}
 
 	// Since we're in the neighbourhood, set the root and scale
-	setRootNote((currentSong->rootNote + scaleAndRootNoteOffset.second) % kOctaveSize);
-	setScale(scaleAndRootNoteOffset.first);
+	setRootNote(currentSong->rootNote % kOctaveSize);
+	setScale(currentScale);
 
 	// Run colour-setting hook.
 	hookOnRecalculateColour();
@@ -75,17 +74,12 @@ void MIDIDeviceLumiKeys::hookOnWriteHostedDeviceToFile() {
 }
 
 void MIDIDeviceLumiKeys::hookOnChangeRootNote() {
-	std::pair<MIDIDeviceLumiKeys::Scale, int16_t> scaleAndRootNoteOffset =
-	    determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes, currentSong->numModeNotes);
-	setRootNote((currentSong->rootNote + scaleAndRootNoteOffset.second) % kOctaveSize);
-	setScale(scaleAndRootNoteOffset.first);
+	setRootNote(currentSong->rootNote % kOctaveSize);
 }
 
 void MIDIDeviceLumiKeys::hookOnChangeScale() {
-	std::pair<MIDIDeviceLumiKeys::Scale, int16_t> scaleAndRootNoteOffset =
-	    determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes, currentSong->numModeNotes);
-	setRootNote((currentSong->rootNote + scaleAndRootNoteOffset.second) % kOctaveSize);
-	setScale(scaleAndRootNoteOffset.first);
+	Scale scale = determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes, currentSong->numModeNotes);
+	setScale(scale);
 }
 
 void MIDIDeviceLumiKeys::hookOnEnterScaleMode() {
@@ -242,9 +236,8 @@ void MIDIDeviceLumiKeys::setRootNote(int16_t rootNote) {
 }
 
 // Efficient binary comparison of notes to Lumi builtin scales
-std::pair<MIDIDeviceLumiKeys::Scale, int16_t>
-MIDIDeviceLumiKeys::determineScaleAndRootNoteOffsetFromNotes(uint8_t* modeNotes, uint8_t noteCount) {
-	// First try with all scales "as is" (without transposition)
+MIDIDeviceLumiKeys::Scale MIDIDeviceLumiKeys::determineScaleAndRootNoteOffsetFromNotes(uint8_t* modeNotes,
+                                                                                       uint8_t noteCount) {
 	// Turn notes in octave into 12 bit binary
 	uint16_t noteInt = 0;
 	for (uint8_t note = 0; note < noteCount; note++) {
@@ -253,26 +246,11 @@ MIDIDeviceLumiKeys::determineScaleAndRootNoteOffsetFromNotes(uint8_t* modeNotes,
 	// Compare with Lumis pre-built binary list of scales
 	for (uint8_t scale = 0; scale < MIDI_DEVICE_LUMI_KEYS_SCALE_COUNT; scale++) {
 		if (noteInt == scaleNotes[scale]) {
-			return {Scale(scale), 0};
+			return Scale(scale);
 		}
 	}
 
-	// Then if no matches found, try with all possible transpositions of all the scales
-	for (int32_t i = 0; i < kOctaveSize; i++) {
-		// Turn notes in octave into 12 bit binary
-		noteInt = 0;
-		for (uint8_t note = 0; note < noteCount; note++) {
-			noteInt |= 1 << ((modeNotes[note] + i) % kOctaveSize);
-		}
-		// Compare with pre-built binary list of scales
-		for (uint8_t scale = 0; scale < MIDI_DEVICE_LUMI_KEYS_SCALE_COUNT; scale++) {
-			if (noteInt == scaleNotes[scale]) {
-				return {Scale(scale), i};
-			}
-		}
-	}
-
-	return {Scale::CHROMATIC, 0};
+	return Scale::CHROMATIC;
 }
 
 void MIDIDeviceLumiKeys::setScale(Scale scale) {

--- a/src/deluge/io/midi/device_specific/midi_device_lumi_keys.h
+++ b/src/deluge/io/midi/device_specific/midi_device_lumi_keys.h
@@ -158,7 +158,7 @@ private:
 	void setMPEZone(MPEZone mpeZone);
 	void setMPENumChannels(uint8_t numChannels);
 	void setRootNote(int16_t rootNote);
-	std::pair<Scale, int16_t> determineScaleAndRootNoteOffsetFromNotes(uint8_t* modeNotes, uint8_t noteCount);
+	Scale determineScaleAndRootNoteOffsetFromNotes(uint8_t* modeNotes, uint8_t noteCount);
 	void setScale(Scale scale);
 	void setColour(ColourZone zone, RGB rgb);
 };

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -309,6 +309,7 @@ const uint8_t presetScaleNotes[NUM_PRESET_SCALES][7] = {
 		// 5-note scales
 		{0, 3, 5, 7, 10, 0, 0}, // PENT Pentatonic Minor (matches Launchpad and Lumi scale)
 		{0, 2, 3, 7, 8, 0, 0},  // HIRA Hirajoshi (matches Launchpad scale, and, transposed, also matches Lumi JAPANESE scale)
+		{0, 2, 3, 7, 8, 0, 0},  // HIRA Hirajoshi (matches Launchpad scale, and, transposed, also matches Lumi JAPANESE scale)
 
 };
 

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -308,7 +308,7 @@ const uint8_t presetScaleNotes[NUM_PRESET_SCALES][7] = {
 		{0, 3, 5, 6, 7, 10, 0}, // BLUE Blues Minor (matches Launchpad and Lumi BLUES scale)
 		// 5-note scales
 		{0, 3, 5, 7, 10, 0, 0}, // PENT Pentatonic Minor (matches Launchpad and Lumi scale)
-		{0, 2, 3, 7, 8, 0, 0},  // HIRA Hirajoshi (matches Launchpad scale, and, transposed, also matches Lumi JAPANESE scale)
+		{0, 2, 3, 7, 8, 0, 0},  // HIRA Hirajoshi (matches Launchpad scale)
 };
 
 

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -309,8 +309,6 @@ const uint8_t presetScaleNotes[NUM_PRESET_SCALES][7] = {
 		// 5-note scales
 		{0, 3, 5, 7, 10, 0, 0}, // PENT Pentatonic Minor (matches Launchpad and Lumi scale)
 		{0, 2, 3, 7, 8, 0, 0},  // HIRA Hirajoshi (matches Launchpad scale, and, transposed, also matches Lumi JAPANESE scale)
-		{0, 2, 3, 7, 8, 0, 0},  // HIRA Hirajoshi (matches Launchpad scale, and, transposed, also matches Lumi JAPANESE scale)
-
 };
 
 


### PR DESCRIPTION
I found that the logic to search for a matching scale for the Lumi keyboard was wrong. If one of the first 7 scales of the Deluge is selected (from Major to Locrian), as the code is searching for transpositions first and all those scales are equivalent, the Lumi keyboard could be highlighting correctly the notes but not the root key, even though the scale is available to choose. So now to fix this:
- First search among all the Deluge scales "as is" without transpositions, if there is a match return it.
- Then if no matches, as a fallback option, search for transpositions of the scales, to at list light up the keys even though the root note is not the same. Besides, the logic was wrong when calculating the notes.