### PR TITLE
tests/fully mock time for testing the scheduler consistently

### DIFF
--- a/tests/unit/mocks/timer_mocks.cpp
+++ b/tests/unit/mocks/timer_mocks.cpp
@@ -15,8 +15,6 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 #include <chrono>
-#include <format>
-#include <iostream>
 #include <time.h>
 extern "C" {
 #include "RZA1/ostm/ostm.h"

--- a/tests/unit/mocks/timer_mocks.cpp
+++ b/tests/unit/mocks/timer_mocks.cpp
@@ -15,16 +15,22 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 #include <chrono>
+#include <format>
+#include <iostream>
 #include <time.h>
 extern "C" {
 #include "RZA1/ostm/ostm.h"
 /* clock_t, clock, CLOCKS_PER_SEC */
 #define clockConversion DELUGE_CLOCKS_PER / CLOCKS_PER_SEC;
 
-std::chrono::time_point<std::chrono::high_resolution_clock> timers[2];
+std::chrono::time_point<std::chrono::steady_clock> timers[2];
+uint32_t mockTimers[2]{0};
+// variable in case some tests need to use the system clock in the future
+bool mockTimeIntervals = true;
 
 void enableTimer(int timerNo) {
-	auto begin = std::chrono::high_resolution_clock::now();
+	auto begin = std::chrono::steady_clock::now();
+	mockTimers[timerNo] = 0;
 	timers[timerNo] = begin;
 }
 
@@ -39,13 +45,25 @@ void setOperatingMode(int timerNo, enum OSTimerOperatingMode mode, bool enable_i
 }
 
 void setTimerValue(int timerNo, uint32_t timerValue) {
-	auto begin = std::chrono::high_resolution_clock::now();
+	auto begin = std::chrono::steady_clock::now();
 	timers[timerNo] = begin;
+	mockTimers[timerNo] = timerValue;
+}
+
+void passMockTime(double seconds) {
+	uint32_t ticks = seconds * DELUGE_CLOCKS_PER;
+	mockTimers[0] += ticks;
+	mockTimers[1] += ticks;
 }
 
 // returns ticks at the rate the deluge clock would generate them
 uint32_t getTimerValue(int timerNo) {
-	auto now = std::chrono::high_resolution_clock::now();
+	/// this ensures that the mocked time keeps advancing
+	passMockTime(0.0000001);
+	auto now = std::chrono::steady_clock::now();
+	if (mockTimeIntervals) {
+		return mockTimers[timerNo];
+	}
 	return DELUGE_CLOCKS_PER * ((std::chrono::duration<double>(now - timers[0]).count()));
 }
 

--- a/tests/unit/mocks/timer_mocks.h
+++ b/tests/unit/mocks/timer_mocks.h
@@ -1,0 +1,11 @@
+//
+// Created by Mark Adams on 2024-05-10.
+//
+
+#ifndef DELUGE_TIMER_MOCKS_H
+#define DELUGE_TIMER_MOCKS_H
+
+#endif // DELUGE_TIMER_MOCKS_H
+extern "C" {
+void passMockTime(double seconds);
+}

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -2,6 +2,7 @@
 #include "CppUTestExt/MockSupport.h"
 #include "OSLikeStuff/task_scheduler.cpp"
 #include "cstdint"
+#include "mocks/timer_mocks.h"
 #include <iostream>
 #include <stdlib.h>
 
@@ -19,6 +20,7 @@ struct SelfRemoving {
 	void runFiveTimes() {
 		mock().actualCall("runFiveTimes");
 		timesCalled += 1;
+		passMockTime(0.001);
 		if (timesCalled >= 5) {
 			removeTask(id);
 		}
@@ -28,24 +30,17 @@ struct SelfRemoving {
 void sleep_50ns() {
 	mock().actualCall("sleep_50ns");
 	uint32_t now = getTimerValue(0);
-	while (getTimerValue(0) < now + 0.00005 * DELUGE_CLOCKS_PER) {
-		__asm__ __volatile__("nop");
-	}
+	passMockTime(0.00005);
 }
 void sleep_20ns() {
 	mock().actualCall("sleep_20ns");
 	uint32_t now = getTimerValue(0);
-
-	while (getTimerValue(0) < now + 0.00002 * DELUGE_CLOCKS_PER) {
-		__asm__ __volatile__("nop");
-	}
+	passMockTime(0.00002);
 }
 void sleep_2ms() {
 	mock().actualCall("sleep_2ms");
 	uint32_t now = getTimerValue(0);
-	while (getTimerValue(0) < now + 0.002 * DELUGE_CLOCKS_PER) {
-		__asm__ __volatile__("nop");
-	}
+	passMockTime(0.002);
 }
 
 TEST_GROUP(Scheduler){


### PR DESCRIPTION
Adds fake time for testing the scheduler

Real time can be used by setting mockTimeIntervals to false - this is in case we reach a point where we're doing higher level integration testing and need the scheduler to work properly (minus that it won't quite be real time) 