### PR TITLE
tests: unpatched_param::Pan::readCurrentValue() & getFinalValue()

### DIFF
--- a/src/deluge/gui/menu_item/unpatched_param/pan.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param/pan.cpp
@@ -16,6 +16,7 @@
  */
 #include "pan.h"
 
+#include "gui/menu_item/value_scaling.h"
 #include "gui/ui/sound_editor.h"
 #include "modulation/params/param_manager.h"
 #include "modulation/params/param_set.h"
@@ -39,22 +40,12 @@ void Pan::drawValue() {    // TODO: should really combine this with the "patched
 }
 
 int32_t Pan::getFinalValue() {
-	if (this->getValue() == kMaxMenuRelativeValue) {
-		return 2147483647;
-	}
-	else if (this->getValue() == kMinMenuRelativeValue) {
-		return -2147483648;
-	}
-	else {
-		return ((int32_t)this->getValue() * (2147483648 / (kMaxMenuRelativeValue * 2)) * 2);
-	}
+	return computeFinalValueForPan(this->getValue());
 }
 
 void Pan::readCurrentValue() {
-	this->setValue(((int64_t)soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP())
-	                    * (kMaxMenuRelativeValue * 2)
-	                + 2147483648)
-	               >> 32);
+	this->setValue(
+	    computeCurrentValueForPan(soundEditor.currentParamManager->getUnpatchedParamSet()->getValue(getP())));
 }
 
 } // namespace deluge::gui::menu_item::unpatched_param

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -11,6 +11,10 @@ int32_t computeCurrentValueForHalfPrecisionMenuItem(int32_t value) {
 	return ((int64_t)value * (kMaxMenuValue * 2) + 2147483648) >> 32;
 }
 
+int32_t computeCurrentValueForPan(int32_t value) {
+	return ((int64_t)value * (kMaxMenuRelativeValue * 2) + 2147483648) >> 32;
+}
+
 int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 	if (value == kMaxMenuValue) {
 		return 2147483647;
@@ -46,5 +50,17 @@ int32_t computeFinalValueForHalfPrecisionMenuItem(int32_t value) {
 	}
 	else {
 		return (uint32_t)value * (2147483648 / kMidMenuValue) >> 1;
+	}
+}
+
+int32_t computeFinalValueForPan(int32_t value) {
+	if (value == kMaxMenuRelativeValue) {
+		return 2147483647;
+	}
+	else if (value == kMinMenuRelativeValue) {
+		return -2147483648;
+	}
+	else {
+		return ((int32_t)value * (2147483648 / (kMaxMenuRelativeValue * 2)) * 2);
 	}
 }

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -25,10 +25,11 @@
 ///     -> computeFinalValueForSomeClass()
 ///
 /// Done:
-/// - UnpatchedParam
+/// - unpatched_param::UnpatchedParam
+/// - unpatched_param::Pan
 /// - patched_param::Integer
-/// - CompParam
-/// - PulseWidth
+/// - audio_compressor::CompParam
+/// - osc::PulseWidth
 ///
 /// As stuff is extraced and turns out to be functionally identical the dupes
 /// should be eliminated.
@@ -57,3 +58,11 @@ int32_t computeCurrentValueForHalfPrecisionMenuItem(int32_t value);
 /** Scales 0-50 range to 0-INT32_MAX for storage and use.
  */
 int32_t computeFinalValueForHalfPrecisionMenuItem(int32_t value);
+
+/** Scales INT32_MIN-INT32_MAX range to -25-25 for display.
+ */
+int32_t computeCurrentValueForPan(int32_t value);
+
+/** Scales -25 to 25 range to INT32_MIN-INT32_MAX for storage and use.
+ */
+int32_t computeFinalValueForPan(int32_t value);

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -27,3 +27,14 @@ TEST(ValueScalingTest, HalfPrecisionValueScaling) {
 	CHECK_EQUAL(1073741812, computeFinalValueForHalfPrecisionMenuItem(25));
 	CHECK_EQUAL(INT32_MAX,  computeFinalValueForHalfPrecisionMenuItem(50));
 }
+
+TEST(ValueScalingTest, panValueScaling) {
+	for (int i = kMinMenuRelativeValue; i <= kMaxMenuRelativeValue; i++) {
+		int32_t finalValue = computeFinalValueForPan(i);
+		int32_t currentValue = computeCurrentValueForPan(finalValue);
+		CHECK_EQUAL(i, currentValue);
+	}
+	CHECK_EQUAL(INT32_MIN, computeFinalValueForPan(-25));
+	CHECK_EQUAL(0,         computeFinalValueForPan(0));
+	CHECK_EQUAL(INT32_MAX, computeFinalValueForPan(25));
+}


### PR DESCRIPTION
- Pull out guts for testing. The other Pan variants coming up separately.