### PR TITLE
Change Transpose Interval shortcut to avoid interfering with Row Mode instant mute workflow

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -400,7 +400,7 @@ Here is a list of features that have been added to the firmware as a list, group
 
 - ([#1159]) Using the same combo as in a Synth / Midi / CV clip, press and turn `▼︎▲︎` to transpose all scale mode clips
   up or down by 1 semitone.
-    - You can customize the amount of semitones that clips are transposed by, by holding Shift and turning `▼︎▲︎`. The
+    - You can customize the amount of semitones that clips are transposed by, by holding Shift and pressing and turning `▼︎▲︎`. The
       display will show the number of semitones.
     - After transposing the display show the new Root Note (and Scale Name if you have an OLED display).
     - Does not affect audio clips or kit clips.

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -350,7 +350,7 @@ doActualSimpleChange:
 	}
 
 	else if (b == Y_ENC) {
-		if (on) {
+		if (on && !Buttons::isShiftButtonPressed()) {
 			currentSong->displayCurrentRootNoteAndScaleName();
 		}
 	}

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -2899,13 +2899,12 @@ ActionResult ArrangerView::verticalEncoderAction(int32_t offset, bool inCardRout
 
 	if (Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
 		if (currentUIMode == UI_MODE_NONE) {
-			currentSong->transpose(offset);
-		}
-		return ActionResult::DEALT_WITH;
-	}
-	else if (Buttons::isShiftButtonPressed()) {
-		if (currentUIMode == UI_MODE_NONE) {
-			currentSong->adjustMasterTransposeInterval(offset);
+			if (Buttons::isShiftButtonPressed()) {
+				currentSong->adjustMasterTransposeInterval(offset);
+			}
+			else {
+				currentSong->transpose(offset);
+			}
 		}
 		return ActionResult::DEALT_WITH;
 	}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2789,8 +2789,13 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 		if (Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
 			currentSong->transpose(offset);
 		}
-		else if (currentUIMode == UI_MODE_NONE && Buttons::isShiftButtonPressed()) {
-			currentSong->adjustMasterTransposeInterval(offset);
+		if (Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
+			if (Buttons::isShiftButtonPressed()) {
+				currentSong->adjustMasterTransposeInterval(offset);
+			}
+			else {
+				currentSong->transpose(offset);
+			}
 		}
 		return ActionResult::DEALT_WITH;
 	}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2787,9 +2787,6 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 
 	if (onArrangerView) {
 		if (Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
-			currentSong->transpose(offset);
-		}
-		if (Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
 			if (Buttons::isShiftButtonPressed()) {
 				currentSong->adjustMasterTransposeInterval(offset);
 			}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1834,7 +1834,7 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 
 // handle by button action if b == Y_ENC
 void AutomationView::handleVerticalEncoderButtonAction(bool on) {
-	if (on && currentUIMode == UI_MODE_NONE) {
+	if (on && currentUIMode == UI_MODE_NONE && !Buttons::isShiftButtonPressed()) {
 		if (onArrangerView || getCurrentInstrumentClip()->isScaleModeClip()) {
 			currentSong->displayCurrentRootNoteAndScaleName();
 		}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -774,7 +774,7 @@ doCancelPopup:
 			}
 		}
 
-		if (on && (currentUIMode == UI_MODE_NONE)) {
+		if (on && (currentUIMode == UI_MODE_NONE) && !Buttons::isShiftButtonPressed()) {
 			if (getCurrentInstrumentClip()->isScaleModeClip()) {
 				currentSong->displayCurrentRootNoteAndScaleName();
 			}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -871,7 +871,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 	}
 
 	else if (b == Y_ENC) {
-		if (on) {
+		if (on && !Buttons::isShiftButtonPressed()) {
 			currentSong->displayCurrentRootNoteAndScaleName();
 		}
 	}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1276,10 +1276,12 @@ ActionResult SessionView::horizontalEncoderAction(int32_t offset) {
 ActionResult SessionView::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
 
 	if (currentUIMode == UI_MODE_NONE && Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
-		currentSong->transpose(offset);
-	}
-	else if (currentUIMode == UI_MODE_NONE && Buttons::isShiftButtonPressed()) {
-		currentSong->adjustMasterTransposeInterval(offset);
+		if (Buttons::isShiftButtonPressed()) {
+			currentSong->adjustMasterTransposeInterval(offset);
+		}
+		else {
+			currentSong->transpose(offset);
+		}
 	}
 	else if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_CLIP_PRESSED_IN_SONG_VIEW
 	         || currentUIMode == UI_MODE_VIEWING_RECORD_ARMING) {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -589,7 +589,7 @@ doActualSimpleChange:
 		}
 	}
 	else if (b == Y_ENC) {
-		if (on) {
+		if (on && !Buttons::isShiftButtonPressed()) {
 			currentSong->displayCurrentRootNoteAndScaleName();
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/2112

To cherry pick for 1.1