### PR TITLE
Bugfix/properly return sd card error if not initialized

### DIFF
--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -235,8 +235,6 @@ bool StorageManager::closeFile() {
 // just no card inserted.
 Error StorageManager::initSD() {
 
-	FRESULT result;
-
 	// If we know the SD card is still initialised, no need to actually initialise
 	DSTATUS status = disk_status(SD_PORT);
 	if ((status & STA_NOINIT) == 0) {
@@ -249,10 +247,13 @@ Error StorageManager::initSD() {
 	}
 
 	// Otherwise, we can mount the filesystem...
-	D_TRY_CATCH(fileSystemStuff.fileSystem.mount(1).transform_error(fatfsErrorToDelugeError), error, {
+	bool success = D_TRY_CATCH(fileSystemStuff.fileSystem.mount(1).transform_error(fatfsErrorToDelugeError), error, {
 		return error; //<
 	});
-	return fresultToDelugeErrorCode(result);
+	if (success) {
+		return Error::NONE;
+	}
+	return Error::SD_CARD;
 }
 
 bool StorageManager::checkSDPresent() {


### PR DESCRIPTION
In debug builds result was used without being initialized, causing deluge to assume the card was setup and read it's cluster size

In release builds this whole block gets optimized out as UB, which is fine because the SD card isn't ready anyway and it gets initialized later in that case

Fix to return an error if the card is not ready