### PR TITLE
Bugfix/midi load error arranger

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1821,7 +1821,7 @@ nothingToDisplay:
 	setCentralLEDStates();
 }
 
-// render session view display on opening
+/// render session view display on opening
 void SessionView::renderViewDisplay(char const* viewString) {
 	if (display->haveOLED()) {
 		deluge::hid::display::OLED::clearMainImage();
@@ -1836,8 +1836,9 @@ void SessionView::renderViewDisplay(char const* viewString) {
 
 		deluge::hid::display::OLED::drawStringCentred(viewString, yPos, deluge::hid::display::OLED::oledMainImage[0],
 		                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
-
-		deluge::hid::display::OLED::sendMainImage();
+		if (!display->hasPopup()) {
+			deluge::hid::display::OLED::sendMainImage();
+		}
 	}
 	else {
 		display->setScrollingText(viewString);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3894,19 +3894,8 @@ Error InstrumentClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 		                                                       instrumentName, dirPath, false);
 
 		if (!output) {
-			if (outputType == OutputType::MIDI_OUT || outputType == OutputType::CV) {
-				output = storageManager.createNewNonAudioInstrument(outputType, backedUpInstrumentSlot[outputTypeAsIdx],
-				                                                    backedUpInstrumentSubSlot[outputTypeAsIdx]);
 
-				if (!output) {
-					return Error::INSUFFICIENT_RAM;
-				}
-
-				modelStack->song->addOutput(output);
-			}
-			else {
-				return Error::FILE_CORRUPTED;
-			}
+			return Error::FILE_CORRUPTED;
 		}
 	}
 

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -95,7 +95,7 @@ public:
 	// could be int8 for aftertouch/Y but Midi 2 will allow those to be 14 bit too
 	int16_t lastOutputMonoExpression[3]{0};
 	char const* getXMLTag() { return "midi"; }
-	char const* getSlotXMLTag() { return sendsToMPE() ? "zone" : sendsToInternal() ? "internalDest" : "midiChannel"; }
+	char const* getSlotXMLTag() { return sendsToMPE() ? "zone" : sendsToInternal() ? "internalDest" : "channel"; }
 	char const* getSubSlotXMLTag() { return "suffix"; }
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,


### PR DESCRIPTION
Fix #1285 , an incorrect tag name was set when internal was added as a midi destination

Stops the song loader from creating fake midi/cv clips if the song loads incorrectly, making errors like this more obvious. 

Also stops the session/arranger display from killing error messages during loading to ensure the error message is shown