### PR TITLE
Bugfix - restore compressor operation

### DIFF
--- a/src/deluge/dsp/compressor/rms_feedback.cpp
+++ b/src/deluge/dsp/compressor/rms_feedback.cpp
@@ -36,7 +36,7 @@ void RMSFeedbackCompressor::updateER(float numSamples, q31_t finalVolume) {
 	// this is effectively where song volume gets applied, so we'll stick an IIR filter (e.g. the envelope) here to
 	// reduce clicking
 	float lastER = er;
-	er = std::max<float>((songVolumedB - threshdb - 1) * reduction, 0);
+	er = std::max<float>((songVolumedB - threshdb - 1) * fraction, 0);
 	// using the envelope is convenient since it means makeup gain and compression amount change at the same rate
 	er = runEnvelope(lastER, er, numSamples);
 }
@@ -57,7 +57,7 @@ void RMSFeedbackCompressor::render(StereoSample* buffer, uint16_t numSamples, q3
 
 	state = runEnvelope(state, over, numSamples);
 
-	float reduction = -state * reduction;
+	float reduction = -state * fraction;
 
 	// this is the most gain available without overflow
 	float dbGain = 3.f + er + reduction;
@@ -85,7 +85,7 @@ void RMSFeedbackCompressor::render(StereoSample* buffer, uint16_t numSamples, q3
 	} while (++thisSample != bufferEnd);
 	// for LEDs
 	// 4 converts to dB, then quadrupled for display range since a 30db reduction is basically killing the signal
-	gainReduction = std::clamp<int32_t>(-(reduction) * 4 * 4, 0, 127);
+	gainReduction = std::clamp<int32_t>(-(reduction)*4 * 4, 0, 127);
 	// calc compression for next round (feedback compressor)
 	rms = calcRMS(buffer, numSamples);
 }

--- a/src/deluge/dsp/compressor/rms_feedback.cpp
+++ b/src/deluge/dsp/compressor/rms_feedback.cpp
@@ -85,7 +85,7 @@ void RMSFeedbackCompressor::render(StereoSample* buffer, uint16_t numSamples, q3
 	} while (++thisSample != bufferEnd);
 	// for LEDs
 	// 4 converts to dB, then quadrupled for display range since a 30db reduction is basically killing the signal
-	gainReduction = std::clamp<int32_t>(-(reduction)*4 * 4, 0, 127);
+	gainReduction = std::clamp<int32_t>(-(reduction) * 4 * 4, 0, 127);
 	// calc compression for next round (feedback compressor)
 	rms = calcRMS(buffer, numSamples);
 }

--- a/src/deluge/dsp/compressor/rms_feedback.cpp
+++ b/src/deluge/dsp/compressor/rms_feedback.cpp
@@ -60,7 +60,7 @@ void RMSFeedbackCompressor::render(StereoSample* buffer, uint16_t numSamples, q3
 	float reduction = -state * fraction;
 
 	// this is the most gain available without overflow
-	float dbGain = 3.f + er + reduction;
+	float dbGain = .85f + er + reduction;
 
 	float gain = std::exp((dbGain));
 	gain = std::min<float>(gain, 31);

--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -70,8 +70,8 @@ public:
 	constexpr int32_t getRatioForDisplay() { return ratio; }
 	constexpr int32_t setRatio(q31_t rat) {
 		ratioKnobPos = rat;
-		reduction = 0.5f + (float(ratioKnobPos) / ONE_Q31f) / 2;
-		ratio = 1 / (1 - reduction);
+		fraction = 0.5f + (float(ratioKnobPos) / ONE_Q31f) / 2;
+		ratio = 1 / (1 - fraction);
 		return ratio;
 	}
 	q31_t getSidechain() { return sideChainKnobPos; }
@@ -95,7 +95,7 @@ private:
 	// parameters in use
 	float a_ = (-1000.0f / kSampleRate);
 	float r_ = (-1000.0f / kSampleRate);
-	float reduction = 0.5;
+	float fraction = 0.5;
 	float er = 0;
 	float threshdb = 17;
 	float threshold = 1;


### PR DESCRIPTION
base dB gain got changed accidentally during the per clip compressor change - with the higher level it exceeeds the maximum gain that can be rendered and most compression settings end up the same

Seperately a refactor in #1557 renamed "ratio" to reduction, which is fine except that reduction is used later in the process causing it to shadow the member variable and totally stop the compressor from reducing volume, making it just a gain. 

Fix  #1610
Fix #1595 