### PR TITLE
oled: defer scannout

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -844,9 +844,6 @@ doNewPress:
 			currentUIMode = UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION;
 
 			view.displayOutputName(output);
-			if (display->haveOLED()) {
-				deluge::hid::display::OLED::sendMainImage();
-			}
 
 			beginAudition(output);
 
@@ -2466,9 +2463,6 @@ void ArrangerView::changeOutputType(OutputType newOutputType) {
 	indicator_leds::setLedState(IndicatorLED::MIDI, false);
 	indicator_leds::setLedState(IndicatorLED::CV, false);
 	view.displayOutputName(newInstrument);
-	if (display->haveOLED()) {
-		deluge::hid::display::OLED::sendMainImage();
-	}
 	view.setActiveModControllableTimelineCounter(newInstrument->activeClip);
 
 	beginAudition(newInstrument);
@@ -2549,9 +2543,6 @@ cant:
 	indicator_leds::setLedState(IndicatorLED::MIDI, false);
 	indicator_leds::setLedState(IndicatorLED::CV, false);
 	view.displayOutputName(newOutput);
-	if (display->haveOLED()) {
-		deluge::hid::display::OLED::sendMainImage();
-	}
 	view.setActiveModControllableTimelineCounter(newClip);
 }
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1247,7 +1247,7 @@ void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_
 		}
 	}
 
-	deluge::hid::display::OLED::sendMainImage();
+	deluge::hid::display::OLED::markChanged();
 }
 
 void AutomationView::renderDisplay7SEG(Clip* clip, OutputType outputType, int32_t knobPosLeft, bool modEncoderAction) {

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -481,7 +481,7 @@ void PerformanceSessionView::renderViewDisplay() {
 			                                              deluge::hid::display::OLED::oledMainImage[0],
 			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
 
-			deluge::hid::display::OLED::sendMainImage();
+			deluge::hid::display::OLED::markChanged();
 		}
 		else {
 			display->setScrollingText(l10n::get(l10n::String::STRING_FOR_PERFORM_EDITOR));
@@ -504,7 +504,7 @@ void PerformanceSessionView::renderViewDisplay() {
 			                                              deluge::hid::display::OLED::oledMainImage[0],
 			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
 
-			deluge::hid::display::OLED::sendMainImage();
+			deluge::hid::display::OLED::markChanged();
 		}
 		else {
 			display->setScrollingText(l10n::get(l10n::String::STRING_FOR_PERFORM_VIEW));
@@ -533,7 +533,7 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 			                                              deluge::hid::display::OLED::oledMainImage[0],
 			                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
 
-			deluge::hid::display::OLED::sendMainImage();
+			deluge::hid::display::OLED::markChanged();
 		}
 		else {
 			display->setScrollingText(parameterName);
@@ -588,7 +588,7 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 				                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
 			}
 
-			deluge::hid::display::OLED::sendMainImage();
+			deluge::hid::display::OLED::markChanged();
 		}
 		// 7Seg Display
 		else {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -557,9 +557,6 @@ doActualSimpleChange:
 								Instrument* newInstrument = currentSong->changeOutputType(instrument, newOutputType);
 								if (newInstrument) {
 									view.displayOutputName(newInstrument);
-									if (display->haveOLED()) {
-										deluge::hid::display::OLED::sendMainImage();
-									}
 									view.setActiveModControllableTimelineCounter(newInstrument->activeClip);
 								}
 							}
@@ -750,9 +747,6 @@ startHoldingDown:
 						selectedClipTimePressed = AudioEngine::audioSampleTimer;
 						view.setActiveModControllableTimelineCounter(clip);
 						view.displayOutputName(clip->output, true, clip);
-						if (display->haveOLED()) {
-							deluge::hid::display::OLED::sendMainImage();
-						}
 					}
 				}
 
@@ -1640,9 +1634,6 @@ void SessionView::replaceInstrumentClipWithAudioClip(Clip* clip) {
 	view.setActiveModControllableTimelineCounter(newClip);
 	view.displayOutputName(newClip->output, true, newClip);
 
-	if (display->haveOLED()) {
-		deluge::hid::display::OLED::sendMainImage();
-	}
 	// If Clip was in keyboard view, need to redraw that
 	requestRendering(this, 1 << selectedClipYDisplay, 1 << selectedClipYDisplay);
 }
@@ -1840,7 +1831,7 @@ void SessionView::renderViewDisplay(char const* viewString) {
 		deluge::hid::display::OLED::drawStringCentred(viewString, yPos, deluge::hid::display::OLED::oledMainImage[0],
 		                                              OLED_MAIN_WIDTH_PIXELS, kTextSpacingX, kTextSpacingY);
 		if (!display->hasPopup()) {
-			deluge::hid::display::OLED::sendMainImage();
+			deluge::hid::display::OLED::markChanged();
 		}
 	}
 	else {
@@ -3402,7 +3393,6 @@ ActionResult SessionView::gridHandlePadsEdit(int32_t x, int32_t y, int32_t on, C
 			view.setActiveModControllableTimelineCounter(clip);
 			view.displayOutputName(clip->output, true, clip);
 			if (display->haveOLED()) {
-				deluge::hid::display::OLED::sendMainImage();
 				// removes potential stuck pop-up if you're previewing / entering a clip
 				// while holding section pad and repeats popup is displayed
 				deluge::hid::display::OLED::removePopup();
@@ -3560,9 +3550,6 @@ ActionResult SessionView::gridHandlePadsLaunchWithSelection(int32_t x, int32_t y
 			selectedClipTimePressed = AudioEngine::audioSampleTimer;
 			currentSong->setCurrentClip(clip);
 			view.displayOutputName(clip->output, true, clip);
-			if (display->haveOLED()) {
-				deluge::hid::display::OLED::sendMainImage();
-			}
 			// this needs to be called after the current clip is set in order to ensure that
 			// if midi follow feedback is enabled, it sends feedback for the right clip
 			view.setActiveModControllableTimelineCounter(clip);
@@ -3628,9 +3615,6 @@ ActionResult SessionView::gridHandlePadsConfig(int32_t x, int32_t y, int32_t on,
 				currentSong->setCurrentClip(clip);
 				currentUIMode = UI_MODE_CLIP_PRESSED_IN_SONG_VIEW;
 				view.displayOutputName(clip->output, true, clip);
-				if (display->haveOLED()) {
-					deluge::hid::display::OLED::sendMainImage();
-				}
 			}
 		}
 		else {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1884,9 +1884,7 @@ char const* View::getReverbPresetDisplayName(int32_t preset) {
 	return deluge::l10n::get(presetReverbNames[preset]);
 }
 
-// If OLED, must make sure deluge::hid::display::OLED::sendMainImage() gets called after this.
 void View::displayOutputName(Output* output, bool doBlink, Clip* clip) {
-
 	int32_t channel, channelSuffix;
 	bool editedByUser = true;
 	if (output->type != OutputType::AUDIO) {
@@ -1904,9 +1902,9 @@ void View::displayOutputName(Output* output, bool doBlink, Clip* clip) {
 	}
 
 	drawOutputNameFromDetails(output->type, channel, channelSuffix, output->name.get(), editedByUser, doBlink, clip);
+	deluge::hid::display::OLED::markChanged();
 }
 
-// If OLED, must make sure deluge::hid::display::OLED::sendMainImage() gets called after this.
 void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int32_t channelSuffix, char const* name,
                                      bool editedByUser, bool doBlink, Clip* clip) {
 	if (doBlink) {
@@ -2154,9 +2152,6 @@ void View::navigateThroughAudioOutputsForAudioClip(int32_t offset, AudioClip* cl
 	}
 
 	displayOutputName(newOutput, doBlink);
-	if (display->haveOLED()) {
-		deluge::hid::display::OLED::sendMainImage();
-	}
 
 	setActiveModControllableTimelineCounter(clip); // Necessary? Does ParamManager get moved over too?
 }
@@ -2366,9 +2361,6 @@ gotAnInstrument:
 		}
 
 		displayOutputName(newInstrument, doBlink);
-		if (display->haveOLED()) {
-			deluge::hid::display::OLED::sendMainImage();
-		}
 
 		// Special case: when it is a saved MIDI preset (with a name), then we need to show the channel in a popup, as
 		// the name will print over the midi channel and we can't see it while changing it
@@ -2517,9 +2509,6 @@ bool View::changeOutputType(OutputType newOutputType, ModelStackWithTimelineCoun
 	// Do a redraw. Obviously the Clip is the same
 	setActiveModControllableTimelineCounter(clip);
 	displayOutputName(newInstrument, doBlink);
-	if (display->haveOLED()) {
-		deluge::hid::display::OLED::sendMainImage();
-	}
 
 	return true;
 }

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -4952,9 +4952,6 @@ cantDoIt:
 		}
 
 		view.displayOutputName(oldNonAudioInstrument);
-		if (display->haveOLED()) {
-			deluge::hid::display::OLED::sendMainImage();
-		}
 	}
 
 	// Or if we're on a Kit or Synth...


### PR DESCRIPTION
This cleans up a bunch of places that were doing OLED scanount immediately in favor of doing it as part of the pendingUIRendering task. This should help avoid situations where we scan out the image a bunch of times in a row, wasting time. It also makes adding OLED features easier since marking the image dirty is cheap and automatically deduplicated.

As a nice little bonus, this change saves a wopping 80 bytes!

```
1236196   24520  422964 1683680  19b0e0 baseline
1236132   24512  422956 1683600  19b090 render deleted
```