### PR TITLE
set a large alignment so that the bootloader finishes its animation

### DIFF
--- a/linker_script_rz_a1l.ld
+++ b/linker_script_rz_a1l.ld
@@ -302,7 +302,7 @@ SECTIONS
 	/* Reset location counter to RAM012L. Warning: Changing relocation sections before that will require change here */
 	. = ADDR(.heap) + SIZEOF(.sdram_text) + SIZEOF(.sdram_data);
 	. = ALIGN(4);
-
+    . = ALIGN(0xFFFF);
 	/* Definition of code_end declared in start.S and referenced in bootloader with DEF_USER_CODE_END */
 	/* end is also used by glibc as start of heap and might be reinitialized */
 	/* For more information see: rdimon's libgloss/arm/syscall.c @ _sbrk */


### PR DESCRIPTION
The binsize in release got too small and the bootloader would transfer execution mid DMA. The extra alignment ensures that the bootloader meets its animation end condition here - https://github.com/SynthstromAudible/DelugeBootloader/blob/6ce8601eef539bcc3ad91432a1b8779a19aaaae5/src/oled_init.c#L511 