### PR TITLE
Bugfix - Automation View ~ Fixed unresponsive sound menu

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1467,7 +1467,7 @@ ActionResult AutomationView::buttonAction(hid::Button b, bool on, bool inCardRou
 
 	// Select encoder
 	// if you're not pressing shift and press down on the select encoder, toggle interpolation on/off
-	else if (!Buttons::isShiftButtonPressed() && b == SELECT_ENC) {
+	else if (!Buttons::isShiftButtonPressed() && b == SELECT_ENC && currentUIMode == UI_MODE_NONE) {
 		handleSelectEncoderButtonAction(on);
 	}
 


### PR DESCRIPTION
Fixed bug where sound menu would be unresponsive if you try to enter the menu while holding the horizontal encoder

Fixed it by blocking menu entry when currentUIMode is not none