### PR TITLE
UI - don't blink when just potentially soft culling

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -430,7 +430,9 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 			// probably bad
 			cullVoice(false, numRoutines == 0 ? SOFT : SOFT_ALWAYS, numSamples, nullptr);
 			logAction("soft cull");
-			culled = true;
+			if (numRoutines > 0) {
+				culled = true;
+			}
 		}
 	}
 	else {


### PR DESCRIPTION
Change the cull blinking so it ignores soft culls. Soft culling isn't guaranteed (no cull happens if a voice is already fast releasing), and even when forced is rarely audible. This should make the indicator more generally usable