### PR TITLE
UX/Disable high cpu by default

### DIFF
--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -662,7 +662,7 @@ void readSettings() {
 		defaultSliceMode = static_cast<SampleRepeatMode>(buffer[167]);
 	}
 
-	if (buffer[169] != false && buffer[169] != true) {
+	if (buffer[169] != 0 && buffer[169] != 1) {
 		highCPUUsageIndicator = false;
 	}
 	else {


### PR DESCRIPTION
Condition would never pass, so this would usually get set to true if there was any garbage in the flash bytes