### PR TITLE
correct cast in get current kit

### DIFF
--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -45,8 +45,8 @@
 namespace params = deluge::modulation::params;
 
 Kit::Kit() : Instrument(OutputType::KIT), drumsWithRenderingActive(sizeof(Drum*)) {
-	firstDrum = NULL;
-	selectedDrum = NULL;
+	firstDrum = nullptr;
+	selectedDrum = nullptr;
 }
 
 Kit::~Kit() {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -82,7 +82,7 @@ Output* getCurrentOutput() {
 Kit* getCurrentKit() {
 	Clip* currentClip = currentSong->getCurrentClip();
 	if (currentClip->output->type == OutputType::KIT) {
-		return (Kit*)currentClip;
+		return static_cast<Kit*>(currentClip->output);
 	}
 	return nullptr;
 }


### PR DESCRIPTION
Accidentally cast the clip instead of the output, which deceptively mostly works but occasionally crashes. Fixes crash reported on discord by boorch, and the issue of selected drum rows not appearing

Fix #1203 
