### PR TITLE
[DRAFT] extended bitcrusher

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -117,7 +117,7 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	bool canRenderDirectlyIntoSongBuffer =
 	    !isKit() && !filterSet.isOn() && compThreshold == 0 && !delayWorkingState.doDelay
 	    && (!pan || !AudioEngine::renderInStereo) && !clippingAmount && !hasBassAdjusted(paramManagerForClip)
-	    && !hasTrebleAdjusted(paramManagerForClip) && !reverbSendAmount && !isBitcrushingEnabled(paramManagerForClip)
+	    && !hasTrebleAdjusted(paramManagerForClip) && !reverbSendAmount && !bitcrushingAmount(paramManagerForClip)
 	    && !isSRREnabled(paramManagerForClip) && getActiveModFXType(paramManagerForClip) == ModFXType::NONE
 	    && stutterer.status == STUTTERER_STATUS_OFF;
 

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -102,7 +102,7 @@ public:
 	                       uint8_t modKnobMode, uint8_t midiChannel, Song* song);
 	bool unlearnKnobs(ParamDescriptor paramDescriptor, Song* song);
 	virtual void ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(Song* song) {} // Song may be NULL
-	bool isBitcrushingEnabled(ParamManager* paramManager);
+	int32_t bitcrushingAmount(ParamManager* paramManager);
 	bool isSRREnabled(ParamManager* paramManager);
 	bool hasBassAdjusted(ParamManager* paramManager);
 	bool hasTrebleAdjusted(ParamManager* paramManager);


### PR DESCRIPTION
- Stock goes from 13 bits to 6 bits, this goes from 15 bits to 1 bit.

TODO:

- [x] Verify that I got the range right: I can't see or hear any reduction at Bitcrush=1 ? Is our sine made out of even numbers, or are my ears and scope 15 bits? (Uh, I need a scope right after Deluge, don't I?) 
- [ ] Change the UX to show number of bits crushed: "1 bts" displays well enough on 7 seg as well, I think.
- [ ] Preserve sound of saved instruments. New tag for new scale, handling for old tag.
  
MAYBE:

- [ ] The MOD-FX volume compensation is not right, maybe fix it. There's a too-obvious jump at one point.
- [x] The crushing is currently reduced by 1 whenever decimation (aka sample rate reduction) is used, why? What to do about that? If the UI shows "4 bit crush", it seems like it should be a 4 bit crush even with SRR? Maybe previously this made made sense when the minimum bitcrush was 3, but now when the minimum is 1, less so? (Could just document it, I guess?)
- [ ] Routing option to move bitcrush before the filters, something like:
  - DEFAULTS > FX > BITCRUSH > BEFORE/AFTER FILTERS
  - CLIP > FX > BITCRUSH > BEFORE/AFTER FILTERS
