### PR TITLE
Bugfix - Don't allow converting audio clip to instrument clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
 - Added a feature save user-defined pad brightness level and restore it at startup.
 - Mod (Gold) Encoder LED indicators are now Bipolar for Bipolar params (e.g. Param, Pitch, Patch Cables). Positive values illuminate the top two LEDs. Negative values illuminate the bottom two LEDs. The middle value doesn't light up any LEDs. 
 - The play button now blinks when the the CPU Usage of the Deluge is high and synth voices/sample playback are being culled.
+- Removed ability to convert an Audio Clip to an Instrument Clip (Synth / Kit / MIDI / CV) as this conversion process is error/bug prone.
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -499,14 +499,8 @@ changeOutputType:
 			Clip* clip = getClipForLayout();
 
 			if (clip != nullptr) {
-				// If AudioClip, we have to convert back to an InstrumentClip
-				if (clip->type == ClipType::AUDIO) {
-					actionLogger.deleteAllLogs();
-					replaceAudioClipWithInstrumentClip(clip, newOutputType);
-				}
-
-				// Or if already an InstrumentClip, changing Instrument type is easier
-				else {
+				// Don't allow converting audio clip to instrument clip
+				if (clip->type != ClipType::AUDIO) {
 
 					InstrumentClip* instrumentClip = (InstrumentClip*)clip;
 					Instrument* instrument = (Instrument*)instrumentClip->output;
@@ -1590,98 +1584,6 @@ doGetInstrument:
 	}
 
 	return newClip;
-}
-
-void SessionView::replaceAudioClipWithInstrumentClip(Clip* clip, OutputType outputType) {
-	int32_t clipIndex = currentSong->sessionClips.getIndexForClip(clip);
-
-	if (!clip || clip->type != ClipType::AUDIO) {
-		return;
-	}
-
-	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid
-	    && currentSong->getClipWithOutput(clip->output, false, clip)) {
-		display->displayPopup(deluge::l10n::get(
-		    deluge::l10n::String::STRING_FOR_AUDIO_TRACKS_WITH_CLIPS_CANT_BE_TURNED_INTO_AN_INSTRUMENT));
-		return;
-	}
-
-	AudioClip* audioClip = (AudioClip*)clip;
-	if (audioClip->sampleHolder.audioFile || audioClip->getCurrentlyRecordingLinearly()) {
-		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CLIP_NOT_EMPTY));
-		return;
-	}
-
-	// Allocate memory for InstrumentClip
-	void* clipMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(InstrumentClip));
-	if (!clipMemory) {
-ramError:
-		display->displayError(Error::INSUFFICIENT_RAM);
-		return;
-	}
-
-	// Create the audio clip and ParamManager
-	InstrumentClip* newClip = new (clipMemory) InstrumentClip(currentSong);
-
-	// Give the new clip its stuff
-	newClip->cloneFrom(clip);
-	newClip->colourOffset = random(72);
-
-	bool instrumentAlreadyInSong;
-	Error error;
-
-	if (outputType == OutputType::SYNTH || outputType == OutputType::KIT) {
-
-		error = setPresetOrNextUnlaunchedOne(newClip, outputType, &instrumentAlreadyInSong);
-		if (error != Error::NONE) {
-gotError:
-			display->displayError(error);
-gotErrorDontDisplay:
-			newClip->~InstrumentClip();
-			delugeDealloc(clipMemory);
-			return;
-		}
-	}
-
-	else {
-		Instrument* newInstrument = currentSong->getNonAudioInstrumentToSwitchTo(
-		    outputType, Availability::INSTRUMENT_UNUSED, 0, -1, &instrumentAlreadyInSong);
-		if (!newInstrument) {
-			goto gotErrorDontDisplay;
-		}
-
-		error = newClip->setNonAudioInstrument(newInstrument, currentSong);
-		if (error != Error::NONE) {
-			// TODO: we'd really want to deallocate the Instrument
-			goto gotError;
-		}
-	}
-
-	if (!instrumentAlreadyInSong) {
-		currentSong->addOutput(newClip->output);
-	}
-
-	// Possibly want to set this as the active Clip...
-	if (!newClip->output->activeClip) {
-
-		char modelStackMemory[MODEL_STACK_MAX_SIZE];
-		ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
-
-		ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(newClip);
-
-		newClip->output->setActiveClip(modelStackWithTimelineCounter);
-	}
-
-	newClip->output->colour = clip->output->colour;
-
-	currentSong->swapClips(newClip, clip, clipIndex);
-
-	view.setActiveModControllableTimelineCounter(newClip);
-	view.displayOutputName(newClip->output, true, newClip);
-
-	if (display->haveOLED()) {
-		deluge::hid::display::OLED::sendMainImage();
-	}
 }
 
 void SessionView::replaceInstrumentClipWithAudioClip(Clip* clip) {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -500,7 +500,10 @@ changeOutputType:
 
 			if (clip != nullptr) {
 				// Don't allow converting audio clip to instrument clip
-				if (clip->type != ClipType::AUDIO) {
+				if (clip->type == ClipType::AUDIO) {
+					display->displayPopup(l10n::get(l10n::String::STRING_FOR_CANT_CONVERT_TYPE));
+				}
+				else {
 
 					InstrumentClip* instrumentClip = (InstrumentClip*)clip;
 					Instrument* instrument = (Instrument*)instrumentClip->output;

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -128,7 +128,6 @@ private:
 	Clip* createNewInstrumentClip(int32_t yDisplay);
 	void goToArrangementEditor();
 	void replaceInstrumentClipWithAudioClip(Clip* clip);
-	void replaceAudioClipWithInstrumentClip(Clip* clip, OutputType outputType);
 	void rowNeedsRenderingDependingOnSubMode(int32_t yDisplay);
 	void setCentralLEDStates();
 


### PR DESCRIPTION
Converting audio clip to instrument is very problematic, thus it is better to eliminate this behaviour and instead direct users to delete the audio clip and create a new clip instead of going through the "nice to have" conversion process.

This closes: 

https://github.com/SynthstromAudible/DelugeFirmware/issues/760
https://github.com/SynthstromAudible/DelugeFirmware/issues/1051