### PR TITLE
Automation View ~ Bug fixes and added select scrolling of patch cables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
   pressing the Pink Mode pad. Allows quick control of Song Global FX.
 - Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
 - Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to access the `AUTOMATION VIEW EDITOR` for that specific Patch Cable / Modulation Depth.
+  - You can also use the `SELECT ENCODER` while in the `AUTOMATION VIEW EDITOR` to scroll to any patch cables that exist.
 - Updated `AUTOMATION VIEW EDITOR` to allow you to edit Bipolar params according to their Bipolar nature. E.g. Positive values are shown in the top four pads, Negative value in the bottom four pads, and the Middle value is shown by not lighting up any pads.
 - Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset
   file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -629,6 +629,7 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
           provide the ability to access the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the menu
           press Clip (if you are in a clip) or Song (if you are in arranger) to open the `AUTOMATION VIEW EDITOR` while you are still in the menu. You will be able to interact with the grid to edit automation for the current parameter / patch cable selected in the menu.
     - ([#1374]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to access the `AUTOMATION VIEW EDITOR` for that specific Patch Cable / Modulation Depth.
+      - ([#1607]) You can also use the `SELECT ENCODER` while in the `AUTOMATION VIEW EDITOR` to scroll to any patch cables that exist.
     - ([#1456]) Added an in-between-layer in the Deluge menu system to be able to access and interact with the `AUTOMATION VIEW EDITOR` while you are still in the menu from the regular `ARRANGER / CLIP VIEW`. When you exit the menu you will be returned to the View you were in prior to entering the menu. Press Clip (if you are in a clip) or Song (if you are in arranger) to temporarily open the `AUTOMATION VIEW EDITOR` while you are still in the menu.    
     - ([#1480]) As a follow-up to [#1374] which enabled enabled patch cables to be edited in Automation View, the Automation Editor has now been modified to display param values according to whether the Param is bipolar or not. If it's a bipolar param, the grid will light up as follows:
       - Middle value = no pads lit up
@@ -1234,6 +1235,8 @@ different firmware
 [#1542]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1542
 
 [#1589]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1589
+
+[#1607]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1607
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -10,7 +10,7 @@ It allows you to edit automatable parameters on a per step basis at any zoom lev
 
 Automatable Parameters are broken down into four categories for Automation View purposes:
 
-1. Automatable Clip View Parameters for Synths, Kits with affect entire DISABLED
+1. Automatable Clip View Parameters for Synths and Kits with a row selected and affect entire DISABLED
 
 >The 61 parameters that can be edited are:
 >
@@ -36,6 +36,8 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **Portamento**
 > - **Stutter** Rate
 > - **Compressor** Threshold
+
+>You can also edit any patch cables that are created
 
 2. Automatable Clip View Parameters for Kits with affect entire ENABLED, and Audio Clips
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3499,8 +3499,11 @@ bool AutomationView::selectPatchCableAtIndex(Clip* clip, PatchCableSet* set, int
 	// need to add patch cable source to the descriptor so that we can get the paramId from it
 	desc.addSource(cable->from);
 
-	// if we've previously selected a patch cable, we want to start scrolling from
-	// that patch cable
+	// if we've previously selected a patch cable, we want to start scrolling from that patch cable
+	// note: the reason why we can't save the patchCableIndex to make finding the previous patch
+	// cable selected easier is because the patch cable array gets re-indexed as patch cables get
+	// added or removed or values change. Thus you need to search for the previous patch cable to get
+	// the updated index and then you can find the adjacent patch cable in the list.
 	if (desc.data == clip->lastSelectedParamID) {
 		foundCurrentPatchCable = true;
 	}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3448,6 +3448,7 @@ void AutomationView::selectNonGlobalParam(int32_t offset, Clip* clip) {
 }
 
 // iterate through the patch cable list to select the previous or next patch cable
+// actual selecting of the patch cable is done in the selectPatchCableAtIndex function
 bool AutomationView::selectPatchCable(int32_t offset, Clip* clip) {
 	ParamManagerForTimeline* paramManager = clip->getCurrentParamManager();
 	if (paramManager) {
@@ -3461,9 +3462,9 @@ bool AutomationView::selectPatchCable(int32_t offset, Clip* clip) {
 				if (offset > 0) {
 					// loop from beginning to end of patch cable list
 					for (int i = 0; i < set->numPatchCables; i++) {
-						// loop through patch cables until we've found a new one
+						// loop through patch cables until we've found a new one and select it
 						// adjacent to current found patch cable (if we previously selected one)
-						if (findPatchCable(clip, set, i, foundCurrentPatchCable)) {
+						if (selectPatchCableAtIndex(clip, set, i, foundCurrentPatchCable)) {
 							return true;
 						}
 					}
@@ -3472,9 +3473,9 @@ bool AutomationView::selectPatchCable(int32_t offset, Clip* clip) {
 				else if (offset < 0) {
 					// loop from end to beginning of patch cable list
 					for (int i = set->numPatchCables - 1; i >= 0; i--) {
-						// loop through patch cables until we've found a new one
+						// loop through patch cables until we've found a new one and select it
 						// adjacent to current found patch cable (if we previously selected one)
-						if (findPatchCable(clip, set, i, foundCurrentPatchCable)) {
+						if (selectPatchCableAtIndex(clip, set, i, foundCurrentPatchCable)) {
 							return true;
 						}
 					}
@@ -3486,12 +3487,13 @@ bool AutomationView::selectPatchCable(int32_t offset, Clip* clip) {
 	return false;
 }
 
+// this function does the actual selecting of a patch cable
 // see if the patch cable selected is different from current one selected (or not selected)
 // if we havent already selected a patch cable, we'll select this one
 // if we selected one previously, we'll see if this one is adjacent to the previous one selected
 // if it's adjacent to the previous one selected, we'll select this one
-bool AutomationView::findPatchCable(Clip* clip, PatchCableSet* set, int32_t patchCableIndex,
-                                    bool& foundCurrentPatchCable) {
+bool AutomationView::selectPatchCableAtIndex(Clip* clip, PatchCableSet* set, int32_t patchCableIndex,
+                                             bool& foundCurrentPatchCable) {
 	PatchCable* cable = &set->patchCables[patchCableIndex];
 	ParamDescriptor desc = cable->destinationParamDescriptor;
 	// need to add patch cable source to the descriptor so that we can get the paramId from it

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -42,6 +42,7 @@ class NoteRow;
 class ParamCollection;
 class ParamManagerForTimeline;
 class ParamNode;
+class PatchCableSet;
 class Sound;
 class SoundDrum;
 
@@ -219,6 +220,8 @@ private:
 	// Select Encoder Action
 	void selectGlobalParam(int32_t offset, Clip* clip);
 	void selectNonGlobalParam(int32_t offset, Clip* clip);
+	bool selectPatchCable(int32_t offset, Clip* clip);
+	bool findPatchCable(Clip* clip, PatchCableSet* set, int32_t patchCableIndex, bool& foundCurrentPatchCable);
 	void selectMIDICC(int32_t offset, Clip* clip);
 	int32_t getNextSelectedParamArrayPosition(int32_t offset, int32_t lastSelectedParamArrayPosition,
 	                                          int32_t numParams);
@@ -228,6 +231,7 @@ private:
 	// Automation Lanes Functions
 	void initPadSelection();
 	void initInterpolation();
+	ParamManagerForTimeline* getParamManagerForClip(Clip* clip);
 	int32_t getEffectiveLength(ModelStackWithTimelineCounter* modelStack);
 	uint32_t getSquareWidth(int32_t square, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
 	uint32_t getMiddlePosFromSquare(int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -221,7 +221,7 @@ private:
 	void selectGlobalParam(int32_t offset, Clip* clip);
 	void selectNonGlobalParam(int32_t offset, Clip* clip);
 	bool selectPatchCable(int32_t offset, Clip* clip);
-	bool findPatchCable(Clip* clip, PatchCableSet* set, int32_t patchCableIndex, bool& foundCurrentPatchCable);
+	bool selectPatchCableAtIndex(Clip* clip, PatchCableSet* set, int32_t patchCableIndex, bool& foundCurrentPatchCable);
 	void selectMIDICC(int32_t offset, Clip* clip);
 	int32_t getNextSelectedParamArrayPosition(int32_t offset, int32_t lastSelectedParamArrayPosition,
 	                                          int32_t numParams);

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1312,3 +1312,7 @@ uint64_t AudioClip::getCullImmunity() {
 	bool doingTimeStretching = (voiceSample && voiceSample->timeStretcher);
 	return ((uint64_t)voicePriority << 33) + ((uint64_t)!doingTimeStretching << 32) + distanceFromEnd;
 }
+
+ParamManagerForTimeline* AudioClip::getCurrentParamManager() {
+	return &paramManager;
+}

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -112,6 +112,8 @@ public:
 		return audioClipView.renderSidebar(whichRows, image, occupancyMask);
 	};
 
+	ParamManagerForTimeline* getCurrentParamManager();
+
 protected:
 	bool cloneOutput(ModelStackWithTimelineCounter* modelStack);
 

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -78,6 +78,7 @@ public:
 	  // for AudioClips
 	virtual void lengthChanged(ModelStackWithTimelineCounter* modelStack, int32_t oldLength, Action* action = NULL);
 	virtual void getSuggestedParamManager(Clip* newClip, ParamManagerForTimeline** suggestedParamManager, Sound* sound);
+	virtual ParamManagerForTimeline* getCurrentParamManager() { return nullptr; }
 
 	// You're likely to want to call pickAnActiveClipIfPossible() after this
 	virtual void detachFromOutput(ModelStackWithTimelineCounter* modelStack, bool shouldRememberDrumName,

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3858,6 +3858,29 @@ void InstrumentClip::getSuggestedParamManager(Clip* newClip, ParamManagerForTime
 	}
 }
 
+ParamManagerForTimeline* InstrumentClip::getCurrentParamManager() {
+	ParamManagerForTimeline* currentParamManager = nullptr;
+
+	if (output->type == OutputType::KIT && !affectEntire) {
+		Drum* selectedDrum = ((Kit*)output)->selectedDrum;
+
+		// If a SoundDrum is selected...
+		if (selectedDrum) {
+			if (selectedDrum->type == DrumType::SOUND) {
+				NoteRow* noteRow = getNoteRowForDrum(selectedDrum);
+				if (noteRow != nullptr) {
+					currentParamManager = &noteRow->paramManager;
+				}
+			}
+		}
+	}
+	else {
+		currentParamManager = &paramManager;
+	}
+
+	return currentParamManager;
+}
+
 Error InstrumentClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 
 	if (!output) { // Would only have an output already if file from before V2.0.0 I think? So, this block normally does

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -217,6 +217,7 @@ public:
 	Error transferVoicesToOriginalClipFromThisClone(ModelStackWithTimelineCounter* modelStackOriginal,
 	                                                ModelStackWithTimelineCounter* modelStackClone);
 	void getSuggestedParamManager(Clip* newClip, ParamManagerForTimeline** suggestedParamManager, Sound* sound);
+	ParamManagerForTimeline* getCurrentParamManager();
 	Error claimOutput(ModelStackWithTimelineCounter* modelStack) override;
 	char const* getXMLTag() { return "instrumentClip"; }
 	void finishLinearRecording(ModelStackWithTimelineCounter* modelStack, Clip* nextPendingLoop,

--- a/src/deluge/modulation/patch/patch_cable_set.h
+++ b/src/deluge/modulation/patch/patch_cable_set.h
@@ -113,8 +113,9 @@ public:
 
 	bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) { return true; };
 
-private:
 	static void dissectParamId(uint32_t paramId, ParamDescriptor* destinationParamDescriptor, PatchSource* s);
+
+private:
 	void swapCables(int32_t c1, int32_t c2);
 	void freeDestinationMemory(bool destructing);
 };


### PR DESCRIPTION
- Added select scrolling of patch cables that exist (they are dynamically added to the end of the non-patch cable param scrolling list for synths and kit rows)
- Handled scenario where you selected a patch cable previously and it no longer exists when re-entering automation view. In this case it now sends you back to the automation overview.
- Fixed select scrolling bug that would cause interpolation shortcut to blink profusely 
- Updated patch cable name displayed to show both sources if it's a patch cable with two sources