### PR TITLE
Bugfix - set current clip as active clip if possible

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -149,7 +149,8 @@ Clip* getSelectedClip() {
 }
 
 // returns activeClip for the selected output
-// special case for note and performance data where you want to let notes and MPE through to the active clip
+// special case for note and performance data where you want to let notes,
+// midi modulation sources (e.g. mod wheel), and MPE through to the active clip
 Clip* getSelectedClip(ModelStack* modelStack) {
 	// If you have an output for which no clip is active,
 	// when auditioning a clip for that output,

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -466,10 +466,8 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 				    ->receivedCCFromMidiFollow(modelStack, clip, ccNumber, value);
 			}
 		}
-		// for these cc's, check if there's an active clip if the clip returned above is NULL
-		if (!clip) {
-			clip = modelStack->song->getCurrentClip();
-		}
+		// for these cc's, always use the active clip for the output selected
+		clip = getSelectedClip(modelStack);
 		if (clip && (clip->output->type != OutputType::AUDIO)) {
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
 			if (modelStackWithTimelineCounter) {

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -110,15 +110,7 @@ void MidiFollow::initMapping(int32_t mapping[kDisplayWidth][kDisplayHeight]) {
 /// 1) pressing and holding a clip pad in arranger view, song view, grid view
 /// 2) pressing and holding the audition pad of a row in arranger view
 /// 3) entering a clip
-Clip* getSelectedClip(bool useActiveClip, ModelStack* modelStack) {
-	// special case for note and performance data where you want to let notes and MPE through to the active clip
-	if (useActiveClip) {
-		// If you have an output for which no clip is active,
-		// when auditioning a clip for that output,
-		// the active clip for that output should be set to the current clip.
-		InstrumentClipMinder::makeCurrentClipActiveOnInstrumentIfPossible(modelStack);
-		return getCurrentClip()->output->activeClip;
-	}
+Clip* getSelectedClip() {
 	Clip* clip = nullptr;
 
 	RootUI* rootUI = getRootUI();
@@ -154,6 +146,16 @@ Clip* getSelectedClip(bool useActiveClip, ModelStack* modelStack) {
 	}
 
 	return clip;
+}
+
+// returns activeClip for the selected output
+// special case for note and performance data where you want to let notes and MPE through to the active clip
+Clip* getSelectedClip(ModelStack* modelStack) {
+	// If you have an output for which no clip is active,
+	// when auditioning a clip for that output,
+	// the active clip for that output should be set to the current clip.
+	InstrumentClipMinder::makeCurrentClipActiveOnInstrumentIfPossible(modelStack);
+	return getCurrentClip()->output->activeClip;
 }
 
 /// based on the current context, as determined by clip returned from the getSelectedClip function
@@ -366,7 +368,7 @@ void MidiFollow::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32_t ch
 		if (note >= 0 && note <= 127) {
 			Clip* clip;
 			if (on) {
-				clip = getSelectedClip(true, modelStack);
+				clip = getSelectedClip(modelStack);
 			}
 			else {
 				// for note off's, see if a note on message was previously sent so you can
@@ -494,7 +496,7 @@ void MidiFollow::pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel, uint
 	MIDIMatchType match = checkMidiFollowMatch(fromDevice, channel);
 	if (match != MIDIMatchType::NO_MATCH) {
 		// obtain clip for active context
-		Clip* clip = getSelectedClip(true, modelStack);
+		Clip* clip = getSelectedClip(modelStack);
 		if (clip && (clip->output->type != OutputType::AUDIO)) {
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
 
@@ -522,7 +524,7 @@ void MidiFollow::aftertouchReceived(MIDIDevice* fromDevice, int32_t channel, int
 	MIDIMatchType match = checkMidiFollowMatch(fromDevice, channel);
 	if (match != MIDIMatchType::NO_MATCH) {
 		// obtain clip for active context
-		Clip* clip = getSelectedClip(true, modelStack);
+		Clip* clip = getSelectedClip(modelStack);
 		if (clip && (clip->output->type != OutputType::AUDIO)) {
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
 

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -32,7 +32,8 @@ class ModelStackWithThreeMainThings;
 class ModelStackWithAutoParam;
 enum class MIDIMatchType;
 
-Clip* getSelectedClip(bool useActiveClip = false, ModelStack* modelStack = nullptr);
+Clip* getSelectedClip();
+Clip* getSelectedClip(ModelStack* modelStack);
 
 class MidiFollow final {
 public:

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -32,7 +32,7 @@ class ModelStackWithThreeMainThings;
 class ModelStackWithAutoParam;
 enum class MIDIMatchType;
 
-Clip* getSelectedClip(bool useActiveClip = false);
+Clip* getSelectedClip(bool useActiveClip = false, ModelStack* modelStack = nullptr);
 
 class MidiFollow final {
 public:

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -46,7 +46,7 @@ public:
 	void displayCurrentScaleName();
 	void selectEncoderAction(int32_t offset);
 	static void drawMIDIControlNumber(int32_t controlNumber, bool automationExists);
-	bool makeCurrentClipActiveOnInstrumentIfPossible(ModelStack* modelStack);
+	static bool makeCurrentClipActiveOnInstrumentIfPossible(ModelStack* modelStack);
 	bool changeOutputType(OutputType newOutputType);
 	void opened();
 


### PR DESCRIPTION
In the midi follow context, when we're looking to control the active clip (e.g. for sending notes and mpe), check if active clip should be set to the current clip and set it if needed.

This is consistent with audition pad behaviour in an instrument clip.

If you have an output for which no clip is active, when auditioning a clip for that output, the active clip should be set to the current clip.

fix: https://github.com/SynthstromAudible/DelugeFirmware/issues/1683