### PR TITLE
song: limit backup param manager insertion to audio clips

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2097,7 +2097,8 @@ loadOutput:
 		}
 
 		if (thisOutput->clipInstances.getNumElements() == 0
-		    && getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)thisOutput, nullptr) == nullptr) {
+		    && getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)thisOutput, nullptr) == nullptr
+		    && thisOutput->type == OutputType::AUDIO) {
 			// This clip has no way to get a param manager, and no clips to help it out. Need to create a backup or
 			// things will go wrong later.
 			ParamManagerForTimeline paramManager{};


### PR DESCRIPTION
Other clip types already have recovery logic in other places.

Fixes #1730