### PR TITLE
tests: fix test build on Clang/Windows

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.24)
 project(DelugeTests)
 
+if (WIN32 AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Gcc")
+    # CPPUTEST_PLATFORM defaults to Gcc, which causes the test binaries to
+    # segfault on Windows/Clang builds, since they use the stdlib from MSVC.
+    set(CPPUTEST_PLATFORM VisualCpp)
+endif()
+
 enable_testing()
 #needs to support -m32 since the memory tests assume a 32 bit architecture
 if (UNIX AND NOT APPLE)


### PR DESCRIPTION
  CppUTest defaults the CPPUTEST_PLATFORM to Gcc, which
  creates faulty binaries with Clang on Windows, since Clang
  uses the MSVC libraries there.

  The fix attempts to be clever, and specifies VisualCpp if the
  compiler on Windows is anything else except GCC.

  Fingers crossed, "works on my clang".