### PR TITLE
Bugfix - move force cull to old hard cull threshold

### DIFF
--- a/src/deluge/modulation/envelope.h
+++ b/src/deluge/modulation/envelope.h
@@ -34,7 +34,7 @@ public:
 	int32_t lastValuePreCurrentStage;
 	uint32_t timeEnteredState;
 	bool ignoredNoteOff;
-	uint32_t fastReleaseIncrement;
+	uint32_t fastReleaseIncrement{4096};
 	int32_t noteOn(bool directlyToDecay);
 	int32_t noteOn(uint8_t envelopeIndex, Sound* sound, Voice* voice);
 	void noteOff(uint8_t envelopeIndex, Sound* sound, ParamManagerForTimeline* paramManager);

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -399,7 +399,7 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 			numToCull = std::min(numToCull, numAudio + numVoice - MIN_VOICES);
 			for (int32_t i = 0; i < numToCull; i++) {
 				// hard cull (no release)
-				cullVoice(false, false, true, numSamples);
+				cullVoice(false, true, true, numSamples);
 			}
 
 #if ALPHA_OR_BETA_VERSION
@@ -409,12 +409,7 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 
 #endif
 		}
-		if (numSamplesOverLimit >= 5) {
 
-			// definitely do a soft cull (won't include audio clips)
-			cullVoice(false, true, true, numSamples);
-			logAction("forced cull");
-		}
 		// Or if it's just a little bit dire, do a soft cull with fade-out, but only cull for sure if numSamples
 		// is increasing
 		else if (numSamplesOverLimit >= -5) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -372,7 +372,7 @@ Debug::AverageDT rvb("reverb", Debug::uS);
 
 uint8_t numRoutines = 0;
 // used for culling
-constexpr int32_t numSamplesLimit = 42; // storageManager.devVarC;
+constexpr int32_t numSamplesLimit = 40; // storageManager.devVarC;
 // used for decisions in rendering engine
 constexpr int32_t direnessThreshold = numSamplesLimit - 20;
 
@@ -413,7 +413,7 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 
 		// Or if it's just a little bit dire, do a soft cull with fade-out, but only cull for sure if numSamples
 		// is increasing
-		else if (numSamplesOverLimit >= -5) {
+		else if (numSamplesOverLimit >= -6) {
 
 			// If not in first routine call this is inaccurate, so just release another voice since things are
 			// probably bad

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -435,7 +435,7 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 	numToCull = 0;
 
 	// don't smooth this - used for other decisions as well
-	if (numSamples >= direnessThreshold) { // 23
+	if (numSamples >= direnessThreshold) {
 
 		int32_t newDireness = numSamples - (direnessThreshold - 1);
 		if (newDireness > 14) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -386,6 +386,7 @@ int32_t numToCull = 0;
 // not in header (private to audio engine)
 /// determines how many voices to cull based on num audio samples, current voices and numSamplesLimit
 inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
+	numToCull = 0;
 	if (numAudio + numVoice > MIN_VOICES) {
 
 		int32_t numSamplesOverLimit = numSamples - numSamplesLimit;

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -171,8 +171,6 @@ void printLog();
 #endif
 int32_t getNumAudio();
 int32_t getNumVoices();
-Voice* cullVoice(bool saveVoice = false, bool justDoFastRelease = false, bool definitelyCull = false,
-                 size_t numSamples = 0);
 
 bool doSomeOutputting();
 void updateReverbParams();


### PR DESCRIPTION
Force cull is a less clicky hard cull. I'd placed it in between soft and hard culling, however there doesn't seem to be a downside to just doing it instead of hard culling. Worst case scenario the high load lasts through one more routine call which isn't really that bad, especially since if the render itself is slow we'll redo it immediately afterwards

Fix #1646 