### PR TITLE
debug: better audio logs on soft cull

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2419,6 +2419,7 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, this);
 
+	AudioEngine::logAction("Start output render");
 	for (Output* output = firstOutput; output; output = output->next) {
 		if (!output->inValidState) {
 			continue;
@@ -2426,10 +2427,11 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 
 		bool isClipActiveNow = (output->activeClip && isClipActive(output->activeClip->getClipBeingRecordedFrom()));
 
-		// AudioEngine::logAction("outp->render");
 		output->renderOutput(modelStack, outputBuffer, outputBuffer + numSamples, numSamples, reverbBuffer,
 		                     volumePostFX >> 1, sideChainHitPending, !isClipActiveNow, isClipActiveNow);
-		// AudioEngine::logAction("/outp->render");
+		char buf[64];
+		snprintf(buf, sizeof(buf), "complete: %s", output->name.get());
+		AudioEngine::logAction(buf);
 	}
 
 	// If recording the "MIX", this is the place where we want to grab it - before any master FX or volume applied

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2429,9 +2429,11 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 
 		output->renderOutput(modelStack, outputBuffer, outputBuffer + numSamples, numSamples, reverbBuffer,
 		                     volumePostFX >> 1, sideChainHitPending, !isClipActiveNow, isClipActiveNow);
+#if DO_AUDIO_LOG
 		char buf[64];
 		snprintf(buf, sizeof(buf), "complete: %s", output->name.get());
 		AudioEngine::logAction(buf);
+#endif
 	}
 
 	// If recording the "MIX", this is the place where we want to grab it - before any master FX or volume applied

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -270,7 +270,6 @@ void songSwapAboutToHappen() {
 
 enum CullType { HARD, FORCE, SOFT_ALWAYS, SOFT };
 
-#define DO_AUDIO_LOG 0 // For advanced debugging printouts.
 #define AUDIO_LOG_SIZE 64
 bool definitelyLog = false;
 #if DO_AUDIO_LOG
@@ -327,7 +326,9 @@ Voice* cullVoice(bool saveVoice, CullType type, size_t numSamples, Sound* stopFr
 #if ALPHA_OR_BETA_VERSION
 				D_PRINTLN("soft-culled 1 voice.  numSamples:  %d. Voices left: %d. Audio clips left: %d", numSamples,
 				          getNumVoices(), getNumAudio());
+#if DO_AUDIO_LOG
 				dumpAudioLog();
+#endif
 #endif
 			}
 			break;
@@ -921,7 +922,9 @@ startAgain:
 		enableTimer(TIMER_MIDI_GATE_OUTPUT);
 	}
 
+#if DO_AUDIO_LOG
 	dumpAudioLog();
+#endif
 
 	sideChainHitPending = 0;
 	audioSampleTimer += numSamples;

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -122,6 +122,9 @@ class Reverb;
  * any that improve overall performance.
  */
 
+/// For advanced debugging printouts.
+#define DO_AUDIO_LOG 0
+
 namespace AudioEngine {
 void routine();
 void routineWithClusterLoading(bool mayProcessUserActionsBetween = false);


### PR DESCRIPTION
Debug logs I added for diagnosing what is going wrong in #1961.

Doesn't handle CV/MIDI tracks well because those don't set `output->name` to anything useful, but I think this is still an improvement.