### PR TITLE
Refactoring: Update clip clear functions (prep for velocity view)

### DIFF
--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -379,7 +379,7 @@ dontDeactivateMarker:
 			ModelStackWithTimelineCounter* modelStack =
 			    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, getCurrentClip());
 
-			getCurrentAudioClip()->clear(action, modelStack, !FlashStorage::automationClear);
+			getCurrentAudioClip()->clear(action, modelStack, !FlashStorage::automationClear, true);
 
 			// New default as part of Automation Clip View Implementation
 			// If this is enabled, then when you are in Audio Clip View, clearing

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1829,7 +1829,8 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 				ModelStackWithTimelineCounter* modelStack =
 				    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, clip);
 
-				clip->clear(action, modelStack, true);
+				// clear automation, don't clear notes and mpe
+				clip->clear(action, modelStack, true, false);
 			}
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_AUTOMATION_CLEARED));
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2974,7 +2974,7 @@ Clip* SessionView::gridCreateClipInTrack(Output* targetOutput) {
 	ModelStackWithTimelineCounter* modelStack =
 	    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, newClip);
 	Action* action = actionLogger.getNewAction(ActionType::CLIP_CLEAR);
-	newClip->clear(action, modelStack, true);
+	newClip->clear(action, modelStack, true, true);
 	actionLogger.deleteAllLogs();
 
 	// For safety we set it up exactly as we want it

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1228,8 +1228,9 @@ bool AudioClip::currentlyScrollableAndZoomable() {
 	return !shouldLock;
 }
 
-void AudioClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) {
-	Clip::clear(action, modelStack, clearAutomation);
+void AudioClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
+                      bool clearNotesAndMPE) {
+	Clip::clear(action, modelStack, clearAutomation, clearNotesAndMPE);
 
 	// do not clear sample when you are in automation view
 	if (getRootUI() != &automationView) {

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -67,7 +67,8 @@ public:
 	RGB getColour();
 	bool currentlyScrollableAndZoomable() override;
 	void getScrollAndZoomInSamples(int32_t xScroll, int32_t xZoom, int64_t* xScrollSamples, int64_t* xZoomSamples);
-	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) override;
+	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
+	           bool clearNotesAndMPE) override;
 	bool getCurrentlyRecordingLinearly() override;
 	void abortRecording() override;
 	void setupPlaybackBounds();

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -979,7 +979,8 @@ trimFoundParamManager:
 	return Error::NONE;
 }
 
-void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) {
+void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
+                 bool clearNotesAndMPE) {
 	// New community feature as part of Automation Clip View Implementation
 	// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing a clip
 	// will only clear the Notes and MPE data (NON MPE automations remain intact).
@@ -1002,7 +1003,7 @@ void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool
 
 			// Special case for MPE only - not even "mono" / Clip-level expression.
 			if (i == paramManager.getExpressionParamSetOffset()) {
-				if (getCurrentUI() != &automationView) { // don't clear MPE if you're in the Automation View
+				if (clearNotesAndMPE) {
 					((ExpressionParamSet*)summary->paramCollection)
 					    ->deleteAllAutomation(action, modelStackWithParamCollection);
 				}

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -106,7 +106,8 @@ public:
 	virtual Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) = 0;
 	virtual bool getCurrentlyRecordingLinearly() = 0;
 	virtual bool currentlyScrollableAndZoomable() = 0;
-	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation);
+	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
+	                   bool clearNotesAndMPE);
 
 	void writeToFile(Serializer& writer, Song* song);
 	virtual void writeDataToFile(Serializer& writer, Song* song);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3547,15 +3547,16 @@ void InstrumentClip::sendMIDIPGM() {
 	}
 }
 
-void InstrumentClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) {
+void InstrumentClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
+                           bool clearNotesAndMPE) {
 	// this clears automations when "affectEntire" is enabled
-	Clip::clear(action, modelStack, clearAutomation);
+	Clip::clear(action, modelStack, clearAutomation, clearNotesAndMPE);
 
 	for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
 		NoteRow* thisNoteRow = noteRows.getElement(i);
 		ModelStackWithNoteRow* modelStackWithNoteRow =
 		    modelStack->addNoteRow(getNoteRowId(thisNoteRow, i), thisNoteRow);
-		thisNoteRow->clear(action, modelStackWithNoteRow, clearAutomation);
+		thisNoteRow->clear(action, modelStackWithNoteRow, clearAutomation, clearNotesAndMPE);
 	}
 
 	// Paul: Note rows were lingering, delete them immediately instead of relying they get deleted along the way

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -199,7 +199,8 @@ public:
 	void stopAllNotesForMIDIOrCV(ModelStackWithTimelineCounter* modelStack);
 	void sendMIDIPGM();
 	void noteRemovedFromMode(int32_t yNoteWithinOctave, Song* song);
-	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation) override;
+	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
+	           bool clearNotesAndMPE) override;
 	bool doesProbabilityExist(int32_t apartFromPos, int32_t probability, int32_t secondProbability = -1);
 	void clearArea(ModelStackWithTimelineCounter* modelStack, int32_t startPos, int32_t endPos, Action* action);
 	ScaleType getScaleType();

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -414,7 +414,10 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 
 			bool clearAutomation = (currentUI == &automationView || !FlashStorage::automationClear);
 
-			getCurrentInstrumentClip()->clear(action, modelStack, clearAutomation);
+			// if you're not in automation view, always clear notes and MPE
+			bool clearNotesAndMPE = (currentUI != &automationView);
+
+			getCurrentInstrumentClip()->clear(action, modelStack, clearAutomation, clearNotesAndMPE);
 
 			// New default as part of Automation Clip View Implementation
 			// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3595,7 +3595,7 @@ void NoteRow::shiftHorizontally(int32_t amount, ModelStackWithNoteRow* modelStac
 	}
 }
 
-void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation) {
+void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation, bool clearNotesAndMPE) {
 	// New default as part of Automation Clip View Implementation
 	// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing a clip
 	// will only clear the Notes and MPE data (NON MPE automations remain intact).
@@ -3618,7 +3618,7 @@ void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack, bool clea
 
 			// Special case for MPE only - not even "mono" / Clip-level expression.
 			if (i == paramManager.getExpressionParamSetOffset()) {
-				if (getCurrentUI() != &automationView) { // don't clear MPE if you're in the automation view
+				if (clearNotesAndMPE) {
 					((ExpressionParamSet*)summary->paramCollection)
 					    ->deleteAllAutomation(action, modelStackWithParamCollection);
 				}
@@ -3637,7 +3637,7 @@ void NoteRow::clear(Action* action, ModelStackWithNoteRow* modelStack, bool clea
 
 	// New addition as part of Automation Clip View Implementation
 	// If you are in Automation Clip View, clearing a kit note row will not clear notes, only NON MPE automations.
-	if (getCurrentUI() != &automationView) {
+	if (clearNotesAndMPE) {
 
 		stopCurrentlyPlayingNote(modelStack);
 

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -162,7 +162,7 @@ public:
 	int8_t getColourOffset(InstrumentClip* clip);
 	void rememberDrumName();
 	void shiftHorizontally(int32_t amount, ModelStackWithNoteRow* modelStack);
-	void clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation);
+	void clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation, bool clearNotesAndMPE);
 	bool doesProbabilityExist(int32_t apartFromPos, int32_t probability, int32_t secondProbability = -1);
 	bool paste(ModelStackWithNoteRow* modelStack, CopiedNoteRow* copiedNoteRow, float scaleFactor, int32_t screenEndPos,
 	           Action* action);


### PR DESCRIPTION
Updating clear functions in preparation of velocity view where I want to be able to clear notes and mpe from velocity view (since it's a note editing view)

Added a parameter to indicate whether or not notes and mpe should be cleared when the clear functions are called as opposed to having several checks if you're in automation view embedded in the functions