### PR TITLE
Bugfix - buffer overflow post arp midi and duplicate MPE data on channel 16

### DIFF
--- a/src/deluge/model/instrument/non_audio_instrument.cpp
+++ b/src/deluge/model/instrument/non_audio_instrument.cpp
@@ -181,10 +181,6 @@ lookAtArpNote:
 				// We'll send even if the gate isn't still active. Seems the most sensible. And the release might still
 				// be sounding on the connected synth, so this probably makes sense
 			}
-
-			// Send this even if arp is on and this note isn't currently sounding: its release might still be
-			polyphonicExpressionEventPostArpeggiator(newValue, noteCodeAfterArpeggiation, whichExpressionDimension,
-			                                         arpNote);
 		}
 	}
 }


### PR DESCRIPTION
NotesAsPlayed is tracking the order of the notes in case the mode is switched in the future. It does not need to send MPE values as it is not actually tracking noes. 

Without this fix all expression data is additionally sent out on channel 255 internally, leading to buffer overflows on all MPE associated arrays and then data being sent on channel 16