### PR TITLE
bug fix - offer learned cc's for song params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - Added indicators to the waveform loop lock feature for both 7seg (rightmost `.`) and OLED (lock indicator).
 - Modified waveform marker rendering to improve clarity.
 - Created a new menu hierarchies document that documents the Deluge menu structure for OLED and 7SEG and can be used as a reference for navigating the various menu's. See: [Menu Hierarchies](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/menu_hierarchies.md)
+- Added MIDI learning of Song Params
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -662,7 +662,7 @@ void Kit::renderOutput(ModelStack* modelStack, StereoSample* outputBuffer, Stere
 void Kit::offerReceivedCCToModControllable(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
                                            ModelStackWithTimelineCounter* modelStack) {
 	// NOTE: this call may change modelStack->timelineCounter etc!
-	ModControllableAudio::offerReceivedCCToLearnedParams(fromDevice, channel, ccNumber, value, modelStack);
+	ModControllableAudio::offerReceivedCCToLearnedParamsForClip(fromDevice, channel, ccNumber, value, modelStack);
 }
 void Kit::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
                                          ModelStackWithTimelineCounter* modelStack) {
@@ -681,7 +681,7 @@ void Kit::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel
 			Drum* thisDrum = thisNoteRow->drum;
 			if (thisDrum && thisDrum->type == DrumType::SOUND) {
 				((SoundDrum*)thisDrum)
-				    ->offerReceivedCCToLearnedParams(fromDevice, channel, ccNumber, value, modelStack, i);
+				    ->offerReceivedCCToLearnedParamsForClip(fromDevice, channel, ccNumber, value, modelStack, i);
 			}
 		}
 	}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1307,9 +1307,10 @@ ModelStackWithThreeMainThings* ModControllableAudio::addNoteRowIndexAndStuff(Mod
 	return modelStackWithThreeMainThings;
 }
 
-bool ModControllableAudio::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber,
-                                                          uint8_t value, ModelStackWithTimelineCounter* modelStack,
-                                                          int32_t noteRowIndex) {
+bool ModControllableAudio::offerReceivedCCToLearnedParamsForClip(MIDIDevice* fromDevice, uint8_t channel,
+                                                                 uint8_t ccNumber, uint8_t value,
+                                                                 ModelStackWithTimelineCounter* modelStack,
+                                                                 int32_t noteRowIndex) {
 	bool messageUsed = false;
 
 	// For each MIDI knob...
@@ -1409,10 +1410,99 @@ bool ModControllableAudio::offerReceivedCCToLearnedParams(MIDIDevice* fromDevice
 						automationView.possiblyRefreshAutomationEditorGrid(clip, kind, id);
 					}
 				}
-				// placeholder: if support is added for midi learning to song params, then you will need
-				// to possibly refresh the performance view display (see midi follow code below for doing this)
-				// you will need to check that you're dealing with a song param and not a clip param otherwise
-				// you may incorrectly refresh the performance view display
+			}
+		}
+	}
+	return messageUsed;
+}
+
+bool ModControllableAudio::offerReceivedCCToLearnedParamsForSong(
+    MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
+    ModelStackWithThreeMainThings* modelStackWithThreeMainThings) {
+	bool messageUsed = false;
+
+	// For each MIDI knob...
+	for (int32_t k = 0; k < midiKnobArray.getNumElements(); k++) {
+		MIDIKnob* knob = midiKnobArray.getElement(k);
+
+		// If this is the knob...
+		if (knob->midiInput.equalsNoteOrCC(fromDevice, channel, ccNumber)) {
+
+			messageUsed = true;
+
+			// See if this message is evidence that the knob is not "relative"
+			if (value >= 16 && value < 112) {
+				knob->relative = false;
+			}
+			// Only if this exact TimelineCounter is having automation step-edited, we can set the value for just a
+			// region.
+			int32_t modPos = 0;
+			int32_t modLength = 0;
+
+			ModelStackWithAutoParam* modelStackWithParam = getParamFromMIDIKnob(knob, modelStackWithThreeMainThings);
+
+			if (modelStackWithParam && modelStackWithParam->autoParam) {
+				int32_t newKnobPos;
+
+				int32_t previousValue =
+				    modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
+				int32_t knobPos =
+				    modelStackWithParam->paramCollection->paramValueToKnobPos(previousValue, modelStackWithParam);
+
+				if (knob->relative) {
+					int32_t offset = value;
+					if (offset >= 64) {
+						offset -= 128;
+					}
+					int32_t lowerLimit = std::min(-64_i32, knobPos);
+					newKnobPos = knobPos + offset;
+					newKnobPos = std::max(newKnobPos, lowerLimit);
+					newKnobPos = std::min(newKnobPos, 64_i32);
+					if (newKnobPos == knobPos) {
+						continue;
+					}
+				}
+				else {
+					// add 64 to internal knobPos to compare to midi cc value received
+					// if internal pos + 64 is greater than 127 (e.g. 128), adjust it to 127
+					// because midi can only send a max midi value of 127
+					int32_t knobPosForMidiValueComparison = knobPos + kKnobPosOffset;
+					if (knobPosForMidiValueComparison > kMaxMIDIValue) {
+						knobPosForMidiValueComparison = kMaxMIDIValue;
+					}
+
+					// is the cc being received for the same value as the current knob pos? If so, do nothing
+					if (value != knobPosForMidiValueComparison) {
+						newKnobPos = calculateKnobPosForMidiTakeover(modelStackWithParam, knobPos, value, knob);
+					}
+					else {
+						continue;
+					}
+				}
+
+				// Convert the New Knob Position to a Parameter Value
+				int32_t newValue =
+				    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
+
+				// Set the new Parameter Value for the MIDI Learned Parameter
+				modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, modPos,
+				                                                          modLength);
+
+				// check if you're currently editing the same learned param in automation view or
+				// performance view if so, you will need to refresh the automation editor grid or the
+				// performance view
+				RootUI* rootUI = getRootUI();
+				if (rootUI == &automationView || rootUI == &performanceSessionView) {
+					int32_t id = modelStackWithParam->paramId;
+					params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+
+					if (rootUI == &automationView) {
+						automationView.possiblyRefreshAutomationEditorGrid(nullptr, kind, id);
+					}
+					else {
+						possiblyRefreshPerformanceViewDisplay(kind, id, newKnobPos);
+					}
+				}
 			}
 		}
 	}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -89,8 +89,10 @@ public:
 	void endStutter(ParamManagerForTimeline* paramManager);
 	virtual ModFXType getModFXType() = 0;
 	virtual bool setModFXType(ModFXType newType);
-	bool offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
-	                                    ModelStackWithTimelineCounter* modelStack, int32_t noteRowIndex = -1);
+	bool offerReceivedCCToLearnedParamsForClip(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
+	                                           ModelStackWithTimelineCounter* modelStack, int32_t noteRowIndex = -1);
+	bool offerReceivedCCToLearnedParamsForSong(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
+	                                           ModelStackWithThreeMainThings* modelStackWithThreeMainThings);
 	void receivedCCFromMidiFollow(ModelStack* modelStack, Clip* clip, int32_t ccNumber, int32_t value);
 	void sendCCWithoutModelStackForMidiFollowFeedback(int32_t channel, bool isAutomation = false);
 	void sendCCForMidiFollowFeedback(int32_t channel, int32_t ccNumber, int32_t knobPos);

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -63,7 +63,7 @@ public:
 	// A TimelineCounter is required
 	void offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
 	                                    ModelStackWithTimelineCounter* modelStack) {
-		ModControllableAudio::offerReceivedCCToLearnedParams(fromDevice, channel, ccNumber, value, modelStack);
+		ModControllableAudio::offerReceivedCCToLearnedParamsForClip(fromDevice, channel, ccNumber, value, modelStack);
 	}
 	bool offerReceivedPitchBendToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
 	                                           ModelStackWithTimelineCounter* modelStack) {

--- a/src/deluge/processing/sound/sound_instrument.h
+++ b/src/deluge/processing/sound/sound_instrument.h
@@ -42,7 +42,7 @@ public:
 	// A timelineCounter is required
 	void offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
 	                                    ModelStackWithTimelineCounter* modelStack) {
-		Sound::offerReceivedCCToLearnedParams(fromDevice, channel, ccNumber, value, modelStack);
+		Sound::offerReceivedCCToLearnedParamsForClip(fromDevice, channel, ccNumber, value, modelStack);
 	}
 	bool offerReceivedPitchBendToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
 	                                           ModelStackWithTimelineCounter* modelStack) {


### PR DESCRIPTION
Fixed bug where you can learn a midi cc to a song param but the cc wasn't being offered to the song mod controllable by creating a new mod controllable audio function for offering the received cc to the song