### PR TITLE
Add update instructions to website, readme, and releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,10 @@ jobs:
           tag_name: ${{ inputs.tag }} #will update tag to point at current head
           name: 'Deluge ${{ inputs.tag }} Release $$' #will fill in with date
           prerelease: true
-          body: 'This is a ${{ inputs.tag }} release and may have bugs - please report them!
-          https://github.com/SynthstromAudible/DelugeFirmware/issues/new/choose'
+          body: |
+            This is a ${{ inputs.tag }} release and may have bugs - please [report them](https://github.com/SynthstromAudible/DelugeFirmware/issues/new/choose)!
+
+            For installation instructions, see the [update guide](https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide).
           files: |
             ./${{ inputs.tag }}.zip
     

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,9 +35,34 @@ jobs:
         with:
           name: ${{ inputs.tag }}_Release_build_bundle
           run-id: ${{inputs.run-id}}
+      - name: Create readme for archive
+        run: |
+          cat <<'END' >README.txt
+          Deluge Community Firmware (${{ inputs.tag }})
+          Git revision ${{ github.sha }}
+          =====================================================
+
+          See the update guide for detailed instructions on how to install this
+          firmware. If you have never updated your Deluge before, please make
+          extra sure to read this, as you might want to update your bootloader
+          first to not risk rendering your Deluge inoperable!
+
+          https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide
+
+          Also, make a backup copy of your SD card before proceeding, just for
+          additional safety.
+
+          More information is also available on the project's website:
+          https://synthstromaudible.github.io/DelugeFirmware/
+
+          If you have done firmware updates on your Deluge before, but need a
+          quick refresher on how to do it: Copy the .bin file to the top level
+          of your SD card. Turn your Deluge off, insert the SD card, hold Shift
+          on the Deluge and power it back on.
+          END
       - name: Create nightlies archive
         run: |
-          zip -j ./${{ inputs.tag }}.zip *.bin
+          zip -j ./${{ inputs.tag }}.zip README.txt *.bin
       - name: Update Nightly Release
         uses: andelf/nightly-release@main #https://github.com/marketplace/actions/nightly-release
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,9 +56,15 @@ jobs:
           https://synthstromaudible.github.io/DelugeFirmware/
 
           If you have done firmware updates on your Deluge before, but need a
-          quick refresher on how to do it: Copy the .bin file to the top level
-          of your SD card. Turn your Deluge off, insert the SD card, hold Shift
-          on the Deluge and power it back on.
+          quick refresher on how to do it:
+
+            * Copy the .bin file to the top level of your SD card.
+            * Make sure that you have removed any other/leftover .bin files from
+              there, otherwise the Deluge cannot know which one to use.
+            * Turn your Deluge off.
+            * Insert the SD card.
+            * Hold SHIFT on the Deluge and power it back on. You can let go of
+              the shift key once the update has begun.
           END
       - name: Create nightlies archive
         run: |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The [Deluge](https://synthstrom.com/product/deluge/) from [Synthstrom Audible](h
 The hardware is built around a Renesas RZ/A1L processor with an Arm® Cortex®-A9 core running at 400MHz and 3MB of on-chip SRAM. Connected to that is a 64MB SDRAM chip, a PIC for button handling and either a 7-Segment array or an OLED screen. The application is written in C and C++ and some occasional assembly in bare metal style without an operating system.
 
 ## Important links
-* For acquiring and using the firmware visit the [Github Page](https://synthstromaudible.github.io/DelugeFirmware)
+* For acquiring and using the firmware visit the [community firmware website](https://synthstromaudible.github.io/DelugeFirmware)
 * Once you have the firmware, consult our detailed [update guide](https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide) for instructions on how to install it
 * To contribute to the project with code, bug reports, suggestions, and feedback see: [How to contribute to Deluge Firmware](docs/CONTRIBUTING.md)
 * To learn about the toolchain, application, and to start working on the code continue with: [Getting Started with Deluge Development](docs/dev/getting_started.md)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The hardware is built around a Renesas RZ/A1L processor with an Arm® Cortex®-A
 
 ## Important links
 * For acquiring and using the firmware visit the [Github Page](https://synthstromaudible.github.io/DelugeFirmware)
+* Once you have the firmware, consult our detailed [update guide](https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide) for instructions on how to install it
 * To contribute to the project with code, bug reports, suggestions, and feedback see: [How to contribute to Deluge Firmware](docs/CONTRIBUTING.md)
 * To learn about the toolchain, application, and to start working on the code continue with: [Getting Started with Deluge Development](docs/dev/getting_started.md)
 * Please also visit the [Synthstrom Forum](https://forums.synthstrom.com/) and the community [Discord](https://discord.gg/BnRcyFSgaT) to interact with other users and the developers

--- a/pages/public/index.html
+++ b/pages/public/index.html
@@ -112,6 +112,7 @@
         </p>
         <a class="btn" target="_blank" href="https://github.com/SynthstromAudible/DelugeFirmware/releases/latest/download/deluge-community-release.zip">Download c1.0.1</a>
         <a class="btn" target="_blank" href="https://github.com/SynthstromAudible/DelugeFirmware/releases/latest">Release notes</a>
+        <a class="btn" target="_blank" href="https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide">Installation instructions</a>
         
         
 


### PR DESCRIPTION
Fixes #1688.

This adds links to the [update guide](https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide) (that originally resided on the wiki's _Home_ page) to several places (links in the following list point to my fork to demonstrate the changes):

* the [readme](https://github.com/scy/DelugeFirmware/blob/add-update-instructions/README.md)
    * new bullet point
    * also changed the link to the website to read "community firmware website" instead of "Github page", because people unfamiliar with GitHub Pages might get confused ("Am I not already on that GitHub page?") when reading this
* the [website](https://scy.github.io/DelugeFirmware/) (new button "Installation instructions")
* the [description text of the nightly & beta releases](https://github.com/scy/DelugeFirmware/releases)
* a new readme.txt inside of the [nightly & beta release zipfiles](https://github.com/scy/DelugeFirmware/releases/download/nightly/nightly.zip)

As far as I can tell, _stable_ releases are not created using GitHub Actions. It's a manual process, right? This PR currently doesn't change anything regarding stable releases, only nightlies and betas, because those are created using GitHub Actions.