### PR TITLE
Save old arpeggiator mode param to song file so it can be read in official firmware. And fix order or arp and reverb param saving

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2344,13 +2344,14 @@ void InstrumentClip::writeDataToFile(StorageManager& bdsm, Song* song) {
 
 	if (output->type != OutputType::KIT) {
 		bdsm.writeOpeningTagBeginning("arpeggiator");
+		bdsm.writeAttribute("mode", (char*)arpPresetToOldArpMode(arpSettings.preset)); // For backwards compatibility
+		bdsm.writeAttribute("syncLevel", arpSettings.syncLevel);
+		bdsm.writeAttribute("syncType", arpSettings.syncType);
+		bdsm.writeAttribute("numOctaves", arpSettings.numOctaves);
 		bdsm.writeAttribute("arpMode", (char*)arpModeToString(arpSettings.mode));
 		bdsm.writeAttribute("noteMode", (char*)arpNoteModeToString(arpSettings.noteMode));
 		bdsm.writeAttribute("octaveMode", (char*)arpOctaveModeToString(arpSettings.octaveMode));
-		bdsm.writeAttribute("numOctaves", arpSettings.numOctaves);
 		bdsm.writeAttribute("mpeVelocity", (char*)arpMpeModSourceToString(arpSettings.mpeVelocity));
-		bdsm.writeAttribute("syncLevel", arpSettings.syncLevel);
-		bdsm.writeAttribute("syncType", arpSettings.syncType);
 
 		if (output->type == OutputType::MIDI_OUT || output->type == OutputType::CV) {
 			bdsm.writeAttribute("gate", arpeggiatorGate);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1377,11 +1377,11 @@ weAreInArrangementEditorOrInClipInstance:
 	damping = std::min(damping, (uint32_t)2147483647);
 	width = std::min(width, (uint32_t)2147483647);
 
-	bdsm.writeAttribute("model", util::to_underlying(model));
 	bdsm.writeAttribute("roomSize", roomSize);
 	bdsm.writeAttribute("dampening", damping);
 	bdsm.writeAttribute("width", width);
 	bdsm.writeAttribute("pan", AudioEngine::reverbPan);
+	bdsm.writeAttribute("model", util::to_underlying(model));
 	bdsm.writeOpeningTagEnd();
 
 	bdsm.writeOpeningTagBeginning("compressor");

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -685,7 +685,7 @@ Error Sound::readTagFromFile(StorageManager& bdsm, char const* tagName, ParamMan
 				}
 				bdsm.exitTag("arpMode");
 			}
-			else if (!strcmp(tagName, "mode") && bdsm.firmware_version < FirmwareVersion::community({1, 0, 0})) {
+			else if (!strcmp(tagName, "mode") && bdsm.firmware_version < FirmwareVersion::community({1, 1, 0})) {
 				// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
 				if (arpSettings) {
 					OldArpMode oldMode = stringToOldArpMode(bdsm.readTagOrAttributeValue());
@@ -3964,13 +3964,14 @@ void Sound::writeToFile(StorageManager& bdsm, bool savingSong, ParamManager* par
 
 	if (arpSettings) {
 		bdsm.writeOpeningTagBeginning("arpeggiator");
+		bdsm.writeAttribute("mode", arpPresetToOldArpMode(arpSettings.preset)); // For backwards compatibility
+		bdsm.writeAttribute("numOctaves", arpSettings->numOctaves);
+		bdsm.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", arpSettings->syncLevel);
+		bdsm.writeSyncTypeToFile(currentSong, "syncType", arpSettings->syncType);
 		bdsm.writeAttribute("arpMode", arpModeToString(arpSettings->mode));
 		bdsm.writeAttribute("noteMode", arpNoteModeToString(arpSettings->noteMode));
 		bdsm.writeAttribute("octaveMode", arpOctaveModeToString(arpSettings->octaveMode));
 		bdsm.writeAttribute("mpeVelocity", arpMpeModSourceToString(arpSettings->mpeVelocity));
-		bdsm.writeAttribute("numOctaves", arpSettings->numOctaves);
-		bdsm.writeSyncTypeToFile(currentSong, "syncType", arpSettings->syncType);
-		bdsm.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", arpSettings->syncLevel);
 		bdsm.closeTag();
 	}
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3964,7 +3964,7 @@ void Sound::writeToFile(StorageManager& bdsm, bool savingSong, ParamManager* par
 
 	if (arpSettings) {
 		bdsm.writeOpeningTagBeginning("arpeggiator");
-		bdsm.writeAttribute("mode", arpPresetToOldArpMode(arpSettings.preset)); // For backwards compatibility
+		bdsm.writeAttribute("mode", arpPresetToOldArpMode(arpSettings->preset)); // For backwards compatibility
 		bdsm.writeAttribute("numOctaves", arpSettings->numOctaves);
 		bdsm.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", arpSettings->syncLevel);
 		bdsm.writeSyncTypeToFile(currentSong, "syncType", arpSettings->syncType);

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1004,7 +1004,7 @@ char const* arpPresetToOldArpMode(ArpPreset preset) {
 	case ArpPreset::RANDOM:
 		return "random";
 
-	case ArpPreset::CUSTOM:
+	default:
 		// In case the user selected a Custom mode, we don't know how to convert it to
 		// the old mode so we default to "up" cause at least the arp is ON for sure
 		return "up";

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -987,6 +987,30 @@ char const* oldArpModeToString(OldArpMode mode) {
 	}
 }
 
+char const* arpPresetToOldArpMode(ArpPreset preset) {
+	switch (preset) {
+	case ArpPreset::OFF:
+		return "off";
+
+	case ArpPreset::UP:
+		return "up";
+
+	case ArpPreset::DOWN:
+		return "down";
+
+	case ArpPreset::BOTH:
+		return "both";
+
+	case ArpPreset::RANDOM:
+		return "random";
+
+	case ArpPreset::CUSTOM:
+		// In case the user selected a Custom mode, we don't know how to convert it to
+		// the old mode so we default to "up" cause at least the arp is ON for sure
+		return "up";
+	}
+}
+
 OldArpMode stringToOldArpMode(char const* string) {
 	if (!strcmp(string, "up")) {
 		return OldArpMode::UP;

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -158,6 +158,7 @@ ArpNoteMode oldModeToArpNoteMode(OldArpMode oldMode);
 ArpOctaveMode oldModeToArpOctaveMode(OldArpMode oldMode);
 
 char const* oldArpModeToString(OldArpMode mode);
+char const* arpPresetToOldArpMode(ArpPreset preset);
 OldArpMode stringToOldArpMode(char const* string);
 
 char const* arpModeToString(ArpMode mode);


### PR DESCRIPTION
To cherry pick (special attention to the use of bdsm)

This PR makes the arpeggiator save an approximation of the current mode settings to the old format, as we have the preset available. In case the user selected a custom config with different Note and Octave modes, we fall back to Mode::UP for the official firmware.

It also reorders how tags are written in the song file for Arpeggiator and for Reverb, so they are compatible (load correctly) with previous versions of the firmware