### PR TITLE
Bugfix - Automation View Shortcut Blinking (1.2 fix)

### DIFF
--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -293,7 +293,6 @@ private:
 	void resetShortcutBlinking();
 	void resetParameterShortcutBlinking();
 
-	bool encoderAction;
 	bool parameterShortcutBlinking;
 
 	bool interpolationShortcutBlinking;


### PR DESCRIPTION
Identified bug where shortcut blinking doesn't get reset when exiting and re-entering automation view while performing an encoder action

Fixed by: Removed encoderAction flag from automation view as it is no longer necessary now that shortcut blinking has been removed from the UI rendering function (renderMainPads)