### PR TITLE
Revert change to load audio clip sample without timestretching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### User Interface
 
 - Added ability to select audio source from within an Audio Clip by opening the Audio Clip Sound Menu (Press `SELECT`) and Selecting the `AUDIO SOURCE` menu
-- Updated audio clip's sample loading to load sample without time stretching. Added new shortcut to remove timestretching from an audio clip and shorten / extend an audio clip without timestretching. 
+- Added new shortcut to remove timestretching from an audio clip and shorten / extend an audio clip without timestretching. 
   - Press `▼︎▲︎` + `◀︎▶︎` to set the Audio Clip length equal to the length of the audio sample. This will effectively remove timestretching from the audio sample.
   - Press `SHIFT` + `◀︎▶︎` + `turn ◀︎▶︎` to shorten / lengthen the audio clip without timestretching.
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -206,7 +206,7 @@ Here is a list of general improvements that have been made, ordered from newest 
   - Not included in c1.1.0
 
 #### 3.18 - Remove Timestretching From Audio Clip Sample
-- ([#1542]) Updated audio clip's sample loading to load sample without time stretching. Added new shortcut to remove timestretching from an audio clip and shorten / extend an audio clip without timestretching. 
+- ([#1542]) Added new shortcut to remove timestretching from an audio clip and shorten / extend an audio clip without timestretching. 
   - Press `▼︎▲︎` + `◀︎▶︎` to set the Audio Clip length equal to the length of the audio sample. This will effectively remove timestretching from the audio sample.
   - Press `SHIFT` + `◀︎▶︎` + `turn ◀︎▶︎` to shorten / lengthen the audio clip without timestretching.
 

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -783,7 +783,7 @@ removeLoadingAnimationAndGetOut:
 		clip->lengthChanged(modelStack, oldLength);
 
 		// load sample without time stretching
-		//audioClipView.adjustLoopLength(clip->sampleHolder.getLoopLengthAtSystemSampleRate(true));
+		// audioClipView.adjustLoopLength(clip->sampleHolder.getLoopLengthAtSystemSampleRate(true));
 
 		clip->sampleHolder.transpose = 0;
 		clip->sampleHolder.cents = 0;


### PR DESCRIPTION
Reverted change which changed default behaviour of loading audio clip samples with timestretching to without timestretching.

Added back loading with timestretching until a load option an be added to load without timestretching.