### PR TITLE
If less than 4 clusters for a voice, load them all

### DIFF
--- a/src/deluge/model/sample/sample_holder_for_voice.cpp
+++ b/src/deluge/model/sample/sample_holder_for_voice.cpp
@@ -91,6 +91,14 @@ void SampleHolderForVoice::claimClusterReasons(bool reversed, int32_t clusterLoa
 		                             clusterLoadInstruction);
 	}
 
+	else if (((Sample*)audioFile)->clusters.getNumElements() <= 4) {
+		// claim the next few reasons for the sample instead since we can keep it all cached
+		int32_t nextClusterStartByte =
+		    ((Sample*)audioFile)->audioDataStartPosBytes + audioFileManager.clusterSizeMagnitude << 1;
+
+		claimClusterReasonsForMarker(clustersForLoopStart, nextClusterStartByte, playDirection, clusterLoadInstruction);
+	}
+
 	// Or if no loop start point now, clear out any reasons we had before
 	else {
 		for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {


### PR DESCRIPTION
Mild performance gain - instead of caching the loop point, if the sample is small cache the whole thing