### PR TITLE
Bugfix - Update session view detection in menu

### DIFF
--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -146,6 +146,11 @@ bool rootUIIsTimelineView() {
 	return (rootUI && rootUI->isTimelineView());
 }
 
+bool currentUIIsClipMinderScreen() {
+	UI* currentUI = getCurrentUI();
+	return (currentUI && currentUI->toClipMinder());
+}
+
 bool rootUIIsClipMinderScreen() {
 	UI* rootUI = getRootUI();
 	return (rootUI && rootUI->toClipMinder());

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -162,6 +162,7 @@ void setRootUILowLevel(UI* newUI);
 void swapOutRootUILowLevel(UI* newUI);
 void nullifyUIs();
 bool rootUIIsTimelineView();
+bool currentUIIsClipMinderScreen();
 bool rootUIIsClipMinderScreen();
 std::pair<uint32_t, uint32_t> getUIGreyoutColsAndRows();
 


### PR DESCRIPTION
Updated code to detect if we're in a session view while entering / already in the menu to ensure that the right menu item gets opened and right model stack gets setup.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1564