### PR TITLE
refactor clock status checks

### DIFF
--- a/src/deluge/gui/context_menu/clear_song.cpp
+++ b/src/deluge/gui/context_menu/clear_song.cpp
@@ -71,7 +71,7 @@ void ClearSong::focusRegained() {
 
 bool ClearSong::acceptCurrentOption() {
 	if (playbackHandler.playbackState
-	    && ((playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) || currentPlaybackMode == &arrangement)) {
+	    && (playbackHandler.isInternalClockActive() || currentPlaybackMode == &arrangement)) {
 
 		playbackHandler.endPlayback();
 	}

--- a/src/deluge/gui/context_menu/clear_song.cpp
+++ b/src/deluge/gui/context_menu/clear_song.cpp
@@ -79,7 +79,7 @@ bool ClearSong::acceptCurrentOption() {
 	actionLogger.deleteAllLogs();
 
 	nullifyUIs();
-	if (!(playbackHandler.playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE)) {
+	if (!playbackHandler.isEitherClockActive()) {
 		deleteOldSongBeforeLoadingNew();
 	}
 	else {
@@ -96,7 +96,7 @@ bool ClearSong::acceptCurrentOption() {
 
 	preLoadedSong->ensureAtLeastOneSessionClip(); // Will load a synth preset from SD card
 
-	playbackHandler.doSongSwap((playbackHandler.playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE));
+	playbackHandler.doSongSwap(playbackHandler.isEitherClockActive());
 	if (toDelete) {
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Song();

--- a/src/deluge/gui/menu_item/trigger/in/ppqn.h
+++ b/src/deluge/gui/menu_item/trigger/in/ppqn.h
@@ -27,7 +27,7 @@ public:
 	void readCurrentValue() override { this->setValue(playbackHandler.analogInTicksPPQN); }
 	void writeCurrentValue() override {
 		playbackHandler.analogInTicksPPQN = this->getValue();
-		if ((playbackHandler.playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE) && playbackHandler.usingAnalogClockInput)
+		if (playbackHandler.isExternalClockActive() && playbackHandler.usingAnalogClockInput)
 			playbackHandler.resyncInternalTicksToInputTicks(currentSong);
 	}
 };

--- a/src/deluge/model/consequence/consequence_begin_playback.cpp
+++ b/src/deluge/model/consequence/consequence_begin_playback.cpp
@@ -24,7 +24,7 @@ ConsequenceBeginPlayback::ConsequenceBeginPlayback() {
 
 Error ConsequenceBeginPlayback::revert(TimeType time, ModelStack* modelStack) {
 	if (time == BEFORE) {
-		if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
+		if (playbackHandler.isInternalClockActive()) {
 			playbackHandler.endPlayback();
 		}
 	}

--- a/src/deluge/model/consequence/consequence_note_row_mute.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_mute.cpp
@@ -36,8 +36,8 @@ Error ConsequenceNoteRowMute::revert(TimeType time, ModelStack* modelStack) {
 	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addTimelineCounter(clip)->addNoteRow(noteRowId, noteRow);
 
 	// Call this instead of Clip::toggleNoteRowMute(), cos that'd go and log another Action
-	noteRow->toggleMute(modelStackWithNoteRow, playbackHandler.isEitherClockActive()
-	                                               && modelStackWithNoteRow->song->isClipActive(clip));
+	noteRow->toggleMute(modelStackWithNoteRow,
+	                    playbackHandler.isEitherClockActive() && modelStackWithNoteRow->song->isClipActive(clip));
 
 	return Error::NONE;
 }

--- a/src/deluge/model/consequence/consequence_note_row_mute.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_mute.cpp
@@ -36,7 +36,7 @@ Error ConsequenceNoteRowMute::revert(TimeType time, ModelStack* modelStack) {
 	ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addTimelineCounter(clip)->addNoteRow(noteRowId, noteRow);
 
 	// Call this instead of Clip::toggleNoteRowMute(), cos that'd go and log another Action
-	noteRow->toggleMute(modelStackWithNoteRow, (playbackHandler.playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE)
+	noteRow->toggleMute(modelStackWithNoteRow, playbackHandler.isEitherClockActive()
 	                                               && modelStackWithNoteRow->song->isClipActive(clip));
 
 	return Error::NONE;

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -2232,7 +2232,7 @@ void NoteRow::attemptLateStartOfNextNoteToPlay(ModelStackWithNoteRow* modelStack
 	}
 
 	/*
-	if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE)
+	if (playbackHandler.isInternalClockActive())
 	    timeAgo += (((uint64_t)ticksAgo * currentSong->timePerTimerTickFraction + 4294967296 -
 	playbackHandler.lastTimerTickDoneFraction) >> 32); // This sometimes ends up 1 sample off, I think - not quite sure
 	why

--- a/src/deluge/model/sample/sample_playback_guide.cpp
+++ b/src/deluge/model/sample/sample_playback_guide.cpp
@@ -127,7 +127,7 @@ int32_t SamplePlaybackGuide::adjustPitchToCorrectDriftFromSync(VoiceSample* voic
 
 	// Not if not following external clock source, or clusters not set up yet (in the case of a very-late-start),
 	// there's no need
-	if (!(playbackHandler.playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE) || !voiceSample->clusters[0]) {
+	if (!playbackHandler.isExternalClockActive() || !voiceSample->clusters[0]) {
 		return phaseIncrement;
 	}
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -4841,7 +4841,7 @@ cantDoIt:
 			oldNonAudioInstrument->channel = oldChannel; // Put it back, before switching notes off etc
 		}
 
-		if (oldNonAudioInstrument->activeClip && (playbackHandler.playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE)) {
+		if (oldNonAudioInstrument->activeClip && playbackHandler.isEitherClockActive()) {
 			oldNonAudioInstrument->activeClip->expectNoFurtherTicks(currentSong);
 		}
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2479,7 +2479,7 @@ void Song::setTimePerTimerTick(uint64_t newTimeBig, bool shouldLogAction) {
 	}
 
 	// Alter timing of next and last timer ticks
-	if (currentSong == this && (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE)) {
+	if (currentSong == this && playbackHandler.isInternalClockActive()) {
 		uint32_t timeSinceLastTimerTick =
 		    AudioEngine::audioSampleTimer - (uint32_t)(playbackHandler.timeLastTimerTickBig >> 32);
 
@@ -2505,7 +2505,7 @@ void Song::setTimePerTimerTick(uint64_t newTimeBig, bool shouldLogAction) {
 	divideByTimePerTimerTick = ((uint64_t)1 << 63) / ((newTimeBig * 3) >> 1);
 
 	// Reschedule upcoming swung, MIDI and trigger clock out ticks
-	if (currentSong == this && (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE)) {
+	if (currentSong == this && playbackHandler.isInternalClockActive()) {
 		playbackHandler.scheduleSwungTickFromInternalClock();
 		if (cvEngine.isTriggerClockOutputEnabled()) {
 			playbackHandler.scheduleTriggerClockOutTick();
@@ -5655,7 +5655,7 @@ void Song::changeSwingInterval(int32_t newValue) {
 
 	swingInterval = newValue;
 
-	if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
+	if (playbackHandler.isInternalClockActive()) {
 
 		int32_t leftShift = 10 - swingInterval;
 		leftShift = std::max(leftShift, 0_i32);

--- a/src/deluge/model/voice/voice_sample.cpp
+++ b/src/deluge/model/voice/voice_sample.cpp
@@ -1759,7 +1759,7 @@ bool VoiceSample::possiblySetUpCache(SampleControls* sampleControls, SamplePlayb
 	if (phaseIncrement == kMaxSampleValue) {
 		return true;
 	}
-	if (guide->sequenceSyncLengthTicks && (playbackHandler.playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE)) {
+	if (guide->sequenceSyncLengthTicks && (playbackHandler.isExternalClockActive())) {
 		return true; // No syncing to external clock
 	}
 	if (sampleControls->interpolationMode != InterpolationMode::SMOOTH) {

--- a/src/deluge/playback/mode/arrangement.cpp
+++ b/src/deluge/playback/mode/arrangement.cpp
@@ -314,7 +314,7 @@ justDoArp:
 
 	// If nothing further in the arrangement, we usually just stop playing
 	if (playbackHandler.swungTicksTilNextEvent == 2147483647
-	    && (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE)
+	    && playbackHandler.isInternalClockActive()
 	    // Only do this if not recording MIDI - but override that and do do it if we're "resampling"
 	    && (playbackHandler.recording == RecordingMode::OFF
 	        || audioRecorder.recordingSource >= AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION)) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -768,7 +768,7 @@ void Session::reSyncClip(ModelStackWithTimelineCounter* modelStack, bool mustSet
 	if (playbackHandler.isEitherClockActive() && modelStack->song->isClipActive(clip)) {
 
 		// If following external clock...
-		if (playbackHandler.playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE) {
+		if (playbackHandler.isExternalClockActive()) {
 
 			// If this is in fact the sync-scaling Clip, we want to resync all Clips. The song will have already updated
 			// its inputTickMagnitude
@@ -1389,7 +1389,7 @@ LaunchStatus Session::investigateSyncedLaunch(Clip* waitForClip, uint32_t* curre
 		else {
 
 			// If a clock is coming in or out, or metronome is on, use that to work out the loop point
-			if ((playbackHandler.playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE) || playbackHandler.midiOutClockEnabled
+			if (playbackHandler.isExternalClockActive() || playbackHandler.midiOutClockEnabled
 			    || playbackHandler.metronomeOn
 			    || cvEngine.gateChannels[WHICH_GATE_OUTPUT_IS_CLOCK].mode == GateType::SPECIAL
 			    || playbackHandler.recording == RecordingMode::ARRANGEMENT) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -599,7 +599,7 @@ doNormalLaunch:
 			if (!anyClipsStillActiveAfter) {
 
 				// If we're using the internal clock, we have the power to stop playback entirely
-				if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
+				if (playbackHandler.isInternalClockActive()) {
 
 					// If user is stopping resampling...
 					if (playbackHandler.stopOutputRecordingAtLoopEnd) {
@@ -1398,7 +1398,7 @@ LaunchStatus Session::investigateSyncedLaunch(Clip* waitForClip, uint32_t* curre
 
 				// If using internal clock (meaning metronome or clock output is on), just quantize to one bar. This is
 				// potentially imperfect.
-				if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
+				if (playbackHandler.isInternalClockActive()) {
 					*quantization = oneBar;
 				}
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -197,8 +197,7 @@ void PlaybackHandler::playButtonPressed(int32_t buttonPressLatency) {
 			// Otherwise, if internal clock, restart playback
 			else {
 
-				if (isInternalClockActive()
-				    && recording != RecordingMode::ARRANGEMENT) {
+				if (isInternalClockActive() && recording != RecordingMode::ARRANGEMENT) {
 					forceResetPlayPos(currentSong);
 				}
 				else {

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -209,6 +209,7 @@ public:
 	void scheduleSwungTickFromInternalClock();
 	bool currentlySendingMIDIOutputClocks();
 
+	inline bool isInternalClockActive() { return (playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE); }
 	inline bool isEitherClockActive() { return (playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE); }
 
 private:

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -209,6 +209,7 @@ public:
 	void scheduleSwungTickFromInternalClock();
 	bool currentlySendingMIDIOutputClocks();
 
+	inline bool isExternalClockActive() { return (playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE); }
 	inline bool isInternalClockActive() { return (playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE); }
 	inline bool isEitherClockActive() { return (playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE); }
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -597,7 +597,7 @@ startAgain:
 		int32_t nextTickType = 0;
 		uint32_t timeNextTick = audioSampleTimer + 9999;
 
-		if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
+		if (playbackHandler.isInternalClockActive()) {
 			timeNextTick = playbackHandler.timeNextTimerTickBig >> 32;
 			nextTickType = TICK_TYPE_TIMER;
 		}

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -278,7 +278,7 @@ void CVEngine::setGateType(uint8_t channel, GateType value) {
 
 		// Clock
 		if (channel == WHICH_GATE_OUTPUT_IS_CLOCK) {
-			if (playbackHandler.playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) {
+			if (playbackHandler.isInternalClockActive()) {
 				playbackHandler.resyncAnalogOutTicksToInternalTicks();
 			}
 			updateClockOutput();


### PR DESCRIPTION
* Use `PlaybackHandler::isEitherClockActive()` consistently.
* Add corresponding `isInternalClockActive()` and `isExternalClockActive()`.
