### PR TITLE
Add a basic yield function to the scheduler

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -333,10 +333,7 @@ void TaskManager::runTask(TaskID id) {
 /// returns whether the condition was met
 bool TaskManager::yield(RunCondition until, double timeout) {
 	if (!running) {
-		disableTimer(0);
-		setTimerValue(0, 0);
-		setOperatingMode(0, FREE_RUNNING, false);
-		enableTimer(0);
+		startClock();
 	}
 	auto yieldingTask = &list[currentID];
 	auto yieldingID = currentID;
@@ -381,7 +378,6 @@ void TaskManager::start(double duration) {
 	// set up os timer 0 as a free running timer
 
 	startClock();
-	lastTime = 0;
 	double startTime = getSecondsFromStart();
 	double lastLoop = startTime;
 	if (duration != 0) {
@@ -413,6 +409,7 @@ void TaskManager::startClock() {
 	setOperatingMode(0, FREE_RUNNING, false);
 	enableTimer(0);
 	running = true;
+	lastTime = 0;
 }
 bool TaskManager::checkConditionalTasks() {
 	bool addedTask = false;

--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -301,31 +301,39 @@ void TaskManager::clockRolledOver() {
 /// pause current task, continue to run scheduler loop until a condition is met, then return to it
 /// current task can be called again if it's repeating - this is to match behaviour of busy waiting with routineForSD
 void TaskManager::yield(RunCondition until) {
-	auto currentTask = &list[currentID];
+	auto yieldingTask = &list[currentID];
+	auto yieldingID = currentID;
 	// for now we first end this as if the task finished - might be advantageous to replace with a context switch later
-	if (currentTask->removeAfterUse) {
+	if (yieldingTask->removeAfterUse) {
 		removeTask(currentID);
 	}
 	else {
 		auto timeNow = getTimerValueSeconds(0);
-		currentTask->lastFinishTime = timeNow;
-		double runtime = (currentTask->lastFinishTime - currentTask->lastCallTime);
+		yieldingTask->lastFinishTime = timeNow;
+		double runtime = (yieldingTask->lastFinishTime - yieldingTask->lastCallTime);
 		if (runtime < 0) {
 			runtime += rollTime;
 		}
 
-		currentTask->durationStats.update(runtime);
-		currentTask->totalTime += runtime;
-		currentTask->timesCalled += 1;
+		yieldingTask->durationStats.update(runtime);
+		yieldingTask->totalTime += runtime;
+		yieldingTask->timesCalled += 1;
 		cpuTime += runtime;
 	}
 	// continue the main loop. The yielding task is still on the stack but that should be fine
-	while (!until()) {
+	// run at least once so this can be used for yielding a single call as well
+	do {
 		TaskID task = chooseBestTask(mustEndBefore);
 		if (task >= 0) {
 			runTask(task);
 		}
-	}
+	} while (!until());
+
+	auto timeNow = getTimerValueSeconds(0);
+#if SCHEDULER_DETAILED_STATS
+	yieldingTask->latency.update(timeNow - yieldingTask->lastCallTime);
+#endif
+	yieldingTask->lastCallTime = timeNow;
 }
 
 /// default duration of 0 signifies infinite loop, intended to be specified only for testing

--- a/src/OSLikeStuff/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler.h
@@ -60,6 +60,7 @@ uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const 
 /// interfere with scheduling
 uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name);
 void removeTask(TaskID id);
+void yield(RunCondition until);
 /// start the task scheduler
 void startTaskManager();
 #ifdef __cplusplus

--- a/src/OSLikeStuff/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler.h
@@ -16,11 +16,11 @@
  */
 #ifndef DELUGE_TASK_SCHEDULER_H
 #define DELUGE_TASK_SCHEDULER_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "RZA1/ostm/ostm.h"
+#include "stdint.h"
 
 /// void function with no arguments
 typedef void (*TaskHandle)();
@@ -59,8 +59,14 @@ uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const 
 /// add a task that runs only after the condition returns true. Condition checks should be very fast or they could
 /// interfere with scheduling
 uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name);
+void ignoreForStats();
+double getLastRunTimeforCurrentTask();
+double getSystemTime();
+void setNextRunTimeforCurrentTask(double seconds);
 void removeTask(TaskID id);
 void yield(RunCondition until);
+/// timeout in seconds, returns whether the condition was met
+bool yieldWithTimeout(RunCondition until, double timeout);
 /// start the task scheduler
 void startTaskManager();
 #ifdef __cplusplus

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -950,6 +950,21 @@ extern "C" void logAudioAction(char const* string) {
 	AudioEngine::logAction(string);
 }
 
+extern "C" void yieldingRoutineForSD(RunCondition until) {
+	if (intc_func_active != 0) {
+		return;
+	}
+
+	// We lock this to prevent multiple entry. Otherwise we could get SD -> routineForSD() -> AudioEngine::routine() ->
+	// USB -> routineForSD()
+	if (sdRoutineLock) {
+		return;
+	}
+	sdRoutineLock = true;
+	yield(until);
+	sdRoutineLock = false;
+}
+
 /// this function is used as a busy wait loop for long SD reads, and while swapping songs
 extern "C" void routineForSD(void) {
 

--- a/src/deluge/deluge.h
+++ b/src/deluge/deluge.h
@@ -33,7 +33,8 @@ extern void loadAnyEnqueuedClustersRoutine(void);
 extern void logAudioAction(char const* string);
 
 extern void consoleTextIfAllBootedUp(char const* text);
-
+typedef bool (*RunCondition)();
+void yieldingRoutineForSD(RunCondition until);
 extern void routineForSD(void);
 extern void sdCardInserted(void);
 extern void sdCardEjected(void);

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -271,9 +271,9 @@ void LoadSongUI::performLoad(StorageManager& bdsm) {
 	else {
 		// Note: this is dodgy, but in this case we don't reset view.activeControllableClip here - we let the user keep
 		// fiddling with it. It won't get deleted.
-		AudioEngine::logAction("a");
+		AudioEngine::logAction("arming for song swap");
 		AudioEngine::songSwapAboutToHappen();
-		AudioEngine::logAction("b");
+		AudioEngine::logAction("song swap armed");
 		playbackHandler.songSwapShouldPreserveTempo = Buttons::isButtonPressed(deluge::hid::button::TEMPO_ENC);
 	}
 
@@ -315,7 +315,7 @@ gotErrorAfterCreatingSong:
 
 	GlobalEffectable::initParams(&preLoadedSong->paramManager);
 
-	AudioEngine::logAction("c");
+	AudioEngine::logAction("initialized new song");
 
 	// Will return false if we ran out of RAM. This isn't currently detected for while loading ParamNodes, but chances
 	// are, after failing on one of those, it'd try to load something else and that would fail.
@@ -323,7 +323,7 @@ gotErrorAfterCreatingSong:
 	if (error != Error::NONE) {
 		goto gotErrorAfterCreatingSong;
 	}
-	AudioEngine::logAction("d");
+	AudioEngine::logAction("read new song from file");
 
 	bool success = storageManager.closeFile();
 
@@ -413,9 +413,9 @@ gotErrorAfterCreatingSong:
 		// We're now waiting, either for the user to arm, or for the arming to launch the song-swap. Get loading all the
 		// rest of the samples which weren't needed right away. (though we might run out of RAM cos we haven't discarded
 		// all the old samples yet)
-		AudioEngine::logAction("g");
+		AudioEngine::logAction("asking for samples");
 		preLoadedSong->loadAllSamples(true);
-		AudioEngine::logAction("h");
+		AudioEngine::logAction("waiting for samples");
 #ifdef USE_TASK_MANAGER
 		yield([]() { return currentUIMode == UI_MODE_LOADING_SONG_NEW_SONG_PLAYING; });
 #else
@@ -441,7 +441,7 @@ swapDone:
 	audioFileManager.loadAnyEnqueuedClusters(99999);
 
 	// Delete the old song
-	AudioEngine::logAction("i");
+	AudioEngine::logAction("deleting old song");
 	if (toDelete) {
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Song();
@@ -452,7 +452,7 @@ swapDone:
 
 	// Try one more time to load all AudioFiles - there might be more RAM free now
 	currentSong->loadAllSamples();
-	AudioEngine::logAction("l");
+	AudioEngine::logAction("done loading new song");
 	currentSong->markAllInstrumentsAsEdited();
 
 	audioFileManager.thingFinishedLoading();

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -433,8 +433,8 @@ gotErrorAfterCreatingSong:
 
 swapDone:
 	if (display->haveOLED()) {
-		deluge::hid::display::OLED::displayWorkingAnimation(
-		    "Loading"); // To override our popup if we did one. (Still necessary?)
+		// To override our popup if we did one. (Still necessary?)
+		deluge::hid::display::OLED::displayWorkingAnimation("Loading");
 	}
 	// Ok, the swap's been done, the first tick of the new song has been done, and there are potentially loads of
 	// samples wanting some data loaded. So do that immediately

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -96,7 +96,8 @@ TEST(Scheduler, scheduleConditional) {
 	mock().clear();
 	mock().expectNCalls(1, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns");
+	addConditionalTask(
+	    sleep_50ns, 0, []() { return true; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -106,7 +107,8 @@ TEST(Scheduler, scheduleConditionalDoesntRun) {
 	mock().clear();
 	mock().expectNCalls(0, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns");
+	addConditionalTask(
+	    sleep_50ns, 0, []() { return false; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();


### PR DESCRIPTION
This is a very basic yield with no context switching. It allows recalling the yielding task to match how routine for sd is used in the sd read functions, so still needs guards (if (sdRoutineLock) ) 