### PR TITLE
Bugfix: Automation Menu View crash in Kit Clip's - Update getModelStackWithParam

### DIFF
--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -138,6 +138,7 @@ public:
 	int32_t getParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t pos);
 	void setKnobIndicatorLevels(ModelStackWithAutoParam* modelStack, int32_t knobPosLeft, int32_t knobPosRight);
 	void resetInterpolationShortcutBlinking();
+	bool getAffectEntire();
 
 private:
 	// button action functions

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -251,8 +251,9 @@ MidiFollow::getModelStackWithParamForSynthClip(ModelStackWithTimelineCounter* mo
 		paramID = unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay];
 	}
 	if ((paramKind != params::Kind::NONE) && (paramID != kNoParamID)) {
+		// Note: useMenuContext parameter will always be false for MidiFollow
 		modelStackWithParam =
-		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind);
+		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind, true, false);
 	}
 
 	return modelStackWithParam;
@@ -285,9 +286,11 @@ MidiFollow::getModelStackWithParamForKitClip(ModelStackWithTimelineCounter* mode
 			paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 		}
 	}
+
 	if ((paramKind != params::Kind::NONE) && (paramID != kNoParamID)) {
-		modelStackWithParam =
-		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind);
+		// Note: useMenuContext parameter will always be false for MidiFollow
+		modelStackWithParam = clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID,
+		                                                           paramKind, instrumentClip->affectEntire, false);
 	}
 
 	return modelStackWithParam;
@@ -301,8 +304,9 @@ MidiFollow::getModelStackWithParamForAudioClip(ModelStackWithTimelineCounter* mo
 	int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
 	if (paramID != kNoParamID) {
+		// Note: useMenuContext parameter will always be false for MidiFollow
 		modelStackWithParam =
-		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind);
+		    clip->output->getModelStackWithParam(modelStackWithTimelineCounter, clip, paramID, paramKind, true, false);
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -17,6 +17,7 @@
 
 #include "model/instrument/kit.h"
 #include "definitions_cxx.hpp"
+#include "gui/ui/sound_editor.h"
 #include "gui/ui/ui.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
@@ -1611,25 +1612,65 @@ gotParamManager:
 
 // for (Drum* drum = firstDrum; drum; drum = drum->next) {
 
+/// for a kit we have two types of automation: with Affect Entire and without Affect Entire
 ModelStackWithAutoParam* Kit::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-                                                     int32_t paramID, params::Kind paramKind) {
+                                                     int32_t paramID, params::Kind paramKind, bool affectEntire,
+                                                     bool useMenuStack) {
+	if (affectEntire) {
+		return getModelStackWithParamForKit(modelStack, clip, paramID, paramKind, useMenuStack);
+	}
+	else {
+		return getModelStackWithParamForKitRow(modelStack, clip, paramID, paramKind, useMenuStack);
+	}
+}
+
+/// for a kit we have two types of automation: with Affect Entire and without Affect Entire
+/// for a kit with affect entire on, we are automating information at the kit level
+ModelStackWithAutoParam* Kit::getModelStackWithParamForKit(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+                                                           int32_t paramID, params::Kind paramKind, bool useMenuStack) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-	InstrumentClip* instrumentClip = (InstrumentClip*)clip;
 
-	// for a kit we have two types of automation: with Affect Entire and without Affect Entire
-	// for a kit with affect entire off, we are automating information at the noterow level
-	if (!instrumentClip->affectEntire) {
-		Drum* drum = selectedDrum;
+	ModelStackWithThreeMainThings* modelStackWithThreeMainThings = nullptr;
 
-		if (drum && drum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
+	if (useMenuStack) {
+		modelStackWithThreeMainThings = modelStack->addOtherTwoThingsButNoNoteRow(soundEditor.currentModControllable,
+		                                                                          soundEditor.currentParamManager);
+	}
+	else {
+		modelStackWithThreeMainThings =
+		    modelStack->addOtherTwoThingsButNoNoteRow(toModControllable(), &clip->paramManager);
+	}
 
-			ModelStackWithNoteRow* modelStackWithNoteRow = instrumentClip->getNoteRowForSelectedDrum(modelStack);
+	if (modelStackWithThreeMainThings) {
+		modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
+	}
 
-			if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+	return modelStackWithParam;
+}
 
-				ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-				    modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow();
+/// for a kit we have two types of automation: with Affect Entire and without Affect Entire
+/// for a kit with affect entire off, we are automating information at the noterow level
+ModelStackWithAutoParam* Kit::getModelStackWithParamForKitRow(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+                                                              int32_t paramID, params::Kind paramKind,
+                                                              bool useMenuStack) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
+	if (selectedDrum && selectedDrum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
+
+		ModelStackWithNoteRow* modelStackWithNoteRow = ((InstrumentClip*)clip)->getNoteRowForSelectedDrum(modelStack);
+
+		if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+			ModelStackWithThreeMainThings* modelStackWithThreeMainThings = nullptr;
+
+			if (useMenuStack) {
+				modelStackWithThreeMainThings = modelStackWithNoteRow->addOtherTwoThings(
+				    soundEditor.currentModControllable, soundEditor.currentParamManager);
+			}
+			else {
+				modelStackWithThreeMainThings = modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow();
+			}
+
+			if (modelStackWithThreeMainThings) {
 				if (paramKind == deluge::modulation::params::Kind::PATCHED) {
 					modelStackWithParam = modelStackWithThreeMainThings->getPatchedAutoParamFromId(paramID);
 				}
@@ -1642,16 +1683,6 @@ ModelStackWithAutoParam* Kit::getModelStackWithParam(ModelStackWithTimelineCount
 					modelStackWithParam = modelStackWithThreeMainThings->getPatchCableAutoParamFromId(paramID);
 				}
 			}
-		}
-	}
-
-	else { // model stack for automating kit params when "affect entire" is enabled
-
-		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-		    modelStack->addOtherTwoThingsButNoNoteRow(toModControllable(), &clip->paramManager);
-
-		if (modelStackWithThreeMainThings) {
-			modelStackWithParam = modelStackWithThreeMainThings->getUnpatchedAutoParamFromId(paramID);
 		}
 	}
 

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -143,7 +143,15 @@ public:
 	OrderedResizeableArrayWith32bitKey drumsWithRenderingActive;
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,
+	                                                bool affectEntire, bool useMenuStack);
+	ModelStackWithAutoParam* getModelStackWithParamForKit(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                                                      int32_t paramID, deluge::modulation::params::Kind paramKind,
+	                                                      bool useMenuStack);
+	ModelStackWithAutoParam* getModelStackWithParamForKitRow(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                                                         int32_t paramID,
+	                                                         deluge::modulation::params::Kind paramKind,
+	                                                         bool useMenuStack);
 
 protected:
 	bool isKit() { return true; }

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -700,7 +700,8 @@ void MelodicInstrument::polyphonicExpressionEventPossiblyToRecord(ModelStackWith
 
 ModelStackWithAutoParam* MelodicInstrument::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack,
                                                                    Clip* clip, int32_t paramID,
-                                                                   deluge::modulation::params::Kind paramKind) {
+                                                                   deluge::modulation::params::Kind paramKind,
+                                                                   bool affectEntire, bool useMenuStack) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
 	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -91,7 +91,8 @@ public:
 	EarlyNoteArray notesAuditioned;
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,
+	                                                bool affectEntire, bool useMenuStack);
 
 private:
 	void possiblyRefreshAutomationEditorGrid(int32_t ccNumber);

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -1015,7 +1015,8 @@ void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t whichExpressionDi
 
 ModelStackWithAutoParam* MIDIInstrument::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
                                                                 int32_t paramID,
-                                                                deluge::modulation::params::Kind paramKind) {
+                                                                deluge::modulation::params::Kind paramKind,
+                                                                bool affectEntire, bool useMenuStack) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
 	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -99,7 +99,8 @@ public:
 	char const* getSubSlotXMLTag() { return "suffix"; }
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,
+	                                                bool affectEntire, bool useMenuStack);
 
 protected:
 	void polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -153,8 +153,8 @@ public:
 	bool recordingInArrangement;
 
 	virtual ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                                                        int32_t paramID,
-	                                                        deluge::modulation::params::Kind paramKind) = 0;
+	                                                        int32_t paramID, deluge::modulation::params::Kind paramKind,
+	                                                        bool affectEntire, bool useMenuStack) = 0;
 	virtual bool needsEarlyPlayback() const { return false; }
 
 protected:

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -419,7 +419,8 @@ void AudioOutput::getThingWithMostReverb(Sound** soundWithMostReverb, ParamManag
 }
 
 ModelStackWithAutoParam* AudioOutput::getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-                                                             int32_t paramID, params::Kind paramKind) {
+                                                             int32_t paramID, params::Kind paramKind, bool affectEntire,
+                                                             bool useMenuStack) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
 	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -83,7 +83,8 @@ public:
 	bool echoing; // Doesn't get cloned - we wouldn't want that!
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
-	                                                int32_t paramID, deluge::modulation::params::Kind paramKind);
+	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,
+	                                                bool affectEntire, bool useMenuStack);
 
 protected:
 	Clip* createNewClipForArrangementRecording(ModelStack* modelStack);


### PR DESCRIPTION
Problem: A kit can have an affect entire state that differs from the model stack context of the menu currently open. When using the automation menu view, this causes the deluge to crash because the automation menu view get's confused about model stack to use to control the parameter open in the menu (e.g. the menu provides a param ID and param Kind for a kit row, but the kit affect entire state was saying to get the affect entire model stack, which is incompatible with the kit row param ID and param Kind provided).

Solution: When in the Menu for Kit's, used the Menu affect entire state (e.g. if it's a kit row menu, the state is off, if it's an affect entire menu, it's on) to determine what getModelStackWithParam to use in the automation menu view. This ensures that even if the kit clip's affect entire state is changed while in the menu, it will not affect the getModelStackWithParam obtained by automation view as the menu model stack remains the same.

Important note: midi follow uses the same getModelStackWithParam functions as automation view, but with midi follow it never uses the menu context, it follows the gold knob context. So it will always pass false for the "useMenuStack" flag.

Changes:
- Updated getModelStackWithParam so that it can be passed the affectEntire state and whether to use the menu model stack (Currently this is only used with Kit's) 
- Added new getAffectEntire function to automation view that check's whether the current UI is the sound editor and if the menu is the kit global FX menu and uses that to return the affect entire state that should be used in automation view - e.g. if you're in the menu it is derived from the menu and if you're not in the menu it is derived from the instrument clip.