### PR TITLE
Bugfix - Midi Follow :: Update getSelectedClip to use Active Clip

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -112,7 +112,7 @@ void MidiFollow::initMapping(int32_t mapping[kDisplayWidth][kDisplayHeight]) {
 Clip* getSelectedClip(bool useActiveClip) {
 	// special case for note and performance data where you want to let notes and MPE through to the active clip
 	if (useActiveClip) {
-		return getCurrentClip();
+		return getCurrentClip()->output->activeClip;
 	}
 	Clip* clip = nullptr;
 


### PR DESCRIPTION
Bug reported by @m-m-adams : it seems like if the current clip used for midi follow isn't the active clip for that output MPE data doesn't get passed through

Fix - when useActiveClip is passed to getSelectedClip in midi follow, return getCurrentClip()->output->activeClip