### PR TITLE
bugfix: use normal pan value scaling for reverb::Pan

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -516,13 +516,17 @@ This mode affects how the Deluge handles MIDI input for learned CC controls.
 
     - This feature is `OFF` by default and can be set to `ON` or `OFF` via `SETTINGS > COMMUNITY FEATURES`.
 
-#### 4.2.8 - Alternate Reverb Models
+#### 4.2.8 - Reverb Improvements
 
 - ([#1065]) New reverb models are available for selection inside of the `FX > REVERB > MODEL` menu. These include:
     - Freeverb (the original Deluge reverb)
     - Mutable (an adapted version of the reverb found in Mutable Instruments' Rings module)
         - The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the
           reverb model used with those songs.
+
+- ([#2080]) Reverb can now be panned fully left or right. Old songs retain their reverb panning behavior, but display
+  it as smaller numbers. This change also fixes an issue with reverb values displaying differently than how they were
+  set.
 
 ### 4.3 - Instrument Clip View - General Features
 

--- a/src/deluge/gui/menu_item/reverb/pan.h
+++ b/src/deluge/gui/menu_item/reverb/pan.h
@@ -38,11 +38,10 @@ public:
 		display->setText(buffer, true);
 	}
 
-	void writeCurrentValue() override { AudioEngine::reverbPan = ((int32_t)this->getValue() * 33554432); }
+	void writeCurrentValue() override { AudioEngine::reverbPan = computeFinalValueForPan(this->getValue()); }
 
-	void readCurrentValue() override {
-		this->setValue(((int64_t)AudioEngine::reverbPan * (kMaxMenuRelativeValue * 4) + 2147483648) >> 32);
-	}
+	void readCurrentValue() override { this->setValue(computeCurrentValueForPan(AudioEngine::reverbPan)); }
+
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuRelativeValue; }
 	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuRelativeValue; }
 };

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -29,6 +29,7 @@
 /// - osc::PulseWidth
 /// - patched_param::Integer
 /// - patched_param::Pan
+/// - reverb::Pan
 /// - unpatched_param::Pan
 /// - unpatched_param::UnpatchedParam
 ///


### PR DESCRIPTION
- Fixes #2063. All panning uses the same doPanning() function, so same value scaling is correct for reverb as well.

- No need to adjust save/load logic: any old saved values will be used as-is and sound the same, they will just display differently.

- This gives access to fully wet and dry sounds if you pan master fully one way and reverb fully the other way.