### PR TITLE
Bugfix - Auditioned arp notes don’t reflect triplet and dotted sync rates

### DIFF
--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -881,6 +881,13 @@ uint32_t ArpeggiatorSettings::getPhaseIncrement(int32_t arpRate) {
 		        .getTimePerInternalTickInverse(); // multiply_32x32_rshift32(playbackHandler.getTimePerInternalTickInverse(),
 		                                          // arpRate);
 		phaseIncrement >>= rightShiftAmount;
+
+		if (syncType == SYNC_TYPE_TRIPLET) {
+			phaseIncrement = phaseIncrement * 3 / 2;
+		}
+		else if (syncType == SYNC_TYPE_DOTTED) {
+			phaseIncrement = phaseIncrement * 2 / 3;
+		}
 	}
 	return phaseIncrement;
 }


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/746