### PR TITLE
Document Deluge Menu Hierarchies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Deluge Community Firmware Change Log
 
-> To find a detailed list of how to use each feature, check
->
-here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/community_features.md)
+> To find a detailed list of how to use each feature, check here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/community_features.md)
 
 ## c1.2.0 Chopin
 
@@ -88,6 +86,7 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
 - Restricted changing Synth/MIDI/CV Instrument CLip types to the Kit Instrument Clip Type and vice versa if the clip is not empty.
 - Added retrigger to all keyboard views.
 - Added a new default setting that controls which playback mode new slices of a kit will get. 
+- Created a new menu hierarchies document that documents the Deluge menu structure for OLED and 7SEG and can be used as a reference for navigating the various menu's. See: [Menu Hierarchies](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/menu_hierarchies.md)
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -5,7 +5,7 @@ This document will document the menu structure hierarchy currently in place in t
 The hierarchy's illustrated below will follow the format of OLED (7SEG) in order to show the Menu name on OLED and the Menu name on 7SEG in brackets.
 
 <details>
-<summary>Settings menu</summary>
+<summary>Settings Menu</summary>
 
 The Settings menu is accessible from anywhere on the Deluge by pressing `SHIFT + SELECT ENCODER`
 

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -399,7 +399,117 @@ Firmware Version (FIRM)
 
 The Song menu is accessible from Arranger View and Song View by pressing on the `SELECT ENCODER`
 
-** Menu hierarchy to be added **
+The Song menu contains the following menu hierarchy:
+
+<blockquote>
+<details><summary>Master</summary>
+
+	- Volume
+	- Pan
+</details>
+<details><summary>Filters</summary>
+
+	- LPF
+		- Frequency
+		- Resonance
+		- Mode
+			- 12DB Ladder
+			- 24DB Ladder
+			- Drive
+			- SVF Bandpass
+			- SVF Notch
+	- HPF
+		- Frequency
+		- Resonance
+		- Mode
+			- SVF Bandpass
+			- SVF Notch
+			- HP Ladder
+	- Filter Route
+		- HPF2LPF
+		- LPF2HPF
+		- PARALLEL
+</details>
+<details><summary>FX</summary>
+
+	- EQ
+		- Bass
+		- Treble
+		- Bass Frequency
+		- Treble Frequency
+	- Delay
+		- Amount
+		- Rate
+		- Pingpong
+			- Disabled
+			- Enabled
+		- Type
+			- Digital
+			- Analog
+		- Sync
+		NOTE: These options can change depending on how your default resolution is set
+				
+			- Off
+			- 2-Bar
+			- 1-Bar
+			- 2nd-Notes
+			- 4th-Notes
+			- 8th-Notes
+			- 16th-Notes
+			- 32nd-Notes
+			- 64th-Notes
+			- 128th-Notes
+			- 2-Bar-TPLTS
+			- 1-Bar-TPLTS
+			- 2nd-TPLTS
+			- 4th-TPLTS
+			- 8th-TPLTS
+			- 16th-TPLTS
+			- 32nd-TPLTS
+			- 64th-TPLTS
+			- 128th-TPLTS
+			- 2-Bar-DTTED
+			- 1-Bar-DTTED
+			- 2nd-DTTED
+			- 4th-DTTED
+			- 8th-DTTED
+			- 16th-DTTED
+			- 32nd-DTTED
+			- 64th-DTTED
+			- 128th-DTTED
+	- Reverb
+		- Amount
+		- Model
+		- Room Size (if Freeverb is Selected) or Time (if Mutable is Selected)
+		- Damping
+		- Width (if Freeverb is Selected) or Diffusion (if Mutable is Selected)
+		- Pan
+		- Reverb Sidechain
+			- Volume Ducking
+	
+	- Mod-FX
+		- Type
+			- Disabled
+			- Flanger
+			- Chorus
+			- Phaser
+			- Stereo Chorus
+			- Grain (if enabled in Community Features menu)
+		- Rate
+		- Depth (if Chorus, Phaser or Grain is selected)
+		- Feedback (if Flanger, Phaser or Grain is selected)
+		- Offset (if Chorus or Grain is selected)
+	- Distortion
+		- Decimation
+		- Bitcrush
+</details>
+<details><summary>MIDI Loopback</summary>
+
+		- Disabled
+		- Enabled
+
+</details>		
+
 </details>
 
 <details>
@@ -407,7 +517,24 @@ The Song menu is accessible from Arranger View and Song View by pressing on the 
 
 The Perform FX menu is accessible from Performance View by pressing on the `SELECT ENCODER`
 
-** Menu hierarchy to be added **
+The Perform FX menu contains the following menu hierarchy:
+
+<blockquote>
+<details><summary>Editing Mode</summary>
+
+	- Disabled
+	- Value
+	- Param
+</details>
+<details><summary>Filters</summary>
+
+	- See Song menu hierarchy above for break-down of Filters menu
+</details>
+<details><summary>FX</summary>
+
+	- See Song menu hierarchy above for break-down of FX menu
+</details>		
+
 </details>
 
 <details>

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -12,176 +12,176 @@ The Settings menu is accessible from anywhere on the Deluge by pressing `SHIFT +
 The Settings menu contains the following menu hierarchy:
 
 - CV
-	- CV Output 1
-		- Volts per Octave
-		- Transpose
-	- CV Output 2
-		- Volts per Octave
-		- Transpose
+	- CV Output 1 (OUT1)
+		- Volts per Octave (VOLT)
+		- Transpose (TRAN)
+	- CV Output 2 (OUT2)
+		- Volts per Octave (VOLT)
+		- Transpose (TRAN)
 - Gate
-	- Gate Output 1
-		- V-Trig
-		- S-Trig
-	- Gate Output 2
-		- V-Trig
-		- S-Trig
-	- Gate Output 3
-		- V-Trig
-		- S-Trig
-	- Gate Output 4
-		- V-Trig
-		- S-Trig
-	- Minimum Off-Time
-- Trigger Clock
-	- Input
-		- PPQN
-		- Auto-Start
-			- Disabled
-			- Enabled
-	- Output
+	- Gate Output 1 (OUT1)
+		- V-Trig (VTRI)
+		- S-Trig (STRI)
+	- Gate Output 2 (OUT2)
+		- V-Trig (VTRI)
+		- S-Trig (STRI)
+	- Gate Output 3 (OUT3)
+		- V-Trig (VTRI)
+		- S-Trig (STRI)
+	- Gate Output 4 (OUT4)
+		- V-Trig (VTRI)
+		- S-Trig (STRI)
+	- Minimum Off-Time (OFFT)
+- Trigger Clock (TCLO)
+	- Input (IN)
+		- PPQN 
+		- Auto-Start (AUTO)
+			- Disabled (ON)
+			- Enabled (OFF)
+	- Output (OUT)
 		- PPQN
 - MIDI
-	- Clock
-		- Input
+	- Clock (CLK)
+		- Input (IN)
+			- Disabled (ON)
+			- Enabled (OFF)
+		- Output (OUT)
+			- Disabled (ON)
+			- Enabled (OFF)
+		- Tempo Magnitude Matching (MAGN)
 			- Disabled
 			- Enabled
-		- Output
-			- Disabled
-			- Enabled
-		- Tempo Magnitude Matching
-			- Disabled
-			- Enabled
-	- MIDI-Follow
-		- Channel
-			- Channel A
-			- Channel B
-			- Channel C
-		- Kit Root Note
-		- Feedback
-			- Channel
-			- Automation Feedback
-				- Disabled
+	- MIDI-Follow (FOLO)
+		- Channel (CHAN)
+			- Channel A (A)
+			- Channel B (B)
+			- Channel C (C)
+		- Kit Root Note (KIT)
+		- Feedback (FEED)
+			- Channel (CHAN)
+			- Automation Feedback (AUTO)
+				- Disabled (OFF)
 				- Low
-				- Medium
+				- Medium (MEDI)
 				- High
-			- Filter Responses
-				- Disabled
-				- Enabled
-		- Display Param
-			- Disabled
-			- Enabled
-	- Select Kit Row
-		- Disabled
-		- Enabled
-	- MIDI-Thru
-		- Disabled
-		- Enabled
-	- Takeover
+			- Filter Responses (FLTR)
+				- Disabled (OFF)
+				- Enabled (ON)
+		- Display Param (DISP)
+			- Disabled (ON)
+			- Enabled (OFF)
+	- Select Kit Row (KROW)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- MIDI-Thru (THRU)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- Takeover (TOVR)
 		- Jump
-		- Pickup
-		- Scale
-	- Commands
+		- Pickup (PICK)
+		- Scale (SCAL)
+	- Commands (CMD)
 		- Play
-		- Restart
-		- Record
-		- Tap Tempo
+		- Restart (REST)
+		- Record (REC)
+		- Tap Tempo (TAP)
 		- Undo
 		- Redo
 		- Loop
-		- Layering Loop
+		- Layering Loop (LAYE)
 		- Fill
-	- Differentiate Inputs
-		- Disabled
-		- Enabled
-	- Devices
-		- DIN Ports
+	- Differentiate Inputs (DIFF)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- Devices (DEVI)
+		- DIN Ports (DIN)
 			- MPE
 				- In
-					- Lower Zone
-					- Upper Zone
+					- Lower Zone (LOWE)
+					- Upper Zone (UPPE)
 				- Out
-					- Lower Zone
-					- Upper Zone					
-			- Velocity
-			- Clock
-				- Disabled
-				- Enabled
+					- Lower Zone (LOWE)
+					- Upper Zone (UPPE)				
+			- Velocity (VELO)
+			- Clock (CLK)
+				- Disabled (OFF)
+				- Enabled (ON)
 		- Loopback
 			- MPE
 				- In
-					- Lower Zone
-					- Upper Zone
+					- Lower Zone (LOWE)
+					- Upper Zone (UPPE)
 				- Out
-					- Lower Zone
-					- Upper Zone					
-			- Velocity
-			- Clock
-				- Disabled
-				- Enabled
-- Defaults
+					- Lower Zone (LOWE)
+					- Upper Zone (UPPE)				
+			- Velocity (VELO)
+			- Clock (CLK)
+				- Disabled (OFF)
+				- Enabled (ON)
+- Defaults (DEFA)
 	- UI
 		- Song
-			- Layout
+			- Layout (LAYT)
 				- Rows
 				- Grid
 			- Grid
-				- Default Active Mode
-					- Selection
-					- Green
+				- Default Active Mode (DEFM)
+					- Selection (SELE)
+					- Green (GREE)
 					- Blue
-				- Select In Green Mode
-					- Disabled
-					- Enabled
-				- Empty Pads
-					- Unarm
-					- Create + Record
-		- Keyboard
-			- Layout
-				- Isomorphic
-				- In-Key
-	- Automation
-		- Interpolation
-			- Disabled
-			- Enabled
-		- Clear
-			- Disabled
-			- Enabled
-		- Shift
-			- Disabled
-			- Enabled
-		- Nudge Note
-			- Disabled
-			- Enabled
-		- Disable Audition Pad Shortcuts
-			- Disabled
-			- Enabled
-	- Tempo
-	- Swing
+				- Select In Green Mode (GREE)
+					- Disabled (OFF)
+					- Enabled (ON)
+				- Empty Pads (EMPT)
+					- Unarm (UNAR)
+					- Create + Record (CREA)
+		- Keyboard (KEY)
+			- Layout (LAYT)
+				- Isomorphic (ISO)
+				- In-Key (INKY)
+	- Automation (AUTO)
+		- Interpolation (INTE)
+			- Disabled (OFF)
+			- Enabled (ON)
+		- Clear (CLEA)
+			- Disabled (OFF)
+			- Enabled (ON)
+		- Shift (SHIF)
+			- Disabled (Off)
+			- Enabled (ON)
+		- Nudge Note (NUDG)
+			- Disabled (OFF)
+			- Enabled (ON)
+		- Disable Audition Pad Shortcuts (SCUT)
+			- Disabled (OFF)
+			- Enabled (ON)
+	- Tempo (TEMP)
+	- Swing (SWIN)
 	- Key
-	- Scale
-		- Major
-		- Minor
-		- Dorian
-		- Phrygian
-		- Lydian
-		- Mixolydian
-		- Locrian
-		- Melodic Minor
-		- Harmonic Minor
-		- Hungarian Minor
-		- Marva
-		- Arabian
-		- Whole Tone
-		- Blues
-		- Pentatonic Minor
-		- Hirajoshi
-		- Random
+	- Scale (SCAL)
+		- Major (MAJO)
+		- Minor (MINO)
+		- Dorian (DORI)
+		- Phrygian (PHRY)
+		- Lydian (LYDI)
+		- Mixolydian (MIXO)
+		- Locrian (LOCR)
+		- Melodic Minor (MELO)
+		- Harmonic Minor (HARM)
+		- Hungarian Minor (HUNG)
+		- Marva (MARV)
+		- Arabian (ARAB)
+		- Whole Tone (WHOL)
+		- Blues (BLUE)
+		- Pentatonic Minor (PENT)
+		- Hirajoshi (HIRA)
+		- Random (RAND)
 		- None
-	- Velocity
-	- Resolution
-	- Bend Range
-	- Metronome
-- Swing Interval
+	- Velocity (VELO)
+	- Resolution (RESO)
+	- Bend Range (BEND)
+	- Metronome (METR)
+- Swing Interval (SWIN) - NOTE: These options can change depending on how your default resolution is set
 	- 2-Bar
 	- 1-Bar
 	- 2nd-Notes
@@ -210,153 +210,153 @@ The Settings menu contains the following menu hierarchy:
 	- 64th-DTTED
 	- 128th-DTTED
 - Pads
-	- Shortcut Version
+	- Shortcut Version (SHOR)
 		- 1.0
 		- 3.0
-	- Keyboard for Text
-		- QWERTY
-		- AZERTY
-		- QWERTZ
-	- Colours
-		- Active
+	- Keyboard for Text (KEYB)
+		- QWERTY (QWER)
+		- AZERTY (AZER)
+		- QWERTZ (QRTZ)
+	- Colours (COLO)
+		- Active (ACTI)
 			- Red
-			- Green
+			- Green (GREEN)
 			- Blue
-			- Yellow
+			- Yellow (YELL)
 			- Cyan
-			- Purple
-			- Amber
-			- White
+			- Purple (PURP)
+			- Amber (AMBE)
+			- White (WHIT)
 			- Pink
-		- Stopped
+		- Stopped (STOP)
 			- Red
-			- Green
+			- Green (GREE)
 			- Blue
-			- Yellow
+			- Yellow (YELL)
 			- Cyan
-			- Purple
-			- Amber
-			- White
+			- Purple (PURP)
+			- Amber (AMBE)
+			- White (WHIT)
 			- Pink
-		- Muted
+		- Muted (MUTE)
 			- Red
-			- Green
+			- Green (GREE)
 			- Blue
-			- Yellow
+			- Yellow (YELL)
 			- Cyan
-			- Purple
-			- Amber
-			- White
+			- Purple (PURP)
+			- Amber (AMBE)
+			- White (WHIT)
 			- Pink
 		- Soloed 
 			- Red
-			- Green
+			- Green (GREE)
 			- Blue
-			- Yellow
+			- Yellow (YELL)
 			- Cyan
-			- Purple
-			- Amber
-			- White
-			- Pink	
-- Sample Preview
-	- Disabled
-	- Conditional
-	- Enabled
-- Play-Cursor
+			- Purple (PURP)
+			- Amber (AMBE)
+			- White (WHIT)
+			- Pink
+- Sample Preview (PREV)
+	- Disabled (OFF)
+	- Conditional (COND)
+	- Enabled (ON)
+- Play-Cursor (CURS)
 	- Fast
-	- Disabled
+	- Disabled (OFF)
 	- Slow
-- Recording
-	- Count-in
-		- Disabled
-		- Enabled
-	- Quantization
+- Recording (RECO)
+	- Count-in (COUN)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- Quantization (QUAN)
 		- Off
-		- 4-Bar
-		- 2-Bar
-		- 1-Bar
-		- 2nd-Notes
-		- 4th-Notes
-		- 8th-Notes
-		- 16th-Notes
-		- 32nd-Notes
-		- 64th-Notes
-		- 128th-Notes
-		- 256th-Notes
-		- 512nd-Notes
-		- 1024th-Notes
-		- 2048th-Notes
-		- 4096th-Notes
-		- 8192nd-Notes
-		- 16834th-Notes
-		- 32768th-Notes
-		- 65536th-Notes
-		- 131072nd-Notes
-		- 262144th-Notes
-		- 524288th-Notes
-		- 1048576th-Nptes
-		- 2097152nd-Notes
-		- 4194304th-Notes
-		- 8388608th-Notes
-		- 16777216th-Notes
-	- Loop Margins
-		- Disabled
-		- Enabled
-	- Sampling Monitoring
-		- Conditional
-		- Enabled
-		- Disabled
-- Community Features
-	- Drum Randomizer
+		- 4-Bar (4BAR)
+		- 2-Bar (2BAR)
+		- 1-Bar (1BAR)
+		- 2nd-Notes (2ND)
+		- 4th-Notes (4TH)
+		- 8th-Notes (8TH)
+		- 16th-Notes (16TH)
+		- 32nd-Notes (32ND)
+		- 64th-Notes (64th)
+		- 128th-Notes (128T)
+		- 256th-Notes (256T)
+		- 512nd-Notes (512T)
+		- 1024th-Notes (1024)
+		- 2048th-Notes (2048)
+		- 4096th-Notes (4096)
+		- 8192nd-Notes (8192)
+		- 16834th-Notes (TINY)
+		- 32768th-Notes (TINY)
+		- 65536th-Notes (TINY)
+		- 131072nd-Notes (TINY)
+		- 262144th-Notes (TINY)
+		- 524288th-Notes (TINY)
+		- 1048576th-Nptes (TINY)
+		- 2097152nd-Notes (TINY)
+		- 4194304th-Notes (TINY)
+		- 8388608th-Notes (TINY)
+		- 16777216th-Notes (TINY)
+	- Loop Margins (MARG)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- Sampling Monitoring (MONI)
+		- Conditional (COND)
+		- Enabled (ON)
+		- Disabled (OFF)
+- Community Features (FEAT)
+	- Drum Randomizer (DRUM)
 		- OFF
 		- ON
-	- Fine Tempo Knob
+	- Fine Tempo Knob (TEMP)
 		- OFF
 		- ON
-	- Quantize
+	- Quantize (QUAN)
 		- OFF
 		- ON
-	- Mod. Depth Decimals
+	- Mod. Depth Decimals (MOD.)
 		- OFF
 		- ON
-	- Catch Notes
+	- Catch Notes (CATC)
 		- OFF
 		- ON
-	- Delete Unused Kit Rows
+	- Delete Unused Kit Rows (UNUS)
 		- OFF
 		- ON
-	- Alternative Golden Knob Delay Params
+	- Alternative Golden Knob Delay Params (DELA)
 		- OFF
 		- ON
-	- Stutter Rate Quantize
+	- Stutter Rate Quantize (STUT)
 		- OFF
 		- ON
-	- Allow Insecure Develop Sysex Messages
+	- Allow Insecure Develop Sysex Messages (SYSX)
 		- OFF
 		- ON
-	- Sync Scaling Action
-		- Sync Scaling
-		- Fill Mode
-	- Highlight Incoming Notes
+	- Sync Scaling Action (SCAL)
+		- Sync Scaling (SCAL)
+		- Fill Mode (FILL)
+	- Highlight Incoming Notes (HIGH)
 		- OFF
 		- ON
-	- Display Norns Layout
+	- Display Norns Layout (NORN)
 		- OFF
 		- ON
-	- Sticky Shift
+	- Sticky Shift (STIC)
 		- OFF
 		- ON
-	- Light Shift
+	- Light Shift (LIGH)
 		- OFF
 		- ON
-	- Enable Grain FX
+	- Enable Grain FX (GRFX)
 		- OFF
 		- ON
-	- Emulated Display
-		- OLED
-		- Toggle
-		- 7SEG 
-- Firmware Version
+	- Emulated Display (EMUL)
+		- OLED (OLED)
+		- Toggle (TOGL)
+		- 7SEG (7SEG)
+- Firmware Version (FIRM)
 </details>
 
 <details>

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -1,0 +1,400 @@
+# Deluge Menu Hierarchies
+
+This document will document the menu structure hierarchy currently in place in the deluge in order to help users understand what exists in the menu structure and how the hierarchy strings are defined for OLED and 7SEG users.
+
+The hierarchy's illustrated below will follow the format of OLED (7SEG) in order to show the Menu name on OLED and the Menu name on 7SEG in brackets.
+
+# Settings menu
+
+The Settings menu is accessible from anywhere on the Deluge by pressing `SHIFT + SELECT ENCODER`
+
+The Settings menu contains the following menu hierarchy:
+
+- CV
+	- CV Output 1
+		- Volts per Octave
+		- Transpose
+	- CV Output 2
+		- Volts per Octave
+		- Transpose
+- Gate
+	- Gate Output 1
+		- V-Trig
+		- S-Trig
+	- Gate Output 2
+		- V-Trig
+		- S-Trig
+	- Gate Output 3
+		- V-Trig
+		- S-Trig
+	- Gate Output 4
+		- V-Trig
+		- S-Trig
+	- Minimum Off-Time
+- Trigger Clock
+	- Input
+		- PPQN
+		- Auto-Start
+			- Disabled
+			- Enabled
+	- Output
+		- PPQN
+- MIDI
+	- Clock
+		- Input
+			- Disabled
+			- Enabled
+		- Output
+			- Disabled
+			- Enabled
+		- Tempo Magnitude Matching
+			- Disabled
+			- Enabled
+	- MIDI-Follow
+		- Channel
+			- Channel A
+			- Channel B
+			- Channel C
+		- Kit Root Note
+		- Feedback
+			- Channel
+			- Automation Feedback
+				- Disabled
+				- Low
+				- Medium
+				- High
+			- Filter Responses
+				- Disabled
+				- Enabled
+		- Display Param
+			- Disabled
+			- Enabled
+	- Select Kit Row
+		- Disabled
+		- Enabled
+	- MIDI-Thru
+		- Disabled
+		- Enabled
+	- Takeover
+		- Jump
+		- Pickup
+		- Scale
+	- Commands
+		- Play
+		- Restart
+		- Record
+		- Tap Tempo
+		- Undo
+		- Redo
+		- Loop
+		- Layering Loop
+		- Fill
+	- Differentiate Inputs
+		- Disabled
+		- Enabled
+	- Devices
+		- DIN Ports
+			- MPE
+				- In
+					- Lower Zone
+					- Upper Zone
+				- Out
+					- Lower Zone
+					- Upper Zone					
+			- Velocity
+			- Clock
+				- Disabled
+				- Enabled
+		- Loopback
+			- MPE
+				- In
+					- Lower Zone
+					- Upper Zone
+				- Out
+					- Lower Zone
+					- Upper Zone					
+			- Velocity
+			- Clock
+				- Disabled
+				- Enabled
+- Defaults
+	- UI
+		- Song
+			- Layout
+				- Rows
+				- Grid
+			- Grid
+				- Default Active Mode
+					- Selection
+					- Green
+					- Blue
+				- Select In Green Mode
+					- Disabled
+					- Enabled
+				- Empty Pads
+					- Unarm
+					- Create + Record
+		- Keyboard
+			- Layout
+				- Isomorphic
+				- In-Key
+	- Automation
+		- Interpolation
+			- Disabled
+			- Enabled
+		- Clear
+			- Disabled
+			- Enabled
+		- Shift
+			- Disabled
+			- Enabled
+		- Nudge Note
+			- Disabled
+			- Enabled
+		- Disable Audition Pad Shortcuts
+			- Disabled
+			- Enabled
+	- Tempo
+	- Swing
+	- Key
+	- Scale
+		- Major
+		- Minor
+		- Dorian
+		- Phrygian
+		- Lydian
+		- Mixolydian
+		- Locrian
+		- Melodic Minor
+		- Harmonic Minor
+		- Hungarian Minor
+		- Marva
+		- Arabian
+		- Whole Tone
+		- Blues
+		- Pentatonic Minor
+		- Hirajoshi
+		- Random
+		- None
+	- Velocity
+	- Resolution
+	- Bend Range
+	- Metronome
+- Swing Interval
+	- 2-Bar
+	- 1-Bar
+	- 2nd-Notes
+	- 4th-Notes
+	- 8th-Notes
+	- 16th-Notes
+	- 32nd-Notes
+	- 64th-Notes
+	- 128th-Notes
+	- 2-Bar-TPLTS
+	- 1-Bar-TPLTS
+	- 2nd-TPLTS
+	- 4th-TPLTS
+	- 8th-TPLTS
+	- 16th-TPLTS
+	- 32nd-TPLTS
+	- 64th-TPLTS
+	- 128th-TPLTS
+	- 2-Bar-DTTED
+	- 1-Bar-DTTED
+	- 2nd-DTTED
+	- 4th-DTTED
+	- 8th-DTTED
+	- 16th-DTTED
+	- 32nd-DTTED
+	- 64th-DTTED
+	- 128th-DTTED
+- Pads
+	- Shortcut Version
+		- 1.0
+		- 3.0
+	- Keyboard for Text
+		- QWERTY
+		- AZERTY
+		- QWERTZ
+	- Colours
+		- Active
+			- Red
+			- Green
+			- Blue
+			- Yellow
+			- Cyan
+			- Purple
+			- Amber
+			- White
+			- Pink
+		- Stopped
+			- Red
+			- Green
+			- Blue
+			- Yellow
+			- Cyan
+			- Purple
+			- Amber
+			- White
+			- Pink
+		- Muted
+			- Red
+			- Green
+			- Blue
+			- Yellow
+			- Cyan
+			- Purple
+			- Amber
+			- White
+			- Pink
+		- Soloed 
+			- Red
+			- Green
+			- Blue
+			- Yellow
+			- Cyan
+			- Purple
+			- Amber
+			- White
+			- Pink	
+- Sample Preview
+	- Disabled
+	- Conditional
+	- Enabled
+- Play-Cursor
+	- Fast
+	- Disabled
+	- Slow
+- Recording
+	- Count-in
+		- Disabled
+		- Enabled
+	- Quantization
+		- Off
+		- 4-Bar
+		- 2-Bar
+		- 1-Bar
+		- 2nd-Notes
+		- 4th-Notes
+		- 8th-Notes
+		- 16th-Notes
+		- 32nd-Notes
+		- 64th-Notes
+		- 128th-Notes
+		- 256th-Notes
+		- 512nd-Notes
+		- 1024th-Notes
+		- 2048th-Notes
+		- 4096th-Notes
+		- 8192nd-Notes
+		- 16834th-Notes
+		- 32768th-Notes
+		- 65536th-Notes
+		- 131072nd-Notes
+		- 262144th-Notes
+		- 524288th-Notes
+		- 1048576th-Nptes
+		- 2097152nd-Notes
+		- 4194304th-Notes
+		- 8388608th-Notes
+		- 16777216th-Notes
+	- Loop Margins
+		- Disabled
+		- Enabled
+	- Sampling Monitoring
+		- Conditional
+		- Enabled
+		- Disabled
+- Community Features
+	- Drum Randomizer
+		- OFF
+		- ON
+	- Fine Tempo Knob
+		- OFF
+		- ON
+	- Quantize
+		- OFF
+		- ON
+	- Mod. Depth Decimals
+		- OFF
+		- ON
+	- Catch Notes
+		- OFF
+		- ON
+	- Delete Unused Kit Rows
+		- OFF
+		- ON
+	- Alternative Golden Knob Delay Params
+		- OFF
+		- ON
+	- Stutter Rate Quantize
+		- OFF
+		- ON
+	- Allow Insecure Develop Sysex Messages
+		- OFF
+		- ON
+	- Sync Scaling Action
+		- Sync Scaling
+		- Fill Mode
+	- Highlight Incoming Notes
+		- OFF
+		- ON
+	- Display Norns Layout
+		- OFF
+		- ON
+	- Sticky Shift
+		- OFF
+		- ON
+	- Light Shift
+		- OFF
+		- ON
+	- Enable Grain FX
+		- OFF
+		- ON
+	- Emulated Display
+		- OLED
+		- Toggle
+		- 7SEG 
+- Firmware Version
+
+# Song Menu
+
+The Song menu is accessible from Arranger View and Song View by pressing on the `SELECT ENCODER`
+
+** Menu hierarchy to be added **
+
+# Perform FX Menu
+
+The Perform FX menu is accessible from Performance View by pressing on the `SELECT ENCODER`
+
+** Menu hierarchy to be added **
+
+# Sound Menu
+
+The Sound menu is accessible from Synth Clips and Kit clips when affect entire is disabled and a kit row is selected by pressing on the `SELECT ENCODER`
+
+** Menu hierarchy to be added **
+
+# Kit FX Menu
+
+The Kit FX menu is accessible from Kit clips when affect entire is enabled by pressing on the `SELECT ENCODER`
+
+** Menu hierarchy to be added **
+
+# MIDI Instrument Menu
+
+The MIDI Instrument menu is accessible from MIDI clips by pressing on the `SELECT ENCODER`
+
+** Menu hierarchy to be added **
+
+# CV Instrument Menu
+
+The CV Instrument menu is accessible from CV clips by pressing on the `SELECT ENCODER`
+
+** Menu hierarchy to be added **
+
+# Audio Clip Menu
+
+The Audio Clip menu is accessible from Audio clips by pressing on the `SELECT ENCODER`
+
+** Menu hierarchy to be added **

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -402,50 +402,50 @@ The Song menu is accessible from Arranger View and Song View by pressing on the 
 The Song menu contains the following menu hierarchy:
 
 <blockquote>
-<details><summary>Master</summary>
+<details><summary>Master (MASTR)</summary>
 
-	- Volume
+	- Volume (VOLU)
 	- Pan
 </details>
-<details><summary>Filters</summary>
+<details><summary>Filters (FLTR)</summary>
 
 	- LPF
-		- Frequency
-		- Resonance
-		- Mode
-			- 12DB Ladder
-			- 24DB Ladder
-			- Drive
-			- SVF Bandpass
-			- SVF Notch
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Mode (MODE)
+			- 12DB Ladder (LA12)
+			- 24DB Ladder (LA24)
+			- Drive (DRIV)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
 	- HPF
-		- Frequency
-		- Resonance
-		- Mode
-			- SVF Bandpass
-			- SVF Notch
-			- HP Ladder
-	- Filter Route
-		- HPF2LPF
-		- LPF2HPF
-		- PARALLEL
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Mode (MODE)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
+			- HP Ladder (HP_L)
+	- Filter Route (ROUT)
+		- HPF2LPF (HPF2)
+		- LPF2HPF (LPF2)
+		- PARALLEL (PARA)
 </details>
 <details><summary>FX</summary>
 
 	- EQ
 		- Bass
-		- Treble
-		- Bass Frequency
-		- Treble Frequency
-	- Delay
-		- Amount
+		- Treble (TREB)
+		- Bass Frequency (BAFR)
+		- Treble Frequency (TRFR)
+	- Delay (DELA)
+		- Amount (AMOU)
 		- Rate
-		- Pingpong
-			- Disabled
-			- Enabled
+		- Pingpong (PING)
+			- Disabled (OFF)
+			- Enabled (ON)
 		- Type
-			- Digital
-			- Analog
+			- Digital (DIGI)
+			- Analog (ANA)
 		- Sync
 		NOTE: These options can change depending on how your default resolution is set
 				
@@ -477,36 +477,38 @@ The Song menu contains the following menu hierarchy:
 			- 32nd-DTTED
 			- 64th-DTTED
 			- 128th-DTTED
-	- Reverb
-		- Amount
-		- Model
-		- Room Size (if Freeverb is Selected) or Time (if Mutable is Selected)
-		- Damping
-		- Width (if Freeverb is Selected) or Diffusion (if Mutable is Selected)
+	- Reverb (REVE)
+		- Amount (AMOU)
+  			- Freeverb (FVRB)
+     			- Mutable (MTBL)
+		- Model (MODE)
+		- Room Size (SIZE) (if Freeverb is Selected) or Time (if Mutable is Selected)
+		- Damping (DAMP)
+		- Width (WIDT) (if Freeverb is Selected) or Diffusion (DIFF) (if Mutable is Selected)
 		- Pan
-		- Reverb Sidechain
-			- Volume Ducking
+		- Reverb Sidechain (SIDE)
+			- Volume Ducking (VOLU)
 	
-	- Mod-FX
+	- Mod-FX (MODU)
 		- Type
-			- Disabled
-			- Flanger
-			- Chorus
-			- Phaser
-			- Stereo Chorus
-			- Grain (if enabled in Community Features menu)
+			- Disabled (OFF)
+			- Flanger (FLAN)
+			- Chorus (CHOR)
+			- Phaser (PHAS)
+			- Stereo Chorus (S.CHO)
+			- Grain (GRAI) (if enabled in Community Features menu)
 		- Rate
-		- Depth (if Chorus, Phaser or Grain is selected)
-		- Feedback (if Flanger, Phaser or Grain is selected)
-		- Offset (if Chorus or Grain is selected)
-	- Distortion
-		- Decimation
-		- Bitcrush
+		- Depth (DEPT) (if Chorus, Phaser or Grain is selected)
+		- Feedback (FEED) (if Flanger, Phaser or Grain is selected)
+		- Offset (OFFS) (if Chorus or Grain is selected)
+	- Distortion (DIST)
+		- Decimation (DECI)
+		- Bitcrush (CRUS)
 </details>
-<details><summary>MIDI Loopback</summary>
+<details><summary>MIDI Loopback (M LP)</summary>
 
-		- Disabled
-		- Enabled
+		- Disabled (OFF)
+		- Enabled (ON)
 
 </details>		
 

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -4,7 +4,8 @@ This document will document the menu structure hierarchy currently in place in t
 
 The hierarchy's illustrated below will follow the format of OLED (7SEG) in order to show the Menu name on OLED and the Menu name on 7SEG in brackets.
 
-# Settings menu
+<details>
+<summary>Settings menu</summary>
 
 The Settings menu is accessible from anywhere on the Deluge by pressing `SHIFT + SELECT ENCODER`
 
@@ -356,45 +357,62 @@ The Settings menu contains the following menu hierarchy:
 		- Toggle
 		- 7SEG 
 - Firmware Version
+</details>
 
-# Song Menu
+<details>
+<summary>Song Menu</summary>
 
 The Song menu is accessible from Arranger View and Song View by pressing on the `SELECT ENCODER`
 
 ** Menu hierarchy to be added **
+</details>
 
-# Perform FX Menu
+<details>
+<summary>Perform FX Menu</summary>
 
 The Perform FX menu is accessible from Performance View by pressing on the `SELECT ENCODER`
 
 ** Menu hierarchy to be added **
+</details>
 
-# Sound Menu
+<details>
+<summary>Sound Menu</summary>
 
 The Sound menu is accessible from Synth Clips and Kit clips when affect entire is disabled and a kit row is selected by pressing on the `SELECT ENCODER`
 
 ** Menu hierarchy to be added **
+</details>
 
-# Kit FX Menu
+<details>
+<summary>Kit FX Menu</summary>
 
 The Kit FX menu is accessible from Kit clips when affect entire is enabled by pressing on the `SELECT ENCODER`
 
 ** Menu hierarchy to be added **
+</details>
 
-# MIDI Instrument Menu
+<details>
+<summary>MIDI Instrument Menu</summary>
 
 The MIDI Instrument menu is accessible from MIDI clips by pressing on the `SELECT ENCODER`
 
 ** Menu hierarchy to be added **
+</details>
 
-# CV Instrument Menu
+<details>
+<summary>CV Instrument Menu</summary>
 
 The CV Instrument menu is accessible from CV clips by pressing on the `SELECT ENCODER`
 
 ** Menu hierarchy to be added **
+</details>
 
-# Audio Clip Menu
+<details>
+<summary>Audio Clip Menu</summary>
 
 The Audio Clip menu is accessible from Audio clips by pressing on the `SELECT ENCODER`
 
 ** Menu hierarchy to be added **
+</details>
+
+

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -11,14 +11,18 @@ The Settings menu is accessible from anywhere on the Deluge by pressing `SHIFT +
 
 The Settings menu contains the following menu hierarchy:
 
-- CV
+<blockquote>
+<details><summary>CV</summary>
+
 	- CV Output 1 (OUT1)
 		- Volts per Octave (VOLT)
 		- Transpose (TRAN)
 	- CV Output 2 (OUT2)
 		- Volts per Octave (VOLT)
 		- Transpose (TRAN)
-- Gate
+</details>		
+<details><summary>Gate</summary>
+
 	- Gate Output 1 (OUT1)
 		- V-Trig (VTRI)
 		- S-Trig (STRI)
@@ -32,7 +36,10 @@ The Settings menu contains the following menu hierarchy:
 		- V-Trig (VTRI)
 		- S-Trig (STRI)
 	- Minimum Off-Time (OFFT)
-- Trigger Clock (TCLO)
+</details>
+
+<details><summary>Trigger Clock (TCLO)</summary>
+
 	- Input (IN)
 		- PPQN 
 		- Auto-Start (AUTO)
@@ -40,7 +47,10 @@ The Settings menu contains the following menu hierarchy:
 			- Enabled (OFF)
 	- Output (OUT)
 		- PPQN
-- MIDI
+</details>
+
+<details><summary>MIDI</summary>
+
 	- Clock (CLK)
 		- Input (IN)
 			- Disabled (ON)
@@ -118,7 +128,10 @@ The Settings menu contains the following menu hierarchy:
 			- Clock (CLK)
 				- Disabled (OFF)
 				- Enabled (ON)
-- Defaults (DEFA)
+</details>
+				
+<details><summary>Defaults (DEFA)</summary>
+
 	- UI
 		- Song
 			- Layout (LAYT)
@@ -181,7 +194,11 @@ The Settings menu contains the following menu hierarchy:
 	- Resolution (RESO)
 	- Bend Range (BEND)
 	- Metronome (METR)
-- Swing Interval (SWIN) - NOTE: These options can change depending on how your default resolution is set
+</details>
+
+<details><summary>Swing Interval (SWIN)</summary>
+NOTE: These options can change depending on how your default resolution is set
+
 	- 2-Bar
 	- 1-Bar
 	- 2nd-Notes
@@ -209,7 +226,10 @@ The Settings menu contains the following menu hierarchy:
 	- 32nd-DTTED
 	- 64th-DTTED
 	- 128th-DTTED
-- Pads
+</details>
+
+<details><summary>Pads</summary>
+
 	- Shortcut Version (SHOR)
 		- 1.0
 		- 3.0
@@ -258,15 +278,24 @@ The Settings menu contains the following menu hierarchy:
 			- Amber (AMBE)
 			- White (WHIT)
 			- Pink
-- Sample Preview (PREV)
+</details>
+
+<details><summary>Sample Preview (PREV)</summary>
+
 	- Disabled (OFF)
 	- Conditional (COND)
 	- Enabled (ON)
-- Play-Cursor (CURS)
+</details>	
+	
+<details><summary>Play-Cursor (CURS)</summary>
+
 	- Fast
 	- Disabled (OFF)
 	- Slow
-- Recording (RECO)
+</details>	
+	
+<details><summary>Recording (RECO)</summary>
+
 	- Count-in (COUN)
 		- Disabled (OFF)
 		- Enabled (ON)
@@ -306,7 +335,10 @@ The Settings menu contains the following menu hierarchy:
 		- Conditional (COND)
 		- Enabled (ON)
 		- Disabled (OFF)
-- Community Features (FEAT)
+</details>
+
+<details><summary>Community Features (FEAT)</summary>
+
 	- Drum Randomizer (DRUM)
 		- OFF
 		- ON
@@ -356,7 +388,10 @@ The Settings menu contains the following menu hierarchy:
 		- OLED (OLED)
 		- Toggle (TOGL)
 		- 7SEG (7SEG)
-- Firmware Version (FIRM)
+</details>
+
+Firmware Version (FIRM)
+
 </details>
 
 <details>
@@ -414,5 +449,3 @@ The Audio Clip menu is accessible from Audio clips by pressing on the `SELECT EN
 
 ** Menu hierarchy to be added **
 </details>
-
-

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -152,6 +152,13 @@ The Settings menu contains the following menu hierarchy:
 			- Layout (LAYT)
 				- Isomorphic (ISO)
 				- In-Key (INKY)
+			- Sidebar Controls (CTRL)
+				- Momentary Velocity (MVEL)
+					- Disabled (OFF)
+					- Enabled (ON)
+				- Momentary Modwheel (MMOD)
+					- Disabled (OFF)
+					- Enabled (ON)
 	- Automation (AUTO)
 		- Interpolation (INTE)
 			- Disabled (OFF)
@@ -194,6 +201,17 @@ The Settings menu contains the following menu hierarchy:
 	- Resolution (RESO)
 	- Bend Range (BEND)
 	- Metronome (METR)
+	- Startup Song (SONG)
+		- New Song (NEW)
+		- Template Song (Default.XML) (TMPL)
+		- Last Opened Song (OPEN)
+		- Last Saved Song (SAVE)
+	- Pad Brightness
+	- Sample Slice Mode
+		- Cut
+		- Once
+		- Loop
+		- Stretch
 </details>
 
 <details><summary>Swing Interval (SWIN)</summary>
@@ -208,24 +226,6 @@ NOTE: These options can change depending on how your default resolution is set
 	- 32nd-Notes
 	- 64th-Notes
 	- 128th-Notes
-	- 2-Bar-TPLTS
-	- 1-Bar-TPLTS
-	- 2nd-TPLTS
-	- 4th-TPLTS
-	- 8th-TPLTS
-	- 16th-TPLTS
-	- 32nd-TPLTS
-	- 64th-TPLTS
-	- 128th-TPLTS
-	- 2-Bar-DTTED
-	- 1-Bar-DTTED
-	- 2nd-DTTED
-	- 4th-DTTED
-	- 8th-DTTED
-	- 16th-DTTED
-	- 32nd-DTTED
-	- 64th-DTTED
-	- 128th-DTTED
 </details>
 
 <details><summary>Pads</summary>
@@ -309,25 +309,7 @@ NOTE: These options can change depending on how your default resolution is set
 		- 8th-Notes (8TH)
 		- 16th-Notes (16TH)
 		- 32nd-Notes (32ND)
-		- 64th-Notes (64th)
-		- 128th-Notes (128T)
-		- 256th-Notes (256T)
-		- 512nd-Notes (512T)
-		- 1024th-Notes (1024)
-		- 2048th-Notes (2048)
-		- 4096th-Notes (4096)
-		- 8192nd-Notes (8192)
-		- 16834th-Notes (TINY)
-		- 32768th-Notes (TINY)
-		- 65536th-Notes (TINY)
-		- 131072nd-Notes (TINY)
-		- 262144th-Notes (TINY)
-		- 524288th-Notes (TINY)
-		- 1048576th-Nptes (TINY)
-		- 2097152nd-Notes (TINY)
-		- 4194304th-Notes (TINY)
-		- 8388608th-Notes (TINY)
-		- 16777216th-Notes (TINY)
+		- 64th-Notes (64TH)
 	- Loop Margins (MARG)
 		- Disabled (OFF)
 		- Enabled (ON)
@@ -412,6 +394,7 @@ The Song menu contains the following menu hierarchy:
 	- LPF
 		- Frequency (FREQ)
 		- Resonance (RESO)
+		- Morph (MORP)
 		- Mode (MODE)
 			- 12DB Ladder (LA12)
 			- 24DB Ladder (LA24)
@@ -421,6 +404,7 @@ The Song menu contains the following menu hierarchy:
 	- HPF
 		- Frequency (FREQ)
 		- Resonance (RESO)
+		- Morph (MORP)
 		- Mode (MODE)
 			- SVF Bandpass (SV_B)
 			- SVF Notch (SV_N)
@@ -522,13 +506,13 @@ The Perform FX menu is accessible from Performance View by pressing on the `SELE
 The Perform FX menu contains the following menu hierarchy:
 
 <blockquote>
-<details><summary>Editing Mode</summary>
+<details><summary>Editing Mode (EDIT)</summary>
 
-	- Disabled
+	- Disabled (OFF)
 	- Value
 	- Param
 </details>
-<details><summary>Filters</summary>
+<details><summary>Filters (FLTR)</summary>
 
 	- See Song menu hierarchy above for break-down of Filters menu
 </details>
@@ -544,7 +528,387 @@ The Perform FX menu contains the following menu hierarchy:
 
 The Sound menu is accessible from Synth Clips and Kit clips when affect entire is disabled and a kit row is selected by pressing on the `SELECT ENCODER`
 
-** Menu hierarchy to be added **
+The Sound menu contains the following menu hierarchy:
+
+<blockquote>
+<details><summary>Master (MASTR)</summary>
+
+	- Volume (VOLU)
+	- Master Transpose (TRAN)
+	- Vibrato (VIBR)
+	- Pan
+	- Synth Mode (MODE) - in Synth's and Kit row's that have loaded a Synth preset
+		- Subtractive
+		- FM
+		- Ringmod
+	- Name - in Kit's only for naming a Kit row
+</details>
+<details><summary>Arpeggiator (ARPE)</summary>
+
+	- Mode
+		- OFF
+		- Arpeggiator (ARP)
+	- Sync
+	NOTE: These options can change depending on how your default resolution is set
+
+			- Off
+			- 2-Bar
+			- 1-Bar
+			- 2nd-Notes
+			- 4th-Notes
+			- 8th-Notes
+			- 16th-Notes
+			- 32nd-Notes
+			- 64th-Notes
+			- 128th-Notes
+			- 2-Bar-TPLTS
+			- 1-Bar-TPLTS
+			- 2nd-TPLTS
+			- 4th-TPLTS
+			- 8th-TPLTS
+			- 16th-TPLTS
+			- 32nd-TPLTS
+			- 64th-TPLTS
+			- 128th-TPLTS
+			- 2-Bar-DTTED
+			- 1-Bar-DTTED
+			- 2nd-DTTED
+			- 4th-DTTED
+			- 8th-DTTED
+			- 16th-DTTED
+			- 32nd-DTTED
+			- 64th-DTTED
+			- 128th-DTTED	
+	- Rate
+	- Gate
+	- Octaves (OCTA)
+	- Octave Mode (OMOD)
+		- Up
+		- Down
+		- Up & Down (UPDN)
+		- Alternate (ALT)
+		- Random (RAND)
+	- Note Mode (NMOD)
+		- Up
+		- Down
+		- Up & Down (UPDN)
+		- As Played (PLAY)
+		- Random (RAND)
+	- Rhythm (RHYT)
+	- Sequence Length (LENG)
+	- Ratchet Amount (RATC)
+	- Ratchet Probability (RPRO)
+	- MPE
+		- Velocity (VELO)
+			- Disabled (OFF)
+			- Aftertouch
+			- MPE Y (Y)
+</details>
+<details><summary>Compressor (COMP)</summary>
+
+	- Threshold (THRE)
+	- Ratio (RATI)
+	- Attack (ATTA)
+	- Release (RELE)
+	- HPF
+</details>
+<details><summary>Filters (FLTR)</summary>
+
+	- LPF
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Mode (MODE)
+			- 12DB Ladder (LA12)
+			- 24DB Ladder (LA24)
+			- Drive (DRIV)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
+		- Drive (DRIV) (if 12DB/24DB/Drive mode is selected) or Morph (MORP) (if SVF mode is selected)
+	- HPF
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Mode (MODE)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
+			- HP Ladder (HP_L)
+		- Morph (MORP) (if SVF mode is selected) or FM (if HP Ladder mode is selected)
+	- Filter Route (ROUT)
+		- HPF2LPF (HPF2)
+		- LPF2HPF (LPF2)
+		- PARALLEL (PARA)
+</details>
+<details><summary>FX</summary>
+
+	- EQ
+		- Bass
+		- Treble (TREB)
+		- Bass Frequency (BAFR)
+		- Treble Frequency (TRFR)
+	- Delay (DELA)
+		- Amount (AMOU)
+		- Rate
+		- Pingpong (PING)
+			- Disabled (OFF)
+			- Enabled (ON)
+		- Type
+			- Digital (DIGI)
+			- Analog (ANA)
+		- Sync
+		NOTE: These options can change depending on how your default resolution is set
+				
+			- Off
+			- 2-Bar
+			- 1-Bar
+			- 2nd-Notes
+			- 4th-Notes
+			- 8th-Notes
+			- 16th-Notes
+			- 32nd-Notes
+			- 64th-Notes
+			- 128th-Notes
+			- 2-Bar-TPLTS
+			- 1-Bar-TPLTS
+			- 2nd-TPLTS
+			- 4th-TPLTS
+			- 8th-TPLTS
+			- 16th-TPLTS
+			- 32nd-TPLTS
+			- 64th-TPLTS
+			- 128th-TPLTS
+			- 2-Bar-DTTED
+			- 1-Bar-DTTED
+			- 2nd-DTTED
+			- 4th-DTTED
+			- 8th-DTTED
+			- 16th-DTTED
+			- 32nd-DTTED
+			- 64th-DTTED
+			- 128th-DTTED
+	- Reverb (REVE)
+		- Amount (AMOU)
+  			- Freeverb (FVRB)
+     			- Mutable (MTBL)
+		- Model (MODE)
+		- Room Size (SIZE) (if Freeverb is Selected) or Time (if Mutable is Selected)
+		- Damping (DAMP)
+		- Width (WIDT) (if Freeverb is Selected) or Diffusion (DIFF) (if Mutable is Selected)
+		- Pan
+		- Reverb Sidechain (SIDE)
+			- Volume Ducking (VOLU)
+	
+	- Mod-FX (MODU)
+		- Type
+			- Disabled (OFF)
+			- Flanger (FLAN)
+			- Chorus (CHOR)
+			- Phaser (PHAS)
+			- Stereo Chorus (S.CHO)
+			- Grain (GRAI) (if enabled in Community Features menu)
+		- Rate
+		- Depth (DEPT) (if Chorus, Phaser or Grain is selected)
+		- Feedback (FEED) (if Flanger, Phaser or Grain is selected)
+		- Offset (OFFS) (if Chorus or Grain is selected)
+	- Distortion (DIST)
+		- Saturation (SATU)
+		- Decimation (DECI)
+		- Bitcrush (CRUS)
+		- Wavefold (FOLD)
+	- Noise Level (NOIS)
+</details>
+<details><summary>Sidechain (SIDE) </summary>
+
+	- Volume Ducking (VOLU)
+	- Sync
+	NOTE: These options can change depending on how your default resolution is set
+				
+		- Off
+		- 2-Bar
+		- 1-Bar
+		- 2nd-Notes
+		- 4th-Notes
+		- 8th-Notes
+		- 16th-Notes
+		- 32nd-Notes
+		- 64th-Notes
+		- 128th-Notes
+		- 2-Bar-TPLTS
+		- 1-Bar-TPLTS
+		- 2nd-TPLTS
+		- 4th-TPLTS
+		- 8th-TPLTS
+		- 16th-TPLTS
+		- 32nd-TPLTS
+		- 64th-TPLTS
+		- 128th-TPLTS
+		- 2-Bar-DTTED
+		- 1-Bar-DTTED
+		- 2nd-DTTED
+		- 4th-DTTED
+		- 8th-DTTED
+		- 16th-DTTED
+		- 32nd-DTTED
+		- 64th-DTTED
+		- 128th-DTTED		
+	- Attack (ATTA)
+	- Release (RELE)
+	- Shape (TYPE)
+</details>	
+<details><summary>Oscillator 1 (OSC1) </summary>
+
+	- Type
+		- Sine
+		- Triangle (TRIA)
+		- Square (SQUA)
+		- Analog Square (ASQUARE)
+		- Saw
+		- Analog Saw (ASAW)
+		- Wavetable
+		- Sample (SAMP)
+		- Input (IN)
+
+	- Volume (VOLU)
+	- Wave-Index (WAVE) - if Wavetable type is selected
+	- File Browser (FILE) - if Wavetable or Sample type is selected
+	- Record Audio (RECO)
+	- Reverse (REVE) - if Sample type is selected
+	- Repeat Mode (MODE)
+	- Start-Point (STAR) - if Sample type is selected
+	- End-Point (END-) - if Sample type is selected
+	- Transpose (TRAN)
+	- Pitch/Speed (PISP)
+	- Interpolation (INTE) - if Input type is selected
+	- Speed (SPEE) - if Sample type selected
+	- Pulse Width (PULS) - if any type except Sample or Input is selected
+	- Retrigger Phase (RETR) - if any type except Sample is selected
+</details>	
+<details><summary>Oscillator 2 (OSC2) </summary>
+
+	- Type
+		- Sine
+		- Triangle (TRIA)
+		- Square (SQUA)
+		- Analog Square (ASQUARE)
+		- Saw
+		- Analog Saw (ASAW)
+		- Wavetable
+		- Sample (SAMP)
+		- Input (IN)
+
+	- Volume (VOLU)
+	- Wave-Index (WAVE) - if Wavetable type is selected
+	- File Browser (FILE) - if Wavetable or Sample type is selected
+	- Record Audio (RECO)
+	- Reverse (REVE) - if Sample type is selected
+	- Repeat Mode (MODE)
+	- Start-Point (STAR) - if Sample type is selected
+	- End-Point (END-) - if Sample type is selected
+	- Transpose (TRAN)
+	- Pitch/Speed (PISP)
+	- Interpolation (INTE) - if Input type is selected
+	- Speed (SPEE) - if Sample type selected
+	- Pulse Width (PULS) - if any type except Sample or Input is selected
+	- Oscillator Sync (SYNC)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- Retrigger Phase (RETR) - if any type except Sample is selected
+</details>	
+<details><summary>Envelope 1 (ENV1) </summary>
+
+	- Attack (ATTA)
+	- Decay (DECA)
+	- Sustain (SUST)
+	- Release (RELE)
+</details>	
+<details><summary>Envelope 2 (ENV2) </summary>
+
+	- Attack (ATTA)
+	- Decay (DECA)
+	- Sustain (SUST)
+	- Release (RELE)
+</details>
+<details><summary>LFO1 </summary>
+
+	- Shape (TYPE)
+		- Sine
+		- Triangle (TRIA)
+		- Square (SQUA)
+		- Saw
+		- S&H (S H)
+		- Random Walk (RWLK)
+	- Rate
+	- Sync
+	NOTE: These options can change depending on how your default resolution is set
+				
+		- Off
+		- 2-Bar
+		- 1-Bar
+		- 2nd-Notes
+		- 4th-Notes
+		- 8th-Notes
+		- 16th-Notes
+		- 32nd-Notes
+		- 64th-Notes
+		- 128th-Notes
+		- 2-Bar-TPLTS
+		- 1-Bar-TPLTS
+		- 2nd-TPLTS
+		- 4th-TPLTS
+		- 8th-TPLTS
+		- 16th-TPLTS
+		- 32nd-TPLTS
+		- 64th-TPLTS
+		- 128th-TPLTS
+		- 2-Bar-DTTED
+		- 1-Bar-DTTED
+		- 2nd-DTTED
+		- 4th-DTTED
+		- 8th-DTTED
+		- 16th-DTTED
+		- 32nd-DTTED
+		- 64th-DTTED
+		- 128th-DTTED	
+</details>
+<details><summary>LFO2 </summary>
+
+	- Shape (TYPE)
+		- Sine
+		- Triangle (TRIA)
+		- Square (SQUA)
+		- Saw
+		- S&H (S H)
+		- Random Walk (RWLK)
+	- Rate	
+</details>
+<details><summary>Voice (VOIC) </summary>
+
+	- Polyphony (POLY)
+		- Auto
+		- Polyphonic
+		- Monophonic
+		- Legato
+	- Unison (UNIS)
+		- Unison Number (NUM)
+		- Unison Detune (DETU)
+		- Unison Stereo Spread (SPRE)
+	- Portamento (PORT)
+	- Priority (PRIO)
+		- Low
+		- Medium
+		- High
+</details>
+<details><summary>Bend Range (BEND) </summary>
+
+	- Normal
+	- Poly / Finger / MPE
+</details>
+<details><summary>Mod Matrix (MMTR) </summary></details>
+<details><summary>Play Direction (DIRE) </summary>
+
+	- Forward
+	- Reversed
+	- Ping-Pong
+</details>
+
 </details>
 
 <details>
@@ -552,7 +916,162 @@ The Sound menu is accessible from Synth Clips and Kit clips when affect entire i
 
 The Kit FX menu is accessible from Kit clips when affect entire is enabled by pressing on the `SELECT ENCODER`
 
-** Menu hierarchy to be added **
+The Kit FX menu contains the following menu hierarchy:
+
+<blockquote>
+<details><summary>Master (MASTR)</summary>
+
+	- Volume (VOLU)
+	- Pitch (PITC)
+	- Pan
+</details>
+<details><summary>Compressor (COMP)</summary>
+
+	- Threshold (THRE)
+	- Ratio (RATI)
+	- Attack (ATTA)
+	- Release (RELE)
+	- HPF
+</details>
+<details><summary>Filters (FLTR)</summary>
+
+	- LPF
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Morph (MORP)
+		- Mode (MODE)
+			- 12DB Ladder (LA12)
+			- 24DB Ladder (LA24)
+			- Drive (DRIV)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
+	- HPF
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Morph (MORP)
+		- Mode (MODE)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
+			- HP Ladder (HP_L)
+	- Filter Route (ROUT)
+		- HPF2LPF (HPF2)
+		- LPF2HPF (LPF2)
+		- PARALLEL (PARA)
+</details>
+<details><summary>FX</summary>
+
+	- EQ
+		- Bass
+		- Treble (TREB)
+		- Bass Frequency (BAFR)
+		- Treble Frequency (TRFR)
+	- Delay (DELA)
+		- Amount (AMOU)
+		- Rate
+		- Pingpong (PING)
+			- Disabled (OFF)
+			- Enabled (ON)
+		- Type
+			- Digital (DIGI)
+			- Analog (ANA)
+		- Sync
+		NOTE: These options can change depending on how your default resolution is set
+				
+			- Off
+			- 2-Bar
+			- 1-Bar
+			- 2nd-Notes
+			- 4th-Notes
+			- 8th-Notes
+			- 16th-Notes
+			- 32nd-Notes
+			- 64th-Notes
+			- 128th-Notes
+			- 2-Bar-TPLTS
+			- 1-Bar-TPLTS
+			- 2nd-TPLTS
+			- 4th-TPLTS
+			- 8th-TPLTS
+			- 16th-TPLTS
+			- 32nd-TPLTS
+			- 64th-TPLTS
+			- 128th-TPLTS
+			- 2-Bar-DTTED
+			- 1-Bar-DTTED
+			- 2nd-DTTED
+			- 4th-DTTED
+			- 8th-DTTED
+			- 16th-DTTED
+			- 32nd-DTTED
+			- 64th-DTTED
+			- 128th-DTTED
+	- Reverb (REVE)
+		- Amount (AMOU)
+  			- Freeverb (FVRB)
+     			- Mutable (MTBL)
+		- Model (MODE)
+		- Room Size (SIZE) (if Freeverb is Selected) or Time (if Mutable is Selected)
+		- Damping (DAMP)
+		- Width (WIDT) (if Freeverb is Selected) or Diffusion (DIFF) (if Mutable is Selected)
+		- Pan
+		- Reverb Sidechain (SIDE)
+			- Volume Ducking (VOLU)
+	
+	- Mod-FX (MODU)
+		- Type
+			- Disabled (OFF)
+			- Flanger (FLAN)
+			- Chorus (CHOR)
+			- Phaser (PHAS)
+			- Stereo Chorus (S.CHO)
+			- Grain (GRAI) (if enabled in Community Features menu)
+		- Rate
+		- Depth (DEPT) (if Chorus, Phaser or Grain is selected)
+		- Feedback (FEED) (if Flanger, Phaser or Grain is selected)
+		- Offset (OFFS) (if Chorus or Grain is selected)
+	- Distortion (DIST)
+		- Decimation (DECI)
+		- Bitcrush (CRUS)
+</details>
+<details><summary>Sidechain (SIDE) </summary>
+
+	- Volume Ducking (VOLU)
+	- Sync
+	NOTE: These options can change depending on how your default resolution is set
+				
+		- Off
+		- 2-Bar
+		- 1-Bar
+		- 2nd-Notes
+		- 4th-Notes
+		- 8th-Notes
+		- 16th-Notes
+		- 32nd-Notes
+		- 64th-Notes
+		- 128th-Notes
+		- 2-Bar-TPLTS
+		- 1-Bar-TPLTS
+		- 2nd-TPLTS
+		- 4th-TPLTS
+		- 8th-TPLTS
+		- 16th-TPLTS
+		- 32nd-TPLTS
+		- 64th-TPLTS
+		- 128th-TPLTS
+		- 2-Bar-DTTED
+		- 1-Bar-DTTED
+		- 2nd-DTTED
+		- 4th-DTTED
+		- 8th-DTTED
+		- 16th-DTTED
+		- 32nd-DTTED
+		- 64th-DTTED
+		- 128th-DTTED		
+	- Attack (ATTA)
+	- Release (RELE)
+	- Shape (TYPE)
+</details>	
+
 </details>
 
 <details>

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -918,8 +918,8 @@ The Sound menu contains the following menu hierarchy:
 </details>
 <details><summary>Bend Range (BEND) </summary>
 
-	- Normal
-	- Poly / Finger / MPE
+	- Normal (NORM)
+	- Poly / Finger / MPE (MPE)
 </details>
 <details><summary>Mod Matrix (MMTR) </summary></details>
 <details><summary>Play Direction (DIRE) </summary>
@@ -1099,7 +1099,94 @@ The Kit FX menu contains the following menu hierarchy:
 
 The MIDI Instrument menu is accessible from MIDI clips by pressing on the `SELECT ENCODER`
 
-** Menu hierarchy to be added **
+The MIDI menu contains the following menu hierarchy:
+
+<blockquote>
+<details><summary>PGM</summary></details>
+<details><summary>Bank</summary></details>
+<details><summary>Sub-Bank (SUB)</summary></details>
+<details><summary>Arpeggiator (ARPE)</summary>
+
+	- Mode
+		- OFF
+		- Arpeggiator (ARP)
+	- Sync
+	NOTE: These options can change depending on how your default resolution is set
+
+			- Off
+			- 2-Bar
+			- 1-Bar
+			- 2nd-Notes
+			- 4th-Notes
+			- 8th-Notes
+			- 16th-Notes
+			- 32nd-Notes
+			- 64th-Notes
+			- 128th-Notes
+			- 2-Bar-TPLTS
+			- 1-Bar-TPLTS
+			- 2nd-TPLTS
+			- 4th-TPLTS
+			- 8th-TPLTS
+			- 16th-TPLTS
+			- 32nd-TPLTS
+			- 64th-TPLTS
+			- 128th-TPLTS
+			- 2-Bar-DTTED
+			- 1-Bar-DTTED
+			- 2nd-DTTED
+			- 4th-DTTED
+			- 8th-DTTED
+			- 16th-DTTED
+			- 32nd-DTTED
+			- 64th-DTTED
+			- 128th-DTTED	
+	- Rate
+	- Gate
+	- Octaves (OCTA)
+	- Octave Mode (OMOD)
+		- Up
+		- Down
+		- Up & Down (UPDN)
+		- Alternate (ALT)
+		- Random (RAND)
+	- Note Mode (NMOD)
+		- Up
+		- Down
+		- Up & Down (UPDN)
+		- As Played (PLAY)
+		- Random (RAND)
+	- Rhythm (RHYT)
+	- Sequence Length (LENG)
+	- Ratchet Amount (RATC)
+	- Ratchet Probability (RPRO)
+	- MPE
+		- Velocity (VELO)
+			- Disabled (OFF)
+			- Aftertouch
+			- MPE Y (Y)
+</details>
+<details><summary>Bend Range (BEND) </summary>
+
+	- Normal (NORM)
+	- Poly / Finger / MPE (MPE)
+</details>
+<details><summary>Poly Expression to Mono (POLY) </summary>
+
+	- Aftertouch (AFTE)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- MPE
+		- Disabled (OFF)
+		- Enabled (ON)
+</details>	
+<details><summary>Play Direction (DIRE) </summary>
+
+	- Forward
+	- Reversed
+	- Ping-Pong
+</details>
+
 </details>
 
 <details>
@@ -1173,8 +1260,8 @@ The CV menu contains the following menu hierarchy:
 </details>
 <details><summary>Bend Range (BEND) </summary>
 
-	- Normal
-	- Poly / Finger / MPE
+	- Normal (NORM)
+	- Poly / Finger / MPE (MPE)
 </details>
 <details><summary>Play Direction (DIRE) </summary>
 

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -771,12 +771,22 @@ The Sound menu contains the following menu hierarchy:
 	- File Browser (FILE) - if Wavetable or Sample type is selected
 	- Record Audio (RECO)
 	- Reverse (REVE) - if Sample type is selected
+		- Disabled (OFF)
+		- Enabled (ON)
 	- Repeat Mode (MODE)
+		- Cut
+		- Once
+		- Loop
+		- Stretch
 	- Start-Point (STAR) - if Sample type is selected
 	- End-Point (END-) - if Sample type is selected
 	- Transpose (TRAN)
 	- Pitch/Speed (PISP)
+		- Linked
+		- Independent
 	- Interpolation (INTE) - if Input type is selected
+		- Linear
+		- Sync
 	- Speed (SPEE) - if Sample type selected
 	- Pulse Width (PULS) - if any type except Sample or Input is selected
 	- Retrigger Phase (RETR) - if any type except Sample is selected
@@ -799,12 +809,22 @@ The Sound menu contains the following menu hierarchy:
 	- File Browser (FILE) - if Wavetable or Sample type is selected
 	- Record Audio (RECO)
 	- Reverse (REVE) - if Sample type is selected
+		- Disabled (OFF)
+		- Enabled (ON)
 	- Repeat Mode (MODE)
+		- Cut
+		- Once
+		- Loop
+		- Stretch
 	- Start-Point (STAR) - if Sample type is selected
 	- End-Point (END-) - if Sample type is selected
 	- Transpose (TRAN)
 	- Pitch/Speed (PISP)
+		- Linked
+		- Independent
 	- Interpolation (INTE) - if Input type is selected
+		- Linear
+		- Sync
 	- Speed (SPEE) - if Sample type selected
 	- Pulse Width (PULS) - if any type except Sample or Input is selected
 	- Oscillator Sync (SYNC)
@@ -1087,7 +1107,82 @@ The MIDI Instrument menu is accessible from MIDI clips by pressing on the `SELEC
 
 The CV Instrument menu is accessible from CV clips by pressing on the `SELECT ENCODER`
 
-** Menu hierarchy to be added **
+The CV menu contains the following menu hierarchy:
+
+<blockquote>
+<details><summary>Arpeggiator (ARPE)</summary>
+
+	- Mode
+		- OFF
+		- Arpeggiator (ARP)
+	- Sync
+	NOTE: These options can change depending on how your default resolution is set
+
+			- Off
+			- 2-Bar
+			- 1-Bar
+			- 2nd-Notes
+			- 4th-Notes
+			- 8th-Notes
+			- 16th-Notes
+			- 32nd-Notes
+			- 64th-Notes
+			- 128th-Notes
+			- 2-Bar-TPLTS
+			- 1-Bar-TPLTS
+			- 2nd-TPLTS
+			- 4th-TPLTS
+			- 8th-TPLTS
+			- 16th-TPLTS
+			- 32nd-TPLTS
+			- 64th-TPLTS
+			- 128th-TPLTS
+			- 2-Bar-DTTED
+			- 1-Bar-DTTED
+			- 2nd-DTTED
+			- 4th-DTTED
+			- 8th-DTTED
+			- 16th-DTTED
+			- 32nd-DTTED
+			- 64th-DTTED
+			- 128th-DTTED	
+	- Rate
+	- Gate
+	- Octaves (OCTA)
+	- Octave Mode (OMOD)
+		- Up
+		- Down
+		- Up & Down (UPDN)
+		- Alternate (ALT)
+		- Random (RAND)
+	- Note Mode (NMOD)
+		- Up
+		- Down
+		- Up & Down (UPDN)
+		- As Played (PLAY)
+		- Random (RAND)
+	- Rhythm (RHYT)
+	- Sequence Length (LENG)
+	- Ratchet Amount (RATC)
+	- Ratchet Probability (RPRO)
+	- MPE
+		- Velocity (VELO)
+			- Disabled (OFF)
+			- Aftertouch
+			- MPE Y (Y)
+</details>
+<details><summary>Bend Range (BEND) </summary>
+
+	- Normal
+	- Poly / Finger / MPE
+</details>
+<details><summary>Play Direction (DIRE) </summary>
+
+	- Forward
+	- Reversed
+	- Ping-Pong
+</details>
+
 </details>
 
 <details>
@@ -1095,5 +1190,193 @@ The CV Instrument menu is accessible from CV clips by pressing on the `SELECT EN
 
 The Audio Clip menu is accessible from Audio clips by pressing on the `SELECT ENCODER`
 
-** Menu hierarchy to be added **
+The Audio Clip menu contains the following menu hierarchy:
+
+<blockquote>
+<details><summary>Audio Source (AUDI)</summary>
+
+	- Disabled (DISA)
+	- Left Input (LEFT)
+	- Left Input (Monitoring) (LEFT)
+	- Right Input (RIGH)
+	- Right Input (Monitoring) (RIGH)
+	- Stereo Input (STER)
+	- Stereo Input (Monitoring) (STER)
+	- Bal. Input (BAL)
+	- Bal. Input (Monitoring) (BAL)
+	- Deluge Mix (Pre FX) (DELU)
+	- Deluge Output (Post FX) (DELU)
+</details>
+<details><summary>Master (MASTR)</summary>
+
+	- Volume (VOLU)
+	- Transpose (TRAN)
+	- Pan
+</details>
+<details><summary>Compressor (COMP)</summary>
+
+	- Threshold (THRE)
+	- Ratio (RATI)
+	- Attack (ATTA)
+	- Release (RELE)
+	- HPF
+</details>
+<details><summary>Filters (FLTR)</summary>
+
+	- LPF
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Morph (MORP)
+		- Mode (MODE)
+			- 12DB Ladder (LA12)
+			- 24DB Ladder (LA24)
+			- Drive (DRIV)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
+	- HPF
+		- Frequency (FREQ)
+		- Resonance (RESO)
+		- Morph (MORP)
+		- Mode (MODE)
+			- SVF Bandpass (SV_B)
+			- SVF Notch (SV_N)
+			- HP Ladder (HP_L)
+	- Filter Route (ROUT)
+		- HPF2LPF (HPF2)
+		- LPF2HPF (LPF2)
+		- PARALLEL (PARA)
+</details>
+<details><summary>FX</summary>
+
+	- EQ
+		- Bass
+		- Treble (TREB)
+		- Bass Frequency (BAFR)
+		- Treble Frequency (TRFR)
+	- Delay (DELA)
+		- Amount (AMOU)
+		- Rate
+		- Pingpong (PING)
+			- Disabled (OFF)
+			- Enabled (ON)
+		- Type
+			- Digital (DIGI)
+			- Analog (ANA)
+		- Sync
+		NOTE: These options can change depending on how your default resolution is set
+				
+			- Off
+			- 2-Bar
+			- 1-Bar
+			- 2nd-Notes
+			- 4th-Notes
+			- 8th-Notes
+			- 16th-Notes
+			- 32nd-Notes
+			- 64th-Notes
+			- 128th-Notes
+			- 2-Bar-TPLTS
+			- 1-Bar-TPLTS
+			- 2nd-TPLTS
+			- 4th-TPLTS
+			- 8th-TPLTS
+			- 16th-TPLTS
+			- 32nd-TPLTS
+			- 64th-TPLTS
+			- 128th-TPLTS
+			- 2-Bar-DTTED
+			- 1-Bar-DTTED
+			- 2nd-DTTED
+			- 4th-DTTED
+			- 8th-DTTED
+			- 16th-DTTED
+			- 32nd-DTTED
+			- 64th-DTTED
+			- 128th-DTTED
+	- Reverb (REVE)
+		- Amount (AMOU)
+  			- Freeverb (FVRB)
+     			- Mutable (MTBL)
+		- Model (MODE)
+		- Room Size (SIZE) (if Freeverb is Selected) or Time (if Mutable is Selected)
+		- Damping (DAMP)
+		- Width (WIDT) (if Freeverb is Selected) or Diffusion (DIFF) (if Mutable is Selected)
+		- Pan
+		- Reverb Sidechain (SIDE)
+			- Volume Ducking (VOLU)
+	
+	- Mod-FX (MODU)
+		- Type
+			- Disabled (OFF)
+			- Flanger (FLAN)
+			- Chorus (CHOR)
+			- Phaser (PHAS)
+			- Stereo Chorus (S.CHO)
+			- Grain (GRAI) (if enabled in Community Features menu)
+		- Rate
+		- Depth (DEPT) (if Chorus, Phaser or Grain is selected)
+		- Feedback (FEED) (if Flanger, Phaser or Grain is selected)
+		- Offset (OFFS) (if Chorus or Grain is selected)
+	- Distortion (DIST)
+		- Saturation (SATU)
+		- Decimation (DECI)
+		- Bitcrush (CRUS)
+</details>
+<details><summary>Sidechain (SIDE) </summary>
+
+	- Volume Ducking (VOLU)
+	- Sync
+	NOTE: These options can change depending on how your default resolution is set
+				
+		- Off
+		- 2-Bar
+		- 1-Bar
+		- 2nd-Notes
+		- 4th-Notes
+		- 8th-Notes
+		- 16th-Notes
+		- 32nd-Notes
+		- 64th-Notes
+		- 128th-Notes
+		- 2-Bar-TPLTS
+		- 1-Bar-TPLTS
+		- 2nd-TPLTS
+		- 4th-TPLTS
+		- 8th-TPLTS
+		- 16th-TPLTS
+		- 32nd-TPLTS
+		- 64th-TPLTS
+		- 128th-TPLTS
+		- 2-Bar-DTTED
+		- 1-Bar-DTTED
+		- 2nd-DTTED
+		- 4th-DTTED
+		- 8th-DTTED
+		- 16th-DTTED
+		- 32nd-DTTED
+		- 64th-DTTED
+		- 128th-DTTED		
+	- Attack (ATTA)
+	- Release (RELE)
+	- Shape (TYPE)
+</details>	
+<details><summary>Sample (SAMP) </summary>
+
+	- File Browser (FILE)
+	- Reverse (REVE)
+		- Disabled (OFF)
+		- Enabled (ON)
+	- Pitch/Speed (PISP)
+		- Linked
+		- Independent
+	- Waveform (WAVE)
+</details>
+<details><summary>Attack (ATTA) </summary></details>
+<details><summary>Priority (PRIO) </summary>
+
+	- Low
+	- Medium
+	- High
+</details>
+
 </details>


### PR DESCRIPTION
Goal: improve documentation by documenting the various menu's that exist on the deluge so users on OLED and 7SEG can have a better idea of what's available in each menu and what the structures are.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1217