### PR TITLE
Bugfix - Adjust Perf View Hold Press Behaviour

### DIFF
--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -1041,6 +1041,13 @@ void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* mode
 		    || ((fxPress[xDisplay].previousKnobPosition != kNoSelection) && (fxPress[xDisplay].yDisplay == yDisplay)
 		        && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) >= kHoldTime))) {
 
+			// if there was a previously held pad in this column and you pressed another pad
+			// but didn't set that pad to held, then when we let go of this pad, we want the
+			// the value to be set back to the value of the previously held pad
+			if (shouldRestorePreviousHoldPress(xDisplay)) {
+				fxPress[xDisplay].previousKnobPosition = backupFXPress[xDisplay].currentKnobPosition;
+			}
+
 			padReleaseAction(modelStack, lastSelectedParamKind, lastSelectedParamID, xDisplay, !defaultEditingMode);
 		}
 		// if releasing a pad that was quickly pressed, give it held status
@@ -1104,8 +1111,18 @@ void PerformanceSessionView::padReleaseAction(ModelStackWithThreeMainThings* mod
                                               int32_t paramID, int32_t xDisplay, bool renderDisplay) {
 	if (setParameterValue(modelStack, paramKind, paramID, xDisplay, fxPress[xDisplay].previousKnobPosition,
 	                      renderDisplay)) {
-		initFXPress(fxPress[xDisplay]);
-		initPadPress(lastPadPress);
+		// if there was a previously held pad in this column and you pressed another pad
+		// but didn't set that pad to held, then when we let go of this pad, we want to
+		// restore the pad press info back to the previous held pad state
+		if (shouldRestorePreviousHoldPress(xDisplay)) {
+			restorePreviousHoldPress(xDisplay);
+		}
+		// otherwise there isn't anymore active presses in this FX column, so we'll
+		// initialize all press info
+		else {
+			initFXPress(fxPress[xDisplay]);
+			initPadPress(lastPadPress);
+		}
 	}
 }
 
@@ -1181,14 +1198,24 @@ bool PerformanceSessionView::isPadShortcut(int32_t xDisplay, int32_t yDisplay) {
 	return false;
 }
 
-/// backup performance layout so changes can be undone / redone later
+/// backup performance layout column press info so changes can be undone / redone later
 void PerformanceSessionView::backupPerformanceLayout() {
-	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
-		if (successfullyReadDefaultsFromFile) {
+	if (successfullyReadDefaultsFromFile) {
+		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 			memcpy(&backupFXPress[xDisplay], &fxPress[xDisplay], sizeof(FXColumnPress));
 		}
 	}
 	performanceLayoutBackedUp = true;
+}
+
+/// re-load performance layout column press info from backup
+void PerformanceSessionView::restorePreviousHoldPress(int32_t xDisplay) {
+	memcpy(&fxPress[xDisplay], &backupFXPress[xDisplay], sizeof(FXColumnPress));
+	lastPadPress.yDisplay = backupFXPress[xDisplay].yDisplay;
+}
+
+bool PerformanceSessionView::shouldRestorePreviousHoldPress(int32_t xDisplay) {
+	return (!fxPress[xDisplay].padPressHeld && backupFXPress[xDisplay].padPressHeld);
 }
 
 /// used in conjunction with backupPerformanceLayout to log changes

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -192,6 +192,8 @@ private:
 	// backup current layout
 	void backupPerformanceLayout();
 	bool performanceLayoutBackedUp;
+	bool shouldRestorePreviousHoldPress(int32_t xDisplay);
+	void restorePreviousHoldPress(int32_t xDisplay);
 	void logPerformanceViewPress(int32_t xDisplay, bool closeAction = true);
 	bool anyChangesToLog();
 	FXColumnPress backupFXPress[kDisplayWidth];


### PR DESCRIPTION
Adjust performance view hold press behaviour

Previously: if you set a pad to held (short press) and then long pressed another pad in the column, it would remove the previously held pad and when let you go of that new press the value would be set back to the default.

Now: when you set a pad to held and long press another pad in the same FX column, when you let go, it will go back to the previous held value, restoring the held press.