### PR TITLE
Increment after routine call

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -955,9 +955,9 @@ void routine() {
 			deluge::hid::encoders::interpretEncoders(true);
 		}
 #endif
-		numRoutines += 1;
 		routine_();
 		routineBeenCalled = true;
+		numRoutines += 1;
 	}
 	audioRoutineLocked = false;
 }


### PR DESCRIPTION
Cull logic assumed numRoutines was zero indexed, leading to repeated soft culls when things aren't that bad