### PR TITLE
voice: use 2x regular release for fast release

### DIFF
--- a/src/deluge/modulation/envelope.cpp
+++ b/src/deluge/modulation/envelope.cpp
@@ -86,6 +86,10 @@ considerEnvelopeStage:
 		break;
 
 	case EnvelopeStage::FAST_RELEASE:
+		if (fastReleaseIncrement < 2 * release) {
+			release = 2 * release;
+			fastReleaseIncrement = release;
+		}
 		pos += fastReleaseIncrement * numSamples;
 		if (pos >= 8388608) {
 			setState(EnvelopeStage::OFF);


### PR DESCRIPTION
This is much more conservative than the original logic, avoiding note-off clicks for soft culls.