### PR TITLE
Bug Fix keyboard screen and other animations

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -132,6 +132,11 @@ void KeyboardLayoutIsomorphic::renderPads(RGB image[][kDisplayWidth + kSideBarWi
 				image[y][x] = noteColours[normalizedPadOffset].forTail();
 			}
 
+			// turn off other pads
+			else {
+				image[y][x] = colours::black;
+			}
+
 			// TODO: In a future revision it would be nice to add this to the API
 			//  Dim note pad if a browser is open with the note highlighted
 			if (getCurrentUI() == &sampleBrowser || getCurrentUI() == &audioRecorder

--- a/src/deluge/gui/ui/keyboard/layout/norns.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/norns.cpp
@@ -51,6 +51,9 @@ void KeyboardLayoutNorns::renderPads(RGB image[][kDisplayWidth + kSideBarWidth])
 			if (getNornsNotes()[note] != 0) {
 				image[y][x] = colours::white_full.adjust(getNornsNotes()[note], 1);
 			}
+			else {
+				image[y][x] = colours::black;
+			}
 		}
 	}
 }

--- a/src/deluge/gui/ui/keyboard/layout/velocity_drums.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/velocity_drums.cpp
@@ -112,6 +112,7 @@ void KeyboardLayoutVelocityDrums::renderPads(RGB image[][kDisplayWidth + kSideBa
 		for (int32_t x = 0; x < kDisplayWidth; x++) {
 			uint8_t note = noteFromCoords(x, y);
 			if (note > highestClipNote) {
+				image[y][x] = colours::black;
 				continue;
 			}
 

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -72,6 +72,7 @@ extern bool pendingUIRenderingLock;
 #define UI_MODE_MACRO_SETTING_UP 60
 #define UI_MODE_DRAGGING_KIT_NOTEROW 61
 #define UI_MODE_HOLDING_STATUS_PAD 62
+#define UI_MODE_IMPLODE_ANIMATION 63
 
 #define EXCLUSIVE_UI_MODES_MASK ((uint32_t)255)
 

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -104,7 +104,7 @@ bool AudioClipView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth
 		return true;
 	}
 
-	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)) {
+	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING) || isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 		return true;
 	}
 
@@ -196,7 +196,7 @@ bool AudioClipView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth 
 		return true;
 	}
 
-	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)) {
+	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING) || isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 		return true;
 	}
 
@@ -220,7 +220,8 @@ void AudioClipView::graphicsRoutine() {
 	int32_t newTickSquare;
 
 	if (!playbackHandler.playbackState || !currentSong->isClipActive(getCurrentClip())
-	    || currentUIMode == UI_MODE_EXPLODE_ANIMATION || playbackHandler.ticksLeftInCountIn) {
+	    || currentUIMode == UI_MODE_EXPLODE_ANIMATION || currentUIMode == UI_MODE_IMPLODE_ANIMATION
+	    || playbackHandler.ticksLeftInCountIn) {
 		newTickSquare = 255;
 	}
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -594,7 +594,7 @@ bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidt
 		return true;
 	}
 
-	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)) {
+	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING) || isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 		return true;
 	}
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4166,7 +4166,7 @@ bool InstrumentClipView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayW
 		return true;
 	}
 
-	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)) {
+	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING) || isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 		return true;
 	}
 
@@ -5117,7 +5117,7 @@ void InstrumentClipView::graphicsRoutine() {
 
 	InstrumentClip* clip = (InstrumentClip*)modelStack->getTimelineCounter();
 
-	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)) {
+	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING) || isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 		return;
 	}
 
@@ -5128,7 +5128,8 @@ void InstrumentClipView::graphicsRoutine() {
 	int32_t newTickSquare;
 
 	bool reallyNoTickSquare = (!playbackHandler.isEitherClockActive() || !currentSong->isClipActive(clip)
-	                           || currentUIMode == UI_MODE_EXPLODE_ANIMATION || playbackHandler.ticksLeftInCountIn);
+	                           || currentUIMode == UI_MODE_EXPLODE_ANIMATION
+	                           || currentUIMode == UI_MODE_IMPLODE_ANIMATION || playbackHandler.ticksLeftInCountIn);
 
 	if (reallyNoTickSquare) {
 		newTickSquare = 255;
@@ -5271,7 +5272,7 @@ bool InstrumentClipView::renderMainPads(uint32_t whichRows, RGB image[][kDisplay
 		return true;
 	}
 
-	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)) {
+	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING) || isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 		return true;
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2103,6 +2103,7 @@ void SessionView::rowNeedsRenderingDependingOnSubMode(int32_t yDisplay) {
 	case UI_MODE_INSTRUMENT_CLIP_COLLAPSING:
 	case UI_MODE_ANIMATION_FADE:
 	case UI_MODE_EXPLODE_ANIMATION:
+	case UI_MODE_IMPLODE_ANIMATION:
 		break;
 
 	default:
@@ -2224,7 +2225,7 @@ void SessionView::flashPlayRoutine() {
 
 		// view.clipArmFlashOn needs to be off so the pad is finally rendered after flashing
 		if (renderFlashing || view.clipArmFlashOn) {
-			if (currentUIMode != UI_MODE_EXPLODE_ANIMATION) {
+			if (currentUIMode != UI_MODE_EXPLODE_ANIMATION && currentUIMode != UI_MODE_IMPLODE_ANIMATION) {
 				requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 				view.flashPlayEnable();
 			}
@@ -2422,6 +2423,7 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 		if (onKeyboardScreen) {
 
 			keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+			keyboardScreen.renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
 
 			PadLEDs::numAnimatedRows = kDisplayHeight;
 			for (int32_t y = 0; y < PadLEDs::numAnimatedRows; y++) {
@@ -3235,7 +3237,7 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
 
-	if (currentUIMode == UI_MODE_EXPLODE_ANIMATION) {
+	if (currentUIMode == UI_MODE_EXPLODE_ANIMATION || currentUIMode == UI_MODE_IMPLODE_ANIMATION) {
 		return ActionResult::DEALT_WITH;
 	}
 
@@ -3305,7 +3307,7 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 		}
 	}
 
-	if (currentUIMode != UI_MODE_EXPLODE_ANIMATION) {
+	if (currentUIMode != UI_MODE_EXPLODE_ANIMATION && currentUIMode != UI_MODE_IMPLODE_ANIMATION) {
 		requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 		view.flashPlayEnable();
 	}
@@ -3687,10 +3689,10 @@ void SessionView::gridTransitionToSessionView() {
 		}
 	}
 
-	currentUIMode = UI_MODE_EXPLODE_ANIMATION;
+	currentUIMode = UI_MODE_IMPLODE_ANIMATION;
 
-	memcpy(PadLEDs::imageStore, PadLEDs::image, (kDisplayWidth + kSideBarWidth) * kDisplayHeight * sizeof(RGB));
-	memcpy(PadLEDs::occupancyMaskStore, PadLEDs::occupancyMask, (kDisplayWidth + kSideBarWidth) * kDisplayHeight);
+	memcpy(PadLEDs::imageStore[1], PadLEDs::image, (kDisplayWidth + kSideBarWidth) * kDisplayHeight * sizeof(RGB));
+	memcpy(PadLEDs::occupancyMaskStore[1], PadLEDs::occupancyMask, (kDisplayWidth + kSideBarWidth) * kDisplayHeight);
 	if (getCurrentUI() == &instrumentClipView) {
 		instrumentClipView.fillOffScreenImageStores();
 	}
@@ -3714,7 +3716,8 @@ void SessionView::gridTransitionToSessionView() {
 	PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
 	PadLEDs::explodeAnimationDirection = -1;
 
-	if (getCurrentUI() == &instrumentClipView || getCurrentUI() == &automationView) {
+	// clear sidebar for instrumentClipView, automationClipView, and keyboardScreen
+	if (getCurrentUI() != &audioClipView) {
 		PadLEDs::clearSideBar();
 	}
 
@@ -3773,9 +3776,9 @@ void SessionView::gridTransitionToViewForClip(Clip* clip) {
 
 		// If going to KeyboardView...
 		if (onKeyboardScreen) {
-			keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+			keyboardScreen.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1]);
 			memset(PadLEDs::occupancyMaskStore[0], 0, kDisplayWidth + kSideBarWidth);
-			memset(PadLEDs::occupancyMaskStore[kDisplayHeight], 0, kDisplayWidth + kSideBarWidth);
+			memset(PadLEDs::occupancyMaskStore[kDisplayHeight + 1], 0, kDisplayWidth + kSideBarWidth);
 		}
 
 		// Or if just regular old InstrumentClipView
@@ -3783,8 +3786,6 @@ void SessionView::gridTransitionToViewForClip(Clip* clip) {
 			instrumentClipView.recalculateColours();
 			instrumentClipView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1],
 			                                  false);
-			instrumentClipView.renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
-
 			instrumentClipView.fillOffScreenImageStores();
 		}
 	}

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -18,6 +18,7 @@
 #include "model/action/action_logger.h"
 #include "definitions_cxx.hpp"
 #include "gui/ui/keyboard/keyboard_screen.h"
+#include "gui/ui/ui.h"
 #include "gui/views/arranger_view.h"
 #include "gui/views/audio_clip_view.h"
 #include "gui/views/automation_view.h"
@@ -718,7 +719,8 @@ currentClipSwitchedOver:
 		// rather than the whichAnimation variable we've been using in this function, because under some circumstances
 		// that'll bypass the actual animation / UI-mode. We would also put the "explode" animation for transitioning
 		// *to* arranger here, but it just doesn't get used during reversion.
-		if (!isUIModeActive(UI_MODE_AUDIO_CLIP_COLLAPSING) && !isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)) {
+		if (!isUIModeActive(UI_MODE_AUDIO_CLIP_COLLAPSING) && !isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)
+		    && !isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 			view.setKnobIndicatorLevels();
 			view.setModLedStates();
 		}


### PR DESCRIPTION
Updated animations for entering / exiting keyboard screen from song row view / back to row view

Updated animations for entering / exiting keyboard screen from song grid view / back to grid view

Split the UI_MODE_EXPLODE_ANIMATION into two: EXPLODE and IMPLODE (UI_MODE_IMPLODE_ANIMATION)

Similar to the check's that were in place in the Clip View rendering functions to not render when INSTRUMENT_CLIP_COLLAPSING was happening (when exiting clip back to Song Row View), I added the same check for the IMPLODE UI mode. This eliminated flicker that I was noticing where it would clear the exiting view's grid and then re-render it again before finally transitioning to song view and rendering that view's grid.

I updated a number of rendering calls as well where I saw that the PadLED::image used was the wrong one (e.g. it should have been image[1] per the Official Firmware source code.

Did a lot of comparing with Official Firmware source code to update things that got changed by mistake.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1893