### PR TITLE
Bugfix - Blink the correct patched param in mod matrix and patch cables

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -524,16 +524,12 @@ bool SoundEditor::findPatchedParam(int32_t paramLookingFor, int32_t* xout, int32
 	bool found = false;
 	for (int32_t x = 0; x < 15; x++) {
 		for (int32_t y = 0; y < kDisplayHeight; y++) {
-			if (paramShortcutsForSounds[x][y] && paramShortcutsForSounds[x][y] != comingSoonMenu
-			    && ((MenuItem*)paramShortcutsForSounds[x][y])->getParamIndex() == paramLookingFor) {
+			if (deluge::modulation::params::patchedParamShortcuts[x][y] == paramLookingFor) {
 
 				*xout = x;
 				*yout = y;
 
-				if ((x & 1) == currentSourceIndex) {
-					// check we're on the corretc index
-					return true;
-				}
+				return true;
 			}
 		}
 	}

--- a/src/deluge/modulation/params/param.cpp
+++ b/src/deluge/modulation/params/param.cpp
@@ -103,7 +103,7 @@ char const* getPatchedParamShortName(ParamType type) {
 	    [LOCAL_ENV_0_RELEASE]            = "Env1 rel",
 	    [LOCAL_ENV_1_RELEASE]            = "Env2 rel",
 	    [GLOBAL_VOLUME_POST_FX]          = "POSTFXLVL",
-	    [GLOBAL_VOLUME_POST_REVERB_SEND] = "POSTRVLVL",
+	    [GLOBAL_VOLUME_POST_REVERB_SEND] = "Side level",
 	    [GLOBAL_REVERB_AMOUNT]           = "Reverb amt",
 	    [GLOBAL_MOD_FX_DEPTH]            = "ModFXdepth",
 	    [GLOBAL_DELAY_FEEDBACK]          = "Delay feed",

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -377,7 +377,7 @@ char const* sourceToStringShort(PatchSource source) {
 		return "note";
 
 	case PatchSource::SIDECHAIN:
-		return "comp";
+		return "side";
 
 	case PatchSource::RANDOM:
 		return "rand";


### PR DESCRIPTION
Fixed code for finding patch param shortcut for mod matrix menu and patch cable menu shortcut blinking

Renamed sidechain source name from "comp" to "side" renamed sidechain level source name from "postrvlvl" to "side level"

Closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1037