### PR TITLE
Reorder handleParameterSelection (follow up to 1877)

### DIFF
--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -176,6 +176,7 @@ private:
 	                       OutputType outputType, int32_t effectiveLength, int32_t x, int32_t y, int32_t velocity,
 	                       int32_t xScroll, int32_t xZoom);
 	bool toggleAutomationInterpolation();
+	bool handleParameterSelection(Clip* clip, OutputType outputType, int32_t xDisplay, int32_t yDisplay);
 	void automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
 	                             int32_t yDisplay, int32_t velocity, int32_t effectiveLength, int32_t xScroll,
 	                             int32_t xZoom);
@@ -265,7 +266,6 @@ private:
 	bool recordSinglePadPress(int32_t xDisplay, int32_t yDisplay);
 	void handleSinglePadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
 	                          int32_t yDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
-	bool handleParameterSelection(Clip* clip, OutputType outputType, int32_t xDisplay, int32_t yDisplay);
 	void handleParameterAutomationChange(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
 	                                     OutputType outputType, int32_t xDisplay, int32_t yDisplay,
 	                                     int32_t effectiveLength, int32_t xScroll, int32_t xZoom);


### PR DESCRIPTION
Just a quick follow up to https://github.com/SynthstromAudible/DelugeFirmware/pull/1877

Moving handleParameterSelection below shortcutPadAction

Did this separately to make 1877 changes easier to review