### PR TITLE
fix bug sending first sample through without filtering

### DIFF
--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -58,7 +58,7 @@ public:
 	 * @param extraSaturation extra saturation value
 	 */
 	[[gnu::hot]] void filterMono(q31_t* startSample, q31_t* endSample, int32_t sampleIncrememt = 1) {
-		if (wetLevel == ONE_Q31) {
+		if (dryFade < 0.001) {
 			static_cast<T*>(this)->doFilter(startSample, endSample, sampleIncrememt);
 		}
 		else {
@@ -84,7 +84,7 @@ public:
 	 * @param extraSaturation extra saturation value
 	 */
 	[[gnu::hot]] void filterStereo(q31_t* startSample, q31_t* endSample) {
-		if (wetLevel == ONE_Q31) {
+		if (dryFade < 0.001) {
 			static_cast<T*>(this)->doFilterStereo(startSample, endSample);
 		}
 		else {


### PR DESCRIPTION
zeroing the filters sets the wet and dry levels both to 0. As a result the render then passes through the blend path (for removing filter activation clicks) and passes the first sample without filtering. The second sample the wet level is updated to 1 minus the dry level and filtering works as normal, so this wasn't noticeable if the first sample was at a zero crossing. 

With this fix the check is done on dry level instead, so zeroing the filters when resetting is fine. Wet level is explicitly set to 1 to start a fade so the fading still works to remove clicks in performance/song view