### PR TITLE
[DRAFT] persistent MIDI learn

### DIFF
--- a/src/deluge/gui/context_menu/load_instrument_preset.cpp
+++ b/src/deluge/gui/context_menu/load_instrument_preset.cpp
@@ -36,21 +36,13 @@ Sized<char const**> LoadInstrumentPreset::getOptions() {
 }
 
 bool LoadInstrumentPreset::acceptCurrentOption() {
-	Error error;
-
-	switch (currentOption) {
-	/*
-	case 0: // Refresh
-		return true;
-		*/
-	default: // Clone
-		error = loadInstrumentPresetUI.performLoad(storageManager, true);
-		if (error != Error::NONE) {
-			display->displayError(error);
-			return true;
-		}
-		loadInstrumentPresetUI.close();
-		return true;
+	Error error = loadInstrumentPresetUI.performLoad(storageManager, true);
+	if (error != Error::NONE) {
+		display->displayError(error);
 	}
+	else {
+		loadInstrumentPresetUI.close();
+	}
+	return true;
 }
 } // namespace deluge::gui::context_menu

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -613,9 +613,9 @@ void LoadInstrumentPresetUI::revertToInitialPreset(StorageManager& bdsm) {
 					return;
 				}
 
-				error =
-				    bdsm.loadInstrumentFromFile(currentSong, instrumentClipToLoadFor, initialOutputType, false,
-				                                &initialInstrument, &tempFilePointer, &initialName, &initialDirPath);
+				error = bdsm.loadInstrumentFromFile(currentSong, instrumentClipToLoadFor, initialOutputType, false,
+				                                    &initialInstrument, instrumentToReplace, &tempFilePointer,
+				                                    &initialName, &initialDirPath);
 				if (error != Error::NONE) {
 					return;
 				}
@@ -918,8 +918,9 @@ giveUsedError:
 		// Browser::checkFP();
 
 		// synth or kit
-		error = bdsm.loadInstrumentFromFile(currentSong, instrumentClipToLoadFor, outputTypeToLoad, false,
-		                                    &newInstrument, &currentFileItem->filePointer, &enteredText, &currentDir);
+		error =
+		    bdsm.loadInstrumentFromFile(currentSong, instrumentClipToLoadFor, outputTypeToLoad, false, &newInstrument,
+		                                instrumentToReplace, &currentFileItem->filePointer, &enteredText, &currentDir);
 
 		if (error != Error::NONE) {
 			return error;
@@ -1564,9 +1565,9 @@ doPendingPresetNavigation:
 	// TODO: This isn't true, it's an argument so that must have changed at some point. This logic will create a clone
 	// if anything other than unused is passed in
 	if (!toReturn.fileItem->instrument) {
-		toReturn.error =
-		    storageManager.loadInstrumentFromFile(currentSong, NULL, outputType, false, &toReturn.fileItem->instrument,
-		                                          &toReturn.fileItem->filePointer, &newName, &Browser::currentDir);
+		toReturn.error = storageManager.loadInstrumentFromFile(
+		    currentSong, NULL, outputType, false, &toReturn.fileItem->instrument, oldInstrument,
+		    &toReturn.fileItem->filePointer, &newName, &Browser::currentDir);
 		if (toReturn.error != Error::NONE) {
 			goto emptyFileItemsAndReturn;
 		}

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -763,7 +763,7 @@ Instrument* ArrangerView::createNewInstrument(OutputType newOutputType, bool* in
 		String newPresetName;
 		result.fileItem->getDisplayNameWithoutExtension(&newPresetName);
 		result.error =
-		    storageManager.loadInstrumentFromFile(currentSong, NULL, newOutputType, false, &newInstrument,
+		    storageManager.loadInstrumentFromFile(currentSong, NULL, newOutputType, false, &newInstrument, nullptr,
 		                                          &result.fileItem->filePointer, &newPresetName, &Browser::currentDir);
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1468,7 +1468,7 @@ Error setPresetOrNextUnlaunchedOne(InstrumentClip* clip, OutputType outputType, 
 		String newPresetName;
 		result.fileItem->getDisplayNameWithoutExtension(&newPresetName);
 		result.error =
-		    storageManager.loadInstrumentFromFile(currentSong, NULL, outputType, false, &newInstrument,
+		    storageManager.loadInstrumentFromFile(currentSong, NULL, outputType, false, &newInstrument, clip->output,
 		                                          &result.fileItem->filePointer, &newPresetName, &Browser::currentDir);
 	}
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3805,7 +3805,7 @@ Instrument* InstrumentClip::changeOutputType(ModelStackWithTimelineCounter* mode
 			String newPresetName;
 			result.fileItem->getDisplayNameWithoutExtension(&newPresetName);
 			result.error = storageManager.loadInstrumentFromFile(modelStack->song, NULL, newOutputType, false,
-			                                                     &newInstrument, &result.fileItem->filePointer,
+			                                                     &newInstrument, output, &result.fileItem->filePointer,
 			                                                     &newPresetName, &Browser::currentDir);
 		}
 

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1689,3 +1689,7 @@ ModelStackWithAutoParam* Kit::getModelStackWithParamForKitRow(ModelStackWithTime
 
 	return modelStackWithParam;
 }
+
+MidiKnobArray* Kit::getMidiKnobs() {
+	return &midiKnobArray;
+}

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -152,6 +152,7 @@ public:
 	                                                         int32_t paramID,
 	                                                         deluge::modulation::params::Kind paramKind,
 	                                                         bool useMenuStack);
+	MidiKnobArray* getMidiKnobs() override;
 
 protected:
 	bool isKit() { return true; }

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -19,6 +19,7 @@
 
 #include "definitions_cxx.hpp"
 #include "model/clip/clip_instance_vector.h"
+#include "modulation/midi/midi_knob_array.h"
 #include "modulation/params/param.h"
 #include "util/d_string.h"
 #include <cstdint>
@@ -158,6 +159,7 @@ public:
 	                                                        int32_t paramID, deluge::modulation::params::Kind paramKind,
 	                                                        bool affectEntire, bool useMenuStack) = 0;
 	virtual bool needsEarlyPlayback() const { return false; }
+	virtual MidiKnobArray* getMidiKnobs() { return nullptr; }
 
 protected:
 	virtual Clip* createNewClipForArrangementRecording(ModelStack* modelStack) = 0;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -404,7 +404,7 @@ bool Song::ensureAtLeastOneSessionClip() {
 			String newPresetName;
 			result.fileItem->getDisplayNameWithoutExtension(&newPresetName);
 			result.error = storageManager.loadInstrumentFromFile(this, firstClip, OutputType::SYNTH, false,
-			                                                     &newInstrument, &result.fileItem->filePointer,
+			                                                     &newInstrument, nullptr, &result.fileItem->filePointer,
 			                                                     &newPresetName, &Browser::currentDir);
 
 			Browser::emptyFileItems();
@@ -5117,7 +5117,7 @@ gotAnInstrument: {}
 			String newPresetName;
 			result.fileItem->getDisplayNameWithoutExtension(&newPresetName);
 			result.error = storageManager.loadInstrumentFromFile(this, NULL, newOutputType, false, &newInstrument,
-			                                                     &result.fileItem->filePointer, &newPresetName,
+			                                                     nullptr, &result.fileItem->filePointer, &newPresetName,
 			                                                     &Browser::currentDir);
 		}
 

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -432,3 +432,7 @@ ModelStackWithAutoParam* AudioOutput::getModelStackWithParam(ModelStackWithTimel
 
 	return modelStackWithParam;
 }
+
+MidiKnobArray* AudioOutput::getMidiKnobs() {
+	return &midiKnobArray;
+}

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -85,6 +85,7 @@ public:
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
 	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,
 	                                                bool affectEntire, bool useMenuStack);
+	MidiKnobArray* getMidiKnobs() override;
 
 protected:
 	Clip* createNewClipForArrangementRecording(ModelStack* modelStack);

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -518,3 +518,7 @@ bool SoundInstrument::noteIsOn(int32_t noteCode, bool resetTimeEntered) {
 	}
 	return false;
 }
+
+MidiKnobArray* SoundInstrument::getMidiKnobs() {
+	return &midiKnobArray;
+}

--- a/src/deluge/processing/sound/sound_instrument.h
+++ b/src/deluge/processing/sound/sound_instrument.h
@@ -81,5 +81,6 @@ public:
 	uint8_t* getModKnobMode() { return &modKnobMode; }
 	ArpeggiatorBase* getArp();
 	char const* getXMLTag() { return "sound"; }
+	MidiKnobArray* getMidiKnobs() override;
 	ArpeggiatorSettings defaultArpSettings;
 };

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -317,7 +317,7 @@ Error StorageManager::openInstrumentFile(OutputType outputType, FilePointer* fil
 // Returns error status
 // clip may be NULL
 Error StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip, OutputType outputType,
-                                             bool mayReadSamplesFromFiles, Instrument** getInstrument,
+                                             bool mayReadSamplesFromFiles, Instrument** getInstrument, Output* output,
                                              FilePointer* filePointer, String* name, String* dirPath) {
 
 	AudioEngine::logAction("loadInstrumentFromFile");
@@ -332,6 +332,15 @@ Error StorageManager::loadInstrumentFromFile(Song* song, InstrumentClip* clip, O
 
 	AudioEngine::logAction("loadInstrumentFromFile");
 	Instrument* newInstrument = createNewInstrument(outputType);
+	if (output) {
+		// If we have an output, copy learned controls from it:
+		// otherwise loading a new instrument would reset controls.
+		MidiKnobArray* newKnobs = newInstrument->getMidiKnobs();
+		MidiKnobArray* oldKnobs = output->getMidiKnobs();
+		if (newKnobs && oldKnobs) {
+			newKnobs->cloneFrom(oldKnobs);
+		}
+	}
 
 	if (!newInstrument) {
 		closeFile();

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -37,6 +37,7 @@ struct FileSystemStuff {
 extern struct FileSystemStuff fileSystemStuff;
 
 class Instrument;
+class Output;
 class PlaybackMode;
 class ParamManagerForTimeline;
 class ArpeggiatorSettings;
@@ -224,7 +225,8 @@ public:
 
 	Instrument* createNewInstrument(OutputType newOutputType, ParamManager* getParamManager = NULL);
 	Error loadInstrumentFromFile(Song* song, InstrumentClip* clip, OutputType outputType, bool mayReadSamplesFromFiles,
-	                             Instrument** getInstrument, FilePointer* filePointer, String* name, String* dirPath);
+	                             Instrument** getInstrument, Output* output, FilePointer* filePointer, String* name,
+	                             String* dirPath);
 	Instrument* createNewNonAudioInstrument(OutputType outputType, int32_t slot, int32_t subSlot);
 
 	Drum* createNewDrum(DrumType drumType);


### PR DESCRIPTION
- Preserve learned MIDI controls across synth loads.
- Output::getMidiKnobs() -- Those subclasses that are also ModControllableAudio override the default.
- MidiKnobArray::cloneFrom() -- for cloning initial values from the previous output.
- StorageManager::loadInstrumentFromFile() -- add argument from which to copy MIDI settings,

TODO:

- [ ] When a new synth is loaded, it resets parameters from MIDI knobs to their default values. Current knob settings should instead be respected.
- [ ] Retain controls even when an entirely new synth is created.
- [ ] What happens when you have midi learned a control (eg. LPF) that the loaded synth does not suppot (eg. FM synth), and what should happen?
  - Partial answer: "nothing" happens, the mapped control does nothing, but is retained for
    the next synth. This is right now by accident, need to check that it works by design as well.
- [ ] CRASHES:
  - [ ] Map master volume, convert to kit, adjust master volume, BOOM.