### PR TITLE
Fix audition pads for kits while loading

### DIFF
--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -333,7 +333,7 @@ void doAnyPendingUIRendering() {
 	uint32_t sideRowsNow = whichSideRowsNeedRendering;
 
 	// Clear the overall instructions - so it may now be written to again during this function call
-	whichMainRowsNeedRendering = whichSideRowsNeedRendering = 0;
+	clearPendingUIRendering();
 
 	for (int32_t u = numUIsOpen - 1; u >= 0; u--) {
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3353,6 +3353,11 @@ void InstrumentClipView::setSelectedDrum(Drum* drum, bool shouldRedrawStuff, Kit
 						renderingNeededRegardlessOfUI(0, 0xFFFFFFFF);
 					}
 				}
+				else {
+					// Some other top-level view currently, don't overwrite the active ModControllable but do request
+					// rendering
+					renderingNeededRegardlessOfUI(0, 0xFFFFFFFF);
+				}
 			}
 		}
 	}
@@ -4247,6 +4252,12 @@ drawNormally:
 
 		// Kit - draw "selected Drum"
 		if (getCurrentOutputType() == OutputType::KIT) {
+			if (getCurrentUI() != this) {
+				// we're not the top-level UI, just turn the pad off
+				thisColour = colours::black;
+				return;
+			}
+
 			NoteRow* noteRow = getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, currentSong);
 			if (noteRow != NULL && noteRow->drum != NULL && noteRow->drum == getCurrentKit()->selectedDrum) {
 


### PR DESCRIPTION
Fixes #1404.

I'm not super happy with how the fix works but architecturally the UI system is a mess and fixing that is probably out of scope for 1.1