### PR TITLE
spread note ons over a few ticks

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -258,7 +258,8 @@ constexpr int32_t kNumVoicesStatic = 24;
 constexpr int32_t kNumVoiceSamplesStatic = 20;
 constexpr int32_t kNumTimeStretchersStatic = 6;
 
-constexpr int32_t kMaxNumNoteOnsPending = 64;
+// used to be 64 - it's pretty sketchy to render more than 8 at once though, so maybe we can let them get delayed a tick
+constexpr int32_t kMaxNumNoteOnsPending = 32;
 
 constexpr int32_t kNumUnsignedIntegersToRepPatchCables = 1;
 constexpr int32_t kMaxNumPatchCables = (kNumUnsignedIntegersToRepPatchCables * 32);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -900,7 +900,7 @@ doNewProbability:
 		playbackHandler.swungTicksTilNextEvent = ticksTilNextNoteRowEvent;
 	}
 	uint8_t numPending = skippedNoteOns.length();
-	for (int i = 0; i < numPending && noteOnsThisTick < 1; i++) {
+	for (int i = 0; i < numPending && noteOnsThisTick < maxNoteOnsThisTick; i++) {
 		sendPendingNoteOn(modelStack, skippedNoteOns.pop());
 	}
 	if (skippedNoteOns.length() > 0) {

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -888,9 +888,6 @@ doNewProbability:
 			}
 
 			if (conditionPassed) {
-				if (i == 0) {
-					sendPendingNoteOn(modelStack, &pendingNoteOnList.pendingNoteOns[i]);
-				}
 				storePendingNoteOn(modelStack, &pendingNoteOnList.pendingNoteOns[i]);
 			}
 			else {
@@ -903,8 +900,13 @@ doNewProbability:
 		playbackHandler.swungTicksTilNextEvent = ticksTilNextNoteRowEvent;
 	}
 	uint8_t numPending = skippedNoteOns.length();
-	for (int i = 0; i < 2 && i < numPending; i++) {
+	for (int i = 0; i < numPending && noteOnsThisTick < 1; i++) {
 		sendPendingNoteOn(modelStack, skippedNoteOns.pop());
+	}
+	if (skippedNoteOns.length() > 0) {
+		// come back immediately to start the skipped note
+		playbackHandler.swungTicksTilNextEvent = 1;
+		D_PRINTLN("skipped %d notes", skippedNoteOns.length());
 	}
 }
 
@@ -912,7 +914,9 @@ void InstrumentClip::storePendingNoteOn(ModelStackWithTimelineCounter* modelStac
 	if (skippedNoteOns.hasSpace()) {
 		skippedNoteOns.push(*pendingNoteOn);
 	}
-	sendPendingNoteOn(modelStack, pendingNoteOn);
+	else {
+		sendPendingNoteOn(modelStack, pendingNoteOn);
+	}
 }
 
 void InstrumentClip::sendPendingNoteOn(ModelStackWithTimelineCounter* modelStack, PendingNoteOn* pendingNoteOn) {

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -21,6 +21,7 @@
 #include "gui/ui/keyboard/state_data.h"
 #include "gui/views/instrument_clip_view.h"
 #include "model/clip/clip.h"
+#include "model/note/note_row.h"
 #include "model/note/note_row_vector.h"
 #include "model/timeline_counter.h"
 #include "modulation/arpeggiator.h"
@@ -251,11 +252,13 @@ protected:
 	void pingpongOccurred(ModelStackWithTimelineCounter* modelStack);
 
 private:
+	PendingNoteOnList skippedNoteOns;
 	InstrumentClip* instrumentWasLoadedByReferenceFromClip;
 
 	void deleteEmptyNoteRowsAtEitherEnd(bool onlyIfNoDrum, ModelStackWithTimelineCounter* modelStack,
 	                                    bool mustKeepLastOne = true, bool keepOnesWithMIDIInput = true);
 	void sendPendingNoteOn(ModelStackWithTimelineCounter* modelStack, PendingNoteOn* pendingNoteOn);
+	void storePendingNoteOn(ModelStackWithTimelineCounter* modelStack, PendingNoteOn* pendingNoteOn);
 	Error undoUnassignmentOfAllNoteRowsFromDrums(ModelStackWithTimelineCounter* modelStack);
 	void deleteBackedUpParamManagerMIDI();
 	bool possiblyDeleteEmptyNoteRow(NoteRow* noteRow, bool onlyIfNoDrum, Song* song, bool onlyIfNonNumeric = false,

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -72,7 +72,7 @@ struct PendingNoteOnList {
 		}
 		return &pendingNoteOns[0];
 	}
-	bool hasSpace() { return count < kMaxNumNoteOnsPending; }
+	bool hasSpace() { return (count + 1) < kMaxNumNoteOnsPending; }
 	uint8_t length() { return count; }
 };
 

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -59,8 +59,21 @@ struct PendingNoteOn {
 };
 
 struct PendingNoteOnList {
-	PendingNoteOn pendingNoteOns[kMaxNumNoteOnsPending];
-	uint8_t count;
+	PendingNoteOn pendingNoteOns[kMaxNumNoteOnsPending] = {0};
+	uint8_t count = 0;
+	void push(PendingNoteOn note) {
+		count = std::min<uint8_t>(count + 1, kMaxNumNoteOnsPending);
+		pendingNoteOns[count - 1] = note;
+	}
+	// must ensure one is present before calling
+	PendingNoteOn* pop() {
+		if (count > 0) {
+			return &pendingNoteOns[--count];
+		}
+		return &pendingNoteOns[0];
+	}
+	bool hasSpace() { return count < kMaxNumNoteOnsPending; }
+	uint8_t length() { return count; }
 };
 
 constexpr int32_t kQuantizationPrecision = 10;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -717,8 +717,10 @@ void PlaybackHandler::doMIDIClockOutTick() {
 }
 
 int noteOnsThisTick = 0;
+int maxNoteOnsThisTick = 0;
 void PlaybackHandler::actionSwungTick() {
 	noteOnsThisTick = 0;
+	maxNoteOnsThisTick = std::max<int>(1, 14 - AudioEngine::cpuDireness);
 	currentlyActioningSwungTickOrResettingPlayPos = true;
 
 	swungTickScheduled = false;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -716,8 +716,9 @@ void PlaybackHandler::doMIDIClockOutTick() {
 	midiEngine.sendClock(true);
 }
 
+int noteOnsThisTick = 0;
 void PlaybackHandler::actionSwungTick() {
-
+	noteOnsThisTick = 0;
 	currentlyActioningSwungTickOrResettingPlayPos = true;
 
 	swungTickScheduled = false;
@@ -789,6 +790,7 @@ void PlaybackHandler::actionSwungTick() {
 	swungTicksTilNextEvent = 2147483647;
 
 	if (isEitherClockActive()) { // Occasionally, considerLaunchEvent() will stop playback
+
 		currentPlaybackMode->doTickForward(swungTickIncrement);
 
 		if (isEitherClockActive()) { // Occasionally, doTickForward() will stop playback

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -251,3 +251,4 @@ private:
 };
 
 extern PlaybackHandler playbackHandler;
+extern int noteOnsThisTick;

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -252,3 +252,4 @@ private:
 
 extern PlaybackHandler playbackHandler;
 extern int noteOnsThisTick;
+extern int maxNoteOnsThisTick;

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -27,6 +27,7 @@
 #include "model/song/song.h"
 #include "model/voice/voice.h"
 #include "model/voice/voice_vector.h"
+#include "playback/playback_handler.h"
 #include "processing/engines/audio_engine.h"
 #include "storage/storage_manager.h"
 #include "util/misc.h"
@@ -100,6 +101,7 @@ void SoundDrum::noteOn(ModelStackWithThreeMainThings* modelStack, uint8_t veloci
 
 	Sound::noteOn(modelStack, &arpeggiator, kNoteForDrum, mpeValues, sampleSyncLength, ticksLate, samplesLate, velocity,
 	              fromMIDIChannel);
+	noteOnsThisTick += 1;
 }
 void SoundDrum::noteOff(ModelStackWithThreeMainThings* modelStack, int32_t velocity) {
 	Sound::allNotesOff(modelStack, &arpeggiator);

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -379,6 +379,7 @@ void SoundInstrument::sendNote(ModelStackWithThreeMainThings* modelStack, bool i
 	if (isOn) {
 		noteOn(modelStack, &arpeggiator, noteCode, mpeValues, sampleSyncLength, ticksLate, samplesLate, velocity,
 		       fromMIDIChannel);
+		noteOnsThisTick += 1;
 	}
 	else {
 		ArpeggiatorSettings* arpSettings = getArpSettings();


### PR DESCRIPTION
Experimenting with limiting the number of note ons per clip per step (at tick resolution)

This has performance improvements on medium songs (e.g. barely culling) and can avoid culling entirely by spreading out the allocations over a slightly longer period of time

~This has severe negative side effects on extremely heavy songs - if the deluge is being severely overloaded at note on (e.g. 15+ new notes), rather than culling almost all of them immediately (so they don't play at all) they will all attempt to play, and lead to cracks as they hard cull.~

No longer has side effects on heavy songs