### PR TITLE
Bugfix/fallback for files saved with incorrect tag on nightly builds

### DIFF
--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -12,7 +12,8 @@ class NumericLayerScrollingText;
 
 enum DisplayPopupType {
 	NONE,
-	GENERAL,     // Default popup type, if not specified
+	GENERAL,
+	LOADING,     // Default popup type, if not specified
 	PROBABILITY, // Popup shown when editing note or row probability
 	             // Note: Add here more popup types
 };

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -12,8 +12,11 @@ class NumericLayerScrollingText;
 
 enum DisplayPopupType {
 	NONE,
+	/// Default popup type, if not specified.
 	GENERAL,
-	LOADING,     // Default popup type, if not specified
+	/// Used for popups generated during file loading.
+	LOADING,
+	/// Popup shown when editing note or row probability.
 	PROBABILITY, // Popup shown when editing note or row probability
 	             // Note: Add here more popup types
 };

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -17,8 +17,8 @@ enum DisplayPopupType {
 	/// Used for popups generated during file loading.
 	LOADING,
 	/// Popup shown when editing note or row probability.
-	PROBABILITY, // Popup shown when editing note or row probability
-	             // Note: Add here more popup types
+	PROBABILITY,
+	// Note: Add here more popup types
 };
 
 namespace deluge::hid {

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -899,7 +899,7 @@ void updateWorkingAnimation() {
 	}
 
 	error = textNow.concatenate(buffer);
-	OLED::popupText(textNow.get(), true, DisplayPopupType::GENERAL);
+	OLED::popupText(textNow.get(), true, DisplayPopupType::LOADING);
 }
 
 void OLED::displayWorkingAnimation(char const* word) {
@@ -909,8 +909,11 @@ void OLED::displayWorkingAnimation(char const* word) {
 }
 
 void OLED::removeWorkingAnimation() {
-	if (workingAnimationText) {
+	if (hasPopupOfType(DisplayPopupType::LOADING)) {
 		removePopup();
+	}
+	else if (workingAnimationText) {
+		workingAnimationText = NULL;
 	}
 }
 

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -356,6 +356,10 @@ bool MIDIInstrument::readTagFromFile(StorageManager& bdsm, char const* tagName) 
 			channel = MIDI_CHANNEL_TRANSPOSE;
 		}
 	}
+	else if (!strcmp(tagName, "midiChannel")) {
+		// fix for incorrect save files created on nightlies between 18/02/24 and 08/04/24
+		channel = bdsm.readTagOrAttributeValueInt();
+	}
 	else if (!strcmp(tagName, "zone")) {
 		char const* text = bdsm.readTagOrAttributeValue();
 		if (!strcmp(text, "lower")) {


### PR DESCRIPTION
Fallback in midi instrument parser to use midiChannel as the channel if present. Was accidentally saved as midiChannel instead of channel for a few weeks

Fix to show error message on OLED (7seg already handles popups vs loading differently)
