### PR TITLE
add option to ignore patched params, add static assert to check parsing

### DIFF
--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1219,7 +1219,7 @@ doReadPatchedParam:
 						relative = bdsm.readTagOrAttributeValueInt();
 					}
 					else if (!strcmp(tagName, "controlsParam")) {
-						p = params::fileStringToParam(unpatchedParamKind_, bdsm.readTagOrAttributeValue());
+						p = params::fileStringToParam(unpatchedParamKind_, bdsm.readTagOrAttributeValue(), false);
 					}
 					else if (!strcmp(tagName, "patchAmountFromSource")) {
 						s = stringToSource(bdsm.readTagOrAttributeValue());

--- a/src/deluge/modulation/params/param.h
+++ b/src/deluge/modulation/params/param.h
@@ -258,7 +258,7 @@ char const* paramNameForFile(Kind kind, ParamType param);
 /// Given a string and the expected Kind, attempts to find the ParamType value for that param.
 ///
 /// As with paramNameForFile, the returned ParamType is offset by UNPATCHED_START for unpatched params.
-ParamType fileStringToParam(Kind kind, char const* name);
+ParamType fileStringToParam(Kind kind, char const* name, bool allowPatched);
 
 /// Magic number which represents an invalid or missing param type
 constexpr uint32_t kNoParamID = 0xFFFFFFFF;

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -819,7 +819,7 @@ void PatchCableSet::readPatchCablesFromFile(StorageManager& bdsm, int32_t readAu
 				}
 				else if (!strcmp(tagName, "destination")) {
 					destinationParamDescriptor.setToHaveParamOnly(
-					    params::fileStringToParam(params::Kind::UNPATCHED_SOUND, bdsm.readTagOrAttributeValue()));
+					    params::fileStringToParam(params::Kind::UNPATCHED_SOUND, bdsm.readTagOrAttributeValue(), true));
 				}
 				else if (!strcmp(tagName, "amount")) {
 					tempParam.readFromFile(bdsm, readAutomationUpToPos);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -921,7 +921,8 @@ Error Sound::readTagFromFile(StorageManager& bdsm, char const* tagName, ParamMan
 
 				while (*(tagName = bdsm.readNextTagOrAttributeName())) {
 					if (!strcmp(tagName, "controlsParam")) {
-						p = params::fileStringToParam(params::Kind::UNPATCHED_SOUND, bdsm.readTagOrAttributeValue());
+						p = params::fileStringToParam(params::Kind::UNPATCHED_SOUND, bdsm.readTagOrAttributeValue(),
+						                              true);
 					}
 					else if (!strcmp(tagName, "patchAmountFromSource")) {
 						s = stringToSource(bdsm.readTagOrAttributeValue());


### PR DESCRIPTION
Add parsing option to not include patched params, add some static asserts to check that you get the same parm to name mapping in both directions 