### PR TITLE
Bugfix / Automation View - Calculate and Render Average Value on Automation Editor Grid

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3412,7 +3412,6 @@ uint32_t AutomationView::getMiddlePosFromSquare(int32_t xDisplay, int32_t effect
 }
 
 // calculates value of all nodes within a square for automation editor rendering
-// and for display of square value in pad selection mode
 int32_t AutomationView::getAverageSquareKnobPosition(ModelStackWithAutoParam* modelStack, int32_t xDisplay,
                                                      int32_t effectiveLength, int32_t xScroll, int32_t xZoom) {
 	int32_t squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3423,11 +3423,10 @@ int32_t AutomationView::getAverageSquareKnobPosition(ModelStackWithAutoParam* mo
 
 	for (int32_t i = 0; i < numNodesWithinSquare; i++) {
 		int32_t value = modelStack->autoParam->getValuePossiblyAtPos(squareStart + (i * kParamNodeWidth), modelStack);
-		totalKnobPos =
-		    totalKnobPos + modelStack->paramCollection->paramValueToKnobPos(value, modelStack) + kKnobPosOffset;
+		totalKnobPos = totalKnobPos + modelStack->paramCollection->paramValueToKnobPos(value, modelStack);
 	}
 
-	int32_t averageKnobPos = totalKnobPos / numNodesWithinSquare;
+	int32_t averageKnobPos = (totalKnobPos / numNodesWithinSquare) + kKnobPosOffset;
 
 	return averageKnobPos;
 }

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -219,6 +219,8 @@ private:
 	int32_t getEffectiveLength(ModelStackWithTimelineCounter* modelStack);
 	uint32_t getSquareWidth(int32_t square, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
 	uint32_t getMiddlePosFromSquare(int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
+	int32_t getAverageSquareKnobPosition(ModelStackWithAutoParam* modelStack, int32_t xDisplay, int32_t effectiveLength,
+	                                     int32_t xScroll, int32_t xZoom);
 
 	void getParameterName(Clip* clip, OutputType outputType, char* parameterName);
 	int32_t getParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t pos);


### PR DESCRIPTION
This addresses issue https://github.com/SynthstromAudible/DelugeFirmware/issues/903
- The issue reported that if you enter automation at a lower zoom level that it does not always show up at higher zoom levels
- This is because I was getting the value from the "middle node" within a column to display automation at higher zoom levels. The middle node may not always have a value if you manually enter automation at lower zoom levels.

To resolve this: 
- I added a calculation function to calculate the average value of all nodes within a grid square position
- I then used that average to render automation on the grid

A follow PR will be opened to address this remaining issue: https://github.com/SynthstromAudible/DelugeFirmware/issues/1172