### PR TITLE
Add compressor threshold to automation view list

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -12,7 +12,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 
 1. Automatable Clip View Parameters for Synths, Kits with affect entire DISABLED
 
->The 60 parameters that can be edited are:
+>The 61 parameters that can be edited are:
 >
 > - **Master** Level, Pitch, Pan
 > - **LPF** Frequency, Resonance, Morph
@@ -35,10 +35,11 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **Noise** Level
 > - **Portamento**
 > - **Stutter** Rate
+> - **Compressor** Threshold
 
 2. Automatable Clip View Parameters for Kits with affect entire ENABLED, and Audio Clips
 
->The 25 parameters that can be edited are:
+>The 26 parameters that can be edited are:
 >
 > - **Master** Level, Pitch, Pan
 > - **LPF** Frequency, Resonance, Morph
@@ -50,6 +51,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **Distortion** Decimation, Bitcrush
 > - **Mod FX** Offset, Feedback, Depth, Rate
 > - **Stutter** Rate
+> - **Compressor** Threshold
 
 3. Automatable Parameters for Arranger
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -327,8 +327,8 @@ constexpr int32_t kMaxMenuMetronomeVolumeValue = 50;
 constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 
 // Automation View constants
-constexpr int32_t kNumNonGlobalParamsForAutomation = 60;
-constexpr int32_t kNumGlobalParamsForAutomation = 25;
+constexpr int32_t kNumNonGlobalParamsForAutomation = 61;
+constexpr int32_t kNumGlobalParamsForAutomation = 26;
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kKnobPosOffset = 64;
 constexpr int32_t kMaxKnobPos = 128;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -202,6 +202,8 @@ const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutom
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_PORTAMENTO},
     // Stutter Rate
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE},
+    // Compressor Threshold
+    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_COMPRESSOR_THRESHOLD},
 }};
 
 // global FX - sorted in the order that Parameters are scrolled through on the display
@@ -243,6 +245,8 @@ const std::array<std::pair<params::Kind, ParamType>, kNumGlobalParamsForAutomati
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_RATE},
     // Stutter Rate
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_STUTTER_RATE},
+    // Compressor Threshold
+    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_COMPRESSOR_THRESHOLD},
 }};
 
 // let's render some love <3
@@ -3304,7 +3308,7 @@ void AutomationView::selectGlobalParam(int32_t offset, Clip* clip) {
 		auto [kind, id] = globalParamsForAutomation[idx];
 		{
 			while ((id == params::UNPATCHED_PITCH_ADJUST || id == params::UNPATCHED_SIDECHAIN_SHAPE
-			        || id == params::UNPATCHED_SIDECHAIN_VOLUME)) {
+			        || id == params::UNPATCHED_SIDECHAIN_VOLUME || id == params::UNPATCHED_COMPRESSOR_THRESHOLD)) {
 
 				if (offset < 0) {
 					offset -= 1;
@@ -3385,7 +3389,7 @@ int32_t AutomationView::getNextSelectedParamArrayPosition(int32_t offset, int32_
 	}
 	// if you are scrolling left and are at the beginning of the list, go to the end of the list
 	else if ((lastSelectedParamArrayPosition + offset) < 0) {
-		idx = numParams - 1;
+		idx = numParams + offset;
 	}
 	// if you are scrolling right and are at the end of the list, go to the beginning of the list
 	else if ((lastSelectedParamArrayPosition + offset) > (numParams - 1)) {


### PR DESCRIPTION
Added compressor threshold parameter to automation view select scrolling list

Excluded this param from arranger view as it is automatable there yet