### PR TITLE
Bugfix - Transition back to keyboard screen when automation clip view flag is set

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2388,7 +2388,11 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 	PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
 
-	if (clip->onAutomationClipView) {
+	bool onKeyboardScreen = ((clip->type == ClipType::INSTRUMENT) && ((InstrumentClip*)clip)->onKeyboardScreen);
+
+	// when transitioning back to clip, if keyboard view is enabled, it takes precedent
+	// over automation and instrument clip views.
+	if (clip->onAutomationClipView && !onKeyboardScreen) {
 		currentUIMode = UI_MODE_INSTRUMENT_CLIP_EXPANDING;
 
 		automationView.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore, false);
@@ -2415,7 +2419,7 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 		currentUIMode = UI_MODE_INSTRUMENT_CLIP_EXPANDING;
 
-		if (((InstrumentClip*)clip)->onKeyboardScreen) {
+		if (onKeyboardScreen) {
 
 			keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
 
@@ -3728,8 +3732,11 @@ void SessionView::gridTransitionToViewForClip(Clip* clip) {
 	                                 kDisplayWidth);
 	auto clipY = std::clamp<int32_t>(gridYFromSection(getCurrentClip()->section), 0, kDisplayHeight);
 
-	// If going to automationView...
-	if (clip->onAutomationClipView) {
+	bool onKeyboardScreen = ((clip->type == ClipType::INSTRUMENT) && ((InstrumentClip*)clip)->onKeyboardScreen);
+
+	// when transitioning back to clip, if keyboard view is enabled, it takes precedent
+	// over automation and instrument clip views.
+	if (clip->onAutomationClipView && !onKeyboardScreen) {
 		PadLEDs::explodeAnimationYOriginBig = clipY << 16;
 
 		if (clip->type == ClipType::INSTRUMENT) {
@@ -3761,12 +3768,11 @@ void SessionView::gridTransitionToViewForClip(Clip* clip) {
 			PadLEDs::setupAudioClipCollapseOrExplodeAnimation((AudioClip*)clip);
 		}
 	}
-
 	else {
 		PadLEDs::explodeAnimationYOriginBig = clipY << 16;
 
 		// If going to KeyboardView...
-		if (((InstrumentClip*)clip)->onKeyboardScreen) {
+		if (onKeyboardScreen) {
 			keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
 			memset(PadLEDs::occupancyMaskStore[0], 0, kDisplayWidth + kSideBarWidth);
 			memset(PadLEDs::occupancyMaskStore[kDisplayHeight], 0, kDisplayWidth + kSideBarWidth);

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -988,13 +988,18 @@ void renderAudioClipExpandOrCollapse() {
 }
 
 void renderClipExpandOrCollapse() {
-
 	int32_t progress = getTransitionProgress();
 	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING)) {
 		if (progress >= 65536) {
 			currentUIMode = UI_MODE_NONE;
 
-			if (getCurrentClip()->onAutomationClipView) {
+			Clip* clip = getCurrentClip();
+
+			bool onKeyboardScreen = ((clip->type == ClipType::INSTRUMENT) && ((InstrumentClip*)clip)->onKeyboardScreen);
+
+			// when transitioning back to clip, if keyboard view is enabled, it takes precedent
+			// over automation and instrument clip views.
+			if (clip->onAutomationClipView && !onKeyboardScreen) {
 				changeRootUI(&automationView);
 				// If we need to zoom in horizontally because the Clip's too short...
 				bool anyZoomingDone = instrumentClipView.zoomToMax(true);
@@ -1003,7 +1008,7 @@ void renderClipExpandOrCollapse() {
 				}
 			}
 			else {
-				if (getCurrentInstrumentClip()->onKeyboardScreen) {
+				if (onKeyboardScreen) {
 					changeRootUI(&keyboardScreen);
 				}
 				else {


### PR DESCRIPTION
Fixed bug whereby if you were on keyboard screen and exited back to session view and the clip's onAutomationClipView flag was set that upon returning to the clip it would go back to automation view and not the keyboard screen (it should go back to keyboard screen as it is a layer on top of instrument / automation clip view and is the current root UI)