### PR TITLE
Allow Gold Knobs to Access Full Patch Cable / Mod Depth Range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,10 +75,11 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
 - Updated the count-in setting to allow specifying the number of bars (1-4).
 - Added `VU Meter` rendering in the sidebar in Song / Arranger / Performance Views.
 - Added ability to save a synth/sample drum back to an instrument preset by holding audition and pressing save.
+- Mod (Gold) Encoders learned to the Mod Matrix can now access the full range of the Mod Matrix / Patch Cable parameters (e.g. from -50 to +50).
 
 In addition, a number of improvements have been made to how the OLED display is used:
 
-- Added parameter name to Mod (Gold) Encoder popups.
+- Added parameter name (including mod matrix / patch cable mappings) to Mod (Gold) Encoder popups.
 - `ARRANGER VIEW` and `SONG VIEW` now display the name of the current view on the screen.
 - The 12TET note name is now displayed along with the MIDI note number.
 - Added a new community setting which allows emulating the 7SEG style on the OLED display.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -1096,6 +1096,8 @@ different firmware
 
 [#1272]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1272
 
+[#1312]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1312
+
 [#1344]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
 
 [#1374]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1374

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -1094,7 +1094,7 @@ different firmware
 
 [#1344]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
 
-[#1374]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
+[#1374]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1374
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -180,6 +180,10 @@ Here is a list of general improvements that have been made, ordered from newest 
     - Default : Full brightness (`25`).
     - Min value `1`, Max Value `25`.
 
+#### 3.14 - Learn Mod (Gold) Encoders to full Mod Matrix / Patch Cable value range
+- ([#1382]) Mod (Gold) Encoders learned to the Mod Matrix / Patch Cable parameters can now access the full value range of those parameters (e.g. from -50 to +50)
+  - In addition, a pop-up was added when using gold encoders learned to the Mod Matrix / Patch Cable parameters to show the source parameter(s) and destination parameter.
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -1095,6 +1099,8 @@ different firmware
 [#1344]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1344
 
 [#1374]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1374
+
+[#1382]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1382
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/src/deluge/gui/menu_item/master_transpose.h
+++ b/src/deluge/gui/menu_item/master_transpose.h
@@ -36,7 +36,7 @@ public:
 	}
 	MenuItem* selectButtonPress() override { return PatchedParam::selectButtonPress(); }
 	uint8_t shouldDrawDotOnName() override { return PatchedParam::shouldDrawDotOnName(); }
-	uint8_t getPatchedParamIndex() override { return deluge::modulation::params::LOCAL_PITCH_ADJUST; }
+	uint32_t getParamIndex() override { return deluge::modulation::params::LOCAL_PITCH_ADJUST; }
 	uint8_t getP() override { return deluge::modulation::params::LOCAL_PITCH_ADJUST; }
 	uint8_t shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour) override {
 		return PatchedParam::shouldBlinkPatchingSourceShortcut(s, colour);

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -118,8 +118,12 @@ public:
 	/// Declares which parameter we intend to edit. SoundEditor uses this to find which shortcut pad to blink based on
 	/// paramShortcutsForSounds.
 	///
+	/// @return the parameter kind (\ref deluge::modulation::params::Kind) we edit if we're a patched param, otherwise
+	/// Kind::NONE
+	virtual deluge::modulation::params::Kind getParamKind() { return deluge::modulation::params::Kind::NONE; }
+	///
 	/// @return the parameter index (\ref deluge::modulation::params) we edit if we're a patched param, otherwise 255.
-	virtual uint8_t getPatchedParamIndex() { return 255; }
+	virtual uint32_t getParamIndex() { return 255; }
 
 	/// Get the frequency at which this pad should blink the given source.
 	///

--- a/src/deluge/gui/menu_item/param.cpp
+++ b/src/deluge/gui/menu_item/param.cpp
@@ -71,7 +71,7 @@ ActionResult Param::buttonAction(deluge::hid::Button b, bool on) {
 	}
 	// Select encoder button, used to change current parameter selection in automation view
 	// if you are already in automation view and entered an automatable parameter menu
-	else if (b == SELECT_ENC && (clipMinder || arrangerView)) {
+	else if ((b == SELECT_ENC || b == BACK) && (clipMinder || arrangerView)) {
 		if (on) {
 			if (rootUI == &automationView) {
 				selectAutomationViewParameter(clipMinder);
@@ -89,6 +89,7 @@ void Param::selectAutomationViewParameter(bool clipMinder) {
 
 	int32_t p = modelStack->paramId;
 	modulation::params::Kind kind = modelStack->paramCollection->getParamKind();
+
 	Clip* clip = getCurrentClip();
 
 	if (clipMinder) {

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -29,6 +29,7 @@
 #include "model/action/action_logger.h"
 #include "model/model_stack.h"
 #include "model/song/song.h"
+#include "modulation/params/param_descriptor.h"
 #include "modulation/patch/patch_cable_set.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/sound/sound.h"
@@ -228,6 +229,14 @@ uint8_t PatchCableStrength::getIndexOfPatchedParamToBlink() {
 	return soundEditor.patchingParamSelected;
 }
 
+deluge::modulation::params::Kind PatchCableStrength::getParamKind() {
+	return deluge::modulation::params::Kind::PATCH_CABLE;
+}
+
+uint32_t PatchCableStrength::getParamIndex() {
+	return getLearningThing().data;
+}
+
 MenuItem* PatchCableStrength::selectButtonPress() {
 
 	// If shift held down, delete automation
@@ -268,7 +277,7 @@ ActionResult PatchCableStrength::buttonAction(deluge::hid::Button b, bool on) {
 	}
 	// Select encoder button, used to change current parameter selection in automation view
 	// if you are already in automation view and entered an automatable parameter menu
-	else if (b == SELECT_ENC && clipMinder) {
+	else if ((b == SELECT_ENC || b == BACK) && clipMinder) {
 		if (on) {
 			if (rootUI == &automationView) {
 				selectAutomationViewParameter(clipMinder);
@@ -281,16 +290,11 @@ ActionResult PatchCableStrength::buttonAction(deluge::hid::Button b, bool on) {
 }
 
 void PatchCableStrength::selectAutomationViewParameter(bool clipMinder) {
-	char modelStackMemory[MODEL_STACK_MAX_SIZE];
-	ModelStackWithAutoParam* modelStack = getModelStack(modelStackMemory, true);
-
-	int32_t p = modelStack->paramId;
-	modulation::params::Kind kind = modelStack->paramCollection->getParamKind();
 	Clip* clip = getCurrentClip();
 
 	if (clipMinder) {
-		clip->lastSelectedParamID = p;
-		clip->lastSelectedParamKind = kind;
+		clip->lastSelectedParamID = getParamIndex();
+		clip->lastSelectedParamKind = getParamKind();
 		clip->lastSelectedOutputType = clip->output->type;
 		clip->lastSelectedPatchSource = getS();
 	}

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -41,6 +41,9 @@ public:
 	ActionResult buttonAction(deluge::hid::Button b, bool on);
 	void selectAutomationViewParameter(bool clipMinder);
 
+	deluge::modulation::params::Kind getParamKind();
+	uint32_t getParamIndex();
+
 	// OLED Only
 	void renderOLED();
 

--- a/src/deluge/gui/menu_item/patched_param.cpp
+++ b/src/deluge/gui/menu_item/patched_param.cpp
@@ -58,7 +58,11 @@ ParamSet* PatchedParam::getParamSet() {
 	return soundEditor.currentParamManager->getPatchedParamSet();
 }
 
-uint8_t PatchedParam::getPatchedParamIndex() {
+deluge::modulation::params::Kind PatchedParam::getParamKind() {
+	return deluge::modulation::params::Kind::PATCHED;
+}
+
+uint32_t PatchedParam::getParamIndex() {
 	return this->getP();
 }
 

--- a/src/deluge/gui/menu_item/patched_param.h
+++ b/src/deluge/gui/menu_item/patched_param.h
@@ -40,7 +40,8 @@ public:
 	virtual void drawValue() = 0;
 
 	ParamDescriptor getLearningThing() override;
-	virtual uint8_t getPatchedParamIndex();
+	virtual deluge::modulation::params::Kind getParamKind();
+	virtual uint32_t getParamIndex();
 	virtual uint8_t shouldDrawDotOnName();
 
 	uint8_t shouldBlinkPatchingSourceShortcut(PatchSource s, uint8_t* colour);

--- a/src/deluge/gui/menu_item/patched_param/integer.h
+++ b/src/deluge/gui/menu_item/patched_param/integer.h
@@ -42,7 +42,8 @@ public:
 	// is likely a multi-inheritance issue that needs to be resolved
 	ActionResult buttonAction(deluge::hid::Button b, bool on) final { return PatchedParam::buttonAction(b, on); }
 
-	uint8_t getPatchedParamIndex() final { return PatchedParam::getPatchedParamIndex(); }
+	deluge::modulation::params::Kind getParamKind() final { return PatchedParam::getParamKind(); }
+	uint32_t getParamIndex() final { return PatchedParam::getParamIndex(); }
 	MenuItem* patchingSourceShortcutPress(PatchSource s, bool previousPressStillActive = false) final {
 		return PatchedParam::patchingSourceShortcutPress(s, previousPressStillActive);
 	}

--- a/src/deluge/gui/menu_item/transpose.h
+++ b/src/deluge/gui/menu_item/transpose.h
@@ -32,7 +32,7 @@ public:
 	[[nodiscard]] int32_t getMinValue() const final { return -9600; }
 	[[nodiscard]] int32_t getMaxValue() const final { return 9600; }
 	[[nodiscard]] int32_t getNumDecimalPlaces() const final { return 2; }
-	uint8_t getPatchedParamIndex() final { return PatchedParam::getPatchedParamIndex(); }
+	uint32_t getParamIndex() final { return PatchedParam::getParamIndex(); }
 	uint8_t shouldDrawDotOnName() final { return PatchedParam::shouldDrawDotOnName(); }
 
 	void drawValue() final { Decimal::drawValue(); }

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -83,6 +83,15 @@ ParamSet* UnpatchedParam::getParamSet() {
 	return soundEditor.currentParamManager->getUnpatchedParamSet();
 }
 
+deluge::modulation::params::Kind UnpatchedParam::getParamKind() {
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	return getModelStack(modelStackMemory)->paramCollection->getParamKind();
+}
+
+uint32_t UnpatchedParam::getParamIndex() {
+	return this->getP();
+}
+
 // ---------------------------------------
 
 // ---------------------------------------

--- a/src/deluge/gui/menu_item/unpatched_param.h
+++ b/src/deluge/gui/menu_item/unpatched_param.h
@@ -49,6 +49,8 @@ public:
 		MenuItemWithCCLearning::learnKnob(fromDevice, whichKnob, modKnobMode, midiChannel);
 	};
 
+	deluge::modulation::params::Kind getParamKind();
+	uint32_t getParamIndex();
 	ParamSet* getParamSet() final;
 	ModelStackWithAutoParam* getModelStack(void* memory) final;
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -261,6 +261,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				else {
 					goUpOneLevel();
 				}
+				// potentially refresh automation view if entering a new param menu
 				getCurrentMenuItem()->buttonAction(b, on);
 			}
 		}
@@ -281,6 +282,12 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				else {
 					goUpOneLevel();
 				}
+				// if we back out of a patch cable menu
+				// (e.g. LFO -> Velocity -> Level back out to Velocity -> Level)
+				// or if you back out of a patch cable menu back to a regular param menu
+				// (e.g. Velocity -> Level back out to Level)
+				// potentially refresh automation view
+				getCurrentMenuItem()->buttonAction(b, on);
 			}
 		}
 	}
@@ -400,6 +407,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 	}
 
 	else {
+		// potentially exit out of param / patch cable menu into automation view
 		return getCurrentMenuItem()->buttonAction(b, on);
 	}
 
@@ -459,7 +467,7 @@ bool SoundEditor::findPatchedParam(int32_t paramLookingFor, int32_t* xout, int32
 	for (int32_t x = 0; x < 15; x++) {
 		for (int32_t y = 0; y < kDisplayHeight; y++) {
 			if (paramShortcutsForSounds[x][y] && paramShortcutsForSounds[x][y] != comingSoonMenu
-			    && ((MenuItem*)paramShortcutsForSounds[x][y])->getPatchedParamIndex() == paramLookingFor) {
+			    && ((MenuItem*)paramShortcutsForSounds[x][y])->getParamIndex() == paramLookingFor) {
 
 				*xout = x;
 				*yout = y;
@@ -925,6 +933,12 @@ doSetup:
 					else {
 						display->setNextTransitionDirection(0);
 						beginScreen();
+
+						if (getRootUI() == &automationView) {
+							// if automation view is open in the background
+							// potentially refresh grid if opening a new parameter menu
+							getCurrentMenuItem()->buttonAction(hid::button::SELECT_ENC, on);
+						}
 					}
 				}
 			}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3329,8 +3329,7 @@ void AutomationView::setKnobIndicatorLevels(int32_t knobPos) {
 	// if you're dealing with a patch cable which has a -128 to +128 range
 	// we'll need to convert it to a 0 - 128 range for purpose of rendering on knob indicators
 	if (!onArrangerView && (getCurrentClip()->lastSelectedParamKind == params::Kind::PATCH_CABLE)) {
-		float floatKnobPos = kMaxKnobPos * ((static_cast<float>(knobPos) + kMaxKnobPos) / (kMaxKnobPos * 2));
-		knobPos = static_cast<int32_t>(floatKnobPos);
+		knobPos = view.convertPatchCableKnobPosToIndicatorLevel(knobPos);
 	}
 
 	indicator_leds::setKnobIndicatorLevel(0, knobPos);
@@ -3761,13 +3760,8 @@ void AutomationView::renderDisplayForMultiPadPress(ModelStackWithAutoParam* mode
 		// if you're dealing with a patch cable which has a -128 to +128 range
 		// we'll need to convert it to a 0 - 128 range for purpose of rendering on knob indicators
 		if (!onArrangerView && (clip->lastSelectedParamKind == params::Kind::PATCH_CABLE)) {
-			float floatKnobPosLeft =
-			    kMaxKnobPos * ((static_cast<float>(knobPosLeft) + kMaxKnobPos) / (kMaxKnobPos * 2));
-			knobPosLeft = static_cast<int32_t>(floatKnobPosLeft);
-
-			float floatKnobPosRight =
-			    kMaxKnobPos * ((static_cast<float>(knobPosRight) + kMaxKnobPos) / (kMaxKnobPos * 2));
-			knobPosRight = static_cast<int32_t>(floatKnobPosRight);
+			knobPosLeft = view.convertPatchCableKnobPosToIndicatorLevel(knobPosLeft);
+			knobPosRight = view.convertPatchCableKnobPosToIndicatorLevel(knobPosRight);
 		}
 		indicator_leds::setKnobIndicatorLevel(0, knobPosLeft);
 		indicator_leds::setKnobIndicatorLevel(1, knobPosRight);

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -72,6 +72,7 @@ public:
 	void modButtonAction(uint8_t whichButton, bool on);
 	void setKnobIndicatorLevels();
 	void setKnobIndicatorLevel(uint8_t whichModEncoder);
+	int32_t convertPatchCableKnobPosToIndicatorLevel(int32_t knobPos);
 	void setActiveModControllableTimelineCounter(TimelineCounter* playPositionCounter);
 	void setActiveModControllableWithoutTimelineCounter(ModControllable* modControllable, ParamManager* paramManager);
 	void cycleThroughReverbPresets();

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -129,7 +129,8 @@ public:
 	uint32_t modLength;
 
 	int32_t calculateKnobPosForDisplay(deluge::modulation::params::Kind kind, int32_t paramID, int32_t knobPos);
-	void displayModEncoderValuePopup(deluge::modulation::params::Kind kind, int32_t paramID, int32_t newKnobPos);
+	void displayModEncoderValuePopup(deluge::modulation::params::Kind kind, int32_t paramID, int32_t newKnobPos,
+	                                 PatchSource source1 = PatchSource::NONE, PatchSource source2 = PatchSource::NONE);
 	void sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam = nullptr, int32_t knobPos = kNoSelection,
 	                            bool isAutomation = false);
 

--- a/src/deluge/modulation/patch/patch_cable_set.h
+++ b/src/deluge/modulation/patch/patch_cable_set.h
@@ -111,6 +111,8 @@ public:
 
 	Destination* destinations[2];
 
+	bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) { return true; };
+
 private:
 	static void dissectParamId(uint32_t paramId, ParamDescriptor* destinationParamDescriptor, PatchSource* s);
 	void swapCables(int32_t c1, int32_t c2);


### PR DESCRIPTION
- [x] Allow gold knobs to access full patch cable / mod depth range (-50 to +50 / -128 to +128)
- [x] Update LED indicators to display full patch cable / mod depth range (-50 to +50 / -128 to +128)
- [x] Update mod encoder pop-ups so that they don't display if you're editing the same parameter in the menu
- [x] Fix bug where mod encoder pop-ups still display if you're editing the same patch cable / mod depth in the menu
- [x] Display patch cable source(s) and destination on the mod-encoder pop-up for OLED (e.g. Source -> Destination : ###)
- [x] Fixed bug where if root UI is automation view, switching parameter menu's by backing out of one menu into another one wouldn't refresh the background automation editor grid
- [x] Fix bug where LED indicators turn off when blinking the middle value (0)

There will be one more follow-up PR where the above changes will made for MIDI as well - specifically: I want to allow external midi that is learned to a patch cable to control the full range (-50 to +50).