### PR TITLE
Flash OMODE and NMODE for 7Seg users when setting CUSTOM arp mode from pad shortcuts

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/note_mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/note_mode.h
@@ -26,7 +26,7 @@
 #include "processing/sound/sound.h"
 
 namespace deluge::gui::menu_item::arpeggiator {
-class NoteMode final : public Selection {
+class NoteMode : public Selection {
 public:
 	using Selection::Selection;
 	void readCurrentValue() override { this->setValue(soundEditor.currentArpSettings->noteMode); }
@@ -51,5 +51,16 @@ public:
 	}
 };
 
-extern NoteMode arpNoteModeMenu;
+class NoteModeFromOctaveMode final : public NoteMode {
+public:
+	using NoteMode::NoteMode;
+	void readCurrentValue() override {
+		if (display->have7SEG()) {
+			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NOTE_MODE));
+		}
+		NoteMode::readCurrentValue();
+	}
+};
+
+extern NoteModeFromOctaveMode arpNoteModeFromOctaveModeMenu;
 } // namespace deluge::gui::menu_item::arpeggiator

--- a/src/deluge/gui/menu_item/arpeggiator/octave_mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/octave_mode.h
@@ -52,7 +52,13 @@ public:
 class OctaveModeToNoteMode final : public OctaveMode {
 public:
 	using OctaveMode::OctaveMode;
-	MenuItem* selectButtonPress() override { return &arpeggiator::arpNoteModeMenu; }
+	void readCurrentValue() override {
+		if (display->have7SEG()) {
+			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_OCTAVE_MODE));
+		}
+		OctaveMode::readCurrentValue();
+	}
+	MenuItem* selectButtonPress() override { return &arpeggiator::arpNoteModeFromOctaveModeMenu; }
 };
 
 extern OctaveModeToNoteMode arpOctaveModeToNoteModeMenu;

--- a/src/deluge/gui/menu_item/arpeggiator/preset_mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/preset_mode.h
@@ -20,6 +20,7 @@
 #include "gui/menu_item/arpeggiator/octave_mode.h"
 #include "gui/menu_item/selection.h"
 #include "gui/ui/sound_editor.h"
+#include "hid/display/display.h"
 #include "model/clip/clip.h"
 #include "model/clip/instrument_clip.h"
 #include "model/model_stack.h"

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -305,7 +305,9 @@ arpeggiator::Octaves arpOctavesMenu{STRING_FOR_NUMBER_OF_OCTAVES, STRING_FOR_ARP
 arpeggiator::OctaveMode arpOctaveModeMenu{STRING_FOR_OCTAVE_MODE, STRING_FOR_ARP_OCTAVE_MODE_MENU_TITLE};
 arpeggiator::OctaveModeToNoteMode arpeggiator::arpOctaveModeToNoteModeMenu{STRING_FOR_OCTAVE_MODE,
                                                                            STRING_FOR_ARP_OCTAVE_MODE_MENU_TITLE};
-arpeggiator::NoteMode arpeggiator::arpNoteModeMenu{STRING_FOR_NOTE_MODE, STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
+arpeggiator::NoteMode arpNoteModeMenu{STRING_FOR_NOTE_MODE, STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
+arpeggiator::NoteModeFromOctaveMode arpeggiator::arpNoteModeFromOctaveModeMenu{STRING_FOR_NOTE_MODE,
+                                                                               STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
 arpeggiator::OnlyForSoundUnpatchedParam arpGateMenu{STRING_FOR_GATE, STRING_FOR_ARP_GATE_MENU_TITLE,
                                                     params::UNPATCHED_ARP_GATE};
 arpeggiator::midi_cv::Gate arpGateMenuMIDIOrCV{STRING_FOR_GATE, STRING_FOR_ARP_GATE_MENU_TITLE};
@@ -336,7 +338,7 @@ submenu::Arpeggiator arpMenu{
         &arpGateMenuMIDIOrCV,
         &arpOctavesMenu,
         &arpOctaveModeMenu,
-        &arpeggiator::arpNoteModeMenu,
+        &arpNoteModeMenu,
         &arpSequenceLengthMenu,
         &arpSequenceLengthMenuMIDIOrCV,
         &arpRatchetAmountMenu,


### PR DESCRIPTION
As the Octave Mode and Note Mode options for arp have similar options, it becomes difficult for user to know what they are editing when they select the arp preset Custom and go to OMODE and NMODE. This flashes the menu name when entering it

NOTE: must be cherry picked!!