### PR TITLE
Use conditional tasks for song loading instead of scheduled callbacks

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -332,9 +332,9 @@ void TaskManager::start(double duration) {
 }
 bool TaskManager::checkConditionalTasks() {
 	bool addedTask = false;
-	for (int i = 0; i < numRegisteredTasks; i++) {
+	for (int i = 0; i < kMaxTasks; i++) {
 		struct Task* t = &list[i];
-		if (t->handle != nullptr && !(t->runnable)) {
+		if (t->condition != nullptr && !(t->runnable)) {
 			t->runnable = t->condition();
 			if (t->runnable) {
 				addedTask = true;

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -385,7 +385,11 @@ gotErrorAfterCreatingSong:
 		// Ensure all AudioFile Clusters needed for new song are loaded
 		// Prevent any unforeseen loop. Not sure if that actually could happen
 		if (audioFileManager.loadingQueueHasAnyLowestPriorityElements() && count < 50) {
-			addOnceTask([]() { loadSongUI.performLoadFixedSM(); }, 100, 0.05, nullptr);
+			// addOnceTask([]() { loadSongUI.performLoadFixedSM(); }, 100, 0.05, nullptr);
+			addConditionalTask(
+			    []() { loadSongUI.performLoadFixedSM(); }, 100,
+			    []() { return !(audioFileManager.loadingQueueHasAnyLowestPriorityElements() && count < 50); },
+			    "Song loading");
 			return;
 		}
 
@@ -434,7 +438,11 @@ gotErrorAfterCreatingSong:
 			AudioEngine::logAction("h");
 			// If any more waiting required before the song swap actually happens, do that
 			if (currentUIMode != UI_MODE_LOADING_SONG_NEW_SONG_PLAYING) {
-				addOnceTask([]() { loadSongUI.performLoadFixedSM(); }, 100, 0.05, nullptr);
+				// addOnceTask([]() { loadSongUI.performLoadFixedSM(); }, 100, 0.05, nullptr);
+				addConditionalTask([]() { loadSongUI.performLoadFixedSM(); }, 100,
+				                   []() { return currentUIMode == UI_MODE_LOADING_SONG_NEW_SONG_PLAYING; },
+				                   "Song loading");
+
 				return;
 			}
 		}
@@ -445,7 +453,9 @@ gotErrorAfterCreatingSong:
 	}
 	case LoadStatus::WAIT_FOR_SAMPLES: {
 		if (currentUIMode != UI_MODE_LOADING_SONG_NEW_SONG_PLAYING) {
-			addOnceTask([]() { loadSongUI.performLoadFixedSM(); }, 100, 0.05, nullptr);
+			// I don't think this is possible anymore but just in case
+			addConditionalTask([]() { loadSongUI.performLoadFixedSM(); }, 100,
+			                   []() { return currentUIMode == UI_MODE_LOADING_SONG_NEW_SONG_PLAYING; }, "Song loading");
 			return;
 		}
 swapDone:


### PR DESCRIPTION
Fix a bug where conditions could be un checked if a task had been removed after the conditional task was added (e.g. it was beyond numRegisteredTasks in the task array)

Switch the song loading code to use conditional tasks instead of scheduled callbacks. Possibly more efficient, definitely clearer about what's going on