### PR TITLE
Bug fix - performance view - default value gets lost + some other minor bug fixes

### DIFF
--- a/src/deluge/gui/menu_item/performance_session_view/editing_mode.h
+++ b/src/deluge/gui/menu_item/performance_session_view/editing_mode.h
@@ -61,12 +61,15 @@ public:
 			indicator_leds::setLedState(IndicatorLED::KEYBOARD, true);
 		}
 
-		if (performanceSessionView.defaultEditingMode && !performanceSessionView.editingParam) {
+		if (!performanceSessionView.editingParam) {
+			// reset performance view when you switch modes
+			// but not when in param editing mode cause that would reset param assignments to FX columns
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithThreeMainThings* modelStack =
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 			performanceSessionView.resetPerformanceView(modelStack);
 		}
+
 		uiNeedsRendering(&performanceSessionView, 0xFFFFFFFF, 0); // refresh main pads only);
 	}
 	deluge::vector<std::string_view> getOptions() override {

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -191,8 +191,7 @@ PerformanceSessionView::PerformanceSessionView() {
 	gridModeActive = false;
 	timeGridModePress = 0;
 
-	initPadPress(firstPadPress);
-	initPadPress(lastPadPress);
+	resetPadPressInfo();
 
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		initFXPress(fxPress[xDisplay]);
@@ -900,7 +899,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				releaseStutter(modelStack);
 			}
 			else if (b == BACK) {
-				initPadPress(lastPadPress);
+				resetPadPressInfo();
 				updateLayoutChangeStatus();
 				if (onFXDisplay) {
 					renderViewDisplay();
@@ -1292,8 +1291,7 @@ bool PerformanceSessionView::anyChangesToLog() {
 /// in param editor, it will clear existing param mappings
 /// in regular performance view or value editor, it will clear held pads and reset param values to pre-held state
 void PerformanceSessionView::resetPerformanceView(ModelStackWithThreeMainThings* modelStack) {
-	initPadPress(firstPadPress);
-	initPadPress(lastPadPress);
+	resetPadPressInfo();
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		if (editingParam) {
 			initLayout(layoutForPerformance[xDisplay]);
@@ -1330,9 +1328,14 @@ void PerformanceSessionView::resetFXColumn(ModelStackWithThreeMainThings* modelS
 
 /// reset press info and stutter when exiting performance view
 void PerformanceSessionView::releaseViewOnExit(ModelStackWithThreeMainThings* modelStack) {
+	resetPadPressInfo();
+	releaseStutter(modelStack);
+}
+
+/// initialize pad press info structs
+void PerformanceSessionView::resetPadPressInfo() {
 	initPadPress(firstPadPress);
 	initPadPress(lastPadPress);
-	releaseStutter(modelStack);
 }
 
 /// check if stutter is active and release it if it is

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -1027,7 +1027,8 @@ void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* mode
 					if ((layoutForPerformance[i].paramKind == lastSelectedParamKind)
 					    && (layoutForPerformance[i].paramID == lastSelectedParamID)) {
 						// check if you're holding a pad for the same param in another column
-						// check if you're not holding a pad, but a pad is in held state for the same param in another column
+						// check if you're not holding a pad, but a pad is in held state for the same param in another
+						// column
 						if ((lastPadPress.isActive && lastPadPress.xDisplay == i) || fxPress[i].padPressHeld) {
 							fxPress[xDisplay].previousKnobPosition = fxPress[i].previousKnobPosition;
 							initFXPress(fxPress[i]);

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -707,7 +707,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
-			releaseStutter(modelStack);
+			releaseViewOnExit(modelStack);
 			sessionView.transitionToViewForClip(); // May fail if no currentClip
 		}
 	}
@@ -871,10 +871,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 			}
 			else {
 				gridModeActive = false;
-				// reset press info and stutter when exiting performance view
-				initPadPress(firstPadPress);
-				initPadPress(lastPadPress);
-				releaseStutter(modelStack);
+				releaseViewOnExit(modelStack);
 				if (currentSong->lastClipInstanceEnteredStartPos != -1) {
 					changeRootUI(&arrangerView);
 				}
@@ -992,20 +989,14 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 								    && ((AudioEngine::audioSampleTimer - timeGridModePress)
 								        >= FlashStorage::holdTime)) {
 									gridModeActive = false;
-									// reset press info and stutter when exiting performance view
-									initPadPress(firstPadPress);
-									initPadPress(lastPadPress);
-									releaseStutter(modelStack);
+									releaseViewOnExit(modelStack);
 									changeRootUI(&sessionView);
 								}
 							}
 							// if you pressed the green or blue mode pads, go back to grid view and change mode
 							else if ((yDisplay == 7) || (yDisplay == 6)) {
 								gridModeActive = false;
-								// reset press info and stutter when exiting performance view
-								initPadPress(firstPadPress);
-								initPadPress(lastPadPress);
-								releaseStutter(modelStack);
+								releaseViewOnExit(modelStack);
 								changeRootUI(&sessionView);
 								sessionView.gridHandlePads(xDisplay, yDisplay, on);
 							}
@@ -1335,6 +1326,13 @@ void PerformanceSessionView::resetFXColumn(ModelStackWithThreeMainThings* modelS
 		}
 	}
 	updateLayoutChangeStatus();
+}
+
+/// reset press info and stutter when exiting performance view
+void PerformanceSessionView::releaseViewOnExit(ModelStackWithThreeMainThings* modelStack) {
+	initPadPress(firstPadPress);
+	initPadPress(lastPadPress);
+	releaseStutter(modelStack);
 }
 
 /// check if stutter is active and release it if it is

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -853,13 +853,17 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 				}
 				else {
 					if (!defaultEditingMode) {
-						resetPerformanceView(modelStack);
 						indicator_leds::blinkLed(IndicatorLED::KEYBOARD);
 					}
 					else {
 						editingParam = true;
 					}
 					defaultEditingMode = true;
+				}
+				if (!editingParam) {
+					// reset performance view when you switch modes
+					// but not when in param editing mode cause that would reset param assignments to FX columns
+					resetPerformanceView(modelStack);
 				}
 				updateLayoutChangeStatus();
 				renderViewDisplay();
@@ -1288,6 +1292,8 @@ bool PerformanceSessionView::anyChangesToLog() {
 /// in param editor, it will clear existing param mappings
 /// in regular performance view or value editor, it will clear held pads and reset param values to pre-held state
 void PerformanceSessionView::resetPerformanceView(ModelStackWithThreeMainThings* modelStack) {
+	initPadPress(firstPadPress);
+	initPadPress(lastPadPress);
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 		if (editingParam) {
 			initLayout(layoutForPerformance[xDisplay]);

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -871,6 +871,9 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 			}
 			else {
 				gridModeActive = false;
+				// reset press info and stutter when exiting performance view
+				initPadPress(firstPadPress);
+				initPadPress(lastPadPress);
 				releaseStutter(modelStack);
 				if (currentSong->lastClipInstanceEnteredStartPos != -1) {
 					changeRootUI(&arrangerView);
@@ -989,6 +992,9 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 								    && ((AudioEngine::audioSampleTimer - timeGridModePress)
 								        >= FlashStorage::holdTime)) {
 									gridModeActive = false;
+									// reset press info and stutter when exiting performance view
+									initPadPress(firstPadPress);
+									initPadPress(lastPadPress);
 									releaseStutter(modelStack);
 									changeRootUI(&sessionView);
 								}
@@ -996,6 +1002,9 @@ ActionResult PerformanceSessionView::padAction(int32_t xDisplay, int32_t yDispla
 							// if you pressed the green or blue mode pads, go back to grid view and change mode
 							else if ((yDisplay == 7) || (yDisplay == 6)) {
 								gridModeActive = false;
+								// reset press info and stutter when exiting performance view
+								initPadPress(firstPadPress);
+								initPadPress(lastPadPress);
 								releaseStutter(modelStack);
 								changeRootUI(&sessionView);
 								sessionView.gridHandlePads(xDisplay, yDisplay, on);

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -1026,9 +1026,13 @@ void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* mode
 				if (i != xDisplay) {
 					if ((layoutForPerformance[i].paramKind == lastSelectedParamKind)
 					    && (layoutForPerformance[i].paramID == lastSelectedParamID)) {
-						fxPress[xDisplay].previousKnobPosition = fxPress[i].previousKnobPosition;
-						initFXPress(fxPress[i]);
-						logPerformanceViewPress(i, false);
+						// check if you're holding a pad for the same param in another column
+						// check if you're not holding a pad, but a pad is in held state for the same param in another column
+						if ((lastPadPress.isActive && lastPadPress.xDisplay == i) || fxPress[i].padPressHeld) {
+							fxPress[xDisplay].previousKnobPosition = fxPress[i].previousKnobPosition;
+							initFXPress(fxPress[i]);
+							logPerformanceViewPress(i, false);
+						}
 					}
 				}
 			}

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -153,6 +153,7 @@ private:
 	                      int32_t paramID, int32_t xDisplay, bool renderDisplay = true);
 	void resetFXColumn(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay);
 	void releaseViewOnExit(ModelStackWithThreeMainThings* modelStack);
+	void resetPadPressInfo();
 	void releaseStutter(ModelStackWithThreeMainThings* modelStack);
 
 	/// write/load default values

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -152,6 +152,7 @@ private:
 	void padReleaseAction(ModelStackWithThreeMainThings* modelStack, deluge::modulation::params::Kind paramKind,
 	                      int32_t paramID, int32_t xDisplay, bool renderDisplay = true);
 	void resetFXColumn(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay);
+	void releaseViewOnExit(ModelStackWithThreeMainThings* modelStack);
 	void releaseStutter(ModelStackWithThreeMainThings* modelStack);
 
 	/// write/load default values


### PR DESCRIPTION
Fixed scenario where when you assign the same param to multiple FX columns that when you transfer a held pad from one column to the next (whether via short press or long press), the release (default) value was getting lost.

This was happening because it was iterating through all FX columns, even the ones not currently active (only active ones hold the default release value).

Also somewhat related, fixed some issues where stale pad press info could exist when changing performance view modes or exiting performance view which can result in stuck presses. Made sure to reset things properly.

fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1974