### PR TITLE
Change from 0x7D to official Synthstrom Sysex ID.

### DIFF
--- a/contrib/load/loadfw.c
+++ b/contrib/load/loadfw.c
@@ -115,32 +115,52 @@ int main(int argc, char **argv)
 		unsigned char *bytes = (unsigned char*)(buffer+buf_pos);
 
 		data[0] = 0xf0;
-		data[1] = 0x7d;
-		data[2] = 3;  // debug
-		data[3] = 1;  // send packet
-		pack_8bit_to_7bit(data+4, 5, &handshake, 4);
-		data[9] = pos_low;
-		data[10] = pos_high;
+// 		data[1] = 0x7d;
+		data[1] = 0x00;
+		data[2] = 0x21;
+		data[3] = 0x7B;
+		data[4] = 0x01;
+//		data[2] = 3;  // debug
+		data[5] = 3;  // debug
+// 		data[3] = 1;  // send packet
+		data[6] = 1;  // send packet
+//		pack_8bit_to_7bit(data+4, 5, &handshake, 4);
+		pack_8bit_to_7bit(data+7, 5, &handshake, 4);
+//		data[9] = pos_low;
+		data[12] = pos_low;
+//		data[10] = pos_high;
+		data[13] = pos_high;
 
 		const int packed_size = 586; // ceil(512+512/7)
-		pack_8bit_to_7bit(data+11, packed_size, bytes, 512);
+//		pack_8bit_to_7bit(data+11, packed_size, bytes, 512);
+		pack_8bit_to_7bit(data+14, packed_size, bytes, 512);
+//		data[11+packed_size] = 0xf7;
 		data[11+packed_size] = 0xf7;
-		int len = packed_size+12;
+//		int len = packed_size+12;
+		int len = packed_size+15;
 
 		send(data, len);
 	}
 
 	data[0] = 0xf0;
-	data[1] = 0x7d;
-	data[2] = 3; // debug
-	data[3] = 2; // run
+	// data[1] = 0x7d;
+	data[1] = 0x00;
+	data[2] = 0x21;
+	data[3] = 0x7B;
+	data[4] = 0x01;
+// 	data[2] = 3; // debug
+	data[5] = 3; // debug
+//	data[3] = 2; // run
+	data[6] = 2; // run
 
 	uint32_t fields[3] = {handshake, size, crc};
 	// TODO: Litle-endian mandated
-	pack_8bit_to_7bit(data+4, 14, fields, 12);
-
-	data[14+4] = 0xf7;
-	send(data, 19);
+//	pack_8bit_to_7bit(data+4, 14, fields, 12);
+	pack_8bit_to_7bit(data+7, 14, fields, 12);
+// 	data[14+4] = 0xf7;
+	data[14+7] = 0xf7;
+// 	send(data, 19);
+	send(data, 22);
 
 	if (use_alsa) {
 #ifdef USE_ALSA

--- a/scripts/tasks/task-loadfw.py
+++ b/scripts/tasks/task-loadfw.py
@@ -74,25 +74,41 @@ def load_fw(port, handshake, file, delay_ms=2):
             "Firmware Upload ",
         ):
             data[0] = 0xF0  # Sysex Start
-            data[1] = 0x7D  # Deluge
-            data[2] = 3  # Debug
-            data[3] = 1  # Send Firmware
-            data[4:9] = pack87(handshake.to_bytes(4, byteorder="little"), 5)
-            data[9] = i & 0x7F  # Position Low
-            data[10] = (i >> 7) & 0x7F  # Position High
-            data[11:-1] = pack87(segment, 586)
+            #            data[1] = 0x7D  # Deluge
+            data[1] = 0x00
+            data[2] = 0x21
+            data[3] = 0x7B
+            data[4] = 0x01
+
+            #           data[2] = 3  # Debug
+            data[5] = 3  # Debug
+            #           data[3] = 1  # Send Firmware
+            data[6] = 1  # Send Firmware
+            #           data[4:9] = pack87(handshake.to_bytes(4, byteorder="little"), 5)
+            data[7:12] = pack87(handshake.to_bytes(4, byteorder="little"), 5)
+            #           data[9] = i & 0x7F  # Position Low
+            data[12] = i & 0x7F  # Position Low
+            #           data[10] = (i >> 7) & 0x7F  # Position High
+            data[13] = (i >> 7) & 0x7F  # Position High
+            #           data[11:-1] = pack87(segment, 586)
+            data[14:-1] = pack87(segment, 586)
+            #           data[-1] = 0xF7  # Sysex End
             data[-1] = 0xF7  # Sysex End
             midiout.send_message(data)
             time.sleep(0.001 * delay_ms)
-        data = data[:19]
-        data[3] = 2  # Load Firmware
-        data[4:18] = pack87(
+        #         data = data[:19]
+        data = data[:22]
+        #       data[3] = 2  # Load Firmware
+        data[6] = 2  # Load Firmware
+        #        data[4:18] = pack87(
+        data[7:21] = pack87(
             handshake.to_bytes(4, byteorder="little")
             + len(binary).to_bytes(4, byteorder="little")
             + checksum.to_bytes(4, byteorder="little"),
             14,
         )
-        data[18] = 0xF7
+        #       data[18] = 0xF7
+        data[21] = 0xF7
         midiout.send_message(data)
 
 

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -25,6 +25,7 @@
 #include "hid/display/oled.h"
 #include "hid/hid_sysex.h"
 #include "io/debug/log.h"
+#include "io/debug/sysex.h"
 #include "processing/engines/audio_engine.h"
 #include "util/cfunctions.h"
 #include "util/d_string.h"

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -27,6 +27,7 @@
 #include "hid/hid_sysex.h"
 #include "hid/led/indicator_leds.h"
 #include "io/debug/log.h"
+#include "io/debug/sysex.h"
 #include "memory/general_memory_allocator.h"
 #include "model/action/action_logger.h"
 #include "util/cfunctions.h"

--- a/src/deluge/hid/hid_sysex.cpp
+++ b/src/deluge/hid/hid_sysex.cpp
@@ -4,6 +4,7 @@
 #include "gui/ui_timer_manager.h"
 #include "hid/display/oled.h"
 #include "hid/display/seven_segment.h"
+#include "io/debug/sysex.h"
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_engine.h"
 #include "memory/general_memory_allocator.h"
@@ -17,11 +18,11 @@ uint8_t* oledDeltaImage = nullptr;
 bool oledDeltaForce = true;
 
 void HIDSysex::sysexReceived(MIDIDevice* device, uint8_t* data, int32_t len) {
-	if (len < 6) {
+	if (len < 3) {
 		return;
 	}
 	// first three bytes are already used, next is command
-	switch (data[3]) {
+	switch (data[1]) {
 	case 0:
 		requestOLEDDisplay(device, data, len);
 		break;
@@ -36,11 +37,15 @@ void HIDSysex::sysexReceived(MIDIDevice* device, uint8_t* data, int32_t len) {
 }
 
 void HIDSysex::requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int32_t len) {
-	if (data[4] == 0 or data[4] == 1) {
-		sendOLEDData(device, (data[4] == 1));
+//	if (data[4] == 0 or data[4] == 1) {
+	if (data[2] == 0 or data[2] == 1) {
+	// sendOLEDData(device, (data[4] == 1)); // Adjustting by -2 to correct for payload offset.
+		sendOLEDData(device, (data[2] == 1));
 	}
-	else if (data[4] == 2 || data[4] == 3) {
-		bool force = (data[4] == 3);
+	// else if (data[4] == 2 || data[4] == 3) {
+	else if (data[2] == 2 || data[2] == 3) {
+	// bool force = (data[4] == 3);
+		bool force = (data[2] == 3);
 		midiDisplayDevice = device;
 		// two seconds
 		midiDisplayUntil = AudioEngine::audioSampleTimer + 2 * 44100;
@@ -59,7 +64,8 @@ void HIDSysex::requestOLEDDisplay(MIDIDevice* device, uint8_t* data, int32_t len
 			send7SegData(device);
 		}
 	}
-	else if (data[4] == 4) { // SWAP
+// else if (data[4] == 4) { // SWAP
+	else if (data[2] == 4) { // SWAP
 		deluge::hid::display::swapDisplayType();
 		oledDeltaForce = true;
 	}
@@ -91,31 +97,38 @@ void HIDSysex::sendOLEDData(MIDIDevice* device, bool rle) {
 	if (display->haveOLED()) {
 		const int32_t data_size = 768;
 		const int32_t max_packed_size = 922;
-
-		uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, rle ? 0x01_u8 : 0x00_u8};
+// 		uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, rle ? 0x01_u8 : 0x00_u8};
+		uint8_t reply_hdr[8] = {0xF0, 0x00, 0x21, 0x7B, 0x01, 0x02, 0x40, rle ? 0x01_u8 : 0x00_u8};
 		uint8_t* reply = midiEngine.sysex_fmt_buffer;
-		memcpy(reply, reply_hdr, 5);
-		reply[5] = 0; // nominally 32*data[5] is start pos for a delta
+// 		memcpy(reply, reply_hdr, 5);
+		memcpy(reply, reply_hdr, 8); //
+//		reply[5] = 0; // nominally 32*data[5] is start pos for a delta
+		reply[8] = 0; // nominally 32*data[8] is start pos for a delta //
 
 		int32_t packed;
 		if (rle) {
 			packed =
-			    pack_8to7_rle(reply + 6, max_packed_size, deluge::hid::display::OLED::oledCurrentImage[0], data_size);
+//				pack_8to7_rle(reply + 6, max_packed_size, deluge::hid::display::OLED::oledCurrentImage[0], data_size);
+			    pack_8to7_rle(reply + 9, max_packed_size, deluge::hid::display::OLED::oledCurrentImage[0], data_size);
 		}
 		else {
-			packed = pack_8bit_to_7bit(reply + 6, max_packed_size, deluge::hid::display::OLED::oledCurrentImage[0],
-			                           data_size);
+//			packed = pack_8bit_to_7bit(reply + 6, max_packed_size, deluge::hid::display::OLED::oledCurrentImage[0],
+//			                           data_size);
+			packed = pack_8bit_to_7bit(reply + 9, max_packed_size, deluge::hid::display::OLED::oledCurrentImage[0],
+			                           data_size); //
 		}
 		if (packed < 0) {
-			display->popupTextTemporary("eror: fail");
+			display->popupTextTemporary("error: fail");
 		}
-		reply[6 + packed] = 0xf7; // end of transmission
-		device->sendSysex(reply, packed + 7);
+//		reply[6 + packed] = 0xf7; // end of transmission
+		reply[9 + packed] = 0xf7; // end of transmission
+// 		device->sendSysex(reply, packed + 7); //
+		device->sendSysex(reply, packed + 10); //
 	}
 }
 
 void HIDSysex::request7SegDisplay(MIDIDevice* device, uint8_t* data, int32_t len) {
-	if (data[4] == 0) {
+	if (data[2] == 0) { // was 4
 		send7SegData(device);
 	}
 }
@@ -125,10 +138,16 @@ void HIDSysex::send7SegData(MIDIDevice* device) {
 		// aschually 8 segments if you count the dot
 		auto data = display->getLast();
 		const int32_t packed_data_size = 5;
-		uint8_t reply[12] = {0xf0, 0x7d, 0x02, 0x41, 0x00, 0x00};
-		pack_8bit_to_7bit(reply + 6, packed_data_size, data.data(), data.size());
-		reply[6 + packed_data_size] = 0xf7; // end of transmission
-		device->sendSysex(reply, packed_data_size + 7);
+//		uint8_t reply[12] = {0xf0, 0x7d, 0x02, 0x41, 0x00, 0x00};
+		uint8_t reply[15] = {0xf0, 0x00, 0x21, 0x7B, 0x01, 0x02, 0x41, 0x00, 0x00};
+//  	pack_8bit_to_7bit(reply + 6, packed_data_size, data.data(), data.size());
+// int32_t pack_8bit_to_7bit(uint8_t* dst, int32_t dst_size, uint8_t* src, int32_t src_len);
+		pack_8bit_to_7bit(reply + 9, packed_data_size, data.data(), data.size());
+//		reply[6 + packed_data_size] = 0xf7; // end of transmission
+		reply[9 + packed_data_size] = 0xf7; // end of transmission
+//		device->sendSysex(reply, packed_data_size + 7);
+		device->sendSysex(reply, packed_data_size + 10);
+
 	}
 }
 
@@ -166,19 +185,23 @@ void HIDSysex::sendOLEDDataDelta(MIDIDevice* device, bool force) {
 
 	int start = first_change / 2;
 	int len = (last_change / 2) - start + 1;
-
-	uint8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, 0x02};
+//	int8_t reply_hdr[5] = {0xf0, 0x7d, 0x02, 0x40, 0x02};
+	uint8_t reply_hdr[8] = {0xF0, 0x00, 0x21, 0x7B, 0x01, 0x02, 0x40, 0x02};
 	uint8_t* reply = midiEngine.sysex_fmt_buffer;
-	memcpy(reply, reply_hdr, 5);
-	reply[5] = start;
-	reply[6] = len;
-
-	int32_t packed = pack_8to7_rle(reply + 7, max_packed_size, current + 8 * start, 8 * len);
+	memcpy(reply, reply_hdr, sizeof(reply_hdr));
+//	reply[5] = start;
+	reply[sizeof(reply_hdr) + 0] = start;
+//  reply[6] = len;
+	reply[sizeof(reply_hdr) + 1] = len;
+// 	int32_t packed = pack_8to7_rle(reply + 7, max_packed_size, current + 8 * start, 8 * len);
+	int32_t packed = pack_8to7_rle(reply + 10, max_packed_size, current + 8 * start, 8 * len);
 	if (packed <= 0) {
 		return;
 	}
 	memcpy(oledDeltaImage + (8 * start), current + (8 * start), 8 * len);
 	oledDeltaForce = false;
-	reply[7 + packed] = 0xf7; // end of transmission
-	device->sendSysex(reply, packed + 8);
+	// reply[7 + packed] = 0xf7; // end of transmission
+	reply[10 + packed] = 0xf7; // end of transmission //
+	// device->sendSysex(reply, packed + 8);
+	device->sendSysex(reply, packed + 11);
 }

--- a/src/deluge/io/debug/print.h
+++ b/src/deluge/io/debug/print.h
@@ -20,7 +20,7 @@
 #include <cstdint>
 
 #ifndef SYSEX_LOGGING_ENABLED
-#define SYSEX_LOGGING_ENABLED false
+#define SYSEX_LOGGING_ENABLED true
 #endif
 
 class MIDIDevice;

--- a/src/deluge/io/debug/sysex.h
+++ b/src/deluge/io/debug/sysex.h
@@ -20,8 +20,8 @@
 #include <cstdint>
 
 class MIDIDevice;
-
 #include "definitions_cxx.hpp"
+
 namespace Debug {
 
 void sysexReceived(MIDIDevice* device, uint8_t* data, int32_t len);
@@ -32,3 +32,24 @@ void loadCheckAndRun(uint8_t* data, int32_t len);
 #endif
 
 } // namespace Debug
+
+namespace SysEx {
+
+#define DELUGE_SYSEX_ID_BYTES 0x00, 0x21, 0x7B, 0x01
+//#define DELUGE_SYSEX_HEADER 0xF0, 0x00, 0x21, 0x7B, 0x01
+
+
+#define SYSEX_END 0xD7
+
+const static uint8_t DELUGE_SYSEX_ID[] = {DELUGE_SYSEX_ID_BYTES};
+
+enum SysexCommands: uint8_t {
+	Ping,		// reply with pong
+	Popup,		// display info in popup
+	HID,		// HID access
+	Debug,		// Debugging
+	Pong = 0x7F // Pong reply
+};
+
+} // namespace SysEx
+


### PR DESCRIPTION
I have gone thru the Deluge Firmware and the delugeclient that Wook created and changed everything over to using the Synthstrom SysEx ID. This changes the offsets by +3. I also changed the convention where SysEx handlers are now called with the uint8_t* data pointer is now set to the first byte of the "payload", which is the address of the command code used and just past the final address of the SysEx message involved. I also decrease the length parameter so that it now represents the length from the payload start to the end of the message.

With my changes, the Deluge handles either 0x7D or 0x00, 0x21, 0x7B, 0x01, which is the Midi Association assigned code + the Synthstrom model code for the Deluge model. Since we control the model byte, we can get away with subdividing it into bitfields if we need to encode a protocol version and/or a new model of something we develop someday.

No matter which format you use, the Deluge will reply with the longer address form. I did this so the SysEx code in the Deluge will react to an old-form message rather than just eating it, even though your reply handling may need to be fixed.

I have also changed the code around chain-loading the firmware but I have not tested it out yet. I will also have to change the python script to use the new ID scheme. 

We will obviously need to be able to chain load into earlier versions too.