### PR TITLE
Bugfix - read patched params if the mod controllable is a sound

### DIFF
--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1221,8 +1221,12 @@ doReadPatchedParam:
 						relative = storageManager.readTagOrAttributeValueInt();
 					}
 					else if (!strcmp(tagName, "controlsParam")) {
+						// if the unpatched kind for the current mod controllable is sound then we also want to check
+						// against patched params. Otherwise skip them to avoid a bug from patched volume params having
+						// the same name in files as unpatched global volumes
 						p = params::fileStringToParam(unpatchedParamKind_, storageManager.readTagOrAttributeValue(),
-						                              false);
+						                              unpatchedParamKind_
+						                                  == deluge::modulation::params::Kind::UNPATCHED_SOUND);
 					}
 					else if (!strcmp(tagName, "patchAmountFromSource")) {
 						s = stringToSource(storageManager.readTagOrAttributeValue());

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -79,6 +79,7 @@ const PatchableInfo patchableInfoForSound = {
     GLOBALITY_GLOBAL};
 
 Sound::Sound() : patcher(&patchableInfoForSound) {
+	unpatchedParamKind_ = params::Kind::UNPATCHED_SOUND;
 
 	for (int32_t s = 0; s < kNumSources; s++) {
 		oscRetriggerPhase[s] = 0xFFFFFFFF;


### PR DESCRIPTION
Reading patched params when the mod controllable is a global effectable leads to a bug since names are reused for song parameters and patched sound parameters. They were incorrectly never read, this restores reading them for sounds.

This was brought into release by #1959 but existed in nightly since #1778 