### PR TITLE
tests: CompParam::readCurrentValue() & getFinalValue()

### DIFF
--- a/src/deluge/gui/menu_item/audio_compressor/compressor_params.h
+++ b/src/deluge/gui/menu_item/audio_compressor/compressor_params.h
@@ -17,6 +17,7 @@
 #pragma once
 #include "definitions_cxx.hpp"
 #include "gui/menu_item/unpatched_param.h"
+#include "gui/menu_item/value_scaling.h"
 #include "gui/ui/sound_editor.h"
 #include "modulation/params/param_set.h"
 
@@ -26,21 +27,10 @@ class CompParam final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
 	void readCurrentValue() override {
-		auto value = (int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP());
-		this->setValue((value * (kMaxMenuValue * 2) + 2147483648) >> 32);
+		this->setValue(
+		    computeCurrentValueForCompParam(soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP())));
 	}
-	// comp params aren't set up for negative inputs - this is the same as osc pulse width
-	int32_t getFinalValue() override {
-		if (this->getValue() == kMaxMenuValue) {
-			return 2147483647;
-		}
-		else if (this->getValue() == kMinMenuValue) {
-			return 0;
-		}
-		else {
-			return (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
-		}
-	}
+	int32_t getFinalValue() override { return computeFinalValueForCompParam(this->getValue()); }
 };
 
 } // namespace deluge::gui::menu_item::audio_compressor

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -7,6 +7,10 @@ int32_t computeCurrentValueForStandardMenuItem(int32_t value) {
 	return (((int64_t)value + 2147483648) * kMaxMenuValue + 2147483648) >> 32;
 }
 
+int32_t computeCurrentValueForCompParam(int32_t value) {
+	return ((int64_t)value * (kMaxMenuValue * 2) + 2147483648) >> 32;
+}
+
 int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 	if (value == kMaxMenuValue) {
 		return 2147483647;
@@ -16,5 +20,18 @@ int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 	}
 	else {
 		return (uint32_t)value * (2147483648 / kMidMenuValue) - 2147483648;
+	}
+}
+
+int32_t computeFinalValueForCompParam(int32_t value) {
+	// comp params aren't set up for negative inputs - this is the same as osc pulse width
+	if (value == kMaxMenuValue) {
+		return 2147483647;
+	}
+	else if (value == kMinMenuValue) {
+		return 0;
+	}
+	else {
+		return (uint32_t)value * (2147483648 / kMidMenuValue) >> 1;
 	}
 }

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -27,6 +27,7 @@
 /// Done:
 /// - UnpatchedParam
 /// - patched_param::Integer
+/// - CompParam
 ///
 /// As stuff is extraced and turns out to be functionally identical the dupes
 /// should be eliminated.
@@ -40,10 +41,18 @@
 /// needing specialized code to handle existing saves -- or at least have
 /// unit tests for the conversion code if it is needed.
 
-/** Scales int32_t range to 0-50 for display.
+/** Scales INT32_MIN-INT32_MAX range to 0-50 for display.
  */
 int32_t computeCurrentValueForStandardMenuItem(int32_t value);
 
-/** Scales 0-50 range to int32_t for storage and use.
+/** Scales 0-50 range to INT32_MIN-INT32_MAX for storage and use.
  */
 int32_t computeFinalValueForStandardMenuItem(int32_t value);
+
+/** Scales 0-INT32_MAX range to 0-50 for display.
+ */
+int32_t computeCurrentValueForCompParam(int32_t value);
+
+/** Scales 0-50 range to 0-INT32_MAX for storage and use.
+ */
+int32_t computeFinalValueForCompParam(int32_t value);

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -6,7 +6,7 @@
 
 TEST_GROUP(ValueScalingTest) {};
 
-TEST(ValueScalingTest, standardMenuItemValueRoundTrip) {
+TEST(ValueScalingTest, standardMenuItemValueScaling) {
 	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
 		int32_t finalValue = computeFinalValueForStandardMenuItem(i);
 		int32_t currentValue = computeCurrentValueForStandardMenuItem(finalValue);
@@ -15,4 +15,15 @@ TEST(ValueScalingTest, standardMenuItemValueRoundTrip) {
 	CHECK_EQUAL(INT32_MIN, computeFinalValueForStandardMenuItem(0));
 	CHECK_EQUAL(-23,       computeFinalValueForStandardMenuItem(25));
 	CHECK_EQUAL(INT32_MAX, computeFinalValueForStandardMenuItem(50));
+}
+
+TEST(ValueScalingTest, compParamMenuItemValueScaling) {
+	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
+		int32_t finalValue = computeFinalValueForCompParam(i);
+		int32_t currentValue = computeCurrentValueForCompParam(finalValue);
+		CHECK_EQUAL(i, currentValue);
+	}
+	CHECK_EQUAL(0,          computeFinalValueForCompParam(0));
+	CHECK_EQUAL(1073741812, computeFinalValueForCompParam(25));
+	CHECK_EQUAL(INT32_MAX,  computeFinalValueForCompParam(50));
 }


### PR DESCRIPTION
- Pull out the guts for testing.

- Rename standard menu item roundtrip test to "scaling test", since it tests a few specific values in addition to roundtripping.