### PR TITLE
refactor: split out side bar functions to separate classes

### DIFF
--- a/src/deluge/gui/ui/keyboard/column_controls/chord.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/chord.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "chord.h"
+#include "gui/ui/keyboard/layout/column_controls.h"
+
+using namespace deluge::gui::ui::keyboard::layout;
+
+namespace deluge::gui::ui::keyboard::controls {
+
+uint8_t chordTypeSemitoneOffsets[][MAX_CHORD_NOTES] = {
+    /* NO_CHORD  */ {0, 0, 0, 0},
+    /* FIFTH     */ {7, 0, 0, 0},
+    /* SUS2      */ {2, 7, 0, 0},
+    /* MINOR     */ {3, 7, 0, 0},
+    /* MAJOR     */ {4, 7, 0, 0},
+    /* SUS4      */ {5, 7, 0, 0},
+    /* MINOR7    */ {3, 7, 10, 0},
+    /* DOMINANT7 */ {4, 7, 10, 0},
+    /* MAJOR7    */ {4, 7, 11, 0},
+};
+
+const char* chordNames[] = {
+    /* NO_CHORD  */ "NONE",
+    /* FIFTH     */ "5TH",
+    /* SUS2      */ "SUS2",
+    /* MINOR     */ "MIN",
+    /* MAJOR     */ "MAJ",
+    /* SUS4      */ "SUS4",
+    /* MINOR7    */ "MIN7",
+    /* DOMINANT7 */ "DOM7",
+    /* MAJOR7    */ "MAJ7",
+};
+
+void ChordColumn::setActiveChord(ChordModeChord chord) {
+	activeChord = chord;
+	chordSemitoneOffsets[0] = chordTypeSemitoneOffsets[activeChord][0];
+	chordSemitoneOffsets[1] = chordTypeSemitoneOffsets[activeChord][1];
+	chordSemitoneOffsets[2] = chordTypeSemitoneOffsets[activeChord][2];
+	chordSemitoneOffsets[3] = chordTypeSemitoneOffsets[activeChord][3];
+}
+
+void ChordColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
+	uint8_t otherChannels = 0;
+	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+		bool chord_selected = y + 1 == activeChord;
+		otherChannels = chord_selected ? 0xf0 : 0;
+		uint8_t base = chord_selected ? 0xff : 0x7F;
+		image[y][column] = {otherChannels, base, otherChannels};
+	}
+}
+
+bool ChordColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
+	return false;
+};
+
+void ChordColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+                            KeyboardLayout* layout) {
+	if (pad.active) {
+		setActiveChord(static_cast<ChordModeChord>(pad.y + 1));
+		display->displayPopup(chordNames[activeChord]);
+	}
+	else if (!pad.padPressHeld) {
+		if (defaultChord != static_cast<ChordModeChord>(pad.y + 1)) {
+			defaultChord = static_cast<ChordModeChord>(pad.y + 1);
+		}
+		else {
+			defaultChord = NO_CHORD;
+		}
+		setActiveChord(defaultChord);
+		display->displayPopup(chordNames[activeChord]);
+	}
+	else {
+		setActiveChord(defaultChord);
+	}
+};
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/chord.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/chord.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/keyboard/column_controls/control_column.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+#define MAX_CHORD_NOTES 4
+
+enum ChordModeChord {
+	NO_CHORD = 0,
+	FIFTH,
+	SUS2,
+	MINOR,
+	MAJOR,
+	SUS4,
+	MINOR7,
+	DOMINANT7,
+	MAJOR7,
+	CHORD_MODE_CHORD_MAX, /* should be 9, 8 chord pads plus NO_CHORD */
+};
+
+class ChordColumn : public ControlColumn {
+public:
+	ChordColumn() = default;
+
+	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
+	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;
+	void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+	               KeyboardLayout* layout) override;
+
+	uint8_t chordSemitoneOffsets[4] = {0};
+
+private:
+	ChordModeChord activeChord = NO_CHORD;
+	ChordModeChord defaultChord = NO_CHORD;
+
+	void setActiveChord(ChordModeChord chord);
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/chord_mem.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/chord_mem.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "chord_mem.h"
+#include "hid/buttons.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+
+void ChordMemColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
+	uint8_t otherChannels = 0;
+	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+		bool chord_selected = y == activeChordMem;
+		uint8_t chord_slot_filled = chordMemNoteCount[y] > 0 ? 0x7f : 0;
+		otherChannels = chord_selected ? 0xf0 : 0;
+		uint8_t base = chord_selected ? 0xff : chord_slot_filled;
+		image[y][column] = {otherChannels, base, base};
+	}
+}
+
+bool ChordMemColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
+	return false;
+};
+
+void ChordMemColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+                               KeyboardLayout* layout) {
+	NotesState& currentNotesState = layout->getNotesState();
+
+	if (pad.active) {
+		activeChordMem = pad.y;
+		auto noteCount = chordMemNoteCount[pad.y];
+		for (int i = 0; i < noteCount && i < kMaxNotesChordMem; i++) {
+			currentNotesState.enableNote(chordMem[pad.y][i], layout->velocity);
+		}
+		chordMemNoteCount[pad.y] = noteCount;
+	}
+	else {
+		activeChordMem = 0xFF;
+		if ((!chordMemNoteCount[pad.y] || Buttons::isShiftButtonPressed()) && currentNotesState.count) {
+			auto noteCount = currentNotesState.count;
+			for (int i = 0; i < noteCount && i < kMaxNotesChordMem; i++) {
+				chordMem[pad.y][i] = currentNotesState.notes[i].note;
+			}
+			chordMemNoteCount[pad.y] = noteCount;
+		}
+		else if (Buttons::isShiftButtonPressed()) {
+			chordMemNoteCount[pad.y] = 0;
+		}
+	}
+};
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/chord_mem.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/chord_mem.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/keyboard/column_controls/control_column.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+
+constexpr int32_t kMaxNotesChordMem = 10;
+
+class ChordMemColumn : public ControlColumn {
+public:
+	ChordMemColumn() = default;
+
+	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
+	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;
+	void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+	               KeyboardLayout* layout) override;
+
+private:
+	uint8_t chordMemNoteCount[8] = {0};
+	uint8_t chordMem[8][kMaxNotesChordMem] = {0};
+	uint8_t activeChordMem = 0xFF;
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/control_column.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/control_column.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/colour/rgb.h"
+#include "gui/ui/keyboard/layout.h"
+#include "gui/ui/keyboard/notes_state.h"
+#include "model/model_stack.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+
+constexpr uint32_t kVelModShift = 24;
+
+class ControlColumn {
+public:
+	virtual void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) = 0;
+	virtual bool handleVerticalEncoder(int8_t pad, int32_t offset) = 0;
+	virtual void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+	                       KeyboardLayout* layout) = 0;
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/mod.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/mod.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "mod.h"
+#include "gui/ui/keyboard/layout/column_controls.h"
+
+using namespace deluge::gui::ui::keyboard::layout;
+
+namespace deluge::gui::ui::keyboard::controls {
+
+void ModColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
+	uint8_t brightness = 1;
+	uint8_t otherChannels = 0;
+	uint32_t modVal = modMin;
+
+	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+		bool mod_selected = modDisplay >= (y > 0 ? (modVal - (modStep - 1)) : 0) && modDisplay <= modVal;
+		otherChannels = mod_selected ? 0xf0 : 0;
+		uint8_t base = mod_selected ? 0xff : brightness + 0x04;
+		image[y][column] = {otherChannels, otherChannels, base};
+		modVal += modStep;
+		brightness += 10;
+	}
+}
+
+bool ModColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
+	if (pad == 7) {
+		modMax += offset << kVelModShift;
+		modMax = std::clamp(modMax, modMin, (uint32_t)127 << kVelModShift);
+		display->displayPopup(modMax >> kVelModShift);
+		modStep = (modMax - modMin) / 7;
+		return true;
+	}
+	else if (pad == 0) {
+		modMin += offset << kVelModShift;
+		modMin = std::clamp((int32_t)modMin, (int32_t)0, (int32_t)modMax);
+		display->displayPopup(modMin >> kVelModShift);
+		modStep = (modMax - modMin) / 7;
+		return true;
+	}
+	return false;
+};
+
+void ModColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+                          KeyboardLayout* layout) {
+
+	if (pad.active) {
+		modDisplay = modMin + pad.y * modStep;
+		getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, modDisplay,
+		                                                         modelStackWithTimelineCounter);
+		display->displayPopup((modDisplay + kHalfStep) >> kVelModShift);
+	}
+	else if (!pad.padPressHeld) {
+		mod32 = modMin + pad.y * modStep;
+		getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, mod32,
+		                                                         modelStackWithTimelineCounter);
+	}
+	else {
+		modDisplay = mod32;
+		getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, mod32,
+		                                                         modelStackWithTimelineCounter);
+	}
+};
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/mod.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/mod.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/keyboard/column_controls/control_column.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+
+class ModColumn : public ControlColumn {
+public:
+	ModColumn() = default;
+
+	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
+	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;
+	void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+	               KeyboardLayout* layout) override;
+
+private:
+	uint32_t modMax = 127 << kVelModShift;
+	uint32_t modMin = 15 << kVelModShift;
+	uint32_t modStep = 16 << kVelModShift;
+	uint32_t mod32 = 0 << kVelModShift;
+	uint32_t modDisplay;
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/scale_mode.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/scale_mode.cpp
@@ -1,0 +1,57 @@
+
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "scale_mode.h"
+#include "gui/ui/keyboard/layout/column_controls.h"
+
+using namespace deluge::gui::ui::keyboard::layout;
+
+namespace deluge::gui::ui::keyboard::controls {
+
+void ScaleModeColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
+	uint8_t otherChannels = 0;
+	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+		bool mode_selected = y == currentScalePad;
+		uint8_t mode_available = y < NUM_PRESET_SCALES ? 0x7f : 0;
+		otherChannels = mode_selected ? 0xf0 : 0;
+		uint8_t base = mode_selected ? 0xff : mode_available;
+		image[y][column] = {base, base, otherChannels};
+	}
+}
+
+bool ScaleModeColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
+	scaleModes[pad] = (scaleModes[pad] + offset) % NUM_PRESET_SCALES;
+	return true;
+};
+
+void ScaleModeColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+                                KeyboardLayout* layout) {
+	if (pad.active) {
+		currentScalePad = pad.y;
+		keyboardScreen.setScale(scaleModes[pad.y]);
+	}
+	else if (!pad.padPressHeld) {
+		previousScalePad = pad.y;
+		currentScalePad = pad.y;
+	}
+	else {
+		keyboardScreen.setScale(scaleModes[previousScalePad]);
+		currentScalePad = previousScalePad;
+	}
+};
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/scale_mode.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/scale_mode.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/keyboard/column_controls/control_column.h"
+#include "model/song/song.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+
+class ScaleModeColumn : public ControlColumn {
+public:
+	ScaleModeColumn() = default;
+
+	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
+	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;
+	void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+	               KeyboardLayout* layout) override;
+
+private:
+	int32_t currentScalePad = currentSong->getCurrentPresetScale();
+	int32_t previousScalePad = currentSong->getCurrentPresetScale();
+	uint8_t scaleModes[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/velocity.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/velocity.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "velocity.h"
+#include "gui/ui/keyboard/layout/column_controls.h"
+
+using namespace deluge::gui::ui::keyboard::layout;
+
+namespace deluge::gui::ui::keyboard::controls {
+
+void VelocityColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
+	uint8_t brightness = 1;
+	uint8_t otherChannels = 0;
+	uint32_t velocityVal = velocityMin;
+
+	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+		bool velocity_selected =
+		    vDisplay >= (y > 0 ? (velocityVal - (velocityStep - 1)) : 0) && vDisplay <= velocityVal + kHalfStep;
+		otherChannels = velocity_selected ? 0xf0 : 0;
+		uint8_t base = velocity_selected ? 0xff : brightness + 0x04;
+		image[y][column] = {base, otherChannels, otherChannels};
+		velocityVal += velocityStep;
+		brightness += 10;
+	}
+}
+
+bool VelocityColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
+	if (pad == 7) {
+		velocityMax += offset << kVelModShift;
+		velocityMax = std::clamp(velocityMax, velocityMin, (uint32_t)127 << kVelModShift);
+		display->displayPopup(velocityMax >> kVelModShift);
+		velocityStep = (velocityMax - velocityMin) / 7;
+		return true;
+	}
+	else if (pad == 0) {
+		velocityMin += offset << kVelModShift;
+		velocityMin = std::clamp((int32_t)velocityMin, (int32_t)0, (int32_t)velocityMax);
+		display->displayPopup(velocityMin >> kVelModShift);
+		velocityStep = (velocityMax - velocityMin) / 7;
+		return true;
+	}
+	return false;
+};
+
+void VelocityColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+                               KeyboardLayout* layout) {
+	if (pad.active) {
+		vDisplay = velocityMin + pad.y * velocityStep;
+		layout->velocity = (vDisplay + kHalfStep) >> kVelModShift;
+		display->displayPopup(layout->velocity);
+	}
+	else if (!pad.padPressHeld) {
+		velocity32 = velocityMin + pad.y * velocityStep;
+		vDisplay = velocity32;
+		layout->velocity = (velocity32 + kHalfStep) >> kVelModShift;
+	}
+	else {
+		vDisplay = velocity32;
+		layout->velocity = (velocity32 + kHalfStep) >> kVelModShift;
+	}
+};
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/velocity.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/velocity.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/keyboard/column_controls/control_column.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+
+class VelocityColumn : public ControlColumn {
+public:
+	VelocityColumn(uint8_t velocity) : vDisplay(velocity), velocity32(velocity << kVelModShift){};
+
+	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
+	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;
+	void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+	               KeyboardLayout* layout) override;
+
+private:
+	// use higher precision internally so that scaling and stepping is cleaner
+	uint32_t velocityMax = 127 << kVelModShift;
+	uint32_t velocityMin = 15 << kVelModShift;
+	uint32_t velocityStep = 16 << kVelModShift;
+	uint32_t velocity32;
+	uint32_t vDisplay;
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/layout.h
+++ b/src/deluge/gui/ui/keyboard/layout.h
@@ -118,6 +118,9 @@ protected:
 
 	inline KeyboardState& getState() { return getCurrentInstrumentClip()->keyboardState; }
 
+public:
+	uint8_t velocity = 64;
+
 protected:
 	NotesState currentNotesState;
 };

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -29,33 +29,10 @@
 
 #define LEFT_COL kDisplayWidth
 #define RIGHT_COL (kDisplayWidth + 1)
-#define MAX_CHORD_NOTES 4
+
+using namespace deluge::gui::ui::keyboard::controls;
 
 namespace deluge::gui::ui::keyboard::layout {
-
-uint8_t chordTypeSemitoneOffsets[][MAX_CHORD_NOTES] = {
-    /* NO_CHORD  */ {0, 0, 0, 0},
-    /* FIFTH     */ {7, 0, 0, 0},
-    /* SUS2      */ {2, 7, 0, 0},
-    /* MINOR     */ {3, 7, 0, 0},
-    /* MAJOR     */ {4, 7, 0, 0},
-    /* SUS4      */ {5, 7, 0, 0},
-    /* MINOR7    */ {3, 7, 10, 0},
-    /* DOMINANT7 */ {4, 7, 10, 0},
-    /* MAJOR7    */ {4, 7, 11, 0},
-};
-
-const char* chordNames[] = {
-    /* NO_CHORD  */ "NONE",
-    /* FIFTH     */ "5TH",
-    /* SUS2      */ "SUS2",
-    /* MINOR     */ "MIN",
-    /* MAJOR     */ "MAJ",
-    /* SUS4      */ "SUS4",
-    /* MINOR7    */ "MIN7",
-    /* DOMINANT7 */ "DOM7",
-    /* MAJOR7    */ "MAJ7",
-};
 
 const char* functionNames[][2] = {
     /* VELOCITY    */ {"VEL", "Velocity"},
@@ -69,7 +46,7 @@ const char* functionNames[][2] = {
 void ColumnControlsKeyboard::enableNote(uint8_t note, uint8_t velocity) {
 	currentNotesState.enableNote(note, velocity);
 	for (int i = 0; i < MAX_CHORD_NOTES; i++) {
-		auto offset = chordSemitoneOffsets[i];
+		auto offset = chordColumn.chordSemitoneOffsets[i];
 		if (!offset) {
 			break;
 		}
@@ -94,12 +71,12 @@ void ColumnControlsKeyboard::evaluatePads(PressedPad presses[kMaxNumKeyboardPadP
 				leftColHeld = pressed.y;
 			}
 			else if (horizontalScrollingLeftCol && pressed.y == 7) {
-				handlePad(modelStackWithTimelineCounter, leftColPrev, pressed);
+				leftColPrev->handlePad(modelStackWithTimelineCounter, pressed, this);
 				horizontalScrollingLeftCol = false;
 				continue;
 			}
 			if (!horizontalScrollingLeftCol && !pressed.dead) {
-				handlePad(modelStackWithTimelineCounter, leftCol, pressed);
+				leftCol->handlePad(modelStackWithTimelineCounter, pressed, this);
 			}
 		}
 		else if (pressed.x == RIGHT_COL) {
@@ -107,122 +84,15 @@ void ColumnControlsKeyboard::evaluatePads(PressedPad presses[kMaxNumKeyboardPadP
 				rightColHeld = pressed.y;
 			}
 			else if (horizontalScrollingRightCol && pressed.y == 7) {
-				handlePad(modelStackWithTimelineCounter, rightColPrev, pressed);
+				rightColPrev->handlePad(modelStackWithTimelineCounter, pressed, this);
 				horizontalScrollingRightCol = false;
 				continue;
 			}
 			if (!horizontalScrollingRightCol && !pressed.dead) {
-				handlePad(modelStackWithTimelineCounter, rightCol, pressed);
+				rightCol->handlePad(modelStackWithTimelineCounter, pressed, this);
 			}
 		}
 	}
-}
-
-void ColumnControlsKeyboard::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
-                                       ColumnControlFunction func, PressedPad pad) {
-	switch (func) {
-	case VELOCITY:
-		if (pad.active) {
-			vDisplay = velocityMin + pad.y * velocityStep;
-			velocity = (vDisplay + kHalfStep) >> kVelModShift;
-			display->displayPopup(velocity);
-		}
-		else if (!pad.padPressHeld) {
-			velocity32 = velocityMin + pad.y * velocityStep;
-			vDisplay = velocity32;
-			velocity = (velocity32 + kHalfStep) >> kVelModShift;
-		}
-		else {
-			vDisplay = velocity32;
-			velocity = (velocity32 + kHalfStep) >> kVelModShift;
-		}
-		break;
-	case MOD:
-		if (pad.active) {
-			modDisplay = modMin + pad.y * modStep;
-			getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, modDisplay,
-			                                                         modelStackWithTimelineCounter);
-			display->displayPopup((modDisplay + kHalfStep) >> kVelModShift);
-		}
-		else if (!pad.padPressHeld) {
-			mod32 = modMin + pad.y * modStep;
-			getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, mod32,
-			                                                         modelStackWithTimelineCounter);
-		}
-		else {
-			modDisplay = mod32;
-			getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, mod32,
-			                                                         modelStackWithTimelineCounter);
-		}
-		break;
-	case CHORD:
-		if (pad.active) {
-			setActiveChord(static_cast<ChordModeChord>(pad.y + 1));
-			display->displayPopup(chordNames[activeChord]);
-		}
-		else if (!pad.padPressHeld) {
-			if (defaultChord != static_cast<ChordModeChord>(pad.y + 1)) {
-				defaultChord = static_cast<ChordModeChord>(pad.y + 1);
-			}
-			else {
-				defaultChord = NO_CHORD;
-			}
-			setActiveChord(defaultChord);
-			display->displayPopup(chordNames[activeChord]);
-		}
-		else {
-			setActiveChord(defaultChord);
-		}
-		break;
-	case CHORD_MEM:
-		if (pad.active) {
-			activeChordMem = pad.y;
-			auto noteCount = chordMemNoteCount[pad.y];
-			for (int i = 0; i < noteCount && i < kMaxNotesChordMem; i++) {
-				currentNotesState.enableNote(chordMem[pad.y][i], velocity);
-			}
-			chordMemNoteCount[pad.y] = noteCount;
-		}
-		else {
-			activeChordMem = 0xFF;
-			if ((!chordMemNoteCount[pad.y] || Buttons::isShiftButtonPressed()) && currentNotesState.count) {
-				auto noteCount = currentNotesState.count;
-				for (int i = 0; i < noteCount && i < kMaxNotesChordMem; i++) {
-					chordMem[pad.y][i] = currentNotesState.notes[i].note;
-				}
-				chordMemNoteCount[pad.y] = noteCount;
-			}
-			else if (Buttons::isShiftButtonPressed()) {
-				chordMemNoteCount[pad.y] = 0;
-			}
-		}
-		break;
-	case SCALE_MODE:
-		if (pad.active) {
-			currentScalePad = pad.y;
-			keyboardScreen.setScale(scaleModes[pad.y]);
-		}
-		else if (!pad.padPressHeld) {
-			previousScalePad = pad.y;
-			currentScalePad = pad.y;
-		}
-		else {
-			keyboardScreen.setScale(scaleModes[previousScalePad]);
-			currentScalePad = previousScalePad;
-		}
-		break;
-		// case BEAT_REPEAT:
-		//	/* TODO */
-		//	break;
-	}
-}
-
-void ColumnControlsKeyboard::setActiveChord(ChordModeChord chord) {
-	activeChord = chord;
-	chordSemitoneOffsets[0] = chordTypeSemitoneOffsets[activeChord][0];
-	chordSemitoneOffsets[1] = chordTypeSemitoneOffsets[activeChord][1];
-	chordSemitoneOffsets[2] = chordTypeSemitoneOffsets[activeChord][2];
-	chordSemitoneOffsets[3] = chordTypeSemitoneOffsets[activeChord][3];
 }
 
 void ColumnControlsKeyboard::handleVerticalEncoder(int32_t offset) {
@@ -231,49 +101,10 @@ void ColumnControlsKeyboard::handleVerticalEncoder(int32_t offset) {
 
 bool ColumnControlsKeyboard::verticalEncoderHandledByColumns(int32_t offset) {
 	if (leftColHeld != -1) {
-		return verticalEncoderHandledByFunc(leftCol, leftColHeld, offset);
+		return leftCol->handleVerticalEncoder(leftColHeld, offset);
 	}
 	if (rightColHeld != -1) {
-		return verticalEncoderHandledByFunc(rightCol, rightColHeld, offset);
-	}
-	return false;
-}
-
-bool ColumnControlsKeyboard::verticalEncoderHandledByFunc(ColumnControlFunction func, int8_t pad, int32_t offset) {
-	switch (func) {
-	case VELOCITY:
-		if (pad == 7) {
-			velocityMax += offset << kVelModShift;
-			velocityMax = std::clamp(velocityMax, velocityMin, (uint32_t)127 << kVelModShift);
-			display->displayPopup(velocityMax >> kVelModShift);
-			velocityStep = (velocityMax - velocityMin) / 7;
-			return true;
-		}
-		else if (pad == 0) {
-			velocityMin += offset << kVelModShift;
-			velocityMin = std::clamp((int32_t)velocityMin, (int32_t)0, (int32_t)velocityMax);
-			display->displayPopup(velocityMin >> kVelModShift);
-			velocityStep = (velocityMax - velocityMin) / 7;
-			return true;
-		}
-	case SCALE_MODE:
-		scaleModes[pad] = (scaleModes[pad] + offset) % NUM_PRESET_SCALES;
-		return true;
-	case MOD:
-		if (pad == 7) {
-			modMax += offset << kVelModShift;
-			modMax = std::clamp(modMax, modMin, (uint32_t)127 << kVelModShift);
-			display->displayPopup(modMax >> kVelModShift);
-			modStep = (modMax - modMin) / 7;
-			return true;
-		}
-		else if (pad == 0) {
-			modMin += offset << kVelModShift;
-			modMin = std::clamp((int32_t)modMin, (int32_t)0, (int32_t)modMax);
-			display->displayPopup(modMin >> kVelModShift);
-			modStep = (modMax - modMin) / 7;
-			return true;
-		}
+		return rightCol->handleVerticalEncoder(rightColHeld, offset);
 	}
 	return false;
 }
@@ -304,14 +135,32 @@ ColumnControlFunction prevControlFunction(ColumnControlFunction cur, ColumnContr
 	return out;
 }
 
+ControlColumn* ColumnControlsKeyboard::getColumnForFunc(ColumnControlFunction func) {
+	switch (func) {
+	case VELOCITY:
+		return &velocityColumn;
+	case MOD:
+		return &modColumn;
+	case CHORD:
+		return &chordColumn;
+	case CHORD_MEM:
+		return &chordMemColumn;
+	case SCALE_MODE:
+		return &scaleModeColumn;
+	}
+	return nullptr;
+}
+
 bool ColumnControlsKeyboard::horizontalEncoderHandledByColumns(int32_t offset, bool shiftEnabled) {
 	if (leftColHeld == 7) {
 		if (!horizontalScrollingLeftCol) {
 			leftColPrev = leftCol;
 		}
 		horizontalScrollingLeftCol = true;
-		leftCol = (offset > 0) ? nextControlFunction(leftCol, rightCol) : prevControlFunction(leftCol, rightCol);
-		display->displayPopup(functionNames[leftCol]);
+		leftColFunc = (offset > 0) ? nextControlFunction(leftColFunc, rightColFunc)
+		                           : prevControlFunction(leftColFunc, rightColFunc);
+		display->displayPopup(functionNames[leftColFunc]);
+		leftCol = getColumnForFunc(leftColFunc);
 		return true;
 	}
 	if (rightColHeld == 7) {
@@ -319,97 +168,18 @@ bool ColumnControlsKeyboard::horizontalEncoderHandledByColumns(int32_t offset, b
 			rightColPrev = rightCol;
 		}
 		horizontalScrollingRightCol = true;
-		rightCol = (offset > 0) ? nextControlFunction(rightCol, leftCol) : prevControlFunction(rightCol, leftCol);
-		display->displayPopup(functionNames[rightCol]);
+		rightColFunc = (offset > 0) ? nextControlFunction(rightColFunc, leftColFunc)
+		                            : prevControlFunction(rightColFunc, leftColFunc);
+		display->displayPopup(functionNames[rightColFunc]);
+		rightCol = getColumnForFunc(rightColFunc);
 		return true;
 	}
 	return false;
 }
 
 void ColumnControlsKeyboard::renderSidebarPads(RGB image[][kDisplayWidth + kSideBarWidth]) {
-	// Iterate over velocity and mod pads in sidebar
-	switch (leftCol) {
-	case VELOCITY:
-		renderColumnVelocity(image, LEFT_COL);
-		break;
-	case MOD:
-		renderColumnMod(image, LEFT_COL);
-		break;
-	case CHORD:
-		renderColumnChord(image, LEFT_COL);
-		break;
-	case CHORD_MEM:
-		renderColumnChordMem(image, LEFT_COL);
-		break;
-	case SCALE_MODE:
-		renderColumnScaleMode(image, LEFT_COL);
-		break;
-		// case BEAT_REPEAT:
-		//	renderColumnBeatRepeat(image, LEFT_COL);
-		//	break;
-	}
-
-	switch (image, rightCol) {
-	case VELOCITY:
-		renderColumnVelocity(image, RIGHT_COL);
-		break;
-	case MOD:
-		renderColumnMod(image, RIGHT_COL);
-		break;
-	case CHORD:
-		renderColumnChord(image, RIGHT_COL);
-		break;
-	case CHORD_MEM:
-		renderColumnChordMem(image, RIGHT_COL);
-		break;
-	case SCALE_MODE:
-		renderColumnScaleMode(image, RIGHT_COL);
-		break;
-		// case BEAT_REPEAT:
-		//	renderColumnBeatRepeat(image, RIGHT_COL);
-		//	break;
-	}
-}
-
-void ColumnControlsKeyboard::renderColumnVelocity(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
-	uint8_t brightness = 1;
-	uint8_t otherChannels = 0;
-	uint32_t velocityVal = velocityMin;
-
-	for (int32_t y = 0; y < kDisplayHeight; ++y) {
-		bool velocity_selected =
-		    vDisplay >= (y > 0 ? (velocityVal - (velocityStep - 1)) : 0) && vDisplay <= velocityVal + kHalfStep;
-		otherChannels = velocity_selected ? 0xf0 : 0;
-		uint8_t base = velocity_selected ? 0xff : brightness + 0x04;
-		image[y][column] = {base, otherChannels, otherChannels};
-		velocityVal += velocityStep;
-		brightness += 10;
-	}
-}
-
-void ColumnControlsKeyboard::renderColumnMod(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
-	uint8_t brightness = 1;
-	uint8_t otherChannels = 0;
-	uint32_t modVal = modMin;
-
-	for (int32_t y = 0; y < kDisplayHeight; ++y) {
-		bool mod_selected = modDisplay >= (y > 0 ? (modVal - (modStep - 1)) : 0) && modDisplay <= modVal;
-		otherChannels = mod_selected ? 0xf0 : 0;
-		uint8_t base = mod_selected ? 0xff : brightness + 0x04;
-		image[y][column] = {otherChannels, otherChannels, base};
-		modVal += modStep;
-		brightness += 10;
-	}
-}
-
-void ColumnControlsKeyboard::renderColumnChord(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
-	uint8_t otherChannels = 0;
-	for (int32_t y = 0; y < kDisplayHeight; ++y) {
-		bool chord_selected = y + 1 == activeChord;
-		otherChannels = chord_selected ? 0xf0 : 0;
-		uint8_t base = chord_selected ? 0xff : 0x7F;
-		image[y][column] = {otherChannels, base, otherChannels};
-	}
+	leftCol->renderColumn(image, LEFT_COL);
+	rightCol->renderColumn(image, RIGHT_COL);
 }
 
 void ColumnControlsKeyboard::renderColumnBeatRepeat(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
@@ -420,28 +190,6 @@ void ColumnControlsKeyboard::renderColumnBeatRepeat(RGB image[][kDisplayWidth + 
 		otherChannels = beat_selected ? 0xf0 : 0;
 		uint8_t base = beat_selected ? 0xff : 0x50;
 		image[y][column] = {base, otherChannels, base};
-	}
-}
-
-void ColumnControlsKeyboard::renderColumnChordMem(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
-	uint8_t otherChannels = 0;
-	for (int32_t y = 0; y < kDisplayHeight; ++y) {
-		bool chord_selected = y == activeChordMem;
-		uint8_t chord_slot_filled = chordMemNoteCount[y] > 0 ? 0x7f : 0;
-		otherChannels = chord_selected ? 0xf0 : 0;
-		uint8_t base = chord_selected ? 0xff : chord_slot_filled;
-		image[y][column] = {otherChannels, base, base};
-	}
-}
-
-void ColumnControlsKeyboard::renderColumnScaleMode(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
-	uint8_t otherChannels = 0;
-	for (int32_t y = 0; y < kDisplayHeight; ++y) {
-		bool mode_selected = y == currentScalePad;
-		uint8_t mode_available = y < NUM_PRESET_SCALES ? 0x7f : 0;
-		otherChannels = mode_selected ? 0xf0 : 0;
-		uint8_t base = mode_selected ? 0xff : mode_available;
-		image[y][column] = {base, base, otherChannels};
 	}
 }
 


### PR DESCRIPTION
This will scale better when we add yet more functions.

Some cross-references were a bit tricky. maybe `velocity` value should just live in the KeyboardLayout root class ?