### PR TITLE
Fix sync rate display bug

### DIFF
--- a/src/deluge/gui/menu_item/sync_level.cpp
+++ b/src/deluge/gui/menu_item/sync_level.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "sync_level.h"
-#include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"

--- a/src/deluge/gui/menu_item/sync_level.cpp
+++ b/src/deluge/gui/menu_item/sync_level.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "sync_level.h"
+#include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
@@ -58,9 +59,10 @@ void SyncLevel::getNoteLengthName(StringBuf& buffer) {
 	}
 
 	currentSong->getNoteLengthName(buffer, noteLength, typeStr);
-
 	if (typeStr != nullptr) {
-		if ((value >= SYNC_TYPE_TRIPLET && level <= SYNC_LEVEL_2ND) || display->have7SEG()) {
+		int32_t magnitudeLevelBars = SYNC_LEVEL_8TH - currentSong->insideWorldTickMagnitude;
+		if (((type == SYNC_TYPE_TRIPLET || type == SYNC_TYPE_DOTTED) && level <= magnitudeLevelBars)
+		    || display->have7SEG()) {
 			// On OLED, getNoteLengthName handles adding this for the non-bar levels. On 7seg, always append it
 			buffer.append(typeStr);
 		}


### PR DESCRIPTION
The sync_level menu item was assuming that the resolution was always 384 (insideWorldTickMagnitude = 2) for the calculations of which delay sync rates must include or not the typeStr ("-DTTED" and "-TRPLT"). Now I made it dependent on the song resolution so it creates the correct name for the sync rate. Now it displays correctly the sync rates in all available song resolutions

Example with 768 resolution 
Before:
![IMG_4485](https://github.com/SynthstromAudible/DelugeFirmware/assets/6472762/8240e2e4-3df7-4fbe-8a37-59f78bbbba89)

After:
![IMG_4484](https://github.com/SynthstromAudible/DelugeFirmware/assets/6472762/8c6bb107-1617-4207-8119-4753dffd5e74)


