### PR TITLE
Refactoring: Update sequence/mpe/automation clear/shift/nudge code and documentation

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1793,7 +1793,7 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 				ModelStackWithTimelineCounter* modelStack =
 				    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, clip);
 
-				// clear automation, don't clear notes and mpe
+				// clear automation, don't clear sample and mpe
 				clip->clear(action, modelStack, true, false);
 			}
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_AUTOMATION_CLEARED));

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1794,7 +1794,9 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 				    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, clip);
 
 				// clear automation, don't clear sample and mpe
-				clip->clear(action, modelStack, true, false);
+				bool clearAutomation = true;
+				bool clearSequenceAndMPE = false;
+				clip->clear(action, modelStack, clearAutomation, clearSequenceAndMPE);
 			}
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_AUTOMATION_CLEARED));
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2965,7 +2965,10 @@ Clip* SessionView::gridCreateClipInTrack(Output* targetOutput) {
 	ModelStackWithTimelineCounter* modelStack =
 	    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, newClip);
 	Action* action = actionLogger.getNewAction(ActionType::CLIP_CLEAR);
-	newClip->clear(action, modelStack, true, true);
+	// clear everything
+	bool clearAutomation = true;
+	bool clearSequenceAndMPE = true;
+	newClip->clear(action, modelStack, clearAutomation, clearSequenceAndMPE);
 	actionLogger.deleteAllLogs();
 
 	// For safety we set it up exactly as we want it

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -68,7 +68,7 @@ public:
 	bool currentlyScrollableAndZoomable() override;
 	void getScrollAndZoomInSamples(int32_t xScroll, int32_t xZoom, int64_t* xScrollSamples, int64_t* xZoomSamples);
 	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
-	           bool clearNotesAndMPE) override;
+	           bool clearSequenceAndMPE) override;
 	bool getCurrentlyRecordingLinearly() override;
 	void abortRecording() override;
 	void setupPlaybackBounds();
@@ -80,7 +80,8 @@ public:
 	int64_t getNumSamplesTilLoop(ModelStackWithTimelineCounter* modelStack);
 	void setPos(ModelStackWithTimelineCounter* modelStack, int32_t newPos, bool useActualPosForParamManagers) override;
 	/// Return true if successfully shifted, as clip cannot be shifted past beginning
-	bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount) override;
+	bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount, bool shiftAutomation,
+	                       bool shiftSequenceAndMPE) override;
 
 	Error readFromFile(Deserializer& reader, Song* song) override;
 	void writeDataToFile(Serializer& writer, Song* song) override;

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -980,14 +980,10 @@ trimFoundParamManager:
 }
 
 void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
-                 bool clearNotesAndMPE) {
-	// New community feature as part of Automation Clip View Implementation
-	// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing a clip
-	// will only clear the Notes and MPE data (NON MPE automations remain intact).
-
-	// If this is enabled, if you want to clear NON MPE automations, you will enter Automation Clip View and clear the
-	// clip there.
-
+                 bool clearSequenceAndMPE) {
+	// the following code iterates through all param collections and clears automation and MPE separately
+	// automation only gets cleared if clearAutomation is true
+	// MPE only gets cleared if clearSequenceAndMPE is true
 	ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 	    modelStack->addOtherTwoThingsButNoNoteRow(output->toModControllable(), &paramManager);
 
@@ -1003,13 +999,13 @@ void Clip::clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool
 
 			// Special case for MPE only - not even "mono" / Clip-level expression.
 			if (i == paramManager.getExpressionParamSetOffset()) {
-				if (clearNotesAndMPE) {
+				if (clearSequenceAndMPE) {
 					((ExpressionParamSet*)summary->paramCollection)
 					    ->deleteAllAutomation(action, modelStackWithParamCollection);
 				}
 			}
 
-			// Normal case
+			// Normal case (non MPE automation)
 			else {
 				if (clearAutomation) {
 					summary->paramCollection->deleteAllAutomation(action, modelStackWithParamCollection);

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -107,7 +107,7 @@ public:
 	virtual bool getCurrentlyRecordingLinearly() = 0;
 	virtual bool currentlyScrollableAndZoomable() = 0;
 	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
-	                   bool clearNotesAndMPE);
+	                   bool clearSequenceAndMPE);
 
 	void writeToFile(Serializer& writer, Song* song);
 	virtual void writeDataToFile(Serializer& writer, Song* song);
@@ -130,7 +130,8 @@ public:
 	void setSequenceDirectionMode(ModelStackWithTimelineCounter* modelStack, SequenceDirection newSequenceDirection);
 	virtual void incrementPos(ModelStackWithTimelineCounter* modelStack, int32_t numTicks);
 	/// Return true if successfully shifted
-	virtual bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount) = 0;
+	virtual bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount, bool shiftAutomation,
+	                               bool shiftSequenceAndMPE) = 0;
 
 	// ----- TimelineCounter implementation -------
 	[[nodiscard]] uint32_t getLivePos() const override;

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -97,7 +97,8 @@ public:
 	int32_t getNoteRowId(NoteRow* noteRow, int32_t noteRowIndex);
 	NoteRow* getNoteRowFromId(int32_t id);
 	/// Return true if successfully shifted. Instrument clips always succeed
-	bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount) override;
+	bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount, bool shiftAutomation,
+	                       bool shiftSequenceAndMPE) override;
 	bool isEmpty();
 	bool containsAnyNotes();
 	ModelStackWithNoteRow* getNoteRowOnScreen(int32_t yDisplay, ModelStackWithTimelineCounter* modelStack);
@@ -200,7 +201,7 @@ public:
 	void sendMIDIPGM();
 	void noteRemovedFromMode(int32_t yNoteWithinOctave, Song* song);
 	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
-	           bool clearNotesAndMPE) override;
+	           bool clearSequenceAndMPE) override;
 	bool doesProbabilityExist(int32_t apartFromPos, int32_t probability, int32_t secondProbability = -1);
 	void clearArea(ModelStackWithTimelineCounter* modelStack, int32_t startPos, int32_t endPos, Action* action);
 	ScaleType getScaleType();
@@ -238,7 +239,8 @@ public:
 	bool getCurrentlyRecordingLinearly() override;
 	void abortRecording() override;
 	void yDisplayNoLongerAuditioning(int32_t yDisplay, Song* song);
-	void shiftOnlyOneNoteRowHorizontally(ModelStackWithNoteRow* modelStack, int32_t shiftAmount);
+	void shiftOnlyOneNoteRowHorizontally(ModelStackWithNoteRow* modelStack, int32_t shiftAmount, bool shiftAutomation,
+	                                     bool shiftSequenceAndMPE);
 	int32_t getMaxLength() override;
 	bool hasAnyPitchExpressionAutomationOnNoteRows();
 	ModelStackWithNoteRow* duplicateModelStackForClipBeingRecordedFrom(ModelStackWithNoteRow* modelStack,

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -412,12 +412,14 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 
 			UI* currentUI = getCurrentUI();
 
+			// Always clear automation when in Automation View
+			// or also clear automation when default setting to only clear automation in Automation View is false
 			bool clearAutomation = (currentUI == &automationView || !FlashStorage::automationClear);
 
-			// if you're not in automation view, always clear notes and MPE
-			bool clearNotesAndMPE = (currentUI != &automationView);
+			// Always clear Notes and MPE when you're not in Automation View
+			bool clearSequenceAndMPE = (currentUI != &automationView);
 
-			getCurrentInstrumentClip()->clear(action, modelStack, clearAutomation, clearNotesAndMPE);
+			getCurrentInstrumentClip()->clear(action, modelStack, clearAutomation, clearSequenceAndMPE);
 
 			// New default as part of Automation Clip View Implementation
 			// If this is enabled, then when you are in a regular Instrument Clip View (Synth, Kit, MIDI, CV), clearing

--- a/src/deluge/model/consequence/consequence_clip_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_clip_horizontal_shift.cpp
@@ -20,8 +20,11 @@
 #include "model/model_stack.h"
 #include "model/song/song.h"
 
-ConsequenceClipHorizontalShift::ConsequenceClipHorizontalShift(int32_t newAmount) {
+ConsequenceClipHorizontalShift::ConsequenceClipHorizontalShift(int32_t newAmount, bool newShiftAutomation,
+                                                               bool newShiftSequenceAndMPE) {
 	amount = newAmount;
+	shiftAutomation = newShiftAutomation;
+	shiftSequenceAndMPE = newShiftSequenceAndMPE;
 }
 
 Error ConsequenceClipHorizontalShift::revert(TimeType time, ModelStack* modelStack) {
@@ -36,7 +39,7 @@ Error ConsequenceClipHorizontalShift::revert(TimeType time, ModelStack* modelSta
 	    modelStack->addTimelineCounter(modelStack->song->getCurrentClip());
 
 	((Clip*)modelStackWithTimelineCounter->getTimelineCounter())
-	    ->shiftHorizontally(modelStackWithTimelineCounter, amountNow);
+	    ->shiftHorizontally(modelStackWithTimelineCounter, amountNow, shiftAutomation, shiftSequenceAndMPE);
 
 	return Error::NONE;
 }

--- a/src/deluge/model/consequence/consequence_clip_horizontal_shift.h
+++ b/src/deluge/model/consequence/consequence_clip_horizontal_shift.h
@@ -22,8 +22,10 @@
 
 class ConsequenceClipHorizontalShift final : public Consequence {
 public:
-	ConsequenceClipHorizontalShift(int32_t newAmount);
+	ConsequenceClipHorizontalShift(int32_t newAmount, bool newShiftAutomation, bool newShiftSequenceAndMPE);
 	Error revert(TimeType time, ModelStack* modelStack) override;
 
 	int32_t amount;
+	bool shiftAutomation;
+	bool shiftSequenceAndMPE;
 };

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
@@ -23,9 +23,13 @@
 #include "model/song/song.h"
 #include "playback/playback_handler.h"
 
-ConsequenceNoteRowHorizontalShift::ConsequenceNoteRowHorizontalShift(int32_t newNoteRowId, int32_t newAmount) {
+ConsequenceNoteRowHorizontalShift::ConsequenceNoteRowHorizontalShift(int32_t newNoteRowId, int32_t newAmount,
+                                                                     bool newShiftAutomation,
+                                                                     bool newShiftSequenceAndMPE) {
 	amount = newAmount;
 	noteRowId = newNoteRowId;
+	shiftAutomation = newShiftAutomation;
+	shiftSequenceAndMPE = newShiftSequenceAndMPE;
 }
 
 Error ConsequenceNoteRowHorizontalShift::revert(TimeType time, ModelStack* modelStack) {
@@ -48,7 +52,7 @@ Error ConsequenceNoteRowHorizontalShift::revert(TimeType time, ModelStack* model
 	}
 
 	((InstrumentClip*)modelStackWithNoteRow->getTimelineCounter())
-	    ->shiftOnlyOneNoteRowHorizontally(modelStackWithNoteRow, amountNow);
+	    ->shiftOnlyOneNoteRowHorizontally(modelStackWithNoteRow, amountNow, shiftAutomation, shiftSequenceAndMPE);
 
 	return Error::NONE;
 }

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.h
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.h
@@ -22,9 +22,12 @@
 
 class ConsequenceNoteRowHorizontalShift final : public Consequence {
 public:
-	ConsequenceNoteRowHorizontalShift(int32_t newNoteRowId, int32_t newAmount);
+	ConsequenceNoteRowHorizontalShift(int32_t newNoteRowId, int32_t newAmount, bool newShiftAutomation,
+	                                  bool newShiftSequenceAndMPE);
 	Error revert(TimeType time, ModelStack* modelStack) override;
 
 	int32_t noteRowId;
 	int32_t amount;
+	bool shiftAutomation;
+	bool shiftSequenceAndMPE;
 };

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -161,8 +161,9 @@ public:
 	void recordNoteOff(uint32_t pos, ModelStackWithNoteRow* modelStack, Action* action, int32_t velocity);
 	int8_t getColourOffset(InstrumentClip* clip);
 	void rememberDrumName();
-	void shiftHorizontally(int32_t amount, ModelStackWithNoteRow* modelStack);
-	void clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation, bool clearNotesAndMPE);
+	void shiftHorizontally(int32_t amount, ModelStackWithNoteRow* modelStack, bool shiftAutomation,
+	                       bool shiftSequenceAndMPE);
+	void clear(Action* action, ModelStackWithNoteRow* modelStack, bool clearAutomation, bool clearSequenceAndMPE);
 	bool doesProbabilityExist(int32_t apartFromPos, int32_t probability, int32_t secondProbability = -1);
 	bool paste(ModelStackWithNoteRow* modelStack, CopiedNoteRow* copiedNoteRow, float scaleFactor, int32_t screenEndPos,
 	           Action* action);

--- a/src/deluge/modulation/params/param_manager.cpp
+++ b/src/deluge/modulation/params/param_manager.cpp
@@ -556,7 +556,11 @@ void ParamManagerForTimeline::tickSamples(int32_t numSamples, ModelStackWithThre
 void ParamManagerForTimeline::nudgeAutomationHorizontallyAtPos(int32_t pos, int32_t offset, int32_t lengthBeforeLoop,
                                                                Action* action,
                                                                ModelStackWithThreeMainThings* modelStack,
+                                                               bool nudgeAutomation, bool nudgeMPE,
                                                                int32_t moveMPEDataWithinRegionLength) {
+	// the following code iterates through all param collections and nudges automation and MPE separately
+	// automation only gets nudged if nudgeAutomation is true
+	// MPE only gets nudged if nudgeMPE is true
 
 	ParamCollectionSummary* summary = summaries;
 	int32_t i = 0;
@@ -566,16 +570,16 @@ void ParamManagerForTimeline::nudgeAutomationHorizontallyAtPos(int32_t pos, int3
 
 		// Special case for MPE only - not even "mono" / Clip-level expression.
 		if (moveMPEDataWithinRegionLength && i == getExpressionParamSetOffset()) {
-			((ExpressionParamSet*)summary->paramCollection)
-			    ->moveRegionHorizontally(modelStackWithParamCollection, pos, moveMPEDataWithinRegionLength, offset,
-			                             lengthBeforeLoop, action);
+			if (nudgeMPE) {
+				((ExpressionParamSet*)summary->paramCollection)
+				    ->moveRegionHorizontally(modelStackWithParamCollection, pos, moveMPEDataWithinRegionLength, offset,
+				                             lengthBeforeLoop, action);
+			}
 		}
 
-		// Normal case
+		// Normal case (non MPE automation)
 		else {
-
-			// if this community feature is on, regular (non MPE) automation will not be nudged when you nudge a note
-			if (!FlashStorage::automationNudgeNote) {
+			if (nudgeAutomation) {
 				summary->paramCollection->nudgeNonInterpolatingNodesAtPos(pos, offset, lengthBeforeLoop, action,
 				                                                          modelStackWithParamCollection);
 			}

--- a/src/deluge/modulation/params/param_manager.h
+++ b/src/deluge/modulation/params/param_manager.h
@@ -192,8 +192,8 @@ public:
 
 	void shiftHorizontally(ModelStackWithThreeMainThings* modelStack, int32_t amount, int32_t effectiveLength);
 	void nudgeAutomationHorizontallyAtPos(int32_t pos, int32_t offset, int32_t lengthBeforeLoop, Action* action,
-	                                      ModelStackWithThreeMainThings* modelStack,
-	                                      int32_t moveMPEDataWithinRegionLength = 0);
+	                                      ModelStackWithThreeMainThings* modelStack, bool nudgeAutomation,
+	                                      bool nudgeMPE, int32_t moveMPEDataWithinRegionLength = 0);
 	void deleteAllAutomation(Action* action, ModelStackWithThreeMainThings* modelStack);
 	void notifyPingpongOccurred(ModelStackWithThreeMainThings* modelStack);
 	void ensureSomeParamCollections(); // For debugging only


### PR DESCRIPTION
Updated implementation of the automation defaults which dictate the behaviour of clearing / shifting / nudging sequences on automation parameters and notes/sample and MPE

The refactoring in this PR extends the previous refactoring done for clearing a clip by passing "clear/shift/nudgeAutomation" and "clearSequenceAndMPE" as variables to the various clear/shift/nudge functions as opposed to checking in those functions for the automation defaults or whether you're in automation view, etc.

Also refactored the code for shifting audio clip automation into MPE and non-MPE automation.

Update documentation as well where appropriate.