### PR TITLE
Bugfix/crossfade filters when activated

### DIFF
--- a/src/deluge/dsp/filter/filter.cpp
+++ b/src/deluge/dsp/filter/filter.cpp
@@ -15,4 +15,6 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 #include "util/fixedpoint.h"
+namespace deluge::dsp::filter {
 q31_t blendBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2] = {0};
+}

--- a/src/deluge/dsp/filter/filter.cpp
+++ b/src/deluge/dsp/filter/filter.cpp
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2015-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "util/fixedpoint.h"
+q31_t blendBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2] = {0};

--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -23,10 +23,8 @@
 #include <cstdint>
 
 namespace deluge::dsp::filter {
-constexpr uint32_t ONE_Q31U = 2147483648u;
 constexpr int32_t ONE_Q16 = 134217728;
-// fade in filter over 1/100th of a second to avoid click
-constexpr q31_t fadeIncrement = 1 * (ONE_Q31 / kSampleRate);
+
 extern q31_t blendBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2];
 /**
  *  Interface for filters in the sound engine
@@ -117,6 +115,7 @@ public:
 	}
 
 	inline void updateBlend() {
+		// fades over around 500 samples
 		dryFade = dryFade * 0.99;
 		wetLevel = (q31_t)(ONE_Q31 * (1 - dryFade));
 	}

--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -21,9 +21,11 @@
 #include "util/fixedpoint.h"
 #include "util/functions.h"
 #include <cstdint>
+
 namespace deluge::dsp::filter {
 constexpr uint32_t ONE_Q31U = 2147483648u;
 constexpr int32_t ONE_Q16 = 134217728;
+extern q31_t blendBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2];
 /**
  *  Interface for filters in the sound engine
  * This is a CRTP base class for all filters used in the sound engine. To implement a new filter,
@@ -42,7 +44,8 @@ class Filter {
 public:
 	Filter() = default;
 	// returns a gain compensation value
-	q31_t configure(q31_t frequency, q31_t resonance, FilterMode lpfMode, q31_t lpfMorph, q31_t filterGain) {
+	q31_t configure(q31_t frequency, q31_t resonance, FilterMode lpfMode, q31_t lpfMorph, q31_t filterGain,
+	                q31_t dryLevel = 0) {
 		// lpfmorph comes in q28 but we want q31
 		return static_cast<T*>(this)->setConfig(frequency, resonance, lpfMode, lshiftAndSaturate<2>(lpfMorph),
 		                                        filterGain);
@@ -86,6 +89,7 @@ public:
 		fc = multiply_32x32_rshift32_rounded(tannedFrequency, divideBy1PlusTannedFrequency) << 4;
 	}
 	q31_t fc;
+	q31_t dryLevel;
 	q31_t tannedFrequency;
 	q31_t divideBy1PlusTannedFrequency;
 };

--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -105,6 +105,7 @@ public:
 	}
 	/**
 	 * reset the internal filter state to avoid clicks and pops
+	 * All zeroes must be a valid reset state as the filter data will be zeroed by the filterset
 	 */
 	void reset(bool fade = false) {
 		static_cast<T*>(this)->resetFilter();

--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -54,7 +54,7 @@ public:
 	 * @param sampleIncrement increment between samples
 	 * @param extraSaturation extra saturation value
 	 */
-	void filterMono(q31_t* startSample, q31_t* endSample, int32_t sampleIncrememt = 1) {
+	[[gnu::hot]] void filterMono(q31_t* startSample, q31_t* endSample, int32_t sampleIncrememt = 1) {
 		static_cast<T*>(this)->doFilter(startSample, endSample, sampleIncrememt);
 	}
 	/**
@@ -63,7 +63,7 @@ public:
 	 * @param endSample pointer to last sample
 	 * @param extraSaturation extra saturation value
 	 */
-	void filterStereo(q31_t* startSample, q31_t* endSample) {
+	[[gnu::hot]] void filterStereo(q31_t* startSample, q31_t* endSample) {
 		static_cast<T*>(this)->doFilterStereo(startSample, endSample);
 		;
 	}

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -30,7 +30,7 @@ FilterSet::FilterSet() {
 }
 q31_t tempRenderBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2]; // * 2 to accomodate stereo samples
 
-void FilterSet::renderHPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
+[[gnu::hot]] void FilterSet::renderHPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
 	if (HPFOn) {
 		if (hpfMode_ == FilterMode::HPLADDER) {
 			hpladder.filterMono(startSample, endSample, sampleIncrement);
@@ -40,7 +40,7 @@ void FilterSet::renderHPFLong(q31_t* startSample, q31_t* endSample, int32_t samp
 		}
 	}
 }
-void FilterSet::renderHPFLongStereo(q31_t* startSample, q31_t* endSample) {
+[[gnu::hot]] void FilterSet::renderHPFLongStereo(q31_t* startSample, q31_t* endSample) {
 	if (HPFOn) {
 		if (hpfMode_ == FilterMode::HPLADDER) {
 			hpladder.filterStereo(startSample, endSample);
@@ -51,7 +51,7 @@ void FilterSet::renderHPFLongStereo(q31_t* startSample, q31_t* endSample) {
 	}
 }
 
-void FilterSet::renderLPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
+[[gnu::hot]] void FilterSet::renderLPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
 	if (LPFOn) {
 		if ((lpfMode_ == FilterMode::SVF_BAND) || (lpfMode_ == FilterMode::SVF_NOTCH)) {
 			lpsvf.filterMono(startSample, endSample, sampleIncrement);
@@ -62,7 +62,7 @@ void FilterSet::renderLPFLong(q31_t* startSample, q31_t* endSample, int32_t samp
 	}
 }
 
-void FilterSet::renderLPFLongStereo(q31_t* startSample, q31_t* endSample) {
+[[gnu::hot]] void FilterSet::renderLPFLongStereo(q31_t* startSample, q31_t* endSample) {
 	if (LPFOn) {
 		if ((lpfMode_ == FilterMode::SVF_BAND) || (lpfMode_ == FilterMode::SVF_NOTCH)) {
 
@@ -74,7 +74,8 @@ void FilterSet::renderLPFLongStereo(q31_t* startSample, q31_t* endSample) {
 		}
 	}
 }
-void FilterSet::renderLong(q31_t* startSample, q31_t* endSample, int32_t numSamples, int32_t sampleIncrememt) {
+[[gnu::hot]] void FilterSet::renderLong(q31_t* startSample, q31_t* endSample, int32_t numSamples,
+                                        int32_t sampleIncrememt) {
 	switch (routing_) {
 	case FilterRoute::HIGH_TO_LOW:
 
@@ -105,7 +106,7 @@ void FilterSet::renderLong(q31_t* startSample, q31_t* endSample, int32_t numSamp
 	}
 }
 // expects to receive an interleaved stereo stream
-void FilterSet::renderLongStereo(q31_t* startSample, q31_t* endSample) {
+[[gnu::hot]] void FilterSet::renderLongStereo(q31_t* startSample, q31_t* endSample) {
 	// Do HPF, if it's on
 	switch (routing_) {
 	case FilterRoute::HIGH_TO_LOW:

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -153,14 +153,14 @@ int32_t FilterSet::setConfig(int32_t lpfFrequency, int32_t lpfResonance, FilterM
 
 	if (LPFOn) {
 		if ((lpfMode_ == FilterMode::SVF_BAND) || (lpfMode_ == FilterMode::SVF_NOTCH)) {
-			if (lastLPFMode_ <= kLastLadder) {
-				lpsvf.reset();
+			if (SpecificFilter(lastLPFMode_).getFamily() != FilterFamily::SVF) {
+				lpsvf.reset(lastLPFMode_ == FilterMode::OFF);
 			}
 			filterGain = lpsvf.configure(lpfFrequency, lpfResonance, lpfMode_, lpfMorph, filterGain);
 		}
 		else {
-			if (lastLPFMode_ > kLastLadder) {
-				lpladder.reset();
+			if (SpecificFilter(lastLPFMode_).getFamily() != FilterFamily::LP_LADDER) {
+				lpladder.reset(lastLPFMode_ == FilterMode::OFF);
 			}
 			filterGain = lpladder.configure(lpfFrequency, lpfResonance, lpfMode_, lpfMorph, filterGain);
 		}
@@ -178,7 +178,7 @@ int32_t FilterSet::setConfig(int32_t lpfFrequency, int32_t lpfResonance, FilterM
 		if (hpfMode_ == FilterMode::HPLADDER) {
 			filterGain = hpladder.configure(hpfFrequency, hpfResonance, hpfmode, hpfMorph, filterGain);
 			if (lastHPFMode_ != hpfMode_) {
-				hpladder.reset();
+				hpladder.reset(lastHPFMode_ == FilterMode::OFF);
 			}
 		}
 		// otherwise it's an SVF ((lpfmode == FilterMode::SVF_BAND) || (lpfmode == FilterMode::SVF_NOTCH))
@@ -186,7 +186,7 @@ int32_t FilterSet::setConfig(int32_t lpfFrequency, int32_t lpfResonance, FilterM
 			// invert the morph for the HPF so it goes high-band/notch-low
 			filterGain = hpsvf.configure(hpfFrequency, hpfResonance, hpfmode, ((1 << 29) - 1) - hpfMorph, filterGain);
 			if (lastHPFMode_ != hpfMode_) {
-				hpsvf.reset();
+				hpsvf.reset(lastHPFMode_ == FilterMode::OFF);
 			}
 		}
 		lastHPFMode_ = hpfMode_;

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -203,6 +203,5 @@ void FilterSet::reset() {
 	lpsvf.reset();
 	hpsvf.reset();
 	lpladder.reset();
-	noiseLastValue = 0;
 }
 } // namespace deluge::dsp::filter

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -192,9 +192,7 @@ int32_t FilterSet::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode 
 }
 
 void FilterSet::reset() {
-	hpfilter.ladder.reset();
-	lpfilter.svf.reset();
-	hpfilter.svf.reset();
-	lpfilter.ladder.reset();
+	memset(&lpfilter, 0, sizeof(LowPass));
+	memset(&hpfilter, 0, sizeof(HighPass));
 }
 } // namespace deluge::dsp::filter

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -142,8 +142,8 @@ int32_t FilterSet::setConfig(int32_t lpfFrequency, int32_t lpfResonance, bool do
                              int32_t hpfFrequency, int32_t hpfResonance, bool doHPF, FilterMode hpfmode, q31_t hpfMorph,
                              int32_t filterGain, FilterRoute routing, bool adjustVolumeForHPFResonance,
                              int32_t* overallOscAmplitude) {
-	LPFOn = doLPF;
-	HPFOn = doHPF;
+	LPFOn = lpfmode != FilterMode::OFF;
+	HPFOn = hpfmode != FilterMode::OFF;
 	lpfMode_ = lpfmode;
 	hpfMode_ = hpfmode;
 	routing_ = routing;

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -22,12 +22,7 @@
 #include "util/fixedpoint.h"
 
 namespace deluge::dsp::filter {
-FilterSet::FilterSet() {
 
-	lpsvf = SVFilter();
-	lpladder = LpLadderFilter();
-	hpladder = HpLadderFilter();
-}
 q31_t tempRenderBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2]; // * 2 to accomodate stereo samples
 
 [[gnu::hot]] void FilterSet::renderHPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -138,8 +138,8 @@ void FilterSet::renderLongStereo(q31_t* startSample, q31_t* endSample) {
 	}
 }
 
-int32_t FilterSet::setConfig(int32_t lpfFrequency, int32_t lpfResonance, bool doLPF, FilterMode lpfmode, q31_t lpfMorph,
-                             int32_t hpfFrequency, int32_t hpfResonance, bool doHPF, FilterMode hpfmode, q31_t hpfMorph,
+int32_t FilterSet::setConfig(int32_t lpfFrequency, int32_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph,
+                             int32_t hpfFrequency, int32_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph,
                              int32_t filterGain, FilterRoute routing, bool adjustVolumeForHPFResonance,
                              int32_t* overallOscAmplitude) {
 	LPFOn = lpfmode != FilterMode::OFF;

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -139,10 +139,10 @@ q31_t tempRenderBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2]; // * 2 to accomodate ster
 	}
 }
 
-int32_t FilterSet::setConfig(int32_t lpfFrequency, int32_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph,
-                             int32_t hpfFrequency, int32_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph,
-                             int32_t filterGain, FilterRoute routing, bool adjustVolumeForHPFResonance,
-                             int32_t* overallOscAmplitude) {
+int32_t FilterSet::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph,
+                             q31_t hpfFrequency, q31_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph,
+                             q31_t filterGain, FilterRoute routing, bool adjustVolumeForHPFResonance,
+                             q31_t* overallOscAmplitude) {
 	LPFOn = lpfmode != FilterMode::OFF;
 	HPFOn = hpfmode != FilterMode::OFF;
 	lpfMode_ = lpfmode;

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -32,10 +32,10 @@ class FilterSet {
 public:
 	FilterSet();
 	void reset();
-	q31_t setConfig(q31_t lpfFrequency, q31_t lpfResonance, bool doLPF, FilterMode lpfmode, q31_t lpfMorph,
-	                q31_t hpfFrequency, q31_t hpfResonance, bool doHPF, FilterMode hpfmode, q31_t hpfMorph,
-	                q31_t filterGain, FilterRoute routing, bool adjustVolumeForHPFResonance = true,
-	                q31_t* overallOscAmplitude = NULL);
+	int32_t setConfig(int32_t lpfFrequency, int32_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph,
+	                  int32_t hpfFrequency, int32_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph,
+	                  int32_t filterGain, FilterRoute routing, bool adjustVolumeForHPFResonance,
+	                  int32_t* overallOscAmplitude);
 
 	void renderLong(q31_t* startSample, q31_t* endSample, int32_t numSamples, int32_t sampleIncrememt = 1);
 

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -32,13 +32,13 @@ namespace deluge::dsp::filter {
 union LowPass {
 	LpLadderFilter ladder;
 	SVFilter svf;
-	LowPass() { memset(this, 0, sizeof(LowPass)); }
+	LowPass() {}
 };
 
 union HighPass {
 	HpLadderFilter ladder;
 	SVFilter svf;
-	HighPass() { memset(this, 0, sizeof(HighPass)); }
+	HighPass() {}
 };
 
 class FilterSet {

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -28,12 +28,21 @@
 class Sound;
 
 namespace deluge::dsp::filter {
-constexpr size_t lpfilterSize = std::max(sizeof(SVFilter), sizeof(LpLadderFilter));
-constexpr size_t hpfilterSize = std::max(sizeof(SVFilter), sizeof(HpLadderFilter));
+
+union LowPass {
+	LpLadderFilter ladder;
+	SVFilter svf;
+	LowPass() { memset(this, 0, sizeof(LowPass)); }
+};
+
+union HighPass {
+	HpLadderFilter ladder;
+	SVFilter svf;
+	HighPass() { memset(this, 0, sizeof(HighPass)); }
+};
 
 class FilterSet {
 public:
-	FilterSet() = default;
 	void reset();
 	int32_t setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph, q31_t hpfFrequency,
 	                  q31_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph, q31_t filterGain, FilterRoute routing,
@@ -62,15 +71,12 @@ private:
 	void renderHPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement = 1);
 
 	// all filters share a state. This is fine since they just hold plain data and initialization is handled by
-	// reset/configure calls.  This is faster than using a variant at the cost of not throwing on unitialized access.
+	// reset/configure calls.  This is faster than using a variant at the cost of not throwing on incorrect access.
 	// However since there are no invariants to uphold, the worst case scenario is an audio glitch so whatever
 	// This cuts 250 bytes from the size of this class, which is fairly significant since every voice has a filterset
-	char lpfilterstate[lpfilterSize];
-	char hpfilterstate[hpfilterSize];
-	SVFilter& lpsvf = *(SVFilter*)lpfilterstate;
-	LpLadderFilter& lpladder = *(LpLadderFilter*)lpfilterstate;
-	HpLadderFilter& hpladder = *(HpLadderFilter*)hpfilterstate;
-	SVFilter& hpsvf = *(SVFilter*)hpfilterstate;
+	LowPass lpfilter;
+	HighPass hpfilter;
+
 	bool LPFOn;
 	bool HPFOn;
 };

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -48,7 +48,6 @@ public:
 	inline bool isOn() { return HPFOn || LPFOn; }
 
 private:
-	q31_t noiseLastValue;
 	FilterMode lpfMode_;
 	FilterMode lastLPFMode_;
 	FilterMode hpfMode_;
@@ -59,7 +58,6 @@ private:
 	void renderLPFLongStereo(q31_t* startSample, q31_t* endSample);
 	void renderHPFLongStereo(q31_t* startSample, q31_t* endSample);
 	void renderHPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement = 1);
-	void renderLadderHPF(q31_t* outputSample);
 
 	SVFilter lpsvf;
 	LpLadderFilter lpladder;

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -32,10 +32,9 @@ class FilterSet {
 public:
 	FilterSet();
 	void reset();
-	int32_t setConfig(int32_t lpfFrequency, int32_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph,
-	                  int32_t hpfFrequency, int32_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph,
-	                  int32_t filterGain, FilterRoute routing, bool adjustVolumeForHPFResonance,
-	                  int32_t* overallOscAmplitude);
+	int32_t setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph, q31_t hpfFrequency,
+	                  q31_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph, q31_t filterGain, FilterRoute routing,
+	                  bool adjustVolumeForHPFResonance, q31_t* overallOscAmplitude);
 
 	void renderLong(q31_t* startSample, q31_t* endSample, int32_t numSamples, int32_t sampleIncrememt = 1);
 

--- a/src/deluge/dsp/filter/hpladder.cpp
+++ b/src/deluge/dsp/filter/hpladder.cpp
@@ -66,7 +66,7 @@ q31_t HpLadderFilter::setConfig(q31_t hpfFrequency, q31_t hpfResonance, FilterMo
 
 	return filterGain;
 }
-void HpLadderFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
+[[gnu::hot]] void HpLadderFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
 	q31_t* currentSample = startSample;
 	do {
 		*currentSample = doHPF(*currentSample, l);
@@ -74,7 +74,7 @@ void HpLadderFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t samp
 	} while (currentSample < endSample);
 }
 // filter an interleaved stereo buffer
-void HpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
+[[gnu::hot]] void HpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
 	q31_t* currentSample = startSample;
 	do {
 		*currentSample = doHPF(*currentSample, l);

--- a/src/deluge/dsp/filter/lpladder.cpp
+++ b/src/deluge/dsp/filter/lpladder.cpp
@@ -171,7 +171,7 @@ q31_t LpLadderFilter::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMo
 	return filterGain;
 }
 
-void LpLadderFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
+[[gnu::hot]] void LpLadderFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement) {
 
 	// Half ladder
 	if (lpfMode == FilterMode::TRANSISTOR_12DB) {
@@ -239,7 +239,7 @@ void LpLadderFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t samp
 		}
 	}
 }
-void LpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
+[[gnu::hot]] void LpLadderFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
 
 	// Half ladder
 	if (lpfMode == FilterMode::TRANSISTOR_12DB) {

--- a/src/deluge/dsp/filter/svf.cpp
+++ b/src/deluge/dsp/filter/svf.cpp
@@ -17,7 +17,7 @@
 #include "dsp/filter/svf.h"
 
 namespace deluge::dsp::filter {
-void SVFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t sampleIncrememt) {
+[[gnu::hot]] void SVFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t sampleIncrememt) {
 	q31_t* currentSample = startSample;
 	do {
 		q31_t outs = doSVF(*currentSample, l);
@@ -26,7 +26,7 @@ void SVFilter::doFilter(q31_t* startSample, q31_t* endSample, int32_t sampleIncr
 		currentSample += sampleIncrememt;
 	} while (currentSample < endSample);
 }
-void SVFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
+[[gnu::hot]] void SVFilter::doFilterStereo(q31_t* startSample, q31_t* endSample) {
 	q31_t* currentSample = startSample;
 	do {
 		q31_t outs = doSVF(*currentSample, l);

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -756,9 +756,8 @@ void GlobalEffectable::setupFilterSetConfig(int32_t* postFXVolume, ParamManager*
 	             || unpatchedParams->getValue(params::UNPATCHED_HPF_MORPH) > NEGATIVE_ONE_Q31;
 
 	// no morph for global effectable
-	*postFXVolume =
-	    filterSet.setConfig(lpfFrequency, lpfResonance, doLPF, lpfMode, lpfMorph, hpfFrequency, hpfResonance, doHPF,
-	                        FilterMode::HPLADDER, hpfMorph, *postFXVolume, filterRoute, false, NULL);
+	*postFXVolume = filterSet.setConfig(lpfFrequency, lpfResonance, lpfMode, lpfMorph, hpfFrequency, hpfResonance,
+	                                    FilterMode::HPLADDER, hpfMorph, *postFXVolume, filterRoute, false, NULL);
 }
 
 void GlobalEffectable::processFilters(StereoSample* buffer, int32_t numSamples) {

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -754,9 +754,11 @@ void GlobalEffectable::setupFilterSetConfig(int32_t* postFXVolume, ParamManager*
 	              || unpatchedParams->getValue(params::UNPATCHED_LPF_MORPH) > NEGATIVE_ONE_Q31);
 	bool doHPF = unpatchedParams->getValue(params::UNPATCHED_HPF_FREQ) > NEGATIVE_ONE_Q31
 	             || unpatchedParams->getValue(params::UNPATCHED_HPF_MORPH) > NEGATIVE_ONE_Q31;
-
-	*postFXVolume = filterSet.setConfig(lpfFrequency, lpfResonance, lpfMode, lpfMorph, hpfFrequency, hpfResonance,
-	                                    FilterMode::HPLADDER, hpfMorph, *postFXVolume, filterRoute, false, NULL);
+	FilterMode lpfModeForRender = doLPF ? lpfMode : FilterMode::OFF;
+	FilterMode hpfModeForRender = doHPF ? hpfMode : FilterMode::OFF;
+	*postFXVolume =
+	    filterSet.setConfig(lpfFrequency, lpfResonance, lpfModeForRender, lpfMorph, hpfFrequency, hpfResonance,
+	                        hpfModeForRender, hpfMorph, *postFXVolume, filterRoute, false, NULL);
 }
 
 [[gnu::hot]] void GlobalEffectable::processFilters(StereoSample* buffer, int32_t numSamples) {

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -759,7 +759,7 @@ void GlobalEffectable::setupFilterSetConfig(int32_t* postFXVolume, ParamManager*
 	                                    FilterMode::HPLADDER, hpfMorph, *postFXVolume, filterRoute, false, NULL);
 }
 
-void GlobalEffectable::processFilters(StereoSample* buffer, int32_t numSamples) {
+[[gnu::hot]] void GlobalEffectable::processFilters(StereoSample* buffer, int32_t numSamples) {
 	filterSet.renderLongStereo(&buffer->l, &(buffer + numSamples)->l);
 }
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -755,7 +755,6 @@ void GlobalEffectable::setupFilterSetConfig(int32_t* postFXVolume, ParamManager*
 	bool doHPF = unpatchedParams->getValue(params::UNPATCHED_HPF_FREQ) > NEGATIVE_ONE_Q31
 	             || unpatchedParams->getValue(params::UNPATCHED_HPF_MORPH) > NEGATIVE_ONE_Q31;
 
-	// no morph for global effectable
 	*postFXVolume = filterSet.setConfig(lpfFrequency, lpfResonance, lpfMode, lpfMorph, hpfFrequency, hpfResonance,
 	                                    FilterMode::HPLADDER, hpfMorph, *postFXVolume, filterRoute, false, NULL);
 }

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -47,10 +47,12 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 }
 
 // Beware - unlike usual, modelStack might have a NULL timelineCounter.
-void GlobalEffectableForClip::renderOutput(ModelStackWithTimelineCounter* modelStack, ParamManager* paramManagerForClip,
-                                           StereoSample* outputBuffer, int32_t numSamples, int32_t* reverbBuffer,
-                                           int32_t reverbAmountAdjust, int32_t sideChainHitPending,
-                                           bool shouldLimitDelayFeedback, bool isClipActive, OutputType outputType) {
+[[gnu::hot]] void GlobalEffectableForClip::renderOutput(ModelStackWithTimelineCounter* modelStack,
+                                                        ParamManager* paramManagerForClip, StereoSample* outputBuffer,
+                                                        int32_t numSamples, int32_t* reverbBuffer,
+                                                        int32_t reverbAmountAdjust, int32_t sideChainHitPending,
+                                                        bool shouldLimitDelayFeedback, bool isClipActive,
+                                                        OutputType outputType) {
 	UnpatchedParamSet* unpatchedParams = paramManagerForClip->getUnpatchedParamSet();
 
 	// Process FX and stuff. For kits, stutter happens before reverb send

--- a/src/deluge/model/mod_controllable/filters/filter_config.h
+++ b/src/deluge/model/mod_controllable/filters/filter_config.h
@@ -35,6 +35,8 @@ constexpr int32_t kNumFilterModes = util::to_underlying(FilterMode::OFF);
 constexpr FilterMode kLastLadder = FilterMode::TRANSISTOR_24DB_DRIVE;
 // Off is not an LPF mode but is used to reset filters
 constexpr int32_t kNumLPFModes = util::to_underlying(FilterMode::SVF_NOTCH) + 1;
+constexpr FilterMode lastLpfMode = FilterMode::SVF_NOTCH;
+constexpr FilterMode firstHPFMode = FilterMode::SVF_BAND;
 constexpr int32_t kFirstHPFMode = util::to_underlying(FilterMode::SVF_BAND);
 constexpr int32_t kNumHPFModes = util::to_underlying(FilterMode::OFF) - kFirstHPFMode;
 enum class FilterRoute {

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1997,7 +1997,16 @@ char const* ModControllableAudio::getFilterTypeDisplayName(FilterType currentFil
 }
 
 void ModControllableAudio::switchLPFMode() {
-	lpfMode = static_cast<FilterMode>((util::to_underlying(lpfMode) + 1) % kNumLPFModes);
+	switch (lpfMode) {
+	case FilterMode::OFF:
+		lpfMode = FilterMode::TRANSISTOR_12DB;
+		break;
+	case lastLpfMode:
+		lpfMode = FilterMode::OFF;
+		break;
+	default:
+		lpfMode = static_cast<FilterMode>((util::to_underlying(lpfMode) + 1));
+	}
 }
 
 char const* ModControllableAudio::getFilterModeDisplayName(FilterType currentFilterType) {
@@ -2012,7 +2021,7 @@ char const* ModControllableAudio::getFilterModeDisplayName(FilterType currentFil
 }
 
 char const* ModControllableAudio::getLPFModeDisplayName() {
-	lpfMode = static_cast<FilterMode>(util::to_underlying(lpfMode) % kNumLPFModes);
+
 	using enum deluge::l10n::String;
 	switch (lpfMode) {
 	case FilterMode::TRANSISTOR_12DB:
@@ -2031,12 +2040,17 @@ char const* ModControllableAudio::getLPFModeDisplayName() {
 }
 
 void ModControllableAudio::switchHPFMode() {
-	// this works fine, the offset to the first hpf doesn't matter with the modulus
-	hpfMode = static_cast<FilterMode>((util::to_underlying(hpfMode) + 1) % kNumHPFModes + kFirstHPFMode);
+
+	switch (hpfMode) {
+	case FilterMode::OFF:
+		hpfMode = firstHPFMode;
+		break;
+	default:
+		hpfMode = static_cast<FilterMode>((util::to_underlying(hpfMode) + 1));
+	}
 }
 
 char const* ModControllableAudio::getHPFModeDisplayName() {
-	hpfMode = static_cast<FilterMode>(util::to_underlying(hpfMode) % kNumHPFModes + kFirstHPFMode);
 	using enum deluge::l10n::String;
 	switch (hpfMode) {
 	case FilterMode::HPLADDER:

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1997,6 +1997,12 @@ char const* ModControllableAudio::getFilterTypeDisplayName(FilterType currentFil
 }
 
 void ModControllableAudio::switchLPFMode() {
+	lpfMode = static_cast<FilterMode>((util::to_underlying(lpfMode) + 1) % kNumLPFModes);
+}
+
+// for future use with FM
+void ModControllableAudio::switchLPFModeWithOff() {
+	lpfMode = static_cast<FilterMode>((util::to_underlying(lpfMode) + 1) % kNumLPFModes);
 	switch (lpfMode) {
 	case FilterMode::OFF:
 		lpfMode = FilterMode::TRANSISTOR_12DB;
@@ -2040,7 +2046,12 @@ char const* ModControllableAudio::getLPFModeDisplayName() {
 }
 
 void ModControllableAudio::switchHPFMode() {
+	// this works fine, the offset to the first hpf doesn't matter with the modulus
+	hpfMode = static_cast<FilterMode>((util::to_underlying(hpfMode) + 1) % kNumHPFModes + kFirstHPFMode);
+}
 
+// for future use with FM
+void ModControllableAudio::switchHPFModeWithOff() {
 	switch (hpfMode) {
 	case FilterMode::OFF:
 		hpfMode = firstHPFMode;

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -209,4 +209,6 @@ private:
 	void doEQ(bool doBass, bool doTreble, int32_t* inputL, int32_t* inputR, int32_t bassAmount, int32_t trebleAmount);
 	ModelStackWithThreeMainThings* addNoteRowIndexAndStuff(ModelStackWithTimelineCounter* modelStack,
 	                                                       int32_t noteRowIndex);
+	void switchHPFModeWithOff();
+	void switchLPFModeWithOff();
 };

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -685,9 +685,9 @@ bool Voice::sampleZoneChanged(ModelStackWithVoice* modelStack, int32_t s, Marker
 // Before calling this, you must set the filterSetConfig's doLPF and doHPF to default values
 
 // Returns false if became inactive and needs unassigning
-bool Voice::render(ModelStackWithVoice* modelStack, int32_t* soundBuffer, int32_t numSamples,
-                   bool soundRenderingInStereo, bool applyingPanAtVoiceLevel, uint32_t sourcesChanged, bool doLPF,
-                   bool doHPF, int32_t externalPitchAdjust) {
+[[gnu::hot]] bool Voice::render(ModelStackWithVoice* modelStack, int32_t* soundBuffer, int32_t numSamples,
+                                bool soundRenderingInStereo, bool applyingPanAtVoiceLevel, uint32_t sourcesChanged,
+                                bool doLPF, bool doHPF, int32_t externalPitchAdjust) {
 
 	GeneralMemoryAllocator::get().checkStack("Voice::render");
 

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -950,11 +950,11 @@ skipAutoRelease: {}
 	// Prepare the filters
 	// Checking if filters should run now happens within the filterset
 	filterGain = filterSet.setConfig(
-	    paramFinalValues[params::LOCAL_LPF_FREQ], paramFinalValues[params::LOCAL_LPF_RESONANCE], doLPF, sound->lpfMode,
+	    paramFinalValues[params::LOCAL_LPF_FREQ], paramFinalValues[params::LOCAL_LPF_RESONANCE], sound->lpfMode,
 	    paramFinalValues[params::LOCAL_LPF_MORPH], paramFinalValues[params::LOCAL_HPF_FREQ],
 	    (paramFinalValues[params::LOCAL_HPF_RESONANCE]), // >> storageManager.devVarA) << storageManager.devVarA,
-	    doHPF, sound->hpfMode, paramFinalValues[params::LOCAL_HPF_MORPH], sound->volumeNeutralValueForUnison << 1,
-	    sound->filterRoute); // Level adjustment for unison now happens *before* the filter!
+	    sound->hpfMode, paramFinalValues[params::LOCAL_HPF_MORPH], sound->volumeNeutralValueForUnison << 1,
+	    sound->filterRoute, false, nullptr); // Level adjustment for unison now happens *before* the filter!
 
 	SynthMode synthMode = sound->getSynthMode();
 

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -949,12 +949,14 @@ skipAutoRelease: {}
 
 	// Prepare the filters
 	// Checking if filters should run now happens within the filterset
+	FilterMode lpfMode = doLPF ? sound->lpfMode : FilterMode::OFF;
+	FilterMode hpfMode = doHPF ? sound->hpfMode : FilterMode::OFF;
 	filterGain = filterSet.setConfig(
-	    paramFinalValues[params::LOCAL_LPF_FREQ], paramFinalValues[params::LOCAL_LPF_RESONANCE], sound->lpfMode,
+	    paramFinalValues[params::LOCAL_LPF_FREQ], paramFinalValues[params::LOCAL_LPF_RESONANCE], lpfMode,
 	    paramFinalValues[params::LOCAL_LPF_MORPH], paramFinalValues[params::LOCAL_HPF_FREQ],
 	    (paramFinalValues[params::LOCAL_HPF_RESONANCE]), // >> storageManager.devVarA) << storageManager.devVarA,
-	    sound->hpfMode, paramFinalValues[params::LOCAL_HPF_MORPH], sound->volumeNeutralValueForUnison << 1,
-	    sound->filterRoute, false, nullptr); // Level adjustment for unison now happens *before* the filter!
+	    hpfMode, paramFinalValues[params::LOCAL_HPF_MORPH], sound->volumeNeutralValueForUnison << 1, sound->filterRoute,
+	    false, nullptr); // Level adjustment for unison now happens *before* the filter!
 
 	SynthMode synthMode = sound->getSynthMode();
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -485,7 +485,7 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 }
 
 /// inner loop of audio rendering, deliberately not in header
-void routine_() {
+[[gnu::hot]] void routine_() {
 #if JFTRACE
 	aeCtr.note();
 #endif


### PR DESCRIPTION
Adds a crossfade when filters are first turned on to avoid clicks and pops

Fixes #932 

In order to do that makes a number of other supporting changes:
1. Refactors filter functions to remove extraneous doFilter booleans, that is now passed by setting the filter off
2. Modifies getFilterDisplayName to not turn the filters back on
3. Adds new functions for toggling filter modes including off - not used in this PR, will be part of a future PR to enable filters in FM


Also marks rendering functions as hot, which adds a couple voices overall