### PR TITLE
Don't show mod popup's in song browser

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -934,7 +934,10 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 					}
 				}
 
-				if (!editingParamInPerformanceView && !editingParamInMenu) {
+				// let's see if we're browsing for a song
+				bool inSongBrowser = getCurrentUI() == &loadSongUI;
+
+				if (!editingParamInPerformanceView && !editingParamInMenu && !inSongBrowser) {
 					PatchSource source1 = PatchSource::NONE;
 					PatchSource source2 = PatchSource::NONE;
 					if (kind == params::Kind::PATCH_CABLE) {


### PR DESCRIPTION
This closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1499

Added a simple to check to make sure that the currentUI is not the loadSongUI before displaying mod popup.