### PR TITLE
Fixed Scale cycling, which was not possible from OTHER SCALE even if you emptied notes

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3054,7 +3054,7 @@ int32_t Song::getCurrentPresetScale() {
 		// If we're here, must be this one!
 		return p;
 
-notThisOne : {}
+notThisOne: {}
 	}
 
 	return CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
@@ -4972,7 +4972,7 @@ Instrument* Song::changeOutputType(Instrument* oldInstrument, OutputType newOutp
 			return NULL;
 		}
 
-gotAnInstrument : {}
+gotAnInstrument: {}
 	}
 
 	// Synth or Kit

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2920,16 +2920,10 @@ int32_t Song::cycleThroughScales() {
 		// If past the last scale, start from the beginning
 		newScale = 0;
 	}
-	int32_t result = setPresetScale(newScale);
-	if (result == CANT_SET_PRESET_BUT_MAJOR_IS_POSSIBLE) {
-		// We cycle back to the beginning of the list
-		result = setPresetScale(0);
-	}
-	return result;
+	return setPresetScale(newScale);
 }
 
 /// Returns CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES if there are more than 7 notes and no preset is possible.
-/// Returns CANT_SET_PRESET_BUT_MAJOR_IS_POSSIBLE if at least a 7-note scale is possible.
 int32_t Song::setPresetScale(int32_t newScale) {
 	int32_t numNotesInCurrentScale = numModeNotes;
 	int32_t numNotesInNewScale = 7;
@@ -2982,8 +2976,14 @@ traverseClips3:
 	if ((newScale >= 0 && notesWithinOctavePresentCount > 7)
 	    || (newScale >= FIRST_6_NOTE_SCALE_INDEX && notesWithinOctavePresentCount > 6)
 	    || (newScale >= FIRST_5_NOTE_SCALE_INDEX && notesWithinOctavePresentCount > 5)) {
-		return notesWithinOctavePresentCount <= 7 ? CANT_SET_PRESET_BUT_MAJOR_IS_POSSIBLE
-		                                          : CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
+		if (notesWithinOctavePresentCount <= 7) {
+			// We can cycle back to Major scale, becasue number of notes allows it
+			newScale = 0;
+			numNotesInNewScale = 7;
+		}
+		else {
+			return CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
+		}
 	}
 
 	// The new scale can perfectly fit all notes from the old one, so mark all notes to be transposed
@@ -3054,7 +3054,7 @@ int32_t Song::getCurrentPresetScale() {
 		// If we're here, must be this one!
 		return p;
 
-notThisOne: {}
+notThisOne : {}
 	}
 
 	return CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
@@ -4972,7 +4972,7 @@ Instrument* Song::changeOutputType(Instrument* oldInstrument, OutputType newOutp
 			return NULL;
 		}
 
-gotAnInstrument: {}
+gotAnInstrument : {}
 	}
 
 	// Synth or Kit

--- a/src/deluge/util/lookuptables/lookuptables.h
+++ b/src/deluge/util/lookuptables/lookuptables.h
@@ -135,7 +135,6 @@ extern const int16_t windowedSincKernelBasicForWavetableBetweenCycles[];
 #define FIRST_7_NOTE_SCALE_INDEX 0
 #define FIRST_6_NOTE_SCALE_INDEX 12
 #define FIRST_5_NOTE_SCALE_INDEX 14
-#define CANT_SET_PRESET_BUT_MAJOR_IS_POSSIBLE 254
 #define CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES 255
 extern const uint8_t presetScaleNotes[NUM_PRESET_SCALES][7];
 extern std::array<char const*, NUM_PRESET_SCALES> presetScaleNames;

--- a/src/deluge/util/lookuptables/lookuptables.h
+++ b/src/deluge/util/lookuptables/lookuptables.h
@@ -135,6 +135,8 @@ extern const int16_t windowedSincKernelBasicForWavetableBetweenCycles[];
 #define FIRST_7_NOTE_SCALE_INDEX 0
 #define FIRST_6_NOTE_SCALE_INDEX 12
 #define FIRST_5_NOTE_SCALE_INDEX 14
+#define CANT_SET_PRESET_BUT_MAJOR_IS_POSSIBLE 254
+#define CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES 255
 extern const uint8_t presetScaleNotes[NUM_PRESET_SCALES][7];
 extern std::array<char const*, NUM_PRESET_SCALES> presetScaleNames;
 #define PRESET_SCALE_RANDOM 254


### PR DESCRIPTION
Some user in discord complained that he had added more than 7 notes, getting him into the "OTHER SCALE" type of scale. But after he removed the extra notes from the clip, he couldn't do Shift + Scale to go back to normal scales. This PR fixes this by taking into account always, even if coming from OTHER SCALES, the real number of used notes.

NOTE: needs to be cherry picked as it is a fix for the "New scales" feature in 1.1