### PR TITLE
FIX: Keyboard in file browser not showing when scrolling with horizontal encode #1030

### DIFF
--- a/src/deluge/gui/ui/browser/slot_browser.cpp
+++ b/src/deluge/gui/ui/browser/slot_browser.cpp
@@ -56,9 +56,8 @@ int32_t SlotBrowser::beginSlotSession(bool shouldDrawKeys, bool allowIfNoFolder)
 	}
 
 	if (shouldDrawKeys) {
-		PadLEDs::clearAllPadsWithoutSending();
+
 		drawKeys();
-		PadLEDs::sendOutMainPadColours();
 	}
 
 	return NO_ERROR;

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -205,9 +205,8 @@ useDefaultFolder:
 
 	// The redrawing of the sidebar only actually has to happen if we just changed to a different type *or* if we came
 	// in from (musical) keyboard view, I think
-	PadLEDs::clearAllPadsWithoutSending();
+
 	drawKeys();
-	PadLEDs::sendOutMainPadColours();
 
 	if (showingAuditionPads()) {
 		instrumentClipView.recalculateColours();

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -778,15 +778,8 @@ void LoadSongUI::displayText(bool blinkImmediately) {
 	if (qwertyVisible) {
 		FileItem* currentFileItem = getCurrentFileItem();
 
-		if (currentFileItem && !currentFileItem->isFolder) {
-			drawSongPreview(false); // Only draw this again so we can draw the keyboard on top of it. I think...
-		}
-		else {
-			PadLEDs::clearAllPadsWithoutSending();
-		}
-
 		drawKeys();
-		PadLEDs::sendOutMainPadColours();
+
 		PadLEDs::sendOutSidebarColours();
 	}
 }

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -53,7 +53,6 @@ bool QwertyUI::opened() {
 	return true;
 }
 
-// Won't "send"
 void QwertyUI::drawKeys() {
 	PadLEDs::clearMainPadsWithoutSending();
 

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -55,6 +55,7 @@ bool QwertyUI::opened() {
 
 // Won't "send"
 void QwertyUI::drawKeys() {
+	PadLEDs::clearMainPadsWithoutSending();
 
 	PadLEDs::clearTickSquares(false);
 
@@ -98,6 +99,8 @@ void QwertyUI::drawKeys() {
 		PadLEDs::image[kQwertyHomeRow - 1][1 + x] = colours::blue;
 		PadLEDs::image[kQwertyHomeRow - 1][13 + x] = colours::blue;
 	}
+
+	PadLEDs::sendOutMainPadColours();
 }
 
 void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t yPixel, int32_t maxNumChars,

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -46,9 +46,8 @@ bool RenameDrumUI::opened() {
 
 	displayText();
 
-	PadLEDs::clearMainPadsWithoutSending();
 	drawKeys();
-	PadLEDs::sendOutMainPadColours();
+
 	return true;
 }
 

--- a/src/deluge/gui/ui/rename/rename_output_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_output_ui.cpp
@@ -50,9 +50,8 @@ bool RenameOutputUI::opened() {
 
 	displayText();
 
-	PadLEDs::clearMainPadsWithoutSending();
 	drawKeys();
-	PadLEDs::sendOutMainPadColours();
+
 	return true;
 }
 


### PR DESCRIPTION
FIX: Keyboard in file browser not showing when scrolling with horizontal encode #1030

I also took the liberty to remove the "draw keyboard on top of waveform/song preview" thing - I'd bet money that nobody will miss it - it makes the keyboard very hard to see, does not provide useful information, and IMHO does not even "look cool". It's just visual clutter and unnecessary code.

This also enabled pulling the "clear pads" and "send pads" into the draw keyboard function, saving a bunch of code duplication.