### PR TITLE
Fix Portamento Grid Shortcut Crash

### DIFF
--- a/src/deluge/gui/menu_item/patched_param.cpp
+++ b/src/deluge/gui/menu_item/patched_param.cpp
@@ -83,10 +83,7 @@ MenuItem* PatchedParam::patchingSourceShortcutPress(PatchSource s, bool previous
 
 ModelStackWithAutoParam* PatchedParam::getModelStack(void* memory) {
 	ModelStackWithThreeMainThings* modelStack = soundEditor.getCurrentModelStack(memory);
-	ParamCollectionSummary* summary = modelStack->paramManager->getPatchedParamSetSummary();
-	int32_t p = this->getP();
-	return modelStack->addParam(summary->paramCollection, summary, p,
-	                            &(static_cast<ParamSet*>(summary->paramCollection))->params[p]);
+	return modelStack->getPatchedAutoParamFromId(getP());
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -38,10 +38,7 @@ void UnpatchedParam::readCurrentValue() {
 
 ModelStackWithAutoParam* UnpatchedParam::getModelStack(void* memory) {
 	ModelStackWithThreeMainThings* modelStack = soundEditor.getCurrentModelStack(memory);
-	ParamCollectionSummary* summary = modelStack->paramManager->getUnpatchedParamSetSummary();
-	int32_t p = getP();
-	return modelStack->addParam(summary->paramCollection, summary, p,
-	                            &((ParamSet*)summary->paramCollection)->params[p]);
+	return modelStack->getUnpatchedAutoParamFromId(getP());
 }
 
 void UnpatchedParam::writeCurrentValue() {

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -972,13 +972,19 @@ doSetup:
 						return ActionResult::DEALT_WITH;
 					}
 
-					// let's check if we're entering a parameter / patch cable menu
+					// if we're in the menu and automation view is the root (background) UI
+					// and you're using a grid shortcut, only allow use of shortcuts for parameters / patch cables
 					MenuItem* newItem;
 					newItem = (MenuItem*)item;
-					deluge::modulation::params::Kind kind = newItem->getParamKind();
-					if ((newItem->getParamKind() == deluge::modulation::params::Kind::NONE)
-					    && getRootUI() == &automationView) {
-						return ActionResult::DEALT_WITH;
+					// need to make sure we're already in the menu
+					// because at this point menu may not have been setup yet
+					// menu needs to be setup before menu items can call soundEditor.getCurrentModelStack()
+					if (getCurrentUI() == &soundEditor) {
+						deluge::modulation::params::Kind kind = newItem->getParamKind();
+						if ((newItem->getParamKind() == deluge::modulation::params::Kind::NONE)
+						    && getRootUI() == &automationView) {
+							return ActionResult::DEALT_WITH;
+						}
 					}
 
 					if (display->haveOLED()) {


### PR DESCRIPTION
This closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1500

It was crashing because it was trying to getParamKind() for a menu item when the menu hadn't been setup yet, the modelStack used to get the paramKind was therefore invalid and resulted in a crash due to an invalid param collection.

Also took the opportunity to clean up the getModelStack() functions in the patch param and unpatched param menu classes.

