### PR TITLE
Improve sysex logging script

### DIFF
--- a/scripts/tasks/task-sysex-logging.py
+++ b/scripts/tasks/task-sysex-logging.py
@@ -64,6 +64,7 @@ def sysex_console(port):
         data[4] = 0x01  # 0x01 = enable, 0x00 = disable
         data[5] = 0xF7
         midiout.send_message(data)
+    del midiout
 
     midiin = rtmidi.MidiIn()
     midiin.open_port(port)
@@ -91,7 +92,7 @@ def sysex_console(port):
                 print(decoded)
         else:
             # add a short sleep so the while loop doesn't hammer your cpu
-            time.sleep(0.001)
+            time.sleep(0.01)
 
 
 def main():


### PR DESCRIPTION
Reduced the sleep wait time so it is not so CPU intensive when there are no messages to read. Free up the midiout connection when the config message was already sent, as per the docs from rtmidi