### PR TITLE
Bugfix - Sample waveform scrolled outside sample size

### DIFF
--- a/src/deluge/gui/waveform/waveform_basic_navigator.cpp
+++ b/src/deluge/gui/waveform/waveform_basic_navigator.cpp
@@ -29,8 +29,8 @@ WaveformBasicNavigator waveformBasicNavigator{};
 WaveformBasicNavigator::WaveformBasicNavigator() {
 }
 
-void WaveformBasicNavigator::opened(
-    SampleHolder* holder) { // Only if range is provided, grabs navigation from that if possible
+void WaveformBasicNavigator::opened(SampleHolder* holder) {
+	// Only if range is provided, grabs navigation from that if possible
 
 	renderData.xScroll = -1;
 
@@ -38,6 +38,8 @@ void WaveformBasicNavigator::opened(
 	if (holder && holder->waveformViewZoom) {
 		xScroll = holder->waveformViewScroll;
 		xZoom = holder->waveformViewZoom;
+
+		potentiallyAdjustScrollPosition();
 	}
 	else {
 		xScroll = 0;
@@ -168,20 +170,7 @@ bestYet:
 		xScroll = xScroll / xZoom * xZoom;
 	}
 
-	// Make sure not scrolled too far left
-	if (xScroll < 0) {
-		xScroll = 0;
-	}
-	else {
-		if (!shouldAllowExtraScrollRight) {
-			// Make sure not scrolled too far right
-			uint32_t lengthInSamples = sample->lengthInSamples;
-			int32_t scrollLimit = ((lengthInSamples - 1) / xZoom + 1 - kDisplayWidth) * xZoom;
-			if (xScroll > scrollLimit) {
-				xScroll = scrollLimit;
-			}
-		}
-	}
+	potentiallyAdjustScrollPosition(shouldAllowExtraScrollRight);
 
 	memcpy(PadLEDs::imageStore[(offset > 0) ? kDisplayHeight : 0], PadLEDs::image,
 	       (kDisplayWidth + kSideBarWidth) * kDisplayHeight * sizeof(RGB));
@@ -247,4 +236,21 @@ bool WaveformBasicNavigator::scroll(int32_t offset, bool shouldAllowExtraScrollR
 
 bool WaveformBasicNavigator::isZoomedIn() {
 	return (xZoom != getMaxZoom());
+}
+
+void WaveformBasicNavigator::potentiallyAdjustScrollPosition(bool shouldAllowExtraScrollRight) {
+	// Make sure not scrolled too far left
+	if (xScroll < 0) {
+		xScroll = 0;
+	}
+	else {
+		if (!shouldAllowExtraScrollRight) {
+			// Make sure not scrolled too far right
+			uint32_t lengthInSamples = sample->lengthInSamples;
+			int32_t scrollLimit = ((lengthInSamples - 1) / xZoom + 1 - kDisplayWidth) * xZoom;
+			if (xScroll > scrollLimit) {
+				xScroll = scrollLimit;
+			}
+		}
+	}
 }

--- a/src/deluge/gui/waveform/waveform_basic_navigator.h
+++ b/src/deluge/gui/waveform/waveform_basic_navigator.h
@@ -39,6 +39,7 @@ public:
 	bool zoom(int32_t offset, bool shouldAllowExtraScrollRight = false, MarkerColumn* cols = NULL,
 	          MarkerType markerType = MarkerType::NONE);
 	bool scroll(int32_t offset, bool shouldAllowExtraScrollRight = false, MarkerColumn* cols = NULL);
+	void potentiallyAdjustScrollPosition(bool shouldAllowExtraScrollRight = false);
 
 	Sample* sample;
 


### PR DESCRIPTION
Closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1044

Changing sample in a kit row can result in the sample waveform being too far right.

Fixed it by checking to make sure that the scroll position makes sense for the length of the sample