### PR TITLE
LFO: S&H and random walk step properly on overflow

### DIFF
--- a/src/deluge/modulation/lfo.h
+++ b/src/deluge/modulation/lfo.h
@@ -48,12 +48,9 @@ public:
 			break;
 
 		case LFOType::SAMPLE_AND_HOLD:
-			if (phase == 0) {
+			if ((phase == 0) || (phase + phaseIncrement * numSamples < phase)) {
 				value = CONG;
 				holdValue = value;
-			}
-			else if (phase + phaseIncrement * numSamples < phase) {
-				holdValue = CONG;
 			}
 			else {
 				value = holdValue;
@@ -78,6 +75,7 @@ public:
 				// holdValue == -8 * range => (holdValue / -16) + (range / 2) ==
 				// range => next holdValue >= current holdValuie
 				holdValue += (holdValue / -16) + (range / 2) - CONG % range;
+				value = holdValue;
 			}
 			else {
 				value = holdValue;
@@ -89,5 +87,9 @@ public:
 		return value;
 	}
 
-	void tick(int32_t numSamples, uint32_t phaseIncrement) { phase += phaseIncrement * numSamples; }
+	void tick(int32_t numSamples, uint32_t phaseIncrement) {
+		// Note: if this overflows and we're using S&H or RANDOM_WALK, the
+		// next render() won't know it has overflown. Probably not an issue.
+		phase += phaseIncrement * numSamples;
+	}
 };

--- a/tests/unit/lfo_tests.cpp
+++ b/tests/unit/lfo_tests.cpp
@@ -95,6 +95,19 @@ TEST(LFOTest, renderSampleAndHold) {
 	value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-28442955, value);
 	CHECK_EQUAL(100, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-28442955, value);
+	CHECK_EQUAL(200, lfo.phase);
+
+	lfo.phase = UINT32_MAX; // phase to max, so next will overflow
+	value = lfo.render(10, type, 10);
+	CHECK_EQUAL(-1725170056, value);
+	CHECK_EQUAL(99, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-1725170056, value);
+	CHECK_EQUAL(199, lfo.phase);
 }
 
 TEST(LFOTest, renderRandomWalk) {
@@ -116,4 +129,17 @@ TEST(LFOTest, renderRandomWalk) {
 	value = lfo.render(10, type, 10);
 	CHECK_EQUAL(-78931243, value);
 	CHECK_EQUAL(100, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-78931243, value);
+	CHECK_EQUAL(200, lfo.phase);
+
+	lfo.phase = UINT32_MAX; // overflow
+	value = lfo.render(10, type, 10);
+	CHECK_EQUAL(-174189095, value);
+	CHECK_EQUAL(99, lfo.phase);
+
+	value = lfo.render(10, type, 10); // no change
+	CHECK_EQUAL(-174189095, value);
+	CHECK_EQUAL(199, lfo.phase);
 }


### PR DESCRIPTION
* Overflow causes by LFO::tick() still misses a cycle.

* I'm not 100% convinced the difference is audible. I _think_ I can hear tiny bit of clickiness when modulating LPF with a random LFO without this patch, but my ears my be deceiving me... might also be luck involved, as to which bits happen to be present in the uninitialized value.