### PR TITLE
Bugfix/kit auditioning crash

### DIFF
--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1535,7 +1535,9 @@ bool Kit::isAnyAuditioningHappening() {
 // activeClip. Drum must not be NULL - check first if not sure!
 void Kit::beginAuditioningforDrum(ModelStackWithNoteRow* modelStack, Drum* drum, int32_t velocity,
                                   int16_t const* mpeValues, int32_t fromMIDIChannel) {
-
+	if (!drum) {
+		return;
+	}
 	ParamManager* paramManagerForDrum = NULL;
 
 	if (modelStack->getNoteRowAllowNull()) {


### PR DESCRIPTION
fix crash when playing notes while loading a kit with less rows than the current kit, in which case the drum will be null 