### PR TITLE
Scheduler - reconfigure minimum time to be a gauranteed backoff between calls

### DIFF
--- a/src/OSLikeStuff/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler.h
@@ -25,10 +25,12 @@ extern "C" {
 /// void function with no arguments
 typedef void (*TaskHandle)();
 typedef int8_t TaskID;
-/// highest priority is 0. Attempt to schedule the task every maxTime after minTime has passed, in priority order
-/// if runToCompletion is false the task will be interrupted by higher priority requirements, otherwise it will run
-/// until it returns. returns the index of the task in the global table
-uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double minTimeBetweenCalls, double targetTimeBetweenCalls,
+/// highest priority is 0.
+/// min time is the minimum time from when the task finishes to when it's next called
+/// target time is the desired time between calls
+/// max time is the maximum time between calls
+/// The scheduler runs the lowest priority task that can finish before anything higher priority needs to start
+uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, double targetTimeBetweenCalls,
                          double maxTimeBetweenCalls);
 
 /// Add a task to run once, aiming to run at current time + timeToWait and worst case run at timeToWait*10

--- a/src/OSLikeStuff/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler.h
@@ -25,11 +25,20 @@ extern "C" {
 /// void function with no arguments
 typedef void (*TaskHandle)();
 typedef int8_t TaskID;
-/// highest priority is 0.
-/// min time is the minimum time from when the task finishes to when it's next called
-/// target time is the desired time between calls
-/// max time is the maximum time between calls
-/// The scheduler runs the lowest priority task that can finish before anything higher priority needs to start
+/// Schedule a task that will be called at a regular interval.
+///
+/// The scheduler will try to run the task at a regular cadence such that the time between start of calls to the
+/// task is approximately targetTimeBetweenCalls. It will never call the task sooner than backOffTime seconds after it
+/// last completed.
+///
+/// Tasks are selected to run based on priority and expected duration (computed via a running average of previous
+/// invocations of the task). The task with the lowest priority that can complete before a task with higher
+/// priority needs to start will run, without violation of the backOffTime.
+///
+/// @param task The task to call
+/// @param priority Priority of the task. Tasks with lower numbers are given preference over tasks with higher numbers.
+/// @param backOffTime Minimum time from completing the task to calling it again in seconds.
+/// @param targetTimeBetweenCalls Desired time between calls to the task, including the runtime for the task itself.
 uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, double targetTimeBetweenCalls,
                          double maxTimeBetweenCalls);
 

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -88,6 +88,17 @@ TEST(Scheduler, scheduleOnce) {
 	mock().checkExpectations();
 };
 
+TEST(Scheduler, backOffTime) {
+	mock().clear();
+	// will be called one less time due to the time the sleep takes not being zero
+	mock().expectNCalls(9, "sleep_50ns");
+	taskManager.addRepeatingTask(sleep_50ns, 1, 0.01, 0.001, 1);
+	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
+	taskManager.start(0.1);
+	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
+	mock().checkExpectations();
+};
+
 TEST(Scheduler, scheduleOnceWithRepeating) {
 	mock().clear();
 	mock().expectNCalls(0.01 / 0.001 - 1, "sleep_50ns");


### PR DESCRIPTION
Change the minimum time to measure from last return instead of last call

This makes it into a backoff that guarantees some time for lower priority tasks to run