### PR TITLE
Bugfix - don't set sticky shift if a matrix pad was pressed

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -295,6 +295,9 @@ bool readButtonsAndPads() {
 			if (Pad::isPad(util::to_underlying(value))) {
 				auto p = Pad(util::to_underlying(value));
 				result = matrixDriver.padAction(p.x, p.y, thisPadPressIsOn);
+				if (thisPadPressIsOn) {
+					Buttons::ignoreCurrentShiftForSticky();
+				}
 				/* while this function takes an int32_t for velocity, 255 indicates to the downstream audition pad
 				 * function that it should use the default velocity for the instrument
 				 */

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -294,13 +294,13 @@ bool readButtonsAndPads() {
 			ActionResult result;
 			if (Pad::isPad(util::to_underlying(value))) {
 				auto p = Pad(util::to_underlying(value));
+				/* while this function takes an int32_t for velocity, 255 indicates to the downstream audition pad
+				 * function that it should use the default velocity for the instrument
+				 */
 				result = matrixDriver.padAction(p.x, p.y, thisPadPressIsOn);
 				if (thisPadPressIsOn) {
 					Buttons::ignoreCurrentShiftForSticky();
 				}
-				/* while this function takes an int32_t for velocity, 255 indicates to the downstream audition pad
-				 * function that it should use the default velocity for the instrument
-				 */
 			}
 			else {
 				auto b = deluge::hid::Button(value);

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -283,4 +283,7 @@ void noPressesHappening(bool inCardRoutine) {
 		}
 	}
 }
+void ignoreCurrentShiftForSticky() {
+	considerShiftReleaseForSticky = false;
+}
 } // namespace Buttons

--- a/src/deluge/hid/buttons.h
+++ b/src/deluge/hid/buttons.h
@@ -27,7 +27,7 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 bool isButtonPressed(deluge::hid::Button b);
 bool isShiftButtonPressed();
 void noPressesHappening(bool inCardRoutine);
-
+void ignoreCurrentShiftForSticky();
 /**
  * Notify the button management code that the shift button should no longer be considered sticky. We need an explicit
  * notification so we can clear the buttons.cpp:shiftIsHeld to avoid shift getting permanantly stuck.


### PR DESCRIPTION
pressing a pad on the grid while holding shift wouldn't cause shift to not stick, making it inconsistent with other buttons and frustrating @ok-reza 