### PR TITLE
Replace routine for sd with yields, rejig cull thresholds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,6 +191,7 @@ add_compile_options(
     $<$<CONFIG:RELEASE,RELWITHDEBINFO>:-fuse-linker-plugin>
     -ffunction-sections
     -fdata-sections
+    -DUSE_TASK_MANAGER
 
     # C++ stuff
     $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
@@ -201,6 +202,8 @@ add_compile_options(
     # ASM stuff
     $<$<COMPILE_LANGUAGE:ASM>:-x>
     $<$<COMPILE_LANGUAGE:ASM>:assembler-with-cpp>
+
+
 )
 
 # Add libraries
@@ -232,7 +235,6 @@ list(APPEND DELUGE_COMMON_COMPILE_OPTIONS
     $<$<CONFIG:DEBUG>:-Wno-unused-parameter>
 
     $<$<CONFIG:DEBUG>:-Werror=write-strings>
-    -DUSE_TASK_MANAGER
     # Offsetof for non standard types is supported in GCC,
     # if another compiler does not support it they are obligated to error
 

--- a/src/RZA1/diskio.c
+++ b/src/RZA1/diskio.c
@@ -194,7 +194,7 @@ DRESULT disk_read_without_streaming_first(BYTE pdrv, /* Physical drive nmuber to
     BYTE err;
 
     if (currentlyAccessingCard)
-    { //@todo: make sure yield sets the sd card routine flags!
+    {
         if (ALPHA_OR_BETA_VERSION)
         {
             // Operatricks got! But I think I fixed.

--- a/src/RZA1/diskio.c
+++ b/src/RZA1/diskio.c
@@ -194,7 +194,7 @@ DRESULT disk_read_without_streaming_first(BYTE pdrv, /* Physical drive nmuber to
     BYTE err;
 
     if (currentlyAccessingCard)
-    {
+    { //@todo: make sure yield sets the sd card routine flags!
         if (ALPHA_OR_BETA_VERSION)
         {
             // Operatricks got! But I think I fixed.

--- a/src/RZA1/sdhi/src/sd/access/sd_read.c
+++ b/src/RZA1/sdhi/src/sd/access/sd_read.c
@@ -136,7 +136,8 @@ int sd_read_sect(int sd_port, unsigned char *buff,unsigned long psn,long cnt)
 
 
 	logAudioAction("sd_read_sect");
-	routineForSD(); // By Rohan
+
+	routineForSD(); // By Rohan. // called during disk reads but only once per read
 
 	if( (sd_port != 0) && (sd_port != 1) ){
 		return SD_ERR;

--- a/src/RZA1/sdhi/userdef/sd_dev_low.c
+++ b/src/RZA1/sdhi/userdef/sd_dev_low.c
@@ -53,6 +53,7 @@ Includes   <System Includes> , "Project Includes"
 #include "deluge/drivers/uart/uart.h"
 #include "deluge/deluge.h"
 #include "OSLikeStuff/timers_interrupts/timers_interrupts.h"
+#include "OSLikeStuff/task_scheduler.h"
 
 /******************************************************************************
 Typedef definitions
@@ -1090,6 +1091,9 @@ static int sddev_wait_dma_end_0(long cnt)
 
 #endif
 }
+bool sd_DMAC_Get_Endflag1() {
+return sd_DMAC_Get_Endflag(SD1_DMA_CHANNEL) == 1;
+};
 
 /******************************************************************************
 * Function Name: static int sddev_wait_dma_end_1(long cnt);
@@ -1109,34 +1113,37 @@ static int sddev_wait_dma_end_1(long cnt)
 
     if (time < 2000) time = 2000; // I've seen block write operations sometimes just randomly take as long as 1250ms, despite it normally being 2ms
 
-    if (time > 1024) {
-        loop = (time >> 10);
-        time = time & 1023;
-    }
-
-    do {
-        sddev_start_timer(loop ? 1024 : time);
-
-        while (1)
-        {
-
-            /* get end flag? */
-            if ( sd_DMAC_Get_Endflag(SD1_DMA_CHANNEL) == 1 )
-            {
-                sddev_end_timer();
-                return SD_OK;
-            }
-            /* detect timeout? */
-            if (sddev_check_timer() == SD_ERR)
-            {
-                break;
-            }
-
-            routineForSD(); // By Rohan
-        }
-    } while (loop--);
-
-    sddev_end_timer();
+    if (yieldingRoutineWithTimeoutForSD(sd_DMAC_Get_Endflag1, time/1000.)) {
+return SD_OK;
+} else return SD_ERR;
+//    if (time > 1024) {
+//        loop = (time >> 10);
+//        time = time & 1023;
+//    }
+//
+//    do {
+//        sddev_start_timer(loop ? 1024 : time);
+//
+//        while (1)
+//        {
+//
+//            /* get end flag? */
+//            if ( sd_DMAC_Get_Endflag(SD1_DMA_CHANNEL) == 1 )
+//            {
+//                sddev_end_timer();
+//                return SD_OK;
+//            }
+//            /* detect timeout? */
+//            if (sddev_check_timer() == SD_ERR)
+//            {
+//                break;
+//            }
+//
+//            routineForSD(); // By Rohan. // called during reads
+//        }
+//    } while (loop--);
+//
+//    sddev_end_timer();
 
     return SD_ERR;
 #else

--- a/src/RZA1/sdhi/userdef/sd_dev_low.c
+++ b/src/RZA1/sdhi/userdef/sd_dev_low.c
@@ -1112,40 +1112,45 @@ static int sddev_wait_dma_end_1(long cnt)
     time = ((time * 1000) >> 10);
 
     if (time < 2000) time = 2000; // I've seen block write operations sometimes just randomly take as long as 1250ms, despite it normally being 2ms
-
+#ifdef USE_TASK_MANAGER
     if (yieldingRoutineWithTimeoutForSD(sd_DMAC_Get_Endflag1, time/1000.)) {
-return SD_OK;
-} else return SD_ERR;
-//    if (time > 1024) {
-//        loop = (time >> 10);
-//        time = time & 1023;
-//    }
-//
-//    do {
-//        sddev_start_timer(loop ? 1024 : time);
-//
-//        while (1)
-//        {
-//
-//            /* get end flag? */
-//            if ( sd_DMAC_Get_Endflag(SD1_DMA_CHANNEL) == 1 )
-//            {
-//                sddev_end_timer();
-//                return SD_OK;
-//            }
-//            /* detect timeout? */
-//            if (sddev_check_timer() == SD_ERR)
-//            {
-//                break;
-//            }
-//
-//            routineForSD(); // By Rohan. // called during reads
-//        }
-//    } while (loop--);
-//
-//    sddev_end_timer();
+        return SD_OK;
+      }
+    else {
+        return SD_ERR;
+    }
+#else
+    if (time > 1024) {
+        loop = (time >> 10);
+        time = time & 1023;
+    }
+
+    do {
+        sddev_start_timer(loop ? 1024 : time);
+
+        while (1)
+        {
+
+            /* get end flag? */
+            if ( sd_DMAC_Get_Endflag(SD1_DMA_CHANNEL) == 1 )
+            {
+                sddev_end_timer();
+                return SD_OK;
+            }
+            /* detect timeout? */
+            if (sddev_check_timer() == SD_ERR)
+            {
+                break;
+            }
+
+            routineForSD(); // By Rohan. // called during reads
+        }
+    } while (loop--);
+
+    sddev_end_timer();
 
     return SD_ERR;
+#endif
 #else
     return SD_OK;
 

--- a/src/deluge/deluge.h
+++ b/src/deluge/deluge.h
@@ -34,6 +34,7 @@ extern void logAudioAction(char const* string);
 
 extern void consoleTextIfAllBootedUp(char const* text);
 typedef bool (*RunCondition)();
+bool yieldingRoutineWithTimeoutForSD(RunCondition until, double timeoutSeconds);
 void yieldingRoutineForSD(RunCondition until);
 extern void routineForSD(void);
 extern void sdCardInserted(void);

--- a/src/deluge/drivers/sd/sd.c
+++ b/src/deluge/drivers/sd/sd.c
@@ -44,11 +44,14 @@ int32_t sddev_power_on(int32_t sd_port) {
 
 	/* ---- Wait for  SD Wake up ---- */
 	sddev_start_timer(100); /* wait 100ms */
-	                        //	while (sddev_check_timer() == SD_OK) {
-	                        //		/* wait */
-	                        //		routineForSD(); // By Rohan
-	                        //	}
+#ifdef USE_TASK_MANAGER
 	yieldingRoutineForSD(wrappedCheckTimer);
+#else
+	while (sddev_check_timer() == SD_OK) {
+		/* wait */
+		routineForSD(); // By Rohan
+	}
+#endif
 	sddev_end_timer();
 
 	return SD_OK;
@@ -68,13 +71,13 @@ int32_t sddev_int_wait(int32_t sd_port, int32_t time) {
 
 	logAudioAction("sddev_int_wait");
 	int32_t loop;
-
+#ifdef USE_TASK_MANAGER
 	if (yieldingRoutineWithTimeoutForSD(sdIntFinished, time / 1000.)) {
 		return SD_OK;
 	}
 	else
 		return SD_ERR;
-
+#else
 	if (time > 500) {
 		/* @1000ms */
 		loop = (time / 500);
@@ -115,6 +118,7 @@ int32_t sddev_int_wait(int32_t sd_port, int32_t time) {
 	sddev_end_timer();
 
 	return SD_ERR;
+#endif
 }
 
 /******************************************************************************

--- a/src/deluge/drivers/sd/sd.c
+++ b/src/deluge/drivers/sd/sd.c
@@ -38,10 +38,11 @@ int32_t sddev_power_on(int32_t sd_port) {
 
 	/* ---- Wait for  SD Wake up ---- */
 	sddev_start_timer(100); /* wait 100ms */
-	while (sddev_check_timer() == SD_OK) {
-		/* wait */
-		routineForSD(); // By Rohan
-	}
+	                        //	while (sddev_check_timer() == SD_OK) {
+	                        //		/* wait */
+	                        //		routineForSD(); // By Rohan
+	                        //	}
+	yieldingRoutineForSD((RunCondition)sddev_check_timer);
 	sddev_end_timer();
 
 	return SD_OK;

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -44,7 +44,7 @@ extern uint32_t timeModEncoderLastTurned[];
 
 void init();
 void readEncoders();
-bool interpretEncoders(bool inCardRoutine = false);
+bool interpretEncoders(bool skipActioning = false);
 
 Encoder& getEncoder(EncoderName which);
 } // namespace deluge::hid::encoders

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -236,6 +236,7 @@ Song::~Song() {
 
 #include "gui/menu_item/integer_range.h"
 #include "gui/menu_item/key_range.h"
+#include "timers_interrupts/timers_interrupts.h"
 extern gui::menu_item::IntegerRange defaultTempoMenu;
 extern gui::menu_item::IntegerRange defaultSwingMenu;
 extern gui::menu_item::KeyRange defaultKeyMenu;
@@ -2486,9 +2487,10 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 		}
 
 		bool isClipActiveNow = (output->activeClip && isClipActive(output->activeClip->getClipBeingRecordedFrom()));
-
+		DISABLE_ALL_INTERRUPTS();
 		output->renderOutput(modelStack, outputBuffer, outputBuffer + numSamples, numSamples, reverbBuffer,
 		                     volumePostFX >> 1, sideChainHitPending, !isClipActiveNow, isClipActiveNow);
+		ENABLE_INTERRUPTS();
 #if DO_AUDIO_LOG
 		char buf[64];
 		snprintf(buf, sizeof(buf), "complete: %s", output->name.get());


### PR DESCRIPTION
This makes the time between audio rendering much more predictable, which means that the thresholds don't have to incorporate enough buffer to handle a large jump in rendering requirements 

Because the time between renders is predictable it also means we can estimate based on the render time instead of the time between render calls, which is much more accurate
