### PR TITLE
Set default unpatched volume and adjust volume of songs saved on community

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -856,6 +856,7 @@ bool GlobalEffectable::readParamTagFromFile(char const* tagName, ParamManagerFor
 
 	else if (!strcmp(tagName, "volume")) {
 		unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_VOLUME, readAutomationUpToPos);
+		// volume adjustment for songs saved on community 1.0.0 or later, but before version 1.1.0
 		if (storageManager.firmwareVersionOfFileBeingRead >= FIRMWARE_4P1P4_ALPHA
 		    && storageManager.firmwareVersionOfFileBeingRead < COMMUNITY_1P1) {
 			unpatchedParams->shiftParamValues(params::UNPATCHED_VOLUME, -889516852);

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -71,8 +71,8 @@ void GlobalEffectable::initParams(ParamManager* paramManager) {
 	unpatchedParams->params[params::UNPATCHED_DELAY_AMOUNT].setCurrentValueBasicForSetup(-2147483648);
 	unpatchedParams->params[params::UNPATCHED_REVERB_SEND_AMOUNT].setCurrentValueBasicForSetup(-2147483648);
 
-	unpatchedParams->params[params::UNPATCHED_VOLUME].setCurrentValueBasicForSetup(
-	    889516852); // 3 quarters of the way up
+	// 2 quarters of the way up
+	unpatchedParams->params[params::UNPATCHED_VOLUME].setCurrentValueBasicForSetup(0);
 	unpatchedParams->params[params::UNPATCHED_SIDECHAIN_VOLUME].setCurrentValueBasicForSetup(-2147483648);
 	unpatchedParams->params[params::UNPATCHED_PITCH_ADJUST].setCurrentValueBasicForSetup(0);
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -856,6 +856,10 @@ bool GlobalEffectable::readParamTagFromFile(char const* tagName, ParamManagerFor
 
 	else if (!strcmp(tagName, "volume")) {
 		unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_VOLUME, readAutomationUpToPos);
+		if (storageManager.firmwareVersionOfFileBeingRead >= FIRMWARE_4P1P4_ALPHA
+		    && storageManager.firmwareVersionOfFileBeingRead < COMMUNITY_1P1) {
+			unpatchedParams->shiftParamValues(params::UNPATCHED_VOLUME, -889516852);
+		}
 		storageManager.exitTag("volume");
 	}
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -71,8 +71,7 @@ void GlobalEffectable::initParams(ParamManager* paramManager) {
 	unpatchedParams->params[params::UNPATCHED_DELAY_AMOUNT].setCurrentValueBasicForSetup(-2147483648);
 	unpatchedParams->params[params::UNPATCHED_REVERB_SEND_AMOUNT].setCurrentValueBasicForSetup(-2147483648);
 
-	// 2 quarters of the way up
-	unpatchedParams->params[params::UNPATCHED_VOLUME].setCurrentValueBasicForSetup(0);
+	unpatchedParams->params[params::UNPATCHED_VOLUME].setCurrentValueBasicForSetup(0); // half of the way up
 	unpatchedParams->params[params::UNPATCHED_SIDECHAIN_VOLUME].setCurrentValueBasicForSetup(-2147483648);
 	unpatchedParams->params[params::UNPATCHED_PITCH_ADJUST].setCurrentValueBasicForSetup(0);
 
@@ -857,6 +856,7 @@ bool GlobalEffectable::readParamTagFromFile(char const* tagName, ParamManagerFor
 	else if (!strcmp(tagName, "volume")) {
 		unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_VOLUME, readAutomationUpToPos);
 		// volume adjustment for songs saved on community 1.0.0 or later, but before version 1.1.0
+		// reduces the saved song volume by approximately 21% (889516852 / 4294967295)
 		if (storageManager.firmwareVersionOfFileBeingRead >= FIRMWARE_4P1P4_ALPHA
 		    && storageManager.firmwareVersionOfFileBeingRead < COMMUNITY_1P1) {
 			unpatchedParams->shiftParamValues(params::UNPATCHED_VOLUME, -889516852);


### PR DESCRIPTION
With the adjustment to volume levels in the community firmware, the init unpatched volume levels are now too high and cause distortion and clipping

So now we are adjusting unpatched volume to be set at 2/4 level instead of the previous 3/4 level

I also added an adjustment for the volume of songs being read that were saved on firmware version FIRMWARE_4P1P4_ALPHA or higher, but less than the current firmware version of COMMUNITY_1P1.

```
	else if (!strcmp(tagName, "volume")) {
		unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_VOLUME, readAutomationUpToPos);
		if (storageManager.firmwareVersionOfFileBeingRead >= FIRMWARE_4P1P4_ALPHA
		    && storageManager.firmwareVersionOfFileBeingRead < COMMUNITY_1P1) {
			unpatchedParams->shiftParamValues(params::UNPATCHED_VOLUME, -889516852);
		}
		storageManager.exitTag("volume");
	}
```