### PR TITLE
Workflow fixups - correct names and tags

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -28,5 +28,3 @@ jobs:
           branch: release/1.1
           labels: |
             cherry-picked
-          reviewers: |
-            m-m-adams

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -65,3 +65,4 @@ jobs:
     needs: beta-build
     with:
       tag: 'beta'
+      branch: 'release/1.1'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,13 +13,13 @@ on:
 
 jobs:
   release-build:
-    name: Build Check
+    name: Build check - Release
     uses: ./.github/workflows/build.yml
     with:
       firmware-retention-days: 5
       build-type: 'Release'
   debug-build:
-    name: Build Check
+    name: Build check - Debug
     uses: ./.github/workflows/build.yml
     with:
       firmware-retention-days: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,8 @@ on:
       tag:
         required: true
         type: string
+      branch:
+        type: string
   workflow_dispatch:
     inputs:
       run-id:
@@ -15,6 +17,11 @@ on:
         options:
           - nightly
           - beta
+      branch:
+        type: choice
+        options:
+          - release/1.1
+          - community
 
 permissions:
   contents: write #required to update release tags
@@ -24,6 +31,11 @@ jobs:
     name: PublishRelease
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout branch #required to put the tag on the correct branch
+        if: inputs.branch != null
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
       - name: Download Build Artifact
         if: inputs.run-id == null
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Checkout the release branch before the nightly publish, otherwise it moves the beta tag back to community which looks dumb. This was previously handled by the build and publish being in the same job, but broke silently when I split them up

Give the two PR build checks different names for the type of build

Remove the review request from the cherry pick bot so I don't get notifications now that it's working smoothly

