### PR TITLE
Bugfix/recover from not finding synth on card

### DIFF
--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -38,8 +38,9 @@ Error FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernating)
 		tempFilePath.concatenate(filename.get());
 		bool fileExists = storageManager.fileExists(tempFilePath.get(), &filePointer);
 		if (!fileExists) {
-			D_PRINTLN("couldn't get filepath for file %d", filename.get());
-			return Error::FILE_NOT_FOUND;
+			// this is recoverable later - will make a default synth or browse from top folder when encountering the
+			// null filepointer
+			D_PRINTLN("couldn't get filepath for file %s", filename.get());
 		}
 	}
 

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -41,6 +41,8 @@ Error FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernating)
 			// this is recoverable later - will make a default synth or browse from top folder when encountering the
 			// null filepointer
 			D_PRINTLN("couldn't get filepath for file %s", filename.get());
+			// so we don't look for it again
+			newInstrument->existsOnCard = false;
 		}
 	}
 


### PR DESCRIPTION
Fix #1792 
Fix #1789 

For projects where the synth is no longer in it's original location it will be loaded as "exists on card" but might not be in it's original location. In this case we'll cache that it's not on card but not return an error, as that's signalled through changing the existsOnCard attribute and the null file pointer.