### PR TITLE
Fix save synth bug in performance view

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1368,8 +1368,7 @@ bool SoundEditor::inSettingsMenu() {
 }
 
 bool SoundEditor::inSongMenu() {
-	return ((menuItemNavigationRecord[0] == &soundEditorRootMenuSongView)
-	        || (menuItemNavigationRecord[0] == &soundEditorRootMenuPerformanceView));
+	return ((menuItemNavigationRecord[0] == &soundEditorRootMenuSongView) || (getRootUI() == &performanceSessionView));
 }
 
 bool SoundEditor::isUntransposedNoteWithinRange(int32_t noteCode) {


### PR DESCRIPTION
Fixed bug where when in the sound editor menu in value editing mode, pressing the save button would ask you to save a synth.