### PR TITLE
cache whether the instrument is on card to avoid re checking

### DIFF
--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -31,7 +31,7 @@
 
 Instrument::Instrument(OutputType newType) : Output(newType) {
 	editedByUser = false;
-	existsOnCard = true;
+	existsOnCard = false;
 	defaultVelocity = FlashStorage::defaultVelocity;
 }
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1942,7 +1942,7 @@ loadOutput:
 						if (error != Error::NONE) {
 							goto gotError;
 						}
-
+						((Instrument*)newOutput)->existsOnCard = true;
 						*lastPointer = newOutput;
 						lastPointer = &newOutput->next;
 					}

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -31,14 +31,18 @@ Error FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernating)
 	isFolder = false;
 	instrumentAlreadyInSong = !hibernating;
 	displayName = filename.get();
-	String tempFilePath;
-	tempFilePath.set(newInstrument->dirPath.get());
-	tempFilePath.concatenate("/");
-	tempFilePath.concatenate(filename.get());
-	bool fileExists = storageManager.fileExists(tempFilePath.get(), &filePointer);
-	if (!fileExists) {
-		D_PRINTLN("couldn't get filepath for file %d", filename.get());
+	if (newInstrument->existsOnCard && filePointer.sclust == 0) {
+		String tempFilePath;
+		tempFilePath.set(newInstrument->dirPath.get());
+		tempFilePath.concatenate("/");
+		tempFilePath.concatenate(filename.get());
+		bool fileExists = storageManager.fileExists(tempFilePath.get(), &filePointer);
+		if (!fileExists) {
+			D_PRINTLN("couldn't get filepath for file %d", filename.get());
+			return Error::FILE_NOT_FOUND;
+		}
 	}
+
 	return Error::NONE;
 }
 

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -1443,7 +1443,7 @@ paramManagersMissing:
 
 	newInstrument->name.set(name);
 	newInstrument->dirPath.set(dirPath);
-
+	newInstrument->existsOnCard = true;
 	newInstrument->loadAllAudioFiles(mayReadSamplesFromFiles); // Needs name, directory and slots set first, above.
 
 	*getInstrument = newInstrument;


### PR DESCRIPTION
Fix #787 

Save whether an instrument exists on card or not, and only grab the file pointer if it exists but we don't know it