### PR TITLE
Bugfix - Automation Overview Crash

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -909,7 +909,6 @@ void AutomationView::renderDisplay7SEG(Clip* clip, OutputType outputType, int32_
 	if (isOnAutomationOverview() || (outputType == OutputType::CV)) {
 		char const* overviewText;
 		if (onArrangerView || outputType != OutputType::CV) {
-			char const* overviewText;
 			if (!onArrangerView
 			    && (outputType == OutputType::KIT && !instrumentClipView.getAffectEntire()
 			        && !((Kit*)clip->output)->selectedDrum)) {


### PR DESCRIPTION
Fixed crash bug on 7Seg when rendering the Automation Overview display

Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/1120