### PR TITLE
Drop duplicate count-in bars entry from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,6 @@
 - Added sidebar functionality in keyboard screens - by default it is velocity (red) and mod wheel (blue), holding a pad
   sets it momentarily and tapping latches it. The functionality can be changed by holding the top pad and scrolling
   select.
-- Updated the count-in setting to allow specifying the number of bars (1-4).
 - Added `VU Meter` rendering in the sidebar in Song / Arranger / Performance Views.
 - Added ability to save a synth/sample drum back to an instrument preset by holding audition and pressing save.
 - Mod (Gold) Encoders learned to the Mod Matrix can now access the full range of the Mod Matrix / Patch Cable parameters (e.g. from -50 to +50).


### PR DESCRIPTION
The configurable count-in bars change (PR #1305 commit 2a68d0eba28d47d6bb57b2a8b86e2a478f003801) had a changelog entry but lacked the community features documentation part. PR #1419 (commit 21c4a75a9312fda96830e05179998d23e83e5f83) added a second changelog entry along with the feature doc. Dropping my original changelog as the latter one is more detailed.