### PR TITLE
Remove constructor for column keyboard since song/instrument doesn't exist yet from a cold boot

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/column_controls.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.h
@@ -70,13 +70,7 @@ enum BeatRepeat {
 // keyboard classes
 class ColumnControlsKeyboard : public KeyboardLayout {
 public:
-	ColumnControlsKeyboard() {
-		auto instrument = getCurrentInstrument();
-		if (instrument && instrument->defaultVelocity) {
-			velocity = instrument->defaultVelocity;
-			velocity32 = velocity << kVelModShift;
-		}
-	}
+	ColumnControlsKeyboard() = default;
 
 	// call this instead of on notestate directly as chord and beat repeat helper
 	void enableNote(uint8_t note, uint8_t velocity);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -55,10 +55,13 @@
 extern "C" {}
 
 namespace params = deluge::modulation::params;
+
+/// Do not call in static/global constructors, song won't exist yet
 Clip* getCurrentClip() {
 	return currentSong->getCurrentClip();
 }
 
+/// Do not call in static/global constructors, song won't exist yet
 InstrumentClip* getCurrentInstrumentClip() {
 	Clip* currentClip = currentSong->getCurrentClip();
 	if (currentClip->type == ClipType::INSTRUMENT) {
@@ -67,6 +70,7 @@ InstrumentClip* getCurrentInstrumentClip() {
 	return nullptr;
 }
 
+/// Do not call in static/global constructors, song won't exist yet
 AudioClip* getCurrentAudioClip() {
 	Clip* currentClip = currentSong->getCurrentClip();
 	if (currentClip->type == ClipType::AUDIO) {
@@ -75,10 +79,12 @@ AudioClip* getCurrentAudioClip() {
 	return nullptr;
 }
 
+/// Do not call in static/global constructors, song won't exist yet
 Output* getCurrentOutput() {
 	return currentSong->getCurrentClip()->output;
 }
 
+/// Do not call in static/global constructors, song won't exist yet
 Kit* getCurrentKit() {
 	Clip* currentClip = currentSong->getCurrentClip();
 	if (currentClip->output->type == OutputType::KIT) {
@@ -87,6 +93,7 @@ Kit* getCurrentKit() {
 	return nullptr;
 }
 
+/// Do not call in static/global constructors, song won't exist yet
 Instrument* getCurrentInstrument() {
 	auto output = currentSong->getCurrentClip()->output;
 	if (output == nullptr) {
@@ -100,6 +107,7 @@ Instrument* getCurrentInstrument() {
 	return static_cast<Instrument*>(output);
 }
 
+/// Do not call in static/global constructors, song won't exist yet
 OutputType getCurrentOutputType() {
 	return currentSong->getCurrentClip()->output->type;
 }


### PR DESCRIPTION
getCurrentInstrument etc. aren't safe to call from cold boot - annotate them, remove usage in column keyboard