### PR TITLE
Bugfix/add playback handler to sd routine

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -919,8 +919,9 @@ extern "C" void logAudioAction(char const* string) {
 	AudioEngine::logAction(string);
 }
 
+/// this function is used as a busy wait loop for long SD reads, and while swapping songs
 extern "C" void routineForSD(void) {
-
+	
 	if (intc_func_active != 0) {
 		return;
 	}
@@ -935,7 +936,7 @@ extern "C" void routineForSD(void) {
 
 	AudioEngine::logAction("from routineForSD()");
 	AudioEngine::routine();
-
+	playbackHandler.routine();
 	uiTimerManager.routine();
 
 	if (display->haveOLED()) {

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -921,7 +921,7 @@ extern "C" void logAudioAction(char const* string) {
 
 /// this function is used as a busy wait loop for long SD reads, and while swapping songs
 extern "C" void routineForSD(void) {
-	
+
 	if (intc_func_active != 0) {
 		return;
 	}


### PR DESCRIPTION
Fix #1862 

Song loading uses the SD routine, which wasn't checking midi anymore. Re add midi checks to that routine

Longer term this whole thing should be replaced by a "block until" function in the scheduler, similar to free rtos's interrupt unblocking api, as it's use is to call routineForSD repeatedly and then check if it's time for a song swap/SD DMA change