### PR TITLE
Remove recursive render and include attempted audio clips in min voice calculation

### DIFF
--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -390,13 +390,6 @@ noEmptySpace:
 			return NULL;
 		}
 
-#if 0 && TEST_GENERAL_MEMORY_ALLOCATION
-		if (allocatedSize < requiredSize) {
-			D_PRINTLN("freeSomeStealableMemory() got too little memory");
-			while (1);
-		}
-#endif
-
 		// D_PRINTLN("Reclaimed");
 
 		// See if there was some extra space left over

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3192,7 +3192,7 @@ int32_t Song::getMaxMIDIChannelSuffix(int32_t channel) {
 	return 25; // "Z"
 }
 
-bool Song::getAnyClipsSoloing() {
+bool Song::getAnyClipsSoloing() const {
 	return anyClipsSoloing;
 }
 
@@ -4153,7 +4153,7 @@ traverseClips:
 	output->setActiveClip(modelStack);
 }
 
-bool Song::isClipActive(Clip* clip) {
+bool Song::isClipActive(Clip* clip) const {
 	return clip->soloingInSessionMode || (clip->activeIfNoSolo && !getAnyClipsSoloing());
 }
 
@@ -5519,7 +5519,7 @@ bool Song::hasAnyPendingNextOverdubs() {
 	return false;
 }
 
-int32_t Song::countAudioClips() {
+int32_t Song::countAudioClips() const {
 	int32_t i = 0;
 	for (Output* output = firstOutput; output; output = output->next) {
 		if (output->type == OutputType::AUDIO) {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5519,14 +5519,14 @@ bool Song::hasAnyPendingNextOverdubs() {
 	return false;
 }
 
-int32_t Song::countAudioClips() const {
+int32_t Song::countAudioClips() {
 	int32_t i = 0;
 	for (Output* output = firstOutput; output; output = output->next) {
 		if (output->type == OutputType::AUDIO) {
 			if (output->activeClip) {
 				AudioClip* clip = (AudioClip*)output->activeClip;
 				// this seems to be the only way to find whether the voice is sounding
-				if (clip->voiceSample && clip->voiceSample->oscPos > 0) {
+				if (isClipActive(clip)) {
 					i++;
 				}
 			}

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -383,7 +383,7 @@ public:
 	bool hasBeenTransposed = 0;
 	int16_t transposeOffset = 0;
 
-	int32_t countAudioClips() const;
+	int32_t countAudioClips();
 
 private:
 	bool fillModeActive;

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -218,7 +218,7 @@ public:
 
 	String dirPath;
 
-	bool getAnyClipsSoloing();
+	bool getAnyClipsSoloing() const;
 	Clip* getCurrentClip();
 	void setCurrentClip(Clip* clip) {
 		if (currentClip != nullptr) {
@@ -279,7 +279,7 @@ public:
 	void deleteOrAddToHibernationListOutput(Output* output);
 	int32_t getLowestSectionWithNoSessionClipForOutput(Output* output);
 	void assertActiveness(ModelStackWithTimelineCounter* modelStack, int32_t endInstanceAtTime = -1);
-	bool isClipActive(Clip* clip);
+	bool isClipActive(Clip* clip) const;
 	void sendAllMIDIPGMs();
 	void sortOutWhichClipsAreActiveWithoutSendingPGMs(ModelStack* modelStack, int32_t playbackWillStartInArrangerAtPos);
 	void deactivateAnyArrangementOnlyClips();
@@ -383,7 +383,7 @@ public:
 	bool hasBeenTransposed = 0;
 	int16_t transposeOffset = 0;
 
-	int32_t countAudioClips();
+	int32_t countAudioClips() const;
 
 private:
 	bool fillModeActive;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -851,14 +851,6 @@ startAgain:
 	renderingBufferOutputPos = renderingBuffer.begin();
 	renderingBufferOutputEnd = renderingBuffer.begin() + numSamples;
 
-	// doSomeOutputting();
-
-	/*
-	if (!getRandom255()) {
-	    D_PRINTLN("samples:  %d . voices:  %d", numSamples, getNumVoices());
-	}
-*/
-
 	bool anyGateOutputPending =
 	    cvEngine.gateOutputPending || cvEngine.clockOutputPending || cvEngine.asapGateOutputPending;
 
@@ -951,7 +943,7 @@ void routine() {
 	audioRoutineLocked = true;
 
 	numRoutines = 0;
-	while (doSomeOutputting() && numRoutines < 3) {
+	while (doSomeOutputting() && numRoutines < 2) {
 		numRoutines += 1;
 		routine_();
 		routineBeenCalled = true;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -456,6 +456,7 @@ void setDireness(size_t numSamples) { // Consider direness and culling - before 
 	}
 }
 
+/// inner loop of audio rendering, deliberately not in header
 void routine_() {
 #if JFTRACE
 	aeCtr.note();
@@ -910,12 +911,10 @@ startAgain:
 		for (int32_t i = 0; i < numAudioLogItems; i++) {
 			uint16_t timePassed = (uint16_t)audioLogTimes[i] - lastRoutineTime;
 			uint32_t timePassedUS = fastTimerCountToUS(timePassed);
-			D_PRINT("%d", timePassedUS);
-			D_PRINTLN(":  %s", audioLogStrings[i]);
+			D_PRINTLN("%d:  %s", timePassedUS, audioLogStrings[i]);
 		}
 
-		D_PRINT("%d", timePassedUSA);
-		D_PRINTLN(": end");
+		D_PRINTLN("%d: end", timePassedUSA);
 	}
 	definitelyLog = false;
 	lastRoutineTime = *TCNT[TIMER_SYSTEM_FAST];
@@ -948,6 +947,7 @@ void routine() {
 	}
 	audioRoutineLocked = false;
 }
+
 int32_t getNumSamplesLeftToOutputFromPreviousRender() {
 	return ((uint32_t)renderingBufferOutputEnd - (uint32_t)renderingBufferOutputPos) >> 3;
 }

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -529,7 +529,6 @@ void routine_() {
 
 	setDireness(numSamples);
 
-	bool shortenedWindow = false;
 	// Double the number of samples we're going to do - within some constraints
 	int32_t sampleThreshold = 6; // If too low, it'll lead to bigger audio windows and stuff
 	constexpr size_t maxAdjustedNumSamples = SSI_TX_BUFFER_NUM_SAMPLES;
@@ -601,7 +600,6 @@ startAgain:
 		// If the tick is during this window, shorten the window so we stop right at the tick
 		if (timeTilNextTick < numSamples) {
 			numSamples = timeTilNextTick;
-			shortenedWindow = true;
 		}
 
 		// And now we know how long the window's definitely going to be, see if we want to do any trigger clock or MIDI

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -268,10 +268,10 @@ Voice* cullVoice(bool saveVoice, bool justDoFastRelease, bool definitelyCull) {
 
 		if (ratingThisVoice > bestRating) {
 			// if we're not skipping releasing voices, or if we are and this one isn't in fast release
-			if (!skipReleasing || thisVoice->envelopes[0].state < EnvelopeStage::FAST_RELEASE) {
-				bestRating = ratingThisVoice;
-				bestVoice = thisVoice;
-			}
+			// if (!skipReleasing || thisVoice->envelopes[0].state < EnvelopeStage::FAST_RELEASE) {
+			bestRating = ratingThisVoice;
+			bestVoice = thisVoice;
+			//}
 		}
 	}
 
@@ -293,6 +293,14 @@ Voice* cullVoice(bool saveVoice, bool justDoFastRelease, bool definitelyCull) {
 				D_PRINTLN("soft-culled 1 voice.  numSamples:  %d. Voices left: %d", smoothedSamples, getNumVoices());
 #endif
 			}
+
+			else if (definitelyCull) {
+				unassignVoice(bestVoice, bestVoice->assignedToSound);
+#if ALPHA_OR_BETA_VERSION
+				D_PRINTLN("force-culled 1 voice.  numSamples:  %d. Voices left: %d", smoothedSamples, getNumVoices());
+#endif
+			}
+
 			else {
 				// Otherwise, it's already fast-releasing, so just leave it
 				D_PRINTLN("Didn't cull - best voice already releasing. numSamples:  %d. Voices left: %d",
@@ -408,7 +416,7 @@ void setDireness(size_t numSamples) { // Consider direness and culling - before 
 
 				// definitely do a soft cull (won't include audio clips)
 				cullVoice(false, true, true);
-				D_PRINTLN("forced cull");
+				logAction("forced cull");
 			}
 			// Or if it's just a little bit dire, do a soft cull with fade-out, but only cull for sure if numSamples is
 			// increasing
@@ -863,7 +871,7 @@ startAgain:
 	renderingBufferOutputPos = renderingBuffer.begin();
 	renderingBufferOutputEnd = renderingBuffer.begin() + numSamples;
 
-	doSomeOutputting();
+	// doSomeOutputting();
 
 	/*
 	if (!getRandom255()) {


### PR DESCRIPTION
Change the render routine from a recursive call to a loop, fixing an issue where it wasn't always tail call optimized

count all audio clips for min voice calculation - previously counted currently playing ones only, ignoring clips which were attempting to play and still loading from SD

slightly lower cull thresholds

force soft cull as a hard cull - soft culling a second voice is slower to react and leads to overculling

Fixes some issues with clicks and pops