### PR TITLE
UI Consistency - Align compressor display values

### DIFF
--- a/src/deluge/dsp/compressor/rms_feedback.cpp
+++ b/src/deluge/dsp/compressor/rms_feedback.cpp
@@ -85,7 +85,7 @@ void RMSFeedbackCompressor::render(StereoSample* buffer, uint16_t numSamples, q3
 	} while (++thisSample != bufferEnd);
 	// for LEDs
 	// 4 converts to dB, then quadrupled for display range since a 30db reduction is basically killing the signal
-	gainReduction = std::clamp<int32_t>(-(reduction)*4 * 4, 0, 127);
+	gainReduction = std::clamp<int32_t>(-(reduction) * 4 * 4, 0, 127);
 	// calc compression for next round (feedback compressor)
 	rms = calcRMS(buffer, numSamples);
 }

--- a/src/deluge/dsp/compressor/rms_feedback.cpp
+++ b/src/deluge/dsp/compressor/rms_feedback.cpp
@@ -36,7 +36,7 @@ void RMSFeedbackCompressor::updateER(float numSamples, q31_t finalVolume) {
 	// this is effectively where song volume gets applied, so we'll stick an IIR filter (e.g. the envelope) here to
 	// reduce clicking
 	float lastER = er;
-	er = std::max<float>((songVolumedB - threshdb - 1) * ratio, 0);
+	er = std::max<float>((songVolumedB - threshdb - 1) * reduction, 0);
 	// using the envelope is convenient since it means makeup gain and compression amount change at the same rate
 	er = runEnvelope(lastER, er, numSamples);
 }
@@ -57,7 +57,7 @@ void RMSFeedbackCompressor::render(StereoSample* buffer, uint16_t numSamples, q3
 
 	state = runEnvelope(state, over, numSamples);
 
-	float reduction = -state * ratio;
+	float reduction = -state * reduction;
 
 	// this is the most gain available without overflow
 	float dbGain = 3.f + er + reduction;
@@ -85,7 +85,7 @@ void RMSFeedbackCompressor::render(StereoSample* buffer, uint16_t numSamples, q3
 	} while (++thisSample != bufferEnd);
 	// for LEDs
 	// 4 converts to dB, then quadrupled for display range since a 30db reduction is basically killing the signal
-	gainReduction = std::clamp<int32_t>(-(reduction) * 4 * 4, 0, 127);
+	gainReduction = std::clamp<int32_t>(-(reduction)*4 * 4, 0, 127);
 	// calc compression for next round (feedback compressor)
 	rms = calcRMS(buffer, numSamples);
 }

--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -67,16 +67,16 @@ public:
 		threshold = 1 - 0.8f * (float(thresholdKnobPos) / ONE_Q31f);
 	}
 	q31_t getRatio() { return ratioKnobPos; }
-	constexpr int32_t getRatioForDisplay() { return (1 / (1 - ratio)); }
+	constexpr int32_t getRatioForDisplay() { return (1 / (1 - reduction)); }
 	constexpr int32_t setRatio(q31_t rat) {
 		ratioKnobPos = rat;
-		ratio = 0.5f + (float(ratioKnobPos) / ONE_Q31f) / 2;
-		return 1 / (1 - ratio);
+		reduction = 0.5f + (float(ratioKnobPos) / ONE_Q31f) / 2;
+		return 1 / (1 - reduction);
 	}
 	q31_t getSidechain() { return sideChainKnobPos; }
-	constexpr int32_t getSidechainForDisplay() { 
+	constexpr int32_t getSidechainForDisplay() {
 		float fc_hz = (std::exp(1.5 * float(sideChainKnobPos) / ONE_Q31f) - 1) * 30;
-		return fc_hz; 
+		return fc_hz;
 	}
 	constexpr int32_t setSidechain(q31_t f) {
 		sideChainKnobPos = f;
@@ -97,7 +97,7 @@ private:
 	// parameters in use
 	float a_ = (-1000.0f / kSampleRate);
 	float r_ = (-1000.0f / kSampleRate);
-	float ratio = 2;
+	float reduction = 2;
 	float er = 0;
 	float threshdb = 17;
 	float threshold = 1;

--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -67,22 +67,20 @@ public:
 		threshold = 1 - 0.8f * (float(thresholdKnobPos) / ONE_Q31f);
 	}
 	q31_t getRatio() { return ratioKnobPos; }
-	constexpr int32_t getRatioForDisplay() { return (1 / (1 - reduction)); }
+	constexpr int32_t getRatioForDisplay() { return ratio; }
 	constexpr int32_t setRatio(q31_t rat) {
 		ratioKnobPos = rat;
 		reduction = 0.5f + (float(ratioKnobPos) / ONE_Q31f) / 2;
-		return 1 / (1 - reduction);
+		ratio = 1 / (1 - reduction);
+		return ratio;
 	}
 	q31_t getSidechain() { return sideChainKnobPos; }
-	constexpr int32_t getSidechainForDisplay() {
-		float fc_hz = (std::exp(1.5 * float(sideChainKnobPos) / ONE_Q31f) - 1) * 30;
-		return fc_hz;
-	}
+	constexpr int32_t getSidechainForDisplay() { return fc_hz; }
 	constexpr int32_t setSidechain(q31_t f) {
 		sideChainKnobPos = f;
 		// this exp will be between 1 and 5ish, half the knob range is about 2
 		// the result will then be from 0 to 100hz with half the knob range at 60hz
-		float fc_hz = (std::exp(1.5 * float(f) / ONE_Q31f) - 1) * 30;
+		fc_hz = (std::exp(1.5 * float(f) / ONE_Q31f) - 1) * 30;
 		float fc = fc_hz / float(kSampleRate);
 		float wc = fc / (1 + fc);
 		a = wc * ONE_Q31;
@@ -97,7 +95,7 @@ private:
 	// parameters in use
 	float a_ = (-1000.0f / kSampleRate);
 	float r_ = (-1000.0f / kSampleRate);
-	float reduction = 2;
+	float reduction = 0.5;
 	float er = 0;
 	float threshdb = 17;
 	float threshold = 1;
@@ -116,6 +114,8 @@ private:
 	// for display
 	float attackMS = 0;
 	float releaseMS = 0;
+	float ratio = 2;
+	float fc_hz;
 
 	// raw knob positions
 	q31_t thresholdKnobPos = 0;

--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -67,13 +67,17 @@ public:
 		threshold = 1 - 0.8f * (float(thresholdKnobPos) / ONE_Q31f);
 	}
 	q31_t getRatio() { return ratioKnobPos; }
+	constexpr int32_t getRatioForDisplay() { return (1 / (1 - ratio)); }
 	constexpr int32_t setRatio(q31_t rat) {
 		ratioKnobPos = rat;
 		ratio = 0.5f + (float(ratioKnobPos) / ONE_Q31f) / 2;
 		return 1 / (1 - ratio);
 	}
 	q31_t getSidechain() { return sideChainKnobPos; }
-
+	constexpr int32_t getSidechainForDisplay() { 
+		float fc_hz = (std::exp(1.5 * float(sideChainKnobPos) / ONE_Q31f) - 1) * 30;
+		return fc_hz; 
+	}
 	constexpr int32_t setSidechain(q31_t f) {
 		sideChainKnobPos = f;
 		// this exp will be between 1 and 5ish, half the knob range is about 2

--- a/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
+++ b/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
@@ -22,6 +22,7 @@ public:
 		}
 	}
 	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getAttackMS(); }
+	const char* getUnit() override { return " MS"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 class Release final : public Integer {
@@ -39,6 +40,7 @@ public:
 		}
 	}
 	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getReleaseMS(); }
+	const char* getUnit() override { return " MS"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 class Ratio final : public Integer {
@@ -56,6 +58,7 @@ public:
 		}
 	}
 	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getRatioForDisplay(); }
+	const char* getUnit() override { return " : 1"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 class SideHPF final : public Integer {
@@ -75,6 +78,7 @@ public:
 	int32_t getDisplayValue() override {
 		return soundEditor.currentModControllable->compressor.getSidechainForDisplay();
 	}
+	const char* getUnit() override { return " HZ"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 } // namespace deluge::gui::menu_item::audio_compressor

--- a/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
+++ b/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
@@ -12,77 +12,69 @@ public:
 	using Integer::Integer;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getAttack();
-		this->setValue((value * (kMaxMenuValue * 2) + 2147483648) >> 32);
+		this->setValue(value >> 24);
 	}
 	void writeCurrentValue() override {
-		if (this->getValue() == kMaxMenuValue) {
-			soundEditor.currentModControllable->compressor.setAttack(ONE_Q31);
-		}
-		else {
-			q31_t knobPos = (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
+		auto value = this->getValue();
+		if (value < kMaxKnobPos) {
+			q31_t knobPos = lshiftAndSaturate<24>(value);
 			soundEditor.currentModControllable->compressor.setAttack(knobPos);
 		}
 	}
 	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getAttackMS(); }
-	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 class Release final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getRelease();
-		this->setValue((value * (kMaxMenuValue * 2) + 2147483648) >> 32);
+		this->setValue(value >> 24);
 	}
 	void writeCurrentValue() override {
-		if (this->getValue() == kMaxMenuValue) {
-			soundEditor.currentModControllable->compressor.setRelease(ONE_Q31);
-		}
-		else {
-			q31_t knobPos = (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
+		auto value = this->getValue();
+		if (value < kMaxKnobPos) {
+			q31_t knobPos = lshiftAndSaturate<24>(value);
 			soundEditor.currentModControllable->compressor.setRelease(knobPos);
 		}
 	}
 	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getReleaseMS(); }
-	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 class Ratio final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getRatio();
-		this->setValue((value * (kMaxMenuValue * 2) + 2147483648) >> 32);
+		this->setValue(value >> 24);
 	}
 	void writeCurrentValue() override {
-		if (this->getValue() == kMaxMenuValue) {
-			soundEditor.currentModControllable->compressor.setRatio(ONE_Q31);
-		}
-		else {
-			q31_t knobPos = (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
+		auto value = this->getValue();
+		if (value < kMaxKnobPos) {
+			q31_t knobPos = lshiftAndSaturate<24>(value);
 			soundEditor.currentModControllable->compressor.setRatio(knobPos);
 		}
 	}
 	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getRatioForDisplay(); }
-	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 class SideHPF final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getSidechain();
-		this->setValue((value * (kMaxMenuValue * 2) + 2147483648) >> 32);
+		this->setValue(value >> 24);
 	}
 	void writeCurrentValue() override {
-		if (this->getValue() == kMaxMenuValue) {
-			soundEditor.currentModControllable->compressor.setSidechain(ONE_Q31);
-		}
-		else {
-			q31_t knobPos = (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
+		auto value = this->getValue();
+		if (value < kMaxKnobPos) {
+			q31_t knobPos = lshiftAndSaturate<24>(value);
 			soundEditor.currentModControllable->compressor.setSidechain(knobPos);
 		}
 	}
 	int32_t getDisplayValue() override {
 		return soundEditor.currentModControllable->compressor.getSidechainForDisplay();
 	}
-	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
+	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 } // namespace deluge::gui::menu_item::audio_compressor

--- a/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
+++ b/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
@@ -23,6 +23,7 @@ public:
 			soundEditor.currentModControllable->compressor.setAttack(knobPos);
 		}
 	}
+	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getAttackMS(); }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };
 class Release final : public Integer {
@@ -41,6 +42,7 @@ public:
 			soundEditor.currentModControllable->compressor.setRelease(knobPos);
 		}
 	}
+	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getReleaseMS(); }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };
 class Ratio final : public Integer {
@@ -59,6 +61,7 @@ public:
 			soundEditor.currentModControllable->compressor.setRatio(knobPos);
 		}
 	}
+	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getRatioForDisplay(); }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };
 class SideHPF final : public Integer {
@@ -76,6 +79,9 @@ public:
 			q31_t knobPos = (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
 			soundEditor.currentModControllable->compressor.setSidechain(knobPos);
 		}
+	}
+	int32_t getDisplayValue() override {
+		return soundEditor.currentModControllable->compressor.getSidechainForDisplay();
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };

--- a/src/deluge/gui/menu_item/integer.cpp
+++ b/src/deluge/gui/menu_item/integer.cpp
@@ -54,7 +54,7 @@ void IntegerWithOff::drawValue() {
 void Integer::drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
 	char buffer[12];
 	intToString(getDisplayValue(), buffer, 1);
-	strncat(buffer, getUnit(), 11);
+	strncat(buffer, getUnit(), 4);
 	deluge::hid::display::OLED::drawStringCentred(buffer, yPixel + OLED_MAIN_TOPMOST_PIXEL,
 	                                              deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
 	                                              textWidth, textHeight);

--- a/src/deluge/gui/menu_item/integer.cpp
+++ b/src/deluge/gui/menu_item/integer.cpp
@@ -39,7 +39,7 @@ void Integer::selectEncoderAction(int32_t offset) {
 }
 
 void Integer::drawValue() {
-	display->setTextAsNumber(this->getValue());
+	display->setTextAsNumber(getDisplayValue());
 }
 
 void IntegerWithOff::drawValue() {
@@ -53,7 +53,7 @@ void IntegerWithOff::drawValue() {
 
 void Integer::drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
 	char buffer[12];
-	intToString(this->getValue(), buffer, 1);
+	intToString(getDisplayValue(), buffer, 1);
 	deluge::hid::display::OLED::drawStringCentred(buffer, yPixel + OLED_MAIN_TOPMOST_PIXEL,
 	                                              deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
 	                                              textWidth, textHeight);

--- a/src/deluge/gui/menu_item/integer.cpp
+++ b/src/deluge/gui/menu_item/integer.cpp
@@ -54,6 +54,7 @@ void IntegerWithOff::drawValue() {
 void Integer::drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
 	char buffer[12];
 	intToString(getDisplayValue(), buffer, 1);
+	strncat(buffer, getUnit(), 11);
 	deluge::hid::display::OLED::drawStringCentred(buffer, yPixel + OLED_MAIN_TOPMOST_PIXEL,
 	                                              deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
 	                                              textWidth, textHeight);

--- a/src/deluge/gui/menu_item/integer.h
+++ b/src/deluge/gui/menu_item/integer.h
@@ -28,6 +28,7 @@ public:
 
 protected:
 	virtual int32_t getDisplayValue() { return this->getValue(); }
+	virtual const char* getUnit() { return ""; }
 
 	void drawPixelsForOled();
 	virtual void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel);

--- a/src/deluge/gui/menu_item/integer.h
+++ b/src/deluge/gui/menu_item/integer.h
@@ -27,6 +27,8 @@ public:
 	void selectEncoderAction(int32_t offset) override;
 
 protected:
+	virtual int32_t getDisplayValue() { return this->getValue(); }
+
 	void drawPixelsForOled();
 	virtual void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel);
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -583,7 +583,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 		char buffer[12];
 		intToString(displayLevel, buffer);
 		if (display->haveOLED()) {
-			strncat(buffer, unit, 11);
+			strncat(buffer, unit, 4);
 		}
 		display->displayPopup(buffer);
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -542,8 +542,6 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				// this range is ratio of 2 to 20
 				current = std::clamp(current, -64, 64);
 				ledLevel = (64 + current);
-				displayLevel = ((ledLevel)*kMaxMenuValue) / 128;
-
 				displayLevel = compressor.setRatio(lshiftAndSaturate<24>(current + 64));
 				break;
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -523,6 +523,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 		int current;
 		int displayLevel;
 		int ledLevel;
+		const char* unit;
 		// this is only reachable in comp editing mode, otherwise it's an existent param
 		if (whichModEncoder == 1) { // sidechain (threshold)
 			current = (compressor.getThreshold() >> 24) - 64;
@@ -532,6 +533,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 			displayLevel = ((ledLevel)*kMaxMenuValue) / 128;
 			compressor.setThreshold(lshiftAndSaturate<24>(current + 64));
 			indicator_leds::setKnobIndicatorLevel(1, ledLevel);
+			unit = "";
 		}
 		else if (whichModEncoder == 0) {
 			switch (currentCompParam) {
@@ -543,6 +545,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				current = std::clamp(current, -64, 64);
 				ledLevel = (64 + current);
 				displayLevel = compressor.setRatio(lshiftAndSaturate<24>(current + 64));
+				unit = " : 1";
 				break;
 
 			case CompParam::ATTACK:
@@ -552,6 +555,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				ledLevel = (64 + current);
 
 				displayLevel = compressor.setAttack(lshiftAndSaturate<24>(current + 64));
+				unit = " MS";
 				break;
 
 			case CompParam::RELEASE:
@@ -561,6 +565,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				ledLevel = (64 + current);
 
 				displayLevel = compressor.setRelease(lshiftAndSaturate<24>(current + 64));
+				unit = " MS";
 				break;
 
 			case CompParam::SIDECHAIN:
@@ -570,12 +575,16 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				ledLevel = (64 + current);
 
 				displayLevel = compressor.setSidechain(lshiftAndSaturate<24>(current + 64));
+				unit = " HZ";
 				break;
 			}
 			indicator_leds::setKnobIndicatorLevel(0, ledLevel);
 		}
-		char buffer[5];
+		char buffer[12];
 		intToString(displayLevel, buffer);
+		if (display->haveOLED()) {
+			strncat(buffer, unit, 11);
+		}
 		display->displayPopup(buffer);
 
 		return ActionResult::DEALT_WITH;


### PR DESCRIPTION
Updated clip comp values displayed in menu to align them with the pop-up values displayed in the Song Master Compressor

Added units next to comp param values on OLED

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1187