### PR TITLE
BugFix isRelevant flag for GlobalEffectable ModFXType params in Global Menu's

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/gate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/gate.h
@@ -22,7 +22,9 @@ namespace deluge::gui::menu_item::arpeggiator {
 class Gate final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return !soundEditor.editingCVOrMIDIClip(); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		return !soundEditor.editingCVOrMIDIClip();
+	}
 };
 
 } // namespace deluge::gui::menu_item::arpeggiator

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
@@ -33,6 +33,8 @@ public:
 		getCurrentInstrumentClip()->arpeggiatorGate = (uint32_t)this->getValue() * 85899345 - 2147483648;
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return soundEditor.editingCVOrMIDIClip(); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		return soundEditor.editingCVOrMIDIClip();
+	}
 };
 } // namespace deluge::gui::menu_item::arpeggiator::midi_cv

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
@@ -37,6 +37,8 @@ public:
 		}
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return soundEditor.editingCVOrMIDIClip(); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		return soundEditor.editingCVOrMIDIClip();
+	}
 };
 } // namespace deluge::gui::menu_item::arpeggiator::midi_cv

--- a/src/deluge/gui/menu_item/arpeggiator/rate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/rate.h
@@ -22,7 +22,9 @@ namespace deluge::gui::menu_item::arpeggiator {
 class Rate final : public patched_param::Integer {
 public:
 	using patched_param::Integer::Integer;
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return !soundEditor.editingCVOrMIDIClip(); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		return !soundEditor.editingCVOrMIDIClip();
+	}
 };
 
 } // namespace deluge::gui::menu_item::arpeggiator

--- a/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.cpp
+++ b/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.cpp
@@ -25,10 +25,10 @@
 
 namespace deluge::gui::menu_item::audio_clip {
 
-MenuPermission SampleMarkerEditor::checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
-                                                                 MultiRange** currentRange) {
+MenuPermission SampleMarkerEditor::checkPermissionToBeginSession(ModControllableAudio* modControllable,
+                                                                 int32_t whichThing, MultiRange** currentRange) {
 
-	if (!isRelevant(sound, whichThing)) {
+	if (!isRelevant(modControllable, whichThing)) {
 		return MenuPermission::NO;
 	}
 

--- a/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.h
+++ b/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.h
@@ -26,7 +26,8 @@ public:
 	SampleMarkerEditor(l10n::String newName, MarkerType newWhichMarker = MarkerType::START)
 	    : MenuItem(newName), whichMarker(newWhichMarker) {}
 
-	virtual MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange);
+	virtual MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+	                                                     MultiRange** currentRange);
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
 
 	MarkerType whichMarker;

--- a/src/deluge/gui/menu_item/bend_range/per_finger.h
+++ b/src/deluge/gui/menu_item/bend_range/per_finger.h
@@ -38,7 +38,7 @@ public:
 			expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL] = this->getValue();
 		}
 	}
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return soundEditor.navigationDepth == 1 || soundEditor.editingKit();
 	}
 };

--- a/src/deluge/gui/menu_item/drum_name.cpp
+++ b/src/deluge/gui/menu_item/drum_name.cpp
@@ -22,7 +22,7 @@
 
 namespace deluge::gui::menu_item {
 
-bool DrumName::isRelevant(Sound* sound, int32_t whichThing) {
+bool DrumName::isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
 	return soundEditor.editingKit();
 }
 

--- a/src/deluge/gui/menu_item/drum_name.h
+++ b/src/deluge/gui/menu_item/drum_name.h
@@ -25,6 +25,6 @@ class DrumName final : public MenuItem {
 public:
 	using MenuItem::MenuItem;
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
-	bool isRelevant(Sound* sound, int32_t whichThing) override;
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override;
 };
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/file_selector.cpp
+++ b/src/deluge/gui/menu_item/file_selector.cpp
@@ -42,10 +42,13 @@ void FileSelector::beginSession(MenuItem* navigatedBackwardFrom) {
 		uiTimerManager.unsetTimer(TIMER_SHORTCUT_BLINK);
 	}
 }
-bool FileSelector::isRelevant(Sound* sound, int32_t whichThing) {
+bool FileSelector::isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
 	if (getCurrentClip()->type == ClipType::AUDIO) {
 		return true;
 	}
+
+	Sound* sound = static_cast<Sound*>(modControllable);
+
 	Source* source = &sound->sources[whichThing];
 
 	if (source->oscType == OscType::WAVETABLE) {
@@ -54,12 +57,14 @@ bool FileSelector::isRelevant(Sound* sound, int32_t whichThing) {
 
 	return (sound->getSynthMode() == SynthMode::SUBTRACTIVE && source->oscType == OscType::SAMPLE);
 }
-MenuPermission FileSelector::checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
+MenuPermission FileSelector::checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
                                                            ::MultiRange** currentRange) {
 
 	if (getCurrentClip()->type == ClipType::AUDIO) {
 		return MenuPermission::YES;
 	}
+
+	Sound* sound = static_cast<Sound*>(modControllable);
 
 	bool can =
 	    (sound->getSynthMode() == SynthMode::SUBTRACTIVE

--- a/src/deluge/gui/menu_item/file_selector.h
+++ b/src/deluge/gui/menu_item/file_selector.h
@@ -25,8 +25,9 @@ class FileSelector final : public MenuItem {
 public:
 	using MenuItem::MenuItem;
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
-	bool isRelevant(Sound* sound, int32_t whichThing) override;
-	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) override;
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override;
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+	                                             MultiRange** currentRange) override;
 };
 
 extern FileSelector fileSelectorMenu;

--- a/src/deluge/gui/menu_item/filter/hpf_mode.h
+++ b/src/deluge/gui/menu_item/filter/hpf_mode.h
@@ -41,7 +41,8 @@ public:
 		    l10n::getView(STRING_FOR_HPLADDER),
 		};
 	}
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		return ((sound == nullptr) || sound->synthMode != ::SynthMode::FM);
 	}
 };

--- a/src/deluge/gui/menu_item/filter/lpf_mode.h
+++ b/src/deluge/gui/menu_item/filter/lpf_mode.h
@@ -36,7 +36,8 @@ public:
 		    l10n::getView(STRING_FOR_SVF_NOTCH),
 		};
 	}
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		return ((sound == nullptr) || sound->synthMode != ::SynthMode::FM);
 	}
 };

--- a/src/deluge/gui/menu_item/filter_route.h
+++ b/src/deluge/gui/menu_item/filter_route.h
@@ -32,7 +32,8 @@ public:
 	deluge::vector<std::string_view> getOptions() override {
 		return {"HPF2LPF", "LPF2HPF", l10n::getView(l10n::String::STRING_FOR_PARALLEL)};
 	}
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		return ((sound == nullptr) || sound->synthMode != ::SynthMode::FM);
 	}
 };

--- a/src/deluge/gui/menu_item/lfo/global/rate.h
+++ b/src/deluge/gui/menu_item/lfo/global/rate.h
@@ -23,6 +23,9 @@ class Rate final : public patched_param::Integer {
 public:
 	using Integer::Integer;
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->lfoGlobalSyncLevel == 0); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->lfoGlobalSyncLevel == 0);
+	}
 };
 } // namespace deluge::gui::menu_item::lfo::global

--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -16,14 +16,16 @@
  */
 
 #include "menu_item.h"
+#include "gui/ui/sound_editor.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h" //todo: this probably shouldn't be needed
 #include <string_view>
 
 using namespace deluge;
 
-MenuPermission MenuItem::checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) {
-	bool toReturn = isRelevant(sound, whichThing);
+MenuPermission MenuItem::checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+                                                       MultiRange** currentRange) {
+	bool toReturn = isRelevant(modControllable, whichThing);
 	return toReturn ? MenuPermission::YES : MenuPermission::NO;
 }
 

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -21,6 +21,7 @@
 #include "gui/l10n/l10n.h"
 #include "gui/l10n/strings.h"
 #include "hid/buttons.h"
+#include "model/mod_controllable/mod_controllable_audio.h"
 #include <cstdint>
 #include <span>
 
@@ -59,9 +60,10 @@ public:
 	virtual void horizontalEncoderAction(int32_t offset) {}
 	virtual void selectEncoderAction(int32_t offset) {}
 	virtual void beginSession(MenuItem* navigatedBackwardFrom = nullptr){};
-	virtual bool isRelevant(Sound* sound, int32_t whichThing) { return true; }
+	virtual bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) { return true; }
 	virtual MenuItem* selectButtonPress() { return nullptr; }
-	virtual MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange);
+	virtual MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+	                                                     MultiRange** currentRange);
 	virtual void readValueAgain() {}
 	virtual bool selectEncoderActionEditsInstrument() { return false; }
 	virtual uint8_t getPatchedParamIndex() { return 255; }

--- a/src/deluge/gui/menu_item/midi/preset.h
+++ b/src/deluge/gui/menu_item/midi/preset.h
@@ -54,7 +54,7 @@ public:
 		}
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return getCurrentOutputType() == OutputType::MIDI_OUT;
 	}
 

--- a/src/deluge/gui/menu_item/mod_fx/depth_patched.h
+++ b/src/deluge/gui/menu_item/mod_fx/depth_patched.h
@@ -17,16 +17,17 @@
 #pragma once
 #include "definitions_cxx.hpp"
 #include "gui/menu_item/patched_param/integer.h"
-#include "processing/sound/sound.h"
+#include "gui/ui/sound_editor.h"
+#include "model/mod_controllable/mod_controllable_audio.h"
 #include "util/comparison.h"
 
 namespace deluge::gui::menu_item::mod_fx {
-class Depth final : public patched_param::Integer {
+class Depth_Patched final : public patched_param::Integer {
 public:
 	using patched_param::Integer::Integer;
 
 	bool isRelevant(Sound* sound, int32_t whichThing) {
-		return util::one_of(sound->modFXType,
+		return util::one_of(soundEditor.currentModControllable->getModFXType(),
 		                    {ModFXType::CHORUS, ModFXType::CHORUS_STEREO, ModFXType::GRAIN, ModFXType::PHASER});
 	}
 };

--- a/src/deluge/gui/menu_item/mod_fx/depth_patched.h
+++ b/src/deluge/gui/menu_item/mod_fx/depth_patched.h
@@ -26,8 +26,8 @@ class Depth_Patched final : public patched_param::Integer {
 public:
 	using patched_param::Integer::Integer;
 
-	bool isRelevant(Sound* sound, int32_t whichThing) {
-		return util::one_of(soundEditor.currentModControllable->getModFXType(),
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
+		return util::one_of(modControllable->getModFXType(),
 		                    {ModFXType::CHORUS, ModFXType::CHORUS_STEREO, ModFXType::GRAIN, ModFXType::PHASER});
 	}
 };

--- a/src/deluge/gui/menu_item/mod_fx/depth_unpatched.h
+++ b/src/deluge/gui/menu_item/mod_fx/depth_unpatched.h
@@ -25,8 +25,8 @@ class Depth_Unpatched final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
 
-	bool isRelevant(Sound* sound, int32_t whichThing) {
-		return util::one_of(soundEditor.currentModControllable->getModFXType(),
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
+		return util::one_of(modControllable->getModFXType(),
 		                    {ModFXType::CHORUS, ModFXType::CHORUS_STEREO, ModFXType::GRAIN, ModFXType::PHASER});
 	}
 };

--- a/src/deluge/gui/menu_item/mod_fx/depth_unpatched.h
+++ b/src/deluge/gui/menu_item/mod_fx/depth_unpatched.h
@@ -21,15 +21,13 @@
 #include "util/comparison.h"
 
 namespace deluge::gui::menu_item::mod_fx {
-
-class Offset final : public UnpatchedParam {
+class Depth_Unpatched final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
 
 	bool isRelevant(Sound* sound, int32_t whichThing) {
-		return (util::one_of(soundEditor.currentModControllable->getModFXType(),
-		                     {ModFXType::CHORUS, ModFXType::CHORUS_STEREO, ModFXType::GRAIN}));
+		return util::one_of(soundEditor.currentModControllable->getModFXType(),
+		                    {ModFXType::CHORUS, ModFXType::CHORUS_STEREO, ModFXType::GRAIN, ModFXType::PHASER});
 	}
 };
-
 } // namespace deluge::gui::menu_item::mod_fx

--- a/src/deluge/gui/menu_item/mod_fx/feedback.h
+++ b/src/deluge/gui/menu_item/mod_fx/feedback.h
@@ -25,9 +25,9 @@ class Feedback final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
 
-	bool isRelevant(Sound* sound, int32_t whichThing) {
-		return (util::one_of(soundEditor.currentModControllable->getModFXType(),
-		                     {ModFXType::FLANGER, ModFXType::PHASER, ModFXType::GRAIN}));
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
+		return (
+		    util::one_of(modControllable->getModFXType(), {ModFXType::FLANGER, ModFXType::PHASER, ModFXType::GRAIN}));
 	}
 };
 } // namespace deluge::gui::menu_item::mod_fx

--- a/src/deluge/gui/menu_item/mod_fx/feedback.h
+++ b/src/deluge/gui/menu_item/mod_fx/feedback.h
@@ -16,16 +16,18 @@
  */
 #pragma once
 #include "gui/menu_item/unpatched_param.h"
-#include "processing/sound/sound.h"
+#include "gui/ui/sound_editor.h"
+#include "model/mod_controllable/mod_controllable_audio.h"
 #include "util/comparison.h"
 
 namespace deluge::gui::menu_item::mod_fx {
 class Feedback final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
+
 	bool isRelevant(Sound* sound, int32_t whichThing) {
-		// TODO: really want to receive a ModControllableAudio here!
-		return (!sound || util::one_of(sound->modFXType, {ModFXType::FLANGER, ModFXType::PHASER, ModFXType::GRAIN}));
+		return (util::one_of(soundEditor.currentModControllable->getModFXType(),
+		                     {ModFXType::FLANGER, ModFXType::PHASER, ModFXType::GRAIN}));
 	}
 };
 } // namespace deluge::gui::menu_item::mod_fx

--- a/src/deluge/gui/menu_item/mod_fx/offset.h
+++ b/src/deluge/gui/menu_item/mod_fx/offset.h
@@ -26,8 +26,8 @@ class Offset final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
 
-	bool isRelevant(Sound* sound, int32_t whichThing) {
-		return (util::one_of(soundEditor.currentModControllable->getModFXType(),
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
+		return (util::one_of(modControllable->getModFXType(),
 		                     {ModFXType::CHORUS, ModFXType::CHORUS_STEREO, ModFXType::GRAIN}));
 	}
 };

--- a/src/deluge/gui/menu_item/modulator/destination.h
+++ b/src/deluge/gui/menu_item/modulator/destination.h
@@ -34,7 +34,8 @@ public:
 		    mod1,
 		};
 	}
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		return (whichThing == 1 && sound->synthMode == SynthMode::FM);
 	}
 };

--- a/src/deluge/gui/menu_item/modulator/transpose.h
+++ b/src/deluge/gui/menu_item/modulator/transpose.h
@@ -46,7 +46,10 @@ public:
 		soundEditor.currentSound->setModulatorCents(soundEditor.currentSourceIndex, cents, modelStack);
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() == SynthMode::FM); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->getSynthMode() == SynthMode::FM);
+	}
 };
 
 } // namespace deluge::gui::menu_item::modulator

--- a/src/deluge/gui/menu_item/osc/audio_recorder.h
+++ b/src/deluge/gui/menu_item/osc/audio_recorder.h
@@ -39,19 +39,22 @@ public:
 			audioRecorder.process();
 		}
 	}
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		Source* source = &sound->sources[whichThing];
 		return (sound->getSynthMode() == SynthMode::SUBTRACTIVE);
 	}
 
-	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
 	                                             ::MultiRange** currentRange) override {
 
-		bool can = isRelevant(sound, whichThing);
+		bool can = isRelevant(modControllable, whichThing);
 		if (!can) {
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_CANT_RECORD_AUDIO_FM_MODE));
 			return MenuPermission::NO;
 		}
+
+		Sound* sound = static_cast<Sound*>(modControllable);
 
 		return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, false, currentRange);
 	}

--- a/src/deluge/gui/menu_item/osc/pulse_width.h
+++ b/src/deluge/gui/menu_item/osc/pulse_width.h
@@ -48,7 +48,8 @@ public:
 		    >> 32);
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		if (sound->getSynthMode() == SynthMode::FM) {
 			return false;
 		}

--- a/src/deluge/gui/menu_item/osc/retrigger_phase.h
+++ b/src/deluge/gui/menu_item/osc/retrigger_phase.h
@@ -82,7 +82,8 @@ public:
 		}
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		Source* source = &sound->sources[whichThing];
 		if (forModulator && sound->getSynthMode() != SynthMode::FM) {
 			return false;

--- a/src/deluge/gui/menu_item/osc/source/feedback.h
+++ b/src/deluge/gui/menu_item/osc/source/feedback.h
@@ -27,7 +27,10 @@ public:
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() == SynthMode::FM); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->getSynthMode() == SynthMode::FM);
+	}
 };
 
 } // namespace deluge::gui::menu_item::osc::source

--- a/src/deluge/gui/menu_item/osc/source/volume.h
+++ b/src/deluge/gui/menu_item/osc/source/volume.h
@@ -28,6 +28,9 @@ public:
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() != SynthMode::RINGMOD); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->getSynthMode() != SynthMode::RINGMOD);
+	}
 };
 } // namespace deluge::gui::menu_item::osc::source

--- a/src/deluge/gui/menu_item/osc/source/wave_index.h
+++ b/src/deluge/gui/menu_item/osc/source/wave_index.h
@@ -27,7 +27,8 @@ public:
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		Source* source = &sound->sources[whichThing];
 		return (sound->getSynthMode() != SynthMode::FM && source->oscType == OscType::WAVETABLE);
 	}

--- a/src/deluge/gui/menu_item/osc/sync.h
+++ b/src/deluge/gui/menu_item/osc/sync.h
@@ -25,7 +25,8 @@ public:
 	using Toggle::Toggle;
 	void readCurrentValue() override { this->setValue(soundEditor.currentSound->oscillatorSync); }
 	void writeCurrentValue() override { soundEditor.currentSound->oscillatorSync = this->getValue(); }
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		return (whichThing == 1 && sound->synthMode != SynthMode::FM && sound->sources[0].oscType != OscType::SAMPLE
 		        && sound->sources[1].oscType != OscType::SAMPLE);
 	}

--- a/src/deluge/gui/menu_item/osc/type.h
+++ b/src/deluge/gui/menu_item/osc/type.h
@@ -87,7 +87,10 @@ public:
 		return {options.begin(), options.begin() + kNumOscTypes - 2};
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() != SynthMode::FM); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->getSynthMode() != SynthMode::FM);
+	}
 };
 
 } // namespace deluge::gui::menu_item::osc

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -181,8 +181,8 @@ void PatchCableStrength::writeCurrentValue() {
 	modelStackWithParam->autoParam->setCurrentValueInResponseToUserInput(finalValue, modelStackWithParam);
 }
 
-MenuPermission PatchCableStrength::checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
-                                                                 MultiRange** currentRange) {
+MenuPermission PatchCableStrength::checkPermissionToBeginSession(ModControllableAudio* modControllable,
+                                                                 int32_t whichThing, MultiRange** currentRange) {
 
 	ParamDescriptor destinationDescriptor = getDestinationDescriptor();
 	PatchSource s = getS();
@@ -201,6 +201,8 @@ MenuPermission PatchCableStrength::checkPermissionToBeginSession(Sound* sound, i
 	}
 
 	int32_t p = destinationDescriptor.getJustTheParam();
+
+	Sound* sound = static_cast<Sound*>(modControllable);
 
 	// Note, that requires soundEditor.currentParamManager be set before this is called, which isn't quite ideal.
 	if (sound->maySourcePatchToParam(s, p, ((ParamManagerForTimeline*)soundEditor.currentParamManager))

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -32,7 +32,8 @@ public:
 	[[nodiscard]] int32_t getMaxValue() const final { return kMaxMenuPatchCableValue; }
 	[[nodiscard]] int32_t getNumDecimalPlaces() const final { return 2; }
 	virtual int32_t getDefaultEditPos() { return 2; }
-	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) override;
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+	                                             MultiRange** currentRange) override;
 	virtual ParamDescriptor getDestinationDescriptor() = 0;
 	virtual PatchSource getS() = 0;
 	uint8_t getIndexOfPatchedParamToBlink() final;

--- a/src/deluge/gui/menu_item/patch_cable_strength/fixed.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength/fixed.cpp
@@ -24,10 +24,11 @@
 #include "storage/multi_range/multi_range.h"
 
 namespace deluge::gui::menu_item::patch_cable_strength {
-MenuPermission Fixed::checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) {
+MenuPermission Fixed::checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+                                                    MultiRange** currentRange) {
 	soundEditor.patchingParamSelected = p;
 	source_selection::regularMenu.s = s;
-	return PatchCableStrength::checkPermissionToBeginSession(sound, whichThing, currentRange);
+	return PatchCableStrength::checkPermissionToBeginSession(modControllable, whichThing, currentRange);
 }
 
 uint8_t Fixed::shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour) {

--- a/src/deluge/gui/menu_item/patch_cable_strength/fixed.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength/fixed.h
@@ -25,7 +25,8 @@ public:
 	Fixed(l10n::String newName, int32_t newP = 0, PatchSource newS = PatchSource::LFO_GLOBAL)
 	    : Regular(newName), p(newP), s(newS) {}
 
-	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) final;
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+	                                             MultiRange** currentRange) final;
 	uint8_t shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour) final;
 	MenuItem* patchingSourceShortcutPress(PatchSource s, bool previousPressStillActive) final;
 

--- a/src/deluge/gui/menu_item/patch_cable_strength/regular.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength/regular.cpp
@@ -52,7 +52,10 @@ PatchSource Regular::getS() {
 	return source_selection::regularMenu.s;
 }
 
-MenuPermission Regular::checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) {
+MenuPermission Regular::checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+                                                      MultiRange** currentRange) {
+
+	Sound* sound = static_cast<Sound*>(modControllable);
 
 	if (soundEditor.patchingParamSelected == deluge::modulation::params::GLOBAL_VOLUME_POST_FX) {
 		if (sound->maySourcePatchToParam(getS(), soundEditor.patchingParamSelected,
@@ -67,7 +70,7 @@ MenuPermission Regular::checkPermissionToBeginSession(Sound* sound, int32_t whic
 		}
 	}
 
-	return PatchCableStrength::checkPermissionToBeginSession(sound, whichThing, currentRange);
+	return PatchCableStrength::checkPermissionToBeginSession(modControllable, whichThing, currentRange);
 }
 
 uint8_t Regular::shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour) {

--- a/src/deluge/gui/menu_item/patch_cable_strength/regular.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength/regular.h
@@ -27,7 +27,8 @@ public:
 	ParamDescriptor getDestinationDescriptor() final;
 	PatchSource getS() final;
 	ParamDescriptor getLearningThing() final;
-	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) override;
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+	                                             MultiRange** currentRange) override;
 	uint8_t shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour) override;
 	MenuItem* patchingSourceShortcutPress(PatchSource s, bool previousPressStillActive) override;
 	MenuItem* selectButtonPress() final;

--- a/src/deluge/gui/menu_item/patched_param/integer_non_fm.h
+++ b/src/deluge/gui/menu_item/patched_param/integer_non_fm.h
@@ -22,6 +22,9 @@ namespace deluge::gui::menu_item::patched_param {
 class IntegerNonFM : public Integer {
 public:
 	using Integer::Integer;
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->synthMode != SynthMode::FM); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->synthMode != SynthMode::FM);
+	}
 };
 } // namespace deluge::gui::menu_item::patched_param

--- a/src/deluge/gui/menu_item/reverb/sidechain/shape.h
+++ b/src/deluge/gui/menu_item/reverb/sidechain/shape.h
@@ -33,6 +33,8 @@ public:
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (AudioEngine::reverbSidechainVolume >= 0); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		return (AudioEngine::reverbSidechainVolume >= 0);
+	}
 };
 } // namespace deluge::gui::menu_item::reverb::sidechain

--- a/src/deluge/gui/menu_item/sample/interpolation.h
+++ b/src/deluge/gui/menu_item/sample/interpolation.h
@@ -40,7 +40,8 @@ public:
 		return {l10n::getView(l10n::String::STRING_FOR_LINEAR), l10n::getView(l10n::String::STRING_FOR_SINC)};
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		if (sound == nullptr) {
 			return true;
 		}

--- a/src/deluge/gui/menu_item/sample/loop_point.cpp
+++ b/src/deluge/gui/menu_item/sample/loop_point.cpp
@@ -28,18 +28,23 @@
 
 namespace deluge::gui::menu_item::sample {
 
-bool LoopPoint::isRelevant(Sound* sound, int32_t whichThing) {
+bool LoopPoint::isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
+
+	Sound* sound = static_cast<Sound*>(modControllable);
 
 	Source* source = &sound->sources[whichThing];
 
 	return (sound->getSynthMode() == SynthMode::SUBTRACTIVE && source->oscType == OscType::SAMPLE);
 }
 
-MenuPermission LoopPoint::checkPermissionToBeginSession(Sound* sound, int32_t whichThing, MultiRange** currentRange) {
+MenuPermission LoopPoint::checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+                                                        MultiRange** currentRange) {
 
-	if (!isRelevant(sound, whichThing)) {
+	if (!isRelevant(modControllable, whichThing)) {
 		return MenuPermission::NO;
 	}
+
+	Sound* sound = static_cast<Sound*>(modControllable);
 
 	MenuPermission permission =
 	    soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, true, currentRange);

--- a/src/deluge/gui/menu_item/sample/loop_point.h
+++ b/src/deluge/gui/menu_item/sample/loop_point.h
@@ -26,9 +26,10 @@ class LoopPoint : public MenuItem {
 public:
 	using MenuItem::MenuItem;
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) final;
-	bool isRelevant(::Sound* sound, int32_t whichThing) final;
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) final;
 	bool isRangeDependent() final { return true; }
-	MenuPermission checkPermissionToBeginSession(::Sound* sound, int32_t whichThing, ::MultiRange** currentRange) final;
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
+	                                             ::MultiRange** currentRange) final;
 
 	int32_t xZoom;
 	int32_t xScroll;

--- a/src/deluge/gui/menu_item/sample/selection.h
+++ b/src/deluge/gui/menu_item/sample/selection.h
@@ -23,7 +23,7 @@ template <size_t n>
 class Selection : public menu_item::Selection {
 public:
 	using menu_item::Selection::Selection;
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		if (sound == nullptr) {
 			return true; // For AudioClips
 		}

--- a/src/deluge/gui/menu_item/sample/time_stretch.h
+++ b/src/deluge/gui/menu_item/sample/time_stretch.h
@@ -58,7 +58,8 @@ public:
 	}
 	[[nodiscard]] int32_t getMinValue() const override { return -48; }
 	[[nodiscard]] int32_t getMaxValue() const override { return 48; }
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		Source* source = &sound->sources[whichThing];
 		return (sound->getSynthMode() == SynthMode::SUBTRACTIVE && source->oscType == OscType::SAMPLE);
 	}

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -66,13 +66,14 @@ public:
 		soundEditor.currentSound->recalculateAllVoicePhaseIncrements(modelStack);
 	}
 
-	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
 	                                             ::MultiRange** currentRange) override {
 
-		if (!isRelevant(sound, whichThing)) {
+		if (!isRelevant(modControllable, whichThing)) {
 			return MenuPermission::NO;
 		}
 
+		Sound* sound = static_cast<Sound*>(modControllable);
 		Source* source = &sound->sources[whichThing];
 
 		if (sound->getSynthMode() == SynthMode::FM

--- a/src/deluge/gui/menu_item/sequence/direction.h
+++ b/src/deluge/gui/menu_item/sequence/direction.h
@@ -84,7 +84,7 @@ public:
 		return sequenceDirectionOptions;
 	}
 
-	MenuPermission checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
+	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
 	                                             ::MultiRange** currentRange) override {
 		if (!getCurrentInstrumentClip()->affectEntire && getCurrentOutputType() == OutputType::KIT
 		    && (getCurrentKit()->selectedDrum == nullptr)) {

--- a/src/deluge/gui/menu_item/sidechain/attack.h
+++ b/src/deluge/gui/menu_item/sidechain/attack.h
@@ -32,7 +32,7 @@ public:
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingReverbSidechain() || AudioEngine::reverbSidechainVolume >= 0;
 	}
 };

--- a/src/deluge/gui/menu_item/sidechain/release.h
+++ b/src/deluge/gui/menu_item/sidechain/release.h
@@ -32,7 +32,7 @@ public:
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return 50; }
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingReverbSidechain() || AudioEngine::reverbSidechainVolume >= 0;
 	}
 };

--- a/src/deluge/gui/menu_item/sidechain/send.h
+++ b/src/deluge/gui/menu_item/sidechain/send.h
@@ -35,6 +35,8 @@ public:
 		}
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (soundEditor.editingKit()); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		return (soundEditor.editingKit());
+	}
 };
 } // namespace deluge::gui::menu_item::sidechain

--- a/src/deluge/gui/menu_item/sidechain/sync.h
+++ b/src/deluge/gui/menu_item/sidechain/sync.h
@@ -35,7 +35,7 @@ public:
 		soundEditor.currentSidechain->syncLevel = menuOptionToSyncLevel(this->getValue());
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	}
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingReverbSidechain() || AudioEngine::reverbSidechainVolume >= 0;
 	}
 };

--- a/src/deluge/gui/menu_item/source/patched_param/fm.h
+++ b/src/deluge/gui/menu_item/source/patched_param/fm.h
@@ -27,6 +27,9 @@ public:
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->getSynthMode() == SynthMode::FM); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->getSynthMode() == SynthMode::FM);
+	}
 };
 } // namespace deluge::gui::menu_item::source::patched_param

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -17,7 +17,7 @@ void Submenu::beginSession(MenuItem* navigatedBackwardFrom) {
 	}
 	// loop through non-null items until we find a relevant one
 	while ((*current_item_ != nullptr)
-	       && !(*current_item_)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
+	       && !(*current_item_)->isRelevant(soundEditor.currentModControllable, soundEditor.currentSourceIndex)) {
 		current_item_++;
 		if (current_item_ == items.end()) { // Not sure we need this since we don't wrap submenu items?
 			current_item_ = items.begin();
@@ -44,7 +44,7 @@ void Submenu::drawPixelsForOled() {
 	static_vector<std::string_view, kOLEDMenuNumOptionsVisible> nextItemNames = {};
 	int32_t idx = selectedRow;
 	for (auto it = current_item_; it != this->items.end() && idx < kOLEDMenuNumOptionsVisible; it++) {
-		if ((*it)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
+		if ((*it)->isRelevant(soundEditor.currentModControllable, soundEditor.currentSourceIndex)) {
 			nextItemNames.push_back((*it)->getName());
 			idx++;
 		}
@@ -53,7 +53,7 @@ void Submenu::drawPixelsForOled() {
 	static_vector<std::string_view, kOLEDMenuNumOptionsVisible> prevItemNames = {};
 	idx = selectedRow - 1;
 	for (auto it = current_item_ - 1; it != this->items.begin() - 1 && idx >= 0; it--) {
-		if ((*it)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex)) {
+		if ((*it)->isRelevant(soundEditor.currentModControllable, soundEditor.currentSourceIndex)) {
 			prevItemNames.push_back((*it)->getName());
 			idx--;
 		}
@@ -99,7 +99,7 @@ void Submenu::selectEncoderAction(int32_t offset) {
 					thisSubmenuItem--;
 				}
 			}
-		} while (!(*thisSubmenuItem)->isRelevant(soundEditor.currentSound, soundEditor.currentSourceIndex));
+		} while (!(*thisSubmenuItem)->isRelevant(soundEditor.currentModControllable, soundEditor.currentSourceIndex));
 
 		current_item_ = thisSubmenuItem;
 

--- a/src/deluge/gui/menu_item/submenu/MPE.h
+++ b/src/deluge/gui/menu_item/submenu/MPE.h
@@ -23,7 +23,7 @@ namespace deluge::gui::menu_item::submenu {
 class PolyMonoConversion final : public Submenu {
 public:
 	using Submenu::Submenu;
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		// not relevant for cv currently
 		const auto type = getCurrentOutputType();
 		return (type == OutputType::MIDI_OUT);

--- a/src/deluge/gui/menu_item/submenu/bend.h
+++ b/src/deluge/gui/menu_item/submenu/bend.h
@@ -23,7 +23,7 @@ namespace deluge::gui::menu_item::submenu {
 class Bend final : public Submenu {
 public:
 	using Submenu::Submenu;
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		// Drums within a Kit don't need the two-item submenu - they have their own single item.
 		const auto type = getCurrentOutputType();
 		return (type == OutputType::SYNTH || type == OutputType::CV || type == OutputType::MIDI_OUT);

--- a/src/deluge/gui/menu_item/submenu/filter.h
+++ b/src/deluge/gui/menu_item/submenu/filter.h
@@ -22,7 +22,10 @@ namespace deluge::gui::menu_item::submenu {
 class Filter final : public Submenu {
 public:
 	using Submenu::Submenu;
-	bool isRelevant(Sound* sound, int32_t whichThing) override { return (sound->synthMode != SynthMode::FM); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->synthMode != SynthMode::FM);
+	}
 };
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/submenu/modulator.h
+++ b/src/deluge/gui/menu_item/submenu/modulator.h
@@ -30,7 +30,10 @@ public:
 		SubmenuReferringToOneThing::beginSession(navigatedBackwardFrom);
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) { return (sound->synthMode == SynthMode::FM); }
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
+		Sound* sound = static_cast<Sound*>(modControllable);
+		return (sound->synthMode == SynthMode::FM);
+	}
 };
 
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/menu_item/synth_mode.h
+++ b/src/deluge/gui/menu_item/synth_mode.h
@@ -40,7 +40,8 @@ public:
 		};
 	}
 
-	bool isRelevant(Sound* sound, int32_t whichThing) override {
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		Sound* sound = static_cast<Sound*>(modControllable);
 		return (sound->sources[0].oscType <= kLastRingmoddableOscType
 		        && sound->sources[1].oscType <= kLastRingmoddableOscType);
 	}

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -69,7 +69,8 @@
 #include "gui/menu_item/midi/pgm.h"
 #include "gui/menu_item/midi/sub.h"
 #include "gui/menu_item/midi/takeover.h"
-#include "gui/menu_item/mod_fx/depth.h"
+#include "gui/menu_item/mod_fx/depth_patched.h"
+#include "gui/menu_item/mod_fx/depth_unpatched.h"
 #include "gui/menu_item/mod_fx/feedback.h"
 #include "gui/menu_item/mod_fx/offset.h"
 #include "gui/menu_item/mod_fx/type.h"
@@ -347,7 +348,7 @@ Submenu lfo1Menu{STRING_FOR_LFO2, {&lfo2TypeMenu, &lfo2RateMenu}};
 mod_fx::Type modFXTypeMenu{STRING_FOR_TYPE, STRING_FOR_MODFX_TYPE};
 patched_param::Integer modFXRateMenu{STRING_FOR_RATE, STRING_FOR_MODFX_RATE, params::GLOBAL_MOD_FX_RATE};
 mod_fx::Feedback modFXFeedbackMenu{STRING_FOR_FEEDBACK, STRING_FOR_MODFX_FEEDBACK, params::UNPATCHED_MOD_FX_FEEDBACK};
-mod_fx::Depth modFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MODFX_DEPTH, params::GLOBAL_MOD_FX_DEPTH};
+mod_fx::Depth_Patched modFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MODFX_DEPTH, params::GLOBAL_MOD_FX_DEPTH};
 mod_fx::Offset modFXOffsetMenu{STRING_FOR_OFFSET, STRING_FOR_MODFX_OFFSET, params::UNPATCHED_MOD_FX_OFFSET};
 
 Submenu modFXMenu{
@@ -612,7 +613,7 @@ Submenu globalReverbMenu{
 
 // Mod FX Menu
 
-UnpatchedParam globalModFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MOD_FX_DEPTH, params::UNPATCHED_MOD_FX_DEPTH};
+mod_fx::Depth_Unpatched globalModFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MOD_FX_DEPTH, params::UNPATCHED_MOD_FX_DEPTH};
 UnpatchedParam globalModFXRateMenu{STRING_FOR_RATE, STRING_FOR_MOD_FX_RATE, params::UNPATCHED_MOD_FX_RATE};
 
 Submenu globalModFXMenu{

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -240,8 +240,8 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				if (newItem) {
 					if (newItem != (MenuItem*)0xFFFFFFFF) {
 
-						MenuPermission result = newItem->checkPermissionToBeginSession(currentSound, currentSourceIndex,
-						                                                               &currentMultiRange);
+						MenuPermission result = newItem->checkPermissionToBeginSession(
+						    currentModControllable, currentSourceIndex, &currentMultiRange);
 
 						if (result != MenuPermission::NO) {
 
@@ -413,7 +413,8 @@ void SoundEditor::goUpOneLevel() {
 			return;
 		}
 		navigationDepth--;
-	} while (getCurrentMenuItem()->checkPermissionToBeginSession(currentSound, currentSourceIndex, &currentMultiRange)
+	} while (getCurrentMenuItem()->checkPermissionToBeginSession(currentModControllable, currentSourceIndex,
+	                                                             &currentMultiRange)
 	         == MenuPermission::NO);
 	display->setNextTransitionDirection(-1);
 
@@ -980,7 +981,7 @@ getOut:
 
 						// If we've been given a MenuItem to go into, do that
 						if (newMenuItem
-						    && newMenuItem->checkPermissionToBeginSession(currentSound, currentSourceIndex,
+						    && newMenuItem->checkPermissionToBeginSession(currentModControllable, currentSourceIndex,
 						                                                  &currentMultiRange)
 						           != MenuPermission::NO) {
 							navigationDepth = newNavigationDepth + 1;
@@ -1305,7 +1306,7 @@ doMIDIOrCV:
 	// depth", it needs this.
 	currentParamManager = newParamManager;
 
-	MenuPermission result = newItem->checkPermissionToBeginSession(newSound, sourceIndex, &newRange);
+	MenuPermission result = newItem->checkPermissionToBeginSession(newModControllable, sourceIndex, &newRange);
 
 	if (result == MenuPermission::NO) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PARAMETER_NOT_APPLICABLE));

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -650,6 +650,10 @@ ModelStackWithAutoParam* GlobalEffectable::getParamFromModEncoder(int32_t whichM
 	}
 }
 
+ModFXType GlobalEffectable::getModFXType() {
+	return modFXType;
+}
+
 void GlobalEffectable::ensureModFXParamIsValid() {
 	while (true) {
 		if (currentModFXParam == ModFXParam::DEPTH) {

--- a/src/deluge/model/global_effectable/global_effectable.h
+++ b/src/deluge/model/global_effectable/global_effectable.h
@@ -62,6 +62,8 @@ public:
 	bool editingComp;
 	CompParam currentCompParam;
 
+	ModFXType getModFXType();
+
 protected:
 	int maxCompParam = 0;
 	virtual int32_t getParameterFromKnob(int32_t whichModEncoder);

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -86,6 +86,7 @@ public:
 	virtual void wontBeRenderedForAWhile();
 	void beginStutter(ParamManagerForTimeline* paramManager);
 	void endStutter(ParamManagerForTimeline* paramManager);
+	virtual ModFXType getModFXType() = 0;
 	virtual bool setModFXType(ModFXType newType);
 	bool offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
 	                                    ModelStackWithTimelineCounter* modelStack, int32_t noteRowIndex = -1);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -348,6 +348,10 @@ void Sound::setupAsBlankSynth(ParamManager* paramManager) {
 	doneReadingFromFile();
 }
 
+ModFXType Sound::getModFXType() {
+	return modFXType;
+}
+
 // Returns false if not enough ram
 bool Sound::setModFXType(ModFXType newType) {
 	if (newType == ModFXType::FLANGER || newType == ModFXType::CHORUS || newType == ModFXType::CHORUS_STEREO) {

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -140,6 +140,7 @@ public:
 	virtual ArpeggiatorSettings* getArpSettings(InstrumentClip* clip = NULL) = 0;
 	virtual void setSkippingRendering(bool newSkipping);
 
+	ModFXType getModFXType();
 	bool setModFXType(ModFXType newType) final;
 
 	void patchedParamPresetValueChanged(uint8_t p, ModelStackWithSoundFlags* modelStack, int32_t oldValue,


### PR DESCRIPTION
Global effectible Mod FX menu's weren't using the isRelevant flag to make the Mod FX params listed conditional on Mod FX type selected.

Upon investigation, I found:

- [x] we were missing a Depth menu for the unpatched global effectable mod fx param. This meant that the Depth param didn't have an isRelevant check in the Global Menu's To fix this I added an unpatched menu class for the Depth param.
- [x] the isRelevant check was only working for sound params and not global effectable params. So I replaced sound with a new function I added to the sound and global effectable classes, and accessed through the currentModControllable class (ModControllableAudio) as a virtual function.
- [x] Refactored isRelevant and checkPermissionToBeginSession menu functions to receive a ModControllableAudio* instead of a Sound* and then cast the modControllable to a Sound where the sound pointer was still needed.

I think this is what Rohan originally wanted when he wrote "// TODO: really want to receive a ModControllableAudio here!"