### PR TITLE
Bugfix - clear automation overview in kit when no drum is selected

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1049,6 +1049,9 @@ void AutomationView::renderLove(RGB image[][kDisplayWidth + kSideBarWidth],
 			pixel = rowColour[yDisplay];
 			occupancyMask[yDisplay][xDisplay] = 64;
 		}
+		else {
+			pixel = colours::black; // clear pads
+		}
 	}
 }
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -722,17 +722,9 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 				renderLove(image, occupancyMask, xDisplay);
 			}
 			else {
-				clearColumn(image, xDisplay);
+				PadLEDs::clearColumnWithoutSending(xDisplay);
 			}
 		}
-	}
-}
-
-// erase all pads in a column of the grid
-void AutomationView::clearColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t xDisplay) {
-	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-		RGB& pixel = image[yDisplay][xDisplay];
-		pixel = colours::black;
 	}
 }
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -721,7 +721,18 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 			if (outputType == OutputType::CV) {
 				renderLove(image, occupancyMask, xDisplay);
 			}
+			else {
+				clearColumn(image, xDisplay);
+			}
 		}
+	}
+}
+
+// erase all pads in a column of the grid
+void AutomationView::clearColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t xDisplay) {
+	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+		RGB& pixel = image[yDisplay][xDisplay];
+		pixel = colours::black;
 	}
 }
 

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -214,6 +214,7 @@ private:
 	                         TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay);
 	void renderLove(RGB image[][kDisplayWidth + kSideBarWidth], uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
 	                int32_t xDisplay);
+	void clearColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t xDisplay);
 	void renderDisplayOLED(Clip* clip, OutputType outputType, int32_t knobPosLeft = kNoSelection,
 	                       int32_t knobPosRight = kNoSelection);
 	void renderDisplay7SEG(Clip* clip, OutputType outputType, int32_t knobPosLeft = kNoSelection,

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -214,7 +214,6 @@ private:
 	                         TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay);
 	void renderLove(RGB image[][kDisplayWidth + kSideBarWidth], uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
 	                int32_t xDisplay);
-	void clearColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t xDisplay);
 	void renderDisplayOLED(Clip* clip, OutputType outputType, int32_t knobPosLeft = kNoSelection,
 	                       int32_t knobPosRight = kNoSelection);
 	void renderDisplay7SEG(Clip* clip, OutputType outputType, int32_t knobPosLeft = kNoSelection,

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -243,6 +243,12 @@ void clearSideBar() {
 	sendOutSidebarColours();
 }
 
+void clearColumnWithoutSending(int32_t x) {
+	for (auto& y : image) {
+		y[x] = gui::colours::black;
+	}
+}
+
 RGB prepareColour(int32_t x, int32_t y, RGB colourSource);
 
 // You'll want to call uartFlushToPICIfNotSending() after this

--- a/src/deluge/hid/led/pad_leds.h
+++ b/src/deluge/hid/led/pad_leds.h
@@ -65,6 +65,7 @@ void renderClipExpandOrCollapse();
 void renderNoteRowExpandOrCollapse();
 void clearAllPadsWithoutSending();
 void clearMainPadsWithoutSending();
+void clearColumnWithoutSending(int32_t x);
 
 void sendOutMainPadColours();
 void sendOutMainPadColoursSoon();


### PR DESCRIPTION
Clear automation overview pads in kit clip when no drum is selected

Also fixed bug with some pads not getting cleared on cv clip automation overview