### PR TITLE
replace calls to new button with shift button

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -493,7 +493,7 @@ ActionResult KeyboardScreen::buttonAction(deluge::hid::Button b, bool on, bool i
 	else if (b == KIT && currentUIMode == UI_MODE_NONE) {
 		if (on) {
 			bool result;
-			if (Buttons::isNewOrShiftButtonPressed()) {
+			if (Buttons::isShiftButtonPressed()) {
 				result = createNewInstrument(OutputType::KIT);
 			}
 			else {
@@ -508,7 +508,7 @@ ActionResult KeyboardScreen::buttonAction(deluge::hid::Button b, bool on, bool i
 	else if (b == SYNTH && currentUIMode == UI_MODE_NONE) {
 		if (on) {
 			bool result;
-			if (Buttons::isNewOrShiftButtonPressed()) {
+			if (Buttons::isShiftButtonPressed()) {
 				result = createNewInstrument(OutputType::SYNTH);
 			}
 			else {

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -259,7 +259,7 @@ void nullifyUIs() {
 
 void renderUIsForOled() {
 	int32_t u = numUIsOpen - 1;
-	while (u && uiNavigationHierarchy[u]->oledShowsUIUnderneath) {
+	while ((u > 0) && uiNavigationHierarchy[u]->oledShowsUIUnderneath) {
 		u--;
 	}
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1688,7 +1688,7 @@ void AutomationView::handleKitButtonAction(OutputType outputType, bool on) {
 			initParameterSelection();
 			resetParameterShortcutBlinking();
 		}
-		if (Buttons::isNewOrShiftButtonPressed()) {
+		if (Buttons::isShiftButtonPressed()) {
 			instrumentClipView.createNewInstrument(OutputType::KIT);
 		}
 		else {
@@ -1706,7 +1706,7 @@ void AutomationView::handleSynthButtonAction(OutputType outputType, bool on) {
 			resetParameterShortcutBlinking();
 		}
 		// this gets triggered when you change an existing clip to synth / create a new synth clip in song mode
-		if (Buttons::isNewOrShiftButtonPressed()) {
+		if (Buttons::isShiftButtonPressed()) {
 			instrumentClipView.createNewInstrument(OutputType::SYNTH);
 		}
 		// this gets triggered when you change clip type to synth from within inside clip view

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -443,7 +443,7 @@ doOther:
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
 
-			if (Buttons::isNewOrShiftButtonPressed()) {
+			if (Buttons::isShiftButtonPressed()) {
 				createNewInstrument(OutputType::KIT);
 			}
 			else {
@@ -460,7 +460,7 @@ doOther:
 			}
 
 			if (currentUIMode == UI_MODE_NONE) {
-				if (Buttons::isNewOrShiftButtonPressed()) {
+				if (Buttons::isShiftButtonPressed()) {
 					createNewInstrument(OutputType::SYNTH);
 				}
 				else {

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -272,14 +272,6 @@ bool shiftHasChanged() {
 	return toReturn;
 }
 
-bool isNewOrShiftButtonPressed() {
-#ifdef BUTTON_NEW_X
-	return buttonStates[BUTTON_NEW_X][BUTTON_NEW_Y];
-#else
-	return buttonStates[shiftButtonCoord.x][shiftButtonCoord.y];
-#endif
-}
-
 // Correct any misunderstandings
 void noPressesHappening(bool inCardRoutine) {
 	for (int32_t x = 0; x < NUM_BUTTON_COLS; x++) {

--- a/src/deluge/hid/buttons.h
+++ b/src/deluge/hid/buttons.h
@@ -26,7 +26,6 @@ namespace Buttons {
 ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 bool isButtonPressed(deluge::hid::Button b);
 bool isShiftButtonPressed();
-bool isNewOrShiftButtonPressed();
 void noPressesHappening(bool inCardRoutine);
 
 /**

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -433,7 +433,7 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 	// Which-instrument-type buttons
 	else if (b == SYNTH) {
 		if (on && currentUIMode == UI_MODE_NONE) {
-			if (Buttons::isNewOrShiftButtonPressed()) {
+			if (Buttons::isShiftButtonPressed()) {
 				createNewInstrument(OutputType::SYNTH);
 			}
 			else {


### PR DESCRIPTION
Fix #1736 

New instruments used a function "newOrShiftButtonPressed", which had a macro that made it just check the shift button without going through the shift function. Just correct that to call the shift button function instead