### PR TITLE
[Draft] Implement more arpeggiator parameter modulations by MPE expression

### DIFF
--- a/src/deluge/gui/l10n/english.cpp
+++ b/src/deluge/gui/l10n/english.cpp
@@ -182,9 +182,6 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_MODFX_DEPTH, "MOD-FX depth"},
         {STRING_FOR_MODFX_RATE, "MOD-FX rate"},
 
-        // Arp Gate
-        {STRING_FOR_ARP_GATE_MENU_TITLE, "Arp. gate"},
-
         // Portamento
         {STRING_FOR_PORTAMENTO, "PORTAMENTO"},
 
@@ -708,6 +705,7 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_ARP_RATCHET_PROBABILITY_MENU_TITLE, "Arp ratc prob"},
         {STRING_FOR_ARP_SEQUENCE_LENGTH_MENU_TITLE, "Arp seq length"},
         {STRING_FOR_ARP_RATE_MENU_TITLE, "Arp rate"},
+        {STRING_FOR_ARP_GATE_MENU_TITLE, "Arp gate"},
         {STRING_FOR_FM_MOD_TRAN_MENU_TITLE, "FM Mod* tran."},
         {STRING_FOR_FM_MOD_LEVEL_MENU_TITLE, "FM Mod* level"},
         {STRING_FOR_FM_MOD_FBACK_MENU_TITLE, "FM Mod* f.back"},

--- a/src/deluge/gui/menu_item/arpeggiator/mpe_mod_source.h
+++ b/src/deluge/gui/menu_item/arpeggiator/mpe_mod_source.h
@@ -26,13 +26,17 @@
 #include "processing/sound/sound.h"
 
 namespace deluge::gui::menu_item::arpeggiator {
-class ArpMpeVelocity final : public Selection {
+class ArpMpeModSourceSelection : public Selection {
 public:
 	using Selection::Selection;
-	void readCurrentValue() override { this->setValue(soundEditor.currentArpSettings->mpeVelocity); }
-	void writeCurrentValue() override {
-		soundEditor.currentArpSettings->mpeVelocity = this->getValue<ArpMpeModSource>();
+
+	ArpMpeModSourceSelection(l10n::String newName, l10n::String title, ArpMpeModSource* (*getSelectionPtr)())
+	    : Selection(newName, title) {
+		getSPtr = getSelectionPtr;
 	}
+
+	void readCurrentValue() override { this->setValue(*(getSPtr())); }
+	void writeCurrentValue() override { *(getSPtr()) = this->getValue<ArpMpeModSource>(); }
 
 	deluge::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
@@ -42,5 +46,7 @@ public:
 		    l10n::getView(STRING_FOR_PATCH_SOURCE_Y),          //<
 		};
 	}
+
+	ArpMpeModSource* (*getSPtr)();
 };
 } // namespace deluge::gui::menu_item::arpeggiator

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -1,3 +1,4 @@
+#include "definitions_cxx.hpp"
 #include "gui/l10n/strings.h"
 #include "gui/menu_item/arpeggiator/midi_cv/gate.h"
 #include "gui/menu_item/arpeggiator/midi_cv/ratchet_amount.h"
@@ -5,7 +6,7 @@
 #include "gui/menu_item/arpeggiator/midi_cv/rate.h"
 #include "gui/menu_item/arpeggiator/midi_cv/sequence_length.h"
 #include "gui/menu_item/arpeggiator/mode.h"
-#include "gui/menu_item/arpeggiator/mpe_velocity.h"
+#include "gui/menu_item/arpeggiator/mpe_mod_source.h"
 #include "gui/menu_item/arpeggiator/note_mode.h"
 #include "gui/menu_item/arpeggiator/octave_mode.h"
 #include "gui/menu_item/arpeggiator/octaves.h"
@@ -335,8 +336,38 @@ arpeggiator::midi_cv::RatchetProbability arpRatchetProbabilityMenuMIDIOrCV{
     STRING_FOR_RATCHET_PROBABILITY, STRING_FOR_ARP_RATCHET_PROBABILITY_MENU_TITLE};
 
 // Arp: MPE
-arpeggiator::ArpMpeVelocity arpMpeVelocityMenu{STRING_FOR_VELOCITY, STRING_FOR_VELOCITY};
-Submenu arpMpeMenu{STRING_FOR_MPE, {&arpMpeVelocityMenu}};
+ArpMpeModSource* getArpSettingsMpeVelocity() {
+	return &(soundEditor.currentArpSettings->mpeVelocity);
+}
+ArpMpeModSource* getArpSettingsMpeGate() {
+	return &(soundEditor.currentArpSettings->mpeGate);
+}
+ArpMpeModSource* getArpSettingsMpeOctaves() {
+	return &(soundEditor.currentArpSettings->mpeOctaves);
+}
+ArpMpeModSource* getArpSettingsMpeRatchetAmount() {
+	return &(soundEditor.currentArpSettings->mpeRatchetAmount);
+}
+ArpMpeModSource* getArpSettingsMpeRatchetProbability() {
+	return &(soundEditor.currentArpSettings->mpeRatchetProbability);
+}
+arpeggiator::ArpMpeModSourceSelection arpMpeVelocityMenu{STRING_FOR_VELOCITY, STRING_FOR_VELOCITY,
+                                                         getArpSettingsMpeVelocity};
+arpeggiator::ArpMpeModSourceSelection arpMpeGateMenu{STRING_FOR_GATE, STRING_FOR_GATE, getArpSettingsMpeGate};
+arpeggiator::ArpMpeModSourceSelection arpMpeOctavesMenu{STRING_FOR_NUMBER_OF_OCTAVES, STRING_FOR_NUMBER_OF_OCTAVES,
+                                                        getArpSettingsMpeOctaves};
+arpeggiator::ArpMpeModSourceSelection arpMpeRatchetAmountMenu{
+    STRING_FOR_NUMBER_OF_RATCHETS, STRING_FOR_NUMBER_OF_RATCHETS, getArpSettingsMpeRatchetAmount};
+arpeggiator::ArpMpeModSourceSelection arpMpeRatchetProbabilityMenu{
+    STRING_FOR_RATCHET_PROBABILITY, STRING_FOR_RATCHET_PROBABILITY, getArpSettingsMpeRatchetProbability};
+Submenu arpMpeMenu{STRING_FOR_MPE,
+                   {
+                       &arpMpeVelocityMenu,
+                       &arpMpeGateMenu,
+                       &arpMpeOctavesMenu,
+                       &arpMpeRatchetAmountMenu,
+                       &arpMpeRatchetProbabilityMenu,
+                   }};
 
 submenu::Arpeggiator arpMenu{
     STRING_FOR_ARPEGGIATOR,

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2343,6 +2343,12 @@ void InstrumentClip::writeDataToFile(Song* song) {
 			storageManager.writeAttribute("numOctaves", arpSettings.numOctaves);
 			storageManager.writeAttribute("rhythm", arpSettings.rhythm);
 			storageManager.writeAttribute("mpeVelocity", (char*)arpMpeModSourceToString(arpSettings.mpeVelocity));
+			storageManager.writeAttribute("mpeGate", (char*)arpMpeModSourceToString(arpSettings.mpeGate));
+			storageManager.writeAttribute("mpeOctaves", (char*)arpMpeModSourceToString(arpSettings.mpeOctaves));
+			storageManager.writeAttribute("mpeRatchetAmount",
+			                              (char*)arpMpeModSourceToString(arpSettings.mpeRatchetAmount));
+			storageManager.writeAttribute("mpeRatchetProbability",
+			                              (char*)arpMpeModSourceToString(arpSettings.mpeRatchetProbability));
 			storageManager.writeAttribute("syncLevel", arpSettings.syncLevel);
 
 			if (output->type == OutputType::MIDI_OUT || output->type == OutputType::CV) {
@@ -2667,6 +2673,23 @@ someError:
 				else if (!strcmp(tagName, "mpeVelocity")) {
 					arpSettings.mpeVelocity = stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
 					storageManager.exitTag("mpeVelocity");
+				}
+				else if (!strcmp(tagName, "mpeGate")) {
+					arpSettings.mpeGate = stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+					storageManager.exitTag("mpeGate");
+				}
+				else if (!strcmp(tagName, "mpeOctaves")) {
+					arpSettings.mpeOctaves = stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+					storageManager.exitTag("mpeOctaves");
+				}
+				else if (!strcmp(tagName, "mpeRatchetAmount")) {
+					arpSettings.mpeRatchetAmount = stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+					storageManager.exitTag("mpeRatchetAmount");
+				}
+				else if (!strcmp(tagName, "mpeRatchetProbability")) {
+					arpSettings.mpeRatchetProbability =
+					    stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+					storageManager.exitTag("mpeRatchetProbability");
 				}
 				else if (!strcmp(tagName, "gate")) {
 					arpeggiatorGate = storageManager.readTagOrAttributeValueInt();

--- a/src/deluge/modulation/arpeggiator.h
+++ b/src/deluge/modulation/arpeggiator.h
@@ -67,6 +67,10 @@ public:
 		syncLevel = other->syncLevel;
 		rhythm = other->rhythm;
 		mpeVelocity = other->mpeVelocity;
+		mpeGate = other->mpeGate;
+		mpeRatchetAmount = other->mpeRatchetAmount;
+		mpeRatchetProbability = other->mpeRatchetProbability;
+		mpeOctaves = other->mpeOctaves;
 	}
 
 	void updatePresetFromCurrentSettings() {
@@ -145,6 +149,10 @@ public:
 
 	// MPE settings
 	ArpMpeModSource mpeVelocity{ArpMpeModSource::OFF};
+	ArpMpeModSource mpeOctaves{ArpMpeModSource::OFF};
+	ArpMpeModSource mpeGate{ArpMpeModSource::OFF};
+	ArpMpeModSource mpeRatchetAmount{ArpMpeModSource::OFF};
+	ArpMpeModSource mpeRatchetProbability{ArpMpeModSource::OFF};
 
 	// Temporary flags
 	bool flagForceArpRestart{false};
@@ -213,9 +221,19 @@ public:
 	bool isRatcheting = false;
 
 	// Unpatched Automated Params
+	uint16_t ratchetAmount = 0;
 	uint16_t ratchetProbability = 0;
+	uint32_t gate = 1 << 23; // Default Gate: 25 (0-50)
+
+	uint32_t modulatedVelocity = 0; // This is the modulated velocity (once any MPE modulations are applied)
+	uint32_t modulatedRatchetProbability =
+	    0; // This is the modulated ratchet probability (once any MPE modulations are applied)
+	uint32_t modulatedRatchetAmount = 0; // This is the modulated ratchet amount (once any MPE modulations are applied)
+	uint32_t modulatedGate = gate;       // This is the modulated gate threshold (once any MPE modulations are applied)
+	uint32_t modulatedOctaveOffset =
+	    0; // This is the modulated octave number to offset the notes (once any MPE modulations are applied)
+
 	uint32_t maxSequenceLength = 0;
-	uint32_t ratchetAmount = 0;
 
 protected:
 	void resetRatchet();
@@ -223,6 +241,9 @@ protected:
 	void carryOnOctaveSequenceForSingleNoteArpeggio(ArpeggiatorSettings* settings);
 	void maybeSetupNewRatchet(ArpeggiatorSettings* settings);
 	bool evaluateRhythm(ArpeggiatorSettings* settings, int32_t rhythmPatternIndex);
+	uint32_t calculateSingleMpeModulatedParameter(ArpMpeModSource source, int16_t zPressure, int16_t ySlideTimbre,
+	                                              int32_t baseValue, int32_t maxValue);
+	void calculateAllMpeModulatedParameters(ArpeggiatorSettings* settings, int16_t zPressure, int16_t ySlideTimbre);
 	int32_t getOctaveDirection(ArpeggiatorSettings* settings);
 	virtual void switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstruction* instruction, bool isRatchet) = 0;
 	void switchAnyNoteOff(ArpReturnInstruction* instruction);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -679,6 +679,31 @@ Error Sound::readTagFromFile(char const* tagName, ParamManagerForTimeline* param
 				}
 				storageManager.exitTag("mpeVelocity");
 			}
+			else if (!strcmp(tagName, "mpeGate")) {
+				if (arpSettings) {
+					arpSettings->mpeGate = stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+				}
+				storageManager.exitTag("mpeGate");
+			}
+			else if (!strcmp(tagName, "mpeOctaves")) {
+				if (arpSettings) {
+					arpSettings->mpeOctaves = stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+				}
+				storageManager.exitTag("mpeOctaves");
+			}
+			else if (!strcmp(tagName, "mpeRatchetAmount")) {
+				if (arpSettings) {
+					arpSettings->mpeRatchetAmount = stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+				}
+				storageManager.exitTag("mpeRatchetAmount");
+			}
+			else if (!strcmp(tagName, "mpeRatchetProbability")) {
+				if (arpSettings) {
+					arpSettings->mpeRatchetProbability =
+					    stringToArpMpeModSource(storageManager.readTagOrAttributeValue());
+				}
+				storageManager.exitTag("mpeRatchetProbability");
+			}
 			else if (!strcmp(tagName, "arpMode")) {
 				if (arpSettings) {
 					arpSettings->mode = stringToArpMode(storageManager.readTagOrAttributeValue());
@@ -3927,6 +3952,11 @@ void Sound::writeToFile(bool savingSong, ParamManager* paramManager, Arpeggiator
 		storageManager.writeAttribute("noteMode", arpNoteModeToString(arpSettings->noteMode));
 		storageManager.writeAttribute("octaveMode", arpOctaveModeToString(arpSettings->octaveMode));
 		storageManager.writeAttribute("mpeVelocity", arpMpeModSourceToString(arpSettings->mpeVelocity));
+		storageManager.writeAttribute("mpeGate", arpMpeModSourceToString(arpSettings->mpeGate));
+		storageManager.writeAttribute("mpeOctaves", arpMpeModSourceToString(arpSettings->mpeOctaves));
+		storageManager.writeAttribute("mpeRatchetAmount", arpMpeModSourceToString(arpSettings->mpeRatchetAmount));
+		storageManager.writeAttribute("mpeRatchetProbability",
+		                              arpMpeModSourceToString(arpSettings->mpeRatchetProbability));
 		storageManager.writeAttribute("numOctaves", arpSettings->numOctaves);
 		storageManager.writeAttribute("rhythm", arpSettings->rhythm);
 		storageManager.writeSyncTypeToFile(currentSong, "syncType", arpSettings->syncType);


### PR DESCRIPTION
Now also Gate, Octaves, Ratchet Amount and Ratchet Probability are eligible to be modulated by MPE expressions (Z or Y). The modulation range is fixed for simplicity and would be:
- Base minimum value: the one you set up in the main Arpeggiator menu
- Maximum value: The maximum value for the parameter (usually 50)

Special case for “Octaves” which has a fixed range of 0 to 3 octaves note shifting.

NOTE: also to cherry-pick