### PR TITLE
Bugfix kit row audition pad rendering in automation view and kit row audition pad usage in menu

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -957,7 +957,7 @@ void AutomationView::renderLove(RGB* image, uint8_t occupancyMask[], int32_t yDi
 	}
 }
 
-// defers to audio clip or instrument clip sidebar render functions
+// defers to arranger, audio clip or instrument clip sidebar render functions
 // depending on the active clip
 bool AutomationView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
@@ -2204,10 +2204,6 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 			drum = modelStackWithNoteRowOnCurrentClip->getNoteRow()->drum;
 			Drum* selectedDrum = ((Kit*)output)->selectedDrum;
 			if (selectedDrum != drum) {
-				// But not if we're actually not on this screen
-				if (getCurrentUI() != this) {
-					return;
-				}
 				selectedDrumChanged = true;
 			}
 		}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4252,8 +4252,12 @@ drawNormally:
 
 		// Kit - draw "selected Drum"
 		if (getCurrentOutputType() == OutputType::KIT) {
-			if (getCurrentUI() != this) {
-				// we're not the top-level UI, just turn the pad off
+			// only turn selected drum off if we're not currently in that UI and affect entire is on
+			// we turn it off when affect entire is on because the selected drum is not relevant in that context
+			// e.g. if you're in the affect entire menu, you're not editing params for the selected drum
+			UI* currentUI = getCurrentUI();
+			bool isInstrumentClipView = ((currentUI == &instrumentClipView) || (currentUI == &automationView));
+			if (!isInstrumentClipView && instrumentClipView.getAffectEntire()) {
 				thisColour = colours::black;
 				return;
 			}


### PR DESCRIPTION
This closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1497

The bug: Kit row selection which is rendered on audition pads was being turned off in automation view.

The fix: only turn off LED's if you're not in instrumentClipView or automationInstrumentClipView and if affect entire is on

Also removed a restriction added in another PR that didn't let you audition non-selected drum pads while in the menu