### PR TITLE
Bugfix - unintended mod wheel values in midi clips

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -131,9 +131,10 @@ enum FirmwareVersion : uint8_t {
 	FIRMWARE_4P1P4_ALPHA = 68,
 	FIRMWARE_4P1P4_BETA = 69,
 	FIRMWARE_4P1P4 = 70,
+	COMMUNITY_1P1 = 71,
 	FIRMWARE_TOO_NEW = 255,
 };
-constexpr FirmwareVersion kCurrentFirmwareVersion = FIRMWARE_4P1P4_ALPHA;
+constexpr FirmwareVersion kCurrentFirmwareVersion = COMMUNITY_1P1;
 
 constexpr uint8_t kOctaveSize = 12;
 
@@ -406,7 +407,6 @@ constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kNumNonGlobalParamsForAutomation = 56;
 constexpr int32_t kNumGlobalParamsForAutomation = 23;
-constexpr int32_t kLastMidiCCForAutomation = 121;
 constexpr int32_t kKnobPosOffset = 64;
 constexpr int32_t kMaxKnobPos = 128;
 constexpr int32_t kParamValueIncrementForAutomationSinglePadPress = 18;
@@ -724,6 +724,7 @@ enum class ExistenceChangeType {
 };
 
 enum CCNumber {
+	/// note - only for incoming/outgoing midi. Internally use CC_NUMBER_Y_AXIS
 	CC_NUMBER_MOD_WHEEL = 1,
 	CC_NUMBER_PITCH_BEND = 120,
 	CC_NUMBER_AFTERTOUCH = 121,
@@ -731,6 +732,7 @@ enum CCNumber {
 	CC_NUMBER_NONE = 123,
 };
 constexpr int32_t kNumCCNumbersIncludingFake = 124;
+constexpr int32_t kNumCCExpression = kNumCCNumbersIncludingFake - 1;
 constexpr int32_t kNumRealCCNumbers = 120;
 constexpr int32_t kMaxMIDIValue = 127;
 constexpr int32_t ALL_NOTES_OFF = -32768;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3065,7 +3065,7 @@ void AutomationView::selectMIDICC(int32_t offset, Clip* clip) {
 	else if (newCC >= kNumCCExpression) {
 		newCC = 0;
 	}
-	if (newCC == 1) {
+	if (newCC == CC_NUMBER_MOD_WHEEL) {
 		// mod wheel is actually CC_NUMBER_Y_AXIS (122) internally
 		newCC += offset;
 	}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -299,7 +299,7 @@ void AutomationView::initMIDICCShortcutsForAutomation() {
 
 	midiCCShortcutsForAutomation[14][7] = CC_NUMBER_PITCH_BEND;
 	midiCCShortcutsForAutomation[15][0] = CC_NUMBER_AFTERTOUCH;
-	midiCCShortcutsForAutomation[15][7] = CC_NUMBER_MOD_WHEEL;
+	midiCCShortcutsForAutomation[15][7] = CC_NUMBER_Y_AXIS;
 }
 
 // called everytime you open up the automation view
@@ -1041,7 +1041,7 @@ void AutomationView::getParameterName(Clip* clip, OutputType outputType, char* p
 		else if (clip->lastSelectedParamID == CC_NUMBER_AFTERTOUCH) {
 			strcpy(parameterName, deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
 		}
-		else if (clip->lastSelectedParamID == CC_NUMBER_MOD_WHEEL) {
+		else if (clip->lastSelectedParamID == CC_NUMBER_MOD_WHEEL || clip->lastSelectedParamID == CC_NUMBER_Y_AXIS) {
 			strcpy(parameterName, deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
 		}
 		else {
@@ -3055,17 +3055,21 @@ void AutomationView::selectNonGlobalParam(int32_t offset, Clip* clip) {
 // used with SelectEncoderAction to get the next midi CC
 void AutomationView::selectMIDICC(int32_t offset, Clip* clip) {
 	if (isOnAutomationOverview()) {
-		clip->lastSelectedParamID = 0;
+		clip->lastSelectedParamID = CC_NUMBER_NONE;
 	}
-	else if ((clip->lastSelectedParamID + offset) < 0) {
-		clip->lastSelectedParamID = kLastMidiCCForAutomation;
+	auto newCC = clip->lastSelectedParamID;
+	newCC += offset;
+	if (newCC < 0) {
+		newCC += kNumCCExpression;
 	}
-	else if ((clip->lastSelectedParamID + offset) > kLastMidiCCForAutomation) {
-		clip->lastSelectedParamID = 0;
+	else if (newCC >= kNumCCExpression) {
+		newCC -= kNumCCExpression;
 	}
-	else {
-		clip->lastSelectedParamID += offset;
+	if (newCC == 1) {
+		// mod wheel is actually CC_NUMBER_Y_AXIS (122) internally
+		newCC += offset;
 	}
+	clip->lastSelectedParamID = newCC;
 }
 
 // used with SelectEncoderAction to get the next parameter in the list of parameters

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3060,10 +3060,10 @@ void AutomationView::selectMIDICC(int32_t offset, Clip* clip) {
 	auto newCC = clip->lastSelectedParamID;
 	newCC += offset;
 	if (newCC < 0) {
-		newCC += kNumCCExpression;
+		newCC = CC_NUMBER_Y_AXIS;
 	}
 	else if (newCC >= kNumCCExpression) {
-		newCC -= kNumCCExpression;
+		newCC = 0;
 	}
 	if (newCC == 1) {
 		// mod wheel is actually CC_NUMBER_Y_AXIS (122) internally

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1963,8 +1963,7 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 				if (outputType == OutputType::MIDI_OUT) {
 					MIDIInstrument* newMIDIInstrument = (MIDIInstrument*)newInstrument;
 					MIDIInstrument* oldMIDIInstrument = (MIDIInstrument*)clip->output;
-					memcpy(newMIDIInstrument->modKnobCCAssignments, oldMIDIInstrument->modKnobCCAssignments,
-					       sizeof(oldMIDIInstrument->modKnobCCAssignments));
+					newMIDIInstrument->modKnobCCAssignments = oldMIDIInstrument->modKnobCCAssignments;
 					newInstrument->editedByUser =
 					    oldNonAudioInstrument->editedByUser; // This keeps a record of "whether there are any CC
 					                                         // assignments", so must be copied across

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2905,7 +2905,7 @@ int32_t InstrumentClip::readMIDIParamsFromFile(int32_t readAutomationUpToPos) {
 				if (!strcmp(tagName, "cc")) {
 					char const* contents = storageManager.readTagOrAttributeValue();
 					if (!strcasecmp(contents, "bend")) {
-						paramId = 0;
+						paramId = X_PITCH_BEND;
 expressionParam:
 						// If we're here, we're reading a pre-V3.2 file, and need to read what we're now regarding as
 						// "expression".
@@ -2917,21 +2917,21 @@ expressionParam:
 						param = &expressionParams->params[paramId];
 					}
 					else if (!strcasecmp(contents, "aftertouch")) {
-						paramId = 2;
+						paramId = Z_PRESSURE;
 						goto expressionParam;
 					}
-					else if (!strcasecmp(contents, "none")
-					         || !strcmp(contents, "120")) { // We used to write 120 for "none", pre V2.0
+					else if (!strcasecmp(contents, "none")) {
+						// We used to write 120 for "none", pre V2.0, but that's now bend
 						paramId = CC_NUMBER_NONE;
 					}
 					else {
 						paramId = stringToInt(contents);
 						if (paramId < kNumRealCCNumbers) {
-							if (paramId == 1) {
+							if (paramId == CC_NUMBER_MOD_WHEEL) {
 								// m-m-adams - used to convert CC74 to y-axis, and I don't think that would
 								// ever have been desireable. Now convert mod wheel, as mono y axis outputs as mod wheel
 								if (storageManager.firmwareVersionOfFileBeingRead < FirmwareVersion::COMMUNITY_1P1) {
-									paramId = 1;
+									paramId = Y_SLIDE_TIMBRE;
 									goto expressionParam;
 								}
 							}

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2927,9 +2927,10 @@ expressionParam:
 					else {
 						paramId = stringToInt(contents);
 						if (paramId < kNumRealCCNumbers) {
-							if (paramId == 74) {
-								if (storageManager.firmwareVersionOfFileBeingRead
-								    < FirmwareVersion::FIRMWARE_3P2P0_ALPHA) {
+							if (paramId == 1) {
+								// m-m-adams - used to convert CC74 to y-axis, and I don't think that would
+								// ever have been desireable. Now convert mod wheel, as mono y axis outputs as mod wheel
+								if (storageManager.firmwareVersionOfFileBeingRead < FirmwareVersion::COMMUNITY_1P1) {
 									paramId = 1;
 									goto expressionParam;
 								}

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -136,7 +136,8 @@ void InstrumentClipMinder::drawMIDIControlNumber(int32_t controlNumber, bool aut
 	else if (controlNumber == CC_NUMBER_AFTERTOUCH) {
 		strcpy(buffer, deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
 	}
-	else if (controlNumber == CC_NUMBER_MOD_WHEEL) {
+	else if (controlNumber == CC_NUMBER_Y_AXIS) {
+		// in mono expression this is mod wheel, and y-axis is not directly controllable
 		strcpy(buffer, deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
 	}
 	else {

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -218,7 +218,7 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimens
 	int32_t masterChannel = getOutputMasterChannel();
 
 	switch (whichExpressionDimension) {
-	case 0: {
+	case X_PITCH_BEND: {
 		int32_t newValue = add_saturation(lastCombinedPolyExpression[whichExpressionDimension],
 		                                  lastMonoExpression[whichExpressionDimension]);
 		int32_t valueSmall = (newValue >> 18) + 8192;
@@ -226,7 +226,7 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimens
 		break;
 	}
 
-	case 1: {
+	case Y_SLIDE_TIMBRE: {
 		// mono y expression is limited to positive values
 		// this means that without sending CC1 on the master channel poly expression below 64 will
 		// send as mod wheel 0. However this is better than the alternative of sending erroneous values
@@ -236,10 +236,10 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimens
 		int32_t newValue = std::clamp<int32_t>(polyPart + monoPart, 0, 127);
 		// send CC1 for monophonic expression - monophonic synths won't do anything useful with CC74
 
-		midiEngine.sendCC(masterChannel, 1, newValue, channel);
+		midiEngine.sendCC(masterChannel, CC_NUMBER_MOD_WHEEL, newValue, channel);
 		break;
 	}
-	case 2: {
+	case Z_PRESSURE: {
 		int32_t newValue = add_saturation(lastCombinedPolyExpression[whichExpressionDimension],
 		                                  lastMonoExpression[whichExpressionDimension])
 		                   >> 24;

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -45,8 +45,8 @@ MIDIInstrument::MIDIInstrument()
     : NonAudioInstrument(OutputType::MIDI_OUT), mpeOutputMemberChannels(),
       ratio(float(cachedBendRanges[BEND_RANGE_FINGER_LEVEL]) / float(cachedBendRanges[BEND_RANGE_MAIN])),
       modKnobCCAssignments() {
-
 	modKnobMode = 0;
+	modKnobCCAssignments.fill(CC_NUMBER_NONE);
 }
 
 // Returns whether any change made. For MIDI Instruments, this has no consequence
@@ -417,6 +417,10 @@ int32_t MIDIInstrument::changeControlNumberForModKnob(int32_t offset, int32_t wh
 	}
 	else if (newCC >= kNumCCNumbersIncludingFake) {
 		newCC -= kNumCCNumbersIncludingFake;
+	}
+	if (newCC == 1) {
+		// mod wheel is actually CC_NUMBER_Y_AXIS (122) internally
+		newCC += offset;
 	}
 
 	*cc = newCC;

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -25,10 +25,10 @@ class ModelStackWithThreeMainThings;
 class ModelStackWithSoundFlags;
 
 struct MPEOutputMemberChannel {
-	int16_t lastNoteCode;
-	uint16_t noteOffOrder;
-	int16_t lastXValueSent;        // The actual 14-bit number. But signed (goes positive and negative).
-	int8_t lastYAndZValuesSent[2]; // The actual 7-bit numbers. Y goes both positive and negative.
+	int16_t lastNoteCode{32767};
+	uint16_t noteOffOrder{0};
+	int16_t lastXValueSent{0};        // The actual 14-bit number. But signed (goes positive and negative).
+	int8_t lastYAndZValuesSent[2]{0}; // The actual 7-bit numbers. Y goes both positive and negative.
 };
 
 class MIDIInstrument final : public NonAudioInstrument {
@@ -69,10 +69,10 @@ public:
 
 	inline bool sendsToMPE() { return (channel >= 16); }
 
-	int32_t channelSuffix;
-	int32_t lastNoteCode;
-	bool collapseAftertouch;
-	bool collapseMPE;
+	int32_t channelSuffix{-1};
+	int32_t lastNoteCode{32767};
+	bool collapseAftertouch{false};
+	bool collapseMPE{true};
 	float ratio; // for combining per finger and global bend
 
 	int8_t modKnobCCAssignments[kNumModButtons * kNumPhysicalModKnobs];
@@ -81,8 +81,10 @@ public:
 	MPEOutputMemberChannel mpeOutputMemberChannels[16];
 
 	// for tracking mono expression output
-	int32_t lastMonoExpression[3];
-	int32_t lastCombinedPolyExpression[3];
+	int32_t lastMonoExpression[3]{0};
+	int32_t lastCombinedPolyExpression[3]{0};
+	// could be int8 for aftertouch/Y but Midi 2 will allow those to be 14 bit too
+	int16_t lastOutputMonoExpression[3]{0};
 	char const* getXMLTag() { return sendsToMPE() ? "mpeZone" : "midiChannel"; }
 	char const* getSlotXMLTag() { return sendsToMPE() ? "zone" : "channel"; }
 	char const* getSubSlotXMLTag() { return "suffix"; }

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "model/instrument/non_audio_instrument.h"
+#include <array>
 
 class ParamManagerMIDI;
 class ModelStack;
@@ -75,7 +76,7 @@ public:
 	bool collapseMPE{true};
 	float ratio; // for combining per finger and global bend
 
-	int8_t modKnobCCAssignments[kNumModButtons * kNumPhysicalModKnobs];
+	std::array<int8_t, kNumModButtons * kNumPhysicalModKnobs> modKnobCCAssignments;
 
 	// Numbers 0 to 15 can all be an MPE member depending on configuration
 	MPEOutputMemberChannel mpeOutputMemberChannels[16];

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -531,7 +531,6 @@ bool PatchedParamSet::shouldParamIndicateMiddleValue(ModelStackWithParamId const
 }
 
 // ExpressionParamSet --------------------------------------------------------------------------------------------
-
 ExpressionParamSet::ExpressionParamSet(ParamCollectionSummary* summary, bool forDrum)
     : ParamSet(sizeof(ExpressionParamSet), summary) {
 	params = params_.data();
@@ -575,11 +574,11 @@ void ExpressionParamSet::notifyParamModifiedInSomeWay(ModelStackWithAutoParam co
 	}
 }
 
-// Displays text number. This will only actually end up getting used/seen on MIDI Clips, at channel/Clip level - not
-// MPE/polyphonic.
+/// mono expression only - used just for knobs in midi clips currently. If mpe expression ever gets modified to call
+/// this, the expression set needs to be made MPE aware to treat Y_SLIDE_TIMBRE as bipolar
 int32_t ExpressionParamSet::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
-	// Everything but aftertouch gets handled by parent from here
-	if (modelStack->paramId != 2) {
+	// mono pitch bend is still bipolar and gets handled by parent from here
+	if (modelStack->paramId == X_PITCH_BEND) {
 		return ParamSet::knobPosToParamValue(knobPos, modelStack);
 	}
 
@@ -589,10 +588,11 @@ int32_t ExpressionParamSet::knobPosToParamValue(int32_t knobPos, ModelStackWithA
 	return (knobPos + 64) << 24;
 }
 
+/// mono expression only - used just for knobs in midi clips currently. If mpe expression ever gets modified to call
+/// this, the expression set needs to be made MPE aware to treat Y_SLIDE_TIMBRE as bipolar
 int32_t ExpressionParamSet::paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack) {
-
-	// Everything but aftertouch gets handled by parent
-	if (modelStack->paramId != 2) {
+	// mono pitch bend is still bipolar and gets handled by parent from here
+	if (modelStack->paramId == X_PITCH_BEND) {
 		return ParamSet::paramValueToKnobPos(paramValue, modelStack);
 	}
 

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1654,7 +1654,7 @@ int32_t StorageManager::readMIDIParamFromFile(int32_t readAutomationUpToPos, MID
 				cc = stringToInt(contents);
 			}
 			// will be sent as mod wheel and also map to internal mono expression
-			if (cc == 1) {
+			if (cc == CC_NUMBER_MOD_WHEEL) {
 				cc = CC_NUMBER_Y_AXIS;
 			}
 

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1296,7 +1296,7 @@ bool StorageManager::closeFile() {
 }
 
 void StorageManager::writeFirmwareVersion() {
-	writeAttribute("firmwareVersion", "4.1.4-alpha");
+	writeAttribute("firmwareVersion", "c1.1.0");
 }
 
 void StorageManager::writeEarliestCompatibleFirmwareVersion(char const* versionString) {
@@ -1647,14 +1647,17 @@ int32_t StorageManager::readMIDIParamFromFile(int32_t readAutomationUpToPos, MID
 			else if (!strcasecmp(contents, "aftertouch")) {
 				cc = CC_NUMBER_AFTERTOUCH;
 			}
-			else if (!strcasecmp(contents, "none")
-			         || !strcmp(contents, "120")) { // We used to write 120 for "none", pre V2.0
+			else if (!strcasecmp(contents, "none")) {
 				cc = CC_NUMBER_NONE;
 			}
 			else {
 				cc = stringToInt(contents);
 			}
-			// TODO: Pre-V2.0 files could still have CC74, so ideally I'd move that to "expression" params here...
+			// will be sent as mod wheel and also map to internal mono expression
+			if (cc == 1) {
+				cc = CC_NUMBER_Y_AXIS;
+			}
+
 			exitTag("cc");
 		}
 		else if (!strcmp(tagName, "value")) {

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1933,6 +1933,9 @@ int32_t stringToFirmwareVersion(char const* firmwareVersionString) {
 	else if (!strcmp(firmwareVersionString, "4.1.4")) {
 		return FIRMWARE_4P1P4;
 	}
+	else if (!strcmp(firmwareVersionString, "c1.1.0")) {
+		return COMMUNITY_1P1;
+	}
 
 	else {
 		return FIRMWARE_TOO_NEW;


### PR DESCRIPTION
Fix issue of sending un needed mod wheel values reported on discord

Fix related issue where some ways of recording mod wheel did not link to mono expression y axis, causing them to be ignored in the MPE collapsing calculation