### PR TITLE
Fix enumeration menu item value and offset wrapping bug

### DIFF
--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -13,48 +13,19 @@ void Enumeration::beginSession(MenuItem* navigatedBackwardFrom) {
 }
 
 void Enumeration::selectEncoderAction(int32_t offset) {
-	this->setValue(this->getValue() + offset);
 	int32_t numOptions = size();
-	int32_t sign = (offset < 0) ? -1 : ((offset > 0) ? 1 : 0);
+	int32_t startValue = getValue();
 
-	switch (numOptions) {
-	case 0:
-		[[fallthrough]];
-	case 1:
-		[[fallthrough]];
-	case 2:
-		offset = 1 * sign;
-		break;
-	case 3:
-		offset = std::min<int32_t>(offset * sign, 2) * sign;
-		break;
-	case 4:
-		offset = std::min<int32_t>(offset * sign, 3) * sign;
-		break;
-	case 5:
-		offset = std::min<int32_t>(offset * sign, 4) * sign;
-		break;
-	default:
-		break;
+	// valid values are [0, numOptions), so wrap as needed
+	int32_t nextValue = (startValue + offset) % numOptions;
+	if (nextValue < 0) {
+		nextValue += numOptions;
 	}
 
-	if (display->haveOLED()) {
-		if (this->getValue() >= numOptions) {
-			this->setValue(numOptions - 1);
-		}
-		else if (this->getValue() < 0) {
-			this->setValue(0);
-		}
-	}
-	else {
-		if (this->getValue() >= numOptions) {
-			this->setValue(this->getValue() - numOptions);
-		}
-		else if (this->getValue() < 0) {
-			this->setValue(this->getValue() + numOptions);
-		}
-	}
+	setValue(nextValue);
 
+	// reset offset to account for wrapping
+	offset = startValue - nextValue;
 	Value::selectEncoderAction(offset);
 }
 

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -25,7 +25,7 @@ void Enumeration::selectEncoderAction(int32_t offset) {
 	setValue(nextValue);
 
 	// reset offset to account for wrapping
-	offset = startValue - nextValue;
+	offset = nextValue - startValue;
 	Value::selectEncoderAction(offset);
 }
 

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -16,10 +16,16 @@ void Enumeration::selectEncoderAction(int32_t offset) {
 	int32_t numOptions = size();
 	int32_t startValue = getValue();
 
-	// valid values are [0, numOptions), so wrap as needed
-	int32_t nextValue = (startValue + offset) % numOptions;
-	if (nextValue < 0) {
-		nextValue += numOptions;
+	int32_t nextValue = startValue + offset;
+	// valid values are [0, numOptions), so wrap on 7SEG, clamp on OLED
+	if (display->haveOLED()) {
+		nextValue = std::clamp<int32_t>(nextValue, 0, numOptions - 1);
+	}
+	else {
+		nextValue = nextValue % numOptions;
+		if (nextValue < 0) {
+			nextValue += numOptions;
+		}
 	}
 
 	setValue(nextValue);

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -17,10 +17,10 @@ void Enumeration::selectEncoderAction(int32_t offset) {
 	int32_t startValue = getValue();
 
 	int32_t nextValue = startValue + offset;
-	// valid values are [0, numOptions), so wrap on 7SEG, clamp on OLED
-	if (display->haveOLED()) {
+	// valid values are [0, numOptions), so on OLED and in shif + select, clamp to valid values
+	if (display->haveOLED() || (offset > 1 || offset < -1)) {
 		nextValue = std::clamp<int32_t>(nextValue, 0, numOptions - 1);
-	}
+	} // 7SEG can wrap with +/-1 offset
 	else {
 		nextValue = nextValue % numOptions;
 		if (nextValue < 0) {


### PR DESCRIPTION
With the current code, if you go to the Community Features => Sysex menu (so that you are looking at the on or off option), hold shift, and scroll select up and down, the firmware will crash.

This seems to be because the code below doesn't properly handle wrapping the selected value to the [0, size()) range. I'm not completely sure my reading of what the code was trying to do is accurate (W.R.T. the sign and switch) or why anything would be different on OLED vs. 7SEG, so I may be missing something here.

This does fix the bug described above (setValue is never called with an invalid value), and to me seems reasonable (recalculate the offset as the difference between the old and new values before calling into the value).