### PR TITLE
Bugfix - Clearing automation

### DIFF
--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -378,7 +378,7 @@ dontDeactivateMarker:
 			ModelStackWithTimelineCounter* modelStack =
 			    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, getCurrentClip());
 
-			getCurrentAudioClip()->clear(action, modelStack);
+			getCurrentAudioClip()->clear(action, modelStack, !FlashStorage::automationClear);
 
 			// New default as part of Automation Clip View Implementation
 			// If this is enabled, then when you are in Audio Clip View, clearing

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1798,7 +1798,7 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 				ModelStackWithTimelineCounter* modelStack =
 				    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, clip);
 
-				clip->clear(action, modelStack);
+				clip->clear(action, modelStack, true);
 			}
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_AUTOMATION_CLEARED));
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2968,7 +2968,7 @@ Clip* SessionView::gridCreateClipInTrack(Output* targetOutput) {
 	ModelStackWithTimelineCounter* modelStack =
 	    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, newClip);
 	Action* action = actionLogger.getNewAction(ActionType::CLIP_CLEAR);
-	newClip->clear(action, modelStack);
+	newClip->clear(action, modelStack, true);
 	actionLogger.deleteAllLogs();
 
 	// For safety we set it up exactly as we want it

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1228,8 +1228,8 @@ bool AudioClip::currentlyScrollableAndZoomable() {
 	return !shouldLock;
 }
 
-void AudioClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
-	Clip::clear(action, modelStack);
+void AudioClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) {
+	Clip::clear(action, modelStack, clearAutomation);
 
 	// If recording, stop that - but only if we're not doing tempoless recording
 	if (recorder) {

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -67,7 +67,7 @@ public:
 	RGB getColour();
 	bool currentlyScrollableAndZoomable();
 	void getScrollAndZoomInSamples(int32_t xScroll, int32_t xZoom, int64_t* xScrollSamples, int64_t* xZoomSamples);
-	void clear(Action* action, ModelStackWithTimelineCounter* modelStack);
+	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation);
 	bool getCurrentlyRecordingLinearly();
 	void abortRecording();
 	void setupPlaybackBounds();

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -985,7 +985,7 @@ trimFoundParamManager:
 	return Error::NONE;
 }
 
-void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
+void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) {
 	// New community feature as part of Automation Clip View Implementation
 	// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing a clip
 	// will only clear the Notes and MPE data (NON MPE automations remain intact).
@@ -1016,7 +1016,7 @@ void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
 
 			// Normal case
 			else {
-				if (getCurrentUI() == &automationView || !FlashStorage::automationClear) {
+				if (clearAutomation) {
 					summary->paramCollection->deleteAllAutomation(action, modelStackWithParamCollection);
 				}
 			}

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -105,7 +105,7 @@ public:
 	virtual Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) = 0;
 	virtual bool getCurrentlyRecordingLinearly() = 0;
 	virtual bool currentlyScrollableAndZoomable() = 0;
-	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack);
+	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation);
 
 	void writeToFile(StorageManager& bdsm, Song* song);
 	virtual bool writeDataToFile(StorageManager& bdsm, Song* song);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3552,15 +3552,15 @@ void InstrumentClip::sendMIDIPGM() {
 	}
 }
 
-void InstrumentClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack) {
+void InstrumentClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) {
 	// this clears automations when "affectEntire" is enabled
-	Clip::clear(action, modelStack);
+	Clip::clear(action, modelStack, clearAutomation);
 
 	for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
 		NoteRow* thisNoteRow = noteRows.getElement(i);
 		ModelStackWithNoteRow* modelStackWithNoteRow =
 		    modelStack->addNoteRow(getNoteRowId(thisNoteRow, i), thisNoteRow);
-		thisNoteRow->clear(action, modelStackWithNoteRow);
+		thisNoteRow->clear(action, modelStackWithNoteRow, clearAutomation);
 	}
 
 	// Paul: Note rows were lingering, delete them immediately instead of relying they get deleted along the way

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -197,7 +197,7 @@ public:
 	void stopAllNotesForMIDIOrCV(ModelStackWithTimelineCounter* modelStack);
 	void sendMIDIPGM();
 	void noteRemovedFromMode(int32_t yNoteWithinOctave, Song* song);
-	void clear(Action* action, ModelStackWithTimelineCounter* modelStack);
+	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation);
 	bool doesProbabilityExist(int32_t apartFromPos, int32_t probability, int32_t secondProbability = -1);
 	void clearArea(ModelStackWithTimelineCounter* modelStack, int32_t startPos, int32_t endPos, Action* action);
 	ScaleType getScaleType();

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -399,7 +399,11 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 			ModelStackWithTimelineCounter* modelStack =
 			    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, getCurrentClip());
 
-			getCurrentInstrumentClip()->clear(action, modelStack);
+			UI* currentUI = getCurrentUI();
+
+			bool clearAutomation = (currentUI == &automationView || !FlashStorage::automationClear);
+
+			getCurrentInstrumentClip()->clear(action, modelStack, clearAutomation);
 
 			// New default as part of Automation Clip View Implementation
 			// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing
@@ -408,25 +412,17 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 			// message displayed on the OLED screen is adjusted to reflect the nature of what is being cleared
 
 			if (FlashStorage::automationClear) {
-				if (getCurrentUI() == &automationView) {
+				if (currentUI == &automationView) {
 					display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_CLEARED));
-					uiNeedsRendering(&automationView, 0xFFFFFFFF, 0);
 				}
-				else if (getCurrentUI() == &instrumentClipView) {
+				else if (currentUI == &instrumentClipView) {
 					display->displayPopup(l10n::get(l10n::String::STRING_FOR_NOTES_CLEARED));
-					uiNeedsRendering(&instrumentClipView, 0xFFFFFFFF, 0);
 				}
 			}
 			else {
-				if (getCurrentUI() == &instrumentClipView) {
-					display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CLIP_CLEARED));
-					uiNeedsRendering(&instrumentClipView, 0xFFFFFFFF, 0);
-				}
-				else if (getCurrentUI() == &automationView) {
-					display->displayPopup(l10n::get(l10n::String::STRING_FOR_CLIP_CLEARED));
-					uiNeedsRendering(&automationView, 0xFFFFFFFF, 0);
-				}
+				display->displayPopup(l10n::get(l10n::String::STRING_FOR_CLIP_CLEARED));
 			}
+			uiNeedsRendering(currentUI, 0xFFFFFFFF, 0);
 		}
 	}
 

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3592,7 +3592,7 @@ void NoteRow::shiftHorizontally(int32_t amount, ModelStackWithNoteRow* modelStac
 	}
 }
 
-void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack) {
+void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation) {
 	// New default as part of Automation Clip View Implementation
 	// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing a clip
 	// will only clear the Notes and MPE data (NON MPE automations remain intact).
@@ -3623,8 +3623,7 @@ void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack) {
 
 			// Normal case
 			else {
-				if (getCurrentUI() == &automationView || !FlashStorage::automationClear) {
-
+				if (clearAutomation) {
 					summary->paramCollection->deleteAllAutomation(action, modelStackWithParamCollection);
 				}
 			}

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -162,7 +162,7 @@ public:
 	int8_t getColourOffset(InstrumentClip* clip);
 	void rememberDrumName();
 	void shiftHorizontally(int32_t amount, ModelStackWithNoteRow* modelStack);
-	void clear(Action* action, ModelStackWithNoteRow* modelStack);
+	void clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation);
 	bool doesProbabilityExist(int32_t apartFromPos, int32_t probability, int32_t secondProbability = -1);
 	bool paste(ModelStackWithNoteRow* modelStack, CopiedNoteRow* copiedNoteRow, float scaleFactor, int32_t screenEndPos,
 	           Action* action);


### PR DESCRIPTION
Fixed a bug where creating a new clip in grid view would clone an existing clip and then clear the clip but automation would not get cleared due to a global setting to only clear automation when in automation view.

Fixed this by refactoring the clear functions to accept a clearAutomation flag.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1840