### PR TITLE
Bugfix MIDI Takeover Pickup & Value Scaling + Add Relative Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - Created a new menu hierarchies document that documents the Deluge menu structure for OLED and 7SEG and can be used as a reference for navigating the various menu's. See: [Menu Hierarchies](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/menu_hierarchies.md)
 - Added MIDI learning of Song Params.
 - Added Synth/MIDI/CV clip configuration of note row play direction. Hold `AUDITION` while entering the `PLAY DIRECTION` menu to set the play direction for the selected note row. While in the note row play direction menu, you can select other note rows to quickly set the play directiom for multiple note rows.
+- Added New MIDI Takeover Mode: `RELATIVE` for use with controllers sending relative value changes
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -421,6 +421,8 @@ This mode affects how the Deluge handles MIDI input for learned CC controls.
   controller reaches its maximum or minimum position, the MIDI encoder/Fader will move in sync with the Deluge. The
   Deluge value will always decrease/increase in the same direction as the MIDI controller.
 
+  **4. `RELATIVE`:** The Deluge will increase/decrease its internal encoder position/Parameter value using the relative value changes (offset) sent by the controller. The controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
+
 #### 4.2.4 - Alternative Delay Types for Param Encoders (Gold encoders)
 
 - ([#282]) Ability to select in `COMMUNITY FEATURES` menu, which parameters are controlled when you click the `DELAY`

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -93,6 +93,7 @@ The Settings menu contains the following menu hierarchy:
 		- Jump
 		- Pickup (PICK)
 		- Scale (SCAL)
+		- Relative (RELA)
 	- Commands (CMD)
 		- Play
 		- Restart (REST)

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -591,9 +591,9 @@ enum class MIDITakeoverMode : uint8_t {
 	JUMP,
 	PICKUP,
 	SCALE,
+	RELATIVE,
 };
-constexpr auto kNumMIDITakeoverModes = util::to_underlying(MIDITakeoverMode::SCALE) + 1;
-constexpr int32_t kMIDITakeoverKnobSyncThreshold = 5;
+constexpr auto kNumMIDITakeoverModes = util::to_underlying(MIDITakeoverMode::RELATIVE) + 1;
 
 enum class MIDIFollowChannelType : uint8_t {
 	A,

--- a/src/deluge/gui/l10n/english.cpp
+++ b/src/deluge/gui/l10n/english.cpp
@@ -311,6 +311,8 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_PICK_UP, "Pickup"},
         {STRING_FOR_SCALE, "Scale"},
         {STRING_FOR_RELATIVE, "Relative"},
+
+        // gui/menu_item/mod_fx/type.h
         {STRING_FOR_FLANGER, "Flanger"},
         {STRING_FOR_CHORUS, "Chorus"},
         {STRING_FOR_PHASER, "Phaser"},

--- a/src/deluge/gui/l10n/english.cpp
+++ b/src/deluge/gui/l10n/english.cpp
@@ -310,8 +310,7 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_JUMP, "Jump"},
         {STRING_FOR_PICK_UP, "Pickup"},
         {STRING_FOR_SCALE, "Scale"},
-
-        // gui/menu_item/mod_fx/type.h
+        {STRING_FOR_RELATIVE, "Relative"},
         {STRING_FOR_FLANGER, "Flanger"},
         {STRING_FOR_CHORUS, "Chorus"},
         {STRING_FOR_PHASER, "Phaser"},

--- a/src/deluge/gui/l10n/seven_segment.cpp
+++ b/src/deluge/gui/l10n/seven_segment.cpp
@@ -151,6 +151,8 @@ PLACE_SDRAM_DATA Language seven_segment{
         {STRING_FOR_PICK_UP, "PICK"},
         {STRING_FOR_SCALE, "SCAL"},
         {STRING_FOR_RELATIVE, "RELA"},
+
+        // gui/menu_item/mod_fx/type.h
         {STRING_FOR_FLANGER, "FLANGER"},
         {STRING_FOR_CHORUS, "CHORUS"},
         {STRING_FOR_PHASER, "PHASER"},

--- a/src/deluge/gui/l10n/seven_segment.cpp
+++ b/src/deluge/gui/l10n/seven_segment.cpp
@@ -150,8 +150,7 @@ PLACE_SDRAM_DATA Language seven_segment{
         {STRING_FOR_JUMP, "JUMP"},
         {STRING_FOR_PICK_UP, "PICK"},
         {STRING_FOR_SCALE, "SCAL"},
-
-        // gui/menu_item/mod_fx/type.h
+        {STRING_FOR_RELATIVE, "RELA"},
         {STRING_FOR_FLANGER, "FLANGER"},
         {STRING_FOR_CHORUS, "CHORUS"},
         {STRING_FOR_PHASER, "PHASER"},

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -208,6 +208,7 @@ enum class String : size_t {
 	STRING_FOR_JUMP,
 	STRING_FOR_PICK_UP,
 	STRING_FOR_SCALE,
+	STRING_FOR_RELATIVE,
 
 	// gui/menu_item/mod_fx/type.h
 	STRING_FOR_FLANGER,

--- a/src/deluge/gui/menu_item/midi/takeover.h
+++ b/src/deluge/gui/menu_item/midi/takeover.h
@@ -32,6 +32,7 @@ public:
 		    l10n::getView(STRING_FOR_JUMP),
 		    l10n::getView(STRING_FOR_PICK_UP),
 		    l10n::getView(STRING_FOR_SCALE),
+		    l10n::getView(STRING_FOR_RELATIVE),
 		};
 	}
 };

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -535,7 +535,7 @@ void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithT
 					    modelStackWithParam->paramCollection->paramValueToKnobPos(oldValue, modelStackWithParam);
 
 					// calculate new knob position based on value received and deluge current value
-					int32_t newKnobPos = midiTakeover.calculateKnobPos(knobPos, value, nullptr, true, ccNumber);
+					int32_t newKnobPos = MidiTakeover::calculateKnobPos(knobPos, value, nullptr, true, ccNumber);
 					// is the cc being received for the same value as the current knob pos? If so, do nothing
 					if (newKnobPos != knobPos) {
 						// Convert the New Knob Position to a Parameter Value

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -480,7 +480,6 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 			        && (!midiEngine.midiFollowFeedbackFilter
 			            || (midiEngine.midiFollowFeedbackFilter
 			                && ((AudioEngine::audioSampleTimer - timeLastCCSent[ccNumber]) >= kSampleRate))))) {
-
 				// setup model stack for the active context
 				if (modelStack) {
 					auto modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
@@ -535,20 +534,10 @@ void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithT
 					int32_t knobPos =
 					    modelStackWithParam->paramCollection->paramValueToKnobPos(oldValue, modelStackWithParam);
 
-					// add 64 to internal knobPos to compare to midi cc value received
-					// if internal pos + 64 is greater than 127 (e.g. 128), adjust it to 127
-					// because midi can only send a max midi value of 127
-					int32_t knobPosForMidiValueComparison = knobPos + kKnobPosOffset;
-					if (knobPosForMidiValueComparison > kMaxMIDIValue) {
-						knobPosForMidiValueComparison = kMaxMIDIValue;
-					}
-
+					// calculate new knob position based on value received and deluge current value
+					int32_t newKnobPos = midiTakeover.calculateKnobPos(knobPos, value, nullptr, true, ccNumber);
 					// is the cc being received for the same value as the current knob pos? If so, do nothing
-					if (value != knobPosForMidiValueComparison) {
-						// calculate new knob position based on value received and deluge current value
-						int32_t newKnobPos =
-						    midiTakeover.calculateKnobPos(modelStackWithParam, knobPos, value, nullptr, true, ccNumber);
-
+					if (newKnobPos != knobPos) {
 						// Convert the New Knob Position to a Parameter Value
 						int32_t newValue =
 						    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);

--- a/src/deluge/io/midi/midi_takeover.cpp
+++ b/src/deluge/io/midi/midi_takeover.cpp
@@ -17,6 +17,7 @@
 
 #include "io/midi/midi_takeover.h"
 #include "definitions_cxx.hpp"
+#include "hid/display/display.h"
 #include "io/midi/midi_engine.h"
 #include "io/midi/midi_follow.h"
 
@@ -33,11 +34,11 @@ MidiTakeover midiTakeover{};
 MidiTakeover::MidiTakeover() {
 }
 
-/// based on the midi takeover default setting of JUMP, PICKUP, or SCALE
+/// based on the midi takeover default setting of RELATIVE, JUMP, PICKUP, or SCALE
 /// this function will calculate the knob position that the deluge parameter that the midi cc
 /// received is learned to should be set at based on the midi cc value received
-int32_t MidiTakeover::calculateKnobPos(ModelStackWithAutoParam* modelStackWithParam, int32_t knobPos, int32_t value,
-                                       MIDIKnob* knob, bool doingMidiFollow, int32_t ccNumber) {
+int32_t MidiTakeover::calculateKnobPos(int32_t knobPos, int32_t value, MIDIKnob* knob, bool doingMidiFollow,
+                                       int32_t ccNumber) {
 	/*
 
 	Step #1: Convert Midi Controller's CC Value to Deluge Knob Position Value
@@ -58,138 +59,145 @@ int32_t MidiTakeover::calculateKnobPos(ModelStackWithAutoParam* modelStackWithPa
 		midiKnobPos = value - 64;
 	}
 
-	int32_t newKnobPos = 0;
+	// we'll first set newKnobPos equal to current knobPos
+	// if newKnobPos should be updated it will happen below
+	int32_t newKnobPos = knobPos;
 
-	if (midiEngine.midiTakeover == MIDITakeoverMode::JUMP) { // Midi Takeover Mode = Jump
+	// for controller's sending relative values
+	if (((knob != nullptr) && (knob->relative)) || (midiEngine.midiTakeover == MIDITakeoverMode::RELATIVE)) {
+		int32_t offset = value;
+		if (offset >= 64) {
+			offset -= 128;
+		}
+		int32_t lowerLimit = std::min(-64_i32, knobPos);
+		newKnobPos = knobPos + offset;
+		newKnobPos = std::max(newKnobPos, lowerLimit);
+		newKnobPos = std::min(newKnobPos, 64_i32);
+
+		savePreviousKnobPos(newKnobPos, knob, doingMidiFollow, ccNumber);
+	}
+	// deluge value will always jump to the current midi controller value
+	else if (midiEngine.midiTakeover == MIDITakeoverMode::JUMP) {
 		newKnobPos = midiKnobPos;
-		if (knob != nullptr) {
-			knob->previousPosition = midiKnobPos;
-		}
-		else if (doingMidiFollow) {
-			midiFollow.previousKnobPos[ccNumber] = midiKnobPos;
-		}
+
+		savePreviousKnobPos(newKnobPos, knob, doingMidiFollow, ccNumber);
 	}
 	else { // Midi Takeover Mode = Pickup or Value Scaling
-		// Save previous knob position for first time
+		// Get or Save previous knob position for first time
 		// The first time a midi knob is turned in a session, no previous midi knob position information exists, so to
-		// start, it will be equal to the current midiKnobPos This code is also executed when takeover mode is changed
-		// to Jump and back to Pickup/Scale because in Jump mode no previousPosition information gets saved
+		// start, it will be equal to the current midiKnobPos.
 
-		if (knob != nullptr) {
-			if (!knob->previousPositionSaved) {
-				knob->previousPosition = midiKnobPos;
+		int32_t previousKnobPosition = getPreviousKnobPos(midiKnobPos, knob, doingMidiFollow, ccNumber);
 
-				knob->previousPositionSaved = true;
-			}
+		// have we met or exceeded the deluge knob position in either direction?
+		// if so, we've "picked up"
+		// note: if previous knob position information becomes invalid (e.g. switching banks / unplugging midi
+		// controller) then the deluge will behave like "jump" and jump to the current midi controller value
+		if (((previousKnobPosition <= knobPos) && (midiKnobPos >= knobPos))
+		    || ((previousKnobPosition >= knobPos) && (midiKnobPos <= knobPos))) {
+			newKnobPos = midiKnobPos;
 		}
-		else if (doingMidiFollow) {
-			if (midiFollow.previousKnobPos[ccNumber] == kNoSelection) {
-				midiFollow.previousKnobPos[ccNumber] = midiKnobPos;
-			}
-		}
+		// if we haven't picked up and scale is enabled, we'll scale deluge value in direction knob is turning
+		// so that the deluge knob position and midi knob position reach the min/max of knob range at same time
+		else if (midiEngine.midiTakeover == MIDITakeoverMode::SCALE) {
+			// Set the max and min of the deluge midi knob position range
+			int32_t knobMaxPos = 64;
+			int32_t knobMinPos = -64;
 
-		// adjust previous knob position saved
+			// position range
+			int32_t delugeKnobMaxPosDelta = knobMaxPos - knobPos; // Positive Runway
+			int32_t delugeKnobMinPosDelta = knobPos - knobMinPos; // Negative Runway
 
-		// Here we check to see if the midi knob position previously saved is greater or less than the current midi knob
-		// position +/- 1 If it's by more than 1, the previous position is adjusted. This could happen for example if
-		// you changed banks and the previous position is no longer valid. By resetting the previous position we ensure
-		// that the there isn't unwanted jumpyness in the calculation of the midi knob position change amount
-		if (knob != nullptr) {
-			if (knob->previousPosition > (midiKnobPos + 1) || knob->previousPosition < (midiKnobPos - 1)) {
+			// calculate amount of midi "knob runway" is remaining from current knob position to max and min of knob
+			// position range
+			int32_t midiKnobMaxPosDelta = knobMaxPos - midiKnobPos; // Positive Runway
+			int32_t midiKnobMinPosDelta = midiKnobPos - knobMinPos; // Negative Runway
 
-				knob->previousPosition = midiKnobPos;
-			}
-		}
-		else if (doingMidiFollow) {
-			int32_t previousPosition = midiFollow.previousKnobPos[ccNumber];
-			if (previousPosition > (midiKnobPos + 1) || previousPosition < (midiKnobPos - 1)) {
+			// calculate change in value from midi controller
+			// used to determine direction of midi controller value change (increase / decrease)
+			int32_t midiKnobPosChange = midiKnobPos - previousKnobPosition;
 
-				midiFollow.previousKnobPos[ccNumber] = midiKnobPos;
-			}
-		}
+			// we can only scale when we have a change in value
+			if (midiKnobPosChange != 0) {
+				float newKnobPosFloat = static_cast<float>(newKnobPos);
+				float midiKnobPosFloat = static_cast<float>(midiKnobPos);
+				float midiKnobPosChangeFloat = static_cast<float>(midiKnobPosChange);
+				float midiKnobPosChangePercentage;
 
-		// Here is where we check if the Knob/Fader on the Midi Controller is out of sync with the Deluge Knob Position
-
-		// First we check if the Midi Knob/Fader is sending a Value that is greater than or less than the current Deluge
-		// Knob Position by a max difference of +/- kMIDITakeoverKnobSyncThreshold If the difference is greater than
-		// kMIDITakeoverKnobSyncThreshold, ignore the CC value change (or scale it if value scaling is on)
-		int32_t midiKnobMinPos = knobPos - kMIDITakeoverKnobSyncThreshold;
-		int32_t midiKnobMaxPos = knobPos + kMIDITakeoverKnobSyncThreshold;
-
-		if ((midiKnobMinPos <= midiKnobPos) && (midiKnobPos <= midiKnobMaxPos)) {
-			newKnobPos = knobPos + (midiKnobPos - knobPos);
-		}
-		else {
-			// if the above conditions fail and pickup mode is enabled, then the Deluge Knob Position (and therefore the
-			// Parameter Value with it) remains unchanged
-			if (midiEngine.midiTakeover == MIDITakeoverMode::PICKUP) { // Midi Pickup Mode On
-				newKnobPos = knobPos;
-			}
-			// if the first two conditions fail and value scaling mode is enabled, then the Deluge Knob Position is
-			// scaled upwards or downwards based on relative positions of Midi Controller Knob and Deluge Knob to
-			// min/max of knob range.
-			else { // Midi Value Scaling Mode On
-				// Set the max and min of the deluge midi knob position range
-				int32_t knobMaxPos = 64;
-				int32_t knobMinPos = -64;
-
-				// calculate amount of deluge "knob runway" is remaining from current knob position to max and min of
-				// knob position range
-				int32_t delugeKnobMaxPosDelta = knobMaxPos - knobPos; // Positive Runway
-				int32_t delugeKnobMinPosDelta = knobPos - knobMinPos; // Negative Runway
-
-				// calculate amount of midi "knob runway" is remaining from current knob position to max and min of knob
-				// position range
-				int32_t midiKnobMaxPosDelta = knobMaxPos - midiKnobPos; // Positive Runway
-				int32_t midiKnobMinPosDelta = midiKnobPos - knobMinPos; // Negative Runway
-
-				// calculate by how much the current midiKnobPos has changed from the previous midiKnobPos recorded
-				int32_t midiKnobPosChange = 0;
-				if (knob != nullptr) {
-					midiKnobPosChange = midiKnobPos - knob->previousPosition;
-				}
-				else if (doingMidiFollow) {
-					midiKnobPosChange = midiKnobPos - midiFollow.previousKnobPos[ccNumber];
-				}
-
-				// Set fixed point variable which will be used calculate the percentage in midi knob position
-				int32_t midiKnobPosChangePercentage;
-
-				// if midi knob position change is greater than 0, then the midi knob position has increased (e.g.
-				// turned knob right)
+				// turning knob right
 				if (midiKnobPosChange > 0) {
-					// fixed point math calculation of new deluge knob position when midi knob position has increased
+					if (midiKnobMaxPosDelta != 0) { // so we don't potentially divide by 0
+						midiKnobPosChangePercentage = midiKnobPosChangeFloat / midiKnobMaxPosDelta;
+						newKnobPosFloat = newKnobPosFloat + (delugeKnobMaxPosDelta * midiKnobPosChangePercentage);
 
-					midiKnobPosChangePercentage = (midiKnobPosChange << 20) / midiKnobMaxPosDelta;
-
-					newKnobPos = knobPos + ((delugeKnobMaxPosDelta * midiKnobPosChangePercentage) >> 20);
+						// make sure scaled value is not less than current value when we're turning right
+						// (can happen when midi and deluge knob values get close)
+						if (newKnobPosFloat < newKnobPos) {
+							newKnobPosFloat = newKnobPos;
+						}
+					}
 				}
-				// if midi knob position change is less than 0, then the midi knob position has decreased (e.g. turned
-				// knob left)
-				else if (midiKnobPosChange < 0) {
-					// fixed point math calculation of new deluge knob position when midi knob position has decreased
-
-					midiKnobPosChangePercentage = (midiKnobPosChange << 20) / midiKnobMinPosDelta;
-
-					newKnobPos = knobPos + ((delugeKnobMinPosDelta * midiKnobPosChangePercentage) >> 20);
-				}
-				// if midi knob position change is 0, then the midi knob position has not changed and thus no change in
-				// deluge knob position / parameter value is required
+				// turning knob left
 				else {
-					newKnobPos = knobPos;
+					if (midiKnobMinPosDelta != 0) { // so we don't potentially divide by 0
+						midiKnobPosChangePercentage = midiKnobPosChangeFloat / midiKnobMinPosDelta;
+						newKnobPosFloat = newKnobPosFloat + (delugeKnobMinPosDelta * midiKnobPosChangePercentage);
+
+						// make sure scaled value is not greater than current value when we're turning left
+						// (can happen when midi and deluge knob values get close)
+						if (newKnobPosFloat > newKnobPos) {
+							newKnobPosFloat = newKnobPos;
+						}
+					}
 				}
+				newKnobPosFloat = std::round(newKnobPosFloat);
+				newKnobPos = static_cast<int32_t>(newKnobPosFloat);
+				newKnobPos = std::clamp(newKnobPos, -64_i32, 64_i32);
 			}
 		}
 
-		// save the current midi knob position as the previous midi knob position so that it can be used next time the
-		// takeover code is executed
-		if (knob != nullptr) {
-			knob->previousPosition = midiKnobPos;
-		}
-		else if (doingMidiFollow) {
-			midiFollow.previousKnobPos[ccNumber] = midiKnobPos;
-		}
+		savePreviousKnobPos(midiKnobPos, knob, doingMidiFollow, ccNumber);
 	}
 
 	return newKnobPos;
+}
+
+/// save the current midi knob position as the previous midi knob position so that it can be used next time the
+/// takeover code is executed
+void MidiTakeover::savePreviousKnobPos(int32_t knobPos, MIDIKnob* knob, bool doingMidiFollow, int32_t ccNumber) {
+	if (knob != nullptr) {
+		saveKnobPos(knobPos, knob);
+	}
+	else if (doingMidiFollow) {
+		saveKnobPos(knobPos, ccNumber);
+	}
+}
+
+// save previous knob position if regular midi learn is being used
+void MidiTakeover::saveKnobPos(int32_t knobPos, MIDIKnob* knob) {
+	knob->previousPosition = knobPos;
+	knob->previousPositionSaved = true;
+}
+
+// save previous knob position if midi follow is being used
+void MidiTakeover::saveKnobPos(int32_t knobPos, int32_t ccNumber) {
+	midiFollow.previousKnobPos[ccNumber] = knobPos;
+}
+
+// returns previous knob position saved
+// checks if a previous knob position has been saved, if not, it saves current midi knob position
+int32_t MidiTakeover::getPreviousKnobPos(int32_t knobPos, MIDIKnob* knob, bool doingMidiFollow, int32_t ccNumber) {
+	if (knob != nullptr) {
+		if (!knob->previousPositionSaved) {
+			saveKnobPos(knobPos, knob);
+		}
+		return knob->previousPosition;
+	}
+	else if (doingMidiFollow) {
+		if (midiFollow.previousKnobPos[ccNumber] == kNoSelection) {
+			saveKnobPos(knobPos, ccNumber);
+		}
+		return midiFollow.previousKnobPos[ccNumber];
+	}
+	return knobPos;
 }

--- a/src/deluge/io/midi/midi_takeover.cpp
+++ b/src/deluge/io/midi/midi_takeover.cpp
@@ -28,11 +28,12 @@ extern "C" {
 using namespace deluge;
 using namespace gui;
 
-MidiTakeover midiTakeover{};
-
-// initialize variables
-MidiTakeover::MidiTakeover() {
-}
+void savePreviousKnobPos(int32_t knobPos, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
+                         int32_t ccNumber = MIDI_CC_NONE);
+void saveKnobPos(int32_t knobPos, MIDIKnob* knob);
+void saveKnobPos(int32_t knobPos, int32_t ccNumber);
+int32_t getPreviousKnobPos(int32_t knobPos, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
+                           int32_t ccNumber = MIDI_CC_NONE);
 
 /// based on the midi takeover default setting of RELATIVE, JUMP, PICKUP, or SCALE
 /// this function will calculate the knob position that the deluge parameter that the midi cc
@@ -164,7 +165,7 @@ int32_t MidiTakeover::calculateKnobPos(int32_t knobPos, int32_t value, MIDIKnob*
 
 /// save the current midi knob position as the previous midi knob position so that it can be used next time the
 /// takeover code is executed
-void MidiTakeover::savePreviousKnobPos(int32_t knobPos, MIDIKnob* knob, bool doingMidiFollow, int32_t ccNumber) {
+void savePreviousKnobPos(int32_t knobPos, MIDIKnob* knob, bool doingMidiFollow, int32_t ccNumber) {
 	if (knob != nullptr) {
 		saveKnobPos(knobPos, knob);
 	}
@@ -174,19 +175,19 @@ void MidiTakeover::savePreviousKnobPos(int32_t knobPos, MIDIKnob* knob, bool doi
 }
 
 // save previous knob position if regular midi learn is being used
-void MidiTakeover::saveKnobPos(int32_t knobPos, MIDIKnob* knob) {
+void saveKnobPos(int32_t knobPos, MIDIKnob* knob) {
 	knob->previousPosition = knobPos;
 	knob->previousPositionSaved = true;
 }
 
 // save previous knob position if midi follow is being used
-void MidiTakeover::saveKnobPos(int32_t knobPos, int32_t ccNumber) {
+void saveKnobPos(int32_t knobPos, int32_t ccNumber) {
 	midiFollow.previousKnobPos[ccNumber] = knobPos;
 }
 
 // returns previous knob position saved
 // checks if a previous knob position has been saved, if not, it saves current midi knob position
-int32_t MidiTakeover::getPreviousKnobPos(int32_t knobPos, MIDIKnob* knob, bool doingMidiFollow, int32_t ccNumber) {
+int32_t getPreviousKnobPos(int32_t knobPos, MIDIKnob* knob, bool doingMidiFollow, int32_t ccNumber) {
 	if (knob != nullptr) {
 		if (!knob->previousPositionSaved) {
 			saveKnobPos(knobPos, knob);

--- a/src/deluge/io/midi/midi_takeover.h
+++ b/src/deluge/io/midi/midi_takeover.h
@@ -25,8 +25,16 @@ class MidiTakeover final {
 public:
 	MidiTakeover();
 
-	int32_t calculateKnobPos(ModelStackWithAutoParam* modelStackWithParam, int32_t knobPos, int32_t value,
-	                         MIDIKnob* knob = nullptr, bool doingMidiFollow = false, int32_t ccNumber = MIDI_CC_NONE);
+	int32_t calculateKnobPos(int32_t knobPos, int32_t value, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
+	                         int32_t ccNumber = MIDI_CC_NONE);
+
+private:
+	void savePreviousKnobPos(int32_t knobPos, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
+	                         int32_t ccNumber = MIDI_CC_NONE);
+	void saveKnobPos(int32_t knobPos, MIDIKnob* knob);
+	void saveKnobPos(int32_t knobPos, int32_t ccNumber);
+	int32_t getPreviousKnobPos(int32_t knobPos, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
+	                           int32_t ccNumber = MIDI_CC_NONE);
 };
 
 extern MidiTakeover midiTakeover;

--- a/src/deluge/io/midi/midi_takeover.h
+++ b/src/deluge/io/midi/midi_takeover.h
@@ -21,20 +21,7 @@
 #include "modulation/knob.h"
 #include "modulation/params/param_set.h"
 
-class MidiTakeover final {
-public:
-	MidiTakeover();
-
-	int32_t calculateKnobPos(int32_t knobPos, int32_t value, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
-	                         int32_t ccNumber = MIDI_CC_NONE);
-
-private:
-	void savePreviousKnobPos(int32_t knobPos, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
-	                         int32_t ccNumber = MIDI_CC_NONE);
-	void saveKnobPos(int32_t knobPos, MIDIKnob* knob);
-	void saveKnobPos(int32_t knobPos, int32_t ccNumber);
-	int32_t getPreviousKnobPos(int32_t knobPos, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
-	                           int32_t ccNumber = MIDI_CC_NONE);
-};
-
-extern MidiTakeover midiTakeover;
+namespace MidiTakeover {
+int32_t calculateKnobPos(int32_t knobPos, int32_t value, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
+                         int32_t ccNumber = MIDI_CC_NONE);
+} // namespace MidiTakeover

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1364,35 +1364,11 @@ bool ModControllableAudio::offerReceivedCCToLearnedParamsForClip(MIDIDevice* fro
 				int32_t knobPos =
 				    modelStackWithParam->paramCollection->paramValueToKnobPos(previousValue, modelStackWithParam);
 
-				if (knob->relative) {
-					int32_t offset = value;
-					if (offset >= 64) {
-						offset -= 128;
-					}
-					int32_t lowerLimit = std::min(-64_i32, knobPos);
-					newKnobPos = knobPos + offset;
-					newKnobPos = std::max(newKnobPos, lowerLimit);
-					newKnobPos = std::min(newKnobPos, 64_i32);
-					if (newKnobPos == knobPos) {
-						continue;
-					}
-				}
-				else {
-					// add 64 to internal knobPos to compare to midi cc value received
-					// if internal pos + 64 is greater than 127 (e.g. 128), adjust it to 127
-					// because midi can only send a max midi value of 127
-					int32_t knobPosForMidiValueComparison = knobPos + kKnobPosOffset;
-					if (knobPosForMidiValueComparison > kMaxMIDIValue) {
-						knobPosForMidiValueComparison = kMaxMIDIValue;
-					}
-
-					// is the cc being received for the same value as the current knob pos? If so, do nothing
-					if (value != knobPosForMidiValueComparison) {
-						newKnobPos = midiTakeover.calculateKnobPos(modelStackWithParam, knobPos, value, knob);
-					}
-					else {
-						continue;
-					}
+				// calculate new knob position based on value received and deluge current value
+				newKnobPos = midiTakeover.calculateKnobPos(knobPos, value, knob);
+				// is the cc being received for the same value as the current knob pos? If so, do nothing
+				if (newKnobPos == knobPos) {
+					continue;
 				}
 
 				// Convert the New Knob Position to a Parameter Value
@@ -1456,35 +1432,11 @@ bool ModControllableAudio::offerReceivedCCToLearnedParamsForSong(
 				int32_t knobPos =
 				    modelStackWithParam->paramCollection->paramValueToKnobPos(previousValue, modelStackWithParam);
 
-				if (knob->relative) {
-					int32_t offset = value;
-					if (offset >= 64) {
-						offset -= 128;
-					}
-					int32_t lowerLimit = std::min(-64_i32, knobPos);
-					newKnobPos = knobPos + offset;
-					newKnobPos = std::max(newKnobPos, lowerLimit);
-					newKnobPos = std::min(newKnobPos, 64_i32);
-					if (newKnobPos == knobPos) {
-						continue;
-					}
-				}
-				else {
-					// add 64 to internal knobPos to compare to midi cc value received
-					// if internal pos + 64 is greater than 127 (e.g. 128), adjust it to 127
-					// because midi can only send a max midi value of 127
-					int32_t knobPosForMidiValueComparison = knobPos + kKnobPosOffset;
-					if (knobPosForMidiValueComparison > kMaxMIDIValue) {
-						knobPosForMidiValueComparison = kMaxMIDIValue;
-					}
-
-					// is the cc being received for the same value as the current knob pos? If so, do nothing
-					if (value != knobPosForMidiValueComparison) {
-						newKnobPos = midiTakeover.calculateKnobPos(modelStackWithParam, knobPos, value, knob);
-					}
-					else {
-						continue;
-					}
+				// calculate new knob position based on value received and deluge current value
+				newKnobPos = midiTakeover.calculateKnobPos(knobPos, value, knob);
+				// is the cc being received for the same value as the current knob pos? If so, do nothing
+				if (newKnobPos == knobPos) {
+					continue;
 				}
 
 				// Convert the New Knob Position to a Parameter Value

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1365,7 +1365,7 @@ bool ModControllableAudio::offerReceivedCCToLearnedParamsForClip(MIDIDevice* fro
 				    modelStackWithParam->paramCollection->paramValueToKnobPos(previousValue, modelStackWithParam);
 
 				// calculate new knob position based on value received and deluge current value
-				newKnobPos = midiTakeover.calculateKnobPos(knobPos, value, knob);
+				newKnobPos = MidiTakeover::calculateKnobPos(knobPos, value, knob);
 				// is the cc being received for the same value as the current knob pos? If so, do nothing
 				if (newKnobPos == knobPos) {
 					continue;
@@ -1433,7 +1433,7 @@ bool ModControllableAudio::offerReceivedCCToLearnedParamsForSong(
 				    modelStackWithParam->paramCollection->paramValueToKnobPos(previousValue, modelStackWithParam);
 
 				// calculate new knob position based on value received and deluge current value
-				newKnobPos = midiTakeover.calculateKnobPos(knobPos, value, knob);
+				newKnobPos = MidiTakeover::calculateKnobPos(knobPos, value, knob);
 				// is the cc being received for the same value as the current knob pos? If so, do nothing
 				if (newKnobPos == knobPos) {
 					continue;


### PR DESCRIPTION
**This cherry pick got missed from community**

Fixed bug with MIDI Takeover Pickup and Value Scaling modes which did not work well with acceleration-enabled USB controllers that send fast value changes with large value jumps in between.

Added new relative midi takeover mode that can be used with midi follow controllers which send relative values.

Fix: https://github.com/SynthstromAudible/DelugeFirmware/issues/1707