### PR TITLE
Bug fix / Set correct playback mode for alternate arranger views (automation and performance)

### DIFF
--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -108,8 +108,8 @@ public:
 	// called by playback_handler.cpp
 	void notifyPlaybackBegun();
 
-	// not sure how this is used
-	ClipMinder* toClipMinder() { return this; }
+	// used to identify the UI as a clip UI or not.
+	ClipMinder* toClipMinder() { return getAutomationSubType() == AutomationSubType::ARRANGER ? NULL : this; }
 
 	bool isOnAutomationOverview();
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -382,6 +382,10 @@ void PlaybackHandler::decideOnCurrentPlaybackMode() {
 		goto useArranger;
 	}
 
+	if (!rootUIIsClipMinderScreen() && currentSong->lastClipInstanceEnteredStartPos != -1) {
+		goto useArranger;
+	}
+
 	if (rootUIIsClipMinderScreen()
 	    && (currentSong->lastClipInstanceEnteredStartPos != -1 || getCurrentClip()->isArrangementOnlyClip())) {
 useArranger:


### PR DESCRIPTION
Bug fix to set correct playback mode to arrangement when in an arranger view or arranger white clip

This wasn't working when in automation arranger view or in performance view launched from arranger

This closes issue https://github.com/SynthstromAudible/DelugeFirmware/issues/1189