### PR TITLE
Bug Fix incorrect sound editor menu mod controllable setup in performance view

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1162,8 +1162,10 @@ bool SoundEditor::setup(Clip* clip, const MenuItem* item, int32_t sourceIndex) {
 		automationSubType = automationView.getAutomationSubType();
 	}
 
-	bool isUISessionView = (currentUI == &performanceSessionView) || (currentUI == &sessionView)
-	                       || (currentUI == &arrangerView) || (automationSubType == AutomationSubType::ARRANGER);
+	bool isUIPerformanceView = ((getRootUI() == &performanceSessionView) || currentUI == &performanceSessionView);
+
+	bool isUISessionView = isUIPerformanceView || (currentUI == &sessionView) || (currentUI == &arrangerView)
+	                       || (automationSubType == AutomationSubType::ARRANGER);
 
 	// getParamManager and ModControllable for Performance Session View (and Session View)
 	if (isUISessionView) {


### PR DESCRIPTION
When entering the menu using shortcuts or using the pads in value editing mode, the menu's model controllable stack was not getting setup correctly on subsequent menu item changes when you are already in the menu (e.g. after performance view becomes the root UI instead of the current UI).

Fixed by checking if rootUI is performance view prior to setup in order to correctly detect the UI as a "Session View" UI.