### PR TITLE
oled: create canvas class

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -908,8 +908,12 @@ constexpr int32_t kMIDIOutputFilterNoMPE = 0;
 constexpr int32_t kOLEDWidthChars = 16;
 constexpr int32_t kOLEDMenuNumOptionsVisible = (OLED_HEIGHT_CHARS - 1);
 
-constexpr int32_t kConsoleImageHeight = (OLED_MAIN_HEIGHT_PIXELS + 16);
-constexpr int32_t kConsoleImageNumRows = (kConsoleImageHeight >> 3);
+/// XXX: THIS MUST ALWAYS MATCH THE CONSTANTS IN Canvas
+///
+/// They used to be decoupled but that would force us to either make the height a dynamic variable or double up the code
+/// size.
+constexpr int32_t kConsoleImageHeight = (OLED_MAIN_HEIGHT_PIXELS);
+constexpr int32_t kConsoleImageNumRows = (OLED_MAIN_HEIGHT_PIXELS >> 3);
 
 constexpr int32_t kTextSpacingX = 6;
 constexpr int32_t kTextSpacingY = 9;

--- a/src/deluge/gui/context_menu/context_menu.cpp
+++ b/src/deluge/gui/context_menu/context_menu.cpp
@@ -55,7 +55,7 @@ void ContextMenu::focusRegained() {
 	}
 }
 
-void ContextMenu::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void ContextMenu::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	const auto [options, numOptions] = getOptions();
 
 	int32_t windowWidth = 100;
@@ -67,12 +67,11 @@ void ContextMenu::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 	int32_t windowMinY = (OLED_MAIN_HEIGHT_PIXELS - windowHeight) >> 1;
 	int32_t windowMaxY = OLED_MAIN_HEIGHT_PIXELS - windowMinY;
 
-	hid::display::OLED::clearAreaExact(windowMinX + 1, windowMinY + 1, windowMaxX - 1, windowMaxY - 1, image);
+	canvas.clearAreaExact(windowMinX + 1, windowMinY + 1, windowMaxX - 1, windowMaxY - 1);
 
-	hid::display::OLED::drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY, image);
-	hid::display::OLED::drawHorizontalLine(windowMinY + 15, 22, OLED_MAIN_WIDTH_PIXELS - 30, &image[0]);
-	hid::display::OLED::drawString(this->getTitle(), 22, windowMinY + 6, image[0], OLED_MAIN_WIDTH_PIXELS,
-	                               kTextSpacingX, kTextSpacingY);
+	canvas.drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY);
+	canvas.drawHorizontalLine(windowMinY + 15, 22, OLED_MAIN_WIDTH_PIXELS - 30);
+	canvas.drawString(this->getTitle(), 22, windowMinY + 6, kTextSpacingX, kTextSpacingY);
 
 	int32_t textPixelY = windowMinY + 18;
 	int32_t actualCurrentOption = currentOption;
@@ -89,12 +88,10 @@ void ContextMenu::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 		}
 
 		if (isCurrentOptionAvailable()) {
-			deluge::hid::display::OLED::drawString(options[currentOption], 22, textPixelY, image[0],
-			                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY, 0,
-			                                       OLED_MAIN_WIDTH_PIXELS - 26);
+			canvas.drawString(options[currentOption], 22, textPixelY, kTextSpacingX, kTextSpacingY, 0,
+			                  OLED_MAIN_WIDTH_PIXELS - 26);
 			if (currentOption == actualCurrentOption) {
-				deluge::hid::display::OLED::invertArea(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8,
-				                                       &image[0]);
+				canvas.invertArea(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8);
 				deluge::hid::display::OLED::setupSideScroller(0, options[currentOption], 22,
 				                                              OLED_MAIN_WIDTH_PIXELS - 26, textPixelY, textPixelY + 8,
 				                                              kTextSpacingX, kTextSpacingY, true);

--- a/src/deluge/gui/context_menu/context_menu.h
+++ b/src/deluge/gui/context_menu/context_menu.h
@@ -47,7 +47,7 @@ public:
 
 	int32_t currentOption = 0; // Don't make static. We'll have multiple nested ContextMenus open at the same time
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override;
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 	int32_t scrollPos = 0; // Don't make static. We'll have multiple nested ContextMenus open at the same time
 	virtual char const* getTitle() = 0;
 

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rhythm.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rhythm.h
@@ -44,9 +44,10 @@ public:
 	void drawValue() override { display->setScrollingText(arpRhythmPatternNames[this->getValue()]); }
 
 	void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) override {
-		deluge::hid::display::OLED::drawStringCentred(
-		    arpRhythmPatternNames[this->getValue()], yPixel + OLED_MAIN_TOPMOST_PIXEL,
-		    deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, textWidth, textHeight);
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+
+		canvas.drawStringCentred(arpRhythmPatternNames[this->getValue()], yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth,
+		                         textHeight);
 	}
 };
 } // namespace deluge::gui::menu_item::arpeggiator::midi_cv

--- a/src/deluge/gui/menu_item/arpeggiator/rhythm.h
+++ b/src/deluge/gui/menu_item/arpeggiator/rhythm.h
@@ -34,11 +34,11 @@ public:
 
 	void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) override {
 		char name[12];
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+
 		// Index: Name
 		snprintf(name, sizeof(name), "%d: %s", this->getValue(), arpRhythmPatternNames[this->getValue()]);
-		deluge::hid::display::OLED::drawStringCentred(name, yPixel + OLED_MAIN_TOPMOST_PIXEL,
-		                                              deluge::hid::display::OLED::oledMainImage[0],
-		                                              OLED_MAIN_WIDTH_PIXELS, textWidth, textHeight);
+		canvas.drawStringCentred(name, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
 	}
 
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/cv/volts.h
+++ b/src/deluge/gui/menu_item/cv/volts.h
@@ -40,9 +40,9 @@ public:
 		cvEngine.setCVVoltsPerOctave(soundEditor.currentSourceIndex, this->getValue());
 	}
 	void drawPixelsForOled() override {
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 		if (this->getValue() == 0) {
-			deluge::hid::display::OLED::drawStringCentred("Hz/V", 20, deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextHugeSpacingX, kTextHugeSizeY);
+			canvas.drawStringCentred("Hz/V", 20, kTextHugeSpacingX, kTextHugeSizeY);
 		}
 		else {
 			Decimal::drawPixelsForOled();

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -152,8 +152,7 @@ void Decimal::drawPixelsForOled() {
 	int32_t stringWidth = digitWidth * length;
 	int32_t stringStartX = (OLED_MAIN_WIDTH_PIXELS - stringWidth) >> 1;
 
-	hid::display::OLED::drawString(buffer, stringStartX, 20, deluge::hid::display::OLED::oledMainImage[0],
-	                               OLED_MAIN_WIDTH_PIXELS, digitWidth, kTextHugeSizeY);
+	hid::display::OLED::main.drawString(buffer, stringStartX, 20, digitWidth, kTextHugeSizeY);
 
 	int32_t ourDigitStartX = stringStartX + editingChar * digitWidth;
 	hid::display::OLED::setupBlink(ourDigitStartX, digitWidth, 40, 44, movingCursor);

--- a/src/deluge/gui/menu_item/defaults/magnitude.h
+++ b/src/deluge/gui/menu_item/defaults/magnitude.h
@@ -30,10 +30,10 @@ public:
 
 	void drawPixelsForOled() override {
 		char buffer[12];
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+
 		intToString(96 << this->getValue(), buffer);
-		deluge::hid::display::OLED::drawStringCentred(buffer, 18 + OLED_MAIN_TOPMOST_PIXEL,
-		                                              deluge::hid::display::OLED::oledMainImage[0],
-		                                              OLED_MAIN_WIDTH_PIXELS, 18, 20);
+		canvas.drawStringCentred(buffer, 18 + OLED_MAIN_TOPMOST_PIXEL, 18, 20);
 	}
 
 	void drawValue() override { display->setTextAsNumber(96 << this->getValue()); }

--- a/src/deluge/gui/menu_item/dx/param.cpp
+++ b/src/deluge/gui/menu_item/dx/param.cpp
@@ -355,11 +355,10 @@ using deluge::hid::display::OLED;
 static void show(const char* text, int r, int c, bool inv = false) {
 	int ybel = 7 + (2 + r) * (kTextSizeYUpdated + 2);
 	int xpos = 5 + c * kTextSpacingX;
-	OLED::drawString(text, xpos, ybel, OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, kTextSpacingX,
-	                 kTextSizeYUpdated);
+	OLED::main.drawString(text, xpos, ybel, kTextSpacingX, kTextSizeYUpdated);
 	if (inv) {
 		int width = strlen(text);
-		OLED::invertArea(xpos - 1, kTextSpacingX * width + 1, ybel - 1, ybel + kTextSizeYUpdated, OLED::oledMainImage);
+		OLED::main.invertArea(xpos - 1, kTextSpacingX * width + 1, ybel - 1, ybel + kTextSizeYUpdated);
 	}
 }
 
@@ -395,11 +394,9 @@ static void renderScaling(uint8_t* params, int op, int idx) {
 	int val = params[op * 21 + 8];
 	intToString(val, buffer, 2);
 	int xpos = 14 + 6 * kTextSpacingX;
-	OLED::drawString(buffer, xpos, ybelmid, OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, kTextSpacingX,
-	                 kTextSizeYUpdated);
+	OLED::main.drawString(buffer, xpos, ybelmid, kTextSpacingX, kTextSizeYUpdated);
 	if (8 == idx) {
-		OLED::invertArea(xpos - 1, kTextSpacingX * 2 + 1, ybelmid - 1, ybelmid + kTextSizeYUpdated,
-		                 OLED::oledMainImage);
+		OLED::main.invertArea(xpos - 1, kTextSpacingX * 2 + 1, ybelmid - 1, ybelmid + kTextSizeYUpdated);
 	}
 
 	int noteCode = val + 17;
@@ -491,7 +488,7 @@ static void renderAlgorithm(uint8_t* params) {
 
 	char buffer[12];
 	intToString(params[134] + 1, buffer, 2);
-	OLED::drawString(buffer, 113, 7, OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+	OLED::main.drawString(buffer, 113, 7, kTextSpacingX, kTextSizeYUpdated);
 
 	FmAlgorithm a = FmCore::algorithms[params[134]];
 	for (int i = 0; i < 6; i++) {
@@ -521,8 +518,7 @@ void DxParam::drawPixelsForOled() {
 	if (param < 0 || param == 135 || param == 136) {
 		int val = getValue();
 		intToString(val, buffer, param < 0 ? 2 : 1);
-		OLED::drawString(buffer, 50, y0, OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, kTextHugeSpacingX,
-		                 kTextHugeSizeY);
+		OLED::main.drawString(buffer, 50, y0, kTextHugeSpacingX, kTextHugeSizeY);
 		return;
 	}
 

--- a/src/deluge/gui/menu_item/firmware/version.h
+++ b/src/deluge/gui/menu_item/firmware/version.h
@@ -27,8 +27,8 @@ public:
 	using MenuItem::MenuItem;
 
 	void drawPixelsForOled() {
-		deluge::hid::display::OLED::drawStringCentredShrinkIfNecessary(
-		    kFirmwareVersionString, 22, deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, 18, 20);
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+		canvas.drawStringCentredShrinkIfNecessary(kFirmwareVersionString, 22, 18, 20);
 	}
 
 	void beginSession(MenuItem* navigatedBackwardFrom) override { drawValue(); }

--- a/src/deluge/gui/menu_item/integer.cpp
+++ b/src/deluge/gui/menu_item/integer.cpp
@@ -52,9 +52,8 @@ void IntegerWithOff::drawValue() {
 }
 void IntegerWithOff::drawPixelsForOled() {
 	if (this->getValue() == 0) {
-		deluge::hid::display::OLED::drawStringCentred("OFF", 18 + OLED_MAIN_TOPMOST_PIXEL,
-		                                              deluge::hid::display::OLED::oledMainImage[0],
-		                                              OLED_MAIN_WIDTH_PIXELS, kTextHugeSpacingX, kTextHugeSizeY);
+		deluge::hid::display::OLED::main.drawStringCentred("OFF", 18 + OLED_MAIN_TOPMOST_PIXEL, kTextHugeSpacingX,
+		                                                   kTextHugeSizeY);
 	}
 
 	else {
@@ -66,9 +65,7 @@ void Integer::drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel)
 	char buffer[12];
 	intToString(getDisplayValue(), buffer, 1);
 	strncat(buffer, getUnit(), 4);
-	deluge::hid::display::OLED::drawStringCentred(buffer, yPixel + OLED_MAIN_TOPMOST_PIXEL,
-	                                              deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-	                                              textWidth, textHeight);
+	deluge::hid::display::OLED::main.drawStringCentred(buffer, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
 }
 
 void Integer::drawPixelsForOled() {

--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -34,7 +34,7 @@ void MenuItem::learnCC(MIDIDevice* fromDevice, int32_t channel, int32_t ccNumber
 }
 
 void MenuItem::renderOLED() {
-	deluge::hid::display::OLED::drawScreenTitle(getTitle());
+	deluge::hid::display::OLED::main.drawScreenTitle(getTitle());
 	drawPixelsForOled();
 }
 
@@ -45,6 +45,7 @@ void MenuItem::drawName() {
 // A couple of our child classes call this - that's all
 void MenuItem::drawItemsForOled(std::span<std::string_view> options, const int32_t selectedOption,
                                 const int32_t offset) {
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 	int32_t baseY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 15 : 14;
 	baseY += OLED_MAIN_TOPMOST_PIXEL;
 
@@ -52,13 +53,10 @@ void MenuItem::drawItemsForOled(std::span<std::string_view> options, const int32
 	for (int32_t o = 0; o < OLED_HEIGHT_CHARS - 1 && o < options.size() - offset; o++) {
 		int32_t yPixel = o * kTextSpacingY + baseY;
 
-		deluge::hid::display::OLED::drawString(options[o + offset], kTextSpacingX, yPixel,
-		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-		                                       kTextSpacingX, kTextSpacingY);
+		image.drawString(options[o + offset], kTextSpacingX, yPixel, kTextSpacingX, kTextSpacingY);
 
 		if (o == selectedOption) {
-			deluge::hid::display::OLED::invertArea(0, OLED_MAIN_WIDTH_PIXELS, yPixel, yPixel + 8,
-			                                       &deluge::hid::display::OLED::oledMainImage[0]);
+			image.invertArea(0, OLED_MAIN_WIDTH_PIXELS, yPixel, yPixel + 8);
 			deluge::hid::display::OLED::setupSideScroller(0, options[o + offset], kTextSpacingX, OLED_MAIN_WIDTH_PIXELS,
 			                                              yPixel, yPixel + 8, kTextSpacingX, kTextSpacingY, true);
 		}

--- a/src/deluge/gui/menu_item/midi/command.cpp
+++ b/src/deluge/gui/menu_item/midi/command.cpp
@@ -34,20 +34,19 @@ void Command::beginSession(MenuItem* navigatedBackwardFrom) {
 }
 
 void Command::drawPixelsForOled() {
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 	LearnedMIDI* command = &midiEngine.globalMIDICommands[util::to_underlying(commandNumber)];
 	int32_t yPixel = 20;
 	if (!command->containsSomething()) {
-		deluge::hid::display::OLED::drawString(l10n::get(l10n::String::STRING_FOR_COMMAND_UNASSIGNED), 0, yPixel,
-		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-		                                       kTextSpacingX, kTextSizeYUpdated);
+		image.drawString(l10n::get(l10n::String::STRING_FOR_COMMAND_UNASSIGNED), 0, yPixel, kTextSpacingX,
+		                 kTextSizeYUpdated);
 	}
 	else {
 		char const* deviceString = l10n::get(l10n::String::STRING_FOR_ANY_MIDI_DEVICE);
 		if (command->device) {
 			deviceString = command->device->getDisplayName();
 		}
-		deluge::hid::display::OLED::drawString(deviceString, 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
-		                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+		image.drawString(deviceString, 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		deluge::hid::display::OLED::setupSideScroller(0, deviceString, kTextSpacingX, OLED_MAIN_WIDTH_PIXELS, yPixel,
 		                                              yPixel + 8, kTextSpacingX, kTextSpacingY, false);
 
@@ -71,32 +70,24 @@ void Command::drawPixelsForOled() {
 				channelmod = IS_A_CC;
 			}
 			intToString(command->channelOrZone + 1 - channelmod, buffer, 1);
-			deluge::hid::display::OLED::drawString(buffer, kTextSpacingX * 8, yPixel,
-			                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-			                                       kTextSpacingX, kTextSizeYUpdated);
+			image.drawString(buffer, kTextSpacingX * 8, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		}
-		deluge::hid::display::OLED::drawString(channelText, 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
-		                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+		image.drawString(channelText, 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 
 		yPixel += kTextSpacingY;
 		if (command->channelOrZone < IS_A_CC) {
-			deluge::hid::display::OLED::drawString("Note", 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
-			                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+			image.drawString("Note", 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		}
 		else if (command->channelOrZone < IS_A_PC) {
-			deluge::hid::display::OLED::drawString("CC", 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
-			                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+			image.drawString("CC", 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		}
 		else {
-			deluge::hid::display::OLED::drawString("PC", 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
-			                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+			image.drawString("PC", 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		}
 
 		char buffer[12];
 		intToString(command->noteOrCC, buffer, 1);
-		deluge::hid::display::OLED::drawString(buffer, kTextSpacingX * 5, yPixel,
-		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-		                                       kTextSpacingX, kTextSizeYUpdated);
+		image.drawString(buffer, kTextSpacingX * 5, yPixel, kTextSpacingX, kTextSizeYUpdated);
 	}
 }
 

--- a/src/deluge/gui/menu_item/midi/follow/follow_channel.h
+++ b/src/deluge/gui/menu_item/midi/follow/follow_channel.h
@@ -36,7 +36,9 @@ public:
 	[[nodiscard]] int32_t getMaxValue() const override { return NUM_CHANNELS; }
 	bool allowsLearnMode() override { return true; }
 
-	void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
+	void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) override {
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+
 		yPixel = 20;
 
 		char const* differentiationString;
@@ -46,9 +48,7 @@ public:
 		else {
 			differentiationString = l10n::get(l10n::String::STRING_FOR_INPUT_DIFFERENTIATION_OFF);
 		}
-		deluge::hid::display::OLED::drawString(differentiationString, 0, yPixel,
-		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-		                                       kTextSpacingX, kTextSizeYUpdated);
+		canvas.drawString(differentiationString, 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 
 		yPixel += kTextSpacingY;
 
@@ -56,8 +56,7 @@ public:
 		if (midiInput.device) {
 			deviceString = midiInput.device->getDisplayName();
 		}
-		deluge::hid::display::OLED::drawString(deviceString, 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
-		                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+		canvas.drawString(deviceString, 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		deluge::hid::display::OLED::setupSideScroller(0, deviceString, kTextSpacingX, OLED_MAIN_WIDTH_PIXELS, yPixel,
 		                                              yPixel + 8, kTextSpacingX, kTextSpacingY, false);
 
@@ -78,12 +77,9 @@ public:
 			char buffer[12];
 			int32_t channelmod = (midiInput.channelOrZone >= IS_A_CC) * IS_A_CC;
 			intToString(midiInput.channelOrZone + 1 - channelmod, buffer, 1);
-			deluge::hid::display::OLED::drawString(buffer, kTextSpacingX * 8, yPixel,
-			                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-			                                       kTextSpacingX, kTextSizeYUpdated);
+			canvas.drawString(buffer, kTextSpacingX * 8, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		}
-		deluge::hid::display::OLED::drawString(channelText, 0, yPixel, deluge::hid::display::OLED::oledMainImage[0],
-		                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSizeYUpdated);
+		canvas.drawString(channelText, 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 	}
 
 	void drawValue() override {

--- a/src/deluge/gui/menu_item/midi/preset.h
+++ b/src/deluge/gui/menu_item/midi/preset.h
@@ -31,6 +31,7 @@ public:
 	[[nodiscard]] int32_t getMaxValue() const override { return 128; } // Probably not needed cos we override below...
 
 	void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 		char buffer[12];
 		char const* text;
 		if (this->getValue() == 128) {
@@ -40,9 +41,7 @@ public:
 			intToString(this->getValue() + 1, buffer, 1);
 			text = buffer;
 		}
-		deluge::hid::display::OLED::drawStringCentred(text, yPixel + OLED_MAIN_TOPMOST_PIXEL,
-		                                              deluge::hid::display::OLED::oledMainImage[0],
-		                                              OLED_MAIN_WIDTH_PIXELS, textWidth, textHeight);
+		canvas.drawStringCentred(text, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
 	}
 
 	void drawValue() override {

--- a/src/deluge/gui/menu_item/multi_range.cpp
+++ b/src/deluge/gui/menu_item/multi_range.cpp
@@ -466,8 +466,7 @@ void MultiRange::drawPixelsForOled() {
 		baseY += OLED_MAIN_TOPMOST_PIXEL;
 		baseY += (this->getValue() - soundEditor.menuCurrentScroll) * kTextSpacingY;
 		// -1 adjustment to invert the area 1px around the digits being rendered
-		deluge::hid::display::OLED::invertArea(highlightStartX, highlightWidth, baseY, baseY + kTextSpacingY - 1,
-		                                       deluge::hid::display::OLED::oledMainImage);
+		deluge::hid::display::OLED::main.invertArea(highlightStartX, highlightWidth, baseY, baseY + kTextSpacingY - 1);
 	}
 }
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/number.cpp
+++ b/src/deluge/gui/menu_item/number.cpp
@@ -21,6 +21,7 @@
 namespace deluge::gui::menu_item {
 
 void Number::drawBar(int32_t yTop, int32_t marginL, int32_t marginR) {
+	deluge::hid::display::oled_canvas::Canvas& canvas = deluge::hid::display::OLED::main;
 	if (marginR == -1) {
 		marginR = marginL;
 	}
@@ -51,16 +52,13 @@ void Number::drawBar(int32_t yTop, int32_t marginL, int32_t marginR) {
 
 	if (posHorizontal <= zeroPosHorizontal) {
 		int32_t xMin = leftMost + posHorizontal;
-		deluge::hid::display::OLED::invertArea(xMin, zeroPosHorizontal - posHorizontal + 1, yTop, yTop + height,
-		                                       deluge::hid::display::OLED::oledMainImage);
+		canvas.invertArea(xMin, zeroPosHorizontal - posHorizontal + 1, yTop, yTop + height);
 	}
 	else {
 		int32_t xMin = leftMost + zeroPosHorizontal;
-		deluge::hid::display::OLED::invertArea(xMin, posHorizontal - zeroPosHorizontal, yTop, yTop + height,
-		                                       deluge::hid::display::OLED::oledMainImage);
+		canvas.invertArea(xMin, posHorizontal - zeroPosHorizontal, yTop, yTop + height);
 	}
-	deluge::hid::display::OLED::drawRectangle(leftMost, yTop, rightMost, yTop + height,
-	                                          deluge::hid::display::OLED::oledMainImage);
+	canvas.drawRectangle(leftMost, yTop, rightMost, yTop + height);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/osc/retrigger_phase.h
+++ b/src/deluge/gui/menu_item/osc/retrigger_phase.h
@@ -66,10 +66,9 @@ public:
 	}
 
 	void drawPixelsForOled() override {
+		deluge::hid::display::oled_canvas::Canvas& canvas = deluge::hid::display::OLED::main;
 		if (this->getValue() < 0) {
-			deluge::hid::display::OLED::drawStringCentred(l10n::get(l10n::String::STRING_FOR_OFF), 20,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextHugeSpacingX, kTextHugeSizeY);
+			canvas.drawStringCentred(l10n::get(l10n::String::STRING_FOR_OFF), 20, kTextHugeSpacingX, kTextHugeSizeY);
 		}
 		else {
 			Decimal::drawPixelsForOled();

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -37,6 +37,8 @@
 #include "source_selection.h"
 #include "util/functions.h"
 
+using deluge::hid::display::OLED;
+
 namespace deluge::gui::menu_item {
 extern bool movingCursor;
 
@@ -68,46 +70,37 @@ void PatchCableStrength::renderOLED() {
 
 	int32_t yPixel = yTop;
 
-	deluge::hid::display::OLED::drawString(getSourceDisplayNameForOLED(s), 0, yPixel,
-	                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-	                                       kTextSpacingX, kTextSizeYUpdated);
+	OLED::main.drawString(getSourceDisplayNameForOLED(s), 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
 	yPixel += ySpacing;
 
 	if (!destinationDescriptor.isJustAParam()) {
 		// deluge::hid::display::OLED::drawGraphicMultiLine(deluge::hid::display::OLED::downArrowIcon, 0, yPixel, 8,
 		// deluge::hid::display::OLED::oledMainImage[0]);
 		int32_t horizontalLineY = yPixel + (ySpacing << 1);
-		deluge::hid::display::OLED::drawVerticalLine(4, yPixel + 1, horizontalLineY,
-		                                             deluge::hid::display::OLED::oledMainImage);
+		OLED::main.drawVerticalLine(4, yPixel + 1, horizontalLineY);
 		int32_t rightArrowX = 3 + kTextSpacingX;
-		deluge::hid::display::OLED::drawHorizontalLine(horizontalLineY, 4, kTextSpacingX * 2 + 4,
-		                                               deluge::hid::display::OLED::oledMainImage);
-		deluge::hid::display::OLED::drawGraphicMultiLine(deluge::hid::display::OLED::rightArrowIcon, rightArrowX,
-		                                                 horizontalLineY - 2, 3,
-		                                                 deluge::hid::display::OLED::oledMainImage[0]);
+		OLED::main.drawHorizontalLine(horizontalLineY, 4, kTextSpacingX * 2 + 4);
+		OLED::main.drawGraphicMultiLine(deluge::hid::display::OLED::rightArrowIcon, rightArrowX, horizontalLineY - 2,
+		                                3);
 
 		yPixel += ySpacing - 1;
 
 		PatchSource s2 = destinationDescriptor.getTopLevelSource();
-		deluge::hid::display::OLED::drawString(getSourceDisplayNameForOLED(s2), kTextSpacingX * 2, yPixel - 3,
-		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-		                                       kTextSpacingX, kTextSizeYUpdated);
+		OLED::main.drawString(getSourceDisplayNameForOLED(s2), kTextSpacingX * 2, yPixel - 3, kTextSpacingX,
+		                      kTextSizeYUpdated);
 		yPixel += ySpacing;
 
-		deluge::hid::display::OLED::drawVerticalLine(kTextSpacingX * 2 + 4, yPixel - 2, yPixel + 2,
-		                                             deluge::hid::display::OLED::oledMainImage);
+		OLED::main.drawVerticalLine(kTextSpacingX * 2 + 4, yPixel - 2, yPixel + 2);
 	}
 
-	deluge::hid::display::OLED::drawGraphicMultiLine(deluge::hid::display::OLED::downArrowIcon,
-	                                                 destinationDescriptor.isJustAParam() ? 2 : (kTextSpacingX * 2 + 2),
-	                                                 yPixel, 5, deluge::hid::display::OLED::oledMainImage[0]);
+	OLED::main.drawGraphicMultiLine(deluge::hid::display::OLED::downArrowIcon,
+	                                destinationDescriptor.isJustAParam() ? 2 : (kTextSpacingX * 2 + 2), yPixel, 5);
 	yPixel += ySpacing;
 
 	int32_t p = destinationDescriptor.getJustTheParam();
 
-	deluge::hid::display::OLED::drawString(deluge::modulation::params::getPatchedParamDisplayName(p), 0, yPixel,
-	                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-	                                       kTextSpacingX, kTextSizeYUpdated);
+	OLED::main.drawString(deluge::modulation::params::getPatchedParamDisplayName(p), 0, yPixel, kTextSpacingX,
+	                      kTextSizeYUpdated);
 
 	if (soundEditor.numberEditPos != getDefaultEditPos()) {
 		preferBarDrawing = false;
@@ -117,9 +110,8 @@ void PatchCableStrength::renderOLED() {
 	if (preferBarDrawing) {
 		int32_t rounded = this->getValue() / 100;
 		intToString(rounded, buffer, 1);
-		deluge::hid::display::OLED::drawStringAlignRight(
-		    buffer, extraY + OLED_MAIN_TOPMOST_PIXEL + 4 + destinationDescriptor.isJustAParam(),
-		    deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, 18, 20);
+		OLED::main.drawStringAlignRight(
+		    buffer, extraY + OLED_MAIN_TOPMOST_PIXEL + 4 + destinationDescriptor.isJustAParam(), 18, 20);
 
 		int32_t marginL = destinationDescriptor.isJustAParam() ? 0 : 80;
 		int32_t yBar = destinationDescriptor.isJustAParam() ? 36 : 37;
@@ -130,18 +122,14 @@ void PatchCableStrength::renderOLED() {
 		const int32_t digitHeight = kTextBigSizeY;
 		intToString(this->getValue(), buffer, 3);
 		int32_t textPixelY = extraY + OLED_MAIN_TOPMOST_PIXEL + 10 + destinationDescriptor.isJustAParam();
-		deluge::hid::display::OLED::drawStringAlignRight(buffer, textPixelY,
-		                                                 deluge::hid::display::OLED::oledMainImage[0],
-		                                                 OLED_MAIN_WIDTH_PIXELS, digitWidth, digitHeight);
+		OLED::main.drawStringAlignRight(buffer, textPixelY, digitWidth, digitHeight);
 
 		int32_t ourDigitStartX = OLED_MAIN_WIDTH_PIXELS - (soundEditor.numberEditPos + 1) * digitWidth;
-		deluge::hid::display::OLED::setupBlink(ourDigitStartX, digitWidth, 40, 44, movingCursor);
-		deluge::hid::display::OLED::drawVerticalLine(OLED_MAIN_WIDTH_PIXELS - 2 * digitWidth,
-		                                             textPixelY + digitHeight + 1, textPixelY + digitHeight + 3,
-		                                             deluge::hid::display::OLED::oledMainImage);
-		deluge::hid::display::OLED::drawVerticalLine(OLED_MAIN_WIDTH_PIXELS - 2 * digitWidth - 1,
-		                                             textPixelY + digitHeight + 1, textPixelY + digitHeight + 3,
-		                                             deluge::hid::display::OLED::oledMainImage);
+		OLED::setupBlink(ourDigitStartX, digitWidth, 40, 44, movingCursor);
+		OLED::main.drawVerticalLine(OLED_MAIN_WIDTH_PIXELS - 2 * digitWidth, textPixelY + digitHeight + 1,
+		                            textPixelY + digitHeight + 3);
+		OLED::main.drawVerticalLine(OLED_MAIN_WIDTH_PIXELS - 2 * digitWidth - 1, textPixelY + digitHeight + 1,
+		                            textPixelY + digitHeight + 3);
 	}
 }
 

--- a/src/deluge/gui/menu_item/range.cpp
+++ b/src/deluge/gui/menu_item/range.cpp
@@ -171,6 +171,7 @@ void Range::drawValueForEditingRange(bool blinkImmediately) {
 }
 
 void Range::drawPixelsForOled() {
+	deluge::hid::display::oled_canvas::Canvas& canvas = deluge::hid::display::OLED::main;
 	int32_t leftLength, rightLength;
 	char* buffer = shortStringBuffer;
 
@@ -185,9 +186,7 @@ void Range::drawPixelsForOled() {
 	int32_t stringWidth = digitWidth * textLength;
 	int32_t stringStartX = (OLED_MAIN_WIDTH_PIXELS - stringWidth) >> 1;
 
-	deluge::hid::display::OLED::drawString(buffer, stringStartX, baseY + OLED_MAIN_TOPMOST_PIXEL,
-	                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-	                                       digitWidth, digitHeight);
+	canvas.drawString(buffer, stringStartX, baseY + OLED_MAIN_TOPMOST_PIXEL, digitWidth, digitHeight);
 
 	int32_t highlightStartX, highlightWidth;
 
@@ -197,8 +196,7 @@ void Range::drawPixelsForOled() {
 doHighlightJustOneEdge:
 		// Invert the area 1px around the digits being rendered
 		baseY += OLED_MAIN_TOPMOST_PIXEL - 1;
-		deluge::hid::display::OLED::invertArea(highlightStartX, highlightWidth, baseY, baseY + digitHeight + 1,
-		                                       deluge::hid::display::OLED::oledMainImage);
+		canvas.invertArea(highlightStartX, highlightWidth, baseY, baseY + digitHeight + 1);
 	}
 	else if (soundEditor.editingRangeEdge == RangeEdit::RIGHT) {
 		int32_t stringEndX = (OLED_MAIN_WIDTH_PIXELS + stringWidth) >> 1;

--- a/src/deluge/gui/menu_item/reverb/sidechain/volume.h
+++ b/src/deluge/gui/menu_item/reverb/sidechain/volume.h
@@ -42,11 +42,10 @@ public:
 	}
 
 	void drawPixelsForOled() override {
+		deluge::hid::display::oled_canvas::Canvas& canvas = deluge::hid::display::OLED::main;
 		if (this->getValue() < 0) {
-			deluge::hid::display::OLED::drawStringCentred(l10n::get(l10n::String::STRING_FOR_AUTO),
-			                                              18 + OLED_MAIN_TOPMOST_PIXEL,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextHugeSpacingX, kTextHugeSizeY);
+			canvas.drawStringCentred(l10n::get(l10n::String::STRING_FOR_AUTO), 18 + OLED_MAIN_TOPMOST_PIXEL,
+			                         kTextHugeSpacingX, kTextHugeSizeY);
 		}
 		else {
 			Integer::drawPixelsForOled();

--- a/src/deluge/gui/menu_item/sync_level.cpp
+++ b/src/deluge/gui/menu_item/sync_level.cpp
@@ -75,9 +75,8 @@ void SyncLevel::drawPixelsForOled() {
 		text = buffer.data();
 		getNoteLengthName(buffer);
 	}
-	deluge::hid::display::OLED::drawStringCentred(text, 20 + OLED_MAIN_TOPMOST_PIXEL,
-	                                              deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-	                                              kTextBigSpacingX, kTextBigSizeY);
+	deluge::hid::display::OLED::main.drawStringCentred(text, 20 + OLED_MAIN_TOPMOST_PIXEL, kTextBigSpacingX,
+	                                                   kTextBigSizeY);
 }
 
 SyncType SyncLevel::menuOptionToSyncType(int32_t option) {

--- a/src/deluge/gui/menu_item/toggle.cpp
+++ b/src/deluge/gui/menu_item/toggle.cpp
@@ -36,6 +36,8 @@ void Toggle::drawValue() {
 }
 
 void Toggle::drawPixelsForOled() {
+	deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+
 	const int32_t val = static_cast<int32_t>(this->getValue());
 	// Move scroll
 	soundEditor.menuCurrentScroll = std::clamp<int32_t>(soundEditor.menuCurrentScroll, 0, 1);
@@ -52,13 +54,10 @@ void Toggle::drawPixelsForOled() {
 	for (int32_t o = 0; o < 2; o++) {
 		int32_t yPixel = o * kTextSpacingY + baseY;
 
-		deluge::hid::display::OLED::drawString(options[o], kTextSpacingX, yPixel,
-		                                       deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS,
-		                                       kTextSpacingX, kTextSpacingY);
+		canvas.drawString(options[o], kTextSpacingX, yPixel, kTextSpacingX, kTextSpacingY);
 
 		if (o == selectedOption) {
-			deluge::hid::display::OLED::invertArea(0, OLED_MAIN_WIDTH_PIXELS, yPixel, yPixel + 8,
-			                                       &deluge::hid::display::OLED::oledMainImage[0]);
+			canvas.invertArea(0, OLED_MAIN_WIDTH_PIXELS, yPixel, yPixel + 8);
 			deluge::hid::display::OLED::setupSideScroller(0, options[o], kTextSpacingX, OLED_MAIN_WIDTH_PIXELS, yPixel,
 			                                              yPixel + 8, kTextSpacingX, kTextSpacingY, true);
 		}

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -123,9 +123,8 @@ gotError:
 	return success;
 }
 
-void AudioRecorder::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
-	deluge::hid::display::OLED::drawStringCentred("Recording", 19, image[0], OLED_MAIN_WIDTH_PIXELS, kTextBigSpacingX,
-	                                              kTextBigSizeY);
+void AudioRecorder::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
+	canvas.drawStringCentred("Recording", 19, kTextBigSpacingX, kTextBigSizeY);
 }
 
 bool AudioRecorder::setupRecordingToFile(AudioInputChannel newMode, int32_t newNumChannels,

--- a/src/deluge/gui/ui/audio_recorder.h
+++ b/src/deluge/gui/ui/audio_recorder.h
@@ -45,7 +45,7 @@ public:
 
 	void endRecordingSoon(int32_t buttonLatency = 0);
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	// ui
 	UIType getUIType() { return UIType::AUDIO_RECORDER; }

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1307,8 +1307,8 @@ void Browser::currentFileDeleted() {
 
 int32_t textStartX = 14;
 
-void Browser::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
-	deluge::hid::display::OLED::drawScreenTitle(title);
+void Browser::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
+	canvas.drawScreenTitle(title);
 
 	int32_t yPixel = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 15 : 14;
 	yPixel += OLED_MAIN_TOPMOST_PIXEL;
@@ -1344,8 +1344,7 @@ void Browser::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 drawAFile:
 			// Draw graphic
 			uint8_t const* graphic = isFolder ? deluge::hid::display::OLED::folderIcon : fileIcon;
-			deluge::hid::display::OLED::drawGraphicMultiLine(graphic, 1, yPixel + 0, 8,
-			                                                 deluge::hid::display::OLED::oledMainImage[0]);
+			canvas.drawGraphicMultiLine(graphic, 1, yPixel + 0, 8);
 
 			// Draw filename
 			char finalChar = isFolder ? 0 : '.';
@@ -1359,8 +1358,7 @@ searchForChar:
 			int32_t displayStringLength = (uint32_t)finalCharAddress - (uint32_t)displayName;
 
 			if (isSelectedIndex) {
-				drawTextForOLEDEditing(textStartX, OLED_MAIN_WIDTH_PIXELS, yPixel, maxChars,
-				                       deluge::hid::display::OLED::oledMainImage);
+				drawTextForOLEDEditing(textStartX, OLED_MAIN_WIDTH_PIXELS, yPixel, maxChars, canvas);
 				if (!enteredTextEditPos) {
 					deluge::hid::display::OLED::setupSideScroller(0, enteredText.get(), textStartX,
 					                                              OLED_MAIN_WIDTH_PIXELS, yPixel, yPixel + 8,
@@ -1368,9 +1366,8 @@ searchForChar:
 				}
 			}
 			else {
-				deluge::hid::display::OLED::drawStringFixedLength(displayName, displayStringLength, textStartX, yPixel,
-				                                                  deluge::hid::display::OLED::oledMainImage[0],
-				                                                  OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+				canvas.drawString(std::string_view{displayName, static_cast<size_t>(displayStringLength)}, textStartX,
+				                  yPixel, kTextSpacingX, kTextSpacingY);
 			}
 
 			yPixel += kTextSpacingY;

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -90,7 +90,7 @@ public:
 	void cullSomeFileItems();
 	bool checkFP();
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	static String currentDir;
 	static CStringArray fileItems;

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.h
@@ -78,7 +78,9 @@ private:
 
 	void unscrolledPadAudition(int32_t velocity, int32_t note, bool shiftButtonDown);
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) { InstrumentClipMinder::renderOLED(image); }
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override {
+		InstrumentClipMinder::renderOLED(canvas);
+	}
 
 	void selectLayout(int8_t offset);
 	void enterScaleMode(int32_t selectedRootNote = kDefaultCalculateRootNote);

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -102,7 +102,7 @@ void QwertyUI::drawKeys() {
 }
 
 void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t yPixel, int32_t maxNumChars,
-                                      uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+                                      deluge::hid::display::oled_canvas::Canvas& canvas) {
 
 	char const* displayName = enteredText.get();
 	int32_t displayStringLength = enteredText.getLength();
@@ -122,9 +122,8 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 	maxXScroll = std::max(maxXScroll, 0_i32);
 	scrollPosHorizontal = std::min(scrollPosHorizontal, maxXScroll);
 
-	deluge::hid::display::OLED::drawString(&displayName[scrollPosHorizontal], xPixel, yPixel, image[0],
-	                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY, 0,
-	                                       xPixel + maxNumChars * kTextSpacingX);
+	canvas.drawString(&displayName[scrollPosHorizontal], xPixel, yPixel, kTextSpacingX, kTextSpacingY, 0,
+	                  xPixel + maxNumChars * kTextSpacingX);
 
 	int32_t highlightStartX = xPixel + kTextSpacingX * (enteredTextEditPos - scrollPosHorizontal);
 	// int32_t highlightEndX = xPixel + TEXT_SIZE_X * (displayStringLength - scrollPosHorizontal);
@@ -139,8 +138,7 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 		}
 	}
 	else {
-		deluge::hid::display::OLED::invertArea(highlightStartX, highlightWidth, yPixel, yPixel + kTextSpacingY - 1,
-		                                       image);
+		canvas.invertArea(highlightStartX, highlightWidth, yPixel, yPixel + kTextSpacingY - 1);
 	}
 }
 

--- a/src/deluge/gui/ui/qwerty_ui.h
+++ b/src/deluge/gui/ui/qwerty_ui.h
@@ -47,7 +47,7 @@ protected:
 
 	char const* title;
 	void drawTextForOLEDEditing(int32_t textStartX, int32_t xPixelMax, int32_t yPixel, int32_t maxChars,
-	                            uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	                            deluge::hid::display::oled_canvas::Canvas& canvas);
 
 	// 7SEG only
 	virtual void displayText(bool blinkImmediately = false);

--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -33,7 +33,7 @@ void RenameUI::displayText(bool blinkImmediately) {
 	}
 }
 
-void RenameUI::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void RenameUI::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 
 	int32_t windowWidth = 120;
 	int32_t windowHeight = 40;
@@ -44,19 +44,16 @@ void RenameUI::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 	int32_t windowMinY = (OLED_MAIN_HEIGHT_PIXELS - windowHeight) >> 1;
 	int32_t windowMaxY = OLED_MAIN_HEIGHT_PIXELS - windowMinY;
 
-	deluge::hid::display::OLED::clearAreaExact(windowMinX + 1, windowMinY + 1, windowMaxX - 1, windowMaxY - 1, image);
-
-	deluge::hid::display::OLED::drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY, image);
-
-	deluge::hid::display::OLED::drawStringCentred(title, windowMinY + 6, image[0], OLED_MAIN_WIDTH_PIXELS,
-	                                              kTextSpacingX, kTextSpacingY);
+	canvas.clearAreaExact(windowMinX + 1, windowMinY + 1, windowMaxX - 1, windowMaxY - 1);
+	canvas.drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY);
+	canvas.drawStringCentred(title, windowMinY + 6, kTextSpacingX, kTextSpacingY);
 
 	int32_t maxNumChars = 17; // "RENAME INSTRUMENT" should be the longest title string, so match that, so match that
 	int32_t charsWidthPixels = maxNumChars * kTextSpacingX;
 	int32_t charsStartPixel = (OLED_MAIN_WIDTH_PIXELS - charsWidthPixels) >> 1;
 	int32_t boxStartPixel = charsStartPixel - 3;
 
-	deluge::hid::display::OLED::drawRectangle(boxStartPixel, 24, OLED_MAIN_WIDTH_PIXELS - boxStartPixel, 38, &image[0]);
+	canvas.drawRectangle(boxStartPixel, 24, OLED_MAIN_WIDTH_PIXELS - boxStartPixel, 38);
 
-	drawTextForOLEDEditing(charsStartPixel, OLED_MAIN_WIDTH_PIXELS - charsStartPixel + 1, 27, maxNumChars, &image[0]);
+	drawTextForOLEDEditing(charsStartPixel, OLED_MAIN_WIDTH_PIXELS - charsStartPixel + 1, 27, maxNumChars, canvas);
 }

--- a/src/deluge/gui/ui/rename/rename_ui.h
+++ b/src/deluge/gui/ui/rename/rename_ui.h
@@ -24,5 +24,5 @@ public:
 	RenameUI();
 
 	void displayText(bool blinkImmediately = false);
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 };

--- a/src/deluge/gui/ui/sample_marker_editor.cpp
+++ b/src/deluge/gui/ui/sample_marker_editor.cpp
@@ -1119,7 +1119,7 @@ void SampleMarkerEditor::renderMarkerInCol(int32_t xDisplay,
 	}
 }
 
-void SampleMarkerEditor::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void SampleMarkerEditor::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	using deluge::hid::display::OLED;
 
 	MarkerColumn cols[kNumMarkerTypes];
@@ -1149,13 +1149,11 @@ void SampleMarkerEditor::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 		__builtin_unreachable();
 	}
 
-	OLED::drawScreenTitle(markerTypeText);
+	canvas.drawScreenTitle(markerTypeText);
 
 	if (isLoopLocked()) {
-		OLED::drawGraphicMultiLine(OLED::lockIcon, OLED_MAIN_WIDTH_PIXELS - 10, OLED_MAIN_TOPMOST_PIXEL + 1, 7,
-		                           OLED::oledMainImage[0]);
-		OLED::invertArea(OLED_MAIN_WIDTH_PIXELS - 10, 7, OLED_MAIN_TOPMOST_PIXEL + 9, OLED_MAIN_TOPMOST_PIXEL + 9,
-		                 &OLED::oledMainImage[0]);
+		canvas.drawGraphicMultiLine(OLED::lockIcon, OLED_MAIN_WIDTH_PIXELS - 10, OLED_MAIN_TOPMOST_PIXEL + 1, 7);
+		canvas.invertArea(OLED_MAIN_WIDTH_PIXELS - 10, 7, OLED_MAIN_TOPMOST_PIXEL + 9, OLED_MAIN_TOPMOST_PIXEL + 9);
 	}
 
 	int32_t smallTextSpacingX = kTextSpacingX;
@@ -1178,22 +1176,19 @@ void SampleMarkerEditor::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 
 			char buffer[12];
 			intToString(hours, buffer);
-			OLED::drawString(buffer, xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX,
-			                 smallTextSizeY);
+			canvas.drawString(buffer, xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 			xPixel += strlen(buffer) * smallTextSpacingX;
 
-			OLED::drawChar('h', smallTextSpacingX, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX,
-			               smallTextSizeY);
+			canvas.drawChar('h', smallTextSpacingX, yPixel, smallTextSpacingX, smallTextSizeY);
 			xPixel += smallTextSpacingX * 2;
 		}
 
 		char buffer[12];
 		intToString(minutes, buffer);
-		OLED::drawString(buffer, xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX, smallTextSizeY);
+		canvas.drawString(buffer, xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 		xPixel += strlen(buffer) * smallTextSpacingX;
 
-		OLED::drawChar('m', smallTextSpacingX, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX,
-		               smallTextSizeY);
+		canvas.drawChar('m', smallTextSpacingX, yPixel, smallTextSpacingX, smallTextSizeY);
 		xPixel += smallTextSpacingX * 2;
 	}
 	else {
@@ -1221,17 +1216,16 @@ printSeconds:
 		memmove(&buffer[length - numDecimalPlaces + 1], &buffer[length - numDecimalPlaces], numDecimalPlaces + 1);
 		buffer[length - numDecimalPlaces] = '.';
 
-		OLED::drawString(buffer, xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX, smallTextSizeY);
+		canvas.drawString(buffer, xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 		xPixel += (length + 1) * smallTextSpacingX;
 
 		if (hours || minutes) {
-			OLED::drawChar('s', xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX, smallTextSizeY);
+			canvas.drawChar('s', xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 		}
 		else {
 			xPixel += smallTextSpacingX;
 			char const* secString = (numDecimalPlaces == 2) ? "msec" : "sec";
-			OLED::drawString(secString, xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX,
-			                 smallTextSizeY);
+			canvas.drawString(secString, xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 		}
 	}
 
@@ -1240,17 +1234,15 @@ printSeconds:
 	// Sample count
 	xPixel = 1;
 
-	OLED::drawChar('(', xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX, smallTextSizeY);
+	canvas.drawChar('(', xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 	xPixel += smallTextSpacingX;
 
 	char buffer[12];
 	intToString(markerPosSamples, buffer);
-	deluge::hid::display::OLED::drawString(buffer, xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX,
-	                                       smallTextSizeY);
+	canvas.drawString(buffer, xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 	xPixel += smallTextSpacingX * (strlen(buffer) + 1);
 
-	deluge::hid::display::OLED::drawString("smpl)", xPixel, yPixel, image[0], OLED_MAIN_WIDTH_PIXELS, smallTextSpacingX,
-	                                       smallTextSizeY);
+	canvas.drawString("smpl)", xPixel, yPixel, smallTextSpacingX, smallTextSizeY);
 	xPixel += smallTextSpacingX * 6;
 }
 

--- a/src/deluge/gui/ui/sample_marker_editor.h
+++ b/src/deluge/gui/ui/sample_marker_editor.h
@@ -49,7 +49,7 @@ public:
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth] = nullptr) override;
 
 	// OLED
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override;
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	// 7SEG
 	void displayText();

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -73,7 +73,7 @@ void Slicer::focusRegained() {
 	}
 }
 
-void Slicer::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void Slicer::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 
 	int32_t windowWidth = 100;
 	int32_t windowHeight = 31;
@@ -87,17 +87,16 @@ void Slicer::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
 	windowMinY += 2;
 	int32_t windowMaxY = windowMinY + windowHeight;
 
-	deluge::hid::display::OLED::clearAreaExact(windowMinX + 1, windowMinY + 1, windowMaxX - 1, windowMaxY - 1, image);
+	canvas.clearAreaExact(windowMinX + 1, windowMinY + 1, windowMaxX - 1, windowMaxY - 1);
 
-	deluge::hid::display::OLED::drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY, image);
-	deluge::hid::display::OLED::drawHorizontalLine(windowMinY + 15, 26, OLED_MAIN_WIDTH_PIXELS - 22, &image[0]);
-	deluge::hid::display::OLED::drawString("Num. slices", 30, windowMinY + 6, image[0], OLED_MAIN_WIDTH_PIXELS,
-	                                       kTextSpacingX, kTextSpacingY);
+	canvas.drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY);
+	canvas.drawHorizontalLine(windowMinY + 15, 26, OLED_MAIN_WIDTH_PIXELS - 22);
+	canvas.drawString("Num. slices", 30, windowMinY + 6, kTextSpacingX, kTextSpacingY);
+
 	char buffer[12];
 	intToString(slicerMode == SLICER_MODE_REGION ? numClips : numManualSlice, buffer);
-	deluge::hid::display::OLED::drawStringCentred(buffer, windowMinY + 18, image[0], OLED_MAIN_WIDTH_PIXELS,
-	                                              kTextSpacingX, kTextSpacingY,
-	                                              (OLED_MAIN_WIDTH_PIXELS >> 1) + horizontalShift);
+	canvas.drawStringCentred(buffer, windowMinY + 18, kTextSpacingX, kTextSpacingY,
+	                         (OLED_MAIN_WIDTH_PIXELS >> 1) + horizontalShift);
 }
 
 void Slicer::redraw() {

--- a/src/deluge/gui/ui/slicer.h
+++ b/src/deluge/gui/ui/slicer.h
@@ -53,7 +53,7 @@ public:
 	int32_t slicerMode;
 	SliceItem manualSlicePoints[MAX_MANUAL_SLICES];
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	int16_t numClips;
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1661,7 +1661,7 @@ void SoundEditor::mpeZonesPotentiallyUpdated() {
 	}
 }
 
-void SoundEditor::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void SoundEditor::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 
 	// Sorry - extremely ugly hack here.
 	MenuItem* currentMenuItem = getCurrentMenuItem();

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -142,7 +142,7 @@ public:
 	AudioFileHolder* getCurrentAudioFileHolder();
 	void mpeZonesPotentiallyUpdated();
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas);
 
 	// ui
 	UIType getUIType() { return UIType::SOUND_EDITOR; }

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -356,11 +356,11 @@ void doAnyPendingOLEDRendering() {
 			u--;
 		}
 
-		OLED::clearMainImage();
+		OLED::main.clear();
 
 		for (; u < numUIsOpen; u++) {
 			OLED::stopScrollingAnimation();
-			uiNavigationHierarchy[u]->renderOLED(deluge::hid::display::OLED::oledMainImage);
+			uiNavigationHierarchy[u]->renderOLED(deluge::hid::display::OLED::main);
 		}
 
 		// Don't need to mark dirty because clearMainImage has already done that for us

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -20,6 +20,7 @@
 #include "definitions_cxx.hpp"
 #include "gui/colour/colour.h"
 #include "hid/button.h"
+#include "hid/display/oled_canvas/canvas.h"
 
 class RootUI;
 class ClipMinder;
@@ -140,7 +141,7 @@ public:
 
 	void close();
 
-	virtual void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) = 0;
+	virtual void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) = 0;
 	bool oledShowsUIUnderneath;
 
 	virtual UIType getUIType() = 0;

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -97,8 +97,8 @@ ArrangerView::ArrangerView() {
 	lastInteractedClipInstance = nullptr;
 }
 
-void ArrangerView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
-	sessionView.renderOLED(image);
+void ArrangerView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
+	sessionView.renderOLED(canvas);
 }
 
 void ArrangerView::moveClipToSession() {

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -85,7 +85,7 @@ public:
 	ActionResult verticalScrollOneSquare(int32_t direction);
 	ActionResult horizontalScrollOneSquare(int32_t direction);
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override;
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	Output* outputsOnScreen[kDisplayHeight];
 	int8_t yPressedEffective;

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -94,7 +94,7 @@ void AudioClipView::focusRegained() {
 #endif
 }
 
-void AudioClipView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void AudioClipView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	view.displayOutputName(getCurrentOutput(), false);
 }
 

--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -55,7 +55,7 @@ public:
 	uint32_t getMaxLength() override;
 	uint32_t getMaxZoom() override;
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override;
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	// ui
 	UIType getUIType() override { return UIType::AUDIO_CLIP_VIEW; }

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1132,7 +1132,8 @@ void AutomationView::renderDisplay(int32_t knobPosLeft, int32_t knobPosRight, bo
 }
 
 void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_t knobPosLeft, int32_t knobPosRight) {
-	deluge::hid::display::OLED::clearMainImage();
+	deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+	canvas.clear();
 
 	if (onAutomationOverview() || (outputType == OutputType::CV)) {
 
@@ -1158,9 +1159,7 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 			}
 			else {
 				overviewText = l10n::get(l10n::String::STRING_FOR_AUTOMATION_OVERVIEW);
-				deluge::hid::display::OLED::drawStringCentred(overviewText, yPos,
-				                                              deluge::hid::display::OLED::oledMainImage[0],
-				                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+				canvas.drawStringCentred(overviewText, yPos, kTextSpacingX, kTextSpacingY);
 			}
 		}
 		else {
@@ -1178,9 +1177,7 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 #else
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 #endif
-		deluge::hid::display::OLED::drawStringCentredShrinkIfNecessary(
-		    parameterName, yPos, deluge::hid::display::OLED::oledMainImage[0], OLED_MAIN_WIDTH_PIXELS, kTextSpacingX,
-		    kTextSpacingY);
+		canvas.drawStringCentredShrinkIfNecessary(parameterName, yPos, kTextSpacingX, kTextSpacingY);
 
 		// display automation status
 		yPos = yPos + 12;
@@ -1215,8 +1212,7 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 			}
 		}
 
-		deluge::hid::display::OLED::drawStringCentred(isAutomated, yPos, deluge::hid::display::OLED::oledMainImage[0],
-		                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+		canvas.drawStringCentred(isAutomated, yPos, kTextSpacingX, kTextSpacingY);
 
 		// display parameter value
 		yPos = yPos + 12;
@@ -1227,23 +1223,19 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 			bufferLeft[1] = ':';
 			bufferLeft[2] = ' ';
 			intToString(knobPosLeft, &bufferLeft[3]);
-			deluge::hid::display::OLED::drawString(bufferLeft, 0, yPos, deluge::hid::display::OLED::oledMainImage[0],
-			                                       OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			canvas.drawString(bufferLeft, 0, yPos, kTextSpacingX, kTextSpacingY);
 
 			char bufferRight[10];
 			bufferRight[0] = 'R';
 			bufferRight[1] = ':';
 			bufferRight[2] = ' ';
 			intToString(knobPosRight, &bufferRight[3]);
-			deluge::hid::display::OLED::drawStringAlignRight(bufferRight, yPos,
-			                                                 deluge::hid::display::OLED::oledMainImage[0],
-			                                                 OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			canvas.drawStringAlignRight(bufferRight, yPos, kTextSpacingX, kTextSpacingY);
 		}
 		else {
 			char buffer[5];
 			intToString(knobPosLeft, buffer);
-			deluge::hid::display::OLED::drawStringCentred(buffer, yPos, deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			canvas.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
 		}
 	}
 

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -71,7 +71,9 @@ public:
 	void displayAutomation(bool padSelected = false, bool updateDisplay = true);
 	bool possiblyRefreshAutomationEditorGrid(Clip* clip, deluge::modulation::params::Kind paramKind, int32_t paramID);
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) { InstrumentClipMinder::renderOLED(image); }
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override {
+		InstrumentClipMinder::renderOLED(canvas);
+	}
 
 	// button action
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -158,7 +158,9 @@ public:
 	void pasteAutomation(int32_t whichModEncoder, int32_t navSysId = NAVIGATION_CLIP);
 	// made these public so they can be accessed by the automation clip view
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override { InstrumentClipMinder::renderOLED(image); }
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override {
+		InstrumentClipMinder::renderOLED(canvas);
+	}
 
 	CopiedNoteRow* firstCopiedNoteRow;
 	int32_t copiedScreenWidth;

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -442,10 +442,13 @@ bool PerformanceSessionView::renderSidebar(uint32_t whichRows, RGB image[][kDisp
 }
 
 /// render performance view display on opening
+///
+/// XXX: This should take a canvas and render to it rather than pulling the main image all the time.
 void PerformanceSessionView::renderViewDisplay() {
 	if (defaultEditingMode) {
 		if (display->haveOLED()) {
-			deluge::hid::display::OLED::clearMainImage();
+			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+			image.clear();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -454,9 +457,8 @@ void PerformanceSessionView::renderViewDisplay() {
 #endif
 
 			// render "Performance View" at top of OLED screen
-			deluge::hid::display::OLED::drawStringCentred(l10n::get(l10n::String::STRING_FOR_PERFORM_VIEW), yPos,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			image.drawStringCentred(l10n::get(l10n::String::STRING_FOR_PERFORM_VIEW), yPos, kTextSpacingX,
+			                        kTextSpacingY);
 
 			yPos = yPos + 12;
 
@@ -470,16 +472,13 @@ void PerformanceSessionView::renderViewDisplay() {
 				editingModeType = l10n::get(l10n::String::STRING_FOR_PERFORM_EDIT_VALUE);
 			}
 
-			deluge::hid::display::OLED::drawStringCentred(editingModeType, yPos,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			image.drawStringCentred(editingModeType, yPos, kTextSpacingX, kTextSpacingY);
 
 			yPos = yPos + 12;
 
 			// render "Editing Mode" at the bottom of the OLED screen
-			deluge::hid::display::OLED::drawStringCentred(l10n::get(l10n::String::STRING_FOR_PERFORM_EDITOR), yPos,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			image.drawStringCentred(l10n::get(l10n::String::STRING_FOR_PERFORM_EDITOR), yPos, kTextSpacingX,
+			                        kTextSpacingY);
 
 			deluge::hid::display::OLED::markChanged();
 		}
@@ -489,7 +488,8 @@ void PerformanceSessionView::renderViewDisplay() {
 	}
 	else {
 		if (display->haveOLED()) {
-			deluge::hid::display::OLED::clearMainImage();
+			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+			image.clear();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -500,9 +500,8 @@ void PerformanceSessionView::renderViewDisplay() {
 			yPos = yPos + 12;
 
 			// Render "Performance View" in the middle of the OLED screen
-			deluge::hid::display::OLED::drawStringCentred(l10n::get(l10n::String::STRING_FOR_PERFORM_VIEW), yPos,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			image.drawStringCentred(l10n::get(l10n::String::STRING_FOR_PERFORM_VIEW), yPos, kTextSpacingX,
+			                        kTextSpacingY);
 
 			deluge::hid::display::OLED::markChanged();
 		}
@@ -520,7 +519,8 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 		char parameterName[30];
 		strncpy(parameterName, getParamDisplayName(paramKind, paramID), 29);
 		if (display->haveOLED()) {
-			deluge::hid::display::OLED::clearMainImage();
+			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+			image.clear();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -529,9 +529,7 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 #endif
 			yPos = yPos + 12;
 
-			deluge::hid::display::OLED::drawStringCentred(parameterName, yPos,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			image.drawStringCentred(parameterName, yPos, kTextSpacingX, kTextSpacingY);
 
 			deluge::hid::display::OLED::markChanged();
 		}
@@ -541,7 +539,8 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 	}
 	else {
 		if (display->haveOLED()) {
-			deluge::hid::display::OLED::clearMainImage();
+			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+			image.clear();
 
 			// display parameter name
 			char parameterName[30];
@@ -552,9 +551,7 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 #else
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 #endif
-			deluge::hid::display::OLED::drawStringCentred(parameterName, yPos,
-			                                              deluge::hid::display::OLED::oledMainImage[0],
-			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+			image.drawStringCentred(parameterName, yPos, kTextSpacingX, kTextSpacingY);
 
 			// display parameter value
 			yPos = yPos + 24;
@@ -576,16 +573,12 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 				else { // 64ths stutter: all 4 leds turned on
 					buffer = "64ths";
 				}
-				deluge::hid::display::OLED::drawStringCentred(buffer, yPos,
-				                                              deluge::hid::display::OLED::oledMainImage[0],
-				                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+				image.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
 			}
 			else {
 				char buffer[5];
 				intToString(knobPos, buffer);
-				deluge::hid::display::OLED::drawStringCentred(buffer, yPos,
-				                                              deluge::hid::display::OLED::oledMainImage[0],
-				                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+				image.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
 			}
 
 			deluge::hid::display::OLED::markChanged();
@@ -643,9 +636,9 @@ bool PerformanceSessionView::possiblyRefreshPerformanceViewDisplay(params::Kind 
 	return false;
 }
 
-void PerformanceSessionView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void PerformanceSessionView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	renderViewDisplay();
-	sessionView.renderOLED(image);
+	sessionView.renderOLED(canvas);
 }
 
 void PerformanceSessionView::redrawNumericDisplay() {

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -73,7 +73,7 @@ public:
 	bool renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) override;
 	void renderViewDisplay();
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) override;
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 	// 7SEG only
 	void redrawNumericDisplay();
 	void setLedStates();

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1714,7 +1714,7 @@ void SessionView::setLedStates() {
 
 extern char loopsRemainingText[];
 
-void SessionView::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void SessionView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	UI* currentUI = getCurrentUI();
 	if (currentUI != &performanceSessionView) {
 		renderViewDisplay(currentUI == &arrangerView ? l10n::get(l10n::String::STRING_FOR_ARRANGER_VIEW)
@@ -1818,7 +1818,9 @@ nothingToDisplay:
 /// render session view display on opening
 void SessionView::renderViewDisplay(char const* viewString) {
 	if (display->haveOLED()) {
-		deluge::hid::display::OLED::clearMainImage();
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+
+		canvas.clear();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -1828,8 +1830,7 @@ void SessionView::renderViewDisplay(char const* viewString) {
 
 		yPos = yPos + 12;
 
-		deluge::hid::display::OLED::drawStringCentred(viewString, yPos, deluge::hid::display::OLED::oledMainImage[0],
-		                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+		canvas.drawStringCentred(viewString, yPos, kTextSpacingX, kTextSpacingY);
 		if (!display->hasPopup()) {
 			deluge::hid::display::OLED::markChanged();
 		}

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -95,7 +95,7 @@ public:
 	void modEncoderAction(int32_t whichModEncoder, int32_t offset);
 	ActionResult verticalScrollOneSquare(int32_t direction);
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 
 	// 7SEG only
 	void redrawNumericDisplay();

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1965,7 +1965,9 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 	}
 
 	if (display->haveOLED()) {
-		deluge::hid::display::OLED::clearMainImage();
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+		canvas.clear();
+
 		char const* outputTypeText;
 		switch (outputType) {
 		case OutputType::SYNTH:
@@ -2000,9 +2002,7 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 #else
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 #endif
-		deluge::hid::display::OLED::drawStringCentred(outputTypeText, yPos,
-		                                              deluge::hid::display::OLED::oledMainImage[0],
-		                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
+		canvas.drawStringCentred(outputTypeText, yPos, kTextSpacingX, kTextSpacingY);
 	}
 
 	char buffer[12];
@@ -2012,6 +2012,7 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 		if (display->haveOLED()) {
 			nameToDraw = name;
 oledDrawString:
+			deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 32;
 #else
@@ -2024,14 +2025,10 @@ oledDrawString:
 			int32_t textLength = strlen(name);
 			int32_t stringLengthPixels = textLength * textSpacingX;
 			if (stringLengthPixels <= OLED_MAIN_WIDTH_PIXELS) {
-				deluge::hid::display::OLED::drawStringCentred(nameToDraw, yPos,
-				                                              deluge::hid::display::OLED::oledMainImage[0],
-				                                              OLED_MAIN_WIDTH_PIXELS, textSpacingX, textSpacingY);
+				canvas.drawStringCentred(nameToDraw, yPos, textSpacingX, textSpacingY);
 			}
 			else {
-				deluge::hid::display::OLED::drawString(nameToDraw, 0, yPos,
-				                                       deluge::hid::display::OLED::oledMainImage[0],
-				                                       OLED_MAIN_WIDTH_PIXELS, textSpacingX, textSpacingY);
+				canvas.drawString(nameToDraw, 0, yPos, textSpacingX, textSpacingY);
 				deluge::hid::display::OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos,
 				                                              yPos + textSpacingY, textSpacingX, textSpacingY, false);
 			}

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -21,6 +21,7 @@
 #ifdef __cplusplus
 #include "definitions_cxx.hpp"
 #include "display.h"
+#include "oled_canvas/canvas.h"
 
 #define OLED_LOG_TIMING (0 && ENABLE_TEXT_OUTPUT)
 
@@ -37,43 +38,13 @@ public:
 		}
 	}
 
-	static void drawOnePixel(int32_t x, int32_t y);
 	/// Clear the canvas currently being used as the main image.
 	///
 	/// Marks the OLED as dirty, so you don't need to do that later yourself.
 	static void clearMainImage();
-	static void clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY,
-	                           uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
-
-	static void drawRectangle(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY,
-	                          uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
-	static void drawVerticalLine(int32_t pixelX, int32_t startY, int32_t endY, uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
-	static void drawHorizontalLine(int32_t pixelY, int32_t startX, int32_t endX,
-	                               uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
-	static void drawString(std::string_view, int32_t pixelX, int32_t pixelY, uint8_t* image, int32_t imageWidth,
-	                       int32_t textWidth, int32_t textHeight, int32_t scrollPos = 0,
-	                       int32_t endX = OLED_MAIN_WIDTH_PIXELS);
-	static void drawStringFixedLength(char const* string, int32_t length, int32_t pixelX, int32_t pixelY,
-	                                  uint8_t* image, int32_t imageWidth, int32_t textWidth, int32_t textHeight);
-	static void drawStringCentred(char const* string, int32_t pixelY, uint8_t* image, int32_t imageWidth,
-	                              int32_t textWidth, int32_t textHeight,
-	                              int32_t centrePos = (OLED_MAIN_WIDTH_PIXELS >> 1));
-	static void drawStringCentredShrinkIfNecessary(char const* string, int32_t pixelY, uint8_t* image,
-	                                               int32_t imageWidth, int32_t textWidth, int32_t textHeight);
-	static void drawStringAlignRight(char const* string, int32_t pixelY, uint8_t* image, int32_t imageWidth,
-	                                 int32_t textWidth, int32_t textHeight, int32_t rightPos = OLED_MAIN_WIDTH_PIXELS);
-	static void drawChar(uint8_t theChar, int32_t pixelX, int32_t pixelY, uint8_t* image, int32_t imageWidth,
-	                     int32_t textWidth, int32_t textHeight, int32_t scrollPos = 0,
-	                     int32_t endX = OLED_MAIN_WIDTH_PIXELS);
-	static void drawGraphicMultiLine(uint8_t const* graphic, int32_t startX, int32_t startY, int32_t width,
-	                                 uint8_t* image, int32_t height = 8, int32_t numBytesTall = 1);
-	static void drawScreenTitle(std::string_view text);
 
 	static void setupBlink(int32_t minX, int32_t width, int32_t minY, int32_t maxY, bool shouldBlinkImmediately);
 	static void stopBlink();
-
-	static void invertArea(int32_t xMin, int32_t width, int32_t startY, int32_t endY,
-	                       uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
 
 	static void sendMainImage();
 
@@ -109,9 +80,9 @@ public:
 
 	static void renderEmulated7Seg(const std::array<uint8_t, kNumericDisplayLength>& display);
 
-	static uint8_t oledMainImage[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS];
-	static uint8_t oledMainPopupImage[OLED_MAIN_HEIGHT_PIXELS >> 3][OLED_MAIN_WIDTH_PIXELS];
-	static uint8_t oledMainConsoleImage[kConsoleImageNumRows][OLED_MAIN_WIDTH_PIXELS];
+	static oled_canvas::Canvas main;
+	static oled_canvas::Canvas popup;
+	static oled_canvas::Canvas console;
 
 	// pointer to one of the three above (the one currently displayed)
 	static uint8_t (*oledCurrentImage)[OLED_MAIN_WIDTH_PIXELS];

--- a/src/deluge/hid/display/oled_canvas/canvas.cpp
+++ b/src/deluge/hid/display/oled_canvas/canvas.cpp
@@ -1,0 +1,374 @@
+/*
+ * Copyright © 2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "canvas.h"
+#include "definitions_cxx.hpp"
+#include "gui/fonts/fonts.h"
+
+using deluge::hid::display::oled_canvas::Canvas;
+
+void Canvas::clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY) {
+	int32_t firstRow = minY >> 3;
+	int32_t lastRow = maxY >> 3;
+
+	int32_t firstCompleteRow = firstRow;
+	int32_t lastCompleteRow = lastRow;
+
+	int32_t lastRowPixelWithin = maxY & 7;
+	bool willDoLastRow = (lastRowPixelWithin != 7);
+	uint8_t lastRowMask = 255 << (lastRowPixelWithin + 1);
+
+	// First row
+	int32_t firstRowPixelWithin = minY & 7;
+	if (firstRowPixelWithin) {
+		firstCompleteRow++;
+		uint8_t firstRowMask = ~(255 << firstRowPixelWithin);
+		if (willDoLastRow && firstRow == lastRow) {
+			firstRowMask &= lastRowMask;
+		}
+		for (int32_t x = minX; x <= maxX; x++) {
+			image_[firstRow][x] &= firstRowMask;
+		}
+
+		if (firstRow == lastRow) {
+			return;
+		}
+	}
+
+	// Last row
+	if (willDoLastRow) {
+		lastCompleteRow--;
+		for (int32_t x = minX; x <= maxX; x++) {
+			image_[lastRow][x] &= lastRowMask;
+		}
+	}
+
+	for (int32_t row = firstCompleteRow; row <= lastCompleteRow; row++) {
+		memset(&image_[row][minX], 0, maxX - minX + 1);
+	}
+}
+
+void Canvas::drawPixel(int32_t x, int32_t y) {
+	int32_t yRow = y >> 3;
+	image_[yRow][x] |= 1 << (y & 0x7);
+}
+
+void Canvas::drawHorizontalLine(int32_t pixelY, int32_t startX, int32_t endX) {
+	uint8_t mask = 1 << (pixelY & 7);
+
+	uint8_t* __restrict__ currentPos = &image_[pixelY >> 3][startX];
+	uint8_t* const lastPos = currentPos + (endX - startX);
+	do {
+		*currentPos |= mask;
+		currentPos++;
+	} while (currentPos <= lastPos);
+}
+
+void Canvas::drawVerticalLine(int32_t pixelX, int32_t startY, int32_t endY) {
+	int32_t firstRowY = startY >> 3;
+	int32_t lastRowY = endY >> 3;
+
+	uint8_t firstRowMask = (255 << (startY & 7));
+	uint8_t lastRowMask = (255 >> (7 - (endY & 7)));
+
+	uint8_t* __restrict__ currentPos = &image_[firstRowY][pixelX];
+
+	if (firstRowY == lastRowY) {
+		uint8_t mask = firstRowMask & lastRowMask;
+		*currentPos |= mask;
+	}
+
+	else {
+		uint8_t* const finalPos = &image_[lastRowY][pixelX];
+
+		// First row
+		*currentPos |= firstRowMask;
+
+		// Intermediate rows
+		goto drawSolid;
+		do {
+			*currentPos = 255;
+drawSolid:
+			currentPos += OLED_MAIN_WIDTH_PIXELS;
+		} while (currentPos != finalPos);
+
+		// Last row
+		*currentPos |= lastRowMask;
+	}
+}
+
+void Canvas::drawRectangle(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY) {
+	drawVerticalLine(minX, minY, maxY);
+	drawVerticalLine(maxX, minY, maxY);
+
+	drawHorizontalLine(minY, minX + 1, maxX - 1);
+	drawHorizontalLine(maxY, minX + 1, maxX - 1);
+}
+
+void Canvas::drawString(std::string_view string, int32_t pixelX, int32_t pixelY, int32_t textWidth, int32_t textHeight,
+                        int32_t scrollPos, int32_t endX) {
+	if (scrollPos) {
+		int32_t numCharsToChopOff = (uint16_t)scrollPos / (uint8_t)textWidth;
+		if (numCharsToChopOff) {
+			if (numCharsToChopOff >= string.length()) {
+				return;
+			}
+
+			string = string.substr(numCharsToChopOff);
+			scrollPos -= numCharsToChopOff * textWidth;
+		}
+	}
+	for (char const c : string) {
+		drawChar(c, pixelX, pixelY, textWidth, textHeight, scrollPos, endX);
+		pixelX += textWidth - scrollPos;
+		if (pixelX >= endX) {
+			break;
+		}
+		scrollPos = 0;
+	}
+}
+
+void Canvas::drawStringCentred(char const* string, int32_t pixelY, int32_t textWidth, int32_t textHeight,
+                               int32_t centrePos) {
+	std::string_view str{string};
+	int32_t pixelX = centrePos - ((textWidth * str.length()) >> 1);
+	drawString(str, pixelX, pixelY, textWidth, textHeight);
+}
+
+/// Draw a string, reducing its height so the string fits within the specified width
+///
+/// @param string A null-terminated C string
+/// @param pixelY The Y coordinate of the top of the string
+/// @param textWidth Requested width for each character in the string
+/// @param textHeight Requested height for each character in the string
+void Canvas::drawStringCentredShrinkIfNecessary(char const* string, int32_t pixelY, int32_t textWidth,
+                                                int32_t textHeight) {
+	std::string_view str{string};
+	int32_t maxTextWidth = (uint8_t)OLED_MAIN_WIDTH_PIXELS / (uint32_t)str.length();
+	if (textWidth > maxTextWidth) {
+		int32_t newHeight = (uint32_t)(textHeight * maxTextWidth) / (uint32_t)textWidth;
+		if (newHeight >= 20) {
+			newHeight = 20;
+		}
+		else if (newHeight >= 13) {
+			newHeight = 13;
+		}
+		else if (newHeight >= 10) {
+			newHeight = 10;
+		}
+		else {
+			newHeight = 7;
+		}
+
+		textWidth = maxTextWidth;
+
+		int32_t heightDiff = textHeight - newHeight;
+		pixelY += heightDiff >> 1;
+		textHeight = newHeight;
+	}
+	int32_t pixelX = (kImageWidth - textWidth * str.length()) >> 1;
+	drawString(str, pixelX, pixelY, textWidth, textHeight);
+}
+
+void Canvas::drawStringAlignRight(char const* string, int32_t pixelY, int32_t textWidth, int32_t textHeight,
+                                  int32_t rightPos) {
+	std::string_view str{string};
+	int32_t pixelX = rightPos - (textWidth * str.length());
+	drawString(str, pixelX, pixelY, textWidth, textHeight);
+}
+
+#define DO_CHARACTER_SCALING 0
+
+void Canvas::drawChar(uint8_t theChar, int32_t pixelX, int32_t pixelY, int32_t spacingX, int32_t textHeight,
+                      int32_t scrollPos, int32_t endX) {
+
+	if (theChar > '~') {
+		return;
+	}
+
+	if (theChar >= 'a') {
+		if (theChar <= 'z') {
+			theChar -= 32;
+		}
+		else {
+			theChar -= 26; // Lowercase chars have been snipped out of the tables.
+		}
+	}
+
+	int32_t charIndex = theChar - 0x20;
+	if (charIndex <= 0) {
+		return;
+	}
+
+	lv_font_glyph_dsc_t const* descriptor;
+	uint8_t const* font;
+	int32_t fontNativeHeight;
+
+	switch (textHeight) {
+	case 9:
+		pixelY++;
+		[[fallthrough]];
+	case 7:
+		[[fallthrough]];
+	case 8:
+		textHeight = 7;
+		descriptor = font_apple_desc;
+		font = font_apple;
+		fontNativeHeight = 8;
+		break;
+	case 10:
+		textHeight = 9;
+		descriptor = font_metric_bold_9px_desc;
+		font = font_metric_bold_9px;
+		fontNativeHeight = 9;
+		break;
+	case 13:
+		descriptor = font_metric_bold_13px_desc;
+		font = font_metric_bold_13px;
+		fontNativeHeight = 13;
+		break;
+	case 20:
+		[[fallthrough]];
+	default:
+		fontNativeHeight = 20;
+		descriptor = font_metric_bold_20px_desc;
+		font = font_metric_bold_20px;
+		break;
+	}
+
+	descriptor += charIndex;
+
+#if DO_CHARACTER_SCALING
+	int32_t scaledFontWidth =
+	    (uint16_t)(descriptor->w_px * textHeight + (fontNativeHeight >> 1) - 1) / (uint8_t)fontNativeHeight;
+#else
+	int32_t scaledFontWidth = descriptor->w_px;
+#endif
+	pixelX += (spacingX - scaledFontWidth) >> 1;
+
+	if (pixelX < 0) {
+		scrollPos += -pixelX;
+		pixelX = 0;
+	}
+
+	int32_t bytesPerCol = ((textHeight - 1) >> 3) + 1;
+
+	int32_t textWidth = descriptor->w_px - scrollPos;
+	drawGraphicMultiLine(&font[descriptor->glyph_index + scrollPos * bytesPerCol], pixelX, pixelY, textWidth,
+	                     textHeight, bytesPerCol);
+}
+
+void Canvas::drawGraphicMultiLine(uint8_t const* graphic, int32_t startX, int32_t startY, int32_t width, int32_t height,
+                                  int32_t numBytesTall) {
+	int32_t rowOnDisplay = startY >> 3;
+	int32_t yOffset = startY & 7;
+	int32_t rowOnGraphic = 0;
+
+	if (width > OLED_MAIN_WIDTH_PIXELS - startX) {
+		width = OLED_MAIN_WIDTH_PIXELS - startX;
+	}
+
+	// First row
+	uint8_t* __restrict__ currentPos = &image_[rowOnDisplay][startX];
+	uint8_t const* endPos = currentPos + width;
+	uint8_t const* __restrict__ graphicPos = graphic;
+
+	while (currentPos < endPos) {
+		*currentPos |= (*graphicPos << yOffset);
+		currentPos++;
+		graphicPos += numBytesTall;
+	}
+
+	int32_t yOffsetNegative = 8 - yOffset;
+
+	// Do middle rows
+	while (true) {
+		rowOnDisplay++;
+		if (rowOnDisplay >= (OLED_MAIN_HEIGHT_PIXELS >> 3)) {
+			return;
+		}
+
+		rowOnGraphic++;
+		if (height <= ((rowOnGraphic << 3) - yOffset)) {
+			return; // If no more of graphic to draw...
+		}
+
+		currentPos = &image_[rowOnDisplay][startX];
+		endPos = currentPos + width;
+		graphicPos = graphic++; // Takes value before we increment
+
+		if (rowOnGraphic >= numBytesTall) {
+			break; // If only drawing that remains is final row of graphic...
+		}
+
+		while (currentPos < endPos) {
+			// Cleverly read 2 bytes in one go. Doesn't really speed things up. I should try addressing display
+			// vertically, so I can do 32 bits in one go on both the graphic and the display...
+			uint32_t data = *(uint16_t*)graphicPos;
+			*currentPos |= data >> yOffsetNegative;
+
+			//*currentPos |= (*graphicPos >> yOffsetNegative) | (*(graphicPos + 1) << yOffset);
+			currentPos++;
+			graphicPos += numBytesTall;
+		}
+	}
+
+	// Final row
+	while (currentPos < endPos) {
+		*currentPos |= (*graphicPos >> yOffsetNegative);
+		currentPos++;
+		graphicPos += numBytesTall;
+	}
+}
+
+/// Draw a screen title and underline it.
+///
+/// @param text Title text
+void Canvas::drawScreenTitle(std::string_view title) {
+	int32_t extraY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 0 : 1;
+
+	int32_t startY = extraY + OLED_MAIN_TOPMOST_PIXEL;
+
+	drawString(title, 0, startY, kTextTitleSpacingX, kTextTitleSizeY);
+	drawHorizontalLine(extraY + 11 + OLED_MAIN_TOPMOST_PIXEL, 0, OLED_MAIN_WIDTH_PIXELS - 1);
+}
+
+void Canvas::invertArea(int32_t xMin, int32_t width, int32_t startY, int32_t endY) {
+	int32_t firstRowY = startY >> 3;
+	int32_t lastRowY = endY >> 3;
+
+	uint8_t currentRowMask = (255 << (startY & 7));
+	uint8_t lastRowMask = (255 >> (7 - (endY & 7)));
+
+	// For each row
+	for (int32_t rowY = firstRowY; rowY <= lastRowY; rowY++) {
+
+		if (rowY == lastRowY) {
+			currentRowMask &= lastRowMask;
+		}
+
+		uint8_t* __restrict__ currentPos = &image_[rowY][xMin];
+		uint8_t* const endPos = currentPos + width;
+
+		while (currentPos < endPos) {
+			*currentPos ^= currentRowMask;
+			currentPos++;
+		}
+
+		currentRowMask = 0xFF;
+	}
+}

--- a/src/deluge/hid/display/oled_canvas/canvas.h
+++ b/src/deluge/hid/display/oled_canvas/canvas.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "RZA1/cpu_specific.h"
+#include "definitions.h"
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+namespace deluge::hid::display {
+class OLED;
+
+namespace oled_canvas {
+class Canvas {
+public:
+	Canvas() = default;
+	~Canvas() = default;
+
+	Canvas(Canvas const& other) = delete;
+	Canvas(Canvas&& other) = delete;
+
+	Canvas& operator=(Canvas const& other) = delete;
+	Canvas& operator=(Canvas&& other) = delete;
+
+	/// @{
+	/// @name Rendering routines
+
+	/// Clear the entire image
+	void clear() {
+		// Takes about 1 fast-timer tick (whereas entire rendering takes around 8 to 15).
+		// So, not worth trying to use DMA here or anything.
+		memset(image_, 0, sizeof(image_));
+	};
+
+	/// Clear only a subset of the image
+	///
+	/// @param minX minimum X coordinate, inclusive
+	/// @param minY minimum Y coordinate, inclusive
+	/// @param maxX maximum X coordinate, inclusive
+	/// @param maxY maximum Y coordinate, *exclusive*
+	void clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY);
+
+	/// Set a single pixel
+	void drawPixel(int32_t x, int32_t y);
+
+	/// Draw a horizontal line.
+	///
+	/// @param pixelY Y coordinate of the line to draw
+	/// @param startX Starting X coordinate, inclusive
+	/// @param endY Ending Y coordinate, inclusive
+	void drawHorizontalLine(int32_t pixelY, int32_t startX, int32_t endX);
+
+	/// Draw a vertical line.
+	///
+	/// @param pixelX X coordinate of the line
+	/// @param startY Y coordinate of the line, inclusive
+	/// @param endY Y coordinate of the line, inclusive
+	void drawVerticalLine(int32_t pixelX, int32_t startY, int32_t endY);
+
+	/// Draw a 1-px wide rectangle.
+	///
+	/// @param minX Minimum X coordinate, inclusive
+	/// @param minY Minimum Y coordinate, inclusive
+	/// @param maxX Maximum X coordinate, inclusive
+	/// @param maxY Maximum Y coordinate, inclusive
+	void drawRectangle(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY);
+
+	/// Draw a string
+	///
+	/// @param str The string
+	/// @param pixelX X coordinate of the left side of the string
+	/// @param pixelY Y coordinate of the top side of the string
+	/// @param textWidth Base width in pixels of each character
+	/// @param textHeight Height in pixels of each character
+	/// @param scrollPos Offset in pixels representing how far the text has scrolled from the left.
+	/// @param endX Maximum X coordinate after which we bail out. N.B. this means the *actual* maximum X coordinate
+	///             rendered is endX + textWidth, as the individual character rendering work can overshoot.
+	void drawString(std::string_view str, int32_t pixelX, int32_t pixelY, int32_t textWidth, int32_t textHeight,
+	                int32_t scrollPos = 0, int32_t endX = OLED_MAIN_WIDTH_PIXELS);
+
+	/// Draw a string, centered at the provided location.
+	///
+	/// @param string A null-terminated C string
+	/// @param pixelY Y coordinate of the top side of the string
+	/// @param textWidth Base width in pixels of each character
+	/// @param textHeight Height in pixels of each character
+	/// @param scrollPos Offset in pixels representing how far the text has scrolled from the left.
+	/// @param endX Maximum X coordinate after which we bail out. N.B. this means the *actual* maximum X coordinate
+	///             rendered is endX + textWidth, as the individual character rendering work can overshoot.
+	void drawStringCentred(char const* string, int32_t pixelY, int32_t textWidth, int32_t textHeight,
+	                       int32_t centrePos = OLED_MAIN_WIDTH_PIXELS / 2);
+
+	/// Draw a string, reducing its height so the string fits within the specified width
+	///
+	/// @param string A null-terminated C string
+	/// @param pixelY The Y coordinate of the top of the string
+	/// @param textWidth Requested width for each character in the string
+	/// @param textHeight Requested height for each character in the string
+	void drawStringCentredShrinkIfNecessary(char const* string, int32_t pixelY, int32_t textWidth, int32_t textHeight);
+
+	/// Draw a string, aligned to the right.
+	///
+	/// @param string A null-terminated C string
+	/// @param pixelY The Y coordinate of the top of the string
+	/// @param textWidth The width for each character in the string
+	/// @param textHeight The height for each character in the string
+	/// @param rightPos X coordinate, exclusive, of the rightmost pixel to use for the string
+	void drawStringAlignRight(char const* string, int32_t pixelY, int32_t textWidth, int32_t textHeight,
+	                          int32_t rightPos = OLED_MAIN_WIDTH_PIXELS);
+
+	/// Draw a single character
+	void drawChar(uint8_t theChar, int32_t pixelX, int32_t pixelY, int32_t textWidth, int32_t textHeight,
+	              int32_t scrollPos = 0, int32_t endX = OLED_MAIN_WIDTH_PIXELS);
+
+	/// Draw a "graphic".
+	///
+	/// The provided \ref graphic array is used as a bit mask and added to the existing content.
+	///
+	/// @param graphic Pointer to the start of an array representing the graphic.
+	/// @param startX X coodinate of the left edge of the graphic
+	/// @param startY Y coordinate of the top of the graphic
+	/// @param width Width of the graphic in pixels
+	/// @param height Height of the graphic in pixels
+	/// @param numBytesTall Number of bytes in the Y direction, determines the stride in the graphic array
+	void drawGraphicMultiLine(uint8_t const* graphic, int32_t startX, int32_t startY, int32_t width, int32_t height = 8,
+	                          int32_t numBytesTall = 1);
+
+	/// Draw a screen title and underline it.
+	///
+	/// @param text Title text
+	void drawScreenTitle(std::string_view text);
+
+	/// Invert an area of the canvas.
+	///
+	/// @param xMin Minimum X coordinate, inclusive
+	/// @param width Width of the region to invert. End coordinate is excluded, I think.
+	/// @param startY Minimum Y coordinate, inclusive
+	/// @param endY Maximum Y coordinate, inclusive
+	void invertArea(int32_t xMin, int32_t width, int32_t startY, int32_t endY);
+
+	/// @}
+
+	/// Height of the image in bytes
+	static constexpr uint32_t kImageHeight = OLED_MAIN_HEIGHT_PIXELS >> 3;
+	/// Width of the image in pixels
+	static constexpr uint32_t kImageWidth = OLED_MAIN_WIDTH_PIXELS;
+
+	using ImageStore = uint8_t[kImageHeight][kImageWidth];
+
+	/// XXX: DO NOT USE THIS OUTSIDE OF THE CORE OLED CODE
+	ImageStore& hackGetImageStore() { return image_; }
+
+private:
+	[[gnu::aligned(CACHE_LINE_SIZE)]] uint8_t image_[kImageHeight][kImageWidth];
+};
+} // namespace oled_canvas
+} // namespace deluge::hid::display

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -105,7 +105,7 @@ void InstrumentClipMinder::redrawNumericDisplay() {
 	}
 }
 
-void InstrumentClipMinder::renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]) {
+void InstrumentClipMinder::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	view.displayOutputName(getCurrentOutput(), false);
 }
 

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -19,6 +19,7 @@
 
 #include "definitions_cxx.hpp"
 #include "hid/button.h"
+#include "hid/display/oled_canvas/canvas.h"
 #include "model/clip/clip_minder.h"
 #include <cstdint>
 
@@ -50,7 +51,7 @@ public:
 	bool changeOutputType(OutputType newOutputType);
 	void opened();
 
-	void renderOLED(uint8_t image[][OLED_MAIN_WIDTH_PIXELS]);
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas);
 
 	static int16_t defaultRootNote; // Stores the calculated "default" root note between the user pressing the
 	                                // scale-mode button and releasing it

--- a/src/deluge/testing/hardware_testing.cpp
+++ b/src/deluge/testing/hardware_testing.cpp
@@ -247,9 +247,11 @@ void ramTestLED(bool stuffAlreadySetUp) {
 	cvEngine.sendVoltageOut(1, 65520);
 
 	if (display->haveOLED()) {
-		deluge::hid::display::OLED::clearMainImage();
-		deluge::hid::display::OLED::invertArea(0, OLED_MAIN_WIDTH_PIXELS, OLED_MAIN_TOPMOST_PIXEL,
-		                                       OLED_MAIN_HEIGHT_PIXELS - 1, deluge::hid::display::OLED::oledMainImage);
+
+		deluge::hid::display::oled_canvas::Canvas& canvas = deluge::hid::display::OLED::main;
+
+		canvas.clear();
+		canvas.invertArea(0, OLED_MAIN_WIDTH_PIXELS, OLED_MAIN_TOPMOST_PIXEL, OLED_MAIN_HEIGHT_PIXELS - 1);
 		deluge::hid::display::OLED::sendMainImage();
 	}
 


### PR DESCRIPTION
This should be a non-functional change, but it makes working with the OLED APIs marginally easier.

Sorta based on @stellar-aria's oled-gfx-rewrite branch, but focusing on just creating the Canvas class for now and re-using the old rendering logic everywhere.

This change is mostly size-neutral:

```
1235876   24520  422956 1683352  19af98 -- baseline
1236206   24480  422676 1683362  19afa2 -- With this change
```
