### PR TITLE
Bugfix: Automation View - Remove patch param sidechain level for synths and kit rows

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -12,7 +12,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 
 1. Automatable Clip View Parameters for Synths and Kits with a row selected and affect entire DISABLED
 
->The 61 parameters that can be edited are:
+>The 60 parameters that can be edited are:
 >
 > - **Master** Level, Pitch, Pan
 > - **LPF** Frequency, Resonance, Morph
@@ -20,7 +20,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **EQ** Bass, Bass Frequency, Treble, Treble Frequency
 > - **Reverb** Amount
 > - **Delay** Rate, Amount
-> - **Sidechain** Level, Shape
+> - **Sidechain** Shape
 > - **Distortion** Decimation, Bitcrush, Wavefolder
 > - **OSC 1** Level, Pitch, Phase Width, Carrier Feedback, Wave Position
 > - **OSC 2** Level, Pitch, Phase Width, Carrier Feedback, Wave Position

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -322,7 +322,7 @@ constexpr int32_t kMaxMenuMetronomeVolumeValue = 50;
 constexpr int32_t kMinMenuMetronomeVolumeValue = 1;
 
 // Automation View constants
-constexpr int32_t kNumNonGlobalParamsForAutomation = 61;
+constexpr int32_t kNumNonGlobalParamsForAutomation = 60;
 constexpr int32_t kNumGlobalParamsForAutomation = 26;
 constexpr int32_t kNoSelection = 255;
 constexpr int32_t kKnobPosOffset = 64;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -143,8 +143,7 @@ const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutom
     // Delay Rate, Amount
     {params::Kind::PATCHED, params::GLOBAL_DELAY_RATE},
     {params::Kind::PATCHED, params::GLOBAL_DELAY_FEEDBACK},
-    // Sidechain Send, Shape
-    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_REVERB_SEND},
+    // Sidechain Shape
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SIDECHAIN_SHAPE},
     // Decimation, Bitcrush, Wavefolder
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SAMPLE_RATE_REDUCTION},
@@ -4086,8 +4085,9 @@ bool AutomationView::handleParameterSelection(Clip* clip, OutputType outputType,
 		int32_t paramID = unpatchedGlobalParamShortcuts[xDisplay][yDisplay];
 
 		// don't allow automation of pitch adjust, or sidechain in arranger
-		if (onArrangerView && (paramID == params::UNPATCHED_PITCH_ADJUST)
-		    || (paramID == params::UNPATCHED_SIDECHAIN_SHAPE) || (paramID == params::UNPATCHED_SIDECHAIN_VOLUME)) {
+		if (onArrangerView
+		    && ((paramID == params::UNPATCHED_PITCH_ADJUST) || (paramID == params::UNPATCHED_SIDECHAIN_SHAPE)
+		        || (paramID == params::UNPATCHED_SIDECHAIN_VOLUME))) {
 			return true;
 		}
 

--- a/src/deluge/modulation/params/param.h
+++ b/src/deluge/modulation/params/param.h
@@ -277,7 +277,7 @@ const uint32_t patchedParamShortcuts[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID              , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , LOCAL_FOLD},
     {LOCAL_ENV_0_RELEASE     , LOCAL_ENV_0_SUSTAIN           , LOCAL_ENV_0_DECAY             , LOCAL_ENV_0_ATTACK     , LOCAL_LPF_MORPH, kNoParamID                , LOCAL_LPF_RESONANCE   , LOCAL_LPF_FREQ},
     {LOCAL_ENV_1_RELEASE     , LOCAL_ENV_1_SUSTAIN           , LOCAL_ENV_1_DECAY             , LOCAL_ENV_1_ATTACK     , LOCAL_HPF_MORPH, kNoParamID                , LOCAL_HPF_RESONANCE   , LOCAL_HPF_FREQ},
-    {kNoParamID              , kNoParamID                    , GLOBAL_VOLUME_POST_REVERB_SEND, kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},
+    {kNoParamID              , kNoParamID                    , kNoParamID					 , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},
     {GLOBAL_ARP_RATE         , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},
     {GLOBAL_LFO_FREQ         , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , GLOBAL_MOD_FX_DEPTH   , GLOBAL_MOD_FX_RATE},
     {LOCAL_LFO_LOCAL_FREQ    , kNoParamID                    , kNoParamID                    , GLOBAL_REVERB_AMOUNT   , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},


### PR DESCRIPTION
Cherry pick https://github.com/SynthstromAudible/DelugeFirmware/pull/2094 (had to do this manually due to merge conflicts and divergence between 1.1 and 1.2

Removed patched param sidechain level from automation view synths and kit rows because sidechain for synths and kit rows is a patch cable (Sidechain -> Sidechain Level) and this Sidechain Level param was never previously exposed.

Also fixed a bug with parameter selection on the automation overview which prevented selecting the params sidechain shape and sidechain level for global params (audio clips and kit affect entire)