### PR TITLE
Bugfix - Further Restrict Clip Type Conversions

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -492,40 +492,48 @@ ActionResult KeyboardScreen::buttonAction(deluge::hid::Button b, bool on, bool i
 	// Kit button
 	else if (b == KIT && currentUIMode == UI_MODE_NONE) {
 		if (on) {
+			bool result;
 			if (Buttons::isNewOrShiftButtonPressed()) {
-				createNewInstrument(OutputType::KIT);
+				result = createNewInstrument(OutputType::KIT);
 			}
 			else {
-				changeOutputType(OutputType::KIT);
+				result = changeOutputType(OutputType::KIT);
 			}
-			selectLayout(0);
+			if (result) {
+				selectLayout(0);
+			}
 		}
 	}
 
 	else if (b == SYNTH && currentUIMode == UI_MODE_NONE) {
 		if (on) {
+			bool result;
 			if (Buttons::isNewOrShiftButtonPressed()) {
-				createNewInstrument(OutputType::SYNTH);
+				result = createNewInstrument(OutputType::SYNTH);
 			}
 			else {
-				changeOutputType(OutputType::SYNTH);
+				result = changeOutputType(OutputType::SYNTH);
 			}
-			selectLayout(0);
+			if (result) {
+				selectLayout(0);
+			}
 		}
 	}
 
 	else if (b == MIDI) {
 		if (on && currentUIMode == UI_MODE_NONE) {
-			changeOutputType(OutputType::MIDI_OUT);
+			if (changeOutputType(OutputType::MIDI_OUT)) {
+				selectLayout(0);
+			}
 		}
-		selectLayout(0);
 	}
 
 	else if (b == CV) {
 		if (on && currentUIMode == UI_MODE_NONE) {
-			changeOutputType(OutputType::CV);
+			if (changeOutputType(OutputType::CV)) {
+				selectLayout(0);
+			}
 		}
-		selectLayout(0);
 	}
 
 	else if (b == SELECT_ENC && on && getCurrentInstrumentClip()->inScaleMode

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -435,6 +435,15 @@ void LoadInstrumentPresetUI::changeOutputType(OutputType newOutputType) {
 		return;
 	}
 
+	InstrumentClip* clip = getCurrentInstrumentClip();
+
+	// don't allow clip type change if clip is not empty
+	// only impose this restriction if switching to/from kit clip
+	if (((outputTypeToLoad == OutputType::KIT) || (newOutputType == OutputType::KIT))
+	    && (!clip->isEmpty() || !clip->output->isEmpty())) {
+		return;
+	}
+
 	// If MIDI or CV, we have a different method for this, and the UI will be exited
 	if (newOutputType == OutputType::MIDI_OUT || newOutputType == OutputType::CV) {
 

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -147,7 +147,6 @@ private:
 	bool renderRowForOutput(ModelStack* modelStack, Output* output, int32_t xScroll, uint32_t xZoom, RGB* image,
 	                        uint8_t occupancyMask[], int32_t renderWidth, int32_t ignoreI);
 	Instrument* createNewInstrument(OutputType newOutputType, bool* instrumentAlreadyInSong);
-	void changeOutputToInstrument(OutputType newOutputType);
 	uint32_t doActualRender(int32_t xScroll, uint32_t xZoom, uint32_t whichRows, RGB* image,
 	                        uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
 	                        int32_t imageWidth);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1239,20 +1239,20 @@ void InstrumentClipView::doubleClipLengthAction() {
 
 void InstrumentClipView::createNewInstrument(OutputType newOutputType) {
 
-	InstrumentClipMinder::createNewInstrument(newOutputType);
+	if (InstrumentClipMinder::createNewInstrument(newOutputType)) {
+		recalculateColours();
+		uiNeedsRendering(this);
 
-	recalculateColours();
-	uiNeedsRendering(this);
+		if (newOutputType == OutputType::KIT) {
+			char modelStackMemory[MODEL_STACK_MAX_SIZE];
+			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
-	if (newOutputType == OutputType::KIT) {
-		char modelStackMemory[MODEL_STACK_MAX_SIZE];
-		ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+			NoteRow* noteRow = getCurrentInstrumentClip()->noteRows.getElement(0);
 
-		NoteRow* noteRow = getCurrentInstrumentClip()->noteRows.getElement(0);
+			ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(0, noteRow);
 
-		ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(0, noteRow);
-
-		enterDrumCreator(modelStackWithNoteRow);
+			enterDrumCreator(modelStackWithNoteRow);
+		}
 	}
 }
 
@@ -1262,17 +1262,10 @@ void InstrumentClipView::changeOutputType(OutputType newOutputType) {
 		return;
 	}
 
-	// don't allow clip type change if clip is not empty
-	// only impose this restriction if switching to/from kit clip
-	if (((getCurrentOutputType() == OutputType::KIT) || (newOutputType == OutputType::KIT))
-	    && !getCurrentInstrumentClip()->isEmpty()) {
-		return;
+	if (InstrumentClipMinder::changeOutputType(newOutputType)) {
+		recalculateColours();
+		uiNeedsRendering(this);
 	}
-
-	InstrumentClipMinder::changeOutputType(newOutputType);
-
-	recalculateColours();
-	uiNeedsRendering(this);
 }
 
 void InstrumentClipView::selectEncoderAction(int8_t offset) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2427,6 +2427,13 @@ bool View::changeOutputType(OutputType newOutputType, ModelStackWithTimelineCoun
 		return false;
 	}
 
+	// don't allow clip type change if clip is not empty
+	// only impose this restriction if switching to/from kit clip
+	if (((oldOutputType == OutputType::KIT) || (newOutputType == OutputType::KIT))
+	    && (!clip->isEmpty() || !clip->output->isEmpty())) {
+		return false;
+	}
+
 	Instrument* newInstrument = clip->changeOutputType(modelStack, newOutputType);
 	if (!newInstrument) {
 		return false;

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3696,7 +3696,8 @@ bool InstrumentClip::isScrollWithinRange(int32_t scrollAmount, int32_t newYNote)
 }
 
 bool InstrumentClip::isEmpty() {
-	if (containsAnyNotes() || output->clipHasInstance(this)) {
+	// does this clip have notes?
+	if (containsAnyNotes()) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CLIP_NOT_EMPTY));
 		return false;
 	}

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -152,12 +152,21 @@ void InstrumentClipMinder::drawMIDIControlNumber(int32_t controlNumber, bool aut
 	}
 }
 #pragma GCC pop
-void InstrumentClipMinder::createNewInstrument(OutputType newOutputType) {
+bool InstrumentClipMinder::createNewInstrument(OutputType newOutputType) {
 	Error error;
 
 	OutputType oldOutputType = getCurrentOutputType();
 
-	bool shouldReplaceWholeInstrument = currentSong->shouldOldOutputBeReplaced(getCurrentInstrumentClip());
+	InstrumentClip* clip = getCurrentInstrumentClip();
+
+	// don't allow clip type change if clip is not empty
+	// only impose this restriction if switching to/from kit clip
+	if ((oldOutputType != newOutputType) && ((oldOutputType == OutputType::KIT) || (newOutputType == OutputType::KIT))
+	    && (!clip->isEmpty() || !clip->output->isEmpty())) {
+		return false;
+	}
+
+	bool shouldReplaceWholeInstrument = currentSong->shouldOldOutputBeReplaced(clip);
 
 	String newName;
 	char const* thingName = (newOutputType == OutputType::SYNTH) ? "SYNT" : "KIT";
@@ -165,7 +174,7 @@ void InstrumentClipMinder::createNewInstrument(OutputType newOutputType) {
 	if (error != Error::NONE) {
 gotError:
 		display->displayError(error);
-		return;
+		return false;
 	}
 
 	error = loadInstrumentPresetUI.getUnusedSlot(newOutputType, &newName, thingName);
@@ -175,7 +184,7 @@ gotError:
 
 	if (newName.isEmpty()) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_FURTHER_UNUSED_INSTRUMENT_NUMBERS));
-		return;
+		return false;
 	}
 
 	ParamManagerForTimeline newParamManager;
@@ -198,7 +207,7 @@ gotError:
 
 	currentSong->ensureAllInstrumentsHaveAClipOrBackedUpParamManager("E059", "H059");
 
-	getCurrentInstrumentClip()->backupPresetSlot();
+	clip->backupPresetSlot();
 
 	if (newOutputType == OutputType::KIT) {
 		display->consoleText(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NEW_KIT_CREATED));
@@ -227,8 +236,8 @@ gotError:
 	else {
 		// There'll be no samples cos it's new and blank
 		// TODO: deal with errors
-		Error error = getCurrentInstrumentClip()->changeInstrument(
-		    modelStack, newInstrument, &newParamManager, InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED, NULL, false);
+		Error error = clip->changeInstrument(modelStack, newInstrument, &newParamManager,
+		                                     InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED, NULL, false);
 
 		currentSong->addOutput(newInstrument);
 	}
@@ -239,12 +248,12 @@ gotError:
 	if (newOutputType == OutputType::KIT) {
 		// If we weren't a Kit already...
 		if (oldOutputType != OutputType::KIT) {
-			getCurrentInstrumentClip()->yScroll = 0;
+			clip->yScroll = 0;
 		}
 
 		// Or if we were...
 		else {
-			getCurrentInstrumentClip()->ensureScrollWithinKitBounds();
+			clip->ensureScrollWithinKitBounds();
 		}
 	}
 
@@ -262,6 +271,8 @@ gotError:
 	else {
 		redrawNumericDisplay();
 	}
+
+	return true;
 }
 
 void InstrumentClipMinder::displayOrLanguageChanged() {
@@ -329,21 +340,26 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 	else if (currentUIMode == UI_MODE_HOLDING_LOAD_BUTTON && on) {
 		currentUIMode = UI_MODE_NONE;
 		indicator_leds::setLedState(IndicatorLED::LOAD, false);
-		OutputType out;
+		OutputType newOutputType;
 		if (b == SYNTH) {
-			out = OutputType::SYNTH;
+			newOutputType = OutputType::SYNTH;
 		}
 		else if (b == KIT) {
-			out = OutputType::KIT;
+			newOutputType = OutputType::KIT;
 		}
 		else if (b == MIDI) {
-			out = OutputType::MIDI_OUT;
+			newOutputType = OutputType::MIDI_OUT;
 		}
+		InstrumentClip* clip = getCurrentInstrumentClip();
+		Output* output = clip->output;
+		OutputType oldOutputType = output->type;
+		Instrument* instrument = (Instrument*)output;
 		// don't allow clip type change if clip is not empty
 		// only impose this restriction if switching to/from kit clip
-		if (!(((getCurrentOutputType() == OutputType::KIT) || (out == OutputType::KIT))
-		      && !getCurrentInstrumentClip()->isEmpty())) {
-			loadInstrumentPresetUI.setupLoadInstrument(out, getCurrentInstrument(), getCurrentInstrumentClip());
+		if (!((oldOutputType != newOutputType)
+		      && ((oldOutputType == OutputType::KIT) || (newOutputType == OutputType::KIT))
+		      && (!clip->isEmpty() || !clip->output->isEmpty()))) {
+			loadInstrumentPresetUI.setupLoadInstrument(newOutputType, instrument, clip);
 			openUI(&loadInstrumentPresetUI);
 		}
 	}
@@ -445,8 +461,7 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 	return ActionResult::DEALT_WITH;
 }
 
-void InstrumentClipMinder::changeOutputType(OutputType newOutputType) {
-
+bool InstrumentClipMinder::changeOutputType(OutputType newOutputType) {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
@@ -455,6 +470,8 @@ void InstrumentClipMinder::changeOutputType(OutputType newOutputType) {
 	if (success) {
 		setLedStates(); // Might need to change the scale LED's state
 	}
+
+	return success;
 }
 
 void InstrumentClipMinder::calculateDefaultRootNote() {

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -34,7 +34,7 @@ public:
 	InstrumentClipMinder();
 	static void redrawNumericDisplay();
 	void displayOrLanguageChanged();
-	void createNewInstrument(OutputType newOutputType);
+	bool createNewInstrument(OutputType newOutputType);
 	void setLedStates();
 	void focusRegained();
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
@@ -47,7 +47,7 @@ public:
 	void selectEncoderAction(int32_t offset);
 	static void drawMIDIControlNumber(int32_t controlNumber, bool automationExists);
 	bool makeCurrentClipActiveOnInstrumentIfPossible(ModelStack* modelStack);
-	void changeOutputType(OutputType newOutputType);
+	bool changeOutputType(OutputType newOutputType);
 	void opened();
 
 	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -21,6 +21,7 @@
 #include "model/action/action_logger.h"
 #include "model/clip/clip.h"
 #include "model/clip/clip_instance.h"
+#include "model/clip/instrument_clip.h"
 #include "model/consequence/consequence_clip_existence.h"
 #include "model/model_stack.h"
 #include "model/song/song.h"
@@ -137,6 +138,20 @@ bool Output::clipHasInstance(Clip* clip) {
 	}
 
 	return false;
+}
+
+// check all instrument clip instances belonging to an output to see if they have any notes
+// if so, then we need to check if there are other clip's assigned to that output which have notes
+// because we don't want to change the output type for all the clips assigned to that output if some have notes
+bool Output::isEmpty() {
+	// loop through the output selected to see if any of the clips are not empty
+	for (int32_t i = 0; i < clipInstances.getNumElements(); i++) {
+		InstrumentClip* clip = (InstrumentClip*)clipInstances.getElement(i)->clip;
+		if (clip && !clip->isEmpty()) {
+			return false;
+		}
+	}
+	return true;
 }
 
 void Output::clipLengthChanged(Clip* clip, int32_t oldLength) {

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -89,6 +89,7 @@ public:
 	virtual ModControllable* toModControllable() { return nullptr; }
 	virtual bool isSkippingRendering() { return true; } // Not valid for Kits
 	bool clipHasInstance(Clip* clip);
+	bool isEmpty();
 	void clipLengthChanged(Clip* clip, int32_t oldLength);
 	virtual void cutAllSound() {}
 	virtual void getThingWithMostReverb(Sound** soundWithMostReverb, ParamManager** paramManagerWithMostReverb,


### PR DESCRIPTION
Revised clip type conversion checks to ensure that you cannot switch from an audio clip to an instrument clip and you cannot switch to from a kit clip type if the clip already has notes in it.

Also added checks to ensure that if it is an arranger only white clip that it won't change the clip type if other clips for the same output as the white clip have notes in them.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1582