### PR TITLE
Bugfix/scheduler segfault pri0 tasks

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -44,7 +44,7 @@ struct SortedTask {
 /// internal only to the task scheduler, hence all public. External interaction to use the api
 struct TaskManager {
 
-	std::array<Task, kMaxTasks> list;
+	std::array<Task, kMaxTasks> list{nullptr};
 	std::array<SortedTask, kMaxTasks> sortedList;
 	TaskID index = 0;
 	double mustEndBefore = 128;
@@ -63,8 +63,12 @@ struct TaskManager {
 TaskManager taskManager;
 
 void TaskManager::createSortedList() {
-	for (TaskID i = 0; i <= index; i++) {
-		sortedList[i] = (SortedTask{list[i].priority, i});
+	int j = 0;
+	for (TaskID i = 0; i <= kMaxTasks; i++) {
+		if (list[i].handle != nullptr) {
+			sortedList[j] = (SortedTask{list[i].priority, i});
+			j++;
+		}
 	}
 	std::sort(&sortedList[0], &sortedList[index + 1]);
 }

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -101,6 +101,22 @@ TEST(Scheduler, scheduleOnceWithRepeating) {
 	mock().checkExpectations();
 };
 
+TEST(Scheduler, removeWithPriZero) {
+	mock().clear();
+	mock().expectNCalls((0.01 - 0.002) / 0.001 - 1, "sleep_50ns");
+	mock().expectNCalls(2, "sleep_2ms");
+	// every 1ms sleep for 50ns and 10ns
+	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001);
+	addRepeatingTask([]() { passMockTime(0.00001); }, 0, 0.001, 0.001, 0.001);
+	addOnceTask(sleep_2ms, 11, 0.002);
+	addRepeatingTask([]() { passMockTime(0.00003); }, 0, 0.001, 0.001, 0.001);
+	addOnceTask(sleep_2ms, 11, 0.009);
+	// run the scheduler for 10ms
+	taskManager.start(0.01);
+	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
+	mock().checkExpectations();
+};
+
 TEST(Scheduler, scheduleMultiple) {
 	mock().clear();
 	mock().expectNCalls(0.01 / 0.001 - 1, "sleep_50ns");


### PR DESCRIPTION
Removing a task while a zero priority task is present leads to a bug in sorting, where the null task would be included in the sort. Remove null tasks while generating the sorted list to walk through