### PR TITLE
refactor: share value scaling between PulseWidth and CompParam

### DIFF
--- a/src/deluge/gui/menu_item/audio_compressor/compressor_params.h
+++ b/src/deluge/gui/menu_item/audio_compressor/compressor_params.h
@@ -27,10 +27,10 @@ class CompParam final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
 	void readCurrentValue() override {
-		this->setValue(
-		    computeCurrentValueForCompParam(soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP())));
+		this->setValue(computeCurrentValueForHalfPrecisionMenuItem(
+		    soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP())));
 	}
-	int32_t getFinalValue() override { return computeFinalValueForCompParam(this->getValue()); }
+	int32_t getFinalValue() override { return computeFinalValueForHalfPrecisionMenuItem(this->getValue()); }
 };
 
 } // namespace deluge::gui::menu_item::audio_compressor

--- a/src/deluge/gui/menu_item/osc/pulse_width.h
+++ b/src/deluge/gui/menu_item/osc/pulse_width.h
@@ -29,23 +29,11 @@ public:
 
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
-	int32_t getFinalValue() override {
-		if (this->getValue() == kMaxMenuValue) {
-			return 2147483647;
-		}
-		else if (this->getValue() == kMinMenuValue) {
-			return 0;
-		}
-		else {
-			return (uint32_t)this->getValue() * (2147483648 / kMidMenuValue) >> 1;
-		}
-	}
+	int32_t getFinalValue() override { return computeFinalValueForHalfPrecisionMenuItem(this->getValue()); }
 
 	void readCurrentValue() override {
-		this->setValue(
-		    ((int64_t)soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP()) * (kMaxMenuValue * 2)
-		     + 2147483648)
-		    >> 32);
+		this->setValue(computeCurrentValueForHalfPrecisionMenuItem(
+		    soundEditor.currentParamManager->getPatchedParamSet()->getValue(getP())));
 	}
 
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -7,7 +7,7 @@ int32_t computeCurrentValueForStandardMenuItem(int32_t value) {
 	return (((int64_t)value + 2147483648) * kMaxMenuValue + 2147483648) >> 32;
 }
 
-int32_t computeCurrentValueForCompParam(int32_t value) {
+int32_t computeCurrentValueForHalfPrecisionMenuItem(int32_t value) {
 	return ((int64_t)value * (kMaxMenuValue * 2) + 2147483648) >> 32;
 }
 
@@ -25,6 +25,19 @@ int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 
 int32_t computeFinalValueForCompParam(int32_t value) {
 	// comp params aren't set up for negative inputs - this is the same as osc pulse width
+	if (value == kMaxMenuValue) {
+		return 2147483647;
+	}
+	else if (value == kMinMenuValue) {
+		return 0;
+	}
+	else {
+		return (uint32_t)value * (2147483648 / kMidMenuValue) >> 1;
+	}
+}
+
+int32_t computeFinalValueForHalfPrecisionMenuItem(int32_t value) {
+	// comp params and osc pulse width aren't set up for negative inputs
 	if (value == kMaxMenuValue) {
 		return 2147483647;
 	}

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -28,6 +28,7 @@
 /// - UnpatchedParam
 /// - patched_param::Integer
 /// - CompParam
+/// - PulseWidth
 ///
 /// As stuff is extraced and turns out to be functionally identical the dupes
 /// should be eliminated.
@@ -51,8 +52,8 @@ int32_t computeFinalValueForStandardMenuItem(int32_t value);
 
 /** Scales 0-INT32_MAX range to 0-50 for display.
  */
-int32_t computeCurrentValueForCompParam(int32_t value);
+int32_t computeCurrentValueForHalfPrecisionMenuItem(int32_t value);
 
 /** Scales 0-50 range to 0-INT32_MAX for storage and use.
  */
-int32_t computeFinalValueForCompParam(int32_t value);
+int32_t computeFinalValueForHalfPrecisionMenuItem(int32_t value);

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -17,13 +17,13 @@ TEST(ValueScalingTest, standardMenuItemValueScaling) {
 	CHECK_EQUAL(INT32_MAX, computeFinalValueForStandardMenuItem(50));
 }
 
-TEST(ValueScalingTest, compParamMenuItemValueScaling) {
+TEST(ValueScalingTest, HalfPrecisionValueScaling) {
 	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
-		int32_t finalValue = computeFinalValueForCompParam(i);
-		int32_t currentValue = computeCurrentValueForCompParam(finalValue);
+		int32_t finalValue = computeFinalValueForHalfPrecisionMenuItem(i);
+		int32_t currentValue = computeCurrentValueForHalfPrecisionMenuItem(finalValue);
 		CHECK_EQUAL(i, currentValue);
 	}
-	CHECK_EQUAL(0,          computeFinalValueForCompParam(0));
-	CHECK_EQUAL(1073741812, computeFinalValueForCompParam(25));
-	CHECK_EQUAL(INT32_MAX,  computeFinalValueForCompParam(50));
+	CHECK_EQUAL(0,          computeFinalValueForHalfPrecisionMenuItem(0));
+	CHECK_EQUAL(1073741812, computeFinalValueForHalfPrecisionMenuItem(25));
+	CHECK_EQUAL(INT32_MAX,  computeFinalValueForHalfPrecisionMenuItem(50));
 }


### PR DESCRIPTION
- Math is exactly the same in both, let's call it compute(Current|Final)ValueForHalfPrecisionMenuItem().