### PR TITLE
Bugfix - Adjust display of negative values in mod matrix menu

### DIFF
--- a/src/deluge/gui/menu_item/patch_cables.cpp
+++ b/src/deluge/gui/menu_item/patch_cables.cpp
@@ -80,7 +80,10 @@ void PatchCables::renderOptions() {
 		int32_t param_value = cable->param.getCurrentValue();
 		int32_t level = ((int64_t)param_value * kMaxMenuPatchCableValue + (1 << 29)) >> 30;
 
-		floatToString((float)level / 100, buf + off + 5, 2, 2);
+		float floatLevel = (float)level / 100;
+		int floatoff = floatLevel < 0 ? 1 : 0;
+
+		floatToString(floatLevel, buf + off + 5 - floatoff, 2, 2);
 		// fmt::vformat_to_n(buf + off + 5, 5, "{:4}", fmt::make_format_args();
 
 		buf[off + 9] = ' ';


### PR DESCRIPTION
Adjusted display of negative values in mod matrix menu so that 1 decimal place is not cut off.