### PR TITLE
Automation View ~ Refactor and update shortcut for pad selection mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Press `▼︎▲︎` + `◀︎▶︎` to set the Audio Clip length equal to the length of the audio sample. This will effectively remove timestretching from the audio sample.
   - Press `SHIFT` + `◀︎▶︎` + `turn ◀︎▶︎` to shorten / lengthen the audio clip without timestretching.
 - Added new `YELLOW GRID MODE` which allows you configure the clip type between `DEFAULT`, `FILL`, and `ONCE` by holding on a clip pad and pressing `SELECT`. In this mode, while clips are inactive, the clip pads are highlighted different colours to indicate the current clip type.
+- Updated `AUTOMATION VIEW` shortcut to enter/exit `PAD SELECTION MODE` to `SHIFT` + `WAVEFORM` (the very top left pad in first column of grid).
 
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -654,6 +654,7 @@ Synchronization modes accessible through `SYNC` shortcuts for `ARP`, `LFO1`, `DE
       - Negative value = bottom 4 pads lit up according to position in middle to minimum value range
       - Note: per the functionality added in [#887] mentioned above, you can set a param to the middle value by pressing the two pads in a column or you can use the fine tuning method with the gold encoders in or out of pad selection mode by selecting a pad and turning gold encoder.
       - To make it easier to set the middle value, functionality has been added to blink the LED indicators when you reach the middle value and it also makes it more difficult to turn the knob past the middle value as it currently did outside automation view editor.
+    - ([#1898]) Updated `AUTOMATION VIEW` shortcut to enter/exit `PAD SELECTION MODE` to `SHIFT` + `WAVEFORM` (the very top left pad in first column of grid).
 
 #### 4.3.6 - Set Probability By Row
 
@@ -1273,6 +1274,8 @@ different firmware
 [#1739]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1739
 
 [#1846]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1846
+
+[#1898]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1898
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -238,12 +238,10 @@ The Automation Editor **will:**
 
 > **Note 3:** If the parameter selected is not currently automated, turning the Mod Encoders (Gold Knobs) will increase the value of every step in the automation grid in unison (e.g. same value for all steps).
 
-- you can also fine tune automation values by entering **Pad Selection Mode**. You enter this mode by pressing on either of the Mod Encoders.
+- you can also fine tune automation values by entering **Pad Selection Mode**. You enter / exit this mode by pressing the pad selection mode shortcut (Shift + Waveform Pad in first column of grid / the very top left pad)
 
 ![image](https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/1e4b3653-c1a1-4d21-bfa0-826df378b063)
 
-> Pad selection mode is accessed by pressing on either of the mod encoder buttons
-> 
 > In pad selection mode, you cannot edit the automation grid by pressing on the pads. 
 > 
 > With a single or multi pad (long) press you select the pad(s) to edit. 
@@ -471,4 +469,3 @@ These are the main button shortcuts/combos that will be used in the Automation C
 This image shows the default MIDI Follow CC to Grid Parameter Shortcut mappings. You can edit these mappings in MIDIFollow.XML which will update the CC to Grid Parameter Shortcut mappings used in Automation View for MIDI Clips.
 
 ![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/6ecbb774-deb9-466c-9469-e86e5e904ce3)
-

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -319,6 +319,12 @@ const int32_t patchCableMaxPadDisplayValues[kDisplayHeight] = {-97, -65, -33, -1
 // y = 1 ::  17 <  18 <  32
 // y = 0 ::  0  <   0 <  16
 
+// shortcuts for toggling interpolation and pad selection mode
+constexpr uint8_t kInterpolationShortcutX = 0;
+constexpr uint8_t kInterpolationShortcutY = 6;
+constexpr uint8_t kPadSelectionShortcutX = 0;
+constexpr uint8_t kPadSelectionShortcutY = 7;
+
 AutomationView automationView{};
 
 AutomationView::AutomationView() {
@@ -348,12 +354,8 @@ AutomationView::AutomationView() {
 	parameterShortcutBlinking = false;
 	// used to set interpolation shortcut blinking
 	interpolationShortcutBlinking = false;
-	interpolationShortcutX = 0;
-	interpolationShortcutY = 6;
 	// used to enter pad selection mode
 	padSelectionOn = false;
-	padSelectionShortcutX = 0;
-	padSelectionShortcutY = 7;
 	multiPadPressSelected = false;
 	multiPadPressActive = false;
 	leftPadSelectedX = kNoSelection;
@@ -2024,11 +2026,11 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 		    || (isUIModeActive(UI_MODE_AUDITIONING) && !FlashStorage::automationDisableAuditionPadShortcuts)) {
 
 			// toggle interpolation on / off
-			if (x == interpolationShortcutX && y == interpolationShortcutY) {
+			if (x == kInterpolationShortcutX && y == kInterpolationShortcutY) {
 				return toggleAutomationInterpolation();
 			}
 			// toggle pad selection on / off
-			else if (x == padSelectionShortcutX && y == padSelectionShortcutY) {
+			else if (x == kPadSelectionShortcutX && y == kPadSelectionShortcutY) {
 				return toggleAutomationPadSelectionMode(modelStackWithParam, effectiveLength, xScroll, xZoom);
 			}
 
@@ -4536,7 +4538,7 @@ void AutomationView::resetInterpolationShortcutBlinking() {
 }
 
 void AutomationView::blinkInterpolationShortcut() {
-	PadLEDs::flashMainPad(interpolationShortcutX, interpolationShortcutY);
+	PadLEDs::flashMainPad(kInterpolationShortcutX, kInterpolationShortcutY);
 	uiTimerManager.setTimer(TimerName::INTERPOLATION_SHORTCUT_BLINK, 3000);
 	interpolationShortcutBlinking = true;
 }

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -166,6 +166,8 @@ private:
 	                       OutputType outputType, int32_t effectiveLength, int32_t x, int32_t y, int32_t velocity,
 	                       int32_t xScroll, int32_t xZoom);
 	bool toggleAutomationInterpolation();
+	bool toggleAutomationPadSelectionMode(ModelStackWithAutoParam* modelStackWithParam, int32_t effectiveLength,
+	                                      int32_t xScroll, int32_t xZoom);
 	bool handleParameterSelection(Clip* clip, OutputType outputType, int32_t xDisplay, int32_t yDisplay);
 	void automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
 	                             int32_t yDisplay, int32_t velocity, int32_t effectiveLength, int32_t xScroll,
@@ -296,6 +298,8 @@ private:
 	uint8_t interpolationShortcutY;
 
 	bool padSelectionOn;
+	uint8_t padSelectionShortcutX;
+	uint8_t padSelectionShortcutY;
 	bool multiPadPressActive;
 	bool middlePadPressSelected;
 	int32_t leftPadSelectedX;

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -294,12 +294,8 @@ private:
 	bool parameterShortcutBlinking;
 
 	bool interpolationShortcutBlinking;
-	uint8_t interpolationShortcutX;
-	uint8_t interpolationShortcutY;
 
 	bool padSelectionOn;
-	uint8_t padSelectionShortcutX;
-	uint8_t padSelectionShortcutY;
 	bool multiPadPressActive;
 	bool middlePadPressSelected;
 	int32_t leftPadSelectedX;


### PR DESCRIPTION
Refactored and updated shortcut for pad selection mode

Shortcut is now `SHIFT` + `WAVEFORM` (the very top left pad in first column of grid).

more prep for velocity view