### PR TITLE
Refactor automation overview / editor checks (prep for velocity editing view)

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -155,7 +155,7 @@ bool SoundEditor::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 		break;
 	case UIType::AUTOMATION_VIEW:
 		// only greyout if you're on automation overview
-		doGreyout = automationView.isOnAutomationOverview();
+		doGreyout = automationView.onAutomationOverview();
 		if (doGreyout) {
 			*cols = 0xFFFFFFFC; // don't greyout sidebar
 		}

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -133,7 +133,7 @@ void UITimerManager::routine() {
 
 				case TimerName::DISPLAY_AUTOMATION:
 					if (((getCurrentUI() == &automationView) || (getRootUI() == &automationView))
-					    && !automationView.isOnAutomationOverview()) {
+					    && automationView.inAutomationEditor()) {
 
 						automationView.displayAutomation();
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -875,7 +875,7 @@ void ArrangerView::auditionEnded() {
 	setLedStates();
 
 	if (getRootUI() == &automationView) {
-		if (!automationView.isOnAutomationOverview()) {
+		if (automationView.inAutomationEditor()) {
 			automationView.displayAutomation(true, !display->have7SEG());
 		}
 		else {

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -113,7 +113,8 @@ public:
 	// used to identify the UI as a clip UI or not.
 	ClipMinder* toClipMinder() { return getAutomationSubType() == AutomationSubType::ARRANGER ? NULL : this; }
 
-	bool isOnAutomationOverview();
+	bool onAutomationOverview();
+	bool inAutomationEditor();
 
 	bool interpolation;
 	bool interpolationBefore;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1242,7 +1242,7 @@ void View::setKnobIndicatorLevels() {
 	}
 
 	// don't update knob indicator levels when you're in automation editor
-	if ((getRootUI() == &automationView) && !automationView.isOnAutomationOverview()) {
+	if ((getRootUI() == &automationView) && automationView.inAutomationEditor()) {
 		automationView.displayAutomation();
 		return;
 	}
@@ -1357,7 +1357,7 @@ void View::modButtonAction(uint8_t whichButton, bool on) {
 	RootUI* rootUI = getRootUI();
 
 	// ignore modButtonAction when in the Automation View Automation Editor
-	if ((rootUI == &automationView) && !automationView.isOnAutomationOverview()) {
+	if ((rootUI == &automationView) && automationView.inAutomationEditor()) {
 		// exception for arranger view and pressing mod button 0 so you can toggle VU meter
 		if (!(automationView.onArrangerView && whichButton == 0)) {
 			return;
@@ -1576,7 +1576,7 @@ void View::setModLedStates() {
 			indicator_leds::blinkLed(indicator_leds::modLed[i]);
 		}
 		// if you're in the Automation View Automation Editor, turn off Mod LED's
-		else if ((getRootUI() == &automationView) && !automationView.isOnAutomationOverview()) {
+		else if ((getRootUI() == &automationView) && automationView.inAutomationEditor()) {
 			indicator_leds::setLedState(indicator_leds::modLed[i], false);
 		}
 		// otherwise update mod led's to reflect current mod led selection
@@ -1963,7 +1963,7 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 
 	// hook to render display for OLED and 7SEG when in Automation Clip View
 	if (getCurrentUI() == &automationView && !isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION)) {
-		if (!automationView.isOnAutomationOverview()) {
+		if (automationView.inAutomationEditor()) {
 			automationView.displayAutomation(true, !display->have7SEG());
 		}
 		else {


### PR DESCRIPTION
Refactored code for checking if you're on automation overview vs automation editor to make naming explicit about what you're checking

- `!isOnAutomationOverview()` --> became `inAutomationEditor()`
- `isOnAutomationOverview()` --> became `onAutomationOverview()`

These changes are prep for adding a Velocity Note Editor which will add an additional checking function to see if you're in the Note Editor (as opposed to the Automation Editor)