### PR TITLE
Add Note Row Play Direction to Synth / Midi / CV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@
 - Modified waveform marker rendering to improve clarity.
 - Created a new menu hierarchies document that documents the Deluge menu structure for OLED and 7SEG and can be used as a reference for navigating the various menu's. See: [Menu Hierarchies](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/menu_hierarchies.md)
 - Added MIDI learning of Song Params
+- Added Synth/MIDI/CV clip configuration of note row play direction. Hold audition pad while entering the play direction menu to set the play direction for the selected note row. While in the note row play direction menu, you can select other note rows to quickly set the play directiom for multiple note rows.
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -910,6 +910,9 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
   i.e. the existing notes will not be deleted and the clipboard contents will be added to the existing notes.
   Positioning/scale/timing semantics have not changed, only whether the notes are cleared before pasting.
 
+#### 4.5.6 - Configure Note Row Play Direction
+- ([#1739]) Added Synth/MIDI/CV clip configuration of note row play direction. Hold audition pad while entering the play direction menu to set the play direction for the selected note row. While in the note row play direction menu, you can select other note rows to quickly set the play directiom for multiple note rows.
+
 ### 4.6 - Instrument Clip View - Kit Clip Features
 
 #### 4.6.1 - Keyboard View
@@ -1237,6 +1240,8 @@ different firmware
 [#1589]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1589
 
 [#1607]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1607
+
+[#1739]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1739
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -127,6 +127,7 @@ SoundEditor::SoundEditor() {
 	timeLastAttemptedAutomatedParamEdit = 0;
 	shouldGoUpOneLevelOnBegin = false;
 	setupKitGlobalFXMenu = false;
+	selectedNoteRow = false;
 }
 
 bool SoundEditor::editingKit() {

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -145,6 +145,8 @@ public:
 	// ui
 	UIType getUIType() { return UIType::SOUND_EDITOR; }
 
+	bool selectedNoteRow;
+
 private:
 	bool beginScreen(MenuItem* oldMenuItem = NULL);
 	uint8_t getActualParamFromScreen(uint8_t screen);

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2441,7 +2441,14 @@ doSilentAudition:
 			}
 
 			drawNoteCode = true;
+			bool lastAuditionedYDisplayChanged = instrumentClipView.lastAuditionedYDisplay != yDisplay;
 			instrumentClipView.lastAuditionedYDisplay = yDisplay;
+
+			// are we in a synth / midi / cv clip
+			// and have we changed our note row selection
+			if (!isKit && lastAuditionedYDisplayChanged) {
+				instrumentClipView.potentiallyRefreshNoteRowMenu();
+			}
 
 			// Begin resampling / output-recording
 			if (Buttons::isButtonPressed(hid::button::RECORD)

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -27,6 +27,7 @@
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/load/load_instrument_preset_ui.h"
+#include "gui/ui/menus.h"
 #include "gui/ui/rename/rename_drum_ui.h"
 #include "gui/ui/sample_marker_editor.h"
 #include "gui/ui/save/save_kit_row_ui.h"
@@ -3596,7 +3597,14 @@ doSilentAudition:
 			}
 
 			drawNoteCode(yDisplay);
+			bool lastAuditionedYDisplayChanged = lastAuditionedYDisplay != yDisplay;
 			lastAuditionedYDisplay = yDisplay;
+
+			// are we in a synth / midi / cv clip
+			// and have we changed our note row selection
+			if (!isKit && lastAuditionedYDisplayChanged) {
+				potentiallyRefreshNoteRowMenu();
+			}
 
 			// Begin resampling / output-recording
 			if (Buttons::isButtonPressed(deluge::hid::button::RECORD)
@@ -3636,6 +3644,19 @@ getOut:
 	// This has to happen after setSelectedDrum is called, cos that resets LEDs
 	if (!clipIsActiveOnInstrument && velocity) {
 		indicator_leds::indicateAlertOnLed(IndicatorLED::SESSION_VIEW);
+	}
+}
+
+void InstrumentClipView::potentiallyRefreshNoteRowMenu() {
+	// are we in the sound editor menu for a selected note row?
+	if (getCurrentUI() == &soundEditor && soundEditor.selectedNoteRow) {
+		MenuItem* currentMenuItem = soundEditor.getCurrentMenuItem();
+		// are we in the play direction menu?
+		if (currentMenuItem == &sequenceDirectionMenu) {
+			// if yes to all the above, then we want to refresh the menu
+			// to update play direction for the newly selected note row
+			currentMenuItem->readValueAgain();
+		}
 	}
 }
 

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -88,6 +88,7 @@ public:
 	int32_t getYVisualFromYDisplay(int32_t yDisplay);
 	int32_t getYVisualWithinOctaveFromYDisplay(int32_t yDisplay);
 	void auditionPadAction(int32_t velocity, int32_t yDisplay, bool shiftButtonDown);
+	void potentiallyRefreshNoteRowMenu();
 	void enterScaleMode(uint8_t yDisplay = 255);
 	void exitScaleMode();
 	void changeRootNote(uint8_t yDisplay);


### PR DESCRIPTION
Added note row config of play direction for synth / midi / cv clips.

Hold audition pad while entering play direction menu

This also allows for quickly setting play direction for multiple note rows while in the note row play direction menu. Auditioning different note rows will refresh the play direction menu to show the play direction setting for each note row

I think we should merge this to 1.1 since we removed the previous kit workaround for setting note row play direction