### PR TITLE
Show quantized stutter rate popup only while not stuttering

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1120,7 +1120,7 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 
 	// if turning stutter mod encoder and stutter quantize is enabled
 	// display stutter quantization instead of knob position
-	if (isParamQuantizedStutter(kind, paramID)) {
+	if (isParamQuantizedStutter(kind, paramID) && !isUIModeActive(UI_MODE_STUTTERING)) {
 		if (newKnobPos < -39) { // 4ths stutter: no leds turned on
 			popupMsg.append("4ths");
 		}


### PR DESCRIPTION
to cherry pick

The popup while stuttering should be:
STUTTER RATE: 0
to
STUTTER RATE: 50
being the center which flashes
STUTTER RATE: 25

The quantized stutter rate popup (like STUTTER RATE: 4ths) should only appear when selecting the rate to stutter, before pressing the knob