### PR TITLE
failsafe mechanism for startup song feature

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -457,7 +457,7 @@ void setupStartupSong() {
 	    startupSongMode == StartupSongMode::TEMPLATE ? defaultSongFullPath : runtimeFeatureSettings.getStartupSong();
 	String failSafePath;
 	failSafePath.concatenate("SONGS/__STARTUP_OFF_CHECK_");
-	failSafePath.concatenate(replace_char((char*)filename, '/', '_'));
+	failSafePath.concatenate(replace_char(filename, '/', '_'));
 	if (storageManager.fileExists(failSafePath.get())) {
 		setupBlankSong();
 		String msgReason;

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -453,12 +453,12 @@ void setupBlankSong() {
 void setupStartupSong() {
 	auto startupSongMode = FlashStorage::defaultStartupSongMode;
 	auto defaultSongFullPath = "SONGS/DEFAULT.XML";
-	auto failSafePath = "AUTOLOAD_OFF__open_file_for_reason__remove_file_to_reactivate_autoload";
+	auto failSafePath = "STARTUP_OFF__open_file_for_reason__remove_file_to_reactivate_STARTUP";
 
 	if (storageManager.fileExists(failSafePath)) {
 		setupBlankSong();
 		String msgReason;
-		msgReason.concatenate("AUTOLOAD OFF, reason: ");
+		msgReason.concatenate("STARTUP OFF, reason: ");
 		FIL f;
 		if (f_open(&f, failSafePath, FA_READ) == FR_OK) {
 			uint32_t maxBufSize = 256;
@@ -489,7 +489,7 @@ void setupStartupSong() {
 		auto filename = startupSongMode == StartupSongMode::TEMPLATE ? defaultSongFullPath
 		                                                             : runtimeFeatureSettings.getStartupSong();
 		FIL f;
-		if (f_open(&f, failSafePath, FA_CREATE_ALWAYS) == FR_OK) {
+		if (f_open(&f, failSafePath, FA_WRITE | FA_CREATE_ALWAYS) == FR_OK) {
 			UINT written;
 			f_write(&f, filename, strlen(filename) + 1, &written);
 			f_close(&f);

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -65,7 +65,6 @@
 #include "util/misc.h"
 #include "util/pack.h"
 #include <stdlib.h>
-#include <sys/_stdint.h>
 
 #if AUTOMATED_TESTER_ENABLED
 #include "testing/automated_tester.h"

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1762,6 +1762,18 @@ doNormal:
 	}
 }
 
+char* replace_char(const char* str, char find, char replace) {
+	char* copy = new char[sizeof(char) * strlen(str) + 1];
+
+	strcpy(copy, str);
+	char* current_pos = strchr(copy, find);
+	while (current_pos) {
+		*current_pos = replace;
+		current_pos = strchr(current_pos, find);
+	}
+	return copy;
+}
+
 bool charCaseEqual(char firstChar, char secondChar) {
 	// Make lowercase
 	if (firstChar >= 'A' && firstChar <= 'Z') {

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -125,6 +125,8 @@ template <uint8_t lshift>
 	}
 }
 
+char* replace_char(const char* str, char find, char replace);
+
 int32_t stringToInt(char const* string);
 int32_t stringToUIntOrError(char const* mem);
 int32_t memToUIntOrError(char const* mem, char const* const memEnd);


### PR DESCRIPTION
failsafe description :
- we first check if SONGS/__STARTUP_OFF_CHECK_{SONG} exists on sd card, if so, we fallback.
- a popup will alert the user that STARTUP mode has been switched off for this given song.
- Two options for the user  :
- > if load/save another song, it will load that one, previous canary file will be ignored.
- > can remove the canary file from song browser.

if no canary file at startup :
- we create one
- process the load
- remove it
