### PR TITLE
Implement Universal SysEx Identity response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/b
   - Press `▼︎▲︎` + `◀︎▶︎` to set the Audio Clip length equal to the length of the audio sample. This will effectively remove timestretching from the audio sample.
   - Press `SHIFT` + `◀︎▶︎` + `turn ◀︎▶︎` to shorten / lengthen the audio clip without timestretching.
 
+### MIDI
+- Added Universal SysEx Identity response, including firmware version.
+
 ## c1.1.0 Beethoven
 
 ### Sound Engine

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -404,7 +404,7 @@ int32_t MIDIDeviceUSB::sendBufferSpace() {
 
 extern bool developerSysexCodeReceived;
 
-void MIDIDeviceUSB::sendSysex(uint8_t* data, int32_t len) {
+void MIDIDeviceUSB::sendSysex(const uint8_t* data, int32_t len) {
 	if (len < 6 || data[0] != 0xf0 || data[len - 1] != 0xf7) {
 		return;
 	}
@@ -563,7 +563,7 @@ int32_t MIDIDeviceDINPorts::sendBufferSpace() {
 	return uartGetTxBufferSpace(UART_ITEM_MIDI);
 }
 
-void MIDIDeviceDINPorts::sendSysex(uint8_t* data, int32_t len) {
+void MIDIDeviceDINPorts::sendSysex(const uint8_t* data, int32_t len) {
 	if (len < 3 || data[0] != 0xf0 || data[len - 1] != 0xf7) {
 		return;
 	}
@@ -593,5 +593,5 @@ int32_t MIDIDeviceLoopback::sendBufferSpace() {
 	return 0;
 }
 
-void MIDIDeviceLoopback::sendSysex(uint8_t* data, int32_t len) {
+void MIDIDeviceLoopback::sendSysex(const uint8_t* data, int32_t len) {
 }

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -100,7 +100,7 @@ public:
 	inline void sendCC(int32_t channel, int32_t cc, int32_t value) { sendMessage(0x0B, channel, cc, value); }
 
 	// data should be a complete message with data[0] = 0xf0, data[len-1] = 0xf7
-	virtual void sendSysex(uint8_t* data, int32_t len) = 0;
+	virtual void sendSysex(const uint8_t* data, int32_t len) = 0;
 
 	virtual int32_t sendBufferSpace() = 0;
 
@@ -147,7 +147,7 @@ public:
 		needsToSendMCMs = 0;
 	}
 	void sendMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
-	void sendSysex(uint8_t* data, int32_t len) override;
+	void sendSysex(const uint8_t* data, int32_t len) override;
 	int32_t sendBufferSpace() override;
 	void connectedNow(int32_t midiDeviceNum);
 	void sendMCMsNowIfNeeded();
@@ -240,7 +240,7 @@ public:
 	void writeToFlash(uint8_t* memory);
 	char const* getDisplayName();
 	void sendMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
-	void sendSysex(uint8_t* data, int32_t len) override;
+	void sendSysex(const uint8_t* data, int32_t len) override;
 	int32_t sendBufferSpace() override;
 };
 
@@ -251,6 +251,6 @@ public:
 	void writeToFlash(uint8_t* memory);
 	char const* getDisplayName();
 	void sendMessage(uint8_t statusType, uint8_t channel, uint8_t data1, uint8_t data2);
-	void sendSysex(uint8_t* data, int32_t len) override;
+	void sendSysex(const uint8_t* data, int32_t len) override;
 	int32_t sendBufferSpace() override;
 };

--- a/src/deluge/io/midi/sysex.h
+++ b/src/deluge/io/midi/sysex.h
@@ -41,6 +41,10 @@ const uint8_t DELUGE_SYSEX_ID_BYTE1 = 0x21;
 const uint8_t DELUGE_SYSEX_ID_BYTE2 = 0x7B;
 const uint8_t DELUGE_SYSEX_ID_BYTE3 = 0x01;
 
+const uint8_t SYSEX_UNIVERSAL_NONRT = 0x7E;
+const uint8_t SYSEX_UNIVERSAL_RT = 0x7F;
+const uint8_t SYSEX_UNIVERSAL_IDENTITY = 0x06;
+
 const uint8_t SYSEX_END = 0xF7;
 
 enum SysexCommands : uint8_t {


### PR DESCRIPTION
Be a good MIDI citizen and implement standard identity request (f07e7f0601f7) and response with manufacturer ID, device ID + firmware version string.

The first commit is just a minor refactor for const correctness.