### PR TITLE
Move automation view and performance view specific constants out of definitions + refactor perform view

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -323,26 +323,12 @@ constexpr int32_t kMinMenuPatchCableValue = -1 * kMaxMenuPatchCableValue;
 constexpr int32_t kMaxMenuMetronomeVolumeValue = 50;
 constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 
-// Automation View constants
-constexpr int32_t kNumNonGlobalParamsForAutomation = 61;
-constexpr int32_t kNumGlobalParamsForAutomation = 26;
+// Param constants
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kKnobPosOffset = 64;
 constexpr int32_t kMaxKnobPos = 128;
-constexpr float kParamValueIncrementForAutomationSinglePadPress = 18.2857142857143; // 128 / 7
-constexpr int32_t kParamValueIncrementForAutomationDisplay = 16;
-constexpr int32_t kParamValueIncrementForAutomationPatchCableSinglePadPress = 30;
-constexpr int32_t kParamValueIncrementForAutomationPatchCableDisplay = 32;
-constexpr int32_t kParamNodeWidth = 3;
-//
 
-// Performance View constant
-constexpr int32_t kNumParamsForPerformance = 18;
-constexpr int32_t kParamValueIncrementForDelayAmount = kParamValueIncrementForAutomationSinglePadPress / 2;
-constexpr int32_t kMaxKnobPosForDelayAmount = (kMaxKnobPos / 2) - 1;
-constexpr int32_t kParamValueIncrementForQuantizedStutter = 15;
-constexpr int32_t kMinKnobPosForQuantizedStutter = 52;
-
+// Performance View Modes
 enum class PerformanceEditingMode : uint8_t {
 	DISABLED,
 	VALUE,

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -118,6 +118,10 @@ const uint32_t mutePadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITION
 
 const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_RECORD_COUNT_IN, 0};
 
+constexpr int32_t kNumNonGlobalParamsForAutomation = 61;
+constexpr int32_t kNumGlobalParamsForAutomation = 26;
+constexpr int32_t kParamNodeWidth = 3;
+
 // synth and kit rows FX - sorted in the order that Parameters are scrolled through on the display
 const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutomation> nonGlobalParamsForAutomation{{
     // Master Volume, Pitch, Pan

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -179,9 +179,8 @@ private:
 	ParamsForPerformance backupXMLDefaultLayoutForPerformance[kDisplayWidth];
 	int32_t backupXMLDefaultFXValues[kDisplayWidth][kDisplayHeight];
 
-	int32_t calculateKnobPosForSinglePadPress(int32_t xDisplay, int32_t yDisplay);
+	int32_t getKnobPosForSinglePadPress(int32_t xDisplay, int32_t yDisplay);
 	int32_t calculateKnobPosForSelectEncoderTurn(int32_t knobPos, int32_t offset);
-	int32_t adjustKnobPosForQuantizedStutter(int32_t yDisplay);
 
 	PadPress firstPadPress;
 	ParamsForPerformance layoutForPerformance[kDisplayWidth];


### PR DESCRIPTION
Moved automation and performance view specific constants out of definitions_cxx.hpp

Refactored perf view to convert pad press value calculation functions into a get function that retrieves press values from pre defined constant arrays (as was done a while back in automation view).