### PR TITLE
Bugfix - Fixed patch cable selection of decimal number pos

### DIFF
--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -255,7 +255,18 @@ ActionResult PatchCableStrength::buttonAction(deluge::hid::Button b, bool on, bo
 }
 
 void PatchCableStrength::horizontalEncoderAction(int32_t offset) {
-	Automation::horizontalEncoderAction(offset);
+	int8_t currentEditPos = soundEditor.numberEditPos;
+	// don't adjust patch cable decimal edit pos if you're holding down the horizontal encoder
+	// reserve holding down horizontal encoder for zooming in automation view
+	if (!Buttons::isButtonPressed(hid::button::X_ENC)) {
+		Decimal::horizontalEncoderAction(offset);
+	}
+	// if editPos hasn't changed, then you reached start (far left) or end (far right) of the decimal number
+	// or you're holding down the horizontal encoder because you want to zoom in/out
+	// if this is the case, then you can potentially engage scrolling/zooming of the underlying automation view
+	if (currentEditPos == soundEditor.numberEditPos) {
+		Automation::horizontalEncoderAction(offset);
+	}
 }
 
 } // namespace deluge::gui::menu_item


### PR DESCRIPTION
Fixed selection of patch cable decimal number pos for editing with the horizontal encoder

If automation view is the underlying root UI, it will only engage horizontal scrolling if you've reached the far left or far right edit pos for the decimal patch cable number

also disabled scrolling patch cable number if you're holding down horizontal encoder as it makes zooming in/out in automation view more cumbersome

closes https://github.com/SynthstromAudible/DelugeFirmware/issues/1546