### PR TITLE
Fix keyboard column controls

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -36,10 +36,8 @@
 //   - slew
 //   - beat repeat
 //   - strum
-// - turn off key press / hold mode
 // - save current settings
-// BUG scrolling vertical encoder sometimes triggers horizontal encoder behavior (CHRD, CMEM)
-// BUG scrolling select knob changes sidebar when top pad held
+// - find better glide mode solution
 
 namespace deluge::gui::ui::keyboard::layout {
 
@@ -212,16 +210,13 @@ void ColumnControlsKeyboard::handlePad(ModelStackWithTimelineCounter* modelStack
 		break;
 	case SCALE_MODE:
 		if (pad.active) {
-			currentScalePad = pad.y;
 			keyboardScreen.setScale(scaleModes[pad.y]);
 		}
 		else if (!pad.padPressHeld) {
 			previousScalePad = pad.y;
-			currentScalePad = pad.y;
 		}
 		else {
 			keyboardScreen.setScale(scaleModes[previousScalePad]);
-			currentScalePad = previousScalePad;
 		}
 		break;
 		// case BEAT_REPEAT:
@@ -458,9 +453,10 @@ void ColumnControlsKeyboard::renderColumnChordMem(RGB image[][kDisplayWidth + kS
 }
 
 void ColumnControlsKeyboard::renderColumnScaleMode(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
+	int32_t currentScale = currentSong->getCurrentPresetScale();
 	uint8_t otherChannels = 0;
 	for (int32_t y = 0; y < kDisplayHeight; ++y) {
-		bool mode_selected = y == currentScalePad;
+		bool mode_selected = scaleModes[y] == currentScale;
 		uint8_t mode_available = y < NUM_PRESET_SCALES ? 0x7f : 0;
 		otherChannels = mode_selected ? 0xf0 : 0;
 		uint8_t base = mode_selected ? 0xff : mode_available;

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.h
@@ -137,7 +137,6 @@ private:
 	uint8_t chordMem[8][kMaxNotesChordMem] = {0};
 	uint8_t activeChordMem = 0xFF;
 
-	int32_t currentScalePad = currentSong->getCurrentPresetScale();
 	int32_t previousScalePad = currentSong->getCurrentPresetScale();
 	uint8_t scaleModes[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.h
@@ -120,12 +120,14 @@ private:
 	uint32_t velocityStep = 16 << kVelModShift;
 	uint32_t velocity32 = velocity << kVelModShift;
 	uint32_t vDisplay = velocity;
+	bool velocityGlide = false;
 
 	uint32_t modMax = 127 << kVelModShift;
 	uint32_t modMin = 15 << kVelModShift;
 	uint32_t modStep = 16 << kVelModShift;
 	uint32_t mod32 = 0 << kVelModShift;
 	uint32_t modDisplay;
+	bool modGlide = false;
 
 	ChordModeChord activeChord = NO_CHORD;
 	ChordModeChord defaultChord = NO_CHORD;

--- a/src/deluge/gui/ui/keyboard/layout/in_key.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.cpp
@@ -41,13 +41,17 @@ void KeyboardLayoutInKey::handleVerticalEncoder(int32_t offset) {
 	if (verticalEncoderHandledByColumns(offset)) {
 		return;
 	}
-	handleHorizontalEncoder(offset * getState().inKey.rowInterval, false);
+	_handleHorizontalEncoder(offset * getState().inKey.rowInterval, false);
 }
 
 void KeyboardLayoutInKey::handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	if (horizontalEncoderHandledByColumns(offset, shiftEnabled)) {
 		return;
 	}
+	_handleHorizontalEncoder(offset * getState().inKey.rowInterval, shiftEnabled);
+}
+
+void KeyboardLayoutInKey::_handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	KeyboardStateInKey& state = getState().inKey;
 
 	if (shiftEnabled) {

--- a/src/deluge/gui/ui/keyboard/layout/in_key.h
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.h
@@ -32,6 +32,7 @@ public:
 	void evaluatePads(PressedPad presses[kMaxNumKeyboardPadPresses]) override;
 	void handleVerticalEncoder(int32_t offset) override;
 	void handleHorizontalEncoder(int32_t offset, bool shiftEnabled) override;
+	void _handleHorizontalEncoder(int32_t offset, bool shiftEnabled);
 	void precalculate() override;
 
 	void renderPads(RGB image[][kDisplayWidth + kSideBarWidth]) override;

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -43,13 +43,17 @@ void KeyboardLayoutIsomorphic::handleVerticalEncoder(int32_t offset) {
 	if (verticalEncoderHandledByColumns(offset)) {
 		return;
 	}
-	handleHorizontalEncoder(offset * getState().isomorphic.rowInterval, false);
+	_handleHorizontalEncoder(offset * getState().isomorphic.rowInterval, false);
 }
 
 void KeyboardLayoutIsomorphic::handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	if (horizontalEncoderHandledByColumns(offset, shiftEnabled)) {
 		return;
 	}
+	_handleHorizontalEncoder(offset, shiftEnabled);
+}
+
+void KeyboardLayoutIsomorphic::_handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	KeyboardStateIsomorphic& state = getState().isomorphic;
 
 	if (shiftEnabled) {

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.h
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.h
@@ -29,6 +29,7 @@ public:
 	void evaluatePads(PressedPad presses[kMaxNumKeyboardPadPresses]) override;
 	void handleVerticalEncoder(int32_t offset) override;
 	void handleHorizontalEncoder(int32_t offset, bool shiftEnabled) override;
+	void _handleHorizontalEncoder(int32_t offset, bool shiftEnabled);
 	void precalculate() override;
 
 	void renderPads(RGB image[][kDisplayWidth + kSideBarWidth]) override;


### PR DESCRIPTION
- Fix vertical encoder handlers spilling into horizontal 
- Ignore select-knob caused zero offset horizontal encoders
- Make mode highlighting following scale mode instead of selected pad
- Velocity / mod glide mode (Pad 6 + vertical to enable disable) this works, but the UI is bad, so let's leave this as an easter egg will change in the future type of thing (also the popup gets eaten by the value when the pad retriggers, so you don't actually get an on / off display)