### PR TITLE
Bugfix automation view shortcut blinking

### DIFF
--- a/src/deluge/gui/menu_item/automation/automation.cpp
+++ b/src/deluge/gui/menu_item/automation/automation.cpp
@@ -74,12 +74,12 @@ ActionResult Automation::buttonAction(deluge::hid::Button b, bool on, bool inCar
 			// flag automation view as onMenuView so we know that we're dealing with the background
 			// automation view used exclusively with the menu
 			if (rootUI != &automationView) {
+				automationView.onMenuView = true;
 				automationView.previousUI = rootUI;
 				selectAutomationViewParameter(clipMinder);
 				swapOutRootUILowLevel(&automationView);
 				automationView.initializeView();
 				automationView.openedInBackground();
-				automationView.onMenuView = true;
 			}
 			// if we're in automation view and it's the menu view
 			// swap out background UI from automation view to the previous UI


### PR DESCRIPTION
Cherry picked https://github.com/SynthstromAudible/DelugeFirmware/pull/2024

Fixed bug where shortcut blinking in automation view could persist after exiting automation view.

Removed initialization of shortcut blinking from renderMainPads and added it to where shortcut blinking actually gets changed (e.g. parameter selection, view open, etc) / needs to be initialized

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2022