### PR TITLE
Render VUMeter in the Sidebar in Song, Arranger and Performance Views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added feature to automatically load song projects at startup.
     - To activate the feature, press `SHIFT` + `SELECT` : `MENU > DEFAULTS > STARTUP SONG`. 
     - Modes are `NEW SONG`,`TEMPLATE`,`LAST OPENED SONG`,`LAST SAVED SONG`.
-- Added `VU Meter` rendering on the grid in Song / Arranger Views. 
+- Added `VU Meter` rendering in the sidebar in Song / Arranger / Performance Views. 
 
 ## c1.1.0 Beethoven
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
 
 ### User Interface
 
-- Added feature to load automatically projects at startup.
-To activate the feature, press `SHIFT` + `SELECT` : `MENU > DEFAULTS > STARTUP SONG`. 
-Modes are `NEW SONG`,`TEMPLATE`,`LAST OPENED SONG`,`LAST SAVED SONG`.
+- Added feature to automatically load song projects at startup.
+    - To activate the feature, press `SHIFT` + `SELECT` : `MENU > DEFAULTS > STARTUP SONG`. 
+    - Modes are `NEW SONG`,`TEMPLATE`,`LAST OPENED SONG`,`LAST SAVED SONG`.
+- Added `VU Meter` rendering on the grid in Song / Arranger Views. 
 
 ## c1.1.0 Beethoven
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -272,7 +272,7 @@ Here is a list of features that have been added to the firmware as a list, group
 
 ### 4.1.8 - Added VU Meter rendering to Song / Arranger View
 
-- ([#1344]) Added `VU Meter` rendering on the grid in Song / Arranger Views. 
+- ([#1344]) Added `VU Meter` rendering in the sidebar in Song / Arranger / Performance Views. 
     - To display the VU meter:
       - turn `Affect Entire` on
       - select the `Volume mod button`

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -270,6 +270,26 @@ Here is a list of features that have been added to the firmware as a list, group
     - Does not affect audio clips or kit clips.
     - Works in Song Row/Grid View, Arranger View, Arranger Automation View and Performance View.
 
+### 4.1.8 - Added VU Meter rendering to Song / Arranger View
+
+- ([#1344]) Added `VU Meter` rendering on the grid in Song / Arranger Views. 
+    - To display the VU meter:
+      - turn `Affect Entire` on
+      - select the `Volume mod button`
+      - press the `Volume mod button` again to toggle the VU Meter on / off. 
+    - The VU meter will stop rendering if you switch mod button selections, turn affect entire off, select a clip, or exit Song/Arranger views.      
+    - The VU meter will render the decibels below clipping on the grid with the colours green, orange and red. 
+      - Red indicates clipping and is rendered on the top row of the grid. 
+      - Each row on the grid corresponds to the following decibels below clipping values:
+        - y7 = clipping (0 or higher)
+        - y6 = -4.4 to -0.1
+        - y5 = -8.8 to -4.5
+        - y4 = -13.2 to -8.9
+        - y3 = -17.6 to -13.3
+        - y2 = -22.0 to -17.7
+        - y1 = -26.4 to -22.1
+        - y0 = -30.8 to -26.5      
+
 ### 4.2 - Clip View - General Features (Instrument and Audio Clips)
 
 #### 4.2.1 - Filters
@@ -1001,6 +1021,10 @@ different firmware
 [#1198]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1198
 
 [#1251]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1251
+
+[#1272]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1272
+
+[#1344]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/src/deluge/dsp/envelope_follower/absolute_value.cpp
+++ b/src/deluge/dsp/envelope_follower/absolute_value.cpp
@@ -37,7 +37,7 @@ float AbsValueFollower::runEnvelope(float current, float desired, float numSampl
 
 // output range is 0-21 (2^31)
 // dac clipping is at 16
-stereo AbsValueFollower::calcRMS(StereoSample* buffer, uint16_t numSamples) {
+stereo AbsValueFollower::calcApproxRMS(StereoSample* buffer, uint16_t numSamples) {
 	StereoSample* thisSample = buffer;
 	StereoSample* bufferEnd = buffer + numSamples;
 	q31_t l = 0;

--- a/src/deluge/dsp/envelope_follower/absolute_value.cpp
+++ b/src/deluge/dsp/envelope_follower/absolute_value.cpp
@@ -37,12 +37,12 @@ float AbsValueFollower::runEnvelope(float current, float desired, float numSampl
 
 // output range is 0-21 (2^31)
 // dac clipping is at 16
-stereo AbsValueFollower::calcApproxRMS(StereoSample* buffer, uint16_t numSamples) {
+StereoFloatSample AbsValueFollower::calcApproxRMS(StereoSample* buffer, uint16_t numSamples) {
 	StereoSample* thisSample = buffer;
 	StereoSample* bufferEnd = buffer + numSamples;
 	q31_t l = 0;
 	q31_t r = 0;
-	stereo logMean;
+	StereoFloatSample logMean;
 
 	do {
 		l += std::abs(thisSample->l);

--- a/src/deluge/dsp/envelope_follower/absolute_value.h
+++ b/src/deluge/dsp/envelope_follower/absolute_value.h
@@ -45,7 +45,7 @@ public:
 		return releaseMS;
 	};
 
-	float calcRMS(StereoSample* buffer, uint16_t numSamples);
+	stereo calcRMS(StereoSample* buffer, uint16_t numSamples);
 
 private:
 	float runEnvelope(float current, float desired, float numSamples);
@@ -57,8 +57,10 @@ private:
 	// state
 	float state{0};
 	float rms{0};
-	float mean{0};
-	float lastMean{0};
+	float meanL{0};
+	float lastMeanL{0};
+	float meanR{0};
+	float lastMeanR{0};
 
 	// for display
 	float attackMS{1};

--- a/src/deluge/dsp/envelope_follower/absolute_value.h
+++ b/src/deluge/dsp/envelope_follower/absolute_value.h
@@ -45,7 +45,7 @@ public:
 		return releaseMS;
 	};
 
-	stereo calcApproxRMS(StereoSample* buffer, uint16_t numSamples);
+	StereoFloatSample calcApproxRMS(StereoSample* buffer, uint16_t numSamples);
 
 private:
 	float runEnvelope(float current, float desired, float numSamples);

--- a/src/deluge/dsp/envelope_follower/absolute_value.h
+++ b/src/deluge/dsp/envelope_follower/absolute_value.h
@@ -45,7 +45,7 @@ public:
 		return releaseMS;
 	};
 
-	stereo calcRMS(StereoSample* buffer, uint16_t numSamples);
+	stereo calcApproxRMS(StereoSample* buffer, uint16_t numSamples);
 
 private:
 	float runEnvelope(float current, float desired, float numSamples);

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -2086,6 +2086,10 @@ bool ArrangerView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth 
 		return true;
 	}
 
+	if (view.potentiallyRenderVUMeter(whichRows, image, occupancyMask)) {
+		return true;
+	}
+
 	PadLEDs::renderingLock = true;
 
 	uint32_t whichRowsCouldntBeRendered =
@@ -2978,6 +2982,11 @@ void ArrangerView::graphicsRoutine() {
 				// indicator_leds::setKnobIndicatorLevel(0, mv); //Input level LED
 			}
 		}
+		// if volume / pan mod button is selected, displayVUMeter is toggled on
+		// and we're not currently selecting a clip
+		if (modKnobMode == 0 && view.displayVUMeter && !getClipForSelection()) {
+			uiNeedsRendering(this);
+		}
 	}
 
 	if (PadLEDs::flashCursor != FLASH_CURSOR_OFF) {
@@ -3246,4 +3255,17 @@ void ArrangerView::clipNeedsReRendering(Clip* clip) {
 			break;
 		}
 	}
+}
+
+Clip* ArrangerView::getClipForSelection() {
+	Clip* clip = nullptr;
+	// if you're in arranger view, check if you're pressing a clip or holding audition pad to control that clip
+	if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW) && lastInteractedClipInstance) {
+		clip = lastInteractedClipInstance->clip;
+	}
+	else if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION)) {
+		Output* output = outputsOnScreen[yPressedEffective];
+		clip = currentSong->getClipWithOutput(output);
+	}
+	return clip;
 }

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -514,6 +514,10 @@ bool ArrangerView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth +
 		return true;
 	}
 
+	if (view.potentiallyRenderVUMeter(image)) {
+		return true;
+	}
+
 	for (int32_t i = 0; i < kDisplayHeight; i++) {
 		if (whichRows & (1 << i)) {
 			drawMuteSquare(i, image[i]);
@@ -2086,10 +2090,6 @@ bool ArrangerView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth 
 		return true;
 	}
 
-	if (view.potentiallyRenderVUMeter(whichRows, image, occupancyMask)) {
-		return true;
-	}
-
 	PadLEDs::renderingLock = true;
 
 	uint32_t whichRowsCouldntBeRendered =
@@ -2982,11 +2982,11 @@ void ArrangerView::graphicsRoutine() {
 				// indicator_leds::setKnobIndicatorLevel(0, mv); //Input level LED
 			}
 		}
-		// if volume / pan mod button is selected, displayVUMeter is toggled on
-		// and we're not currently selecting a clip
-		if (modKnobMode == 0 && view.displayVUMeter && !getClipForSelection()) {
-			uiNeedsRendering(this);
-		}
+	}
+
+	// if we're not currently selecting a clip
+	if (!getClipForSelection() && view.potentiallyRenderVUMeter(PadLEDs::image)) {
+		PadLEDs::sendOutSidebarColours();
 	}
 
 	if (PadLEDs::flashCursor != FLASH_CURSOR_OFF) {

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -121,6 +121,8 @@ public:
 	// ui
 	UIType getUIType() { return UIType::ARRANGER_VIEW; }
 
+	Clip* getClipForSelection();
+
 private:
 	void changeOutputType(OutputType newOutputType);
 	void moveClipToSession();

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -285,6 +285,13 @@ void PerformanceSessionView::graphicsRoutine() {
 		}
 	}
 
+	// if we're not currently selecting a clip
+	if (!((currentSong->lastClipInstanceEnteredStartPos != -1) && arrangerView.getClipForSelection())) {
+		if (view.potentiallyRenderVUMeter(PadLEDs::image)) {
+			PadLEDs::sendOutSidebarColours();
+		}
+	}
+
 	uint8_t tickSquares[kDisplayHeight];
 	uint8_t colours[kDisplayHeight];
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1384,6 +1384,10 @@ bool SessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + 
 		return true;
 	}
 
+	if (view.potentiallyRenderVUMeter(image)) {
+		return true;
+	}
+
 	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
 		return gridRenderSidebar(whichRows, image, occupancyMask);
 	}
@@ -2026,11 +2030,11 @@ void SessionView::graphicsRoutine() {
 				indicator_leds::setMeterLevel(1, gr); // Gain Reduction LED
 			}
 		}
-		// if volume / pan mod button is selected, displayVUMeter is toggled on
-		// and we're not currently selecting a clip
-		if (modKnobMode == 0 && view.displayVUMeter && !getClipForLayout()) {
-			uiNeedsRendering(this);
-		}
+	}
+
+	// if we're not currently selecting a clip
+	if (!getClipForLayout() && view.potentiallyRenderVUMeter(PadLEDs::image)) {
+		PadLEDs::sendOutSidebarColours();
 	}
 
 	uint8_t tickSquares[kDisplayHeight];
@@ -2356,10 +2360,6 @@ uint32_t SessionView::getGreyedOutRowsNotRepresentingOutput(Output* output) {
 bool SessionView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                  uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
 	if (!image) {
-		return true;
-	}
-
-	if (view.potentiallyRenderVUMeter(whichRows, image, occupancyMask)) {
 		return true;
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2026,6 +2026,11 @@ void SessionView::graphicsRoutine() {
 				indicator_leds::setMeterLevel(1, gr); // Gain Reduction LED
 			}
 		}
+		// if volume / pan mod button is selected, displayVUMeter is toggled on
+		// and we're not currently selecting a clip
+		if (modKnobMode == 0 && view.displayVUMeter && !getClipForLayout()) {
+			uiNeedsRendering(this);
+		}
 	}
 
 	uint8_t tickSquares[kDisplayHeight];
@@ -2354,6 +2359,10 @@ bool SessionView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth +
 		return true;
 	}
 
+	if (view.potentiallyRenderVUMeter(whichRows, image, occupancyMask)) {
+		return true;
+	}
+
 	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
 		return gridRenderMainPads(whichRows, image, occupancyMask, drawUndefinedArea);
 	}
@@ -2385,7 +2394,6 @@ bool SessionView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth +
 // Returns false if can't because in card routine
 bool SessionView::renderRow(ModelStack* modelStack, uint8_t yDisplay, RGB thisImage[kDisplayWidth + kSideBarWidth],
                             uint8_t thisOccupancyMask[kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
-
 	Clip* clip = getClipOnScreen(yDisplay);
 
 	if (clip) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1497,8 +1497,9 @@ void View::renderVUMeter(uint8_t yDisplay, RGB thisImage[kDisplayWidth + kSideBa
 	// dBFSForYDisplay calculates the minimum value of the dBFS ranged displayed for a given grid row (Y)
 	// 9 is the rmsLevel at which the sound becomes inaudible
 	// so for grid rendering purposes, any rmsLevel value below 9 doesn't get rendered on grid
-	// 4.3 is dBFS range for a given row
-	// 0.1 is added to the dBFS range for a given row to arriving at the minimum value for the next row
+	// -30.8 dBFS = (9 - 16.7) * 4
+	// 4.4 = 4.3 is dBFS range for a given row + 0.1
+	// 0.1 is added to the dBFS range for a given row to arrive at the minimum value for the next row
 	/*
 	y7 = clipping (0 or higher)
 	y6 = -4.4 to -0.1
@@ -1509,7 +1510,7 @@ void View::renderVUMeter(uint8_t yDisplay, RGB thisImage[kDisplayWidth + kSideBa
 	y1 = -26.4 to -22.1
 	y0 = -30.8 to -26.5
 	*/
-	float dBFSForYDisplay = ((9 - 16.7) * 4) + (yDisplay * 4.3) + (yDisplay * 0.1);
+	float dBFSForYDisplay = -30.8 + (yDisplay * 4.4);
 
 	// if dBFS >= dBFSForYDisplay it means that the dBFS value should be rendered in that Y row
 	if (dBFS >= dBFSForYDisplay) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -105,8 +105,8 @@ View::View() {
 	clipArmFlashOn = false;
 	displayVUMeter = false;
 	renderedVUMeter = false;
-	cachedMaxYDisplayForVUMeter.l = 255;
-	cachedMaxYDisplayForVUMeter.r = 255;
+	cachedMaxYDisplayForVUMeterL = 255;
+	cachedMaxYDisplayForVUMeterR = 255;
 }
 
 void View::focusRegained() {
@@ -120,8 +120,8 @@ void View::focusRegained() {
 
 	// when switching between UI's we want to start with a fresh VU meter render
 	renderedVUMeter = false;
-	cachedMaxYDisplayForVUMeter.l = 255;
-	cachedMaxYDisplayForVUMeter.r = 255;
+	cachedMaxYDisplayForVUMeterL = 255;
+	cachedMaxYDisplayForVUMeterR = 255;
 }
 
 void View::setTripletsLedState() {
@@ -1469,19 +1469,18 @@ bool View::potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]) 
 		PadLEDs::renderingLock = true;
 
 		// get max Y display that would be rendered based on AudioEngine::approxRMSLevel
-		vuMeter maxYDisplayForVUMeter;
-		maxYDisplayForVUMeter.l = getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.l);
-		maxYDisplayForVUMeter.r = getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.r);
+		int32_t maxYDisplayForVUMeterL = getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.l);
+		int32_t maxYDisplayForVUMeterR = getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.r);
 
 		// if we haven't yet rendered
 		// or previously rendered VU meter was rendered to a different maxYDisplay
 		// then we want to refresh the VU meter rendered in the sidebar
 		// if we've already rendered and maxYDisplay hasn't changed, no need to refresh sidebar image
-		if (!renderedVUMeter || (maxYDisplayForVUMeter.l != cachedMaxYDisplayForVUMeter.l)
-		    || (maxYDisplayForVUMeter.r != cachedMaxYDisplayForVUMeter.r)) {
+		if (!renderedVUMeter || (maxYDisplayForVUMeterL != cachedMaxYDisplayForVUMeterL)
+		    || (maxYDisplayForVUMeterR != cachedMaxYDisplayForVUMeterR)) {
 			// save maxYDisplay about to be rendered
-			cachedMaxYDisplayForVUMeter.l = maxYDisplayForVUMeter.l;
-			cachedMaxYDisplayForVUMeter.r = maxYDisplayForVUMeter.r;
+			cachedMaxYDisplayForVUMeterL = maxYDisplayForVUMeterL;
+			cachedMaxYDisplayForVUMeterR = maxYDisplayForVUMeterR;
 
 			// erase current image as it will be refreshed
 			for (int32_t y = 0; y < kDisplayHeight; y++) {
@@ -1490,13 +1489,13 @@ bool View::potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]) 
 			}
 
 			// render left VU meter
-			if (maxYDisplayForVUMeter.l != 255) {
-				renderVUMeter(maxYDisplayForVUMeter.l, kDisplayWidth, image);
+			if (maxYDisplayForVUMeterL != 255) {
+				renderVUMeter(maxYDisplayForVUMeterL, kDisplayWidth, image);
 			}
 
 			// render right VU meter
-			if (maxYDisplayForVUMeter.r != 255) {
-				renderVUMeter(maxYDisplayForVUMeter.r, kDisplayWidth + 1, image);
+			if (maxYDisplayForVUMeterR != 255) {
+				renderVUMeter(maxYDisplayForVUMeterR, kDisplayWidth + 1, image);
 			}
 			// save the VU meter rendering status so that grid can be refreshed later if required
 			// (e.g. if you switch mod buttons or turn off affect entire)

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1468,10 +1468,10 @@ bool View::potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]) 
 	    && *activeModControllableModelStack.modControllable->getModKnobMode() == 0) {
 		PadLEDs::renderingLock = true;
 
-		// get max Y display that would be rendered based on AudioEngine::rmsLevel
+		// get max Y display that would be rendered based on AudioEngine::approxRMSLevel
 		vuMeter maxYDisplayForVUMeter;
-		maxYDisplayForVUMeter.l = getMaxYDisplayForVUMeter(AudioEngine::rmsLevel.l);
-		maxYDisplayForVUMeter.r = getMaxYDisplayForVUMeter(AudioEngine::rmsLevel.r);
+		maxYDisplayForVUMeter.l = getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.l);
+		maxYDisplayForVUMeter.r = getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.r);
 
 		// if we haven't yet rendered
 		// or previously rendered VU meter was rendered to a different maxYDisplay
@@ -1518,14 +1518,14 @@ bool View::potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]) 
 
 int32_t View::getMaxYDisplayForVUMeter(float level) {
 	// dBFS (dB below clipping) calculation
-	// 16.7 = log(2^24) which is the rmsLevel at which clipping begins
+	// 16.7 = log(2^24) which is the approxRMSLevel at which clipping begins
 	float dBFS = (level - 16.7) * 4;
 	int32_t maxYDisplay = 255;
 
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 		// dBFSForYDisplay calculates the minimum value of the dBFS ranged displayed for a given grid row (Y)
-		// 9 is the rmsLevel at which the sound becomes inaudible
-		// so for grid rendering purposes, any rmsLevel value below 9 doesn't get rendered on grid
+		// 9 is the approxRMSLevel at which the sound becomes inaudible
+		// so for grid rendering purposes, any approxRMSLevel value below 9 doesn't get rendered on grid
 		// -30.8 dBFS = (9 - 16.7) * 4
 		// 4.4 = 4.3 is dBFS range for a given row + 0.1
 		// 0.1 is added to the dBFS range for a given row to arrive at the minimum value for the next row
@@ -1551,7 +1551,7 @@ int32_t View::getMaxYDisplayForVUMeter(float level) {
 	return maxYDisplay;
 }
 
-/// render AudioEngine::rmsLevel as a VU meter on the grid
+/// render AudioEngine::approxRMSLevel as a VU meter on the grid
 void View::renderVUMeter(int32_t maxYDisplay, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]) {
 	for (int32_t yDisplay = 0; yDisplay < (maxYDisplay + 1); yDisplay++) {
 		// y0 - y4 = green

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -133,16 +133,19 @@ public:
 	void sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam = nullptr, int32_t knobPos = kNoSelection,
 	                            bool isAutomation = false);
 
+	// vu meter rendering
 	bool displayVUMeter;
-	bool potentiallyRenderVUMeter(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
-	                              uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
+	bool potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]);
 
 private:
 	void pretendModKnobsUntouchedForAWhile();
 	void instrumentBeenEdited();
 	void clearMelodicInstrumentMonoExpressionIfPossible();
-	void renderVUMeter(uint8_t yDisplay, RGB thisImage[kDisplayWidth + kSideBarWidth],
-	                   uint8_t thisOccupancyMask[kDisplayWidth + kSideBarWidth]);
+
+	// vu meter rendering
+	int32_t getMaxYDisplayForVUMeter();
+	int32_t cachedMaxYDisplayForVUMeter;
+	void renderVUMeter(uint8_t maxYDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]);
 	bool renderedVUMeter;
 };
 

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -133,10 +133,17 @@ public:
 	void sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam = nullptr, int32_t knobPos = kNoSelection,
 	                            bool isAutomation = false);
 
+	bool displayVUMeter;
+	bool potentiallyRenderVUMeter(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
+	                              uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
+
 private:
 	void pretendModKnobsUntouchedForAWhile();
 	void instrumentBeenEdited();
 	void clearMelodicInstrumentMonoExpressionIfPossible();
+	void renderVUMeter(uint8_t yDisplay, RGB thisImage[kDisplayWidth + kSideBarWidth],
+	                   uint8_t thisOccupancyMask[kDisplayWidth + kSideBarWidth]);
+	bool renderedVUMeter;
 };
 
 extern View view;

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -24,6 +24,11 @@
 #include "modulation/params/param.h"
 #include <cstdint>
 
+struct vuMeter {
+	int32_t l;
+	int32_t r;
+};
+
 class InstrumentClip;
 class NoteRow;
 class UI;
@@ -143,9 +148,9 @@ private:
 	void clearMelodicInstrumentMonoExpressionIfPossible();
 
 	// vu meter rendering
-	int32_t getMaxYDisplayForVUMeter();
-	int32_t cachedMaxYDisplayForVUMeter;
-	void renderVUMeter(uint8_t maxYDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]);
+	int32_t getMaxYDisplayForVUMeter(float level);
+	vuMeter cachedMaxYDisplayForVUMeter;
+	void renderVUMeter(int32_t maxYDisplay, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]);
 	bool renderedVUMeter;
 };
 

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -24,11 +24,6 @@
 #include "modulation/params/param.h"
 #include <cstdint>
 
-struct vuMeter {
-	int32_t l;
-	int32_t r;
-};
-
 class InstrumentClip;
 class NoteRow;
 class UI;
@@ -149,7 +144,8 @@ private:
 
 	// vu meter rendering
 	int32_t getMaxYDisplayForVUMeter(float level);
-	vuMeter cachedMaxYDisplayForVUMeter;
+	int32_t cachedMaxYDisplayForVUMeterL;
+	int32_t cachedMaxYDisplayForVUMeterR;
 	void renderVUMeter(int32_t maxYDisplay, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]);
 	bool renderedVUMeter;
 };

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -131,7 +131,10 @@ Clip* getSelectedClip(bool useActiveClip) {
 		clip = arrangerView.getClipForSelection();
 		break;
 	case UIType::PERFORMANCE_SESSION_VIEW:
-		// if you're in performance view, no clip will be selected for param control
+		// if you're in the arranger performance view, check if you're holding audition pad
+		if (currentSong->lastClipInstanceEnteredStartPos != -1) {
+			clip = arrangerView.getClipForSelection();
+		}
 		break;
 	case UIType::AUTOMATION_VIEW:
 		if (automationView.getAutomationSubType() == AutomationSubType::ARRANGER) {

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -128,14 +128,7 @@ Clip* getSelectedClip(bool useActiveClip) {
 		clip = sessionView.getClipForLayout();
 		break;
 	case UIType::ARRANGER_VIEW:
-		// if you're in arranger view, check if you're pressing a clip or holding audition pad to control that clip
-		if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW) && arrangerView.lastInteractedClipInstance) {
-			clip = arrangerView.lastInteractedClipInstance->clip;
-		}
-		else if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION)) {
-			Output* output = arrangerView.outputsOnScreen[arrangerView.yPressedEffective];
-			clip = currentSong->getClipWithOutput(output);
-		}
+		clip = arrangerView.getClipForSelection();
 		break;
 	case UIType::PERFORMANCE_SESSION_VIEW:
 		// if you're in performance view, no clip will be selected for param control

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -122,7 +122,7 @@ uint32_t timeLastSideChainHit = 2147483648;
 int32_t sizeLastSideChainHit;
 
 Metronome metronome{};
-stereo approxRMSLevel{0};
+StereoFloatSample approxRMSLevel{0};
 AbsValueFollower envelopeFollower{};
 int32_t timeLastPopup{0};
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -122,7 +122,7 @@ uint32_t timeLastSideChainHit = 2147483648;
 int32_t sizeLastSideChainHit;
 
 Metronome metronome{};
-float rmsLevel{0};
+stereo rmsLevel{0};
 AbsValueFollower envelopeFollower{};
 int32_t timeLastPopup{0};
 
@@ -713,7 +713,7 @@ startAgain:
 	// Stop reverb after 12 seconds of inactivity
 	bool reverbOn = ((uint32_t)(audioSampleTimer - timeThereWasLastSomeReverb) < kSampleRate * 12);
 	// around the mutable noise floor, ~70dB from peak
-	reverbOn |= (rmsLevel > 9);
+	reverbOn |= (std::max(rmsLevel.l, rmsLevel.r) > 9);
 
 	if (reverbOn) {
 		// Patch that to reverb volume

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -122,7 +122,7 @@ uint32_t timeLastSideChainHit = 2147483648;
 int32_t sizeLastSideChainHit;
 
 Metronome metronome{};
-stereo rmsLevel{0};
+stereo approxRMSLevel{0};
 AbsValueFollower envelopeFollower{};
 int32_t timeLastPopup{0};
 
@@ -713,7 +713,7 @@ startAgain:
 	// Stop reverb after 12 seconds of inactivity
 	bool reverbOn = ((uint32_t)(audioSampleTimer - timeThereWasLastSomeReverb) < kSampleRate * 12);
 	// around the mutable noise floor, ~70dB from peak
-	reverbOn |= (std::max(rmsLevel.l, rmsLevel.r) > 9);
+	reverbOn |= (std::max(approxRMSLevel.l, approxRMSLevel.r) > 9);
 
 	if (reverbOn) {
 		// Patch that to reverb volume
@@ -800,7 +800,7 @@ startAgain:
 
 	metronome.render(renderingBuffer.data(), numSamples);
 
-	rmsLevel = envelopeFollower.calcRMS(renderingBuffer.data(), numSamples);
+	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), numSamples);
 
 	// Monitoring setup
 	doMonitoring = false;

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -203,5 +203,5 @@ extern Metronome metronome;
 extern RMSFeedbackCompressor mastercompressor;
 extern uint32_t timeLastSideChainHit;
 extern int32_t sizeLastSideChainHit;
-extern stereo approxRMSLevel;
+extern StereoFloatSample approxRMSLevel;
 } // namespace AudioEngine

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -203,5 +203,5 @@ extern Metronome metronome;
 extern RMSFeedbackCompressor mastercompressor;
 extern uint32_t timeLastSideChainHit;
 extern int32_t sizeLastSideChainHit;
-extern float rmsLevel;
+extern stereo rmsLevel;
 } // namespace AudioEngine

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -203,5 +203,5 @@ extern Metronome metronome;
 extern RMSFeedbackCompressor mastercompressor;
 extern uint32_t timeLastSideChainHit;
 extern int32_t sizeLastSideChainHit;
-extern stereo rmsLevel;
+extern stereo approxRMSLevel;
 } // namespace AudioEngine

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -203,4 +203,5 @@ extern Metronome metronome;
 extern RMSFeedbackCompressor mastercompressor;
 extern uint32_t timeLastSideChainHit;
 extern int32_t sizeLastSideChainHit;
+extern float rmsLevel;
 } // namespace AudioEngine

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -503,7 +503,7 @@ extern char miscStringBuffer[];
 constexpr size_t kShortStringBufferSize = 64;
 extern char shortStringBuffer[];
 
-struct stereo {
+struct StereoFloatSample {
 	float l;
 	float r;
 };

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -502,3 +502,8 @@ extern char miscStringBuffer[];
 
 constexpr size_t kShortStringBufferSize = 64;
 extern char shortStringBuffer[];
+
+struct stereo {
+	float l;
+	float r;
+};


### PR DESCRIPTION
Added `VU Meter` rendering in the sidebar in Song / Arranger / Performance Views. 

- To display the VU meter:
  - turn `Affect Entire` on
  - select the `Volume mod button`
  - press the `Volume mod button` again to toggle the VU Meter on / off. 
  
- The VU meter will stop rendering if you switch mod button selections, turn affect entire off, select a clip or exit Song/Arranger views.  
  
- The VU meter will render the decibels below clipping on the grid with the colours green, orange and red. 
  - Red indicates clipping and is rendered on the top row of the grid. 
  - Each row on the grid corresponds to the following decibels below clipping values:
  
        y7 = clipping (0 or higher)
        y6 = -4.4 to -0.1
        y5 = -8.8 to -4.5
        y4 = -13.2 to -8.9
        y3 = -17.6 to -13.3
        y2 = -22.0 to -17.7
        y1 = -26.4 to -22.1
        y0 = -30.8 to -26.5 