### PR TITLE
Bugfix - deluge becomes unresponsive when launching clip while stuttering

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2577,6 +2577,14 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 		// No break
 	case UI_MODE_CLIP_PRESSED_IN_SONG_VIEW:
 	case UI_MODE_STUTTERING:
+		// this code is needed to allow users to launch clips while stuttering
+		// without it the deluge becomes unresponsive if you try to launch a clip while stuttering
+		// this is because it gets stuck in the stuttering UI mode and can't get out
+		if (on) {
+			sessionView.performActionOnPadRelease = false; // Even though there's a chance we're not in session view
+			session.toggleClipStatus(clip, NULL, Buttons::isShiftButtonPressed(), kInternalButtonPressLatency);
+		}
+		break;
 	case UI_MODE_HOLDING_STATUS_PAD:
 		if (on) {
 			enterUIMode(UI_MODE_HOLDING_STATUS_PAD);


### PR DESCRIPTION
Fixed bug where deluge would become unresponsive if you were stuttering while launching a clip

Went back to the 4.1.4 codebase where this issue was not present and noticed that we removed a bit of code (I assume accidentally) that was needed to prevent this issue from happening. So I just added that code back.

- See: https://github.com/SynthstromAudible/DelugeFirmware/blob/695b22af1e9fcc060e59868c83cf8e504bd57ff1/src/View.cpp#L1770

Closes issue https://github.com/SynthstromAudible/DelugeFirmware/issues/1454