### PR TITLE
dbt: nuke handles read-only files and doesn't fail silently

### DIFF
--- a/scripts/tasks/task-nuke.py
+++ b/scripts/tasks/task-nuke.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import shutil
 import util
 import os
+import stat
 
 
 def argparser() -> argparse.ArgumentParser:
@@ -15,12 +16,22 @@ def argparser() -> argparse.ArgumentParser:
     return parser
 
 
+def readonly_handler(func, path, execinfo):
+    # shutil.rmtree can fail after building tests, due to a cpputest's git checkout
+    # under build tree containing read-only files.
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
 def main() -> int:
     build_dirs = util.get_git_root().glob("*build*")
     for dir in build_dirs:
-        print(f"Removing {dir}")
-        shutil.rmtree(dir, ignore_errors=True)
-
+        print(f"Removing {dir}", end="")
+        try:
+            shutil.rmtree(dir, onerror=readonly_handler)
+            print(" - ok!")
+        except Exception:
+            print(" - failed!")
     return 0
 
 


### PR DESCRIPTION
* On Windows at least after running dbt test, dbt nuke would fail silently due to cpputest's git checkout under build/test containing read-only files.

* Add an onerror-handler that sets files to be deleted to writable.

* Add an explicit exception handler to report failure without printing a scary backtrace: seems better than complete silence.