### PR TITLE
[DRAFT] Feature / Add Morph Mode and Alternate Layouts to Performance View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,9 @@
 - Fixed stereo unison spread + ringmod + noise causing excessively loud output.
 - Fixed some bugs around the waveform Loop Lock feature which allowed setting invalid loop points.
 
-
 ### User Interface
 
-- Added `PERFORMANCE VIEW`, accessible in Song Row View by pressing the Keyboard button and in Song Grid View by pressing the Pink Mode pad. Allows quick control of Song Global FX.
+- Added `PERFORMANCE VIEW`, accessible in Song Row View by pressing the Keyboard button and in Song Grid View by pressing the Pink Mode pad. Allows quick control of Song Global FX. Includes support for multiple performance layouts and a midi-controllable morph mode to morph between two performance layouts. 
 - Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
 - Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the Automation Overview and with the shortcut combos (e.g. Shift + Shortcut Pad).
 - Added Mod Button popups to display the current Mod (Gold) Encoder context (e.g. LPF/HPF Mode, Delay Mode and Type, Reverb Room Size, Compressor Mode, ModFX Type and Param).

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -146,11 +146,17 @@ Here is a list of features that have been added to the firmware as a list, group
 			- Long press pads in a column to change value momentarily and reset it (to the value before the pad was pressed) upon pad release
 			- Short press pads in a column to the change value until you press the pad again (resetting it to the value before the pad was pressed)
 		- Editing mode to edit the FX values assigned to each pad and the parameter assigned to each FX column
-		- Save defaults as PerformanceView.xml file
-			- Adjustable default Values assigned to each FX column via "Value" editing mode or PerformanceView.xml
-			- Adjustable default Param assigned to each FX column via "Param" editing mode or PerformanceView.xml
-			- Adjustable default "held pad" settings for each FX column via Performance View or PerformanceView.xml (simply change a held pad in Performance View and save the layout to save the layout with the held pads).
-		- Load defaults from PerformanceView.xml file
+		- Save defaults as xml file
+			- Adjustable default Values assigned to each FX column via "Value" editing mode or the Performance View layout XML files
+			- Adjustable default Param assigned to each FX column via "Param" editing mode or the Performance View layout XML files
+			- Adjustable default "held pad" settings for each FX column via Performance View or xml file(simply change a held pad in Performance View and save the layout to save the layout with the held pads).
+		- Load defaults from xml file
+- ([#1185]) Adds Morph Mode and 8 Alternate Layouts to Performance View
+	- Morph Mode is a new sub-mode in Performance View that lets you load two layouts into two layout banks for morphing between the two layouts. Morph Mode can be MIDI controlled by learning the Global MIDI Command MORPH.
+	- Performance View layouts are now saved in a separate folder titled PERFORMANCE_VIEW on your SD card. 
+	- You can now saved 9 total layouts for Performance View which are saved and named as follows: 
+		- Default.XMl, 1.XML, 2.XML, 3.XML, 4.XML, 5.XML, 6.XML, 7.XML, 8.XML
+	- You can now save the current layout loaded and the layouts assigned in Morph Mode with the Song. When the Song is loaded it will load the layouts used in that Song from the PERFORMANCE_VIEW folder on your SD card.
 
 ### 4.1.7 - Added Master Chromatic Transpose of All Scale Mode Instrument Clips
 - ([#1159]) Using the same combo as in a Synth / Midi / CV clip, press and turn `▼︎▲︎` to transpose all scale mode clips up or down by 1 semitone.
@@ -559,6 +565,7 @@ This list includes all preprocessor switches that can alter firmware behaviour a
 [#1159]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1159
 [#1173]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1173
 [#1183]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1183
+[#1185]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1185
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 [Performance View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/performance_view.md
 [MIDI Follow Mode Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/midi_follow_mode.md

--- a/docs/features/performance_view.md
+++ b/docs/features/performance_view.md
@@ -231,10 +231,7 @@ Morph Mode is a new sub-mode in Performance View that lets you load two layouts 
 
 The control for morphing between Bank A and Bank B in Morph Mode has been made MIDI Learnable so that you can Morph between Bank A and Bank B from anywhere in the Deluge (e.g. whether you're in a Song View or Clip View).
 
-You can MIDI control the Morph Mode cross-fader by learning your MIDI controller to the Deluge using one two methods:
-
-1. Global MIDI Commands
-2. MIDI Follow Mode
+You can MIDI control the Morph Mode cross-fader by learning your MIDI controller to the Deluge through the global MIDI commands menu.
 
 ### Global MIDI Command :: MORPH
 

--- a/docs/features/performance_view.md
+++ b/docs/features/performance_view.md
@@ -15,11 +15,11 @@ Specifications:
     - Long press pads in a column to change value momentarily and reset it (to the value before the pad was pressed) upon pad release
     - Short press pads in a column to the change value until you press the pad again (resetting it to the value before the pad was pressed)
   - Editing mode to edit the FX values assigned to each pad and the parameter assigned to each FX column
-  - Save defaults as PerformanceView.xml file
-    - Adjustable default Values assigned to each FX column via "Value" editing mode or PerformanceView.xml
-    - Adjustable default Param assigned to each FX column via "Param" editing mode or PerformanceView.xml
-    - Adjustable default "held pad" settings for each FX column via Performance View or PerformanceView.xml (simply change a held pad in Performance View and save the layout to save the layout with the held pads).
-  - Load defaults from PerformanceView.xml file
+  - Save defaults as xml file
+    - Adjustable default Values assigned to each FX column via "Value" editing mode or xml
+    - Adjustable default Param assigned to each FX column via "Param" editing mode or xml
+    - Adjustable default "held pad" settings for each FX column via Performance View or xml (simply change a held pad in Performance View and save the layout to save the layout with the held pads).
+  - Load defaults from xml file
   - Perform FX menu
 
 ## Usage:
@@ -49,7 +49,7 @@ Value Editing Mode:
 - You can edit that pad's value by turning the select encoder while selecting a single pad (so it's highlighted white) or holding down on that pad. The updated value will be reflected on the display.
 - After you have edited a value, the Save button will start flashing to indicate that you have "Unsaved" changes. Press and hold the save button + press the keyboard button to save your changes. Once saved, the Save button will stop blinking. To avoid being distracting, the save button will only blink when you are in editing mode. If you exit editing mode it will stop blinking and if you re-enter editing mode it will blink again to remind you that you have unsaved changes.
 - You can re-load saved changes by pressing and holding the Load button + press the keyboard button. This will cause you to lose unsaved changes and the Save button will stop blinking.
-- Defaults are saved in an XML file on your SD card called "PerformanceView.XML" - deleting this file will cause the PerformanceView to revert back to its regular default values for each pad.
+- Defaults are saved in an XML file on your SD card - deleting the xml file will cause the PerformanceView to revert back to its regular default values for each pad.
 - Once you are done with editing mode, repeat the steps above to set editing mode back to "Disabled" and exit out of the menu to use Performance View in its regular state
 
 #### 5) You can edit the Parameter assigned to each FX column by entering a "Param Editing Mode." Here are the instructions for Param Editing mode:
@@ -71,7 +71,7 @@ Param Editing Mode:
 - While holding a shortcut pad, press on the FX columns to assign or unassign a parameter to/from a column.
 - Press <> + back to clear all existing Parameter assignments.
 - When a Parameter has not been assigned to a column, that column will be lit grey and be unusable in Performance View until you assign a Parameter. This applies to editing the values for that FX column as well (assign a Parameter first, then you can edit the values).
-- Parameters are saved to PerformanceView.xml. You can manually edit the Parameters in the xml as well, but you must use the exact Parameter names. It is recommended to save a fresh PerformanceView.xml and back it up so you have a record of the Parameter Names.
+- Parameters are saved to xml. You can manually edit the Parameters in the xml as well, but you must use the exact Parameter names. It is recommended to save a fresh xml and back it up so you have a record of the Parameter Names.
 
 #### 6) You can Undo/Redo your changes in Performance View
 
@@ -112,3 +112,139 @@ Dark Pink:
 
 Dark Blue:
 16 = Stutter Rate + Stutter Trigger
+
+# Morph Mode and Alternate Layouts for Performance View
+
+<img width="349" alt="Screenshot 2024-02-06 at 10 10 37 PM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/09c36028-9679-4184-885c-9226e9654337">
+
+# Description and Instructions
+
+## Alternate Layouts
+
+- There are 9 total performance view layout variants:
+  - Default, 1, 2, 3, 4, 5, 6, 7, 8
+- Layout can be loaded from / saved to your SD card. They are stored in a folder titled PERFORMANCE_VIEW.
+<img width="254" alt="Screenshot 2024-02-06 at 9 30 38 PM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/1c2fde68-f9c0-4f36-be2d-61c027ada132">
+
+### Loading the Default Layout
+  - Hold Load + Press Keyboard to load the Default Layout
+  - The layout from Default.XML will be loaded
+
+### Saving the Default Layout
+  - Hold Save + Press Keyboard to save the Default Layout
+  - The layout will be saved to Default.XML
+  
+### Loading the Alternate Layouts  
+ - To load the 8 alternate layouts, you need to first select a Layout Bank.
+    - There are two banks of 4 layouts.
+    - To select Bank 1, press the Scale button, it will light up.
+    - To select Bank 2, press the Cross-Screen button, it will light up.
+ - After selecting a bank:
+    - Hold Load + Press Synth, Kit, Midi, or CV to load the layout corresponding to those 4 buttons and the bank selected.
+ - Bank 1:
+   - Synth = 1.XML
+   - Kit = 2.XML
+   - Midi = 3.XML
+   - CV = 4.XML
+ - Bank 2:
+   -  Synth = 5.XML
+   - Kit = 6.XML
+   - Midi = 7.XML
+   - CV = 8.XML
+- When you load a layout, a pop up is displayed to tell you the layout you just loaded (e.g. Default, 1, 2, 3, 4, 5, 6, 7, or 8)
+
+### Saving the Alternate Layouts  
+- Use the instructions for Loading a layout above, except instead of holding the Load button, you hold the Save button.
+  - Hold Save + Press Keyboard to save layout changes to Default.XML
+  - Selected Bank 1 or 2 using Scale or Cross-screen:
+    - While in Bank 1, Hold Save + Press Synth/Kit/Midi/CV to save to 1.XML, 2.XML, 3.XML, or 4.XML
+    - While in Bank 2, Hold Save + Press Synth/Kit/Midi/CV to save to 5.XML, 6.XML, 7.XML, or 8.XML
+    
+### Check what layout is currently loaded
+- At any time you can check what layout is currently loaded by pressing on the Bank 1 or Bank 2 buttons (Scale or Cross-screen).
+  - A pop-up will be shown not he display that tells you the name of the layout that is currently loaded (Default, 1, 2, 3, 4, 5, 6, 7, or 8)
+  - If you hold the bank button, the layout currently loaded for the bank selected (if there is one) will also flash to indicate that that layout is loaded (e.g. if you are holding the Bank 1 button (Scale) and Layout 1 is loaded, the Synth button will flash)
+
+## Morph Mode
+
+Morph Mode is a new sub-mode in Performance View that lets you load two layouts into two layout banks for morphing between the two layouts. I will refer to these banks as Bank A and Bank B
+  - Bank A and Bank B are accessed in Morph Mode with the Synth and CV buttons (Synth = Bank A, CV = Bank B)
+  
+### Entering Morph Mode  
+- To enter Morph Mode, press both the Scale button and Cross-screen buttons together
+  - To signal that you are in Morph Mode, the Scale button and Cross-screen buttons will be lit up
+  - The gold encoder led indicators will also be reset and the mod buttons between the gold encoders will turn off
+    - While in morph mode, you cannot control / change parameters using the gold encoders
+    
+### Assign a layout to Bank A and Bank B    
+- After you have entered Morph Mode, you will need to assign a layout to Bank A and Bank B
+  - Note: the layouts you assign to Bank A and Bank B must be compatible for Morphing. This means:
+    - They must have the same FX to column layout structure. E.g. If LPF frequency is in Column 1 in the layout added to Bank A, it must also be in Column 1 in the layout added to Bank B. If you attempt to Morph with two incompatible layouts, you will receive a pop-up saying "Can't Morph"
+    - If both layouts are compatible, either the Bank A button (Synth) or Bank B button (CV) will light up (depending on which bank you assigned a layout to last).
+    - Note: another reason for a "Can't Morph" message is that the layouts assigned to Bank A and Bank B (both) do not have any held values. As soon as you assign a layout to Bank A or B with a held value, they become compatible for morphing.
+  - To assign a layout to Bank A, hold Synth + turn the Select encoder to selected between the 9 layouts available (Default, 1, 2, 3, 4, 5, 6, 7, 8)
+  - To assign a layout to Bank B, hold CV + turn the Select encoder to selected between the 9 layouts available (Default, 1, 2, 3, 4, 5, 6, 7, 8)
+- After you have assigned two compatible layouts to Bank A and Bank B, you are ready to Morph.
+
+### Morphing between Layouts
+- To Morph between the layouts stored in Banks A and B, use either Gold (Mod) encoder.
+
+### Indicator's of your morph position between the layout in Bank A and Bank B
+- The display will show a value range of -50 to +50 as you turn the Gold encoder.
+- The Gold encoder LED indicators will also light up to indicate your position
+- The Synth/Kit/Midi/CV buttons will also light up to show your position.
+  - Synth button lit up = 100% Layout A
+  - Synth and Kit buttons lit up = between 100% and 75% Layout A
+  - Kit button lit up = 75% Layout A, 25% Layout B
+  - Kit and Midi buttons lit up = 50% Layout A, 50% Layout B
+  - Midi button lit up = 25% Layout A, 75% Layout B
+  - Midi and CV buttons lit up = between 100% and 75% Layout B
+  - CV button lit up = 100% Layout B
+  
+### How does Morphing Work?
+- Morphing works by morphing between the Held values for the same parameters in the two layouts assigned to Bank A and Bank B
+- If only one layout has Held values, it means that it will Morph between the held value and the release value saved in that one layout (the other Layout in the other Bank will have no effect on the morphing).
+  - The release value is the value that the parameter would be set back to if you removed the held pad.
+  - Whenever you add a held pad, a snapshot of the current value is stored. It is this snapshot that is used for morphing in this scenario.
+- When you have reached either end of the Morph spectrum (e.g. 100% Bank A or 100% Bank B), the layout loaded on the grid is refreshed. For example, if you started with Bank A, you will see Bank A loaded on the grid with any held pads. Once you have morphed over to Bank B, the grid will be refreshed and show the held pads from Bank B.
+  
+### Changing layout Selection while in Morph Mode
+- While in Morph mode, if you press on the Bank A button or Bank B button, it will load the layout saved in that bank.
+  
+### Non-Destructive / Temporary Morph Layout Changes
+- You can make quick changes to the layouts assigned to Morph A and B without needing to save those layouts
+- For example, you could load the Default layout into Bank A and Bank B
+- To then make changes to the Default layout stored in Bank A and Bank B, do the following:
+  - Hold the Bank A button (Synth) and change any of the held pads on the Performance View grid
+  - Let go of the Bank A button. The changes you made are now temporarily saved in Bank A
+  - You can do the same for Bank B
+  - You now have two temporary variants of the Default layout
+- You could use this technique to test out changes to your morph layouts, and then when you like what you've found, you save those temporary layouts to one of the 9 layout files by repeating the Bank 1/Bank 2 save steps above.
+
+### The OLED display
+- Just a quick overview of the OLED display for Morph Mode
+- While in Morph Mode, the OLED display show in the bottom middle a cross-fader to show the morph position between Bank A and Bank B
+- To the left and right side of the cross fader, if a layout has been assigned to Bank A and Bank B, it will display the name of the layout assigned to Bank A and Bank B (e.g. D for default, 1, 2, 3, 4, 5, 6, 7, 8)
+- Right above the cross-fader, you will see "Can't Morph" if the layouts assigned to Bank A and Bank B are not compatible.
+
+## Midi-Learning Morph Mode
+
+The control for morphing between Bank A and Bank B in Morph Mode has been made MIDI Learnable so that you can Morph between Bank A and Bank B from anywhere in the Deluge (e.g. whether you're in a Song View or Clip View).
+
+You can MIDI control the Morph Mode cross-fader by learning your MIDI controller to the Deluge using one two methods:
+
+1. Global MIDI Commands
+2. MIDI Follow Mode
+
+### Global MIDI Command :: MORPH
+
+- To learn an external controller to the Morph Mode control for use with the Deluge's Global MIDI Command's, you need to access the following menu:
+  - SETTINGS -> MIDI -> COMMANDS -> MORPH
+- While in the MORPH menu, Hold Learn + Send a Note/CC to learn the device.
+- At any time you can unlearn the Morph control by pressing Shift + Learn while in the MORPH menu
+- Exit the menu to save your settings
+
+## Saving Layouts with the Song
+
+- The layout you currently have loaded and the layouts assigned to Bank A and Bank B in Morph Mode get saved with the song.
+- When you load your song again, it will load the layout used in that song from the SD card folder PERFORMANCE_VIEW.

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -275,7 +275,7 @@ enum class UIType : uint8_t {
 	AUDIO_CLIP_VIEW,
 	KEYBOARD_SCREEN,
 	AUTOMATION_VIEW,
-	PERFORMANCE_SESSION_VIEW,
+	PERFORMANCE_VIEW,
 	TIMELINE_VIEW,
 	BROWSER,
 	CONTEXT_MENU,
@@ -420,6 +420,7 @@ constexpr int32_t kParamValueIncrementForDelayAmount = kParamValueIncrementForAu
 constexpr int32_t kMaxKnobPosForDelayAmount = (kMaxKnobPos / 2) - 1;
 constexpr int32_t kParamValueIncrementForQuantizedStutter = 15;
 constexpr int32_t kMinKnobPosForQuantizedStutter = 52;
+constexpr int32_t kMaxPerformanceLayoutVariants = 9;
 
 enum class PerformanceEditingMode : int32_t {
 	DISABLED,
@@ -626,6 +627,7 @@ enum class GlobalMIDICommand {
 	UNDO,
 	REDO,
 	FILL,
+	MORPH,
 	LAST, // Keep as boundary
 };
 constexpr auto kNumGlobalMIDICommands = util::to_underlying(GlobalMIDICommand::LAST) + 1;

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -30,7 +30,7 @@
 #include "gui/views/audio_clip_view.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/buttons.h"
@@ -413,7 +413,7 @@ void setUIForLoadedSong(Song* song) {
 			newUI = &automationView;
 		}
 		else if (song->onPerformanceView) {
-			newUI = &performanceSessionView;
+			newUI = &performanceView;
 		}
 		else if (song->lastClipInstanceEnteredStartPos != -1) {
 			newUI = &arrangerView;

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -30,6 +30,7 @@
 #include "gui/views/audio_clip_view.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
+#include "gui/views/performance_session_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/buttons.h"
@@ -408,7 +409,13 @@ void setUIForLoadedSong(Song* song) {
 
 	// Otherwise we're in session or arranger view
 	else {
-		if (song->lastClipInstanceEnteredStartPos != -1) {
+		if (song->onAutomationArrangerView) {
+			newUI = &automationView;
+		}
+		else if (song->onPerformanceView) {
+			newUI = &performanceSessionView;
+		}
+		else if (song->lastClipInstanceEnteredStartPos != -1) {
 			newUI = &arrangerView;
 		}
 		else {

--- a/src/deluge/gui/l10n/english.cpp
+++ b/src/deluge/gui/l10n/english.cpp
@@ -802,7 +802,7 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_PAD_SELECTION_ON, "Pad Selection On"},
 
         /* Strings Specifically for Performance View
-         * performance_session_view.cpp
+         * performance_view.cpp
          */
 
         {STRING_FOR_PERFORM_VIEW, "Performance View"},
@@ -810,8 +810,8 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_PERFORM_EDITOR, "Editing Mode"},
         {STRING_FOR_PERFORM_EDIT_PARAM, "Param"},
         {STRING_FOR_PERFORM_EDIT_VALUE, "Value"},
-        {STRING_FOR_PERFORM_DEFAULTS_LOADED, "Defaults Loaded"},
-        {STRING_FOR_PERFORM_DEFAULTS_SAVED, "Defaults Saved"},
+        {STRING_FOR_PERFORM_CANT_MORPH, "Can't Morph"},
+        {STRING_FOR_PERFORM_DEFAULT_LAYOUT, "Default"},
 
         /* Strings Specifically for Song View
          * session_view.cpp

--- a/src/deluge/gui/l10n/seven_segment.cpp
+++ b/src/deluge/gui/l10n/seven_segment.cpp
@@ -399,6 +399,13 @@ PLACE_SDRAM_DATA Language seven_segment{
         {STRING_FOR_PAD_SELECTION_OFF, "OFF"},
         {STRING_FOR_PAD_SELECTION_ON, "ON"},
 
+        /* Strings Specifically for Performance View
+         * performance_view.cpp
+         */
+
+        {STRING_FOR_PERFORM_CANT_MORPH, "CANT"},
+        {STRING_FOR_PERFORM_DEFAULT_LAYOUT, "DEFA"},
+
         /* Strings for Midi Learning View
          * midi_follow.cpp
          */

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -728,7 +728,7 @@ enum class String : size_t {
 	STRING_FOR_PAD_SELECTION_ON,
 
 	/* Strings Specifically for Performance View
-	 * performance_session_view.cpp
+	 * performance_view.cpp
 	 */
 
 	STRING_FOR_PERFORM_VIEW,
@@ -736,8 +736,8 @@ enum class String : size_t {
 	STRING_FOR_PERFORM_EDITOR,
 	STRING_FOR_PERFORM_EDIT_PARAM,
 	STRING_FOR_PERFORM_EDIT_VALUE,
-	STRING_FOR_PERFORM_DEFAULTS_LOADED,
-	STRING_FOR_PERFORM_DEFAULTS_SAVED,
+	STRING_FOR_PERFORM_CANT_MORPH,
+	STRING_FOR_PERFORM_DEFAULT_LAYOUT,
 
 	/* Strings Specifically for Song View
 	 * session_view.cpp

--- a/src/deluge/gui/menu_item/midi/command.cpp
+++ b/src/deluge/gui/menu_item/midi/command.cpp
@@ -137,7 +137,7 @@ void Command::unlearnAction() {
 }
 
 void Command::learnProgramChange(MIDIDevice* device, int32_t channel, int32_t programNumber) {
-	if (commandNumber == GlobalMIDICommand::FILL) {
+	if ((commandNumber == GlobalMIDICommand::FILL) || (commandNumber == GlobalMIDICommand::MORPH)) {
 		display->displayPopup(l10n::get(l10n::String::STRING_FOR_CANT_LEARN_PC));
 	}
 	else {

--- a/src/deluge/gui/menu_item/performance_view/editing_mode.h
+++ b/src/deluge/gui/menu_item/performance_view/editing_mode.h
@@ -22,7 +22,7 @@
 #include "model/model_stack.h"
 #include "model/song/song.h"
 
-namespace deluge::gui::menu_item::performance_session_view {
+namespace deluge::gui::menu_item::performance_view {
 class EditingMode final : public Selection {
 public:
 	using Selection::Selection;
@@ -55,6 +55,9 @@ public:
 		}
 
 		if (performanceSessionView.defaultEditingMode) {
+			if (performanceSessionView.morphMode) {
+				performanceSessionView.exitMorphMode();
+			}
 			indicator_leds::blinkLed(IndicatorLED::KEYBOARD);
 		}
 		else {
@@ -79,4 +82,4 @@ public:
 	}
 };
 
-} // namespace deluge::gui::menu_item::performance_session_view
+} // namespace deluge::gui::menu_item::performance_view

--- a/src/deluge/gui/menu_item/performance_view/editing_mode.h
+++ b/src/deluge/gui/menu_item/performance_view/editing_mode.h
@@ -17,7 +17,7 @@
 #pragma once
 #include "definitions_cxx.hpp"
 #include "gui/menu_item/selection.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "hid/led/indicator_leds.h"
 #include "model/model_stack.h"
 #include "model/song/song.h"
@@ -28,10 +28,10 @@ public:
 	using Selection::Selection;
 	void readCurrentValue() override {
 		PerformanceEditingMode currentMode;
-		if (!performanceSessionView.defaultEditingMode) {
+		if (!performanceView.defaultEditingMode) {
 			currentMode = PerformanceEditingMode::DISABLED;
 		}
-		else if (!performanceSessionView.editingParam) {
+		else if (!performanceView.editingParam) {
 			currentMode = PerformanceEditingMode::VALUE;
 		}
 		else {
@@ -42,21 +42,21 @@ public:
 	void writeCurrentValue() override {
 		PerformanceEditingMode currentMode = this->getValue<PerformanceEditingMode>();
 		if (currentMode == PerformanceEditingMode::DISABLED) {
-			performanceSessionView.defaultEditingMode = false;
-			performanceSessionView.editingParam = false;
+			performanceView.defaultEditingMode = false;
+			performanceView.editingParam = false;
 		}
 		else if (currentMode == PerformanceEditingMode::VALUE) {
-			performanceSessionView.defaultEditingMode = true;
-			performanceSessionView.editingParam = false;
+			performanceView.defaultEditingMode = true;
+			performanceView.editingParam = false;
 		}
 		else { // PerformanceEditingMode::PARAM
-			performanceSessionView.defaultEditingMode = true;
-			performanceSessionView.editingParam = true;
+			performanceView.defaultEditingMode = true;
+			performanceView.editingParam = true;
 		}
 
-		if (performanceSessionView.defaultEditingMode) {
-			if (performanceSessionView.morphMode) {
-				performanceSessionView.exitMorphMode();
+		if (performanceView.defaultEditingMode) {
+			if (performanceView.morphMode) {
+				performanceView.exitMorphMode();
 			}
 			indicator_leds::blinkLed(IndicatorLED::KEYBOARD);
 		}
@@ -64,13 +64,13 @@ public:
 			indicator_leds::setLedState(IndicatorLED::KEYBOARD, true);
 		}
 
-		if (performanceSessionView.defaultEditingMode && !performanceSessionView.editingParam) {
+		if (performanceView.defaultEditingMode && !performanceView.editingParam) {
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithThreeMainThings* modelStack =
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-			performanceSessionView.resetPerformanceView(modelStack);
+			performanceView.resetPerformanceView(modelStack);
 		}
-		uiNeedsRendering(&performanceSessionView);
+		uiNeedsRendering(&performanceView);
 	}
 	deluge::vector<std::string_view> getOptions() override {
 		using enum l10n::String;

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -449,7 +449,7 @@ swapDone:
 	display->removeWorkingAnimation();
 
 	// initialize performance view layouts
-	performanceSessionView.initializeLayoutVariantsFromSong();
+	performanceView.initializeLayoutVariantsFromSong();
 }
 
 ActionResult LoadSongUI::timerCallback() {

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -447,6 +447,9 @@ swapDone:
 	currentUIMode = UI_MODE_NONE;
 
 	display->removeWorkingAnimation();
+
+	// initialize performance view layouts
+	performanceSessionView.initializeLayoutVariantsFromSong();
 }
 
 ActionResult LoadSongUI::timerCallback() {

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -90,7 +90,7 @@
 #include "gui/menu_item/patched_param/integer.h"
 #include "gui/menu_item/patched_param/integer_non_fm.h"
 #include "gui/menu_item/patched_param/pan.h"
-#include "gui/menu_item/performance_session_view/editing_mode.h"
+#include "gui/menu_item/performance_view/editing_mode.h"
 #include "gui/menu_item/record/quantize.h"
 #include "gui/menu_item/reverb/damping.h"
 #include "gui/menu_item/reverb/model.h"
@@ -856,6 +856,7 @@ midi::Command redoMidiCommand{STRING_FOR_REDO, GlobalMIDICommand::REDO};
 midi::Command loopMidiCommand{STRING_FOR_LOOP, GlobalMIDICommand::LOOP};
 midi::Command loopContinuousLayeringMidiCommand{STRING_FOR_LAYERING_LOOP, GlobalMIDICommand::LOOP_CONTINUOUS_LAYERING};
 midi::Command fillMidiCommand{STRING_FOR_FILL, GlobalMIDICommand::FILL};
+midi::Command morphMidiCommand{STRING_FOR_MORPH, GlobalMIDICommand::MORPH};
 
 Submenu midiCommandsMenu{
     STRING_FOR_COMMANDS,
@@ -870,6 +871,7 @@ Submenu midiCommandsMenu{
         &loopMidiCommand,
         &loopContinuousLayeringMidiCommand,
         &fillMidiCommand,
+        &morphMidiCommand,
     },
 };
 
@@ -1158,7 +1160,7 @@ menu_item::Submenu soundEditorRootMenuAudioClip{
 };
 
 // Menu for Performance View Editing Mode
-menu_item::performance_session_view::EditingMode performEditorMenu{STRING_FOR_PERFORM_EDITOR};
+menu_item::performance_view::EditingMode performEditorMenu{STRING_FOR_PERFORM_EDITOR};
 
 // Root menu for Performance View
 menu_item::Submenu soundEditorRootMenuPerformanceView{

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -18,7 +18,7 @@
 #include "gui/views/arranger_view.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/buttons.h"
@@ -166,8 +166,8 @@ bool SoundEditor::opened() {
 	setLedStates();
 
 	// update save button blinking status when in performance view
-	if (getRootUI() == &performanceSessionView) {
-		performanceSessionView.updateLayoutChangeStatus();
+	if (getRootUI() == &performanceView) {
+		performanceView.updateLayoutChangeStatus();
 	}
 
 	return true;
@@ -194,8 +194,8 @@ void SoundEditor::focusRegained() {
 	setLedStates();
 
 	// update save button blinking status when in performance view
-	if (getRootUI() == &performanceSessionView) {
-		performanceSessionView.updateLayoutChangeStatus();
+	if (getRootUI() == &performanceView) {
+		performanceView.updateLayoutChangeStatus();
 	}
 }
 
@@ -225,8 +225,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 
 	// Encoder button
 	if (b == SELECT_ENC) {
-		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING
-		    || getRootUI() == &performanceSessionView) {
+		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING || getRootUI() == &performanceView) {
 			if (on) {
 				if (inCardRoutine) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -262,8 +261,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 
 	// Back button
 	else if (b == BACK) {
-		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING
-		    || getRootUI() == &performanceSessionView) {
+		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING || getRootUI() == &performanceView) {
 			if (on) {
 				if (inCardRoutine) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -385,7 +383,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				}
 			}
 
-			if (getRootUI() != &performanceSessionView) {
+			if (getRootUI() != &performanceView) {
 				PadLEDs::reassessGreyout(true);
 
 				indicator_leds::setLedState(IndicatorLED::KEYBOARD, getRootUI() == &keyboardScreen);
@@ -440,7 +438,7 @@ void SoundEditor::exitCompletely() {
 
 	// don't save any of the logs created while using the sound editor to edit param values
 	// in performance view value editing mode
-	if ((getRootUI() == &performanceSessionView) && (performanceSessionView.defaultEditingMode)) {
+	if ((getRootUI() == &performanceView) && (performanceView.defaultEditingMode)) {
 		actionLogger.deleteAllLogs();
 	}
 
@@ -506,7 +504,7 @@ bool SoundEditor::beginScreen(MenuItem* oldMenuItem) {
 		// Find param shortcut
 		currentParamShorcutX = 255;
 		bool isUISessionView =
-		    (getRootUI() == &performanceSessionView) || (getRootUI() == &sessionView) || (getRootUI() == &arrangerView);
+		    (getRootUI() == &performanceView) || (getRootUI() == &sessionView) || (getRootUI() == &arrangerView);
 
 		if (isUISessionView) {
 			int32_t x, y;
@@ -718,8 +716,8 @@ void SoundEditor::selectEncoderAction(int8_t offset) {
 	}
 
 	// if you're in the performance view, let it handle the select encoder action
-	if (getRootUI() == &performanceSessionView) {
-		performanceSessionView.selectEncoderAction(offset);
+	if (getRootUI() == &performanceView) {
+		performanceView.selectEncoderAction(offset);
 	}
 	else {
 		if (currentUIMode != UI_MODE_NONE && currentUIMode != UI_MODE_AUDITIONING
@@ -783,9 +781,9 @@ ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool 
 
 	bool ignoreAction = false;
 	// if in Performance View
-	if ((getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView)) {
+	if ((getRootUI() == &performanceView) || (getCurrentUI() == &performanceView)) {
 		// ignore if you're not in editing mode or if you're in editing mode but editing a param
-		ignoreAction = (!performanceSessionView.defaultEditingMode || performanceSessionView.editingParam);
+		ignoreAction = (!performanceView.defaultEditingMode || performanceView.editingParam);
 	}
 	else {
 		// ignore if you're not auditioning and in instrument clip view
@@ -800,7 +798,7 @@ ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool 
 		return ActionResult::NOT_DEALT_WITH;
 	}
 
-	bool isUIPerformanceView = (getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
+	bool isUIPerformanceView = (getRootUI() == &performanceView) || (getCurrentUI() == &performanceView);
 
 	if (on && (isUIModeWithinRange(shortcutPadUIModes) || isUIPerformanceView)) {
 
@@ -1001,13 +999,13 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
 
-	bool isUIPerformanceView = (getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
+	bool isUIPerformanceView = (getRootUI() == &performanceView) || (getCurrentUI() == &performanceView);
 
 	// used to convert column press to a shortcut to change Perform FX menu displayed
-	if (isUIPerformanceView && !Buttons::isShiftButtonPressed() && performanceSessionView.defaultEditingMode
-	    && !performanceSessionView.editingParam) {
+	if (isUIPerformanceView && !Buttons::isShiftButtonPressed() && performanceView.defaultEditingMode
+	    && !performanceView.editingParam) {
 		if (x < kDisplayWidth) {
-			performanceSessionView.padAction(x, y, on);
+			performanceView.padAction(x, y, on);
 			return ActionResult::DEALT_WITH;
 		}
 	}
@@ -1070,8 +1068,8 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 
 		// used in performanceView to ignore pad presses when you just exited soundEditor
 		// with a padAction
-		if (getRootUI() == &performanceSessionView) {
-			performanceSessionView.justExitedSoundEditor = true;
+		if (getRootUI() == &performanceView) {
+			performanceView.justExitedSoundEditor = true;
 		}
 
 		exitCompletely();
@@ -1149,7 +1147,7 @@ bool SoundEditor::setup(Clip* clip, const MenuItem* item, int32_t sourceIndex) {
 	ModControllableAudio* newModControllable = nullptr;
 
 	bool isUISessionView =
-	    (getRootUI() == &performanceSessionView) || (getRootUI() == &sessionView) || (getRootUI() == &arrangerView);
+	    (getRootUI() == &performanceView) || (getRootUI() == &sessionView) || (getRootUI() == &arrangerView);
 
 	// getParamManager and ModControllable for Performance View (and Session View)
 	if (isUISessionView) {
@@ -1270,7 +1268,7 @@ doMIDIOrCV:
 			if (getCurrentUI() == &automationView) {
 				newItem = &defaultAutomationMenu;
 			}
-			else if ((getCurrentUI() == &performanceSessionView) && !Buttons::isShiftButtonPressed()) {
+			else if ((getCurrentUI() == &performanceView) && !Buttons::isShiftButtonPressed()) {
 				newItem = &soundEditorRootMenuPerformanceView;
 			}
 			else if (((getCurrentUI() == &sessionView) || (getCurrentUI() == &arrangerView))
@@ -1419,7 +1417,7 @@ AudioFileHolder* SoundEditor::getCurrentAudioFileHolder() {
 
 ModelStackWithThreeMainThings* SoundEditor::getCurrentModelStack(void* memory) {
 	bool isUISessionView =
-	    (getRootUI() == &performanceSessionView) || (getRootUI() == &sessionView) || (getRootUI() == &arrangerView);
+	    (getRootUI() == &performanceView) || (getRootUI() == &sessionView) || (getRootUI() == &arrangerView);
 
 	InstrumentClip* clip = getCurrentInstrumentClip();
 	Instrument* instrument = getCurrentInstrument();

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -165,7 +165,7 @@ bool SoundEditor::opened() {
 
 	setLedStates();
 
-	// update save button blinking status when in performance session view
+	// update save button blinking status when in performance view
 	if (getRootUI() == &performanceSessionView) {
 		performanceSessionView.updateLayoutChangeStatus();
 	}
@@ -193,7 +193,7 @@ void SoundEditor::focusRegained() {
 
 	setLedStates();
 
-	// update save button blinking status when in performance session view
+	// update save button blinking status when in performance view
 	if (getRootUI() == &performanceSessionView) {
 		performanceSessionView.updateLayoutChangeStatus();
 	}
@@ -782,7 +782,7 @@ static const uint32_t shortcutPadUIModes[] = {UI_MODE_AUDITIONING, 0};
 ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool on) {
 
 	bool ignoreAction = false;
-	// if in Performance Session View
+	// if in Performance View
 	if ((getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView)) {
 		// ignore if you're not in editing mode or if you're in editing mode but editing a param
 		ignoreAction = (!performanceSessionView.defaultEditingMode || performanceSessionView.editingParam);
@@ -800,10 +800,9 @@ ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool 
 		return ActionResult::NOT_DEALT_WITH;
 	}
 
-	bool isUIPerformanceSessionView =
-	    (getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
+	bool isUIPerformanceView = (getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
 
-	if (on && (isUIModeWithinRange(shortcutPadUIModes) || isUIPerformanceSessionView)) {
+	if (on && (isUIModeWithinRange(shortcutPadUIModes) || isUIPerformanceView)) {
 
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -811,8 +810,8 @@ ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool 
 
 		const MenuItem* item = nullptr;
 
-		// performance session view
-		if (isUIPerformanceSessionView) {
+		// performance view
+		if (isUIPerformanceView) {
 			if (x <= (kDisplayWidth - 2)) {
 				item = paramShortcutsForSongView[x][y];
 			}
@@ -1002,11 +1001,10 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
 
-	bool isUIPerformanceSessionView =
-	    (getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
+	bool isUIPerformanceView = (getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
 
 	// used to convert column press to a shortcut to change Perform FX menu displayed
-	if (isUIPerformanceSessionView && !Buttons::isShiftButtonPressed() && performanceSessionView.defaultEditingMode
+	if (isUIPerformanceView && !Buttons::isShiftButtonPressed() && performanceSessionView.defaultEditingMode
 	    && !performanceSessionView.editingParam) {
 		if (x < kDisplayWidth) {
 			performanceSessionView.padAction(x, y, on);
@@ -1070,7 +1068,7 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 			}
 		}
 
-		// used in performanceSessionView to ignore pad presses when you just exited soundEditor
+		// used in performanceView to ignore pad presses when you just exited soundEditor
 		// with a padAction
 		if (getRootUI() == &performanceSessionView) {
 			performanceSessionView.justExitedSoundEditor = true;
@@ -1153,7 +1151,7 @@ bool SoundEditor::setup(Clip* clip, const MenuItem* item, int32_t sourceIndex) {
 	bool isUISessionView =
 	    (getRootUI() == &performanceSessionView) || (getRootUI() == &sessionView) || (getRootUI() == &arrangerView);
 
-	// getParamManager and ModControllable for Performance Session View (and Session View)
+	// getParamManager and ModControllable for Performance View (and Session View)
 	if (isUISessionView) {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithThreeMainThings* modelStack =

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -21,7 +21,7 @@
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/display/display.h"
@@ -87,7 +87,7 @@ void UITimerManager::routine() {
 
 				case TIMER_PLAY_ENABLE_FLASH: {
 					RootUI* rootUI = getRootUI();
-					if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+					if (rootUI == &sessionView || rootUI == &performanceView) {
 						sessionView.flashPlayRoutine();
 					}
 					break;

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -87,7 +87,7 @@ void UITimerManager::routine() {
 
 				case TIMER_PLAY_ENABLE_FLASH: {
 					RootUI* rootUI = getRootUI();
-					if ((rootUI == &sessionView) || (rootUI == &performanceSessionView)) {
+					if (rootUI == &sessionView || rootUI == &performanceSessionView) {
 						sessionView.flashPlayRoutine();
 					}
 					break;

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -341,7 +341,7 @@ doActualSimpleChange:
 
 	else if (b == KEYBOARD) {
 		if (on && currentUIMode == UI_MODE_NONE) {
-			changeRootUI(&performanceSessionView);
+			changeRootUI(&performanceView);
 		}
 	}
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -177,7 +177,6 @@ ActionResult ArrangerView::buttonAction(deluge::hid::Button b, bool on, bool inC
 			}
 			if (currentUIMode == UI_MODE_NONE) {
 				if (Buttons::isShiftButtonPressed()) {
-					automationView.onArrangerView = true;
 					changeRootUI(&automationView);
 				}
 				else {
@@ -477,6 +476,8 @@ void ArrangerView::focusRegained() {
 	indicator_leds::setLedState(IndicatorLED::KEYBOARD, false);
 
 	currentSong->lastClipInstanceEnteredStartPos = 0;
+	currentSong->onAutomationArrangerView = false;
+	currentSong->onPerformanceView = false;
 
 	if (!doingAutoScrollNow) {
 		reassessWhetherDoingAutoScroll(); // Can start, but can't stop

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -125,7 +125,6 @@ public:
 
 	// public so instrument clip view can access it
 	void initParameterSelection();
-	bool onArrangerView;
 
 private:
 	// button action functions

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -15,7 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "definitions_cxx.hpp"
 #include "dsp/compressor/rms_feedback.h"
 #include "gui/colour/colour.h"
@@ -160,10 +160,10 @@ constexpr uint32_t paramIDShortcutsForPerformanceView[kDisplayWidth][kDisplayHei
     {kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID},
 };
 
-PerformanceSessionView performanceSessionView{};
+PerformanceView performanceView{};
 
 // initialize variables
-PerformanceSessionView::PerformanceSessionView() {
+PerformanceView::PerformanceView() {
 	successfullyReadDefaultsFromFile = false;
 
 	anyChangesToSave = false;
@@ -207,7 +207,7 @@ PerformanceSessionView::PerformanceSessionView() {
 	tempFilePath.clear();
 }
 
-void PerformanceSessionView::initPadPress(PadPress& padPress) {
+void PerformanceView::initPadPress(PadPress& padPress) {
 	padPress.isActive = false;
 	padPress.xDisplay = kNoSelection;
 	padPress.yDisplay = kNoSelection;
@@ -215,7 +215,7 @@ void PerformanceSessionView::initPadPress(PadPress& padPress) {
 	padPress.paramID = kNoSelection;
 }
 
-void PerformanceSessionView::initFXPress(FXColumnPress& columnPress) {
+void PerformanceView::initFXPress(FXColumnPress& columnPress) {
 	columnPress.previousKnobPosition = kNoSelection;
 	columnPress.currentKnobPosition = kNoSelection;
 	columnPress.yDisplay = kNoSelection;
@@ -223,7 +223,7 @@ void PerformanceSessionView::initFXPress(FXColumnPress& columnPress) {
 	columnPress.padPressHeld = false;
 }
 
-void PerformanceSessionView::initLayout(ParamsForPerformance& layout) {
+void PerformanceView::initLayout(ParamsForPerformance& layout) {
 	layout.paramKind = params::Kind::NONE;
 	layout.paramID = kNoSelection;
 	layout.xDisplay = kNoSelection;
@@ -236,7 +236,7 @@ void PerformanceSessionView::initLayout(ParamsForPerformance& layout) {
 	layout.rowTailColour[2] = 0;
 }
 
-void PerformanceSessionView::initDefaultFXValues(int32_t xDisplay) {
+void PerformanceView::initDefaultFXValues(int32_t xDisplay) {
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 		int32_t defaultFXValue = calculateKnobPosForSinglePadPress(xDisplay, yDisplay);
 		defaultFXValues[xDisplay][yDisplay] = defaultFXValue;
@@ -246,7 +246,7 @@ void PerformanceSessionView::initDefaultFXValues(int32_t xDisplay) {
 	}
 }
 
-bool PerformanceSessionView::opened() {
+bool PerformanceView::opened() {
 	if (playbackHandler.playbackState && currentPlaybackMode == &arrangement) {
 		PadLEDs::skipGreyoutFade();
 	}
@@ -256,7 +256,7 @@ bool PerformanceSessionView::opened() {
 	return true;
 }
 
-void PerformanceSessionView::focusRegained() {
+void PerformanceView::focusRegained() {
 	currentSong->onPerformanceView = true;
 	currentSong->affectEntire = true;
 
@@ -284,7 +284,7 @@ void PerformanceSessionView::focusRegained() {
 	uiNeedsRendering(this);
 }
 
-void PerformanceSessionView::graphicsRoutine() {
+void PerformanceView::graphicsRoutine() {
 	static int counter = 0;
 	if (currentUIMode == UI_MODE_NONE) {
 		int32_t modKnobMode = -1;
@@ -315,7 +315,7 @@ void PerformanceSessionView::graphicsRoutine() {
 	PadLEDs::setTickSquares(tickSquares, colours);
 }
 
-ActionResult PerformanceSessionView::timerCallback() {
+ActionResult PerformanceView::timerCallback() {
 	if (currentSong->lastClipInstanceEnteredStartPos == -1) {
 		sessionView.timerCallback();
 	}
@@ -325,9 +325,8 @@ ActionResult PerformanceSessionView::timerCallback() {
 	return ActionResult::DEALT_WITH;
 }
 
-bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
-                                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
-                                            bool drawUndefinedArea) {
+bool PerformanceView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
+                                     uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
 	if (!image) {
 		return true;
 	}
@@ -359,7 +358,7 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 }
 
 /// render every column, one row at a time
-void PerformanceSessionView::renderRow(RGB* image, uint8_t occupancyMask[], int32_t yDisplay) {
+void PerformanceView::renderRow(RGB* image, uint8_t occupancyMask[], int32_t yDisplay) {
 
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		RGB& pixel = image[xDisplay];
@@ -423,7 +422,7 @@ void PerformanceSessionView::renderRow(RGB* image, uint8_t occupancyMask[], int3
 }
 
 /// check if a param has been assigned to any of the FX columns
-bool PerformanceSessionView::isParamAssignedToFXColumn(params::Kind paramKind, int32_t paramID) {
+bool PerformanceView::isParamAssignedToFXColumn(params::Kind paramKind, int32_t paramID) {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		if ((layoutForPerformance[xDisplay].paramKind == paramKind)
 		    && (layoutForPerformance[xDisplay].paramID == paramID)) {
@@ -436,8 +435,8 @@ bool PerformanceSessionView::isParamAssignedToFXColumn(params::Kind paramKind, i
 /// depending on if you entered performance view from arranger or song:
 /// renders the sidebar from song view (grid mode or row mode)
 /// renders the sidebar from arranger view
-bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
-                                           uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
+bool PerformanceView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
+                                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
 	if (!image) {
 		return true;
 	}
@@ -457,7 +456,7 @@ bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisp
 }
 
 /// render performance view display on opening
-void PerformanceSessionView::renderViewDisplay() {
+void PerformanceView::renderViewDisplay() {
 	if (getCurrentUI() == this) {
 		if (defaultEditingMode) {
 			if (display->haveOLED()) {
@@ -532,7 +531,7 @@ void PerformanceSessionView::renderViewDisplay() {
 }
 
 /// Render Parameter Name and Value set when using Performance Pads
-void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t paramID, int32_t knobPos) {
+void PerformanceView::renderFXDisplay(params::Kind paramKind, int32_t paramID, int32_t knobPos) {
 	if (getCurrentUI() == this) {
 		if (editingParam) {
 			// display parameter name
@@ -642,7 +641,7 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 	}
 }
 
-void PerformanceSessionView::renderMorphDisplay() {
+void PerformanceView::renderMorphDisplay() {
 	if (getCurrentUI() == this) {
 		if (display->haveOLED()) {
 			deluge::hid::display::OLED::clearMainImage();
@@ -725,7 +724,7 @@ void PerformanceSessionView::renderMorphDisplay() {
 	}
 }
 
-int32_t PerformanceSessionView::calculateMorphPositionForDisplay() {
+int32_t PerformanceView::calculateMorphPositionForDisplay() {
 	float knobPosFloat = static_cast<float>(morphPosition);
 	float knobPosOffsetFloat = static_cast<float>(kKnobPosOffset);
 	float maxKnobPosFloat = static_cast<float>(kMaxKnobPos);
@@ -739,7 +738,7 @@ int32_t PerformanceSessionView::calculateMorphPositionForDisplay() {
 	return static_cast<int32_t>(std::round(valueForDisplayFloat));
 }
 
-void PerformanceSessionView::drawMorphBar(int32_t yTop) {
+void PerformanceView::drawMorphBar(int32_t yTop) {
 	int32_t marginL = 20;
 	int32_t marginR = marginL;
 
@@ -777,7 +776,7 @@ void PerformanceSessionView::drawMorphBar(int32_t yTop) {
 	                                          deluge::hid::display::OLED::oledMainImage);
 }
 
-void PerformanceSessionView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void PerformanceView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 	if (morphMode) {
 		renderMorphDisplay();
 	}
@@ -787,7 +786,7 @@ void PerformanceSessionView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS])
 	sessionView.renderOLED(image);
 }
 
-void PerformanceSessionView::redrawNumericDisplay() {
+void PerformanceView::redrawNumericDisplay() {
 	if (morphMode) {
 		renderMorphDisplay();
 	}
@@ -797,13 +796,13 @@ void PerformanceSessionView::redrawNumericDisplay() {
 	sessionView.redrawNumericDisplay();
 }
 
-void PerformanceSessionView::setLedStates() {
+void PerformanceView::setLedStates() {
 	setCentralLEDStates();
 	view.setLedStates();
 	view.setModLedStates();
 }
 
-void PerformanceSessionView::setCentralLEDStates() {
+void PerformanceView::setCentralLEDStates() {
 	indicator_leds::setLedState(IndicatorLED::SYNTH, false);
 	indicator_leds::setLedState(IndicatorLED::KIT, false);
 	indicator_leds::setLedState(IndicatorLED::MIDI, false);
@@ -850,7 +849,7 @@ void PerformanceSessionView::setCentralLEDStates() {
 	}
 }
 
-ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 	if (inCardRoutine) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
@@ -986,7 +985,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 }
 
 /// called by button action if b == KEYBOARD
-void PerformanceSessionView::handleKeyboardButtonAction(bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleKeyboardButtonAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		if (Buttons::isShiftButtonPressed()) {
 			if (defaultEditingMode && editingParam) {
@@ -1025,14 +1024,14 @@ void PerformanceSessionView::handleKeyboardButtonAction(bool on, ModelStackWithT
 }
 
 /// called by button action if b == Y_ENC
-void PerformanceSessionView::handleVerticalEncoderButtonAction(bool on) {
+void PerformanceView::handleVerticalEncoderButtonAction(bool on) {
 	if (on) {
 		currentSong->displayCurrentRootNoteAndScaleName();
 	}
 }
 
 /// called by button action if b == X_ENC
-void PerformanceSessionView::handleHorizontalEncoderButtonAction(bool on) {
+void PerformanceView::handleHorizontalEncoderButtonAction(bool on) {
 	if (on) {
 		enterUIMode(UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON);
 	}
@@ -1044,8 +1043,8 @@ void PerformanceSessionView::handleHorizontalEncoderButtonAction(bool on) {
 }
 
 /// called by button action if b == back and UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON
-void PerformanceSessionView::handleBackAndHorizontalEncoderButtonComboAction(
-    bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleBackAndHorizontalEncoderButtonComboAction(bool on,
+                                                                      ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		resetPerformanceView(modelStack);
 	}
@@ -1053,7 +1052,7 @@ void PerformanceSessionView::handleBackAndHorizontalEncoderButtonComboAction(
 
 /// called by button action if scale and cross-screen buttons are both held
 /// enters or exits morph mode
-void PerformanceSessionView::handleScaleAndCrossButtonComboAction(bool on) {
+void PerformanceView::handleScaleAndCrossButtonComboAction(bool on) {
 	if (on) {
 		if (morphMode) {
 			exitMorphMode();
@@ -1066,7 +1065,7 @@ void PerformanceSessionView::handleScaleAndCrossButtonComboAction(bool on) {
 
 /// called by button action if you're not in morph mode and you press the scale button
 /// selects layout bank 1
-void PerformanceSessionView::handleScaleButtonAction(bool on, int32_t variant) {
+void PerformanceView::handleScaleButtonAction(bool on, int32_t variant) {
 	if (on) {
 		layoutBank = 1;
 		indicator_leds::setLedState(IndicatorLED::SCALE_MODE, true);
@@ -1095,7 +1094,7 @@ void PerformanceSessionView::handleScaleButtonAction(bool on, int32_t variant) {
 
 /// called by button action if you're not in morph mode and you press the cross screen button
 /// select layout bank 2
-void PerformanceSessionView::handleCrossButtonAction(bool on, int32_t variant) {
+void PerformanceView::handleCrossButtonAction(bool on, int32_t variant) {
 	if (on) {
 		layoutBank = 2;
 		indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, true);
@@ -1124,7 +1123,7 @@ void PerformanceSessionView::handleCrossButtonAction(bool on, int32_t variant) {
 
 /// called by button action if keyboard button is pressed while UI_MODE_HOLDING_SAVE_BUTTON
 /// saves default layout, unselects bank and displays saved variant popup
-void PerformanceSessionView::handleKeyboardAndSaveButtonComboAction(bool on) {
+void PerformanceView::handleKeyboardAndSaveButtonComboAction(bool on) {
 	if (on) {
 		layoutBank = 0;
 		indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
@@ -1137,7 +1136,7 @@ void PerformanceSessionView::handleKeyboardAndSaveButtonComboAction(bool on) {
 }
 
 /// called by button combo functions below to save bank variant based on current bank selection
-void PerformanceSessionView::handleSavingBankVariantSelection(int32_t bank1Variant, int32_t bank2Variant) {
+void PerformanceView::handleSavingBankVariantSelection(int32_t bank1Variant, int32_t bank2Variant) {
 	if (layoutBank == 1) {
 		currentSong->performanceLayoutVariant = bank1Variant;
 	}
@@ -1154,7 +1153,7 @@ void PerformanceSessionView::handleSavingBankVariantSelection(int32_t bank1Varia
 
 /// called by button action if synth button is pressed while UI_MODE_HOLDING_SAVE_BUTTON
 /// saves layout 1 or 5 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleSynthAndSaveButtonComboAction(bool on) {
+void PerformanceView::handleSynthAndSaveButtonComboAction(bool on) {
 	if (on) {
 		handleSavingBankVariantSelection(1, 5);
 	}
@@ -1162,7 +1161,7 @@ void PerformanceSessionView::handleSynthAndSaveButtonComboAction(bool on) {
 
 /// called by button action if kit button is pressed while UI_MODE_HOLDING_SAVE_BUTTON
 /// saves layout 2 or 6 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleKitAndSaveButtonComboAction(bool on) {
+void PerformanceView::handleKitAndSaveButtonComboAction(bool on) {
 	if (on) {
 		handleSavingBankVariantSelection(2, 6);
 	}
@@ -1170,7 +1169,7 @@ void PerformanceSessionView::handleKitAndSaveButtonComboAction(bool on) {
 
 /// called by button action if midi button is pressed while UI_MODE_HOLDING_SAVE_BUTTON
 /// saves layout 3 or 7 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleMidiAndSaveButtonComboAction(bool on) {
+void PerformanceView::handleMidiAndSaveButtonComboAction(bool on) {
 	if (on) {
 		handleSavingBankVariantSelection(3, 7);
 	}
@@ -1178,7 +1177,7 @@ void PerformanceSessionView::handleMidiAndSaveButtonComboAction(bool on) {
 
 /// called by button action if CV button is pressed while UI_MODE_HOLDING_SAVE_BUTTON
 /// saves layout 4 or 8 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleCVAndSaveButtonComboAction(bool on) {
+void PerformanceView::handleCVAndSaveButtonComboAction(bool on) {
 	if (on) {
 		handleSavingBankVariantSelection(4, 8);
 	}
@@ -1186,8 +1185,7 @@ void PerformanceSessionView::handleCVAndSaveButtonComboAction(bool on) {
 
 /// called by button action if keyboard button is pressed while UI_MODE_HOLDING_LOAD_BUTTON
 /// loads default layout, unselects bank and displays loaded variant popup
-void PerformanceSessionView::handleKeyboardAndLoadButtonComboAction(bool on,
-                                                                    ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleKeyboardAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		if (currentSong->performanceLayoutVariant != 0) {
 			successfullyReadDefaultsFromFile = false;
@@ -1204,8 +1202,8 @@ void PerformanceSessionView::handleKeyboardAndLoadButtonComboAction(bool on,
 }
 
 /// called by button combo functions below to load bank variant based on current bank selection
-void PerformanceSessionView::handleLoadingBankVariantSelection(int32_t bank1Variant, int32_t bank2Variant,
-                                                               ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleLoadingBankVariantSelection(int32_t bank1Variant, int32_t bank2Variant,
+                                                        ModelStackWithThreeMainThings* modelStack) {
 	if (layoutBank == 1) {
 		if (currentSong->performanceLayoutVariant != bank1Variant) {
 			successfullyReadDefaultsFromFile = false;
@@ -1229,7 +1227,7 @@ void PerformanceSessionView::handleLoadingBankVariantSelection(int32_t bank1Vari
 
 /// called by button action if synth button is pressed while UI_MODE_HOLDING_LOAD_BUTTON
 /// loads layout 1 or 5 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleSynthAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleSynthAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		handleLoadingBankVariantSelection(1, 5, modelStack);
 	}
@@ -1237,7 +1235,7 @@ void PerformanceSessionView::handleSynthAndLoadButtonComboAction(bool on, ModelS
 
 /// called by button action if kit button is pressed while UI_MODE_HOLDING_LOAD_BUTTON
 /// loads layout 2 or 6 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleKitAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleKitAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		handleLoadingBankVariantSelection(2, 6, modelStack);
 	}
@@ -1245,7 +1243,7 @@ void PerformanceSessionView::handleKitAndLoadButtonComboAction(bool on, ModelSta
 
 /// called by button action if midi button is pressed while UI_MODE_HOLDING_LOAD_BUTTON
 /// loads layout 3 or 7 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleMidiAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleMidiAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		handleLoadingBankVariantSelection(3, 7, modelStack);
 	}
@@ -1253,14 +1251,14 @@ void PerformanceSessionView::handleMidiAndLoadButtonComboAction(bool on, ModelSt
 
 /// called by button action if CV button is pressed while UI_MODE_HOLDING_LOAD_BUTTON
 /// loads layout 4 or 8 if bank 1 or 2 is selected and displays saved variant popup
-void PerformanceSessionView::handleCVAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleCVAndLoadButtonComboAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		handleLoadingBankVariantSelection(4, 8, modelStack);
 	}
 }
 
 /// called by button action if b == Synth while you're in Morph Mode and CV button isn't also pressed
-void PerformanceSessionView::handleSynthMorphButtonAction(bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleSynthMorphButtonAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		loadMorphALayout(modelStack);
 		if (display->have7SEG()) {
@@ -1277,7 +1275,7 @@ void PerformanceSessionView::handleSynthMorphButtonAction(bool on, ModelStackWit
 }
 
 /// called by button action if b == CV while you're in Morph Mode and Synth button isn't also pressed
-void PerformanceSessionView::handleCVMorphButtonAction(bool on, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::handleCVMorphButtonAction(bool on, ModelStackWithThreeMainThings* modelStack) {
 	if (on) {
 		loadMorphBLayout(modelStack);
 		if (display->have7SEG()) {
@@ -1294,7 +1292,7 @@ void PerformanceSessionView::handleCVMorphButtonAction(bool on, ModelStackWithTh
 }
 
 /// called by button action if b == SELECT_ENC and shift button is not also pressed
-void PerformanceSessionView::handleSelectEncoderButtonAction(bool on) {
+void PerformanceView::handleSelectEncoderButtonAction(bool on) {
 	if (on) {
 		if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_RECORDING_TO_ARRANGEMENT));
@@ -1307,7 +1305,7 @@ void PerformanceSessionView::handleSelectEncoderButtonAction(bool on) {
 	}
 }
 
-ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDisplay, int32_t on) {
+ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int32_t on) {
 	if (!justExitedSoundEditor) {
 		// if pad was pressed in main deluge grid (not sidebar)
 		if (xDisplay < kDisplayWidth) {
@@ -1401,8 +1399,8 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 }
 
 /// process pad actions in the normal performance view or value editor
-void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay,
-                                             int32_t yDisplay, int32_t on) {
+void PerformanceView::normalPadAction(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay, int32_t yDisplay,
+                                      int32_t on) {
 	// obtain Kind, ParamID corresponding to the column pressed on performance grid
 	Kind lastSelectedParamKind = layoutForPerformance[xDisplay].paramKind; // kind;
 	int32_t lastSelectedParamID = layoutForPerformance[xDisplay].paramID;
@@ -1481,8 +1479,8 @@ void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* mode
 	}
 }
 
-void PerformanceSessionView::padPressAction(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
-                                            int32_t paramID, int32_t xDisplay, int32_t yDisplay, bool renderDisplay) {
+void PerformanceView::padPressAction(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind, int32_t paramID,
+                                     int32_t xDisplay, int32_t yDisplay, bool renderDisplay) {
 	if (setParameterValue(modelStack, paramKind, paramID, xDisplay, defaultFXValues[xDisplay][yDisplay],
 	                      renderDisplay)) {
 		// if pressing a new pad in a column, reset held status
@@ -1506,8 +1504,8 @@ void PerformanceSessionView::padPressAction(ModelStackWithThreeMainThings* model
 	}
 }
 
-void PerformanceSessionView::padReleaseAction(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
-                                              int32_t paramID, int32_t xDisplay, bool renderDisplay) {
+void PerformanceView::padReleaseAction(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
+                                       int32_t paramID, int32_t xDisplay, bool renderDisplay) {
 	if (setParameterValue(modelStack, paramKind, paramID, xDisplay, fxPress[xDisplay].previousKnobPosition,
 	                      renderDisplay)) {
 		initFXPress(fxPress[xDisplay]);
@@ -1516,8 +1514,8 @@ void PerformanceSessionView::padReleaseAction(ModelStackWithThreeMainThings* mod
 }
 
 /// process pad actions in the param editor
-void PerformanceSessionView::paramEditorPadAction(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay,
-                                                  int32_t yDisplay, int32_t on) {
+void PerformanceView::paramEditorPadAction(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay,
+                                           int32_t yDisplay, int32_t on) {
 	// pressing a pad
 	if (on) {
 		// if you haven't yet pressed and are holding a param shortcut pad on the param overview
@@ -1579,7 +1577,7 @@ void PerformanceSessionView::paramEditorPadAction(ModelStackWithThreeMainThings*
 }
 
 /// check if pad press corresponds to a shortcut pad on the grid
-bool PerformanceSessionView::isPadShortcut(int32_t xDisplay, int32_t yDisplay) {
+bool PerformanceView::isPadShortcut(int32_t xDisplay, int32_t yDisplay) {
 	if ((paramKindShortcutsForPerformanceView[xDisplay][yDisplay] != params::Kind::NONE)
 	    && (paramIDShortcutsForPerformanceView[xDisplay][yDisplay] != kNoParamID)) {
 		return true;
@@ -1588,7 +1586,7 @@ bool PerformanceSessionView::isPadShortcut(int32_t xDisplay, int32_t yDisplay) {
 }
 
 /// backup performance layout so changes can be undone / redone later
-void PerformanceSessionView::backupPerformanceLayout(bool onlyMorph) {
+void PerformanceView::backupPerformanceLayout(bool onlyMorph) {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		if (successfullyReadDefaultsFromFile) {
 			if (!onlyMorph) {
@@ -1609,7 +1607,7 @@ void PerformanceSessionView::backupPerformanceLayout(bool onlyMorph) {
 
 /// used in conjunction with backupPerformanceLayout to log changes
 /// while in Performance View so that you can undo/redo them afters
-void PerformanceSessionView::logPerformanceViewPress(int32_t xDisplay, bool closeAction) {
+void PerformanceView::logPerformanceViewPress(int32_t xDisplay, bool closeAction) {
 	if (anyChangesToLog()) {
 		actionLogger.recordPerformanceViewPress(backupFXPress, fxPress, xDisplay);
 		if (closeAction) {
@@ -1619,7 +1617,7 @@ void PerformanceSessionView::logPerformanceViewPress(int32_t xDisplay, bool clos
 }
 
 /// check if there are any changes that needed to be logged in action logger for undo/redo mechanism to work
-bool PerformanceSessionView::anyChangesToLog() {
+bool PerformanceView::anyChangesToLog() {
 	if (performanceLayoutBackedUp) {
 		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 			if (backupFXPress[xDisplay].previousKnobPosition != fxPress[xDisplay].previousKnobPosition) {
@@ -1645,7 +1643,7 @@ bool PerformanceSessionView::anyChangesToLog() {
 /// called when you press <> + back
 /// in param editor, it will clear existing param mappings
 /// in regular performance view or value editor, it will clear held pads and reset param values to pre-held state
-void PerformanceSessionView::resetPerformanceView(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::resetPerformanceView(ModelStackWithThreeMainThings* modelStack) {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		// this could get called if you're loading a new song
 		// don't need to reset performance view if you're loading a new song
@@ -1689,7 +1687,7 @@ void PerformanceSessionView::resetPerformanceView(ModelStackWithThreeMainThings*
 
 /// resets a single FX column to remove held status
 /// and reset the param value assigned to that FX column to pre-held state
-void PerformanceSessionView::resetFXColumn(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay) {
+void PerformanceView::resetFXColumn(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay) {
 	if (fxPress[xDisplay].padPressHeld) {
 		// obtain Kind and ParamID corresponding to the column in focus (xDisplay)
 		params::Kind lastSelectedParamKind = layoutForPerformance[xDisplay].paramKind; // kind;
@@ -1703,7 +1701,7 @@ void PerformanceSessionView::resetFXColumn(ModelStackWithThreeMainThings* modelS
 }
 
 /// check if stutter is active and release it if it is
-void PerformanceSessionView::releaseStutter(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::releaseStutter(ModelStackWithThreeMainThings* modelStack) {
 	if (isUIModeActive(UI_MODE_STUTTERING)) {
 		padReleaseAction(modelStack, params::Kind::UNPATCHED_GLOBAL, deluge::modulation::params::UNPATCHED_STUTTER_RATE,
 		                 lastPadPress.xDisplay, false);
@@ -1716,8 +1714,8 @@ void PerformanceSessionView::releaseStutter(ModelStackWithThreeMainThings* model
 /// if you're in the value editor, pressing a column and changing the value will also open the sound editor
 /// menu for the parameter to show you the current value in the menu
 /// in regular performance view, this function will also update the parameter value shown on the display
-bool PerformanceSessionView::setParameterValue(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
-                                               int32_t paramID, int32_t xDisplay, int32_t knobPos, bool renderDisplay) {
+bool PerformanceView::setParameterValue(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
+                                        int32_t paramID, int32_t xDisplay, int32_t knobPos, bool renderDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = currentSong->getModelStackWithParam(modelStack, paramID);
 
 	if (modelStackWithParam && modelStackWithParam->autoParam) {
@@ -1773,8 +1771,8 @@ bool PerformanceSessionView::setParameterValue(ModelStackWithThreeMainThings* mo
 
 /// get the current value for a parameter and update display if value is different than currently shown
 /// update current value stored
-void PerformanceSessionView::getParameterValue(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
-                                               int32_t paramID, int32_t xDisplay, bool renderDisplay) {
+void PerformanceView::getParameterValue(ModelStackWithThreeMainThings* modelStack, params::Kind paramKind,
+                                        int32_t paramID, int32_t xDisplay, bool renderDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = currentSong->getModelStackWithParam(modelStack, paramID);
 
 	if (modelStackWithParam && modelStackWithParam->autoParam) {
@@ -1800,7 +1798,7 @@ void PerformanceSessionView::getParameterValue(ModelStackWithThreeMainThings* mo
 
 /// converts grid pad press yDisplay into a knobPosition value default
 /// this will likely need to be customized based on the parameter to create some more param appropriate ranges
-int32_t PerformanceSessionView::calculateKnobPosForSinglePadPress(int32_t xDisplay, int32_t yDisplay) {
+int32_t PerformanceView::calculateKnobPosForSinglePadPress(int32_t xDisplay, int32_t yDisplay) {
 	int32_t newKnobPos = 0;
 
 	params::Kind paramKind = defaultLayoutForPerformance[xDisplay].paramKind;
@@ -1831,7 +1829,7 @@ int32_t PerformanceSessionView::calculateKnobPosForSinglePadPress(int32_t xDispl
 /// Used to edit a pad's value in editing mode
 /// Also used to select morph layouts in morph mode
 /// and used to edit sidebar actions such as loops remaining / repeats, etc.
-void PerformanceSessionView::selectEncoderAction(int8_t offset) {
+void PerformanceView::selectEncoderAction(int8_t offset) {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithThreeMainThings* modelStack = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
@@ -1889,7 +1887,7 @@ exit:
 }
 
 /// used to calculate new knobPos when you turn the select encoder
-int32_t PerformanceSessionView::calculateKnobPosForSelectEncoderTurn(int32_t knobPos, int32_t offset) {
+int32_t PerformanceView::calculateKnobPosForSelectEncoderTurn(int32_t knobPos, int32_t offset) {
 
 	// adjust the current knob so that it is within the range of 0-128 for calculation purposes
 	knobPos = knobPos + kKnobPosOffset;
@@ -1915,16 +1913,16 @@ int32_t PerformanceSessionView::calculateKnobPosForSelectEncoderTurn(int32_t kno
 	return newKnobPos;
 }
 
-int32_t PerformanceSessionView::adjustKnobPosForQuantizedStutter(int32_t yDisplay) {
+int32_t PerformanceView::adjustKnobPosForQuantizedStutter(int32_t yDisplay) {
 	int32_t knobPos = -kMinKnobPosForQuantizedStutter + (yDisplay * kParamValueIncrementForQuantizedStutter);
 	return knobPos;
 }
 
-ActionResult PerformanceSessionView::horizontalEncoderAction(int32_t offset) {
+ActionResult PerformanceView::horizontalEncoderAction(int32_t offset) {
 	return ActionResult::DEALT_WITH;
 }
 
-ActionResult PerformanceSessionView::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
+ActionResult PerformanceView::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
 	if (currentSong->lastClipInstanceEnteredStartPos == -1) {
 		sessionView.verticalEncoderAction(offset, inCardRoutine);
 	}
@@ -1935,18 +1933,18 @@ ActionResult PerformanceSessionView::verticalEncoderAction(int32_t offset, bool 
 }
 
 /// why do I need this? (code won't compile without it)
-uint32_t PerformanceSessionView::getMaxZoom() {
+uint32_t PerformanceView::getMaxZoom() {
 	return currentSong->getLongestClip(true, false)->getMaxZoom();
 }
 
 /// why do I need this? (code won't compile without it)
-uint32_t PerformanceSessionView::getMaxLength() {
+uint32_t PerformanceView::getMaxLength() {
 	return currentSong->getLongestClip(true, false)->loopLength;
 }
 
 /// updates the display if the mod encoder has just updated the same parameter currently being held / last held
 /// if no param is currently being held, it will reset the display to just show "Performance View"
-void PerformanceSessionView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
+void PerformanceView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 	if (morphMode && !defaultEditingMode) {
 		morph(offset);
 		renderMorphDisplay();
@@ -1970,7 +1968,7 @@ void PerformanceSessionView::modEncoderAction(int32_t whichModEncoder, int32_t o
 }
 
 /// used to reset stutter if it's already active
-void PerformanceSessionView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
+void PerformanceView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 	if (morphMode) {
 		return;
 	}
@@ -2008,13 +2006,13 @@ void PerformanceSessionView::modEncoderButtonAction(uint8_t whichModEncoder, boo
 	}
 }
 
-void PerformanceSessionView::modButtonAction(uint8_t whichButton, bool on) {
+void PerformanceView::modButtonAction(uint8_t whichButton, bool on) {
 	UI::modButtonAction(whichButton, on);
 }
 
 /// this compares the last loaded XML file defaults to the current layout in performance view
 /// to determine if there are any unsaved changes
-void PerformanceSessionView::updateLayoutChangeStatus() {
+void PerformanceView::updateLayoutChangeStatus() {
 	anyChangesToSave = false;
 
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
@@ -2070,7 +2068,7 @@ void PerformanceSessionView::updateLayoutChangeStatus() {
 /// determine the layout file name
 /// append layout file name to folder path
 /// append .XML to end of file name
-void PerformanceSessionView::setLayoutFilePath() {
+void PerformanceView::setLayoutFilePath() {
 	tempFilePath.set(PERFORM_DEFAULTS_FOLDER);
 	tempFilePath.concatenate("/");
 	if (currentSong->performanceLayoutVariant == 0) {
@@ -2085,14 +2083,14 @@ void PerformanceSessionView::setLayoutFilePath() {
 }
 
 /// update saved performance view layout and update saved changes status
-void PerformanceSessionView::savePerformanceViewLayout() {
+void PerformanceView::savePerformanceViewLayout() {
 	setLayoutFilePath();
 	writeDefaultsToFile();
 	updateLayoutChangeStatus();
 }
 
 /// create default XML file and write defaults
-void PerformanceSessionView::writeDefaultsToFile() {
+void PerformanceView::writeDefaultsToFile() {
 	// Default.xml / 1.xml, 2.xml ... 8.xml
 	// if the file already exists, this will overwrite it.
 	int32_t error = storageManager.createXMLFile(tempFilePath.get(), true);
@@ -2123,7 +2121,7 @@ void PerformanceSessionView::writeDefaultsToFile() {
 /// limiting # of FX to the # of columns on the grid (16 = kDisplayWidth)
 /// could expand # of FX in the future if we allow user to selected from a larger bank of FX / build their own
 /// FX
-void PerformanceSessionView::writeDefaultFXValuesToFile() {
+void PerformanceView::writeDefaultFXValuesToFile() {
 	char tagName[10];
 	tagName[0] = 'F';
 	tagName[1] = 'X';
@@ -2139,7 +2137,7 @@ void PerformanceSessionView::writeDefaultFXValuesToFile() {
 }
 
 /// convert paramID to a paramName to write to XML
-void PerformanceSessionView::writeDefaultFXParamToFile(int32_t xDisplay) {
+void PerformanceView::writeDefaultFXParamToFile(int32_t xDisplay) {
 	char const* paramName;
 
 	auto kind = layoutForPerformance[xDisplay].paramKind;
@@ -2158,7 +2156,7 @@ void PerformanceSessionView::writeDefaultFXParamToFile(int32_t xDisplay) {
 
 /// creates "8 - 1 row # tags within a "row" tag"
 /// limiting # of rows to the # of rows on the grid (8 = kDisplayHeight)
-void PerformanceSessionView::writeDefaultFXRowValuesToFile(int32_t xDisplay) {
+void PerformanceView::writeDefaultFXRowValuesToFile(int32_t xDisplay) {
 	//<row>
 	storageManager.writeOpeningTagBeginning(PERFORM_DEFAULTS_ROW_TAG);
 	storageManager.writeOpeningTagEnd();
@@ -2175,7 +2173,7 @@ void PerformanceSessionView::writeDefaultFXRowValuesToFile(int32_t xDisplay) {
 
 /// for each FX column, write the held status, what row is being held, and what previous value was
 /// (previous value is used to reset param after you remove the held status)
-void PerformanceSessionView::writeDefaultFXHoldStatusToFile(int32_t xDisplay) {
+void PerformanceView::writeDefaultFXHoldStatusToFile(int32_t xDisplay) {
 	//<hold>
 	storageManager.writeOpeningTagBeginning(PERFORM_DEFAULTS_HOLD_TAG);
 	storageManager.writeOpeningTagEnd();
@@ -2206,7 +2204,7 @@ void PerformanceSessionView::writeDefaultFXHoldStatusToFile(int32_t xDisplay) {
 }
 
 /// backup current layout, load saved layout, log layout change, update change status
-void PerformanceSessionView::loadPerformanceViewLayout(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::loadPerformanceViewLayout(ModelStackWithThreeMainThings* modelStack) {
 	resetPerformanceView(modelStack);
 	if (successfullyReadDefaultsFromFile) {
 		readDefaultsFromBackedUpFile(modelStack);
@@ -2220,7 +2218,7 @@ void PerformanceSessionView::loadPerformanceViewLayout(ModelStackWithThreeMainTh
 /// after a layout has been loaded, we want to back it up so we can re-load it more quickly next time
 /// and also be able to do comparisons of changes to the backed up layout
 /// we also delete all action logs so that you can't undo after loading a layout
-void PerformanceSessionView::layoutUpdated() {
+void PerformanceView::layoutUpdated() {
 	actionLogger.deleteAllLogs();
 	backupPerformanceLayout();
 	updateLayoutChangeStatus();
@@ -2231,7 +2229,7 @@ void PerformanceSessionView::layoutUpdated() {
 }
 
 /// re-read defaults from backed up XML in memory in order to reduce SD Card IO
-void PerformanceSessionView::readDefaultsFromBackedUpFile(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::readDefaultsFromBackedUpFile(ModelStackWithThreeMainThings* modelStack) {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		memcpy(&layoutForPerformance[xDisplay], &backupXMLDefaultLayoutForPerformance[xDisplay],
 		       sizeof(ParamsForPerformance));
@@ -2247,7 +2245,7 @@ void PerformanceSessionView::readDefaultsFromBackedUpFile(ModelStackWithThreeMai
 }
 
 /// read defaults from XML
-void PerformanceSessionView::readDefaultsFromFile(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::readDefaultsFromFile(ModelStackWithThreeMainThings* modelStack) {
 	// no need to keep reading from SD card after first load
 	if (successfullyReadDefaultsFromFile) {
 		return;
@@ -2256,7 +2254,7 @@ void PerformanceSessionView::readDefaultsFromFile(ModelStackWithThreeMainThings*
 	setLayoutFilePath();
 
 	FilePointer fp;
-	// performanceSessionView.XML
+	// performanceView.XML
 	bool success = storageManager.fileExists(tempFilePath.get(), &fp);
 	if (!success) {
 		loadDefaultLayout();
@@ -2286,7 +2284,7 @@ void PerformanceSessionView::readDefaultsFromFile(ModelStackWithThreeMainThings*
 
 /// if no XML file exists, load default layout (paramKind, paramID, xDisplay, yDisplay, rowColour,
 /// rowTailColour)
-void PerformanceSessionView::loadDefaultLayout() {
+void PerformanceView::loadDefaultLayout() {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		memcpy(&layoutForPerformance[xDisplay], &defaultLayoutForPerformance[xDisplay], sizeof(ParamsForPerformance));
 		memcpy(&backupXMLDefaultLayoutForPerformance[xDisplay], &defaultLayoutForPerformance[xDisplay],
@@ -2305,7 +2303,7 @@ void PerformanceSessionView::loadDefaultLayout() {
 	successfullyReadDefaultsFromFile = true;
 }
 
-void PerformanceSessionView::readDefaultFXValuesFromFile(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::readDefaultFXValuesFromFile(ModelStackWithThreeMainThings* modelStack) {
 	char const* tagName;
 	char tagNameFX[5];
 	tagNameFX[0] = 'F';
@@ -2327,8 +2325,8 @@ void PerformanceSessionView::readDefaultFXValuesFromFile(ModelStackWithThreeMain
 	}
 }
 
-void PerformanceSessionView::readDefaultFXParamAndRowValuesFromFile(int32_t xDisplay,
-                                                                    ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::readDefaultFXParamAndRowValuesFromFile(int32_t xDisplay,
+                                                             ModelStackWithThreeMainThings* modelStack) {
 	char const* tagName;
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
 		//<param>
@@ -2350,7 +2348,7 @@ void PerformanceSessionView::readDefaultFXParamAndRowValuesFromFile(int32_t xDis
 /// compares param name from <param> tag to the list of params available for use in performance view
 /// if param is found, it loads the layout info for that param into the view (paramKind, paramID, xDisplay,
 /// yDisplay, rowColour, rowTailColour)
-void PerformanceSessionView::readDefaultFXParamFromFile(int32_t xDisplay) {
+void PerformanceView::readDefaultFXParamFromFile(int32_t xDisplay) {
 	char const* paramName;
 	char const* tagName = storageManager.readTagOrAttributeValue();
 
@@ -2376,7 +2374,7 @@ void PerformanceSessionView::readDefaultFXParamFromFile(int32_t xDisplay) {
 }
 
 /// this will load the values corresponding to each pad in each column in performance view
-void PerformanceSessionView::readDefaultFXRowNumberValuesFromFile(int32_t xDisplay) {
+void PerformanceView::readDefaultFXRowNumberValuesFromFile(int32_t xDisplay) {
 	char const* tagName;
 	char rowNumber[5];
 	// loop through all row <#> number tags
@@ -2417,8 +2415,7 @@ void PerformanceSessionView::readDefaultFXRowNumberValuesFromFile(int32_t xDispl
 
 /// this function reads layout data relating to held pads
 /// this includes, held status, held value and previous value to reset back to if hold is removed
-void PerformanceSessionView::readDefaultFXHoldStatusFromFile(int32_t xDisplay,
-                                                             ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::readDefaultFXHoldStatusFromFile(int32_t xDisplay, ModelStackWithThreeMainThings* modelStack) {
 	char const* tagName;
 	// loop through the hold tags
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
@@ -2491,7 +2488,7 @@ void PerformanceSessionView::readDefaultFXHoldStatusFromFile(int32_t xDisplay,
 
 /// if there are any held pads in a layout, this function will initialize them by
 /// changing parameter values to the held value
-void PerformanceSessionView::initializeHeldFX(int32_t xDisplay, ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::initializeHeldFX(int32_t xDisplay, ModelStackWithThreeMainThings* modelStack) {
 	if (fxPress[xDisplay].padPressHeld) {
 		// set the value associated with the held pad
 		if ((fxPress[xDisplay].currentKnobPosition != kNoSelection)
@@ -2517,7 +2514,7 @@ void PerformanceSessionView::initializeHeldFX(int32_t xDisplay, ModelStackWithTh
 }
 
 /// when a song is loaded, we want to load the layout settings that were saved with the song
-void PerformanceSessionView::initializeLayoutVariantsFromSong() {
+void PerformanceView::initializeLayoutVariantsFromSong() {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithThreeMainThings* modelStack = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
@@ -2538,7 +2535,7 @@ void PerformanceSessionView::initializeLayoutVariantsFromSong() {
 }
 
 /// used in morph mode with the select encoder to select morph layout variant assigned to A and B
-void PerformanceSessionView::selectLayoutVariant(int32_t offset, int32_t& variant) {
+void PerformanceView::selectLayoutVariant(int32_t offset, int32_t& variant) {
 	if (variant == kNoSelection) {
 		if (offset > 0) {
 			variant = -1;
@@ -2558,7 +2555,7 @@ void PerformanceSessionView::selectLayoutVariant(int32_t offset, int32_t& varian
 }
 
 /// displays if no layout has been loaded, the default layout has been loaded or layouts 1 to 8
-void PerformanceSessionView::displayLayoutVariant(int32_t variant) {
+void PerformanceView::displayLayoutVariant(int32_t variant) {
 	if (variant == kNoSelection) {
 		display->displayPopup(l10n::get(l10n::String::STRING_FOR_NONE));
 	}
@@ -2573,8 +2570,7 @@ void PerformanceSessionView::displayLayoutVariant(int32_t variant) {
 }
 
 /// here we load a layout variant from its XML file
-void PerformanceSessionView::loadSelectedLayoutVariantFromFile(int32_t variant,
-                                                               ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::loadSelectedLayoutVariantFromFile(int32_t variant, ModelStackWithThreeMainThings* modelStack) {
 	if (variant != kNoSelection) {
 		currentSong->performanceLayoutVariant = variant;
 		successfullyReadDefaultsFromFile = false;
@@ -2589,7 +2585,7 @@ void PerformanceSessionView::loadSelectedLayoutVariantFromFile(int32_t variant,
 }
 
 /// enter morph mode, set the led states and render display
-void PerformanceSessionView::enterMorphMode() {
+void PerformanceView::enterMorphMode() {
 	morphMode = true;
 	indicator_leds::setLedState(IndicatorLED::SCALE_MODE, true);
 	indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, true);
@@ -2599,7 +2595,7 @@ void PerformanceSessionView::enterMorphMode() {
 }
 
 /// exit morph mode, set the led states and render display
-void PerformanceSessionView::exitMorphMode() {
+void PerformanceView::exitMorphMode() {
 	morphMode = false;
 	setCentralLEDStates();
 	view.setKnobIndicatorLevels();
@@ -2608,7 +2604,7 @@ void PerformanceSessionView::exitMorphMode() {
 }
 
 /// received morph cc from global midi command MORPH
-void PerformanceSessionView::receivedMorphCC(int32_t value) {
+void PerformanceView::receivedMorphCC(int32_t value) {
 	if (value == kMaxMIDIValue) {
 		value = kMaxKnobPos;
 	}
@@ -2619,7 +2615,7 @@ void PerformanceSessionView::receivedMorphCC(int32_t value) {
 /// this function determines if morphing is possible
 /// if it is possible, it adjusts the morph position and obtains current morph values
 /// and morphs towards the target morph layout (A or B) based on the direction (is offset pos. or neg.)
-void PerformanceSessionView::morph(int32_t offset, bool isMIDICommand) {
+void PerformanceView::morph(int32_t offset, bool isMIDICommand) {
 	if (offset != 0 && (isMIDICommand || isMorphingPossible())) {
 		int32_t currentMorphPosition = morphPosition;
 		adjustMorphPosition(offset);
@@ -2728,7 +2724,7 @@ void PerformanceSessionView::morph(int32_t offset, bool isMIDICommand) {
 /// 2) a parameter has been assigned to every column in both layouts
 /// 3) the parameters assigned to each column in both layouts are the same
 /// 4) you haven't assigned stutter to every column
-bool PerformanceSessionView::isMorphingPossible() {
+bool PerformanceView::isMorphingPossible() {
 	if ((currentSong->performanceMorphLayoutAVariant != kNoSelection)
 	    && (currentSong->performanceMorphLayoutBVariant != kNoSelection)) {
 		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
@@ -2761,7 +2757,7 @@ bool PerformanceSessionView::isMorphingPossible() {
 	return false;
 }
 
-void PerformanceSessionView::adjustMorphPosition(int32_t offset) {
+void PerformanceView::adjustMorphPosition(int32_t offset) {
 	morphPosition += offset;
 	if (morphPosition < 0) {
 		morphPosition = 0;
@@ -2774,8 +2770,8 @@ void PerformanceSessionView::adjustMorphPosition(int32_t offset) {
 
 /// linearly interpolates and sets the current value to the next value in the direction of the
 /// target value in the layout variant we are morphing towards
-void PerformanceSessionView::morphTowardsTarget(params::Kind paramKind, int32_t paramID, int32_t sourceKnobPosition,
-                                                int32_t targetKnobPosition, int32_t offset) {
+void PerformanceView::morphTowardsTarget(params::Kind paramKind, int32_t paramID, int32_t sourceKnobPosition,
+                                         int32_t targetKnobPosition, int32_t offset) {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithThreeMainThings* modelStack = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
@@ -2814,7 +2810,7 @@ void PerformanceSessionView::morphTowardsTarget(params::Kind paramKind, int32_t 
 /// note to self: I'm not sure this is entirely necessary, could probably just copy the fxPress info
 /// and the default values info over from the morph layout to the current layout
 /// e.g. no need to reset the view, initialize held pads or update the layout
-void PerformanceSessionView::loadMorphALayout(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::loadMorphALayout(ModelStackWithThreeMainThings* modelStack) {
 	if (currentSong->performanceMorphLayoutAVariant != kNoSelection) {
 		resetPerformanceView(modelStack);
 
@@ -2844,7 +2840,7 @@ void PerformanceSessionView::loadMorphALayout(ModelStackWithThreeMainThings* mod
 /// note to self: I'm not sure this is entirely necessary, could probably just copy the fxPress info
 /// and the default values info over from the morph layout to the current layout
 /// e.g. no need to reset the view, initialize held pads or update the layout
-void PerformanceSessionView::loadMorphBLayout(ModelStackWithThreeMainThings* modelStack) {
+void PerformanceView::loadMorphBLayout(ModelStackWithThreeMainThings* modelStack) {
 	if (currentSong->performanceMorphLayoutBVariant != kNoSelection) {
 		resetPerformanceView(modelStack);
 
@@ -2870,7 +2866,7 @@ void PerformanceSessionView::loadMorphBLayout(ModelStackWithThreeMainThings* mod
 }
 
 /// set led states for morph mode and for exiting morph mode
-void PerformanceSessionView::setMorphLEDStates() {
+void PerformanceView::setMorphLEDStates() {
 	if (getCurrentUI() == this) {
 		// this could get called by the morph midi command, so only refresh if we're in performance view
 		if (morphMode && isMorphingPossible()) {
@@ -2928,7 +2924,7 @@ void PerformanceSessionView::setMorphLEDStates() {
 }
 
 /// set knob indicator levels for morph mode and for exiting morph mode
-void PerformanceSessionView::setKnobIndicatorLevels() {
+void PerformanceView::setKnobIndicatorLevels() {
 	if (morphMode) {
 		if (isMorphingPossible()) {
 			indicator_leds::setKnobIndicatorLevel(0, morphPosition);

--- a/src/deluge/gui/views/performance_view.h
+++ b/src/deluge/gui/views/performance_view.h
@@ -55,9 +55,9 @@ struct ParamsForPerformance {
 	RGB rowTailColour = deluge::gui::colours::black;
 };
 
-class PerformanceSessionView final : public ClipNavigationTimelineView {
+class PerformanceView final : public ClipNavigationTimelineView {
 public:
-	PerformanceSessionView();
+	PerformanceView();
 
 	bool opened() override;
 	void focusRegained() override;
@@ -271,4 +271,4 @@ private:
 	FXColumnPress backupFXPress[kDisplayWidth];
 };
 
-extern PerformanceSessionView performanceSessionView;
+extern PerformanceView performanceView;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -163,6 +163,7 @@ void SessionView::focusRegained() {
 	setLedStates();
 
 	currentSong->lastClipInstanceEnteredStartPos = -1;
+	currentSong->onPerformanceView = false;
 }
 
 ActionResult SessionView::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -34,7 +34,7 @@
 #include "gui/views/audio_clip_view.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/view.h"
 #include "gui/waveform/waveform_renderer.h"
 #include "hid/button.h"
@@ -592,7 +592,7 @@ doActualSimpleChange:
 	else if (b == KEYBOARD) {
 		if (on && (currentUIMode == UI_MODE_NONE)
 		    && (currentSong->sessionLayout != SessionLayoutType::SessionLayoutTypeGrid)) {
-			changeRootUI(&performanceSessionView);
+			changeRootUI(&performanceView);
 		}
 	}
 	else if (b == Y_ENC) {
@@ -1813,7 +1813,7 @@ extern char loopsRemainingText[];
 
 void SessionView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 	UI* currentUI = getCurrentUI();
-	if (currentUI != &performanceSessionView) {
+	if (currentUI != &performanceView) {
 		renderViewDisplay(currentUI == &arrangerView ? l10n::get(l10n::String::STRING_FOR_ARRANGER_VIEW)
 		                                             : l10n::get(l10n::String::STRING_FOR_SONG_VIEW));
 	}
@@ -1840,7 +1840,7 @@ yesDoIt:
 
 void SessionView::redrawNumericDisplay() {
 	UI* currentUI = getCurrentUI();
-	if (currentUI != &performanceSessionView) {
+	if (currentUI != &performanceView) {
 		renderViewDisplay(currentUI == &arrangerView ? l10n::get(l10n::String::STRING_FOR_ARRANGER_VIEW)
 		                                             : l10n::get(l10n::String::STRING_FOR_SONG_VIEW));
 	}
@@ -2875,7 +2875,7 @@ void SessionView::gridRenderActionModes(int32_t y, RGB image[][kDisplayWidth + k
 		break;
 	}
 	case GridMode::PINK: {
-		modeActive = performanceSessionView.gridModeActive;
+		modeActive = performanceView.gridModeActive;
 		modeColour = colours::magenta; // Pink
 	}
 
@@ -3327,10 +3327,10 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 				break;
 			}
 			case GridMode::PINK: {
-				performanceSessionView.gridModeActive = true;
-				performanceSessionView.timeGridModePress = AudioEngine::audioSampleTimer;
-				changeRootUI(&performanceSessionView);
-				uiNeedsRendering(&performanceSessionView);
+				performanceView.gridModeActive = true;
+				performanceView.timeGridModePress = AudioEngine::audioSampleTimer;
+				changeRootUI(&performanceView);
+				uiNeedsRendering(&performanceView);
 				return ActionResult::DEALT_WITH;
 			}
 			}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -36,7 +36,7 @@
 #include "gui/views/arranger_view.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "hid/buttons.h"
 #include "hid/display/display.h"
@@ -223,7 +223,7 @@ doEndMidiLearnPressSession:
 		if (!Buttons::isButtonPressed(deluge::hid::button::SYNTH) && !Buttons::isButtonPressed(deluge::hid::button::KIT)
 		    && !Buttons::isButtonPressed(deluge::hid::button::MIDI)
 		    && !Buttons::isButtonPressed(deluge::hid::button::CV)
-		    && !((getRootUI() == &performanceSessionView) && Buttons::isButtonPressed(deluge::hid::button::KEYBOARD))) {
+		    && !((getRootUI() == &performanceView) && Buttons::isButtonPressed(deluge::hid::button::KEYBOARD))) {
 			// Press down
 			if (on) {
 				if (currentUIMode == UI_MODE_NONE && !Buttons::isShiftButtonPressed()) {
@@ -273,7 +273,7 @@ doEndMidiLearnPressSession:
 		if (!Buttons::isButtonPressed(deluge::hid::button::SYNTH) && !Buttons::isButtonPressed(deluge::hid::button::KIT)
 		    && !Buttons::isButtonPressed(deluge::hid::button::MIDI)
 		    && !Buttons::isButtonPressed(deluge::hid::button::CV)
-		    && !((getRootUI() == &performanceSessionView) && Buttons::isButtonPressed(deluge::hid::button::KEYBOARD))) {
+		    && !((getRootUI() == &performanceView) && Buttons::isButtonPressed(deluge::hid::button::KEYBOARD))) {
 			// Press down
 			if (on) {
 				if (currentUIMode == UI_MODE_NONE) {
@@ -906,10 +906,10 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				// this checks that the param displayed on the screen in performance view
 				// is the same param currently being edited with mod encoder
 				bool editingParamInPerformanceView = false;
-				if (getRootUI() == &performanceSessionView) {
-					if (!performanceSessionView.defaultEditingMode && performanceSessionView.lastPadPress.isActive) {
-						if ((kind == performanceSessionView.lastPadPress.paramKind)
-						    && (modelStackWithParam->paramId == performanceSessionView.lastPadPress.paramID)) {
+				if (getRootUI() == &performanceView) {
+					if (!performanceView.defaultEditingMode && performanceView.lastPadPress.isActive) {
+						if ((kind == performanceView.lastPadPress.paramKind)
+						    && (modelStackWithParam->paramId == performanceView.lastPadPress.paramID)) {
 							editingParamInPerformanceView = true;
 						}
 					}
@@ -1095,7 +1095,7 @@ void View::setKnobIndicatorLevels() {
 	// don't update knob indicator levels when you're in performance view morph mode
 	UI* currentUI = getCurrentUI();
 	if (((currentUI == &automationView) && !automationView.isOnAutomationOverview())
-	    || ((currentUI == &performanceSessionView) && performanceSessionView.morphMode
+	    || ((currentUI == &performanceView) && performanceView.morphMode
 	        && !isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION))) {
 		return;
 	}
@@ -1177,7 +1177,7 @@ void View::modButtonAction(uint8_t whichButton, bool on) {
 	// ignore modButtonAction when in the Performance View Morph Mode
 	RootUI* rootUI = getRootUI();
 	if (((rootUI == &automationView) && !automationView.isOnAutomationOverview())
-	    || ((rootUI == &performanceSessionView) && performanceSessionView.morphMode
+	    || ((rootUI == &performanceView) && performanceView.morphMode
 	        && !isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION))) {
 		return;
 	}
@@ -1187,7 +1187,7 @@ void View::modButtonAction(uint8_t whichButton, bool on) {
 	if (activeModControllableModelStack.modControllable) {
 		if (on) {
 
-			if (isUIModeWithinRange(modButtonUIModes) || (getRootUI() == &performanceSessionView)) {
+			if (isUIModeWithinRange(modButtonUIModes) || (getRootUI() == &performanceView)) {
 				// change the button selection before calling mod button action so that mod button action
 				// knows the mod button parameter context
 				*activeModControllableModelStack.modControllable->getModKnobMode() = whichButton;
@@ -1381,7 +1381,7 @@ void View::setModLedStates() {
 		// if you're in the Automation View Automation Editor, turn off Mod LED's
 		// if you're in the Performance View Morph Mode, turn off Mod LED's
 		if (((rootUI == &automationView) && !automationView.isOnAutomationOverview())
-		    || ((rootUI == &performanceSessionView) && performanceSessionView.morphMode
+		    || ((rootUI == &performanceView) && performanceView.morphMode
 		        && !isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION))) {
 			indicator_leds::setLedState(indicator_leds::modLed[i], false);
 		}
@@ -2239,7 +2239,7 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 		view.clipStatusMidiLearnPadPressed(on, clip);
 		if (!on) {
 			RootUI* rootUI = getRootUI();
-			if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+			if (rootUI == &sessionView || rootUI == &performanceView) {
 				uiNeedsRendering(rootUI, 0, 1 << yDisplayIfInSessionView);
 			}
 		}
@@ -2316,7 +2316,7 @@ void View::flashPlayDisable() {
 	uiTimerManager.unsetTimer(TIMER_PLAY_ENABLE_FLASH);
 
 	RootUI* rootUI = getRootUI();
-	if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+	if (rootUI == &sessionView || rootUI == &performanceView) {
 		uiNeedsRendering(rootUI, 0, 0xFFFFFFFF);
 	}
 #ifdef currentClipStatusButtonX

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -72,6 +72,7 @@ public:
 	void modButtonAction(uint8_t whichButton, bool on);
 	void setKnobIndicatorLevels();
 	void setKnobIndicatorLevel(uint8_t whichModEncoder);
+	void pretendModKnobsUntouchedForAWhile();
 	void setActiveModControllableTimelineCounter(TimelineCounter* playPositionCounter);
 	void setActiveModControllableWithoutTimelineCounter(ModControllable* modControllable, ParamManager* paramManager);
 	void cycleThroughReverbPresets();
@@ -132,7 +133,6 @@ public:
 	                            bool isAutomation = false);
 
 private:
-	void pretendModKnobsUntouchedForAWhile();
 	void instrumentBeenEdited();
 	void clearMelodicInstrumentMonoExpressionIfPossible();
 };

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -216,6 +216,8 @@ MidiEngine::MidiEngine() {
 	lastStatusByteSent = 0;
 	currentlyReceivingSysExSerial = false;
 	midiThru = false;
+	midiTakeover = MIDITakeoverMode::JUMP;
+
 	for (auto& midiChannelType : midiEngine.midiFollowChannelType) {
 		midiChannelType.clear();
 	}
@@ -223,7 +225,7 @@ MidiEngine::MidiEngine() {
 	midiFollowDisplayParam = false;
 	midiFollowFeedbackAutomation = MIDIFollowFeedbackAutomationMode::DISABLED;
 	midiFollowFeedbackFilter = false;
-	midiTakeover = MIDITakeoverMode::JUMP;
+
 	midiSelectKitRow = false;
 
 	g_usb_peri_connected = 0; // Needs initializing with A2 driver

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -62,12 +62,15 @@ public:
 	LearnedMIDI globalMIDICommands[kNumGlobalMIDICommands];
 
 	bool midiThru;
+
+	MIDITakeoverMode midiTakeover;
+
 	LearnedMIDI midiFollowChannelType[kNumMIDIFollowChannelTypes]; // A, B, C, Feedback
 	uint8_t midiFollowKitRootNote;
 	bool midiFollowDisplayParam;
 	MIDIFollowFeedbackAutomationMode midiFollowFeedbackAutomation;
 	bool midiFollowFeedbackFilter;
-	MIDITakeoverMode midiTakeover;
+
 	bool midiSelectKitRow;
 
 	// shared buffer for formatting sysex messages.

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -21,7 +21,7 @@
 #include "gui/views/arranger_view.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/display/display.h"

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -137,7 +137,7 @@ Clip* getSelectedClip(bool useActiveClip) {
 			clip = currentSong->getClipWithOutput(output);
 		}
 		break;
-	case UIType::PERFORMANCE_SESSION_VIEW:
+	case UIType::PERFORMANCE_VIEW:
 		// if you're in performance view, no clip will be selected for param control
 		break;
 	case UIType::AUTOMATION_VIEW:

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -85,7 +85,7 @@ Action* ActionLogger::getNewAction(ActionType newActionType, ActionAddition addT
 	deleteLog(AFTER);
 
 	// If not on a View, not allowed!
-	// Exception for performanceSessionView where the view can interact with soundEditor UI
+	// Exception for performanceView where the view can interact with soundEditor UI
 	if ((getCurrentUI() != getRootUI()) && (getRootUI() != &performanceSessionView)) {
 		return NULL;
 	}

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -86,7 +86,7 @@ Action* ActionLogger::getNewAction(ActionType newActionType, ActionAddition addT
 
 	// If not on a View, not allowed!
 	// Exception for performanceView where the view can interact with soundEditor UI
-	if ((getCurrentUI() != getRootUI()) && (getRootUI() != &performanceSessionView)) {
+	if ((getCurrentUI() != getRootUI()) && (getRootUI() != &performanceView)) {
 		return NULL;
 	}
 

--- a/src/deluge/model/action/action_logger.h
+++ b/src/deluge/model/action/action_logger.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "model/action/action.h"
 #include <cstdint>
 

--- a/src/deluge/model/consequence/consequence_performance_view_press.cpp
+++ b/src/deluge/model/consequence/consequence_performance_view_press.cpp
@@ -30,7 +30,7 @@ ConsequencePerformanceViewPress::ConsequencePerformanceViewPress(FXColumnPress f
 }
 
 int32_t ConsequencePerformanceViewPress::revert(TimeType time, ModelStack* modelStack) {
-	memcpy(&performanceSessionView.fxPress[xDisplayChanged], &fxPress[time], sizeof(FXColumnPress));
+	memcpy(&performanceView.fxPress[xDisplayChanged], &fxPress[time], sizeof(FXColumnPress));
 
 	return NO_ERROR;
 }

--- a/src/deluge/model/consequence/consequence_performance_view_press.h
+++ b/src/deluge/model/consequence/consequence_performance_view_press.h
@@ -16,7 +16,7 @@
  */
 
 #pragma once
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "model/consequence/consequence.h"
 #include <cstdint>
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -90,7 +90,7 @@ void GlobalEffectable::initParamsForAudioClip(ParamManagerForTimeline* paramMana
 
 void GlobalEffectable::modButtonAction(uint8_t whichModButton, bool on, ParamManagerForTimeline* paramManager) {
 
-	// leave stutter running in perfomance session view
+	// leave stutter running in performance view
 	if (getRootUI() != &performanceSessionView) {
 		// If we're leaving this mod function or anything else is happening, we want to be sure that stutter has stopped
 		endStutter(paramManager);

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -18,7 +18,7 @@
 #include "model/global_effectable/global_effectable.h"
 #include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/view.h"
 #include "hid/buttons.h"
 #include "hid/led/indicator_leds.h"
@@ -91,7 +91,7 @@ void GlobalEffectable::initParamsForAudioClip(ParamManagerForTimeline* paramMana
 void GlobalEffectable::modButtonAction(uint8_t whichModButton, bool on, ParamManagerForTimeline* paramManager) {
 
 	// leave stutter running in performance view
-	if (getRootUI() != &performanceSessionView) {
+	if (getRootUI() != &performanceView) {
 		// If we're leaving this mod function or anything else is happening, we want to be sure that stutter has stopped
 		endStutter(paramManager);
 	}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1790,7 +1790,7 @@ bool ModControllableAudio::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice
 
 				// if you're in automation view and editing the same parameter that was just updated
 				// by a learned midi knob, then re-render the pads on the automation editor grid
-				if (getRootUI() == &automationView && !automationView.onArrangerView) {
+				if (getRootUI() == &automationView && !currentSong->onAutomationArrangerView) {
 					Clip* clip = (Clip*)modelStack->getTimelineCounter();
 					// check that the clip that the param is being edited for is the same as the
 					// current clip as the current clip is what's actively displayed in automation view
@@ -2162,12 +2162,12 @@ int32_t ModControllableAudio::calculateKnobPosForMidiTakeover(ModelStackWithAuto
 // by a learned midi knob, then re-render the pads on the automation editor grid
 bool ModControllableAudio::possiblyRefreshAutomationEditorGrid(Clip* clip, params::Kind kind, int32_t id) {
 	bool doRefreshGrid = false;
-	if (clip && !automationView.onArrangerView) {
+	if (clip && !currentSong->onAutomationArrangerView) {
 		if ((clip->lastSelectedParamID == id) && (clip->lastSelectedParamKind == kind)) {
 			doRefreshGrid = true;
 		}
 	}
-	else if (automationView.onArrangerView) {
+	else if (currentSong->onAutomationArrangerView) {
 		if ((currentSong->lastSelectedParamID == id) && (currentSong->lastSelectedParamKind == kind)) {
 			doRefreshGrid = true;
 		}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -20,7 +20,7 @@
 #include "deluge/model/settings/runtime_feature_settings.h"
 #include "gui/l10n/l10n.h"
 #include "gui/views/automation_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "io/debug/log.h"
@@ -1885,7 +1885,7 @@ void ModControllableAudio::receivedCCFromMidiFollow(ModelStack* modelStack, Clip
 								// performance view
 								bool editingParamInAutomationOrPerformanceView = false;
 								RootUI* rootUI = getRootUI();
-								if (rootUI == &automationView || rootUI == &performanceSessionView) {
+								if (rootUI == &automationView || rootUI == &performanceView) {
 									int32_t id = modelStackWithParam->paramId;
 									params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
 
@@ -2186,17 +2186,16 @@ bool ModControllableAudio::possiblyRefreshAutomationEditorGrid(Clip* clip, param
 bool ModControllableAudio::possiblyRefreshPerformanceViewDisplay(params::Kind kind, int32_t id, int32_t newKnobPos) {
 	// check if you're not in editing mode
 	// and a param hold press is currently active
-	if (!performanceSessionView.defaultEditingMode && performanceSessionView.lastPadPress.isActive) {
-		if ((kind == performanceSessionView.lastPadPress.paramKind)
-		    && (id == performanceSessionView.lastPadPress.paramID)) {
+	if (!performanceView.defaultEditingMode && performanceView.lastPadPress.isActive) {
+		if ((kind == performanceView.lastPadPress.paramKind) && (id == performanceView.lastPadPress.paramID)) {
 			int32_t valueForDisplay = view.calculateKnobPosForDisplay(kind, id, newKnobPos + kKnobPosOffset);
-			performanceSessionView.renderFXDisplay(kind, id, valueForDisplay);
+			performanceView.renderFXDisplay(kind, id, valueForDisplay);
 			return true;
 		}
 	}
 	// if a specific param is not active, reset display
-	else if (performanceSessionView.onFXDisplay) {
-		performanceSessionView.renderViewDisplay();
+	else if (performanceView.onFXDisplay) {
+		performanceView.renderViewDisplay();
 	}
 	return false;
 }

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -172,6 +172,7 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	AudioEngine::reverb.setModel(deluge::dsp::Reverb::Model::MUTABLE);
 
 	// initialize automation arranger view variables
+	onAutomationArrangerView = false;
 	lastSelectedParamID = kNoSelection;
 	lastSelectedParamKind = params::Kind::NONE;
 	lastSelectedParamShortcutX = kNoSelection;
@@ -180,6 +181,13 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	// end initialize of automation arranger view variables
 
 	masterTransposeInterval = 0;
+
+	// initialize performance view variables
+	onPerformanceView = false;
+	performanceLayoutVariant = 0;
+	performanceMorphLayoutAVariant = kNoSelection;
+	performanceMorphLayoutBVariant = kNoSelection;
+	// end initialize performance view variables
 
 	dirPath.set("SONGS");
 }
@@ -1199,6 +1207,10 @@ weAreInArrangementEditorOrInClipInstance:
 
 	storageManager.writeAttribute("midiLoopback", midiLoopback);
 
+	if (onAutomationArrangerView) {
+		storageManager.writeAttribute("onAutomationArrangerView", (char*)"1");
+	}
+
 	if (lastSelectedParamID != kNoSelection) {
 		storageManager.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		storageManager.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
@@ -1206,6 +1218,13 @@ weAreInArrangementEditorOrInClipInstance:
 		storageManager.writeAttribute("lastSelectedParamShortcutY", lastSelectedParamShortcutY);
 		storageManager.writeAttribute("lastSelectedParamArrayPosition", lastSelectedParamArrayPosition);
 	}
+
+	if (onPerformanceView) {
+		storageManager.writeAttribute("onPerformanceView", (char*)"1");
+	}
+	storageManager.writeAttribute("performanceLayoutVariant", performanceLayoutVariant);
+	storageManager.writeAttribute("performanceMorphLayoutAVariant", performanceMorphLayoutAVariant);
+	storageManager.writeAttribute("performanceMorphLayoutBVariant", performanceMorphLayoutBVariant);
 
 	globalEffectable.writeAttributesToFile(false);
 
@@ -1611,6 +1630,12 @@ unknownTag:
 				storageManager.exitTag("midiLoopback");
 			}
 
+			else if (!strcmp(tagName, "onAutomationArrangerView")) {
+				onAutomationArrangerView = storageManager.readTagOrAttributeValueInt();
+				inClipMinderViewOnLoad = !onAutomationArrangerView;
+				storageManager.exitTag("onAutomationArrangerView");
+			}
+
 			else if (!strcmp(tagName, "lastSelectedParamID")) {
 				lastSelectedParamID = storageManager.readTagOrAttributeValueInt();
 				storageManager.exitTag("lastSelectedParamID");
@@ -1635,6 +1660,28 @@ unknownTag:
 				lastSelectedParamArrayPosition = storageManager.readTagOrAttributeValueInt();
 				storageManager.exitTag("lastSelectedParamArrayPosition");
 			}
+
+			else if (!strcmp(tagName, "onPerformanceView")) {
+				onPerformanceView = storageManager.readTagOrAttributeValueInt();
+				inClipMinderViewOnLoad = !onPerformanceView;
+				storageManager.exitTag("onPerformanceView");
+			}
+
+			else if (!strcmp(tagName, "performanceLayoutVariant")) {
+				performanceLayoutVariant = storageManager.readTagOrAttributeValueInt();
+				storageManager.exitTag("performanceLayoutVariant");
+			}
+
+			else if (!strcmp(tagName, "performanceMorphLayoutAVariant")) {
+				performanceMorphLayoutAVariant = storageManager.readTagOrAttributeValueInt();
+				storageManager.exitTag("performanceMorphLayoutAVariant");
+			}
+
+			else if (!strcmp(tagName, "performanceMorphLayoutBVariant")) {
+				performanceMorphLayoutBVariant = storageManager.readTagOrAttributeValueInt();
+				storageManager.exitTag("performanceMorphLayoutBVariant");
+			}
+
 			// legacy section, read as part of global effectable (songParams tag) post c1.1
 			else if (!strcmp(tagName, "songCompressor")) {
 				while (*(tagName = storageManager.readNextTagOrAttributeName())) {

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -359,6 +359,7 @@ public:
 	SyncLevel reverbSidechainSync;
 
 	// START ~ new Automation Arranger View Variables
+	bool onAutomationArrangerView;
 	int32_t lastSelectedParamID; // last selected Parameter to be edited in Automation Arranger View
 	deluge::modulation::params::Kind
 	    lastSelectedParamKind; // 0 = patched, 1 = unpatched, 2 = global effectable, 3 = none
@@ -371,6 +372,20 @@ public:
 	void transpose(int32_t interval);
 	void adjustMasterTransposeInterval(int32_t interval);
 	void displayMasterTransposeInterval();
+
+	// START - performance view variables
+	bool onPerformanceView;
+	int32_t performanceLayoutVariant; // 0, 1, 2, 3, 4, 5, 6, 7, 8
+	// 0 = Default - Load + Keyboard button
+	// 1-4 = Bank A, layout A, B, C, D - Load + Synth/Kit/Midi/CV buttons
+	// 5-8 = Bank B, layout E, F, G, H - Load + Synth/Kit/Midi/CV buttons
+
+	// morph mode
+
+	int32_t performanceMorphLayoutAVariant; // assign layoutVariant above to morph layout A
+	int32_t performanceMorphLayoutBVariant; // assign layoutVariant above to morph Layout B
+
+	// END - performance view variables
 
 private:
 	bool fillModeActive;

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -21,7 +21,7 @@
 #include "gui/views/arranger_view.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "io/debug/log.h"
@@ -710,7 +710,7 @@ void Session::launchSchedulingMightNeedCancelling() {
 			if (getCurrentUI() == &loadSongUI) {
 				loadSongUI.displayLoopsRemainingPopup(); // Wait, could this happen?
 			}
-			else if ((rootUI == &sessionView || rootUI == &performanceSessionView)
+			else if ((rootUI == &sessionView || rootUI == &performanceView)
 			         && !isUIModeActive(UI_MODE_CLIP_PRESSED_IN_SONG_VIEW)) {
 				renderUIsForOled();
 			}
@@ -888,7 +888,7 @@ void Session::cancelArmingForClip(Clip* clip, int32_t* clipIndex) {
 		bool anyDeleted = currentSong->deletePendingOverdubs(clip->output, clipIndex);
 		if (anyDeleted) {
 			RootUI* rootUI = getRootUI();
-			if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+			if (rootUI == &sessionView || rootUI == &performanceView) {
 				uiNeedsRendering(rootUI);
 			}
 		}
@@ -962,7 +962,7 @@ void Session::toggleClipStatus(Clip* clip, int32_t* clipIndex, bool doInstant, i
 				if (playbackHandler.playbackState) {
 					playbackHandler.finishTempolessRecording(true, buttonPressLatency);
 					RootUI* rootUI = getRootUI();
-					if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+					if (rootUI == &sessionView || rootUI == &performanceView) {
 						uiNeedsRendering(rootUI, 0, 0xFFFFFFFF);
 					}
 					return;
@@ -1096,7 +1096,7 @@ void Session::soloClipAction(Clip* clip, int32_t buttonPressLatency) {
 			if (playbackHandler.playbackState) {
 				playbackHandler.finishTempolessRecording(true, buttonPressLatency);
 				RootUI* rootUI = getRootUI();
-				if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+				if (rootUI == &sessionView || rootUI == &performanceView) {
 					uiNeedsRendering(rootUI, 0, 0xFFFFFFFF);
 				}
 				goto renderAndGetOut;
@@ -1114,7 +1114,7 @@ void Session::soloClipAction(Clip* clip, int32_t buttonPressLatency) {
 renderAndGetOut:
 	if (anyClipsDeleted) {
 		RootUI* rootUI = getRootUI();
-		if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+		if (rootUI == &sessionView || rootUI == &performanceView) {
 			uiNeedsRendering(rootUI);
 		}
 	}
@@ -1200,7 +1200,7 @@ void Session::armSectionWhenNeitherClockActive(ModelStack* modelStack, int32_t s
 // Updates LEDs after arming changed
 void Session::armingChanged() {
 	RootUI* rootUI = getRootUI();
-	if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+	if (rootUI == &sessionView || rootUI == &performanceView) {
 		if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
 			uiNeedsRendering(rootUI, 0xFFFFFFFF, 0xFFFFFFFF);
 		}
@@ -2012,7 +2012,7 @@ bool Session::endPlayback() {
 
 		// Re-render
 		RootUI* rootUI = getRootUI();
-		if (rootUI == &sessionView || rootUI == &performanceSessionView) {
+		if (rootUI == &sessionView || rootUI == &performanceView) {
 			uiNeedsRendering(rootUI);
 		}
 
@@ -2253,7 +2253,7 @@ traverseClips:
 				if (getCurrentUI() == &loadSongUI) {
 					loadSongUI.displayLoopsRemainingPopup();
 				}
-				else if ((rootUI == &sessionView || rootUI == &performanceSessionView)
+				else if ((rootUI == &sessionView || rootUI == &performanceView)
 				         && !isUIModeActive(UI_MODE_CLIP_PRESSED_IN_SONG_VIEW)) {
 					renderUIsForOled();
 				}

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -24,7 +24,7 @@
 #include "gui/ui_timer_manager.h"
 #include "gui/views/arranger_view.h"
 #include "gui/views/instrument_clip_view.h"
-#include "gui/views/performance_session_view.h"
+#include "gui/views/performance_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "hid/buttons.h"
@@ -2552,7 +2552,7 @@ bool PlaybackHandler::tryGlobalMIDICommands(MIDIDevice* device, bool on, int32_t
 				break;
 
 			case GlobalMIDICommand::MORPH:
-				performanceSessionView.receivedMorphCC(velocity);
+				performanceView.receivedMorphCC(velocity);
 				break;
 
 			// case GlobalMIDICommand::TAP:

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -239,9 +239,8 @@ private:
 	// void scheduleNextTimerTick();
 	bool startIgnoringMidiClockInputIfNecessary();
 	uint32_t setTempoFromAudioClipLength(uint64_t loopLengthSamples, Action* action);
-	bool offerNoteToLearnedThings(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note);
-	bool tryGlobalMIDICommands(MIDIDevice* device, int32_t channel, int32_t note);
-	bool tryGlobalMIDICommandsOff(MIDIDevice* device, int32_t channel, int32_t note);
+	bool offerNoteToLearnedThings(MIDIDevice* fromDevice, bool on, int32_t channel, int32_t note, int32_t velocity = 0);
+	bool tryGlobalMIDICommands(MIDIDevice* device, bool on, int32_t channel, int32_t note, int32_t velocity);
 	void decideOnCurrentPlaybackMode();
 	float getCurrentInternalTickFloatFollowingExternalClock();
 	void scheduleTriggerClockOutTickParamsKnown(uint32_t analogOutTicksPer, uint64_t fractionLastTimerTick,

--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -137,6 +137,9 @@ namespace FlashStorage {
 151: automationShift;
 152: automationNudgeNote;
 153: automationDisableAuditionPadShortcuts;
+154: GlobalMIDICommand::MORPH channel + 1
+155: GlobalMIDICommand::MORPH noteCode + 1
+156-159: GlobalMIDICommand::MORPH product / vendor ids
 */
 
 uint8_t defaultScale;
@@ -338,6 +341,8 @@ void readSettings() {
 	    buffer[71] - 1;
 	midiEngine.globalMIDICommands[util::to_underlying(GlobalMIDICommand::FILL)].channelOrZone = buffer[114] - 1;
 	midiEngine.globalMIDICommands[util::to_underlying(GlobalMIDICommand::FILL)].noteOrCC = buffer[115] - 1;
+	midiEngine.globalMIDICommands[util::to_underlying(GlobalMIDICommand::MORPH)].channelOrZone = buffer[154] - 1;
+	midiEngine.globalMIDICommands[util::to_underlying(GlobalMIDICommand::MORPH)].noteOrCC = buffer[155] - 1;
 
 	if (previouslySavedByFirmwareVersion >= FIRMWARE_3P2P0_ALPHA) {
 		MIDIDeviceManager::readDeviceReferenceFromFlash(GlobalMIDICommand::PLAYBACK_RESTART, &buffer[80]);
@@ -349,6 +354,7 @@ void readSettings() {
 		MIDIDeviceManager::readDeviceReferenceFromFlash(GlobalMIDICommand::UNDO, &buffer[104]);
 		MIDIDeviceManager::readDeviceReferenceFromFlash(GlobalMIDICommand::REDO, &buffer[108]);
 		MIDIDeviceManager::readDeviceReferenceFromFlash(GlobalMIDICommand::FILL, &buffer[116]);
+		MIDIDeviceManager::readDeviceReferenceFromFlash(GlobalMIDICommand::MORPH, &buffer[156]);
 	}
 
 	if (buffer[50] >= kNumInputMonitoringModes) {
@@ -675,6 +681,8 @@ void writeSettings() {
 	    + 1;
 	buffer[71] =
 	    midiEngine.globalMIDICommands[util::to_underlying(GlobalMIDICommand::LOOP_CONTINUOUS_LAYERING)].noteOrCC + 1;
+	buffer[154] = midiEngine.globalMIDICommands[util::to_underlying(GlobalMIDICommand::MORPH)].channelOrZone + 1;
+	buffer[155] = midiEngine.globalMIDICommands[util::to_underlying(GlobalMIDICommand::MORPH)].noteOrCC + 1;
 
 	/* Global MIDI command device references - these occupy 4 bytes each */
 	MIDIDeviceManager::writeDeviceReferenceToFlash(GlobalMIDICommand::PLAYBACK_RESTART, &buffer[80]);
@@ -686,6 +694,7 @@ void writeSettings() {
 	MIDIDeviceManager::writeDeviceReferenceToFlash(GlobalMIDICommand::UNDO, &buffer[104]);
 	MIDIDeviceManager::writeDeviceReferenceToFlash(GlobalMIDICommand::REDO, &buffer[108]);
 	MIDIDeviceManager::writeDeviceReferenceToFlash(GlobalMIDICommand::FILL, &buffer[116]);
+	MIDIDeviceManager::writeDeviceReferenceToFlash(GlobalMIDICommand::MORPH, &buffer[156]);
 
 	buffer[50] = util::to_underlying(AudioEngine::inputMonitoringMode);
 


### PR DESCRIPTION
# Morph Mode and Alternate Layouts for Performance View

<img width="349" alt="Screenshot 2024-02-06 at 10 10 37 PM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/09c36028-9679-4184-885c-9226e9654337">

# Description and Instructions

## Alternate Layouts

- There are 9 total performance view layout variants:
  - Default, 1, 2, 3, 4, 5, 6, 7, 8
- Layout can be loaded from / saved to your SD card. They are stored in a folder titled PERFORMANCE_VIEW.
<img width="254" alt="Screenshot 2024-02-06 at 9 30 38 PM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/1c2fde68-f9c0-4f36-be2d-61c027ada132">

### Loading the Default Layout
  - Hold Load + Press Keyboard to load the Default Layout
  - The layout from Default.XML will be loaded

### Saving the Default Layout
  - Hold Save + Press Keyboard to save the Default Layout
  - The layout will be saved to Default.XML
  
### Loading the Alternate Layouts  
 - To load the 8 alternate layouts, you need to first select a Layout Bank.
    - There are two banks of 4 layouts.
    - To select Bank 1, press the Scale button, it will light up.
    - To select Bank 2, press the Cross-Screen button, it will light up.
 - After selecting a bank:
    - Hold Load + Press Synth, Kit, Midi, or CV to load the layout corresponding to those 4 buttons and the bank selected.
 - Bank 1:
   - Synth = 1.XML
   - Kit = 2.XML
   - Midi = 3.XML
   - CV = 4.XML
 - Bank 2:
   -  Synth = 5.XML
   - Kit = 6.XML
   - Midi = 7.XML
   - CV = 8.XML
- When you load a layout, a pop up is displayed to tell you the layout you just loaded (e.g. Default, 1, 2, 3, 4, 5, 6, 7, or 8)

### Saving the Alternate Layouts  
- Use the instructions for Loading a layout above, except instead of holding the Load button, you hold the Save button.
  - Hold Save + Press Keyboard to save layout changes to Default.XML
  - Selected Bank 1 or 2 using Scale or Cross-screen:
    - While in Bank 1, Hold Save + Press Synth/Kit/Midi/CV to save to 1.XML, 2.XML, 3.XML, or 4.XML
    - While in Bank 2, Hold Save + Press Synth/Kit/Midi/CV to save to 5.XML, 6.XML, 7.XML, or 8.XML
    
### Check what layout is currently loaded
- At any time you can check what layout is currently loaded by pressing on the Bank 1 or Bank 2 buttons (Scale or Cross-screen).
  - A pop-up will be shown not he display that tells you the name of the layout that is currently loaded (Default, 1, 2, 3, 4, 5, 6, 7, or 8)
  - If you hold the bank button, the layout currently loaded for the bank selected (if there is one) will also flash to indicate that that layout is loaded (e.g. if you are holding the Bank 1 button (Scale) and Layout 1 is loaded, the Synth button will flash)

## Morph Mode

Morph Mode is a new sub-mode in Performance View that lets you load two layouts into two layout banks for morphing between the two layouts. I will refer to these banks as Bank A and Bank B
  - Bank A and Bank B are accessed in Morph Mode with the Synth and CV buttons (Synth = Bank A, CV = Bank B)
  
### Entering Morph Mode  
- To enter Morph Mode, press both the Scale button and Cross-screen buttons together
  - To signal that you are in Morph Mode, the Scale button and Cross-screen buttons will be lit up
  - The gold encoder led indicators will also be reset and the mod buttons between the gold encoders will turn off
    - While in morph mode, you cannot control / change parameters using the gold encoders
    
### Assign a layout to Bank A and Bank B    
- After you have entered Morph Mode, you will need to assign a layout to Bank A and Bank B
  - Note: the layouts you assign to Bank A and Bank B must be compatible for Morphing. This means:
    - They must have the same FX to column layout structure. E.g. If LPF frequency is in Column 1 in the layout added to Bank A, it must also be in Column 1 in the layout added to Bank B. If you attempt to Morph with two incompatible layouts, you will receive a pop-up saying "Can't Morph"
    - If both layouts are compatible, either the Bank A button (Synth) or Bank B button (CV) will light up (depending on which bank you assigned a layout to last).
    - Note: another reason for a "Can't Morph" message is that the layouts assigned to Bank A and Bank B (both) do not have any held values. As soon as you assign a layout to Bank A or B with a held value, they become compatible for morphing.
  - To assign a layout to Bank A, hold Synth + turn the Select encoder to selected between the 9 layouts available (Default, 1, 2, 3, 4, 5, 6, 7, 8)
  - To assign a layout to Bank B, hold CV + turn the Select encoder to selected between the 9 layouts available (Default, 1, 2, 3, 4, 5, 6, 7, 8)
- After you have assigned two compatible layouts to Bank A and Bank B, you are ready to Morph.

### Morphing between Layouts
- To Morph between the layouts stored in Banks A and B, use either Gold (Mod) encoder.

### Indicator's of your morph position between the layout in Bank A and Bank B
- The display will show a value range of -50 to +50 as you turn the Gold encoder.
- The Gold encoder LED indicators will also light up to indicate your position
- The Synth/Kit/Midi/CV buttons will also light up to show your position.
  - Synth button lit up = 100% Layout A
  - Synth and Kit buttons lit up = between 100% and 75% Layout A
  - Kit button lit up = 75% Layout A, 25% Layout B
  - Kit and Midi buttons lit up = 50% Layout A, 50% Layout B
  - Midi button lit up = 25% Layout A, 75% Layout B
  - Midi and CV buttons lit up = between 100% and 75% Layout B
  - CV button lit up = 100% Layout B
  
### How does Morphing Work?
- Morphing works by morphing between the Held values for the same parameters in the two layouts assigned to Bank A and Bank B
- If only one layout has Held values, it means that it will Morph between the held value and the release value saved in that one layout (the other Layout in the other Bank will have no effect on the morphing).
  - The release value is the value that the parameter would be set back to if you removed the held pad.
  - Whenever you add a held pad, a snapshot of the current value is stored. It is this snapshot that is used for morphing in this scenario.
- When you have reached either end of the Morph spectrum (e.g. 100% Bank A or 100% Bank B), the layout loaded on the grid is refreshed. For example, if you started with Bank A, you will see Bank A loaded on the grid with any held pads. Once you have morphed over to Bank B, the grid will be refreshed and show the held pads from Bank B.
  
### Changing layout Selection while in Morph Mode
- While in Morph mode, if you press on the Bank A button or Bank B button, it will load the layout saved in that bank.
  
### Non-Destructive / Temporary Morph Layout Changes
- You can make quick changes to the layouts assigned to Morph A and B without needing to save those layouts
- For example, you could load the Default layout into Bank A and Bank B
- To then make changes to the Default layout stored in Bank A and Bank B, do the following:
  - Hold the Bank A button (Synth) and change any of the held pads on the Performance View grid
  - Let go of the Bank A button. The changes you made are now temporarily saved in Bank A
  - You can do the same for Bank B
  - You now have two temporary variants of the Default layout
- You could use this technique to test out changes to your morph layouts, and then when you like what you've found, you save those temporary layouts to one of the 9 layout files by repeating the Bank 1/Bank 2 save steps above.

### The OLED display
- Just a quick overview of the OLED display for Morph Mode
- While in Morph Mode, the OLED display show in the bottom middle a cross-fader to show the morph position between Bank A and Bank B
- To the left and right side of the cross fader, if a layout has been assigned to Bank A and Bank B, it will display the name of the layout assigned to Bank A and Bank B (e.g. D for default, 1, 2, 3, 4, 5, 6, 7, 8)
- Right above the cross-fader, you will see "Can't Morph" if the layouts assigned to Bank A and Bank B are not compatible.

## Midi-Learning Morph Mode

The control for morphing between Bank A and Bank B in Morph Mode has been made MIDI Learnable so that you can Morph between Bank A and Bank B from anywhere in the Deluge (e.g. whether you're in a Song View or Clip View).

You can MIDI control the Morph Mode cross-fader by learning your MIDI controller to the Deluge through the global MIDI commands menu.

### Global MIDI Command :: MORPH

- To learn an external controller to the Morph Mode control for use with the Deluge's Global MIDI Command's, you need to access the following menu:
  - SETTINGS -> MIDI -> COMMANDS -> MORPH
- While in the MORPH menu, Hold Learn + Send a Note/CC to learn the device.
- At any time you can unlearn the Morph control by pressing Shift + Learn while in the MORPH menu
- Exit the menu to save your settings

## Saving Layouts with the Song

- The layout you currently have loaded and the layouts assigned to Bank A and Bank B in Morph Mode get saved with the song.
- When you load your song again, it will load the layout used in that song from the SD card folder PERFORMANCE_VIEW.

# Summary of changes

- [x] Save Current and Morph Layout Selection to Song so they can be re-loaded with the Song (note: it doesn't actually save the layout data (e.g. what's in the XML's) with the song, just the variant ID # so that the corresponding XML template can be loaded from SD card.). This may not be ideal, so could change pending feedback.
- [x] Bug fixed UI loaded with Song (Automation Arranger View and Performance View weren't loading as the current UI when loading a new song, even if those were the UI's last open when the song was previously saved.
- [x] Fix bug with Load/Save button where button could get stuck in holding mode if you press Load/Save + one of the instrument buttons (e.g. CV) quickly
- [x] Added new display for Morph Mode with a -50 to +50 fader bar
- [x] Added ability to make temporary changes to a Morph Layout by simply holding Synth or CV while in Morph Mode and entering changes on the grid.  Added MIDI control of the Morph Mode control by adding a new Global MIDI Command type MORPH.
- [x] Refactored TryGlobalMidiCommand to received "On" and "Velocity" removing the need for the additional function "TryGlobalMidiCommandOff"  Renamed Performance Session View class to Performance View as it's not just a session view, but an arranger view also.
- [x] Refactored button action to make the code cleaner and easy to follow
- [x] Refactored modelStack usage to pass around the modelStack as much as possible instead of creating it all over the place
- [x] Fixed bug that wouldn't let you alternate between two stutter pads without stutter turning off (closes #1176) 