### PR TITLE
Bugfix - Automation View Rendering

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -603,8 +603,8 @@ bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidt
 	// erase current occupancy mask as it will be refreshed
 	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
-	performActualRender(whichRows, &image[0][0], occupancyMask, currentSong->xScroll[navSysId],
-	                    currentSong->xZoom[navSysId], kDisplayWidth, kDisplayWidth + kSideBarWidth, drawUndefinedArea);
+	performActualRender(image, occupancyMask, currentSong->xScroll[navSysId], currentSong->xZoom[navSysId],
+	                    kDisplayWidth, kDisplayWidth + kSideBarWidth, drawUndefinedArea);
 
 	blinkShortcuts();
 
@@ -657,7 +657,7 @@ void AutomationView::blinkShortcuts() {
 }
 
 // determines whether you should render the automation editor, automation overview or just render some love <3
-void AutomationView::performActualRender(uint32_t whichRows, RGB* image,
+void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWidth],
                                          uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xScroll,
                                          uint32_t xZoom, int32_t renderWidth, int32_t imageWidth,
                                          bool drawUndefinedArea) {
@@ -694,33 +694,27 @@ void AutomationView::performActualRender(uint32_t whichRows, RGB* image,
 		isBipolar = isParamBipolar(kind, modelStackWithParam->paramId);
 	}
 
-	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+		if (onArrangerView
+		    || (outputType != OutputType::CV
+		        && !(outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum))) {
 
-		if (whichRows & (1 << yDisplay)) {
-			uint8_t* occupancyMaskOfRow = occupancyMask[yDisplay];
-
-			if (onArrangerView
-			    || (outputType != OutputType::CV
-			        && !(outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum))) {
-
-				// if parameter has been selected, show Automation Editor
-				if (!isOnAutomationOverview()) {
-					renderAutomationEditor(modelStackWithParam, clip, image + (yDisplay * imageWidth),
-					                       occupancyMaskOfRow, renderWidth, xScroll, xZoom, effectiveLength, yDisplay,
-					                       drawUndefinedArea, kind, isBipolar);
-				}
-
-				// if not editing a parameter, show Automation Overview
-				else {
-					renderAutomationOverview(modelStackWithTimelineCounter, modelStackWithThreeMainThings, clip,
-					                         outputType, image + (yDisplay * imageWidth), occupancyMaskOfRow, yDisplay);
-				}
+			// if parameter has been selected, show Automation Editor
+			if (!isOnAutomationOverview()) {
+				renderAutomationEditor(modelStackWithParam, clip, image, occupancyMask, renderWidth, xScroll, xZoom,
+				                       effectiveLength, xDisplay, drawUndefinedArea, kind, isBipolar);
 			}
 
+			// if not editing a parameter, show Automation Overview
 			else {
-				if (outputType == OutputType::CV) {
-					renderLove(image + (yDisplay * imageWidth), occupancyMaskOfRow, yDisplay);
-				}
+				renderAutomationOverview(modelStackWithTimelineCounter, modelStackWithThreeMainThings, clip, outputType,
+				                         image, occupancyMask, xDisplay);
+			}
+		}
+
+		else {
+			if (outputType == OutputType::CV) {
+				renderLove(image, occupancyMask, xDisplay);
 			}
 		}
 	}
@@ -729,12 +723,13 @@ void AutomationView::performActualRender(uint32_t whichRows, RGB* image,
 // renders automation overview
 void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                               ModelStackWithThreeMainThings* modelStackWithThreeMainThings, Clip* clip,
-                                              OutputType outputType, RGB* image, uint8_t occupancyMask[],
-                                              int32_t yDisplay) {
+                                              OutputType outputType, RGB image[][kDisplayWidth + kSideBarWidth],
+                                              uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+                                              int32_t xDisplay) {
 
-	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 
-		RGB& pixel = image[xDisplay];
+		RGB& pixel = image[yDisplay][xDisplay];
 
 		ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
@@ -798,25 +793,26 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 				pixel = colours::grey;
 			}
 
-			occupancyMask[xDisplay] = 64;
+			occupancyMask[yDisplay][xDisplay] = 64;
 		}
 	}
 }
 
 // gets the length of the clip, renders the pads corresponding to current parameter values set up to the clip length
 // renders the undefined area of the clip that the user can't interact with
-void AutomationView::renderAutomationEditor(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, RGB* image,
-                                            uint8_t occupancyMask[], int32_t renderWidth, int32_t xScroll,
-                                            uint32_t xZoom, int32_t effectiveLength, int32_t yDisplay,
+void AutomationView::renderAutomationEditor(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
+                                            RGB image[][kDisplayWidth + kSideBarWidth],
+                                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
+                                            int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
                                             bool drawUndefinedArea, params::Kind kind, bool isBipolar) {
 	if (modelStackWithParam && modelStackWithParam->autoParam) {
 
-		renderRow(modelStackWithParam, image, occupancyMask, effectiveLength, yDisplay,
-		          modelStackWithParam->autoParam->isAutomated(), xScroll, xZoom, kind, isBipolar);
+		renderAutomationColumn(modelStackWithParam, image, occupancyMask, effectiveLength, xDisplay,
+		                       modelStackWithParam->autoParam->isAutomated(), xScroll, xZoom, kind, isBipolar);
 
 		if (drawUndefinedArea) {
 			renderUndefinedArea(xScroll, xZoom, effectiveLength, image, occupancyMask, renderWidth, this,
-			                    currentSong->tripletsOn);
+			                    currentSong->tripletsOn, xDisplay);
 		}
 	}
 }
@@ -841,16 +837,18 @@ bool AutomationView::possiblyRefreshAutomationEditorGrid(Clip* clip, deluge::mod
 	return false;
 }
 
-/// render each square in each row of the automation editor grid
-void AutomationView::renderRow(ModelStackWithAutoParam* modelStackWithParam, RGB* image, uint8_t occupancyMask[],
-                               int32_t lengthToDisplay, int32_t yDisplay, bool isAutomated, int32_t xScroll,
-                               int32_t xZoom, params::Kind kind, bool isBipolar) {
+/// render each square in each column of the automation editor grid
+void AutomationView::renderAutomationColumn(ModelStackWithAutoParam* modelStackWithParam,
+                                            RGB image[][kDisplayWidth + kSideBarWidth],
+                                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+                                            int32_t lengthToDisplay, int32_t xDisplay, bool isAutomated,
+                                            int32_t xScroll, int32_t xZoom, params::Kind kind, bool isBipolar) {
+
+	uint32_t squareStart = getMiddlePosFromSquare(xDisplay, lengthToDisplay, xScroll, xZoom);
+	int32_t knobPos = getParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
 
 	// iterate through each square
-	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
-		uint32_t squareStart = getMiddlePosFromSquare(xDisplay, lengthToDisplay, xScroll, xZoom);
-		int32_t knobPos = getParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
-
+	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 		if (isBipolar) {
 			renderBipolarSquare(image, occupancyMask, xDisplay, yDisplay, isAutomated, kind, knobPos);
 		}
@@ -861,9 +859,10 @@ void AutomationView::renderRow(ModelStackWithAutoParam* modelStackWithParam, RGB
 }
 
 /// render column for bipolar params - e.g. pan, pitch, patch cable
-void AutomationView::renderBipolarSquare(RGB* image, uint8_t occupancyMask[], int32_t xDisplay, int32_t yDisplay,
-                                         bool isAutomated, params::Kind kind, int32_t knobPos) {
-	RGB& pixel = image[xDisplay];
+void AutomationView::renderBipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+                                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
+                                         int32_t yDisplay, bool isAutomated, params::Kind kind, int32_t knobPos) {
+	RGB& pixel = image[yDisplay][xDisplay];
 
 	int32_t middleKnobPos;
 
@@ -924,7 +923,7 @@ void AutomationView::renderBipolarSquare(RGB* image, uint8_t occupancyMask[], in
 				pixel = rowBipolarDownTailColour[yDisplay];
 			}
 		}
-		occupancyMask[xDisplay] = 64;
+		occupancyMask[yDisplay][xDisplay] = 64;
 	}
 
 	// pad selection mode, render cursor
@@ -940,14 +939,15 @@ void AutomationView::renderBipolarSquare(RGB* image, uint8_t occupancyMask[], in
 		else {
 			pixel = colours::grey;
 		}
-		occupancyMask[xDisplay] = 64;
+		occupancyMask[yDisplay][xDisplay] = 64;
 	}
 }
 
 /// render column for unipolar params (e.g. not pan, pitch, or patch cables)
-void AutomationView::renderUnipolarSquare(RGB* image, uint8_t occupancyMask[], int32_t xDisplay, int32_t yDisplay,
-                                          bool isAutomated, int32_t knobPos) {
-	RGB& pixel = image[xDisplay];
+void AutomationView::renderUnipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+                                          uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
+                                          int32_t yDisplay, bool isAutomated, int32_t knobPos) {
+	RGB& pixel = image[yDisplay][xDisplay];
 
 	// determine whether or not you should render a row based on current value
 	bool doRender = false;
@@ -963,7 +963,7 @@ void AutomationView::renderUnipolarSquare(RGB* image, uint8_t occupancyMask[], i
 		else { // not automated, render less bright tail colour
 			pixel = rowTailColour[yDisplay];
 		}
-		occupancyMask[xDisplay] = 64;
+		occupancyMask[yDisplay][xDisplay] = 64;
 	}
 
 	// pad selection mode, render cursor
@@ -974,14 +974,15 @@ void AutomationView::renderUnipolarSquare(RGB* image, uint8_t occupancyMask[], i
 		else {
 			pixel = colours::grey;
 		}
-		occupancyMask[xDisplay] = 64;
+		occupancyMask[yDisplay][xDisplay] = 64;
 	}
 }
 
 // occupancyMask now optional
-void AutomationView::renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_t lengthToDisplay, RGB* rowImage,
-                                         uint8_t occupancyMask[], int32_t imageWidth, TimelineView* timelineView,
-                                         bool tripletsOnHere) {
+void AutomationView::renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_t lengthToDisplay,
+                                         RGB image[][kDisplayWidth + kSideBarWidth],
+                                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t imageWidth,
+                                         TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay) {
 	// If the visible pane extends beyond the end of the Clip, draw it as grey
 	int32_t greyStart = timelineView->getSquareFromPos(lengthToDisplay - 1, NULL, xScroll, xZoom) + 1;
 
@@ -989,20 +990,20 @@ void AutomationView::renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_
 		greyStart = 0; // This actually happened in a song of Marek's, due to another bug, but best to check for this
 	}
 
-	if (greyStart < imageWidth) {
-		std::fill(rowImage + greyStart, rowImage + greyStart + (imageWidth - greyStart), colours::grey);
-		if (occupancyMask) {
-			memset(occupancyMask + greyStart, 64, imageWidth - greyStart);
+	if (greyStart <= xDisplay) {
+		for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+			image[yDisplay][xDisplay] = colours::grey;
+			occupancyMask[yDisplay][xDisplay] = 64;
 		}
 	}
 
 	if (tripletsOnHere && timelineView->supportsTriplets()) {
-		for (int32_t xDisplay = 0; xDisplay < imageWidth; xDisplay++) {
+		for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 			if (!timelineView->isSquareDefined(xDisplay, xScroll, xZoom)) {
-				rowImage[xDisplay] = colours::grey;
+				image[yDisplay][xDisplay] = colours::grey;
 
 				if (occupancyMask) {
-					occupancyMask[xDisplay] = 64;
+					occupancyMask[yDisplay][xDisplay] = 64;
 				}
 			}
 		}
@@ -1011,16 +1012,17 @@ void AutomationView::renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_
 
 // easter egg lol. it is rendered when you press the CV clip button as you can't use automation view there
 // it draws a cute heart and musical note
-void AutomationView::renderLove(RGB* image, uint8_t occupancyMask[], int32_t yDisplay) {
+void AutomationView::renderLove(RGB image[][kDisplayWidth + kSideBarWidth],
+                                uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay) {
 
-	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 
-		RGB& pixel = image[xDisplay];
+		RGB& pixel = image[yDisplay][xDisplay];
 
 		if (love[xDisplay][yDisplay] == 0xFFFFFFFF) {
 
 			pixel = rowColour[yDisplay];
-			occupancyMask[xDisplay] = 64;
+			occupancyMask[yDisplay][xDisplay] = 64;
 		}
 	}
 }

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -174,26 +174,35 @@ private:
 	                   uint8_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
 
 	// Automation View Render Functions
-	void performActualRender(uint32_t whichRows, RGB* image, uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
-	                         int32_t xScroll, uint32_t xZoom, int32_t renderWidth, int32_t imageWidth,
-	                         bool drawUndefinedArea = true);
+	void performActualRender(RGB image[][kDisplayWidth + kSideBarWidth],
+	                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xScroll, uint32_t xZoom,
+	                         int32_t renderWidth, int32_t imageWidth, bool drawUndefinedArea = true);
 	void renderAutomationOverview(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
 	                              ModelStackWithThreeMainThings* modelStackWithThreeMainThings, Clip* clip,
-	                              OutputType outputType, RGB* image, uint8_t occupancyMask[], int32_t yDisplay);
-	void renderAutomationEditor(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, RGB* image,
-	                            uint8_t occupancyMask[], int32_t renderWidth, int32_t xScroll, uint32_t xZoom,
-	                            int32_t effectiveLength, int32_t yDisplay, bool drawUndefinedArea,
+	                              OutputType outputType, RGB image[][kDisplayWidth + kSideBarWidth],
+	                              uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay);
+	void renderAutomationEditor(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
+	                            RGB image[][kDisplayWidth + kSideBarWidth],
+	                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
+	                            int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
+	                            bool drawUndefinedArea, deluge::modulation::params::Kind kind, bool isBipolar);
+	void renderAutomationColumn(ModelStackWithAutoParam* modelStackWithParam,
+	                            RGB image[][kDisplayWidth + kSideBarWidth],
+	                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t lengthToDisplay,
+	                            int32_t xDisplay, bool isAutomated, int32_t xScroll, int32_t xZoom,
 	                            deluge::modulation::params::Kind kind, bool isBipolar);
-	void renderRow(ModelStackWithAutoParam* modelStackWithParam, RGB* image, uint8_t occupancyMask[],
-	               int32_t lengthToDisplay, int32_t yDisplay, bool isAutomated, int32_t xScroll, int32_t xZoom,
-	               deluge::modulation::params::Kind kind, bool isBipolar);
-	void renderBipolarSquare(RGB* image, uint8_t occupancyMask[], int32_t xDisplay, int32_t yDisplay, bool isAutomated,
-	                         deluge::modulation::params::Kind kind, int32_t knobPos);
-	void renderUnipolarSquare(RGB* image, uint8_t occupancyMask[], int32_t xDisplay, int32_t yDisplay, bool isAutomated,
-	                          int32_t knobPos);
-	void renderUndefinedArea(int32_t localScroll, uint32_t, int32_t lengthToDisplay, RGB* image, uint8_t[],
-	                         int32_t imageWidth, TimelineView* editorScreen, bool tripletsOnHere);
-	void renderLove(RGB* image, uint8_t occupancyMask[], int32_t yDisplay = 0);
+	void renderBipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+	                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay, int32_t yDisplay,
+	                         bool isAutomated, deluge::modulation::params::Kind kind, int32_t knobPos);
+	void renderUnipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+	                          uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
+	                          int32_t yDisplay, bool isAutomated, int32_t knobPos);
+	void renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_t lengthToDisplay,
+	                         RGB image[][kDisplayWidth + kSideBarWidth],
+	                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t imageWidth,
+	                         TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay);
+	void renderLove(RGB image[][kDisplayWidth + kSideBarWidth], uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+	                int32_t xDisplay);
 	void renderDisplayOLED(Clip* clip, OutputType outputType, int32_t knobPosLeft = kNoSelection,
 	                       int32_t knobPosRight = kNoSelection);
 	void renderDisplay7SEG(Clip* clip, OutputType outputType, int32_t knobPosLeft = kNoSelection,


### PR DESCRIPTION
Fixed a bug with arranger automation view rendering when playback is running (the arranger view graphics routine would render over the automation view render clearing some rows). Fixed it by removing the "whichRows" attribute to automation view rendering as it is not used (all rows need to be re-rendered each time to display the updated automation value).

Optimized Automation View rendering code to render on a column by column basis as opposed to a row by row basis.

This enables certain actions (e.g. getting the parameter value for a column) to be performed once instead of numerous times (e.g. 1 time vs 8 times per column).