### PR TITLE
oled: fix popup border clamping

### DIFF
--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -530,8 +530,8 @@ void OLED::setupPopup(int32_t width, int32_t height) {
 	popupMinY = (OLED_MAIN_HEIGHT_PIXELS - popupHeight) >> 1;
 	popupMaxY = OLED_MAIN_HEIGHT_PIXELS - popupMinY;
 
-	if (popupMinY < 0) {
-		popupMinY = 0;
+	if (popupMinY < OLED_MAIN_TOPMOST_PIXEL) {
+		popupMinY = OLED_MAIN_TOPMOST_PIXEL;
 	}
 	if (popupMaxY > OLED_MAIN_HEIGHT_PIXELS - 1) {
 		popupMaxY = OLED_MAIN_HEIGHT_PIXELS - 1;


### PR DESCRIPTION
This might fix #1204. The sample song from that bug has ultra-long sample names which result in maximum size popups. Given the other symptoms in the bug I think some sort of memory corruption is at fault -- this at least constraints the popup to the renderable region. Other fixes we've put in over the last few months hopefully got the rest of the corruption if there was something else going wrong.