### PR TITLE
Fix incorrect naming for arp preset param in OLED

### DIFF
--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -298,7 +298,7 @@ Submenu unisonMenu{
 };
 
 // Arp --------------------------------------------------------------------------------------
-arpeggiator::PresetMode arpPresetModeMenu{STRING_FOR_PRESET, STRING_FOR_ARP_MODE_MENU_TITLE};
+arpeggiator::PresetMode arpPresetModeMenu{STRING_FOR_PRESET, STRING_FOR_ARP_PRESET_MENU_TITLE};
 arpeggiator::Mode arpModeMenu{STRING_FOR_MODE, STRING_FOR_ARP_MODE_MENU_TITLE};
 arpeggiator::Sync arpSyncMenu{STRING_FOR_SYNC, STRING_FOR_ARP_SYNC_MENU_TITLE};
 arpeggiator::Octaves arpOctavesMenu{STRING_FOR_NUMBER_OF_OCTAVES, STRING_FOR_ARP_OCTAVES_MENU_TITLE};


### PR DESCRIPTION
To cherry pick.
For consistency/correctness: In the OLED screen the title should read "Arp preset" and not "Arp mode" as the parameter is now  "Preset"