### PR TITLE
Adjusted text placement in mod button popups

### DIFF
--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -2572,7 +2572,7 @@ void ModControllableAudio::displayLPFMode(bool on) {
 	if (display->haveOLED()) {
 		if (on) {
 			DEF_STACK_STRING_BUF(popupMsg, 40);
-			popupMsg.append("LPF: ");
+			popupMsg.append("LPF\n");
 			popupMsg.append(getLPFModeDisplayName());
 
 			display->popupText(popupMsg.c_str());
@@ -2595,7 +2595,7 @@ void ModControllableAudio::displayHPFMode(bool on) {
 	if (display->haveOLED()) {
 		if (on) {
 			DEF_STACK_STRING_BUF(popupMsg, 40);
-			popupMsg.append("HPF: ");
+			popupMsg.append("HPF\n");
 			popupMsg.append(getHPFModeDisplayName());
 
 			display->popupText(popupMsg.c_str());
@@ -2629,10 +2629,10 @@ void ModControllableAudio::displayDelaySettings(bool on) {
 				popupMsg.append(displayName);
 			}
 			else {
-				popupMsg.append(getDelayTypeDisplayName());
-
-				popupMsg.append("\nPing pong: ");
+				popupMsg.append("Ping pong: ");
 				popupMsg.append(getDelayPingPongStatusDisplayName());
+				popupMsg.append("\n");
+				popupMsg.append(getDelayTypeDisplayName());
 			}
 
 			display->popupText(popupMsg.c_str());
@@ -2655,10 +2655,10 @@ void ModControllableAudio::displayDelaySettings(bool on) {
 		}
 		else {
 			if (on) {
-				display->displayPopup(getDelayTypeDisplayName());
+				display->displayPopup(getDelayPingPongStatusDisplayName());
 			}
 			else {
-				display->displayPopup(getDelayPingPongStatusDisplayName());
+				display->displayPopup(getDelayTypeDisplayName());
 			}
 		}
 	}


### PR DESCRIPTION
Adjusted text placement in mod button pop-ups to reflect Upper/Lower gold encoder assignments.

E.g.

- LPF on top and 24 DB Ladder on the bottom.
- Ping Pong on top, Delay Type on the bottom

<img width="227" alt="Screenshot 2024-02-15 at 6 04 33 AM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/5f7e53c6-d143-4104-b547-ada2a41ab87d">

<img width="212" alt="Screenshot 2024-02-15 at 6 04 21 AM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/80ec8fa5-d25d-4432-a110-bf6a105ac1c1">
