### PR TITLE
Updated uiTimerManager Frequency

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -551,7 +551,7 @@ void registerTasks() {
 	// needs to be called very frequently,
 	// handles animations and checks on the timers for any infrequent actions
 	// long term this should probably be made into an idle task
-	addRepeatingTask([]() { uiTimerManager.routine(); }, 101, 0.0001, 0.001, 0.005);
+	addRepeatingTask([]() { uiTimerManager.routine(); }, 101, 0.0001, 0.0007, 0.005);
 	if (hid::display::have_oled_screen) {
 		addRepeatingTask(&(oledRoutine), 100, 0.01, 0.01, 0.02);
 	}


### PR DESCRIPTION
Updated task manager frequency for uiTimerManager so that it tries to run every 0.0007 seconds as opposed to every 0.001 seconds