### PR TITLE
Bugfix - affect entire context while in menu

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3917,8 +3917,10 @@ ModelStackWithAutoParam* AutomationView::getModelStackWithParamForClip(ModelStac
 		paramKind = clip->lastSelectedParamKind;
 	}
 
-	modelStackWithParam = clip->output->getModelStackWithParam(modelStack, clip, paramID, paramKind, getAffectEntire(),
-	                                                           getCurrentUI() == &soundEditor);
+	bool inSoundMenu = getCurrentUI() == &soundEditor && !soundEditor.inSettingsMenu();
+
+	modelStackWithParam =
+	    clip->output->getModelStackWithParam(modelStack, clip, paramID, paramKind, getAffectEntire(), inSoundMenu);
 
 	return modelStackWithParam;
 }
@@ -4520,8 +4522,9 @@ bool AutomationView::getAffectEntire() {
 	if (onArrangerView) {
 		return true;
 	}
-	// are you in the menu?
-	else if (getCurrentUI() == &soundEditor) {
+	// are you in the sound menu for a kit?
+	else if (getCurrentOutputType() == OutputType::KIT && getCurrentUI() == &soundEditor
+	         && !soundEditor.inSettingsMenu()) {
 		// if you're in the kit global FX menu, the menu context is the same as if affect entire is enabled
 		if (soundEditor.setupKitGlobalFXMenu) {
 			return true;
@@ -4531,10 +4534,8 @@ bool AutomationView::getAffectEntire() {
 			return false;
 		}
 	}
-	// otherwise if you're not in the menu, use the clip affect entire state
-	else {
-		return getCurrentInstrumentClip()->affectEntire;
-	}
+	// otherwise if you're not in the kit sound menu, use the clip affect entire state
+	return getCurrentInstrumentClip()->affectEntire;
 }
 
 void AutomationView::displayCVErrorMessage() {

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3917,6 +3917,8 @@ ModelStackWithAutoParam* AutomationView::getModelStackWithParamForClip(ModelStac
 		paramKind = clip->lastSelectedParamKind;
 	}
 
+	// check if we're in the sound menu and not the settings menu
+	// because in the settings menu, the menu mod controllable's aren't setup, so we don't want to use those
 	bool inSoundMenu = getCurrentUI() == &soundEditor && !soundEditor.inSettingsMenu();
 
 	modelStackWithParam =


### PR DESCRIPTION
Noticed a bug where automation overview would get cleared when entering the settings menu. Figured out it was because getModelStackWithParam was returning null because of some incorrect check's on the menu state.

- Fixed bug where getAffectEntire was returning the wrong state for non-kit's

- Fixed bug where getModelStackWithParam was returning null while in settings menu because it was trying to use the menu mod controllable which isn't setup for the settings menu

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2021