### PR TITLE
Bugfix - Displaying wrong LED indicator lights

### DIFF
--- a/src/deluge/hid/led/indicator_leds.cpp
+++ b/src/deluge/hid/led/indicator_leds.cpp
@@ -34,6 +34,7 @@ LedBlinker ledBlinkers[numLedBlinkers];
 bool ledBlinkState[NUM_LEVEL_INDICATORS];
 
 uint8_t knobIndicatorLevels[NUM_LEVEL_INDICATORS];
+bool knobIndicatorBipolar[NUM_LEVEL_INDICATORS];
 
 uint8_t whichLevelIndicatorBlinking;
 bool levelIndicatorBlinkOn;
@@ -193,7 +194,7 @@ void actuallySetKnobIndicatorLevel(uint8_t whichKnob, uint8_t level, bool isBipo
 		uiTimerManager.unsetTimer(TimerName::LEVEL_INDICATOR_BLINK);
 	}
 	else {
-		if (level == knobIndicatorLevels[whichKnob]) {
+		if (level == knobIndicatorLevels[whichKnob] && isBipolar == knobIndicatorBipolar[whichKnob]) {
 			return;
 		}
 	}
@@ -249,6 +250,7 @@ void actuallySetKnobIndicatorLevel(uint8_t whichKnob, uint8_t level, bool isBipo
 	PIC::setGoldKnobIndicator(whichKnob, indicator);
 
 	knobIndicatorLevels[whichKnob] = level;
+	knobIndicatorBipolar[whichKnob] = isBipolar;
 }
 
 /// return brightness value for current LED indicator being looked at


### PR DESCRIPTION
This fixes issue: https://github.com/SynthstromAudible/DelugeFirmware/issues/1498

LED indicators weren't refreshing when switching between bipolar and non-bipolar params which had the same level. It assumed that because level was the same it shouldn't render anything, which used to be true, but now that bipolar params are rendered differently to non-bipolar params, this is no longer the case.

Added an additional check to make sure that if the level is the same, the type of indicator is also the same (e.g. bipolar vs not) before deciding not to update the LED's.