### PR TITLE
Render VUMeter in the Sidebar in Song, Arranger and Performance Views…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
   sets it momentarily and tapping latches it. The functionality can be changed by holding the top pad and scrolling
   select.
 - Updated the count-in setting to allow specifying the number of bars (1-4).
+- Added `VU Meter` rendering in the sidebar in Song / Arranger / Performance Views. 
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -271,6 +271,26 @@ Here is a list of features that have been added to the firmware as a list, group
     - Does not affect audio clips or kit clips.
     - Works in Song Row/Grid View, Arranger View, Arranger Automation View and Performance View.
 
+### 4.1.8 - Added VU Meter rendering to Song / Arranger View
+
+- ([#1344]) Added `VU Meter` rendering in the sidebar in Song / Arranger / Performance Views. 
+    - To display the VU meter:
+      - turn `Affect Entire` on
+      - select the `Volume mod button`
+      - press the `Volume mod button` again to toggle the VU Meter on / off. 
+    - The VU meter will stop rendering if you switch mod button selections, turn affect entire off, select a clip, or exit Song/Arranger views.      
+    - The VU meter will render the decibels below clipping on the grid with the colours green, orange and red. 
+      - Red indicates clipping and is rendered on the top row of the grid. 
+      - Each row on the grid corresponds to the following decibels below clipping values:
+        - y7 = clipping (0 or higher)
+        - y6 = -4.4 to -0.1
+        - y5 = -8.8 to -4.5
+        - y4 = -13.2 to -8.9
+        - y3 = -17.6 to -13.3
+        - y2 = -22.0 to -17.7
+        - y1 = -26.4 to -22.1
+        - y0 = -30.8 to -26.5      
+
 ### 4.2 - Clip View - General Features (Instrument and Audio Clips)
 
 #### 4.2.1 - Filters
@@ -1007,6 +1027,10 @@ different firmware
 [#1198]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1198
 
 [#1251]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1251
+
+[#1272]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1272
+
+[#1344]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/src/deluge/dsp/envelope_follower/absolute_value.cpp
+++ b/src/deluge/dsp/envelope_follower/absolute_value.cpp
@@ -37,31 +37,35 @@ float AbsValueFollower::runEnvelope(float current, float desired, float numSampl
 
 // output range is 0-21 (2^31)
 // dac clipping is at 16
-float AbsValueFollower::calcRMS(StereoSample* buffer, uint16_t numSamples) {
+StereoFloatSample AbsValueFollower::calcApproxRMS(StereoSample* buffer, uint16_t numSamples) {
 	StereoSample* thisSample = buffer;
 	StereoSample* bufferEnd = buffer + numSamples;
-	q31_t sum = 0;
+	q31_t l = 0;
+	q31_t r = 0;
+	StereoFloatSample logMean;
 
 	do {
-		q31_t l = thisSample->l;
-		q31_t r = thisSample->r;
-		q31_t s = std::max(std::abs(l), std::abs(r));
-		sum += s;
-
+		l += std::abs(thisSample->l);
+		r += std::abs(thisSample->r);
 	} while (++thisSample != bufferEnd);
 
 	auto ns = float(numSamples);
-	mean = (float(sum)) / ns;
+	meanL = (float(l)) / ns;
+	meanR = (float(r)) / ns;
 	// warning this is not good math but it's pretty close and way cheaper than doing it properly
 	// good math would use a long FIR, this is a one pole IIR instead
 	// the more samples we have, the more weight we put on the current mean to avoid response slowing down
 	// at high cpu loads
-	mean = (mean * ns + lastMean) / (1 + ns);
+	meanL = (meanL * ns + lastMeanL) / (1 + ns);
+	meanR = (meanR * ns + lastMeanR) / (1 + ns);
 
-	lastMean = runEnvelope(lastMean, mean, numSamples);
-	float logmean = std::log(lastMean + 1e-24f);
+	lastMeanL = runEnvelope(lastMeanL, meanL, numSamples);
+	logMean.l = std::log(lastMeanL + 1e-24f);
 
-	return logmean;
+	lastMeanR = runEnvelope(lastMeanR, meanR, numSamples);
+	logMean.r = std::log(lastMeanR + 1e-24f);
+
+	return logMean;
 }
 // takes in knob positions in the range 0-ONE_Q31
 void AbsValueFollower::setup(q31_t a, q31_t r) {

--- a/src/deluge/dsp/envelope_follower/absolute_value.h
+++ b/src/deluge/dsp/envelope_follower/absolute_value.h
@@ -45,7 +45,7 @@ public:
 		return releaseMS;
 	};
 
-	float calcRMS(StereoSample* buffer, uint16_t numSamples);
+	StereoFloatSample calcApproxRMS(StereoSample* buffer, uint16_t numSamples);
 
 private:
 	float runEnvelope(float current, float desired, float numSamples);
@@ -57,8 +57,10 @@ private:
 	// state
 	float state{0};
 	float rms{0};
-	float mean{0};
-	float lastMean{0};
+	float meanL{0};
+	float lastMeanL{0};
+	float meanR{0};
+	float lastMeanR{0};
 
 	// for display
 	float attackMS{1};

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -514,6 +514,10 @@ bool ArrangerView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth +
 		return true;
 	}
 
+	if (view.potentiallyRenderVUMeter(image)) {
+		return true;
+	}
+
 	for (int32_t i = 0; i < kDisplayHeight; i++) {
 		if (whichRows & (1 << i)) {
 			drawMuteSquare(i, image[i]);
@@ -2979,6 +2983,11 @@ void ArrangerView::graphicsRoutine() {
 		}
 	}
 
+	// if we're not currently selecting a clip
+	if (!getClipForSelection() && view.potentiallyRenderVUMeter(PadLEDs::image)) {
+		PadLEDs::sendOutSidebarColours();
+	}
+
 	if (PadLEDs::flashCursor != FLASH_CURSOR_OFF) {
 
 		int32_t newTickSquare;
@@ -3245,4 +3254,17 @@ void ArrangerView::clipNeedsReRendering(Clip* clip) {
 			break;
 		}
 	}
+}
+
+Clip* ArrangerView::getClipForSelection() {
+	Clip* clip = nullptr;
+	// if you're in arranger view, check if you're pressing a clip or holding audition pad to control that clip
+	if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW) && lastInteractedClipInstance) {
+		clip = lastInteractedClipInstance->clip;
+	}
+	else if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION)) {
+		Output* output = outputsOnScreen[yPressedEffective];
+		clip = currentSong->getClipWithOutput(output);
+	}
+	return clip;
 }

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -121,6 +121,8 @@ public:
 	// ui
 	UIType getUIType() { return UIType::ARRANGER_VIEW; }
 
+	Clip* getClipForSelection();
+
 private:
 	void changeOutputType(OutputType newOutputType);
 	void moveClipToSession();

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -285,6 +285,13 @@ void PerformanceSessionView::graphicsRoutine() {
 		}
 	}
 
+	// if we're not currently selecting a clip
+	if (!((currentSong->lastClipInstanceEnteredStartPos != -1) && arrangerView.getClipForSelection())) {
+		if (view.potentiallyRenderVUMeter(PadLEDs::image)) {
+			PadLEDs::sendOutSidebarColours();
+		}
+	}
+
 	uint8_t tickSquares[kDisplayHeight];
 	uint8_t colours[kDisplayHeight];
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1384,6 +1384,10 @@ bool SessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + 
 		return true;
 	}
 
+	if (view.potentiallyRenderVUMeter(image)) {
+		return true;
+	}
+
 	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
 		return gridRenderSidebar(whichRows, image, occupancyMask);
 	}
@@ -2028,6 +2032,11 @@ void SessionView::graphicsRoutine() {
 		}
 	}
 
+	// if we're not currently selecting a clip
+	if (!getClipForLayout() && view.potentiallyRenderVUMeter(PadLEDs::image)) {
+		PadLEDs::sendOutSidebarColours();
+	}
+
 	uint8_t tickSquares[kDisplayHeight];
 	uint8_t colours[kDisplayHeight];
 
@@ -2385,7 +2394,6 @@ bool SessionView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth +
 // Returns false if can't because in card routine
 bool SessionView::renderRow(ModelStack* modelStack, uint8_t yDisplay, RGB thisImage[kDisplayWidth + kSideBarWidth],
                             uint8_t thisOccupancyMask[kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
-
 	Clip* clip = getClipOnScreen(yDisplay);
 
 	if (clip) {

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -133,10 +133,21 @@ public:
 	void sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam = nullptr, int32_t knobPos = kNoSelection,
 	                            bool isAutomation = false);
 
+	// vu meter rendering
+	bool displayVUMeter;
+	bool potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]);
+
 private:
 	void pretendModKnobsUntouchedForAWhile();
 	void instrumentBeenEdited();
 	void clearMelodicInstrumentMonoExpressionIfPossible();
+
+	// vu meter rendering
+	int32_t getMaxYDisplayForVUMeter(float level);
+	int32_t cachedMaxYDisplayForVUMeterL;
+	int32_t cachedMaxYDisplayForVUMeterR;
+	void renderVUMeter(int32_t maxYDisplay, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]);
+	bool renderedVUMeter;
 };
 
 extern View view;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -128,17 +128,13 @@ Clip* getSelectedClip(bool useActiveClip) {
 		clip = sessionView.getClipForLayout();
 		break;
 	case UIType::ARRANGER_VIEW:
-		// if you're in arranger view, check if you're pressing a clip or holding audition pad to control that clip
-		if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW) && arrangerView.lastInteractedClipInstance) {
-			clip = arrangerView.lastInteractedClipInstance->clip;
-		}
-		else if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION)) {
-			Output* output = arrangerView.outputsOnScreen[arrangerView.yPressedEffective];
-			clip = currentSong->getClipWithOutput(output);
-		}
+		clip = arrangerView.getClipForSelection();
 		break;
 	case UIType::PERFORMANCE_SESSION_VIEW:
-		// if you're in performance view, no clip will be selected for param control
+		// if you're in the arranger performance view, check if you're holding audition pad
+		if (currentSong->lastClipInstanceEnteredStartPos != -1) {
+			clip = arrangerView.getClipForSelection();
+		}
 		break;
 	case UIType::AUTOMATION_VIEW:
 		if (automationView.getAutomationSubType() == AutomationSubType::ARRANGER) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -122,7 +122,7 @@ uint32_t timeLastSideChainHit = 2147483648;
 int32_t sizeLastSideChainHit;
 
 Metronome metronome{};
-float rmsLevel{0};
+StereoFloatSample approxRMSLevel{0};
 AbsValueFollower envelopeFollower{};
 int32_t timeLastPopup{0};
 
@@ -713,7 +713,7 @@ startAgain:
 	// Stop reverb after 12 seconds of inactivity
 	bool reverbOn = ((uint32_t)(audioSampleTimer - timeThereWasLastSomeReverb) < kSampleRate * 12);
 	// around the mutable noise floor, ~70dB from peak
-	reverbOn |= (rmsLevel > 9);
+	reverbOn |= (std::max(approxRMSLevel.l, approxRMSLevel.r) > 9);
 
 	if (reverbOn) {
 		// Patch that to reverb volume
@@ -800,7 +800,7 @@ startAgain:
 
 	metronome.render(renderingBuffer.data(), numSamples);
 
-	rmsLevel = envelopeFollower.calcRMS(renderingBuffer.data(), numSamples);
+	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), numSamples);
 
 	// Monitoring setup
 	doMonitoring = false;

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -203,4 +203,5 @@ extern Metronome metronome;
 extern RMSFeedbackCompressor mastercompressor;
 extern uint32_t timeLastSideChainHit;
 extern int32_t sizeLastSideChainHit;
+extern StereoFloatSample approxRMSLevel;
 } // namespace AudioEngine

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -505,3 +505,8 @@ extern char miscStringBuffer[];
 
 constexpr size_t kShortStringBufferSize = 64;
 extern char shortStringBuffer[];
+
+struct StereoFloatSample {
+	float l;
+	float r;
+};


### PR DESCRIPTION
… (#1344)

* Render VUMeter on the Grid in Song and Arranger Views

Use AudioEngine::rmsLevel to render a VU meter on the grid in Song and Arranger View

VU meter is displayed by turning Affect Entire on in Song/Arranger, selecting the Volume mod button and then pressing it again to toggle the VU meter on/off.

The VUMeter will stop rendering if you turn Affect Entire off, Switch Mod Buttons (e.g. from Volume to Filter), selected a clip, or exit Song/Arranger View.

* Address first feedback

* Render VU meter in sidebar

Updated code to render VU meter in sidebar and only when there is a change in the rmsLevel such that the maxY to be rendered for the VU meter differs from the previous VU meter maxY that is currently rendered

Added VU meter rendering to Performance View

Replace uiNeedsRendering(this) call in graphicsRoutine with call directly to the VU meter rendering function and then send out sidebar colours directly.

Fixed sidebar rendering when holding audition pad to select instrument in the sidebar in arranger performance view

Fixed couple cases where sidebar wasn't refreshing to remove VU meter when:

- a clip without timeline counter was selected in arranger
- section repeats was selected in song view.

* Render Left and Right audio panning in vu meter

Rendered left and right audio panning in VU Meter

* Rename rmsLevel to approxRMSLevel

Renamed rmsLevel to approxRMSLevel

Renamed AbsValueFollower::calcRMS to calcApproxRMS

* Address feedback

Changed struct stereo to struct StereoFloatSample

Removed vuMeter struct and replaced it with two variables for L and R