### PR TITLE
Remove pull_request_target trigger from release-build

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -5,11 +5,6 @@ on:
   push:
     branches:
       - 'release/1.1'
-  pull_request_target:
-    types:
-      - closed
-    branches:
-      - 'release/1.1'
 
 jobs:
   release-build:


### PR DESCRIPTION
This causes the beta build to run twice and generate weird half-built releases.