### PR TITLE
check that drum exists before dereferencing

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -823,7 +823,7 @@ someError:
 		loadInstrumentPresetUI.instrumentToReplace = nullptr;
 
 		loadInstrumentPresetUI.instrumentClipToLoadFor = nullptr;
-		if (noteRow->drum->type == drumType) {
+		if (noteRow->drum && noteRow->drum->type == drumType) {
 			loadInstrumentPresetUI.soundDrumToReplace = (SoundDrum*)noteRow->drum;
 		}
 		else {


### PR DESCRIPTION
Fix #1222 