### PR TITLE
Bugfix: Disable midi learning of global effectable params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,6 @@
 - Added indicators to the waveform loop lock feature for both 7seg (rightmost `.`) and OLED (lock indicator).
 - Modified waveform marker rendering to improve clarity.
 - Created a new menu hierarchies document that documents the Deluge menu structure for OLED and 7SEG and can be used as a reference for navigating the various menu's. See: [Menu Hierarchies](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/menu_hierarchies.md)
-- Added MIDI learning of Song Params
 - Added Synth/MIDI/CV clip configuration of note row play direction. Hold audition pad while entering the play direction menu to set the play direction for the selected note row. While in the note row play direction menu, you can select other note rows to quickly set the play directiom for multiple note rows.
 
 In addition, a number of improvements have been made to how the OLED display is used:

--- a/src/deluge/gui/menu_item/audio_clip/transpose.h
+++ b/src/deluge/gui/menu_item/audio_clip/transpose.h
@@ -53,8 +53,9 @@ public:
 
 	ParamDescriptor getLearningThing() override {
 		ParamDescriptor paramDescriptor;
-		paramDescriptor.setToHaveParamOnly(deluge::modulation::params::UNPATCHED_START
-		                                   + deluge::modulation::params::UNPATCHED_PITCH_ADJUST);
+		paramDescriptor.setToNull(); // disable global effectable learning until xml parsing code can be repaired
+		// paramDescriptor.setToHaveParamOnly(deluge::modulation::params::UNPATCHED_START
+		//                                    + deluge::modulation::params::UNPATCHED_PITCH_ADJUST);
 		return paramDescriptor;
 	}
 };

--- a/src/deluge/gui/menu_item/menu_item_with_cc_learning.cpp
+++ b/src/deluge/gui/menu_item/menu_item_with_cc_learning.cpp
@@ -41,12 +41,14 @@ void MenuItemWithCCLearning::learnKnob(MIDIDevice* fromDevice, int32_t whichKnob
                                        int32_t midiChannel) {
 	ParamDescriptor paramDescriptor = getLearningThing();
 
-	bool success = soundEditor.currentModControllable->learnKnob(fromDevice, paramDescriptor, whichKnob, modKnobMode,
-	                                                             midiChannel, currentSong);
+	if (!paramDescriptor.isNull()) {
+		bool success = soundEditor.currentModControllable->learnKnob(fromDevice, paramDescriptor, whichKnob,
+		                                                             modKnobMode, midiChannel, currentSong);
 
-	if (success) {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_LEARNED));
-		view.setKnobIndicatorLevels();
-		soundEditor.markInstrumentAsEdited();
+		if (success) {
+			display->displayPopup(l10n::get(l10n::String::STRING_FOR_LEARNED));
+			view.setKnobIndicatorLevels();
+			soundEditor.markInstrumentAsEdited();
+		}
 	}
 }

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -72,7 +72,12 @@ int32_t UnpatchedParam::getFinalValue() {
 
 ParamDescriptor UnpatchedParam::getLearningThing() {
 	ParamDescriptor paramDescriptor;
-	paramDescriptor.setToHaveParamOnly(getP() + deluge::modulation::params::UNPATCHED_START);
+	if (getParamKind() == deluge::modulation::params::Kind::UNPATCHED_GLOBAL) {
+		paramDescriptor.setToNull(); // disable global effectable learning until xml parsing code can be repaired
+	}
+	else {
+		paramDescriptor.setToHaveParamOnly(getP() + deluge::modulation::params::UNPATCHED_START);
+	}
 	return paramDescriptor;
 }
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2868,15 +2868,16 @@ void PlaybackHandler::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, ui
 	}
 
 	// See if midi cc received has been learned to a song param
-	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+	// disabled this for now until midi learning for global effectable params can be repaired
+	/*ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 	    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 	if (modelStackWithThreeMainThings) {
-		ModControllableAudio* modControllable = (ModControllableAudio*)modelStackWithThreeMainThings->modControllable;
-		if (modControllable) {
-			modControllable->offerReceivedCCToLearnedParamsForSong(fromDevice, channel, ccNumber, value,
-			                                                       modelStackWithThreeMainThings);
-		}
-	}
+	    ModControllableAudio* modControllable = (ModControllableAudio*)modelStackWithThreeMainThings->modControllable;
+	    if (modControllable) {
+	        modControllable->offerReceivedCCToLearnedParamsForSong(fromDevice, channel, ccNumber, value,
+	                                                               modelStackWithThreeMainThings);
+	    }
+	}*/
 
 	// Go through all Outputs...
 	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {


### PR DESCRIPTION
There is a bug with parsing midi learns for global effectables. Until this can be fixed, midi learning for global effectables has been disabled.