### PR TITLE
move stutter out of the fallthrough cases

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2597,7 +2597,7 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 			exitUIMode(UI_MODE_HOLDING_STATUS_PAD);
 		}
 		break;
-		
+
 	case UI_MODE_STUTTERING:
 		// this code is needed to allow users to launch clips while stuttering
 		// without it the deluge becomes unresponsive if you try to launch a clip while stuttering

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2585,15 +2585,7 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 		}
 		// No break
 	case UI_MODE_CLIP_PRESSED_IN_SONG_VIEW:
-	case UI_MODE_STUTTERING:
-		// this code is needed to allow users to launch clips while stuttering
-		// without it the deluge becomes unresponsive if you try to launch a clip while stuttering
-		// this is because it gets stuck in the stuttering UI mode and can't get out
-		if (on) {
-			sessionView.performActionOnPadRelease = false; // Even though there's a chance we're not in session view
-			session.toggleClipStatus(clip, NULL, Buttons::isShiftButtonPressed(), kInternalButtonPressLatency);
-		}
-		break;
+
 	case UI_MODE_HOLDING_STATUS_PAD:
 		if (on) {
 			enterUIMode(UI_MODE_HOLDING_STATUS_PAD);
@@ -2603,6 +2595,16 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 		}
 		else {
 			exitUIMode(UI_MODE_HOLDING_STATUS_PAD);
+		}
+		break;
+		
+	case UI_MODE_STUTTERING:
+		// this code is needed to allow users to launch clips while stuttering
+		// without it the deluge becomes unresponsive if you try to launch a clip while stuttering
+		// this is because it gets stuck in the stuttering UI mode and can't get out
+		if (on) {
+			sessionView.performActionOnPadRelease = false; // Even though there's a chance we're not in session view
+			session.toggleClipStatus(clip, NULL, Buttons::isShiftButtonPressed(), kInternalButtonPressLatency);
 		}
 		break;
 


### PR DESCRIPTION
Fixes a bug introduced by #1556 which stopped deluge from entering the UI_MODE_HOLDING_STATUS_PAD and instead taking the stutter action, even when stutter isn't active