### PR TITLE
Fix vertical encoder triggering horizontal handler in column controls

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/in_key.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.cpp
@@ -41,13 +41,17 @@ void KeyboardLayoutInKey::handleVerticalEncoder(int32_t offset) {
 	if (verticalEncoderHandledByColumns(offset)) {
 		return;
 	}
-	handleHorizontalEncoder(offset * getState().inKey.rowInterval, false);
+	_handleHorizontalEncoder(offset * getState().inKey.rowInterval, false);
 }
 
 void KeyboardLayoutInKey::handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	if (horizontalEncoderHandledByColumns(offset, shiftEnabled)) {
 		return;
 	}
+	_handleHorizontalEncoder(offset, shiftEnabled);
+}
+
+void KeyboardLayoutInKey::_handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	KeyboardStateInKey& state = getState().inKey;
 
 	if (shiftEnabled) {

--- a/src/deluge/gui/ui/keyboard/layout/in_key.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.cpp
@@ -41,17 +41,17 @@ void KeyboardLayoutInKey::handleVerticalEncoder(int32_t offset) {
 	if (verticalEncoderHandledByColumns(offset)) {
 		return;
 	}
-	_handleHorizontalEncoder(offset * getState().inKey.rowInterval, false);
+	offsetPads(offset * getState().inKey.rowInterval, false);
 }
 
 void KeyboardLayoutInKey::handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	if (horizontalEncoderHandledByColumns(offset, shiftEnabled)) {
 		return;
 	}
-	_handleHorizontalEncoder(offset, shiftEnabled);
+	offsetPads(offset, shiftEnabled);
 }
 
-void KeyboardLayoutInKey::_handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
+void KeyboardLayoutInKey::offsetPads(int32_t offset, bool shiftEnabled) {
 	KeyboardStateInKey& state = getState().inKey;
 
 	if (shiftEnabled) {

--- a/src/deluge/gui/ui/keyboard/layout/in_key.h
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.h
@@ -42,6 +42,7 @@ public:
 	RequiredScaleMode requiredScaleMode() override { return RequiredScaleMode::Enabled; }
 
 private:
+	void _handleHorizontalEncoder(int32_t offset, bool shiftEnabled);
 	inline uint16_t noteFromCoords(int32_t x, int32_t y) { return noteFromPadIndex(padIndexFromCoords(x, y)); }
 
 	inline uint16_t padIndexFromCoords(int32_t x, int32_t y) {

--- a/src/deluge/gui/ui/keyboard/layout/in_key.h
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.h
@@ -42,7 +42,7 @@ public:
 	RequiredScaleMode requiredScaleMode() override { return RequiredScaleMode::Enabled; }
 
 private:
-	void _handleHorizontalEncoder(int32_t offset, bool shiftEnabled);
+	void offsetPads(int32_t offset, bool shiftEnabled);
 	inline uint16_t noteFromCoords(int32_t x, int32_t y) { return noteFromPadIndex(padIndexFromCoords(x, y)); }
 
 	inline uint16_t padIndexFromCoords(int32_t x, int32_t y) {

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -43,17 +43,17 @@ void KeyboardLayoutIsomorphic::handleVerticalEncoder(int32_t offset) {
 	if (verticalEncoderHandledByColumns(offset)) {
 		return;
 	}
-	_handleHorizontalEncoder(offset * getState().isomorphic.rowInterval, false);
+	offsetPads(offset * getState().isomorphic.rowInterval, false);
 }
 
 void KeyboardLayoutIsomorphic::handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	if (horizontalEncoderHandledByColumns(offset, shiftEnabled)) {
 		return;
 	}
-	_handleHorizontalEncoder(offset, shiftEnabled);
+	offsetPads(offset, shiftEnabled);
 }
 
-void KeyboardLayoutIsomorphic::_handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
+void KeyboardLayoutIsomorphic::offsetPads(int32_t offset, bool shiftEnabled) {
 	KeyboardStateIsomorphic& state = getState().isomorphic;
 
 	if (shiftEnabled) {

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -43,13 +43,17 @@ void KeyboardLayoutIsomorphic::handleVerticalEncoder(int32_t offset) {
 	if (verticalEncoderHandledByColumns(offset)) {
 		return;
 	}
-	handleHorizontalEncoder(offset * getState().isomorphic.rowInterval, false);
+	_handleHorizontalEncoder(offset * getState().isomorphic.rowInterval, false);
 }
 
 void KeyboardLayoutIsomorphic::handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	if (horizontalEncoderHandledByColumns(offset, shiftEnabled)) {
 		return;
 	}
+	_handleHorizontalEncoder(offset, shiftEnabled);
+}
+
+void KeyboardLayoutIsomorphic::_handleHorizontalEncoder(int32_t offset, bool shiftEnabled) {
 	KeyboardStateIsomorphic& state = getState().isomorphic;
 
 	if (shiftEnabled) {

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.h
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.h
@@ -38,7 +38,7 @@ public:
 	bool supportsKit() override { return false; }
 
 private:
-	void _handleHorizontalEncoder(int32_t offset, bool shiftEnabled);
+	void offsetPads(int32_t offset, bool shiftEnabled);
 	inline uint8_t noteFromCoords(int32_t x, int32_t y) {
 		return getState().isomorphic.scrollOffset + x + y * getState().isomorphic.rowInterval;
 	}

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.h
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.h
@@ -38,6 +38,7 @@ public:
 	bool supportsKit() override { return false; }
 
 private:
+	void _handleHorizontalEncoder(int32_t offset, bool shiftEnabled);
 	inline uint8_t noteFromCoords(int32_t x, int32_t y) {
 		return getState().isomorphic.scrollOffset + x + y * getState().isomorphic.rowInterval;
 	}


### PR DESCRIPTION
In merging the various fixes / improvements / refactors, it looks like this fix got dropped. To test, switch to chord mode or chord memory, hold the top pad, and scroll the vertical encoder. Previously, this would trigger transitioning to the next column control as if the horizontal encoder was used when it should have been ignored as unhandled.