### PR TITLE
High CPU Usage Indicator: Blink Play Button When Hard Culling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
     - Failsafe mode introduced using canary file to deactivate feature in case of crash at startup.
 - Added a feature save user-defined pad brightness level and restore it at startup.
 - Mod (Gold) Encoder LED indicators are now Bipolar for Bipolar params (e.g. Param, Pitch, Patch Cables). Positive values illuminate the top two LEDs. Negative values illuminate the bottom two LEDs. The middle value doesn't light up any LEDs. 
+- The play button now blinks when the the CPU Usage of the Deluge is high and synth voices/sample playback are being culled.
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -108,7 +108,6 @@ Here is a list of general improvements that have been made, ordered from newest 
   updating the kit row selection, you can now control the parameters for that kit row. With midi follow and midi
   feedback enabled, this will also send updated cc feedback for the new kit row selection.
 
-
 #### 3.4 - Tempo
 
 - ([#178]) New option (`FINE TEMPO` in the `COMMUNITY FEATURES` menu). Inverts the push+turn behavior of the `TEMPO`
@@ -198,6 +197,9 @@ Here is a list of general improvements that have been made, ordered from newest 
     - Between middle and maximum the top two lights will be lit up proportionately to the value in that range
   - Minimum value = Bottom two lights fully lit
     - Between middle and minimum, the bottom two lights will be lit up proportionately to the value in that range
+
+#### 3.16 - Heavy CPU Usage (Culling) Indicator
+- ([#1506]) The play button now blinks when the the CPU Usage of the Deluge is high and synth voices/sample playback are being culled.
 
 ## 4. New Features Added
 
@@ -1189,6 +1191,8 @@ different firmware
 [#1456]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1456
 
 [#1480]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1480
+
+[#1506]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1506
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -29,6 +29,7 @@
 #include "gui/ui_timer_manager.h"
 #include "gui/views/view.h"
 #include "hid/display/display.h"
+#include "hid/led/indicator_leds.h"
 #include "io/debug/log.h"
 #include "io/midi/midi_engine.h"
 #include "memory/general_memory_allocator.h"
@@ -556,6 +557,11 @@ void routine_() {
 		smoothedSamples = numSamples;
 	}
 	setDireness(smoothedSamples);
+
+	// when playback is enabled, blink play button to indicate high cpu usage
+	if (playbackHandler.isEitherClockActive() && cpuDireness >= 14) {
+		indicator_leds::indicateAlertOnLed(IndicatorLED::PLAY);
+	}
 
 	// Double the number of samples we're going to do - within some constraints
 	int32_t sampleThreshold = 6; // If too low, it'll lead to bigger audio windows and stuff


### PR DESCRIPTION
Add simple blinking of play button when cpu direness is high to give user indication that their song is too heavy and that voices/samples are being culled.