### PR TITLE
Added Celtic scale

### DIFF
--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -197,6 +197,7 @@ std::array<char const*, NUM_PRESET_SCALES> presetScaleNames = {
 	"ARABIAN",
 	"WHOLE TONE",
 	"BLUES",
+	"CELTIC",
 	"PENTATONIC MINOR",
 	"HIRAJOSHI",
 };
@@ -305,6 +306,7 @@ const uint8_t presetScaleNotes[NUM_PRESET_SCALES][7] = {
 		// 6-note scales
 		{0, 2, 4, 6, 8, 10, 0}, // WHOL Whole Tone (matches Launchpad and Lumi scale)
 		{0, 3, 5, 6, 7, 10, 0}, // BLUE Blues Minor (matches Launchpad and Lumi BLUES scale)
+		{0, 2, 3, 5, 7, 10, 0}, // CELT Celtic Minor
 		// 5-note scales
 		{0, 3, 5, 7, 10, 0, 0}, // PENT Pentatonic Minor (matches Launchpad and Lumi scale)
 		{0, 2, 3, 7, 8, 0, 0},  // HIRA Hirajoshi (matches Launchpad scale)

--- a/src/deluge/util/lookuptables/lookuptables.h
+++ b/src/deluge/util/lookuptables/lookuptables.h
@@ -131,10 +131,10 @@ extern const int16_t windowedSincKernelBasicForWavetableBetweenCycles[];
 
 #define OFFICIAL_FIRMWARE_RANDOM_SCALE_INDEX 7
 #define OFFICIAL_FIRMWARE_NONE_SCALE_INDEX 8
-#define NUM_PRESET_SCALES 16
+#define NUM_PRESET_SCALES 17
 #define FIRST_7_NOTE_SCALE_INDEX 0
 #define FIRST_6_NOTE_SCALE_INDEX 12
-#define FIRST_5_NOTE_SCALE_INDEX 14
+#define FIRST_5_NOTE_SCALE_INDEX 15
 #define CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES 255
 extern const uint8_t presetScaleNotes[NUM_PRESET_SCALES][7];
 extern std::array<char const*, NUM_PRESET_SCALES> presetScaleNames;


### PR DESCRIPTION
Celtic scale is a common scale used for handpans. It is like a minor scale, but without one note (example: D E F G A C), so it is a 6-note scale. Adding this as it is a nice addition when playing with other musicians.

Thanks to how scale selection is saved now, it won't interfere with already saved songs