### PR TITLE
Update MIDI Follow Feedback to use MIDI Follow Channel's

### DIFF
--- a/docs/features/midi_follow_mode.md
+++ b/docs/features/midi_follow_mode.md
@@ -36,8 +36,7 @@ To use MIDI follow mode, you will need to configure the various MIDI Follow Mode
 - In the MIDI-Follow > Kit Root Note submenu, set the root note for kits between 1 and 127 in order to map MIDI Notes received to Kit rows. The root note corresponds to the bottom row in a Kit.
 - In the MIDI-Follow > Display Param submenu, enable or disable param pop-ups
 - In the MIDI-Follow > Feedback > Channel submenu, Enable or Disable MIDI follow feedback by setting a MIDI Follow Feedback Channel.
-  - You can quickly learn a Channel (and Device) by pressing LEARN and sending a CC/Note while in the Channel submenu
-  - You can quickly unlearn a Channel by pressing SHIFT + LEARN while in the Channel submenu
+  - You can choose MIDI Follow Channel A/B/C or NONE. Thus, when you update MIDI Follow Channel A/B/C it will automatically update the channel used for MIDI Feedback.
       - Note: if no Channel has been set, MIDI Feedback will be Disabled
 - In the MIDI-Follow > Feedback > Automation Feedback submenu, Enable or Disable MIDI follow feedback for automated parameters and set the rate at which feedback for automated parameters is sent
 - In the MIDI-Follow > Feedback > Filter Responses submenu, Enable or Disable filtering of responses received within 1 second of sending a MIDI feedback value update.
@@ -59,8 +58,8 @@ You can also use this method for updating the Kit Root Note. In the Kit Root Not
 
 You can unlearn a channel and device by pressing Shift + Learn while in the channel submenu's.
 
-If you unlearn all MIDI Follow channels, MIDI Follow Mode will be disabled.
-If you unlearn the MIDI Feedback channel, MIDI Feedback will be disabled.
+If you unlearn all MIDI Follow channels, MIDI Follow Mode will be disabled (including MIDI Feedback).
+If set the MIDI Feedback channel to NONE, MIDI Feedback will be disabled.
 
 You can also unlearn a channel using the Select encoder by scrolling between MPE Upper Zone and Channel 1.
 
@@ -135,7 +134,7 @@ Note: if the MIDI CC being received is for a Parameter that cannot be controlled
 2. When MIDI Follow Mode is enabled, a MIDI Follow Channel has been set, and you have mapped your MIDI CC's, your external controller's Notes and MIDI CC's will be automatically directed to control the Notes of the Active Instrument (e.g. Synth, Kit, MIDI, CV) or the Parameters of the Active View (e.g. Song View, Arranger View, Audio Clip View, Instrument Clip View).
 3. By default, the root note for kit's is C1 for the bottom kit row but this can be configured in the MIDI Follow menu.
 4. Pop-up's are shown on the display for mapped MIDI CC's to show the name of the parameter being controlled and value being set for the parameter. This can be disabled in the menu.
-5. MIDI feedback is sent for mapped CC's when the active context changes, change presets, or you change the value of a mapped parameter on the deluge (e.g. using mod encoders or select encoder if you're int he menu). MIDI feedback can be disabled in the menu by unlearning the MIDI feedback channel.
+5. MIDI feedback is sent for mapped CC's when the active context changes, change presets, or you change the value of a mapped parameter on the deluge (e.g. using mod encoders or select encoder if you're int he menu). MIDI feedback can be disabled in the menu by setting the MIDI feedback channel to NONE.
 6. MIDI feedback for automated parameters can also be sent and can be enabled or disabled in the MIDI feedback sub menu. When enabled, you choose between 3 speeds at which to send feedback for automated parameters: Low (500 ms), Medium (150 ms), High (40 ms). Sending automated parameter feedback can be taxing on the deluge MIDI output system, so depending on the amount of automation you do, you may want to adjust the speed (e.g. slow it down) to not affect the performance of the Deluge.
 7. MIDI feedback can cause an undesirable result with certain applications when the application responds back to the Deluge after the Deluge has sent it an updated value (Loopy Pro and Drambo on iPad are known to do this). This can cause lag in the deluge and potential feedback loops. To handle this, a toggable filter was added which ignores messages received for the same ccNumber within 1 second of sending a MIDI feedback update. If the application receiving the MIDI feedback update does not send responses back to the Deluge, then this setting should be set to Disabled in the MIDI Feedback Filter Responses sub menu.
     - Note: To control the deluge with midi follow while receiving midi automation feedback, MIDI Feedback Filter Responses needs to be disabled. If your device requires filter responses to be enabled to avoid a feedback loop, you cannot use that same device to control the deluge while automation feedback is being received - you will only be able to display the automation on your device.
@@ -148,7 +147,7 @@ If you experience MIDI stutter / lag while using MIDI follow mode, you may need 
 
 Things you can try:
 
-1) Disable MIDI Feedback altogether by unlearning the MIDI Feedback Channel. Press SHIFT + LEARN in the following sub-menu to disable MIDI Feedback: MIDI > MIDI-FOLLOW > FEEDBACK > CHANNEL 
+1) Disable MIDI Feedback altogether by setting the MIDI Feedback Channel to NONE in the following sub-menu: MIDI > MIDI-FOLLOW > FEEDBACK > CHANNEL 
 
 2) Disable MIDI Automation Feedback. Set the following menu to Disabled: MIDI > MIDI-FOLLOW > FEEDBACK > AUTOMATION FEEDBACK
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -672,9 +672,9 @@ enum class MIDIFollowChannelType : uint8_t {
 	A,
 	B,
 	C,
-	FEEDBACK,
+	NONE,
 };
-constexpr auto kNumMIDIFollowChannelTypes = util::to_underlying(MIDIFollowChannelType::FEEDBACK) + 1;
+constexpr auto kNumMIDIFollowChannelTypes = util::to_underlying(MIDIFollowChannelType::NONE);
 
 enum class MIDITransposeControlMethod : uint8_t {
 	INKEY,

--- a/src/deluge/gui/menu_item/midi/follow/follow_channel.h
+++ b/src/deluge/gui/menu_item/midi/follow/follow_channel.h
@@ -39,30 +39,27 @@ public:
 	void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
 		yPixel = 20;
 
-		if (channelType != MIDIFollowChannelType::FEEDBACK) {
-			char const* differentiationString;
-			if (MIDIDeviceManager::differentiatingInputsByDevice) {
-				differentiationString = l10n::get(l10n::String::STRING_FOR_INPUT_DIFFERENTIATION_ON);
-			}
-			else {
-				differentiationString = l10n::get(l10n::String::STRING_FOR_INPUT_DIFFERENTIATION_OFF);
-			}
-			deluge::hid::display::OLED::drawString(differentiationString, 0, yPixel,
-			                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-			                                       kTextSpacingX, kTextSizeYUpdated);
-
-			yPixel += kTextSpacingY;
-
-			char const* deviceString = l10n::get(l10n::String::STRING_FOR_FOLLOW_DEVICE_UNASSIGNED);
-			if (midiInput.device) {
-				deviceString = midiInput.device->getDisplayName();
-			}
-			deluge::hid::display::OLED::drawString(deviceString, 0, yPixel,
-			                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-			                                       kTextSpacingX, kTextSizeYUpdated);
-			deluge::hid::display::OLED::setupSideScroller(0, deviceString, kTextSpacingX, OLED_MAIN_WIDTH_PIXELS,
-			                                              yPixel, yPixel + 8, kTextSpacingX, kTextSpacingY, false);
+		char const* differentiationString;
+		if (MIDIDeviceManager::differentiatingInputsByDevice) {
+			differentiationString = l10n::get(l10n::String::STRING_FOR_INPUT_DIFFERENTIATION_ON);
 		}
+		else {
+			differentiationString = l10n::get(l10n::String::STRING_FOR_INPUT_DIFFERENTIATION_OFF);
+		}
+		deluge::hid::display::OLED::drawString(differentiationString, 0, yPixel,
+		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
+		                                       kTextSpacingX, kTextSizeYUpdated);
+
+		yPixel += kTextSpacingY;
+
+		char const* deviceString = l10n::get(l10n::String::STRING_FOR_FOLLOW_DEVICE_UNASSIGNED);
+		if (midiInput.device) {
+			deviceString = midiInput.device->getDisplayName();
+		}
+		deluge::hid::display::OLED::drawString(deviceString, 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
+		                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+		deluge::hid::display::OLED::setupSideScroller(0, deviceString, kTextSpacingX, OLED_MAIN_WIDTH_PIXELS, yPixel,
+		                                              yPixel + 8, kTextSpacingX, kTextSpacingY, false);
 
 		yPixel += kTextSpacingY;
 

--- a/src/deluge/gui/menu_item/midi/follow/follow_feedback_channel_type.h
+++ b/src/deluge/gui/menu_item/midi/follow/follow_feedback_channel_type.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include "definitions_cxx.hpp"
+#include "gui/l10n/l10n.h"
+#include "gui/menu_item/selection.h"
+#include "gui/ui/sound_editor.h"
+#include "io/midi/midi_engine.h"
+#include "util/misc.h"
+
+namespace deluge::gui::menu_item::midi {
+class FollowFeedbackChannelType final : public Selection {
+public:
+	using Selection::Selection;
+	void readCurrentValue() override { this->setValue(midiEngine.midiFollowFeedbackChannelType); }
+	void writeCurrentValue() override {
+		midiEngine.midiFollowFeedbackChannelType = this->getValue<MIDIFollowChannelType>();
+	}
+	deluge::vector<std::string_view> getOptions() override {
+		using enum l10n::String;
+		return {
+		    l10n::getView(STRING_FOR_FOLLOW_CHANNEL_A),
+		    l10n::getView(STRING_FOR_FOLLOW_CHANNEL_B),
+		    l10n::getView(STRING_FOR_FOLLOW_CHANNEL_C),
+		    l10n::getView(STRING_FOR_NONE),
+		};
+	}
+};
+} // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -69,6 +69,7 @@
 #include "gui/menu_item/midi/devices.h"
 #include "gui/menu_item/midi/follow/follow_channel.h"
 #include "gui/menu_item/midi/follow/follow_feedback_automation.h"
+#include "gui/menu_item/midi/follow/follow_feedback_channel_type.h"
 #include "gui/menu_item/midi/follow/follow_kit_root_note.h"
 #include "gui/menu_item/midi/mpe_to_mono.h"
 #include "gui/menu_item/midi/pgm.h"
@@ -851,8 +852,7 @@ midi::FollowChannel midiFollowChannelCMenu{STRING_FOR_FOLLOW_CHANNEL_C, STRING_F
 midi::FollowKitRootNote midiFollowKitRootNoteMenu{STRING_FOR_FOLLOW_KIT_ROOT_NOTE};
 ToggleBool midiFollowDisplayParamMenu{STRING_FOR_FOLLOW_DISPLAY_PARAM, STRING_FOR_FOLLOW_DISPLAY_PARAM,
                                       midiEngine.midiFollowDisplayParam};
-midi::FollowChannel midiFollowChannelFeedbackMenu{STRING_FOR_CHANNEL, STRING_FOR_CHANNEL,
-                                                  MIDIFollowChannelType::FEEDBACK};
+midi::FollowFeedbackChannelType midiFollowFeedbackChannelMenu{STRING_FOR_CHANNEL};
 midi::FollowFeedbackAutomation midiFollowFeedbackAutomationMenu{STRING_FOR_FOLLOW_FEEDBACK_AUTOMATION};
 ToggleBool midiFollowFeedbackFilterMenu{STRING_FOR_FOLLOW_FEEDBACK_FILTER, STRING_FOR_FOLLOW_FEEDBACK_FILTER,
                                         midiEngine.midiFollowFeedbackFilter};
@@ -871,7 +871,7 @@ Submenu midiFollowFeedbackSubmenu{
     STRING_FOR_FOLLOW_FEEDBACK,
     STRING_FOR_FOLLOW_FEEDBACK,
     {
-        &midiFollowChannelFeedbackMenu,
+        &midiFollowFeedbackChannelMenu,
         &midiFollowFeedbackAutomationMenu,
         &midiFollowFeedbackFilterMenu,
     },

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1405,20 +1405,23 @@ void View::notifyParamAutomationOccurred(ParamManager* paramManager, bool update
 }
 
 void View::sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam, int32_t knobPos, bool isAutomation) {
-	int32_t channel =
-	    midiEngine.midiFollowChannelType[util::to_underlying(MIDIFollowChannelType::FEEDBACK)].channelOrZone;
-	if ((channel != MIDI_CHANNEL_NONE) && activeModControllableModelStack.modControllable) {
-		if (modelStackWithParam && modelStackWithParam->autoParam) {
-			params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-			int32_t ccNumber = midiFollow.getCCFromParam(kind, modelStackWithParam->paramId);
-			if (ccNumber != MIDI_CC_NONE) {
-				((ModControllableAudio*)activeModControllableModelStack.modControllable)
-				    ->sendCCForMidiFollowFeedback(channel, ccNumber, knobPos);
+	if (midiEngine.midiFollowFeedbackChannelType != MIDIFollowChannelType::NONE) {
+		int32_t channel =
+		    midiEngine.midiFollowChannelType[util::to_underlying(midiEngine.midiFollowFeedbackChannelType)]
+		        .channelOrZone;
+		if ((channel != MIDI_CHANNEL_NONE) && activeModControllableModelStack.modControllable) {
+			if (modelStackWithParam && modelStackWithParam->autoParam) {
+				params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+				int32_t ccNumber = midiFollow.getCCFromParam(kind, modelStackWithParam->paramId);
+				if (ccNumber != MIDI_CC_NONE) {
+					((ModControllableAudio*)activeModControllableModelStack.modControllable)
+					    ->sendCCForMidiFollowFeedback(channel, ccNumber, knobPos);
+				}
 			}
-		}
-		else {
-			((ModControllableAudio*)activeModControllableModelStack.modControllable)
-			    ->sendCCWithoutModelStackForMidiFollowFeedback(channel, isAutomation);
+			else {
+				((ModControllableAudio*)activeModControllableModelStack.modControllable)
+				    ->sendCCWithoutModelStackForMidiFollowFeedback(channel, isAutomation);
+			}
 		}
 	}
 }

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -216,11 +216,12 @@ MidiEngine::MidiEngine() {
 	lastStatusByteSent = 0;
 	currentlyReceivingSysExSerial = false;
 	midiThru = false;
-	for (auto& midiChannelType : midiEngine.midiFollowChannelType) {
+	for (auto& midiChannelType : midiFollowChannelType) {
 		midiChannelType.clear();
 	}
 	midiFollowKitRootNote = 36;
 	midiFollowDisplayParam = false;
+	midiFollowFeedbackChannelType = MIDIFollowChannelType::NONE;
 	midiFollowFeedbackAutomation = MIDIFollowFeedbackAutomationMode::DISABLED;
 	midiFollowFeedbackFilter = false;
 	midiTakeover = MIDITakeoverMode::JUMP;

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -62,7 +62,8 @@ public:
 	LearnedMIDI globalMIDICommands[kNumGlobalMIDICommands];
 
 	bool midiThru;
-	LearnedMIDI midiFollowChannelType[kNumMIDIFollowChannelTypes]; // A, B, C, Feedback
+	LearnedMIDI midiFollowChannelType[kNumMIDIFollowChannelTypes]; // A, B, C
+	MIDIFollowChannelType midiFollowFeedbackChannelType;           // A, B, C, NONE
 	uint8_t midiFollowKitRootNote;
 	bool midiFollowDisplayParam;
 	MIDIFollowFeedbackAutomationMode midiFollowFeedbackAutomation;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -543,10 +543,9 @@ void MidiFollow::aftertouchReceived(MIDIDevice* fromDevice, int32_t channel, int
 
 /// obtain match to check if device is compatible with the midi follow channel
 /// a valid match is passed through to the instruments for further evaluation
-/// don't check for match to the midi feedback channel type
 MIDIMatchType MidiFollow::checkMidiFollowMatch(MIDIDevice* fromDevice, uint8_t channel) {
 	MIDIMatchType m = MIDIMatchType::NO_MATCH;
-	for (auto i = 0; i < (kNumMIDIFollowChannelTypes - 1); i++) {
+	for (auto i = 0; i < kNumMIDIFollowChannelTypes; i++) {
 		m = midiEngine.midiFollowChannelType[i].checkMatch(fromDevice, channel);
 		if (m != MIDIMatchType::NO_MATCH) {
 			return m;
@@ -556,10 +555,13 @@ MIDIMatchType MidiFollow::checkMidiFollowMatch(MIDIDevice* fromDevice, uint8_t c
 }
 
 bool MidiFollow::isFeedbackEnabled() {
-	uint8_t channel =
-	    midiEngine.midiFollowChannelType[util::to_underlying(MIDIFollowChannelType::FEEDBACK)].channelOrZone;
-	if (channel != MIDI_CHANNEL_NONE) {
-		return true;
+	if (midiEngine.midiFollowFeedbackChannelType != MIDIFollowChannelType::NONE) {
+		uint8_t channel =
+		    midiEngine.midiFollowChannelType[util::to_underlying(midiEngine.midiFollowFeedbackChannelType)]
+		        .channelOrZone;
+		if (channel != MIDI_CHANNEL_NONE) {
+			return true;
+		}
 	}
 	return false;
 }

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1984,17 +1984,20 @@ void ModControllableAudio::sendCCWithoutModelStackForMidiFollowFeedback(int32_t 
 
 /// called when updating parameter values using mod (gold) encoders or the select encoder in the soudnEditor menu
 void ModControllableAudio::sendCCForMidiFollowFeedback(int32_t channel, int32_t ccNumber, int32_t knobPos) {
-	LearnedMIDI& midiInput = midiEngine.midiFollowChannelType[util::to_underlying(MIDIFollowChannelType::FEEDBACK)];
+	if (midiEngine.midiFollowFeedbackChannelType != MIDIFollowChannelType::NONE) {
+		LearnedMIDI& midiInput =
+		    midiEngine.midiFollowChannelType[util::to_underlying(midiEngine.midiFollowFeedbackChannelType)];
 
-	if (midiInput.isForMPEZone()) {
-		channel = midiInput.getMasterChannel();
+		if (midiInput.isForMPEZone()) {
+			channel = midiInput.getMasterChannel();
+		}
+
+		int32_t midiOutputFilter = midiInput.channelOrZone;
+
+		midiEngine.sendCC(channel, ccNumber, knobPos + kKnobPosOffset, midiOutputFilter);
+
+		midiFollow.timeLastCCSent[ccNumber] = AudioEngine::audioSampleTimer;
 	}
-
-	int32_t midiOutputFilter = midiInput.channelOrZone;
-
-	midiEngine.sendCC(channel, ccNumber, knobPos + kKnobPosOffset, midiOutputFilter);
-
-	midiFollow.timeLastCCSent[ccNumber] = AudioEngine::audioSampleTimer;
 }
 
 /// based on the midi takeover default setting of JUMP, PICKUP, or SCALE


### PR DESCRIPTION
Updated the MIDI Follow Feedback Channel menu to select from the three available MIDI Follow Channels (A/B/C) or NONE

This ensures that if a MIDI Follow channel is unlearned, MIDI Feedback will be disabled as well.