### PR TITLE
limit quantization to values which work

### DIFF
--- a/src/deluge/gui/menu_item/record/quantize.h
+++ b/src/deluge/gui/menu_item/record/quantize.h
@@ -22,6 +22,8 @@ namespace deluge::gui::menu_item::record {
 class Quantize final : public sync_level::RelativeToSong {
 public:
 	using RelativeToSong::RelativeToSong;
+	// can't do triplets/dots for quantize
+	size_t size() override { return SYNC_TYPE_TRIPLET; }
 	void readCurrentValue() { this->setValue(FlashStorage::recordQuantizeLevel); }
 	void writeCurrentValue() { FlashStorage::recordQuantizeLevel = this->getValue(); }
 };


### PR DESCRIPTION
In official the list is 10 items - the triplets/dotted support extended that, but in the case of quantizaiton they don't work and cause notes to fail to record