### PR TITLE
Release/1.1 - Always read the old “mode” arp param (later overriden by new params) 

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2669,14 +2669,18 @@ someError:
 					arpSettings.syncType = (SyncType)storageManager.readTagOrAttributeValueInt();
 					storageManager.exitTag("syncType");
 				}
-				else if (!strcmp(tagName, "mode")
-				         && storageManager.firmware_version < FirmwareVersion::community({1, 1, 0})) {
+				else if (!strcmp(tagName, "mode")) {
 					// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
+					// but only if the new params are not already read and set,
+					// that is, if we detect they have a value other than default
 					OldArpMode oldMode = stringToOldArpMode(storageManager.readTagOrAttributeValue());
-					arpSettings.mode = oldModeToArpMode(oldMode);
-					arpSettings.noteMode = oldModeToArpNoteMode(oldMode);
-					arpSettings.octaveMode = oldModeToArpOctaveMode(oldMode);
-					arpSettings.updatePresetFromCurrentSettings();
+					if (arpSettings.mode == ArpMode::OFF && arpSettings.noteMode == ArpNoteMode::UP
+					    && arpSettings.octaveMode == ArpOctaveMode::UP) {
+						arpSettings.mode = oldModeToArpMode(oldMode);
+						arpSettings.noteMode = oldModeToArpNoteMode(oldMode);
+						arpSettings.octaveMode = oldModeToArpOctaveMode(oldMode);
+						arpSettings.updatePresetFromCurrentSettings();
+					}
 					storageManager.exitTag("mode");
 				}
 				else if (!strcmp(tagName, "arpMode")) {

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2669,7 +2669,8 @@ someError:
 					arpSettings.syncType = (SyncType)storageManager.readTagOrAttributeValueInt();
 					storageManager.exitTag("syncType");
 				}
-				else if (!strcmp(tagName, "mode")) {
+				else if (!strcmp(tagName, "mode")
+				         && storageManager.firmware_version < FirmwareVersion::community({1, 2, 0})) {
 					// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
 					// but only if the new params are not already read and set,
 					// that is, if we detect they have a value other than default

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -681,15 +681,19 @@ Error Sound::readTagFromFile(char const* tagName, ParamManagerForTimeline* param
 				}
 				storageManager.exitTag("arpMode");
 			}
-			else if (!strcmp(tagName, "mode")
-			         && storageManager.firmware_version < FirmwareVersion::community({1, 1, 0})) {
+			else if (!strcmp(tagName, "mode")) {
 				// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
+				// but only if the new params are not already read and set,
+				// that is, if we detect they have a value other than default
 				if (arpSettings) {
 					OldArpMode oldMode = stringToOldArpMode(storageManager.readTagOrAttributeValue());
-					arpSettings->mode = oldModeToArpMode(oldMode);
-					arpSettings->noteMode = oldModeToArpNoteMode(oldMode);
-					arpSettings->octaveMode = oldModeToArpOctaveMode(oldMode);
-					arpSettings->updatePresetFromCurrentSettings();
+					if (arpSettings->mode == ArpMode::OFF && arpSettings->noteMode == ArpNoteMode::UP
+					    && arpSettings->octaveMode == ArpOctaveMode::UP) {
+						arpSettings->mode = oldModeToArpMode(oldMode);
+						arpSettings->noteMode = oldModeToArpNoteMode(oldMode);
+						arpSettings->octaveMode = oldModeToArpOctaveMode(oldMode);
+						arpSettings->updatePresetFromCurrentSettings();
+					}
 				}
 				storageManager.exitTag("mode");
 			}

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -681,7 +681,8 @@ Error Sound::readTagFromFile(char const* tagName, ParamManagerForTimeline* param
 				}
 				storageManager.exitTag("arpMode");
 			}
-			else if (!strcmp(tagName, "mode")) {
+			else if (!strcmp(tagName, "mode")
+			         && storageManager.firmware_version < FirmwareVersion::community({1, 2, 0})) {
 				// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
 				// but only if the new params are not already read and set,
 				// that is, if we detect they have a value other than default


### PR DESCRIPTION
Same PR as this one https://github.com/SynthstromAudible/DelugeFirmware/pull/1800 but adapted to release/1.1 branch due to changes in bdsm vs storageManager