### PR TITLE
[DRAFT] Timeline position indicator

### DIFF
--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -150,10 +150,6 @@ ActionResult ClipView::horizontalEncoderAction(int32_t offset) {
 
 		// If we're not scrolled all the way to the right, go there now
 		if (scrollRightToEndOfLengthIfNecessary(oldLength)) {
-
-			if (display->haveOLED()) {
-				renderUIsForOled();
-			}
 			return ActionResult::DEALT_WITH;
 		}
 
@@ -171,10 +167,6 @@ ActionResult ClipView::horizontalEncoderAction(int32_t offset) {
 
 		if (action) {
 			action->xScrollClip[AFTER] = currentSong->xScroll[NAVIGATION_CLIP];
-		}
-
-		if (display->haveOLED()) {
-			renderUIsForOled();
 		}
 		return ActionResult::DEALT_WITH;
 	}

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -150,6 +150,10 @@ ActionResult ClipView::horizontalEncoderAction(int32_t offset) {
 
 		// If we're not scrolled all the way to the right, go there now
 		if (scrollRightToEndOfLengthIfNecessary(oldLength)) {
+
+			if (display->haveOLED()) {
+				renderUIsForOled();
+			}
 			return ActionResult::DEALT_WITH;
 		}
 
@@ -167,6 +171,10 @@ ActionResult ClipView::horizontalEncoderAction(int32_t offset) {
 
 		if (action) {
 			action->xScrollClip[AFTER] = currentSong->xScroll[NAVIGATION_CLIP];
+		}
+
+		if (display->haveOLED()) {
+			renderUIsForOled();
 		}
 		return ActionResult::DEALT_WITH;
 	}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -5334,6 +5334,8 @@ void InstrumentClipView::performActualRender(uint32_t whichRows, RGB* image,
 
 		image += imageWidth;
 	}
+
+	renderMainImage(*clip, clip->getLoopLength());
 }
 
 void InstrumentClipView::playbackEnded() {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -689,6 +689,7 @@ doOther:
 					else {
 						displayZoomLevel();
 					}
+					renderUIsForOled();
 				}
 			}
 			// Whether or not we did the "multiply" action above, we need to be in this UI mode, e.g. for rotating
@@ -5265,6 +5266,12 @@ void InstrumentClipView::notifyPlaybackBegun() {
 	reassessAllAuditionStatus();
 }
 
+void InstrumentClipView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
+	InstrumentClip* clip = getCurrentInstrumentClip();
+	InstrumentClipMinder::renderOLED(canvas);
+	TimelineView::renderTickIndicator(canvas, *clip, clip->getLoopLength());
+}
+
 bool InstrumentClipView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
                                         bool drawUndefinedArea) {
@@ -5334,8 +5341,6 @@ void InstrumentClipView::performActualRender(uint32_t whichRows, RGB* image,
 
 		image += imageWidth;
 	}
-
-	renderMainImage(*clip, clip->getLoopLength());
 }
 
 void InstrumentClipView::playbackEnded() {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -689,7 +689,6 @@ doOther:
 					else {
 						displayZoomLevel();
 					}
-					renderUIsForOled();
 				}
 			}
 			// Whether or not we did the "multiply" action above, we need to be in this UI mode, e.g. for rotating
@@ -4554,7 +4553,6 @@ wantToEditNoteRowLength:
 
 			editNoteRowLength(modelStackWithNoteRow, offset, lastAuditionedYDisplay);
 			editedAnyPerNoteRowStuffSinceAuditioningBegan = true;
-			renderUIsForOled();
 		}
 
 		// Unlike for all other cases where we protect against the user accidentally turning the encoder more after
@@ -5118,6 +5116,9 @@ void InstrumentClipView::graphicsRoutine() {
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
 	InstrumentClip* clip = (InstrumentClip*)modelStack->getTimelineCounter();
+
+	TimelineView::renderTickIndicator(deluge::hid::display::OLED::main, *clip, clip->getMaxLength());
+	deluge::hid::display::OLED::sendMainImage();
 
 	if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING) || isUIModeActive(UI_MODE_IMPLODE_ANIMATION)) {
 		return;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4554,6 +4554,7 @@ wantToEditNoteRowLength:
 
 			editNoteRowLength(modelStackWithNoteRow, offset, lastAuditionedYDisplay);
 			editedAnyPerNoteRowStuffSinceAuditioningBegan = true;
+			renderUIsForOled();
 		}
 
 		// Unlike for all other cases where we protect against the user accidentally turning the encoder more after
@@ -5269,7 +5270,7 @@ void InstrumentClipView::notifyPlaybackBegun() {
 void InstrumentClipView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	InstrumentClip* clip = getCurrentInstrumentClip();
 	InstrumentClipMinder::renderOLED(canvas);
-	TimelineView::renderTickIndicator(canvas, *clip, clip->getLoopLength());
+	TimelineView::renderTickIndicator(canvas, *clip, clip->getMaxLength());
 }
 
 bool InstrumentClipView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -158,9 +158,7 @@ public:
 	void pasteAutomation(int32_t whichModEncoder, int32_t navSysId = NAVIGATION_CLIP);
 	// made these public so they can be accessed by the automation clip view
 
-	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override {
-		InstrumentClipMinder::renderOLED(canvas);
-	}
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	CopiedNoteRow* firstCopiedNoteRow;
 	int32_t copiedScreenWidth;

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -210,10 +210,6 @@ ActionResult TimelineView::horizontalEncoderAction(int32_t offset) {
 	}
 
 getOut:
-	if (display->haveOLED()) {
-		renderUIsForOled();
-	}
-
 	horizontalEncoderActionLock = false;
 	return ActionResult::DEALT_WITH;
 }
@@ -326,7 +322,7 @@ void TimelineView::renderTickIndicator(deluge::hid::display::oled_canvas::Canvas
 	constexpr int32_t kBarRenderTop = OLED_MAIN_TOPMOST_PIXEL - 1;
 	constexpr int32_t kBarRenderHeight = 2;
 
-	canvas.clearAreaExact(0, kBarRenderTop - 1, OLED_MAIN_WIDTH_PIXELS - 1, OLED_MAIN_HEIGHT_PIXELS - 1);
+	canvas.clearAreaExact(0, kBarRenderTop, OLED_MAIN_WIDTH_PIXELS - 1, kBarRenderTop + kBarRenderHeight);
 
 	canvas.drawPixel(0, kBarRenderTop);
 	for (auto i = 1; i <= totalBars; ++i) {
@@ -339,6 +335,10 @@ void TimelineView::renderTickIndicator(deluge::hid::display::oled_canvas::Canvas
 	auto lineEnd = static_cast<int32_t>(((viewEndPos - 1) * OLED_MAIN_WIDTH_PIXELS) / totalTicks);
 
 	canvas.drawHorizontalLine(kBarRenderTop, lineStart, lineEnd);
+	canvas.drawPixel((livePos * OLED_MAIN_WIDTH_PIXELS) / totalTicks, kBarRenderTop + 1);
+
+	// TODO: only mark dirty if we actually changed some pixels.
+	hid::display::OLED::markDirty();
 }
 
 // Changes the actual xScroll.

--- a/src/deluge/gui/views/timeline_view.h
+++ b/src/deluge/gui/views/timeline_view.h
@@ -23,6 +23,7 @@
 
 class InstrumentClip;
 class NoteRow;
+class TimelineCounter;
 
 class TimelineView : public RootUI {
 public:
@@ -44,9 +45,14 @@ public:
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	void displayZoomLevel(bool justPopup = false);
 	ActionResult horizontalEncoderAction(int32_t offset) override;
+
 	void displayScrollPos();
 	void displayNumberOfBarsAndBeats(uint32_t number, uint32_t quantization, bool countFromOne,
 	                                 char const* tooLongText);
+
+	/// Render indication of where the view is given the current playback state.
+	void renderMainImage(TimelineCounter const& counter, uint32_t totalTicks) const;
+
 	void initiateXScroll(uint32_t newXScroll, int32_t numSquaresToScroll = kDisplayWidth);
 	bool zoomToMax(bool inOnly = false);
 	void initiateXZoom(int32_t zoomMagnitude, int32_t newScroll, uint32_t oldZoom);

--- a/src/deluge/gui/views/timeline_view.h
+++ b/src/deluge/gui/views/timeline_view.h
@@ -51,7 +51,8 @@ public:
 	                                 char const* tooLongText);
 
 	/// Render indication of where the view is given the current playback state.
-	void renderMainImage(TimelineCounter const& counter, uint32_t totalTicks) const;
+	void renderTickIndicator(deluge::hid::display::oled_canvas::Canvas& canvas, TimelineCounter const& counter,
+	                         uint32_t totalTicks) const;
 
 	void initiateXScroll(uint32_t newXScroll, int32_t numSquaresToScroll = kDisplayWidth);
 	bool zoomToMax(bool inOnly = false);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2029,8 +2029,9 @@ oledDrawString:
 			}
 			else {
 				canvas.drawString(nameToDraw, 0, yPos, textSpacingX, textSpacingY);
-				deluge::hid::display::OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos,
-				                                              yPos + textSpacingY, textSpacingX, textSpacingY, false);
+				deluge::hid::display::OLED::setupSideScroller(kScrollerIndexPrimary, name, 0, OLED_MAIN_WIDTH_PIXELS,
+				                                              yPos, yPos + textSpacingY, textSpacingX, textSpacingY,
+				                                              false);
 			}
 		}
 		else {

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -700,6 +700,10 @@ void OLED::setupSideScroller(int32_t index, std::string_view text, int32_t start
 	uiTimerManager.setTimer(TimerName::OLED_SCROLLING_AND_BLINKING, kScrollTime);
 }
 
+bool OLED::isScrollerRunning(int32_t index) {
+	return sideScrollers[index].text != nullptr;
+}
+
 void OLED::stopScrollingAnimation() {
 	if (sideScrollerDirection) {
 		sideScrollerDirection = 0;

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -23,11 +23,13 @@
 #include "display.h"
 #include "oled_canvas/canvas.h"
 
-#define OLED_LOG_TIMING (0 && ENABLE_TEXT_OUTPUT)
+#define OLED_LOG_TIMING (1 && ENABLE_TEXT_OUTPUT)
 
 #if OLED_LOG_TIMING
 #include "io/debug/log.h"
 #endif
+
+constexpr int32_t kScrollerIndexPrimary = 0;
 
 namespace deluge::hid::display {
 class OLED : public Display {
@@ -62,6 +64,7 @@ public:
 	static void stopScrollingAnimation();
 	static void setupSideScroller(int32_t index, std::string_view text, int32_t startX, int32_t endX, int32_t startY,
 	                              int32_t endY, int32_t textSpacingX, int32_t textSizeY, bool doHighlight);
+	static bool isScrollerRunning(int32_t index);
 	static void drawPermanentPopupLookingText(char const* text);
 
 	/// Call this after doing any rendering work so the next trip through the UI rendering loop actually sends the image

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -337,8 +337,11 @@ public:
 	                                          int32_t whichBendRange, int32_t bendSemitones);
 	Error addInstrumentsToFileItems(OutputType outputType);
 
+	/// Get the number of sequencer ticks for a quarter note
 	uint32_t getQuarterNoteLength();
+	/// Get the number of sequencer ticks in a bar
 	uint32_t getBarLength();
+
 	ModelStackWithThreeMainThings* setupModelStackWithSongAsTimelineCounter(void* memory);
 	ModelStackWithTimelineCounter* setupModelStackWithCurrentClip(void* memory);
 	ModelStackWithThreeMainThings* addToModelStack(ModelStack* modelStack);


### PR DESCRIPTION
Uses the OLED to provide visual context about where the current view is in relation to the total clip lengths.

 - [ ] Add playhead indicator
 - [ ] Add support in Song view
 - [ ] Add support in Arranger view
 - [ ] Add support in Audio Clip view
 - [ ] Add support in Automation view