### PR TITLE
Bugfix - Pad LED Greyout Cols and Rows mixup

### DIFF
--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -112,7 +112,7 @@ bool AudioInputSelector::setupAndCheckAvailability() {
 	return true;
 }
 
-bool AudioInputSelector::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool AudioInputSelector::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*rows = getRootUI()->getGreyedOutRowsNotRepresentingOutput(audioOutput);
 	return true;
 }

--- a/src/deluge/gui/context_menu/audio_input_selector.h
+++ b/src/deluge/gui/context_menu/audio_input_selector.h
@@ -28,7 +28,7 @@ class AudioInputSelector final : public ContextMenu {
 
 public:
 	AudioInputSelector() = default;
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) override;
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
 	void selectEncoderAction(int8_t offset) override;
 	bool setupAndCheckAvailability();
 	bool canSeeViewUnderneath() override { return true; }

--- a/src/deluge/gui/context_menu/context_menu.cpp
+++ b/src/deluge/gui/context_menu/context_menu.cpp
@@ -25,7 +25,7 @@
 
 namespace deluge::gui {
 
-bool ContextMenu::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool ContextMenu::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*cols = 0xFFFFFFFF;
 	return true;
 }

--- a/src/deluge/gui/context_menu/context_menu.h
+++ b/src/deluge/gui/context_menu/context_menu.h
@@ -39,7 +39,7 @@ public:
 
 	virtual Sized<char const**> getOptions() = 0;
 
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) override;
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
 	bool setupAndCheckAvailability();
 

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -62,7 +62,7 @@ AudioRecorder::AudioRecorder() {
 	recorder = NULL;
 }
 
-bool AudioRecorder::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool AudioRecorder::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*cols = 0xFFFFFFFF;
 	return true;
 }

--- a/src/deluge/gui/ui/audio_recorder.h
+++ b/src/deluge/gui/ui/audio_recorder.h
@@ -37,7 +37,7 @@ class AudioRecorder final : public UI {
 public:
 	AudioRecorder();
 	bool opened();
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	bool beginOutputRecording();

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -502,7 +502,7 @@ gotError:
 	return Error::NONE;
 }
 
-bool SampleBrowser::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool SampleBrowser::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 
 	if (currentlyShowingSamplePreview || qwertyVisible || getRootUI() == &keyboardScreen) {
 		*cols = 0b10;

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -38,7 +38,7 @@ class Sample;
 class SampleBrowser final : public Browser {
 public:
 	SampleBrowser();
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 	bool opened();
 	void focusRegained();
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -52,7 +52,7 @@ LoadInstrumentPresetUI loadInstrumentPresetUI{};
 LoadInstrumentPresetUI::LoadInstrumentPresetUI() {
 }
 
-bool LoadInstrumentPresetUI::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool LoadInstrumentPresetUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	if (showingAuditionPads()) {
 		*cols = 0b10;
 	}

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.h
@@ -40,7 +40,7 @@ public:
 	Error performLoad(bool doClone = false);
 	Error performLoadSynthToKit();
 	ActionResult timerCallback();
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth] = NULL,
 	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth] = NULL, bool drawUndefinedArea = true,
 	                    int32_t navSys = -1) {

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -49,7 +49,7 @@ bool RenameDrumUI::opened() {
 	return true;
 }
 
-bool RenameDrumUI::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool RenameDrumUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*cols = 0b11;
 	return true;
 }

--- a/src/deluge/gui/ui/rename/rename_drum_ui.h
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.h
@@ -29,7 +29,7 @@ public:
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine);
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 
 	// ui
 	UIType getUIType() { return UIType::RENAME_DRUM; }

--- a/src/deluge/gui/ui/rename/rename_output_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_output_ui.cpp
@@ -54,7 +54,7 @@ bool RenameOutputUI::opened() {
 	return true;
 }
 
-bool RenameOutputUI::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool RenameOutputUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*cols = 0b11;
 	return true;
 }

--- a/src/deluge/gui/ui/rename/rename_output_ui.h
+++ b/src/deluge/gui/ui/rename/rename_output_ui.h
@@ -29,7 +29,7 @@ public:
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine);
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 
 	Output* output;
 

--- a/src/deluge/gui/ui/sample_marker_editor.cpp
+++ b/src/deluge/gui/ui/sample_marker_editor.cpp
@@ -79,7 +79,7 @@ SampleControls* getCurrentSampleControls() {
 	}
 }
 
-bool SampleMarkerEditor::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool SampleMarkerEditor::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*cols = 0b10;
 	return true;
 }

--- a/src/deluge/gui/ui/sample_marker_editor.h
+++ b/src/deluge/gui/ui/sample_marker_editor.h
@@ -34,7 +34,7 @@ public:
 	SampleMarkerEditor();
 
 	bool opened();
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 	void selectEncoderAction(int8_t offset);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -142,7 +142,7 @@ bool SoundEditor::editingCVOrMIDIClip() {
 	return (getCurrentOutputType() == OutputType::MIDI_OUT || getCurrentOutputType() == OutputType::CV);
 }
 
-bool SoundEditor::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool SoundEditor::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	if (getRootUI() == &keyboardScreen) {
 		return false;
 	}

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -55,7 +55,7 @@ public:
 	bool opened();
 	void focusRegained();
 	void displayOrLanguageChanged() final;
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 	Sound* currentSound;
 	ModControllableAudio* currentModControllable;
 	int8_t currentSourceIndex;

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -61,13 +61,13 @@ UI* lastUIBeforeNullifying = nullptr;
  *
  * @return std::pair<uint32_t, uint32_t> a pair with [rows, columns]
  */
-std::pair<uint32_t, uint32_t> getUIGreyoutRowsAndCols() {
+std::pair<uint32_t, uint32_t> getUIGreyoutColsAndRows() {
 	uint32_t cols = 0;
 	uint32_t rows = 0;
 	for (int32_t u = numUIsOpen - 1; u >= 0; u--) {
-		bool useThis = uiNavigationHierarchy[u]->getGreyoutRowsAndCols(&cols, &rows);
+		bool useThis = uiNavigationHierarchy[u]->getGreyoutColsAndRows(&cols, &rows);
 		if (useThis) {
-			return std::make_pair(rows, cols);
+			return std::make_pair(cols, rows);
 		}
 	}
 	return std::make_pair(0, 0);

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -120,7 +120,7 @@ public:
 		return false;
 	} // Returns whether it was used, I think?
 
-	virtual bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+	virtual bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 		return false;
 	} // Returning false means obey UI under me
 
@@ -163,7 +163,7 @@ void swapOutRootUILowLevel(UI* newUI);
 void nullifyUIs();
 bool rootUIIsTimelineView();
 bool rootUIIsClipMinderScreen();
-std::pair<uint32_t, uint32_t> getUIGreyoutRowsAndCols();
+std::pair<uint32_t, uint32_t> getUIGreyoutColsAndRows();
 
 void uiNeedsRendering(UI* ui, uint32_t whichMainRows = 0xFFFFFFFF, uint32_t whichSideRows = 0xFFFFFFFF);
 void renderingNeededRegardlessOfUI(uint32_t whichMainRows = 0xFFFFFFFF, uint32_t whichSideRows = 0xFFFFFFFF);

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -3200,7 +3200,7 @@ void ArrangerView::notifyPlaybackBegun() {
 	}
 }
 
-bool ArrangerView::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool ArrangerView::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	if (currentUIMode == UI_MODE_VIEWING_RECORD_ARMING) {
 		*cols = 0xFFFFFFFD;
 		*rows = 0;

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -80,7 +80,7 @@ public:
 	void clipNeedsReRendering(Clip* clip) override;
 	void exitSubModeWithoutAction(UI* ui = nullptr);
 	bool transitionToArrangementEditor();
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) override;
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
 	void setLedStates();
 	ActionResult verticalScrollOneSquare(int32_t direction);
 	ActionResult horizontalScrollOneSquare(int32_t direction);

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -88,7 +88,7 @@ SessionView::SessionView() {
 	xScrollBeforeFollowingAutoExtendingLinearRecording = -1;
 }
 
-bool SessionView::getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows) {
+bool SessionView::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	if (currentUIMode == UI_MODE_VIEWING_RECORD_ARMING) {
 		switch (currentSong->sessionLayout) {
 		case SessionLayoutType::SessionLayoutTypeRows: {

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -44,7 +44,7 @@ extern const uint8_t defaultClipGroupColours[];
 class SessionView final : public ClipNavigationTimelineView {
 public:
 	SessionView();
-	bool getGreyoutRowsAndCols(uint32_t* cols, uint32_t* rows);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
 	bool opened();
 	void focusRegained();
 

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -631,7 +631,7 @@ void renderExplodeAnimation(int32_t explodedness, bool shouldSendOut) {
 }
 
 void reassessGreyout(bool doInstantly) {
-	auto [newCols, newRows] = getUIGreyoutRowsAndCols();
+	auto [newCols, newRows] = getUIGreyoutColsAndRows();
 
 	// If same as before, get out
 	if (newCols == greyoutCols && newRows == greyoutRows) {


### PR DESCRIPTION
Fixed erroneous swap of pad LED cols and rows for assessing greyout

Renamed function names to match order of pair (cols and rows)