### PR TITLE
Bugfix/check output exists before checking if it needs early playback

### DIFF
--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -2316,6 +2316,7 @@ void Session::doTickForward(int32_t posIncrement) {
 		for (int32_t c = 0; c < clipArray->getNumElements(); c++) {
 			Clip* clip = clipArray->getClipAtIndex(c);
 			if (!(clip->output)) {
+				// possible while swapping songs and render is called between deallocating the output and its clips
 				continue;
 			}
 			if (clip->output->needsEarlyPlayback() == (iPass > 1)) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -2315,7 +2315,9 @@ void Session::doTickForward(int32_t posIncrement) {
 
 		for (int32_t c = 0; c < clipArray->getNumElements(); c++) {
 			Clip* clip = clipArray->getClipAtIndex(c);
-
+			if (!(clip->output)) {
+				continue;
+			}
 			if (clip->output->needsEarlyPlayback() == (iPass > 1)) {
 				continue; // 1st/2nd time through, skip anything but priority clips, which must take effect first
 				          // 3rd/4th time through, skip the priority clips already actioned.


### PR DESCRIPTION
During a song swap the output may not exist, causing a null dereference