### PR TITLE
Keyboard retriggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
 - The play button now blinks when the the CPU Usage of the Deluge is high and synth voices/sample playback are being culled.
 - Removed ability to convert an Audio Clip to an Instrument Clip (Synth / Kit / MIDI / CV) as this conversion process is error/bug prone.
 - Restricted changing Synth/MIDI/CV Instrument CLip types to the Kit Instrument Clip Type and vice versa if the clip is not empty.
+- Added retrigger to all keyboard views.
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.h
@@ -25,6 +25,7 @@
 #include "model/clip/instrument_clip_minder.h"
 
 class ModelStack;
+class Instrument;
 
 namespace deluge::gui::ui::keyboard {
 
@@ -64,6 +65,8 @@ private:
 
 	void evaluateActiveNotes();
 	void updateActiveNotes();
+
+	void noteOff(ModelStack& modelStack, Instrument& activeInstrument, bool clipIsActiveOnInstrument, int32_t note);
 
 	ClipMinder* toClipMinder() { return this; }
 	void setLedStates();

--- a/src/deluge/gui/ui/keyboard/notes_state.h
+++ b/src/deluge/gui/ui/keyboard/notes_state.h
@@ -18,8 +18,11 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "util/misc.h"
+#include <climits>
 #include <cstdint>
 #include <cstring>
+#include <ranges>
 
 constexpr uint8_t kMaxNumActiveNotes = 10;
 
@@ -36,6 +39,9 @@ struct PressedPad : Cartesian {
 
 struct NoteState {
 	uint8_t note = 0;
+	/// Number of times this note has been activated.
+	/// Used to detect retriggers
+	uint8_t activationCount = 0;
 	uint8_t velocity = 0;
 	int16_t mpeValues[3] = {0};
 	/// Generated notes will only create sound and not be used for interaction (e.g. setting root note)
@@ -46,12 +52,28 @@ struct NoteState {
 constexpr uint8_t kLowestKeyboardNote = 0;
 constexpr uint8_t kHighestKeyboardNote = kOctaveSize * 12;
 struct NotesState {
-	uint64_t states[3] = {0};
-	NoteState notes[kMaxNumActiveNotes] = {0};
+	using NoteArray = std::array<NoteState, kMaxNumActiveNotes>;
+
+	uint64_t states[util::div_ceil(size_t{kHighestKeyboardNote}, size_t{64})] = {0};
+	NoteArray notes;
 	uint8_t count = 0;
+
+	[[nodiscard]] NoteArray::iterator begin() { return notes.begin(); }
+
+	[[nodiscard]] NoteArray::iterator end() { return notes.begin() + count; }
+
+	[[nodiscard]] NoteArray::const_iterator begin() const { return notes.begin(); }
+
+	[[nodiscard]] NoteArray::const_iterator end() const { return notes.end() + count; }
 
 	void enableNote(uint8_t note, uint8_t velocity, bool generatedNote = false, int16_t* mpeValues = nullptr) {
 		if (noteEnabled(note)) {
+			for (auto& noteState : *this) {
+				if (noteState.note == note) {
+					noteState.activationCount++;
+					break;
+				}
+			}
 			return;
 		}
 		notes[count].note = note;

--- a/src/deluge/util/misc.h
+++ b/src/deluge/util/misc.h
@@ -85,6 +85,13 @@ template <std::integral T>
 	return (a + (b - 1)) / b;
 }
 
+/// Returns true if `a < b`, when treating `a` and `b` as though they were 31-bit views in to an infinitely large
+/// number, usually a timer. That is, it assumes that if `a < b` but `b - a > (1 << 31)` then then what actually
+/// happened was `a` wrapped and `b` hasn't yet, so `a` actually represents a later point in time.
+[[nodiscard]] constexpr bool infinite_a_lt_b(uint32_t a, uint32_t b) {
+	return ((int32_t)(a - b) < 0);
+}
+
 } // namespace util
 
 // unsigned literal operators

--- a/src/deluge/util/misc.h
+++ b/src/deluge/util/misc.h
@@ -75,6 +75,16 @@ template <typename T>
 [[nodiscard]] constexpr T map(T x, T in_min, T in_max, T out_min, T out_max) {
 	return out_min + ((x - in_min) * (out_max - out_min)) / (in_max - in_min);
 }
+
+/// Compute (a/b), rounding up.
+///
+/// @param a Numerator. Must be less than std::numeric_limits<T>::max() - (b - 1)
+/// @param b Denominator.
+template <std::integral T>
+[[nodiscard]] constexpr T div_ceil(T a, T b) {
+	return (a + (b - 1)) / b;
+}
+
 } // namespace util
 
 // unsigned literal operators


### PR DESCRIPTION
This is especially important for velocity drums but it works for all the keyboard views.

Also required some special logic in the velocity drums view to make sure the most recent pad press is the one that determines the velocity.