### PR TITLE
Bugfix - automation view crash

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -426,6 +426,17 @@ void AutomationView::initializeView() {
 				clip->lastSelectedOutputType = outputType;
 			}
 
+			// if we're in a kit, we want to make sure the param selected is valid for current context
+			// e.g. only UNPATCHED_GLOBAL param kind's can be used with Kit Affect Entire enabled
+			if ((outputType == OutputType::KIT) && (clip->lastSelectedParamKind != params::Kind::NONE)) {
+				if (clip->lastSelectedParamKind == params::Kind::UNPATCHED_GLOBAL) {
+					clip->affectEntire = true;
+				}
+				else {
+					clip->affectEntire = false;
+				}
+			}
+
 			if (clip->wrapEditing) { // turn led off if it's on
 				indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
 			}


### PR DESCRIPTION
1) Fixed crash bug where automation view would crash if a non-global param was previously selected and affect entire is enabled when entering automation view (it would crash because it would try to get a model stack with param for the affect entire context with a non global effectable param. 

Fixed it by checking the param Kind when initializing automation view and setting the affect entire state to match the param kind selection.

Fix #1754 