### PR TITLE
Bugfix ~ Automation View - kit row - affect entire selection error message

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -700,9 +700,17 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 	}
 
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+		// only render if:
+		// you're on arranger view
+		// you're not in a CV clip type
+		// you're not in a kit where you haven't selected a drum and you haven't selected affect entire either
+		// you're not in a kit where no sound drum has been selected
 		if (onArrangerView
 		    || (outputType != OutputType::CV
-		        && !(outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum))) {
+		        && !(outputType == OutputType::KIT && !getAffectEntire()
+		             && (!((Kit*)clip->output)->selectedDrum
+		                 || ((Kit*)clip->output)->selectedDrum
+		                        && ((Kit*)clip->output)->selectedDrum->type != DrumType::SOUND)))) {
 
 			// if parameter has been selected, show Automation Editor
 			if (inAutomationEditor()) {
@@ -1129,7 +1137,12 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 		char const* overviewText;
 		if (onArrangerView || outputType != OutputType::CV) {
 			if (!onArrangerView
-			    && (outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)clip->output)->selectedDrum)) {
+			    && (outputType == OutputType::KIT && !getAffectEntire()
+			        && (!((Kit*)clip->output)->selectedDrum
+			            || ((Kit*)clip->output)->selectedDrum
+			                   && ((Kit*)clip->output)->selectedDrum->type != DrumType::SOUND))) {
+				// display error message to select kit row or affect entire when:
+				// you're in a kit clip and you haven't selected a sound drum or enabled affect entire
 				overviewText = l10n::get(l10n::String::STRING_FOR_SELECT_A_ROW_OR_AFFECT_ENTIRE);
 				deluge::hid::display::OLED::drawPermanentPopupLookingText(overviewText);
 			}
@@ -1233,7 +1246,12 @@ void AutomationView::renderDisplay7SEG(Clip* clip, OutputType outputType, int32_
 		char const* overviewText;
 		if (onArrangerView || outputType != OutputType::CV) {
 			if (!onArrangerView
-			    && (outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)clip->output)->selectedDrum)) {
+			    && (outputType == OutputType::KIT && !getAffectEntire()
+			        && (!((Kit*)clip->output)->selectedDrum
+			            || ((Kit*)clip->output)->selectedDrum
+			                   && ((Kit*)clip->output)->selectedDrum->type != DrumType::SOUND))) {
+				// display error message to select kit row or affect entire when:
+				// you're in a kit clip and you haven't selected a sound drum or enabled affect entire
 				overviewText = l10n::get(l10n::String::STRING_FOR_SELECT_A_ROW_OR_AFFECT_ENTIRE);
 			}
 			else {


### PR DESCRIPTION
Fixed error message in automation view for kit's that advises the user to select a kit row or enable affect entire if they have affect entire disabled and haven't selected a sound drum