### PR TITLE
Refactor/get set api currentclip

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -387,14 +387,14 @@ bool readButtonsAndPads() {
 void setUIForLoadedSong(Song* song) {
 
 	UI* newUI;
-
+	Clip* currentClip = currentSong->getCurrentClip();
 	// If in a Clip-minder view
-	if (getCurrentClip() && song->inClipMinderViewOnLoad) {
-		if (getCurrentClip()->onAutomationClipView) {
+	if (currentClip && song->inClipMinderViewOnLoad) {
+		if (currentClip->onAutomationClipView) {
 			newUI = &automationView;
 		}
-		else if (getCurrentClip()->type == ClipType::INSTRUMENT) {
-			if (getCurrentInstrumentClip()->onKeyboardScreen) {
+		else if (currentClip->type == ClipType::INSTRUMENT) {
+			if (((InstrumentClip*)currentClip)->onKeyboardScreen) {
 				newUI = &keyboardScreen;
 			}
 			else {

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -387,7 +387,7 @@ bool readButtonsAndPads() {
 void setUIForLoadedSong(Song* song) {
 
 	UI* newUI;
-	Clip* currentClip = currentSong->getCurrentClip();
+	Clip* currentClip = song->getCurrentClip();
 	// If in a Clip-minder view
 	if (currentClip && song->inClipMinderViewOnLoad) {
 		if (currentClip->onAutomationClipView) {

--- a/src/deluge/gui/menu_item/file_selector.cpp
+++ b/src/deluge/gui/menu_item/file_selector.cpp
@@ -43,7 +43,7 @@ void FileSelector::beginSession(MenuItem* navigatedBackwardFrom) {
 	}
 }
 bool FileSelector::isRelevant(Sound* sound, int32_t whichThing) {
-	if (currentSong->getCurrentClip()->type == ClipType::AUDIO) {
+	if (getCurrentClip()->type == ClipType::AUDIO) {
 		return true;
 	}
 	Source* source = &sound->sources[whichThing];
@@ -57,7 +57,7 @@ bool FileSelector::isRelevant(Sound* sound, int32_t whichThing) {
 MenuPermission FileSelector::checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
                                                            ::MultiRange** currentRange) {
 
-	if (currentSong->getCurrentClip()->type == ClipType::AUDIO) {
+	if (getCurrentClip()->type == ClipType::AUDIO) {
 		return MenuPermission::YES;
 	}
 

--- a/src/deluge/gui/menu_item/file_selector.cpp
+++ b/src/deluge/gui/menu_item/file_selector.cpp
@@ -43,7 +43,7 @@ void FileSelector::beginSession(MenuItem* navigatedBackwardFrom) {
 	}
 }
 bool FileSelector::isRelevant(Sound* sound, int32_t whichThing) {
-	if (getCurrentClip()->type == ClipType::AUDIO) {
+	if (currentSong->getCurrentClip()->type == ClipType::AUDIO) {
 		return true;
 	}
 	Source* source = &sound->sources[whichThing];
@@ -57,7 +57,7 @@ bool FileSelector::isRelevant(Sound* sound, int32_t whichThing) {
 MenuPermission FileSelector::checkPermissionToBeginSession(Sound* sound, int32_t whichThing,
                                                            ::MultiRange** currentRange) {
 
-	if (getCurrentClip()->type == ClipType::AUDIO) {
+	if (currentSong->getCurrentClip()->type == ClipType::AUDIO) {
 		return MenuPermission::YES;
 	}
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -770,7 +770,7 @@ ActionResult SoundEditor::timerCallback() {
 
 void SoundEditor::markInstrumentAsEdited() {
 	if (!inSettingsMenu()) {
-		Instrument* inst = getCurrentInstrumentOrNull();
+		Instrument* inst = getCurrentInstrument();
 		if (inst) {
 			getCurrentInstrument()->beenEdited();
 		}

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -109,6 +109,8 @@ public:
 	// the `display` and/or `chosenLanguage` object changed. redraw accordingly.
 	virtual void displayOrLanguageChanged() {}
 	virtual bool canSeeViewUnderneath() { return false; }
+	/// Convert this clip to a clip minder. Returns true for views which manage a single clip,
+	/// false for song level views
 	virtual ClipMinder* toClipMinder() { return NULL; }
 	virtual void scrollFinished() {}
 	virtual const char* getName() { return "UI"; }

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1418,6 +1418,8 @@ getItFromSection:
 
 				if (clipInstance->clip) {
 					originallyPressedClipActualLength = clipInstance->clip->loopLength;
+					// we've either created or selected a clip, so set it to be current
+					currentSong->setCurrentClip(clipInstance->clip);
 				}
 				else {
 					originallyPressedClipActualLength = clipInstance->length;
@@ -1687,6 +1689,7 @@ void ArrangerView::exitSubModeWithoutAction(UI* ui) {
 void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 
 	Clip* clip = clipInstance->clip;
+	// it should already be this clip, but if it ever isn't it would be a disaster
 	currentSong->setCurrentClip(clip);
 
 	currentSong->lastClipInstanceEnteredStartPos = clipInstance->pos;

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1687,8 +1687,8 @@ void ArrangerView::exitSubModeWithoutAction(UI* ui) {
 void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 
 	Clip* clip = clipInstance->clip;
+	currentSong->setCurrentClip(clip);
 
-	currentSong->currentClip = clip;
 	currentSong->lastClipInstanceEnteredStartPos = clipInstance->pos;
 
 	uint32_t xZoom = currentSong->xZoom[NAVIGATION_ARRANGEMENT];

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3596,6 +3596,7 @@ ActionResult SessionView::gridHandlePadsLaunchWithSelection(int32_t x, int32_t y
 			performActionOnPadRelease = true;
 			selectedClipTimePressed = AudioEngine::audioSampleTimer;
 			view.setActiveModControllableTimelineCounter(clip);
+			currentSong->setCurrentClip(clip);
 			view.displayOutputName(clip->output, true, clip);
 			if (display->haveOLED()) {
 				deluge::hid::display::OLED::sendMainImage();

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -734,6 +734,8 @@ removePendingOverdub:
 						clipWasSelectedWithShift = Buttons::isShiftButtonPressed();
 startHoldingDown:
 						selectedClipPressYDisplay = yDisplay;
+						// we've either created or selected a clip, so set it to be current
+						currentSong->setCurrentClip(clip);
 						currentUIMode = UI_MODE_CLIP_PRESSED_IN_SONG_VIEW;
 						selectedClipPressXDisplay = xDisplay;
 						performActionOnPadRelease = true;
@@ -2432,7 +2434,7 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 			return;
 		}
 	}
-
+	// it should already be this clip, but if it ever isn't it would be a disaster
 	currentSong->setCurrentClip(clip);
 
 	int32_t clipPlaceOnScreen = std::clamp(getClipPlaceOnScreen(clip), -1_i32, kDisplayHeight);
@@ -3428,6 +3430,8 @@ ActionResult SessionView::gridHandlePadsEdit(int32_t x, int32_t y, int32_t on, C
 			if (clip == nullptr) {
 				return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 			}
+			// we've either created or selected a clip, so set it to be current
+			currentSong->setCurrentClip(clip);
 
 			// Allow clip control (selection)
 			currentUIMode = UI_MODE_CLIP_PRESSED_IN_SONG_VIEW;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3222,7 +3222,8 @@ Clip* SessionView::gridCreateClip(uint32_t targetSection, Output* targetOutput, 
 	if (targetOutput == nullptr && !newClip->output->activeClip) {
 		newClip->output->setActiveClip(modelStack);
 	}
-
+	// set it active in the song
+	currentSong->setCurrentClip(newClip);
 	return newClip;
 }
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2433,7 +2433,7 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 		}
 	}
 
-	currentSong->currentClip = clip;
+	currentSong->setCurrentClip(clip);
 
 	int32_t clipPlaceOnScreen = std::clamp(getClipPlaceOnScreen(clip), -1_i32, kDisplayHeight);
 

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -109,6 +109,10 @@ void MidiFollow::initMapping(int32_t mapping[kDisplayWidth][kDisplayHeight]) {
 /// 2) pressing and holding the audition pad of a row in arranger view
 /// 3) entering a clip
 Clip* getSelectedClip(bool useActiveClip) {
+	// special case for note and performance data where you want to let notes and MPE through to the active clip
+	if (useActiveClip) {
+		return getCurrentClip();
+	}
 	Clip* clip = nullptr;
 
 	RootUI* rootUI = getRootUI();
@@ -146,10 +150,7 @@ Clip* getSelectedClip(bool useActiveClip) {
 		clip = getCurrentClip();
 		break;
 	}
-	// special case for instruments where you want to let notes and MPE through to the active clip
-	if (!clip && useActiveClip) {
-		clip = getCurrentClip();
-	}
+
 	return clip;
 }
 

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -472,7 +472,7 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 		}
 		// for these cc's, check if there's an active clip if the clip returned above is NULL
 		if (!clip) {
-			clip = currentSong->getCurrentClip();
+			clip = modelStack->song->getCurrentClip();
 		}
 		if (clip && (clip->output->type != OutputType::AUDIO)) {
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -471,7 +471,7 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 		}
 		// for these cc's, check if there's an active clip if the clip returned above is NULL
 		if (!clip) {
-			clip = currentSong->currentClip;
+			clip = currentSong->getCurrentClip();
 		}
 		if (clip && (clip->output->type != OutputType::AUDIO)) {
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -592,7 +592,7 @@ otherOption:
 		// earlier, causing a crash. Hopefully moving it later here is ok...
 		if (action->currentClip) { // If song just loaded and we hadn't been into ClipMinder yet, this would be NULL,
 			                       // and we don't want to set currentSong->currentClip back to this
-			currentSong->currentClip = action->currentClip;
+			currentSong->setCurrentClip(action->currentClip);
 		}
 	}
 

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -730,14 +730,14 @@ void Clip::readTagFromFile(char const* tagName, Song* song, int32_t* readAutomat
 
 	else if (!strcmp(tagName, "beingEdited")) {
 		if (storageManager.readTagOrAttributeValueInt()) {
-			song->currentClip = this;
+			song->setCurrentClip(this);
 			song->inClipMinderViewOnLoad = true;
 		}
 	}
 
 	else if (!strcmp(tagName, "selected")) {
 		if (storageManager.readTagOrAttributeValueInt()) {
-			song->currentClip = this;
+			song->setCurrentClip(this);
 			song->inClipMinderViewOnLoad = false;
 		}
 	}
@@ -1023,7 +1023,7 @@ void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
 
 int32_t Clip::beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency) {
 	if (!getRootUI() || !getRootUI()->toClipMinder()) {
-		modelStack->song->currentClip = this;
+		modelStack->song->setCurrentClip(this);
 	}
 	return NO_ERROR;
 }

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -1025,6 +1025,9 @@ void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
 }
 
 int32_t Clip::beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency) {
+
+	// if we're not in a clip level view, set to the clip that's starting linear recording
+	// todo: this should probably only happen if a single clip is recording linearly, but that's not tracked
 	if (!getRootUI() || !getRootUI()->toClipMinder()) {
 		modelStack->song->setCurrentClip(this);
 	}

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -80,6 +80,9 @@ Clip::Clip(ClipType newType) : type(newType) {
 }
 
 Clip::~Clip() {
+	if (getCurrentClip() == this) {
+		currentSong->setCurrentClip(nullptr);
+	}
 }
 
 // This is more exhaustive than copyBasicsFrom(), and is designed to be used *between* different Clip types, just for

--- a/src/deluge/model/consequence/consequence_clip_begin_linear_record.cpp
+++ b/src/deluge/model/consequence/consequence_clip_begin_linear_record.cpp
@@ -53,7 +53,7 @@ int32_t ConsequenceClipBeginLinearRecord::revert(TimeType time, ModelStack* mode
 
 			// Or if we're viewing the Clip, don't deactivate it, cos it's a massive hassle, and confusing, for user to
 			// go out and reactivate it
-			if (modelStack->song->currentClip == clip && getCurrentUI()->toClipMinder()) {
+			if (modelStack->song->getCurrentClip() == clip && getCurrentUI()->toClipMinder()) {
 				return NO_ERROR;
 			}
 

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -102,8 +102,8 @@ int32_t ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) 
 
 		// Make sure the currentClip isn't left pointing to this Clip. Most of the time, ActionLogger::revertAction()
 		// reverts currentClip so we don't have to worry about it - but not if action->currentClip is NULL!
-		if (modelStackWithTimelineCounter->song->currentClip == clip) {
-			modelStackWithTimelineCounter->song->currentClip = NULL;
+		if (modelStackWithTimelineCounter->song->getCurrentClip() == clip) {
+			modelStackWithTimelineCounter->song->setCurrentClip(nullptr);
 		}
 
 		clip->stopAllNotesPlaying(

--- a/src/deluge/model/consequence/consequence_clip_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_clip_horizontal_shift.cpp
@@ -33,7 +33,7 @@ int32_t ConsequenceClipHorizontalShift::revert(TimeType time, ModelStack* modelS
 	}
 
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-	    modelStack->addTimelineCounter(modelStack->song->currentClip);
+	    modelStack->addTimelineCounter(modelStack->song->getCurrentClip());
 
 	((Clip*)modelStackWithTimelineCounter->getTimelineCounter())
 	    ->shiftHorizontally(modelStackWithTimelineCounter, amountNow);

--- a/src/deluge/model/consequence/consequence_instrument_clip_multiply.cpp
+++ b/src/deluge/model/consequence/consequence_instrument_clip_multiply.cpp
@@ -25,7 +25,7 @@ ConsequenceInstrumentClipMultiply::ConsequenceInstrumentClipMultiply() {
 }
 
 int32_t ConsequenceInstrumentClipMultiply::revert(TimeType time, ModelStack* modelStack) {
-	InstrumentClip* clip = (InstrumentClip*)modelStack->song->currentClip;
+	InstrumentClip* clip = (InstrumentClip*)modelStack->song->getCurrentClip();
 	if (time == BEFORE) {
 		modelStack->song->setClipLength(clip, clip->loopLength >> 1, NULL);
 

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
@@ -36,7 +36,7 @@ int32_t ConsequenceNoteRowHorizontalShift::revert(TimeType time, ModelStack* mod
 		amountNow = -amountNow;
 	}
 
-	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addTimelineCounter(modelStack->song->currentClip)
+	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addTimelineCounter(modelStack->song->getCurrentClip())
 	                                                   ->addNoteRowId(noteRowId)
 	                                                   ->automaticallyAddNoteRowFromId();
 

--- a/src/deluge/model/consequence/consequence_note_row_length.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_length.cpp
@@ -27,7 +27,7 @@ ConsequenceNoteRowLength::ConsequenceNoteRowLength(int32_t newNoteRowId, int32_t
 }
 
 int32_t ConsequenceNoteRowLength::revert(TimeType time, ModelStack* modelStack) {
-	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addTimelineCounter(modelStack->song->currentClip)
+	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addTimelineCounter(modelStack->song->getCurrentClip())
 	                                                   ->addNoteRowId(noteRowId)
 	                                                   ->automaticallyAddNoteRowFromId();
 	performChange(modelStackWithNoteRow, NULL, modelStackWithNoteRow->getLastProcessedPos(),

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -367,8 +367,8 @@ public:
 
 private:
 	bool fillModeActive;
-	Clip* currentClip;
-	Clip* previousClip; // for future use, maybe finding an instrument clip or something
+	Clip* currentClip = nullptr;
+	Clip* previousClip = nullptr; // for future use, maybe finding an instrument clip or something
 	void inputTickScalePotentiallyJustChanged(uint32_t oldScale);
 	int32_t readClipsFromFile(ClipArray* clipArray);
 	void addInstrumentToHibernationList(Instrument* instrument);

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -381,11 +381,3 @@ private:
 extern Song* currentSong;
 extern Song* preLoadedSong;
 extern int8_t defaultAudioClipOverdubOutputCloning;
-
-inline Instrument* getCurrentInstrumentOrNull() {
-	Output* out = currentSong->getCurrentClip()->output;
-	if (out->type != OutputType::AUDIO) {
-		return (Instrument*)out;
-	}
-	return nullptr;
-}

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -144,8 +144,6 @@ public:
 	Instrument*
 	    firstHibernatingInstrument; // All Instruments have inValidState set to false when they're added to this list
 
-	Clip* currentClip;
-
 	OrderedResizeableArrayWithMultiWordKey backedUpParamManagers;
 
 	uint32_t xZoom[2];  // Set default zoom at max zoom-out;
@@ -213,6 +211,13 @@ public:
 	String dirPath;
 
 	bool getAnyClipsSoloing();
+	Clip* getCurrentClip();
+	void setCurrentClip(Clip* clip) {
+		if (currentClip != nullptr) {
+			previousClip = currentClip;
+		}
+		currentClip = clip;
+	}
 	uint32_t getInputTickScale();
 	Clip* getSyncScalingClip();
 	void setInputTickScaleClip(Clip* clip);
@@ -362,6 +367,8 @@ public:
 
 private:
 	bool fillModeActive;
+	Clip* currentClip;
+	Clip* previousClip; // for future use, maybe finding an instrument clip or something
 	void inputTickScalePotentiallyJustChanged(uint32_t oldScale);
 	int32_t readClipsFromFile(ClipArray* clipArray);
 	void addInstrumentToHibernationList(Instrument* instrument);
@@ -376,7 +383,7 @@ extern Song* preLoadedSong;
 extern int8_t defaultAudioClipOverdubOutputCloning;
 
 inline Instrument* getCurrentInstrumentOrNull() {
-	Output* out = currentSong->currentClip->output;
+	Output* out = currentSong->getCurrentClip()->output;
 	if (out->type != OutputType::AUDIO) {
 		return (Instrument*)out;
 	}

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -158,7 +158,7 @@ bool Session::giveClipOpportunityToBeginLinearRecording(Clip* clip, int32_t clip
 		// If currently looking at the old clip, teleport us to the new one
 		else if (currentClipHasSameOutput && getCurrentUI()->toClipMinder()) {
 
-			currentSong->currentClip = clip;
+			currentSong->setCurrentClip(clip);
 			getCurrentUI()->focusRegained(); // A bit shifty...
 
 			uiNeedsRendering(getCurrentUI());

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -155,7 +155,8 @@ bool Session::giveClipOpportunityToBeginLinearRecording(Clip* clip, int32_t clip
 			sessionView.clipNeedsReRendering(clip); // Necessary for InstrumentClips
 		}
 
-		// If currently looking at the old clip, teleport us to the new one
+		// if we're creating a new recording based on a previous clip on the same
+		// output, set current clip to the new one
 		else if (currentClipHasSameOutput && getCurrentUI()->toClipMinder()) {
 
 			currentSong->setCurrentClip(clip);


### PR DESCRIPTION
Refactor currentClip to use get/set api

Sets currentClip on following actions:
- pressing a row in rows mode
- pressing a square in selection mode in grid
- creating a clip in grid or row mode, including the create+arm for recording workflow

Existing behaviour of setting current clip on entering clip level views is redundant but retained. Otherwise a future code change allowing entering a clip without one of the above actions would break clip view logic.

Fix #1147 

I believe this makes #1167 and #989 redundant 