### PR TITLE
fix the nightly build tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,12 +28,12 @@ jobs:
         if: inputs.run-id == null
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.build-tag }}_Release_build_bundle
+          name: ${{ inputs.tag }}_Release_build_bundle
       - name: Download Build Artifact
         if: inputs.run-id != null
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.build-tag }}_Release_build_bundle
+          name: ${{ inputs.tag }}_Release_build_bundle
           run-id: ${{inputs.run-id}}
       - name: Create nightlies archive
         run: |


### PR DESCRIPTION
Used wrong input variable name when making the build artifacts unique