### PR TITLE
Miscellaneous arpeggiator bugfixing

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2346,6 +2346,7 @@ void InstrumentClip::writeDataToFile(StorageManager& bdsm, Song* song) {
 			bdsm.writeAttribute("numOctaves", arpSettings.numOctaves);
 			bdsm.writeAttribute("mpeVelocity", (char*)arpMpeModSourceToString(arpSettings.mpeVelocity));
 			bdsm.writeAttribute("syncLevel", arpSettings.syncLevel);
+			bdsm.writeAttribute("syncType", arpSettings.syncType);
 
 			if (output->type == OutputType::MIDI_OUT || output->type == OutputType::CV) {
 				bdsm.writeAttribute("gate", arpeggiatorGate);
@@ -2646,6 +2647,10 @@ someError:
 				else if (!strcmp(tagName, "syncLevel")) {
 					arpSettings.syncLevel = (SyncLevel)bdsm.readTagOrAttributeValueInt();
 					bdsm.exitTag("syncLevel");
+				}
+				else if (!strcmp(tagName, "syncType")) {
+					arpSettings.syncType = (SyncType)bdsm.readTagOrAttributeValueInt();
+					bdsm.exitTag("syncType");
 				}
 				else if (!strcmp(tagName, "mode") && bdsm.firmware_version < FirmwareVersion::community({1, 1, 0})) {
 					// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode

--- a/src/deluge/model/instrument/non_audio_instrument.cpp
+++ b/src/deluge/model/instrument/non_audio_instrument.cpp
@@ -192,6 +192,15 @@ int32_t NonAudioInstrument::doTickForwardForArp(ModelStack* modelStack, int32_t 
 		return 2147483647;
 	}
 
+	InstrumentClip* activeInstrumentClip = (InstrumentClip*)activeClip;
+	if (activeInstrumentClip->arpSettings.mode != ArpMode::OFF) {
+		uint32_t sequenceLength = (uint32_t)activeInstrumentClip->arpeggiatorSequenceLength;
+		uint32_t rhythm = (uint32_t)activeInstrumentClip->arpeggiatorRhythm;
+		uint32_t ratchetAmount = (uint32_t)activeInstrumentClip->arpeggiatorRatchetAmount;
+		uint32_t ratchetProbability = (uint32_t)activeInstrumentClip->arpeggiatorRatchetProbability;
+		arpeggiator.updateParams(sequenceLength, rhythm, ratchetAmount, ratchetProbability);
+	}
+
 	ArpReturnInstruction instruction;
 
 	int32_t ticksTilNextArpEvent = arpeggiator.doTickForward(&((InstrumentClip*)activeClip)->arpSettings, &instruction,

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -103,7 +103,6 @@ void ArpeggiatorForDrum::noteOn(ArpeggiatorSettings* settings, int32_t noteCode,
 			gateCurrentlyActive = false;
 
 			if (!(playbackHandler.isEitherClockActive()) || !settings->syncLevel) {
-				gatePos = 0;
 				switchNoteOn(settings, instruction, false);
 			}
 		}
@@ -236,7 +235,6 @@ noteInserted:
 			gateCurrentlyActive = false;
 
 			if (!(playbackHandler.isEitherClockActive()) || !settings->syncLevel) {
-				gatePos = 0;
 				switchNoteOn(settings, instruction, false);
 			}
 		}
@@ -495,6 +493,8 @@ void ArpeggiatorForDrum::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnIn
 	if (shouldCarryOnRhythmNote) {
 		// Set Gate as active
 		gateCurrentlyActive = true;
+		// Reset gate position
+		gatePos = 0;
 
 		// Check if we need to update velocity with some MPE value
 		switch (settings->mpeVelocity) {
@@ -719,6 +719,8 @@ void Arpeggiator::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstructi
 	if (shouldCarryOnRhythmNote) {
 		// Set Gate as active
 		gateCurrentlyActive = true;
+		// Reset gate position
+		gatePos = 0;
 
 		// Check if we need to update velocity with some MPE value
 		switch (settings->mpeVelocity) {
@@ -822,7 +824,6 @@ void ArpeggiatorBase::render(ArpeggiatorSettings* settings, int32_t numSamples, 
 		}
 		// And maybe (if not syncing) the gatePos is also far enough along that we also want to switch a normal note on?
 		else if (!syncedNow && gatePos >= maxGate) {
-			gatePos = 0;
 			switchNoteOn(settings, instruction, false);
 		}
 	}
@@ -856,7 +857,6 @@ int32_t ArpeggiatorBase::doTickForward(ArpeggiatorSettings* settings, ArpReturnI
 	if (!howFarIntoPeriod) {
 		if (hasAnyInputNotesActive()) {
 			switchAnyNoteOff(instruction);
-			gatePos = 0;
 			switchNoteOn(settings, instruction, false);
 
 			instruction->sampleSyncLengthOn = ticksPerPeriod; // Overwrite this

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -753,15 +753,8 @@ bool ArpeggiatorForDrum::hasAnyInputNotesActive() {
 	return arpNote.velocity;
 }
 
-// Check arpeggiator is on before you call this.
-// May switch notes on and/or off.
-void ArpeggiatorBase::render(ArpeggiatorSettings* settings, int32_t numSamples, uint32_t gateThreshold,
-                             uint32_t phaseIncrement, uint32_t sequenceLength, uint32_t rhythmValue,
-                             uint32_t ratchAmount, uint32_t ratchProb, ArpReturnInstruction* instruction) {
-	if (settings->mode == ArpMode::OFF || !hasAnyInputNotesActive()) {
-		return;
-	}
-
+void ArpeggiatorBase::updateParams(uint32_t sequenceLength, uint32_t rhythmValue,
+                             uint32_t ratchAmount, uint32_t ratchProb) {
 	// Update live Sequence Length value with the most up to date value from automation
 	maxSequenceLength = (((int64_t)sequenceLength) * kMaxMenuValue + 2147483648) >> 32; // in the range 0-50
 
@@ -786,6 +779,18 @@ void ArpeggiatorBase::render(ArpeggiatorSettings* settings, int32_t numSamples, 
 	else { // > 0 -> 4
 		ratchetAmount = 0;
 	}
+}
+
+// Check arpeggiator is on before you call this.
+// May switch notes on and/or off.
+void ArpeggiatorBase::render(ArpeggiatorSettings* settings, int32_t numSamples, uint32_t gateThreshold,
+                             uint32_t phaseIncrement, uint32_t sequenceLength, uint32_t rhythmValue,
+                             uint32_t ratchAmount, uint32_t ratchProb, ArpReturnInstruction* instruction) {
+	if (settings->mode == ArpMode::OFF || !hasAnyInputNotesActive()) {
+		return;
+	}
+
+	updateParams(sequenceLength, rhythmValue, ratchAmount, ratchProb);
 
 	if (settings->flagForceArpRestart) {
 		// If flagged to restart sequence, do it now and reset the flag

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -316,7 +316,6 @@ void Arpeggiator::noteOff(ArpeggiatorSettings* settings, int32_t noteCodePreArp,
 
 void ArpeggiatorBase::switchAnyNoteOff(ArpReturnInstruction* instruction) {
 	if (gateCurrentlyActive) {
-		// triggerable->noteOffPostArpeggiator(modelStack, noteCodeCurrentlyOnPostArp);
 		instruction->noteCodeOffPostArp = noteCodeCurrentlyOnPostArp;
 		instruction->outputMIDIChannelOff = outputMIDIChannelForNoteCurrentlyOnPostArp;
 		gateCurrentlyActive = false;
@@ -518,7 +517,6 @@ void ArpeggiatorForDrum::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnIn
 	}
 	else {
 		// Rhythm silence: Don't play the note
-		instruction->noteCodeOffPostArp = ARP_NOTE_NONE;
 		instruction->noteCodeOnPostArp = ARP_NOTE_NONE;
 	}
 }
@@ -743,7 +741,6 @@ void Arpeggiator::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstructi
 	}
 	else {
 		// Rhythm silence: Don't play the note
-		instruction->noteCodeOffPostArp = ARP_NOTE_NONE;
 		instruction->noteCodeOnPostArp = ARP_NOTE_NONE;
 	}
 }

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -860,6 +860,7 @@ int32_t ArpeggiatorBase::doTickForward(ArpeggiatorSettings* settings, ArpReturnI
 
 	if (!howFarIntoPeriod) {
 		if (hasAnyInputNotesActive()) {
+			switchAnyNoteOff(instruction);
 			switchNoteOn(settings, instruction, false);
 
 			instruction->sampleSyncLengthOn = ticksPerPeriod; // Overwrite this

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -493,8 +493,10 @@ void ArpeggiatorForDrum::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnIn
 	if (shouldCarryOnRhythmNote) {
 		// Set Gate as active
 		gateCurrentlyActive = true;
-		// Reset gate position
-		gatePos = 0;
+		if (!isRatchet) {
+			// Reset gate position (only for normal notes)
+			gatePos = 0;
+		}
 
 		// Check if we need to update velocity with some MPE value
 		switch (settings->mpeVelocity) {
@@ -719,8 +721,10 @@ void Arpeggiator::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstructi
 	if (shouldCarryOnRhythmNote) {
 		// Set Gate as active
 		gateCurrentlyActive = true;
-		// Reset gate position
-		gatePos = 0;
+		if (!isRatchet) {
+			// Reset gate position (only for normal notes)
+			gatePos = 0;
+		}
 
 		// Check if we need to update velocity with some MPE value
 		switch (settings->mpeVelocity) {
@@ -755,8 +759,8 @@ bool ArpeggiatorForDrum::hasAnyInputNotesActive() {
 	return arpNote.velocity;
 }
 
-void ArpeggiatorBase::updateParams(uint32_t sequenceLength, uint32_t rhythmValue,
-                             uint32_t ratchAmount, uint32_t ratchProb) {
+void ArpeggiatorBase::updateParams(uint32_t sequenceLength, uint32_t rhythmValue, uint32_t ratchAmount,
+                                   uint32_t ratchProb) {
 	// Update live Sequence Length value with the most up to date value from automation
 	maxSequenceLength = (((int64_t)sequenceLength) * kMaxMenuValue + 2147483648) >> 32; // in the range 0-50
 
@@ -856,7 +860,6 @@ int32_t ArpeggiatorBase::doTickForward(ArpeggiatorSettings* settings, ArpReturnI
 
 	if (!howFarIntoPeriod) {
 		if (hasAnyInputNotesActive()) {
-			switchAnyNoteOff(instruction);
 			switchNoteOn(settings, instruction, false);
 
 			instruction->sampleSyncLengthOn = ticksPerPeriod; // Overwrite this

--- a/src/deluge/modulation/arpeggiator.h
+++ b/src/deluge/modulation/arpeggiator.h
@@ -295,6 +295,7 @@ class ArpeggiatorBase {
 public:
 	virtual void noteOn(ArpeggiatorSettings* settings, int32_t noteCode, int32_t velocity,
 	                    ArpReturnInstruction* instruction, int32_t fromMIDIChannel, int16_t const* mpeValues) = 0;
+	void updateParams(uint32_t sequenceLength, uint32_t rhythmValue, uint32_t ratchAmount, uint32_t ratchProb);
 	void render(ArpeggiatorSettings* settings, int32_t numSamples, uint32_t gateThreshold, uint32_t phaseIncrement,
 	            uint32_t sequenceLength, uint32_t rhythm, uint32_t ratchetAmount, uint32_t ratchetProbability,
 	            ArpReturnInstruction* instruction);

--- a/src/deluge/modulation/sidechain/sidechain.cpp
+++ b/src/deluge/modulation/sidechain/sidechain.cpp
@@ -50,6 +50,7 @@ SideChain::SideChain() {
 void SideChain::cloneFrom(SideChain* other) {
 	attack = other->attack;
 	release = other->release;
+	syncType = other->syncType;
 	syncLevel = other->syncLevel;
 }
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3815,6 +3815,7 @@ void Sound::writeParamsToFile(StorageManager& bdsm, ParamManager* paramManager, 
 	                                       writeAutomation);
 	unpatchedParams->writeParamAsAttribute(bdsm, "sequenceLength", params::UNPATCHED_ARP_SEQUENCE_LENGTH,
 	                                       writeAutomation);
+	unpatchedParams->writeParamAsAttribute(bdsm, "rhythm", params::UNPATCHED_ARP_RHYTHM, writeAutomation);
 	unpatchedParams->writeParamAsAttribute(bdsm, "portamento", params::UNPATCHED_PORTAMENTO, writeAutomation);
 	unpatchedParams->writeParamAsAttribute(bdsm, "compressorShape", params::UNPATCHED_SIDECHAIN_SHAPE, writeAutomation);
 

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -439,6 +439,14 @@ int32_t SoundInstrument::doTickForwardForArp(ModelStack* modelStack, int32_t cur
 	    modelStack->addTimelineCounter(activeClip)
 	        ->addOtherTwoThingsButNoNoteRow(this, getParamManager(modelStack->song));
 
+	UnpatchedParamSet* unpatchedParams = modelStackWithThreeMainThings->paramManager->getUnpatchedParamSet();
+	uint32_t sequenceLength = (uint32_t)unpatchedParams->getValue(params::UNPATCHED_ARP_SEQUENCE_LENGTH) + 2147483648;
+	uint32_t rhythm = (uint32_t)unpatchedParams->getValue(params::UNPATCHED_ARP_RHYTHM) + 2147483648;
+	uint32_t ratchetAmount = (uint32_t)unpatchedParams->getValue(params::UNPATCHED_ARP_RATCHET_AMOUNT) + 2147483648;
+	uint32_t ratchetProbability =
+	    (uint32_t)unpatchedParams->getValue(params::UNPATCHED_ARP_RATCHET_PROBABILITY) + 2147483648;
+	arpeggiator.updateParams(sequenceLength, rhythm, ratchetAmount, ratchetProbability);
+
 	ArpReturnInstruction instruction;
 
 	int32_t ticksTilNextArpEvent = arpeggiator.doTickForward(&((InstrumentClip*)activeClip)->arpSettings, &instruction,


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/1544

After a deep testing I found not only one but several different bugs and inconsistencies. I fixed them as part of this PR to leave the arpeggiator module totally bug-free.

- Rhythm setting was not read nor written to song files
- Sidechain cloning method was forgetting about syncType param
- SyncType was not saved for arpeggiator sync rate, so if you set for example 8th Dotted, when loading, you got 8th Even.
- Fixed the bug with stuck notes (1544)
- Fixed first rhythm note repeated when loading a project and pressing play. The Rhythm, Ratchet and SeqLength params were only updated in the render method so they were not yet initialized when calling the first sequenced note in the doTick method. Fixed this by calling a new updateParams method before the doTick.