### PR TITLE
Fix Parallel Routing Crash during High CPU Load

### DIFF
--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -28,7 +28,7 @@ FilterSet::FilterSet() {
 	lpladder = LpLadderFilter();
 	hpladder = HpLadderFilter();
 }
-q31_t tempRenderBuffer[SSI_TX_BUFFER_NUM_SAMPLES];
+q31_t tempRenderBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2]; // * 2 to accomodate stereo samples
 
 void FilterSet::renderHPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
 	if (HPFOn) {


### PR DESCRIPTION
Fixed Parallel Routing Crash during High CPU load by increasing the render buffer size to accomodate maximum number of stereo samples that can be rendered

Fixes remaining bug from #1475 