### PR TITLE
Don't send multiple clocks at once

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -629,6 +629,7 @@ maybeDoTriggerClockOutputTick:
 
 			if (fractionNextAnalogOutTick <= fractionLastTimerTick) {
 				doTriggerClockOutTick();
+				D_PRINTLN("double trigger");
 				goto maybeDoTriggerClockOutputTick;
 			}
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -623,13 +623,10 @@ void PlaybackHandler::actionTimerTickPart2() {
 			uint32_t analogOutTicksPer;
 			getAnalogOutTicksToInternalTicksRatio(&internalTicksPer, &analogOutTicksPer);
 			uint64_t fractionLastTimerTick = lastTimerTickActioned * analogOutTicksPer;
-			static bool triggered = false;
 			uint64_t fractionNextAnalogOutTick = (lastTriggerClockOutTickDone + 1) * internalTicksPer;
 
 			if (fractionNextAnalogOutTick <= fractionLastTimerTick) {
-
 				doTriggerClockOutTick();
-
 				fractionNextAnalogOutTick += internalTicksPer;
 			}
 			// Schedule another trigger clock output tick

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -554,7 +554,9 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 		// it)
 		// - otherwise this will all get called soon anyway. I thiiiink this is 100% immune to any synchronization
 		// problems?
+		//@todo - if the timer went off before the routine was called we still shouldn't do this
 		if (!isTimerEnabled(TIMER_MIDI_GATE_OUTPUT)) {
+			D_PRINTLN("no timer ISR");
 			if (anythingInGateOutputBufferNow) {
 				cvEngine.updateGateOutputs();
 			}

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -559,7 +559,6 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 		// problems?
 
 		if (!isTimerEnabled(TIMER_MIDI_GATE_OUTPUT)) {
-			D_PRINTLN("no timer ISR");
 			if (anythingInGateOutputBufferNow) {
 				cvEngine.updateGateOutputs();
 			}

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -546,11 +546,8 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 	// output and MIDI THRU in it. We want any messages like "start" to go out before we send any clocks below, and
 	// also want to give them a head-start being sent and out of the way so the clock messages can be sent on-time
 	bool anythingInMidiOutputBufferNow = midiEngine.anythingInOutputBuffer();
-	// if there's a gate clock pending then this is not the right time for it - needs to be done by the ISR
-	//@todo - it's possible the midi engine suffers from the same problem but there's no way to see if there's a clock
-	// in it's output buffer. If gate clock is on then this fixes the bug for both anyway
-	bool anythingInGateOutputBufferNow =
-	    cvEngine.gateOutputPending && !cvEngine.clockOutputPending; // Not asapGateOutputPending (RUN)
+    bool anythingInGateOutputBufferNow =
+            cvEngine.gateOutputPending || cvEngine.clockOutputPending; // Not asapGateOutputPending (RUN)
 	if (anythingInMidiOutputBufferNow || anythingInGateOutputBufferNow) {
 
 		// We're only allowed to do this if the timer ISR isn't pending (i.e. we haven't enabled to timer to trigger

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -546,8 +546,8 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 	// output and MIDI THRU in it. We want any messages like "start" to go out before we send any clocks below, and
 	// also want to give them a head-start being sent and out of the way so the clock messages can be sent on-time
 	bool anythingInMidiOutputBufferNow = midiEngine.anythingInOutputBuffer();
-    bool anythingInGateOutputBufferNow =
-            cvEngine.gateOutputPending || cvEngine.clockOutputPending; // Not asapGateOutputPending (RUN)
+	bool anythingInGateOutputBufferNow =
+	    cvEngine.gateOutputPending || cvEngine.clockOutputPending; // Not asapGateOutputPending (RUN)
 	if (anythingInMidiOutputBufferNow || anythingInGateOutputBufferNow) {
 
 		// We're only allowed to do this if the timer ISR isn't pending (i.e. we haven't enabled to timer to trigger

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -554,7 +554,6 @@ inline void setDireness(size_t numSamples) { // Consider direness and culling - 
 		// it)
 		// - otherwise this will all get called soon anyway. I thiiiink this is 100% immune to any synchronization
 		// problems?
-
 		if (!isTimerEnabled(TIMER_MIDI_GATE_OUTPUT)) {
 			if (anythingInGateOutputBufferNow) {
 				cvEngine.updateGateOutputs();

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -303,6 +303,9 @@ void CVEngine::setGateType(uint8_t channel, GateType value) {
 }
 
 void CVEngine::updateClockOutput() {
+	if (clockOutputPending) {
+		D_PRINTLN("update clock while clock pending");
+	}
 	if (gateChannels[WHICH_GATE_OUTPUT_IS_CLOCK].mode != GateType::SPECIAL) {
 		return;
 	}

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -251,6 +251,8 @@ int32_t CVEngine::calculateVoltage(int32_t note, uint8_t channel) {
 }
 
 void CVEngine::analogOutTick() {
+	// we need to do this in case there's a clock pending, otherwise both will be sent at once.
+    // gate update function checks and sends the update if there is
 	updateGateOutputs();
 	clockState = !clockState;
 	updateClockOutput();

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -252,7 +252,7 @@ int32_t CVEngine::calculateVoltage(int32_t note, uint8_t channel) {
 
 void CVEngine::analogOutTick() {
 	// we need to do this in case there's a clock pending, otherwise both will be sent at once.
-    // gate update function checks and sends the update if there is
+	// gate update function checks and sends the update if there is
 	updateGateOutputs();
 	clockState = !clockState;
 	updateClockOutput();

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -251,6 +251,7 @@ int32_t CVEngine::calculateVoltage(int32_t note, uint8_t channel) {
 }
 
 void CVEngine::analogOutTick() {
+	updateGateOutputs();
 	clockState = !clockState;
 	updateClockOutput();
 }

--- a/src/deluge/processing/engines/cv_engine.h
+++ b/src/deluge/processing/engines/cv_engine.h
@@ -68,10 +68,11 @@ public:
 	void analogOutTick();
 	void playbackBegun();
 	void playbackEnded();
+	/// toggles clock, does not physically update until updateGateOutputs called
 	void updateClockOutput();
 	void updateRunOutput();
 	bool isTriggerClockOutputEnabled();
-
+	/// physically send all gate outs if any output pending
 	void updateGateOutputs();
 
 	GateChannel gateChannels[NUM_GATE_CHANNELS];


### PR DESCRIPTION
Fix #2144 

Bug occurs because clocks are only scheduled when within numSamples worth of time at the end of the audio routine, but this causes a bug because the next render call is not guaranteed to be before numSamples have passed (there's about 64 samples of extra buffer on average). This would not occur during the main loop in official but was possible in routineForSD, making the bug take much longer to reproduce on official and 1.1. As the sequencer is only updated for the next numSamples it cannot be scheduled further in advance without sequencer changes.

When the clock should have been done before the render started but wasn't scheduled yet it gets added to the gate and midi output buffers. They aren't flushed until the next time the clock ISR runs, at which point two clocks get sent at once.

As a solution I have changed the clock logic to flush anything that's previously in the buffer when a new clock is added. This ensures that clocks go out on time (usually sample accurate, always within 64ish samples) 

Future work should probably re examine the whole output timing issue - clocks and notes/ccs shouldn't be linked in this way but decoupling them would be very difficult.