### PR TITLE
Implemented transpose in scale for Shift + hold and turn vertical encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ In addition, a number of improvements have been made to how the OLED display is 
 - Added support for "gentle paste" of notes which pastes notes without removing old ones.
 - Fixed numerous crash bugs around parameter automation when entering and leaving clip view.
 - The default ModFX type for songs is now DISABLED rather than FLANGER.
+- The shorcut `SHIFT` + hold and turn `▼︎▲︎`, inside a clip, has been changed to "Nudge notes vertically" without unexpectedly changing the scale and root note of the whole song.
 
 ### Audio Clips
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -298,6 +298,13 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
 
 - ([#368]) Extends the probability system to set a row at a time. Hold an `AUDITION` pad and turn `SELECT` to change the whole rows probability. This is particularly useful in combination with the euclidean sequencing to get a semi random pattern going
 
+#### 4.3.7 - Shorcut for "Transpose clip" is now "Nudge notes vertically for clip"
+
+- ([#1183]) The command `SHIFT` + hold and turn `▼︎▲︎` inside a clip was causing an unexpected behavior in which all other clips in the song were also transposed. This has been fixed by changing this command to a "Vertical nudge" command, based on current clip display (either in scale or non-scale mode). This saves user from the need to "zoom out, copy all notes, scroll up or down, and paste all notes" to nudge notes vertically.
+	- If the clip is in scale mode, all the notes are shifted up or down by one step in the scale.
+	- If the clip is not in scale mode, all the notes are shifted up or down by one semitone.
+	- Note: the other command for octave transposition, that is, hold and turn `▼︎▲︎`, keeps working in the same way, by nudging notes by one octave, regardless of the clip scale mode.
+
 ### 4.4 - Instrument Clip View - Synth/MIDI/CV Clip Features
 
 #### 4.4.1 - Keyboard View
@@ -543,6 +550,7 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#1065]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1065
 [#1083]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1083
 [#1173]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1173
+[#1183]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1183
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 [Performance View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/performance_view.md
 [MIDI Follow Mode Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/midi_follow_mode.md

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2286,36 +2286,20 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
+			offset = std::min((int32_t)1, std::max((int32_t)-1, offset));
+
 			// If shift button not pressed, transpose whole octave
 			if (!Buttons::isShiftButtonPressed()) {
-				offset = std::min((int32_t)1, std::max((int32_t)-1, offset));
-				clip->transpose(offset * 12, modelStack);
-				if (clip->isScaleModeClip()) {
-					clip->yScroll += offset * (currentSong->numModeNotes - 12);
-				}
-				// display->displayPopup("OCTAVE");
+				clip->transpose(offset * (clip->isScaleModeClip() ? modelStack->song->numModeNotes : 12), modelStack);
 			}
-
-			// Otherwise, transpose single semitone
+			// Otherwise, transpose single row position
 			else {
-				// If current Clip not in scale-mode, just do it
-				if (!clip->isScaleModeClip()) {
-					clip->transpose(offset, modelStack);
-
-					// If there are no scale-mode Clips at all, move the root note along as well - just in case the user
-					// wants to go back to scale mode (in which case the "previous" root note would be used to help
-					// guess what root note to go with)
-					if (!currentSong->anyScaleModeClips()) {
-						currentSong->rootNote += offset;
-					}
-				}
-
-				// Otherwise, got to do all key-mode Clips
-				else {
-					currentSong->transposeAllScaleModeClips(offset);
-				}
-				// display->displayPopup("SEMITONE");
+				// Transpose just one row up or down (if not in scale mode, then it's a semitone, and if in scale mode,
+				// it's the next note in the scale)¬
+				clip->transpose(offset, modelStack);
 			}
+			instrumentClipView.recalculateColours();
+			uiNeedsRendering(this, 0, 0xFFFFFFFF);
 		}
 	}
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2290,13 +2290,15 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 
 			// If shift button not pressed, transpose whole octave
 			if (!Buttons::isShiftButtonPressed()) {
-				clip->transpose(offset * (clip->isScaleModeClip() ? modelStack->song->numModeNotes : 12), modelStack);
+				// If in scale mode, an octave takes numModeNotes rows while in chromatic mode it takes 12 rows
+				clip->nudgeNotesVertically(offset * (clip->isScaleModeClip() ? modelStack->song->numModeNotes : 12),
+				                           modelStack);
 			}
 			// Otherwise, transpose single row position
 			else {
 				// Transpose just one row up or down (if not in scale mode, then it's a semitone, and if in scale mode,
 				// it's the next note in the scale)¬
-				clip->transpose(offset, modelStack);
+				clip->nudgeNotesVertically(offset, modelStack);
 			}
 			instrumentClipView.recalculateColours();
 			uiNeedsRendering(this, 0, 0xFFFFFFFF);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4344,36 +4344,23 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
+			InstrumentClip* instrumentClip = getCurrentInstrumentClip();
+
+			offset = std::min((int32_t)1, std::max((int32_t)-1, offset));
+
 			// If shift button not pressed, transpose whole octave
 			if (!Buttons::isShiftButtonPressed()) {
-				offset = std::min((int32_t)1, std::max((int32_t)-1, offset));
-				getCurrentInstrumentClip()->transpose(offset * 12, modelStack);
-				if (getCurrentInstrumentClip()->isScaleModeClip()) {
-					getCurrentInstrumentClip()->yScroll += offset * (currentSong->numModeNotes - 12);
-				}
-				// display->displayPopup("OCTAVE");
+				instrumentClip->transpose(
+				    offset * (instrumentClip->isScaleModeClip() ? modelStack->song->numModeNotes : 12), modelStack);
 			}
-
-			// Otherwise, transpose single semitone
+			// Otherwise, transpose single row position
 			else {
-				// If current Clip not in scale-mode, just do it
-				if (!getCurrentInstrumentClip()->isScaleModeClip()) {
-					getCurrentInstrumentClip()->transpose(offset, modelStack);
-
-					// If there are no scale-mode Clips at all, move the root note along as well - just in case the user
-					// wants to go back to scale mode (in which case the "previous" root note would be used to help
-					// guess what root note to go with)
-					if (!currentSong->anyScaleModeClips()) {
-						currentSong->rootNote += offset;
-					}
-				}
-
-				// Otherwise, got to do all key-mode Clips
-				else {
-					currentSong->transposeAllScaleModeClips(offset);
-				}
-				// display->displayPopup("SEMITONE");
+				// Transpose just one row up or down (if not in scale mode, then it's a semitone, and if in scale mode,
+				// it's the next note in the scale)¬
+				instrumentClip->transpose(offset, modelStack);
 			}
+			recalculateColours();
+			uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 		}
 	}
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4351,8 +4351,8 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 			// If shift button not pressed, transpose whole octave
 			if (!Buttons::isShiftButtonPressed()) {
 				// If in scale mode, an octave takes numModeNotes rows while in chromatic mode it takes 12 rows
-				instrumentClip->nudgeNotesVertically(offset * (instrumentClip->isScaleModeClip() ? modelStack->song->numModeNotes : 12),
-				                           modelStack);
+				instrumentClip->nudgeNotesVertically(
+				    offset * (instrumentClip->isScaleModeClip() ? modelStack->song->numModeNotes : 12), modelStack);
 			}
 			// Otherwise, transpose single row position
 			else {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4350,16 +4350,17 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 
 			// If shift button not pressed, transpose whole octave
 			if (!Buttons::isShiftButtonPressed()) {
-				instrumentClip->transpose(
-				    offset * (instrumentClip->isScaleModeClip() ? modelStack->song->numModeNotes : 12), modelStack);
+				// If in scale mode, an octave takes numModeNotes rows while in chromatic mode it takes 12 rows
+				instrumentClip->nudgeNotesVertically(offset * (instrumentClip->isScaleModeClip() ? modelStack->song->numModeNotes : 12),
+				                           modelStack);
 			}
 			// Otherwise, transpose single row position
 			else {
 				// Transpose just one row up or down (if not in scale mode, then it's a semitone, and if in scale mode,
 				// it's the next note in the scale)¬
-				instrumentClip->transpose(offset, modelStack);
+				instrumentClip->nudgeNotesVertically(offset, modelStack);
 			}
-			recalculateColours();
+			instrumentClipView.recalculateColours();
 			uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 		}
 	}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4360,7 +4360,7 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 				// it's the next note in the scale)¬
 				instrumentClip->nudgeNotesVertically(offset, modelStack);
 			}
-			instrumentClipView.recalculateColours();
+			recalculateColours();
 			uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 		}
 	}

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1307,6 +1307,18 @@ void InstrumentClip::transpose(int32_t change, ModelStackWithTimelineCounter* mo
 	// Make sure no notes sounding
 	stopAllNotesPlaying(modelStack);
 
+	for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
+		NoteRow* thisNoteRow = noteRows.getElement(i);
+		thisNoteRow->y += change;
+	}
+	yScroll += change;
+	colourOffset -= change;
+}
+
+void InstrumentClip::nudgeNotesVertically(int32_t change, ModelStackWithTimelineCounter* modelStack) {
+	// Make sure no notes sounding
+	stopAllNotesPlaying(modelStack);
+
 	if (!this->isScaleModeClip()) {
 		// Non scale clip, transpose directly by semitone jumps
 		for (int32_t i = 0; i < noteRows.getNumElements(); i++) {

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1316,6 +1316,10 @@ void InstrumentClip::transpose(int32_t change, ModelStackWithTimelineCounter* mo
 }
 
 void InstrumentClip::nudgeNotesVertically(int32_t change, ModelStackWithTimelineCounter* modelStack) {
+	// Note: the usage of this method is limited to no more than an octave of "change"
+	//  ideally used by the "hold and turn vertical encoder"
+	//  and "shift + hold and turn vertical encoder" shorcuts within clip
+
 	// Make sure no notes sounding
 	stopAllNotesPlaying(modelStack);
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3098,7 +3098,7 @@ void InstrumentClip::prepNoteRowsForExitingKitMode(Song* song) {
 				chosenNoteRowIndex = i;
 				break;
 			}
-noteRowFailed : {}
+noteRowFailed: {}
 		}
 	}
 

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -75,6 +75,7 @@ public:
 	void musicalModeChanged(uint8_t, int32_t, ModelStackWithTimelineCounter* modelStack);
 	void seeWhatNotesWithinOctaveArePresent(bool[], int32_t, Song* song, bool deleteEmptyNoteRows = true);
 	void transpose(int32_t, ModelStackWithTimelineCounter* modelStack);
+	void nudgeNotesVertically(int32_t change, ModelStackWithTimelineCounter* modelStack);
 	void expectNoFurtherTicks(Song* song, bool actuallySoundChange = true);
 	int32_t clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false);
 	NoteRow* createNewNoteRowForYVisual(int32_t, Song* song);

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -75,7 +75,7 @@ public:
 	void musicalModeChanged(uint8_t, int32_t, ModelStackWithTimelineCounter* modelStack);
 	void seeWhatNotesWithinOctaveArePresent(bool[], int32_t, Song* song, bool deleteEmptyNoteRows = true);
 	void transpose(int32_t, ModelStackWithTimelineCounter* modelStack);
-	void nudgeNotesVertically(int32_t change, ModelStackWithTimelineCounter* modelStack);
+	void nudgeNotesVertically(int32_t, ModelStackWithTimelineCounter* modelStack);
 	void expectNoFurtherTicks(Song* song, bool actuallySoundChange = true);
 	int32_t clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false);
 	NoteRow* createNewNoteRowForYVisual(int32_t, Song* song);


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/1179

Now the command "Shift + hold and turn vertical encoder" inside a clip instead of transposing all clips in the song, it will nudge notes vertically according to the mode the clip is in (scale or non-scale).
If in scale, the notes are nudged vertically respecting the scale.
If clip not in scale mode, the notes are nudged by semitones.
Colors of the audition pads and notes are updated (they were not before).

The existing command "Hold and turn vertical encoder" keeps working as always, that is, transposing an octave all notes for this clip.