### PR TITLE
Bug fix gold knob led indicator lights

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -12,7 +12,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 
 1. Automatable Clip View Parameters for Synths, Kits with affect entire DISABLED
 
->The 59 parameters that can be edited are:
+>The 60 parameters that can be edited are:
 >
 > - **Master** Level, Pitch, Pan
 > - **LPF** Frequency, Resonance, Morph
@@ -31,7 +31,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **LFO 1** Rate
 > - **LFO 2** Rate
 > - **Mod FX** Offset, Feedback, Depth, Rate
-> - **Arp** Rate, Gate, Ratchet Probability, Ratchet Amount, Sequence Length
+> - **Arp** Rate, Gate, Ratchet Probability, Ratchet Amount, Sequence Length, Rhythm
 > - **Noise** Level
 > - **Portamento**
 > - **Stutter** Rate

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -327,7 +327,7 @@ constexpr int32_t kMaxMenuMetronomeVolumeValue = 50;
 constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 
 // Automation View constants
-constexpr int32_t kNumNonGlobalParamsForAutomation = 59;
+constexpr int32_t kNumNonGlobalParamsForAutomation = 60;
 constexpr int32_t kNumGlobalParamsForAutomation = 23;
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kKnobPosOffset = 64;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -173,11 +173,13 @@ const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutom
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_FEEDBACK},
     {params::Kind::PATCHED, params::GLOBAL_MOD_FX_DEPTH},
     {params::Kind::PATCHED, params::GLOBAL_MOD_FX_RATE},
-    {params::Kind::PATCHED, params::GLOBAL_ARP_RATE}, // Arp Rate, Gate, Ratchet Prob, Ratchet Amount, Sequence Length
+    {params::Kind::PATCHED,
+     params::GLOBAL_ARP_RATE}, // Arp Rate, Gate, Ratchet Prob, Ratchet Amount, Sequence Length, Rhythm
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_GATE},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_PROBABILITY},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_AMOUNT},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RHYTHM},
     {params::Kind::PATCHED, params::LOCAL_NOISE_VOLUME},             // Noise
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_PORTAMENTO},   // Portamento
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE}, // Stutter Rate

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -120,97 +120,127 @@ const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIO
 
 // synth and kit rows FX - sorted in the order that Parameters are scrolled through on the display
 const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutomation> nonGlobalParamsForAutomation{{
-    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_FX}, // Master Volume, Pitch, Pan
+    // Master Volume, Pitch, Pan
+    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_FX},
     {params::Kind::PATCHED, params::LOCAL_PITCH_ADJUST},
     {params::Kind::PATCHED, params::LOCAL_PAN},
-    {params::Kind::PATCHED, params::LOCAL_LPF_FREQ}, // LPF Cutoff, Resonance, Morph
+    // LPF Cutoff, Resonance, Morph
+    {params::Kind::PATCHED, params::LOCAL_LPF_FREQ},
     {params::Kind::PATCHED, params::LOCAL_LPF_RESONANCE},
     {params::Kind::PATCHED, params::LOCAL_LPF_MORPH},
-    {params::Kind::PATCHED, params::LOCAL_HPF_FREQ}, // HPF Cutoff, Resonance, Morph
+    // HPF Cutoff, Resonance, Morph
+    {params::Kind::PATCHED, params::LOCAL_HPF_FREQ},
     {params::Kind::PATCHED, params::LOCAL_HPF_RESONANCE},
     {params::Kind::PATCHED, params::LOCAL_HPF_MORPH},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS}, // Bass, Bass Freq
+    // Bass, Bass Freq
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS_FREQ},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE}, // Treble, Treble Freq
+    // Treble, Treble Freq
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE_FREQ},
-    {params::Kind::PATCHED, params::GLOBAL_REVERB_AMOUNT}, // Reverb Amount
-    {params::Kind::PATCHED, params::GLOBAL_DELAY_RATE},    // Delay Rate, Amount
+    // Reverb Amount
+    {params::Kind::PATCHED, params::GLOBAL_REVERB_AMOUNT},
+    // Delay Rate, Amount
+    {params::Kind::PATCHED, params::GLOBAL_DELAY_RATE},
     {params::Kind::PATCHED, params::GLOBAL_DELAY_FEEDBACK},
-    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_REVERB_SEND}, // Sidechain Send, Shape
+    // Sidechain Send, Shape
+    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_REVERB_SEND},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SIDECHAIN_SHAPE},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SAMPLE_RATE_REDUCTION}, // Decimation, Bitcrush, Wavefolder
+    // Decimation, Bitcrush, Wavefolder
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SAMPLE_RATE_REDUCTION},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BITCRUSHING},
     {params::Kind::PATCHED, params::LOCAL_FOLD},
-    {params::Kind::PATCHED,
-     params::LOCAL_OSC_A_VOLUME}, // OSC 1 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+    // OSC 1 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+    {params::Kind::PATCHED, params::LOCAL_OSC_A_VOLUME},
     {params::Kind::PATCHED, params::LOCAL_OSC_A_PITCH_ADJUST},
     {params::Kind::PATCHED, params::LOCAL_OSC_A_PHASE_WIDTH},
     {params::Kind::PATCHED, params::LOCAL_CARRIER_0_FEEDBACK},
-    {params::Kind::PATCHED,
-     params::LOCAL_OSC_A_WAVE_INDEX}, // OSC 2 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+    // OSC 2 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+    {params::Kind::PATCHED, params::LOCAL_OSC_A_WAVE_INDEX},
     {params::Kind::PATCHED, params::LOCAL_OSC_B_VOLUME},
     {params::Kind::PATCHED, params::LOCAL_OSC_B_PITCH_ADJUST},
     {params::Kind::PATCHED, params::LOCAL_OSC_B_PHASE_WIDTH},
     {params::Kind::PATCHED, params::LOCAL_CARRIER_1_FEEDBACK},
     {params::Kind::PATCHED, params::LOCAL_OSC_B_WAVE_INDEX},
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_VOLUME}, // FM Mod 1 Volume, Pitch, Feedback
+    // FM Mod 1 Volume, Pitch, Feedback
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_VOLUME},
     {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_PITCH_ADJUST},
     {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_FEEDBACK},
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_VOLUME}, // FM Mod 2 Volume, Pitch, Feedback
+    // FM Mod 2 Volume, Pitch, Feedback
+    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_VOLUME},
     {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_PITCH_ADJUST},
     {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_FEEDBACK},
-    {params::Kind::PATCHED, params::LOCAL_ENV_0_ATTACK}, // Env 1 ADSR
+    // Env 1 ADSR
+    {params::Kind::PATCHED, params::LOCAL_ENV_0_ATTACK},
     {params::Kind::PATCHED, params::LOCAL_ENV_0_DECAY},
     {params::Kind::PATCHED, params::LOCAL_ENV_0_SUSTAIN},
     {params::Kind::PATCHED, params::LOCAL_ENV_0_RELEASE},
-    {params::Kind::PATCHED, params::LOCAL_ENV_1_ATTACK}, // Env 2 ADSR
+    // Env 2 ADSR
+    {params::Kind::PATCHED, params::LOCAL_ENV_1_ATTACK},
     {params::Kind::PATCHED, params::LOCAL_ENV_1_DECAY},
     {params::Kind::PATCHED, params::LOCAL_ENV_1_SUSTAIN},
     {params::Kind::PATCHED, params::LOCAL_ENV_1_RELEASE},
-    {params::Kind::PATCHED, params::GLOBAL_LFO_FREQ},                 // LFO 1 Freq
-    {params::Kind::PATCHED, params::LOCAL_LFO_LOCAL_FREQ},            // LFO 2 Freq
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_OFFSET}, // Mod FX Offset, Feedback, Depth, Rate
+    // LFO 1 Freq
+    {params::Kind::PATCHED, params::GLOBAL_LFO_FREQ},
+    // LFO 2 Freq
+    {params::Kind::PATCHED, params::LOCAL_LFO_LOCAL_FREQ},
+    // Mod FX Offset, Feedback, Depth, Rate
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_OFFSET},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_FEEDBACK},
     {params::Kind::PATCHED, params::GLOBAL_MOD_FX_DEPTH},
     {params::Kind::PATCHED, params::GLOBAL_MOD_FX_RATE},
-    {params::Kind::PATCHED,
-     params::GLOBAL_ARP_RATE}, // Arp Rate, Gate, Ratchet Prob, Ratchet Amount, Sequence Length, Rhythm
+    // Arp Rate, Gate, Ratchet Prob, Ratchet Amount, Sequence Length, Rhythm
+    {params::Kind::PATCHED, params::GLOBAL_ARP_RATE},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_GATE},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_PROBABILITY},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_AMOUNT},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RHYTHM},
-    {params::Kind::PATCHED, params::LOCAL_NOISE_VOLUME},             // Noise
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_PORTAMENTO},   // Portamento
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE}, // Stutter Rate
+    // Noise
+    {params::Kind::PATCHED, params::LOCAL_NOISE_VOLUME},
+    // Portamento
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_PORTAMENTO},
+    // Stutter Rate
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE},
 }};
 
 // global FX - sorted in the order that Parameters are scrolled through on the display
 // used with kit affect entire, audio clips, and arranger
 const std::array<std::pair<params::Kind, ParamType>, kNumGlobalParamsForAutomation> globalParamsForAutomation{{
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_VOLUME}, // Master Volume, Pitch, Pan
+    // Master Volume, Pitch, Pan
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_VOLUME},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PITCH_ADJUST},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PAN},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_FREQ}, // LPF Cutoff, Resonance
+    // LPF Cutoff, Resonance
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_FREQ},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_RES},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_FREQ}, // HPF Cutoff, Resonance
+    // HPF Cutoff, Resonance
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_FREQ},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_RES},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS}, // Bass, Bass Freq
+    // Bass, Bass Freq
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS_FREQ},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE}, // Treble, Treble Freq
+    // Treble, Treble Freq
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE_FREQ},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_REVERB_SEND_AMOUNT}, // Reverb Amount
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_RATE},         // Delay Rate, Amount
+    // Reverb Amount
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_REVERB_SEND_AMOUNT},
+    // Delay Rate, Amount
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_RATE},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_AMOUNT},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_VOLUME}, // Sidechain Send, Shape
+    // Sidechain Send, Shape
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_VOLUME},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_SHAPE},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SAMPLE_RATE_REDUCTION}, // Decimation, Bitcrush
+    // Decimation, Bitcrush
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SAMPLE_RATE_REDUCTION},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BITCRUSHING},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_OFFSET}, // Mod FX Offset, Feedback, Depth, Rate
+    // Mod FX Offset, Feedback, Depth, Rate
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_OFFSET},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_FEEDBACK},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_DEPTH},
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_RATE},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_STUTTER_RATE}, // Stutter Rate
+    // Stutter Rate
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_STUTTER_RATE},
 }};
 
 // let's render some love <3

--- a/src/deluge/hid/led/indicator_leds.cpp
+++ b/src/deluge/hid/led/indicator_leds.cpp
@@ -34,6 +34,7 @@ LedBlinker ledBlinkers[numLedBlinkers];
 bool ledBlinkState[NUM_LEVEL_INDICATORS];
 
 uint8_t knobIndicatorLevels[NUM_LEVEL_INDICATORS];
+bool knobIndicatorBipolar[NUM_LEVEL_INDICATORS];
 
 uint8_t whichLevelIndicatorBlinking;
 bool levelIndicatorBlinkOn;
@@ -193,7 +194,7 @@ void actuallySetKnobIndicatorLevel(uint8_t whichKnob, uint8_t level, bool isBipo
 		uiTimerManager.unsetTimer(TimerName::LEVEL_INDICATOR_BLINK);
 	}
 	else {
-		if (level == knobIndicatorLevels[whichKnob]) {
+		if (level == knobIndicatorLevels[whichKnob] && isBipolar == knobIndicatorBipolar[whichKnob]) {
 			return;
 		}
 	}
@@ -249,6 +250,7 @@ void actuallySetKnobIndicatorLevel(uint8_t whichKnob, uint8_t level, bool isBipo
 	PIC::setGoldKnobIndicator(whichKnob, indicator);
 
 	knobIndicatorLevels[whichKnob] = level;
+	knobIndicatorBipolar[whichKnob] = isBipolar;
 }
 
 /// return brightness value for current LED indicator being looked at


### PR DESCRIPTION
This fixes issue: https://github.com/SynthstromAudible/DelugeFirmware/issues/1498

LED indicators weren't refreshing when switching between bipolar and non-bipolar params which had the same level. It assumed that because level was the same it shouldn't render anything, which used to be true, but now that bipolar params are rendered differently to non-bipolar params, this is no longer the case.

Added an additional check to make sure that if the level is the same, the type of indicator is also the same (e.g. bipolar vs not) before deciding not to update the LED's.