### PR TITLE
check for drum before setting path

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -189,7 +189,7 @@ Error LoadInstrumentPresetUI::setupForOutputType() {
 
 	// Or if the Instruments are different types...
 	else {
-		if (loadingSynthToKitRow) {
+		if (loadingSynthToKitRow && soundDrumToReplace) {
 
 			if (&soundDrumToReplace->name) {
 				String* name = &soundDrumToReplace->name;


### PR DESCRIPTION
In the case where a drum doesn't yet exist this path will not be set, so check for one before dereferencing 