### PR TITLE
Add Automation View for Patch Cables / Modulation Depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@
 
 - Added a feature save user-defined pad brightness level and restore it at startup.
 
-- Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable.
-
 ## c1.1.0 Beethoven
 
 ### Sound Engine
@@ -38,6 +36,7 @@
 - Added `PERFORMANCE VIEW`, accessible in Song Row View by pressing the Keyboard button and in Song Grid View by
   pressing the Pink Mode pad. Allows quick control of Song Global FX.
 - Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
+- Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable / Modulation Depth.
 - Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset
   file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the
   Automation Overview and with the shortcut combos (e.g. Shift + Shortcut Pad).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Added a feature save user-defined pad brightness level and restore it at startup.
 
+- Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable.
+
 ## c1.1.0 Beethoven
 
 ### Sound Engine

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -528,6 +528,7 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
           provide the ability to enter the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu
           press Clip (if you are in a clip) or Song (if you are in arranger) to exit out of the menu and enter
           the `AUTOMATION VIEW EDITOR`.
+    - ([#TBD]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable.
 
 #### 4.3.6 - Set Probability By Row
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -528,7 +528,7 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
           provide the ability to enter the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu
           press Clip (if you are in a clip) or Song (if you are in arranger) to exit out of the menu and enter
           the `AUTOMATION VIEW EDITOR`.
-    - ([#TBD]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable.
+    - ([#TBD]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable / Modulation Depth.
 
 #### 4.3.6 - Set Probability By Row
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -528,7 +528,7 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
           provide the ability to enter the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu
           press Clip (if you are in a clip) or Song (if you are in arranger) to exit out of the menu and enter
           the `AUTOMATION VIEW EDITOR`.
-    - ([#TBD]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable / Modulation Depth.
+    - ([#1374]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable / Modulation Depth.
 
 #### 4.3.6 - Set Probability By Row
 
@@ -1047,6 +1047,8 @@ different firmware
 [#1272]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1272
 
 [#1344]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
+
+[#1374]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -65,7 +65,13 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **Mod FX** Offset, Feedback, Depth, Rate
 > - **Stutter** Rate
 
-4. Automatable CC's for MIDI Clips
+4. Automatable Patch Cables and Modulation Depths
+
+You can automate all patch cables and modulation depths.
+
+Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable.
+
+5. Automatable CC's for MIDI Clips
 
 >You can automate MIDI CC's 0-119, along with Pitch Bend and After Touch. Note: Mod Wheel is MIDI CC 1.
 >In Automation View for MIDI Clips, MIDI CC's have been mapped to grid shortcuts using the template file from MIDI Follow Mode (MIDIFollow.XML). So if you want to change what CC's map to what grid shortcuts in the Automation View for MIDI Clips, you would need to edit the MIDIFollow.XML template for MIDI Follow mode.
@@ -93,6 +99,8 @@ A more detailed break-down of the above sections is found below.
 The Automation Arranger View can be accessed from the Arranger View by pressing the Shift + Song buttons.
 
 The Automation Clip View can be accessed from the Clip View by pressing on the Clip button. The Clip button will flash when you are in the Automation Clip View
+
+Automation View can also be accessed from the Sound menu for any automatable parameter, patch cable, modulation depth. While in the menu, press Clip (if you're in a clip) or Song (if you're in arranger) to exit out of the menu and enter the Automation Editor for that parameter.
 
 Some additional things to note:
 
@@ -182,6 +190,18 @@ The Automation Editor **will:**
 > **Update** The values displayed in automation view have been updated to display the same value range displayed in the menu's for consistency across the Deluge UI. So instead of displaying 0 - 128, it now displays 0 - 50. Calculations in automation view are still being done based on the 0 - 128 range, but the display converts it to the 0 - 50 range.
 
 <img width="347" alt="Screenshot 2023-12-25 at 4 53 23 PM" src="https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/a95c7e5f-5a77-4280-b159-26364d29def2">
+
+> **Note** For patch cables / modulation depth, the grid value ranges for each pad have been adapted to accomodate the full -50 to +50 range.
+>
+> The bottom pad in the grid will set the value to -50 and the top pad in the grid will set the value to +50.
+>
+> You can set the value to 0 by pressing and holding the two middle pads.
+>
+> The LED indicators for the mod encoders have been updated to show the full -50 to +50 range as well.
+> 
+> This diagram shows the updated value ranges for the pads when automating a patch cable / modulation depth.
+
+<img width="315" alt="Screenshot 2024-02-28 at 7 43 23 PM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/ca78acb1-4aaf-4ff0-83a6-ea730da8d76d">
 
 - enable you to press two pads in a single automation column to set the value to the middle point between those two pads
 - enable you to enter long multi-step automations by pressing and holding one pad and then pressing a second pad

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -328,12 +328,12 @@ constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 
 // Automation View constants
 constexpr int32_t kNoSelection = 255;
-constexpr int32_t kNumNonGlobalParamsForAutomation = 57;
-constexpr int32_t kNumGlobalParamsForAutomation = 23;
 constexpr int32_t kKnobPosOffset = 64;
 constexpr int32_t kMaxKnobPos = 128;
 constexpr int32_t kParamValueIncrementForAutomationSinglePadPress = 18;
 constexpr int32_t kParamValueIncrementForAutomationDisplay = 16;
+constexpr int32_t kParamValueIncrementForAutomationPatchCableSinglePadPress = 30;
+constexpr int32_t kParamValueIncrementForAutomationPatchCableDisplay = 32;
 constexpr int32_t kParamNodeWidth = 3;
 //
 

--- a/src/deluge/gui/menu_item/param.cpp
+++ b/src/deluge/gui/menu_item/param.cpp
@@ -87,7 +87,7 @@ void Param::selectAutomationViewParameter(bool clipMinder) {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithAutoParam* modelStack = getModelStack(modelStackMemory);
 
-	int32_t p = getP();
+	int32_t p = modelStack->paramId;
 	modulation::params::Kind kind = modelStack->paramCollection->getParamKind();
 	Clip* clip = getCurrentClip();
 

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -252,7 +252,7 @@ ActionResult PatchCableStrength::buttonAction(deluge::hid::Button b, bool on) {
 	bool clipMinder = rootUIIsClipMinderScreen();
 	RootUI* rootUI = getRootUI();
 
-	// Clip or Song button
+	// Clip button
 	// Used to enter automation view from sound editor
 	if (b == CLIP_VIEW && clipMinder) {
 		if (on) {

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -38,6 +38,8 @@ public:
 	virtual PatchSource getS() = 0;
 	uint8_t getIndexOfPatchedParamToBlink() final;
 	MenuItem* selectButtonPress() override;
+	ActionResult buttonAction(deluge::hid::Button b, bool on);
+	void selectAutomationViewParameter(bool clipMinder);
 
 	// OLED Only
 	void renderOLED();

--- a/src/deluge/gui/menu_item/patched_param/integer.cpp
+++ b/src/deluge/gui/menu_item/patched_param/integer.cpp
@@ -43,7 +43,7 @@ void Integer::writeCurrentValue() {
 	view.sendMidiFollowFeedback(modelStack, knobPos);
 
 	if (getRootUI() == &automationView) {
-		int32_t p = getP();
+		int32_t p = modelStack->paramId;
 		modulation::params::Kind kind = modelStack->paramCollection->getParamKind();
 		automationView.possiblyRefreshAutomationEditorGrid(getCurrentClip(), kind, p);
 	}

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -55,7 +55,7 @@ void UnpatchedParam::writeCurrentValue() {
 	view.sendMidiFollowFeedback(modelStackWithParam, knobPos);
 
 	if (getRootUI() == &automationView) {
-		int32_t p = getP();
+		int32_t p = modelStackWithParam->paramId;
 		modulation::params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
 		automationView.possiblyRefreshAutomationEditorGrid(getCurrentClip(), kind, p);
 	}

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -64,6 +64,7 @@ Clip::Clip(ClipType newType) : type(newType) {
 	lastSelectedParamShortcutX = kNoSelection;
 	lastSelectedParamShortcutY = kNoSelection;
 	lastSelectedOutputType = OutputType::NONE;
+	lastSelectedPatchSource = PatchSource::NONE;
 	// end initialize of automation clip view variables
 
 #if HAVE_SEQUENCE_STEP_CONTROL

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -190,6 +190,7 @@ public:
 	int32_t lastSelectedParamShortcutX;
 	int32_t lastSelectedParamShortcutY;
 	OutputType lastSelectedOutputType;
+	PatchSource lastSelectedPatchSource;
 	// END ~ new Automation Clip View Variables
 
 	virtual bool renderSidebar(uint32_t whichRows = 0, RGB image[][kDisplayWidth + kSideBarWidth] = nullptr,

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2286,6 +2286,7 @@ void InstrumentClip::writeDataToFile(Song* song) {
 		storageManager.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);
 		storageManager.writeAttribute("lastSelectedParamShortcutY", lastSelectedParamShortcutY);
 		storageManager.writeAttribute("lastSelectedInstrumentType", util::to_underlying(lastSelectedOutputType));
+		storageManager.writeAttribute("lastSelectedPatchSource", util::to_underlying(lastSelectedPatchSource));
 	}
 	if (wrapEditing) {
 		storageManager.writeAttribute("crossScreenEditLevel", wrapEditLevel);
@@ -2559,6 +2560,10 @@ someError:
 
 		else if (!strcmp(tagName, "lastSelectedInstrumentType")) {
 			lastSelectedOutputType = static_cast<OutputType>(storageManager.readTagOrAttributeValueInt());
+		}
+
+		else if (!strcmp(tagName, "lastSelectedPatchSource")) {
+			lastSelectedPatchSource = static_cast<PatchSource>(storageManager.readTagOrAttributeValueInt());
 		}
 
 		else if (!strcmp(tagName, "affectEntire")) {

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1621,6 +1621,10 @@ ModelStackWithAutoParam* Kit::getModelStackWithParam(ModelStackWithTimelineCount
 				else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
 					modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
 				}
+
+				else if (paramKind == deluge::modulation::params::Kind::PATCH_CABLE) {
+					modelStackWithParam = modelStackWithThreeMainThings->getPatchCableAutoParamFromId(paramID);
+				}
 			}
 		}
 	}

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -712,6 +712,10 @@ ModelStackWithAutoParam* MelodicInstrument::getModelStackWithParam(ModelStackWit
 		else if (paramKind == deluge::modulation::params::Kind::UNPATCHED_SOUND) {
 			modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
 		}
+
+		else if (paramKind == deluge::modulation::params::Kind::PATCH_CABLE) {
+			modelStackWithParam = modelStackWithThreeMainThings->getPatchCableAutoParamFromId(paramID);
+		}
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -246,3 +246,16 @@ ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchedAutoParamFromI
 	}
 	return modelStackWithParam;
 }
+
+ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchCableAutoParamFromId(int32_t newParamId) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+		ParamCollectionSummary* summary = paramManager->getPatchCableSetSummary();
+
+		ModelStackWithParamId* modelStackWithParamId =
+		    addParamCollectionAndId(summary->paramCollection, summary, newParamId);
+
+		modelStackWithParam = summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
+	}
+	return modelStackWithParam;
+}

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -242,6 +242,7 @@ public:
 	                                  int32_t newParamId, AutoParam* newAutoParam) const;
 	ModelStackWithAutoParam* getUnpatchedAutoParamFromId(int32_t newParamId);
 	ModelStackWithAutoParam* getPatchedAutoParamFromId(int32_t newParamId);
+	ModelStackWithAutoParam* getPatchCableAutoParamFromId(int32_t newParamId);
 
 	inline ModelStackWithSoundFlags* addSoundFlags() const;
 	inline ModelStackWithSoundFlags* addDummySoundFlags() const;


### PR DESCRIPTION
Added ability to jump from the Sound menu for Patch Cables / Modulation Depth into automation view.

For patch cables / modulation depth, the grid value ranges for each pad have been adapted to accomodate the full -50 to +50 range.

The bottom pad in the grid will set the value to -50 and the top pad in the grid will set the value to +50.

You can set the value to 0 by pressing and holding the two middle pads.

The LED indicators for the mod encoders have been updated to show the full -50 to +50 range as well.

This diagram shows the updated value ranges for the pads when automating a patch cable / modulation depth.

<img width="315" alt="Screenshot 2024-02-28 at 7 43 23 PM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/ca78acb1-4aaf-4ff0-83a6-ea730da8d76d"><img width="370" alt="Screenshot 2024-02-28 at 7 47 12 PM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/7214b5c0-b639-4a9f-a460-434480576451">
