### PR TITLE
Bugfix VU meter rendering issues in performance view and automation arranger view

### DIFF
--- a/src/deluge/gui/menu_item/performance_session_view/editing_mode.h
+++ b/src/deluge/gui/menu_item/performance_session_view/editing_mode.h
@@ -67,7 +67,7 @@ public:
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 			performanceSessionView.resetPerformanceView(modelStack);
 		}
-		uiNeedsRendering(&performanceSessionView);
+		uiNeedsRendering(&performanceSessionView, 0xFFFFFFFF, 0); // refresh main pads only);
 	}
 	deluge::vector<std::string_view> getOptions() override {
 		using enum l10n::String;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -605,9 +605,6 @@ bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidt
 		instrumentClipView.recalculateColours();
 	}
 
-	// erase current image as it will be refreshed
-	memset(image, 0, sizeof(RGB) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
-
 	// erase current occupancy mask as it will be refreshed
 	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
@@ -756,6 +753,7 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 				// don't make portamento available for automation in kit rows
 				if ((outputType == OutputType::KIT)
 				    && (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] == params::UNPATCHED_PORTAMENTO)) {
+					pixel = colours::black; // erase pad
 					continue;
 				}
 
@@ -773,6 +771,7 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 				// don't make pitch adjust or sidechain available for automation in arranger
 				if ((paramID == params::UNPATCHED_PITCH_ADJUST) || (paramID == params::UNPATCHED_SIDECHAIN_SHAPE)
 				    || (paramID == params::UNPATCHED_SIDECHAIN_VOLUME)) {
+					pixel = colours::black; // erase pad
 					continue;
 				}
 				modelStackWithParam = currentSong->getModelStackWithParam(modelStackWithThreeMainThings, paramID);
@@ -802,6 +801,9 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 			}
 
 			occupancyMask[yDisplay][xDisplay] = 64;
+		}
+		else {
+			pixel = colours::black; // erase pad
 		}
 	}
 }
@@ -884,10 +886,8 @@ void AutomationView::renderBipolarSquare(RGB image[][kDisplayWidth + kSideBarWid
 	}
 
 	// if it's bipolar, only render grid rows above or below middle value
-	if ((knobPos > middleKnobPos) && (yDisplay < 4)) {
-		return;
-	}
-	else if ((knobPos < middleKnobPos) && (yDisplay > 3)) {
+	if (((knobPos > middleKnobPos) && (yDisplay < 4)) || ((knobPos < middleKnobPos) && (yDisplay > 3))) {
+		pixel = colours::black; // erase pad
 		return;
 	}
 
@@ -933,6 +933,9 @@ void AutomationView::renderBipolarSquare(RGB image[][kDisplayWidth + kSideBarWid
 		}
 		occupancyMask[yDisplay][xDisplay] = 64;
 	}
+	else {
+		pixel = colours::black; // erase pad
+	}
 
 	// pad selection mode, render cursor
 	if (padSelectionOn && ((xDisplay == leftPadSelectedX) || (xDisplay == rightPadSelectedX))) {
@@ -972,6 +975,9 @@ void AutomationView::renderUnipolarSquare(RGB image[][kDisplayWidth + kSideBarWi
 			pixel = rowTailColour[yDisplay];
 		}
 		occupancyMask[yDisplay][xDisplay] = 64;
+	}
+	else {
+		pixel = colours::black; // erase pad
 	}
 
 	// pad selection mode, render cursor
@@ -4480,10 +4486,14 @@ bool AutomationView::inAutomationEditor() {
 	return true;
 }
 
-// used to determine the affect entire context for a kit clip
+// used to determine the affect entire context
 bool AutomationView::getAffectEntire() {
+	// arranger view always uses affect entire
+	if (onArrangerView) {
+		return true;
+	}
 	// are you in the menu?
-	if (getCurrentUI() == &soundEditor) {
+	else if (getCurrentUI() == &soundEditor) {
 		// if you're in the kit global FX menu, the menu context is the same as if affect entire is enabled
 		if (soundEditor.setupKitGlobalFXMenu) {
 			return true;

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -337,19 +337,18 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 
 	PadLEDs::renderingLock = true;
 
-	// erase current image as it will be refreshed
-	memset(image, 0, sizeof(RGB) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
+	// erase current image (excluding sidebar) as it will be refreshed
+	// (don't assume sidebar is always rendered after main pads)
+	memset(image, 0, sizeof(RGB) * kDisplayHeight * kDisplayWidth);
 
-	// erase current occupancy mask as it will be refreshed
-	memset(occupancyMask, 0, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
+	// We assume the whole screen is occupied
+	memset(occupancyMask, 64, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 
 	// render performance view
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-
-		uint8_t* occupancyMaskOfRow = occupancyMask[yDisplay];
 		int32_t imageWidth = kDisplayWidth + kSideBarWidth;
 
-		renderRow(&image[0][0] + (yDisplay * imageWidth), occupancyMaskOfRow, yDisplay);
+		renderRow(&image[0][0] + (yDisplay * imageWidth), yDisplay);
 	}
 
 	PadLEDs::renderingLock = false;
@@ -358,7 +357,7 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 }
 
 /// render every column, one row at a time
-void PerformanceSessionView::renderRow(RGB* image, uint8_t occupancyMask[], int32_t yDisplay) {
+void PerformanceSessionView::renderRow(RGB* image, int32_t yDisplay) {
 
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		RGB& pixel = image[xDisplay];
@@ -416,8 +415,6 @@ void PerformanceSessionView::renderRow(RGB* image, uint8_t occupancyMask[], int3
 				}
 			}
 		}
-
-		occupancyMask[xDisplay] = 64;
 	}
 }
 
@@ -870,7 +867,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				}
 				updateLayoutChangeStatus();
 				renderViewDisplay();
-				uiNeedsRendering(this);
+				uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
 			}
 			else {
 				gridModeActive = false;
@@ -909,7 +906,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 					renderViewDisplay();
 				}
 			}
-			uiNeedsRendering(this);
+			uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
 		}
 		return buttonActionResult;
 	}
@@ -943,7 +940,7 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 			else {
 				paramEditorPadAction(modelStack, xDisplay, yDisplay, on);
 			}
-			uiNeedsRendering(this); // re-render pads
+			uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
 		}
 		else if (xDisplay >= kDisplayWidth) {
 			// don't interact with sidebar if VU Meter is displayed
@@ -1283,7 +1280,7 @@ void PerformanceSessionView::resetPerformanceView(ModelStackWithThreeMainThings*
 	}
 	updateLayoutChangeStatus();
 	renderViewDisplay();
-	uiNeedsRendering(this);
+	uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
 }
 
 /// resets a single FX column to remove held status
@@ -1553,7 +1550,7 @@ void PerformanceSessionView::modEncoderButtonAction(uint8_t whichModEncoder, boo
 
 					releaseStutter(modelStack);
 
-					uiNeedsRendering(this);
+					uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
 
 					if (onFXDisplay) {
 						renderViewDisplay();
@@ -1759,7 +1756,7 @@ void PerformanceSessionView::loadPerformanceViewLayout() {
 	actionLogger.deleteAllLogs();
 	backupPerformanceLayout();
 	updateLayoutChangeStatus();
-	uiNeedsRendering(this);
+	uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
 }
 
 /// re-read defaults from backed up XML in memory in order to reduce SD Card IO

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -337,10 +337,6 @@ bool PerformanceSessionView::renderMainPads(uint32_t whichRows, RGB image[][kDis
 
 	PadLEDs::renderingLock = true;
 
-	// erase current image (excluding sidebar) as it will be refreshed
-	// (don't assume sidebar is always rendered after main pads)
-	memset(image, 0, sizeof(RGB) * kDisplayHeight * kDisplayWidth);
-
 	// We assume the whole screen is occupied
 	memset(occupancyMask, 64, sizeof(uint8_t) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
 

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -134,7 +134,7 @@ private:
 	void initDefaultFXValues(int32_t xDisplay);
 
 	// rendering
-	void renderRow(RGB* image, uint8_t occupancyMask[], int32_t yDisplay = 0);
+	void renderRow(RGB* image, int32_t yDisplay);
 	bool isParamAssignedToFXColumn(deluge::modulation::params::Kind paramKind, int32_t paramID);
 	void setCentralLEDStates();
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1792,11 +1792,9 @@ void View::setActiveModControllableTimelineCounter(TimelineCounter* timelineCoun
 	setKnobIndicatorLevels();
 
 	// refresh sidebar if VU meter previously rendered is still showing and we're in session / arranger / performance
-	// view this could happen when you're turning affect entire off or selecting a clip
-	UI* currentUI = getCurrentUI();
-	if (renderedVUMeter
-	    && (currentUI == &sessionView || currentUI == &arrangerView || currentUI == &performanceSessionView)) {
-		uiNeedsRendering(currentUI, 0);
+	// view / arranger automation view this could happen when you're turning affect entire off or selecting a clip
+	if (renderedVUMeter && !rootUIIsClipMinderScreen()) {
+		uiNeedsRendering(getRootUI(), 0);
 	}
 
 	// midi follow and midi feedback enabled
@@ -1816,11 +1814,10 @@ void View::setActiveModControllableWithoutTimelineCounter(ModControllable* modCo
 	setModLedStates();
 	setKnobIndicatorLevels();
 
-	// refresh sidebar if VU meter previously rendered is still showing and we're in arranger / arranger performance
-	// view this happens when selecting a clip that is not playing back (e.g. white clip with no notes)
-	UI* currentUI = getCurrentUI();
-	if (renderedVUMeter && (currentUI == &arrangerView || currentUI == &performanceSessionView)) {
-		uiNeedsRendering(currentUI, 0);
+	// refresh sidebar if VU meter previously rendered is still showing and we're in session / arranger / performance
+	// view / arranger automation view this could happen when you're turning affect entire off or selecting a clip
+	if (renderedVUMeter && !rootUIIsClipMinderScreen()) {
+		uiNeedsRendering(getRootUI(), 0);
 	}
 
 	// midi follow and midi feedback enabled


### PR DESCRIPTION
When pressing and releasing main pads in performance view and arranger automation view, this can cause the VU meter rendering to flicker / turn off.

Reason for the bug:
- When rendering main pads, it clears the existing image and the VU meter is stuck thinking it already rendered

Fixed it by only clearing pixels in the image that need to be cleared and leaving the other pixels to be updated by the rendering functions.

Also fixed another minor bug with the affect entire button not lighting up in arranger automation view as the new getAffectEntire function added to automation view was not handling returning the right affect entire state while in arranger automation view.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1818