### PR TITLE
tests: UnpatchedParam::readCurrentValue() & getFinalValue()

### DIFF
--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "unpatched_param.h"
+#include "gui/menu_item/value_scaling.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/view.h"
@@ -30,10 +31,8 @@
 namespace deluge::gui::menu_item {
 
 void UnpatchedParam::readCurrentValue() {
-	this->setValue((((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP()) + 2147483648)
-	                    * kMaxMenuValue
-	                + 2147483648)
-	               >> 32);
+	this->setValue(computeCurrentValueForUnpatchedParam(
+	    soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP())));
 }
 
 ModelStackWithAutoParam* UnpatchedParam::getModelStack(void* memory) {
@@ -59,15 +58,7 @@ void UnpatchedParam::writeCurrentValue() {
 }
 
 int32_t UnpatchedParam::getFinalValue() {
-	if (this->getValue() == kMaxMenuValue) {
-		return 2147483647;
-	}
-	else if (this->getValue() == kMinMenuValue) {
-		return -2147483648;
-	}
-	else {
-		return (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) - 2147483648;
-	}
+	return computeFinalValueForUnpatchedParam(this->getValue());
 }
 
 ParamDescriptor UnpatchedParam::getLearningThing() {

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -1,0 +1,20 @@
+#include "gui/menu_item/value_scaling.h"
+#include "definitions_cxx.hpp"
+
+#include <cstdint>
+
+int32_t computeCurrentValueForUnpatchedParam(int32_t value) {
+	return (((int64_t)value + 2147483648) * kMaxMenuValue + 2147483648) >> 32;
+}
+
+int32_t computeFinalValueForUnpatchedParam(int32_t value) {
+	if (value == kMaxMenuValue) {
+		return 2147483647;
+	}
+	else if (value == kMinMenuValue) {
+		return -2147483648;
+	}
+	else {
+		return (uint32_t)value * (2147483648 / kMidMenuValue) - 2147483648;
+	}
+}

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <cstdint>
+
+// Functions that convert parameter values between forms displayed
+// on the UI (typically 0-50, but there are variations), and
+// forms store internally and on SD (typically whole int32_t range.)
+//
+// computeCurrentValueForXXX() takes the internally stored value
+// and computes the value displayed on the UI.
+//
+// computeFinalValueForXXX() takes the value displayed on the UI
+// and computes the internally stored value.
+//
+// These are in non-member functions for ease of testing. The param
+// classes pulls in a lot of stuff!
+//
+// Generally speaking the call chains are:
+//
+//   SomeClass::readCurrentValue() -> computeCurrentValueForSomeClass()
+//
+//   SomeClass::writeCurrentValue() -> SomeClass::getFinalValue() ->
+//     -> computeFinalValueForSomeClass()
+//
+// Right now only UnpatchedParam, but more is coming. As stuff is
+// is extraced and turns out to be functionally identical the dupes
+// will be eliminated.
+//
+// Then when we have only functionally distinct variations here (and
+// we have tests for them), then we can replace them with a parametrized
+// version.
+//
+// ...and then it should be easier to make changes like specifying envelope
+// times in milliseconds and bitcrushing in bits, hopefully without
+// needing specialized code to handle existing saves.
+
+int32_t computeCurrentValueForUnpatchedParam(int32_t value);
+int32_t computeFinalValueForUnpatchedParam(int32_t value);

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -2,37 +2,39 @@
 
 #include <cstdint>
 
-// Functions that convert parameter values between forms displayed
-// on the UI (typically 0-50, but there are variations), and
-// forms store internally and on SD (typically whole int32_t range.)
-//
-// computeCurrentValueForXXX() takes the internally stored value
-// and computes the value displayed on the UI.
-//
-// computeFinalValueForXXX() takes the value displayed on the UI
-// and computes the internally stored value.
-//
-// These are in non-member functions for ease of testing. The param
-// classes pulls in a lot of stuff!
-//
-// Generally speaking the call chains are:
-//
-//   SomeClass::readCurrentValue() -> computeCurrentValueForSomeClass()
-//
-//   SomeClass::writeCurrentValue() -> SomeClass::getFinalValue() ->
-//     -> computeFinalValueForSomeClass()
-//
-// Right now only UnpatchedParam, but more is coming. As stuff is
-// is extraced and turns out to be functionally identical the dupes
-// will be eliminated.
-//
-// Then when we have only functionally distinct variations here (and
-// we have tests for them), then we can replace them with a parametrized
-// version.
-//
-// ...and then it should be easier to make changes like specifying envelope
-// times in milliseconds and bitcrushing in bits, hopefully without
-// needing specialized code to handle existing saves.
+/// \file value_scaling.h.
+///
+/// Functions that convert parameter values between forms displayed
+/// on the UI (typically 0-50, but there are variations), and
+/// forms stored internally and on SD (typically whole int32_t range.)
+///
+/// computeCurrentValueForXXX() takes the internally stored value
+/// and computes the value displayed on the UI.
+///
+/// computeFinalValueForXXX() takes the value displayed on the UI
+/// and computes the internally stored value.
+///
+/// These are in non-member functions for ease of testing. The param
+/// classes pulls in a lot of stuff!
+///
+/// Generally speaking the call chains are:
+///
+///   SomeClass::readCurrentValue() -> computeCurrentValueForSomeClass()
+///
+///   SomeClass::writeCurrentValue() -> SomeClass::getFinalValue() ->
+///     -> computeFinalValueForSomeClass()
+///
+/// Right now only UnpatchedParam, but more is coming. As stuff is
+/// is extraced and turns out to be functionally identical the dupes
+/// will be eliminated.
+///
+/// Then when we have only functionally distinct variations here (and
+/// we have tests for them), then we can replace them with a parametrized
+/// version.
+///
+/// ...and then it should be easier to make changes like specifying envelope
+/// times in milliseconds and bitcrushing in bits, hopefully without
+/// needing specialized code to handle existing saves.
 
 int32_t computeCurrentValueForUnpatchedParam(int32_t value);
 int32_t computeFinalValueForUnpatchedParam(int32_t value);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -32,9 +32,11 @@ file(GLOB_RECURSE deluge_SOURCES
         ../../src/deluge/util/lookuptables.cpp
         ../../src/deluge/util/waves.cpp
         ../../src/deluge/modulation/lfo.cpp
+        # For value scaling
+        ../../src/deluge/gui/menu_item/value_scaling.cpp
 )
 
-add_executable(UnitTests RunAllTests.cpp scheduler_tests.cpp lfo_tests.cpp scale_tests.cpp)
+add_executable(UnitTests RunAllTests.cpp scheduler_tests.cpp lfo_tests.cpp scale_tests.cpp value_scaling_tests.cpp)
 add_test(NAME UnitTests
         COMMAND UnitTests)
 target_sources(UnitTests PRIVATE ${deluge_SOURCES})

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -1,0 +1,15 @@
+#include "CppUTest/TestHarness.h"
+#include "gui/menu_item/value_scaling.h"
+#include "definitions_cxx.hpp"
+
+#include <iostream>
+
+TEST_GROUP(ValueScalingTest) {};
+
+TEST(ValueScalingTest, unpatchedParamValueRoundTrip) {
+	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
+		int32_t finalValue = computeFinalValueForUnpatchedParam(i);
+		int32_t currentValue = computeCurrentValueForUnpatchedParam(finalValue);
+		CHECK_EQUAL(i, currentValue);
+	}
+}


### PR DESCRIPTION
- Pull out the guts for testing, refactoring to come.

- The inputs have an explicit range, which is short enough that we can enumerate it and check that everything roundtrips.