### PR TITLE
Bugfix - set recording file to newly opened one

### DIFF
--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -1458,6 +1458,7 @@ writeFailed:
 			if (!opened) {
 				return Error::SD_CARD;
 			}
+			this->file = opened.value();
 
 			Error error = truncateFileDownToSize(dataLengthAfterAction + sample->audioDataStartPosBytes);
 			if (error != Error::NONE) {


### PR DESCRIPTION
The sample recorder's file wasn't being set to the opened one with FA_WRITE access