### PR TITLE
sysex-logging: flush output after each message

### DIFF
--- a/scripts/tasks/task-sysex-logging.py
+++ b/scripts/tasks/task-sysex-logging.py
@@ -99,7 +99,7 @@ def sysex_console(midiout, midiin):
             ):
                 target_bytes = unpack_7bit_to_8bit(msg[5:-1])
                 decoded = target_bytes.decode("ascii").replace("\n", "")
-                print(decoded)
+                print(decoded, flush=True)
         else:
             # add a short sleep so the while loop doesn't hammer your cpu
             time.sleep(0.01)


### PR DESCRIPTION
* At least on Windows, when running though ./dbt.cmd python doesn't realize there's a terminal, and output was being buffered.