### PR TITLE
Bugfix/use inverse multiplication instead of division

### DIFF
--- a/src/RZA1/ostm/ostm.c
+++ b/src/RZA1/ostm/ostm.c
@@ -49,13 +49,13 @@ void setTimerValue(int timerNo, uint32_t timerValue)
     OSTimers[timerNo]->OSTMnCMP = timerValue;
 }
 
-volatile uint32_t getTimerValue(int timerNo)
+uint32_t getTimerValue(int timerNo)
 {
     return OSTimers[timerNo]->OSTMnCNT;
 }
 
-volatile double getTimerValueSeconds(int timerNo)
+double getTimerValueSeconds(int timerNo)
 {
-    double seconds = ((double)getTimerValue(timerNo) / DELUGE_CLOCKS_PERf);
+    double seconds = getTimerValue(timerNo) * ONE_OVER_CLOCK;
     return seconds;
 }

--- a/src/RZA1/ostm/ostm.h
+++ b/src/RZA1/ostm/ostm.h
@@ -25,6 +25,7 @@
 // ticks at 33.33 MHz
 #define DELUGE_CLOCKS_PER  33330000
 #define DELUGE_CLOCKS_PERf 33330000.
+#define ONE_OVER_CLOCK     (1 / DELUGE_CLOCKS_PERf)
 enum OSTimerOperatingMode { TIMER, FREE_RUNNING };
 /// in timer mode, start or reset the timer
 /// in free mode start the timer iff it's not running


### PR DESCRIPTION
I assumed the compiler would do this, it's 20x faster and this runs a lot