### PR TITLE
Make cycling from 5-note scale to 7-note scale non destructive (remember note positions)

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3179,7 +3179,7 @@ int32_t Song::getCurrentPresetScale() {
 		// If we're here, must be this one!
 		return p;
 
-notThisOne : {}
+notThisOne: {}
 	}
 
 	return CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
@@ -5097,7 +5097,7 @@ Instrument* Song::changeOutputType(Instrument* oldInstrument, OutputType newOutp
 			return NULL;
 		}
 
-gotAnInstrument : {}
+gotAnInstrument: {}
 	}
 
 	// Synth or Kit

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -31,7 +31,6 @@
 #include "hid/led/indicator_leds.h"
 #include "hid/led/pad_leds.h"
 #include "hid/matrix/matrix_driver.h"
-#include "io/debug/log.h"
 #include "io/midi/device_specific/specific_midi_device.h"
 #include "io/midi/midi_engine.h"
 #include "memory/general_memory_allocator.h"

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -30,7 +30,6 @@
 #include "storage/flash_storage.h"
 #include "util/container/array/ordered_resizeable_array_with_multi_word_key.h"
 #include "util/d_string.h"
-#include <sys/_stdint.h>
 
 class MidiCommand;
 class Clip;

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -390,8 +390,8 @@ public:
 	int32_t countAudioClips() const;
 
 private:
-	int8_t indexLastUnusedScaleDegreeFrom7To6 = -1;
-	int8_t indexLastUnusedScaleDegreeFrom6To5 = -1;
+	uint8_t indexLastUnusedScaleDegreeFrom7To6 = 0;
+	uint8_t indexLastUnusedScaleDegreeFrom6To5 = 0;
 	bool fillModeActive;
 	Clip* currentClip = nullptr;
 	Clip* previousClip = nullptr; // for future use, maybe finding an instrument clip or something

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -30,6 +30,7 @@
 #include "storage/flash_storage.h"
 #include "util/container/array/ordered_resizeable_array_with_multi_word_key.h"
 #include "util/d_string.h"
+#include <sys/_stdint.h>
 
 class MidiCommand;
 class Clip;
@@ -390,6 +391,8 @@ public:
 	int32_t countAudioClips() const;
 
 private:
+	int8_t indexLastUnusedScaleDegreeFrom7To6 = -1;
+	int8_t indexLastUnusedScaleDegreeFrom6To5 = -1;
 	bool fillModeActive;
 	Clip* currentClip = nullptr;
 	Clip* previousClip = nullptr; // for future use, maybe finding an instrument clip or something


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/1864

To cherry pick for 1.1