### PR TITLE
columns: save state of control columns per clip

### DIFF
--- a/src/deluge/gui/ui/keyboard/column_controls/chord_mem.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/chord_mem.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "chord_mem.h"
+#include "gui/ui/keyboard/layout/column_controls.h"
 #include "hid/buttons.h"
 #include "model/song/song.h"
 
@@ -23,9 +24,9 @@ namespace deluge::gui::ui::keyboard::controls {
 
 void ChordMemColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
 	uint8_t otherChannels = 0;
-	for (int32_t y = 0; y < kDisplayHeight; ++y) {
+	for (int32_t y = 0; y < kDisplayHeight; y++) {
 		bool chord_selected = y == activeChordMem;
-		uint8_t chord_slot_filled = currentSong->chordMemNoteCount[y] > 0 ? 0x7f : 0;
+		uint8_t chord_slot_filled = chordMemNoteCount[y] > 0 ? 0x7f : 0;
 		otherChannels = chord_selected ? 0xf0 : 0;
 		uint8_t base = chord_selected ? 0xff : chord_slot_filled;
 		image[y][column] = {otherChannels, base, base};
@@ -45,24 +46,87 @@ void ChordMemColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTime
 
 	if (pad.active) {
 		activeChordMem = pad.y;
-		auto noteCount = currentSong->chordMemNoteCount[pad.y];
-		for (int i = 0; i < noteCount && i < MAX_NOTES_CHORD_MEM; i++) {
-			currentNotesState.enableNote(currentSong->chordMem[pad.y][i], layout->velocity);
+		auto noteCount = chordMemNoteCount[pad.y];
+		for (int i = 0; i < noteCount && i < kMaxNotesChordMem; i++) {
+			currentNotesState.enableNote(chordMem[pad.y][i], layout->velocity);
 		}
-		currentSong->chordMemNoteCount[pad.y] = noteCount;
+		chordMemNoteCount[pad.y] = noteCount;
 	}
 	else {
 		activeChordMem = 0xFF;
-		if ((!currentSong->chordMemNoteCount[pad.y] || Buttons::isShiftButtonPressed()) && currentNotesState.count) {
+		if ((!chordMemNoteCount[pad.y] || Buttons::isShiftButtonPressed()) && currentNotesState.count) {
 			auto noteCount = currentNotesState.count;
-			for (int i = 0; i < noteCount && i < MAX_NOTES_CHORD_MEM; i++) {
-				currentSong->chordMem[pad.y][i] = currentNotesState.notes[i].note;
+			for (int i = 0; i < noteCount && i < kMaxNotesChordMem; i++) {
+				chordMem[pad.y][i] = currentNotesState.notes[i].note;
 			}
-			currentSong->chordMemNoteCount[pad.y] = noteCount;
+			chordMemNoteCount[pad.y] = noteCount;
 		}
 		else if (Buttons::isShiftButtonPressed()) {
-			currentSong->chordMemNoteCount[pad.y] = 0;
+			chordMemNoteCount[pad.y] = 0;
 		}
 	}
 };
+
+void ChordMemColumn::writeToFile(Serializer& writer) {
+	int num = 0;
+	for (int32_t y = 0; y < kDisplayHeight; y++) {
+		if (chordMemNoteCount[y] > 0) {
+			num = y + 1;
+		}
+	}
+
+	if (num == 0) {
+		return; // no state to save
+	}
+
+	writer.writeOpeningTag("chordMem");
+	for (int32_t y = 0; y < num; y++) {
+		writer.writeOpeningTag("chordSlot");
+		for (int i = 0; i < chordMemNoteCount[y]; i++) {
+			writer.writeOpeningTagBeginning("note");
+			writer.writeAttribute("code", chordMem[y][i]);
+			writer.closeTag();
+		}
+		writer.writeClosingTag("chordSlot");
+	}
+	writer.writeClosingTag("chordMem");
+}
+
+void ChordMemColumn::readFromFile(Deserializer& reader) {
+	int slot_index = 0;
+	const char* tagName;
+	while (*(tagName = reader.readNextTagOrAttributeName())) {
+		if (!strcmp(tagName, "chordSlot")) {
+			int y = slot_index++;
+			if (y >= 8) {
+				reader.exitTag("chordSlot");
+				continue;
+			}
+			int i = 0;
+			while (*(tagName = reader.readNextTagOrAttributeName())) {
+				if (!strcmp(tagName, "note")) {
+					while (*(tagName = reader.readNextTagOrAttributeName())) {
+						if (!strcmp(tagName, "code")) {
+							if (i < kMaxNotesChordMem) {
+								chordMem[y][i] = reader.readTagOrAttributeValueInt();
+							}
+						}
+						else {
+							reader.exitTag();
+						}
+					}
+					i++;
+				}
+				else {
+					reader.exitTag();
+				}
+			}
+			chordMemNoteCount[y] = std::min(8, i);
+		}
+		else {
+			reader.exitTag();
+		}
+	}
+}
+
 } // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/chord_mem.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/chord_mem.h
@@ -18,9 +18,11 @@
 #pragma once
 
 #include "gui/ui/keyboard/column_controls/control_column.h"
+#include "storage/storage_manager.h"
 
 namespace deluge::gui::ui::keyboard::controls {
 
+constexpr int32_t kMaxNotesChordMem = 10;
 class ChordMemColumn : public ControlColumn {
 public:
 	ChordMemColumn() = default;
@@ -32,7 +34,12 @@ public:
 	void handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
 	               KeyboardLayout* layout) override;
 
+	void writeToFile(Serializer& writer);
+	void readFromFile(Deserializer& reader);
+
 private:
+	uint8_t chordMemNoteCount[8] = {0};
+	uint8_t chordMem[8][kMaxNotesChordMem] = {0};
 	uint8_t activeChordMem = 0xFF;
 };
 

--- a/src/deluge/gui/ui/keyboard/column_controls/control_column.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/control_column.h
@@ -18,9 +18,12 @@
 #pragma once
 
 #include "gui/colour/rgb.h"
-#include "gui/ui/keyboard/layout.h"
 #include "gui/ui/keyboard/notes_state.h"
 #include "model/model_stack.h"
+
+namespace deluge::gui::ui::keyboard {
+class KeyboardLayout;
+}
 
 namespace deluge::gui::ui::keyboard::controls {
 

--- a/src/deluge/gui/ui/keyboard/layout/column_control_state.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_control_state.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/keyboard/column_controls/chord.h"
+#include "gui/ui/keyboard/column_controls/chord_mem.h"
+#include "gui/ui/keyboard/column_controls/dx.h"
+#include "gui/ui/keyboard/column_controls/mod.h"
+#include "gui/ui/keyboard/column_controls/scale_mode.h"
+#include "gui/ui/keyboard/column_controls/velocity.h"
+
+namespace deluge::gui::ui::keyboard::layout {
+
+enum ColumnControlFunction : int8_t {
+	VELOCITY = 0,
+	MOD,
+	CHORD,
+	CHORD_MEM,
+	SCALE_MODE,
+	DX,
+	// BEAT_REPEAT,
+	COL_CTRL_FUNC_MAX,
+};
+
+using namespace deluge::gui::ui::keyboard::controls;
+
+struct ColumnControlState {
+	VelocityColumn velocityColumn{64};
+
+	ModColumn modColumn{};
+	ChordColumn chordColumn{};
+	ChordMemColumn chordMemColumn{};
+	ScaleModeColumn scaleModeColumn{};
+	DXColumn dxColumn{};
+
+	ColumnControlFunction leftColFunc = VELOCITY;
+	ColumnControlFunction rightColFunc = MOD;
+	bool rightColSetAtRuntime = false;
+	ControlColumn* leftCol = &velocityColumn;
+	ControlColumn* rightCol = &modColumn;
+
+	ControlColumn* getColumnForFunc(ColumnControlFunction func);
+
+	void writeToFile(Serializer& writer);
+	void readFromFile(Deserializer& reader);
+};
+
+} // namespace deluge::gui::ui::keyboard::layout

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.h
@@ -17,13 +17,8 @@
 
 #pragma once
 
-#include "gui/ui/keyboard/column_controls/chord.h"
-#include "gui/ui/keyboard/column_controls/chord_mem.h"
-#include "gui/ui/keyboard/column_controls/dx.h"
-#include "gui/ui/keyboard/column_controls/mod.h"
-#include "gui/ui/keyboard/column_controls/scale_mode.h"
-#include "gui/ui/keyboard/column_controls/velocity.h"
 #include "gui/ui/keyboard/layout.h"
+#include "gui/ui/keyboard/layout/column_control_state.h"
 
 namespace deluge::gui::ui::keyboard::layout {
 
@@ -32,17 +27,6 @@ using namespace deluge::gui::ui::keyboard::controls;
 constexpr int32_t kMinIsomorphicRowInterval = 1;
 constexpr int32_t kMaxIsomorphicRowInterval = 16;
 constexpr uint32_t kHalfStep = 0x7FFFFF;
-
-enum ColumnControlFunction : int8_t {
-	VELOCITY = 0,
-	MOD,
-	CHORD,
-	CHORD_MEM,
-	SCALE_MODE,
-	DX,
-	// BEAT_REPEAT,
-	COL_CTRL_FUNC_MAX,
-};
 
 ColumnControlFunction nextControlFunction(ColumnControlFunction cur, ColumnControlFunction skip);
 ColumnControlFunction prevControlFunction(ColumnControlFunction cur, ColumnControlFunction skip);
@@ -87,24 +71,7 @@ public:
 
 	void checkNewInstrument(Instrument* newInstrument) override;
 
-	VelocityColumn velocityColumn{velocity};
-
-private:
-	ModColumn modColumn{};
-	ChordColumn chordColumn{};
-	ChordMemColumn chordMemColumn{};
-	ScaleModeColumn scaleModeColumn{};
-	DXColumn dxColumn{};
-
 	void renderColumnBeatRepeat(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column);
-
-	ColumnControlFunction leftColFunc = VELOCITY;
-	ColumnControlFunction rightColFunc = MOD;
-	bool rightColSetAtRuntime = false;
-	ControlColumn* leftCol = &velocityColumn;
-	ControlColumn* rightCol = &modColumn;
-
-	ControlColumn* getColumnForFunc(ColumnControlFunction func);
 
 	int8_t leftColHeld = -1;
 	int8_t rightColHeld = -1;

--- a/src/deluge/gui/ui/keyboard/state_data.h
+++ b/src/deluge/gui/ui/keyboard/state_data.h
@@ -17,6 +17,7 @@
 
 #pragma once
 #include "definitions_cxx.hpp"
+#include "gui/ui/keyboard/layout/column_control_state.h"
 #include "storage/flash_storage.h"
 
 namespace deluge::gui::ui::keyboard {
@@ -47,6 +48,8 @@ struct KeyboardState {
 	KeyboardStateIsomorphic isomorphic;
 	KeyboardStateDrums drums;
 	KeyboardStateInKey inKey;
+
+	layout::ColumnControlState columnControl;
 };
 
 }; // namespace deluge::gui::ui::keyboard

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2396,6 +2396,10 @@ void InstrumentClip::writeDataToFile(Serializer& writer, Song* song) {
 		}
 	}
 
+	writer.writeOpeningTag("columnControls");
+	keyboardState.columnControl.writeToFile(writer);
+	writer.writeClosingTag("columnControls");
+
 	if (noteRows.getNumElements()) {
 		writer.writeOpeningTag("noteRows");
 
@@ -2904,7 +2908,9 @@ doReadBendRange:
 			temp = BEND_RANGE_FINGER_LEVEL;
 			goto doReadBendRange;
 		}
-
+		else if (!strcmp(tagName, "columnControls")) {
+			keyboardState.columnControl.readFromFile(reader);
+		}
 		else {
 			readTagFromFile(reader, tagName, song, &readAutomationUpToPos);
 		}


### PR DESCRIPTION
Previously,
State for sidebars would just implicitly be associated with KeyboardLayout class. This moves the state to be specific per clip, just like other keyboard state.

Also implement loading/saving of this state as part as .xml song files