### PR TITLE
Bugfix midi follow crash if clip is deleted

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -45,6 +45,7 @@
 #include "hid/led/pad_leds.h"
 #include "io/debug/log.h"
 #include "io/midi/device_specific/specific_midi_device.h"
+#include "io/midi/midi_follow.h"
 #include "memory/general_memory_allocator.h"
 #include "model/action/action_logger.h"
 #include "model/clip/audio_clip.h"
@@ -1671,6 +1672,7 @@ void SessionView::removeClip(Clip* clip) {
 
 	clip->stopAllNotesPlaying(currentSong); // Stops any MIDI-controlled auditioning / stuck notes
 
+	midiFollow.removeClip(clip);
 	currentSong->removeSessionClip(clip, clipIndex);
 
 	if (playbackHandler.isEitherClockActive() && currentPlaybackMode == &session) {

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -347,6 +347,17 @@ int32_t MidiFollow::getCCFromParam(params::Kind paramKind, int32_t paramID) {
 /// used to store the clip's for each note received so that note off's can be sent to the right clip
 PLACE_SDRAM_DATA Clip* clipForLastNoteReceived[kMaxMIDIValue + 1] = {0};
 
+/// removes a specific clip pointer from the clipForLastNoteReceived array
+/// if a clip is deleted, it should be removed from this array to ensure note off's don't get sent
+/// to delete clips
+void MidiFollow::removeClip(Clip* clip) {
+	for (int32_t i = 0; i <= 127; i++) {
+		if (clipForLastNoteReceived[i] == clip) {
+			clipForLastNoteReceived[i] = nullptr;
+		}
+	}
+}
+
 /// called from playback handler
 /// determines whether a note message received is midi follow relevant
 /// and should be routed to the active context for further processing

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -54,6 +54,8 @@ public:
 	void aftertouchReceived(MIDIDevice* fromDevice, int32_t channel, int32_t value, int32_t noteCode,
 	                        bool* doingMidiThru, ModelStack* modelStack);
 
+	void removeClip(Clip* clip);
+
 	// midi CC mappings
 	int32_t getCCFromParam(deluge::modulation::params::Kind paramKind, int32_t paramID);
 


### PR DESCRIPTION
Fixed crash if midi follow note off's are sent to a clip that's been deleted by removing deleted clip's from note off array at time of clip deletion