### PR TITLE
Os stuff/interrupt disabling

### DIFF
--- a/src/OSLikeStuff/fault_handler/fault_handler.c
+++ b/src/OSLikeStuff/fault_handler/fault_handler.c
@@ -253,7 +253,8 @@ extern void fault_handler_print_freeze_pointers(uint32_t addrSYSLR, uint32_t add
 extern void handle_cpu_fault(uint32_t addrSYSLR, uint32_t addrSYSSP, uint32_t addrUSRLR, uint32_t addrUSRSP) {
 	printPointers(addrSYSLR, addrSYSSP, addrUSRLR, addrUSRSP, true);
 
-	__asm__("CPS  0x10"); // Go to USR mode
+	// if we start using user mode then we'd want to do this to get an accurate call stack. We don't so just don't
+	//__asm__("CPS  0x10"); // Go to USR mode
 
 	while (1) {
 		__asm__("nop");

--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
@@ -32,7 +32,9 @@ extern "C" {
 
 /// disable all interrupts - must be in system mode
 static inline __attribute__((no_instrument_function)) void DISABLE_ALL_INTERRUPTS() {
-	__asm volatile("CPSID i" ::: "memory"); // not certain what memory does but it's in the examples from arm - mark
+	// memory creates a memory barrier in GCC to avoid reordering
+	// http://www.ibiblio.org/gferg/ldp/GCC-Inline-Assembly-HOWTO.html#ss5.3
+	__asm volatile("CPSID i" ::: "memory");
 	__asm volatile("DSB");
 	__asm volatile("ISB");
 }

--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
@@ -24,6 +24,25 @@
 extern "C" {
 #endif
 
+// DSB/ISB are required due to pipelining
+// DSB ensures that the write has completed before continuing
+// ISB redoes the prefetch, ensuring that older instructions aren't used
+// ref http://www.rdrop.com/users/paulmck/scalability/paper/whymb.2010.07.23a.pdf
+// in future if we start using user mode this won't work from there
+
+/// disable all interrupts - must be in system mode
+static inline __attribute__((no_instrument_function)) void DISABLE_ALL_INTERRUPTS() {
+	__asm volatile("CPSID i" ::: "memory"); // not certain what memory does but it's in the examples from arm - mark
+	__asm volatile("DSB");
+	__asm volatile("ISB");
+}
+
+/// enable all interrupts - must be in system mode
+static inline __attribute__((no_instrument_function)) void ENABLE_INTERRUPTS() {
+	__asm volatile("CPSIE i" ::: "memory");
+	__asm volatile("DSB");
+	__asm volatile("ISB");
+}
 void clearIRQInterrupt(int irqNumber);
 
 /// sets up a timer with an interrupt and handler but does not enable the timer

--- a/src/RZA1/compiler/asm/reset_handler.S
+++ b/src/RZA1/compiler/asm/reset_handler.S
@@ -243,10 +243,8 @@ reserved_handler:
     CPSID   i                   /* Disable interrupt handling to preserve stack */
     MOV     r0, LR              /* Store SYS LR value as first function parameter */
     MOV     r1, SP              /* Store SYS SP value as second function parameter */
-    CPS  #USR_MODE              /* Switch into user mode to get those register values */
-    MOV     r2, LR              /* Store USR LR value as third function parameter */
-    MOV     r3, SP              /* Store USR SP value as fourth function parameter */
-    CPS  #SYS_MODE              /* Go back to SYS mode */
+    MOV     r2, #0              /* USR LR - 0 since we don't currently use user mode */
+    MOV     r3, #0              /* USR SP - 0 since we don't use user mode */
     LDR  r12,=handle_cpu_fault  /* Load address of handle_cpu_fault */
     BX   r12                    /* Jump to handle_cpu_fault without link */
 .end

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -53,6 +53,7 @@
 #include "storage/flash_storage.h"
 #include "storage/multi_range/multisample_range.h"
 #include "storage/storage_manager.h"
+#include "timers_interrupts/timers_interrupts.h"
 #include "util/functions.h"
 #include "util/misc.h"
 #include <cstring>
@@ -685,21 +686,11 @@ startAgain:
 
 	// Render audio for song
 	if (currentSong) {
-		uint8_t enabledInterrupts[DISABLE_INTERRUPTS_COUNT] = {0};
-		for (uint32_t idx = 0; idx < DISABLE_INTERRUPTS_COUNT; ++idx) {
-			enabledInterrupts[idx] = R_INTC_Enabled(disableInterrupts[idx]);
-			if (enabledInterrupts[idx]) {
-				R_INTC_Disable(disableInterrupts[idx]);
-			}
-		}
+		DISABLE_ALL_INTERRUPTS();
 
 		currentSong->renderAudio(renderingBuffer.data(), numSamples, reverbBuffer.data(), sideChainHitPending);
 
-		for (uint32_t idx = 0; idx < DISABLE_INTERRUPTS_COUNT; ++idx) {
-			if (enabledInterrupts[idx] != 0) {
-				R_INTC_Enable(disableInterrupts[idx]);
-			}
-		}
+		ENABLE_INTERRUPTS();
 	}
 
 #ifdef REPORT_CPU_USAGE

--- a/src/deluge/util/chainload.cpp
+++ b/src/deluge/util/chainload.cpp
@@ -20,6 +20,7 @@
 #include "chainload.h"
 #include "RZA1/mtu/mtu.h"
 #include "definitions.h"
+#include "timers_interrupts/timers_interrupts.h"
 
 extern uint32_t spareRenderingBuffer[][SSI_TX_BUFFER_NUM_SAMPLES];
 
@@ -35,7 +36,7 @@ void chainload_from_buf(uint8_t* buffer, int buf_size) {
 
 	// Disable interrupts so we don't get interrupted during the chainload
 #if defined(__arm__)
-	asm volatile("CPSID   i");
+	DISABLE_ALL_INTERRUPTS();
 #endif
 	// Disable timers
 	disableTimer(TIMER_MIDI_GATE_OUTPUT);

--- a/src/main.c
+++ b/src/main.c
@@ -131,7 +131,7 @@ int main(void) {
 	INTC.ICR1 = 0b0101010101010101;
 	// this is the same priority as the midi/gate interrupt despite the comment saying they need to be different
 	setupAndEnableInterrupt(triggerClockInputHandler, IRQ_INTERRUPT_0 + 6, 5);
-
+	ENABLE_INTERRUPTS();
 	deluge_main();
 
 	while (1) {

--- a/tests/32bit_unit_tests/mocks/timers_interrupts/timers_interrupts.h
+++ b/tests/32bit_unit_tests/mocks/timers_interrupts/timers_interrupts.h
@@ -1,0 +1,13 @@
+//
+// Created by Mark Adams on 2024-05-11.
+//
+
+#ifndef DELUGE_TIMERS_INTERRUPTS_H
+#define DELUGE_TIMERS_INTERRUPTS_H
+
+#endif // DELUGE_TIMERS_INTERRUPTS_H
+static inline __attribute__((no_instrument_function)) void DISABLE_ALL_INTERRUPTS() {
+}
+
+static inline __attribute__((no_instrument_function)) void ENABLE_INTERRUPTS() {
+}


### PR DESCRIPTION
Fix interrupt disabling by adding memory and instruction blocks - cpsid isn't enough on it's own as memory operations or fetched instructions can be out of order

Fix reset handler enterring user mode - we don't use it, and it's not possible to go from usr mode back to sys mode so it just messes up the call stack in debuggers. Sys mode can only be entered from an ISR, in future this could be implemented by a syscall interrupt 