### PR TITLE
Bugfix - When changing midi channel on a Midi Preset, show it as popup

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2288,6 +2288,22 @@ gotAnInstrument:
 		if (display->haveOLED()) {
 			deluge::hid::display::OLED::sendMainImage();
 		}
+
+		// Special case: when it is a saved MIDI preset (with a name), then we need to show the channel in a popup, as
+		// the name will print over the midi channel and we can't see it while changing it
+		if (outputType == OutputType::MIDI_OUT && newInstrument->name.getLength() > 0) {
+			char buffer[12];
+			if (newChannel < 16) {
+				slotToString(newChannel + 1, newChannelSuffix, buffer, 1);
+			}
+			else if (newChannel == MIDI_CHANNEL_MPE_LOWER_ZONE || newChannel == MIDI_CHANNEL_MPE_UPPER_ZONE) {
+				strcpy(buffer, (newChannel == MIDI_CHANNEL_MPE_LOWER_ZONE) ? "Lower" : "Upper");
+			}
+			else {
+				strcpy(buffer, "Transpose");
+			}
+			display->popupTextTemporary(buffer);
+		}
 	}
 
 	// Or if we're on a Kit or Synth...


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/1466

by checking if the name of a midi output is set to something, it means we are dealing with a saved MIDI Preset, so the name of the preset is always visible, even when changing midi channels using the select encoder (so you can't see what channel you are setting). This checks for that and in that case, shows the midi channel being changed in a popup as a fallback mechanism, so the users knows which channel they are setting

To cherry-pick!