### PR TITLE
Bugfix: Midi feedback crash on opening kits with deleted kit rows

### DIFF
--- a/src/deluge/model/action/action_clip_state.cpp
+++ b/src/deluge/model/action/action_clip_state.cpp
@@ -46,6 +46,9 @@ void ActionClipState::grabFromClip(Clip* thisClip) {
 			}
 			else {
 				selectedDrumIndex = kit->getDrumIndex(kit->selectedDrum);
+				if (selectedDrumIndex == -1) {
+					kit->selectedDrum = nullptr;
+				}
 			}
 		}
 	}

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2367,8 +2367,10 @@ void InstrumentClip::writeDataToFile(Song* song) {
 			if (output->type == OutputType::KIT && thisNoteRow->drum) {
 				drumIndex = ((Kit*)output)->getDrumIndex(thisNoteRow->drum);
 			}
-
-			thisNoteRow->writeToFile(drumIndex, this);
+			// no matching drum found
+			if (drumIndex != -1) {
+				thisNoteRow->writeToFile(drumIndex, this);
+			}
 		}
 
 		storageManager.writeClosingTag("noteRows");

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -443,7 +443,7 @@ Drum* Kit::getFirstUnassignedDrum(InstrumentClip* clip) {
 
 int32_t Kit::getDrumIndex(Drum* drum) {
 	int32_t index = 0;
-	for (Drum* thisDrum = firstDrum; thisDrum != drum; thisDrum = thisDrum->next) {
+	for (Drum* thisDrum = firstDrum; thisDrum && thisDrum != drum; thisDrum = thisDrum->next) {
 		index++;
 	}
 	return index;

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -443,10 +443,11 @@ Drum* Kit::getFirstUnassignedDrum(InstrumentClip* clip) {
 
 int32_t Kit::getDrumIndex(Drum* drum) {
 	int32_t index = 0;
-	for (Drum* thisDrum = firstDrum; thisDrum && thisDrum != drum; thisDrum = thisDrum->next) {
+	Drum* thisDrum;
+	for (thisDrum = firstDrum; thisDrum && thisDrum != drum; thisDrum = thisDrum->next) {
 		index++;
 	}
-	return index;
+	return thisDrum ? index : -1;
 }
 
 Drum* Kit::getDrumFromIndex(int32_t index) {

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1497,19 +1497,17 @@ ModelStackWithAutoParam* Kit::getModelStackWithParam(ModelStackWithTimelineCount
 
 			ModelStackWithNoteRow* modelStackWithNoteRow = instrumentClip->getNoteRowForSelectedDrum(modelStack);
 
-			if (modelStackWithNoteRow) {
+			if (modelStackWithNoteRow->getNoteRowAllowNull()) {
 
 				ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 				    modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow();
 
-				if (modelStackWithThreeMainThings) {
-					if (paramKind == deluge::modulation::params::Kind::PATCHED) {
-						modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
-					}
+				if (paramKind == deluge::modulation::params::Kind::PATCHED) {
+					modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
+				}
 
-					else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
-						modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
-					}
+				else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
+					modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
 				}
 			}
 		}


### PR DESCRIPTION
Fixes a crash caused by attempting to send midi follow feedback for a drum that no longer has an assigned note row (e.g. it's been deleted)

Fixes the annoying "unknownTag: xScrollSongView" log message and just makes the parsing slightly more readable in general

Full refactor to come using the enum/string class from the filter types PR 