### PR TITLE
fix force culling resulting in hard culls with monophonic voices

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -145,7 +145,7 @@ void inputRoutine() {
 
 	bool lineInNow = readInput(LINE_IN_DETECT.port, LINE_IN_DETECT.pin) != 0u;
 	if (lineInNow != AudioEngine::lineInPluggedIn) {
-		D_PRINT("line in %d", lineInNow);
+		D_PRINTLN("line in %d", lineInNow);
 		AudioEngine::lineInPluggedIn = lineInNow;
 	}
 

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -3259,6 +3259,20 @@ bool Voice::doFastRelease(uint32_t releaseIncrement) {
 	}
 }
 
+/// Sets envelope to off (will interpolate through this render window).
+/// Returns whether voice should still be left active
+bool Voice::doImmediateRelease() {
+	if (doneFirstRender) {
+		envelopes[0].unconditionalOff();
+		return true;
+	}
+
+	// Or if first render not done yet, we actually don't want to hear anything at all, so just unassign it
+	else {
+		return false;
+	}
+}
+
 bool Voice::hasReleaseStage() {
 	return (paramFinalValues[params::LOCAL_ENV_0_RELEASE] <= 18359);
 }

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -3246,7 +3246,6 @@ storePhase:
 	}
 }
 
-// Returns whether voice should still be left active
 bool Voice::doFastRelease(uint32_t releaseIncrement) {
 	if (doneFirstRender) {
 		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, releaseIncrement);
@@ -3259,8 +3258,6 @@ bool Voice::doFastRelease(uint32_t releaseIncrement) {
 	}
 }
 
-/// Sets envelope to off (will interpolate through this render window).
-/// Returns whether voice should still be left active
 bool Voice::doImmediateRelease() {
 	if (doneFirstRender) {
 		envelopes[0].unconditionalOff();

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -96,7 +96,7 @@ public:
 	            int32_t newNoteCodeAfterArpeggiation, uint8_t velocity, uint32_t newSampleSyncLength, int32_t ticksLate,
 	            uint32_t samplesLate, bool resetEnvelopes, int32_t fromMIDIChannel, const int16_t* mpeValues);
 	void noteOff(ModelStackWithVoice* modelStack, bool allowReleaseStage = true);
-	bool doFastRelease(uint32_t releaseIncrement = 4096);
+
 	void randomizeOscPhases(Sound* sound);
 	void changeNoteCode(ModelStackWithVoice* modelStack, int32_t newNoteCodeBeforeArpeggiation,
 	                    int32_t newNoteCodeAfterArpeggiation, int32_t newInputMIDIChannel, const int16_t* newMPEValues);
@@ -106,6 +106,12 @@ public:
 	void expressionEventImmediate(Sound* sound, int32_t voiceLevelValue, int32_t s);
 	void expressionEventSmooth(int32_t newValue, int32_t s);
 
+	/// Release immediately with provided release rate
+	/// Returns whether voice should still be left active
+	bool doFastRelease(uint32_t releaseIncrement = 4096);
+	
+	/// Sets envelope to off (will interpolate through this render window).
+	/// Returns whether voice should still be left active
 	bool doImmediateRelease();
 
 private:

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -109,7 +109,7 @@ public:
 	/// Release immediately with provided release rate
 	/// Returns whether voice should still be left active
 	bool doFastRelease(uint32_t releaseIncrement = 4096);
-	
+
 	/// Sets envelope to off (will interpolate through this render window).
 	/// Returns whether voice should still be left active
 	bool doImmediateRelease();

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -106,6 +106,8 @@ public:
 	void expressionEventImmediate(Sound* sound, int32_t voiceLevelValue, int32_t s);
 	void expressionEventSmooth(int32_t newValue, int32_t s);
 
+	bool doImmediateRelease();
+
 private:
 	// inline int32_t doFM(uint32_t *carrierPhase, uint32_t* lastShiftedPhase, uint32_t carrierPhaseIncrement, uint32_t
 	// phaseShift);

--- a/src/deluge/modulation/envelope.cpp
+++ b/src/deluge/modulation/envelope.cpp
@@ -159,9 +159,11 @@ void Envelope::unconditionalOff() {
 	setState(EnvelopeStage::OFF);
 }
 void Envelope::unconditionalRelease(EnvelopeStage typeOfRelease, uint32_t newFastReleaseIncrement) {
-	setState(typeOfRelease);
-	pos = 0;
-	lastValuePreCurrentStage = lastValue;
+	if (state != typeOfRelease) {
+		setState(typeOfRelease);
+		pos = 0;
+		lastValuePreCurrentStage = lastValue;
+	}
 
 	if (typeOfRelease == EnvelopeStage::FAST_RELEASE) {
 		fastReleaseIncrement = newFastReleaseIncrement;

--- a/src/deluge/modulation/envelope.cpp
+++ b/src/deluge/modulation/envelope.cpp
@@ -154,6 +154,10 @@ void Envelope::setState(EnvelopeStage newState) {
 	timeEnteredState = AudioEngine::nextVoiceState++;
 }
 
+void Envelope::unconditionalOff() {
+	lastValuePreCurrentStage = lastValue;
+	setState(EnvelopeStage::OFF);
+}
 void Envelope::unconditionalRelease(EnvelopeStage typeOfRelease, uint32_t newFastReleaseIncrement) {
 	setState(typeOfRelease);
 	pos = 0;

--- a/src/deluge/modulation/envelope.h
+++ b/src/deluge/modulation/envelope.h
@@ -42,6 +42,7 @@ public:
 	               const uint16_t* releaseTable);
 	void unconditionalRelease(EnvelopeStage typeOfRelease = EnvelopeStage::RELEASE,
 	                          uint32_t newFastReleaseIncrement = 4096);
+	void unconditionalOff();
 	void resumeAttack(int32_t oldLastValue);
 	void resetTimeEntered();
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -279,7 +279,8 @@ Voice* cullVoice(bool saveVoice, bool justDoFastRelease, bool definitelyCull, si
 		             // https://forums.synthstrom.com/discussion/4097/beta-4-0-0-beta-1-e196-by-loading-wavetable-osc#latest
 
 		if (justDoFastRelease) {
-			if (bestVoice->envelopes[0].state < EnvelopeStage::FAST_RELEASE) {
+			if (bestVoice->envelopes[0].state < EnvelopeStage::FAST_RELEASE
+			    || bestVoice->envelopes[0].fastReleaseIncrement < 65536) {
 				bool stillGoing = bestVoice->doFastRelease(65536);
 
 				if (!stillGoing) {
@@ -293,7 +294,11 @@ Voice* cullVoice(bool saveVoice, bool justDoFastRelease, bool definitelyCull, si
 			}
 
 			else if (definitelyCull) {
-				unassignVoice(bestVoice, bestVoice->assignedToSound);
+				bool stillGoing = bestVoice->doImmediateRelease();
+
+				if (!stillGoing) {
+					unassignVoice(bestVoice, bestVoice->assignedToSound);
+				}
 #if ALPHA_OR_BETA_VERSION
 				D_PRINTLN("force-culled 1 voice.  numSamples:  %d. Voices left: %d. Audio clips left: %d", numSamples,
 				          getNumVoices(), getNumAudio());


### PR DESCRIPTION
Adds an immediate off function to voices - this is similar to a hard cull but with one final render pass. Since volume changes are interpolated and since this is only called when the number of samples in the window is high it reduces the clicking

Adds a check for whether a fast release is actually fast - if not it sets a new fast release rate. Fixes an issue where mono synths and choked samples would be in the 'fast release' state, but releasing 15x slower than a fast release from a cull and get accidentally skipped.

Fix #1447 