### PR TITLE
Fix collect and save

### DIFF
--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -364,7 +364,7 @@ fail3:
 							break; // Stop, on rare case where file ended right at end of last cluster
 						}
 
-						auto written = created.value().write({(std::byte*)smSerializer.writeClusterBuffer, bytesRead});
+						auto written = created.value().write({(std::byte*)smDeserializer.fileClusterBuffer, bytesRead});
 						if (!written || written.value() != bytesRead) {
 							D_PRINTLN("write fail %d", result);
 							goto fail3;


### PR DESCRIPTION
Naive fix that works the same way it used to work before the storage manager refactoring.

Fixes #1995 