### PR TITLE
getTriangle: continuous version

### DIFF
--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -368,8 +368,8 @@ template <unsigned saturationAmount>
 }
 
 [[gnu::always_inline]] inline int32_t getTriangle(uint32_t phase) {
-	constexpr int32_t slope = 2;
-	constexpr int32_t offset = 0x80000000u;
+	int32_t slope = 2;
+	int32_t offset = 0x80000000u;
 	if (phase >= 0x80000000u) {
 		slope = -2;
 		offset = 0x80000000u - 1;

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -368,8 +368,13 @@ template <unsigned saturationAmount>
 }
 
 [[gnu::always_inline]] inline int32_t getTriangle(uint32_t phase) {
-	return ((phase < 2147483648u) ? 2 : -2) * phase + 2147483648u;
-	// return getTriangleSmall(phase) << 1;
+	int32_t slope = 2;
+	int32_t offset = 0x80000000u;
+	if (phase >= 0x80000000u) {
+		slope = -2;
+		offset = 0x80000000u - 1;
+	}
+	return slope * phase + offset;
 }
 
 int32_t getDecay8(uint32_t input, uint8_t numBitsInInput);

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -368,8 +368,8 @@ template <unsigned saturationAmount>
 }
 
 [[gnu::always_inline]] inline int32_t getTriangle(uint32_t phase) {
-	int32_t slope = 2;
-	int32_t offset = 0x80000000u;
+	constexpr int32_t slope = 2;
+	constexpr int32_t offset = 0x80000000u;
 	if (phase >= 0x80000000u) {
 		slope = -2;
 		offset = 0x80000000u - 1;


### PR DESCRIPTION
* The original had a discontinuiety at the peak, due to an overflow to the sign bit.

Separate PR for community includes tests. This fixes the LFO sync -associated cracle
for the release.