### PR TITLE
Refactor drawDrumName (prep for velocity editing view)

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -115,6 +115,7 @@ public:
 
 	void tellMatrixDriverWhichRowsContainSomethingZoomable();
 	void drawDrumName(Drum* drum, bool justPopUp = false);
+	void getDrumName(Drum* drum, char* drumName);
 	void notifyPlaybackBegun();
 	void openedInBackground();
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -23,6 +23,7 @@
 #include "model/clip/instrument_clip_minder.h"
 #include "modulation/automation/copied_param_automation.h"
 #include "modulation/params/param_node.h"
+#include "util/d_string.h"
 
 class InstrumentClip;
 class NoteRow;
@@ -115,7 +116,7 @@ public:
 
 	void tellMatrixDriverWhichRowsContainSomethingZoomable();
 	void drawDrumName(Drum* drum, bool justPopUp = false);
-	void getDrumName(Drum* drum, char* drumName);
+	void getDrumName(Drum* drum, StringBuf& drumName);
 	void notifyPlaybackBegun();
 	void openedInBackground();
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],


### PR DESCRIPTION
Refactored drawDrumName function by separating code for getting drum name out into a new function called getDrumName

Prep for new velocity editing view which will render Drum name for kit note row selection on the display