### PR TITLE
dbt: task-test.py runs tests in addition to building them

### DIFF
--- a/scripts/tasks/task-test.py
+++ b/scripts/tasks/task-test.py
@@ -8,6 +8,12 @@ import util
 
 def argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="test", description="Run deluge tests")
+    parser.add_argument(
+        "-n",
+        "--no-run",
+        action="store_true",
+        help="Only build the tests, without running them.",
+    )
 
     return parser
 
@@ -17,6 +23,15 @@ def cmake_build() -> int:
     cmake_args += ["--build", "build/tests/"]
 
     return subprocess.run(cmake_args, env=os.environ).returncode
+
+
+def cmake_test() -> int:
+    cmake_args = ["ctest"]
+    cmake_args += ["--test-dir", "build/tests", "-C", "Debug"]
+
+    return subprocess.run(
+        cmake_args, env=dict(os.environ, CTEST_OUTPUT_ON_FAILURE="1")
+    ).returncode
 
 
 def cmake_configure() -> int:
@@ -38,7 +53,11 @@ def main() -> int:
         if result != 0:
             return result
 
-    return cmake_build()
+    build = cmake_build()
+    if build != 0 or args.no_run:
+        return build
+
+    return cmake_test()
 
 
 if __name__ == "__main__":

--- a/tests/32bit_unit_tests/CMakeLists.txt
+++ b/tests/32bit_unit_tests/CMakeLists.txt
@@ -31,6 +31,8 @@ file(GLOB_RECURSE deluge_SOURCES
 )
 
 add_executable(32BitTests RunAllTests.cpp memory_tests.cpp)
+add_test(NAME 32BitTests
+         COMMAND 32BitTests)
 target_sources(32BitTests PRIVATE ${deluge_SOURCES})
 target_include_directories(32BitTests PRIVATE
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -31,6 +31,8 @@ file(GLOB_RECURSE deluge_SOURCES
 )
 
 add_executable(UnitTests RunAllTests.cpp scheduler_tests.cpp)
+add_test(NAME UnitTests
+        COMMAND UnitTests)
 target_sources(UnitTests PRIVATE ${deluge_SOURCES})
 target_include_directories(UnitTests PRIVATE
         # include the non test project source


### PR DESCRIPTION
* Option -n / --no-run allows skipping running tests.

* Specify UnitTests and 32BitUnitTests as tests in CMakeLists, so
  they get picked up by CTest.

* This appears to also work around #1886: cmake runs it as

      ./build/tests/spec/Debug/all_specs semver_spec --verbose

  bypassing the interactive test selection, which is where the
  segfault appears to be coming.

---

On Discord @m-m-adams said a command-line option to run the tests in addition to building them
was fine. I would push to running them by default and having a command-line option to skip running, as in this PR.

If the "no, only build by default" is the way to go, I'll happily switch this PR around to work the other way around, but thought to try this way first. :)

Depending on your view this may or may not close issue #1886.