### PR TITLE
Performance improvements - make a static voice array, limit each sounds polyphony to 16

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -253,11 +253,6 @@ constexpr int32_t kNumModulators = 2;
 
 constexpr int32_t kMaxNumVoicesUnison = 8;
 
-// TODO: Investigate whether we can move static voices to dynamic allocation and remove these
-constexpr int32_t kNumVoicesStatic = 24;
-constexpr int32_t kNumVoiceSamplesStatic = 20;
-constexpr int32_t kNumTimeStretchersStatic = 6;
-
 constexpr int32_t kMaxNumNoteOnsPending = 64;
 
 constexpr int32_t kNumUnsignedIntegersToRepPatchCables = 1;

--- a/src/deluge/modulation/envelope.h
+++ b/src/deluge/modulation/envelope.h
@@ -23,7 +23,7 @@
 class Sound;
 class Voice;
 class ParamManagerForTimeline;
-
+constexpr uint32_t SOFT_CULL_INCREMENT = 65536;
 class Envelope {
 public:
 	Envelope();

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -550,14 +550,8 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 	//  	D_PRINTLN(" samples but output ");
 	//  	D_PRINTLN(numSamples);
 	//  }
-	size_t smoothedSamples;
-	if (numSamples > numSamplesLastTime) {
-		smoothedSamples = (3 * numSamples + numSamplesLastTime) >> 2;
-	}
-	else {
-		smoothedSamples = numSamples;
-	}
-	setDireness(smoothedSamples);
+
+	setDireness(numSamples);
 
 	// when playback is enabled, blink play button to indicate high cpu usage
 	if (playbackHandler.isEitherClockActive() && cpuDireness >= 14) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -405,9 +405,9 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 			numToCull = std::min(numToCull, numAudio + numVoice - MIN_VOICES);
 			for (int32_t i = 0; i < numToCull; i++) {
 				// hard cull (no release)
-				cullVoice(false, HARD, numSamples, nullptr);
+				cullVoice(false, FORCE, numSamples, nullptr);
 			}
-			cullVoice(false, FORCE, numSamples, nullptr);
+			cullVoice(false, SOFT_ALWAYS, numSamples, nullptr);
 #if ALPHA_OR_BETA_VERSION
 
 			definitelyLog = true;
@@ -424,6 +424,12 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 			// probably bad
 			cullVoice(false, numRoutines == 0 ? SOFT : SOFT_ALWAYS, numSamples, nullptr);
 			logAction("soft cull");
+		}
+		// blink LED to alert the user
+		if (numSamplesOverLimit >= -6) {
+			if (indicator_leds::getLedBlinkerIndex(IndicatorLED::PLAY) == 255) {
+				indicator_leds::indicateAlertOnLed(IndicatorLED::PLAY);
+			}
 		}
 	}
 	else {
@@ -552,14 +558,6 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 	//  }
 
 	setDireness(numSamples);
-
-	// when playback is enabled, blink play button to indicate high cpu usage
-	if (playbackHandler.isEitherClockActive() && cpuDireness >= 14) {
-		// check if indicator isn't already active
-		if (indicator_leds::getLedBlinkerIndex(IndicatorLED::PLAY) == 255) {
-			indicator_leds::indicateAlertOnLed(IndicatorLED::PLAY);
-		}
-	}
 
 	// Double the number of samples we're going to do - within some constraints
 	int32_t sampleThreshold = 6; // If too low, it'll lead to bigger audio windows and stuff

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -107,6 +107,19 @@ int16_t zeroMPEValues[kNumExpressionDimensions] = {0, 0, 0};
 
 namespace AudioEngine {
 
+constexpr int32_t kNumVoicesStatic = 48;
+constexpr int32_t kNumVoiceSamplesStatic = 24;
+constexpr int32_t kNumTimeStretchersStatic = 24;
+// used for culling
+constexpr int32_t numSamplesLimit = 40; // storageManager.devVarC;
+// used for decisions in rendering engine
+constexpr int32_t direnessThreshold = numSamplesLimit - 20;
+
+// 7 can overwhelm SD bandwidth if we schedule the loads badly. It could be improved by starting future loads
+// earlier for now we provide an outlet in culling a single voice if we're under MIN_VOICES and still getting close
+// to the limit
+constexpr int MIN_VOICES = 5;
+
 dsp::Reverb reverb{};
 PLACE_INTERNAL_FRUNK SideChain reverbSidechain{};
 int32_t reverbSidechainVolume;
@@ -181,8 +194,9 @@ VoiceSample* firstUnassignedVoiceSample = voiceSamples;
 
 TimeStretcher timeStretchers[kNumTimeStretchersStatic] = {};
 TimeStretcher* firstUnassignedTimeStretcher = timeStretchers;
-
-Voice* firstUnassignedVoice;
+Voice staticVoices[kNumVoicesStatic] = {};
+/// will be garbage, reconstruct when used
+Voice* firstUnassignedVoice = staticVoices;
 
 // You must set up dynamic memory allocation before calling this, because of its call to setupWithPatching()
 void init() {
@@ -211,6 +225,9 @@ void init() {
 	for (int32_t i = 0; i < kNumTimeStretchersStatic; i++) {
 		timeStretchers[i].nextUnassigned = (i == kNumTimeStretchersStatic - 1) ? NULL : &timeStretchers[i + 1];
 	}
+	for (int32_t i = 0; i < kNumVoicesStatic; i++) {
+		staticVoices[i].nextUnassigned = (i == kNumVoicesStatic - 1) ? NULL : &staticVoices[i + 1];
+	}
 
 	i2sTXBufferPos = (uint32_t)getTxBufferStart();
 
@@ -223,9 +240,7 @@ void unassignAllVoices(bool deletingSong) {
 
 	for (int32_t v = 0; v < activeVoices.getNumElements(); v++) {
 		Voice* thisVoice = activeVoices.getVoice(v);
-
-		thisVoice->setAsUnassigned(NULL, deletingSong);
-		disposeOfVoice(thisVoice);
+		unassignVoice(thisVoice, thisVoice->assignedToSound, nullptr);
 	}
 	activeVoices.empty();
 
@@ -255,7 +270,7 @@ enum CullType { HARD, FORCE, SOFT_ALWAYS, SOFT };
 
 // To be called when CPU is overloaded and we need to free it up. This stops the voice which has been
 // releasing longest, or if none, the voice playing longest.
-Voice* cullVoice(bool saveVoice, CullType type, size_t numSamples) {
+Voice* cullVoice(bool saveVoice, CullType type, size_t numSamples, Sound* stopFrom) {
 	// Only include audio if doing a hard cull and not saving the voice
 	bool includeAudio = !saveVoice && type == HARD;
 	// Skip releasing voices if doing a soft cull and definitely culling
@@ -269,9 +284,13 @@ Voice* cullVoice(bool saveVoice, CullType type, size_t numSamples) {
 
 		if (ratingThisVoice > bestRating) {
 			// if we're not skipping releasing voices, or if we are and this one isn't in fast release
-			if (!skipReleasing || thisVoice->envelopes[0].fastReleaseIncrement < 65536) {
-				bestRating = ratingThisVoice;
-				bestVoice = thisVoice;
+			if (!skipReleasing
+			    || (thisVoice->envelopes[0].state <= EnvelopeStage::FAST_RELEASE
+			        && thisVoice->envelopes[0].fastReleaseIncrement < SOFT_CULL_INCREMENT)) {
+				if (stopFrom == nullptr || thisVoice->assignedToSound == stopFrom) {
+					bestRating = ratingThisVoice;
+					bestVoice = thisVoice;
+				}
 			}
 		}
 	}
@@ -286,8 +305,8 @@ Voice* cullVoice(bool saveVoice, CullType type, size_t numSamples) {
 		case SOFT_ALWAYS:
 		case SOFT: {
 			if (bestVoice->envelopes[0].state < EnvelopeStage::FAST_RELEASE
-			    || bestVoice->envelopes[0].fastReleaseIncrement < 65536) {
-				bool stillGoing = bestVoice->doFastRelease(65536);
+			    || bestVoice->envelopes[0].fastReleaseIncrement < SOFT_CULL_INCREMENT) {
+				bool stillGoing = bestVoice->doFastRelease(SOFT_CULL_INCREMENT);
 
 				if (!stillGoing) {
 					unassignVoice(bestVoice, bestVoice->assignedToSound);
@@ -368,23 +387,11 @@ Debug::AverageDT rvb("reverb", Debug::uS);
 #endif
 
 uint8_t numRoutines = 0;
-// used for culling
-constexpr int32_t numSamplesLimit = 40; // storageManager.devVarC;
-// used for decisions in rendering engine
-constexpr int32_t direnessThreshold = numSamplesLimit - 20;
-
-// 7 can overwhelm SD bandwidth if we schedule the loads badly. It could be improved by starting future loads
-// earlier for now we provide an outlet in culling a single voice if we're under MIN_VOICES and still getting close
-// to the limit
-constexpr int MIN_VOICES = 5;
-
-// global (to this file) because it's used for determining whether to solicit voices via culling as well
-int32_t numToCull = 0;
 
 // not in header (private to audio engine)
 /// determines how many voices to cull based on num audio samples, current voices and numSamplesLimit
 inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
-	numToCull = 0;
+	int32_t numToCull = 0;
 	if (numAudio + numVoice > MIN_VOICES) {
 
 		int32_t numSamplesOverLimit = numSamples - numSamplesLimit;
@@ -398,9 +405,9 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 			numToCull = std::min(numToCull, numAudio + numVoice - MIN_VOICES);
 			for (int32_t i = 0; i < numToCull; i++) {
 				// hard cull (no release)
-				cullVoice(false, HARD, numSamples);
+				cullVoice(false, HARD, numSamples, nullptr);
 			}
-			cullVoice(false, FORCE, numSamples);
+			cullVoice(false, FORCE, numSamples, nullptr);
 #if ALPHA_OR_BETA_VERSION
 
 			definitelyLog = true;
@@ -415,7 +422,7 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 
 			// If not in first routine call this is inaccurate, so just release another voice since things are
 			// probably bad
-			cullVoice(false, numRoutines == 0 ? SOFT : SOFT_ALWAYS, numSamples);
+			cullVoice(false, numRoutines == 0 ? SOFT : SOFT_ALWAYS, numSamples, nullptr);
 			logAction("soft cull");
 		}
 	}
@@ -424,7 +431,7 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 		// If it's real dire, do a proper immediate cull
 		if (numSamplesOverLimit >= 10) {
 			D_PRINTLN("under min voices but culling anyway");
-			cullVoice(false, FORCE, numSamples);
+			cullVoice(false, FORCE, numSamples, nullptr);
 		}
 	}
 }
@@ -432,7 +439,6 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 // not in header (private to audio engine)
 /// set the direness level and cull any voices
 inline void setDireness(size_t numSamples) { // Consider direness and culling - before increasing the number of samples
-	numToCull = 0;
 
 	// don't smooth this - used for other decisions as well
 	if (numSamples >= direnessThreshold) {
@@ -463,8 +469,8 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 			}
 		}
 	}
-
-	else if (numSamples < direnessThreshold - 10) {
+	// otherwise lower it (with some hysteresis to avoid jittering
+	else if (numSamples < direnessThreshold - 3) {
 
 		if ((int32_t)(audioSampleTimer - timeDirenessChanged) >= (kSampleRate >> 3)) { // Only if it's been long enough
 			timeDirenessChanged = audioSampleTimer;
@@ -1281,27 +1287,20 @@ void getReverbParamsFromSong(Song* song) {
 Voice* solicitVoice(Sound* forSound) {
 
 	Voice* newVoice;
-	// if we're gonna hard cull, just do it now instead of allocating
-	if (cpuDireness > 13 && numToCull > 0) {
 
-		cpuDireness -= 1; // Stop this triggering for lots of new voices. We just don't know how they'll weigh
-		                  // up to the ones being culled
-		D_PRINTLN("soliciting via culling");
-doCull:
-		newVoice = cullVoice(true, HARD, numSamplesLastTime);
-	}
-
-	else if (firstUnassignedVoice) {
-
+	if (firstUnassignedVoice) {
 		newVoice = firstUnassignedVoice;
+		// reconstruct it
+		new (newVoice) Voice();
 		firstUnassignedVoice = firstUnassignedVoice->nextUnassigned;
 	}
 
 	else {
+
 		void* memory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(Voice));
 		if (!memory) {
 			if (activeVoices.getNumElements()) {
-				goto doCull;
+				memory = cullVoice(true, HARD, numSamplesLastTime, forSound);
 			}
 			else {
 				return NULL;
@@ -1324,6 +1323,10 @@ doCull:
 		disposeOfVoice(newVoice);
 		return NULL;
 	}
+	/// @todo: maybe this should be configurable between 4/8/16/unlimited?
+	if (forSound->numVoicesAssigned > 16) {
+		cullVoice(false, SOFT_ALWAYS, numSamplesLastTime, forSound);
+	}
 	return newVoice;
 }
 
@@ -1335,7 +1338,7 @@ void unassignVoice(Voice* voice, Sound* sound, ModelStackWithSoundFlags* modelSt
 
 	activeVoices.checkVoiceExists(voice, sound, "E195");
 
-	voice->setAsUnassigned(modelStack->addVoice(voice));
+	voice->setAsUnassigned(modelStack ? modelStack->addVoice(voice) : nullptr);
 	if (removeFromVector) {
 		uint32_t keyWords[2];
 		keyWords[0] = (uint32_t)sound;
@@ -1344,7 +1347,13 @@ void unassignVoice(Voice* voice, Sound* sound, ModelStackWithSoundFlags* modelSt
 	}
 
 	if (shouldDispose) {
-		disposeOfVoice(voice);
+		if (voice >= staticVoices && voice < &staticVoices[kNumVoicesStatic]) {
+			voice->nextUnassigned = firstUnassignedVoice;
+			firstUnassignedVoice = voice;
+		}
+		else {
+			disposeOfVoice(voice);
+		}
 	}
 }
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -240,7 +240,7 @@ void unassignAllVoices(bool deletingSong) {
 
 	for (int32_t v = 0; v < activeVoices.getNumElements(); v++) {
 		Voice* thisVoice = activeVoices.getVoice(v);
-		unassignVoice(thisVoice, thisVoice->assignedToSound, nullptr);
+		unassignVoice(thisVoice, thisVoice->assignedToSound, nullptr, false);
 	}
 	activeVoices.empty();
 


### PR DESCRIPTION
Static voice array - pre allocate 48 voices to avoid allocations during renders. This eliminates the issue of allocating voices for multiple simultaneous note ons causing clicks. Note that if the new voices are heavy the sudden increase in render time can still lead to a click. 

16 note polyphony limit - when a 17th note for the same sound is started, soft cull one voice from that sound

These two changes combine to eliminate all clicks in @seangoodvibes test song Outdoor_Bells