### PR TITLE
Update mod button popups with mod encoder selection

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1504,8 +1504,6 @@ void View::cycleThroughReverbPresets() {
 
 	AudioEngine::reverb.setRoomSize((float)presetReverbRoomSize[newPreset] / 50);
 	AudioEngine::reverb.setDamping((float)presetReverbDamping[newPreset] / 50);
-
-	display->displayPopup(getReverbPresetDisplayName(newPreset));
 }
 
 int32_t View::getCurrentReverbPreset() {

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -97,25 +97,7 @@ void GlobalEffectable::modButtonAction(uint8_t whichModButton, bool on, ParamMan
 
 	// LPF/HPF/EQ
 	if (whichModButton == 1) {
-		currentFilterType = static_cast<FilterType>(util::to_underlying(currentFilterType) % kNumFilterTypes);
-		switch (currentFilterType) {
-		case FilterType::LPF:
-			displayLPFMode(on);
-			break;
-
-		case FilterType::HPF:
-			displayHPFMode(on);
-			break;
-
-		case FilterType::EQ:
-			if (on) {
-				display->popupText(deluge::l10n::get(deluge::l10n::String::STRING_FOR_EQ));
-			}
-			else {
-				display->cancelPopup();
-			}
-			break;
-		}
+		displayFilterSettings(on, currentFilterType);
 	}
 	// Delay
 	else if (whichModButton == 3) {
@@ -277,31 +259,16 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				if (modFXType == ModFXType::NONE) {
 					modFXType = static_cast<ModFXType>(1);
 				}
-				std::string_view displayText;
-				switch (modFXType) {
-				case ModFXType::FLANGER:
-					displayText = l10n::getView(STRING_FOR_FLANGER);
-					break;
-
-				case ModFXType::PHASER:
-					displayText = l10n::getView(STRING_FOR_PHASER);
-					break;
-
-				case ModFXType::CHORUS:
-					displayText = l10n::getView(STRING_FOR_CHORUS);
-					break;
-
-				case ModFXType::CHORUS_STEREO:
-					displayText = l10n::getView(STRING_FOR_STEREO_CHORUS);
-					break;
-				case ModFXType::GRAIN:
-					displayText = l10n::getView(STRING_FOR_GRAIN);
-					break;
-				case ModFXType::NONE:
-					__builtin_unreachable();
-				}
-				display->displayPopup(displayText.data());
 				ensureModFXParamIsValid();
+
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayModFXSettings(on);
+				}
+				else {
+					display->displayPopup(getModFXTypeDisplayName());
+				}
 				return true;
 			}
 			else {
@@ -314,21 +281,15 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				    static_cast<ModFXParam>((util::to_underlying(currentModFXParam) + 1) % kNumModFXParams);
 				ensureModFXParamIsValid();
 
-				std::string_view displayText;
-				switch (currentModFXParam) {
-				case ModFXParam::DEPTH:
-					displayText = l10n::getView(STRING_FOR_DEPTH);
-					break;
-
-				case ModFXParam::FEEDBACK:
-					displayText = l10n::getView(STRING_FOR_FEEDBACK);
-					break;
-
-				case ModFXParam::OFFSET:
-					displayText = l10n::getView(STRING_FOR_OFFSET);
-					break;
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayModFXSettings(on);
 				}
-				display->displayPopup(displayText.data());
+				else {
+					display->displayPopup(getModFXParamDisplayName());
+				}
+				return true;
 			}
 
 			return false;
@@ -342,21 +303,15 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				currentFilterType =
 				    static_cast<FilterType>((util::to_underlying(currentFilterType) + 1) % kNumFilterTypes);
 
-				std::string_view displayText;
-				switch (currentFilterType) {
-				case FilterType::LPF:
-					displayText = l10n::getView(STRING_FOR_LPF);
-					break;
-
-				case FilterType::HPF:
-					displayText = l10n::getView(STRING_FOR_HPF);
-					break;
-
-				case FilterType::EQ:
-					displayText = l10n::getView(STRING_FOR_EQ);
-					break;
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayFilterSettings(on, currentFilterType);
 				}
-				display->displayPopup(displayText.data());
+				else {
+					display->displayPopup(getFilterTypeDisplayName(currentFilterType));
+				}
+				return true;
 			}
 
 			return false;
@@ -365,10 +320,28 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 			if (on) {
 				if (currentFilterType == FilterType::LPF) {
 					switchLPFMode();
+
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayFilterSettings(on, currentFilterType);
+					}
+					else {
+						display->displayPopup(getFilterModeDisplayName(currentFilterType));
+					}
 					return true;
 				}
 				else if (currentFilterType == FilterType::HPF) {
 					switchHPFMode();
+
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayFilterSettings(on, currentFilterType);
+					}
+					else {
+						display->displayPopup(getFilterModeDisplayName(currentFilterType));
+					}
 					return true;
 				}
 				else {
@@ -389,9 +362,27 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
 				    == RuntimeFeatureStateToggle::On) {
 					switchDelaySyncType();
+
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayDelaySettings(on);
+					}
+					else {
+						display->displayPopup(getDelaySyncTypeDisplayName());
+					}
 				}
 				else {
 					switchDelayPingPong();
+
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayDelaySettings(on);
+					}
+					else {
+						display->displayPopup(getDelayPingPongStatusDisplayName());
+					}
 				}
 				return true;
 			}
@@ -404,9 +395,29 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
 				    == RuntimeFeatureStateToggle::On) {
 					switchDelaySyncLevel();
+
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayDelaySettings(on);
+					}
+					else {
+						char displayName[30];
+						getDelaySyncLevelDisplayName(displayName);
+						display->displayPopup(displayName);
+					}
 				}
 				else {
 					switchDelayAnalog();
+
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayDelaySettings(on);
+					}
+					else {
+						display->displayPopup(getDelayTypeDisplayName());
+					}
 				}
 				return true;
 			}
@@ -416,26 +427,51 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 		}
 	}
 
-	// Reverb / sidechain section
+	// Reverb / compressor section
 	else if (modKnobMode == 4) {
 		if (whichModEncoder == 0) { // Reverb
 			if (on) {
-				// if we're in full move/editingComp then we cycle through the comp params
+				// if we're in full mode/editingComp then we cycle through the comp params
 				// otherwise cycle reverb sizes
 				if (!editingComp) {
 					view.cycleThroughReverbPresets();
+
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayCompressorAndReverbSettings(on);
+					}
+					else {
+						display->displayPopup(view.getReverbPresetDisplayName(view.getCurrentReverbPreset()));
+					}
 				}
 				else {
 					currentCompParam =
 					    static_cast<CompParam>((util::to_underlying(currentCompParam) + 1) % maxCompParam);
-					display->displayPopup(getCompressorParamDisplayName());
+					
+					// if mod button is pressed, update mod button pop up
+					if (Buttons::isButtonPressed(
+					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+						displayCompressorAndReverbSettings(on);
+					}
+					else {
+						display->displayPopup(getCompressorParamDisplayName());
+					}
 				}
 			}
 		}
 		else {
 			if (on) {
 				editingComp = !editingComp;
-				display->displayPopup(getCompressorModeDisplayName());
+
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayCompressorAndReverbSettings(on);
+				}
+				else {
+					display->displayPopup(getCompressorModeDisplayName());
+				}
 			}
 		}
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -448,7 +448,7 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 				else {
 					currentCompParam =
 					    static_cast<CompParam>((util::to_underlying(currentCompParam) + 1) % maxCompParam);
-					
+
 					// if mod button is pressed, update mod button pop up
 					if (Buttons::isButtonPressed(
 					        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -70,5 +70,4 @@ protected:
 
 private:
 	bool renderedLastTime;
-	void displaySidechainAndReverbSettings(bool on);
 };

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -2317,23 +2317,10 @@ void ModControllableAudio::endStutter(ParamManagerForTimeline* paramManager) {
 
 void ModControllableAudio::switchDelayPingPong() {
 	delay.pingPong = !delay.pingPong;
-
-	char const* displayText;
-	switch (delay.pingPong) {
-	case 0:
-		displayText = "Normal delay";
-		break;
-
-	default:
-		displayText = "Ping-pong delay";
-		break;
-	}
-	display->displayPopup(displayText);
 }
 
 void ModControllableAudio::switchDelayAnalog() {
 	delay.analog = !delay.analog;
-	display->displayPopup(getDelayTypeDisplayName());
 }
 
 char const* ModControllableAudio::getDelayTypeDisplayName() {
@@ -2359,7 +2346,6 @@ void ModControllableAudio::switchDelaySyncType() {
 		delay.syncType = SYNC_TYPE_TRIPLET;
 		break;
 	}
-	display->displayPopup(getDelaySyncTypeDisplayName());
 }
 
 char const* ModControllableAudio::getDelaySyncTypeDisplayName() {
@@ -2376,9 +2362,6 @@ char const* ModControllableAudio::getDelaySyncTypeDisplayName() {
 void ModControllableAudio::switchDelaySyncLevel() {
 	// Note: SYNC_LEVEL_NONE (value 0) can't be selected
 	delay.syncLevel = (SyncLevel)((delay.syncLevel) % SyncLevel::SYNC_LEVEL_256TH + 1); // cycle from 1 to 9 (omit 0)
-	char displayName[30];
-	getDelaySyncLevelDisplayName(displayName);
-	display->displayPopup(displayName);
 }
 
 void ModControllableAudio::getDelaySyncLevelDisplayName(char* displayName) {
@@ -2389,9 +2372,33 @@ void ModControllableAudio::getDelaySyncLevelDisplayName(char* displayName) {
 	strncpy(displayName, buffer.data(), 29);
 }
 
+char const* ModControllableAudio::getFilterTypeDisplayName(FilterType currentFilterType) {
+	using enum deluge::l10n::String;
+	switch (currentFilterType) {
+	case FilterType::LPF:
+		return l10n::get(STRING_FOR_LPF);
+	case FilterType::HPF:
+		return l10n::get(STRING_FOR_HPF);
+	case FilterType::EQ:
+		return l10n::get(STRING_FOR_EQ);
+	default:
+		return l10n::get(STRING_FOR_NONE);
+	}
+}
+
 void ModControllableAudio::switchLPFMode() {
 	lpfMode = static_cast<FilterMode>((util::to_underlying(lpfMode) + 1) % kNumLPFModes);
-	display->displayPopup(getLPFModeDisplayName());
+}
+
+char const* ModControllableAudio::getFilterModeDisplayName(FilterType currentFilterType) {
+	switch (currentFilterType) {
+	case FilterType::LPF:
+		return getLPFModeDisplayName();
+	case FilterType::HPF:
+		return getHPFModeDisplayName();
+	default:
+		return l10n::get(deluge::l10n::String::STRING_FOR_NONE);
+	}
 }
 
 char const* ModControllableAudio::getLPFModeDisplayName() {
@@ -2416,7 +2423,6 @@ char const* ModControllableAudio::getLPFModeDisplayName() {
 void ModControllableAudio::switchHPFMode() {
 	// this works fine, the offset to the first hpf doesn't matter with the modulus
 	hpfMode = static_cast<FilterMode>((util::to_underlying(hpfMode) + 1) % kNumHPFModes + kFirstHPFMode);
-	display->displayPopup(getHPFModeDisplayName());
 }
 
 char const* ModControllableAudio::getHPFModeDisplayName() {
@@ -2550,31 +2556,15 @@ bool ModControllableAudio::unlearnKnobs(ParamDescriptor paramDescriptor, Song* s
 	return anythingFound;
 }
 
-char const* ModControllableAudio::getSidechainDisplayName() {
-	int32_t insideWorldTickMagnitude;
-	if (currentSong) { // Bit of a hack just referring to currentSong in here...
-		insideWorldTickMagnitude =
-		    (currentSong->insideWorldTickMagnitude + currentSong->insideWorldTickMagnitudeOffsetFromBPM);
-	}
-	else {
-		insideWorldTickMagnitude = FlashStorage::defaultMagnitude;
-	}
-	using enum deluge::l10n::String;
-	if (sidechain.syncLevel == (SyncLevel)(7 - insideWorldTickMagnitude)) {
-		return l10n::get(STRING_FOR_SLOW);
-	}
-	else {
-		return l10n::get(STRING_FOR_FAST);
-	}
-}
-
-void ModControllableAudio::displayLPFMode(bool on) {
+void ModControllableAudio::displayFilterSettings(bool on, FilterType currentFilterType) {
 	if (display->haveOLED()) {
 		if (on) {
 			DEF_STACK_STRING_BUF(popupMsg, 40);
-			popupMsg.append("LPF\n");
-			popupMsg.append(getLPFModeDisplayName());
-
+			popupMsg.append(getFilterTypeDisplayName(currentFilterType));
+			if (currentFilterType != FilterType::EQ) {
+				popupMsg.append("\n");
+				popupMsg.append(getFilterModeDisplayName(currentFilterType));
+			}
 			display->popupText(popupMsg.c_str());
 		}
 		else {
@@ -2583,33 +2573,10 @@ void ModControllableAudio::displayLPFMode(bool on) {
 	}
 	else {
 		if (on) {
-			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_LPF));
+			display->displayPopup(getFilterTypeDisplayName(currentFilterType));
 		}
 		else {
-			display->displayPopup(getLPFModeDisplayName());
-		}
-	}
-}
-
-void ModControllableAudio::displayHPFMode(bool on) {
-	if (display->haveOLED()) {
-		if (on) {
-			DEF_STACK_STRING_BUF(popupMsg, 40);
-			popupMsg.append("HPF\n");
-			popupMsg.append(getHPFModeDisplayName());
-
-			display->popupText(popupMsg.c_str());
-		}
-		else {
-			display->cancelPopup();
-		}
-	}
-	else {
-		if (on) {
-			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_HPF));
-		}
-		else {
-			display->displayPopup(getHPFModeDisplayName());
+			display->displayPopup(getFilterModeDisplayName(currentFilterType));
 		}
 	}
 }
@@ -2665,11 +2632,59 @@ void ModControllableAudio::displayDelaySettings(bool on) {
 }
 
 char const* ModControllableAudio::getDelayPingPongStatusDisplayName() {
+	using enum deluge::l10n::String;
 	switch (delay.pingPong) {
-		using enum deluge::l10n::String;
 	case 0:
 		return l10n::get(STRING_FOR_DISABLED);
 	default:
 		return l10n::get(STRING_FOR_ENABLED);
+	}
+}
+
+void ModControllableAudio::displaySidechainAndReverbSettings(bool on) {
+	// Sidechain
+	if (display->haveOLED()) {
+		if (on) {
+			DEF_STACK_STRING_BUF(popupMsg, 100);
+			// Sidechain
+			popupMsg.append("Sidechain: ");
+			popupMsg.append(getSidechainDisplayName());
+
+			popupMsg.append("\n");
+
+			// Reverb
+			popupMsg.append(view.getReverbPresetDisplayName(view.getCurrentReverbPreset()));
+
+			display->popupText(popupMsg.c_str());
+		}
+		else {
+			display->cancelPopup();
+		}
+	}
+	else {
+		if (on) {
+			display->displayPopup(getSidechainDisplayName());
+		}
+		else {
+			display->displayPopup(view.getReverbPresetDisplayName(view.getCurrentReverbPreset()));
+		}
+	}
+}
+
+char const* ModControllableAudio::getSidechainDisplayName() {
+	int32_t insideWorldTickMagnitude;
+	if (currentSong) { // Bit of a hack just referring to currentSong in here...
+		insideWorldTickMagnitude =
+		    (currentSong->insideWorldTickMagnitude + currentSong->insideWorldTickMagnitudeOffsetFromBPM);
+	}
+	else {
+		insideWorldTickMagnitude = FlashStorage::defaultMagnitude;
+	}
+	using enum deluge::l10n::String;
+	if (sidechain.syncLevel == (SyncLevel)(7 - insideWorldTickMagnitude)) {
+		return l10n::get(STRING_FOR_SLOW);
+	}
+	else {
+		return l10n::get(STRING_FOR_FAST);
 	}
 }

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -189,17 +189,19 @@ protected:
 	/// subclass is
 	deluge::modulation::params::Kind unpatchedParamKind_;
 
+	char const* getFilterTypeDisplayName(FilterType currentFilterType);
+	char const* getFilterModeDisplayName(FilterType currentFilterType);
 	char const* getLPFModeDisplayName();
 	char const* getHPFModeDisplayName();
 	char const* getDelayTypeDisplayName();
 	char const* getDelayPingPongStatusDisplayName();
 	char const* getDelaySyncTypeDisplayName();
 	void getDelaySyncLevelDisplayName(char* displayName);
-
 	char const* getSidechainDisplayName();
-	void displayLPFMode(bool on);
-	void displayHPFMode(bool on);
+
+	void displayFilterSettings(bool on, FilterType currentFilterType);
 	void displayDelaySettings(bool on);
+	void displaySidechainAndReverbSettings(bool on);
 
 private:
 	void initializeSecondaryDelayBuffer(int32_t newNativeRate, bool makeNativeRatePreciseRelativeToOtherBuffer);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3957,21 +3957,18 @@ void Sound::modButtonAction(uint8_t whichModButton, bool on, ParamManagerForTime
 	// LPF/HPF/EQ
 	if (whichModButton == 1) {
 		if (getSynthMode() != SynthMode::FM) {
+			FilterType currentFilterType;
 			if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_LPF_FREQ)) {
-				displayLPFMode(on);
+				currentFilterType = FilterType::LPF;
 			}
 			else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_HPF_FREQ)) {
-				displayHPFMode(on);
+				currentFilterType = FilterType::HPF;
 			}
 			else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::UNPATCHED_START
 			                                                              + params::UNPATCHED_TREBLE)) {
-				if (on) {
-					display->popupText(deluge::l10n::get(deluge::l10n::String::STRING_FOR_EQ));
-				}
-				else {
-					display->cancelPopup();
-				}
+				currentFilterType = FilterType::EQ;
 			}
+			displayFilterSettings(on, currentFilterType);
 		}
 	}
 	// Delay
@@ -3985,36 +3982,6 @@ void Sound::modButtonAction(uint8_t whichModButton, bool on, ParamManagerForTime
 		if ((ourModKnob->paramDescriptor.hasJustOneSource()
 		     && ourModKnob->paramDescriptor.getTopLevelSource() == PatchSource::SIDECHAIN)) {
 			displaySidechainAndReverbSettings(on);
-		}
-	}
-}
-
-void Sound::displaySidechainAndReverbSettings(bool on) {
-	// Sidechain
-	if (display->haveOLED()) {
-		if (on) {
-			DEF_STACK_STRING_BUF(popupMsg, 100);
-			// Sidechain
-			popupMsg.append("Sidechain: ");
-			popupMsg.append(getSidechainDisplayName());
-
-			popupMsg.append("\n");
-
-			// Reverb
-			popupMsg.append(view.getReverbPresetDisplayName(view.getCurrentReverbPreset()));
-
-			display->popupText(popupMsg.c_str());
-		}
-		else {
-			display->cancelPopup();
-		}
-	}
-	else {
-		if (on) {
-			display->displayPopup(getSidechainDisplayName());
-		}
-		else {
-			display->displayPopup(view.getReverbPresetDisplayName(view.getCurrentReverbPreset()));
 		}
 	}
 }
@@ -4094,9 +4061,27 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 			if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
 			    == RuntimeFeatureStateToggle::On) {
 				switchDelaySyncType();
+
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayDelaySettings(on);
+				}
+				else {
+					display->displayPopup(getDelaySyncTypeDisplayName());
+				}
 			}
 			else {
 				switchDelayPingPong();
+
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayDelaySettings(on);
+				}
+				else {
+					display->displayPopup(getDelayPingPongStatusDisplayName());
+				}
 			}
 			return true;
 		}
@@ -4111,9 +4096,29 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 			if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AltGoldenKnobDelayParams)
 			    == RuntimeFeatureStateToggle::On) {
 				switchDelaySyncLevel();
+
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayDelaySettings(on);
+				}
+				else {
+					char displayName[30];
+					getDelaySyncLevelDisplayName(displayName);
+					display->displayPopup(displayName);
+				}
 			}
 			else {
 				switchDelayAnalog();
+
+				// if mod button is pressed, update mod button pop up
+				if (Buttons::isButtonPressed(
+				        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+					displayDelaySettings(on);
+				}
+				else {
+					display->displayPopup(getDelayTypeDisplayName());
+				}
 			}
 			return true;
 		}
@@ -4126,6 +4131,16 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 	else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_LPF_RESONANCE)) {
 		if (on) {
 			switchLPFMode();
+			FilterType currentFilterType = FilterType::LPF;
+
+			// if mod button is pressed, update mod button pop up
+			if (Buttons::isButtonPressed(
+			        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+				displayFilterSettings(on, currentFilterType);
+			}
+			else {
+				display->displayPopup(getFilterModeDisplayName(currentFilterType));
+			}
 			return true;
 		}
 		else {
@@ -4136,6 +4151,16 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 	else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_HPF_RESONANCE)) {
 		if (on) {
 			switchHPFMode();
+			FilterType currentFilterType = FilterType::HPF;
+
+			// if mod button is pressed, update mod button pop up
+			if (Buttons::isButtonPressed(
+			        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+				displayFilterSettings(on, currentFilterType);
+			}
+			else {
+				display->displayPopup(getFilterModeDisplayName(currentFilterType));
+			}
 			return true;
 		}
 		else {
@@ -4146,6 +4171,15 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 	else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::GLOBAL_REVERB_AMOUNT)) {
 		if (on) {
 			view.cycleThroughReverbPresets();
+
+			// if mod button is pressed, update mod button pop up
+			if (Buttons::isButtonPressed(
+			        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+				displaySidechainAndReverbSettings(on);
+			}
+			else {
+				display->displayPopup(view.getReverbPresetDisplayName(view.getCurrentReverbPreset()));
+			}
 		}
 		return false;
 	}
@@ -4165,11 +4199,18 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 
 			if (sidechain.syncLevel == (SyncLevel)(7 - insideWorldTickMagnitude)) {
 				sidechain.syncLevel = (SyncLevel)(9 - insideWorldTickMagnitude);
-				display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_FAST));
 			}
 			else {
 				sidechain.syncLevel = (SyncLevel)(7 - insideWorldTickMagnitude);
-				display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_SLOW));
+			}
+
+			// if mod button is pressed, update mod button pop up
+			if (Buttons::isButtonPressed(
+			        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+				displaySidechainAndReverbSettings(on);
+			}
+			else {
+				display->displayPopup(getSidechainDisplayName());
 			}
 			return true;
 		}
@@ -4188,7 +4229,16 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 				modKnobs[modKnobMode][1 - whichModEncoder].paramDescriptor.setToHaveParamOnly(
 				    params::LOCAL_HPF_RESONANCE);
 			}
-			display->displayPopup("HPF");
+			FilterType currentFilterType = FilterType::HPF;
+
+			// if mod button is pressed, update mod button pop up
+			if (Buttons::isButtonPressed(
+			        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+				displayFilterSettings(on, currentFilterType);
+			}
+			else {
+				display->displayPopup(getFilterTypeDisplayName(currentFilterType));
+			}
 		}
 		return false;
 	}
@@ -4202,7 +4252,16 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 				modKnobs[modKnobMode][1 - whichModEncoder].paramDescriptor.setToHaveParamOnly(params::UNPATCHED_START
 				                                                                              + params::UNPATCHED_BASS);
 			}
-			display->displayPopup("EQ");
+			FilterType currentFilterType = FilterType::EQ;
+
+			// if mod button is pressed, update mod button pop up
+			if (Buttons::isButtonPressed(
+			        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+				displayFilterSettings(on, currentFilterType);
+			}
+			else {
+				display->displayPopup(getFilterTypeDisplayName(currentFilterType));
+			}
 		}
 		return false;
 	}
@@ -4216,7 +4275,16 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 				modKnobs[modKnobMode][1 - whichModEncoder].paramDescriptor.setToHaveParamOnly(
 				    params::LOCAL_LPF_RESONANCE);
 			}
-			display->displayPopup("LPF");
+			FilterType currentFilterType = FilterType::LPF;
+
+			// if mod button is pressed, update mod button pop up
+			if (Buttons::isButtonPressed(
+			        deluge::hid::button::fromXY(modButtonX[modKnobMode], modButtonY[modKnobMode]))) {
+				displayFilterSettings(on, currentFilterType);
+			}
+			else {
+				display->displayPopup(getFilterTypeDisplayName(currentFilterType));
+			}
 		}
 		return false;
 	}

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -294,6 +294,4 @@ private:
 	ModelStackWithAutoParam* getParamFromModEncoderDeeper(int32_t whichModEncoder,
 	                                                      ModelStackWithThreeMainThings* modelStack,
 	                                                      bool allowCreation = true);
-
-	void displaySidechainAndReverbSettings(bool on);
 };


### PR DESCRIPTION
If a mod button is currently being held and a pop-up is displayed showing the current mod encoder selection, update mod button pop-up if mod encoder selection changes.