### PR TITLE
Refactor to explicitly return ErrorType

### DIFF
--- a/src/deluge/gui/context_menu/delete_file.cpp
+++ b/src/deluge/gui/context_menu/delete_file.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gui/context_menu/delete_file.h"
+#include "definitions_cxx.hpp"
 #include "gui/context_menu/save_song_or_instrument.h"
 #include "gui/l10n/l10n.h"
 #include "gui/ui/browser/browser.h"
@@ -66,7 +67,7 @@ bool DeleteFile::acceptCurrentOption() {
 	auto* browser = static_cast<Browser*>(ui);
 
 	String filePath;
-	int32_t error = browser->getCurrentFilePath(&filePath);
+	ErrorType error = browser->getCurrentFilePath(&filePath);
 	if (error) {
 		display->displayError(error);
 		return false;

--- a/src/deluge/gui/context_menu/load_instrument_preset.cpp
+++ b/src/deluge/gui/context_menu/load_instrument_preset.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gui/context_menu/load_instrument_preset.h"
+#include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
 #include "gui/ui/load/load_instrument_preset_ui.h"
 #include "hid/display/display.h"
@@ -35,7 +36,7 @@ Sized<char const**> LoadInstrumentPreset::getOptions() {
 }
 
 bool LoadInstrumentPreset::acceptCurrentOption() {
-	int32_t error;
+	ErrorType error;
 
 	switch (currentOption) {
 	/*

--- a/src/deluge/gui/context_menu/save_song_or_instrument.cpp
+++ b/src/deluge/gui/context_menu/save_song_or_instrument.cpp
@@ -49,7 +49,7 @@ bool SaveSongOrInstrument::acceptCurrentOption() {
 
 	case 1: { // Create folder
 		Browser* browser = (Browser*)getUIUpOneLevel();
-		int32_t error = browser->createFolder();
+		ErrorType error = browser->createFolder();
 
 		if (error) {
 			display->displayError(error);

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -82,7 +82,7 @@ bool AudioRecorder::opened() {
 		SoundDrum* drum = (SoundDrum*)soundEditor.currentSound;
 		String newName;
 
-		int32_t error = newName.set("REC");
+		ErrorType error = newName.set("REC");
 		if (error) {
 gotError:
 			display->displayError(error);

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -69,7 +69,7 @@ public:
 	Browser();
 
 	void close();
-	virtual int32_t getCurrentFilePath(String* path) = 0;
+	virtual ErrorType getCurrentFilePath(String* path) = 0;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	void currentFileDeleted();
 	int32_t goIntoFolder(char const* folderName);

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -39,13 +39,13 @@ class Song;
 
 struct PresetNavigationResult {
 	FileItem* fileItem;
-	int32_t error;
+	ErrorType error;
 	bool loadedFromFile;
 };
 
 struct ReturnOfConfirmPresetOrNextUnlaunchedOne {
 	FileItem* fileItem;
-	int32_t error;
+	ErrorType error;
 };
 
 struct Slot {
@@ -72,19 +72,20 @@ public:
 	virtual ErrorType getCurrentFilePath(String* path) = 0;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	void currentFileDeleted();
-	int32_t goIntoFolder(char const* folderName);
-	int32_t createFolder();
+	ErrorType goIntoFolder(char const* folderName);
+	ErrorType createFolder();
 	void selectEncoderAction(int8_t offset);
 	static FileItem* getCurrentFileItem();
-	int32_t readFileItemsForFolder(char const* filePrefixHere, bool allowFolders,
-	                               char const** allowedFileExtensionsHere, char const* filenameToStartAt,
-	                               int32_t newMaxNumFileItems, int32_t newCatalogSearchDirection = CATALOG_SEARCH_BOTH);
+	ErrorType readFileItemsForFolder(char const* filePrefixHere, bool allowFolders,
+	                                 char const** allowedFileExtensionsHere, char const* filenameToStartAt,
+	                                 int32_t newMaxNumFileItems,
+	                                 int32_t newCatalogSearchDirection = CATALOG_SEARCH_BOTH);
 	void sortFileItems();
 	FileItem* getNewFileItem();
 	static void emptyFileItems();
 	static void deleteSomeFileItems(int32_t startAt, int32_t stopAt);
 	static void deleteFolderAndDuplicateItems(Availability instrumentAvailabilityRequirement = Availability::ANY);
-	int32_t getUnusedSlot(OutputType outputType, String* newName, char const* thingName);
+	ErrorType getUnusedSlot(OutputType outputType, String* newName, char const* thingName);
 	bool opened();
 	void cullSomeFileItems();
 	bool checkFP();
@@ -105,10 +106,10 @@ public:
 	UIType getUIType() { return UIType::BROWSER; }
 
 protected:
-	int32_t setEnteredTextFromCurrentFilename();
-	int32_t goUpOneDirectoryLevel();
-	virtual int32_t arrivedInNewFolder(int32_t direction, char const* filenameToStartAt = NULL,
-	                                   char const* defaultDir = NULL);
+	ErrorType setEnteredTextFromCurrentFilename();
+	ErrorType goUpOneDirectoryLevel();
+	virtual ErrorType arrivedInNewFolder(int32_t direction, char const* filenameToStartAt = nullptr,
+	                                     char const* defaultDir = nullptr);
 	bool predictExtendedText();
 	void goIntoDeleteFileContextMenu();
 	ActionResult mainButtonAction(bool on);
@@ -118,11 +119,11 @@ protected:
 	virtual void currentFileChanged(int32_t movementDirection) {}
 	void displayText(bool blinkImmediately = false);
 	static Slot getSlot(char const* displayName);
-	int32_t readFileItemsFromFolderAndMemory(Song* song, OutputType outputType, char const* filePrefixHere,
-	                                         char const* filenameToStartAt, char const* defaultDirToAlsoTry,
-	                                         bool allowFoldersint,
-	                                         Availability availabilityRequirement = Availability::ANY,
-	                                         int32_t newCatalogSearchDirection = CATALOG_SEARCH_RIGHT);
+	ErrorType readFileItemsFromFolderAndMemory(Song* song, OutputType outputType, char const* filePrefixHere,
+	                                           char const* filenameToStartAt, char const* defaultDirToAlsoTry,
+	                                           bool allowFoldersint,
+	                                           Availability availabilityRequirement = Availability::ANY,
+	                                           int32_t newCatalogSearchDirection = CATALOG_SEARCH_RIGHT);
 
 	static int32_t fileIndexSelected; // If -1, we have not selected any real file/folder. Maybe there are no files, or
 	                                  // maybe we're typing a new name.

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -111,7 +111,7 @@ bool SampleBrowser::opened() {
 		instrumentClipView.cancelAllAuditioning();
 	}
 
-	int32_t error = storageManager.initSD();
+	ErrorType error = storageManager.initSD();
 	if (error) {
 sdError:
 		display->displayError(error);
@@ -351,7 +351,7 @@ void SampleBrowser::enterKeyPress() {
 		// it returns an empty string (&nothing). Surely this is a compiler error??
 		char const* filenameChars = currentFileItem->filename.get();
 
-		int32_t error = goIntoFolder(filenameChars);
+		ErrorType error = goIntoFolder(filenameChars);
 
 		if (error) {
 			display->displayError(error);
@@ -411,7 +411,7 @@ ActionResult SampleBrowser::buttonAction(deluge::hid::Button b, bool on, bool in
 
 					// Ensure sample isn't used in current song
 					String filePath;
-					int32_t error = getCurrentFilePath(&filePath);
+					ErrorType error = getCurrentFilePath(&filePath);
 					if (error) {
 						display->displayError(error);
 						return ActionResult::DEALT_WITH;
@@ -531,7 +531,7 @@ void SampleBrowser::previewIfPossible(int32_t movementDirection) {
 	if (currentFileItem && !currentFileItem->isFolder) {
 
 		String filePath;
-		int32_t error = getCurrentFilePath(&filePath);
+		ErrorType error = getCurrentFilePath(&filePath);
 		if (error) {
 			display->displayError(error);
 			return;
@@ -701,12 +701,12 @@ possiblyExit:
 	return ActionResult::DEALT_WITH;
 }
 
-int32_t SampleBrowser::claimAudioFileForInstrument(bool makeWaveTableWorkAtAllCosts) {
+ErrorType SampleBrowser::claimAudioFileForInstrument(bool makeWaveTableWorkAtAllCosts) {
 	soundEditor.cutSound();
 
 	AudioFileHolder* holder = soundEditor.getCurrentAudioFileHolder();
 	holder->setAudioFile(NULL);
-	int32_t error = getCurrentFilePath(&holder->filePath);
+	ErrorType error = getCurrentFilePath(&holder->filePath);
 	if (error) {
 		return error;
 	}
@@ -715,12 +715,12 @@ int32_t SampleBrowser::claimAudioFileForInstrument(bool makeWaveTableWorkAtAllCo
 	                        makeWaveTableWorkAtAllCosts);
 }
 
-int32_t SampleBrowser::claimAudioFileForAudioClip() {
+ErrorType SampleBrowser::claimAudioFileForAudioClip() {
 	soundEditor.cutSound();
 
 	AudioFileHolder* holder = soundEditor.getCurrentAudioFileHolder();
 	holder->setAudioFile(NULL);
-	int32_t error = getCurrentFilePath(&holder->filePath);
+	ErrorType error = getCurrentFilePath(&holder->filePath);
 	if (error) {
 		return error;
 	}
@@ -749,7 +749,7 @@ bool SampleBrowser::claimCurrentFile(int32_t mayDoPitchDetection, int32_t mayDoS
 
 	display->displayLoadingAnimationText("Working");
 
-	int32_t error;
+	ErrorType error;
 
 	// If for AudioClip...
 	if (getCurrentClip()->type == ClipType::AUDIO) {
@@ -1145,7 +1145,7 @@ bool SampleBrowser::loadAllSamplesInFolder(bool detectPitch, int32_t* getNumSamp
                                            bool* getDoingSingleCycle, int32_t* getPrefixAndDirLength) {
 
 	String dirToLoad;
-	uint8_t error;
+	ErrorType error;
 
 	FileItem* currentFileItem = getCurrentFileItem();
 
@@ -1886,7 +1886,7 @@ getOut:
 				// Make the Drum and its ParamManager
 
 				ParamManagerForTimeline paramManager;
-				int32_t error = paramManager.setupWithPatching();
+				ErrorType error = paramManager.setupWithPatching();
 				if (error) {
 					goto getOut;
 				}
@@ -1922,7 +1922,7 @@ getOut:
 			autoDetectSideChainSending(drum, source, thisSample->filePath.get());
 
 			String newName;
-			int32_t error = newName.set(&thisSample->filePath.get()[prefixAndDirLength]);
+			ErrorType error = newName.set(&thisSample->filePath.get()[prefixAndDirLength]);
 			if (!error) {
 
 				char const* newNameChars = newName.get();

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -478,8 +478,8 @@ bool SampleBrowser::canImportWholeKit() {
 	        && (!getCurrentKit()->firstDrum->next));
 }
 
-int32_t SampleBrowser::getCurrentFilePath(String* path) {
-	int32_t error;
+ErrorType SampleBrowser::getCurrentFilePath(String* path) {
+	ErrorType error;
 
 	path->set(&currentDir);
 	int32_t oldLength = path->getLength();

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -46,8 +46,8 @@ public:
 	ActionResult horizontalEncoderAction(int32_t offset);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	bool canSeeViewUnderneath();
-	int32_t claimAudioFileForInstrument(bool makeWaveTableWorkAtAllCosts = false);
-	int32_t claimAudioFileForAudioClip();
+	ErrorType claimAudioFileForInstrument(bool makeWaveTableWorkAtAllCosts = false);
+	ErrorType claimAudioFileForAudioClip();
 	void scrollFinished();
 	bool importFolderAsKit();
 	bool importFolderAsMultisamples();

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -74,7 +74,7 @@ private:
 	bool canImportWholeKit();
 	bool loadAllSamplesInFolder(bool detectPitch, int32_t* getNumSamples, Sample*** getSortArea,
 	                            bool* getDoingSingleCycle = NULL, int32_t* getNumCharsInPrefix = NULL);
-	int32_t getCurrentFilePath(String* path);
+	ErrorType getCurrentFilePath(String* path);
 	void drawKeysOverWaveform();
 	void autoDetectSideChainSending(SoundDrum* drum, Source* source, char const* fileName);
 	void possiblySetUpBlinking();

--- a/src/deluge/gui/ui/browser/slot_browser.cpp
+++ b/src/deluge/gui/ui/browser/slot_browser.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gui/ui/browser/slot_browser.h"
+#include "definitions_cxx.hpp"
 #include "hid/display/display.h"
 #include "hid/led/pad_leds.h"
 #include "hid/matrix/matrix_driver.h"
@@ -28,17 +29,14 @@
 
 bool SlotBrowser::currentFileHasSuffixFormatNameImplied;
 
-SlotBrowser::SlotBrowser() {
-}
-
 // Todo: turn this into the open() function - which will need to also be able to return error codes?
-int32_t SlotBrowser::beginSlotSession(bool shouldDrawKeys, bool allowIfNoFolder) {
+ErrorType SlotBrowser::beginSlotSession(bool shouldDrawKeys, bool allowIfNoFolder) {
 
 	currentFileHasSuffixFormatNameImplied = false;
 
 	// We want to check the SD card is generally working here, so that if not, we can exit out before drawing the QWERTY
 	// keyboard.
-	int32_t error = storageManager.initSD();
+	ErrorType error = storageManager.initSD();
 	if (error) {
 		return error;
 	}
@@ -177,8 +175,8 @@ void SlotBrowser::convertToPrefixFormatIfPossible() {
 	}
 }
 
-int32_t SlotBrowser::getCurrentFilenameWithoutExtension(String* filenameWithoutExtension) {
-	int32_t error;
+ErrorType SlotBrowser::getCurrentFilenameWithoutExtension(String* filenameWithoutExtension) {
+	ErrorType error;
 	if (display->have7SEG()) {
 		// If numeric...
 		Slot slot = getSlot(enteredText.get());
@@ -212,10 +210,10 @@ int32_t SlotBrowser::getCurrentFilenameWithoutExtension(String* filenameWithoutE
 	return NO_ERROR;
 }
 
-int32_t SlotBrowser::getCurrentFilePath(String* path) {
+ErrorType SlotBrowser::getCurrentFilePath(String* path) {
 	path->set(&currentDir);
 
-	int32_t error = path->concatenate("/");
+	ErrorType error = path->concatenate("/");
 	if (error) {
 		return error;
 	}

--- a/src/deluge/gui/ui/browser/slot_browser.h
+++ b/src/deluge/gui/ui/browser/slot_browser.h
@@ -17,34 +17,36 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "gui/ui/browser/browser.h"
 
 class Instrument;
 
 class SlotBrowser : public Browser {
 public:
-	SlotBrowser();
+	SlotBrowser() = default;
 
 	// 7SEG ONLY
 	void focusRegained();
 	ActionResult horizontalEncoderAction(int32_t offset);
 
-	int32_t getCurrentFilePath(String* path);
+	ErrorType getCurrentFilePath(String* path) override;
 
 protected:
-	int32_t beginSlotSession(bool shouldDrawKeys = true, bool allowIfNoFolder = false);
+	ErrorType beginSlotSession(bool shouldDrawKeys = true, bool allowIfNoFolder = false);
 	void processBackspace();
 	// bool predictExtendedText();
 	virtual void predictExtendedTextFromMemory() {}
 	void convertToPrefixFormatIfPossible();
 	void enterKeyPress();
-	int32_t getCurrentFilenameWithoutExtension(String* filename);
+	ErrorType getCurrentFilenameWithoutExtension(String* filename);
 
 	static bool currentFileHasSuffixFormatNameImplied;
 
-	Instrument* currentInstrument; // Although this is only needed by the child class LoadInstrumentPresetUI, we cut a
-	                               // corner by including it here so our functions can set it to NULL, which is needed.
-	                               // This is the Instrument we're currently scrolled onto. Might not be actually loaded
-	                               // (yet)? We do need this, separate from the current FileItem, because if user moves
-	                               // onto a folder, the currentInstrument needs to remain the same.
+	// Although this is only needed by the child class LoadInstrumentPresetUI, we cut a
+	// corner by including it here so our functions can set it to NULL, which is needed.
+	// This is the Instrument we're currently scrolled onto. Might not be actually loaded
+	// (yet)? We do need this, separate from the current FileItem, because if user moves
+	// onto a folder, the currentInstrument needs to remain the same.
+	Instrument* currentInstrument = nullptr;
 };

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.h
@@ -37,8 +37,8 @@ public:
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine);
 	void instrumentEdited(Instrument* instrument);
-	int32_t performLoad(bool doClone = false);
-	int32_t performLoadSynthToKit();
+	ErrorType performLoad(bool doClone = false);
+	ErrorType performLoadSynthToKit();
 	ActionResult timerCallback();
 	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth] = NULL,
@@ -76,14 +76,14 @@ protected:
 
 private:
 	bool showingAuditionPads();
-	int32_t setupForOutputType();
+	ErrorType setupForOutputType();
 	void changeOutputType(OutputType newOutputType);
 	void revertToInitialPreset();
 	void exitAction();
 	bool isInstrumentInList(Instrument* searchInstrument, Output* list);
 	bool findUnusedSlotVariation(String* oldName, String* newName);
 
-	uint8_t currentInstrumentLoadError;
+	ErrorType currentInstrumentLoadError;
 
 	int16_t initialChannel;
 	int8_t initialChannelSuffix;

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -64,7 +64,7 @@ bool LoadSongUI::opened() {
 	outputTypeToLoad = OutputType::NONE;
 	currentDir.set(&currentSong->dirPath);
 
-	int32_t error = beginSlotSession(false, true);
+	ErrorType error = beginSlotSession(false, true);
 	if (error) {
 gotError:
 		display->displayError(error);
@@ -145,7 +145,7 @@ void LoadSongUI::enterKeyPress() {
 	// If it's a directory...
 	if (currentFileItem && currentFileItem->isFolder) {
 
-		int32_t error = goIntoFolder(currentFileItem->filename.get());
+		ErrorType error = goIntoFolder(currentFileItem->filename.get());
 
 		if (error) {
 			display->displayError(error);
@@ -240,7 +240,7 @@ void LoadSongUI::performLoad() {
 		playbackHandler.switchToSession();
 	}
 
-	int32_t error = storageManager.openXMLFile(&currentFileItem->filePointer, "song");
+	ErrorType error = storageManager.openXMLFile(&currentFileItem->filePointer, "song");
 	if (error) {
 		display->displayError(error);
 		return;
@@ -711,7 +711,7 @@ void LoadSongUI::drawSongPreview(bool toStore) {
 		return;
 	}
 
-	int32_t error = storageManager.openXMLFile(&currentFileItem->filePointer, "song", "", true);
+	ErrorType error = storageManager.openXMLFile(&currentFileItem->filePointer, "song", "", true);
 	if (error) {
 		if (error) {
 			display->displayError(error);

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -366,7 +366,7 @@ ActionResult QwertyUI::padAction(int32_t x, int32_t y, int32_t on) {
 						stringToConcat[0] = newChar;
 						stringToConcat[1] = 0;
 
-						int32_t error = enteredText.concatenateAtPos(stringToConcat, enteredTextEditPos);
+						ErrorType error = enteredText.concatenateAtPos(stringToConcat, enteredTextEditPos);
 
 						if (error) {
 							display->displayError(error);

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
@@ -78,7 +78,7 @@ tryDefaultDir:
 
 	filePrefix = (outputTypeToLoad == OutputType::SYNTH) ? "SYNT" : "KIT";
 
-	int32_t error = arrivedInNewFolder(0, enteredText.get(), defaultDir);
+	ErrorType error = arrivedInNewFolder(0, enteredText.get(), defaultDir);
 	if (error) {
 gotError:
 		display->displayError(error);
@@ -128,7 +128,7 @@ bool SaveInstrumentPresetUI::performSave(bool mayOverwrite) {
 	}
 
 	String filePath;
-	int32_t error = getCurrentFilePath(&filePath);
+	ErrorType error = getCurrentFilePath(&filePath);
 	if (error) {
 fail:
 		display->displayError(error);
@@ -197,7 +197,7 @@ void SaveInstrumentPresetUI::selectEncoderAction(int8_t offset) {
 
         int32_t previouslySavedSlot = instrument->name.isEmpty() ? instrument->slot : -1;
 
-        int32_t error = storageManager.decideNextSaveableSlot(offset,
+        ErrorType error = storageManager.decideNextSaveableSlot(offset,
                 &currentSlot, &currentSubSlot, &enteredText, &currentFileIsFolder,
                 previouslySavedSlot, &currentFileExists, numInstrumentSlots, getThingName(outputType), currentDir.get(),
 outputType, getCurrentInstrument()); if (error) { display->displayError(error); if (error != ERROR_FOLDER_DOESNT_EXIST)

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -60,7 +60,7 @@ doReturnFalse:
 		return false;
 	}
 
-	int32_t error;
+	ErrorType error;
 
 	String searchFilename;
 	searchFilename.set(&currentSong->name);
@@ -119,7 +119,7 @@ bool SaveSongUI::performSave(bool mayOverwrite) {
 	display->displayLoadingAnimationText("Saving");
 
 	String filePath;
-	int32_t error = getCurrentFilePath(&filePath);
+	ErrorType error = getCurrentFilePath(&filePath);
 	if (error) {
 gotError:
 		display->removeLoadingAnimation();

--- a/src/deluge/gui/ui/save/save_ui.cpp
+++ b/src/deluge/gui/ui/save/save_ui.cpp
@@ -35,7 +35,7 @@ SaveUI::SaveUI() {
 }
 
 bool SaveUI::opened() {
-	int32_t error = beginSlotSession(true, true);
+	ErrorType error = beginSlotSession(true, true);
 	if (error) {
 		display->displayError(error);
 		return false;
@@ -73,7 +73,7 @@ void SaveUI::enterKeyPress() {
 	// If it's a directory...
 	if (currentFileItem && currentFileItem->isFolder) {
 
-		int32_t error = goIntoFolder(currentFileItem->filename.get());
+		ErrorType error = goIntoFolder(currentFileItem->filename.get());
 
 		if (error) {
 			display->displayError(error);

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -593,7 +593,7 @@ void Slicer::doSlice() {
 
 	AudioEngine::stopAnyPreviewing();
 
-	int32_t error = sampleBrowser.claimAudioFileForInstrument();
+	ErrorType error = sampleBrowser.claimAudioFileForInstrument();
 	if (error) {
 getOut:
 		display->displayError(error);

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -134,7 +134,7 @@ void ArrangerView::moveClipToSession() {
 			}
 
 			clip->section = currentSong->getLowestSectionWithNoSessionClipForOutput(output);
-			int32_t error = currentSong->sessionClips.insertClipAtIndex(clip, intendedIndex);
+			ErrorType error = currentSong->sessionClips.insertClipAtIndex(clip, intendedIndex);
 			if (error) {
 				display->displayError(error);
 				return;
@@ -1201,7 +1201,7 @@ void ArrangerView::editPadAction(int32_t x, int32_t y, bool on) {
 				if (oldClip && !oldClip->isArrangementOnlyClip() && !oldClip->getCurrentlyRecordingLinearly()) {
 					actionLogger.deleteAllLogs();
 
-					int32_t error = arrangement.doUniqueCloneOnClipInstance(clipInstance, clipInstance->length, true);
+					ErrorType error = arrangement.doUniqueCloneOnClipInstance(clipInstance, clipInstance->length, true);
 					if (error) {
 						display->displayError(error);
 					}
@@ -1586,7 +1586,7 @@ justGetOut:
 								ModelStackWithTimelineCounter* modelStack =
 								    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, newClip);
 
-								int32_t error;
+								ErrorType error;
 
 								if (output->type == OutputType::AUDIO) {
 									error = ((AudioClip*)newClip)->setOutput(modelStack, output);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -786,7 +786,7 @@ void InstrumentClipView::createDrumForAuditionedNoteRow(DrumType drumType) {
 		return;
 	}
 
-	int32_t error;
+	ErrorType error;
 	NoteRow* noteRow;
 	int32_t noteRowIndex;
 
@@ -1890,7 +1890,7 @@ void InstrumentClipView::editPadAction(bool state, uint8_t yDisplay, uint8_t xDi
 
 						// If we're cross-screen-editing, create other corresponding notes too
 						if (clip->wrapEditing) {
-							int32_t error = noteRow->addCorrespondingNotes(
+							ErrorType error = noteRow->addCorrespondingNotes(
 							    squareStart, desiredNoteLength, editPadPresses[i].intendedVelocity,
 							    modelStackWithNoteRow, clip->allowNoteTails(modelStackWithNoteRow), action);
 
@@ -3655,7 +3655,7 @@ void InstrumentClipView::enterDrumCreator(ModelStackWithNoteRow* modelStack, boo
 	// safe since we can't get here without being in a kit
 	Kit* kit = getCurrentKit();
 
-	int32_t error = kit->makeDrumNameUnique(&soundName, 1);
+	ErrorType error = kit->makeDrumNameUnique(&soundName, 1);
 	if (error) {
 doDisplayError:
 		display->displayError(error);
@@ -4962,7 +4962,7 @@ doCompareNote:
 					int32_t distanceTilNext =
 					    noteRow->getDistanceToNextNote(editPadPresses[i].intendedPos, modelStackWithNoteRow);
 
-					int32_t error =
+					ErrorType error =
 					    noteRow->nudgeNotesAcrossAllScreens(editPadPresses[i].intendedPos, modelStackWithNoteRow,
 					                                        action, currentClip->getWrapEditLevel(), offset);
 					if (error) {
@@ -5486,7 +5486,7 @@ justDisplayOldNumNotes:
 					// Make new NoteVector for the new Notes, since ActionLogger should be "stealing" the old data
 					NoteVector newNotes;
 					if (newNumNotes) {
-						int32_t error = newNotes.insertAtIndex(0, newNumNotes); // Pre-allocate, so no errors later
+						ErrorType error = newNotes.insertAtIndex(0, newNumNotes); // Pre-allocate, so no errors later
 						if (error) {
 							display->displayError(error);
 							return;

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -712,7 +712,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 					currentSong->clearArrangementBeyondPos(
 					    arrangerView.xScrollWhenPlaybackStarted,
 					    action); // Want to do this before setting up playback or place new instances
-					int32_t error =
+					ErrorType error =
 					    currentSong->placeFirstInstancesOfActiveClips(arrangerView.xScrollWhenPlaybackStarted);
 
 					if (error) {
@@ -1577,7 +1577,7 @@ void PerformanceSessionView::savePerformanceViewLayout() {
 /// I should check if file exists before creating one
 void PerformanceSessionView::writeDefaultsToFile() {
 	// PerformanceView.xml
-	int32_t error = storageManager.createXMLFile(PERFORM_DEFAULTS_XML, true);
+	ErrorType error = storageManager.createXMLFile(PERFORM_DEFAULTS_XML, true);
 	if (error) {
 		return;
 	}
@@ -1736,7 +1736,7 @@ void PerformanceSessionView::readDefaultsFromFile() {
 	}
 
 	//<defaults>
-	int32_t error = storageManager.openXMLFile(&fp, PERFORM_DEFAULTS_TAG);
+	ErrorType error = storageManager.openXMLFile(&fp, PERFORM_DEFAULTS_TAG);
 	if (error) {
 		loadDefaultLayout();
 		return;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -216,7 +216,7 @@ ActionResult SessionView::buttonAction(deluge::hid::Button b, bool on, bool inCa
 					currentSong->clearArrangementBeyondPos(
 					    arrangerView.xScrollWhenPlaybackStarted,
 					    action); // Want to do this before setting up playback or place new instances
-					int32_t error =
+					ErrorType error =
 					    currentSong->placeFirstInstancesOfActiveClips(arrangerView.xScrollWhenPlaybackStarted);
 
 					if (error) {
@@ -287,7 +287,7 @@ moveAfterClipInstance:
 				}
 
 				// If we're here, we're ok!
-				int32_t error = output->clipInstances.insertAtIndex(i);
+				ErrorType error = output->clipInstances.insertAtIndex(i);
 				if (error) {
 					display->displayError(error);
 					return ActionResult::DEALT_WITH;
@@ -1439,8 +1439,8 @@ void SessionView::drawSectionSquare(uint8_t yDisplay, RGB thisImage[]) {
 }
 
 // Will now look in subfolders too if need be.
-int32_t setPresetOrNextUnlaunchedOne(InstrumentClip* clip, OutputType outputType, bool* instrumentAlreadyInSong,
-                                     bool copyDrumsFromClip = true) {
+ErrorType setPresetOrNextUnlaunchedOne(InstrumentClip* clip, OutputType outputType, bool* instrumentAlreadyInSong,
+                                       bool copyDrumsFromClip = true) {
 	ReturnOfConfirmPresetOrNextUnlaunchedOne result;
 	result.error = Browser::currentDir.set(getInstrumentFolder(outputType));
 	if (result.error) {
@@ -1507,7 +1507,7 @@ int32_t setPresetOrNextUnlaunchedOne(InstrumentClip* clip, OutputType outputType
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithTimelineCounter* modelStack =
 		    setupModelStackWithSong(modelStackMemory, currentSong)->addTimelineCounter(clip);
-		int32_t error = clip->changeInstrument(modelStack, newInstrument, NULL, InstrumentRemoval::NONE);
+		ErrorType error = clip->changeInstrument(modelStack, newInstrument, NULL, InstrumentRemoval::NONE);
 		if (error != NO_ERROR) {
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_SWITCHING_TO_TRACK_FAILED));
 		}
@@ -1553,7 +1553,7 @@ Clip* SessionView::createNewInstrumentClip(int32_t yDisplay) {
 
 	OutputType outputType = OutputType::SYNTH;
 doGetInstrument:
-	int32_t error = setPresetOrNextUnlaunchedOne(newClip, outputType, &instrumentAlreadyInSong);
+	ErrorType error = setPresetOrNextUnlaunchedOne(newClip, outputType, &instrumentAlreadyInSong);
 	if (error) {
 
 		// If that was for a synth and there were none, try a kit
@@ -1637,7 +1637,7 @@ ramError:
 	newClip->colourOffset = random(72);
 
 	bool instrumentAlreadyInSong;
-	int32_t error;
+	ErrorType error;
 
 	if (outputType == OutputType::SYNTH || outputType == OutputType::KIT) {
 
@@ -1978,7 +1978,7 @@ ramError:
 	ModelStackWithTimelineCounter* modelStack =
 	    setupModelStackWithSong(modelStackMemory, currentSong)->addTimelineCounter(clipToClone);
 
-	int32_t error = clipToClone->clone(modelStack);
+	ErrorType error = clipToClone->clone(modelStack);
 	if (error) {
 		goto ramError;
 	}
@@ -3002,7 +3002,7 @@ Clip* SessionView::gridCloneClip(Clip* sourceClip) {
 	ModelStackWithTimelineCounter* modelStack =
 	    setupModelStackWithSong(modelStackMemory, currentSong)->addTimelineCounter(sourceClip);
 
-	int32_t error = sourceClip->clone(modelStack, false);
+	ErrorType error = sourceClip->clone(modelStack, false);
 	if (error) {
 		display->displayError(ERROR_INSUFFICIENT_RAM);
 		return nullptr;
@@ -3055,7 +3055,7 @@ Clip* SessionView::gridCreateClipInTrack(Output* targetOutput) {
 bool SessionView::gridCreateNewTrackForClip(OutputType type, InstrumentClip* clip, bool copyDrumsFromClip) {
 	bool instrumentAlreadyInSong = false;
 	if (type == OutputType::SYNTH || type == OutputType::KIT) {
-		int32_t error = setPresetOrNextUnlaunchedOne(clip, type, &instrumentAlreadyInSong, copyDrumsFromClip);
+		ErrorType error = setPresetOrNextUnlaunchedOne(clip, type, &instrumentAlreadyInSong, copyDrumsFromClip);
 		if (error || instrumentAlreadyInSong) {
 			if (error) {
 				display->displayError(error);
@@ -3199,8 +3199,8 @@ Clip* SessionView::gridCreateClip(uint32_t targetSection, Output* targetOutput, 
 
 			// Different instrument, switch the cloned clip to it
 			else if (targetOutput != sourceClip->output) {
-				int32_t error = newInstrumentClip->changeInstrument(modelStack, (Instrument*)targetOutput, NULL,
-				                                                    InstrumentRemoval::NONE);
+				ErrorType error = newInstrumentClip->changeInstrument(modelStack, (Instrument*)targetOutput, NULL,
+				                                                      InstrumentRemoval::NONE);
 				if (error != NO_ERROR) {
 					display->displayPopup(l10n::get(l10n::String::STRING_FOR_SWITCHING_TO_TRACK_FAILED));
 				}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2004,8 +2004,8 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 			}
 gotAnInstrument:
 
-			int32_t error = clip->changeInstrument(modelStack, newInstrument, NULL,
-			                                       InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED, NULL, true);
+			ErrorType error = clip->changeInstrument(modelStack, newInstrument, NULL,
+			                                         InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED, NULL, true);
 			// TODO: deal with errors
 
 			if (!instrumentAlreadyInSong) {
@@ -2085,8 +2085,8 @@ getOut:
 			// If we're here, we know the Clip is not playing in the arranger (and doesn't even have an instance in
 			// there)
 
-			int32_t error = clip->changeInstrument(modelStack, newInstrument, NULL,
-			                                       InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED, NULL, true);
+			ErrorType error = clip->changeInstrument(modelStack, newInstrument, NULL,
+			                                         InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED, NULL, true);
 			// TODO: deal with errors!
 
 			if (!instrumentAlreadyInSong) {

--- a/src/deluge/hid/display/display.cpp
+++ b/src/deluge/hid/display/display.cpp
@@ -7,7 +7,7 @@
 deluge::hid::Display* display = nullptr;
 namespace deluge::hid::display {
 
-std::string_view getErrorMessage(int32_t error) {
+std::string_view getErrorMessage(ErrorType error) {
 	using enum l10n::String;
 	switch (error) {
 	case ERROR_INSUFFICIENT_RAM:

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -58,7 +58,7 @@ public:
 	virtual void cancelPopup() = 0;
 	virtual void freezeWithError(char const* text) = 0;
 	virtual bool isLayerCurrentlyOnTop(NumericLayer* layer) = 0;
-	virtual void displayError(int32_t error) = 0;
+	virtual void displayError(ErrorType error) = 0;
 
 	virtual void removeWorkingAnimation() = 0;
 

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -874,7 +874,7 @@ void OLED::popupText(char const* text, bool persistent, DisplayPopupType type) {
 
 void updateWorkingAnimation() {
 	String textNow;
-	int32_t error = textNow.set(workingAnimationText);
+	ErrorType error = textNow.set(workingAnimationText);
 	if (error) {
 		return;
 	}
@@ -1330,9 +1330,9 @@ void OLED::freezeWithError(char const* text) {
 	OLED::popupText("Operation resumed. Save to new file then reboot.", false, DisplayPopupType::GENERAL);
 }
 
-extern std::string_view getErrorMessage(int32_t);
+extern std::string_view getErrorMessage(ErrorType);
 
-void OLED::displayError(int32_t error) {
+void OLED::displayError(ErrorType error) {
 	char const* message = nullptr;
 	switch (error) {
 	case NO_ERROR:

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -128,7 +128,7 @@ public:
 
 	void cancelPopup() override { removePopup(); }
 	bool isLayerCurrentlyOnTop(NumericLayer* layer) override { return (!this->hasPopup()); }
-	void displayError(int32_t error) override;
+	void displayError(ErrorType error) override;
 
 	// Loading animations
 	void displayLoadingAnimationText(char const* text, bool delayed = false, bool transparent = false) override {

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -645,9 +645,9 @@ bool SevenSegment::isLayerCurrentlyOnTop(NumericLayer* layer) {
 	return (!popupActive && layer == topLayer);
 }
 
-extern std::string_view getErrorMessage(int32_t error);
+extern std::string_view getErrorMessage(ErrorType error);
 
-void SevenSegment::displayError(int32_t error) {
+void SevenSegment::displayError(ErrorType error) {
 	char const* message = nullptr;
 	switch (error) {
 	case NO_ERROR:

--- a/src/deluge/hid/display/seven_segment.h
+++ b/src/deluge/hid/display/seven_segment.h
@@ -40,7 +40,7 @@ public:
 	                  int32_t blinkSpeed = 1, DisplayPopupType type = DisplayPopupType::GENERAL) override;
 	void freezeWithError(char const* text) override;
 	void cancelPopup() override;
-	void displayError(int32_t error) override;
+	void displayError(ErrorType error) override;
 
 	void setTextAsNumber(int16_t number, uint8_t drawDot = 255, bool doBlink = false) override;
 	void setTextAsSlot(int16_t currentSlot, int8_t currentSubSlot, bool currentSlotExists, bool doBlink = false,

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -172,7 +172,7 @@ MIDIDeviceUSBHosted* getOrCreateHostedMIDIDeviceFromDetails(String* name, uint16
 	device->productId = productId;
 
 	// Store record of this device
-	int32_t error = hostedMIDIDevices.insertElement(device, i); // We made sure, above, that there's space
+	ErrorType error = hostedMIDIDevices.insertElement(device, i); // We made sure, above, that there's space
 #if ALPHA_OR_BETA_VERSION
 	if (error) {
 		FREEZE_WITH_ERROR("E405");
@@ -251,7 +251,7 @@ extern "C" void hostedDeviceConfigured(int32_t ip, int32_t midiDeviceNum) {
 	if (display->haveOLED()) {
 		String text;
 		text.set(&device->name);
-		int32_t error = text.concatenate(" attached");
+		ErrorType error = text.concatenate(" attached");
 		if (!error) {
 			consoleTextIfAllBootedUp(text.get());
 		}
@@ -480,7 +480,7 @@ void writeDevicesToFile() {
 	return;
 
 worthIt:
-	int32_t error = storageManager.createXMLFile("MIDIDevices.XML", true);
+	ErrorType error = storageManager.createXMLFile("MIDIDevices.XML", true);
 	if (error) {
 		return;
 	}
@@ -537,7 +537,7 @@ void readDevicesFromFile() {
 		return;
 	}
 
-	int32_t error = storageManager.openXMLFile(&fp, "midiDevices");
+	ErrorType error = storageManager.openXMLFile(&fp, "midiDevices");
 	if (error) {
 		return;
 	}

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -568,7 +568,7 @@ bool MidiFollow::isFeedbackEnabled() {
 /// I should check if file exists before creating one
 void MidiFollow::writeDefaultsToFile() {
 	// MidiFollow.xml
-	int32_t error = storageManager.createXMLFile(MIDI_DEFAULTS_XML, true);
+	ErrorType error = storageManager.createXMLFile(MIDI_DEFAULTS_XML, true);
 	if (error) {
 		return;
 	}
@@ -643,7 +643,7 @@ void MidiFollow::readDefaultsFromFile() {
 	}
 
 	//<defaults>
-	int32_t error = storageManager.openXMLFile(&fp, MIDI_DEFAULTS_TAG);
+	ErrorType error = storageManager.openXMLFile(&fp, MIDI_DEFAULTS_TAG);
 	if (error) {
 		writeDefaultsToFile();
 		successfullyReadDefaultsFromFile = true;

--- a/src/deluge/model/action/action.cpp
+++ b/src/deluge/model/action/action.cpp
@@ -83,7 +83,7 @@ void Action::addConsequence(Consequence* consequence) {
 }
 
 // Returns error code
-int32_t Action::revert(TimeType time, ModelStack* modelStack) {
+ErrorType Action::revert(TimeType time, ModelStack* modelStack) {
 
 	Consequence* thisConsequence = firstConsequence;
 
@@ -99,7 +99,7 @@ int32_t Action::revert(TimeType time, ModelStack* modelStack) {
 
 	Consequence* newFirstConsequence = NULL;
 
-	int32_t error = NO_ERROR;
+	ErrorType error = NO_ERROR;
 
 	while (thisConsequence) {
 		if (!error) {
@@ -205,9 +205,9 @@ bool Action::containsConsequenceNoteArrayChange(InstrumentClip* clip, int32_t no
 	return false;
 }
 
-int32_t Action::recordNoteArrayChangeIfNotAlreadySnapshotted(InstrumentClip* clip, int32_t noteRowId,
-                                                             NoteVector* noteVector, bool stealData,
-                                                             bool moveToFrontIfAlreadySnapshotted) {
+ErrorType Action::recordNoteArrayChangeIfNotAlreadySnapshotted(InstrumentClip* clip, int32_t noteRowId,
+                                                               NoteVector* noteVector, bool stealData,
+                                                               bool moveToFrontIfAlreadySnapshotted) {
 	if (containsConsequenceNoteArrayChange(clip, noteRowId, moveToFrontIfAlreadySnapshotted)) {
 		return NO_ERROR;
 	}
@@ -216,8 +216,8 @@ int32_t Action::recordNoteArrayChangeIfNotAlreadySnapshotted(InstrumentClip* cli
 	return recordNoteArrayChangeDefinitely(clip, noteRowId, noteVector, stealData);
 }
 
-int32_t Action::recordNoteArrayChangeDefinitely(InstrumentClip* clip, int32_t noteRowId, NoteVector* noteVector,
-                                                bool stealData) {
+ErrorType Action::recordNoteArrayChangeDefinitely(InstrumentClip* clip, int32_t noteRowId, NoteVector* noteVector,
+                                                  bool stealData) {
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceNoteArrayChange));
 
 	if (!consMemory) {

--- a/src/deluge/model/action/action.h
+++ b/src/deluge/model/action/action.h
@@ -74,15 +74,15 @@ class Action {
 public:
 	Action(ActionType newActionType);
 	void addConsequence(Consequence* consequence);
-	int32_t revert(TimeType time, ModelStack* modelStack);
+	ErrorType revert(TimeType time, ModelStack* modelStack);
 	bool containsConsequenceParamChange(ParamCollection* paramCollection, int32_t paramId);
 	void recordParamChangeIfNotAlreadySnapshotted(ModelStackWithAutoParam const* modelStack, bool stealData = false);
 	void recordParamChangeDefinitely(ModelStackWithAutoParam const* modelStack, bool stealData);
-	int32_t recordNoteArrayChangeIfNotAlreadySnapshotted(InstrumentClip* clip, int32_t noteRowId,
-	                                                     NoteVector* noteVector, bool stealData,
-	                                                     bool moveToFrontIfAlreadySnapshotted = false);
-	int32_t recordNoteArrayChangeDefinitely(InstrumentClip* clip, int32_t noteRowId, NoteVector* noteVector,
-	                                        bool stealData);
+	ErrorType recordNoteArrayChangeIfNotAlreadySnapshotted(InstrumentClip* clip, int32_t noteRowId,
+	                                                       NoteVector* noteVector, bool stealData,
+	                                                       bool moveToFrontIfAlreadySnapshotted = false);
+	ErrorType recordNoteArrayChangeDefinitely(InstrumentClip* clip, int32_t noteRowId, NoteVector* noteVector,
+	                                          bool stealData);
 	bool containsConsequenceNoteArrayChange(InstrumentClip* clip, int32_t noteRowId, bool moveToFrontIfFound = false);
 	void recordNoteExistenceChange(InstrumentClip* clip, int32_t noteRowId, Note* note, ExistenceChangeType type);
 	void recordNoteChange(InstrumentClip* clip, int32_t noteRowId, Note* note, int32_t lengthAfter,

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -601,7 +601,7 @@ currentClipSwitchedOver:
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
 
-	int32_t error = action->revert(time, modelStack);
+	ErrorType error = action->revert(time, modelStack);
 
 	// Some "animations", we prefer to do after we've reverted the action
 	if (whichAnimation == Animation::ENTER_KEYBOARD_VIEW) {

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -36,7 +36,7 @@ public:
 	~AudioClip();
 	void processCurrentPos(ModelStackWithTimelineCounter* modelStack, uint32_t ticksSinceLast);
 	void expectNoFurtherTicks(Song* song, bool actuallySoundChange = true);
-	int32_t clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false);
+	ErrorType clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false) override;
 	void render(ModelStackWithTimelineCounter* modelStack, int32_t* outputBuffer, int32_t numSamples, int32_t amplitude,
 	            int32_t amplitudeIncrement, int32_t pitchAdjust);
 	void detachFromOutput(ModelStackWithTimelineCounter* modelStack, bool shouldRememberDrumName,
@@ -47,13 +47,13 @@ public:
 	                       uint32_t xZoom, RGB* image, uint8_t occupancyMask[], bool addUndefinedArea,
 	                       int32_t noteRowIndexStart = 0, int32_t noteRowIndexEnd = 2147483647, int32_t xStart = 0,
 	                       int32_t xEnd = kDisplayWidth, bool allowBlur = true, bool drawRepeats = false);
-	int32_t claimOutput(ModelStackWithTimelineCounter* modelStack);
+	ErrorType claimOutput(ModelStackWithTimelineCounter* modelStack) override;
 	void loadSample(bool mayActuallyReadFile);
 	bool wantsToBeginLinearRecording(Song* song);
 	bool isAbandonedOverdub();
 	void finishLinearRecording(ModelStackWithTimelineCounter* modelStack, Clip* nextPendingLoop,
 	                           int32_t buttonLatencyForTempolessRecord);
-	int32_t beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency);
+	ErrorType beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency) override;
 	void quantizeLengthForArrangementRecording(ModelStackWithTimelineCounter* modelStack, int32_t lengthSoFar,
 	                                           uint32_t timeRemainder, int32_t suggestedLength,
 	                                           int32_t alternativeLongerLength);
@@ -61,9 +61,9 @@ public:
 	int64_t getSamplesFromTicks(int32_t ticks);
 	void unassignVoiceSample(bool wontBeUsedAgain);
 	void resumePlayback(ModelStackWithTimelineCounter* modelStack, bool mayMakeSound = true);
-	int32_t changeOutput(ModelStackWithTimelineCounter* modelStack, Output* newOutput);
-	int32_t setOutput(ModelStackWithTimelineCounter* modelStack, Output* newOutput,
-	                  AudioClip* favourClipForCloningParamManager = NULL);
+	ErrorType changeOutput(ModelStackWithTimelineCounter* modelStack, Output* newOutput);
+	ErrorType setOutput(ModelStackWithTimelineCounter* modelStack, Output* newOutput,
+	                    AudioClip* favourClipForCloningParamManager = NULL);
 	RGB getColour();
 	bool currentlyScrollableAndZoomable();
 	void getScrollAndZoomInSamples(int32_t xScroll, int32_t xZoom, int64_t* xScrollSamples, int64_t* xZoomSamples);
@@ -81,7 +81,7 @@ public:
 	/// Return true if successfully shifted, as clip cannot be shifted past beginning
 	bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount);
 
-	int32_t readFromFile(Song* song);
+	ErrorType readFromFile(Song* song);
 	void writeDataToFile(Song* song);
 	char const* getXMLTag() { return "audioClip"; }
 

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -319,8 +319,8 @@ playingForwardNow:
 	}
 }
 
-int32_t Clip::appendClip(ModelStackWithTimelineCounter* thisModelStack,
-                         ModelStackWithTimelineCounter* otherModelStack) {
+ErrorType Clip::appendClip(ModelStackWithTimelineCounter* thisModelStack,
+                           ModelStackWithTimelineCounter* otherModelStack) {
 	Clip* otherClip = (Clip*)otherModelStack->getTimelineCounter();
 	if (paramManager.containsAnyParamCollectionsIncludingExpression()
 	    && otherClip->paramManager.containsAnyParamCollectionsIncludingExpression()) {
@@ -427,7 +427,7 @@ bool Clip::opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounte
 		originalLength = loopLength;
 		isPendingOverdub = false;
 
-		int32_t error = beginLinearRecording(modelStack, buttonPressLatency);
+		ErrorType error = beginLinearRecording(modelStack, buttonPressLatency);
 		if (error != 0) {
 			display->displayError(error);
 			return false;
@@ -562,7 +562,7 @@ void Clip::endInstance(int32_t arrangementRecordPos, bool evenIfOtherClip) {
 // Returns error code
 // This whole function is virtual and overridden in (and sometimes called from) InstrumentClip, so don't worry about
 // MIDI / CV cases - they're dealt with there
-int32_t Clip::undoDetachmentFromOutput(ModelStackWithTimelineCounter* modelStack) {
+ErrorType Clip::undoDetachmentFromOutput(ModelStackWithTimelineCounter* modelStack) {
 
 	ModControllable* modControllable = output->toModControllable();
 
@@ -903,7 +903,7 @@ yesMakeItActive:
 }
 
 // Obviously don't call this for MIDI clips!
-int32_t Clip::solicitParamManager(Song* song, ParamManager* newParamManager, Clip* favourClipForCloningParamManager) {
+ErrorType Clip::solicitParamManager(Song* song, ParamManager* newParamManager, Clip* favourClipForCloningParamManager) {
 
 	// Occasionally, like for AudioClips changing their Output, they will actually have a paramManager already, so
 	// everything's fine and we can return
@@ -956,7 +956,7 @@ trimFoundParamManager:
 			Clip* otherClip = song->getClipWithOutput(output, false, this); // Exclude self
 			if (otherClip) {
 
-				int32_t error = paramManager.cloneParamCollectionsFrom(&otherClip->paramManager, false, true);
+				ErrorType error = paramManager.cloneParamCollectionsFrom(&otherClip->paramManager, false, true);
 
 				if (error) {
 					FREEZE_WITH_ERROR("E050");
@@ -1016,7 +1016,7 @@ void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
 	}
 }
 
-int32_t Clip::beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency) {
+ErrorType Clip::beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency) {
 
 	// if we're not in a clip level view, set to the clip that's starting linear recording
 	// todo: this should probably only happen if a single clip is recording linearly, but that's not tracked
@@ -1092,7 +1092,7 @@ bool Clip::possiblyCloneForArrangementRecording(ModelStackWithTimelineCounter* m
 					// automation on
 					clipInstanceI++;
 
-					int32_t error = output->clipInstances.insertAtIndex(clipInstanceI);
+					ErrorType error = output->clipInstances.insertAtIndex(clipInstanceI);
 					if (error) {
 						return false;
 					}
@@ -1103,7 +1103,7 @@ bool Clip::possiblyCloneForArrangementRecording(ModelStackWithTimelineCounter* m
 				}
 			}
 
-			int32_t error = clone(modelStack, true); // Puts the cloned Clip into the modelStack. Flattens reversing.
+			ErrorType error = clone(modelStack, true); // Puts the cloned Clip into the modelStack. Flattens reversing.
 			if (error) {
 				return false;
 			}

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -41,7 +41,7 @@ public:
 	bool cancelAnyArming();
 	int32_t getMaxZoom();
 	virtual int32_t getMaxLength();
-	virtual int32_t clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false) = 0;
+	virtual ErrorType clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false) = 0;
 	void cloneFrom(Clip* other);
 	void beginInstance(Song* song, int32_t arrangementRecordPos);
 	void endInstance(int32_t arrangementRecordPos, bool evenIfOtherClip = false);
@@ -63,8 +63,8 @@ public:
 	bool isArrangementOnlyClip();
 	bool isActiveOnOutput();
 	virtual bool deleteSoundsWhichWontSound(Song* song);
-	virtual int32_t appendClip(ModelStackWithTimelineCounter* thisModelStack,
-	                           ModelStackWithTimelineCounter* otherModelStack);
+	virtual ErrorType appendClip(ModelStackWithTimelineCounter* thisModelStack,
+	                             ModelStackWithTimelineCounter* otherModelStack);
 	int32_t resumeOriginalClipFromThisClone(ModelStackWithTimelineCounter* modelStackOriginal,
 	                                        ModelStackWithTimelineCounter* modelStackClone);
 	virtual int32_t transferVoicesToOriginalClipFromThisClone(ModelStackWithTimelineCounter* modelStackOriginal,
@@ -85,7 +85,7 @@ public:
 	                              bool shouldRetainLinksToSounds = false, bool keepNoteRowsWithMIDIInput = true,
 	                              bool shouldGrabMidiCommands = false, bool shouldBackUpExpressionParamsToo = true) = 0;
 
-	virtual int32_t undoDetachmentFromOutput(ModelStackWithTimelineCounter* modelStack);
+	virtual ErrorType undoDetachmentFromOutput(ModelStackWithTimelineCounter* modelStack);
 	virtual bool renderAsSingleRow(ModelStackWithTimelineCounter* modelStack, TimelineView* editorScreen,
 	                               int32_t xScroll, uint32_t xZoom, RGB* image, uint8_t occupancyMask[],
 	                               bool addUndefinedArea = true, int32_t noteRowIndexStart = 0,
@@ -93,10 +93,10 @@ public:
 	                               int32_t xEnd = kDisplayWidth, bool allowBlur = true, bool drawRepeats = false);
 
 	// To be called after Song loaded, to link to the relevant Output object
-	virtual int32_t claimOutput(ModelStackWithTimelineCounter* modelStack) = 0;
+	virtual ErrorType claimOutput(ModelStackWithTimelineCounter* modelStack) = 0;
 	virtual void finishLinearRecording(ModelStackWithTimelineCounter* modelStack, Clip* nextPendingLoop = NULL,
 	                                   int32_t buttonLatencyForTempolessRecord = 0) = 0;
-	virtual int32_t beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency) = 0;
+	virtual ErrorType beginLinearRecording(ModelStackWithTimelineCounter* modelStack, int32_t buttonPressLatency) = 0;
 	void drawUndefinedArea(int32_t localScroll, uint32_t, int32_t lengthToDisplay, RGB* image, uint8_t[],
 	                       int32_t imageWidth, TimelineView* editorScreen, bool tripletsOnHere);
 	bool opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounter* modelStack, bool* newOutputCreated,
@@ -109,7 +109,7 @@ public:
 	void writeToFile(Song* song);
 	virtual void writeDataToFile(Song* song);
 	virtual char const* getXMLTag() = 0;
-	virtual int32_t readFromFile(Song* song) = 0;
+	virtual ErrorType readFromFile(Song* song) = 0;
 	void readTagFromFile(char const* tagName, Song* song, int32_t* readAutomationUpToPos);
 
 	virtual void copyBasicsFrom(Clip* otherClip);
@@ -200,7 +200,7 @@ protected:
 	                                                                       // modelStack if new Clip got created
 	virtual bool
 	cloneOutput(ModelStackWithTimelineCounter* modelStack) = 0; // Returns whether a new Output was in fact created
-	int32_t solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
-	                            Clip* favourClipForCloningParamManager = NULL);
+	ErrorType solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
+	                              Clip* favourClipForCloningParamManager = NULL);
 	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {}
 };

--- a/src/deluge/model/clip/clip_array.cpp
+++ b/src/deluge/model/clip/clip_array.cpp
@@ -16,12 +16,9 @@
  */
 
 #include "model/clip/clip_array.h"
+#include "definitions_cxx.hpp"
 
-ClipArray::ClipArray() {
-	// TODO Auto-generated constructor stub
-}
-
-int32_t ClipArray::insertClipAtIndex(Clip* clip, int32_t index) {
+ErrorType ClipArray::insertClipAtIndex(Clip* clip, int32_t index) {
 	return insertPointerAtIndex(clip, index);
 }
 

--- a/src/deluge/model/clip/clip_array.h
+++ b/src/deluge/model/clip/clip_array.h
@@ -17,14 +17,15 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "util/container/array/resizeable_pointer_array.h"
 
 class Clip;
 
 class ClipArray final : public ResizeablePointerArray {
 public:
-	ClipArray();
-	int32_t insertClipAtIndex(Clip* clip, int32_t index);
+	ClipArray() = default;
+	ErrorType insertClipAtIndex(Clip* clip, int32_t index);
 	Clip* getClipAtIndex(int32_t index);
 	int32_t getIndexForClip(Clip* clip);
 };

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -152,7 +152,7 @@ void InstrumentClipMinder::drawMIDIControlNumber(int32_t controlNumber, bool aut
 }
 #pragma GCC pop
 void InstrumentClipMinder::createNewInstrument(OutputType newOutputType) {
-	int32_t error;
+	ErrorType error;
 
 	OutputType oldOutputType = getCurrentOutputType();
 
@@ -226,7 +226,7 @@ gotError:
 	else {
 		// There'll be no samples cos it's new and blank
 		// TODO: deal with errors
-		int32_t error = getCurrentInstrumentClip()->changeInstrument(
+		ErrorType error = getCurrentInstrumentClip()->changeInstrument(
 		    modelStack, newInstrument, &newParamManager, InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED, NULL, false);
 
 		currentSong->addOutput(newInstrument);

--- a/src/deluge/model/consequence/consequence.h
+++ b/src/deluge/model/consequence/consequence.h
@@ -37,7 +37,7 @@ public:
 	virtual ~Consequence();
 
 	virtual void prepareForDestruction(int32_t whichQueueActionIn, Song* song) {}
-	virtual int32_t revert(TimeType time, ModelStack* modelStack) = 0;
+	virtual ErrorType revert(TimeType time, ModelStack* modelStack) = 0;
 	Consequence* next;
 	uint8_t type;
 };

--- a/src/deluge/model/consequence/consequence_arranger_params_time_inserted.cpp
+++ b/src/deluge/model/consequence/consequence_arranger_params_time_inserted.cpp
@@ -28,7 +28,7 @@ ConsequenceArrangerParamsTimeInserted::ConsequenceArrangerParamsTimeInserted(int
 	length = newLength;
 }
 
-int32_t ConsequenceArrangerParamsTimeInserted::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceArrangerParamsTimeInserted::revert(TimeType time, ModelStack* modelStack) {
 
 	ParamCollectionSummary* unpatchedParamsSummary = modelStack->song->paramManager.getUnpatchedParamSetSummary();
 

--- a/src/deluge/model/consequence/consequence_arranger_params_time_inserted.h
+++ b/src/deluge/model/consequence/consequence_arranger_params_time_inserted.h
@@ -23,7 +23,7 @@
 class ConsequenceArrangerParamsTimeInserted final : public Consequence {
 public:
 	ConsequenceArrangerParamsTimeInserted(int32_t newPos, int32_t newLength);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 	int32_t pos;
 	int32_t length;
 };

--- a/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
+++ b/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
@@ -30,7 +30,7 @@ ConsequenceAudioClipSetSample::ConsequenceAudioClipSetSample(AudioClip* newClip)
 	endPosToRevertTo = newClip->sampleHolder.endPos;
 }
 
-int32_t ConsequenceAudioClipSetSample::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceAudioClipSetSample::revert(TimeType time, ModelStack* modelStack) {
 
 	String filePathBeforeRevert;
 	filePathBeforeRevert.set(&clip->sampleHolder.filePath);
@@ -51,7 +51,7 @@ int32_t ConsequenceAudioClipSetSample::revert(TimeType time, ModelStack* modelSt
 		}
 	}
 	else {
-		int32_t error = clip->sampleHolder.loadFile(false, false, true);
+		ErrorType error = clip->sampleHolder.loadFile(false, false, true);
 		if (error) {
 			display->displayError(error); // Rare, shouldn't cause later problems.
 		}

--- a/src/deluge/model/consequence/consequence_audio_clip_set_sample.h
+++ b/src/deluge/model/consequence/consequence_audio_clip_set_sample.h
@@ -25,7 +25,7 @@ class AudioClip;
 class ConsequenceAudioClipSetSample final : public Consequence {
 public:
 	ConsequenceAudioClipSetSample(AudioClip* newClip);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	AudioClip* clip;
 	String filePathToRevertTo;

--- a/src/deluge/model/consequence/consequence_begin_playback.cpp
+++ b/src/deluge/model/consequence/consequence_begin_playback.cpp
@@ -22,7 +22,7 @@ ConsequenceBeginPlayback::ConsequenceBeginPlayback() {
 	// TODO Auto-generated constructor stub
 }
 
-int32_t ConsequenceBeginPlayback::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceBeginPlayback::revert(TimeType time, ModelStack* modelStack) {
 	if (time == BEFORE) {
 		if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
 			playbackHandler.endPlayback();

--- a/src/deluge/model/consequence/consequence_begin_playback.h
+++ b/src/deluge/model/consequence/consequence_begin_playback.h
@@ -22,5 +22,5 @@
 class ConsequenceBeginPlayback final : public Consequence {
 public:
 	ConsequenceBeginPlayback();
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 };

--- a/src/deluge/model/consequence/consequence_clip_begin_linear_record.cpp
+++ b/src/deluge/model/consequence/consequence_clip_begin_linear_record.cpp
@@ -29,7 +29,7 @@ ConsequenceClipBeginLinearRecord::ConsequenceClipBeginLinearRecord(Clip* newClip
 	type = Consequence::CLIP_BEGIN_LINEAR_RECORD;
 }
 
-int32_t ConsequenceClipBeginLinearRecord::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceClipBeginLinearRecord::revert(TimeType time, ModelStack* modelStack) {
 
 	// Going backwards...
 	if (time == BEFORE) {

--- a/src/deluge/model/consequence/consequence_clip_begin_linear_record.h
+++ b/src/deluge/model/consequence/consequence_clip_begin_linear_record.h
@@ -25,7 +25,7 @@ class ConsequenceClipBeginLinearRecord final : public Consequence {
 public:
 	ConsequenceClipBeginLinearRecord(Clip* newClip);
 
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	Clip* clip;
 };

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -56,7 +56,7 @@ void ConsequenceClipExistence::prepareForDestruction(int32_t whichQueueActionIn,
 	}
 }
 
-int32_t ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) {
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
 
 	if (time != util::to_underlying(type)) { // (Re-)create
@@ -65,7 +65,7 @@ int32_t ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) 
 			return ERROR_INSUFFICIENT_RAM;
 		}
 
-		int32_t error = clip->undoDetachmentFromOutput(modelStackWithTimelineCounter);
+		ErrorType error = clip->undoDetachmentFromOutput(modelStackWithTimelineCounter);
 		if (error) { // This shouldn't actually happen, but if it does...
 #if ALPHA_OR_BETA_VERSION
 			FREEZE_WITH_ERROR("E046");

--- a/src/deluge/model/consequence/consequence_clip_existence.h
+++ b/src/deluge/model/consequence/consequence_clip_existence.h
@@ -28,7 +28,7 @@ class ConsequenceClipExistence final : public Consequence {
 public:
 	ConsequenceClipExistence(Clip* newClip, ClipArray* newClipArray, ExistenceChangeType newType);
 	void prepareForDestruction(int32_t whichQueueActionIn, Song* song) override;
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	Clip* clip;
 	ClipArray* clipArray;

--- a/src/deluge/model/consequence/consequence_clip_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_clip_horizontal_shift.cpp
@@ -24,7 +24,7 @@ ConsequenceClipHorizontalShift::ConsequenceClipHorizontalShift(int32_t newAmount
 	amount = newAmount;
 }
 
-int32_t ConsequenceClipHorizontalShift::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceClipHorizontalShift::revert(TimeType time, ModelStack* modelStack) {
 
 	int32_t amountNow = amount;
 

--- a/src/deluge/model/consequence/consequence_clip_horizontal_shift.h
+++ b/src/deluge/model/consequence/consequence_clip_horizontal_shift.h
@@ -23,7 +23,7 @@
 class ConsequenceClipHorizontalShift final : public Consequence {
 public:
 	ConsequenceClipHorizontalShift(int32_t newAmount);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	int32_t amount;
 };

--- a/src/deluge/model/consequence/consequence_clip_instance_change.cpp
+++ b/src/deluge/model/consequence/consequence_clip_instance_change.cpp
@@ -31,7 +31,7 @@ ConsequenceClipInstanceChange::ConsequenceClipInstanceChange(Output* newOutput, 
 	clip[AFTER] = clipAfter;
 }
 
-int32_t ConsequenceClipInstanceChange::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceClipInstanceChange::revert(TimeType time, ModelStack* modelStack) {
 	int32_t i = output->clipInstances.search(pos[1 - time], GREATER_OR_EQUAL);
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
 	if (!clipInstance) {

--- a/src/deluge/model/consequence/consequence_clip_instance_change.h
+++ b/src/deluge/model/consequence/consequence_clip_instance_change.h
@@ -27,7 +27,7 @@ class ConsequenceClipInstanceChange final : public Consequence {
 public:
 	ConsequenceClipInstanceChange(Output* newOutput, ClipInstance* clipInstance, int32_t posAfter, int32_t lengthAfter,
 	                              Clip* clipAfter);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	Output* output;
 	int32_t pos[2];

--- a/src/deluge/model/consequence/consequence_clip_instance_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_instance_existence.cpp
@@ -31,7 +31,7 @@ ConsequenceClipInstanceExistence::ConsequenceClipInstanceExistence(Output* newOu
 	type = newType;
 }
 
-int32_t ConsequenceClipInstanceExistence::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceClipInstanceExistence::revert(TimeType time, ModelStack* modelStack) {
 
 	if (time == util::to_underlying(type)) { // (Re-)delete
 		int32_t i = output->clipInstances.search(pos, GREATER_OR_EQUAL);

--- a/src/deluge/model/consequence/consequence_clip_instance_existence.h
+++ b/src/deluge/model/consequence/consequence_clip_instance_existence.h
@@ -28,7 +28,7 @@ class ConsequenceClipInstanceExistence final : public Consequence {
 public:
 	ConsequenceClipInstanceExistence(Output* newOutput, ClipInstance* clipInstance, ExistenceChangeType newType);
 
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	Output* output;
 	Clip* clip;

--- a/src/deluge/model/consequence/consequence_clip_length.cpp
+++ b/src/deluge/model/consequence/consequence_clip_length.cpp
@@ -28,7 +28,7 @@ ConsequenceClipLength::ConsequenceClipLength(Clip* newClip, int32_t oldLength) {
 	pointerToMarkerValue = NULL;
 }
 
-int32_t ConsequenceClipLength::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceClipLength::revert(TimeType time, ModelStack* modelStack) {
 
 	uint64_t markerValueBeforeRevert;
 	if (pointerToMarkerValue) {

--- a/src/deluge/model/consequence/consequence_clip_length.h
+++ b/src/deluge/model/consequence/consequence_clip_length.h
@@ -25,7 +25,7 @@ class Clip;
 class ConsequenceClipLength final : public Consequence {
 public:
 	ConsequenceClipLength(Clip* newClip, int32_t oldLength);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	Clip* clip;
 	int32_t lengthToRevertTo;

--- a/src/deluge/model/consequence/consequence_instrument_clip_multiply.cpp
+++ b/src/deluge/model/consequence/consequence_instrument_clip_multiply.cpp
@@ -24,7 +24,7 @@ ConsequenceInstrumentClipMultiply::ConsequenceInstrumentClipMultiply() {
 	// TODO Auto-generated constructor stub
 }
 
-int32_t ConsequenceInstrumentClipMultiply::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceInstrumentClipMultiply::revert(TimeType time, ModelStack* modelStack) {
 	InstrumentClip* clip = (InstrumentClip*)modelStack->song->getCurrentClip();
 	if (time == BEFORE) {
 		modelStack->song->setClipLength(clip, clip->loopLength >> 1, NULL);

--- a/src/deluge/model/consequence/consequence_instrument_clip_multiply.h
+++ b/src/deluge/model/consequence/consequence_instrument_clip_multiply.h
@@ -24,5 +24,5 @@ class ConsequenceInstrumentClipMultiply final : public Consequence {
 public:
 	ConsequenceInstrumentClipMultiply();
 
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 };

--- a/src/deluge/model/consequence/consequence_note_array_change.cpp
+++ b/src/deluge/model/consequence/consequence_note_array_change.cpp
@@ -37,7 +37,7 @@ ConsequenceNoteArrayChange::ConsequenceNoteArrayChange(InstrumentClip* newClip, 
 	}
 }
 
-int32_t ConsequenceNoteArrayChange::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceNoteArrayChange::revert(TimeType time, ModelStack* modelStack) {
 
 	NoteRow* noteRow = clip->getNoteRowFromId(noteRowId);
 	if (!noteRow) {

--- a/src/deluge/model/consequence/consequence_note_array_change.h
+++ b/src/deluge/model/consequence/consequence_note_array_change.h
@@ -27,7 +27,7 @@ class ConsequenceNoteArrayChange final : public Consequence {
 public:
 	ConsequenceNoteArrayChange(InstrumentClip* newClip, int32_t newNoteRowId, NoteVector* newNoteVector,
 	                           bool stealData);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	InstrumentClip* clip;
 	int32_t noteRowId;

--- a/src/deluge/model/consequence/consequence_note_existence.cpp
+++ b/src/deluge/model/consequence/consequence_note_existence.cpp
@@ -36,7 +36,7 @@ ConsequenceNoteExistence::ConsequenceNoteExistence(InstrumentClip* newClip, int3
 	type = newType;
 }
 
-int32_t ConsequenceNoteExistence::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceNoteExistence::revert(TimeType time, ModelStack* modelStack) {
 	NoteRow* noteRow = clip->getNoteRowFromId(noteRowId);
 	if (!noteRow) {
 		return ERROR_BUG;

--- a/src/deluge/model/consequence/consequence_note_existence.h
+++ b/src/deluge/model/consequence/consequence_note_existence.h
@@ -26,7 +26,7 @@ class Note;
 class ConsequenceNoteExistence final : public Consequence {
 public:
 	ConsequenceNoteExistence(InstrumentClip* newClip, int32_t newNoteRowId, Note* note, ExistenceChangeType newType);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	InstrumentClip* clip;
 	int32_t noteRowId;

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
@@ -28,7 +28,7 @@ ConsequenceNoteRowHorizontalShift::ConsequenceNoteRowHorizontalShift(int32_t new
 	noteRowId = newNoteRowId;
 }
 
-int32_t ConsequenceNoteRowHorizontalShift::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceNoteRowHorizontalShift::revert(TimeType time, ModelStack* modelStack) {
 
 	int32_t amountNow = amount;
 

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.h
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.h
@@ -23,7 +23,7 @@
 class ConsequenceNoteRowHorizontalShift final : public Consequence {
 public:
 	ConsequenceNoteRowHorizontalShift(int32_t newNoteRowId, int32_t newAmount);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	int32_t noteRowId;
 	int32_t amount;

--- a/src/deluge/model/consequence/consequence_note_row_length.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_length.cpp
@@ -26,7 +26,7 @@ ConsequenceNoteRowLength::ConsequenceNoteRowLength(int32_t newNoteRowId, int32_t
 	backedUpLength = newLength;
 }
 
-int32_t ConsequenceNoteRowLength::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceNoteRowLength::revert(TimeType time, ModelStack* modelStack) {
 	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addTimelineCounter(modelStack->song->getCurrentClip())
 	                                                   ->addNoteRowId(noteRowId)
 	                                                   ->automaticallyAddNoteRowFromId();

--- a/src/deluge/model/consequence/consequence_note_row_length.h
+++ b/src/deluge/model/consequence/consequence_note_row_length.h
@@ -25,7 +25,7 @@ class ModelStackWithNoteRow;
 class ConsequenceNoteRowLength final : public Consequence {
 public:
 	ConsequenceNoteRowLength(int32_t newNoteRowId, int32_t newLength);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 	void performChange(ModelStackWithNoteRow* modelStack, Action* actionToRecordTo, int32_t oldPos,
 	                   bool hadIndependentPlayPosBefore);
 	int32_t backedUpLength;

--- a/src/deluge/model/consequence/consequence_note_row_mute.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_mute.cpp
@@ -27,7 +27,7 @@ ConsequenceNoteRowMute::ConsequenceNoteRowMute(InstrumentClip* newClip, int32_t 
 	clip = newClip;
 }
 
-int32_t ConsequenceNoteRowMute::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceNoteRowMute::revert(TimeType time, ModelStack* modelStack) {
 	NoteRow* noteRow = clip->getNoteRowFromId(noteRowId);
 	if (!noteRow) {
 		return ERROR_BUG;

--- a/src/deluge/model/consequence/consequence_note_row_mute.h
+++ b/src/deluge/model/consequence/consequence_note_row_mute.h
@@ -22,7 +22,7 @@
 class ConsequenceNoteRowMute final : public Consequence {
 public:
 	ConsequenceNoteRowMute(InstrumentClip* newClip, int32_t newNoteRowId);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	int32_t noteRowId;
 	InstrumentClip* clip;

--- a/src/deluge/model/consequence/consequence_output_existence.cpp
+++ b/src/deluge/model/consequence/consequence_output_existence.cpp
@@ -30,7 +30,7 @@ ConsequenceOutputExistence::ConsequenceOutputExistence(Output* newOutput, Existe
 
 // TODO: wait a minute, do we have a memory leak here? Never deletes the Output?
 
-int32_t ConsequenceOutputExistence::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceOutputExistence::revert(TimeType time, ModelStack* modelStack) {
 	if (time != util::to_underlying(type)) { // Re-create
 		modelStack->song->addOutput(output, true);
 	}

--- a/src/deluge/model/consequence/consequence_output_existence.h
+++ b/src/deluge/model/consequence/consequence_output_existence.h
@@ -25,7 +25,7 @@ class Output;
 class ConsequenceOutputExistence final : public Consequence {
 public:
 	ConsequenceOutputExistence(Output* newOutput, ExistenceChangeType newType);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	Output* output;
 	int32_t outputIndex;

--- a/src/deluge/model/consequence/consequence_param_change.cpp
+++ b/src/deluge/model/consequence/consequence_param_change.cpp
@@ -40,7 +40,7 @@ ConsequenceParamChange::ConsequenceParamChange(ModelStackWithAutoParam const* mo
 	}
 }
 
-int32_t ConsequenceParamChange::revert(TimeType time, ModelStack* modelStackWithSong) {
+ErrorType ConsequenceParamChange::revert(TimeType time, ModelStack* modelStackWithSong) {
 
 	// We only actually store one state at a time - either the before, or the after. As we revert in either direction,
 	// we swap our stored state with that of the param in question - like, actually swap the pointer to the

--- a/src/deluge/model/consequence/consequence_param_change.h
+++ b/src/deluge/model/consequence/consequence_param_change.h
@@ -25,7 +25,7 @@
 class ConsequenceParamChange final : public Consequence {
 public:
 	ConsequenceParamChange(ModelStackWithAutoParam const* modelStack, bool stealData);
-	int32_t revert(TimeType time, ModelStack* modelStackWithSong) override;
+	ErrorType revert(TimeType time, ModelStack* modelStackWithSong) override;
 
 	union {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];

--- a/src/deluge/model/consequence/consequence_performance_view_press.cpp
+++ b/src/deluge/model/consequence/consequence_performance_view_press.cpp
@@ -29,7 +29,7 @@ ConsequencePerformanceViewPress::ConsequencePerformanceViewPress(FXColumnPress f
 	xDisplayChanged = xDisplay;
 }
 
-int32_t ConsequencePerformanceViewPress::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequencePerformanceViewPress::revert(TimeType time, ModelStack* modelStack) {
 	memcpy(&performanceSessionView.fxPress[xDisplayChanged], &fxPress[time], sizeof(FXColumnPress));
 
 	return NO_ERROR;

--- a/src/deluge/model/consequence/consequence_performance_view_press.h
+++ b/src/deluge/model/consequence/consequence_performance_view_press.h
@@ -24,7 +24,7 @@ class ConsequencePerformanceViewPress final : public Consequence {
 public:
 	ConsequencePerformanceViewPress(FXColumnPress fxPressBefore[kDisplayWidth],
 	                                FXColumnPress fxPressAfter[kDisplayWidth], int32_t xDisplay);
-	int32_t revert(TimeType time, ModelStack* modelStack);
+	ErrorType revert(TimeType time, ModelStack* modelStack);
 
 	int32_t xDisplayChanged = kNoSelection;
 	FXColumnPress fxPress[2];

--- a/src/deluge/model/consequence/consequence_scale_add_note.cpp
+++ b/src/deluge/model/consequence/consequence_scale_add_note.cpp
@@ -23,7 +23,7 @@ ConsequenceScaleAddNote::ConsequenceScaleAddNote(int32_t newNoteWithinOctave) {
 	noteWithinOctave = newNoteWithinOctave;
 }
 
-int32_t ConsequenceScaleAddNote::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceScaleAddNote::revert(TimeType time, ModelStack* modelStack) {
 
 	// The only thing we actually have to do is delete any NoteRows that had the new yNoteWithinOctave.
 	// The changing back of the scale itself is handled by the Action, which

--- a/src/deluge/model/consequence/consequence_scale_add_note.h
+++ b/src/deluge/model/consequence/consequence_scale_add_note.h
@@ -23,7 +23,7 @@
 class ConsequenceScaleAddNote final : public Consequence {
 public:
 	ConsequenceScaleAddNote(int32_t newNoteWithinOctave);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	uint8_t noteWithinOctave;
 };

--- a/src/deluge/model/consequence/consequence_swing_change.cpp
+++ b/src/deluge/model/consequence/consequence_swing_change.cpp
@@ -24,7 +24,7 @@ ConsequenceSwingChange::ConsequenceSwingChange(int8_t newSwingBefore, int8_t new
 	swing[AFTER] = newSwingAfter;
 }
 
-int32_t ConsequenceSwingChange::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceSwingChange::revert(TimeType time, ModelStack* modelStack) {
 	modelStack->song->swingAmount = swing[time];
 
 	return NO_ERROR;

--- a/src/deluge/model/consequence/consequence_swing_change.h
+++ b/src/deluge/model/consequence/consequence_swing_change.h
@@ -23,7 +23,7 @@
 class ConsequenceSwingChange final : public Consequence {
 public:
 	ConsequenceSwingChange(int8_t newSwingBefore, int8_t newSwingAfter);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	int8_t swing[2];
 };

--- a/src/deluge/model/consequence/consequence_tempo_change.cpp
+++ b/src/deluge/model/consequence/consequence_tempo_change.cpp
@@ -26,7 +26,7 @@ ConsequenceTempoChange::ConsequenceTempoChange(uint64_t newTimePerBigBefore, uin
 	timePerBig[AFTER] = newTimePerBigAfter;
 }
 
-int32_t ConsequenceTempoChange::revert(TimeType time, ModelStack* modelStack) {
+ErrorType ConsequenceTempoChange::revert(TimeType time, ModelStack* modelStack) {
 	float oldBPM = playbackHandler.calculateBPM(modelStack->song->getTimePerTimerTickFloat());
 
 	modelStack->song->setTimePerTimerTick(timePerBig[time], false);

--- a/src/deluge/model/consequence/consequence_tempo_change.h
+++ b/src/deluge/model/consequence/consequence_tempo_change.h
@@ -23,7 +23,7 @@
 class ConsequenceTempoChange final : public Consequence {
 public:
 	ConsequenceTempoChange(uint64_t newTimePerBigBefore, uint64_t newTimePerBigAfter);
-	int32_t revert(TimeType time, ModelStack* modelStack) override;
+	ErrorType revert(TimeType time, ModelStack* modelStack) override;
 
 	uint64_t timePerBig[2];
 };

--- a/src/deluge/model/drum/drum.h
+++ b/src/deluge/model/drum/drum.h
@@ -71,12 +71,12 @@ public:
 	virtual bool hasAnyVoices() = 0;
 	virtual void unassignAllVoices() = 0;
 
-	virtual int32_t loadAllSamples(bool mayActuallyReadFiles) { return NO_ERROR; }
+	virtual ErrorType loadAllSamples(bool mayActuallyReadFiles) { return NO_ERROR; }
 	virtual void prepareForHibernation() {}
 	virtual void prepareDrumToHaveNoActiveClip() {}
 
 	virtual void writeToFile(bool savingSong, ParamManager* paramManager) = 0;
-	virtual int32_t readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) = 0;
+	virtual ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) = 0;
 	virtual void drumWontBeRenderedForAWhile();
 
 	virtual void getName(char* buffer) = 0; // May return up to 5 actual characters, so supply at least a char[6]

--- a/src/deluge/model/drum/gate_drum.cpp
+++ b/src/deluge/model/drum/gate_drum.cpp
@@ -50,7 +50,7 @@ void GateDrum::writeToFile(bool savingSong, ParamManager* paramManager) {
 	}
 }
 
-int32_t GateDrum::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
+ErrorType GateDrum::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 	char const* tagName;
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {

--- a/src/deluge/model/drum/gate_drum.h
+++ b/src/deluge/model/drum/gate_drum.h
@@ -33,7 +33,7 @@ public:
 	            uint32_t samplesLate = 0);
 	void noteOff(ModelStackWithThreeMainThings* modelStack, int32_t velocity);
 	void writeToFile(bool savingSong, ParamManager* paramManager);
-	int32_t readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
+	ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
 	void getName(char* buffer);
 	int32_t getNumChannels();
 };

--- a/src/deluge/model/drum/midi_drum.cpp
+++ b/src/deluge/model/drum/midi_drum.cpp
@@ -61,7 +61,7 @@ void MIDIDrum::writeToFile(bool savingSong, ParamManager* paramManager) {
 	}
 }
 
-int32_t MIDIDrum::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
+ErrorType MIDIDrum::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 	char const* tagName;
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {

--- a/src/deluge/model/drum/midi_drum.h
+++ b/src/deluge/model/drum/midi_drum.h
@@ -28,7 +28,7 @@ public:
 	            uint32_t samplesLate = 0);
 	void noteOff(ModelStackWithThreeMainThings* modelStack, int32_t velocity = kDefaultLiftValue);
 	void writeToFile(bool savingSong, ParamManager* paramManager);
-	int32_t readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
+	ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
 	void getName(char* buffer);
 	int32_t getNumChannels() { return 16; }
 	void unassignAllVoices();

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -944,8 +944,8 @@ bool GlobalEffectable::readParamTagFromFile(char const* tagName, ParamManagerFor
 }
 
 // paramManager is optional
-int32_t GlobalEffectable::readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager,
-                                          int32_t readAutomationUpToPos, Song* song) {
+ErrorType GlobalEffectable::readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager,
+                                            int32_t readAutomationUpToPos, Song* song) {
 
 	// This is here for compatibility only for people (Lou and Ian) who saved songs with firmware in September 2016
 	// if (paramManager && strcmp(tagName, "delay") && GlobalEffectable::readParamTagFromFile(tagName, paramManager,
@@ -955,7 +955,7 @@ int32_t GlobalEffectable::readTagFromFile(char const* tagName, ParamManagerForTi
 	if (paramManager && !strcmp(tagName, "defaultParams")) {
 
 		if (!paramManager->containsAnyMainParamCollections()) {
-			int32_t error = paramManager->setupUnpatched();
+			ErrorType error = paramManager->setupUnpatched();
 			if (error) {
 				return error;
 			}

--- a/src/deluge/model/global_effectable/global_effectable.h
+++ b/src/deluge/model/global_effectable/global_effectable.h
@@ -41,8 +41,8 @@ public:
 
 	void writeAttributesToFile(bool writeToFile);
 	void writeTagsToFile(ParamManager* paramManager, bool writeToFile);
-	int32_t readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos,
-	                        Song* song);
+	ErrorType readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos,
+	                          Song* song);
 	static void writeParamAttributesToFile(ParamManager* paramManager, bool writeAutomation,
 	                                       int32_t* valuesForOverride = NULL);
 	static void writeParamTagsToFile(ParamManager* paramManager, bool writeAutomation,

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -157,7 +157,7 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 
 	if (type == OutputType::SYNTH || type == OutputType::KIT) {
 
-		int32_t error = newParamManager.cloneParamCollectionsFrom(getParamManager(modelStack->song), false, true);
+		ErrorType error = newParamManager.cloneParamCollectionsFrom(getParamManager(modelStack->song), false, true);
 
 		if (error) {
 			delugeDealloc(clipMemory);
@@ -183,9 +183,9 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 	return newInstrumentClip;
 }
 
-int32_t Instrument::setupDefaultAudioFileDir() {
+ErrorType Instrument::setupDefaultAudioFileDir() {
 	char const* dirPathChars = dirPath.get();
-	int32_t error =
+	ErrorType error =
 	    audioFileManager.setupAlternateAudioFileDir(&audioFileManager.alternateAudioFileLoadPath, dirPathChars, &name);
 	if (error) {
 		return error;

--- a/src/deluge/model/instrument/instrument.h
+++ b/src/deluge/model/instrument/instrument.h
@@ -80,5 +80,5 @@ public:
 
 protected:
 	Clip* createNewClipForArrangementRecording(ModelStack* modelStack) final;
-	int32_t setupDefaultAudioFileDir();
+	ErrorType setupDefaultAudioFileDir();
 };

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -241,7 +241,7 @@ void Kit::writeDrumToFile(Drum* thisDrum, ParamManager* paramManagerForDrum, boo
 	(*drumIndex)++;
 }
 
-int32_t Kit::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
+ErrorType Kit::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 
 	int32_t selectedDrumIndex = -1;
 
@@ -257,7 +257,7 @@ int32_t Kit::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos)
 				if (!strcmp(tagName, "sample") || !strcmp(tagName, "synth") || !strcmp(tagName, "sound")) {
 					drumType = DrumType::SOUND;
 doReadDrum:
-					int32_t error = readDrumFromFile(song, clip, drumType, readAutomationUpToPos);
+					ErrorType error = readDrumFromFile(song, clip, drumType, readAutomationUpToPos);
 					if (error) {
 						return error;
 					}
@@ -282,7 +282,7 @@ doReadDrum:
 			storageManager.exitTag("selectedDrumIndex");
 		}
 		else {
-			int32_t result =
+			ErrorType result =
 			    GlobalEffectableForClip::readTagFromFile(tagName, &paramManager, readAutomationUpToPos, song);
 			if (result == NO_ERROR) {}
 			else if (result != RESULT_TAG_UNUSED) {
@@ -291,7 +291,7 @@ doReadDrum:
 			else {
 				if (Instrument::readTagFromFile(tagName)) {}
 				else {
-					int32_t result = storageManager.tryReadingFirmwareTagFromFile(tagName);
+					ErrorType result = storageManager.tryReadingFirmwareTagFromFile(tagName);
 					if (result && result != RESULT_TAG_UNUSED) {
 						return result;
 					}
@@ -313,14 +313,14 @@ doReadDrum:
 	return NO_ERROR;
 }
 
-int32_t Kit::readDrumFromFile(Song* song, Clip* clip, DrumType drumType, int32_t readAutomationUpToPos) {
+ErrorType Kit::readDrumFromFile(Song* song, Clip* clip, DrumType drumType, int32_t readAutomationUpToPos) {
 
 	Drum* newDrum = storageManager.createNewDrum(drumType);
 	if (!newDrum) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
 
-	int32_t error = newDrum->readFromFile(
+	ErrorType error = newDrum->readFromFile(
 	    song, clip, readAutomationUpToPos); // Will create and "back up" a new ParamManager if anything to read into it
 	if (error) {
 		void* toDealloc = dynamic_cast<void*>(newDrum);
@@ -334,9 +334,9 @@ int32_t Kit::readDrumFromFile(Song* song, Clip* clip, DrumType drumType, int32_t
 }
 
 // Returns true if more loading needed later
-int32_t Kit::loadAllAudioFiles(bool mayActuallyReadFiles) {
+ErrorType Kit::loadAllAudioFiles(bool mayActuallyReadFiles) {
 
-	int32_t error = NO_ERROR;
+	ErrorType error = NO_ERROR;
 
 	bool doingAlternatePath =
 	    mayActuallyReadFiles && (audioFileManager.alternateLoadDirStatus == AlternateLoadDirStatus::NONE_SET);
@@ -372,7 +372,7 @@ void Kit::loadCrucialAudioFilesOnly() {
 
 	bool doingAlternatePath = (audioFileManager.alternateLoadDirStatus == AlternateLoadDirStatus::NONE_SET);
 	if (doingAlternatePath) {
-		int32_t error = setupDefaultAudioFileDir();
+		ErrorType error = setupDefaultAudioFileDir();
 		if (error) {
 			return;
 		}
@@ -722,7 +722,7 @@ ModControllable* Kit::toModControllable() {
 }
 
 // newName must be allowed to be edited by this function
-int32_t Kit::makeDrumNameUnique(String* name, int32_t startAtNumber) {
+ErrorType Kit::makeDrumNameUnique(String* name, int32_t startAtNumber) {
 
 	D_PRINTLN("making unique newName:");
 
@@ -731,7 +731,7 @@ int32_t Kit::makeDrumNameUnique(String* name, int32_t startAtNumber) {
 	do {
 		char numberString[12];
 		intToString(startAtNumber, numberString);
-		int32_t error = name->concatenateAtPos(numberString, originalLength);
+		ErrorType error = name->concatenateAtPos(numberString, originalLength);
 		if (error) {
 			return error;
 		}

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -36,14 +36,14 @@ public:
 	Drum* getPrevDrum(Drum* fromSoundSource);
 	bool writeDataToFile(Clip* clipForSavingOutputOnly, Song* song);
 	void addDrum(Drum* newDrum);
-	int32_t readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
+	ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) override;
 	Drum* getFirstUnassignedDrum(InstrumentClip* clip);
 	~Kit();
 	int32_t getDrumIndex(Drum* drum);
 	Drum* getDrumFromIndex(int32_t index);
 	Drum* getDrumFromIndexAllowNull(int32_t index);
 
-	int32_t loadAllAudioFiles(bool mayActuallyReadFiles) override;
+	ErrorType loadAllAudioFiles(bool mayActuallyReadFiles) override;
 	void cutAllSound() override;
 	void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
 	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
@@ -102,7 +102,7 @@ public:
 	void removeDrum(Drum* drum);
 	ModControllable* toModControllable();
 	SoundDrum* getDrumFromName(char const* name, bool onlyIfNoNoteRow = false);
-	int32_t makeDrumNameUnique(String* name, int32_t startAtNumber);
+	ErrorType makeDrumNameUnique(String* name, int32_t startAtNumber);
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs);
 	void setupPatching(ModelStackWithTimelineCounter* modelStack);
 	void compensateInstrumentVolumeForResonance(ParamManagerForTimeline* paramManager, Song* song);
@@ -149,7 +149,7 @@ protected:
 	bool isKit() { return true; }
 
 private:
-	int32_t readDrumFromFile(Song* song, Clip* clip, DrumType drumType, int32_t readAutomationUpToPos);
+	ErrorType readDrumFromFile(Song* song, Clip* clip, DrumType drumType, int32_t readAutomationUpToPos);
 	void writeDrumToFile(Drum* thisDrum, ParamManager* paramManagerForDrum, bool savingSong, int32_t* selectedDrumIndex,
 	                     int32_t* drumIndex, Song* song);
 	void removeDrumFromLinkedList(Drum* drum);

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -377,8 +377,8 @@ bool MIDIInstrument::readTagFromFile(char const* tagName) {
 
 // paramManager is sometimes NULL (when called from the above function), for reasons I've kinda forgotten, yet
 // everything seems to still work...
-int32_t MIDIInstrument::readModKnobAssignmentsFromFile(int32_t readAutomationUpToPos,
-                                                       ParamManagerForTimeline* paramManager) {
+ErrorType MIDIInstrument::readModKnobAssignmentsFromFile(int32_t readAutomationUpToPos,
+                                                         ParamManagerForTimeline* paramManager) {
 	int32_t m = 0;
 	char const* tagName;
 
@@ -388,8 +388,8 @@ int32_t MIDIInstrument::readModKnobAssignmentsFromFile(int32_t readAutomationUpT
 			if (paramManager) {
 				midiParamCollection = paramManager->getMIDIParamCollection();
 			}
-			int32_t error = storageManager.readMIDIParamFromFile(readAutomationUpToPos, midiParamCollection,
-			                                                     &modKnobCCAssignments[m]);
+			ErrorType error = storageManager.readMIDIParamFromFile(readAutomationUpToPos, midiParamCollection,
+			                                                       &modKnobCCAssignments[m]);
 			if (error) {
 				return error;
 			}

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "model/instrument/non_audio_instrument.h"
 #include <array>
 
@@ -43,7 +44,8 @@ public:
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs);
 	bool writeDataToFile(Clip* clipForSavingOutputOnly, Song* song);
 	bool readTagFromFile(char const* tagName);
-	int32_t readModKnobAssignmentsFromFile(int32_t readAutomationUpToPos, ParamManagerForTimeline* paramManager = NULL);
+	ErrorType readModKnobAssignmentsFromFile(int32_t readAutomationUpToPos,
+	                                         ParamManagerForTimeline* paramManager = nullptr);
 	void sendMIDIPGM();
 
 	void sendNoteToInternal(bool on, int32_t note, uint8_t velocity, uint8_t channel);

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1438,8 +1438,8 @@ bool ModControllableAudio::readParamTagFromFile(char const* tagName, ParamManage
 }
 
 // paramManager is optional
-int32_t ModControllableAudio::readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager,
-                                              int32_t readAutomationUpToPos, Song* song) {
+ErrorType ModControllableAudio::readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager,
+                                                int32_t readAutomationUpToPos, Song* song) {
 
 	int32_t p;
 
@@ -1474,7 +1474,7 @@ int32_t ModControllableAudio::readTagFromFile(char const* tagName, ParamManagerF
 doReadPatchedParam:
 				if (paramManager) {
 					if (!paramManager->containsAnyMainParamCollections()) {
-						int32_t error = Sound::createParamManagerForLoading(paramManager);
+						ErrorType error = Sound::createParamManagerForLoading(paramManager);
 						if (error) {
 							return error;
 						}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -72,8 +72,8 @@ public:
 	                                int32_t pan = 0, bool doAmplitudeIncrement = false);
 	void writeAttributesToFile();
 	void writeTagsToFile();
-	int32_t readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos,
-	                        Song* song);
+	ErrorType readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos,
+	                          Song* song);
 	void processSRRAndBitcrushing(StereoSample* buffer, int32_t numSamples, int32_t* postFXVolume,
 	                              ParamManager* paramManager);
 	static void writeParamAttributesToFile(ParamManager* paramManager, bool writeAutomation,

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -82,7 +82,7 @@ void NoteRow::deleteOldDrumNames(bool shouldUpdatePointer) {
 	}
 }
 
-int32_t NoteRow::beenCloned(ModelStackWithNoteRow* modelStack, bool shouldFlattenReversing) {
+ErrorType NoteRow::beenCloned(ModelStackWithNoteRow* modelStack, bool shouldFlattenReversing) {
 	// No need to clone much stuff - it's been automatically copied already as a block of memory.
 
 	firstOldDrumName = NULL;
@@ -97,7 +97,7 @@ int32_t NoteRow::beenCloned(ModelStackWithNoteRow* modelStack, bool shouldFlatte
 
 	int32_t reverseWithLength = flatteningReversingNow ? effectiveLength : 0;
 
-	int32_t error = paramManager.beenCloned(reverseWithLength); // TODO: flatten reversing here too
+	ErrorType error = paramManager.beenCloned(reverseWithLength); // TODO: flatten reversing here too
 
 	if (error) {
 		notes.init(); // Abandon non-yet-cloned stuff
@@ -343,8 +343,8 @@ addNewNote:
 	}
 }
 
-int32_t NoteRow::addCorrespondingNotes(int32_t targetPos, int32_t newNotesLength, uint8_t velocity,
-                                       ModelStackWithNoteRow* modelStack, bool allowNoteTails, Action* action) {
+ErrorType NoteRow::addCorrespondingNotes(int32_t targetPos, int32_t newNotesLength, uint8_t velocity,
+                                         ModelStackWithNoteRow* modelStack, bool allowNoteTails, Action* action) {
 
 	uint32_t wrapEditLevel = ((InstrumentClip*)modelStack->getTimelineCounter())->getWrapEditLevel();
 	int32_t posWithinEachScreen = (uint32_t)targetPos % wrapEditLevel;
@@ -369,7 +369,7 @@ int32_t NoteRow::addCorrespondingNotes(int32_t targetPos, int32_t newNotesLength
 	// might need
 	NoteVector newNotes;
 	int32_t newNotesInitialSize = notes.getNumElements() + numScreensToAddNoteOn;
-	int32_t error = newNotes.insertAtIndex(0, newNotesInitialSize);
+	ErrorType error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
 		delugeDealloc(searchTerms);
 		return error;
@@ -568,7 +568,7 @@ int32_t NoteRow::attemptNoteAdd(int32_t pos, int32_t length, int32_t velocity, i
 		length = 1; // Special case where note added at the end of linear record must temporarily be allowed to eat into
 		            // note at position 0
 	}
-	int32_t error = notes.insertAtIndex(i);
+	ErrorType error = notes.insertAtIndex(i);
 	if (error) {
 		return 0;
 	}
@@ -626,7 +626,7 @@ int32_t NoteRow::attemptNoteAddReversed(ModelStackWithNoteRow* modelStack, int32
 		// Ok, there was no Note there, so let's make one
 	}
 
-	int32_t error = notes.insertAtIndex(i);
+	ErrorType error = notes.insertAtIndex(i);
 	if (error) {
 		return 0;
 	}
@@ -669,7 +669,7 @@ int32_t NoteRow::clearArea(int32_t areaStart, int32_t areaWidth, ModelStackWithN
 	// might need
 	NoteVector newNotes;
 	int32_t newNotesInitialSize = notes.getNumElements();
-	int32_t error = newNotes.insertAtIndex(0, newNotesInitialSize);
+	ErrorType error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
 		delugeDealloc(searchTerms);
 		return error;
@@ -971,7 +971,7 @@ int32_t NoteRow::editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareW
 	// might need
 	NoteVector newNotes;
 	int32_t newNotesInitialSize = numSourceNotes + (newNumNotes - 1) * numScreens;
-	int32_t error = newNotes.insertAtIndex(0, newNotesInitialSize);
+	ErrorType error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
 		delugeDealloc(searchTerms);
 		return error;
@@ -1130,8 +1130,8 @@ int32_t NoteRow::editNoteRepeatAcrossAllScreens(int32_t editPos, int32_t squareW
 	return NO_ERROR;
 }
 
-int32_t NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
-                                            uint32_t wrapEditLevel, int32_t nudgeOffset) {
+ErrorType NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
+                                              uint32_t wrapEditLevel, int32_t nudgeOffset) {
 
 	int32_t numSourceNotes = notes.getNumElements();
 
@@ -1171,7 +1171,7 @@ int32_t NoteRow::nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteR
 	// might need
 	NoteVector newNotes;
 	int32_t newNotesInitialSize = numSourceNotes;
-	int32_t error = newNotes.insertAtIndex(0, newNotesInitialSize);
+	ErrorType error = newNotes.insertAtIndex(0, newNotesInitialSize);
 	if (error) {
 		delugeDealloc(searchTerms);
 		return error;
@@ -2492,7 +2492,7 @@ basicTrim:
 			else {
 
 				NoteVector newNotes;
-				int32_t error = newNotes.insertAtIndex(0, newNumNotes);
+				ErrorType error = newNotes.insertAtIndex(0, newNumNotes);
 				if (error) {
 					goto basicTrim;
 				}
@@ -2594,7 +2594,7 @@ bool NoteRow::generateRepeats(ModelStackWithNoteRow* modelStack, uint32_t oldLoo
 		// This is crude and lazy, but the amount of elements I'll create is rounded way up, and we'll delete any
 		// extras, below.
 		int32_t maxNewNumNotes = numNotesBefore * numRepeatsRoundedUp;
-		int32_t error = notes.insertAtIndex(numNotesBefore, maxNewNumNotes - numNotesBefore);
+		ErrorType error = notes.insertAtIndex(numNotesBefore, maxNewNumNotes - numNotesBefore);
 		if (error) {
 			return false;
 		}
@@ -2920,7 +2920,7 @@ uint32_t NoteRow::getNumNotes() {
 	return notes.getNumElements();
 }
 
-int32_t NoteRow::readFromFile(int32_t* minY, InstrumentClip* parentClip, Song* song, int32_t readAutomationUpToPos) {
+ErrorType NoteRow::readFromFile(int32_t* minY, InstrumentClip* parentClip, Song* song, int32_t readAutomationUpToPos) {
 	char const* tagName;
 
 	drum = (Drum*)0xFFFFFFFF; // Code for "no drum". We swap this for a real value soon
@@ -2992,7 +2992,7 @@ int32_t NoteRow::readFromFile(int32_t* minY, InstrumentClip* parentClip, Song* s
 					ParamManager* existingParamManager =
 					    song->getBackedUpParamManagerPreferablyWithClip(actualDrum, parentClip);
 					if (existingParamManager) {
-						int32_t error = paramManager.cloneParamCollectionsFrom(existingParamManager, false);
+						ErrorType error = paramManager.cloneParamCollectionsFrom(existingParamManager, false);
 						if (error) {
 							return error;
 						}
@@ -3369,7 +3369,7 @@ void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack
 
 					// If there is no NoteRow for this Drum... Oh dear. Make a blank ParamManager and pray?
 					else {
-						int32_t error = paramManager.setupWithPatching();
+						ErrorType error = paramManager.setupWithPatching();
 						if (error) {
 							FREEZE_WITH_ERROR("E010"); // If there also was no RAM, we're really in trouble.
 						}
@@ -3633,7 +3633,7 @@ void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack) {
 		stopCurrentlyPlayingNote(modelStack);
 
 		if (action) {
-			int32_t error = action->recordNoteArrayChangeIfNotAlreadySnapshotted(
+			ErrorType error = action->recordNoteArrayChangeIfNotAlreadySnapshotted(
 			    (InstrumentClip*)modelStack->getTimelineCounter(), modelStack->noteRowId, &notes, true); // Steal data
 			if (error) {
 				goto justEmpty;
@@ -3740,8 +3740,8 @@ void NoteRow::grabMidiCommandsFromDrum() {
 }
 
 // This function completely flattens iteration dependence (but not probability).
-int32_t NoteRow::appendNoteRow(ModelStackWithNoteRow* thisModelStack, ModelStackWithNoteRow* otherModelStack,
-                               int32_t offset, int32_t whichRepeatThisIs, int32_t otherNoteRowLength) {
+ErrorType NoteRow::appendNoteRow(ModelStackWithNoteRow* thisModelStack, ModelStackWithNoteRow* otherModelStack,
+                                 int32_t offset, int32_t whichRepeatThisIs, int32_t otherNoteRowLength) {
 
 	NoteRow* otherNoteRow = otherModelStack->getNoteRow();
 	InstrumentClip* clip = (InstrumentClip*)thisModelStack->getTimelineCounter();
@@ -3798,7 +3798,7 @@ int32_t NoteRow::appendNoteRow(ModelStackWithNoteRow* thisModelStack, ModelStack
 	int32_t insertIndex = notes.getNumElements();
 
 	// Pre-emptively insert space for all the notes.
-	int32_t error = notes.insertAtIndex(insertIndex, numToInsert);
+	ErrorType error = notes.insertAtIndex(insertIndex, numToInsert);
 	if (error) {
 		return error;
 	}

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -93,7 +93,7 @@ public:
 	bool hasNoNotes();
 	void resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMakeSound);
 	void writeToFile(int32_t drumIndex, InstrumentClip* clip);
-	int32_t readFromFile(int32_t*, InstrumentClip*, Song* song, int32_t readAutomationUpToPos);
+	ErrorType readFromFile(int32_t*, InstrumentClip*, Song* song, int32_t readAutomationUpToPos);
 	inline int32_t getNoteCode() { return y; }
 	void writeToFlash();
 	void readFromFlash(InstrumentClip* parentClip);
@@ -141,8 +141,8 @@ public:
 	                       ModelStackWithNoteRow* modelStack, Action* action);
 	int32_t attemptNoteAddReversed(ModelStackWithNoteRow* modelStack, int32_t pos, int32_t velocity,
 	                               bool allowingNoteTails);
-	int32_t addCorrespondingNotes(int32_t pos, int32_t length, uint8_t velocity, ModelStackWithNoteRow* modelStack,
-	                              bool allowNoteTails, Action* action);
+	ErrorType addCorrespondingNotes(int32_t pos, int32_t length, uint8_t velocity, ModelStackWithNoteRow* modelStack,
+	                                bool allowNoteTails, Action* action);
 	int32_t processCurrentPos(ModelStackWithNoteRow* modelStack, int32_t ticksSinceLast,
 	                          PendingNoteOnList* pendingNoteOnList);
 	uint8_t getSquareType(int32_t squareStart, int32_t squareWidth, Note** firstNote, Note** lastNote,
@@ -164,9 +164,9 @@ public:
 	void grabMidiCommandsFromDrum();
 	void deleteParamManager(bool shouldUpdatePointer = true);
 	void deleteOldDrumNames(bool shouldUpdatePointer = true);
-	int32_t appendNoteRow(ModelStackWithNoteRow* thisModelStack, ModelStackWithNoteRow* otherModelStack, int32_t offset,
-	                      int32_t whichRepeatThisIs, int32_t otherClipLength);
-	int32_t beenCloned(ModelStackWithNoteRow* modelStack, bool shouldFlattenReversing);
+	ErrorType appendNoteRow(ModelStackWithNoteRow* thisModelStack, ModelStackWithNoteRow* otherModelStack,
+	                        int32_t offset, int32_t whichRepeatThisIs, int32_t otherClipLength);
+	ErrorType beenCloned(ModelStackWithNoteRow* modelStack, bool shouldFlattenReversing);
 	void resumeOriginalNoteRowFromThisClone(ModelStackWithNoteRow* modelStackOriginal,
 	                                        ModelStackWithNoteRow* modelStackClone);
 	void silentlyResumePlayback(ModelStackWithNoteRow* modelStack);
@@ -178,8 +178,8 @@ public:
 	/// Nudge the note at editPos by either +1 (if nudgeOffset > 0) or -1 (if nudgeOffset < 0)
 	///
 	/// The caller must call Clip::expectEvent on the clip containing this `NoteRow` after this.
-	int32_t nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
-	                                   uint32_t wrapEditLevel, int32_t nudgeOffset);
+	ErrorType nudgeNotesAcrossAllScreens(int32_t editPos, ModelStackWithNoteRow* modelStack, Action* action,
+	                                     uint32_t wrapEditLevel, int32_t nudgeOffset);
 	/// Quantize the notes in this NoteRow so their positions are within `(kQuantizationPrecision - amount) *
 	/// increment/kQuantizationPrecision` of the grid defined by `n * increment`. If `amount` is negative, the row is
 	/// instead "humanized" by jittering the note positions to `±amount * increment / kQuantizationPrecision` sequencer

--- a/src/deluge/model/note/note_row_vector.cpp
+++ b/src/deluge/model/note/note_row_vector.cpp
@@ -32,7 +32,7 @@ NoteRowVector::~NoteRowVector() {
 }
 
 NoteRow* NoteRowVector::insertNoteRowAtIndex(int32_t index) {
-	int32_t error = insertAtIndex(index);
+	ErrorType error = insertAtIndex(index);
 	if (error) {
 		return NULL;
 	}

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -248,7 +248,7 @@ bool Output::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song) {
 }
 
 // Most classes inheriting from Output actually override this with their own version...
-int32_t Output::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
+ErrorType Output::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 	char const* tagName;
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
@@ -363,7 +363,7 @@ getOut:
 	return true;
 }
 
-int32_t Output::possiblyBeginArrangementRecording(Song* song, int32_t newPos) {
+ErrorType Output::possiblyBeginArrangementRecording(Song* song, int32_t newPos) {
 
 	if (!song->arrangementOnlyClips.ensureEnoughSpaceAllocated(1)) {
 		return ERROR_INSUFFICIENT_RAM;

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -106,19 +106,20 @@ public:
 	void endAnyArrangementRecording(Song* song, int32_t actualEndPos, uint32_t timeRemainder);
 	virtual bool wantsToBeginArrangementRecording() { return armedForRecording; }
 
-	virtual int32_t readFromFile(
-	    Song* song, Clip* clip,
-	    int32_t readAutomationUpToPos); // I think that supplying clip here is only a hangover from old pre-2.0 files...
+	// FIXME:I think that supplying clip here is only a hangover from old pre-2.0 files...
+	virtual ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
+
 	virtual bool readTagFromFile(char const* tagName);
 	void writeToFile(Clip* clipForSavingOutputOnly, Song* song);
 	virtual bool writeDataToFile(Clip* clipForSavingOutputOnly,
 	                             Song* song); // Returns true if it's ended the opening tag and gone into the sub-tags
 
-	virtual int32_t loadAllAudioFiles(bool mayActuallyReadFiles) { return NO_ERROR; }
+	virtual ErrorType loadAllAudioFiles(bool mayActuallyReadFiles) { return NO_ERROR; }
 	virtual void loadCrucialAudioFilesOnly() {} // Caller must check that there is an activeClip.
 
-	virtual void
-	resyncLFOs(){}; // No activeClip needed. Call anytime the Instrument comes into existence on the main list thing
+	// No activeClip needed. Call anytime the Instrument comes into existence on the main list thing
+	virtual void resyncLFOs(){};
+
 	virtual void sendMIDIPGM(){};
 	virtual void deleteBackedUpParamManagers(Song* song) {}
 	virtual void prepareForHibernationOrDeletion() {}
@@ -146,7 +147,7 @@ public:
 	                                  int32_t whichBendRange, int32_t bendSemitones) {}
 
 	// Arrangement stuff
-	int32_t possiblyBeginArrangementRecording(Song* song, int32_t newPos);
+	ErrorType possiblyBeginArrangementRecording(Song* song, int32_t newPos);
 	void endArrangementPlayback(Song* song, int32_t actualEndPos, uint32_t timeRemainder);
 	bool recordingInArrangement;
 

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -89,7 +89,7 @@ Sample::Sample()
 #endif
 }
 
-int32_t Sample::initialize(int32_t newNumClusters) {
+ErrorType Sample::initialize(int32_t newNumClusters) {
 	unloadable = false;
 	unplayable = false;
 	waveTableCycleSize = 2048; // Default
@@ -339,7 +339,7 @@ int32_t Sample::fillPercCache(TimeStretcher* timeStretcher, int32_t startPosSamp
 		i = percCacheZones[reversed].search(startPosSamples, GREATER_OR_EQUAL);
 	}
 
-	int32_t error = NO_ERROR;
+	ErrorType error = NO_ERROR;
 	SamplePercCacheZone* percCacheZone;
 	if (i >= 0 && i < percCacheZones[reversed].getNumElements()) {
 		percCacheZone = (SamplePercCacheZone*)percCacheZones[reversed].getElementAddress(i);
@@ -953,7 +953,7 @@ void Sample::percCacheClusterStolen(Cluster* cluster) {
 				// This is reasonably likely to fail, cos it might want to allocate new memory, but that's not allowed
 				// if it's currently allocating a Cluster, which it will be if this Cluster got stolen, which is why
 				// we're here. Oh well
-				int32_t error = percCacheZones[reversed].insertAtIndex(
+				ErrorType error = percCacheZones[reversed].insertAtIndex(
 				    iNew, 1,
 				    this); // Also specify not to steal perc cache Clusters from this Sample. Could that actually even
 				           // happen given the above comment? Not sure.

--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "model/sample/sample_cluster.h"
 #include "model/sample/sample_cluster_array.h"
 #include "storage/audio/audio_file.h"
@@ -48,7 +49,7 @@ public:
 	~Sample();
 
 	void workOutBitMask();
-	int32_t initialize(int32_t numClusters);
+	ErrorType initialize(int32_t numClusters);
 	void markAsUnloadable();
 	float determinePitch(bool doingSingleCycle, float minFreqHz, float maxFreqHz, bool doPrimeTest);
 	void workOutMIDINote(bool doingSingleCycle, float minFreqHz = 20, float maxFreqHz = 10000, bool doPrimeTest = true);

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -23,7 +23,6 @@
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 
-
 SampleCluster::~SampleCluster() {
 	if (cluster) {
 

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -16,20 +16,13 @@
  */
 
 #include "model/sample/sample_cluster.h"
+#include "definitions_cxx.hpp"
 #include "io/debug/log.h"
 #include "memory/general_memory_allocator.h"
 #include "model/sample/sample.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 
-SampleCluster::SampleCluster() {
-	cluster = NULL;
-
-	investigatedWholeLength = false;
-	minValue = 127;
-	maxValue = -128;
-	sdAddress = 0; // 0 means invalid, and we check for this as a last resort before writing
-}
 
 SampleCluster::~SampleCluster() {
 	if (cluster) {
@@ -71,7 +64,7 @@ void SampleCluster::ensureNoReason(Sample* sample) {
 // Calling this will add a reason to the loaded Cluster!
 // priorityRating is only relevant if enqueuing.
 Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_t loadInstruction,
-                                   uint32_t priorityRating, uint8_t* error) {
+                                   uint32_t priorityRating, ErrorType* error) {
 
 	if (error) {
 		*error = NO_ERROR;
@@ -86,7 +79,7 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 			if (error) {
 				*error = ERROR_FILE_NOT_FOUND;
 			}
-			return NULL;
+			return nullptr;
 		}
 
 		// D_PRINTLN("loading");
@@ -97,7 +90,7 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 			if (error) {
 				*error = ERROR_INSUFFICIENT_RAM;
 			}
-			return NULL;
+			return nullptr;
 		}
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
@@ -160,11 +153,11 @@ justEnqueue:
 				audioFileManager.deallocateCluster(cluster); // This removes the 1 reason that it'd still have
 
 				if (error) {
-					*error =
-					    ERROR_UNSPECIFIED; // TODO: get actual error. Although sometimes it'd just be a "can't do it now
-					                       // cos card's being accessed, and that's fine, thanks for checking."
+					// TODO: get actual error. Although sometimes it'd just be a "can't do it now
+					// cos card's being accessed, and that's fine, thanks for checking."
+					*error = ERROR_UNSPECIFIED;
 				}
-				cluster = NULL;
+				cluster = nullptr;
 			}
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
 			if (cluster && cluster->numReasonsToBeLoaded <= 0) {

--- a/src/deluge/model/sample/sample_cluster.h
+++ b/src/deluge/model/sample/sample_cluster.h
@@ -26,16 +26,21 @@ class Sample;
 // audio data for that Sample.
 class SampleCluster {
 public:
-	SampleCluster();
+	SampleCluster() = default;
 	~SampleCluster();
+
+	// TODO: This should return a std::expected<Cluster*, ErrorType), removing the last parameter
 	Cluster* getCluster(Sample* sample, uint32_t clusterIndex, int32_t loadInstruction = CLUSTER_ENQUEUE,
-	                    uint32_t priorityRating = 0xFFFFFFFF, uint8_t* error = NULL);
+	                    uint32_t priorityRating = 0xFFFFFFFF, ErrorType* error = nullptr);
 	void ensureNoReason(Sample* sample);
 
-	uint32_t sdAddress; // In sectors. (Those 512 byte things. Not to be confused with clusters.)
-	Cluster* cluster; // May automatically be set to NULL if the Cluster needs to be deallocated (can only happen if it
-	                  // has no "reasons" left)
-	int8_t minValue;
-	int8_t maxValue;
-	bool investigatedWholeLength;
+	// In sectors. (Those 512 byte things. Not to be confused with clusters.)
+	// 0 means invalid, and we check for this as a last resort before writing
+	uint32_t sdAddress = 0;
+
+	Cluster* cluster = nullptr; // May automatically be set to NULL if the Cluster needs to be deallocated (can only
+	                            // happen if it has no "reasons" left)
+	int8_t minValue = 127;
+	int8_t maxValue = -128;
+	bool investigatedWholeLength = false;
 };

--- a/src/deluge/model/sample/sample_cluster_array.cpp
+++ b/src/deluge/model/sample/sample_cluster_array.cpp
@@ -16,15 +16,16 @@
  */
 
 #include "model/sample/sample_cluster_array.h"
+#include "definitions_cxx.hpp"
 #include "model/sample/sample_cluster.h"
 #include <new>
 
 SampleClusterArray::SampleClusterArray() : ResizeableArray(sizeof(SampleCluster)) {
 }
 
-int32_t SampleClusterArray::insertSampleClustersAtEnd(int32_t numToInsert) {
+ErrorType SampleClusterArray::insertSampleClustersAtEnd(int32_t numToInsert) {
 	int32_t oldNum = getNumElements();
-	int32_t error = insertAtIndex(oldNum, numToInsert);
+	ErrorType error = insertAtIndex(oldNum, numToInsert);
 	if (error) {
 		return error;
 	}

--- a/src/deluge/model/sample/sample_cluster_array.h
+++ b/src/deluge/model/sample/sample_cluster_array.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "util/container/array/resizeable_array.h"
 
 class SampleCluster;
@@ -24,6 +25,6 @@ class SampleCluster;
 class SampleClusterArray : public ResizeableArray {
 public:
 	SampleClusterArray();
-	int32_t insertSampleClustersAtEnd(int32_t numToInsert);
+	ErrorType insertSampleClustersAtEnd(int32_t numToInsert);
 	SampleCluster* getElement(int32_t i);
 };

--- a/src/deluge/model/sample/sample_reader.cpp
+++ b/src/deluge/model/sample/sample_reader.cpp
@@ -16,18 +16,15 @@
  */
 
 #include "model/sample/sample_reader.h"
+#include "definitions_cxx.hpp"
 #include "model/sample/sample.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 
-SampleReader::SampleReader() {
-	// TODO Auto-generated constructor stub
-}
-
-int32_t SampleReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t num) {
+ErrorType SampleReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t num) {
 
 	while (num--) {
-		int32_t error = advanceClustersIfNecessary();
+		ErrorType error = advanceClustersIfNecessary();
 		if (error) {
 			return error;
 		}
@@ -40,7 +37,7 @@ int32_t SampleReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t n
 	return NO_ERROR;
 }
 
-int32_t SampleReader::readNewCluster() {
+ErrorType SampleReader::readNewCluster() {
 	if (currentCluster) {
 		audioFileManager.removeReasonFromCluster(currentCluster, "E031");
 	}
@@ -51,7 +48,5 @@ int32_t SampleReader::readNewCluster() {
 	if (!currentCluster) {
 		return ERROR_SD_CARD; // Failed to load cluster from card
 	}
-	else {
-		return NO_ERROR;
-	}
+	return NO_ERROR;
 }

--- a/src/deluge/model/sample/sample_reader.h
+++ b/src/deluge/model/sample/sample_reader.h
@@ -17,15 +17,16 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "storage/audio/audio_file_reader.h"
 
 class Cluster;
 
 class SampleReader final : public AudioFileReader {
 public:
-	SampleReader();
-	int32_t readBytesPassedErrorChecking(char* outputBuffer, int32_t num);
-	int32_t readNewCluster();
+	SampleReader() = default;
+	ErrorType readBytesPassedErrorChecking(char* outputBuffer, int32_t num) override;
+	ErrorType readNewCluster() override;
 
 	Cluster* currentCluster;
 };

--- a/src/deluge/model/sample/sample_recorder.h
+++ b/src/deluge/model/sample/sample_recorder.h
@@ -46,10 +46,10 @@ class SampleRecorder {
 public:
 	SampleRecorder();
 	~SampleRecorder();
-	int32_t setup(int32_t newNumChannels, AudioInputChannel newMode, bool newKeepingReasons,
-	              bool shouldRecordExtraMargins, AudioRecordingFolder newFolderID, int32_t buttonPressLatency);
+	ErrorType setup(int32_t newNumChannels, AudioInputChannel newMode, bool newKeepingReasons,
+	                bool shouldRecordExtraMargins, AudioRecordingFolder newFolderID, int32_t buttonPressLatency);
 	void feedAudio(int32_t* inputAddress, int32_t numSamples, bool applyGain = false);
-	int32_t cardRoutine();
+	ErrorType cardRoutine();
 	void endSyncedRecording(int32_t buttonLatencyForTempolessRecording);
 	bool inputLooksDifferential();
 	bool inputHasNoRightChannel();
@@ -122,17 +122,17 @@ public:
 
 private:
 	void setExtraBytesOnPreviousCluster(Cluster* currentCluster, int32_t currentClusterIndex);
-	int32_t writeCluster(int32_t clusterIndex, int32_t numBytes);
-	int32_t alterFile(MonitoringAction action, int32_t lshiftAmount, uint32_t idealFileSizeBeforeAction,
+	ErrorType writeCluster(int32_t clusterIndex, int32_t numBytes);
+	ErrorType alterFile(MonitoringAction action, int32_t lshiftAmount, uint32_t idealFileSizeBeforeAction,
 
-	                  uint64_t dataLengthAfterAction);
-	int32_t finalizeRecordedFile();
-	int32_t createNextCluster();
-	int32_t writeAnyCompletedClusters();
+	                    uint64_t dataLengthAfterAction);
+	ErrorType finalizeRecordedFile();
+	ErrorType createNextCluster();
+	ErrorType writeAnyCompletedClusters();
 	void finishCapturing();
 	void updateDataLengthInFirstCluster(Cluster* cluster);
 	void totalSampleLengthNowKnown(uint32_t totalLength, uint32_t loopEndPointSamples = 0);
 	void detachSample();
-	int32_t truncateFileDownToSize(uint32_t newFileSize);
-	int32_t writeOneCompletedCluster();
+	ErrorType truncateFileDownToSize(uint32_t newFileSize);
+	ErrorType writeOneCompletedCluster();
 };

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -176,7 +176,7 @@ void RuntimeFeatureSettings::readSettingsFromFile() {
 		return;
 	}
 
-	int32_t error = storageManager.openXMLFile(&fp, TAG_RUNTIME_FEATURE_SETTINGS);
+	ErrorType error = storageManager.openXMLFile(&fp, TAG_RUNTIME_FEATURE_SETTINGS);
 	if (error) {
 		return;
 	}
@@ -235,7 +235,7 @@ void RuntimeFeatureSettings::readSettingsFromFile() {
 void RuntimeFeatureSettings::writeSettingsToFile() {
 	f_unlink(RUNTIME_FEATURE_SETTINGS_FILE); // May give error, but no real consequence from that.
 
-	int32_t error = storageManager.createXMLFile(RUNTIME_FEATURE_SETTINGS_FILE, true);
+	ErrorType error = storageManager.createXMLFile(RUNTIME_FEATURE_SETTINGS_FILE, true);
 	if (error) {
 		return;
 	}

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -416,8 +416,8 @@ reallyScrewed:
 				while (1) {}
 			}
 
-			int32_t error2 =
-			    newInstrument->dirPath.set("SYNTHS"); // Use new error2 variable to preserve error result from before.
+			// Use new error2 variable to preserve error result from before.
+			ErrorType error2 = newInstrument->dirPath.set("SYNTHS");
 			if (error2) {
 gotError2:
 				result.error = error2;
@@ -1446,7 +1446,7 @@ weAreInArrangementEditorOrInClipInstance:
 	storageManager.writeClosingTag("song");
 }
 
-int32_t Song::readFromFile() {
+ErrorType Song::readFromFile() {
 
 	outputClipInstanceListIsCurrentlyInvalid = true;
 
@@ -1888,7 +1888,7 @@ unknownTag:
 					void* memory;
 					Output* newOutput;
 					char const* defaultDirPath;
-					int32_t error;
+					ErrorType error;
 
 					if (!strcmp(tagName, "audioTrack")) {
 						memory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(AudioOutput));
@@ -1967,7 +1967,7 @@ loadOutput:
 			}
 
 			else if (!strcmp(tagName, "tracks") || !strcmp(tagName, "sessionClips")) {
-				int32_t error = readClipsFromFile(&sessionClips);
+				ErrorType error = readClipsFromFile(&sessionClips);
 				if (error) {
 					return error;
 				}
@@ -1975,7 +1975,7 @@ loadOutput:
 			}
 
 			else if (!strcmp(tagName, "arrangementOnlyTracks") || !strcmp(tagName, "arrangementOnlyClips")) {
-				int32_t error = readClipsFromFile(&arrangementOnlyClips);
+				ErrorType error = readClipsFromFile(&arrangementOnlyClips);
 				if (error) {
 					return error;
 				}
@@ -1983,13 +1983,13 @@ loadOutput:
 			}
 
 			else {
-				int32_t result = globalEffectable.readTagFromFile(tagName, &paramManager, 2147483647, this);
+				ErrorType result = globalEffectable.readTagFromFile(tagName, &paramManager, 2147483647, this);
 				if (result == NO_ERROR) {}
 				else if (result != RESULT_TAG_UNUSED) {
 					return result;
 				}
 				else {
-					int32_t result = storageManager.tryReadingFirmwareTagFromFile(tagName);
+					ErrorType result = storageManager.tryReadingFirmwareTagFromFile(tagName);
 					if (result && result != RESULT_TAG_UNUSED) {
 						return result;
 					}
@@ -2038,7 +2038,7 @@ traverseClips:
 
 		ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(thisClip);
 
-		int32_t error = thisClip->claimOutput(modelStackWithTimelineCounter);
+		ErrorType error = thisClip->claimOutput(modelStackWithTimelineCounter);
 		if (error) {
 			return error;
 		}
@@ -2205,7 +2205,7 @@ skipInstance:
 	return NO_ERROR;
 }
 
-int32_t Song::readClipsFromFile(ClipArray* clipArray) {
+ErrorType Song::readClipsFromFile(ClipArray* clipArray) {
 	char const* tagName;
 
 	while (*(tagName = storageManager.readNextTagOrAttributeName())) {
@@ -2235,7 +2235,7 @@ readClip:
 				newClip = new (memory) AudioClip();
 			}
 
-			int32_t error = newClip->readFromFile(this);
+			ErrorType error = newClip->readFromFile(this);
 			if (error) {
 				newClip->~Clip();
 				delugeDealloc(memory);
@@ -3420,7 +3420,7 @@ traverseClips:
 
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
 
-			int32_t error = instrumentClip->changeInstrument(
+			ErrorType error = instrumentClip->changeInstrument(
 			    modelStackWithTimelineCounter, newOutput, NULL, InstrumentRemoval::NONE,
 			    (InstrumentClip*)favourClipForCloningParamManager, keepNoteRowsWithMIDIInput,
 			    true); // Will call audio routine
@@ -3846,7 +3846,7 @@ doStealing:
 	// Otherwise, insert one
 	else {
 		i = indexToInsertAt;
-		int32_t error = backedUpParamManagers.insertAtIndex(i);
+		ErrorType error = backedUpParamManagers.insertAtIndex(i);
 
 		// If RAM error...
 		if (error) {
@@ -3916,7 +3916,7 @@ void Song::deleteBackedUpParamManagersForClip(Clip* clip) {
 
 				// Otherwise, we insert before it
 				else {
-					int32_t error = backedUpParamManagers.insertAtIndex(j);
+					ErrorType error = backedUpParamManagers.insertAtIndex(j);
 
 					// If RAM error (surely would never happen since we just deleted an element)...
 					if (error) {
@@ -4512,7 +4512,7 @@ void Song::ensureAllInstrumentsHaveAClipOrBackedUpParamManager(char const* error
 #endif
 }
 
-int32_t Song::placeFirstInstancesOfActiveClips(int32_t pos) {
+ErrorType Song::placeFirstInstancesOfActiveClips(int32_t pos) {
 
 	// For each Clip in session
 	for (int32_t c = 0; c < sessionClips.getNumElements(); c++) {
@@ -4520,7 +4520,7 @@ int32_t Song::placeFirstInstancesOfActiveClips(int32_t pos) {
 
 		if (isClipActive(clip)) {
 			int32_t clipInstanceI = clip->output->clipInstances.getNumElements();
-			int32_t error = clip->output->clipInstances.insertAtIndex(clipInstanceI);
+			ErrorType error = clip->output->clipInstances.insertAtIndex(clipInstanceI);
 			if (error) {
 				return error;
 			}
@@ -5088,7 +5088,7 @@ AudioOutput* Song::createNewAudioOutput(Output* replaceOutput) {
 	}
 
 	String newName;
-	int32_t error = newName.set("AUDIO");
+	ErrorType error = newName.set("AUDIO");
 	if (error) {
 		return NULL;
 	}
@@ -5773,7 +5773,7 @@ void Song::midiDeviceBendRangeUpdatedViaMessage(ModelStack* modelStack, MIDIDevi
 	}
 }
 
-int32_t Song::addInstrumentsToFileItems(OutputType outputType) {
+ErrorType Song::addInstrumentsToFileItems(OutputType outputType) {
 	bool doingHibernatingOnes;
 	Output* thisOutput;
 	if (false) {
@@ -5806,7 +5806,7 @@ doHibernatingInstruments:
 			return ERROR_INSUFFICIENT_RAM;
 		}
 
-		int32_t error = thisItem->setupWithInstrument(thisInstrument, doingHibernatingOnes);
+		ErrorType error = thisItem->setupWithInstrument(thisInstrument, doingHibernatingOnes);
 
 		if (error) {
 			return error;

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -234,7 +234,7 @@ public:
 	void setClipLength(Clip* clip, uint32_t newLength, Action* action, bool mayReSyncClip = true);
 	void doubleClipLength(InstrumentClip* clip, Action* action = NULL);
 	Clip* getClipWithOutput(Output* output, bool mustBeActive = false, Clip* excludeClip = NULL);
-	int32_t readFromFile();
+	ErrorType readFromFile();
 	void writeToFile();
 	void loadAllSamples(bool mayActuallyReadFiles = true);
 	bool modeContainsYNoteWithinOctave(uint8_t yNoteWithinOctave);
@@ -299,7 +299,7 @@ public:
 	Output* getOutputFromIndex(int32_t index);
 	void ensureAllInstrumentsHaveAClipOrBackedUpParamManager(char const* errorMessageNormal,
 	                                                         char const* errorMessageHibernating);
-	int32_t placeFirstInstancesOfActiveClips(int32_t pos);
+	ErrorType placeFirstInstancesOfActiveClips(int32_t pos);
 	void endInstancesOfActiveClips(int32_t pos, bool detachClipsToo = false);
 	void clearArrangementBeyondPos(int32_t pos, Action* action);
 	void deletingClipInstanceForClip(Output* output, Clip* clip, Action* action, bool shouldPickNewActiveClip);
@@ -340,7 +340,7 @@ public:
 	void setDefaultVelocityForAllInstruments(uint8_t newDefaultVelocity);
 	void midiDeviceBendRangeUpdatedViaMessage(ModelStack* modelStack, MIDIDevice* device, int32_t channelOrZone,
 	                                          int32_t whichBendRange, int32_t bendSemitones);
-	int32_t addInstrumentsToFileItems(OutputType outputType);
+	ErrorType addInstrumentsToFileItems(OutputType outputType);
 
 	uint32_t getQuarterNoteLength();
 	uint32_t getBarLength();
@@ -388,7 +388,7 @@ private:
 	Clip* currentClip = nullptr;
 	Clip* previousClip = nullptr; // for future use, maybe finding an instrument clip or something
 	void inputTickScalePotentiallyJustChanged(uint32_t oldScale);
-	int32_t readClipsFromFile(ClipArray* clipArray);
+	ErrorType readClipsFromFile(ClipArray* clipArray);
 	void addInstrumentToHibernationList(Instrument* instrument);
 	void deleteAllBackedUpParamManagers(bool shouldAlsoEmptyVector = true);
 	void deleteAllBackedUpParamManagersWithClips();

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -183,7 +183,7 @@ void Arpeggiator::noteOn(ArpeggiatorSettings* settings, int32_t noteCode, int32_
 	// If note does not exist yet in the arrays, we must insert it in both
 	else {
 		// Insert in notes array
-		int32_t error = notes.insertAtIndex(notesKey);
+		ErrorType error = notes.insertAtIndex(notesKey);
 		if (error) {
 			return;
 		}

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -932,7 +932,7 @@ int32_t AutoParam::setNodeAtPos(int32_t pos, int32_t value, bool shouldInterpola
 	}
 
 	{
-		int32_t error = nodes.insertAtIndex(i);
+		ErrorType error = nodes.insertAtIndex(i);
 		if (error) {
 			return -1;
 		}
@@ -1198,7 +1198,7 @@ getValueNormalWay:
 
 		// Otherwise, insert one
 		else {
-			int32_t error = nodes.insertAtIndex(edgeIndexes[REGION_EDGE_RIGHT]);
+			ErrorType error = nodes.insertAtIndex(edgeIndexes[REGION_EDGE_RIGHT]);
 			if (error) {
 				return -1;
 			}
@@ -1224,7 +1224,7 @@ getValueNormalWay:
 
 		// Otherwise, insert one
 		else {
-			int32_t error = nodes.insertAtIndex(edgeIndexes[REGION_EDGE_LEFT]);
+			ErrorType error = nodes.insertAtIndex(edgeIndexes[REGION_EDGE_LEFT]);
 			if (error) {
 				return -1;
 			}
@@ -1415,7 +1415,7 @@ void AutoParam::setPlayPos(uint32_t pos, ModelStackWithAutoParam const* modelSta
 
 int32_t AutoParam::beenCloned(bool copyAutomation, int32_t reverseDirectionWithLength) {
 
-	int32_t error = NO_ERROR;
+	ErrorType error = NO_ERROR;
 
 	if (copyAutomation) {
 
@@ -1524,7 +1524,7 @@ void AutoParam::generateRepeats(uint32_t oldLength, uint32_t newLength, bool sho
 				valueAtZero = nodeBeforeWrap->value;
 			}
 
-			int32_t error = nodes.insertAtIndex(0);
+			ErrorType error = nodes.insertAtIndex(0);
 			if (error) {
 				return;
 			}
@@ -1544,7 +1544,7 @@ void AutoParam::generateRepeats(uint32_t oldLength, uint32_t newLength, bool sho
 
 		int32_t numToInsert = (numRepeats - 1) * numNodesBefore;
 		if (numToInsert) { // Should always be true?
-			int32_t error = nodes.insertAtIndex(numNodesBefore, numToInsert);
+			ErrorType error = nodes.insertAtIndex(numNodesBefore, numToInsert);
 			if (error) {
 				return;
 			}
@@ -1657,7 +1657,7 @@ void AutoParam::appendParam(AutoParam* otherParam, int32_t oldLength, int32_t re
 
 		int32_t newZeroNodeI = nodes.getNumElements();
 
-		int32_t error = nodes.insertAtIndex(newZeroNodeI);
+		ErrorType error = nodes.insertAtIndex(newZeroNodeI);
 		if (error) {
 			return;
 		}
@@ -1672,7 +1672,7 @@ void AutoParam::appendParam(AutoParam* otherParam, int32_t oldLength, int32_t re
 	}
 
 	int32_t oldNumNodes = nodes.getNumElements();
-	int32_t error = nodes.insertAtIndex(oldNumNodes, numToInsert);
+	ErrorType error = nodes.insertAtIndex(oldNumNodes, numToInsert);
 	if (error) {
 		return;
 	}
@@ -1786,7 +1786,7 @@ basicTrim: {
 
 addNewNodeAt0IfNecessary:
 			if (needNewNodeAt0) {
-				int32_t error = nodes.insertAtIndex(0);
+				ErrorType error = nodes.insertAtIndex(0);
 				if (!error) { // Should be fine cos we just deleted some, so some free RAM
 					ParamNode* newNode = nodes.getElement(0);
 					newNode->pos = 0;
@@ -1807,7 +1807,7 @@ addNewNodeAt0IfNecessary:
 			}
 			else {
 				ParamNodeVector newNodes;
-				int32_t error = newNodes.insertAtIndex(0, newNumNodes);
+				ErrorType error = newNodes.insertAtIndex(0, newNumNodes);
 				if (error) {
 					goto basicTrim;
 				}
@@ -1870,7 +1870,7 @@ void AutoParam::writeToFile(bool writeAutomation, int32_t* valueForOverride) {
 // Returns error code.
 // If you're gonna call this, you probably need to tell the ParamSet that this Param has automation now, if it does.
 // Or, to make things easier, you should just call the ParamSet instead, if possible.
-int32_t AutoParam::readFromFile(int32_t readAutomationUpToPos) {
+ErrorType AutoParam::readFromFile(int32_t readAutomationUpToPos) {
 
 	// Must first delete any automation because sometimes, due to that annoying support I have to do for late-2016
 	// files, we'll be overwriting a cloned ParamManager, which might have had automation.
@@ -1957,7 +1957,7 @@ int32_t AutoParam::readFromFile(int32_t readAutomationUpToPos) {
 				if (pos == readAutomationUpToPos) {
 					ParamNode* firstNode = nodes.getElement(0);
 					if (!firstNode || firstNode->pos) {
-						int32_t error = nodes.insertAtIndex(0);
+						ErrorType error = nodes.insertAtIndex(0);
 						if (error) {
 							return error;
 						}
@@ -2225,7 +2225,7 @@ void AutoParam::copy(int32_t startPos, int32_t endPos, CopiedParamAutomation* co
 // Returns error code.
 // quantizationRShift would be 25 for 7-bit CC values (cos 32 - 25 == 7).
 // Or it'd ideally be 18 for 14-bit pitch bend data, but that'd be a bit overkill.
-int32_t AutoParam::makeInterpolationGoodAgain(int32_t clipLength, int32_t quantizationRShift) {
+ErrorType AutoParam::makeInterpolationGoodAgain(int32_t clipLength, int32_t quantizationRShift) {
 
 	if (nodes.getNumElements() <= 1) {
 		return NO_ERROR;
@@ -2376,7 +2376,7 @@ void AutoParam::deleteTime(int32_t startPos, int32_t lengthToDelete, ModelStackW
 		nodes.deleteAtIndex(start, numToDelete, !shouldAddNodeAtPos0);
 
 		if (shouldAddNodeAtPos0) {
-			int32_t error =
+			ErrorType error =
 			    nodes.insertAtIndex(0); // Shouldn't ever fail as we told it not to shorten its memory previously
 			if (!error) {
 				ParamNode* newNode = nodes.getElement(0);
@@ -2661,7 +2661,7 @@ doWrap:
 				else {
 					nextNodeI = nodes.getNumElements();
 					{
-						int32_t error = nodes.insertAtIndex(
+						ErrorType error = nodes.insertAtIndex(
 						    nextNodeI); // This shouldn't be able to fail, cos we just deleted a node
 						if (ALPHA_OR_BETA_VERSION && error) {
 							FREEZE_WITH_ERROR("E333");

--- a/src/deluge/modulation/automation/auto_param.h
+++ b/src/deluge/modulation/automation/auto_param.h
@@ -16,6 +16,7 @@
  */
 
 #pragma once
+#include "definitions_cxx.hpp"
 #include "model/action/action.h"
 #include "modulation/params/param_node_vector.h"
 #include <cstdint>
@@ -65,7 +66,7 @@ public:
 	void deleteAutomation(Action* action, ModelStackWithAutoParam const* modelStack, bool shouldNotify = true);
 	void deleteAutomationBasicForSetup();
 	void writeToFile(bool writeAutomation, int32_t* valueForOverride = NULL);
-	int32_t readFromFile(int32_t readAutomationUpToPos);
+	ErrorType readFromFile(int32_t readAutomationUpToPos);
 	bool containsSomething(uint32_t neutralValue = 0);
 	static bool containedSomethingBefore(bool wasAutomatedBefore, uint32_t valueBefore, uint32_t neutralValue = 0);
 	void shiftValues(int32_t offset);
@@ -76,7 +77,7 @@ public:
 	          ModelStackWithAutoParam const* modelStack);
 	void paste(int32_t startPos, int32_t endPos, float scaleFactor, ModelStackWithAutoParam const* modelStack,
 	           CopiedParamAutomation* copiedParamAutomation, bool isPatchCable);
-	int32_t makeInterpolationGoodAgain(int32_t clipLength, int32_t quantizationRShift);
+	ErrorType makeInterpolationGoodAgain(int32_t clipLength, int32_t quantizationRShift);
 	void transposeCCValuesToChannelPressureValues();
 	void deleteTime(int32_t startPos, int32_t lengthToDelete, ModelStackWithAutoParam* modelStack);
 	void insertTime(int32_t pos, int32_t lengthToInsert);

--- a/src/deluge/modulation/midi/midi_knob_array.cpp
+++ b/src/deluge/modulation/midi/midi_knob_array.cpp
@@ -23,7 +23,7 @@ MidiKnobArray::MidiKnobArray() : ResizeableArray(sizeof(MIDIKnob)) {
 }
 
 MIDIKnob* MidiKnobArray::insertKnob(int32_t i) {
-	int32_t error = insertAtIndex(i);
+	ErrorType error = insertAtIndex(i);
 	if (error) {
 		return NULL;
 	}

--- a/src/deluge/modulation/midi/midi_param_collection.cpp
+++ b/src/deluge/modulation/midi/midi_param_collection.cpp
@@ -201,7 +201,7 @@ void MIDIParamCollection::sendMIDI(int32_t masterChannel, int32_t cc, int32_t ne
 
 // For MIDI CCs, which prior to V2.0 did interpolation
 // Returns error code
-int32_t MIDIParamCollection::makeInterpolatedCCsGoodAgain(int32_t clipLength) {
+ErrorType MIDIParamCollection::makeInterpolatedCCsGoodAgain(int32_t clipLength) {
 
 	for (int32_t i = 0; i < params.getNumElements(); i++) {
 		MIDIParam* midiParam = params.getElement(i);
@@ -209,7 +209,7 @@ int32_t MIDIParamCollection::makeInterpolatedCCsGoodAgain(int32_t clipLength) {
 		if (midiParam->cc >= 120) {
 			return NO_ERROR;
 		}
-		int32_t error = midiParam->param.makeInterpolationGoodAgain(clipLength, 25);
+		ErrorType error = midiParam->param.makeInterpolationGoodAgain(clipLength, 25);
 		if (error) {
 			return error;
 		}

--- a/src/deluge/modulation/midi/midi_param_collection.h
+++ b/src/deluge/modulation/midi/midi_param_collection.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "modulation/midi/midi_param_vector.h"
 #include "modulation/params/param_collection.h"
 
@@ -43,7 +44,7 @@ public:
 	                       bool didPingpong, bool mayInterpolate);
 	void remotelySwapParamState(AutoParamState* state, ModelStackWithParamId* modelStack);
 	void deleteAllAutomation(Action* action, ModelStackWithParamCollection* modelStack);
-	int32_t makeInterpolatedCCsGoodAgain(int32_t clipLength);
+	ErrorType makeInterpolatedCCsGoodAgain(int32_t clipLength);
 	void grabValuesFromPos(uint32_t pos, ModelStackWithParamCollection* modelStack);
 	void nudgeNonInterpolatingNodesAtPos(int32_t pos, int32_t offset, int32_t lengthBeforeLoop, Action* action,
 	                                     ModelStackWithParamCollection* modelStack);

--- a/src/deluge/modulation/midi/midi_param_vector.cpp
+++ b/src/deluge/modulation/midi/midi_param_vector.cpp
@@ -57,7 +57,7 @@ doesntExistYet:
 }
 
 MIDIParam* MIDIParamVector::insertParam(int32_t i) {
-	int32_t error = insertAtIndex(i);
+	ErrorType error = insertAtIndex(i);
 	if (error) {
 		return NULL;
 	}

--- a/src/deluge/modulation/params/param_manager.cpp
+++ b/src/deluge/modulation/params/param_manager.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "modulation/params/param_manager.h"
+#include "definitions_cxx.hpp"
 #include "gui/views/view.h"
 #include "memory/general_memory_allocator.h"
 #include "model/clip/instrument_clip.h"
@@ -56,7 +57,7 @@ ParamManagerForTimeline* ParamManagerForTimeline::toForTimeline() {
 }
 #endif
 
-int32_t ParamManager::setupMIDI() {
+ErrorType ParamManager::setupMIDI() {
 	void* memory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(MIDIParamCollection));
 	if (!memory) {
 		return ERROR_INSUFFICIENT_RAM;
@@ -69,7 +70,7 @@ int32_t ParamManager::setupMIDI() {
 	return NO_ERROR;
 }
 
-int32_t ParamManager::setupUnpatched() {
+ErrorType ParamManager::setupUnpatched() {
 	void* memoryUnpatched = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(UnpatchedParamSet));
 	if (!memoryUnpatched) {
 		return ERROR_INSUFFICIENT_RAM;
@@ -81,7 +82,7 @@ int32_t ParamManager::setupUnpatched() {
 	return NO_ERROR;
 }
 
-int32_t ParamManager::setupWithPatching() {
+ErrorType ParamManager::setupWithPatching() {
 	void* memoryUnpatched = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(UnpatchedParamSet));
 	if (!memoryUnpatched) {
 		return ERROR_INSUFFICIENT_RAM;
@@ -160,8 +161,8 @@ void ParamManager::stealParamCollectionsFrom(ParamManager* other, bool stealExpr
 	other->expressionParamSetOffset = 0;
 }
 
-int32_t ParamManager::cloneParamCollectionsFrom(ParamManager* other, bool copyAutomation, bool cloneExpressionParams,
-                                                int32_t reverseDirectionWithLength) {
+ErrorType ParamManager::cloneParamCollectionsFrom(ParamManager* other, bool copyAutomation, bool cloneExpressionParams,
+                                                  int32_t reverseDirectionWithLength) {
 
 	ParamCollectionSummary mpeParamsOrNullHere = *getExpressionParamSetSummary();
 	// Paul: Prevent MPE data from not getting exchanged with a newly allocated pointer if we allocate the same params
@@ -255,7 +256,7 @@ int32_t ParamManager::cloneParamCollectionsFrom(ParamManager* other, bool copyAu
 }
 
 // This is only called once - for NoteRows after cloning an InstrumentClip.
-int32_t ParamManager::beenCloned(int32_t reverseDirectionWithLength) {
+ErrorType ParamManager::beenCloned(int32_t reverseDirectionWithLength) {
 	return cloneParamCollectionsFrom(this, true, true, reverseDirectionWithLength); // *Does* clone expression params
 }
 

--- a/src/deluge/modulation/params/param_manager.h
+++ b/src/deluge/modulation/params/param_manager.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "modulation/params/param_collection_summary.h"
 #include <cstdint>
 
@@ -51,14 +52,14 @@ public:
 
 	inline bool containsAnyParamCollectionsIncludingExpression() { return summaries[0].paramCollection; }
 
-	int32_t setupWithPatching();
-	int32_t setupUnpatched();
-	int32_t setupMIDI();
+	ErrorType setupWithPatching();
+	ErrorType setupUnpatched();
+	ErrorType setupMIDI();
 
 	void stealParamCollectionsFrom(ParamManager* other, bool stealExpressionParams = false);
-	int32_t cloneParamCollectionsFrom(ParamManager* other, bool copyAutomation, bool cloneExpressionParams = false,
-	                                  int32_t reverseDirectionWithLength = 0);
-	int32_t beenCloned(int32_t reverseDirectionWithLength = 0); // Will clone Collections
+	ErrorType cloneParamCollectionsFrom(ParamManager* other, bool copyAutomation, bool cloneExpressionParams = false,
+	                                    int32_t reverseDirectionWithLength = 0);
+	ErrorType beenCloned(int32_t reverseDirectionWithLength = 0); // Will clone Collections
 	void forgetParamCollections();
 	void destructAndForgetParamCollections();
 	bool ensureExpressionParamSetExists(bool forDrum = false);

--- a/src/deluge/playback/mode/arrangement.cpp
+++ b/src/deluge/playback/mode/arrangement.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "playback/mode/arrangement.h"
+#include "definitions_cxx.hpp"
 #include "gui/ui/audio_recorder.h"
 #include "gui/ui/ui.h"
 #include "gui/views/arranger_view.h"
@@ -359,7 +360,7 @@ void Arrangement::resetPlayPos(int32_t newPos, bool doingComplete, int32_t butto
 			if (doingComplete && playbackHandler.recording != RecordingMode::OFF
 			    && output->wantsToBeginArrangementRecording()) {
 
-				int32_t error = output->possiblyBeginArrangementRecording(currentSong, newPos);
+				ErrorType error = output->possiblyBeginArrangementRecording(currentSong, newPos);
 				if (error) {
 					display->displayError(error);
 				}
@@ -485,8 +486,8 @@ void Arrangement::rowEdited(Output* output, int32_t startPos, int32_t endPos, Cl
 }
 
 // First, be sure the clipInstance has a Clip
-int32_t Arrangement::doUniqueCloneOnClipInstance(ClipInstance* clipInstance, int32_t newLength,
-                                                 bool shouldCloneRepeats) {
+ErrorType Arrangement::doUniqueCloneOnClipInstance(ClipInstance* clipInstance, int32_t newLength,
+                                                   bool shouldCloneRepeats) {
 	if (!currentSong->arrangementOnlyClips.ensureEnoughSpaceAllocated(1)) {
 		return ERROR_INSUFFICIENT_RAM;
 	}
@@ -496,7 +497,7 @@ int32_t Arrangement::doUniqueCloneOnClipInstance(ClipInstance* clipInstance, int
 	ModelStackWithTimelineCounter* modelStack =
 	    setupModelStackWithSong(modelStackMemory, currentSong)->addTimelineCounter(oldClip);
 
-	int32_t error = oldClip->clone(modelStack, true);
+	ErrorType error = oldClip->clone(modelStack, true);
 	if (error) {
 		return error;
 	}

--- a/src/deluge/playback/mode/arrangement.h
+++ b/src/deluge/playback/mode/arrangement.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "playback/mode/playback_mode.h"
 
 class ClipInstance;
@@ -47,8 +48,8 @@ public:
 	                                bool mayActuallyResumeClip = true);
 	void rowEdited(Output* output, int32_t startPos, int32_t endPos, Clip* clipRemoved,
 	               ClipInstance* clipInstanceAdded);
-	int32_t doUniqueCloneOnClipInstance(ClipInstance* clipInstance, int32_t newLength = -1,
-	                                    bool shouldCloneRepeats = false);
+	ErrorType doUniqueCloneOnClipInstance(ClipInstance* clipInstance, int32_t newLength = -1,
+	                                      bool shouldCloneRepeats = false);
 	int32_t getLivePos(uint32_t* timeRemainder = nullptr);
 	void endAnyLinearRecording();
 

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -325,7 +325,7 @@ bool AudioOutput::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song) {
 }
 
 // clip will always be NULL and is of no consequence - see note in parent output.h
-int32_t AudioOutput::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
+ErrorType AudioOutput::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 	char const* tagName;
 
 	ParamManagerForTimeline paramManager;
@@ -346,7 +346,7 @@ int32_t AudioOutput::readFromFile(Song* song, Clip* clip, int32_t readAutomation
 
 		else {
 
-			int32_t result = GlobalEffectableForClip::readTagFromFile(tagName, &paramManager, 0, song);
+			ErrorType result = GlobalEffectableForClip::readTagFromFile(tagName, &paramManager, 0, song);
 			if (result == NO_ERROR) {}
 			else if (result == RESULT_TAG_UNUSED) {
 				storageManager.exitTag();

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -49,7 +49,7 @@ public:
 	void getThingWithMostReverb(Sound** soundWithMostReverb, ParamManagerForTimeline** paramManagerWithMostReverb,
 	                            Kit** kitWithMostReverb, int32_t* highestReverbAmountFound);
 
-	int32_t readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
+	ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) override;
 	bool writeDataToFile(Clip* clipForSavingOutputOnly, Song* song);
 	void deleteBackedUpParamManagers(Song* song);
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack,

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1218,7 +1218,7 @@ void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySo
 		return;
 	}
 	range->sampleHolder.filePath.set(path);
-	int32_t error = range->sampleHolder.loadFile(false, true, true, CLUSTER_LOAD_IMMEDIATELY, filePointer);
+	ErrorType error = range->sampleHolder.loadFile(false, true, true, CLUSTER_LOAD_IMMEDIATELY, filePointer);
 
 	if (error) {
 		display->displayError(error); // Rare, shouldn't cause later problems.
@@ -1423,7 +1423,7 @@ void doRecorderCardRoutines() {
 			break;
 		}
 
-		int32_t error = recorder->cardRoutine();
+		ErrorType error = recorder->cardRoutine();
 		if (error) {
 			display->displayError(error);
 		}
@@ -1496,7 +1496,7 @@ void slowRoutine() {
 
 SampleRecorder* getNewRecorder(int32_t numChannels, AudioRecordingFolder folderID, AudioInputChannel mode,
                                bool keepFirstReasons, bool writeLoopPoints, int32_t buttonPressLatency) {
-	int32_t error;
+	ErrorType error;
 
 	void* recorderMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(SampleRecorder));
 	if (!recorderMemory) {

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -176,8 +176,8 @@ public:
 	void setUnisonStereoSpread(int32_t newAmount);
 	void setModulatorTranspose(int32_t m, int32_t value, ModelStackWithSoundFlags* modelStack);
 	void setModulatorCents(int32_t m, int32_t value, ModelStackWithSoundFlags* modelStack);
-	int32_t readFromFile(ModelStackWithModControllable* modelStack, int32_t readAutomationUpToPos,
-	                     ArpeggiatorSettings* arpSettings);
+	ErrorType readFromFile(ModelStackWithModControllable* modelStack, int32_t readAutomationUpToPos,
+	                       ArpeggiatorSettings* arpSettings);
 	void writeToFile(bool savingSong, ParamManager* paramManager, ArpeggiatorSettings* arpSettings);
 	bool allowNoteTails(ModelStackWithSoundFlags* modelStack, bool disregardSampleLoop = false);
 
@@ -205,7 +205,7 @@ public:
 	virtual bool isDrum() { return false; }
 	void setupAsSample(ParamManagerForTimeline* paramManager);
 	void recalculateAllVoicePhaseIncrements(ModelStackWithSoundFlags* modelStack);
-	int32_t loadAllAudioFiles(bool mayActuallyReadFiles);
+	ErrorType loadAllAudioFiles(bool mayActuallyReadFiles);
 	bool envelopeHasSustainCurrently(int32_t e, ParamManagerForTimeline* paramManager);
 	bool envelopeHasSustainEver(int32_t e, ParamManagerForTimeline* paramManager);
 	bool renderingOscillatorSyncCurrently(ParamManagerForTimeline* paramManager);
@@ -220,7 +220,7 @@ public:
 	static bool readParamTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager,
 	                                 int32_t readAutomationUpToPos);
 	static void initParams(ParamManager* paramManager);
-	static int32_t createParamManagerForLoading(ParamManagerForTimeline* paramManager);
+	static ErrorType createParamManagerForLoading(ParamManagerForTimeline* paramManager);
 	int32_t hasAnyTimeStretchSyncing(ParamManagerForTimeline* paramManager, bool getSampleLength = false,
 	                                 int32_t note = 0);
 	int32_t hasCutOrLoopModeSamples(ParamManagerForTimeline* paramManager, int32_t note, bool* anyLooping = NULL);
@@ -279,11 +279,11 @@ private:
 	void setupUnisonStereoSpread();
 	void calculateEffectiveVolume();
 	void ensureKnobReferencesCorrectVolume(Knob* knob);
-	int32_t readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos,
-	                        ArpeggiatorSettings* arpSettings, Song* song);
+	ErrorType readTagFromFile(char const* tagName, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos,
+	                          ArpeggiatorSettings* arpSettings, Song* song);
 
 	void writeSourceToFile(int32_t s, char const* tagName);
-	int32_t readSourceFromFile(int32_t s, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos);
+	ErrorType readSourceFromFile(int32_t s, ParamManagerForTimeline* paramManager, int32_t readAutomationUpToPos);
 	void stopSkippingRendering(ArpeggiatorSettings* arpSettings);
 	void startSkippingRendering(ModelStackWithSoundFlags* modelStack);
 	void getArpBackInTimeAfterSkippingRendering(ArpeggiatorSettings* arpSettings);

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "processing/sound/sound_drum.h"
+#include "definitions_cxx.hpp"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
 #include "gui/views/view.h"
@@ -131,7 +132,7 @@ void SoundDrum::setupPatchingForAllParamManagers(Song* song) {
 	song->setupPatchingForAllParamManagersForDrum(this);
 }
 
-int32_t SoundDrum::loadAllSamples(bool mayActuallyReadFiles) {
+ErrorType SoundDrum::loadAllSamples(bool mayActuallyReadFiles) {
 	return Sound::loadAllAudioFiles(mayActuallyReadFiles);
 }
 
@@ -155,7 +156,7 @@ void SoundDrum::writeToFile(bool savingSong, ParamManager* paramManager) {
 void SoundDrum::getName(char* buffer) {
 }
 
-int32_t SoundDrum::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
+ErrorType SoundDrum::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithModControllable* modelStack =
 	    setupModelStackWithSong(modelStackMemory, song)->addTimelineCounter(clip)->addModControllableButNoNoteRow(this);

--- a/src/deluge/processing/sound/sound_drum.h
+++ b/src/deluge/processing/sound/sound_drum.h
@@ -44,11 +44,11 @@ public:
 	void unassignAllVoices();
 	void setupPatchingForAllParamManagers(Song* song);
 	bool readTagFromFile(char const* tagName);
-	int32_t loadAllSamples(bool mayActuallyReadFiles);
+	ErrorType loadAllSamples(bool mayActuallyReadFiles);
 	void prepareForHibernation();
 	void writeToFile(bool savingSong, ParamManager* paramManager);
 	void getName(char* buffer);
-	int32_t readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
+	ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
 	void choke(ModelStackWithSoundFlags* modelStack);
 	void setSkippingRendering(bool newSkipping);
 	uint8_t* getModKnobMode();

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -74,7 +74,7 @@ bool SoundInstrument::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song)
 
 // arpSettings optional - no need if you're loading a new V2.0 song where Instruments are all separate from Clips and
 // won't store any arp stuff
-int32_t SoundInstrument::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
+ErrorType SoundInstrument::readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithModControllable* modelStack =
@@ -193,18 +193,18 @@ yesTickParamManagerForClip:
 	}
 }
 
-int32_t SoundInstrument::loadAllAudioFiles(bool mayActuallyReadFiles) {
+ErrorType SoundInstrument::loadAllAudioFiles(bool mayActuallyReadFiles) {
 
 	bool doingAlternatePath =
 	    mayActuallyReadFiles && (audioFileManager.alternateLoadDirStatus == AlternateLoadDirStatus::NONE_SET);
 	if (doingAlternatePath) {
-		int32_t error = setupDefaultAudioFileDir();
+		ErrorType error = setupDefaultAudioFileDir();
 		if (error) {
 			return error;
 		}
 	}
 
-	int32_t error = Sound::loadAllAudioFiles(mayActuallyReadFiles);
+	ErrorType error = Sound::loadAllAudioFiles(mayActuallyReadFiles);
 
 	if (doingAlternatePath) {
 		audioFileManager.thingFinishedLoading();

--- a/src/deluge/processing/sound/sound_instrument.h
+++ b/src/deluge/processing/sound/sound_instrument.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "model/instrument/melodic_instrument.h"
 #include "modulation/arpeggiator.h"
 #include "processing/sound/sound.h"
@@ -30,7 +31,7 @@ class SoundInstrument final : public Sound, public MelodicInstrument {
 public:
 	SoundInstrument();
 	bool writeDataToFile(Clip* clipForSavingOutputOnly, Song* song);
-	int32_t readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos);
+	ErrorType readFromFile(Song* song, Clip* clip, int32_t readAutomationUpToPos) override;
 	void cutAllSound();
 	bool noteIsOn(int32_t noteCode);
 
@@ -48,7 +49,7 @@ public:
 		return Sound::offerReceivedPitchBendToLearnedParams(fromDevice, channel, data1, data2, modelStack);
 	}
 
-	int32_t loadAllAudioFiles(bool mayActuallyReadFiles);
+	ErrorType loadAllAudioFiles(bool mayActuallyReadFiles);
 	void resyncLFOs();
 	ModControllable* toModControllable();
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs);

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -61,12 +61,10 @@ void Source::destructAllMultiRanges() {
 // Only to be called if already determined that oscType == OscType::SAMPLE
 int32_t Source::getLengthInSamplesAtSystemSampleRate(int32_t note, bool forTimeStretching) {
 	MultiRange* range = getRange(note);
-	if (range) {
+	if (range != nullptr) {
 		return ((SampleHolder*)range->getAudioFileHolder())->getLengthInSamplesAtSystemSampleRate(forTimeStretching);
 	}
-	else {
-		return 1; // Why did I put 1?
-	}
+	return 1; // Why did I put 1?
 }
 
 void Source::setCents(int32_t newCents) {
@@ -103,7 +101,7 @@ void Source::detachAllAudioFiles() {
 	}
 }
 
-int32_t Source::loadAllSamples(bool mayActuallyReadFiles) {
+ErrorType Source::loadAllSamples(bool mayActuallyReadFiles) {
 	for (int32_t e = 0; e < ranges.getNumElements(); e++) {
 		AudioEngine::logAction("Source::loadAllSamples");
 		if (!(e & 3)) {
@@ -258,7 +256,7 @@ possiblyDeleteRanges:
 			*/
 
 doChangeType:
-			int32_t error = ranges.changeType(multiRangeSize);
+			ErrorType error = ranges.changeType(multiRangeSize);
 			if (error) {
 				destructAllMultiRanges();
 				ranges.empty();

--- a/src/deluge/processing/source.h
+++ b/src/deluge/processing/source.h
@@ -54,7 +54,7 @@ public:
 	void recalculateFineTuner();
 	int32_t getLengthInSamplesAtSystemSampleRate(int32_t note, bool forTimeStretching = false);
 	void detachAllAudioFiles();
-	int32_t loadAllSamples(bool mayActuallyReadFiles);
+	ErrorType loadAllSamples(bool mayActuallyReadFiles);
 	void setReversed(bool newReversed);
 	int32_t getRangeIndex(int32_t note);
 	MultiRange* getRange(int32_t note);

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -28,7 +28,7 @@
 
 #define MAX_NUM_MARKERS 8
 
-int32_t AudioFile::loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTableWorkAtAllCosts) {
+ErrorType AudioFile::loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTableWorkAtAllCosts) {
 
 	// AIFF files will only be used for WaveTables if the user insists
 	if (type == AudioFileType::WAVETABLE && !makeWaveTableWorkAtAllCosts && isAiff) {
@@ -41,7 +41,7 @@ int32_t AudioFile::loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveT
 
 	uint32_t bytePos = reader->getBytePos();
 
-	int32_t error;
+	ErrorType error;
 	bool foundDataChunk = false; // Also applies to AIFF file's SSND chunk
 	bool foundFmtChunk = false;  // Also applies to AIFF file's COMM chunk
 	bool fileExplicitlySpecifiesSelfAsWaveTable = false;

--- a/src/deluge/storage/audio/audio_file.h
+++ b/src/deluge/storage/audio/audio_file.h
@@ -28,7 +28,7 @@ public:
 	AudioFile(AudioFileType newType) : type(newType) {}
 	~AudioFile() override = default;
 
-	int32_t loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTableWorkAtAllCosts);
+	ErrorType loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTableWorkAtAllCosts);
 	virtual void finalizeAfterLoad(uint32_t fileSize) {}
 
 	void addReason();

--- a/src/deluge/storage/audio/audio_file_holder.cpp
+++ b/src/deluge/storage/audio/audio_file_holder.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "storage/audio/audio_file_holder.h"
+#include "definitions_cxx.hpp"
 #include "storage/audio/audio_file.h"
 #include "storage/audio/audio_file_manager.h"
 
@@ -30,12 +31,12 @@ AudioFileHolder::~AudioFileHolder() {
 // Returns error, but NO_ERROR doesn't necessarily mean there's now a file loaded - it might be that filePath was NULL,
 // but that's not a problem. Or that the SD card would need to be accessed but we didn't have permission for that
 // (!mayActuallyReadFile).
-int32_t AudioFileHolder::loadFile(bool reversed, bool manuallySelected, bool mayActuallyReadFile,
-                                  int32_t clusterLoadInstruction, FilePointer* filePointer,
-                                  bool makeWaveTableWorkAtAllCosts) {
+ErrorType AudioFileHolder::loadFile(bool reversed, bool manuallySelected, bool mayActuallyReadFile,
+                                    int32_t clusterLoadInstruction, FilePointer* filePointer,
+                                    bool makeWaveTableWorkAtAllCosts) {
 
 	// See if this AudioFile object already all loaded up
-	if (audioFile) {
+	if (audioFile != nullptr) {
 		return NO_ERROR;
 	}
 
@@ -43,7 +44,7 @@ int32_t AudioFileHolder::loadFile(bool reversed, bool manuallySelected, bool may
 		return NO_ERROR; // This could happen if the filename tag wasn't present in the file
 	}
 
-	uint8_t error;
+	ErrorType error;
 	AudioFile* newAudioFile = audioFileManager.getAudioFileFromFilename(
 	    &filePath, mayActuallyReadFile, &error, filePointer, audioFileType, makeWaveTableWorkAtAllCosts);
 

--- a/src/deluge/storage/audio/audio_file_holder.h
+++ b/src/deluge/storage/audio/audio_file_holder.h
@@ -33,9 +33,9 @@ public:
 	virtual ~AudioFileHolder();
 	virtual void setAudioFile(AudioFile* newSample, bool reversed = false, bool manuallySelected = false,
 	                          int32_t clusterLoadInstruction = CLUSTER_ENQUEUE);
-	int32_t loadFile(bool reversed, bool manuallySelected, bool mayActuallyReadFile,
-	                 int32_t clusterLoadInstruction = CLUSTER_ENQUEUE, FilePointer* filePointer = NULL,
-	                 bool makeWaveTableWorkAtAllCosts = false);
+	ErrorType loadFile(bool reversed, bool manuallySelected, bool mayActuallyReadFile,
+	                   int32_t clusterLoadInstruction = CLUSTER_ENQUEUE, FilePointer* filePointer = NULL,
+	                   bool makeWaveTableWorkAtAllCosts = false);
 	virtual void unassignAllClusterReasons(bool beingDestructed = false) {}
 
 	String filePath;

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -72,7 +72,7 @@ void AudioFileManager::init() {
 
 	clusterBeingLoaded = NULL;
 
-	int32_t error = storageManager.initSD();
+	ErrorType error = storageManager.initSD();
 	if (!error) {
 		setClusterSize(fileSystemStuff.fileSystem.csize * 512);
 
@@ -250,11 +250,11 @@ void AudioFileManager::deleteAnyTempRecordedSamplesFromMemory() {
 
 // Oi, don't even think about modifying this to take a Sample* pointer - cos the whole Sample could get deleted during
 // the card access.
-int32_t AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
-                                                          AudioRecordingFolder folder, uint32_t* getNumber) {
+ErrorType AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
+                                                            AudioRecordingFolder folder, uint32_t* getNumber) {
 	const auto folderID = util::to_underlying(folder);
 
-	int32_t error = storageManager.initSD();
+	ErrorType error = storageManager.initSD();
 	if (error) {
 		return error;
 	}
@@ -390,10 +390,10 @@ bool AudioFileManager::ensureEnoughMemoryForOneMoreAudioFile() {
 	return audioFiles.ensureEnoughSpaceAllocated(1);
 }
 
-int32_t AudioFileManager::setupAlternateAudioFileDir(String* newPath, char const* rootDir,
-                                                     String* songFilenameWithoutExtension) {
+ErrorType AudioFileManager::setupAlternateAudioFileDir(String* newPath, char const* rootDir,
+                                                       String* songFilenameWithoutExtension) {
 
-	int32_t error = newPath->set(rootDir);
+	ErrorType error = newPath->set(rootDir);
 	if (error) {
 		return error;
 	}
@@ -411,8 +411,8 @@ int32_t AudioFileManager::setupAlternateAudioFileDir(String* newPath, char const
 	return NO_ERROR;
 }
 
-int32_t AudioFileManager::setupAlternateAudioFilePath(String* newPath, int32_t dirPathLength, String* oldPath) {
-	int32_t error = newPath->concatenateAtPos(&oldPath->get()[8], dirPathLength); // The [8] skips us past "SAMPLES/"
+ErrorType AudioFileManager::setupAlternateAudioFilePath(String* newPath, int32_t dirPathLength, String* oldPath) {
+	ErrorType error = newPath->concatenateAtPos(&oldPath->get()[8], dirPathLength); // The [8] skips us past "SAMPLES/"
 	if (error) {
 		return error;
 	}
@@ -426,7 +426,7 @@ int32_t AudioFileManager::setupAlternateAudioFilePath(String* newPath, int32_t d
 			break;
 		}
 		int32_t slashPos = (uint32_t)slashAddress - (uint32_t)newPathChars;
-		int32_t error = newPath->setChar('_', slashPos);
+		ErrorType error = newPath->setChar('_', slashPos);
 		if (error) {
 			return error;
 		}
@@ -436,7 +436,7 @@ int32_t AudioFileManager::setupAlternateAudioFilePath(String* newPath, int32_t d
 	return NO_ERROR;
 }
 
-AudioFile* AudioFileManager::getAudioFileFromFilename(String* filePath, bool mayReadCard, uint8_t* error,
+AudioFile* AudioFileManager::getAudioFileFromFilename(String* filePath, bool mayReadCard, ErrorType* error,
                                                       FilePointer* suppliedFilePointer, AudioFileType type,
                                                       bool makeWaveTableWorkAtAllCosts) {
 
@@ -1255,7 +1255,7 @@ void AudioFileManager::slowRoutine() {
 			// Otherwise, see if we can get it
 		}
 		else {
-			int32_t error = storageManager.initSD();
+			ErrorType error = storageManager.initSD();
 			if (!error) {
 				cardEjected = false;
 				cardReinserted();

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -78,7 +78,7 @@ public:
 	AudioFileVector audioFiles;
 
 	void init();
-	AudioFile* getAudioFileFromFilename(String* fileName, bool mayReadCard, uint8_t* error, FilePointer* filePointer,
+	AudioFile* getAudioFileFromFilename(String* fileName, bool mayReadCard, ErrorType* error, FilePointer* filePointer,
 	                                    AudioFileType type, bool makeWaveTableWorkAtAllCosts = false);
 	Cluster* allocateCluster(ClusterType type = ClusterType::Sample, bool shouldAddReasons = true,
 	                         void* dontStealFromThing = NULL);
@@ -93,11 +93,11 @@ public:
 
 	void slowRoutine();
 	void deallocateCluster(Cluster* cluster);
-	int32_t setupAlternateAudioFilePath(String* newPath, int32_t dirPathLength, String* oldPath);
-	int32_t setupAlternateAudioFileDir(String* newPath, char const* rootDir, String* songFilenameWithoutExtension);
+	ErrorType setupAlternateAudioFilePath(String* newPath, int32_t dirPathLength, String* oldPath);
+	ErrorType setupAlternateAudioFileDir(String* newPath, char const* rootDir, String* songFilenameWithoutExtension);
 	bool loadingQueueHasAnyLowestPriorityElements();
-	int32_t getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
-	                                        AudioRecordingFolder folderID, uint32_t* getNumber);
+	ErrorType getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
+	                                          AudioRecordingFolder folderID, uint32_t* getNumber);
 	void deleteAnyTempRecordedSamplesFromMemory();
 	void deleteUnusedAudioFileFromMemory(AudioFile* audioFile, int32_t i);
 	void deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile* audioFile);

--- a/src/deluge/storage/audio/audio_file_reader.cpp
+++ b/src/deluge/storage/audio/audio_file_reader.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "storage/audio/audio_file_reader.h"
+#include "definitions_cxx.hpp"
 #include "storage/audio/audio_file_manager.h"
 
 AudioFileReader::AudioFileReader() {
@@ -23,7 +24,7 @@ AudioFileReader::AudioFileReader() {
 }
 
 // One limitation of this function is that it can never read the final byte of the file. Not a problem for us
-int32_t AudioFileReader::readBytes(char* outputBuffer, int32_t num) {
+ErrorType AudioFileReader::readBytes(char* outputBuffer, int32_t num) {
 	if ((uint32_t)(getBytePos() + num) > fileSize) {
 		return ERROR_FILE_CORRUPTED;
 	}
@@ -43,7 +44,7 @@ uint32_t AudioFileReader::getBytePos() {
 	return byteIndexWithinCluster + currentClusterIndex * audioFileManager.clusterSize;
 }
 
-int32_t AudioFileReader::advanceClustersIfNecessary() {
+ErrorType AudioFileReader::advanceClustersIfNecessary() {
 
 	int32_t numClustersToAdvance = byteIndexWithinCluster >> audioFileManager.clusterSizeMagnitude;
 

--- a/src/deluge/storage/audio/audio_file_reader.h
+++ b/src/deluge/storage/audio/audio_file_reader.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include <cstdint>
 
 class AudioFile;
@@ -27,12 +28,12 @@ class AudioFile;
 class AudioFileReader {
 public:
 	AudioFileReader();
-	int32_t readBytes(char* outputBuffer, int32_t num);
-	virtual int32_t readBytesPassedErrorChecking(char* outputBuffer, int32_t num) = 0;
+	ErrorType readBytes(char* outputBuffer, int32_t num);
+	virtual ErrorType readBytesPassedErrorChecking(char* outputBuffer, int32_t num) = 0;
 	void jumpForwardToBytePos(uint32_t newPos);
 	uint32_t getBytePos();
-	int32_t advanceClustersIfNecessary();
-	virtual int32_t readNewCluster() = 0;
+	ErrorType advanceClustersIfNecessary();
+	virtual ErrorType readNewCluster() = 0;
 
 	int32_t currentClusterIndex;
 	int32_t byteIndexWithinCluster;

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -20,16 +20,9 @@
 #include "model/instrument/instrument.h"
 #include <cstring>
 
-FileItem::FileItem() {
-	filePointer = {0};
-	instrument = NULL;
-	filenameIncludesExtension = true;
-	instrumentAlreadyInSong = false;
-}
-
-int32_t FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernating) {
+ErrorType FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernating) {
 	filename.set(&newInstrument->name);
-	int32_t error = filename.concatenate(".XML");
+	ErrorType error = filename.concatenate(".XML");
 	if (error) {
 		return error;
 	}
@@ -49,10 +42,10 @@ int32_t FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernatin
 	return NO_ERROR;
 }
 
-int32_t FileItem::getFilenameWithExtension(String* filenameWithExtension) {
+ErrorType FileItem::getFilenameWithExtension(String* filenameWithExtension) {
 	filenameWithExtension->set(&filename);
 	if (!filenameIncludesExtension) {
-		int32_t error = filenameWithExtension->concatenate(".XML");
+		ErrorType error = filenameWithExtension->concatenate(".XML");
 		if (error) {
 			return error;
 		}
@@ -60,14 +53,14 @@ int32_t FileItem::getFilenameWithExtension(String* filenameWithExtension) {
 	return NO_ERROR;
 }
 
-int32_t FileItem::getFilenameWithoutExtension(String* filenameWithoutExtension) {
+ErrorType FileItem::getFilenameWithoutExtension(String* filenameWithoutExtension) {
 	filenameWithoutExtension->set(&filename);
 	if (filenameIncludesExtension) {
 		char const* chars = filenameWithoutExtension->get();
 		char const* dotAddress = strrchr(chars, '.');
 		if (dotAddress) {
 			int32_t newLength = (uint32_t)dotAddress - (uint32_t)chars;
-			int32_t error = filenameWithoutExtension->shorten(newLength);
+			ErrorType error = filenameWithoutExtension->shorten(newLength);
 			if (error) {
 				return error;
 			}
@@ -76,13 +69,13 @@ int32_t FileItem::getFilenameWithoutExtension(String* filenameWithoutExtension) 
 	return NO_ERROR;
 }
 
-int32_t FileItem::getDisplayNameWithoutExtension(String* displayNameWithoutExtension) {
+ErrorType FileItem::getDisplayNameWithoutExtension(String* displayNameWithoutExtension) {
 	if (display->haveOLED()) {
 		return getFilenameWithoutExtension(displayNameWithoutExtension);
 	}
 
 	// 7SEG...
-	int32_t error = displayNameWithoutExtension->set(displayName);
+	ErrorType error = displayNameWithoutExtension->set(displayName);
 	if (error) {
 		return error;
 	}

--- a/src/deluge/storage/file_item.h
+++ b/src/deluge/storage/file_item.h
@@ -23,19 +23,19 @@
 
 class FileItem {
 public:
-	FileItem();
-	int32_t setupWithInstrument(Instrument* newInstrument, bool hibernating);
-	int32_t getFilenameWithExtension(String* filenameWithExtension);
-	int32_t getFilenameWithoutExtension(String* filenameWithoutExtension);
-	int32_t getDisplayNameWithoutExtension(String* displayNameWithoutExtension);
+	FileItem() = default;
+	ErrorType setupWithInstrument(Instrument* newInstrument, bool hibernating);
+	ErrorType getFilenameWithExtension(String* filenameWithExtension);
+	ErrorType getFilenameWithoutExtension(String* filenameWithoutExtension);
+	ErrorType getDisplayNameWithoutExtension(String* displayNameWithoutExtension);
 
 	char const* displayName; // Usually points to filePointer.get(), but for "numeric" files, will cut off the prefix,
 	                         // e.g. "SONG". And I think this always includes the file extension...
 
 	String filename; // May or may not include file extension. (Or actually I think it always does now...)
-	FilePointer filePointer;
-	Instrument* instrument;
+	FilePointer filePointer{0};
+	Instrument* instrument = nullptr;
 	bool isFolder;
-	bool instrumentAlreadyInSong; // Only valid if instrument is set to something.
-	bool filenameIncludesExtension;
+	bool instrumentAlreadyInSong = false; // Only valid if instrument is set to something.
+	bool filenameIncludesExtension = true;
 };

--- a/src/deluge/storage/multi_range/multi_range_array.cpp
+++ b/src/deluge/storage/multi_range/multi_range_array.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "storage/multi_range/multi_range_array.h"
+#include "definitions_cxx.hpp"
 #include "storage/multi_range/multi_wave_table_range.h"
 #include "storage/multi_range/multisample_range.h"
 #include <new>
@@ -35,7 +36,7 @@ MultiRange* MultiRangeArray::getElement(int32_t i) {
 }
 
 MultiRange* MultiRangeArray::insertMultiRange(int32_t i) {
-	int32_t error = insertAtIndex(i);
+	ErrorType error = insertAtIndex(i);
 	if (error) {
 		return NULL;
 	}
@@ -51,7 +52,7 @@ MultiRange* MultiRangeArray::insertMultiRange(int32_t i) {
 	return range;
 }
 
-int32_t MultiRangeArray::changeType(int32_t newSize) {
+ErrorType MultiRangeArray::changeType(int32_t newSize) {
 
 	if (!numElements) {
 		elementSize = newSize;
@@ -60,7 +61,7 @@ int32_t MultiRangeArray::changeType(int32_t newSize) {
 
 	MultiRangeArray newArray;
 	newArray.elementSize = newSize;
-	int32_t error = newArray.insertAtIndex(0, numElements);
+	ErrorType error = newArray.insertAtIndex(0, numElements);
 	if (error) {
 		return error;
 	}

--- a/src/deluge/storage/multi_range/multi_range_array.h
+++ b/src/deluge/storage/multi_range/multi_range_array.h
@@ -28,5 +28,5 @@ public:
 	MultiRangeArray();
 	MultiRange* getElement(int32_t i);
 	MultiRange* insertMultiRange(int32_t i);
-	int32_t changeType(int32_t newSize);
+	ErrorType changeType(int32_t newSize);
 };

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1284,7 +1284,7 @@ void StorageManager::writeEarliestCompatibleFirmwareVersion(char const* versionS
 // Gets ready to access SD card.
 // You should call this before you're gonna do any accessing - otherwise any errors won't reflect if there's in fact
 // just no card inserted.
-int32_t StorageManager::initSD() {
+ErrorType StorageManager::initSD() {
 
 	FRESULT result;
 

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -65,47 +65,47 @@ public:
 	void exitTag(char const* exitTagName = NULL);
 	char const* readTagOrAttributeValue();
 
-	int32_t createFile(FIL* file, char const* filePath, bool mayOverwrite);
-	int32_t createXMLFile(char const* pathName, bool mayOverwrite = false, bool displayErrors = true);
-	int32_t openXMLFile(FilePointer* filePointer, char const* firstTagName, char const* altTagName = "",
-	                    bool ignoreIncorrectFirmware = false);
+	ErrorType createFile(FIL* file, char const* filePath, bool mayOverwrite);
+	ErrorType createXMLFile(char const* pathName, bool mayOverwrite = false, bool displayErrors = true);
+	ErrorType openXMLFile(FilePointer* filePointer, char const* firstTagName, char const* altTagName = "",
+	                      bool ignoreIncorrectFirmware = false);
 	bool prepareToReadTagOrAttributeValueOneCharAtATime();
 	char readNextCharOfTagOrAttributeValue();
 	char const* readNextCharsOfTagOrAttributeValue(int32_t numChars);
 	ErrorType initSD();
 	bool closeFile();
-	int32_t closeFileAfterWriting(char const* path = NULL, char const* beginningString = NULL,
-	                              char const* endString = NULL);
+	ErrorType closeFileAfterWriting(char const* path = nullptr, char const* beginningString = nullptr,
+	                                char const* endString = nullptr);
 	uint32_t readCharXML(char* thisChar);
 	void write(char const* output);
 	void writef(char const* format, ...);
 	bool lseek(uint32_t pos);
 	bool fileExists(char const* pathName);
 	bool fileExists(char const* pathName, FilePointer* fp);
-	int32_t openInstrumentFile(OutputType outputType, FilePointer* filePointer);
+	ErrorType openInstrumentFile(OutputType outputType, FilePointer* filePointer);
 	void writeFirmwareVersion();
 	bool checkSDPresent();
 	bool checkSDInitialized();
 	bool readXMLFileCluster();
 	int32_t getNumCharsRemainingInValue();
 	Instrument* createNewInstrument(OutputType newOutputType, ParamManager* getParamManager = NULL);
-	int32_t loadInstrumentFromFile(Song* song, InstrumentClip* clip, OutputType outputType,
-	                               bool mayReadSamplesFromFiles, Instrument** getInstrument, FilePointer* filePointer,
-	                               String* name, String* dirPath);
+	ErrorType loadInstrumentFromFile(Song* song, InstrumentClip* clip, OutputType outputType,
+	                                 bool mayReadSamplesFromFiles, Instrument** getInstrument, FilePointer* filePointer,
+	                                 String* name, String* dirPath);
 	Instrument* createNewNonAudioInstrument(OutputType outputType, int32_t slot, int32_t subSlot);
 	void writeEarliestCompatibleFirmwareVersion(char const* versionString);
-	int32_t readMIDIParamFromFile(int32_t readAutomationUpToPos, MIDIParamCollection* midiParamCollection,
-	                              int8_t* getCC = NULL);
+	ErrorType readMIDIParamFromFile(int32_t readAutomationUpToPos, MIDIParamCollection* midiParamCollection,
+	                                int8_t* getCC = NULL);
 	Drum* createNewDrum(DrumType drumType);
-	int32_t loadSynthToDrum(Song* song, InstrumentClip* clip, bool mayReadSamplesFromFiles, SoundDrum** getInstrument,
-	                        FilePointer* filePointer, String* name, String* dirPath);
+	ErrorType loadSynthToDrum(Song* song, InstrumentClip* clip, bool mayReadSamplesFromFiles, SoundDrum** getInstrument,
+	                          FilePointer* filePointer, String* name, String* dirPath);
 	void openFilePointer(FilePointer* fp);
-	int32_t tryReadingFirmwareTagFromFile(char const* tagName, bool ignoreIncorrectFirmware = false);
+	ErrorType tryReadingFirmwareTagFromFile(char const* tagName, bool ignoreIncorrectFirmware = false);
 	int32_t readTagOrAttributeValueInt();
 	int32_t readTagOrAttributeValueHex(int32_t errorValue);
 
-	int32_t readTagOrAttributeValueString(String* string);
-	int32_t checkSpaceOnCard();
+	ErrorType readTagOrAttributeValueString(String* string);
+	ErrorType checkSpaceOnCard();
 
 	SyncType readSyncTypeFromFile(Song* song);
 	void writeSyncTypeToFile(Song* song, char const* name, SyncType value, bool onNewLine = true);
@@ -149,12 +149,12 @@ private:
 	bool getIntoAttributeValue();
 	int32_t readAttributeValueInt();
 	bool readXMLFileClusterIfNecessary();
-	int32_t readStringUntilChar(String* string, char endChar);
-	int32_t readAttributeValueString(String* string);
+	ErrorType readStringUntilChar(String* string, char endChar);
+	ErrorType readAttributeValueString(String* string);
 	void restoreBackedUpCharIfNecessary();
 	void xmlReadDone();
 
-	int32_t writeBufferToFile();
+	ErrorType writeBufferToFile();
 };
 
 extern StorageManager storageManager;

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -72,7 +72,7 @@ public:
 	bool prepareToReadTagOrAttributeValueOneCharAtATime();
 	char readNextCharOfTagOrAttributeValue();
 	char const* readNextCharsOfTagOrAttributeValue(int32_t numChars);
-	int32_t initSD();
+	ErrorType initSD();
 	bool closeFile();
 	int32_t closeFileAfterWriting(char const* path = NULL, char const* beginningString = NULL,
 	                              char const* endString = NULL);

--- a/src/deluge/storage/wave_table/wave_table.h
+++ b/src/deluge/storage/wave_table/wave_table.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "storage/audio/audio_file.h"
 #include "storage/wave_table/wave_table_band_data.h"
 #include "util/container/array/ordered_resizeable_array.h"
@@ -46,9 +47,9 @@ public:
 	                bool doOscSync, uint32_t resetterPhase, uint32_t resetterPhaseIncrement,
 	                uint32_t resetterDivideByPhaseIncrement, uint32_t retriggerPhase, int32_t waveIndex,
 	                int32_t waveIndexIncrement);
-	int32_t setup(Sample* sample, int32_t nativeNumSamplesPerCycle = 0, uint32_t audioDataStartPosBytes = 0,
-	              uint32_t audioDataLengthBytes = 0, int32_t byteDepth = 0, int32_t rawDataFormat = 0,
-	              WaveTableReader* reader = NULL);
+	ErrorType setup(Sample* sample, int32_t nativeNumSamplesPerCycle = 0, uint32_t audioDataStartPosBytes = 0,
+	                uint32_t audioDataLengthBytes = 0, int32_t byteDepth = 0, int32_t rawDataFormat = 0,
+	                WaveTableReader* reader = NULL);
 	void deleteAllBandsAndData();
 	void bandDataBeingStolen(WaveTableBandData* bandData);
 

--- a/src/deluge/storage/wave_table/wave_table_reader.cpp
+++ b/src/deluge/storage/wave_table/wave_table_reader.cpp
@@ -16,17 +16,14 @@
  */
 
 #include "storage/wave_table/wave_table_reader.h"
+#include "definitions_cxx.hpp"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/storage_manager.h"
 
-WaveTableReader::WaveTableReader() {
-	// TODO Auto-generated constructor stub
-}
-
-int32_t WaveTableReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t num) {
+ErrorType WaveTableReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t num) {
 
 	while (num--) {
-		int32_t error = advanceClustersIfNecessary();
+		ErrorType error = advanceClustersIfNecessary();
 		if (error) {
 			return error;
 		}
@@ -39,7 +36,7 @@ int32_t WaveTableReader::readBytesPassedErrorChecking(char* outputBuffer, int32_
 	return NO_ERROR;
 }
 
-int32_t WaveTableReader::readNewCluster() {
+ErrorType WaveTableReader::readNewCluster() {
 
 	UINT bytesRead;
 	FRESULT result = f_read(&fileSystemStuff.currentFile, storageManager.fileClusterBuffer,
@@ -47,7 +44,5 @@ int32_t WaveTableReader::readNewCluster() {
 	if (result) {
 		return ERROR_SD_CARD; // Failed to load cluster from card
 	}
-	else {
-		return NO_ERROR;
-	}
+	return NO_ERROR;
 }

--- a/src/deluge/storage/wave_table/wave_table_reader.h
+++ b/src/deluge/storage/wave_table/wave_table_reader.h
@@ -17,11 +17,12 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "storage/audio/audio_file_reader.h"
 
 class WaveTableReader final : public AudioFileReader {
 public:
-	WaveTableReader();
-	int32_t readBytesPassedErrorChecking(char* outputBuffer, int32_t num);
-	int32_t readNewCluster();
+	WaveTableReader() = default;
+	ErrorType readBytesPassedErrorChecking(char* outputBuffer, int32_t num) override;
+	ErrorType readNewCluster() override;
 };

--- a/src/deluge/util/container/array/early_note_array.cpp
+++ b/src/deluge/util/container/array/early_note_array.cpp
@@ -29,7 +29,7 @@ int32_t EarlyNoteArray::insertElementIfNonePresent(int32_t note, int32_t velocit
 
 	if (i >= getNumElements()) {
 doInsert:
-		int32_t error = insertAtIndex(i);
+		ErrorType error = insertAtIndex(i);
 		if (error) {
 			return error;
 		}

--- a/src/deluge/util/container/array/ordered_resizeable_array.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array.cpp
@@ -245,7 +245,7 @@ int32_t OrderedResizeableArray::insertAtKey(int32_t key, bool isDefinitelyLast) 
 		i = search(key, GREATER_OR_EQUAL);
 	}
 
-	int32_t error = insertAtIndex(i);
+	ErrorType error = insertAtIndex(i);
 	if (error) {
 		return -1;
 	}
@@ -383,7 +383,7 @@ startAgain:
 
 			// if (numToInsert == 15) D_PRINTLN("inserting 15");
 
-			int32_t error = insertAtIndex(i, numToInsert);
+			ErrorType error = insertAtIndex(i, numToInsert);
 
 			if (error) {
 				D_PRINTLN("insert failed");

--- a/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
@@ -91,7 +91,7 @@ int32_t OrderedResizeableArrayWithMultiWordKey::insertAtKeyMultiWord(uint32_t* _
                                                                      int32_t rangeBegin, int32_t rangeEnd) {
 	int32_t i = searchMultiWord(keyWords, GREATER_OR_EQUAL, 0, rangeEnd);
 
-	int32_t error = insertAtIndex(i);
+	ErrorType error = insertAtIndex(i);
 	if (error) {
 		return -1;
 	}

--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -108,7 +108,7 @@ void ResizeableArray::empty() {
 }
 
 // Returns error
-int32_t ResizeableArray::beenCloned() {
+ErrorType ResizeableArray::beenCloned() {
 
 	LOCK_ENTRY
 
@@ -116,7 +116,7 @@ int32_t ResizeableArray::beenCloned() {
 	int32_t otherMemoryStart = memoryStart;
 	void* __restrict__ oldMemory = memory;
 
-	int32_t error = copyElementsFromOldMemory(oldMemory, otherMemorySize, otherMemoryStart);
+	ErrorType error = copyElementsFromOldMemory(oldMemory, otherMemorySize, otherMemoryStart);
 
 	LOCK_EXIT
 
@@ -128,7 +128,7 @@ bool ResizeableArray::cloneFrom(ResizeableArray* other) {
 	LOCK_ENTRY
 
 	numElements = other->numElements;
-	int32_t error = copyElementsFromOldMemory(other->memory, other->memorySize, other->memoryStart);
+	ErrorType error = copyElementsFromOldMemory(other->memory, other->memorySize, other->memoryStart);
 
 	LOCK_EXIT
 
@@ -136,8 +136,8 @@ bool ResizeableArray::cloneFrom(ResizeableArray* other) {
 }
 
 // Returns error
-int32_t ResizeableArray::copyElementsFromOldMemory(void* __restrict__ otherMemory, int32_t otherMemorySize,
-                                                   int32_t otherMemoryStart) {
+ErrorType ResizeableArray::copyElementsFromOldMemory(void* __restrict__ otherMemory, int32_t otherMemorySize,
+                                                     int32_t otherMemoryStart) {
 
 	memoryStart = 0;
 

--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -894,7 +894,7 @@ void ResizeableArray::setStaticMemory(void* newMemory, int32_t newMemorySize) {
 }
 
 // Returns error code
-int32_t ResizeableArray::insertAtIndex(int32_t i, int32_t numToInsert, void* thingNotToStealFrom) {
+ErrorType ResizeableArray::insertAtIndex(int32_t i, int32_t numToInsert, void* thingNotToStealFrom) {
 
 	if (ALPHA_OR_BETA_VERSION && (i < 0 || i > numElements || numToInsert < 1)) {
 		FREEZE_WITH_ERROR("E280");

--- a/src/deluge/util/container/array/resizeable_array.h
+++ b/src/deluge/util/container/array/resizeable_array.h
@@ -36,7 +36,7 @@ public:
 	void swapStateWith(ResizeableArray* other);
 	void deleteAtIndex(int32_t i, int32_t numToDelete = 1, bool mayShortenMemoryAfter = true);
 	bool ensureEnoughSpaceAllocated(int32_t numAdditionalElementsNeeded);
-	int32_t insertAtIndex(int32_t i, int32_t numToInsert = 1, void* thingNotToStealFrom = NULL);
+	ErrorType insertAtIndex(int32_t i, int32_t numToInsert = 1, void* thingNotToStealFrom = NULL);
 	void swapElements(int32_t i1, int32_t i2);
 	void repositionElement(int32_t iFrom, int32_t iTo);
 	int32_t beenCloned();

--- a/src/deluge/util/container/array/resizeable_array.h
+++ b/src/deluge/util/container/array/resizeable_array.h
@@ -39,7 +39,7 @@ public:
 	ErrorType insertAtIndex(int32_t i, int32_t numToInsert = 1, void* thingNotToStealFrom = NULL);
 	void swapElements(int32_t i1, int32_t i2);
 	void repositionElement(int32_t iFrom, int32_t iTo);
-	int32_t beenCloned();
+	ErrorType beenCloned();
 	void setMemory(void* newMemory, int32_t newMemorySize);
 	void setStaticMemory(void* newMemory, int32_t newMemorySize);
 
@@ -80,7 +80,7 @@ private:
 	                            void* thingNotToStealFrom);
 	void copyToNewMemory(void* newMemory, uint32_t destinationIndex, void* source, uint32_t numElementsToCopy,
 	                     uint32_t newMemorySize, uint32_t newMemoryStartIndex);
-	int32_t copyElementsFromOldMemory(void* otherMemory, int32_t otherMemorySize, int32_t otherMemoryStart);
+	ErrorType copyElementsFromOldMemory(void* otherMemory, int32_t otherMemorySize, int32_t otherMemoryStart);
 
 	void moveElementsRightNoWrap(int32_t oldStartIndex, int32_t oldStopIndex, int32_t distance);
 	void moveElementsLeftNoWrap(int32_t oldStartIndex, int32_t oldStopIndex, int32_t distance);

--- a/src/deluge/util/container/array/resizeable_pointer_array.cpp
+++ b/src/deluge/util/container/array/resizeable_pointer_array.cpp
@@ -21,8 +21,8 @@
 ResizeablePointerArray::ResizeablePointerArray() : ResizeableArray(sizeof(void*)) {
 }
 
-int32_t ResizeablePointerArray::insertPointerAtIndex(void* pointer, int32_t index) {
-	int32_t error = insertAtIndex(index);
+ErrorType ResizeablePointerArray::insertPointerAtIndex(void* pointer, int32_t index) {
+	ErrorType error = insertAtIndex(index);
 	if (error) {
 		return error;
 	}

--- a/src/deluge/util/container/array/resizeable_pointer_array.h
+++ b/src/deluge/util/container/array/resizeable_pointer_array.h
@@ -22,7 +22,7 @@
 class ResizeablePointerArray : public ResizeableArray {
 public:
 	ResizeablePointerArray();
-	int32_t insertPointerAtIndex(void* pointer, int32_t index);
+	ErrorType insertPointerAtIndex(void* pointer, int32_t index);
 	void* getPointerAtIndex(int32_t index);
 	void setPointerAtIndex(void* pointer, int32_t index);
 };

--- a/src/deluge/util/container/vector/named_thing_vector.cpp
+++ b/src/deluge/util/container/vector/named_thing_vector.cpp
@@ -74,7 +74,7 @@ String* NamedThingVector::getName(void* namedThing) {
 }
 
 // Returns error code
-int32_t NamedThingVector::insertElement(void* namedThing) {
+ErrorType NamedThingVector::insertElement(void* namedThing) {
 
 	String* name = getName(namedThing);
 
@@ -83,10 +83,10 @@ int32_t NamedThingVector::insertElement(void* namedThing) {
 	return insertElement(namedThing, i);
 }
 
-int32_t NamedThingVector::insertElement(void* namedThing, int32_t i) {
-	int32_t error = insertAtIndex(i, 1,
-	                              this); // While inserting, the stealing of any AudioFiles would cause a simultaneous
-	                                     // delete. They all know not to allow theft when passed this AudioFileVector.
+ErrorType NamedThingVector::insertElement(void* namedThing, int32_t i) {
+	// While inserting, the stealing of any AudioFiles would cause a simultaneous
+	// delete. They all know not to allow theft when passed this AudioFileVector.
+	ErrorType error = insertAtIndex(i, 1, this);
 	if (error) {
 		return error;
 	}

--- a/src/deluge/util/container/vector/named_thing_vector.h
+++ b/src/deluge/util/container/vector/named_thing_vector.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include "util/container/array/resizeable_array.h"
 
 #include "util/d_string.h"
@@ -37,8 +38,8 @@ public:
 	int32_t search(char const* searchString, int32_t comparison, bool* foundExact = NULL);
 	void* getElement(int32_t index);
 	void removeElement(int32_t i);
-	int32_t insertElement(void* namedThing);
-	int32_t insertElement(void* namedThing, int32_t i);
+	ErrorType insertElement(void* namedThing);
+	ErrorType insertElement(void* namedThing, int32_t i);
 	void renameMember(int32_t i, String* newName);
 
 	const int32_t stringOffset;

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "definitions_cxx.hpp"
 #include <cstdint>
 #include <cstring>
 extern "C" {
@@ -42,46 +43,50 @@ extern const char nothing;
 
 class String {
 public:
-	String();
+	String() = default;
 	// String(String* otherString); // BEWARE - using this on stack instances sometimes just caused crashes and stuff.
 	// Made no sense. Instead, constructing then calling set() works
 	~String();
 	void clear(bool destructing = false);
-	int32_t set(char const* newChars, int32_t newLength = -1);
+	ErrorType set(char const* newChars, int32_t newLength = -1);
 	void set(String* otherString);
 	void beenCloned();
-	int32_t getLength();
-	int32_t shorten(int32_t newLength);
-	int32_t concatenateAtPos(char const* newChars, int32_t pos, int32_t newCharsLength = -1);
-	int32_t concatenateInt(int32_t number, int32_t minNumDigits = 1);
-	int32_t setInt(int32_t number, int32_t minNumDigits = 1);
-	int32_t setChar(char newChar, int32_t pos);
-	int32_t concatenate(String* otherString);
-	int32_t concatenate(char const* newChars);
+	size_t getLength();
+	ErrorType shorten(int32_t newLength);
+	ErrorType concatenateAtPos(char const* newChars, int32_t pos, int32_t newCharsLength = -1);
+	ErrorType concatenateInt(int32_t number, int32_t minNumDigits = 1);
+	ErrorType setInt(int32_t number, int32_t minNumDigits = 1);
+	ErrorType setChar(char newChar, int32_t pos);
+	ErrorType concatenate(String* otherString);
+	ErrorType concatenate(char const* newChars);
 	bool equals(char const* otherChars);
 	bool equalsCaseIrrespective(char const* otherChars);
 
 	inline bool equals(String* otherString) {
-		if (stringMemory == otherString->stringMemory)
+		if (stringMemory == otherString->stringMemory) {
 			return true; // Works if both lengths are 0, too
-		if (!stringMemory || !otherString->stringMemory)
+		}
+		if (!stringMemory || !otherString->stringMemory) {
 			return false; // If just one is empty, then not equal
+		}
 		return equals(otherString->get());
 	}
 
 	inline bool equalsCaseIrrespective(String* otherString) {
-		if (stringMemory == otherString->stringMemory)
+		if (stringMemory == otherString->stringMemory) {
 			return true; // Works if both lengths are 0, too
-		if (!stringMemory || !otherString->stringMemory)
+		}
+		if (!stringMemory || !otherString->stringMemory) {
 			return false; // If just one is empty, then not equal
+		}
 		return equalsCaseIrrespective(otherString->get());
 	}
 
 	inline char const* get() {
-		if (!stringMemory)
+		if (!stringMemory) {
 			return &nothing;
-		else
-			return stringMemory;
+		}
+		return stringMemory;
 	}
 
 	inline bool isEmpty() { return !stringMemory; }
@@ -90,7 +95,7 @@ private:
 	int32_t getNumReasons();
 	void setNumReasons(int32_t newNum);
 
-	char* stringMemory;
+	char* stringMemory = nullptr;
 };
 
 /// A string buffer with utility functions to append and format contents.

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -2268,7 +2268,7 @@ bool doesFilenameFitPrefixFormat(char const* fileName, char const* filePrefix, i
 	return true;
 }
 
-int32_t fresultToDelugeErrorCode(FRESULT result) {
+ErrorType fresultToDelugeErrorCode(FRESULT result) {
 	switch (result) {
 	case FR_OK:
 		return NO_ERROR;

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -486,7 +486,7 @@ bool shouldAbortLoading();
 void getNoteLengthNameFromMagnitude(StringBuf& buf, int32_t magnitude, char const* durrationSuffix = "-notes",
                                     bool clarifyPerColumn = false);
 bool doesFilenameFitPrefixFormat(char const* fileName, char const* filePrefix, int32_t prefixLength);
-int32_t fresultToDelugeErrorCode(FRESULT result);
+ErrorType fresultToDelugeErrorCode(FRESULT result);
 
 [[gnu::always_inline]] inline void writeInt16(char** address, uint16_t number) {
 	*(uint16_t*)*address = number;

--- a/tests/unit/mocks/mock_display.cpp
+++ b/tests/unit/mocks/mock_display.cpp
@@ -25,7 +25,7 @@ public:
 	void cancelPopup(){};
 	void freezeWithError(char const* text) { std::cout << text << std::endl; };
 	bool isLayerCurrentlyOnTop(NumericLayer* layer) { return false; };
-	void displayError(int32_t error) { std::cout << error << std::endl; };
+	void displayError(ErrorType error) { std::cout << error << std::endl; };
 
 	void removeWorkingAnimation(){};
 


### PR DESCRIPTION
Now that we have a proper enum (ErrorType) for errors instead of macro definitions, functions that were previously returning errors typed as `int`/ `int32_t` can be properly refactored to return `ErrorType`