### PR TITLE
refactor: share value scaling between RatchetAmount and RatchetProbability

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/ratchet_amount.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/ratchet_amount.h
@@ -25,12 +25,10 @@ class RatchetAmount final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		this->setValue(
-		    computeCurrentValueForArpMidiCvRatchetAmount(getCurrentInstrumentClip()->arpeggiatorRatchetAmount));
+		this->setValue(computeCurrentValueForArpMidiCvRatchets(getCurrentInstrumentClip()->arpeggiatorRatchetAmount));
 	}
 	void writeCurrentValue() override {
-		getCurrentInstrumentClip()->arpeggiatorRatchetAmount =
-		    computeFinalValueForArpMidiCvRatchetAmount(this->getValue());
+		getCurrentInstrumentClip()->arpeggiatorRatchetAmount = computeFinalValueForArpMidiCvRatchets(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/ratchet_probability.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/ratchet_probability.h
@@ -25,12 +25,12 @@ class RatchetProbability final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		auto* current_clip = getCurrentInstrumentClip();
-		int64_t value = (int64_t)current_clip->arpeggiatorRatchetProbability;
-		this->setValue((value * kMaxMenuValue + 2147483648) >> 32);
+		this->setValue(
+		    computeCurrentValueForArpMidiCvRatchets(getCurrentInstrumentClip()->arpeggiatorRatchetProbability));
 	}
 	void writeCurrentValue() override {
-		getCurrentInstrumentClip()->arpeggiatorRatchetProbability = (uint32_t)this->getValue() * 85899345;
+		getCurrentInstrumentClip()->arpeggiatorRatchetProbability =
+		    computeFinalValueForArpMidiCvRatchets(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -19,7 +19,7 @@ int32_t computeCurrentValueForArpMidiCvGate(int32_t value) {
 	return computeCurrentValueForStandardMenuItem(value);
 }
 
-int32_t computeCurrentValueForArpMidiCvRatchetAmount(uint32_t value) {
+int32_t computeCurrentValueForArpMidiCvRatchets(uint32_t value) {
 	return ((int64_t)value * kMaxMenuValue + 2147483648) >> 32;
 }
 
@@ -77,6 +77,6 @@ int32_t computeFinalValueForArpMidiCvGate(int32_t value) {
 	return (uint32_t)value * 85899345 - 2147483648;
 }
 
-uint32_t computeFinalValueForArpMidiCvRatchetAmount(int32_t value) {
+uint32_t computeFinalValueForArpMidiCvRatchets(int32_t value) {
 	return (uint32_t)value * 85899345;
 }

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -28,6 +28,7 @@
 /// - audio_compressor::CompParam
 /// - arpeggiator::midi_cv::Gate
 /// - arpeggiator::midi_cv::RatchetAmount
+/// - arpeggiator::midi_cv::RatchetProbability
 /// - osc::PulseWidth
 /// - patched_param::Integer
 /// - patched_param::Pan
@@ -88,11 +89,15 @@ int32_t computeFinalValueForArpMidiCvGate(int32_t value);
 
 /** Scales UINT32 range to 0-50 for display.
  *
+ * Note UNSIGNED input!
+ *
  * Is well behaved for whole UINT32 range despite the final value
  * computation not utilizing the whole range.
  */
-int32_t computeCurrentValueForArpMidiCvRatchetAmount(uint32_t value);
+int32_t computeCurrentValueForArpMidiCvRatchets(uint32_t value);
 
 /** Scales 0-50 range to 0-(UINT32-45) for storage and use.
+ *
+ * Note UNSIGNED output!
  */
-uint32_t computeFinalValueForArpMidiCvRatchetAmount(int32_t value);
+uint32_t computeFinalValueForArpMidiCvRatchets(int32_t value);

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -56,16 +56,16 @@ TEST(ValueScalingTest, arpMidiCvGateValueScaling) {
 	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueForArpMidiCvGate(50));
 }
 
-TEST(ValueScalingTest, arpMidiCvRatchetAmountValueScaling) {
+TEST(ValueScalingTest, arpMidiCvRatchetValueScaling) {
 	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
-		int32_t finalValue = computeFinalValueForArpMidiCvRatchetAmount(i);
-		int32_t currentValue = computeCurrentValueForArpMidiCvRatchetAmount(finalValue);
+		int32_t finalValue = computeFinalValueForArpMidiCvRatchets(i);
+		int32_t currentValue = computeCurrentValueForArpMidiCvRatchets(finalValue);
 		CHECK_EQUAL(i, currentValue);
 	}
-	CHECK_EQUAL(0, computeFinalValueForArpMidiCvRatchetAmount(0));
-	CHECK_EQUAL(UINT32_MAX / 2 - 22, computeFinalValueForArpMidiCvRatchetAmount(25));
-	CHECK_EQUAL(UINT32_MAX - 45, computeFinalValueForArpMidiCvRatchetAmount(50));
+	CHECK_EQUAL(0, computeFinalValueForArpMidiCvRatchets(0));
+	CHECK_EQUAL(UINT32_MAX / 2 - 22, computeFinalValueForArpMidiCvRatchets(25));
+	CHECK_EQUAL(UINT32_MAX - 45, computeFinalValueForArpMidiCvRatchets(50));
 	// while 50 doesn't quite get to UINT32_MAX, make sure the current value math
 	// behaves well on the whole range
-	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvRatchetAmount(UINT32_MAX));
+	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvRatchets(UINT32_MAX));
 }


### PR DESCRIPTION
- Math is exactly the same, call it compute(Current|Final)ValueForRatchets().