### PR TITLE
Always read the old “mode” arp param (later overriden by new params)

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2669,13 +2669,18 @@ someError:
 					arpSettings.syncType = (SyncType)bdsm.readTagOrAttributeValueInt();
 					bdsm.exitTag("syncType");
 				}
-				else if (!strcmp(tagName, "mode") && bdsm.firmware_version < FirmwareVersion::community({1, 1, 0})) {
+				else if (!strcmp(tagName, "mode")) {
 					// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
+					// but only if the new params are not already read and set,
+					// that is, if we detect they have a value other than default
 					OldArpMode oldMode = stringToOldArpMode(bdsm.readTagOrAttributeValue());
-					arpSettings.mode = oldModeToArpMode(oldMode);
-					arpSettings.noteMode = oldModeToArpNoteMode(oldMode);
-					arpSettings.octaveMode = oldModeToArpOctaveMode(oldMode);
-					arpSettings.updatePresetFromCurrentSettings();
+					if (arpSettings.mode == ArpMode::OFF && arpSettings.noteMode == ArpNoteMode::UP
+					    && arpSettings.octaveMode == ArpOctaveMode::UP) {
+						arpSettings.mode = oldModeToArpMode(oldMode);
+						arpSettings.noteMode = oldModeToArpNoteMode(oldMode);
+						arpSettings.octaveMode = oldModeToArpOctaveMode(oldMode);
+						arpSettings.updatePresetFromCurrentSettings();
+					}
 					bdsm.exitTag("mode");
 				}
 				else if (!strcmp(tagName, "arpMode")) {
@@ -3190,7 +3195,7 @@ void InstrumentClip::prepNoteRowsForExitingKitMode(Song* song) {
 				chosenNoteRowIndex = i;
 				break;
 			}
-noteRowFailed: {}
+noteRowFailed : {}
 		}
 	}
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -685,14 +685,19 @@ Error Sound::readTagFromFile(StorageManager& bdsm, char const* tagName, ParamMan
 				}
 				bdsm.exitTag("arpMode");
 			}
-			else if (!strcmp(tagName, "mode") && bdsm.firmware_version < FirmwareVersion::community({1, 1, 0})) {
+			else if (!strcmp(tagName, "mode")) {
 				// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
+				// but only if the new params are not already read and set,
+				// that is, if we detect they have a value other than default
 				if (arpSettings) {
 					OldArpMode oldMode = stringToOldArpMode(bdsm.readTagOrAttributeValue());
-					arpSettings->mode = oldModeToArpMode(oldMode);
-					arpSettings->noteMode = oldModeToArpNoteMode(oldMode);
-					arpSettings->octaveMode = oldModeToArpOctaveMode(oldMode);
-					arpSettings->updatePresetFromCurrentSettings();
+					if (arpSettings->mode == ArpMode::OFF && arpSettings->noteMode == ArpNoteMode::UP
+					    && arpSettings->octaveMode == ArpOctaveMode::UP) {
+						arpSettings->mode = oldModeToArpMode(oldMode);
+						arpSettings->noteMode = oldModeToArpNoteMode(oldMode);
+						arpSettings->octaveMode = oldModeToArpOctaveMode(oldMode);
+						arpSettings->updatePresetFromCurrentSettings();
+					}
 				}
 				bdsm.exitTag("mode");
 			}


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/1790
To cherry pick