### PR TITLE
Fixed parameter shortcut blinking when entering automation view from menu + parameter selection bug

### DIFF
--- a/src/deluge/gui/menu_item/param.cpp
+++ b/src/deluge/gui/menu_item/param.cpp
@@ -62,6 +62,7 @@ ActionResult Param::buttonAction(deluge::hid::Button b, bool on) {
 			if (rootUI != &automationView) {
 				selectAutomationViewParameter(clipMinder);
 				swapOutRootUILowLevel(&automationView);
+				automationView.initializeView();
 				automationView.openedInBackground();
 			}
 			soundEditor.exitCompletely();
@@ -74,7 +75,7 @@ ActionResult Param::buttonAction(deluge::hid::Button b, bool on) {
 		if (on) {
 			if (rootUI == &automationView) {
 				selectAutomationViewParameter(clipMinder);
-				uiNeedsRendering(&automationView);
+				uiNeedsRendering(rootUI);
 			}
 		}
 		return ActionResult::DEALT_WITH;
@@ -88,17 +89,19 @@ void Param::selectAutomationViewParameter(bool clipMinder) {
 
 	int32_t p = getP();
 	modulation::params::Kind kind = modelStack->paramCollection->getParamKind();
+	Clip* clip = getCurrentClip();
 
 	if (clipMinder) {
-		Clip* clip = getCurrentClip();
 		clip->lastSelectedParamID = p;
 		clip->lastSelectedParamKind = kind;
+		clip->lastSelectedOutputType = clip->output->type;
 	}
 	else {
 		currentSong->lastSelectedParamID = p;
 		currentSong->lastSelectedParamKind = kind;
 		automationView.onArrangerView = true;
 	}
+	automationView.getLastSelectedParamShortcut(clip);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -218,6 +218,16 @@ void AutomationView::initMIDICCShortcutsForAutomation() {
 
 // called everytime you open up the automation view
 bool AutomationView::opened() {
+	initializeView();
+
+	openedInBackground();
+
+	focusRegained();
+
+	return true;
+}
+
+void AutomationView::initializeView() {
 	navSysId = getNavSysId();
 
 	if (!midiCCShortcutsLoaded) {
@@ -251,21 +261,6 @@ bool AutomationView::opened() {
 			}
 		}
 	}
-
-	resetShortcutBlinking();
-
-	openedInBackground();
-
-	if (!onArrangerView) {
-		// only applies to instrument clips (not audio)
-		if (clip) {
-			InstrumentClipMinder::opened();
-		}
-	}
-
-	focusRegained();
-
-	return true;
 }
 
 // Initializes some stuff to begin a new editing session
@@ -293,6 +288,13 @@ void AutomationView::focusRegained() {
 			instrumentClipView.setLedStates();
 		}
 	}
+
+	// blink timer got reset by view.focusRegained() above
+	parameterShortcutBlinking = false;
+	// remove patch cable blink frequencies
+	memset(soundEditor.sourceShortcutBlinkFrequencies, 255, sizeof(soundEditor.sourceShortcutBlinkFrequencies));
+	// possibly restablish parameter shortcut blinking (if parameter is selected)
+	blinkShortcuts();
 }
 
 void AutomationView::openedInBackground() {
@@ -399,6 +401,14 @@ bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidt
 	performActualRender(whichRows, &image[0][0], occupancyMask, currentSong->xScroll[navSysId],
 	                    currentSong->xZoom[navSysId], kDisplayWidth, kDisplayWidth + kSideBarWidth, drawUndefinedArea);
 
+	blinkShortcuts();
+
+	PadLEDs::renderingLock = false;
+
+	return true;
+}
+
+void AutomationView::blinkShortcuts() {
 	if (!encoderAction) {
 		int32_t lastSelectedParamShortcutX = kNoSelection;
 		int32_t lastSelectedParamShortcutY = kNoSelection;
@@ -407,6 +417,7 @@ bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidt
 			lastSelectedParamShortcutY = currentSong->lastSelectedParamShortcutY;
 		}
 		else {
+			Clip* clip = getCurrentClip();
 			lastSelectedParamShortcutX = clip->lastSelectedParamShortcutX;
 			lastSelectedParamShortcutY = clip->lastSelectedParamShortcutY;
 		}
@@ -436,10 +447,6 @@ bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidt
 		// doing this so the shortcut doesn't blink like crazy while turning knobs that refresh UI
 		encoderAction = false;
 	}
-
-	PadLEDs::renderingLock = false;
-
-	return true;
 }
 
 // determines whether you should render the automation editor, automation overview or just render some love <3
@@ -2944,7 +2951,7 @@ void AutomationView::selectMIDICC(int32_t offset, Clip* clip) {
 	}
 	clip->lastSelectedParamID = newCC;
 
-	getLastSelectedMIDIParamShortcut(clip);
+	getLastSelectedParamShortcut(clip);
 
 	// update name on display, the LED mod indicators, and refresh the grid
 	lastPadSelectedKnobPos = kNoSelection;
@@ -2970,15 +2977,38 @@ void AutomationView::selectMIDICC(int32_t offset, Clip* clip) {
 }
 
 // used with Select Encoder action to get the X, Y grid shortcut coordinates of the parameter selected
-void AutomationView::getLastSelectedMIDIParamShortcut(Clip* clip) {
+void AutomationView::getLastSelectedParamShortcut(Clip* clip) {
 	bool paramShortcutFound = false;
 	for (int32_t x = 0; x < kDisplayWidth; x++) {
 		for (int32_t y = 0; y < kDisplayHeight; y++) {
-			if (midiCCShortcutsForAutomation[x][y] == clip->lastSelectedParamID) {
-				clip->lastSelectedParamShortcutX = x;
-				clip->lastSelectedParamShortcutY = y;
-				paramShortcutFound = true;
-				break;
+			if (onArrangerView) {
+				if (unpatchedGlobalParamShortcuts[x][y] == currentSong->lastSelectedParamID) {
+					currentSong->lastSelectedParamShortcutX = x;
+					currentSong->lastSelectedParamShortcutY = y;
+					paramShortcutFound = true;
+					break;
+				}
+			}
+			else if (clip->output->type == OutputType::MIDI_OUT) {
+				if (midiCCShortcutsForAutomation[x][y] == clip->lastSelectedParamID) {
+					clip->lastSelectedParamShortcutX = x;
+					clip->lastSelectedParamShortcutY = y;
+					paramShortcutFound = true;
+					break;
+				}
+			}
+			else {
+				if ((clip->lastSelectedParamKind == params::Kind::PATCHED
+				     && patchedParamShortcuts[x][y] == clip->lastSelectedParamID)
+				    || (clip->lastSelectedParamKind == params::Kind::UNPATCHED_SOUND
+				        && unpatchedNonGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)
+				    || (clip->lastSelectedParamKind == params::Kind::UNPATCHED_GLOBAL
+				        && unpatchedGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)) {
+					clip->lastSelectedParamShortcutX = x;
+					clip->lastSelectedParamShortcutY = y;
+					paramShortcutFound = true;
+					break;
+				}
 			}
 		}
 		if (paramShortcutFound) {
@@ -2986,8 +3016,14 @@ void AutomationView::getLastSelectedMIDIParamShortcut(Clip* clip) {
 		}
 	}
 	if (!paramShortcutFound) {
-		clip->lastSelectedParamShortcutX = kNoSelection;
-		clip->lastSelectedParamShortcutY = kNoSelection;
+		if (onArrangerView) {
+			currentSong->lastSelectedParamShortcutX = kNoSelection;
+			currentSong->lastSelectedParamShortcutY = kNoSelection;
+		}
+		else {
+			clip->lastSelectedParamShortcutX = kNoSelection;
+			clip->lastSelectedParamShortcutY = kNoSelection;
+		}
 	}
 }
 

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -49,6 +49,7 @@ class AutomationView final : public ClipView, public InstrumentClipMinder {
 public:
 	AutomationView();
 	bool opened();
+	void initializeView();
 	void openedInBackground();
 	void focusRegained();
 
@@ -102,6 +103,7 @@ public:
 
 	// Select encoder action
 	void selectEncoderAction(int8_t offset);
+	void getLastSelectedParamShortcut(Clip* clip);
 
 	// called by melodic_instrument.cpp or kit.cpp
 	void noteRowChanged(InstrumentClip* clip, NoteRow* noteRow);
@@ -200,7 +202,6 @@ private:
 	void selectGlobalParam(int32_t offset, Clip* clip);
 	void selectNonGlobalParam(int32_t offset, Clip* clip);
 	void selectMIDICC(int32_t offset, Clip* clip);
-	void getLastSelectedMIDIParamShortcut(Clip* clip);
 
 	// Automation Lanes Functions
 	void initPadSelection();
@@ -239,6 +240,7 @@ private:
 
 	int32_t calculateKnobPosForModEncoderTurn(int32_t knobPos, int32_t offset);
 	void displayCVErrorMessage();
+	void blinkShortcuts();
 	void resetShortcutBlinking();
 	void resetParameterShortcutBlinking();
 	void resetInterpolationShortcutBlinking();


### PR DESCRIPTION
Fixed bug where when entering automation view from menu it would not blink the shortcut for the parameter currently selected in the automation editor

Added missing "lastSelectedOutputType" value when entering automation view from menu which resulted in a de-selection of last selected parameter when re-entering automation view

This closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1221