### PR TITLE
Enhancement / MIDI Follow - Allow unlearning MIDI Follow Channels with Select Encoder

### DIFF
--- a/docs/features/midi_follow_mode.md
+++ b/docs/features/midi_follow_mode.md
@@ -62,6 +62,8 @@ You can unlearn a channel and device by pressing Shift + Learn while in the chan
 If you unlearn all MIDI Follow channels, MIDI Follow Mode will be disabled.
 If you unlearn the MIDI Feedback channel, MIDI Feedback will be disabled.
 
+You can also unlearn a channel using the Select encoder by scrolling between MPE Upper Zone and Channel 1.
+
 ### **Notes:**
 Notes received on the master MIDI channel will play the instrument in the active clip (e.g. a synth, MIDI clip, cv clip, or all kit rows).
 

--- a/src/deluge/gui/menu_item/midi/follow/follow_channel.h
+++ b/src/deluge/gui/menu_item/midi/follow/follow_channel.h
@@ -114,11 +114,11 @@ public:
 		}
 		else {
 			this->setValue(this->getValue() + offset);
-			if (this->getValue() >= NUM_CHANNELS) {
-				this->setValue(this->getValue() - NUM_CHANNELS);
-			}
-			else if (this->getValue() < 0) {
-				this->setValue(this->getValue() + NUM_CHANNELS);
+			if ((this->getValue() >= NUM_CHANNELS) || (this->getValue() < 0)) {
+				this->setValue(MIDI_CHANNEL_NONE);
+				midiInput.clear();
+				renderDisplay();
+				return;
 			}
 		}
 		Number::selectEncoderAction(offset);
@@ -128,12 +128,7 @@ public:
 		this->setValue(MIDI_CHANNEL_NONE);
 		midiInput.clear();
 		if (soundEditor.getCurrentMenuItem() == this) {
-			if (display->haveOLED()) {
-				renderUIsForOled();
-			}
-			else {
-				drawValue();
-			}
+			renderDisplay();
 		}
 		else {
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_UNLEARNED));
@@ -146,12 +141,7 @@ public:
 		midiInput.channelOrZone = channel;
 
 		if (soundEditor.getCurrentMenuItem() == this) {
-			if (display->haveOLED()) {
-				renderUIsForOled();
-			}
-			else {
-				drawValue();
-			}
+			renderDisplay();
 		}
 		else {
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_LEARNED));
@@ -166,15 +156,19 @@ public:
 		midiInput.channelOrZone = channel;
 
 		if (soundEditor.getCurrentMenuItem() == this) {
-			if (display->haveOLED()) {
-				renderUIsForOled();
-			}
-			else {
-				drawValue();
-			}
+			renderDisplay();
 		}
 		else {
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_LEARNED));
+		}
+	}
+
+	void renderDisplay() {
+		if (display->haveOLED()) {
+			renderUIsForOled();
+		}
+		else {
+			drawValue();
 		}
 	}
 


### PR DESCRIPTION
This closes: https://github.com/SynthstromAudible/DelugeFirmware/issues/1143

Select encoder now allows unlearning the Midi Follow Channel when you scroll to 0 (e.g. between MPE Upper and Channel 1).