### PR TITLE
Bugfix - multi range menu text highlighting

### DIFF
--- a/src/deluge/gui/menu_item/multi_range.cpp
+++ b/src/deluge/gui/menu_item/multi_range.cpp
@@ -443,22 +443,23 @@ void MultiRange::drawPixelsForOled() {
 	drawItemsForOled(itemNames, selectedOption);
 
 	if (soundEditor.editingRangeEdge != RangeEdit::OFF) {
-		int32_t hilightStartX = 0;
-		int32_t hilightWidth = 0;
+		int32_t highlightStartX = 0;
+		int32_t highlightWidth = 0;
 
 		if (soundEditor.editingRangeEdge == RangeEdit::LEFT) {
-			hilightStartX = kTextSpacingX;
-			hilightWidth = kTextSpacingX * 6;
+			highlightStartX = kTextSpacingX;
+			highlightWidth = kTextSpacingX * 6;
 		}
 		else if (soundEditor.editingRangeEdge == RangeEdit::RIGHT) {
-			hilightStartX = kTextSpacingX * 10;
-			hilightWidth = OLED_MAIN_WIDTH_PIXELS - hilightStartX;
+			highlightStartX = kTextSpacingX * 10;
+			highlightWidth = OLED_MAIN_WIDTH_PIXELS - highlightStartX;
 		}
 
 		int32_t baseY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 15 : 14;
 		baseY += OLED_MAIN_TOPMOST_PIXEL;
 		baseY += (this->getValue() - soundEditor.menuCurrentScroll) * kTextSpacingY;
-		deluge::hid::display::OLED::invertArea(hilightStartX, hilightWidth, baseY, baseY + kTextSpacingY,
+		// -1 adjustment to invert the area 1px around the digits being rendered
+		deluge::hid::display::OLED::invertArea(highlightStartX, highlightWidth, baseY, baseY + kTextSpacingY - 1,
 		                                       deluge::hid::display::OLED::oledMainImage);
 	}
 }

--- a/src/deluge/gui/menu_item/range.cpp
+++ b/src/deluge/gui/menu_item/range.cpp
@@ -189,22 +189,22 @@ void Range::drawPixelsForOled() {
 	                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
 	                                       digitWidth, digitHeight);
 
-	int32_t hilightStartX, hilightWidth;
+	int32_t highlightStartX, highlightWidth;
 
 	if (soundEditor.editingRangeEdge == RangeEdit::LEFT) {
-		hilightStartX = stringStartX;
-		hilightWidth = digitWidth * leftLength;
-doHilightJustOneEdge:
+		highlightStartX = stringStartX;
+		highlightWidth = digitWidth * leftLength;
+doHighlightJustOneEdge:
 		// Invert the area 1px around the digits being rendered
 		baseY += OLED_MAIN_TOPMOST_PIXEL - 1;
-		deluge::hid::display::OLED::invertArea(hilightStartX, hilightWidth, baseY, baseY + digitHeight + 1,
+		deluge::hid::display::OLED::invertArea(highlightStartX, highlightWidth, baseY, baseY + digitHeight + 1,
 		                                       deluge::hid::display::OLED::oledMainImage);
 	}
 	else if (soundEditor.editingRangeEdge == RangeEdit::RIGHT) {
 		int32_t stringEndX = (OLED_MAIN_WIDTH_PIXELS + stringWidth) >> 1;
-		hilightWidth = digitWidth * rightLength;
-		hilightStartX = stringEndX - hilightWidth;
-		goto doHilightJustOneEdge;
+		highlightWidth = digitWidth * rightLength;
+		highlightStartX = stringEndX - highlightWidth;
+		goto doHighlightJustOneEdge;
 	}
 }
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -126,10 +126,10 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 	                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY, 0,
 	                                       xPixel + maxNumChars * kTextSpacingX);
 
-	int32_t hilightStartX = xPixel + kTextSpacingX * (enteredTextEditPos - scrollPosHorizontal);
-	// int32_t hilightEndX = xPixel + TEXT_SIZE_X * (displayStringLength - scrollPosHorizontal);
-	// if (hilightEndX > OLED_MAIN_WIDTH_PIXELS || !enteredTextEditPos) hilightEndX = OLED_MAIN_WIDTH_PIXELS;
-	int32_t hilightWidth = xPixelMax - hilightStartX;
+	int32_t highlightStartX = xPixel + kTextSpacingX * (enteredTextEditPos - scrollPosHorizontal);
+	// int32_t highlightEndX = xPixel + TEXT_SIZE_X * (displayStringLength - scrollPosHorizontal);
+	// if (highlightEndX > OLED_MAIN_WIDTH_PIXELS || !enteredTextEditPos) highlightEndX = OLED_MAIN_WIDTH_PIXELS;
+	int32_t highlightWidth = xPixelMax - highlightStartX;
 
 	if (atVeryEnd) {
 		if (getCurrentUI() == this) {
@@ -139,7 +139,8 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 		}
 	}
 	else {
-		deluge::hid::display::OLED::invertArea(hilightStartX, hilightWidth, yPixel, yPixel + kTextSpacingY - 1, image);
+		deluge::hid::display::OLED::invertArea(highlightStartX, highlightWidth, yPixel, yPixel + kTextSpacingY - 1,
+		                                       image);
 	}
 }
 

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -1015,7 +1015,7 @@ struct SideScroller {
 	int32_t stringLengthPixels;
 	int32_t boxLengthPixels;
 	bool finished;
-	bool doHilight;
+	bool doHighlight;
 };
 
 #define NUM_SIDE_SCROLLERS 2
@@ -1023,7 +1023,7 @@ struct SideScroller {
 SideScroller sideScrollers[NUM_SIDE_SCROLLERS];
 
 void OLED::setupSideScroller(int32_t index, std::string_view text, int32_t startX, int32_t endX, int32_t startY,
-                             int32_t endY, int32_t textSpacingX, int32_t textSizeY, bool doHilight) {
+                             int32_t endY, int32_t textSpacingX, int32_t textSizeY, bool doHighlight) {
 
 	SideScroller* scroller = &sideScrollers[index];
 	scroller->textLength = text.size();
@@ -1042,7 +1042,7 @@ void OLED::setupSideScroller(int32_t index, std::string_view text, int32_t start
 	scroller->textSpacingX = textSpacingX;
 	scroller->textSizeY = textSizeY;
 	scroller->finished = false;
-	scroller->doHilight = doHilight;
+	scroller->doHighlight = doHighlight;
 
 	sideScrollerDirection = 1;
 	uiTimerManager.setTimer(TimerName::OLED_SCROLLING_AND_BLINKING, 400);
@@ -1107,7 +1107,7 @@ void OLED::scrollingAndBlinkingTimerEvent() {
 			clearAreaExact(scroller->startX, scroller->startY, scroller->endX - 1, scroller->endY, oledMainImage);
 			drawString(scroller->text, scroller->startX, scroller->startY, oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
 			           scroller->textSpacingX, scroller->textSizeY, scroller->pos, scroller->endX);
-			if (scroller->doHilight) {
+			if (scroller->doHighlight) {
 				invertArea(scroller->startX, scroller->endX - scroller->startX, scroller->startY, scroller->endY,
 				           &OLED::oledMainImage[0]);
 			}

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -82,7 +82,7 @@ public:
 
 	static void stopScrollingAnimation();
 	static void setupSideScroller(int32_t index, std::string_view text, int32_t startX, int32_t endX, int32_t startY,
-	                              int32_t endY, int32_t textSpacingX, int32_t textSizeY, bool doHilight);
+	                              int32_t endY, int32_t textSpacingX, int32_t textSizeY, bool doHighlight);
 	static void drawPermanentPopupLookingText(char const* text);
 
 	void consoleTimerEvent();


### PR DESCRIPTION
Fixed highlighting around left / right range values in multi range menu

Fixed spelling of word highlight in a few areas

Closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1064