### PR TITLE
Bugfix - fix incorrect bool conversion

### DIFF
--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -653,7 +653,7 @@ startAgain:
 		memoryStart += extraElementsLeft;
 
 		minNumToExtend -= extraElementsLeft;
-		if (!minNumToExtend) {
+		if (minNumToExtend <= 0) {
 			return true;
 		}
 		idealNumToExtendIfExtendingAllocation -= extraElementsLeft;
@@ -676,7 +676,7 @@ startAgain:
 		memorySize += extraElementsRight;
 
 		minNumToExtend -= extraElementsRight;
-		if (!minNumToExtend) {
+		if (minNumToExtend <= 0) {
 			return true;
 		}
 		idealNumToExtendIfExtendingAllocation -= extraElementsRight;


### PR DESCRIPTION
Incorrect cast meant that resizeable arrays could get stuck if they try to expand while having more space available than the size of expansion they're requesting. 

In dynamic ones this causes extra allocations, in static ones this causing insertion failures. 