### PR TITLE
Bugfix - Disable sidebar actions while VU meter is shown

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -361,6 +361,7 @@ Here is a list of features that have been added to the firmware as a list, group
         - turn `Affect Entire` on
         - select the `Volume mod button`
         - press the `Volume mod button` again to toggle the VU Meter on / off.
+          - note: the `Volume mod button` will blink when the VU meter is on and displayed
     - The VU meter will stop rendering if you switch mod button selections, turn affect entire off, select a clip, or
       exit Song/Arranger views.
     - The VU meter will render the decibels below clipping on the grid with the colours green, orange and red.

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -930,6 +930,11 @@ ActionResult ArrangerView::padAction(int32_t x, int32_t y, int32_t velocity) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
 
+	// don't interact with sidebar if VU Meter is displayed
+	if (x >= kDisplayWidth && view.displayVUMeter) {
+		return ActionResult::DEALT_WITH;
+	}
+
 	// Audition pad
 	if (x == kDisplayWidth + 1) {
 		return handleAuditionPadAction(y, velocity, this);

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1875,6 +1875,11 @@ ActionResult AutomationView::padAction(int32_t x, int32_t y, int32_t velocity) {
 		}
 	}
 
+	// don't interact with sidebar if VU Meter is displayed
+	if (onArrangerView && x >= kDisplayWidth && view.displayVUMeter) {
+		return ActionResult::DEALT_WITH;
+	}
+
 	Output* output = clip->output;
 	OutputType outputType = output->type;
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -911,6 +911,10 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 			uiNeedsRendering(this); // re-render pads
 		}
 		else if (xDisplay >= kDisplayWidth) {
+			// don't interact with sidebar if VU Meter is displayed
+			if (view.displayVUMeter) {
+				return ActionResult::DEALT_WITH;
+			}
 			// if in arranger view
 			if (currentSong->lastClipInstanceEnteredStartPos != -1) {
 				// pressing the first column in sidebar to trigger sections / clips

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -611,6 +611,11 @@ void SessionView::beginEditingSectionRepeatsNum() {
 }
 
 ActionResult SessionView::padAction(int32_t xDisplay, int32_t yDisplay, int32_t on) {
+	// don't interact with sidebar if VU Meter is displayed
+	if (xDisplay >= kDisplayWidth && view.displayVUMeter) {
+		return ActionResult::DEALT_WITH;
+	}
+
 	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
 		return gridHandlePads(xDisplay, yDisplay, on);
 	}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1517,10 +1517,16 @@ void View::setModLedStates() {
 
 	for (int32_t i = 0; i < kNumModButtons; i++) {
 		bool on = (i == modKnobMode);
+		// if you're in a song view and volume mod button is selected and VU meter is enabled
+		// blink volume mod led
+		if (itsTheSong && on && modKnobMode == 0 && view.displayVUMeter) {
+			indicator_leds::blinkLed(indicator_leds::modLed[i]);
+		}
 		// if you're in the Automation View Automation Editor, turn off Mod LED's
-		if ((getRootUI() == &automationView) && !automationView.isOnAutomationOverview()) {
+		else if ((getRootUI() == &automationView) && !automationView.isOnAutomationOverview()) {
 			indicator_leds::setLedState(indicator_leds::modLed[i], false);
 		}
+		// otherwise update mod led's to reflect current mod led selection
 		else {
 			indicator_leds::setLedState(indicator_leds::modLed[i], on);
 		}


### PR DESCRIPTION
Disabled interacting with sidebar while VU meter is displayed

Volume mod button now blinks when VU meter is on and being displayed