### PR TITLE
sidebar: session macros in keyboard

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -409,6 +409,10 @@ Here is a list of features that have been added to the firmware as a list, group
             - Track color can be changed by holding any populated clip in a column and rotating `▼︎▲︎`. For fine changes
               to the color press `▼︎▲︎` while turning it.
             - Section pads (left sidebar column) will allow changing repeat count while held
+        - `Purple mode`
+           - [Song macros](#419---song-macros) can be set up. First select a macro slot in the left sidebar and then press a clip to
+             put it in the slot. press the same clip multiple times to switch between macro kinds (i e affect the entire
+             output or section for the clip)
 - ([#970]) Streamline recording new clips while Deluge is playing
     - This assumes the Deluge is in Grid mode, you are in Green mode, the Deluge is Playing, and Recording is enabled.
     - To use this feature you will need to enable it in the menu:
@@ -479,6 +483,23 @@ Here is a list of features that have been added to the firmware as a list, group
             - y2 = -22.0 to -17.7
             - y1 = -26.4 to -22.1
             - y0 = -30.8 to -26.5
+
+### 4.1.9 - Song macros
+
+Macros are a way to quickly switch playing clips without needing to go into song view.
+Within grid view, purple mode is used to edit macros. There are 8 macro slots
+shown in the left sidebar. To assign a macro,
+first select a macro slot and then press a clip in the grid. Pressing the same clip multiple
+time cycles though different modes:
+
+- clip macro: Launch or mute the clip
+- output macro: cycle though all clips for this particular output
+- section macro: Launch all clips for this section
+
+Inside a clip timeline view, hold SONG button and press the left sidebar to launch a macro.
+In keyboard view, macros are available as a sidebar control.
+SHIFT makes the launch immediate just like in song view. AFFECT ENTIRE + clip macro can be
+used to jump to edit the clip.
 
 ### 4.2 - Clip View - General Features (Instrument and Audio Clips)
 
@@ -950,6 +971,8 @@ to each individual note onset. ([#1978])
       pads will default to the first 7 scale modes, but you can change any pad to any scale by
       holding it down and turning the vertical encoder. If the scale that is going to be set
       can't fit/transpose the existing notes from your clips, screen will show `Can't`.
+    - **`Song Macro Mode (SONG - various):`** Activate [Song macros](#419---song-macros).
+
 - ([#2174]) With the addition of the new Keyboard Sidebar Controls, the default behaviour of being able to immediately exit the menu by pressing a sidebar pad while in Keyboard View was removed. To accomodate users that still wish to be able to exit the menus immediately by pressing a sidebar pad, a new community feature toggle has been added (`Enable KB View Sidebar Menu Exit (EXIT)`) which will enable you to immediately exit the menu using the top left sidebar pad if you are in the `SETTINGS` or `SOUND` menu for `KEYBOARD VIEW`.
 
 #### 4.4.2 - Scales

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -997,7 +997,7 @@ enum GridMode : uint8_t {
 	Unassigned1,
 	Unassigned2,
 	Unassigned3,
-	Unassigned4,
+	MAGENTA,
 	YELLOW,
 	BLUE,
 	GREEN,

--- a/src/deluge/gui/ui/keyboard/column_controls/session.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/session.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "session.h"
+#include "gui/ui/keyboard/layout/column_controls.h"
+#include "gui/views/session_view.h"
+#include "gui/views/view.h"
+#include "hid/buttons.h"
+#include "playback/mode/session.h"
+
+using namespace deluge::gui::ui::keyboard::layout;
+
+namespace deluge::gui::ui::keyboard::controls {
+
+void SessionColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
+	bool armed = false;
+	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+		armed |= view.renderMacros(column, y, -1, image, nullptr);
+	}
+	if (armed) {
+		view.flashPlayEnable();
+	}
+}
+
+bool SessionColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
+	SessionMacro& m = currentSong->sessionMacros[pad];
+	int kindIndex = (int32_t)m.kind + offset;
+	if (kindIndex >= SessionMacroKind::NUM_KINDS) {
+		kindIndex = 0;
+	}
+	else if (kindIndex < 0) {
+		kindIndex = SessionMacroKind::NUM_KINDS - 1;
+	}
+
+	m.kind = (SessionMacroKind)kindIndex;
+	m.clip = nullptr;
+	m.output = nullptr;
+	m.section = 0;
+
+	switch (m.kind) {
+	case CLIP_LAUNCH:
+		m.clip = getCurrentClip();
+		break;
+
+	case OUTPUT_CYCLE:
+		m.output = getCurrentOutput();
+		break;
+
+	case SECTION:
+		m.section = getCurrentClip()->section;
+
+	default:
+		break;
+	}
+
+	return true;
+};
+
+void SessionColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+                                        KeyboardLayout* layout){};
+
+void SessionColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+                              KeyboardLayout* layout) {
+
+	if (pad.active) {}
+	else {
+		view.activateMacro(pad.y);
+	}
+	view.flashPlayEnable();
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/session.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/session.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/keyboard/column_controls/control_column.h"
+#include "model/song/song.h"
+
+namespace deluge::gui::ui::keyboard::controls {
+
+class SessionColumn : public ControlColumn {
+public:
+	SessionColumn() = default;
+
+	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
+	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;
+	void handleLeavingColumn(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+	                         KeyboardLayout* layout) override;
+	void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
+	               KeyboardLayout* layout) override;
+
+	void handleOutput(SessionMacro& m, PressedPad pad);
+	Clip* findNextClipForOutput(SessionMacro& m, PressedPad pad);
+
+private:
+};
+
+} // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/layout/column_control_state.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_control_state.h
@@ -22,6 +22,7 @@
 #include "gui/ui/keyboard/column_controls/dx.h"
 #include "gui/ui/keyboard/column_controls/mod.h"
 #include "gui/ui/keyboard/column_controls/scale_mode.h"
+#include "gui/ui/keyboard/column_controls/session.h"
 #include "gui/ui/keyboard/column_controls/song_chord_mem.h"
 #include "gui/ui/keyboard/column_controls/velocity.h"
 
@@ -35,6 +36,7 @@ enum ColumnControlFunction : int8_t {
 	CHORD_MEM,
 	SCALE_MODE,
 	DX,
+	SESSION,
 	// BEAT_REPEAT,
 	COL_CTRL_FUNC_MAX,
 };
@@ -50,6 +52,7 @@ struct ColumnControlState {
 	ChordMemColumn chordMemColumn{};
 	ScaleModeColumn scaleModeColumn{};
 	DXColumn dxColumn{};
+	SessionColumn sessionColumn{};
 
 	ColumnControlFunction leftColFunc = VELOCITY;
 	ColumnControlFunction rightColFunc = MOD;

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -44,6 +44,7 @@ const char* functionNames[][2] = {
     /* CHORD_MEM   */ {"CCME", "Clip Chord Memory"},
     /* SCALE_MODE  */ {"SMOD", "Scales"},
     /* DX          */ {"DX", "DX operators"},
+    /* SESSION     */ {"SONG", "song macros"},
     /* BEAT_REPEAT */ {"BEAT", "Beat Repeat"},
 };
 
@@ -204,6 +205,8 @@ ControlColumn* ColumnControlState::getColumnForFunc(ColumnControlFunction func) 
 		return &scaleModeColumn;
 	case DX:
 		return &dxColumn;
+	case SESSION:
+		return &sessionColumn;
 	}
 	return nullptr;
 }
@@ -224,6 +227,8 @@ const char* columnFunctionToString(ColumnControlFunction func) {
 		return "scale_mode";
 	case DX:
 		return "dx";
+	case SESSION:
+		return "session";
 	}
 	return "";
 }
@@ -249,6 +254,9 @@ ColumnControlFunction stringToColumnFunction(char const* string) {
 	}
 	else if (!strcmp(string, "dx")) {
 		return DX;
+	}
+	else if (!strcmp(string, "session")) {
+		return SESSION;
 	}
 	else {
 		return VELOCITY; // unknown column, just pick the default

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -75,6 +75,7 @@ extern bool pendingUIRenderingLock;
 #define UI_MODE_HOLDING_STATUS_PAD 62
 #define UI_MODE_IMPLODE_ANIMATION 63
 #define UI_MODE_STEM_EXPORT 64
+#define UI_MODE_HOLDING_SONG_BUTTON 65
 
 #define EXCLUSIVE_UI_MODES_MASK ((uint32_t)255)
 

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -85,10 +85,7 @@ void UITimerManager::routine() {
 					break;
 
 				case TimerName::PLAY_ENABLE_FLASH: {
-					RootUI* rootUI = getRootUI();
-					if ((rootUI == &sessionView) || (rootUI == &performanceSessionView)) {
-						sessionView.flashPlayRoutine();
-					}
+					view.flashPlayRoutine();
 					break;
 				}
 				case TimerName::DISPLAY:

--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -62,6 +62,7 @@ public:
 	const char* getName() { return "audio_clip_view"; }
 
 private:
+	uint32_t timeSongButtonPressed;
 	void needsRenderingDependingOnSubMode();
 	int32_t lastTickSquare;
 	bool mustRedrawTickSquares;

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -241,6 +241,7 @@ private:
 	uint8_t yDisplayOfNewNoteRow;
 
 	int32_t quantizeAmount;
+	uint32_t timeSongButtonPressed;
 
 	std::array<RGB, kDisplayHeight> rowColour;
 	std::array<RGB, kDisplayHeight> rowTailColour;

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -32,6 +32,7 @@ class ModelStackWithTimelineCounter;
 enum SessionGridMode : uint8_t {
 	SessionGridModeEdit,
 	SessionGridModeLaunch,
+	SessionGridModeMacros,
 	SessionGridModeMaxElement // Keep as boundary
 };
 
@@ -64,7 +65,7 @@ public:
 	bool renderRow(ModelStack* modelStack, uint8_t yDisplay, RGB thisImage[kDisplayWidth + kSideBarWidth],
 	               uint8_t thisOccupancyMask[kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true);
 	void graphicsRoutine();
-	int32_t displayLoopsRemainingPopup();
+	int32_t displayLoopsRemainingPopup(bool ephemeral = false);
 	void potentiallyRenderClipLaunchPlayhead(bool reallyNoTickSquare, int32_t sixteenthNotesRemaining);
 	void requestRendering(UI* ui, uint32_t whichMainRows = 0xFFFFFFFF, uint32_t whichSideRows = 0xFFFFFFFF);
 
@@ -114,6 +115,7 @@ public:
 	                                       // action to set this to false
 	uint8_t sectionPressed;
 	uint8_t masterCompEditMode;
+	int8_t selectedMacro = -1;
 
 	Clip* getClipForLayout();
 
@@ -179,6 +181,7 @@ private:
 	ActionResult gridHandlePadsLaunch(int32_t x, int32_t y, int32_t on, Clip* clip);
 	ActionResult gridHandlePadsLaunchImmediate(int32_t x, int32_t y, int32_t on, Clip* clip);
 	ActionResult gridHandlePadsLaunchWithSelection(int32_t x, int32_t y, int32_t on, Clip* clip);
+	ActionResult gridHandlePadsMacros(int32_t x, int32_t y, int32_t on, Clip* clip);
 	void gridHandlePadsLaunchToggleArming(Clip* clip, bool immediate);
 
 	ActionResult gridHandleScroll(int32_t offsetX, int32_t offsetY);

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -96,6 +96,12 @@ public:
 	ActionResult clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfInSessionView = -1);
 	void flashPlayEnable();
 	void flashPlayDisable();
+	void flashPlayRoutine();
+
+	void activateMacro(uint32_t y);
+	Clip* findNextClipForOutput(Output* output);
+	bool renderMacros(int32_t column, uint32_t y, int32_t selectedMacro, RGB image[][kDisplayWidth + kSideBarWidth],
+	                  uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]);
 
 	// MIDI learn stuff
 	MidiLearn thingPressedForMidiLearn = MidiLearn::NONE;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1237,6 +1237,55 @@ weAreInArrangementEditorOrInClipInstance:
 		writer.writeClosingTag("chordMem");
 	}
 
+	// macros
+	int maxSessionMacroToSave = 0;
+	for (int32_t y = 0; y < kDisplayHeight; y++) {
+		if (sessionMacros[y].kind != SessionMacroKind::NO_MACRO) {
+			maxSessionMacroToSave = y + 1;
+		}
+	}
+	if (maxSessionMacroToSave > 0) {
+		// some macros to save
+		writer.writeOpeningTag("sessionMacros");
+		for (int32_t y = 0; y < maxSessionMacroToSave; y++) {
+			auto& m = sessionMacros[y];
+			writer.writeOpeningTagBeginning("macro");
+			switch (m.kind) {
+			case CLIP_LAUNCH: {
+				int32_t index = sessionClips.getIndexForClip(m.clip);
+				if (index >= 0) {
+					writer.writeAttribute("kind", "clip_launch");
+					writer.writeAttribute("clip", index);
+				}
+				break;
+			}
+			case OUTPUT_CYCLE: {
+				int32_t i = 0;
+				Output* thisOutput;
+				for (thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
+					if (thisOutput == m.output) {
+						break;
+					}
+					i++;
+				}
+				if (thisOutput != nullptr) {
+					writer.writeAttribute("kind", "output_cycle");
+					writer.writeAttribute("output", i);
+				}
+				break;
+			}
+			case SECTION:
+				writer.writeAttribute("kind", "section");
+				writer.writeAttribute("section", m.section);
+				break;
+			case NO_MACRO:
+				break;
+			}
+			writer.closeTag();
+		}
+		writer.writeClosingTag("sessionMacros");
+	}
+
 	writer.writeClosingTag("song");
 }
 
@@ -1252,6 +1301,9 @@ Error Song::readFromFile(Deserializer& reader) {
 
 	for (int32_t s = 0; s < kMaxNumSections; s++) {
 		sections[s].numRepetitions = -1;
+	}
+	for (int32_t y = 0; y < 8; y++) {
+		sessionMacros[y].kind = NO_MACRO;
 	}
 
 	uint64_t newTimePerTimerTick = (uint64_t)1 << 32; // TODO: make better!
@@ -1655,6 +1707,62 @@ unknownTag:
 				reader.exitTag("chordMem");
 			}
 
+			else if (!strcmp(tagName, "sessionMacros")) {
+				int slot_index = 0;
+				while (*(tagName = reader.readNextTagOrAttributeName())) {
+					if (!strcmp(tagName, "macro")) {
+						int y = slot_index++;
+						if (y >= 8) {
+							reader.exitTag("macro");
+							continue;
+						}
+						auto& m = sessionMacros[y];
+						while (*(tagName = reader.readNextTagOrAttributeName())) {
+							if (!strcmp(tagName, "kind")) {
+								const char* kind = reader.readTagOrAttributeValue();
+								if (!strcmp(kind, "clip_launch")) {
+									m.kind = CLIP_LAUNCH;
+								}
+								else if (!strcmp(kind, "output_cycle")) {
+									m.kind = OUTPUT_CYCLE;
+								}
+								else if (!strcmp(kind, "section")) {
+									m.kind = SECTION;
+								}
+							}
+							else if (!strcmp(tagName, "clip")) {
+								int32_t index = reader.readTagOrAttributeValueInt();
+								if (index >= 0 && index < sessionClips.getNumElements()) {
+									m.clip = sessionClips.getClipAtIndex(index);
+								}
+							}
+							else if (!strcmp(tagName, "output")) {
+								int32_t index = reader.readTagOrAttributeValueInt();
+								Output* thisOutput;
+								for (thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
+									if (index == 0) {
+										break;
+									}
+									index--;
+								}
+								m.output = thisOutput;
+							}
+							else if (!strcmp(tagName, "section")) {
+								m.section = reader.readTagOrAttributeValueInt();
+							}
+						}
+
+						if ((m.kind == CLIP_LAUNCH && m.clip == nullptr)
+						    || (m.kind == OUTPUT_CYCLE && m.output == nullptr)) {
+							m.kind = NO_MACRO;
+						}
+					}
+					else {
+						reader.exitTag();
+					}
+				}
+				reader.exitTag("chordMem");
+			}
 			else if (!strcmp(tagName, "sections")) {
 				// Read in all the sections
 				while (*(tagName = reader.readNextTagOrAttributeName())) {
@@ -3237,6 +3345,13 @@ deleteIt:
 }
 
 void Song::deleteOutput(Output* output) {
+	for (int y = 0; y < 8; y++) {
+		auto& m = sessionMacros[y];
+		if (m.kind == OUTPUT_CYCLE && m.output == output) {
+			m.kind = NO_MACRO;
+		}
+	}
+
 	output->deleteBackedUpParamManagers(this);
 	void* toDealloc = dynamic_cast<void*>(output);
 	output->~Output();
@@ -5080,6 +5195,13 @@ void Song::removeSessionClipLowLevel(Clip* clip, int32_t clipIndex) {
 	if (playbackHandler.isEitherClockActive() && currentPlaybackMode == &session && clip->activeIfNoSolo) {
 		clip->expectNoFurtherTicks(this);
 		clip->activeIfNoSolo = false;
+	}
+
+	for (int y = 0; y < 8; y++) {
+		auto& m = sessionMacros[y];
+		if (m.kind == CLIP_LAUNCH && m.clip == clip) {
+			m.kind = NO_MACRO;
+		}
 	}
 
 	sessionClips.deleteAtIndex(clipIndex);

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -84,6 +84,21 @@ struct BackedUpParamManager {
 
 #define MAX_NOTES_CHORD_MEM 10
 
+enum SessionMacroKind : int8_t {
+	NO_MACRO = 0,
+	CLIP_LAUNCH,
+	OUTPUT_CYCLE,
+	SECTION,
+	NUM_KINDS,
+};
+
+struct SessionMacro {
+	SessionMacroKind kind;
+	Clip* clip;
+	Output* output;
+	uint8_t section;
+};
+
 class Song final : public TimelineCounter {
 public:
 	Song();
@@ -221,6 +236,8 @@ public:
 	int32_t unautomatedParamValues[deluge::modulation::params::kMaxNumUnpatchedParams];
 
 	String dirPath;
+
+	SessionMacro sessionMacros[8];
 
 	bool getAnyClipsSoloing() const;
 	Clip* getCurrentClip();

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -1232,6 +1232,10 @@ probablyDoFlashPlayEnable:
 			}
 		}
 	}
+	else {
+		// TODO: only if sidebar visible!
+		uiNeedsRendering(getCurrentUI(), 0x00000000, 0xFFFFFFFF);
+	}
 }
 
 void Session::scheduleOverdubToStartRecording(Clip* overdub, Clip* clipAbove) {


### PR DESCRIPTION
One of my major workflow issues with the deluge has been, that while jamming on the keyboard on a part, jumping to song view and back to change some background part is just too many keypresses to switch to session view, press the right button which just wasn't visible until now and then jump back in to the correct keyboard part again, and now the "flow" of the jam is already lost.

Add a sidebar where the song parts can be controlled directly from the keyboard screen. This is done as 8 configurable "macros" which in this draft can be one of 

- switch given clip on/off
- cycle all clips for a specific output
- switch to a specific section (for all relevant output)

Suggestions for more behaviors welcome. Like I considered expanding the first option to layer any set of part in an arbitrary combination (not just sections), but wanted to start with something simple.

Very early draft, some missing pieces:

- [x] configure this sidebar directly from grid view 
- [x] save macros with song
- [x] add validation for Clips/Outputs which might be deleted and now are dangling pointers
- [ ] consider the right use of colors