### PR TITLE
Bugfix/retry sd init

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -19,6 +19,7 @@
 #include "RZA1/ostm/ostm.h"
 #include "util/container/static_vector.hpp"
 #include <algorithm>
+#include <format>
 #include <iostream>
 // currently 14 are in use
 constexpr int kMaxTasks = 20;
@@ -64,13 +65,13 @@ TaskManager taskManager;
 
 void TaskManager::createSortedList() {
 	int j = 0;
-	for (TaskID i = 0; i <= kMaxTasks; i++) {
+	for (TaskID i = 0; i < kMaxTasks; i++) {
 		if (list[i].handle != nullptr) {
 			sortedList[j] = (SortedTask{list[i].priority, i});
 			j++;
 		}
 	}
-	std::sort(&sortedList[0], &sortedList[index + 1]);
+	std::sort(&sortedList[0], &sortedList[index]);
 }
 
 TaskID TaskManager::chooseBestTask(double deadline) {
@@ -113,22 +114,31 @@ TaskID TaskManager::chooseBestTask(double deadline) {
 
 TaskID TaskManager::addRepeatingTask(TaskHandle task, uint8_t priority, double minTimeBetweenCalls,
                                      double targetTimeBetweenCalls, double maxTimeBetweenCalls) {
-	list[index] = (Task{task, priority, 0, 0, minTimeBetweenCalls, targetTimeBetweenCalls, maxTimeBetweenCalls, false});
+	if (index >= (kMaxTasks)) {
+		return -1;
+	}
+	list[index++] =
+	    (Task{task, priority, 0, 0, minTimeBetweenCalls, targetTimeBetweenCalls, maxTimeBetweenCalls, false});
+
 	createSortedList();
-	return index++;
+	return index - 1;
 }
 
 TaskID TaskManager::addOnceTask(TaskHandle task, uint8_t priority, double timeToWait) {
+	if (index >= (kMaxTasks)) {
+		return -1;
+	}
 	double timeToStart = running ? getTimerValueSeconds(0) : 0;
-	list[index] = (Task{task, priority, timeToStart, 0, timeToWait, timeToWait, 10 * timeToWait, true});
+	list[index++] = (Task{task, priority, timeToStart, 0, timeToWait, timeToWait, 10 * timeToWait, true});
+
 	createSortedList();
-	return index++;
+	return index - 1;
 }
 
 void TaskManager::removeTask(TaskID id) {
 	list[id] = Task{0, 0, 0, 0, 0, 0, false};
-	createSortedList();
 	index--;
+	createSortedList();
 	return;
 }
 

--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -19,8 +19,6 @@
 #include "RZA1/ostm/ostm.h"
 #include "util/container/static_vector.hpp"
 #include <algorithm>
-#include <format>
-#include <iostream>
 // currently 14 are in use
 constexpr int kMaxTasks = 20;
 constexpr double rollTime = ((double)(UINT32_MAX) / DELUGE_CLOCKS_PERf);

--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -59,6 +59,7 @@ struct TaskManager {
 	void createSortedList();
 	void clockRolledOver();
 	bool running{false};
+	TaskID insertTaskToList(Task task);
 };
 
 TaskManager taskManager;
@@ -112,16 +113,30 @@ TaskID TaskManager::chooseBestTask(double deadline) {
 	return bestTask;
 }
 
+/// insert task into the first empty spot in the list
+TaskID TaskManager::insertTaskToList(Task task) {
+	int index = 0;
+	while (list[index].handle && index < kMaxTasks) {
+		index += 1;
+	}
+	if (index < kMaxTasks) {
+		list[index] = task;
+		numActiveTasks++;
+	}
+
+	return index;
+};
+
 TaskID TaskManager::addRepeatingTask(TaskHandle task, uint8_t priority, double minTimeBetweenCalls,
                                      double targetTimeBetweenCalls, double maxTimeBetweenCalls) {
 	if (numActiveTasks >= (kMaxTasks)) {
 		return -1;
 	}
-	list[numActiveTasks++] =
-	    (Task{task, priority, 0, 0, minTimeBetweenCalls, targetTimeBetweenCalls, maxTimeBetweenCalls, false});
+	int index = insertTaskToList(
+	    Task{task, priority, 0, 0, minTimeBetweenCalls, targetTimeBetweenCalls, maxTimeBetweenCalls, false});
 
 	createSortedList();
-	return numActiveTasks - 1;
+	return index;
 }
 
 TaskID TaskManager::addOnceTask(TaskHandle task, uint8_t priority, double timeToWait) {
@@ -129,10 +144,9 @@ TaskID TaskManager::addOnceTask(TaskHandle task, uint8_t priority, double timeTo
 		return -1;
 	}
 	double timeToStart = running ? getTimerValueSeconds(0) : 0;
-	list[numActiveTasks++] = (Task{task, priority, timeToStart, 0, timeToWait, timeToWait, 10 * timeToWait, true});
-
+	int index = insertTaskToList(Task{task, priority, timeToStart, 0, timeToWait, timeToWait, 10 * timeToWait, true});
 	createSortedList();
-	return numActiveTasks - 1;
+	return index;
 }
 
 void TaskManager::removeTask(TaskID id) {

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -37,6 +37,7 @@
 #include "processing/sound/sound_drum.h"
 #include "processing/sound/sound_instrument.h"
 #include "storage/audio/audio_file_manager.h"
+#include "task_scheduler.h"
 #include "util/firmware_version.h"
 #include "util/functions.h"
 #include "util/try.h"
@@ -252,6 +253,16 @@ Error StorageManager::initSD() {
 	});
 	if (success) {
 		return Error::NONE;
+	}
+	else {
+		// no error but not ready yet - try again in a moment
+		D_PRINTLN("card not ready, trying again soon");
+		addOnceTask(
+		    []() {
+			    D_PRINTLN("checking if card is ready yet");
+			    storageManager.initSD();
+		    },
+		    100, 0.1);
 	}
 	return Error::SD_CARD;
 }

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -117,6 +117,22 @@ TEST(Scheduler, removeWithPriZero) {
 	mock().checkExpectations();
 };
 
+TEST(Scheduler, tooManyTasks) {
+	mock().clear();
+	// will be called one less time due to the time the sleep takes not being zero
+
+	mock().expectNCalls(kMaxTasks, "sleep_50ns");
+	// one more than allowed
+	for (int i = 0; i <= kMaxTasks + 10; i++) {
+		addOnceTask(sleep_50ns, 0, 0.001);
+	}
+
+	// run the scheduler for 10ms
+	taskManager.start(0.01);
+
+	mock().checkExpectations();
+};
+
 TEST(Scheduler, scheduleMultiple) {
 	mock().clear();
 	mock().expectNCalls(0.01 / 0.001 - 1, "sleep_50ns");


### PR DESCRIPTION
Possibly fix #1894 

Changes to startup timing mean that the SD card is typically not ready when it's first read. It's rechecked at every attempted read, but if the first one is done from a scheduled task it will pessimize the estimation for that paths run time, potentially causing a stall. Schedule another to run in its own task instead

Note - based on 1916, but should probably merge seperately. I'll rebase this PR if it fixes the problem 