### PR TITLE
oled: stop scrolling animation

### DIFF
--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -35,6 +35,7 @@ void MenuItem::learnCC(MIDIDevice* fromDevice, int32_t channel, int32_t ccNumber
 
 void MenuItem::renderOLED() {
 	deluge::hid::display::OLED::main.drawScreenTitle(getTitle());
+	deluge::hid::display::OLED::markChanged();
 	drawPixelsForOled();
 }
 
@@ -46,6 +47,7 @@ void MenuItem::drawName() {
 void MenuItem::drawItemsForOled(std::span<std::string_view> options, const int32_t selectedOption,
                                 const int32_t offset) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+
 	int32_t baseY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 15 : 14;
 	baseY += OLED_MAIN_TOPMOST_PIXEL;
 

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -356,7 +356,7 @@ void doAnyPendingOLEDRendering() {
 			u--;
 		}
 
-		OLED::main.clear();
+		OLED::clearMainImage();
 
 		for (; u < numUIsOpen; u++) {
 			OLED::stopScrollingAnimation();

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1090,7 +1090,7 @@ void AutomationView::renderDisplay(int32_t knobPosLeft, int32_t knobPosRight, bo
 
 void AutomationView::renderDisplayOLED(Clip* clip, OutputType outputType, int32_t knobPosLeft, int32_t knobPosRight) {
 	deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
-	canvas.clear();
+	hid::display::OLED::clearMainImage();
 
 	if (onAutomationOverview() || (outputType == OutputType::CV)) {
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -448,7 +448,7 @@ void PerformanceSessionView::renderViewDisplay() {
 	if (defaultEditingMode) {
 		if (display->haveOLED()) {
 			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
-			image.clear();
+			deluge::hid::display::OLED::clearMainImage();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -489,7 +489,7 @@ void PerformanceSessionView::renderViewDisplay() {
 	else {
 		if (display->haveOLED()) {
 			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
-			image.clear();
+			deluge::hid::display::OLED::clearMainImage();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -520,7 +520,7 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 		strncpy(parameterName, getParamDisplayName(paramKind, paramID), 29);
 		if (display->haveOLED()) {
 			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
-			image.clear();
+			deluge::hid::display::OLED::clearMainImage();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -540,7 +540,7 @@ void PerformanceSessionView::renderFXDisplay(params::Kind paramKind, int32_t par
 	else {
 		if (display->haveOLED()) {
 			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
-			image.clear();
+			deluge::hid::display::OLED::clearMainImage();
 
 			// display parameter name
 			char parameterName[30];

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1819,8 +1819,7 @@ nothingToDisplay:
 void SessionView::renderViewDisplay(char const* viewString) {
 	if (display->haveOLED()) {
 		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
-
-		canvas.clear();
+		hid::display::OLED::clearMainImage();
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1966,7 +1966,7 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 
 	if (display->haveOLED()) {
 		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
-		canvas.clear();
+		hid::display::OLED::clearMainImage();
 
 		char const* outputTypeText;
 		switch (outputType) {

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -40,6 +40,8 @@ public:
 
 	/// Clear the canvas currently being used as the main image.
 	///
+	/// This also stops any active scrolling and blinking animations.
+	///
 	/// Marks the OLED as dirty, so you don't need to do that later yourself.
 	static void clearMainImage();
 

--- a/src/deluge/testing/hardware_testing.cpp
+++ b/src/deluge/testing/hardware_testing.cpp
@@ -247,10 +247,9 @@ void ramTestLED(bool stuffAlreadySetUp) {
 	cvEngine.sendVoltageOut(1, 65520);
 
 	if (display->haveOLED()) {
-
+		deluge::hid::display::OLED::clearMainImage();
 		deluge::hid::display::oled_canvas::Canvas& canvas = deluge::hid::display::OLED::main;
 
-		canvas.clear();
 		canvas.invertArea(0, OLED_MAIN_WIDTH_PIXELS, OLED_MAIN_TOPMOST_PIXEL, OLED_MAIN_HEIGHT_PIXELS - 1);
 		deluge::hid::display::OLED::sendMainImage();
 	}


### PR DESCRIPTION
This used to be done implicitly by `clearMainImage`