### PR TITLE
Refactor InstrumentClipView::horizontalEncoderAction

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -97,6 +97,8 @@ public:
 	void cutAuditionedNotesToOne();
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
 	ActionResult horizontalEncoderAction(int32_t offset) override;
+	void editNoteRowLength(int32_t offset);
+	void rotateNoteRowHorizontally(int32_t offset);	
 	void fillOffScreenImageStores();
 	void graphicsRoutine() override;
 

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -98,7 +98,7 @@ public:
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
 	ActionResult horizontalEncoderAction(int32_t offset) override;
 	void editNoteRowLength(int32_t offset);
-	void rotateNoteRowHorizontally(int32_t offset);	
+	void rotateNoteRowHorizontally(int32_t offset);
 	void fillOffScreenImageStores();
 	void graphicsRoutine() override;
 


### PR DESCRIPTION
Refactored code for editing note row length and rotating note row horizontally out of horizontalEncoderAction into their own separate functions

Prep for velocity note view