### PR TITLE
Bugfix - properly save kit row

### DIFF
--- a/src/deluge/gui/ui/save/save_kit_row_ui.h
+++ b/src/deluge/gui/ui/save/save_kit_row_ui.h
@@ -27,6 +27,7 @@ public:
 	void setup(SoundDrum* drum, ParamManagerForTimeline* paramManager) {
 		soundDrumToSave = drum;
 		paramManagerToSave = paramManager;
+		outputTypeToLoad = OutputType::SYNTH;
 	}
 	bool opened();
 	// void selectEncoderAction(int8_t offset);


### PR DESCRIPTION
Set the storage manager root directory to SYNTHS when saving a kit row, previously it only worked if you'd recently saved/loaded a synth so the directory was already set

Fix #1958 