### PR TITLE
Bug fix performance view param editor rendering

### DIFF
--- a/docs/features/performance_view.md
+++ b/docs/features/performance_view.md
@@ -73,7 +73,7 @@ Param Editing Mode:
 - Press on a shortcut pad to illuminate the FX columns that that parameter has been assigned to.
 - While holding a shortcut pad, press on the FX columns to assign or unassign a parameter to/from a column.
 - Press `HORIZONTAL ENCODER ◀︎▶︎` + `BACK` to clear all existing Parameter assignments.
-- When a Parameter has not been assigned to a column, that column will be lit grey and be unusable in Performance View until you assign a Parameter. This applies to editing the values for that FX column as well (assign a Parameter first, then you can edit the values).
+- When a Parameter has not been assigned to a column, that column will not be lit and be unusable in Performance View until you assign a Parameter. This applies to editing the values for that FX column as well (assign a Parameter first, then you can edit the values).
 - Parameters are saved to PerformanceView.xml. You can manually edit the Parameters in the xml as well, but you must use the exact Parameter names. It is recommended to save a fresh PerformanceView.xml and back it up so you have a record of the Parameter Names.
 
 #### 7) You can Undo/Redo your changes in Performance View

--- a/docs/features/performance_view.md
+++ b/docs/features/performance_view.md
@@ -73,7 +73,7 @@ Param Editing Mode:
 - Press on a shortcut pad to illuminate the FX columns that that parameter has been assigned to.
 - While holding a shortcut pad, press on the FX columns to assign or unassign a parameter to/from a column.
 - Press `HORIZONTAL ENCODER ◀︎▶︎` + `BACK` to clear all existing Parameter assignments.
-- When a Parameter has not been assigned to a column, that column will not be lit and be unusable in Performance View until you assign a Parameter. This applies to editing the values for that FX column as well (assign a Parameter first, then you can edit the values).
+- When a Parameter has not been assigned to a column, that column will not be lit and will be unusable in Performance View until you assign a Parameter. This applies to editing the values for that FX column as well (assign a Parameter first, then you can edit the values).
 - Parameters are saved to PerformanceView.xml. You can manually edit the Parameters in the xml as well, but you must use the exact Parameter names. It is recommended to save a fresh PerformanceView.xml and back it up so you have a record of the Parameter Names.
 
 #### 7) You can Undo/Redo your changes in Performance View

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -358,6 +358,30 @@ void PerformanceSessionView::renderRow(RGB* image, int32_t yDisplay) {
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		RGB& pixel = image[xDisplay];
 
+		// if an FX column has not been assigned a param, erase pad
+		if (layoutForPerformance[xDisplay].paramID == kNoSelection) {
+			pixel = colours::black;
+		}
+		else {
+			// if you're currently pressing an FX column, highlight it a bright colour
+			if ((fxPress[xDisplay].currentKnobPosition != kNoSelection) && (fxPress[xDisplay].padPressHeld == false)) {
+				pixel = layoutForPerformance[xDisplay].rowColour;
+			}
+			// if you're not currently pressing an FX column, highlight it a dimmer colour
+			else {
+				pixel = layoutForPerformance[xDisplay].rowTailColour;
+			}
+
+			// if you're currently pressing an FX column, highlight the pad you're pressing white
+			if ((fxPress[xDisplay].currentKnobPosition == defaultFXValues[xDisplay][yDisplay])
+			    && (fxPress[xDisplay].yDisplay == yDisplay)) {
+				pixel = {
+				    .r = 130,
+				    .g = 120,
+				    .b = 130,
+				};
+			}
+		}
 		if (editingParam) {
 			// if you're in param editing mode, highlight shortcuts for performance view params
 			// if param has been assigned to an FX column, highlight it white, otherwise highlight it grey
@@ -379,35 +403,7 @@ void PerformanceSessionView::renderRow(RGB* image, int32_t yDisplay) {
 			if (firstPadPress.isActive) {
 				if ((layoutForPerformance[xDisplay].paramKind == firstPadPress.paramKind)
 				    && (layoutForPerformance[xDisplay].paramID == firstPadPress.paramID)) {
-					pixel = layoutForPerformance[xDisplay].rowTailColour;
-				}
-			}
-		}
-		else {
-			// elsewhere in performance view, if an FX column has not been assigned a param,
-			// highlight the column grey
-			if (layoutForPerformance[xDisplay].paramID == kNoSelection) {
-				pixel = colours::grey;
-			}
-			else {
-				// if you're currently pressing an FX column, highlight it a bright colour
-				if ((fxPress[xDisplay].currentKnobPosition != kNoSelection)
-				    && (fxPress[xDisplay].padPressHeld == false)) {
 					pixel = layoutForPerformance[xDisplay].rowColour;
-				}
-				// if you're not currently pressing an FX column, highlight it a dimmer colour
-				else {
-					pixel = layoutForPerformance[xDisplay].rowTailColour;
-				}
-
-				// if you're currently pressing an FX column, highlight the pad you're pressing white
-				if ((fxPress[xDisplay].currentKnobPosition == defaultFXValues[xDisplay][yDisplay])
-				    && (fxPress[xDisplay].yDisplay == yDisplay)) {
-					pixel = {
-					    .r = 130,
-					    .g = 120,
-					    .b = 130,
-					};
 				}
 			}
 		}


### PR DESCRIPTION
Fixed rendering of param editor by always rendering the FX columns when a param has been assigned to them

Render param shortcuts on top of the rendered FX columns

Render param columns their bright colour when holding a shortcut pad

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1973
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1976