### PR TITLE
Bugfix - clip menu crash bug when using grid shortcut

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1331,7 +1331,7 @@ bool SoundEditor::setup(Clip* clip, const MenuItem* item, int32_t sourceIndex) {
 
 	bool isUIPerformanceView = ((getRootUI() == &performanceSessionView) || currentUI == &performanceSessionView);
 
-	bool isUISessionView = isUIPerformanceView || !currentUIIsClipMinderScreen();
+	bool isUISessionView = isUIPerformanceView || !rootUIIsClipMinderScreen();
 
 	// getParamManager and ModControllable for Performance Session View (and Session View)
 	if (isUISessionView) {


### PR DESCRIPTION
FIxed bug with menu crashing when using grid shortcut after you are already in the menu