### PR TITLE
demonstrate what looks like an LFO bug

### DIFF
--- a/src/deluge/modulation/lfo.cpp
+++ b/src/deluge/modulation/lfo.cpp
@@ -1,0 +1,24 @@
+#include "modulation/lfo.h"
+
+uint32_t getLFOInitialPhaseForNegativeExtreme(LFOType waveType) {
+	switch (waveType) {
+	case LFOType::SAW:
+		return 2147483648u;
+
+	case LFOType::SINE:
+		return 3221225472u;
+
+	default:
+		return 0;
+	}
+}
+
+uint32_t getLFOInitialPhaseForZero(LFOType waveType) {
+	switch (waveType) {
+	case LFOType::TRIANGLE:
+		return 1073741824;
+
+	default:
+		return 0;
+	}
+}

--- a/src/deluge/modulation/lfo.h
+++ b/src/deluge/modulation/lfo.h
@@ -48,12 +48,9 @@ public:
 			break;
 
 		case LFOType::SAMPLE_AND_HOLD:
-			if (phase == 0) {
+			if ((phase == 0) || (phase + phaseIncrement * numSamples < phase)) {
 				value = CONG;
 				holdValue = value;
-			}
-			else if (phase + phaseIncrement * numSamples < phase) {
-				holdValue = CONG;
 			}
 			else {
 				value = holdValue;
@@ -78,6 +75,7 @@ public:
 				// holdValue == -8 * range => (holdValue / -16) + (range / 2) ==
 				// range => next holdValue >= current holdValuie
 				holdValue += (holdValue / -16) + (range / 2) - CONG % range;
+				value = holdValue;
 			}
 			else {
 				value = holdValue;
@@ -89,5 +87,9 @@ public:
 		return value;
 	}
 
-	void tick(int32_t numSamples, uint32_t phaseIncrement) { phase += phaseIncrement * numSamples; }
+	void tick(int32_t numSamples, uint32_t phaseIncrement) {
+		// Note: if this overflows and we're using S&H or RANDOM_WALK, the
+		// next render() won't know it has overflown. Probably not an issue.
+		phase += phaseIncrement * numSamples;
+	}
 };

--- a/src/deluge/modulation/lfo.h
+++ b/src/deluge/modulation/lfo.h
@@ -18,7 +18,10 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
-#include "util/functions.h"
+#include "util/waves.h"
+
+uint32_t getLFOInitialPhaseForNegativeExtreme(LFOType waveType);
+uint32_t getLFOInitialPhaseForZero(LFOType waveType);
 
 class LFO {
 public:

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1392,7 +1392,7 @@ int32_t combineHitStrengths(int32_t strength1, int32_t strength2) {
 	return (maxOne >> 1) + (sum >> 1);
 }
 
-uint32_t z = 362436069, w = 521288629, jcong = 380116160;
+uint32_t z = 362436069, w = 521288629;
 
 int32_t random(int32_t upperLimit) {
 	return (uint16_t)(CONG >> 16) % (upperLimit + 1);
@@ -1409,29 +1409,6 @@ bool shouldDoPanning(int32_t panAmount, int32_t* amplitudeL, int32_t* amplitudeR
 	*amplitudeR = (panAmount >= 0) ? 1073741823 : (1073741824 + panOffset);
 	*amplitudeL = (panAmount <= 0) ? 1073741823 : (1073741824 - panOffset);
 	return true;
-}
-
-uint32_t getLFOInitialPhaseForNegativeExtreme(LFOType waveType) {
-	switch (waveType) {
-	case LFOType::SAW:
-		return 2147483648u;
-
-	case LFOType::SINE:
-		return 3221225472u;
-
-	default:
-		return 0;
-	}
-}
-
-uint32_t getLFOInitialPhaseForZero(LFOType waveType) {
-	switch (waveType) {
-	case LFOType::TRIANGLE:
-		return 1073741824;
-
-	default:
-		return 0;
-	}
 }
 
 uint32_t getOscInitialPhaseForZero(OscType waveType) {

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -25,6 +25,7 @@
 #include "util/d_string.h"
 #include "util/fixedpoint.h"
 #include "util/lookuptables/lookuptables.h"
+#include "util/waves.h"
 #include <bit>
 #include <cstdint>
 #include <cstring>
@@ -261,21 +262,6 @@ int32_t quickLog(uint32_t input);
 	return outputValue;
 }
 
-// input must not have any extra bits set than numBitsInInput specifies
-[[gnu::always_inline]] inline int32_t interpolateTableSigned(uint32_t input, int32_t numBitsInInput,
-                                                             const int16_t* table, int32_t numBitsInTableSize = 8) {
-	int32_t whichValue = input >> (numBitsInInput - numBitsInTableSize);
-	int32_t rshiftAmount = numBitsInInput - 16 - numBitsInTableSize;
-	uint32_t rshifted;
-	if (rshiftAmount >= 0)
-		rshifted = input >> rshiftAmount;
-	else
-		rshifted = input << (-rshiftAmount);
-	int32_t strength2 = rshifted & 65535;
-	int32_t strength1 = 65536 - strength2;
-	return (int32_t)table[whichValue] * strength1 + (int32_t)table[whichValue + 1] * strength2;
-}
-
 int32_t interpolateTable(uint32_t input, int32_t numBitsInInput, const uint16_t* table, int32_t numBitsInTableSize = 8);
 uint32_t interpolateTableInverse(int32_t tableValueBig, int32_t numBitsInLookupOutput, const uint16_t* table,
                                  int32_t numBitsInTableSize = 8);
@@ -343,44 +329,12 @@ template <unsigned saturationAmount>
 	return toReturn;
 }
 
-[[gnu::always_inline]] inline int32_t getSine(uint32_t phase, uint8_t numBitsInInput = 32) {
-	return interpolateTableSigned(phase, numBitsInInput, sineWaveSmall, 8);
-}
-
-[[gnu::always_inline]] inline int32_t getSquare(uint32_t phase, uint32_t phaseWidth = 2147483648u) {
-	return ((phase >= phaseWidth) ? (-2147483648) : 2147483647);
-}
-
-[[gnu::always_inline]] inline int32_t getSquareSmall(uint32_t phase, uint32_t phaseWidth = 2147483648u) {
-	return ((phase >= phaseWidth) ? (-1073741824) : 1073741823);
-}
-
-/* Should be faster, but isn't...
- * inline int32_t getTriangleSmall(int32_t phase) {
-    int32_t multiplier = (phase >> 31) | 1;
-    phase *= multiplier;
- */
-
-[[gnu::always_inline]] inline int32_t getTriangleSmall(uint32_t phase) {
-	if (phase >= 2147483648u)
-		phase = -phase;
-	return phase - 1073741824;
-}
-
-[[gnu::always_inline]] inline int32_t getTriangle(uint32_t phase) {
-	return ((phase < 2147483648u) ? 2 : -2) * phase + 2147483648u;
-	// return getTriangleSmall(phase) << 1;
-}
-
 int32_t getDecay8(uint32_t input, uint8_t numBitsInInput);
 int32_t getDecay4(uint32_t input, uint8_t numBitsInInput);
 
 #define znew (z = 36969 * (z & 65535) + (z >> 16))
 #define wnew (w = 18000 * (w & 65535) + (w >> 16))
 #define MWC (int32_t)((znew << 16) + wnew)
-#define CONG (jcong = 69069 * jcong + 1234567)
-
-extern uint32_t z, w, jcong;
 
 [[gnu::always_inline]] inline uint8_t getRandom255() {
 	return CONG >> 24;
@@ -397,9 +351,6 @@ extern bool octaveStartsFromA;
 
 int32_t random(int32_t upperLimit);
 bool shouldDoPanning(int32_t panAmount, int32_t* amplitudeL, int32_t* amplitudeR);
-
-uint32_t getLFOInitialPhaseForNegativeExtreme(LFOType waveType);
-uint32_t getLFOInitialPhaseForZero(LFOType waveType);
 
 uint32_t getOscInitialPhaseForZero(OscType waveType);
 int32_t fastPythag(int32_t x, int32_t y);

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -19,7 +19,6 @@
 
 #include "util/lookuptables/lookuptables.h"
 #include "gui/l10n/l10n.h"
-#include "util/functions.h"
 #include "definitions_cxx.hpp"
 
 const uint16_t centAdjustTableSmall[257] = {

--- a/src/deluge/util/waves.cpp
+++ b/src/deluge/util/waves.cpp
@@ -1,0 +1,3 @@
+#include "util/waves.h"
+
+uint32_t jcong = 380116160;

--- a/src/deluge/util/waves.h
+++ b/src/deluge/util/waves.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "util/lookuptables/lookuptables.h"
+
+#define CONG (jcong = 69069 * jcong + 1234567)
+
+extern uint32_t z, w, jcong;
+
+/* Basic waveform generation functions.
+ *
+ * Extracted from functions.h.
+ */
+
+// input must not have any extra bits set than numBitsInInput specifies
+[[gnu::always_inline]] inline int32_t interpolateTableSigned(uint32_t input, int32_t numBitsInInput,
+                                                             const int16_t* table, int32_t numBitsInTableSize = 8) {
+	int32_t whichValue = input >> (numBitsInInput - numBitsInTableSize);
+	int32_t rshiftAmount = numBitsInInput - 16 - numBitsInTableSize;
+	uint32_t rshifted;
+	if (rshiftAmount >= 0)
+		rshifted = input >> rshiftAmount;
+	else
+		rshifted = input << (-rshiftAmount);
+	int32_t strength2 = rshifted & 65535;
+	int32_t strength1 = 65536 - strength2;
+	return (int32_t)table[whichValue] * strength1 + (int32_t)table[whichValue + 1] * strength2;
+}
+
+[[gnu::always_inline]] inline int32_t getSine(uint32_t phase, uint8_t numBitsInInput = 32) {
+	return interpolateTableSigned(phase, numBitsInInput, sineWaveSmall, 8);
+}
+
+[[gnu::always_inline]] inline int32_t getSquare(uint32_t phase, uint32_t phaseWidth = 2147483648u) {
+	return ((phase >= phaseWidth) ? (-2147483648) : 2147483647);
+}
+
+[[gnu::always_inline]] inline int32_t getSquareSmall(uint32_t phase, uint32_t phaseWidth = 2147483648u) {
+	return ((phase >= phaseWidth) ? (-1073741824) : 1073741823);
+}
+
+/* Should be faster, but isn't...
+ * inline int32_t getTriangleSmall(int32_t phase) {
+    int32_t multiplier = (phase >> 31) | 1;
+    phase *= multiplier;
+ */
+
+[[gnu::always_inline]] inline int32_t getTriangleSmall(uint32_t phase) {
+	if (phase >= 2147483648u)
+		phase = -phase;
+	return phase - 1073741824;
+}
+
+[[gnu::always_inline]] inline int32_t getTriangle(uint32_t phase) {
+	return ((phase < 2147483648u) ? 2 : -2) * phase + 2147483648u;
+	// return getTriangleSmall(phase) << 1;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -28,9 +28,13 @@ FetchContent_MakeAvailable(CppUTest)
 file(GLOB_RECURSE deluge_SOURCES
         # Mock implementations
         mocks/*
+        # For LFO
+        ../../src/deluge/util/lookuptables.cpp
+        ../../src/deluge/util/waves.cpp
+        ../../src/deluge/modulation/lfo.cpp
 )
 
-add_executable(UnitTests RunAllTests.cpp scheduler_tests.cpp)
+add_executable(UnitTests RunAllTests.cpp scheduler_tests.cpp lfo_tests.cpp)
 add_test(NAME UnitTests
         COMMAND UnitTests)
 target_sources(UnitTests PRIVATE ${deluge_SOURCES})

--- a/tests/unit/lfo_tests.cpp
+++ b/tests/unit/lfo_tests.cpp
@@ -14,9 +14,9 @@ TEST(LFOTest, renderGlobalTriangle) {
 	LFOType type = LFOType::TRIANGLE;
 	// as per resyncGlobalLFO()
 	lfo.phase = getLFOInitialPhaseForZero(type);
-	CHECK_EQUAL(0, lfo.render(0, type, 0));
-	lfo.tick(10, 100);
-	CHECK_EQUAL(2000, lfo.render(0, type, 0));
+	int32_t numSamples = 10, phaseIncrement = 100;
+	CHECK_EQUAL(0, lfo.render(10, type, 100));
+	CHECK_EQUAL(numSamples*phaseIncrement*2, lfo.render(0, type, 0));
 }
 
 TEST(LFOTest, renderLocalTriangle) {
@@ -24,10 +24,8 @@ TEST(LFOTest, renderLocalTriangle) {
 	LFOType type = LFOType::TRIANGLE;
 	// as per Voice::noteOn()
 	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
-	CHECK_EQUAL(-2147483648, lfo.render(0, type, 0));
-
-	lfo.tick(10, 100);
-	CHECK_EQUAL(-2147481648, lfo.render(0, type, 0));
+	CHECK_EQUAL(INT32_MIN, lfo.render(10, type, 100));
+	CHECK_EQUAL(INT32_MIN+2000, lfo.render(0, type, 0));
 }
 
 TEST(LFOTest, renderGlobalSine) {
@@ -35,10 +33,11 @@ TEST(LFOTest, renderGlobalSine) {
 	LFOType type = LFOType::SINE;
 	// as per resyncGlobalLFO()
 	lfo.phase = getLFOInitialPhaseForZero(type);
-	CHECK_EQUAL(0, lfo.render(0, type, 0));
-
-	lfo.tick(10, 100);
-	CHECK_EQUAL(2412, lfo.render(0, type, 0));
+	// sin(0) == 0
+	CHECK_EQUAL(0, lfo.phase);
+	lfo.phase = 1024;
+	// (2^31)*sin(2*pi*1024/(2^32)) = 3216.99
+	CHECK_EQUAL(3216, lfo.render(0, type, 0));
 }
 
 TEST(LFOTest, renderLocalSine) {
@@ -46,9 +45,13 @@ TEST(LFOTest, renderLocalSine) {
 	LFOType type = LFOType::SINE;
 	// as per Voice::noteOn()
 	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
-	CHECK_EQUAL(-2147418112, lfo.render(0, type, 0));
-
-	lfo.tick(10, 100);
+	CHECK_EQUAL(3221225472, lfo.phase);
+	// These are nasty numbers, but the first one represents the
+	// initial value for a local sine LFO, and a second one is a
+	// an arbitray step forward.
+	//
+	// (2^31)*sin(2*pi*3221225472/(2^32)) = -2147483648 ... close?
+	CHECK_EQUAL(-2147418112, lfo.render(10, type, 100));
 	CHECK_EQUAL(-2147418082, lfo.render(0, type, 0));
 }
 
@@ -57,10 +60,8 @@ TEST(LFOTest, renderSaw) {
 	LFOType type = LFOType::SAW;
 	// as per resyncGlobalLFO() AND Voice::noteOn()
 	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
-	CHECK_EQUAL(-2147483648, lfo.render(0, type, 0));
-
-	lfo.tick(10, 100);
-	CHECK_EQUAL(-2147482648, lfo.render(0, type, 0));
+	CHECK_EQUAL(INT32_MIN, lfo.render(10, type, 100));
+	CHECK_EQUAL(INT32_MIN+1000, lfo.render(0, type, 0));
 }
 
 TEST(LFOTest, renderSquare) {
@@ -68,10 +69,11 @@ TEST(LFOTest, renderSquare) {
 	LFOType type = LFOType::SQUARE;
 	// as per resyncGlobalLFO() AND Voice::noteOn()
 	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
-	CHECK_EQUAL(2147483647, lfo.render(0, type, 0));
-
-	lfo.tick(1328979, 193287); // need a big shift to see the jump
-	CHECK_EQUAL(-2147483648, lfo.render(0, type, 0));
+	// ...it's interesting that our initial phase for "negative extreme"
+	// for square LFO actually gets the positive extreme...
+	CHECK_EQUAL(INT32_MAX, lfo.render(0, type, 0));
+	lfo.phase = 0x80000001; // force over phase width
+	CHECK_EQUAL(INT32_MIN, lfo.render(0, type, 0));
 }
 
 TEST(LFOTest, renderSampleAndHold) {
@@ -79,19 +81,20 @@ TEST(LFOTest, renderSampleAndHold) {
 	LFOType type = LFOType::SAMPLE_AND_HOLD;
 	// as per resyncGlobalLFO() AND Voice::noteOn()
 	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	CHECK_EQUAL(0, lfo.phase);
 	// CHECK_EQUAL evaluates multiple times: get the value just once.
-	int32_t value = lfo.render(0, type, 0);
+	int32_t value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-1392915738, value);
+	CHECK_EQUAL(100, lfo.phase);
 
-	lfo.tick(1328979, 193287); // no change...
-	value = lfo.render(0, type, 0);
+	value = lfo.render(10, type, 10); // no change
 	CHECK_EQUAL(-1392915738, value);
-	CHECK(lfo.phase != 0);
+	CHECK_EQUAL(200, lfo.phase);
 
 	lfo.phase = 0; // force reset
-	value = lfo.render(0, type, 0);
+	value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-28442955, value);
-	CHECK(lfo.phase == 0);
+	CHECK_EQUAL(100, lfo.phase);
 }
 
 TEST(LFOTest, renderRandomWalk) {
@@ -99,17 +102,18 @@ TEST(LFOTest, renderRandomWalk) {
 	LFOType type = LFOType::RANDOM_WALK;
 	// as per resyncGlobalLFO() AND Voice::noteOn()
 	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	CHECK_EQUAL(0, lfo.phase);
 	// CHECK_EQUAL evaluates multiple times: get the value just once.
-	int32_t value = lfo.render(0, type, 0);
+	int32_t value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-2948644, value);
-	CHECK(lfo.phase == 0);
+	CHECK_EQUAL(100, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-2948644, value);
+	CHECK_EQUAL(200, lfo.phase);
 
 	lfo.phase = 0; // force reset
-	value = lfo.render(1, type, 1);
+	value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-78931243, value);
-
-	lfo.tick(10, 10); // no change...
-	value = lfo.render(1, type, 1);
-	CHECK_EQUAL(-78931243, value);
-	CHECK_EQUAL(102, lfo.phase);
+	CHECK_EQUAL(100, lfo.phase);
 }

--- a/tests/unit/lfo_tests.cpp
+++ b/tests/unit/lfo_tests.cpp
@@ -1,0 +1,115 @@
+#include "CppUTest/TestHarness.h"
+#include "modulation/lfo.h"
+#include "definitions_cxx.hpp"
+
+TEST_GROUP(LFOTest) {
+	void setup() {
+		// Set CONG for all tests, so they're deterministic
+		CONG = 13287131;
+	}
+};
+
+TEST(LFOTest, renderGlobalTriangle) {
+	LFO lfo;
+	LFOType type = LFOType::TRIANGLE;
+	// as per resyncGlobalLFO()
+	lfo.phase = getLFOInitialPhaseForZero(type);
+	CHECK_EQUAL(0, lfo.render(0, type, 0));
+	lfo.tick(10, 100);
+	CHECK_EQUAL(2000, lfo.render(0, type, 0));
+}
+
+TEST(LFOTest, renderLocalTriangle) {
+	LFO lfo;
+	LFOType type = LFOType::TRIANGLE;
+	// as per Voice::noteOn()
+	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	CHECK_EQUAL(-2147483648, lfo.render(0, type, 0));
+
+	lfo.tick(10, 100);
+	CHECK_EQUAL(-2147481648, lfo.render(0, type, 0));
+}
+
+TEST(LFOTest, renderGlobalSine) {
+	LFO lfo;
+	LFOType type = LFOType::SINE;
+	// as per resyncGlobalLFO()
+	lfo.phase = getLFOInitialPhaseForZero(type);
+	CHECK_EQUAL(0, lfo.render(0, type, 0));
+
+	lfo.tick(10, 100);
+	CHECK_EQUAL(2412, lfo.render(0, type, 0));
+}
+
+TEST(LFOTest, renderLocalSine) {
+	LFO lfo;
+	LFOType type = LFOType::SINE;
+	// as per Voice::noteOn()
+	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	CHECK_EQUAL(-2147418112, lfo.render(0, type, 0));
+
+	lfo.tick(10, 100);
+	CHECK_EQUAL(-2147418082, lfo.render(0, type, 0));
+}
+
+TEST(LFOTest, renderSaw) {
+	LFO lfo;
+	LFOType type = LFOType::SAW;
+	// as per resyncGlobalLFO() AND Voice::noteOn()
+	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	CHECK_EQUAL(-2147483648, lfo.render(0, type, 0));
+
+	lfo.tick(10, 100);
+	CHECK_EQUAL(-2147482648, lfo.render(0, type, 0));
+}
+
+TEST(LFOTest, renderSquare) {
+	LFO lfo;
+	LFOType type = LFOType::SQUARE;
+	// as per resyncGlobalLFO() AND Voice::noteOn()
+	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	CHECK_EQUAL(2147483647, lfo.render(0, type, 0));
+
+	lfo.tick(1328979, 193287); // need a big shift to see the jump
+	CHECK_EQUAL(-2147483648, lfo.render(0, type, 0));
+}
+
+TEST(LFOTest, renderSampleAndHold) {
+	LFO lfo;
+	LFOType type = LFOType::SAMPLE_AND_HOLD;
+	// as per resyncGlobalLFO() AND Voice::noteOn()
+	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	// CHECK_EQUAL evaluates multiple times: get the value just once.
+	int32_t value = lfo.render(0, type, 0);
+	CHECK_EQUAL(-1392915738, value);
+
+	lfo.tick(1328979, 193287); // no change...
+	value = lfo.render(0, type, 0);
+	CHECK_EQUAL(-1392915738, value);
+	CHECK(lfo.phase != 0);
+
+	lfo.phase = 0; // force reset
+	value = lfo.render(0, type, 0);
+	CHECK_EQUAL(-28442955, value);
+	CHECK(lfo.phase == 0);
+}
+
+TEST(LFOTest, renderRandomWalk) {
+	LFO lfo;
+	LFOType type = LFOType::RANDOM_WALK;
+	// as per resyncGlobalLFO() AND Voice::noteOn()
+	lfo.phase = getLFOInitialPhaseForNegativeExtreme(type);
+	// CHECK_EQUAL evaluates multiple times: get the value just once.
+	int32_t value = lfo.render(0, type, 0);
+	CHECK_EQUAL(-2948644, value);
+	CHECK(lfo.phase == 0);
+
+	lfo.phase = 0; // force reset
+	value = lfo.render(1, type, 1);
+	CHECK_EQUAL(-78931243, value);
+
+	lfo.tick(10, 10); // no change...
+	value = lfo.render(1, type, 1);
+	CHECK_EQUAL(-78931243, value);
+	CHECK_EQUAL(102, lfo.phase);
+}

--- a/tests/unit/lfo_tests.cpp
+++ b/tests/unit/lfo_tests.cpp
@@ -95,6 +95,19 @@ TEST(LFOTest, renderSampleAndHold) {
 	value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-28442955, value);
 	CHECK_EQUAL(100, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-28442955, value);
+	CHECK_EQUAL(200, lfo.phase);
+
+	lfo.phase = UINT32_MAX; // phase to max, so next will overflow
+	value = lfo.render(10, type, 10);
+	CHECK_EQUAL(-1725170056, value);
+	CHECK_EQUAL(99, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-1725170056, value);
+	CHECK_EQUAL(199, lfo.phase);
 }
 
 TEST(LFOTest, renderRandomWalk) {
@@ -116,4 +129,17 @@ TEST(LFOTest, renderRandomWalk) {
 	value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-78931243, value);
 	CHECK_EQUAL(100, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-78931243, value);
+	CHECK_EQUAL(200, lfo.phase);
+
+	lfo.phase = UINT32_MAX; // overflow
+	value = lfo.render(10, type, 10);
+	CHECK_EQUAL(-174189095, value);
+	CHECK_EQUAL(99, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-174189095, value);
+	CHECK_EQUAL(199, lfo.phase);
 }


### PR DESCRIPTION
This is on top of https://github.com/SynthstromAudible/DelugeFirmware/pull/1921

Once there's a reasonable consensus as to what to do here, I'll implement that and drop this PR. This is just a demonstration.

* In SAMPLE_AND_HOLD / RANDOM_WALK: if we hit the second leg of
  the conditional, value is never assigned to, and LFO returns an
  unitialized value, which is _probably_ zero, but not guaranteed.

* This commit changes it to return zero always, but that seems
  incorrect: instead the new holdValue should be returned?

* Additionally, the intent of the second leg is a bit unclear as
  well: is intended to trigger on phase overflow, or something else?
  I have not checked what kinds of values usually get passed to
  `LFO::render()` and `LFO::tick()` so maybe it does trigger regularly?