### PR TITLE
refactor: share value scaling between Integer and UnpatchedParam

### DIFF
--- a/src/deluge/gui/menu_item/patched_param/integer.cpp
+++ b/src/deluge/gui/menu_item/patched_param/integer.cpp
@@ -15,6 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 #include "integer.h"
+#include "gui/menu_item/value_scaling.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/view.h"
@@ -26,10 +27,8 @@
 
 namespace deluge::gui::menu_item::patched_param {
 void Integer::readCurrentValue() {
-	this->setValue(
-	    (((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) + 2147483648) * kMaxMenuValue
-	     + 2147483648)
-	    >> 32);
+	this->setValue(computeCurrentValueForStandardMenuItem(
+	    soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP())));
 }
 
 void Integer::writeCurrentValue() {
@@ -53,15 +52,7 @@ void Integer::writeCurrentValue() {
 }
 
 int32_t Integer::getFinalValue() {
-	if (this->getValue() == kMaxMenuValue) {
-		return 2147483647;
-	}
-	else if (this->getValue() == kMinMenuValue) {
-		return -2147483648;
-	}
-	else {
-		return (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) - 2147483648;
-	}
+	return computeFinalValueForStandardMenuItem(this->getValue());
 }
 
 } // namespace deluge::gui::menu_item::patched_param

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -31,7 +31,7 @@
 namespace deluge::gui::menu_item {
 
 void UnpatchedParam::readCurrentValue() {
-	this->setValue(computeCurrentValueForUnpatchedParam(
+	this->setValue(computeCurrentValueForStandardMenuItem(
 	    soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP())));
 }
 
@@ -58,7 +58,7 @@ void UnpatchedParam::writeCurrentValue() {
 }
 
 int32_t UnpatchedParam::getFinalValue() {
-	return computeFinalValueForUnpatchedParam(this->getValue());
+	return computeFinalValueForStandardMenuItem(this->getValue());
 }
 
 ParamDescriptor UnpatchedParam::getLearningThing() {

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -3,11 +3,11 @@
 
 #include <cstdint>
 
-int32_t computeCurrentValueForUnpatchedParam(int32_t value) {
+int32_t computeCurrentValueForStandardMenuItem(int32_t value) {
 	return (((int64_t)value + 2147483648) * kMaxMenuValue + 2147483648) >> 32;
 }
 
-int32_t computeFinalValueForUnpatchedParam(int32_t value) {
+int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 	if (value == kMaxMenuValue) {
 		return 2147483647;
 	}

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -24,17 +24,26 @@
 ///   SomeClass::writeCurrentValue() -> SomeClass::getFinalValue() ->
 ///     -> computeFinalValueForSomeClass()
 ///
-/// Right now only UnpatchedParam, but more is coming. As stuff is
-/// is extraced and turns out to be functionally identical the dupes
-/// will be eliminated.
+/// Done:
+/// - UnpatchedParam
+/// - patched_param::Integer
 ///
-/// Then when we have only functionally distinct variations here (and
-/// we have tests for them), then we can replace them with a parametrized
-/// version.
+/// As stuff is extraced and turns out to be functionally identical the dupes
+/// should be eliminated.
+///
+/// When we have all the functionally distinct variations here, and we have
+/// tests for them, then we can replace them with a parametrized version or
+/// two.
 ///
 /// ...and then it should be easier to make changes like specifying envelope
-/// times in milliseconds and bitcrushing in bits, hopefully without
-/// needing specialized code to handle existing saves.
+/// times in seconds and bitcrushing in bits, hopefully without
+/// needing specialized code to handle existing saves -- or at least have
+/// unit tests for the conversion code if it is needed.
 
-int32_t computeCurrentValueForUnpatchedParam(int32_t value);
-int32_t computeFinalValueForUnpatchedParam(int32_t value);
+/** Scales int32_t range to 0-50 for display.
+ */
+int32_t computeCurrentValueForStandardMenuItem(int32_t value);
+
+/** Scales 0-50 range to int32_t for storage and use.
+ */
+int32_t computeFinalValueForStandardMenuItem(int32_t value);

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -6,10 +6,13 @@
 
 TEST_GROUP(ValueScalingTest) {};
 
-TEST(ValueScalingTest, unpatchedParamValueRoundTrip) {
+TEST(ValueScalingTest, standardMenuItemValueRoundTrip) {
 	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
-		int32_t finalValue = computeFinalValueForUnpatchedParam(i);
-		int32_t currentValue = computeCurrentValueForUnpatchedParam(finalValue);
+		int32_t finalValue = computeFinalValueForStandardMenuItem(i);
+		int32_t currentValue = computeCurrentValueForStandardMenuItem(finalValue);
 		CHECK_EQUAL(i, currentValue);
 	}
+	CHECK_EQUAL(INT32_MIN, computeFinalValueForStandardMenuItem(0));
+	CHECK_EQUAL(-23,       computeFinalValueForStandardMenuItem(25));
+	CHECK_EQUAL(INT32_MAX, computeFinalValueForStandardMenuItem(50));
 }


### PR DESCRIPTION
- Math is exactly the same in both, let's call it compute(Current|Final)ValueForStandardMenuItem.

- Add a few tests with explicit values in addition to the roundtripping.