### PR TITLE
set edited if mpe collapse loaded

### DIFF
--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -338,9 +338,11 @@ bool MIDIInstrument::readTagFromFile(char const* tagName) {
 		while (*(tagName = storageManager.readNextTagOrAttributeName())) {
 			if (!strcmp(tagName, "aftertouch")) {
 				collapseAftertouch = (bool)storageManager.readTagOrAttributeValueInt();
+				editedByUser = true;
 			}
 			else if (!strcmp(tagName, "mpe")) {
 				collapseMPE = (bool)storageManager.readTagOrAttributeValueInt();
+				editedByUser = true;
 			}
 			else
 				break;


### PR DESCRIPTION
Fixes a minor bug where resaving a song could lose the value for collapsing poly aftertouch and mpe to mono