### PR TITLE
Fix note-on ignoring during quantized record

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -4446,7 +4446,9 @@ void InstrumentClip::recordNoteOn(ModelStackWithNoteRow* modelStack, int32_t vel
 
 			int32_t amountLaterThanMiddle = offset - (quantizeInterval / 2);
 			if (reversed) {
-				amountLaterThanMiddle = (quantizeInterval / 2) - amountLaterThanMiddle;
+				// Invert the sense of "amountLaterThanMiddle", and offset by 1 to account for the reversed sense of
+				// time.
+				amountLaterThanMiddle = 1 - amountLaterThanMiddle;
 			}
 			quantizedLater = (amountLaterThanMiddle >= 0);
 

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -826,6 +826,8 @@ void NoteRow::recordNoteOff(uint32_t noteOffPos, ModelStackWithNoteRow* modelSta
 		return;
 	}
 
+	D_PRINTLN("rno %u", noteOffPos);
+
 	if (!notes.getNumElements()) {
 		return;
 	}

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -586,7 +586,7 @@ int32_t NoteRow::attemptNoteAdd(int32_t pos, int32_t length, int32_t velocity, i
 		    ExistenceChangeType::CREATE); // This only gets called (action is only supplied) when drag-scrolling Notes
 	}
 
-	((InstrumentClip*)modelStack->getTimelineCounter())->expectEvent();
+	modelStack->getTimelineCounter()->expectEvent();
 	return distanceToNextNote;
 }
 
@@ -637,7 +637,7 @@ int32_t NoteRow::attemptNoteAddReversed(ModelStackWithNoteRow* modelStack, int32
 	newNote->setLift(kDefaultLiftValue);
 	newNote->setProbability(getDefaultProbability(modelStack));
 
-	((InstrumentClip*)modelStack->getTimelineCounter())->expectEvent();
+	modelStack->getTimelineCounter()->expectEvent();
 
 	return distanceToNextNote;
 }

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -134,8 +134,14 @@ public:
 	// which calls Clip::expectEvent(), which is needed
 	uint8_t soundingStatus;
 
-	bool skipNextNote; // To be used if we recorded a note which was quantized forwards, and we have to remember not to
-	                   // play it
+	/// Time before which all note events should be ignored during live playback. 0 means all notes should play (i.e. a
+	/// note event at the time stored here should be allowed to sound). When doing quantized recording, we might have
+	/// quantized the note to a later point in time so this is used to inhibit re-sounding of the quantized note.
+	///
+	/// This is always stored in "forward time", so even when playback is reversed this can only be meaningfully be
+	/// compared with the time since this NoteRow started (i.e., time from the end during reversed playback).
+	uint32_t ignoreNoteOnsBefore_;
+
 	int32_t getDefaultProbability(ModelStackWithNoteRow* ModelStack);
 	int32_t attemptNoteAdd(int32_t pos, int32_t length, int32_t velocity, int32_t probability,
 	                       ModelStackWithNoteRow* modelStack, Action* action);

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1640,7 +1640,7 @@ void PlaybackHandler::inputTick(bool fromTriggerClock, uint32_t time) {
 	if (lastInputTickReceived != 0) {
 		uint32_t timeLastInputTickTook = timeThisInputTick - timeLastInputTicks[0];
 
-		D_PRINTLN("time since last:  %d", timeLastInputTickTook);
+		// D_PRINTLN("time since last:  %d", timeLastInputTickTook);
 
 		uint32_t internalTicksPer;
 		uint32_t inputTicksPer;


### PR DESCRIPTION
Rather than using a boolean that gets out of sync easily, we record the actual relative time stamp at which we should start paying attention.

There's probably gremlins in the reverse clip recording code, but I don't think this makes it any worse at least.

Fixes #1422.