### PR TITLE
Make Hold Time Configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@
 - Added MIDI learning of Song Params.
 - Added Synth/MIDI/CV clip configuration of note row play direction. Hold `AUDITION` while entering the `PLAY DIRECTION` menu to set the play direction for the selected note row. While in the note row play direction menu, you can select other note rows to quickly set the play directiom for multiple note rows.
 - Added New MIDI Takeover Mode: `RELATIVE` for use with controllers sending relative value changes
+- Added new default menu to set the length of time to register a `Hold Press` for use with `Sticky Shift`, `Performance View`, and the `Keyboard Sidebar Layouts.`
+  - Set the default Hold Press time by accessing `SETTINGS > DEFAULTS > HOLD PRESS TIME`
 
 In addition, a number of improvements have been made to how the OLED display is used:
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -210,6 +210,11 @@ Here is a list of general improvements that have been made, ordered from newest 
   - the setting is persistent after reboot
   - if a kit slice is shorter then 2s, the slicer will automatically switch to `ONCE` (default behaviour)
 
+#### 3.20 Default Hold Press Time
+
+- ([#1846]) Added new default menu to set the length of time to register a `Hold Press` for use with `Sticky Shift`, `Performance View`, and the `Keyboard Sidebar Layouts.`
+  - Set the default Hold Press time by accessing `SETTINGS > DEFAULTS > HOLD PRESS TIME`
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -1215,6 +1220,8 @@ different firmware
 [#1607]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1607
 
 [#1739]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1739
+
+[#1846]: https://github.com/SynthstromAudible/DelugeFirmware/pull/1846
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
 

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -219,6 +219,7 @@ The Settings menu contains the following menu hierarchy:
 	- High CPU Indicator (CPU)
 		- Disabled (OFF)
 		- Enabled (ON)
+	- Hold Press Time (HOLD)
 </details>
 
 <details><summary>Swing Interval (SWIN)</summary>

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -955,10 +955,6 @@ constexpr int32_t kMaxSampleValue = 1 << kBitDepth; // 2 ** kBitDepth
 /// AudioEngine::audioSampleTimer)
 constexpr uint32_t kShortPressTime = kSampleRate / 2;
 
-/// Length of a press that delineates a "hold" press.
-/// Used in Performance View and with Sticky Shift
-constexpr uint32_t kHoldTime = kSampleRate / 10;
-
 /// Rate at which midi follow feedback for automation is sent
 constexpr uint32_t kLowFeedbackAutomationRate = (kSampleRate / 1000) * 500;    // 500 ms
 constexpr uint32_t kMediumFeedbackAutomationRate = (kSampleRate / 1000) * 150; // 150 ms

--- a/src/deluge/gui/l10n/english.cpp
+++ b/src/deluge/gui/l10n/english.cpp
@@ -910,9 +910,9 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_TRANSPOSE_CHROMATIC, "Chromatic"},
         {STRING_FOR_TRANSPOSE_CHORD, "Chord"},
         {STRING_FOR_CANT_ENTER_SCALE, "Can't enter scale mode, MIDI transpose is chromatic"},
-       
+
         {STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR, "High CPU Indicator"},
-        
+
         {STRING_FOR_HOLD_TIME, "Hold Press Time"},
     },
 };

--- a/src/deluge/gui/l10n/english.cpp
+++ b/src/deluge/gui/l10n/english.cpp
@@ -910,7 +910,10 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_TRANSPOSE_CHROMATIC, "Chromatic"},
         {STRING_FOR_TRANSPOSE_CHORD, "Chord"},
         {STRING_FOR_CANT_ENTER_SCALE, "Can't enter scale mode, MIDI transpose is chromatic"},
+       
         {STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR, "High CPU Indicator"},
+        
+        {STRING_FOR_HOLD_TIME, "Hold Press Time"},
     },
 };
 } // namespace deluge::l10n::built_in

--- a/src/deluge/gui/l10n/seven_segment.cpp
+++ b/src/deluge/gui/l10n/seven_segment.cpp
@@ -463,7 +463,10 @@ PLACE_SDRAM_DATA Language seven_segment{
         {STRING_FOR_TRANSPOSE_CHROMATIC, "CHRM"},
         {STRING_FOR_TRANSPOSE_CHORD, "CHRD"},
         {STRING_FOR_CANT_ENTER_SCALE, "CANT"},
+        
         {STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR, "CPU"},
+        
+        {STRING_FOR_HOLD_TIME, "HOLD"},
     },
     &built_in::english,
 };

--- a/src/deluge/gui/l10n/seven_segment.cpp
+++ b/src/deluge/gui/l10n/seven_segment.cpp
@@ -463,9 +463,9 @@ PLACE_SDRAM_DATA Language seven_segment{
         {STRING_FOR_TRANSPOSE_CHROMATIC, "CHRM"},
         {STRING_FOR_TRANSPOSE_CHORD, "CHRD"},
         {STRING_FOR_CANT_ENTER_SCALE, "CANT"},
-        
+
         {STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR, "CPU"},
-        
+
         {STRING_FOR_HOLD_TIME, "HOLD"},
     },
     &built_in::english,

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -840,7 +840,7 @@ enum class String : size_t {
 
 	// string for high CPU usage indicator default setting
 	STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
-	
+
 	STRING_FOR_HOLD_TIME,
 
 	STRING_LAST

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -840,6 +840,8 @@ enum class String : size_t {
 
 	// string for high CPU usage indicator default setting
 	STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
+	
+	STRING_FOR_HOLD_TIME,
 
 	STRING_LAST
 };

--- a/src/deluge/gui/menu_item/defaults/hold_time.h
+++ b/src/deluge/gui/menu_item/defaults/hold_time.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include "gui/menu_item/integer.h"
+#include "model/song/song.h"
+#include "storage/flash_storage.h"
+
+namespace deluge::gui::menu_item::defaults {
+class HoldTime final : public Integer {
+public:
+	using Integer::Integer;
+	[[nodiscard]] int32_t getMinValue() const override { return 1; }
+	[[nodiscard]] int32_t getMaxValue() const override { return 20; }
+	void readCurrentValue() override { this->setValue(FlashStorage::defaultHoldTime); }
+	void writeCurrentValue() override {
+		FlashStorage::defaultHoldTime = this->getValue();
+		FlashStorage::holdTime = (FlashStorage::defaultHoldTime * kSampleRate) / 20;
+	}
+	int32_t getDisplayValue() override {
+		int32_t currentValue = FlashStorage::defaultHoldTime;
+		if (currentValue == 20) {
+			return 1;
+		}
+		else {
+			return currentValue * 50;
+		}
+	}
+	const char* getUnit() override {
+		if (FlashStorage::defaultHoldTime == 20) {
+			return " SEC";
+		}
+		else {
+			return " MS";
+		}
+	}
+};
+} // namespace deluge::gui::menu_item::defaults

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -104,7 +104,7 @@ ActionResult KeyboardScreen::padAction(int32_t x, int32_t y, int32_t velocity) {
 			// Pad was already active
 			if (pressedPads[idx].active && pressedPads[idx].x == x && pressedPads[idx].y == y) {
 				freeSlotIdx = -1; // If a free slot was found previously, reset it so we don't write a second entry
-				if ((AudioEngine::audioSampleTimer - pressedPads[idx].timeLastPadPress) > kHoldTime) {
+				if ((AudioEngine::audioSampleTimer - pressedPads[idx].timeLastPadPress) > FlashStorage::holdTime) {
 					pressedPads[idx].padPressHeld = true;
 				}
 				break;
@@ -129,7 +129,7 @@ ActionResult KeyboardScreen::padAction(int32_t x, int32_t y, int32_t velocity) {
 			if (pressedPads[idx].active && pressedPads[idx].x == x && pressedPads[idx].y == y) {
 				pressedPads[idx].active = false;
 				markDead = idx;
-				if ((AudioEngine::audioSampleTimer - pressedPads[idx].timeLastPadPress) > kHoldTime) {
+				if ((AudioEngine::audioSampleTimer - pressedPads[idx].timeLastPadPress) > FlashStorage::holdTime) {
 					pressedPads[idx].padPressHeld = true;
 				}
 				break;

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -29,6 +29,7 @@
 #include "gui/menu_item/cv/volts.h"
 #include "gui/menu_item/defaults/bend_range.h"
 #include "gui/menu_item/defaults/grid_default_active_mode.h"
+#include "gui/menu_item/defaults/hold_time.h"
 #include "gui/menu_item/defaults/keyboard_layout.h"
 #include "gui/menu_item/defaults/magnitude.h"
 #include "gui/menu_item/defaults/metronome_volume.h"
@@ -1133,6 +1134,8 @@ defaults::SliceMode defaultSliceMode{STRING_FOR_DEFAULT_SLICE_MODE, STRING_FOR_D
 ToggleBool defaultHighCPUUsageIndicatorMode{STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
                                             STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
                                             FlashStorage::highCPUUsageIndicator};
+defaults::HoldTime defaultHoldTimeMenu{STRING_FOR_HOLD_TIME, STRING_FOR_HOLD_TIME};
+
 Submenu defaultsSubmenu{
     STRING_FOR_DEFAULTS,
     {
@@ -1150,6 +1153,7 @@ Submenu defaultsSubmenu{
         &defaultPadBrightness,
         &defaultSliceMode,
         &defaultHighCPUUsageIndicatorMode,
+        &defaultHoldTimeMenu,
     },
 };
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -979,7 +979,9 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 								// if you released the pink pad and it was held for longer than hold time
 								// switch back to session view (this happens if you enter performance view with a
 								// long press from grid mode - it just peeks performance view)
-								if (!on && ((AudioEngine::audioSampleTimer - timeGridModePress) >= kHoldTime)) {
+								if (!on
+								    && ((AudioEngine::audioSampleTimer - timeGridModePress)
+								        >= FlashStorage::holdTime)) {
 									gridModeActive = false;
 									changeRootUI(&sessionView);
 								}
@@ -1037,9 +1039,9 @@ void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* mode
 		if ((params::isParamStutter(lastSelectedParamKind, lastSelectedParamID) && lastPadPress.isActive
 		     && lastPadPress.yDisplay == yDisplay)
 		    || (fxPress[xDisplay].padPressHeld
-		        && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) < kHoldTime))
+		        && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) < FlashStorage::holdTime))
 		    || ((fxPress[xDisplay].previousKnobPosition != kNoSelection) && (fxPress[xDisplay].yDisplay == yDisplay)
-		        && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) >= kHoldTime))) {
+		        && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) >= FlashStorage::holdTime))) {
 
 			// if there was a previously held pad in this column and you pressed another pad
 			// but didn't set that pad to held, then when we let go of this pad, we want the
@@ -1053,7 +1055,7 @@ void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* mode
 		// if releasing a pad that was quickly pressed, give it held status
 		else if (!params::isParamStutter(lastSelectedParamKind, lastSelectedParamID)
 		         && (fxPress[xDisplay].previousKnobPosition != kNoSelection) && (fxPress[xDisplay].yDisplay == yDisplay)
-		         && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) < kHoldTime)) {
+		         && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) < FlashStorage::holdTime)) {
 			fxPress[xDisplay].padPressHeld = true;
 		}
 		// no saving of logs in performance view editing mode

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -26,6 +26,7 @@
 #include "playback/mode/playback_mode.h"
 #include "playback/playback_handler.h"
 #include "processing/engines/audio_engine.h"
+#include "storage/flash_storage.h"
 #include "testing/hardware_testing.h"
 
 namespace Buttons {
@@ -173,7 +174,7 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 				}
 				// We got a short press, maybe enable sticky keys
 				// 5th of a second
-				if (delta < kHoldTime) {
+				if (delta < FlashStorage::holdTime) {
 					// unstick shift if another button was pressed while shift was held, or we were already stuck and
 					// this short press is to get us unstuck.
 					shiftCurrentlyStuck = considerShiftReleaseForSticky && !shiftCurrentlyStuck;

--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -901,7 +901,7 @@ void writeSettings() {
 	buffer[167] = util::to_underlying(defaultSliceMode);
 
 	buffer[169] = highCPUUsageIndicator;
-	
+
 	buffer[170] = defaultHoldTime;
 
 	R_SFLASH_EraseSector(0x80000 - 0x1000, SPIBSC_CH, SPIBSC_CMNCR_BSZ_SINGLE, 1, SPIBSC_OUTPUT_ADDR_24);

--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -172,6 +172,7 @@ enum Entries {
 167: defaultSliceMode
 168: midiFollow control song params
 169: High CPU Usage Indicator
+170: default hold time (1-20)
 */
 
 uint8_t defaultScale;
@@ -212,6 +213,9 @@ bool automationDisableAuditionPadShortcuts = true;
 StartupSongMode defaultStartupSongMode;
 
 bool highCPUUsageIndicator;
+
+uint8_t defaultHoldTime;
+int32_t holdTime;
 
 void resetSettings() {
 
@@ -297,6 +301,9 @@ void resetSettings() {
 	defaultSliceMode = SampleRepeatMode::CUT;
 
 	highCPUUsageIndicator = false;
+
+	defaultHoldTime = 2;
+	holdTime = (defaultHoldTime * kSampleRate) / 20;
 }
 
 void resetMidiFollowSettings() {
@@ -637,6 +644,12 @@ void readSettings() {
 	else {
 		highCPUUsageIndicator = buffer[169];
 	}
+
+	defaultHoldTime = buffer[170];
+	if (defaultHoldTime > 20 || defaultHoldTime <= 0) {
+		defaultHoldTime = 2;
+	}
+	holdTime = (defaultHoldTime * kSampleRate) / 20;
 }
 
 static bool areMidiFollowSettingsValid(std::span<uint8_t> buffer) {
@@ -888,6 +901,8 @@ void writeSettings() {
 	buffer[167] = util::to_underlying(defaultSliceMode);
 
 	buffer[169] = highCPUUsageIndicator;
+	
+	buffer[170] = defaultHoldTime;
 
 	R_SFLASH_EraseSector(0x80000 - 0x1000, SPIBSC_CH, SPIBSC_CMNCR_BSZ_SINGLE, 1, SPIBSC_OUTPUT_ADDR_24);
 	R_SFLASH_ByteProgram(0x80000 - 0x1000, buffer.data(), 256, SPIBSC_CH, SPIBSC_CMNCR_BSZ_SINGLE, SPIBSC_1BIT,

--- a/src/deluge/storage/flash_storage.h
+++ b/src/deluge/storage/flash_storage.h
@@ -60,7 +60,11 @@ extern bool automationDisableAuditionPadShortcuts;
 extern StartupSongMode defaultStartupSongMode;
 extern uint8_t defaultPadBrightness;
 extern SampleRepeatMode defaultSliceMode;
+
 extern bool highCPUUsageIndicator;
+
+extern uint8_t defaultHoldTime;
+extern int32_t holdTime;
 
 void readSettings();
 void writeSettings();


### PR DESCRIPTION
**Cherry pick for this PR got missed to 1.1**

Added new default hold press time menu to configure default time to trigger hold presses in various views, namely:

stick shift
performance view
keyboard sidebar

Fix: https://github.com/SynthstromAudible/DelugeFirmware/issues/1725