### PR TITLE
Bugfix - automation view clip clear popup message

### DIFF
--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -422,17 +422,16 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 			// automations, you will enter Automation Clip View and clear the clip there. If this is enabled, the
 			// message displayed on the OLED screen is adjusted to reflect the nature of what is being cleared
 
-			if (FlashStorage::automationClear) {
-				if (currentUI == &automationView) {
-					display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_CLEARED));
-				}
-				else if (currentUI == &instrumentClipView) {
-					display->displayPopup(l10n::get(l10n::String::STRING_FOR_NOTES_CLEARED));
-				}
+			if (currentUI == &automationView) {
+				display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_CLEARED));
+			}
+			else if (FlashStorage::automationClear) {
+				display->displayPopup(l10n::get(l10n::String::STRING_FOR_NOTES_CLEARED));
 			}
 			else {
 				display->displayPopup(l10n::get(l10n::String::STRING_FOR_CLIP_CLEARED));
 			}
+			
 			uiNeedsRendering(currentUI, 0xFFFFFFFF, 0);
 		}
 	}

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -431,7 +431,7 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 			else {
 				display->displayPopup(l10n::get(l10n::String::STRING_FOR_CLIP_CLEARED));
 			}
-			
+
 			uiNeedsRendering(currentUI, 0xFFFFFFFF, 0);
 		}
 	}


### PR DESCRIPTION
Fixed message displayed when you clear clip while in automation view

When FlashStorage::automationClear is false, it was incorrectly showing "clip cleared" instead of "automation cleared" while in automation view.

While in automation view, you're never clearing the whole clip, so that message was wrong.