### PR TITLE
Fix renaming for 7SEG display for both Arranger tracks and kit rows

### DIFF
--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gui/ui/rename/rename_ui.h"
+#include "gui/ui/qwerty_ui.h"
 #include "hid/display/oled.h"
 
 RenameUI::RenameUI() {
@@ -24,7 +25,10 @@ RenameUI::RenameUI() {
 }
 
 void RenameUI::displayText(bool blinkImmediately) {
-	renderUIsForOled();
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+	QwertyUI::displayText(blinkImmediately);
 }
 
 void RenameUI::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {

--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -28,7 +28,9 @@ void RenameUI::displayText(bool blinkImmediately) {
 	if (display->haveOLED()) {
 		renderUIsForOled();
 	}
-	QwertyUI::displayText(blinkImmediately);
+	else {
+		QwertyUI::displayText(blinkImmediately);
+	}
 }
 
 void RenameUI::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/823

Now when renaming an arranger track or renaming a kit row, in 7SEG displays, it will show the name while you are typing it. Before, you were able to rename it anyways, the only problem was that the screen was not refreshing and showing the characters you were typing

To cherry pick