### PR TITLE
Refactor/rearrange tags written in XMLs so the songs load ok in official firmware

### DIFF
--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1002,7 +1002,7 @@ bool AudioClip::renderAsSingleRow(ModelStackWithTimelineCounter* modelStack, Tim
 	return true;
 }
 
-void AudioClip::writeDataToFile(Song* song) {
+bool AudioClip::writeDataToFile(Song* song) {
 
 	storageManager.writeAttribute("trackName", output->name.get());
 
@@ -1042,11 +1042,17 @@ void AudioClip::writeDataToFile(Song* song) {
 
 	Clip::writeDataToFile(song);
 
+	storageManager.writeOpeningTagEnd();
+
+	Clip::writeMidiCommandsToFile(song);
+
 	storageManager.writeOpeningTagBeginning("params");
 	GlobalEffectableForClip::writeParamAttributesToFile(&paramManager, true);
 	storageManager.writeOpeningTagEnd();
 	GlobalEffectableForClip::writeParamTagsToFile(&paramManager, true);
 	storageManager.writeClosingTag("params");
+
+	return true;
 }
 
 Error AudioClip::readFromFile(Song* song) {

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -82,7 +82,7 @@ public:
 	bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount);
 
 	Error readFromFile(Song* song);
-	void writeDataToFile(Song* song);
+	bool writeDataToFile(Song* song);
 	char const* getXMLTag() { return "audioClip"; }
 
 	SampleControls sampleControls;

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -649,12 +649,18 @@ void Clip::writeToFile(Song* song) {
 
 	storageManager.writeOpeningTagBeginning(xmlTag);
 
-	writeDataToFile(song);
+	bool endedOpeningTag = writeDataToFile(song);
+
+	if (!endedOpeningTag) {
+		bdsm.writeOpeningTagEnd();
+	}
+
+	Clip::writeMidiCommandsToFile(song);
 
 	storageManager.writeClosingTag(xmlTag);
 }
 
-void Clip::writeDataToFile(Song* song) {
+bool Clip::writeDataToFile(Song* song) {
 
 	storageManager.writeAttribute("isPlaying", activeIfNoSolo);
 	storageManager.writeAttribute("isSoloing", soloingInSessionMode);
@@ -684,8 +690,11 @@ void Clip::writeDataToFile(Song* song) {
 	if (launchStyle != LaunchStyle::DEFAULT) {
 		storageManager.writeAttribute("launchStyle", launchStyleToString(launchStyle));
 	}
-	storageManager.writeOpeningTagEnd();
 
+	return false;
+}
+
+void Clip::writeMidiCommandsToFile(Song* song) {
 	muteMIDICommand.writeNoteToFile("muteMidiCommand");
 }
 

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -652,7 +652,7 @@ void Clip::writeToFile(Song* song) {
 	bool endedOpeningTag = writeDataToFile(song);
 
 	if (!endedOpeningTag) {
-		bdsm.writeOpeningTagEnd();
+		storageManager.writeOpeningTagEnd();
 	}
 
 	Clip::writeMidiCommandsToFile(song);

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -108,7 +108,8 @@ public:
 	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack);
 
 	void writeToFile(Song* song);
-	virtual void writeDataToFile(Song* song);
+	virtual bool writeDataToFile(Song* song);
+	void writeMidiCommandsToFile(Song* song);
 	virtual char const* getXMLTag() = 0;
 	virtual Error readFromFile(Song* song) = 0;
 	void readTagFromFile(char const* tagName, Song* song, int32_t* readAutomationUpToPos);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2345,13 +2345,14 @@ void InstrumentClip::writeDataToFile(Song* song) {
 
 	if (output->type != OutputType::KIT) {
 		storageManager.writeOpeningTagBeginning("arpeggiator");
+		storageManager.writeAttribute("mode", (char*)arpPresetToOldArpMode(arpSettings.preset)); // For backwards compatibility
+		storageManager.writeAttribute("syncLevel", arpSettings.syncLevel);
+		storageManager.writeAttribute("syncType", arpSettings.syncType);
+		storageManager.writeAttribute("numOctaves", arpSettings.numOctaves);
 		storageManager.writeAttribute("arpMode", (char*)arpModeToString(arpSettings.mode));
 		storageManager.writeAttribute("noteMode", (char*)arpNoteModeToString(arpSettings.noteMode));
 		storageManager.writeAttribute("octaveMode", (char*)arpOctaveModeToString(arpSettings.octaveMode));
-		storageManager.writeAttribute("numOctaves", arpSettings.numOctaves);
 		storageManager.writeAttribute("mpeVelocity", (char*)arpMpeModSourceToString(arpSettings.mpeVelocity));
-		storageManager.writeAttribute("syncLevel", arpSettings.syncLevel);
-		storageManager.writeAttribute("syncType", arpSettings.syncType);
 
 		if (output->type == OutputType::MIDI_OUT || output->type == OutputType::CV) {
 			storageManager.writeAttribute("gate", arpeggiatorGate);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2330,6 +2330,8 @@ void InstrumentClip::writeDataToFile(Song* song) {
 		}
 	}
 
+	Clip::writeDataToFile(song);
+
 	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
 	storageManager.writeAttribute("keyboardLayout", keyboardState.currentLayout);
 	storageManager.writeAttribute("keyboardRowInterval", keyboardState.isomorphic.rowInterval);
@@ -2337,8 +2339,6 @@ void InstrumentClip::writeDataToFile(Song* song) {
 	storageManager.writeAttribute("drumsEdgeSize", keyboardState.drums.edgeSize);
 	storageManager.writeAttribute("inKeyScrollOffset", keyboardState.inKey.scrollOffset);
 	storageManager.writeAttribute("inKeyRowInterval", keyboardState.inKey.rowInterval);
-
-	Clip::writeDataToFile(song);
 
 	if (output->type == OutputType::MIDI_OUT) {
 		paramManager.getMIDIParamCollection()->writeToFile();

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2273,16 +2273,9 @@ Error InstrumentClip::setAudioInstrument(Instrument* newInstrument, Song* song, 
 }
 
 void InstrumentClip::writeDataToFile(Song* song) {
-
 	storageManager.writeAttribute("inKeyMode", inScaleMode);
 	storageManager.writeAttribute("yScroll", yScroll);
-	storageManager.writeAttribute("keyboardLayout", keyboardState.currentLayout);
 	storageManager.writeAttribute("yScrollKeyboard", keyboardState.isomorphic.scrollOffset);
-	storageManager.writeAttribute("keyboardRowInterval", keyboardState.isomorphic.rowInterval);
-	storageManager.writeAttribute("drumsScrollOffset", keyboardState.drums.scrollOffset);
-	storageManager.writeAttribute("drumsEdgeSize", keyboardState.drums.edgeSize);
-	storageManager.writeAttribute("inKeyScrollOffset", keyboardState.inKey.scrollOffset);
-	storageManager.writeAttribute("inKeyRowInterval", keyboardState.inKey.rowInterval);
 
 	if (onKeyboardScreen) {
 		storageManager.writeAttribute("onKeyboardScreen", (char*)"1");
@@ -2337,6 +2330,14 @@ void InstrumentClip::writeDataToFile(Song* song) {
 		}
 	}
 
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	storageManager.writeAttribute("keyboardLayout", keyboardState.currentLayout);
+	storageManager.writeAttribute("keyboardRowInterval", keyboardState.isomorphic.rowInterval);
+	storageManager.writeAttribute("drumsScrollOffset", keyboardState.drums.scrollOffset);
+	storageManager.writeAttribute("drumsEdgeSize", keyboardState.drums.edgeSize);
+	storageManager.writeAttribute("inKeyScrollOffset", keyboardState.inKey.scrollOffset);
+	storageManager.writeAttribute("inKeyRowInterval", keyboardState.inKey.rowInterval);
+
 	Clip::writeDataToFile(song);
 
 	if (output->type == OutputType::MIDI_OUT) {
@@ -2345,23 +2346,29 @@ void InstrumentClip::writeDataToFile(Song* song) {
 
 	if (output->type != OutputType::KIT) {
 		storageManager.writeOpeningTagBeginning("arpeggiator");
-		storageManager.writeAttribute("mode", (char*)arpPresetToOldArpMode(arpSettings.preset)); // For backwards compatibility
+		storageManager.writeAttribute("mode",
+		                              (char*)arpPresetToOldArpMode(arpSettings.preset)); // For backwards compatibility
 		storageManager.writeAttribute("syncLevel", arpSettings.syncLevel);
-		storageManager.writeAttribute("syncType", arpSettings.syncType);
 		storageManager.writeAttribute("numOctaves", arpSettings.numOctaves);
-		storageManager.writeAttribute("arpMode", (char*)arpModeToString(arpSettings.mode));
-		storageManager.writeAttribute("noteMode", (char*)arpNoteModeToString(arpSettings.noteMode));
-		storageManager.writeAttribute("octaveMode", (char*)arpOctaveModeToString(arpSettings.octaveMode));
-		storageManager.writeAttribute("mpeVelocity", (char*)arpMpeModSourceToString(arpSettings.mpeVelocity));
 
 		if (output->type == OutputType::MIDI_OUT || output->type == OutputType::CV) {
 			storageManager.writeAttribute("gate", arpeggiatorGate);
 			storageManager.writeAttribute("rate", arpeggiatorRate);
+			// Community Firmware parameters (always write them after the official ones, just before closing the parent
+			// tag)
 			storageManager.writeAttribute("ratchetProbability", arpeggiatorRatchetProbability);
 			storageManager.writeAttribute("ratchetAmount", arpeggiatorRatchetAmount);
 			storageManager.writeAttribute("sequenceLength", arpeggiatorSequenceLength);
 			storageManager.writeAttribute("rhythm", arpeggiatorRhythm);
 		}
+
+		// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+		storageManager.writeAttribute("syncType", arpSettings.syncType);
+		storageManager.writeAttribute("arpMode", (char*)arpModeToString(arpSettings.mode));
+		storageManager.writeAttribute("noteMode", (char*)arpNoteModeToString(arpSettings.noteMode));
+		storageManager.writeAttribute("octaveMode", (char*)arpOctaveModeToString(arpSettings.octaveMode));
+		storageManager.writeAttribute("mpeVelocity", (char*)arpMpeModSourceToString(arpSettings.mpeVelocity));
+
 		storageManager.closeTag();
 	}
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2272,7 +2272,7 @@ Error InstrumentClip::setAudioInstrument(Instrument* newInstrument, Song* song, 
 	return Error::NONE;
 }
 
-void InstrumentClip::writeDataToFile(Song* song) {
+bool InstrumentClip::writeDataToFile(Song* song) {
 	storageManager.writeAttribute("inKeyMode", inScaleMode);
 	storageManager.writeAttribute("yScroll", yScroll);
 	storageManager.writeAttribute("yScrollKeyboard", keyboardState.isomorphic.scrollOffset);
@@ -2339,6 +2339,10 @@ void InstrumentClip::writeDataToFile(Song* song) {
 	storageManager.writeAttribute("drumsEdgeSize", keyboardState.drums.edgeSize);
 	storageManager.writeAttribute("inKeyScrollOffset", keyboardState.inKey.scrollOffset);
 	storageManager.writeAttribute("inKeyRowInterval", keyboardState.inKey.rowInterval);
+
+	bdsm.writeOpeningTagEnd();
+
+	Clip::writeMidiCommandsToFile(bdsm, song);
 
 	if (output->type == OutputType::MIDI_OUT) {
 		paramManager.getMIDIParamCollection()->writeToFile();
@@ -2416,6 +2420,8 @@ void InstrumentClip::writeDataToFile(Song* song) {
 
 		storageManager.writeClosingTag("noteRows");
 	}
+
+	return true;
 }
 
 Error InstrumentClip::readFromFile(Song* song) {

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2340,9 +2340,9 @@ bool InstrumentClip::writeDataToFile(Song* song) {
 	storageManager.writeAttribute("inKeyScrollOffset", keyboardState.inKey.scrollOffset);
 	storageManager.writeAttribute("inKeyRowInterval", keyboardState.inKey.rowInterval);
 
-	bdsm.writeOpeningTagEnd();
+	storageManager.writeOpeningTagEnd();
 
-	Clip::writeMidiCommandsToFile(bdsm, song);
+	Clip::writeMidiCommandsToFile(song);
 
 	if (output->type == OutputType::MIDI_OUT) {
 		paramManager.getMIDIParamCollection()->writeToFile();

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -169,7 +169,7 @@ public:
 	                                  bool shouldRetainLinksToSounds, bool shouldGrabMidiCommands,
 	                                  bool shouldBackUpExpressionParamsToo);
 	Error readFromFile(Song* song);
-	void writeDataToFile(Song* song);
+	bool writeDataToFile(Song* song);
 	void prepNoteRowsForExitingKitMode(Song* song);
 	void deleteNoteRow(ModelStackWithTimelineCounter* modelStack, int32_t i);
 	int16_t getTopYNote();

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -786,17 +786,14 @@ void GlobalEffectable::setupFilterSetConfig(int32_t* postFXVolume, ParamManager*
 }
 
 void GlobalEffectable::writeAttributesToFile(bool writeAutomation) {
-
-	ModControllableAudio::writeAttributesToFile();
-
 	storageManager.writeAttribute("modFXCurrentParam", (char*)modFXParamToString(currentModFXParam));
 	storageManager.writeAttribute("currentFilterType", (char*)filterTypeToString(currentFilterType));
+	ModControllableAudio::writeAttributesToFile();
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	// <--
 }
 
 void GlobalEffectable::writeTagsToFile(ParamManager* paramManager, bool writeAutomation) {
-
-	ModControllableAudio::writeTagsToFile();
-
 	if (paramManager) {
 		storageManager.writeOpeningTagBeginning("defaultParams");
 		GlobalEffectable::writeParamAttributesToFile(paramManager, writeAutomation);
@@ -804,6 +801,8 @@ void GlobalEffectable::writeTagsToFile(ParamManager* paramManager, bool writeAut
 		GlobalEffectable::writeParamTagsToFile(paramManager, writeAutomation);
 		storageManager.writeClosingTag("defaultParams");
 	}
+
+	ModControllableAudio::writeTagsToFile();
 }
 
 void GlobalEffectable::writeParamAttributesToFile(ParamManager* paramManager, bool writeAutomation,
@@ -816,11 +815,6 @@ void GlobalEffectable::writeParamAttributesToFile(ParamManager* paramManager, bo
 	unpatchedParams->writeParamAsAttribute("volume", params::UNPATCHED_VOLUME, writeAutomation, false,
 	                                       valuesForOverride);
 	unpatchedParams->writeParamAsAttribute("pan", params::UNPATCHED_PAN, writeAutomation, false, valuesForOverride);
-
-	unpatchedParams->writeParamAsAttribute("lpfMorph", params::UNPATCHED_LPF_MORPH, writeAutomation, false,
-	                                       valuesForOverride);
-	unpatchedParams->writeParamAsAttribute("hpfMorph", params::UNPATCHED_HPF_MORPH, writeAutomation, false,
-	                                       valuesForOverride);
 
 	if (unpatchedParams->params[params::UNPATCHED_PITCH_ADJUST].containsSomething(0)) {
 		unpatchedParams->writeParamAsAttribute("pitchAdjust", params::UNPATCHED_PITCH_ADJUST, writeAutomation, false,
@@ -841,6 +835,12 @@ void GlobalEffectable::writeParamAttributesToFile(ParamManager* paramManager, bo
 	                                       valuesForOverride);
 
 	ModControllableAudio::writeParamAttributesToFile(paramManager, writeAutomation, valuesForOverride);
+
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	unpatchedParams->writeParamAsAttribute("lpfMorph", params::UNPATCHED_LPF_MORPH, writeAutomation, false,
+	                                       valuesForOverride);
+	unpatchedParams->writeParamAsAttribute("hpfMorph", params::UNPATCHED_HPF_MORPH, writeAutomation, false,
+	                                       valuesForOverride);
 }
 
 void GlobalEffectable::writeParamTagsToFile(ParamManager* paramManager, bool writeAutomation,

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -817,6 +817,11 @@ void GlobalEffectable::writeParamAttributesToFile(ParamManager* paramManager, bo
 	                                       valuesForOverride);
 	unpatchedParams->writeParamAsAttribute("pan", params::UNPATCHED_PAN, writeAutomation, false, valuesForOverride);
 
+	unpatchedParams->writeParamAsAttribute("lpfMorph", params::UNPATCHED_LPF_MORPH, writeAutomation, false,
+	                                       valuesForOverride);
+	unpatchedParams->writeParamAsAttribute("hpfMorph", params::UNPATCHED_HPF_MORPH, writeAutomation, false,
+	                                       valuesForOverride);
+
 	if (unpatchedParams->params[params::UNPATCHED_PITCH_ADJUST].containsSomething(0)) {
 		unpatchedParams->writeParamAsAttribute("pitchAdjust", params::UNPATCHED_PITCH_ADJUST, writeAutomation, false,
 		                                       valuesForOverride);
@@ -855,16 +860,12 @@ void GlobalEffectable::writeParamTagsToFile(ParamManager* paramManager, bool wri
 	                                       valuesForOverride);
 	unpatchedParams->writeParamAsAttribute("resonance", params::UNPATCHED_LPF_RES, writeAutomation, false,
 	                                       valuesForOverride);
-	unpatchedParams->writeParamAsAttribute("morph", params::UNPATCHED_LPF_MORPH, writeAutomation, false,
-	                                       valuesForOverride);
 	storageManager.closeTag();
 
 	storageManager.writeOpeningTagBeginning("hpf");
 	unpatchedParams->writeParamAsAttribute("frequency", params::UNPATCHED_HPF_FREQ, writeAutomation, false,
 	                                       valuesForOverride);
 	unpatchedParams->writeParamAsAttribute("resonance", params::UNPATCHED_HPF_RES, writeAutomation, false,
-	                                       valuesForOverride);
-	unpatchedParams->writeParamAsAttribute("morph", params::UNPATCHED_HPF_MORPH, writeAutomation, false,
 	                                       valuesForOverride);
 	storageManager.closeTag();
 
@@ -942,6 +943,16 @@ bool GlobalEffectable::readParamTagFromFile(char const* tagName, ParamManagerFor
 	else if (!strcmp(tagName, "reverbAmount")) {
 		unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_REVERB_SEND_AMOUNT, readAutomationUpToPos);
 		storageManager.exitTag("reverbAmount");
+	}
+
+	else if (!strcmp(tagName, "lpfMorph")) {
+		unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_LPF_MORPH, readAutomationUpToPos);
+		storageManager.exitTag("lpfMorph");
+	}
+
+	else if (!strcmp(tagName, "hpfMorph")) {
+		unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_HPF_MORPH, readAutomationUpToPos);
+		storageManager.exitTag("hpfMorph");
 	}
 
 	else if (!strcmp(tagName, "volume")) {

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -915,6 +915,8 @@ bool GlobalEffectable::readParamTagFromFile(char const* tagName, ParamManagerFor
 				storageManager.exitTag("resonance");
 			}
 			else if (!strcmp(tagName, "morph")) {
+				// We leave this here for compatibility with songs saved before moving this parameter to "lpfMorph" at
+				// root level
 				unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_LPF_MORPH, readAutomationUpToPos);
 				storageManager.exitTag("morph");
 			}
@@ -933,6 +935,8 @@ bool GlobalEffectable::readParamTagFromFile(char const* tagName, ParamManagerFor
 				storageManager.exitTag("resonance");
 			}
 			else if (!strcmp(tagName, "morph")) {
+				// We leave this here for compatibility with songs saved before moving this parameter to "lpfMorph" at
+				// root level
 				unpatchedParams->readParam(unpatchedParamsSummary, params::UNPATCHED_HPF_MORPH, readAutomationUpToPos);
 				storageManager.exitTag("morph");
 			}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -868,9 +868,10 @@ inline void ModControllableAudio::doEQ(bool doBass, bool doTreble, int32_t* inpu
 }
 
 void ModControllableAudio::writeAttributesToFile() {
-	storageManager.writeAttribute("lpfMode", (char*)lpfTypeToString(lpfMode));
-	storageManager.writeAttribute("hpfMode", (char*)lpfTypeToString(hpfMode));
 	storageManager.writeAttribute("modFXType", (char*)fxTypeToString(modFXType));
+	storageManager.writeAttribute("lpfMode", (char*)lpfTypeToString(lpfMode));
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	storageManager.writeAttribute("hpfMode", (char*)lpfTypeToString(hpfMode));
 	storageManager.writeAttribute("filterRoute", (char*)filterRouteToString(filterRoute));
 	if (clippingAmount) {
 		storageManager.writeAttribute("clippingAmount", clippingAmount);
@@ -882,25 +883,9 @@ void ModControllableAudio::writeTagsToFile() {
 	storageManager.writeOpeningTagBeginning("delay");
 	storageManager.writeAttribute("pingPong", delay.pingPong);
 	storageManager.writeAttribute("analog", delay.analog);
-	storageManager.writeSyncTypeToFile(currentSong, "syncType", delay.syncType);
 	storageManager.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", delay.syncLevel);
-	storageManager.closeTag();
-
-	// Sidechain
-	storageManager.writeOpeningTagBeginning("sidechain");
-	storageManager.writeSyncTypeToFile(currentSong, "syncType", sidechain.syncType);
-	storageManager.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", sidechain.syncLevel);
-	storageManager.writeAttribute("attack", sidechain.attack);
-	storageManager.writeAttribute("release", sidechain.release);
-	storageManager.closeTag();
-
-	// Audio compressor
-	storageManager.writeOpeningTagBeginning("audioCompressor");
-	storageManager.writeAttribute("attack", compressor.getAttack());
-	storageManager.writeAttribute("release", compressor.getRelease());
-	storageManager.writeAttribute("thresh", compressor.getThreshold());
-	storageManager.writeAttribute("ratio", compressor.getRatio());
-	storageManager.writeAttribute("compHPF", compressor.getSidechain());
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	storageManager.writeSyncTypeToFile(currentSong, "syncType", delay.syncType);
 	storageManager.closeTag();
 
 	// MIDI knobs
@@ -938,6 +923,24 @@ void ModControllableAudio::writeTagsToFile() {
 		}
 		storageManager.writeClosingTag("midiKnobs");
 	}
+
+	// Sidechain (renamed from "compressor" from the official firmware)
+	storageManager.writeOpeningTagBeginning("sidechain");
+	storageManager.writeAttribute("attack", sidechain.attack);
+	storageManager.writeAttribute("release", sidechain.release);
+	storageManager.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", sidechain.syncLevel);
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	storageManager.writeSyncTypeToFile(currentSong, "syncType", sidechain.syncType);
+	storageManager.closeTag();
+
+	// Audio compressor
+	storageManager.writeOpeningTagBeginning("audioCompressor");
+	storageManager.writeAttribute("attack", compressor.getAttack());
+	storageManager.writeAttribute("release", compressor.getRelease());
+	storageManager.writeAttribute("thresh", compressor.getThreshold());
+	storageManager.writeAttribute("ratio", compressor.getRatio());
+	storageManager.writeAttribute("compHPF", compressor.getSidechain());
+	storageManager.closeTag();
 }
 
 void ModControllableAudio::writeParamAttributesToFile(ParamManager* paramManager, bool writeAutomation,
@@ -954,6 +957,8 @@ void ModControllableAudio::writeParamAttributesToFile(ParamManager* paramManager
 	                                       valuesForOverride);
 	unpatchedParams->writeParamAsAttribute("modFXFeedback", params::UNPATCHED_MOD_FX_FEEDBACK, writeAutomation, false,
 	                                       valuesForOverride);
+
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
 	unpatchedParams->writeParamAsAttribute("compressorThreshold", params::UNPATCHED_COMPRESSOR_THRESHOLD,
 	                                       writeAutomation, false, valuesForOverride);
 }

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -222,7 +222,6 @@ bool Output::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song) {
 		}
 		storageManager.writeAttribute("isArmedForRecording", armedForRecording);
 		storageManager.writeAttribute("activeModFunction", modKnobMode);
-		storageManager.writeAttribute("colour", colour);
 
 		if (clipInstances.getNumElements()) {
 			storageManager.write("\n");
@@ -257,6 +256,8 @@ bool Output::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song) {
 			}
 			storageManager.write("\"");
 		}
+
+		storageManager.writeAttribute("colour", colour);
 	}
 
 	return false;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1378,11 +1378,11 @@ weAreInArrangementEditorOrInClipInstance:
 	damping = std::min(damping, (uint32_t)2147483647);
 	width = std::min(width, (uint32_t)2147483647);
 
-	storageManager.writeAttribute("model", util::to_underlying(model));
 	storageManager.writeAttribute("roomSize", roomSize);
 	storageManager.writeAttribute("dampening", damping);
 	storageManager.writeAttribute("width", width);
 	storageManager.writeAttribute("pan", AudioEngine::reverbPan);
+	storageManager.writeAttribute("model", util::to_underlying(model));
 	storageManager.writeOpeningTagEnd();
 
 	storageManager.writeOpeningTagBeginning("compressor");

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1325,10 +1325,6 @@ weAreInArrangementEditorOrInClipInstance:
 	storageManager.writeAttribute("xScroll", xScroll[NAVIGATION_CLIP]);
 	storageManager.writeAttribute("xZoom", xZoom[NAVIGATION_CLIP]);
 	storageManager.writeAttribute("yScrollSongView", songViewYScroll);
-	storageManager.writeAttribute("songGridScrollX", songGridScrollX);
-	storageManager.writeAttribute("songGridScrollY", songGridScrollY);
-	storageManager.writeAttribute("sessionLayout", sessionLayout);
-
 	storageManager.writeAttribute("yScrollArrangementView", arrangementYScroll);
 	storageManager.writeAttribute("xScrollArrangementView", xScroll[NAVIGATION_ARRANGEMENT]);
 	storageManager.writeAttribute("xZoomArrangementView", xZoom[NAVIGATION_ARRANGEMENT]);
@@ -1347,8 +1343,6 @@ weAreInArrangementEditorOrInClipInstance:
 	storageManager.writeAttribute("affectEntire", affectEntire);
 	storageManager.writeAttribute("activeModFunction", globalEffectable.modKnobMode);
 
-	storageManager.writeAttribute("midiLoopback", midiLoopback);
-
 	if (lastSelectedParamID != kNoSelection) {
 		storageManager.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		storageManager.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
@@ -1358,6 +1352,12 @@ weAreInArrangementEditorOrInClipInstance:
 	}
 
 	globalEffectable.writeAttributesToFile(false);
+
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	storageManager.writeAttribute("midiLoopback", midiLoopback);
+	storageManager.writeAttribute("songGridScrollX", songGridScrollX);
+	storageManager.writeAttribute("songGridScrollY", songGridScrollY);
+	storageManager.writeAttribute("sessionLayout", sessionLayout);
 
 	storageManager
 	    .writeOpeningTagEnd(); // -------------------------------------------------------------- Attributes end
@@ -1382,6 +1382,7 @@ weAreInArrangementEditorOrInClipInstance:
 	storageManager.writeAttribute("dampening", damping);
 	storageManager.writeAttribute("width", width);
 	storageManager.writeAttribute("pan", AudioEngine::reverbPan);
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
 	storageManager.writeAttribute("model", util::to_underlying(model));
 	storageManager.writeOpeningTagEnd();
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3870,7 +3870,8 @@ void Sound::writeParamsToFile(ParamManager* paramManager, bool writeAutomation) 
 	ModControllableAudio::writeParamTagsToFile(paramManager, writeAutomation);
 }
 
-void Sound::writeToFile(bool savingSong, ParamManager* paramManager, ArpeggiatorSettings* arpSettings) {
+void Sound::writeToFile(bool savingSong, ParamManager* paramManager, ArpeggiatorSettings* arpSettings,
+                        const char* pathAttribute) {
 
 	storageManager.writeAttribute("polyphonic", polyphonyModeToString(polyphonic));
 	storageManager.writeAttribute("voicePriority", util::to_underlying(voicePriority));
@@ -3887,6 +3888,11 @@ void Sound::writeToFile(bool savingSong, ParamManager* paramManager, Arpeggiator
 	}
 
 	ModControllableAudio::writeAttributesToFile();
+
+	// Community Firmware parameters (always write them after the official ones)
+	if (pathAttribute) {
+		storageManager.writeAttribute("path", pathAttribute);
+	}
 
 	storageManager.writeOpeningTagEnd(); // -------------------------------------------------------------------------
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -682,7 +682,7 @@ Error Sound::readTagFromFile(char const* tagName, ParamManagerForTimeline* param
 				storageManager.exitTag("arpMode");
 			}
 			else if (!strcmp(tagName, "mode")
-			         && storageManager.firmware_version < FirmwareVersion::community({1, 0, 0})) {
+			         && storageManager.firmware_version < FirmwareVersion::community({1, 1, 0})) {
 				// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
 				if (arpSettings) {
 					OldArpMode oldMode = stringToOldArpMode(storageManager.readTagOrAttributeValue());
@@ -3930,13 +3930,15 @@ void Sound::writeToFile(bool savingSong, ParamManager* paramManager, Arpeggiator
 
 	if (arpSettings) {
 		storageManager.writeOpeningTagBeginning("arpeggiator");
+		storageManager.writeAttribute("mode",
+		                              arpPresetToOldArpMode(arpSettings->preset)); // For backwards compatibility
+		storageManager.writeAttribute("numOctaves", arpSettings->numOctaves);
+		storageManager.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", arpSettings->syncLevel);
+		storageManager.writeSyncTypeToFile(currentSong, "syncType", arpSettings->syncType);
 		storageManager.writeAttribute("arpMode", arpModeToString(arpSettings->mode));
 		storageManager.writeAttribute("noteMode", arpNoteModeToString(arpSettings->noteMode));
 		storageManager.writeAttribute("octaveMode", arpOctaveModeToString(arpSettings->octaveMode));
 		storageManager.writeAttribute("mpeVelocity", arpMpeModSourceToString(arpSettings->mpeVelocity));
-		storageManager.writeAttribute("numOctaves", arpSettings->numOctaves);
-		storageManager.writeSyncTypeToFile(currentSong, "syncType", arpSettings->syncType);
-		storageManager.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", arpSettings->syncLevel);
 		storageManager.closeTag();
 	}
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3784,11 +3784,6 @@ void Sound::writeParamsToFile(ParamManager* paramManager, bool writeAutomation) 
 	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 
 	unpatchedParams->writeParamAsAttribute("arpeggiatorGate", params::UNPATCHED_ARP_GATE, writeAutomation);
-	unpatchedParams->writeParamAsAttribute("ratchetProbability", params::UNPATCHED_ARP_RATCHET_PROBABILITY,
-	                                       writeAutomation);
-	unpatchedParams->writeParamAsAttribute("ratchetAmount", params::UNPATCHED_ARP_RATCHET_AMOUNT, writeAutomation);
-	unpatchedParams->writeParamAsAttribute("sequenceLength", params::UNPATCHED_ARP_SEQUENCE_LENGTH, writeAutomation);
-	unpatchedParams->writeParamAsAttribute("rhythm", params::UNPATCHED_ARP_RHYTHM, writeAutomation);
 	unpatchedParams->writeParamAsAttribute("portamento", params::UNPATCHED_PORTAMENTO, writeAutomation);
 	unpatchedParams->writeParamAsAttribute("compressorShape", params::UNPATCHED_SIDECHAIN_SHAPE, writeAutomation);
 
@@ -3802,15 +3797,12 @@ void Sound::writeParamsToFile(ParamManager* paramManager, bool writeAutomation) 
 
 	patchedParams->writeParamAsAttribute("volume", params::GLOBAL_VOLUME_POST_FX, writeAutomation);
 	patchedParams->writeParamAsAttribute("pan", params::LOCAL_PAN, writeAutomation);
-	patchedParams->writeParamAsAttribute("waveFold", params::LOCAL_FOLD, writeAutomation);
-	// Filters
+
 	patchedParams->writeParamAsAttribute("lpfFrequency", params::LOCAL_LPF_FREQ, writeAutomation);
 	patchedParams->writeParamAsAttribute("lpfResonance", params::LOCAL_LPF_RESONANCE, writeAutomation);
-	patchedParams->writeParamAsAttribute("lpfMorph", params::LOCAL_LPF_MORPH, writeAutomation);
 
 	patchedParams->writeParamAsAttribute("hpfFrequency", params::LOCAL_HPF_FREQ, writeAutomation);
 	patchedParams->writeParamAsAttribute("hpfResonance", params::LOCAL_HPF_RESONANCE, writeAutomation);
-	patchedParams->writeParamAsAttribute("hpfMorph", params::LOCAL_HPF_MORPH, writeAutomation);
 
 	patchedParams->writeParamAsAttribute("lfo1Rate", params::GLOBAL_LFO_FREQ, writeAutomation);
 	patchedParams->writeParamAsAttribute("lfo2Rate", params::LOCAL_LFO_LOCAL_FREQ, writeAutomation);
@@ -3840,7 +3832,21 @@ void Sound::writeParamsToFile(ParamManager* paramManager, bool writeAutomation) 
 	patchedParams->writeParamAsAttribute("reverbAmount", params::GLOBAL_REVERB_AMOUNT, writeAutomation);
 
 	patchedParams->writeParamAsAttribute("arpeggiatorRate", params::GLOBAL_ARP_RATE, writeAutomation);
+
 	ModControllableAudio::writeParamAttributesToFile(paramManager, writeAutomation);
+
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+
+	patchedParams->writeParamAsAttribute("lpfMorph", params::LOCAL_LPF_MORPH, writeAutomation);
+	patchedParams->writeParamAsAttribute("hpfMorph", params::LOCAL_HPF_MORPH, writeAutomation);
+
+	patchedParams->writeParamAsAttribute("waveFold", params::LOCAL_FOLD, writeAutomation);
+
+	unpatchedParams->writeParamAsAttribute("ratchetProbability", params::UNPATCHED_ARP_RATCHET_PROBABILITY,
+	                                       writeAutomation);
+	unpatchedParams->writeParamAsAttribute("ratchetAmount", params::UNPATCHED_ARP_RATCHET_AMOUNT, writeAutomation);
+	unpatchedParams->writeParamAsAttribute("sequenceLength", params::UNPATCHED_ARP_SEQUENCE_LENGTH, writeAutomation);
+	unpatchedParams->writeParamAsAttribute("rhythm", params::UNPATCHED_ARP_RHYTHM, writeAutomation);
 
 	storageManager.writeOpeningTagEnd();
 
@@ -3890,8 +3896,9 @@ void Sound::writeToFile(bool savingSong, ParamManager* paramManager, Arpeggiator
 	// LFOs
 	storageManager.writeOpeningTagBeginning("lfo1");
 	storageManager.writeAttribute("type", lfoTypeToString(lfoGlobalWaveType), false);
-	storageManager.writeSyncTypeToFile(currentSong, "syncType", lfoGlobalSyncType, false);
 	storageManager.writeAbsoluteSyncLevelToFile(currentSong, "syncLevel", lfoGlobalSyncLevel, false);
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	storageManager.writeSyncTypeToFile(currentSong, "syncType", lfoGlobalSyncType, false);
 	storageManager.closeTag();
 
 	storageManager.writeOpeningTagBeginning("lfo2");
@@ -3917,10 +3924,9 @@ void Sound::writeToFile(bool savingSong, ParamManager* paramManager, Arpeggiator
 	storageManager.writeOpeningTagBeginning("unison");
 	storageManager.writeAttribute("num", numUnison, false);
 	storageManager.writeAttribute("detune", unisonDetune, false);
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
 	storageManager.writeAttribute("spread", unisonStereoSpread, false);
 	storageManager.closeTag();
-
-	ModControllableAudio::writeTagsToFile();
 
 	if (paramManager) {
 		storageManager.writeOpeningTagBeginning("defaultParams");
@@ -3965,6 +3971,8 @@ void Sound::writeToFile(bool savingSong, ParamManager* paramManager, Arpeggiator
 		}
 	}
 	storageManager.writeClosingTag("modKnobs");
+
+	ModControllableAudio::writeTagsToFile();
 }
 
 int16_t Sound::getMaxOscTranspose(InstrumentClip* clip) {

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -178,7 +178,8 @@ public:
 	void setModulatorCents(int32_t m, int32_t value, ModelStackWithSoundFlags* modelStack);
 	Error readFromFile(ModelStackWithModControllable* modelStack, int32_t readAutomationUpToPos,
 	                   ArpeggiatorSettings* arpSettings);
-	void writeToFile(bool savingSong, ParamManager* paramManager, ArpeggiatorSettings* arpSettings);
+	void writeToFile(bool savingSong, ParamManager* paramManager, ArpeggiatorSettings* arpSettings,
+	                 const char* pathAttribute = NULL);
 	bool allowNoteTails(ModelStackWithSoundFlags* modelStack, bool disregardSampleLoop = false);
 
 	void voiceUnassigned(ModelStackWithVoice* modelStack);

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -170,12 +170,14 @@ void SoundDrum::writeToFileAsInstrument(bool savingSong, ParamManager* paramMana
 void SoundDrum::writeToFile(bool savingSong, ParamManager* paramManager) {
 	storageManager.writeOpeningTagBeginning("sound");
 	storageManager.writeAttribute("name", name.get());
-	storageManager.writeAttribute("path", path.get());
 	Sound::writeToFile(savingSong, paramManager, &arpSettings);
 
 	if (savingSong) {
 		Drum::writeMIDICommandsToFile();
 	}
+
+	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
+	storageManager.writeAttribute("path", path.get());
 
 	storageManager.writeClosingTag("sound");
 }

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -158,7 +158,7 @@ void SoundDrum::writeToFileAsInstrument(bool savingSong, ParamManager* paramMana
 	storageManager.writeOpeningTagBeginning("sound");
 	storageManager.writeFirmwareVersion();
 	storageManager.writeEarliestCompatibleFirmwareVersion("4.1.0-alpha");
-	Sound::writeToFile(savingSong, paramManager, &arpSettings);
+	Sound::writeToFile(savingSong, paramManager, &arpSettings, NULL);
 
 	if (savingSong) {
 		Drum::writeMIDICommandsToFile();
@@ -170,14 +170,12 @@ void SoundDrum::writeToFileAsInstrument(bool savingSong, ParamManager* paramMana
 void SoundDrum::writeToFile(bool savingSong, ParamManager* paramManager) {
 	storageManager.writeOpeningTagBeginning("sound");
 	storageManager.writeAttribute("name", name.get());
-	Sound::writeToFile(savingSong, paramManager, &arpSettings);
+
+	Sound::writeToFile(savingSong, paramManager, &arpSettings, path.get());
 
 	if (savingSong) {
 		Drum::writeMIDICommandsToFile();
 	}
-
-	// Community Firmware parameters (always write them after the official ones, just before closing the parent tag)
-	storageManager.writeAttribute("path", path.get());
 
 	storageManager.writeClosingTag("sound");
 }

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -65,7 +65,7 @@ bool SoundInstrument::writeDataToFile(Clip* clipForSavingOutputOnly, Song* song)
 	}
 
 	Sound::writeToFile(clipForSavingOutputOnly == NULL, paramManager,
-	                   clipForSavingOutputOnly ? &((InstrumentClip*)clipForSavingOutputOnly)->arpSettings : NULL);
+	                   clipForSavingOutputOnly ? &((InstrumentClip*)clipForSavingOutputOnly)->arpSettings : NULL, NULL);
 
 	MelodicInstrument::writeMelodicInstrumentTagsToFile(clipForSavingOutputOnly, song);
 

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -987,6 +987,30 @@ char const* oldArpModeToString(OldArpMode mode) {
 	}
 }
 
+char const* arpPresetToOldArpMode(ArpPreset preset) {
+	switch (preset) {
+	case ArpPreset::OFF:
+		return "off";
+
+	case ArpPreset::UP:
+		return "up";
+
+	case ArpPreset::DOWN:
+		return "down";
+
+	case ArpPreset::BOTH:
+		return "both";
+
+	case ArpPreset::RANDOM:
+		return "random";
+
+	default:
+		// In case the user selected a Custom mode, we don't know how to convert it to
+		// the old mode so we default to "up" cause at least the arp is ON for sure
+		return "up";
+	}
+}
+
 OldArpMode stringToOldArpMode(char const* string) {
 	if (!strcmp(string, "up")) {
 		return OldArpMode::UP;

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -158,6 +158,7 @@ ArpNoteMode oldModeToArpNoteMode(OldArpMode oldMode);
 ArpOctaveMode oldModeToArpOctaveMode(OldArpMode oldMode);
 
 char const* oldArpModeToString(OldArpMode mode);
+char const* arpPresetToOldArpMode(ArpPreset preset);
 OldArpMode stringToOldArpMode(char const* string);
 
 char const* arpModeToString(ArpMode mode);


### PR DESCRIPTION
This fixes the issue of not being able to load a song saved with community 1.1.0/1.2.0 with official firmware 4.1.2

NOTE: this PR is like this https://github.com/SynthstromAudible/DelugeFirmware/pull/1728 but for release/1.1 branch