### PR TITLE
Voice efficiency

### DIFF
--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -168,7 +168,8 @@ void TimeStretcher::reInit(int64_t newSamplePosBig, SamplePlaybackGuide* guide, 
 void TimeStretcher::beenUnassigned() {
 	unassignAllReasonsForPercLookahead();
 	unassignAllReasonsForPercCacheClusters();
-	olderPartReader.unassignAllReasons();
+	// we might sometimes want to dealloc the clusters but I'm not sure
+	olderPartReader.unassignAllReasons(false);
 	if (buffer) {
 		delugeDealloc(buffer);
 	}
@@ -984,7 +985,7 @@ bool TimeStretcher::setupNewPlayHead(Sample* sample, VoiceSample* voiceSample, S
                                      int32_t newHeadBytePos, int32_t additionalOscPos, int32_t priorityRating,
                                      LoopType loopingType) {
 	// clear the current reasons since setting up the clusters will add new ones
-	voiceSample->unassignAllReasons();
+	voiceSample->unassignAllReasons(false);
 	bool success = voiceSample->setupClustersForPlayFromByte(guide, sample, newHeadBytePos, priorityRating);
 	if (!success) {
 		return false;

--- a/src/deluge/gui/menu_item/audio_clip/reverse.h
+++ b/src/deluge/gui/menu_item/audio_clip/reverse.h
@@ -34,7 +34,7 @@ public:
 		auto* clip = getCurrentAudioClip();
 		bool active = (playbackHandler.isEitherClockActive() && currentSong->isClipActive(clip) && clip->voiceSample);
 
-		clip->unassignVoiceSample();
+		clip->unassignVoiceSample(false);
 
 		clip->sampleControls.reversed = this->getValue();
 

--- a/src/deluge/gui/ui/sample_marker_editor.cpp
+++ b/src/deluge/gui/ui/sample_marker_editor.cpp
@@ -136,7 +136,7 @@ void SampleMarkerEditor::writeValue(uint32_t value, MarkerType markerTypeNow) {
 		audioClipActive = (playbackHandler.isEitherClockActive() && currentSong->isClipActive(getCurrentClip())
 		                   && getCurrentAudioClip()->voiceSample);
 
-		getCurrentAudioClip()->unassignVoiceSample();
+		getCurrentAudioClip()->unassignVoiceSample(false);
 	}
 
 	if (markerTypeNow == MarkerType::START) {

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1409,7 +1409,7 @@ MenuPermission SoundEditor::checkPermissionToBeginSessionForRangeSpecificParam(S
 
 void SoundEditor::cutSound() {
 	if (getCurrentClip()->type == ClipType::AUDIO) {
-		getCurrentAudioClip()->unassignVoiceSample();
+		getCurrentAudioClip()->unassignVoiceSample(false);
 	}
 	else {
 		soundEditor.currentSound->unassignAllVoices();

--- a/src/deluge/memory/cache_manager.h
+++ b/src/deluge/memory/cache_manager.h
@@ -16,14 +16,15 @@ public:
 
 	uint32_t& longest_runs(size_t idx) { return longest_runs_.at(idx); }
 
-	void PutAtEndOfQueue(size_t q, Stealable* stealable) {
-		reclamation_queue_[q].addToEnd(stealable);
-		longest_runs_[q] = 0xFFFFFFFF; // TODO: actually investigate neighbouring memory "run".
-	}
-
-	/// adds to start of queue - logic is that a recently freed sample is unlikely to be immediately needed again
+	/// add a stealable to end of given queue
 	void QueueForReclamation(size_t q, Stealable* stealable) {
-		reclamation_queue_[q].addToStart(stealable);
+		/// Alternatively we could add to start of queue - logic is that a recently freed sample is unlikely
+		/// to be immediately needed again. This increases average and max voice counts, but has a problem with medium
+		/// memory pressure songs where it tends to prioritize earlier sounds in the song and makes it possible for
+		/// later songs to break in. This occurs since there's no mechanism to determine if a sample is going to be used
+		/// in the remainder of the song, so if there's not enough memory pressure for all stealable clusters to get
+		/// reclaimed the same few just get put on and off the list repeatedly
+		reclamation_queue_[q].addToEnd(stealable);
 		longest_runs_[q] = 0xFFFFFFFF; // TODO: actually investigate neighbouring memory "run".
 	}
 

--- a/src/deluge/memory/cache_manager.h
+++ b/src/deluge/memory/cache_manager.h
@@ -16,8 +16,14 @@ public:
 
 	uint32_t& longest_runs(size_t idx) { return longest_runs_.at(idx); }
 
-	void QueueForReclamation(size_t q, Stealable* stealable) {
+	void PutAtEndOfQueue(size_t q, Stealable* stealable) {
 		reclamation_queue_[q].addToEnd(stealable);
+		longest_runs_[q] = 0xFFFFFFFF; // TODO: actually investigate neighbouring memory "run".
+	}
+
+	/// adds to start of queue - logic is that a recently freed sample is unlikely to be immediately needed again
+	void QueueForReclamation(size_t q, Stealable* stealable) {
+		reclamation_queue_[q].addToStart(stealable);
 		longest_runs_[q] = 0xFFFFFFFF; // TODO: actually investigate neighbouring memory "run".
 	}
 

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -59,7 +59,7 @@ public:
 	                                           int32_t alternativeLongerLength);
 	Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature);
 	int64_t getSamplesFromTicks(int32_t ticks);
-	void unassignVoiceSample();
+	void unassignVoiceSample(bool wontBeUsedAgain);
 	void resumePlayback(ModelStackWithTimelineCounter* modelStack, bool mayMakeSound = true);
 	int32_t changeOutput(ModelStackWithTimelineCounter* modelStack, Output* newOutput);
 	int32_t setOutput(ModelStackWithTimelineCounter* modelStack, Output* newOutput,

--- a/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
+++ b/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
@@ -35,8 +35,8 @@ int32_t ConsequenceAudioClipSetSample::revert(TimeType time, ModelStack* modelSt
 	String filePathBeforeRevert;
 	filePathBeforeRevert.set(&clip->sampleHolder.filePath);
 	uint64_t endPosBeforeRevert = clip->sampleHolder.endPos;
-
-	clip->unassignVoiceSample();
+	// don't keep cached since we undid the set
+	clip->unassignVoiceSample(true);
 
 	clip->sampleHolder.filePath.set(&filePathToRevertTo);
 	clip->sampleHolder.endPos = endPosToRevertTo;

--- a/src/deluge/model/sample/sample_cache.cpp
+++ b/src/deluge/model/sample/sample_cache.cpp
@@ -186,7 +186,7 @@ void SampleCache::prioritizeNotStealingCluster(int32_t clusterIndex) {
 		Cluster* cluster = clusters[clusterIndex];
 		if (cluster->list != &cache_manager.queue(q) || !cluster->isLast()) {
 			cluster->remove(); // Remove from old list, if it was already in one (might not have been).
-			cache_manager.PutAtEndOfQueue(q, cluster);
+			cache_manager.QueueForReclamation(q, cluster);
 		}
 	}
 

--- a/src/deluge/model/sample/sample_cache.cpp
+++ b/src/deluge/model/sample/sample_cache.cpp
@@ -186,7 +186,7 @@ void SampleCache::prioritizeNotStealingCluster(int32_t clusterIndex) {
 		Cluster* cluster = clusters[clusterIndex];
 		if (cluster->list != &cache_manager.queue(q) || !cluster->isLast()) {
 			cluster->remove(); // Remove from old list, if it was already in one (might not have been).
-			cache_manager.QueueForReclamation(q, cluster);
+			cache_manager.PutAtEndOfQueue(q, cluster);
 		}
 	}
 

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -41,10 +41,10 @@ SampleLowLevelReader::~SampleLowLevelReader() {
 	// actually destructed
 }
 
-void SampleLowLevelReader::unassignAllReasons() {
+void SampleLowLevelReader::unassignAllReasons(bool wontBeUsedAgain) {
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
 		if (clusters[l]) {
-			audioFileManager.removeReasonFromCluster(clusters[l], "E027");
+			audioFileManager.removeReasonFromCluster(clusters[l], "E027", wontBeUsedAgain);
 			clusters[l] = NULL;
 		}
 	}
@@ -133,8 +133,8 @@ bool SampleLowLevelReader::reassessReassessmentLocation(SamplePlaybackGuide* gui
 		clusterIndex = finalClusterIndex;
 	}
 
-	unassignAllReasons(); // Can only do this after we've done the above stuff, which references clusters, which this
-	                      // will clear
+	unassignAllReasons(false); // Can only do this after we've done the above stuff, which references clusters, which
+	                           // this will clear
 	bool success = assignClusters(guide, sample, clusterIndex, priorityRating);
 	if (!success) {
 		D_PRINTLN("reassessReassessmentLocation fail");
@@ -436,7 +436,7 @@ bool SampleLowLevelReader::changeClusterIfNecessary(SamplePlaybackGuide* guide, 
 			}
 		}
 		else { // LOOP_OR_STOP
-			unassignAllReasons();
+			unassignAllReasons(false);
 			if (loopingAtLowLevel) {
 				bool success = setupClusersForInitialPlay(guide, sample, byteOvershoot, true, priorityRating);
 				if (!success) {
@@ -1282,7 +1282,7 @@ void SampleLowLevelReader::cloneFrom(SampleLowLevelReader* other, bool stealReas
 
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
 		if (clusters[l]) {
-			audioFileManager.removeReasonFromCluster(clusters[l], "E131");
+			audioFileManager.removeReasonFromCluster(clusters[l], "E131", false);
 		}
 
 		clusters[l] = other->clusters[l];

--- a/src/deluge/model/sample/sample_low_level_reader.h
+++ b/src/deluge/model/sample/sample_low_level_reader.h
@@ -36,7 +36,7 @@ public:
 	SampleLowLevelReader();
 	~SampleLowLevelReader();
 
-	void unassignAllReasons();
+	void unassignAllReasons(bool wontBeUsedAgain);
 	void jumpForwardLinear(int32_t numChannels, int32_t byteDepth, uint32_t bitMask, int32_t jumpAmount,
 	                       int32_t phaseIncrement);
 	void jumpForwardZeroes(int32_t bufferSize, int32_t numChannels, int32_t phaseIncrement);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5459,7 +5459,7 @@ void Song::cullAudioClipVoice() {
 	}
 
 	if (bestClip) {
-		bestClip->unassignVoiceSample();
+		bestClip->unassignVoiceSample(false);
 		D_PRINTLN("audio clip voice culled!");
 	}
 }

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -93,17 +93,17 @@ Voice::Voice() : patcher(&patchableInfoForVoice) {
 // it. You'll normally want to call audioDriver.voiceUnassigned() after this.
 void Voice::setAsUnassigned(ModelStackWithVoice* modelStack, bool deletingSong) {
 
-	unassignStuff();
+	unassignStuff(deletingSong);
 
 	if (!deletingSong) {
 		assignedToSound->voiceUnassigned(modelStack);
 	}
 }
 
-void Voice::unassignStuff() {
+void Voice::unassignStuff(bool deletingSong) {
 	for (int32_t s = 0; s < kNumSources; s++) {
 		for (int32_t u = 0; u < assignedToSound->numUnison; u++) {
-			unisonParts[u].sources[s].unassign();
+			unisonParts[u].sources[s].unassign(deletingSong);
 		}
 	}
 }
@@ -610,7 +610,7 @@ void Voice::noteOff(ModelStackWithVoice* modelStack, bool allowReleaseStage) {
 						    unisonParts[u].sources[s].voiceSample->noteOffWhenLoopEndPointExists(this, &guides[s]);
 
 						if (!success) {
-							unisonParts[u].sources[s].unassign();
+							unisonParts[u].sources[s].unassign(false);
 						}
 					}
 				}
@@ -652,7 +652,7 @@ bool Voice::sampleZoneChanged(ModelStackWithVoice* modelStack, int32_t s, Marker
 			                                                                         loopingType, getPriorityRating());
 			if (!stillActive) {
 				D_PRINTLN("returned false ---------");
-				voiceUnisonPartSource->unassign();
+				voiceUnisonPartSource->unassign(false);
 			}
 			else {
 				anyStillActive = true;
@@ -2056,7 +2056,7 @@ instantUnassign:
 #endif
 
 			*unisonPartBecameInactive = true;
-			voiceUnisonPartSource->unassign();
+			voiceUnisonPartSource->unassign(false);
 			continue;
 		}
 

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -101,7 +101,7 @@ public:
 	void changeNoteCode(ModelStackWithVoice* modelStack, int32_t newNoteCodeBeforeArpeggiation,
 	                    int32_t newNoteCodeAfterArpeggiation, int32_t newInputMIDIChannel, const int16_t* newMPEValues);
 	bool hasReleaseStage();
-	void unassignStuff();
+	void unassignStuff(bool deletingSong);
 	uint32_t getPriorityRating();
 	void expressionEventImmediate(Sound* sound, int32_t voiceLevelValue, int32_t s);
 	void expressionEventSmooth(int32_t newValue, int32_t s);

--- a/src/deluge/model/voice/voice_sample.cpp
+++ b/src/deluge/model/voice/voice_sample.cpp
@@ -38,8 +38,8 @@ VoiceSample::VoiceSample() {
 	timeStretcher = NULL;
 }
 
-void VoiceSample::beenUnassigned() {
-	unassignAllReasons();
+void VoiceSample::beenUnassigned(bool wontBeUsedAgain) {
+	unassignAllReasons(wontBeUsedAgain);
 	endTimeStretching();
 }
 
@@ -222,7 +222,7 @@ int32_t VoiceSample::attemptLateSampleStart(SamplePlaybackGuide* voiceSource, Sa
 
 	// Remove all old reasons - there might be some if this function has been called multiple times while we wait for
 	// Clusters to load
-	unassignAllReasons();
+	unassignAllReasons(false);
 
 	// Copy in the new reasons we just made
 	memcpy(clusters, newClusters, sizeof(clusters));
@@ -823,7 +823,7 @@ readCachedWindow:
 		// But, if we're more than 1 cluster outside of the waveform, let's just not be silly.
 		if (uncachedClusterIndex < sample->getFirstClusterIndexWithAudioData() - 1
 		    || uncachedClusterIndex > sample->getFirstClusterIndexWithNoAudioData()) {
-			unassignAllReasons(); // Remember, this doesn't cut the voice - just sets clusters[0] to NULL.
+			unassignAllReasons(false); // Remember, this doesn't cut the voice - just sets clusters[0] to NULL.
 			currentPlayPos = 0;
 		}
 
@@ -841,7 +841,7 @@ readCachedWindow:
 
 			// If uncached Cluster has changed, update queue
 			if (!clusters[0] || clusters[0]->clusterIndex != uncachedClusterIndex) {
-				unassignAllReasons(); // We're going to set new "reasons".
+				unassignAllReasons(false); // We're going to set new "reasons".
 
 				int32_t nextUncachedClusterIndex = uncachedClusterIndex;
 				for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
@@ -1698,7 +1698,7 @@ loopBackToStartCached:
 					// If we're looping, restart it
 					if (loopingType != LoopType::NONE) {
 loopBackToStartUncached:
-						unassignAllReasons();
+						unassignAllReasons(false);
 						setupClusersForInitialPlay(voiceSource, sample, 0, true, priorityRating);
 					}
 
@@ -1720,7 +1720,7 @@ justDoReassessment:
 
 	if (false) {
 loopBackToStartTimeStretched:
-		unassignAllReasons();
+		unassignAllReasons(false);
 
 		endTimeStretching(); // It'll get started again at next render
 

--- a/src/deluge/model/voice/voice_sample.h
+++ b/src/deluge/model/voice/voice_sample.h
@@ -44,7 +44,7 @@ public:
 	            LoopType loopingType, int32_t phaseIncrement, int32_t timeStretchRatio, int32_t amplitude,
 	            int32_t amplitudeIncrement, int32_t bufferSize, InterpolationMode desiredInterpolationMode,
 	            int32_t priorityRating);
-	void beenUnassigned();
+	void beenUnassigned(bool wontBeUsedAgain);
 	bool shouldObeyMarkers() {
 		return (!cache && !timeStretcher && !forAudioClip);
 	} // AudioClips don't obey markers because they "fudge" instead.

--- a/src/deluge/model/voice/voice_unison_part_source.cpp
+++ b/src/deluge/model/voice/voice_unison_part_source.cpp
@@ -52,7 +52,7 @@ bool VoiceUnisonPartSource::noteOn(Voice* voice, Source* source, VoiceSamplePlay
 			// otherwise we'll increase now but only reduce by one at note off
 			// not quite thread safe - if the sample is shorter than 64k
 			// an allocation before setupClustersForInitialPlay could steal it
-			voiceSample->beenUnassigned();
+			voiceSample->beenUnassigned(false);
 		}
 		voiceSample->noteOn(guide, samplesLate, voice->getPriorityRating());
 		if (samplesLate) {
@@ -79,10 +79,10 @@ bool VoiceUnisonPartSource::noteOn(Voice* voice, Source* source, VoiceSamplePlay
 	return true;
 }
 
-void VoiceUnisonPartSource::unassign() {
+void VoiceUnisonPartSource::unassign(bool deletingSong) {
 	active = false;
 	if (voiceSample) {
-		voiceSample->beenUnassigned();
+		voiceSample->beenUnassigned(deletingSong);
 		AudioEngine::voiceSampleUnassigned(voiceSample);
 		voiceSample = NULL;
 	}

--- a/src/deluge/model/voice/voice_unison_part_source.h
+++ b/src/deluge/model/voice/voice_unison_part_source.h
@@ -32,7 +32,7 @@ public:
 	VoiceUnisonPartSource();
 	bool noteOn(Voice* voice, Source* source, VoiceSamplePlaybackGuide* voiceSource, uint32_t samplesLate,
 	            uint32_t oscPhase, bool resetEverything, SynthMode synthMode);
-	void unassign();
+	void unassign(bool deletingSong);
 	bool getPitchAndSpeedParams(Source* source, VoiceSamplePlaybackGuide* voiceSource, uint32_t* phaseIncrement,
 	                            uint32_t* timeStretchRatio, uint32_t* noteLengthInSamples);
 	uint32_t getSpeedParamForNoSyncing(Source* source, int32_t phaseIncrement, int32_t pitchAdjustNeutralValue);

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -103,7 +103,8 @@ renderEnvelope:
 				}
 
 				else {
-					activeAudioClip->unassignVoiceSample();
+					// I think we can only be here for one shot audio clips, so maybe we shouldn't keep it?
+					activeAudioClip->unassignVoiceSample(false);
 				}
 			}
 
@@ -283,7 +284,7 @@ bool AudioOutput::willRenderAsOneChannelOnlyWhichWillNeedCopying() {
 
 void AudioOutput::cutAllSound() {
 	if (activeClip) {
-		((AudioClip*)activeClip)->unassignVoiceSample();
+		((AudioClip*)activeClip)->unassignVoiceSample(false);
 		((AudioClip*)activeClip)->abortRecording(); // Needed for when this is being called as part of a song-swap - we
 		                                            // can't leave recording happening in such a case.
 	}
@@ -395,7 +396,7 @@ bool AudioOutput::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmCh
 	if (activeClip
 	    && (activeClip != modelStack->getTimelineCounter()
 	        || (playbackHandler.playbackState && currentPlaybackMode == &arrangement))) {
-		((AudioClip*)activeClip)->unassignVoiceSample();
+		((AudioClip*)activeClip)->unassignVoiceSample(false);
 	}
 	bool clipChanged = Output::setActiveClip(modelStack, maySendMIDIPGMs);
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1261,7 +1261,7 @@ Voice* solicitVoice(Sound* forSound) {
 
 	Voice* newVoice;
 	// if we're probably gonna cull, just do it now instead of allocating
-	if (cpuDireness > 13 && numSamplesLastTime > direnessThreshold && activeVoices.getNumElements()) {
+	if (cpuDireness >= 13 && numSamplesLastTime > direnessThreshold && activeVoices.getNumElements()) {
 
 		cpuDireness -= 1; // Stop this triggering for lots of new voices. We just don't know how they'll weigh
 		                  // up to the ones being culled

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -171,7 +171,7 @@ void printLog();
 #endif
 
 int32_t getNumVoices();
-Voice* cullVoice(bool saveVoice = false, bool justDoFastRelease = false);
+Voice* cullVoice(bool saveVoice = false, bool justDoFastRelease = false, bool definitelyCull = false);
 
 bool doSomeOutputting();
 void updateReverbParams();

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -1462,7 +1462,7 @@ justUnassign:
 					// Ideally, we want to save this voice to reuse. But we can only do that for the first such one
 					if (!voiceToReuse) {
 						voiceToReuse = thisVoice;
-						thisVoice->unassignStuff();
+						thisVoice->unassignStuff(false);
 					}
 
 					// Or if we'd already found one, have to just unassign this new one
@@ -2930,7 +2930,7 @@ void Sound::setNumUnison(int32_t newNum, ModelStackWithSoundFlags* modelStack) {
 						}
 						else if (newNum < oldNum) {
 							for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
-								thisVoice->unisonParts[newNum].sources[s].unassign();
+								thisVoice->unisonParts[newNum].sources[s].unassign(false);
 							}
 						}
 					}

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -1393,7 +1393,7 @@ void AudioFileManager::addReasonToCluster(Cluster* cluster) {
 	cluster->numReasonsToBeLoaded++;
 }
 
-void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* errorCode) {
+void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* errorCode, bool deletingSong) {
 	cluster->numReasonsToBeLoaded--;
 
 	if (cluster == clusterBeingLoaded && cluster->numReasonsToBeLoaded < minNumReasonsForClusterBeingLoaded) {
@@ -1410,7 +1410,8 @@ void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* err
 
 		// If it's still in the load queue, remove it from there. (We know that it isn't in the process of being loaded
 		// right now because that would have added a "reason", so we wouldn't be here.)
-		if (loadingQueue.removeIfPresent(cluster)) {
+		// also do this on song swap
+		if (loadingQueue.removeIfPresent(cluster) || deletingSong) {
 
 			// Tell its Cluster to forget it exists
 			cluster->sample->clusters.getElement(cluster->clusterIndex)->cluster = NULL;

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -86,7 +86,7 @@ public:
 	bool loadCluster(Cluster* cluster, int32_t minNumReasonsAfter = 0);
 	void loadAnyEnqueuedClusters(int32_t maxNum = 128, bool mayProcessUserActionsBetween = false);
 	void addReasonToCluster(Cluster* cluster);
-	void removeReasonFromCluster(Cluster* cluster, char const* errorCode);
+	void removeReasonFromCluster(Cluster* cluster, char const* errorCode, bool deletingSong = false);
 	void testQueue();
 
 	bool ensureEnoughMemoryForOneMoreAudioFile();

--- a/src/deluge/util/container/list/bidirectional_linked_list.cpp
+++ b/src/deluge/util/container/list/bidirectional_linked_list.cpp
@@ -40,6 +40,20 @@ void BidirectionalLinkedList::addToEnd(BidirectionalLinkedListNode* node) {
 #endif
 }
 
+void BidirectionalLinkedList::addToStart(BidirectionalLinkedListNode* node) {
+	node->prevPointer = &first->next;
+	node->next = first->next;
+	first->next = node;
+
+	node->list = this;
+
+#if ALPHA_OR_BETA_VERSION
+	// Have deactivated this, because some of the lists will have up to 2000 elements in them on boot, and searching
+	// through all of these causes voice culls
+	// test();
+#endif
+}
+
 BidirectionalLinkedListNode* BidirectionalLinkedList::getFirst() {
 	if (first == &endNode) {
 		return NULL;

--- a/src/deluge/util/container/list/bidirectional_linked_list.h
+++ b/src/deluge/util/container/list/bidirectional_linked_list.h
@@ -46,4 +46,5 @@ public:
 
 	BidirectionalLinkedListNode endNode;
 	BidirectionalLinkedListNode* first;
+	void addToStart(BidirectionalLinkedListNode* node);
 };


### PR DESCRIPTION
Three changes to increase voice count - 
1. <s>When a sample is no longer needed, add it to the start of the stealable queue instead of the end</s> Removed - negative side effects with songs close to max load but not over it
2. After rendering the song, always try rendering it again (exits if it's ahead or after 5 renders). Previously only done when clocks interfered with rendering
3. Re introduce the cull smoothing - in combo with 2 this no longer has the risk of over shooting our samples, as if it's not keeping up with output it'll go again and cull a second time immediately 
4. Fix soft cull logic so that more than one voice can be soft culled, avoiding the issue of "overshooting" hard culls
5. Fix voice allocation logic so that voices are solicited via culling when it's likely that the next render round will cull voices
6. Fix memory leakage between songs by immediately deallocating voices when they won't be used again
7. Soft cull more agressively, avoid going into hard culling to reduce the clicks associated with hard culls


Fix #804 (I think)