### PR TITLE
Release 1.2 - Midi follow - check for null drum when offering note to kit

### DIFF
--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1374,8 +1374,10 @@ void Kit::receivedNoteForKit(ModelStackWithTimelineCounter* modelStack, MIDIDevi
 	Kit* kit = (Kit*)clip->output;
 	Drum* thisDrum = getDrumFromNoteCode(clip, note);
 
-	kit->receivedNoteForDrum(modelStack, fromDevice, on, channel, note, velocity, shouldRecordNotes, doingMidiThru,
-	                         thisDrum);
+	if (thisDrum) {
+		kit->receivedNoteForDrum(modelStack, fromDevice, on, channel, note, velocity, shouldRecordNotes, doingMidiThru,
+		                         thisDrum);
+	}
 }
 
 /// for learning a whole kit to a single channel, offer cc to all drums


### PR DESCRIPTION
Add null drum check when offering note to kit to prevent crash

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2154