### PR TITLE
Bugfix UI lag

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -500,7 +500,7 @@ void routine_() {
 	size_t numSamples = ((uint32_t)(saddr - i2sTXBufferPos) >> (2 + NUM_MONO_OUTPUT_CHANNELS_MAGNITUDE))
 	                    & (SSI_TX_BUFFER_NUM_SAMPLES - 1);
 
-	if (!numSamples) {
+	if (numSamples <= (10 * numRoutines)) {
 		return;
 	}
 #if AUTOMATED_TESTER_ENABLED


### PR DESCRIPTION
Partially Addresses https://github.com/SynthstromAudible/DelugeFirmware/issues/1475

This one isn't fixed:

"changing song view filter routing to parallel during playback seems to cause additional strain and crash deluge as well (unsure if related, videos demonstrate songs crash soon after being set to parallel)"