### PR TITLE
smarter dbt loadfw, making things easier for new devs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ __pycache__
 .idea
 *.srctrl*
 
+.deluge_hex_key

--- a/scripts/tasks/task-loadfw.py
+++ b/scripts/tasks/task-loadfw.py
@@ -4,44 +4,53 @@ import argparse
 import util
 import itertools
 import rtmidi
+import os
 
 
 def argparser():
-    midiout = rtmidi.MidiOut()
-    available_ports = midiout.get_ports()
-    s = "\n\nusage example: dbt loadfw 123 abcd1243 /path/deluge.bin"
-    s += "\n\nloads /path/deluge.bin to the deluge with key abcd1243, connected on MIDI port # 123"
-    s += "\n\nAvailable MIDI ports:\n\n"
-    for i, p in enumerate(available_ports):
-        s += "Port # " + str(i) + " : " + str(p) + "\n"
-
     parser = argparse.ArgumentParser(
         prog="loadfw",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Send firmware to Deluge via MIDI",
-        epilog=s,
-        exit_on_error=True,
+        epilog="""\nusage example: dbt loadfw relwithdebinfo
+                  Send build/relwithdebinfo/deluge.bin to MIDI port identified with deluge,
+                  using hex key stored in .deluge_hex_key.""",
+        exit_on_error=False,
     )
     parser.group = "Development"
     parser.add_argument(
-        "port_number",
-        help="MIDI port number (example: 123). Use 'dbt loadfw -h' to list available ports.",
+        "build",
+        help="""Path to firmware binary file, or build type.
+                Examples:
+                   ./build/Debug/deluge.bin # Sends the specified file
+                   release                  # Sends ./build/release/deluge.bin""",
     )
-    parser.add_argument("hex_key", help="8-digit Deluge Hex Key (example 1234abcd)")
     parser.add_argument(
-        "firmware_file",
-        help="Path to firmware binary file (example ./build/Debug/deluge.bin)",
+        "-p",
+        "--port",
+        type=int,
+        help="""MIDI output port. Default is first port with device called Deluge.
+                Use dbt loadfw -h to list available ports.""",
+    )
+    parser.add_argument(
+        "-k",
+        "--key",
+        help="""Deluge hex key. 8 digit key in SETTINGS > COMMUNITY FEATURES
+                > ALLOW INSECURE DEVELOP SYSEX MESSAGES. Defaults to string
+                stored in .deluge_hex_key, or an interactive request for the key.""",
     )
     parser.add_argument(
         "-d",
+        "--delay",
         default=2,
         type=int,
-        help="Delay in ms between SysEx packets. Default is 2. Increase in case of checksum errors.",
+        help="""Delay in ms between SysEx packets. Default is 2.
+                Increase in case of checksum errors.""",
     )
     parser.add_argument(
         "-o",
-        action="store_true",
-        help="Output SysEx data to file. Specify filename instead of port number.",
+        "--outfile",
+        help="Output SysEx data to file specified, instead of sending it over MIDI.",
     )
 
     return parser
@@ -122,31 +131,85 @@ def make_sysex_messages(binary, handshake):
     return messages
 
 
-def load_fw(port, handshake, file, delay_ms=2, output_to_file=False):
+def load_fw(output, handshake, file, delay_ms=2, output_to_file=False):
     with open(file, "rb") as f:
         binary = f.read()
 
     sysex_data = make_sysex_messages(binary, handshake)
 
     if output_to_file:
-        with open(port, "wb") as f:
+        with open(output, "wb") as f:
             text = f"Writing SysEx File '{f.name}': "
             for msg in util.progressbar(sysex_data, text):
                 f.write(msg)
 
     else:
-        midiout = rtmidi.MidiOut()
-        midiout.open_port(int(port))
-        with midiout:
+        with output:
             for msg in util.progressbar(sysex_data, "Firmware Upload: "):
-                midiout.send_message(msg)
+                output.send_message(msg)
                 time.sleep(0.001 * delay_ms)
 
 
+def try_read_hex_key():
+    name = ".deluge_hex_key"
+    try:
+        with open(name, "r") as f:
+            return f.read().strip()
+    except:
+        hex_key = input(
+            "Enter hex key from COMMUNITY FEATURES > ALLOW INSECURE DEVELOP SYSEX MESSAGES: "
+        )
+        if "Y" == input("Save hex key (Y/N)? ").upper():
+            with open(name, "w") as f:
+                f.write(hex_key)
+        return hex_key
+
+
+def find_binary(build):
+    if os.path.isfile(build):
+        return build
+    id = build.upper()
+    if id == "RELEASE":
+        return "build/Release/deluge.bin"
+    if id == "DBEUG":
+        return "build/Debug/deluge.bin"
+    if id == "RELWITHDEBINFO":
+        return "build/RelWithDebInfo/deluge.bin"
+    raise RuntimeError(
+        f"""Unknown build type: {build}. Should be either
+                           path to a binary, or one of: release, debug, or
+                           relwithdebinfo."""
+    )
+
+
 def main():
+    hex_key = None
+    binary = None
+    delay = None
+    output = None
+    output_to_file = True
     parser = argparser()
-    args = parser.parse_args()
-    load_fw(args.port_number, int(args.hex_key, 16), args.firmware_file, args.d, args.o)
+    ok = False
+    try:
+        args = parser.parse_args()
+        binary = find_binary(args.build)
+        hex_key = args.key or try_read_hex_key()
+        output = args.outfile
+        if output is None:
+            output_to_file = False
+            output = rtmidi.MidiOut()
+            port = util.ensure_midi_port("output", output, args.port)
+            output.open_port(port)
+        delay = args.delay
+        ok = True
+    except Exception as e:
+        util.note(f"ERROR: {e}")
+    finally:
+        if not ok:
+            util.report_available_midi_ports("output", rtmidi.MidiOut())
+            exit(1)
+
+    load_fw(output, int(hex_key, 16), binary, delay, output_to_file)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Given build type, figure out the file.

- If no hex key is given, use a stored one, or input one interactively. Figure out the MIDI port automagically, if possible. Explicit instructions for finding the key.

- Just one positional arguments.

- This means that: a simple `./dbt loadfw relwithdebinfo` does the right thing.

- Minor one-time cost for old devs to update their local setups which probably have something like ./dbt loadfw 2 128793 build/relwithdebinfo/deluge.bin scripted somewhere: keeping old command-lines working would have meant more complicated command line logic to figure out which positional arguments are elided.

- Use the third MIDI port for in & output for loadfw and sysex logging both, not the first one: the third one is intended as a dedicated sysex port.

- For --help cases report available ports to stdout: argparser uses stdout for help messages.

- Prettier output for cases where there are no midi ports of a given type: say "none" instead of printing nothing.

