### PR TITLE
Refactor/move midi match to kit

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -539,8 +539,9 @@ void MidiFollow::aftertouchReceived(MIDIDevice* fromDevice, int32_t channel, int
 
 			if (modelStackWithTimelineCounter) {
 				if (clip->output->type == OutputType::KIT) {
-					offerReceivedAftertouchToKit(modelStackWithTimelineCounter, fromDevice, match, channel, value,
-					                             noteCode, doingMidiThru, clip);
+					Kit* kit = (Kit*)clip->output;
+					kit->receivedAftertouchForKit(modelStackWithTimelineCounter, fromDevice, match, channel, value,
+					                              noteCode, doingMidiThru);
 				}
 				else {
 					MelodicInstrument* melodicInstrument = (MelodicInstrument*)clip->output;
@@ -548,28 +549,6 @@ void MidiFollow::aftertouchReceived(MIDIDevice* fromDevice, int32_t channel, int
 					                                      value, noteCode, doingMidiThru);
 				}
 			}
-		}
-	}
-}
-
-void MidiFollow::offerReceivedAftertouchToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-                                              MIDIDevice* fromDevice, MIDIMatchType match, int32_t channel,
-                                              int32_t value, int32_t noteCode, bool* doingMidiThru, Clip* clip) {
-	Kit* kit = (Kit*)clip->output;
-	// Channel pressure message...
-	if (noteCode == -1) {
-		Drum* firstDrum = kit->getDrumFromIndex(0);
-		for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
-			int32_t level = BEND_RANGE_FINGER_LEVEL;
-			kit->receivedAftertouchForDrum(modelStackWithTimelineCounter, thisDrum, match, channel, value);
-		}
-	}
-	// Or a polyphonic aftertouch message - these aren't allowed for MPE except on the "master" channel.
-	else {
-		Drum* thisDrum = kit->getDrumFromNoteCode(clip, noteCode);
-		if ((thisDrum != nullptr) && (channel == thisDrum->lastMIDIChannelAuditioned)) {
-			kit->receivedAftertouchForDrum(modelStackWithTimelineCounter, thisDrum, MIDIMatchType::CHANNEL, channel,
-			                               value);
 		}
 	}
 }

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -404,7 +404,7 @@ void MidiFollow::sendNoteToClip(MIDIDevice* fromDevice, Clip* clip, MIDIMatchTyp
 				auto kit = (Kit*)clip->output;
 				kit->receivedNoteForKit(modelStackWithTimelineCounter, fromDevice, on, channel,
 				                        note - midiEngine.midiFollowKitRootNote, velocity, shouldRecordNotes,
-				                        doingMidiThru, clip);
+				                        doingMidiThru, (InstrumentClip*)clip);
 			}
 			else {
 				MelodicInstrument* melodicInstrument = (MelodicInstrument*)clip->output;
@@ -472,8 +472,8 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 			if (modelStackWithTimelineCounter) {
 				if (clip->output->type == OutputType::KIT) {
 					Kit* kit = (Kit*)clip->output;
-					kit->receivedCCForInputChannel(modelStackWithTimelineCounter, fromDevice, match, channel, ccNumber,
-					                               value, doingMidiThru, clip);
+					kit->receivedCCForKit(modelStackWithTimelineCounter, fromDevice, match, channel, ccNumber, value,
+					                      doingMidiThru, clip);
 				}
 				else {
 					MelodicInstrument* melodicInstrument = (MelodicInstrument*)clip->output;
@@ -500,8 +500,8 @@ void MidiFollow::pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel, uint
 			if (modelStackWithTimelineCounter) {
 				if (clip->output->type == OutputType::KIT) {
 					Kit* kit = (Kit*)clip->output;
-					kit->offerReceivedPitchBendToKit(modelStackWithTimelineCounter, fromDevice, match, channel, data1,
-					                                 data2, doingMidiThru);
+					kit->receivedPitchBendForKit(modelStackWithTimelineCounter, fromDevice, match, channel, data1,
+					                             data2, doingMidiThru);
 				}
 				else {
 					MelodicInstrument* melodicInstrument = (MelodicInstrument*)clip->output;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -499,8 +499,9 @@ void MidiFollow::pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel, uint
 
 			if (modelStackWithTimelineCounter) {
 				if (clip->output->type == OutputType::KIT) {
-					offerReceivedPitchBendToKit(modelStackWithTimelineCounter, fromDevice, match, channel, data1, data2,
-					                            doingMidiThru, clip);
+					Kit* kit = (Kit*)clip->output;
+					kit->offerReceivedPitchBendToKit(modelStackWithTimelineCounter, fromDevice, match, channel, data1,
+					                                 data2, doingMidiThru);
 				}
 				else {
 					MelodicInstrument* melodicInstrument = (MelodicInstrument*)clip->output;
@@ -509,19 +510,6 @@ void MidiFollow::pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel, uint
 				}
 			}
 		}
-	}
-}
-
-// todo: this should be a kit function to avoid accessing kit internals directly
-void MidiFollow::offerReceivedPitchBendToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-                                             MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel,
-                                             uint8_t data1, uint8_t data2, bool* doingMidiThru, Clip* clip) {
-	Kit* kit = (Kit*)clip->output;
-	Drum* firstDrum = kit->getDrumFromIndex(0);
-
-	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
-		kit->receivedPitchBendForDrum(modelStackWithTimelineCounter, thisDrum, data1, data2, match, channel,
-		                              doingMidiThru);
 	}
 }
 

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -479,8 +479,9 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
 			if (modelStackWithTimelineCounter) {
 				if (clip->output->type == OutputType::KIT) {
-					offerReceivedCCToKit(modelStackWithTimelineCounter, fromDevice, match, channel, ccNumber, value,
-					                     doingMidiThru, clip);
+					Kit* kit = (Kit*)clip->output;
+					kit->receivedCCForInputChannel(modelStackWithTimelineCounter, fromDevice, match, channel, ccNumber,
+					                               value, doingMidiThru, clip);
 				}
 				else {
 					MelodicInstrument* melodicInstrument = (MelodicInstrument*)clip->output;
@@ -489,27 +490,6 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 				}
 			}
 		}
-	}
-}
-// todo: should be a kit function
-void MidiFollow::offerReceivedCCToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-                                      MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t ccNumber,
-                                      uint8_t value, bool* doingMidiThru, Clip* clip) {
-	if (match != MIDIMatchType::MPE_MASTER && match != MIDIMatchType::MPE_MEMBER) {
-		return;
-	}
-	if (ccNumber != 74) {
-		return;
-	}
-	if (!fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isChannelPartOfAnMPEZone(channel)) {
-		return;
-	}
-
-	Kit* kit = (Kit*)clip->output;
-	Drum* firstDrum = kit->getDrumFromIndex(0);
-
-	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
-		kit->receivedMPEYForDrum(modelStackWithTimelineCounter, thisDrum, match, channel, value);
 	}
 }
 

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -81,11 +81,7 @@ private:
 	getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
 	                                   int32_t xDisplay, int32_t yDisplay);
 	void displayParamControlError(int32_t xDisplay, int32_t yDisplay);
-
-	void offerReceivedPitchBendToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-	                                 MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
-	                                 uint8_t data2, bool* doingMidiThru, Clip* clip);
-
+	
 	MIDIMatchType checkMidiFollowMatch(MIDIDevice* fromDevice, uint8_t channel);
 	bool isFeedbackEnabled();
 

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -87,10 +87,6 @@ private:
 	                            int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
 	                            bool* doingMidiThru, Clip* clip);
 
-	void offerReceivedCCToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
-	                          MIDIMatchType match, uint8_t channel, uint8_t ccNumber, uint8_t value,
-	                          bool* doingMidiThru, Clip* clip);
-
 	void offerReceivedPitchBendToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
 	                                 MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
 	                                 uint8_t data2, bool* doingMidiThru, Clip* clip);

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -86,10 +86,6 @@ private:
 	                                 MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
 	                                 uint8_t data2, bool* doingMidiThru, Clip* clip);
 
-	void offerReceivedAftertouchToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-	                                  MIDIDevice* fromDevice, MIDIMatchType match, int32_t channel, int32_t value,
-	                                  int32_t noteCode, bool* doingMidiThru, Clip* clip);
-
 	MIDIMatchType checkMidiFollowMatch(MIDIDevice* fromDevice, uint8_t channel);
 	bool isFeedbackEnabled();
 

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -81,7 +81,7 @@ private:
 	getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Clip* clip,
 	                                   int32_t xDisplay, int32_t yDisplay);
 	void displayParamControlError(int32_t xDisplay, int32_t yDisplay);
-	
+
 	MIDIMatchType checkMidiFollowMatch(MIDIDevice* fromDevice, uint8_t channel);
 	bool isFeedbackEnabled();
 

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -82,11 +82,6 @@ private:
 	                                   int32_t xDisplay, int32_t yDisplay);
 	void displayParamControlError(int32_t xDisplay, int32_t yDisplay);
 
-	// handle midi received for midi follow
-	void offerReceivedNoteToKit(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
-	                            int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
-	                            bool* doingMidiThru, Clip* clip);
-
 	void offerReceivedPitchBendToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
 	                                 MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
 	                                 uint8_t data2, bool* doingMidiThru, Clip* clip);
@@ -97,7 +92,6 @@ private:
 
 	MIDIMatchType checkMidiFollowMatch(MIDIDevice* fromDevice, uint8_t channel);
 	bool isFeedbackEnabled();
-	Drum* getDrumFromNoteCode(Clip* clip, Kit* kit, int32_t noteCode);
 
 	// saving
 	void writeDefaultsToFile();

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1301,6 +1301,27 @@ void Kit::offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineC
 		}
 	}
 }
+/// for learning a whole kit to a single channel, offer cc to all drums
+void Kit::receivedCCForInputChannel(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+                                    MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t ccNumber,
+                                    uint8_t value, bool* doingMidiThru, Clip* clip) {
+	if (match != MIDIMatchType::MPE_MASTER && match != MIDIMatchType::MPE_MEMBER) {
+		return;
+	}
+	if (ccNumber != 74) {
+		return;
+	}
+	if (!fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isChannelPartOfAnMPEZone(channel)) {
+		return;
+	}
+
+	Kit* kit = (Kit*)clip->output;
+	Drum* firstDrum = kit->getDrumFromIndex(0);
+
+	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
+		kit->receivedMPEYForDrum(modelStackWithTimelineCounter, thisDrum, match, channel, value);
+	}
+}
 
 void Kit::receivedAftertouchForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
                                     MIDIMatchType match, uint8_t channel, uint8_t value) {

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1301,6 +1301,35 @@ void Kit::offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineC
 		}
 	}
 }
+/// find the drum matching the noteCode, counting up from 0
+Drum* Kit::getDrumFromNoteCode(Clip* clip, int32_t noteCode) {
+	Drum* thisDrum = nullptr;
+	// bottom kit noteRowId = 0
+	// default middle C1 note number = 36
+	// noteRowId + 36 = C1 up for kit sounds
+	// this is configurable through the default menu
+	if (noteCode >= 0) {
+		int32_t index = noteCode;
+		if (index < ((InstrumentClip*)clip)->noteRows.getNumElements()) {
+			NoteRow* noteRow = ((InstrumentClip*)clip)->noteRows.getElement(index);
+			if (noteRow) {
+				thisDrum = noteRow->drum;
+			}
+		}
+	}
+	return thisDrum;
+}
+
+/// maps a note received on kit input channel to a drum. Note is zero indexed to first drum
+void Kit::receivedNoteForKit(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
+                             int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,
+                             bool* doingMidiThru, Clip* clip) {
+	Kit* kit = (Kit*)clip->output;
+	Drum* thisDrum = getDrumFromNoteCode(clip, note);
+
+	kit->receivedNoteForDrum(modelStack, fromDevice, on, channel, note, velocity, shouldRecordNotes, doingMidiThru,
+	                         thisDrum);
+}
 /// for learning a whole kit to a single channel, offer cc to all drums
 void Kit::receivedCCForInputChannel(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                     MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t ccNumber,

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1320,6 +1320,16 @@ Drum* Kit::getDrumFromNoteCode(Clip* clip, int32_t noteCode) {
 	return thisDrum;
 }
 
+// for pitch bend received on a channel learnt to a whole clip
+void Kit::offerReceivedPitchBendToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+                                      MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
+                                      uint8_t data2, bool* doingMidiThru) {
+
+	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
+		receivedPitchBendForDrum(modelStackWithTimelineCounter, thisDrum, data1, data2, match, channel, doingMidiThru);
+	}
+}
+
 /// maps a note received on kit input channel to a drum. Note is zero indexed to first drum
 void Kit::receivedNoteForKit(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on,
                              int32_t channel, int32_t note, int32_t velocity, bool shouldRecordNotes,

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -134,6 +134,10 @@ public:
 	                              MIDIMatchType match, int32_t channel, int32_t value, int32_t noteCode,
 	                              bool* doingMidiThru);
 
+	void offerReceivedPitchBendToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+	                                 MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
+	                                 uint8_t data2, bool* doingMidiThru);
+
 protected:
 	bool isKit() { return true; }
 

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -125,6 +125,11 @@ public:
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
 	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
 
+	void receivedNoteForKit(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on, int32_t channel,
+	                        int32_t note, int32_t velocity, bool shouldRecordNotes, bool* doingMidiThru, Clip* clip);
+
+	Drum* getDrumFromNoteCode(Clip* clip, int32_t noteCode);
+
 protected:
 	bool isKit() { return true; }
 
@@ -132,7 +137,6 @@ private:
 	int32_t readDrumFromFile(Song* song, Clip* clip, DrumType drumType, int32_t readAutomationUpToPos);
 	void writeDrumToFile(Drum* thisDrum, ParamManager* paramManagerForDrum, bool savingSong, int32_t* selectedDrumIndex,
 	                     int32_t* drumIndex, Song* song);
-
 	void removeDrumFromLinkedList(Drum* drum);
 	void drumRemoved(Drum* drum);
 	void possiblySetSelectedDrumAndRefreshUI(Drum* thisDrum);

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -69,7 +69,9 @@ public:
 	                             int32_t channel, int32_t value, int32_t noteCode, bool* doingMidiThru);
 	void receivedAftertouchForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
 	                               MIDIMatchType match, uint8_t channel, uint8_t value);
-
+	void receivedCCForInputChannel(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+	                               MIDIMatchType match, uint8_t channel, uint8_t ccNumber, uint8_t value,
+	                               bool* doingMidiThru, Clip* clip);
 	void choke();
 	void resyncLFOs();
 	void removeDrum(Drum* drum);

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -69,9 +69,9 @@ public:
 	                             int32_t channel, int32_t value, int32_t noteCode, bool* doingMidiThru);
 	void receivedAftertouchForDrum(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, Drum* thisDrum,
 	                               MIDIMatchType match, uint8_t channel, uint8_t value);
-	void receivedCCForInputChannel(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
-	                               MIDIMatchType match, uint8_t channel, uint8_t ccNumber, uint8_t value,
-	                               bool* doingMidiThru, Clip* clip);
+	void receivedCCForKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+	                      MIDIMatchType match, uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru,
+	                      Clip* clip);
 	void choke();
 	void resyncLFOs();
 	void removeDrum(Drum* drum);
@@ -126,17 +126,16 @@ public:
 	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
 
 	void receivedNoteForKit(ModelStackWithTimelineCounter* modelStack, MIDIDevice* fromDevice, bool on, int32_t channel,
-	                        int32_t note, int32_t velocity, bool shouldRecordNotes, bool* doingMidiThru, Clip* clip);
-
-	Drum* getDrumFromNoteCode(Clip* clip, int32_t noteCode);
+	                        int32_t note, int32_t velocity, bool shouldRecordNotes, bool* doingMidiThru,
+	                        InstrumentClip* clip);
 
 	void receivedAftertouchForKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
 	                              MIDIMatchType match, int32_t channel, int32_t value, int32_t noteCode,
 	                              bool* doingMidiThru);
 
-	void offerReceivedPitchBendToKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-	                                 MIDIDevice* fromDevice, MIDIMatchType match, uint8_t channel, uint8_t data1,
-	                                 uint8_t data2, bool* doingMidiThru);
+	void receivedPitchBendForKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+	                             MIDIMatchType match, uint8_t channel, uint8_t data1, uint8_t data2,
+	                             bool* doingMidiThru);
 
 protected:
 	bool isKit() { return true; }
@@ -148,4 +147,5 @@ private:
 	void removeDrumFromLinkedList(Drum* drum);
 	void drumRemoved(Drum* drum);
 	void possiblySetSelectedDrumAndRefreshUI(Drum* thisDrum);
+	Drum* getDrumFromNoteCode(InstrumentClip* clip, int32_t noteCode);
 };

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -130,6 +130,10 @@ public:
 
 	Drum* getDrumFromNoteCode(Clip* clip, int32_t noteCode);
 
+	void receivedAftertouchForKit(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDIDevice* fromDevice,
+	                              MIDIMatchType match, int32_t channel, int32_t value, int32_t noteCode,
+	                              bool* doingMidiThru);
+
 protected:
 	bool isKit() { return true; }
 


### PR DESCRIPTION
The kit offer functions don't rely on the midi follow class and make more sense in kit. Moving them enables future work to learn a whole kit to a single input midi channel using a similar mechanism to midi follow