### PR TITLE
Bugfix - Allow use of sidebar when VU meter is active but changed mod knob mode

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -901,7 +901,8 @@ ActionResult ArrangerView::padAction(int32_t x, int32_t y, int32_t velocity) {
 	}
 
 	// don't interact with sidebar if VU Meter is displayed
-	if (x >= kDisplayWidth && view.displayVUMeter) {
+	// and you're in the volume/pan mod knob mode (0)
+	if (x >= kDisplayWidth && view.displayVUMeter && (view.getModKnobMode() == 0)) {
 		return ActionResult::DEALT_WITH;
 	}
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -917,7 +917,8 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 		}
 		else if (xDisplay >= kDisplayWidth) {
 			// don't interact with sidebar if VU Meter is displayed
-			if (view.displayVUMeter) {
+			// and you're in the volume/pan mod knob mode (0)
+			if (view.displayVUMeter && (view.getModKnobMode() == 0)) {
 				return ActionResult::DEALT_WITH;
 			}
 			// if in arranger view

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -617,7 +617,8 @@ void SessionView::beginEditingSectionRepeatsNum() {
 
 ActionResult SessionView::padAction(int32_t xDisplay, int32_t yDisplay, int32_t on) {
 	// don't interact with sidebar if VU Meter is displayed
-	if (xDisplay >= kDisplayWidth && view.displayVUMeter) {
+	// and you're in the volume/pan mod knob mode (0)
+	if (xDisplay >= kDisplayWidth && view.displayVUMeter && (view.getModKnobMode() == 0)) {
 		return ActionResult::DEALT_WITH;
 	}
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1507,13 +1507,7 @@ void View::setModLedStates() {
 	}
 
 	// Sort out actual "mod" LEDs
-	int32_t modKnobMode = -1;
-	if (activeModControllableModelStack.modControllable) {
-		uint8_t* modKnobModePointer = activeModControllableModelStack.modControllable->getModKnobMode();
-		if (modKnobModePointer) {
-			modKnobMode = *modKnobModePointer;
-		}
-	}
+	int32_t modKnobMode = getModKnobMode();
 
 	for (int32_t i = 0; i < kNumModButtons; i++) {
 		bool on = (i == modKnobMode);
@@ -1531,6 +1525,17 @@ void View::setModLedStates() {
 			indicator_leds::setLedState(indicator_leds::modLed[i], on);
 		}
 	}
+}
+
+int32_t View::getModKnobMode() {
+	int32_t modKnobMode = -1;
+	if (activeModControllableModelStack.modControllable) {
+		uint8_t* modKnobModePointer = activeModControllableModelStack.modControllable->getModKnobMode();
+		if (modKnobModePointer) {
+			modKnobMode = *modKnobModePointer;
+		}
+	}
+	return modKnobMode;
 }
 
 void View::notifyParamAutomationOccurred(ParamManager* paramManager, bool updateModLevels) {

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -67,6 +67,7 @@ public:
 	void sectionMidiLearnPadPressed(bool on, uint8_t section);
 	void midiLearnFlash();
 	void setModLedStates();
+	int32_t getModKnobMode();
 	void modEncoderAction(int32_t whichModEncoder, int32_t offset);
 	void modEncoderButtonAction(uint8_t whichModEncoder, bool on);
 	void modButtonAction(uint8_t whichButton, bool on);


### PR DESCRIPTION
When VU meter is active and displayed, we disabled interaction with the sidebar.

This introduced a bug however where if you switch Mod LED selections (e.g. to filter) while the VU meter is still active that it would not allow you to interact with the sidebar in those other mod led states.

This fixes that by only ignoring sidebar actions if vu meter is active AND you're currently in the volume / pan mod led state / knob mode.

Also took the opportunity to factor out some code for getting mod knob mode which can be used in some other places as well (saving that for another PR)

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1715