### PR TITLE
bugfix/block triplet and dotted from being set

### DIFF
--- a/src/deluge/gui/menu_item/swing/interval.h
+++ b/src/deluge/gui/menu_item/swing/interval.h
@@ -26,7 +26,8 @@ public:
 
 	void readCurrentValue() override { this->setValue(currentSong->swingInterval); }
 	void writeCurrentValue() override { currentSong->changeSwingInterval(this->getValue()); }
-
+	// triplet/dotted not yet supported
+	size_t size() override { return SYNC_TYPE_TRIPLET; }
 	void selectEncoderAction(int32_t offset) override { // So that there's no "off" option
 		this->setValue(this->getValue() + offset);
 		int32_t numOptions = this->size();


### PR DESCRIPTION
Triplet and dotted swing intervals instead get treated as increasingly small intervals, so just block them from being set

Swing interval is internally done very differently from delay sync so the same approach cannot easily be taken