### PR TITLE
Selection menu item should scroll on 7SEG

### DIFF
--- a/src/deluge/gui/menu_item/selection.cpp
+++ b/src/deluge/gui/menu_item/selection.cpp
@@ -10,7 +10,7 @@ void Selection::drawValue() {
 	}
 	if (display->have7SEG()) {
 		const auto options = this->getOptions();
-		display->setText(options[this->getValue()].data());
+		display->setScrollingText(options[this->getValue()].data());
 	}
 }
 


### PR DESCRIPTION
The sysex on menu item wasn't scrolling, so you couldn't see the hex code on 7SEG.