### PR TITLE
Automation View ~ Interact With Editor From Menu + Re-instate Select Encoder Scrolling of Params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
 - Added `PERFORMANCE VIEW`, accessible in Song Row View by pressing the Keyboard button and in Song Grid View by
   pressing the Pink Mode pad. Allows quick control of Song Global FX.
 - Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
-- Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable / Modulation Depth.
+- Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to access the `AUTOMATION VIEW EDITOR` for that specific Patch Cable / Modulation Depth.
 - Updated `AUTOMATION VIEW EDITOR` to allow you to edit Bipolar params according to their Bipolar nature. E.g. Positive values are shown in the top four pads, Negative value in the bottom four pads, and the Middle value is shown by not lighting up any pads.
 - Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset
   file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the
@@ -41,9 +41,7 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
   now used to fine tune non-MIDI parameter values in the `AUTOMATION VIEW EDITOR`.
 - Updated `AUTOMATION VIEW` to provide access to Settings menu (hold shift + press select encoder)
 - Updated `AUTOMATION VIEW` to provide access to the Sound menu (press select encoder)
-- Updated automatable parameter editing menu's (accessed via Sound menu or Shift + parameter shortcut) to provide the
-  ability to enter the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu press Clip (if you
-  are in a clip) or Song (if you are in arranger) to exit out of the menu and enter the `AUTOMATION VIEW EDITOR`.
+- Updated automatable parameter editing menu's (accessed via Sound menu or Shift + parameter shortcut) to provide the ability to access the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu press Clip (if you are in a clip) or Song (if you are in arranger) to open the `AUTOMATION VIEW EDITOR` while you are still in the menu. You will be able to interact with the grid to edit automation for the current parameter / patch cable selected in the menu.
 - Added configuration of the number of count-in bars under `SETTINGS > RECORDING > COUNT-IN BARS`
 - Added Mod Button popups to display the current Mod (Gold) Encoder context (e.g. LPF/HPF Mode, Delay Mode and Type,
   Reverb Room Size, Compressor Mode, ModFX Type and Param).

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -589,10 +589,10 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
         - Updated `AUTOMATION VIEW` to provide access to Settings menu (hold shift + press select encoder)
         - Updated `AUTOMATION VIEW` to provide access to the Sound menu (press select encoder)
         - Updated automatable parameter editing menu's (accessed via Sound menu or Shift + parameter shortcut) to
-          provide the ability to enter the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu
-          press Clip (if you are in a clip) or Song (if you are in arranger) to exit out of the menu and enter
-          the `AUTOMATION VIEW EDITOR`.
-    - ([#1374]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to enter Automation View for that specific Patch Cable / Modulation Depth.
+          provide the ability to access the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu
+          press Clip (if you are in a clip) or Song (if you are in arranger) to open the `AUTOMATION VIEW EDITOR` while you are still in the menu. You will be able to interact with the grid to edit automation for the current parameter / patch cable selected in the menu.
+    - ([#1374]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to access the `AUTOMATION VIEW EDITOR` for that specific Patch Cable / Modulation Depth.
+    - ([#1456]) Added an in-between-layer in the Deluge menu system to be able to access and interact with the `AUTOMATION VIEW EDITOR` while you are still in the menu from the regular `ARRANGER / CLIP VIEW`. When you exit the menu you will be returned to the View you were in prior to entering the menu. Press Clip (if you are in a clip) or Song (if you are in arranger) to temporarily open the `AUTOMATION VIEW EDITOR` while you are still in the menu.    
     - ([#1480]) As a follow-up to [#1374] which enabled enabled patch cables to be edited in Automation View, the Automation Editor has now been modified to display param values according to whether the Param is bipolar or not. If it's a bipolar param, the grid will light up as follows:
       - Middle value = no pads lit up
       - Positive value = top 4 pads lit up according to position in middle to maximum value rnage
@@ -1185,6 +1185,8 @@ different firmware
 [#1374]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1374
 
 [#1382]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1382
+
+[#1456]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1456
 
 [#1480]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1480
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -12,7 +12,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 
 1. Automatable Clip View Parameters for Synths, Kits with affect entire DISABLED
 
->The 56 parameters that can be edited are:
+>The 59 parameters that can be edited are:
 >
 > - **Master** Level, Pitch, Pan
 > - **LPF** Frequency, Resonance, Morph
@@ -31,7 +31,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **LFO 1** Rate
 > - **LFO 2** Rate
 > - **Mod FX** Offset, Feedback, Depth, Rate
-> - **Arp** Rate, Gate
+> - **Arp** Rate, Gate, Ratchet Probability, Ratchet Amount, Sequence Length
 > - **Noise** Level
 > - **Portamento**
 > - **Stutter** Rate
@@ -135,7 +135,7 @@ The Automation Overview **will:**
 
 > **Note 3:** In a Kit clip, if you press and hold an audition pad and turn the vertical encoder, you can quickly scroll through all automation overview's for kit clip's rows
 
-- enable you to quickly access the Automation Editor for any automatable parameter by pressing any of the pads that are illuminated
+- enable you to quickly access the Automation Editor for any automatable parameter by pressing any of the pads that are illuminated or by turning select
 - enable you to clear all automations using the current combo of pressing down on Horizontal Encoder at the same time as pressing the Back button (note: for kit clip the behaviour will operate differently than usual: with affect entire enabled you will only clear all kit level automations. with affect entire disabled it will clear all kit row level automations).
 
 > **Note:** When automations are cleared, Parameters are reset to the current value in the Sound Editor. E.g. if an automation playing back and you deleted it mid playback, the parameter value would be set to the last played back value. Or if you just edited the automation by pressing on the grid, the last value would be the value corresponding to the last pad you pressed.
@@ -158,12 +158,14 @@ The Automation Overview **will not allow you to:**
 
 ## Parameter Selection
 
-You can select the Parameter that you want to edit in three ways:
+You can select the Parameter that you want to edit in four ways:
 
 1. From the Automation Overview by pressing any of the illuminated pads
-2. From the menu by selecting a parameter for editing and then pressing song (if you're in arranger) or clip (if you're in a clip)
-3. By pressing shift + the shortcut pad corresponding to the parameter you want to edit
-4. Once you select a Parameter in the Automation Clip View, it will be remembered and stored on a per clip basis unless you go back to the Automation Overview. This means that if you are editing a Parameter and go back to the regular Clip View, Song View or Arranger View, when you transition back to the Automation Clip View it will open the last Parameter that you were editing in the Automation Editor. Similarly if you were last on the Automation Overview it will remember that. 
+2. By turning select
+3. From the menu by selecting a parameter for editing and then pressing song (if you're in arranger) or clip (if you're in a clip)
+4. By pressing shift + the shortcut pad corresponding to the parameter you want to edit
+
+Once you select a Parameter in the Automation Clip View, it will be remembered and stored on a per clip basis unless you go back to the Automation Overview. This means that if you are editing a Parameter and go back to the regular Clip View, Song View or Arranger View, when you transition back to the Automation Clip View it will open the last Parameter that you were editing in the Automation Editor. Similarly if you were last on the Automation Overview it will remember that. 
 
 > **Note:** This information is saved with the song.
 
@@ -181,8 +183,8 @@ The Automation Editor **will:**
 
 - show you visually whether automation is enabled on a parameter by dimming the pads when automation is off, and increasing the brightness when automation is on
 - display on the screen what parameter you are currently editing and its automation status (for 7seg it will only display on the screen for MIDI clips)
-- enable you to use either of the Mod Encoders (gold knobs) to quickly change the parameter value of the parameter in focus. The knobs automatically map to the selected parameter and you can use either knob (eliminating the guess work about which knob to turn). You can also use the select encoder to change the value of the parameter in focus.
-- enable you to quickly change parameters in focus for editing by using shift + shortcut pad or going back to automation overview using affect entire or shift/audition pad + clip
+- enable you to use either of the Mod Encoders (gold knobs) to quickly change the parameter value of the parameter in focus. The knobs automatically map to the selected parameter and you can use either knob (eliminating the guess work about which knob to turn).
+- enable you to quickly change parameters in focus for editing by turning select or using shift + shortcut pad or going back to automation overview using affect entire or shift/audition pad + clip
 - enable you to view the current parameter value setting for the parameters that are currently automatable.
 - illuminate each pad row according to the current value within the range of 0-128. E.g. bottom pad = 0-16, then 17-32, 33-48, 49-64, 65-80, 81-96, 97-112, 113-128) 
 > **Update** The values displayed in automation view have been updated to display the same value range displayed in the menu's for consistency across the Deluge UI. So instead of displaying 0 - 128, it now displays 0 - 50. Calculations in automation view are still being done based on the 0 - 128 range, but the display converts it to the 0 - 50 range.

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -327,6 +327,8 @@ constexpr int32_t kMaxMenuMetronomeVolumeValue = 50;
 constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 
 // Automation View constants
+constexpr int32_t kNumNonGlobalParamsForAutomation = 59;
+constexpr int32_t kNumGlobalParamsForAutomation = 23;
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kKnobPosOffset = 64;
 constexpr int32_t kMaxKnobPos = 128;

--- a/src/deluge/gui/menu_item/automation/automation.cpp
+++ b/src/deluge/gui/menu_item/automation/automation.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2017-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "automation.h"
+#include "definitions_cxx.hpp"
+#include "gui/l10n/l10n.h"
+#include "gui/ui/sound_editor.h"
+#include "gui/views/automation_view.h"
+#include "gui/views/view.h"
+#include "hid/buttons.h"
+#include "hid/display/display.h"
+#include "hid/led/pad_leds.h"
+#include "model/action/action.h"
+#include "model/action/action_logger.h"
+#include "model/clip/clip.h"
+#include "model/model_stack.h"
+#include "model/song/song.h"
+#include "modulation/automation/auto_param.h"
+#include "modulation/params/param_set.h"
+
+namespace deluge::gui::menu_item {
+
+MenuItem* Automation::selectButtonPress() {
+	// If shift held down, delete automation
+	if (Buttons::isShiftButtonPressed()) {
+		char modelStackMemory[MODEL_STACK_MAX_SIZE];
+		ModelStackWithAutoParam* modelStack = getModelStackWithParam(modelStackMemory);
+		if (modelStack && modelStack->autoParam) {
+			Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE, ActionAddition::NOT_ALLOWED);
+
+			modelStack->autoParam->deleteAutomation(action, modelStack);
+
+			display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_DELETED));
+
+			// if automation view is open in background and automation is deleted
+			// then refresh automation view UI
+			if (getRootUI() == &automationView) {
+				uiNeedsRendering(&automationView);
+			}
+		}
+
+		return (MenuItem*)0xFFFFFFFF; // No navigation
+	}
+	return nullptr; // Navigate back
+}
+
+ActionResult Automation::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+	using namespace deluge::hid::button;
+
+	bool clipMinder = rootUIIsClipMinderScreen();
+	bool arrangerView = !clipMinder && (currentSong->lastClipInstanceEnteredStartPos != -1);
+	RootUI* rootUI = getRootUI();
+
+	// Clip or Song button
+	// Used to enter automation view from sound editor
+	if ((b == CLIP_VIEW && clipMinder) || (b == SESSION_VIEW && arrangerView)) {
+		if (on) {
+			// if we're not in automation view yet
+			// save current UI so you can switch back to it once we exit out of current menu
+			// flag automation view as onMenuView so we know that we're dealing with the background
+			// automation view used exclusively with the menu
+			if (rootUI != &automationView) {
+				automationView.previousUI = rootUI;
+				selectAutomationViewParameter(clipMinder);
+				swapOutRootUILowLevel(&automationView);
+				automationView.initializeView();
+				automationView.openedInBackground();
+				automationView.onMenuView = true;
+			}
+			// if we're in automation view and it's the menu view
+			// swap out background UI from automation view to the previous UI
+			else if (automationView.onMenuView) {
+				automationView.onMenuView = false;
+				automationView.resetInterpolationShortcutBlinking();
+				swapOutRootUILowLevel(automationView.previousUI);
+				uiNeedsRendering(automationView.previousUI);
+				view.setKnobIndicatorLevels();
+			}
+			view.setModLedStates();
+			PadLEDs::reassessGreyout();
+		}
+		return ActionResult::DEALT_WITH;
+	}
+	// Select encoder button, used to change current parameter selection in automation view
+	// Back button, used to back out of current automatable parameter menu
+	else if ((b == SELECT_ENC || b == BACK) && (clipMinder || arrangerView)) {
+		if (on) {
+			if (rootUI == &automationView) {
+				// if we got here, and we're in the automation menu view
+				// then we want to reset the background root UI to the previous UI
+				// because you just entered a new menu or backed out of the current param menu
+				if (automationView.onMenuView) {
+					automationView.onMenuView = false;
+					automationView.resetInterpolationShortcutBlinking();
+					swapOutRootUILowLevel(automationView.previousUI);
+					uiNeedsRendering(automationView.previousUI);
+					view.setKnobIndicatorLevels();
+				}
+				// if you are already in automation view and entered an automatable parameter menu
+				else {
+					selectAutomationViewParameter(clipMinder);
+					uiNeedsRendering(rootUI);
+				}
+				view.setModLedStates();
+				PadLEDs::reassessGreyout();
+			}
+		}
+		return ActionResult::DEALT_WITH;
+	}
+	else if ((b == X_ENC) && (clipMinder || arrangerView)) {
+		// Horizontal encoder button to zoom in/out of underlying automation view
+		if (rootUI == &automationView) {
+			automationView.buttonAction(b, on, inCardRoutine);
+			return ActionResult::DEALT_WITH;
+		}
+	}
+	return ActionResult::NOT_DEALT_WITH;
+}
+
+void Automation::selectAutomationViewParameter(bool clipMinder) {
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithAutoParam* modelStack = getModelStackWithParam(modelStackMemory);
+	if (modelStack) {
+		int32_t knobPos = automationView.getParameterKnobPos(modelStack, view.modPos) + kKnobPosOffset;
+		automationView.setKnobIndicatorLevels(modelStack, knobPos, knobPos);
+
+		int32_t p = modelStack->paramId;
+		modulation::params::Kind kind = modelStack->paramCollection->getParamKind();
+
+		Clip* clip = getCurrentClip();
+
+		if (clipMinder) {
+			clip->lastSelectedParamID = p;
+			clip->lastSelectedParamKind = kind;
+			clip->lastSelectedOutputType = clip->output->type;
+			clip->lastSelectedPatchSource = getPatchSource();
+			clip->lastSelectedParamShortcutX = kNoSelection;
+			clip->lastSelectedParamShortcutY = kNoSelection;
+			clip->lastSelectedParamArrayPosition = 0;
+		}
+		else {
+			currentSong->lastSelectedParamID = p;
+			currentSong->lastSelectedParamKind = kind;
+			currentSong->lastSelectedParamShortcutX = kNoSelection;
+			currentSong->lastSelectedParamShortcutY = kNoSelection;
+			currentSong->lastSelectedParamArrayPosition = 0;
+			automationView.onArrangerView = true;
+		}
+		// not blinking any shortcuts for patch cables
+		// no scroll selection for patch cables
+		if (kind != deluge::modulation::params::Kind::PATCH_CABLE) {
+			automationView.getLastSelectedParamShortcut(clip);
+			automationView.getLastSelectedParamArrayPosition(clip);
+		}
+	}
+}
+
+void Automation::horizontalEncoderAction(int32_t offset) {
+	if (getRootUI() == &automationView) {
+		automationView.horizontalEncoderAction(offset);
+	}
+}
+
+} // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/automation/automation.h
+++ b/src/deluge/gui/menu_item/automation/automation.h
@@ -17,31 +17,22 @@
 
 #pragma once
 
-#include "gui/menu_item/automation/automation.h"
 #include "gui/menu_item/menu_item.h"
 #include <cstdint>
+
 class ParamSet;
 class ModelStackWithAutoParam;
 
 namespace deluge::gui::menu_item {
 
 // Note that this does *not* inherit from MenuItem actually!
-class Param : public Automation {
+class Automation {
 public:
-	Param(int32_t newP = 0) : p(newP) {}
-	[[nodiscard]] virtual int32_t getMaxValue() const { return kMaxMenuValue; }
-	[[nodiscard]] virtual int32_t getMinValue() const { return kMinMenuValue; }
-	virtual uint8_t getP() { return p; };
 	MenuItem* selectButtonPress();
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
-	virtual ModelStackWithAutoParam* getModelStack(void* memory) = 0;
+	virtual ModelStackWithAutoParam* getModelStackWithParam(void* memory) = 0;
+	virtual PatchSource getPatchSource() { return PatchSource::NONE; }
+	void selectAutomationViewParameter(bool clipMinder);
 	void horizontalEncoderAction(int32_t offset);
-
-	uint8_t p;
-
-	virtual ModelStackWithAutoParam* getModelStackWithParam(void* memory);
-
-protected:
-	virtual ParamSet* getParamSet() = 0;
 };
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -63,7 +63,9 @@ public:
 	///
 	/// This is called with `(b == SELECT_ENC && on)` immediately after the menu is entered, or after
 	/// \ref selectButtonPress is called and returns `(MenuItem*)0xFFFFFFFF`.
-	virtual ActionResult buttonAction(deluge::hid::Button b, bool on) { return ActionResult::NOT_DEALT_WITH; }
+	virtual ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+		return ActionResult::NOT_DEALT_WITH;
+	}
 	/// @brief Handle horizontal encoder movement.
 	///
 	/// @param offset must be either -1 or 1, jumping is not supported by many children.

--- a/src/deluge/gui/menu_item/param.cpp
+++ b/src/deluge/gui/menu_item/param.cpp
@@ -16,9 +16,11 @@
  */
 
 #include "param.h"
+#include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
+#include "gui/views/view.h"
 #include "hid/buttons.h"
 #include "hid/display/display.h"
 #include "model/action/action.h"
@@ -32,77 +34,19 @@
 namespace deluge::gui::menu_item {
 
 MenuItem* Param::selectButtonPress() {
-	if (!Buttons::isShiftButtonPressed()) { // Shift button not pressed,
-		return nullptr;                     // So navigate backwards
-	}
-
-	// If shift button pressed, delete automation
-	Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE, ActionAddition::NOT_ALLOWED);
-
-	char modelStackMemory[MODEL_STACK_MAX_SIZE];
-	ModelStackWithAutoParam* modelStack = getModelStack(modelStackMemory);
-
-	modelStack->autoParam->deleteAutomation(action, modelStack);
-
-	display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_DELETED));
-	return (MenuItem*)0xFFFFFFFF; // Don't navigate away
+	return Automation::selectButtonPress();
 }
 
-ActionResult Param::buttonAction(deluge::hid::Button b, bool on) {
-	using namespace deluge::hid::button;
-
-	bool clipMinder = rootUIIsClipMinderScreen();
-	bool arrangerView = !clipMinder && (currentSong->lastClipInstanceEnteredStartPos != -1);
-	RootUI* rootUI = getRootUI();
-
-	// Clip or Song button
-	// Used to enter automation view from sound editor
-	if ((b == CLIP_VIEW && clipMinder) || (b == SESSION_VIEW && arrangerView)) {
-		if (on) {
-			if (rootUI != &automationView) {
-				selectAutomationViewParameter(clipMinder);
-				swapOutRootUILowLevel(&automationView);
-				automationView.initializeView();
-				automationView.openedInBackground();
-			}
-			soundEditor.exitCompletely();
-		}
-		return ActionResult::DEALT_WITH;
-	}
-	// Select encoder button, used to change current parameter selection in automation view
-	// if you are already in automation view and entered an automatable parameter menu
-	else if ((b == SELECT_ENC || b == BACK) && (clipMinder || arrangerView)) {
-		if (on) {
-			if (rootUI == &automationView) {
-				selectAutomationViewParameter(clipMinder);
-				uiNeedsRendering(rootUI);
-			}
-		}
-		return ActionResult::DEALT_WITH;
-	}
-	return ActionResult::NOT_DEALT_WITH;
+ActionResult Param::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+	return Automation::buttonAction(b, on, inCardRoutine);
 }
 
-void Param::selectAutomationViewParameter(bool clipMinder) {
-	char modelStackMemory[MODEL_STACK_MAX_SIZE];
-	ModelStackWithAutoParam* modelStack = getModelStack(modelStackMemory);
+void Param::horizontalEncoderAction(int32_t offset) {
+	Automation::horizontalEncoderAction(offset);
+}
 
-	int32_t p = modelStack->paramId;
-	modulation::params::Kind kind = modelStack->paramCollection->getParamKind();
-
-	Clip* clip = getCurrentClip();
-
-	if (clipMinder) {
-		clip->lastSelectedParamID = p;
-		clip->lastSelectedParamKind = kind;
-		clip->lastSelectedOutputType = clip->output->type;
-	}
-	else {
-		currentSong->lastSelectedParamID = p;
-		currentSong->lastSelectedParamKind = kind;
-		automationView.onArrangerView = true;
-	}
-	automationView.getLastSelectedParamShortcut(clip);
+ModelStackWithAutoParam* Param::getModelStackWithParam(void* memory) {
+	return getModelStack(memory);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -17,12 +17,13 @@
 
 #pragma once
 #include "decimal.h"
+#include "gui/menu_item/automation/automation.h"
 #include "menu_item_with_cc_learning.h"
 class MultiRange;
 
 namespace deluge::gui::menu_item {
 
-class PatchCableStrength : public Decimal, public MenuItemWithCCLearning {
+class PatchCableStrength : public Decimal, public MenuItemWithCCLearning, public Automation {
 public:
 	using Decimal::Decimal;
 	void beginSession(MenuItem* navigatedBackwardFrom) final;
@@ -38,11 +39,12 @@ public:
 	virtual PatchSource getS() = 0;
 	uint8_t getIndexOfPatchedParamToBlink() final;
 	MenuItem* selectButtonPress() override;
-	ActionResult buttonAction(deluge::hid::Button b, bool on);
-	void selectAutomationViewParameter(bool clipMinder);
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
+	void horizontalEncoderAction(int32_t offset);
 
 	deluge::modulation::params::Kind getParamKind();
 	uint32_t getParamIndex();
+	virtual PatchSource getPatchSource();
 
 	// OLED Only
 	void renderOLED();
@@ -52,6 +54,8 @@ public:
 	void learnKnob(MIDIDevice* fromDevice, int32_t whichKnob, int32_t modKnobMode, int32_t midiChannel) final {
 		MenuItemWithCCLearning::learnKnob(fromDevice, whichKnob, modKnobMode, midiChannel);
 	};
+
+	virtual ModelStackWithAutoParam* getModelStackWithParam(void* memory);
 
 protected:
 	bool preferBarDrawing = false;

--- a/src/deluge/gui/menu_item/patched_param.h
+++ b/src/deluge/gui/menu_item/patched_param.h
@@ -34,7 +34,10 @@ public:
 	// this button action function definition should not be required as it should be inherited
 	// from the param class, however it does not work if the definition is removed, so there
 	// is likely a multi-inheritance issue that needs to be resolved
-	ActionResult buttonAction(deluge::hid::Button b, bool on) { return Param::buttonAction(b, on); }
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+		return Param::buttonAction(b, on, inCardRoutine);
+	}
+	void horizontalEncoderAction(int32_t offset) { return Param::horizontalEncoderAction(offset); }
 
 	// 7SEG Only
 	virtual void drawValue() = 0;

--- a/src/deluge/gui/menu_item/patched_param/integer.h
+++ b/src/deluge/gui/menu_item/patched_param/integer.h
@@ -40,7 +40,10 @@ public:
 	// this button action function definition should not be required as it should be inherited
 	// from the param class, however it does not work if the definition is removed, so there
 	// is likely a multi-inheritance issue that needs to be resolved
-	ActionResult buttonAction(deluge::hid::Button b, bool on) final { return PatchedParam::buttonAction(b, on); }
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) final {
+		return PatchedParam::buttonAction(b, on, inCardRoutine);
+	}
+	void horizontalEncoderAction(int32_t offset) final { return PatchedParam::horizontalEncoderAction(offset); }
 
 	deluge::modulation::params::Kind getParamKind() final { return PatchedParam::getParamKind(); }
 	uint32_t getParamIndex() final { return PatchedParam::getParamIndex(); }

--- a/src/deluge/gui/menu_item/unpatched_param.h
+++ b/src/deluge/gui/menu_item/unpatched_param.h
@@ -41,7 +41,10 @@ public:
 	// this button action function definition should not be required as it should be inherited
 	// from the param class, however it does not work if the definition is removed, so there
 	// is likely a multi-inheritance issue that needs to be resolved
-	ActionResult buttonAction(deluge::hid::Button b, bool on) final { return Param::buttonAction(b, on); }
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) final {
+		return Param::buttonAction(b, on, inCardRoutine);
+	}
+	void horizontalEncoderAction(int32_t offset) final { return Param::horizontalEncoderAction(offset); }
 
 	void unlearnAction() final { MenuItemWithCCLearning::unlearnAction(); }
 	bool allowsLearnMode() final { return MenuItemWithCCLearning::allowsLearnMode(); }

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -143,16 +143,35 @@ bool SoundEditor::editingCVOrMIDIClip() {
 }
 
 bool SoundEditor::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
-	if (getRootUI() == &keyboardScreen) {
-		return false;
+	bool doGreyout = true;
+
+	RootUI* rootUI = getRootUI();
+	UIType uiType = UIType::NONE;
+	if (rootUI) {
+		uiType = rootUI->getUIType();
 	}
-	else if (getRootUI() == &automationView || getRootUI() == &instrumentClipView) {
+
+	switch (uiType) {
+	case UIType::KEYBOARD_SCREEN:
+		// don't greyout keyboard screen
+		doGreyout = false;
+		break;
+	case UIType::AUTOMATION_VIEW:
+		// only greyout if you're on automation overview
+		doGreyout = automationView.isOnAutomationOverview();
+		if (doGreyout) {
+			*cols = 0xFFFFFFFC; // don't greyout sidebar
+		}
+		break;
+	case UIType::INSTRUMENT_CLIP_VIEW:
 		*cols = 0xFFFFFFFE;
-	}
-	else {
+		break;
+	default:
 		*cols = 0xFFFFFFFF;
+		break;
 	}
-	return true;
+
+	return doGreyout;
 }
 
 bool SoundEditor::opened() {
@@ -236,15 +255,15 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				if (inCardRoutine) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 				}
-				MenuItem* newItem = getCurrentMenuItem()->selectButtonPress();
+
+				MenuItem* currentMenuItem = getCurrentMenuItem();
+				MenuItem* newItem = currentMenuItem->selectButtonPress();
 				if (newItem) {
 					if (newItem != (MenuItem*)0xFFFFFFFF) {
-
 						MenuPermission result = newItem->checkPermissionToBeginSession(
 						    currentModControllable, currentSourceIndex, &currentMultiRange);
 
 						if (result != MenuPermission::NO) {
-
 							if (result == MenuPermission::MUST_SELECT_RANGE) {
 								currentMultiRange = nullptr;
 								menu_item::multiRangeMenu.menuItemHeadingTo = newItem;
@@ -261,8 +280,8 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				else {
 					goUpOneLevel();
 				}
-				// potentially refresh automation view if entering a new param menu
-				getCurrentMenuItem()->buttonAction(b, on);
+
+				handlePotentialParamMenuChange(b, on, inCardRoutine, currentMenuItem, getCurrentMenuItem());
 			}
 		}
 	}
@@ -276,18 +295,16 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 				}
 
+				MenuItem* currentMenuItem = getCurrentMenuItem();
+
 				// Special case if we're editing a range
-				if (getCurrentMenuItem() == &menu_item::multiRangeMenu
-				    && menu_item::multiRangeMenu.cancelEditingIfItsOn()) {}
+				if (currentMenuItem == &menu_item::multiRangeMenu && menu_item::multiRangeMenu.cancelEditingIfItsOn()) {
+				}
 				else {
 					goUpOneLevel();
 				}
-				// if we back out of a patch cable menu
-				// (e.g. LFO -> Velocity -> Level back out to Velocity -> Level)
-				// or if you back out of a patch cable menu back to a regular param menu
-				// (e.g. Velocity -> Level back out to Level)
-				// potentially refresh automation view
-				getCurrentMenuItem()->buttonAction(b, on);
+
+				handlePotentialParamMenuChange(b, on, inCardRoutine, currentMenuItem, getCurrentMenuItem());
 			}
 		}
 	}
@@ -346,7 +363,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 	}
 
 	// Affect-entire button
-	else if (b == AFFECT_ENTIRE && (getRootUI() == &instrumentClipView || getRootUI() == &automationView)) {
+	else if (b == AFFECT_ENTIRE && getRootUI() == &instrumentClipView) {
 		if (getCurrentMenuItem()->usesAffectEntire() && editingKit()) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -391,15 +408,21 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				swapOutRootUILowLevel(&keyboardScreen);
 				keyboardScreen.openedInBackground();
 			}
-			else if (getRootUI() == &automationView) {
+			else if (getRootUI() == &automationView && !automationView.onArrangerView) {
 				if (getCurrentClip()->type == ClipType::INSTRUMENT) {
+					if (automationView.onMenuView) {
+						getCurrentClip()->onAutomationClipView = false;
+						automationView.onMenuView = false;
+						indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, true);
+					}
+					automationView.resetInterpolationShortcutBlinking();
 					swapOutRootUILowLevel(&keyboardScreen);
 					keyboardScreen.openedInBackground();
 				}
 			}
 
 			if (getRootUI() != &performanceSessionView) {
-				PadLEDs::reassessGreyout(true);
+				PadLEDs::reassessGreyout();
 
 				indicator_leds::setLedState(IndicatorLED::KEYBOARD, getRootUI() == &keyboardScreen);
 			}
@@ -407,11 +430,46 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 	}
 
 	else {
-		// potentially exit out of param / patch cable menu into automation view
-		return getCurrentMenuItem()->buttonAction(b, on);
+		// potentially swap root UI to automation view / previous UI
+		return getCurrentMenuItem()->buttonAction(b, on, inCardRoutine);
 	}
 
 	return ActionResult::DEALT_WITH;
+}
+
+/// check if menu we're in has changed
+/// (may not have changed if we were holding shift to delete automation)
+/// potentially enter and refresh automation view if entering a new param menu
+/// potentially exit automation view / switch to automation overview if exiting param menu
+void SoundEditor::handlePotentialParamMenuChange(deluge::hid::Button b, bool on, bool inCardRoutine,
+                                                 MenuItem* previousItem, MenuItem* currentItem) {
+	using namespace deluge::hid::button;
+	if (previousItem != currentItem) {
+		// if we're entering a non-param menu from a param menu
+		// potentially swap out automation view as background root UI
+		// or go back to automation overview in background root UI
+		if ((previousItem->getParamKind() != deluge::modulation::params::Kind::NONE)
+		    && (currentItem->getParamKind() == deluge::modulation::params::Kind::NONE)) {
+			if (getRootUI() == &automationView) {
+				// if on menu view, swap out root UI to previous UI
+				if (automationView.onMenuView) {
+					previousItem->buttonAction(b, on, inCardRoutine);
+				}
+				// if not on menu view, go back to overview
+				else {
+					automationView.initParameterSelection();
+					uiNeedsRendering(&automationView);
+					PadLEDs::reassessGreyout();
+				}
+			}
+		}
+		// if we're entering a param menu from a non-param menu
+		else if ((previousItem->getParamKind() == deluge::modulation::params::Kind::NONE)
+		         && (currentItem->getParamKind() != deluge::modulation::params::Kind::NONE)) {
+			// enter automation view and update parameter selection
+			currentItem->buttonAction(b, on, inCardRoutine);
+		}
+	}
 }
 
 void SoundEditor::goUpOneLevel() {
@@ -725,6 +783,13 @@ ActionResult SoundEditor::horizontalEncoderAction(int32_t offset) {
 	}
 }
 
+void SoundEditor::scrollFinished() {
+	exitUIMode(UI_MODE_HORIZONTAL_SCROLL);
+	// Needed because sometimes we initiate a scroll before reverting an Action, so we need to
+	// properly render again afterwards
+	uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0);
+}
+
 void SoundEditor::selectEncoderAction(int8_t offset) {
 
 	// 5x acceleration of select encoder when holding the shift button
@@ -737,6 +802,11 @@ void SoundEditor::selectEncoderAction(int8_t offset) {
 	// if you're in the performance view, let it handle the select encoder action
 	if (rootUI == &performanceSessionView) {
 		performanceSessionView.selectEncoderAction(offset);
+	}
+	// if you're not on the automation overview and you haven't selected a multi pad press
+	// (multi pad press values are only editable with mod encoders to edit left and right position)
+	else if (rootUI == &automationView && isEditingAutomationViewParam() && !automationView.multiPadPressSelected) {
+		automationView.modEncoderAction(0, offset);
 	}
 	else {
 		if (currentUIMode != UI_MODE_NONE && currentUIMode != UI_MODE_AUDITIONING
@@ -764,8 +834,8 @@ void SoundEditor::selectEncoderAction(int8_t offset) {
 			}
 
 			if (rootUI != &automationView) {
-				// If envelope param preset values were changed, there's a chance that there could have been a change to
-				// whether notes have tails
+				// If envelope param preset values were changed, there's a chance that there could have been a
+				// change to whether notes have tails
 				char modelStackMemory[MODEL_STACK_MAX_SIZE];
 				ModelStackWithSoundFlags* modelStack = getCurrentModelStack(modelStackMemory)->addSoundFlags();
 
@@ -797,21 +867,29 @@ static const uint32_t shortcutPadUIModes[] = {UI_MODE_AUDITIONING, 0};
 ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool on) {
 
 	bool ignoreAction = false;
-	// if in Performance Session View
-	if ((getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView)) {
-		// ignore if you're not in editing mode or if you're in editing mode but editing a param
-		ignoreAction = (!performanceSessionView.defaultEditingMode || performanceSessionView.editingParam);
+	if (!Buttons::isShiftButtonPressed()) {
+		// if in Performance Session View
+		if ((getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView)) {
+			// ignore if you're not in editing mode or if you're in editing mode but editing a param
+			ignoreAction = (!performanceSessionView.defaultEditingMode || performanceSessionView.editingParam);
+		}
+		else {
+			// ignore if you're not auditioning and in instrument clip view
+			ignoreAction = !(isUIModeActive(UI_MODE_AUDITIONING) && getRootUI() == &instrumentClipView);
+		}
 	}
 	else {
-		// ignore if you're not auditioning and in instrument clip view
-		ignoreAction = !(isUIModeActive(UI_MODE_AUDITIONING) && getRootUI() == &instrumentClipView);
+		// allow automation view to handle interpolation shortcut
+		if ((getRootUI() == &automationView) && (x == 0 && y == 6)) {
+			ignoreAction = true;
+		}
 	}
 
 	// ignore if:
 	// A) velocity is off (you let go of pad)
 	// B) you're pressing a pad in sidebar (not a shortcut)
-	// C) or you're not holding shift and ignore criteria above are met
-	if (!on || x >= kDisplayWidth || (!Buttons::isShiftButtonPressed() && ignoreAction)) {
+	// C) ignore criteria above are met
+	if (!on || x >= kDisplayWidth || ignoreAction) {
 		return ActionResult::NOT_DEALT_WITH;
 	}
 
@@ -894,6 +972,15 @@ doSetup:
 						return ActionResult::DEALT_WITH;
 					}
 
+					// let's check if we're entering a parameter / patch cable menu
+					MenuItem* newItem;
+					newItem = (MenuItem*)item;
+					deluge::modulation::params::Kind kind = newItem->getParamKind();
+					if ((newItem->getParamKind() == deluge::modulation::params::Kind::NONE)
+					    && getRootUI() == &automationView) {
+						return ActionResult::DEALT_WITH;
+					}
+
 					if (display->haveOLED()) {
 						switch (x) {
 						case 0 ... 3:
@@ -937,7 +1024,7 @@ doSetup:
 						if (getRootUI() == &automationView) {
 							// if automation view is open in the background
 							// potentially refresh grid if opening a new parameter menu
-							getCurrentMenuItem()->buttonAction(hid::button::SELECT_ENC, on);
+							getCurrentMenuItem()->buttonAction(hid::button::SELECT_ENC, on, sdRoutineLock);
 						}
 					}
 				}
@@ -1004,6 +1091,12 @@ getOut:
 								display->setNextTransitionDirection(1);
 							}
 							beginScreen();
+
+							if (getRootUI() == &automationView) {
+								// if automation view is open in the background
+								// potentially refresh grid if opening a new patch cable menu
+								getCurrentMenuItem()->buttonAction(hid::button::SELECT_ENC, on, sdRoutineLock);
+							}
 						}
 
 						// Otherwise, do nothing
@@ -1023,8 +1116,10 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
 
+	RootUI* rootUI = getRootUI();
+
 	bool isUIPerformanceSessionView =
-	    (getRootUI() == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
+	    (rootUI == &performanceSessionView) || (getCurrentUI() == &performanceSessionView);
 
 	// used to convert column press to a shortcut to change Perform FX menu displayed
 	if (isUIPerformanceSessionView && !Buttons::isShiftButtonPressed() && performanceSessionView.defaultEditingMode
@@ -1042,23 +1137,23 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 		}
 	}
 
-	if (getRootUI() == &keyboardScreen) {
+	if (rootUI == &keyboardScreen) {
 		keyboardScreen.padAction(x, y, on);
 		return ActionResult::DEALT_WITH;
 	}
 
 	// Audition pads
-	else if (getRootUI() == &instrumentClipView) {
+	else if (rootUI == &instrumentClipView) {
 		if (x == kDisplayWidth + 1) {
 			instrumentClipView.padAction(x, y, on);
 			return ActionResult::DEALT_WITH;
 		}
 	}
 
-	else if (getRootUI() == &automationView) {
-		if (x == kDisplayWidth + 1) {
-			automationView.padAction(x, y, on);
-			return ActionResult::DEALT_WITH;
+	else if (rootUI == &automationView) {
+		ActionResult result = handleAutomationViewPadAction(x, y, on);
+		if (result == ActionResult::DEALT_WITH) {
+			return result;
 		}
 	}
 
@@ -1091,7 +1186,7 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 
 		// used in performanceSessionView to ignore pad presses when you just exited soundEditor
 		// with a padAction
-		if (getRootUI() == &performanceSessionView) {
+		if (rootUI == &performanceSessionView) {
 			performanceSessionView.justExitedSoundEditor = true;
 		}
 
@@ -1099,6 +1194,47 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 	}
 
 	return ActionResult::DEALT_WITH;
+}
+
+ActionResult SoundEditor::handleAutomationViewPadAction(int32_t x, int32_t y, int32_t velocity) {
+	// interact with automation view grid from menu
+	bool editingParamInAutomationView = isEditingAutomationViewParam();
+
+	// if we're not interacting with the same parameter currently selected in the menu
+	// then only allow interacting with sidebar pads
+	if ((x >= kDisplayWidth) || editingParamInAutomationView) {
+		automationView.padAction(x, y, velocity);
+		return ActionResult::DEALT_WITH;
+	}
+	return ActionResult::NOT_DEALT_WITH;
+}
+
+bool SoundEditor::isEditingAutomationViewParam() {
+	// get the current menu item open
+	MenuItem* currentMenuItem = getCurrentMenuItem();
+
+	// get the param kind and index for that menu item (if there is one)
+	// returns Kind::NONE / paramID = kNoSelection if we're not in a param menu
+	deluge::modulation::params::Kind kind = currentMenuItem->getParamKind();
+	int32_t paramID = currentMenuItem->getParamIndex();
+
+	bool editingParamInAutomationArrangerView = false;
+	bool editingParamInAutomationClipView = false;
+
+	if (kind != deluge::modulation::params::Kind::NONE && paramID != kNoSelection) {
+		// are in automation arranger view and editing the same param open in the menu?
+		editingParamInAutomationArrangerView = automationView.onArrangerView
+		                                       && (kind == currentSong->lastSelectedParamKind)
+		                                       && (paramID == currentSong->lastSelectedParamID);
+
+		Clip* clip = getCurrentClip();
+
+		// are in automation clip view and editing the same param open in the menu?
+		editingParamInAutomationClipView = !automationView.onArrangerView && (kind == clip->lastSelectedParamKind)
+		                                   && (paramID == clip->lastSelectedParamID);
+	}
+
+	return (editingParamInAutomationArrangerView || editingParamInAutomationClipView);
 }
 
 ActionResult SoundEditor::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
@@ -1142,23 +1278,37 @@ bool SoundEditor::pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel, uin
 }
 
 void SoundEditor::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
-	// If learn button is pressed, learn this knob for current param
-	if (currentUIMode == UI_MODE_MIDI_LEARN) {
+	if (getRootUI() == &automationView) {
+		automationView.modEncoderAction(whichModEncoder, offset);
+	}
+	else {
+		// If learn button is pressed, learn this knob for current param
+		if (currentUIMode == UI_MODE_MIDI_LEARN) {
 
-		// But, can't do it if it's a Kit and affect-entire is on!
-		if (editingKit() && getCurrentInstrumentClip()->affectEntire) {
-			// IndicatorLEDs::indicateErrorOnLed(affectEntireLedX, affectEntireLedY);
+			// But, can't do it if it's a Kit and affect-entire is on!
+			if (editingKit() && getCurrentInstrumentClip()->affectEntire) {
+				// IndicatorLEDs::indicateErrorOnLed(affectEntireLedX, affectEntireLedY);
+			}
+
+			// Otherwise, everything's fine
+			else {
+				getCurrentMenuItem()->learnKnob(nullptr, whichModEncoder, getCurrentOutput()->modKnobMode, 255);
+			}
 		}
 
-		// Otherwise, everything's fine
+		// Otherwise, send the action to the Editor as usual
 		else {
-			getCurrentMenuItem()->learnKnob(nullptr, whichModEncoder, getCurrentOutput()->modKnobMode, 255);
+			UI::modEncoderAction(whichModEncoder, offset);
 		}
 	}
+}
 
-	// Otherwise, send the action to the Editor as usual
+void SoundEditor::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
+	if (getRootUI() == &automationView) {
+		automationView.modEncoderButtonAction(whichModEncoder, on);
+	}
 	else {
-		UI::modEncoderAction(whichModEncoder, offset);
+		UI::modEncoderButtonAction(whichModEncoder, on);
 	}
 }
 

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -74,7 +74,9 @@ public:
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine);
 	void modEncoderAction(int32_t whichModEncoder, int32_t offset);
+	void modEncoderButtonAction(uint8_t whichModEncoder, bool on);
 	ActionResult horizontalEncoderAction(int32_t offset);
+	void scrollFinished();
 	bool editingKit();
 
 	ActionResult timerCallback() override;
@@ -147,6 +149,10 @@ private:
 	bool beginScreen(MenuItem* oldMenuItem = NULL);
 	uint8_t getActualParamFromScreen(uint8_t screen);
 	void setLedStates();
+	ActionResult handleAutomationViewPadAction(int32_t x, int32_t y, int32_t velocity);
+	bool isEditingAutomationViewParam();
+	void handlePotentialParamMenuChange(deluge::hid::Button b, bool on, bool inCardRoutine, MenuItem* previousItem,
+	                                    MenuItem* currentItem);
 };
 
 extern SoundEditor soundEditor;

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -132,9 +132,14 @@ void UITimerManager::routine() {
 				}
 
 				case TimerName::DISPLAY_AUTOMATION:
-					if ((getCurrentUI() == &automationView) && !automationView.isOnAutomationOverview()) {
+					if (((getCurrentUI() == &automationView) || (getRootUI() == &automationView))
+					    && !automationView.isOnAutomationOverview()) {
 
 						automationView.displayAutomation();
+
+						if (getCurrentUI() == &soundEditor) {
+							soundEditor.getCurrentMenuItem()->readValueAgain();
+						}
 					}
 
 					else {

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -118,6 +118,99 @@ const uint32_t mutePadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITION
 
 const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_RECORD_COUNT_IN, 0};
 
+// synth and kit rows FX - sorted in the order that Parameters are scrolled through on the display
+const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutomation> nonGlobalParamsForAutomation{{
+    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_FX}, // Master Volume, Pitch, Pan
+    {params::Kind::PATCHED, params::LOCAL_PITCH_ADJUST},
+    {params::Kind::PATCHED, params::LOCAL_PAN},
+    {params::Kind::PATCHED, params::LOCAL_LPF_FREQ}, // LPF Cutoff, Resonance, Morph
+    {params::Kind::PATCHED, params::LOCAL_LPF_RESONANCE},
+    {params::Kind::PATCHED, params::LOCAL_LPF_MORPH},
+    {params::Kind::PATCHED, params::LOCAL_HPF_FREQ}, // HPF Cutoff, Resonance, Morph
+    {params::Kind::PATCHED, params::LOCAL_HPF_RESONANCE},
+    {params::Kind::PATCHED, params::LOCAL_HPF_MORPH},
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS}, // Bass, Bass Freq
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS_FREQ},
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE}, // Treble, Treble Freq
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE_FREQ},
+    {params::Kind::PATCHED, params::GLOBAL_REVERB_AMOUNT}, // Reverb Amount
+    {params::Kind::PATCHED, params::GLOBAL_DELAY_RATE},    // Delay Rate, Amount
+    {params::Kind::PATCHED, params::GLOBAL_DELAY_FEEDBACK},
+    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_REVERB_SEND}, // Sidechain Send, Shape
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SIDECHAIN_SHAPE},
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SAMPLE_RATE_REDUCTION}, // Decimation, Bitcrush, Wavefolder
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BITCRUSHING},
+    {params::Kind::PATCHED, params::LOCAL_FOLD},
+    {params::Kind::PATCHED,
+     params::LOCAL_OSC_A_VOLUME}, // OSC 1 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+    {params::Kind::PATCHED, params::LOCAL_OSC_A_PITCH_ADJUST},
+    {params::Kind::PATCHED, params::LOCAL_OSC_A_PHASE_WIDTH},
+    {params::Kind::PATCHED, params::LOCAL_CARRIER_0_FEEDBACK},
+    {params::Kind::PATCHED,
+     params::LOCAL_OSC_A_WAVE_INDEX}, // OSC 2 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+    {params::Kind::PATCHED, params::LOCAL_OSC_B_VOLUME},
+    {params::Kind::PATCHED, params::LOCAL_OSC_B_PITCH_ADJUST},
+    {params::Kind::PATCHED, params::LOCAL_OSC_B_PHASE_WIDTH},
+    {params::Kind::PATCHED, params::LOCAL_CARRIER_1_FEEDBACK},
+    {params::Kind::PATCHED, params::LOCAL_OSC_B_WAVE_INDEX},
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_VOLUME}, // FM Mod 1 Volume, Pitch, Feedback
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_PITCH_ADJUST},
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_FEEDBACK},
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_VOLUME}, // FM Mod 2 Volume, Pitch, Feedback
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_PITCH_ADJUST},
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_FEEDBACK},
+    {params::Kind::PATCHED, params::LOCAL_ENV_0_ATTACK}, // Env 1 ADSR
+    {params::Kind::PATCHED, params::LOCAL_ENV_0_DECAY},
+    {params::Kind::PATCHED, params::LOCAL_ENV_0_SUSTAIN},
+    {params::Kind::PATCHED, params::LOCAL_ENV_0_RELEASE},
+    {params::Kind::PATCHED, params::LOCAL_ENV_1_ATTACK}, // Env 2 ADSR
+    {params::Kind::PATCHED, params::LOCAL_ENV_1_DECAY},
+    {params::Kind::PATCHED, params::LOCAL_ENV_1_SUSTAIN},
+    {params::Kind::PATCHED, params::LOCAL_ENV_1_RELEASE},
+    {params::Kind::PATCHED, params::GLOBAL_LFO_FREQ},                 // LFO 1 Freq
+    {params::Kind::PATCHED, params::LOCAL_LFO_LOCAL_FREQ},            // LFO 2 Freq
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_OFFSET}, // Mod FX Offset, Feedback, Depth, Rate
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_FEEDBACK},
+    {params::Kind::PATCHED, params::GLOBAL_MOD_FX_DEPTH},
+    {params::Kind::PATCHED, params::GLOBAL_MOD_FX_RATE},
+    {params::Kind::PATCHED, params::GLOBAL_ARP_RATE}, // Arp Rate, Gate, Ratchet Prob, Ratchet Amount, Sequence Length
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_GATE},
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_PROBABILITY},
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_AMOUNT},
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
+    {params::Kind::PATCHED, params::LOCAL_NOISE_VOLUME},             // Noise
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_PORTAMENTO},   // Portamento
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE}, // Stutter Rate
+}};
+
+// global FX - sorted in the order that Parameters are scrolled through on the display
+// used with kit affect entire, audio clips, and arranger
+const std::array<std::pair<params::Kind, ParamType>, kNumGlobalParamsForAutomation> globalParamsForAutomation{{
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_VOLUME}, // Master Volume, Pitch, Pan
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PITCH_ADJUST},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PAN},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_FREQ}, // LPF Cutoff, Resonance
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_RES},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_FREQ}, // HPF Cutoff, Resonance
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_RES},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS}, // Bass, Bass Freq
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS_FREQ},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE}, // Treble, Treble Freq
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE_FREQ},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_REVERB_SEND_AMOUNT}, // Reverb Amount
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_RATE},         // Delay Rate, Amount
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_AMOUNT},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_VOLUME}, // Sidechain Send, Shape
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_SHAPE},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SAMPLE_RATE_REDUCTION}, // Decimation, Bitcrush
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BITCRUSHING},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_OFFSET}, // Mod FX Offset, Feedback, Depth, Rate
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_FEEDBACK},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_DEPTH},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_RATE},
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_STUTTER_RATE}, // Stutter Rate
+}};
+
 // let's render some love <3
 
 const uint32_t love[kDisplayWidth][kDisplayHeight] = {
@@ -230,6 +323,7 @@ AutomationView::AutomationView() {
 	lastPadSelectedKnobPos = kNoSelection;
 	playbackStopped = false;
 	onArrangerView = false;
+	onMenuView = false;
 	navSysId = NAVIGATION_CLIP;
 
 	initMIDICCShortcutsForAutomation();
@@ -327,12 +421,15 @@ void AutomationView::focusRegained() {
 		}
 	}
 
-	// blink timer got reset by view.focusRegained() above
-	parameterShortcutBlinking = false;
-	// remove patch cable blink frequencies
-	memset(soundEditor.sourceShortcutBlinkFrequencies, 255, sizeof(soundEditor.sourceShortcutBlinkFrequencies));
-	// possibly restablish parameter shortcut blinking (if parameter is selected)
-	blinkShortcuts();
+	// don't reset shortcut blinking if were still in the menu
+	if (getCurrentUI() == this) {
+		// blink timer got reset by view.focusRegained() above
+		parameterShortcutBlinking = false;
+		// remove patch cable blink frequencies
+		memset(soundEditor.sourceShortcutBlinkFrequencies, 255, sizeof(soundEditor.sourceShortcutBlinkFrequencies));
+		// possibly restablish parameter shortcut blinking (if parameter is selected)
+		blinkShortcuts();
+	}
 }
 
 void AutomationView::openedInBackground() {
@@ -448,29 +545,31 @@ bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidt
 
 void AutomationView::blinkShortcuts() {
 	if (!encoderAction) {
-		int32_t lastSelectedParamShortcutX = kNoSelection;
-		int32_t lastSelectedParamShortcutY = kNoSelection;
-		if (onArrangerView) {
-			lastSelectedParamShortcutX = currentSong->lastSelectedParamShortcutX;
-			lastSelectedParamShortcutY = currentSong->lastSelectedParamShortcutY;
-		}
-		else {
-			Clip* clip = getCurrentClip();
-			lastSelectedParamShortcutX = clip->lastSelectedParamShortcutX;
-			lastSelectedParamShortcutY = clip->lastSelectedParamShortcutY;
-		}
-		// if a Param has been selected for editing, blink its shortcut pad
-		if (lastSelectedParamShortcutX != kNoSelection) {
-			if (!parameterShortcutBlinking) {
-				soundEditor.setupShortcutBlink(lastSelectedParamShortcutX, lastSelectedParamShortcutY, 10);
-				soundEditor.blinkShortcut();
-
-				parameterShortcutBlinking = true;
+		if (getCurrentUI() == this) {
+			int32_t lastSelectedParamShortcutX = kNoSelection;
+			int32_t lastSelectedParamShortcutY = kNoSelection;
+			if (onArrangerView) {
+				lastSelectedParamShortcutX = currentSong->lastSelectedParamShortcutX;
+				lastSelectedParamShortcutY = currentSong->lastSelectedParamShortcutY;
 			}
-		}
-		// unset previously set blink timers if not editing a parameter
-		else {
-			resetParameterShortcutBlinking();
+			else {
+				Clip* clip = getCurrentClip();
+				lastSelectedParamShortcutX = clip->lastSelectedParamShortcutX;
+				lastSelectedParamShortcutY = clip->lastSelectedParamShortcutY;
+			}
+			// if a Param has been selected for editing, blink its shortcut pad
+			if (lastSelectedParamShortcutX != kNoSelection) {
+				if (!parameterShortcutBlinking) {
+					soundEditor.setupShortcutBlink(lastSelectedParamShortcutX, lastSelectedParamShortcutY, 10);
+					soundEditor.blinkShortcut();
+
+					parameterShortcutBlinking = true;
+				}
+			}
+			// unset previously set blink timers if not editing a parameter
+			else {
+				resetParameterShortcutBlinking();
+			}
 		}
 		if (interpolation) {
 			if (!interpolationShortcutBlinking) {
@@ -891,6 +990,12 @@ DisplayParameterValue
 DisplayParameterName */
 
 void AutomationView::renderDisplay(int32_t knobPosLeft, int32_t knobPosRight, bool modEncoderAction) {
+	// don't refresh display if we're not current in the automation view UI
+	// (e.g. if you're editing automation while in the menu)
+	if (getCurrentUI() != this) {
+		return;
+	}
+
 	Clip* clip = getCurrentClip();
 	OutputType outputType = clip->output->type;
 
@@ -1204,11 +1309,11 @@ void AutomationView::displayAutomation(bool padSelected, bool updateDisplay) {
 			if (modelStackWithParam->getTimelineCounter()
 			    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
-				int32_t knobPos = getParameterKnobPos(modelStackWithParam, view.modPos);
+				int32_t knobPos = getParameterKnobPos(modelStackWithParam, view.modPos) + kKnobPosOffset;
 
 				// update value on the screen when playing back automation
 				if (updateDisplay && !playbackStopped) {
-					renderDisplay(knobPos + kKnobPosOffset);
+					renderDisplay(knobPos);
 				}
 				// on 7SEG re-render parameter name under certain circumstances
 				// e.g. when entering pad selection mode, when stopping playback
@@ -1217,7 +1322,6 @@ void AutomationView::displayAutomation(bool padSelected, bool updateDisplay) {
 					playbackStopped = false;
 				}
 
-				knobPos = knobPos + kKnobPosOffset;
 				setKnobIndicatorLevels(modelStackWithParam, knobPos, knobPos);
 			}
 		}
@@ -1655,6 +1759,9 @@ void AutomationView::handleVerticalEncoderButtonAction(bool on) {
 // called by button action if b == SELECT_ENC and shift button is not pressed
 void AutomationView::handleSelectEncoderButtonAction(bool on) {
 	if (on) {
+		initParameterSelection();
+		uiNeedsRendering(this);
+
 		if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_RECORDING_TO_ARRANGEMENT));
 			return;
@@ -1854,7 +1961,8 @@ ActionResult AutomationView::handleEditPadAction(ModelStackWithAutoParam* modelS
 					display->displayPopup(l10n::get(l10n::String::STRING_FOR_INTERPOLATION_DISABLED));
 				}
 			}
-			else {
+			// don't change parameters this way if we're in the menu
+			else if (getCurrentUI() == &automationView) {
 				initPadSelection();
 				handleSinglePadPress(modelStackWithParam, clip, x, y, effectiveLength, xScroll, xZoom, true);
 			}
@@ -2096,13 +2204,16 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 			drum = modelStackWithNoteRowOnCurrentClip->getNoteRow()->drum;
 			Drum* selectedDrum = ((Kit*)output)->selectedDrum;
 			if (selectedDrum != drum) {
+				// But not if we're actually not on this screen
+				if (getCurrentUI() != this) {
+					return;
+				}
 				selectedDrumChanged = true;
 			}
 		}
 
 		// If NoteRow doesn't exist here, we'll see about creating one
 		else {
-
 			// But not if we're actually not on this screen
 			if (getCurrentUI() != this) {
 				return;
@@ -2304,6 +2415,7 @@ getOut:
 
 // horizontal encoder action
 // using this to shift automations left / right
+// using this to zoom in / out
 ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 	if (sdRoutineLock) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE; // Just be safe - maybe not necessary
@@ -3099,16 +3211,113 @@ void AutomationView::selectEncoderAction(int8_t offset) {
 	// if you're in a midi clip
 	else if (outputType == OutputType::MIDI_OUT) {
 		selectMIDICC(offset, clip);
+		getLastSelectedParamShortcut(clip);
 	}
 	// if you're in arranger view or in a non-midi, non-cv clip (e.g. audio, synth, kit)
 	else if (onArrangerView || outputType != OutputType::CV) {
-		// if you're not on the automation overview and you haven't selected a multi pad press
-		// (multi pad press values are only editable with mod encoders to edit left and right position)
-		if (!isOnAutomationOverview() && !multiPadPressSelected) {
-			modEncoderAction(0, offset);
+		// if you're in a audio clip, a kit with affect entire enabled, or in arranger view
+		if (onArrangerView || (outputType == OutputType::AUDIO)
+		    || (outputType == OutputType::KIT && instrumentClipView.getAffectEntire())) {
+			selectGlobalParam(offset, clip);
+		}
+		// if you're a synth or a kit (with affect entire off and a drum selected)
+		else if (outputType == OutputType::SYNTH || (outputType == OutputType::KIT && ((Kit*)output)->selectedDrum)) {
+			selectNonGlobalParam(offset, clip);
+		}
+		getLastSelectedParamShortcut(clip);
+	}
+	// if you're in a CV clip or function is called for some other reason, do nothing
+	else {
+		return;
+	}
+
+	// update name on display, the LED mod indicators, and refresh the grid
+	lastPadSelectedKnobPos = kNoSelection;
+	if (multiPadPressSelected && padSelectionOn) {
+		char modelStackMemory[MODEL_STACK_MAX_SIZE];
+		ModelStackWithTimelineCounter* modelStackWithTimelineCounter = nullptr;
+		ModelStackWithThreeMainThings* modelStackWithThreeMainThings = nullptr;
+		ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+		if (onArrangerView) {
+			modelStackWithThreeMainThings = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
+			modelStackWithParam =
+			    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
+		}
+		else {
+			modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+			modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
+		}
+		int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
+		int32_t xScroll = currentSong->xScroll[navSysId];
+		int32_t xZoom = currentSong->xZoom[navSysId];
+		renderDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom);
+	}
+	else {
+		displayAutomation(true, !display->have7SEG());
+	}
+	resetShortcutBlinking();
+	view.setModLedStates();
+	uiNeedsRendering(this);
+}
+
+// used with SelectEncoderAction to get the next arranger / audio clip / kit affect entire parameter
+void AutomationView::selectGlobalParam(int32_t offset, Clip* clip) {
+	if (onArrangerView) {
+		auto idx = getNextSelectedParamArrayPosition(offset, currentSong->lastSelectedParamArrayPosition,
+		                                             kNumGlobalParamsForAutomation);
+		auto [kind, id] = globalParamsForAutomation[idx];
+		{
+			while ((id == params::UNPATCHED_PITCH_ADJUST || id == params::UNPATCHED_SIDECHAIN_SHAPE
+			        || id == params::UNPATCHED_SIDECHAIN_VOLUME)) {
+
+				if (offset < 0) {
+					offset -= 1;
+				}
+				else if (offset > 0) {
+					offset += 1;
+				}
+				idx = getNextSelectedParamArrayPosition(offset, currentSong->lastSelectedParamArrayPosition,
+				                                        kNumGlobalParamsForAutomation);
+				id = globalParamsForAutomation[idx].second;
+			}
+		}
+		currentSong->lastSelectedParamID = id;
+		currentSong->lastSelectedParamKind = kind;
+		currentSong->lastSelectedParamArrayPosition = idx;
+	}
+	else {
+		auto idx = getNextSelectedParamArrayPosition(offset, clip->lastSelectedParamArrayPosition,
+		                                             kNumGlobalParamsForAutomation);
+		auto [kind, id] = globalParamsForAutomation[idx];
+		clip->lastSelectedParamID = id;
+		clip->lastSelectedParamKind = kind;
+		clip->lastSelectedParamArrayPosition = idx;
+	}
+}
+
+// used with SelectEncoderAction to get the next synth or kit non-affect entire param
+void AutomationView::selectNonGlobalParam(int32_t offset, Clip* clip) {
+	auto idx = getNextSelectedParamArrayPosition(offset, clip->lastSelectedParamArrayPosition,
+	                                             kNumNonGlobalParamsForAutomation);
+	{
+		auto [kind, id] = nonGlobalParamsForAutomation[idx];
+		if ((clip->output->type == OutputType::KIT) && (kind == params::Kind::UNPATCHED_SOUND)
+		    && (id == params::UNPATCHED_PORTAMENTO)) {
+			if (offset < 0) {
+				offset -= 1;
+			}
+			else if (offset > 0) {
+				offset += 1;
+			}
+			idx = getNextSelectedParamArrayPosition(offset, clip->lastSelectedParamArrayPosition,
+			                                        kNumNonGlobalParamsForAutomation);
 		}
 	}
-	return;
+	auto [kind, id] = nonGlobalParamsForAutomation[idx];
+	clip->lastSelectedParamID = id;
+	clip->lastSelectedParamKind = kind;
+	clip->lastSelectedParamArrayPosition = idx;
 }
 
 // used with SelectEncoderAction to get the next midi CC
@@ -3129,30 +3338,29 @@ void AutomationView::selectMIDICC(int32_t offset, Clip* clip) {
 		newCC += offset;
 	}
 	clip->lastSelectedParamID = newCC;
+}
 
-	getLastSelectedParamShortcut(clip);
-
-	// update name on display, the LED mod indicators, and refresh the grid
-	lastPadSelectedKnobPos = kNoSelection;
-	if (multiPadPressSelected && padSelectionOn) {
-		char modelStackMemory[MODEL_STACK_MAX_SIZE];
-
-		ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-		    currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-		ModelStackWithAutoParam* modelStackWithParam =
-		    getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
-
-		int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
-		int32_t xScroll = currentSong->xScroll[navSysId];
-		int32_t xZoom = currentSong->xZoom[navSysId];
-		renderDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom);
+// used with SelectEncoderAction to get the next parameter in the list of parameters
+int32_t AutomationView::getNextSelectedParamArrayPosition(int32_t offset, int32_t lastSelectedParamArrayPosition,
+                                                          int32_t numParams) {
+	int32_t idx;
+	// if you haven't selected a parameter yet, start at the beginning of the list
+	if (isOnAutomationOverview()) {
+		idx = 0;
 	}
+	// if you are scrolling left and are at the beginning of the list, go to the end of the list
+	else if ((lastSelectedParamArrayPosition + offset) < 0) {
+		idx = numParams - 1;
+	}
+	// if you are scrolling right and are at the end of the list, go to the beginning of the list
+	else if ((lastSelectedParamArrayPosition + offset) > (numParams - 1)) {
+		idx = 0;
+	}
+	// otherwise scrolling left/right within the list
 	else {
-		displayAutomation(true, !display->have7SEG());
+		idx = lastSelectedParamArrayPosition + offset;
 	}
-	resetParameterShortcutBlinking();
-	view.setModLedStates();
-	uiNeedsRendering(this);
+	return idx;
 }
 
 // used with Select Encoder action to get the X, Y grid shortcut coordinates of the parameter selected
@@ -3206,6 +3414,56 @@ void AutomationView::getLastSelectedParamShortcut(Clip* clip) {
 	}
 }
 
+void AutomationView::getLastSelectedParamArrayPosition(Clip* clip) {
+	Output* output = clip->output;
+	OutputType outputType = output->type;
+
+	// if you're in arranger view or in a non-midi, non-cv clip (e.g. audio, synth, kit)
+	if (onArrangerView || outputType != OutputType::CV) {
+		// if you're in a audio clip, a kit with affect entire enabled, or in arranger view
+		if (onArrangerView || (outputType == OutputType::AUDIO)
+		    || (outputType == OutputType::KIT && instrumentClipView.getAffectEntire())) {
+			getLastSelectedGlobalParamArrayPosition(clip);
+		}
+		// if you're a synth or a kit (with affect entire off and a drum selected)
+		else if (outputType == OutputType::SYNTH || (outputType == OutputType::KIT && ((Kit*)output)->selectedDrum)) {
+			getLastSelectedNonGlobalParamArrayPosition(clip);
+		}
+	}
+}
+
+void AutomationView::getLastSelectedNonGlobalParamArrayPosition(Clip* clip) {
+	for (auto idx = 0; idx < kNumNonGlobalParamsForAutomation; idx++) {
+
+		auto [kind, id] = nonGlobalParamsForAutomation[idx];
+
+		if ((id == clip->lastSelectedParamID) && (kind == clip->lastSelectedParamKind)) {
+			clip->lastSelectedParamArrayPosition = idx;
+			break;
+		}
+	}
+}
+
+void AutomationView::getLastSelectedGlobalParamArrayPosition(Clip* clip) {
+	for (auto idx = 0; idx < kNumGlobalParamsForAutomation; idx++) {
+
+		auto [kind, id] = globalParamsForAutomation[idx];
+
+		if (onArrangerView) {
+			if ((id == currentSong->lastSelectedParamID) && (kind == currentSong->lastSelectedParamKind)) {
+				currentSong->lastSelectedParamArrayPosition = idx;
+				break;
+			}
+		}
+		else {
+			if ((id == clip->lastSelectedParamID) && (kind == clip->lastSelectedParamKind)) {
+				clip->lastSelectedParamArrayPosition = idx;
+				break;
+			}
+		}
+	}
+}
+
 // tempo encoder action
 void AutomationView::tempoEncoderAction(int8_t offset, bool encoderButtonPressed, bool shiftButtonPressed) {
 	playbackHandler.tempoEncoderAction(offset, encoderButtonPressed, shiftButtonPressed);
@@ -3233,6 +3491,7 @@ void AutomationView::initParameterSelection() {
 		currentSong->lastSelectedParamKind = params::Kind::NONE;
 		currentSong->lastSelectedParamShortcutX = kNoSelection;
 		currentSong->lastSelectedParamShortcutY = kNoSelection;
+		currentSong->lastSelectedParamArrayPosition = 0;
 	}
 	else {
 		Clip* clip = getCurrentClip();
@@ -3241,6 +3500,7 @@ void AutomationView::initParameterSelection() {
 		clip->lastSelectedParamShortcutX = kNoSelection;
 		clip->lastSelectedParamShortcutY = kNoSelection;
 		clip->lastSelectedPatchSource = PatchSource::NONE;
+		clip->lastSelectedParamArrayPosition = 0;
 	}
 
 	// if we're going back to the Automation Overview, set the display to show "Automation Overview"
@@ -3564,6 +3824,8 @@ bool AutomationView::handleParameterSelection(Clip* clip, OutputType outputType,
 			clip->lastSelectedParamKind = params::Kind::UNPATCHED_SOUND;
 			clip->lastSelectedParamID = unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay];
 		}
+
+		getLastSelectedNonGlobalParamArrayPosition(clip);
 	}
 
 	// if you are in arranger, an audio clip, or a kit clip with affect entire enabled
@@ -3588,6 +3850,8 @@ bool AutomationView::handleParameterSelection(Clip* clip, OutputType outputType,
 			clip->lastSelectedParamKind = paramKind;
 			clip->lastSelectedParamID = paramID;
 		}
+
+		getLastSelectedGlobalParamArrayPosition(clip);
 	}
 
 	else if (outputType == OutputType::MIDI_OUT && midiCCShortcutsForAutomation[xDisplay][yDisplay] != kNoParamID) {

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -99,7 +99,9 @@ public:
 
 	// Select encoder action
 	void selectEncoderAction(int8_t offset);
-	void getLastSelectedParamShortcut(Clip* clip);
+	void getLastSelectedParamShortcut(Clip* clip);      // public so menu can access it
+	void getLastSelectedParamArrayPosition(Clip* clip); // public so menu can access it
+	bool multiPadPressSelected;                         // public so menu can access it
 
 	// called by melodic_instrument.cpp or kit.cpp
 	void noteRowChanged(InstrumentClip* clip, NoteRow* noteRow);
@@ -129,6 +131,13 @@ public:
 	// public so uiTimerManager can access it
 	void blinkInterpolationShortcut();
 
+	// public so menu can access it
+	bool onMenuView;
+	UI* previousUI; // previous UI so you can swap back UI after exiting menu
+	int32_t getParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t pos);
+	void setKnobIndicatorLevels(ModelStackWithAutoParam* modelStack, int32_t knobPosLeft, int32_t knobPosRight);
+	void resetInterpolationShortcutBlinking();
+
 private:
 	// button action functions
 	bool handleScaleButtonAction(InstrumentClip* instrumentClip, OutputType outputType, bool on);
@@ -144,6 +153,7 @@ private:
 	bool handleBackAndHorizontalEncoderButtonComboAction(Clip* clip, bool on);
 	void handleVerticalEncoderButtonAction(bool on);
 	void handleSelectEncoderButtonAction(bool on);
+	void handleAffectEntireButtonAction(bool on);
 
 	// audition pad action
 	ActionResult handleAuditionPadAction(InstrumentClip* instrumentClip, Output* output, OutputType outputType,
@@ -210,6 +220,10 @@ private:
 	void selectGlobalParam(int32_t offset, Clip* clip);
 	void selectNonGlobalParam(int32_t offset, Clip* clip);
 	void selectMIDICC(int32_t offset, Clip* clip);
+	int32_t getNextSelectedParamArrayPosition(int32_t offset, int32_t lastSelectedParamArrayPosition,
+	                                          int32_t numParams);
+	void getLastSelectedNonGlobalParamArrayPosition(Clip* clip);
+	void getLastSelectedGlobalParamArrayPosition(Clip* clip);
 
 	// Automation Lanes Functions
 	void initPadSelection();
@@ -219,13 +233,11 @@ private:
 	uint32_t getMiddlePosFromSquare(int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
 
 	void getParameterName(Clip* clip, OutputType outputType, char* parameterName);
-	int32_t getParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t pos);
 
 	bool getNodeInterpolation(ModelStackWithAutoParam* modelStack, int32_t pos, bool reversed);
 	void setParameterAutomationValue(ModelStackWithAutoParam* modelStack, int32_t knobPos, int32_t squareStart,
 	                                 int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
 	                                 bool modEncoderAction = false);
-	void setKnobIndicatorLevels(ModelStackWithAutoParam* modelStack, int32_t knobPosLeft, int32_t knobPosRight);
 	void updateModPosition(ModelStackWithAutoParam* modelStack, uint32_t squareStart, bool updateDisplay = true,
 	                       bool updateIndicatorLevels = true);
 
@@ -255,7 +267,6 @@ private:
 	void blinkShortcuts();
 	void resetShortcutBlinking();
 	void resetParameterShortcutBlinking();
-	void resetInterpolationShortcutBlinking();
 
 	bool encoderAction;
 	bool parameterShortcutBlinking;
@@ -265,7 +276,6 @@ private:
 	uint8_t interpolationShortcutY;
 
 	bool padSelectionOn;
-	bool multiPadPressSelected;
 	bool multiPadPressActive;
 	bool middlePadPressSelected;
 	int32_t leftPadSelectedX;

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -222,8 +222,11 @@ doReRender:
 	else if ((isNoUIModeActive() && Buttons::isButtonPressed(deluge::hid::button::Y_ENC))
 	         || (isUIModeActiveExclusively(UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON)
 	             && Buttons::isButtonPressed(deluge::hid::button::CLIP_VIEW))) {
-		if (sdRoutineLock)
-			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE; // Just be safe - maybe not necessary
+		// Just be safe - maybe not necessary
+		if (sdRoutineLock) {
+			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+		}
+
 		int32_t squareSize = getPosFromSquare(1) - getPosFromSquare(0);
 		int32_t shiftAmount = offset * squareSize;
 		Clip* clip = getCurrentClip();

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -5372,11 +5372,10 @@ void InstrumentClipView::playbackEnded() {
 
 void InstrumentClipView::scrollFinished() {
 	if (currentUIMode == UI_MODE_AUDITIONING) {
-		uiNeedsRendering(this, 0xFFFFFFFF,
-		                 0); // Needed because sometimes we initiate a scroll before reverting an Action, so we need to
-		                     // properly render again afterwards
+		// Needed because sometimes we initiate a scroll before reverting an Action, so we need to
+		// properly render again afterwards
+		uiNeedsRendering(this, 0xFFFFFFFF, 0);
 	}
-
 	else {
 		ClipView::scrollFinished();
 	}

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -28,9 +28,9 @@
 
 void TimelineView::scrollFinished() {
 	exitUIMode(UI_MODE_HORIZONTAL_SCROLL);
-	uiNeedsRendering(this, 0xFFFFFFFF,
-	                 0); // Needed because sometimes we initiate a scroll before reverting an Action, so we need to
-	                     // properly render again afterwards
+	// Needed because sometimes we initiate a scroll before reverting an Action, so we need to
+	// properly render again afterwards
+	uiNeedsRendering(this, 0xFFFFFFFF, 0);
 }
 
 // Virtual function

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1183,7 +1183,8 @@ void View::setKnobIndicatorLevels() {
 	}
 
 	// don't update knob indicator levels when you're in automation editor
-	if ((getCurrentUI() == &automationView) && !automationView.isOnAutomationOverview()) {
+	if ((getRootUI() == &automationView) && !automationView.isOnAutomationOverview()) {
+		automationView.displayAutomation();
 		return;
 	}
 
@@ -1297,7 +1298,8 @@ void View::modButtonAction(uint8_t whichButton, bool on) {
 	UI* currentUI = getCurrentUI();
 
 	// ignore modButtonAction when in the Automation View Automation Editor
-	if ((currentUI == &automationView) && !automationView.isOnAutomationOverview()) {
+	if (((currentUI == &automationView) || (getRootUI() == &automationView))
+	    && !automationView.isOnAutomationOverview()) {
 		return;
 	}
 
@@ -1513,7 +1515,7 @@ void View::setModLedStates() {
 	for (int32_t i = 0; i < kNumModButtons; i++) {
 		bool on = (i == modKnobMode);
 		// if you're in the Automation View Automation Editor, turn off Mod LED's
-		if ((getCurrentUI() == &automationView) && !automationView.isOnAutomationOverview()) {
+		if ((getRootUI() == &automationView) && !automationView.isOnAutomationOverview()) {
 			indicator_leds::setLedState(indicator_leds::modLed[i], false);
 		}
 		else {

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1037,6 +1037,7 @@ void AudioClip::writeDataToFile(Song* song) {
 		storageManager.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		storageManager.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);
 		storageManager.writeAttribute("lastSelectedParamShortcutY", lastSelectedParamShortcutY);
+		storageManager.writeAttribute("lastSelectedParamArrayPosition", lastSelectedParamArrayPosition);
 	}
 
 	Clip::writeDataToFile(song);
@@ -1141,6 +1142,10 @@ someError:
 
 		else if (!strcmp(tagName, "lastSelectedParamShortcutY")) {
 			lastSelectedParamShortcutY = storageManager.readTagOrAttributeValueInt();
+		}
+
+		else if (!strcmp(tagName, "lastSelectedParamArrayPosition")) {
+			lastSelectedParamArrayPosition = storageManager.readTagOrAttributeValueInt();
 		}
 
 		else {

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -63,6 +63,7 @@ Clip::Clip(ClipType newType) : type(newType) {
 	lastSelectedParamKind = params::Kind::NONE;
 	lastSelectedParamShortcutX = kNoSelection;
 	lastSelectedParamShortcutY = kNoSelection;
+	lastSelectedParamArrayPosition = 0;
 	lastSelectedOutputType = OutputType::NONE;
 	lastSelectedPatchSource = PatchSource::NONE;
 	// end initialize of automation clip view variables

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -189,6 +189,7 @@ public:
 	deluge::modulation::params::Kind lastSelectedParamKind;
 	int32_t lastSelectedParamShortcutX;
 	int32_t lastSelectedParamShortcutY;
+	int32_t lastSelectedParamArrayPosition;
 	OutputType lastSelectedOutputType;
 	PatchSource lastSelectedPatchSource;
 	// END ~ new Automation Clip View Variables

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2289,6 +2289,7 @@ void InstrumentClip::writeDataToFile(Song* song) {
 		storageManager.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		storageManager.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);
 		storageManager.writeAttribute("lastSelectedParamShortcutY", lastSelectedParamShortcutY);
+		storageManager.writeAttribute("lastSelectedParamArrayPosition", lastSelectedParamArrayPosition);
 		storageManager.writeAttribute("lastSelectedInstrumentType", util::to_underlying(lastSelectedOutputType));
 		storageManager.writeAttribute("lastSelectedPatchSource", util::to_underlying(lastSelectedPatchSource));
 	}
@@ -2561,6 +2562,10 @@ someError:
 
 		else if (!strcmp(tagName, "lastSelectedParamShortcutY")) {
 			lastSelectedParamShortcutY = storageManager.readTagOrAttributeValueInt();
+		}
+
+		else if (!strcmp(tagName, "lastSelectedParamArrayPosition")) {
+			lastSelectedParamArrayPosition = storageManager.readTagOrAttributeValueInt();
 		}
 
 		else if (!strcmp(tagName, "lastSelectedInstrumentType")) {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -187,6 +187,7 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	lastSelectedParamKind = params::Kind::NONE;
 	lastSelectedParamShortcutX = kNoSelection;
 	lastSelectedParamShortcutY = kNoSelection;
+	lastSelectedParamArrayPosition = 0;
 	// end initialize of automation arranger view variables
 
 	masterTransposeInterval = 0;
@@ -1353,6 +1354,7 @@ weAreInArrangementEditorOrInClipInstance:
 		storageManager.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		storageManager.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);
 		storageManager.writeAttribute("lastSelectedParamShortcutY", lastSelectedParamShortcutY);
+		storageManager.writeAttribute("lastSelectedParamArrayPosition", lastSelectedParamArrayPosition);
 	}
 
 	globalEffectable.writeAttributesToFile(false);
@@ -1777,6 +1779,11 @@ unknownTag:
 			else if (!strcmp(tagName, "lastSelectedParamShortcutY")) {
 				lastSelectedParamShortcutY = storageManager.readTagOrAttributeValueInt();
 				storageManager.exitTag("lastSelectedParamShortcutY");
+			}
+
+			else if (!strcmp(tagName, "lastSelectedParamArrayPosition")) {
+				lastSelectedParamArrayPosition = storageManager.readTagOrAttributeValueInt();
+				storageManager.exitTag("lastSelectedParamArrayPosition");
 			}
 
 			// legacy section, read as part of global effectable (songParams tag) post c1.1

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -374,6 +374,7 @@ public:
 	    lastSelectedParamKind; // 0 = patched, 1 = unpatched, 2 = global effectable, 3 = none
 	int32_t lastSelectedParamShortcutX;
 	int32_t lastSelectedParamShortcutY;
+	int32_t lastSelectedParamArrayPosition;
 	// END ~ new Automation Arranger View Variables
 
 	// Song level transpose control (encoder actions)

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -996,7 +996,7 @@ void AutoParam::setValueForRegion(uint32_t pos, uint32_t length, int32_t value,
 		// when this feature is enabled, interpolation is enforced on manual automation editing in the automation
 		// instrument clip view
 
-		if (getCurrentUI() == &automationView) {
+		if (getRootUI() == &automationView) {
 			firstI = homogenizeRegion(modelStack, pos, length, value, automationView.interpolationBefore,
 			                          automationView.interpolationAfter, effectiveLength, false);
 		}


### PR DESCRIPTION
Description:
- [x] Added "temporary" in-between automation editor layer to be able to edit params using the automation view editor UI without having to enter the full automation view UI to do it. When you're done editing and exit the menu, you are returned the previous UI you were in prior to entering the menu
- [x] Added back select encoder scrolling of automation view parameters while in the full automation view UI
- [x] Updated documentation

Some additional full automation view UI fine tuning:
- [x] When using the full automation view UI and entering the menu, the background UI will reset to the automation overview when first entering the menu and when you are not in a parameter menu
- [x] When using the full automation view UI, also enable editing the automation editor directly from the menu as users will come to expect this when using the in-between-UI. It also just makes sense.

Did some refactoring:
- [x] Refactored Param::selectButtonAction and PatchCableStrength::selectButtonAction to call Automation::selectButtonAction
- [x] Refactored Param::buttonAction and PatchCableStrength::buttonAction to call Automation::buttonAction
- [x] Refactored Param::selectAutomationViewParameter and PatchCableStrength::selectAutomationViewParameter to call Automation::selectAutomationViewParameter
- [x] Refactored Param::horizontalEncoderAction and PatchCableStrength::horizontalEncoderAction to call Automation::horizontalEncoderAction

To do:
- [x] Bug to fix: interpolation shortcut continues to flash when you're not in automation view
- [x] Bug to fix: fix pad grey out when entering menu