### PR TITLE
Os/conditional tasks

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -65,6 +65,7 @@ struct Task {
 	// makes a conditional task
 	Task(TaskHandle task, uint8_t priority, RunCondition _condition, const char* _name) {
 		handle = task;
+		// good to go as soon as it's marked as runnable
 		schedule = {priority, 0, 0, 0};
 		name = _name;
 		removeAfterUse = true;
@@ -388,6 +389,10 @@ uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, 
 }
 uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name) {
 	return taskManager.addOnceTask(task, priority, timeToWait, name);
+}
+
+uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name) {
+	return taskManager.addConditionalTask(task, priority, condition, name);
 }
 
 void removeTask(TaskID id) {

--- a/src/OSLikeStuff/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler.h
@@ -55,6 +55,10 @@ uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, 
 
 /// Add a task to run once, aiming to run at current time + timeToWait and worst case run at timeToWait*10
 uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name);
+
+/// add a task that runs only after the condition returns true. Condition checks should be very fast or they could
+/// interfere with scheduling
+uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name);
 void removeTask(TaskID id);
 /// start the task scheduler
 void startTaskManager();

--- a/src/OSLikeStuff/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler.h
@@ -24,6 +24,7 @@ extern "C" {
 
 /// void function with no arguments
 typedef void (*TaskHandle)();
+typedef bool (*RunCondition)();
 typedef int8_t TaskID;
 struct TaskSchedule {
 	// 0 is highest priority

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -58,7 +58,6 @@ TEST(Scheduler, schedule) {
 	addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sleep_50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -73,7 +72,6 @@ TEST(Scheduler, remove) {
 
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -84,7 +82,6 @@ TEST(Scheduler, scheduleOnce) {
 	addOnceTask(sleep_50ns, 0, 0.001, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -95,7 +92,6 @@ TEST(Scheduler, scheduleConditional) {
 	taskManager.addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -106,7 +102,6 @@ TEST(Scheduler, scheduleConditionalDoesntRun) {
 	taskManager.addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -117,7 +112,6 @@ TEST(Scheduler, backOffTime) {
 	addRepeatingTask(sleep_50ns, 1, 0.01, 0.001, 1, "sleep_50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.1);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -130,7 +124,6 @@ TEST(Scheduler, scheduleOnceWithRepeating) {
 	addOnceTask(sleep_2ms, 11, 0.0094, "sleep 2ms");
 	// run the scheduler for 10ms
 	taskManager.start(0.0095);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -146,7 +139,6 @@ TEST(Scheduler, removeWithPriZero) {
 	addOnceTask(sleep_2ms, 11, 0.009, "sleep 2ms");
 	// run the scheduler for 10ms
 	taskManager.start(0.01);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -196,7 +188,6 @@ TEST(Scheduler, scheduleMultiple) {
 	addOnceTask(sleep_2ms, 11, 0.0094, "sleep 2ms");
 	// run the scheduler for 10ms
 	taskManager.start(0.0095);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 	mock().checkExpectations();
 };
 
@@ -215,7 +206,6 @@ TEST(Scheduler, overSchedule) {
 	auto twomsHandle = addRepeatingTask(sleep_2ms, 100, 0.001, 0.002, 0.005, "sleep 2ms");
 	// run the scheduler for 10ms
 	taskManager.start(0.0099);
-	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
 
 	mock().checkExpectations();
 };

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -55,7 +55,7 @@ TEST(Scheduler, schedule) {
 	mock().clear();
 	// will be called one less time due to the time the sleep takes not being zero
 	mock().expectNCalls(0.01 / 0.001 - 1, "sleep_50ns");
-	taskManager.addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sleep_50ns");
+	addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sleep_50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
@@ -88,11 +88,33 @@ TEST(Scheduler, scheduleOnce) {
 	mock().checkExpectations();
 };
 
+TEST(Scheduler, scheduleConditional) {
+	mock().clear();
+	mock().expectNCalls(1, "sleep_50ns");
+	// will load as blocked but immediately pass condition
+	taskManager.addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns");
+	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
+	taskManager.start(0.0095);
+	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
+	mock().checkExpectations();
+};
+
+TEST(Scheduler, scheduleConditionalDoesntRun) {
+	mock().clear();
+	mock().expectNCalls(0, "sleep_50ns");
+	// will load as blocked but immediately pass condition
+	taskManager.addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns");
+	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
+	taskManager.start(0.0095);
+	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;
+	mock().checkExpectations();
+};
+
 TEST(Scheduler, backOffTime) {
 	mock().clear();
 	// will be called one less time due to the time the sleep takes not being zero
 	mock().expectNCalls(9, "sleep_50ns");
-	taskManager.addRepeatingTask(sleep_50ns, 1, 0.01, 0.001, 1, "sleep_50ns");
+	addRepeatingTask(sleep_50ns, 1, 0.01, 0.001, 1, "sleep_50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.1);
 	std::cout << "ending tests at " << getTimerValueSeconds(0) << std::endl;

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -89,7 +89,7 @@ TEST(Scheduler, scheduleConditional) {
 	mock().clear();
 	mock().expectNCalls(1, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	taskManager.addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns");
+	addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -99,7 +99,7 @@ TEST(Scheduler, scheduleConditionalDoesntRun) {
 	mock().clear();
 	mock().expectNCalls(0, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	taskManager.addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns");
+	addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();


### PR DESCRIPTION
Adds functionality to run a task after a condition is met. Tasks are added to the main task list, but not included in the sorted list of active tasks until their conditions are met. Conditions are checked when the task manager finds nothing better to do

This should be useful for scheduling something to run after another event finishes, like a song swap or SD reads