### PR TITLE
Bug Fix Mod Button Popups

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -834,13 +834,154 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
 	if (activeModControllableModelStack.modControllable) {
 
+		bool noteTailsAllowedBefore;
+		ModelStackWithAutoParam* modelStackWithParam = getModelStackWithParam(whichModEncoder, noteTailsAllowedBefore);
+
+		// If non-existent param, still let the ModControllable know
+		if (!modelStackWithParam || !modelStackWithParam->autoParam) {
+			ActionResult result = activeModControllableModelStack.modControllable->modEncoderActionForNonExistentParam(
+			    offset, whichModEncoder, modelStackWithParam);
+
+			if (result == ActionResult::ACTIONED_AND_CAUSED_CHANGE) {
+				setKnobIndicatorLevel(whichModEncoder);
+			}
+		}
+
+		// Or, if normal case - an actual param
+		else {
+			char modelStackTempMemory[MODEL_STACK_MAX_SIZE];
+			copyModelStack(modelStackTempMemory, modelStackWithParam, sizeof(ModelStackWithThreeMainThings));
+			ModelStackWithThreeMainThings* tempModelStack = (ModelStackWithThreeMainThings*)modelStackTempMemory;
+
+			params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+
+			int32_t value = modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
+			int32_t knobPos = modelStackWithParam->paramCollection->paramValueToKnobPos(value, modelStackWithParam);
+			int32_t lowerLimit;
+
+			if (kind == params::Kind::PATCH_CABLE) {
+				lowerLimit = std::min(-192_i32, knobPos);
+			}
+			else {
+				lowerLimit = std::min(-64_i32, knobPos);
+			}
+			int32_t newKnobPos = knobPos + offset;
+			newKnobPos = std::clamp(newKnobPos, lowerLimit, 64_i32);
+
+			// ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
+			// if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a value change
+			// gets recorded if newKnobPos exceeds 127, then it means current knobPos was 127 and it was increased
+			// to 128. In which case, ignore value change
+			if (kind == params::Kind::MIDI && (newKnobPos == 64)) {
+				return;
+			}
+
+			// if you had selected a parameter in performance view and the parameter name
+			// and current value is displayed on the screen, don't show pop-up as the display
+			// already shows it
+			// this checks that the param displayed on the screen in performance view
+			// is the same param currently being edited with mod encoder
+			bool editingParamInPerformanceView = false;
+			if (getRootUI() == &performanceSessionView) {
+				if (!performanceSessionView.defaultEditingMode && performanceSessionView.lastPadPress.isActive) {
+					if ((kind == performanceSessionView.lastPadPress.paramKind)
+					    && (modelStackWithParam->paramId == performanceSessionView.lastPadPress.paramID)) {
+						editingParamInPerformanceView = true;
+					}
+				}
+			}
+
+			// let's see if we're editing the same param in the menu, if so, don't show pop-up
+			bool editingParamInMenu = false;
+			if (getCurrentUI() == &soundEditor) {
+				if ((soundEditor.getCurrentMenuItem()->getParamKind() == kind)
+				    && (soundEditor.getCurrentMenuItem()->getParamIndex() == modelStackWithParam->paramId)) {
+					editingParamInMenu = true;
+				}
+			}
+
+			// let's see if we're browsing for a song
+			bool inSongBrowser = getCurrentUI() == &loadSongUI;
+
+			if (!editingParamInPerformanceView && !editingParamInMenu && !inSongBrowser) {
+				PatchSource source1 = PatchSource::NONE;
+				PatchSource source2 = PatchSource::NONE;
+				if (kind == params::Kind::PATCH_CABLE) {
+					ParamDescriptor paramDescriptor;
+					paramDescriptor.data = modelStackWithParam->paramId;
+					source1 = paramDescriptor.getBottomLevelSource();
+					if (!paramDescriptor.hasJustOneSource()) {
+						source2 = paramDescriptor.getTopLevelSource();
+					}
+				}
+				displayModEncoderValuePopup(kind, modelStackWithParam->paramId, newKnobPos, source1, source2);
+			}
+
+			if (newKnobPos == knobPos) {
+				return;
+			}
+
+			// midi follow and midi feedback enabled
+			// re-send midi cc because learned parameter value has changed
+			sendMidiFollowFeedback(modelStackWithParam, newKnobPos);
+
+			char newModelStackMemory[MODEL_STACK_MAX_SIZE];
+
+			// Hack to make it so stutter can't be automated
+			if (modelStackWithParam->timelineCounterIsSet()
+			    && !modelStackWithParam->paramCollection->doesParamIdAllowAutomation(modelStackWithParam)) {
+				copyModelStack(newModelStackMemory, modelStackWithParam, sizeof(ModelStackWithAutoParam));
+				modelStackWithParam = (ModelStackWithAutoParam*)newModelStackMemory;
+				modelStackWithParam->setTimelineCounter(NULL);
+			}
+
+			int32_t newValue =
+			    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
+
+			// Perform the actual change
+			modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, modPos, modLength);
+
+			if (activeModControllableModelStack.timelineCounterIsSet()) {
+				bool noteTailsAllowedAfter =
+				    modelStackWithParam->modControllable->allowNoteTails(tempModelStack->addSoundFlags());
+
+				if (noteTailsAllowedBefore != noteTailsAllowedAfter) {
+					if (getRootUI() && getRootUI()->isTimelineView()) {
+						uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0);
+					}
+				}
+			}
+
+			// if the newKnobPos == 0, and we're dealing with a param that param that should
+			// indicate (blink) middle value
+			// then blink that middle value and make it harder to turn the knob past middle
+			potentiallyMakeItHarderToTurnKnob(whichModEncoder, modelStackWithParam, newKnobPos);
+
+			// if you're updating a param's value while in the sound editor menu
+			// and it's the same param displayed in the automation editor open underneath
+			// then refresh the automation editor grid
+			if ((getCurrentUI() == &soundEditor) && (getRootUI() == &automationView)) {
+				automationView.possiblyRefreshAutomationEditorGrid(getCurrentClip(), kind,
+				                                                   modelStackWithParam->paramId);
+			}
+		}
+	}
+
+	instrumentBeenEdited();
+}
+
+// get's modelStackWithParam for use with Gold Knobs and ModEncoderAction above
+// also used with ModButtonAction to display name's of parameters assigned to gold knobs
+ModelStackWithAutoParam* View::getModelStackWithParam(int32_t whichModEncoder, bool& noteTailsAllowedBefore) {
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	if (activeModControllableModelStack.modControllable) {
+
 		/*
 		char newModelStackMemory[MODEL_STACK_MAX_SIZE];
 		copyModelStack(newModelStackMemory, &activeModControllableModelStack, sizeof(ModelStackWithThreeMainThings));
 		ModelStackWithThreeMainThings* localModelStack = (ModelStackWithThreeMainThings*)newModelStackMemory;
 		*/
-
-		bool noteTailsAllowedBefore;
 
 		if (activeModControllableModelStack.timelineCounterIsSet()) {
 
@@ -864,145 +1005,60 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 			}
 		}
 
-		{
+		modelStackWithParam = activeModControllableModelStack.modControllable->getParamFromModEncoder(
+		    whichModEncoder, &activeModControllableModelStack);
+	}
 
-			ModelStackWithAutoParam* modelStackWithParam =
-			    activeModControllableModelStack.modControllable->getParamFromModEncoder(
-			        whichModEncoder, &activeModControllableModelStack);
+	return modelStackWithParam;
+}
 
-			// If non-existent param, still let the ModControllable know
-			if (!modelStackWithParam || !modelStackWithParam->autoParam) {
-				ActionResult result =
-				    activeModControllableModelStack.modControllable->modEncoderActionForNonExistentParam(
-				        offset, whichModEncoder, modelStackWithParam);
+// used to get name of parameter assigned to mod encoder
+void View::getParameterNameFromModEncoder(int32_t whichModEncoder, char* parameterName) {
+	bool noteTailsAllowedBefore;
+	ModelStackWithAutoParam* modelStackWithParam = getModelStackWithParam(whichModEncoder, noteTailsAllowedBefore);
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+		params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
 
-				if (result == ActionResult::ACTIONED_AND_CAUSED_CHANGE) {
-					setKnobIndicatorLevel(whichModEncoder);
-				}
+		if (kind == params::Kind::PATCH_CABLE) {
+			PatchSource source1 = PatchSource::NONE;
+			PatchSource source2 = PatchSource::NONE;
+			ParamDescriptor paramDescriptor;
+			paramDescriptor.data = modelStackWithParam->paramId;
+			source1 = paramDescriptor.getBottomLevelSource();
+			if (!paramDescriptor.hasJustOneSource()) {
+				source2 = paramDescriptor.getTopLevelSource();
 			}
 
-			// Or, if normal case - an actual param
+			DEF_STACK_STRING_BUF(paramDisplayName, 30);
+			if (source2 == PatchSource::NONE) {
+				paramDisplayName.append(getSourceDisplayNameForOLED(source1));
+			}
 			else {
-				char modelStackTempMemory[MODEL_STACK_MAX_SIZE];
-				copyModelStack(modelStackTempMemory, modelStackWithParam, sizeof(ModelStackWithThreeMainThings));
-				ModelStackWithThreeMainThings* tempModelStack = (ModelStackWithThreeMainThings*)modelStackTempMemory;
+				paramDisplayName.append(sourceToStringShort(source1));
+			}
+			if (display->haveOLED()) {
+				paramDisplayName.append(" -> ");
+			}
+			else {
+				paramDisplayName.append(" - ");
+			}
 
-				params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-
-				int32_t value = modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
-				int32_t knobPos = modelStackWithParam->paramCollection->paramValueToKnobPos(value, modelStackWithParam);
-				int32_t lowerLimit;
-
-				if (kind == params::Kind::PATCH_CABLE) {
-					lowerLimit = std::min(-192_i32, knobPos);
+			if (source2 != PatchSource::NONE) {
+				paramDisplayName.append(sourceToStringShort(source2));
+				if (display->haveOLED()) {
+					paramDisplayName.append(" -> ");
 				}
 				else {
-					lowerLimit = std::min(-64_i32, knobPos);
-				}
-				int32_t newKnobPos = knobPos + offset;
-				newKnobPos = std::clamp(newKnobPos, lowerLimit, 64_i32);
-
-				// ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
-				// if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a value change
-				// gets recorded if newKnobPos exceeds 127, then it means current knobPos was 127 and it was increased
-				// to 128. In which case, ignore value change
-				if (kind == params::Kind::MIDI && (newKnobPos == 64)) {
-					return;
-				}
-
-				// if you had selected a parameter in performance view and the parameter name
-				// and current value is displayed on the screen, don't show pop-up as the display
-				// already shows it
-				// this checks that the param displayed on the screen in performance view
-				// is the same param currently being edited with mod encoder
-				bool editingParamInPerformanceView = false;
-				if (getRootUI() == &performanceSessionView) {
-					if (!performanceSessionView.defaultEditingMode && performanceSessionView.lastPadPress.isActive) {
-						if ((kind == performanceSessionView.lastPadPress.paramKind)
-						    && (modelStackWithParam->paramId == performanceSessionView.lastPadPress.paramID)) {
-							editingParamInPerformanceView = true;
-						}
-					}
-				}
-
-				// let's see if we're editing the same param in the menu, if so, don't show pop-up
-				bool editingParamInMenu = false;
-				if (getCurrentUI() == &soundEditor) {
-					if ((soundEditor.getCurrentMenuItem()->getParamKind() == kind)
-					    && (soundEditor.getCurrentMenuItem()->getParamIndex() == modelStackWithParam->paramId)) {
-						editingParamInMenu = true;
-					}
-				}
-
-				// let's see if we're browsing for a song
-				bool inSongBrowser = getCurrentUI() == &loadSongUI;
-
-				if (!editingParamInPerformanceView && !editingParamInMenu && !inSongBrowser) {
-					PatchSource source1 = PatchSource::NONE;
-					PatchSource source2 = PatchSource::NONE;
-					if (kind == params::Kind::PATCH_CABLE) {
-						ParamDescriptor paramDescriptor;
-						paramDescriptor.data = modelStackWithParam->paramId;
-						source1 = paramDescriptor.getBottomLevelSource();
-						if (!paramDescriptor.hasJustOneSource()) {
-							source2 = paramDescriptor.getTopLevelSource();
-						}
-					}
-					displayModEncoderValuePopup(kind, modelStackWithParam->paramId, newKnobPos, source1, source2);
-				}
-
-				if (newKnobPos == knobPos) {
-					return;
-				}
-
-				// midi follow and midi feedback enabled
-				// re-send midi cc because learned parameter value has changed
-				sendMidiFollowFeedback(modelStackWithParam, newKnobPos);
-
-				char newModelStackMemory[MODEL_STACK_MAX_SIZE];
-
-				// Hack to make it so stutter can't be automated
-				if (modelStackWithParam->timelineCounterIsSet()
-				    && !modelStackWithParam->paramCollection->doesParamIdAllowAutomation(modelStackWithParam)) {
-					copyModelStack(newModelStackMemory, modelStackWithParam, sizeof(ModelStackWithAutoParam));
-					modelStackWithParam = (ModelStackWithAutoParam*)newModelStackMemory;
-					modelStackWithParam->setTimelineCounter(NULL);
-				}
-
-				int32_t newValue =
-				    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
-
-				// Perform the actual change
-				modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, modPos,
-				                                                          modLength);
-
-				if (activeModControllableModelStack.timelineCounterIsSet()) {
-					bool noteTailsAllowedAfter =
-					    modelStackWithParam->modControllable->allowNoteTails(tempModelStack->addSoundFlags());
-
-					if (noteTailsAllowedBefore != noteTailsAllowedAfter) {
-						if (getRootUI() && getRootUI()->isTimelineView()) {
-							uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0);
-						}
-					}
-				}
-
-				// if the newKnobPos == 0, and we're dealing with a param that param that should
-				// indicate (blink) middle value
-				// then blink that middle value and make it harder to turn the knob past middle
-				potentiallyMakeItHarderToTurnKnob(whichModEncoder, modelStackWithParam, newKnobPos);
-
-				// if you're updating a param's value while in the sound editor menu
-				// and it's the same param displayed in the automation editor open underneath
-				// then refresh the automation editor grid
-				if ((getCurrentUI() == &soundEditor) && (getRootUI() == &automationView)) {
-					automationView.possiblyRefreshAutomationEditorGrid(getCurrentClip(), kind,
-					                                                   modelStackWithParam->paramId);
+					paramDisplayName.append(" - ");
 				}
 			}
-		}
 
-		instrumentBeenEdited();
+			paramDisplayName.append(modulation::params::getPatchedParamShortName(modelStackWithParam->paramId));
+			strncpy(parameterName, paramDisplayName.c_str(), 29);
+		}
+		else {
+			strncpy(parameterName, getParamDisplayName(kind, modelStackWithParam->paramId), 29);
+		}
 	}
 }
 
@@ -1578,6 +1634,16 @@ void View::sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam, 
 			}
 		}
 	}
+}
+
+// sets flag to let caller know if we are dealing with clip context
+bool View::isClipContext() {
+	bool itsAClip = false;
+	if (activeModControllableModelStack.modControllable) {
+		itsAClip = (activeModControllableModelStack.timelineCounterIsSet()
+		            && activeModControllableModelStack.getTimelineCounter() != currentSong);
+	}
+	return itsAClip;
 }
 
 void View::displayAutomation() {

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -142,6 +142,10 @@ public:
 	bool displayVUMeter;
 	bool potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]);
 
+	void getParameterNameFromModEncoder(int32_t whichModEncoder, char* parameterName);
+
+	bool isClipContext();
+
 private:
 	void pretendModKnobsUntouchedForAWhile();
 	void instrumentBeenEdited();
@@ -153,6 +157,8 @@ private:
 	int32_t cachedMaxYDisplayForVUMeterR;
 	void renderVUMeter(int32_t maxYDisplay, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]);
 	bool renderedVUMeter;
+
+	ModelStackWithAutoParam* getModelStackWithParam(int32_t whichModEncoder, bool& noteTailsAllowedBefore);
 };
 
 extern View view;

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -115,6 +115,13 @@ void GlobalEffectable::modButtonAction(uint8_t whichModButton, bool on, ParamMan
 	else if (whichModButton == 5) {
 		displayModFXSettings(on);
 	}
+	// Other Mod Buttons
+	else {
+		// Env Attack / Release not relevant for global effectable context
+		if (whichModButton != 2) {
+			displayOtherModKnobSettings(whichModButton, on);
+		}
+	}
 }
 
 void GlobalEffectable::displayCompressorAndReverbSettings(bool on) {
@@ -614,6 +621,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 	}
 	return ActionResult::NOT_DEALT_WITH;
 }
+
 // Always check this doesn't return NULL!
 int32_t GlobalEffectable::getParameterFromKnob(int32_t whichModEncoder) {
 

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -2050,7 +2050,24 @@ char const* ModControllableAudio::getSidechainDisplayName() {
 
 /// displays names of parameters assigned to gold knobs
 void ModControllableAudio::displayOtherModKnobSettings(uint8_t whichModButton, bool on) {
+	// the code below handles displaying parameter names on OLED and 7SEG
+
+	/* logic for OLED:
+	- it will display parameter names when you are holding down the mod button
+	- it will display the parameter name assigned to the top and bottom gold knob
+	- e.g. Volume
+	       Pan
+	*/
+
+	/* logic for 7SEG:
+	- while holding down mod button: display parameter assigned to top gold knob
+	- after mod button is released: display parameter assigned to bottom gold knob
+	*/
+
 	DEF_STACK_STRING_BUF(popupMsg, 100);
+	// if we have an OLED display
+	// or a 7SEG display and mod button is pressed
+	// then we will display the top gold knob parameter
 	if (display->haveOLED() || on) {
 		char parameterName[30];
 		view.getParameterNameFromModEncoder(1, parameterName);
@@ -2059,9 +2076,15 @@ void ModControllableAudio::displayOtherModKnobSettings(uint8_t whichModButton, b
 	// in the song context,
 	// the bottom knob for modButton 6 (stutter) doesn't have a parameter
 	if (!((whichModButton == 6) && (!view.isClipContext()))) {
+		// if we have an OLED display, we want to add a new line so we can
+		// display the bottom gold knob param below the top gold knob param
 		if (display->haveOLED()) {
 			popupMsg.append("\n");
 		}
+		// if we have an OLED display
+		// or a 7SEG display and mod button is released
+		// then we will display the bottom gold knob parameter
+		// on OLED bottom gold knob param is rendered below the top gold knob param
 		if (display->haveOLED() || !on) {
 
 			char parameterName[30];
@@ -2069,6 +2092,8 @@ void ModControllableAudio::displayOtherModKnobSettings(uint8_t whichModButton, b
 			popupMsg.append(parameterName);
 		}
 	}
+	// if we have OLED, a pop up is shown while we are holding down mod button
+	// pop-up is removed after we release the mod button
 	if (display->haveOLED()) {
 		if (on) {
 			display->popupText(popupMsg.c_str());
@@ -2077,6 +2102,8 @@ void ModControllableAudio::displayOtherModKnobSettings(uint8_t whichModButton, b
 			display->cancelPopup();
 		}
 	}
+	// if we have 7SEG, we display a temporary popup whenever mod button is pressed
+	// and when it is released
 	else {
 		display->displayPopup(popupMsg.c_str());
 	}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -2056,7 +2056,7 @@ void ModControllableAudio::displayOtherModKnobSettings(uint8_t whichModButton, b
 		view.getParameterNameFromModEncoder(1, parameterName);
 		popupMsg.append(parameterName);
 	}
-	// in the song context, 
+	// in the song context,
 	// the bottom knob for modButton 6 (stutter) doesn't have a parameter
 	if (!((whichModButton == 6) && (!view.isClipContext()))) {
 		if (display->haveOLED()) {

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -2047,3 +2047,37 @@ char const* ModControllableAudio::getSidechainDisplayName() {
 		return l10n::get(STRING_FOR_FAST);
 	}
 }
+
+/// displays names of parameters assigned to gold knobs
+void ModControllableAudio::displayOtherModKnobSettings(uint8_t whichModButton, bool on) {
+	DEF_STACK_STRING_BUF(popupMsg, 100);
+	if (display->haveOLED() || on) {
+		char parameterName[30];
+		view.getParameterNameFromModEncoder(1, parameterName);
+		popupMsg.append(parameterName);
+	}
+	// in the song context, 
+	// the bottom knob for modButton 6 (stutter) doesn't have a parameter
+	if (!((whichModButton == 6) && (!view.isClipContext()))) {
+		if (display->haveOLED()) {
+			popupMsg.append("\n");
+		}
+		if (display->haveOLED() || !on) {
+
+			char parameterName[30];
+			view.getParameterNameFromModEncoder(0, parameterName);
+			popupMsg.append(parameterName);
+		}
+	}
+	if (display->haveOLED()) {
+		if (on) {
+			display->popupText(popupMsg.c_str());
+		}
+		else {
+			display->cancelPopup();
+		}
+	}
+	else {
+		display->displayPopup(popupMsg.c_str());
+	}
+}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -196,6 +196,7 @@ protected:
 	void displayFilterSettings(bool on, FilterType currentFilterType);
 	void displayDelaySettings(bool on);
 	void displaySidechainAndReverbSettings(bool on);
+	void displayOtherModKnobSettings(uint8_t whichModButton, bool on);
 
 private:
 	void initializeSecondaryDelayBuffer(int32_t newNativeRate, bool makeNativeRatePreciseRelativeToOtherBuffer);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -4113,37 +4113,47 @@ void Sound::modButtonAction(uint8_t whichModButton, bool on, ParamManagerForTime
 
 	int32_t modKnobMode = *getModKnobMode();
 
-	ModKnob* ourModKnob = &modKnobs[modKnobMode][1];
+	ModKnob* ourModKnobTop = &modKnobs[modKnobMode][1];
+	ModKnob* ourModKnobBottom = &modKnobs[modKnobMode][0];
 
-	// LPF/HPF/EQ
-	if (whichModButton == 1) {
-		if (getSynthMode() != SynthMode::FM) {
-			FilterType currentFilterType;
-			if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_LPF_FREQ)) {
-				currentFilterType = FilterType::LPF;
-			}
-			else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_HPF_FREQ)) {
-				currentFilterType = FilterType::HPF;
-			}
-			else if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::UNPATCHED_START
-			                                                              + params::UNPATCHED_TREBLE)) {
-				currentFilterType = FilterType::EQ;
-			}
-			displayFilterSettings(on, currentFilterType);
-		}
+	// mod button popup logic
+	// if top knob == LPF Freq && bottom knob == LPF Reso
+	// if top knob == HPF Freq && bottom knob == HPF Reso
+	// if top knob == Treble && bottom knob == Bass
+	// --> displayFilterSettings(on, currentFilterType);
+
+	// if top knob == Delay Rate && bottom knob == Delay Amount
+	// --> displayDelaySettings(on);
+
+	// if top knob == Sidechain && bottom knob == Reverb Amount
+	// --> displaySidechainAndReverbSettings(on);
+
+	// else --> display param name
+
+	if (ourModKnobTop->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_LPF_FREQ)
+	    && ourModKnobBottom->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_LPF_RESONANCE)) {
+		displayFilterSettings(on, FilterType::LPF);
 	}
-	// Delay
-	else if (whichModButton == 3) {
-		if (ourModKnob->paramDescriptor.isSetToParamWithNoSource(params::GLOBAL_DELAY_RATE)) {
-			displayDelaySettings(on);
-		}
+	else if (ourModKnobTop->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_HPF_FREQ)
+	         && ourModKnobBottom->paramDescriptor.isSetToParamWithNoSource(params::LOCAL_HPF_RESONANCE)) {
+		displayFilterSettings(on, FilterType::HPF);
 	}
-	// Sidechain/Reverb
-	else if (whichModButton == 4) {
-		if ((ourModKnob->paramDescriptor.hasJustOneSource()
-		     && ourModKnob->paramDescriptor.getTopLevelSource() == PatchSource::SIDECHAIN)) {
-			displaySidechainAndReverbSettings(on);
-		}
+	else if (ourModKnobTop->paramDescriptor.isSetToParamWithNoSource(params::UNPATCHED_START + params::UNPATCHED_TREBLE)
+	         && ourModKnobBottom->paramDescriptor.isSetToParamWithNoSource(params::UNPATCHED_START
+	                                                                       + params::UNPATCHED_BASS)) {
+		displayFilterSettings(on, FilterType::EQ);
+	}
+	else if (ourModKnobTop->paramDescriptor.isSetToParamWithNoSource(params::GLOBAL_DELAY_RATE)
+	         && ourModKnobBottom->paramDescriptor.isSetToParamWithNoSource(params::GLOBAL_DELAY_FEEDBACK)) {
+		displayDelaySettings(on);
+	}
+	else if ((ourModKnobTop->paramDescriptor.hasJustOneSource()
+	          && ourModKnobTop->paramDescriptor.getTopLevelSource() == PatchSource::SIDECHAIN)
+	         && ourModKnobBottom->paramDescriptor.isSetToParamWithNoSource(params::GLOBAL_REVERB_AMOUNT)) {
+		displaySidechainAndReverbSettings(on);
+	}
+	else {
+		displayOtherModKnobSettings(whichModButton, on);
 	}
 }
 


### PR DESCRIPTION
Fixed mod button popup's so that all mod button presses now display the parameters assigned to the mod encoder.

fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1813