### PR TITLE
Allow selecting songs to overwrite with select encoder

### DIFF
--- a/src/deluge/gui/ui/save/save_ui.cpp
+++ b/src/deluge/gui/ui/save/save_ui.cpp
@@ -106,10 +106,7 @@ ActionResult SaveUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRou
 		return mainButtonAction(on);
 	}
 
-	// Select encoder button - we want to override default behaviour here and potentially do nothing, so user doesn't
-	// save over something by accident.
-	else if (b == SELECT_ENC && currentFileItem && !currentFileItem->isFolder) {}
-
+	// Pressing on select encoder button will go through here
 	else {
 		return SlotBrowser::buttonAction(b, on, inCardRoutine);
 	}


### PR DESCRIPTION
Currently when you're saving a song, you can overwrite an existing song only by selecting the existing song and pressing save

When you press save, it asks if you want to overwrite that song, and then you can press the select encoder to overwrite it

I think we should also allow selecting an existing song and pressing on the select encoder to select it and then press the select encoder again to overwrite it.

Rohan's reason for not allowing the select encoder to select a song for overwriting was this:

```
// Select encoder button - we want to override default behaviour here and potentially do nothing, so user doesn't
 // save over something by accident.
```

I think that given that on both 7seg and OLED it flashes "Overwrite?" on the screen, that it shouldn't be an issue to allow selecting a song for overwriting with the select encoder.