### PR TITLE
task_scheduler: sort needs consistent types on Windows

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -62,7 +62,7 @@ void TaskManager::createSortedList() {
 	for (TaskID i = 0; i <= index; i++) {
 		sortedList[i] = (SortedTask{list[i].priority, i});
 	}
-	std::sort(sortedList.begin(), &sortedList[index + 1]);
+	std::sort(&sortedList[0], &sortedList[index + 1]);
 }
 
 TaskID TaskManager::chooseBestTask(double deadline) {


### PR DESCRIPTION
On Windows the inconsistent types for beginning and don't compile:
array.begin() is an array iterator, whereas &array[offset] is a pointer.

I expect in some implementations array.begin() returns a pointer as well.