### PR TITLE
tests: silence redefinition spam from CPPUTEST_MEM_LEAK_DETECTION_DISABLED

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -6,12 +6,22 @@ FetchContent_Declare(
         GIT_TAG eccbc2190c672e598c1dd2bf5e4295f5ba27aad1
 )
 
-# Set this to ON if you want to have the CppUTests in your project as well.
+# Set this to ON if you want to have the CppUTest's internal tests in your
+# project as well.
 set(TESTS OFF CACHE BOOL "Switch off CppUTest Test build")
-add_compile_definitions(
-        CPPUTEST_MEM_LEAK_DETECTION_DISABLED
-        IN_UNIT_TESTS=1
-)
+if (WIN32)
+        # Memory leak detection is off by default on Windows, setting
+        # it here will cause a massive spam of redefinition warning during
+        # build.
+        add_compile_definitions(
+                IN_UNIT_TESTS=1
+        )
+else()
+        add_compile_definitions(
+                CPPUTEST_MEM_LEAK_DETECTION_DISABLED
+                IN_UNIT_TESTS=1
+        )
+endif()
 
 FetchContent_MakeAvailable(CppUTest)
 


### PR DESCRIPTION
Based on https://github.com/cpputest/cpputest/issues/1194 it seems that the leak detection is off by default on Windows, which in turn causes a flood of redefinition warnings when we turn if off as well.

So don't toggle it on Windows builds.

Bonus: make the explanation for test TESTS OFF line a little bit more explicit.