### PR TITLE
Bugfix - Update midi follow feedback

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1393,7 +1393,6 @@ getItFromSection:
 				pressedClipInstanceXScrollWhenLastInValidPosition = xScroll;
 				pressedClipInstanceIsInValidPosition = true;
 				pressedClipInstanceOutput = output;
-				view.setActiveModControllableTimelineCounter(clipInstance->clip);
 
 				if (clipInstance->clip) {
 					originallyPressedClipActualLength = clipInstance->clip->loopLength;
@@ -1405,6 +1404,11 @@ getItFromSection:
 				}
 
 				rememberInteractionWithClipInstance(y, clipInstance);
+
+				// this needs to be called after the current clip is set and after
+				// the interaction with clip instance is remembered in order to ensure that
+				// if midi follow feedback is enabled, it sends feedback for the right clip instance
+				view.setActiveModControllableTimelineCounter(clipInstance->clip);
 			}
 
 			// Already pressing - length edit

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3556,12 +3556,14 @@ ActionResult SessionView::gridHandlePadsLaunchWithSelection(int32_t x, int32_t y
 			currentUIMode = UI_MODE_CLIP_PRESSED_IN_SONG_VIEW;
 			performActionOnPadRelease = true;
 			selectedClipTimePressed = AudioEngine::audioSampleTimer;
-			view.setActiveModControllableTimelineCounter(clip);
 			currentSong->setCurrentClip(clip);
 			view.displayOutputName(clip->output, true, clip);
 			if (display->haveOLED()) {
 				deluge::hid::display::OLED::sendMainImage();
 			}
+			// this needs to be called after the current clip is set in order to ensure that
+			// if midi follow feedback is enabled, it sends feedback for the right clip
+			view.setActiveModControllableTimelineCounter(clip);
 		}
 		// Special case, if there are already selected pads we allow immediate arming all others
 		else {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1625,18 +1625,15 @@ void View::sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam, 
 		    midiEngine.midiFollowChannelType[util::to_underlying(midiEngine.midiFollowFeedbackChannelType)]
 		        .channelOrZone;
 		if (channel != MIDI_CHANNEL_NONE) {
-			// make sure we're not sending feedback for Song param context
-			if (isClipContext()) {
-				if (modelStackWithParam && modelStackWithParam->autoParam) {
-					params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-					int32_t ccNumber = midiFollow.getCCFromParam(kind, modelStackWithParam->paramId);
-					if (ccNumber != MIDI_CC_NONE) {
-						midiFollow.sendCCForMidiFollowFeedback(channel, ccNumber, knobPos);
-					}
+			if (modelStackWithParam && modelStackWithParam->autoParam) {
+				params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+				int32_t ccNumber = midiFollow.getCCFromParam(kind, modelStackWithParam->paramId);
+				if (ccNumber != MIDI_CC_NONE) {
+					midiFollow.sendCCForMidiFollowFeedback(channel, ccNumber, knobPos);
 				}
-				else {
-					midiFollow.sendCCWithoutModelStackForMidiFollowFeedback(channel, isAutomation);
-				}
+			}
+			else {
+				midiFollow.sendCCWithoutModelStackForMidiFollowFeedback(channel, isAutomation);
 			}
 		}
 	}

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -118,6 +118,8 @@ Clip* MidiFollow::getSelectedOrActiveClip() {
 
 	clip = getSelectedClip();
 
+	// if the clip is null, it means you're in a song view and you aren't holding a clip
+	// in that case, we want to control the active clip
 	if (!clip) {
 		clip = getCurrentClip();
 		if (clip) {
@@ -134,6 +136,7 @@ Clip* MidiFollow::getSelectedOrActiveClip() {
 /// see if you are pressing and holding a clip in arranger view, song row view, song grid view
 /// see if you are pressing and holding audition pad in arranger view, arranger perf view, or
 /// arranger automation view
+/// if you're in a clip, this will return that clip
 Clip* MidiFollow::getSelectedClip() {
 	Clip* clip = nullptr;
 
@@ -161,8 +164,11 @@ Clip* MidiFollow::getSelectedClip() {
 		// if you're in the arranger automation view, check if you're holding audition pad
 		if (automationView.onArrangerView) {
 			clip = arrangerView.getClipForSelection();
+			break;
 		}
-		break;
+		[[fallthrough]]; // you're in automation clip view
+	default:             // if you're in a clip view, then return the current clip
+		clip = getCurrentClip();
 	}
 
 	return clip;
@@ -452,8 +458,6 @@ void MidiFollow::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, uint8_t
 	if (match != MIDIMatchType::NO_MATCH) {
 		// obtain clip for active context (for params that's only for the active mod controllable stack)
 		Clip* clip = getSelectedOrActiveClip();
-		// clip is allowed to be null here because there may not be an active clip
-		// e.g. you want to control the song level parameters
 
 		bool isMIDIClip = false;
 		bool isCVClip = false;

--- a/src/deluge/playback/mode/arrangement.cpp
+++ b/src/deluge/playback/mode/arrangement.cpp
@@ -48,7 +48,7 @@ void Arrangement::setupPlayback() {
 
 	currentSong->setParamsInAutomationMode(true);
 
-	// It seems strange that I ever put this here. It's now also in PlaybackHandler::setupPlayback,
+	// Rohan: It seems strange that I ever put this here. It's now also in PlaybackHandler::setupPlayback,
 	// so maybe extra unneeded here - but that's not the only place that calls us, so have left it in for now
 	playbackHandler.swungTicksTilNextEvent = 0;
 
@@ -263,10 +263,9 @@ notRecording:
 							                // in which case this has just been set up already. But otherwise...
 							thisClip->activeIfNoSolo = true;
 							thisClip->setPos(modelStackWithTimelineCounter, 0);
-							// Used to call assertActiveness(), but that's actually
-							// unnecessary - be because we're playing in
-							// arrangement, setActiveClip() is actually the only
-							// relevant bit
+							// Rohan: used to call assertActiveness(), but that's actually
+							// unnecessary - because we're playing in arrangement,
+							// setActiveClip() is actually the only relevant bit
 							bool activeClipChanged = output->setActiveClip(modelStackWithTimelineCounter);
 							if (activeClipChanged) {
 								// the play cursor has selected a new active clip for the current output

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -2102,14 +2102,14 @@ yeahNahItsOn:
 
 					giveClipOpportunityToBeginLinearRecording(clip, c, buttonPressLatency);
 
-					if (clip->armState == ArmState::ON_NORMAL) { // What's this for again? Auto arming of sections? I
-						                                         // think not linear recording...
+					if (clip->armState == ArmState::ON_NORMAL) { // Rohan: What's this for again? Auto arming of
+						                                         // sections? I think not linear recording...
 						distanceTilLaunchEvent = std::max(distanceTilLaunchEvent, clip->loopLength);
 					}
 				}
 			}
 
-			// Not sure quite why we needed to set this here?
+			// Rohan: Not quite sure why we needed to set this here?
 			clip->output->setActiveClip(modelStackWithTimelineCounter);
 		}
 	}

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -351,9 +351,8 @@ void Session::doLaunch(bool isFillLaunch) {
 
 				// If wanting to stop recording linearly at the same time as that...
 				if (clip->getCurrentlyRecordingLinearly()) {
-					clip->finishLinearRecording(
-					    modelStackWithTimelineCounter,
-					    NULL); // Won't be a pending overdub - those aren't allowed if we're gonna be soloing
+					// Won't be a pending overdub - those aren't allowed if we're gonna be soloing
+					clip->finishLinearRecording(modelStackWithTimelineCounter, NULL);
 					stoppedLinearRecording = true;
 				}
 			}
@@ -373,8 +372,8 @@ void Session::doLaunch(bool isFillLaunch) {
 doFinishLinearRecording:
 					Clip* nextPendingOverdub = currentSong->getPendingOverdubWithOutput(clip->output);
 					if (nextPendingOverdub) {
-						nextPendingOverdub->copyBasicsFrom(
-						    clip); // Copy this again, in case it's changed since it was created
+						// Copy this again, in case it's changed since it was created
+						nextPendingOverdub->copyBasicsFrom(clip);
 					}
 
 					clip->finishLinearRecording(modelStackWithTimelineCounter, nextPendingOverdub);
@@ -509,9 +508,8 @@ stopOnlyIfOutputTaken:
 
 probablyBecomeActive:
 				// If the Output already got its new Clip, then this Clip has missed out and can't become active on it
-				if (output->alreadyGotItsNewClip
-				    || (output->isGettingSoloingClip && !wasArmedToStartSoloing) // This clip is not the solo clip
-				) {
+				if (output->alreadyGotItsNewClip || (output->isGettingSoloingClip && !wasArmedToStartSoloing)) {
+					// This clip is not the solo clip
 
 					// But, if we're a pending overdub that's going to clone its Output...
 					if (clip->isPendingOverdub && clip->willCloneOutputForOverdub()) {
@@ -549,9 +547,16 @@ doNormalLaunch:
 						clip->armState = ArmState::ON_NORMAL;
 					}
 
-					output->setActiveClip(
-					    modelStackWithTimelineCounter); // Must be after giveClipOpportunityToBeginLinearRecording(),
-					                                    // cos this call clears any recorded-early notes
+					// Must be after giveClipOpportunityToBeginLinearRecording(),
+					// cos this call clears any recorded-early notes
+					bool activeClipChanged = output->setActiveClip(modelStackWithTimelineCounter);
+					if (activeClipChanged) {
+						// a new clip has been launched in song view for the current output selected
+						// that new clip is now the active clip for that output
+						// send updated feedback so that midi controller has the latest values for
+						// the current clip selected for midi follow control
+						view.sendMidiFollowFeedback();
+					}
 
 					if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
 						clip->beginInstance(currentSong, playbackHandler.getActualArrangementRecordPos());
@@ -2051,9 +2056,9 @@ void Session::resetPlayPos(int32_t newPos, bool doingComplete, int32_t buttonPre
 
 	AudioEngine::bypassCulling = true;
 
-	currentSong
-	    ->deactivateAnyArrangementOnlyClips(); // In case any still playing after switch from arrangement. Remember,
-	                                           // this function will be called on playback begin, song swap, and more
+	// In case any still playing after switch from arrangement. Remember,
+	// this function will be called on playback begin, song swap, and more
+	currentSong->deactivateAnyArrangementOnlyClips();
 
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
@@ -2104,8 +2109,8 @@ yeahNahItsOn:
 				}
 			}
 
-			clip->output->setActiveClip(
-			    modelStackWithTimelineCounter); // Not sure quite why we needed to set this here?
+			// Not sure quite why we needed to set this here?
+			clip->output->setActiveClip(modelStackWithTimelineCounter);
 		}
 	}
 
@@ -2329,9 +2334,8 @@ void Session::doTickForward(int32_t posIncrement) {
 			// No need to do the actual incrementing - that's been done for all Clips (except ones which have only just
 			// launched), up in considerLaunchEvent()
 
-			clip->processCurrentPos(
-			    modelStackWithTimelineCounter,
-			    posIncrement); // May create new Clip and put it in the ModelStack - we'll check below.
+			// May create new Clip and put it in the ModelStack - we'll check below.
+			clip->processCurrentPos(modelStackWithTimelineCounter, posIncrement);
 
 			// NOTE: posIncrement is the number of ticks which we incremented by in considerLaunchEvent(). But for Clips
 			// which were only just launched in there, well the won't have been incremented, so it would be more correct

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -347,9 +347,8 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 
 	setupPlayback(newPlaybackState, newPos, true, true, buttonPressLatency);
 
-	timeNextTimerTickBig =
-	    (uint64_t)AudioEngine::audioSampleTimer
-	    << 32; // Set this *after* calling setupPlayback, which will call the audio routine before we do the first tick
+	// Set this *after* calling setupPlayback, which will call the audio routine before we do the first tick
+	timeNextTimerTickBig = (uint64_t)AudioEngine::audioSampleTimer << 32;
 
 	swungTicksTilNextEvent = 0; // Need to ensure this, here, otherwise, it'll be set to some weird thing by some recent
 	                            // call to expectEvent()
@@ -449,9 +448,8 @@ void PlaybackHandler::setupPlayback(int32_t newPlaybackState, int32_t playFromPo
 	bool oldState = AudioEngine::audioRoutineLocked;
 	AudioEngine::audioRoutineLocked = true;
 	currentlyActioningSwungTickOrResettingPlayPos = true;
-	currentPlaybackMode->resetPlayPos(
-	    playFromPos, !ticksLeftInCountIn,
-	    buttonPressLatencyForTempolessRecord); // Have to do this after calling AudioEngine::routine()
+	// Have to do this after calling AudioEngine::routine()
+	currentPlaybackMode->resetPlayPos(playFromPos, !ticksLeftInCountIn, buttonPressLatencyForTempolessRecord);
 	currentlyActioningSwungTickOrResettingPlayPos = false;
 	AudioEngine::audioRoutineLocked = oldState;
 
@@ -461,6 +459,10 @@ void PlaybackHandler::setupPlayback(int32_t newPlaybackState, int32_t playFromPo
 
 	// We can only set these to -1 after calling the stuff above
 	// lastSwungTickDone = -1;
+
+	// when starting playback send updated feedback values for the current clip
+	// or active clip selected for midi follow control
+	view.sendMidiFollowFeedback();
 }
 
 void PlaybackHandler::endPlayback() {
@@ -475,15 +477,15 @@ void PlaybackHandler::endPlayback() {
 
 	bool wasRecordingArrangement = (recording == RecordingMode::ARRANGEMENT);
 
-	bool shouldDoInstantSongSwap =
-	    currentPlaybackMode
-	        ->endPlayback(); // Must happen after currentSong->endInstancesOfActiveClips() is called (ok I can't
-	                         // remember why I wrote that, and now it needs to happen before so that
-	                         // Clip::beingRecordedFrom is still set when playback ends, so notes stop)
+	// Must happen after currentSong->endInstancesOfActiveClips() is called (ok I can't
+	// remember why I wrote that, and now it needs to happen before so that
+	// Clip::beingRecordedFrom is still set when playback ends, so notes stop)
+	bool shouldDoInstantSongSwap = currentPlaybackMode->endPlayback();
 
-	playbackState =
-	    0; // Do this after calling currentPlaybackMode->endPlayback(), cos for arrangement that has to get the current
-	       // tick, which needs to refer to which clock is active, which is stored in playbackState.
+	// Do this after calling currentPlaybackMode->endPlayback(), cos for arrangement that has to get the current
+	// tick, which needs to refer to which clock is active, which is stored in playbackState.
+	playbackState = 0;
+
 	cvEngine.playbackEnded(); // Call this *after* playbackState is set
 	PadLEDs::clearTickSquares();
 
@@ -1267,8 +1269,8 @@ void PlaybackHandler::doSongSwap(bool preservePlayPosition) {
 			lastTriggerClockOutTickDone = -1;
 			lastMIDIClockOutTickDone = -1;
 
-			swungTicksTilNextEvent =
-			    0; // Set it so the tick which we're gonna do right now, at the start of the new song, has 0 increment
+			// Set it so the tick which we're gonna do right now, at the start of the new song, has 0 increment
+			swungTicksTilNextEvent = 0;
 		}
 
 		// And now, if switching to arranger (in which case, remember, we definitely didn't preserve play position), do

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -477,7 +477,7 @@ void PlaybackHandler::endPlayback() {
 
 	bool wasRecordingArrangement = (recording == RecordingMode::ARRANGEMENT);
 
-	// Must happen after currentSong->endInstancesOfActiveClips() is called (ok I can't
+	// Rohan: Must happen after currentSong->endInstancesOfActiveClips() is called (ok I can't
 	// remember why I wrote that, and now it needs to happen before so that
 	// Clip::beingRecordedFrom is still set when playback ends, so notes stop)
 	bool shouldDoInstantSongSwap = currentPlaybackMode->endPlayback();


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1744

Updated midi follow feedback:
- removed a check for IsClipContext() which was preventing updated clip values from being sent while in song / arranger view 
  - e.g. upon release of a selected clip, it should have been sending feedback for the active clip, but it wasn't
- to send feedback for the current clip when you enter a clip view
  - it was sending feedback for the active clip which may not match the current clip you're in
- to send feedback when the active clip changes in song / arranger view
- to send feedback when playback starts 
  - because the feedback values previously received would have been for the last active clip processed which can differ in arranger (and maybe other areas also)
- to send feedback when launching a new clip in song view (which changes the active clip)
- to send feedback when arranger is changing from one clip to the next
  - this also works for sending feedback when you scroll in arranger to another clip and start playback on that clip

Cleaned up some bad comments wrapping I saw as well