### PR TITLE
Bugfix/latch velocity modwheel

### DIFF
--- a/src/deluge/gui/ui/keyboard/column_controls/mod.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/mod.cpp
@@ -59,8 +59,9 @@ bool ModColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
 void ModColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                     KeyboardLayout* layout) {
 	// Restore previously set Modwheel
-	modDisplay = mod32;
-	getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, mod32, modelStackWithTimelineCounter);
+	modDisplay = storedMod;
+	getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, storedMod,
+	                                                         modelStackWithTimelineCounter);
 };
 
 void ModColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
@@ -73,13 +74,14 @@ void ModColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineC
 		display->displayPopup((modDisplay + kHalfStep) >> kVelModShift);
 	}
 	else if (!pad.padPressHeld || FlashStorage::keyboardFunctionsModwheelGlide) {
-		mod32 = modMin + pad.y * modStep;
-		getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, mod32,
+		// short press or momentary velocity is off, latch the display mod from the ON press
+		storedMod = modDisplay;
+		getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, storedMod,
 		                                                         modelStackWithTimelineCounter);
 	}
 	else {
-		modDisplay = mod32;
-		getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, mod32,
+		modDisplay = storedMod;
+		getCurrentInstrument()->processParamFromInputMIDIChannel(CC_NUMBER_Y_AXIS, storedMod,
 		                                                         modelStackWithTimelineCounter);
 	}
 };

--- a/src/deluge/gui/ui/keyboard/column_controls/mod.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/mod.h
@@ -36,7 +36,7 @@ private:
 	uint32_t modMax = 127 << kVelModShift;
 	uint32_t modMin = 0 << kVelModShift;
 	uint32_t modStep = (modMax - modMin) / 7;
-	uint32_t mod32 = 0 << kVelModShift;
+	uint32_t storedMod = 0 << kVelModShift;
 	uint32_t modDisplay;
 };
 

--- a/src/deluge/gui/ui/keyboard/column_controls/velocity.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/velocity.cpp
@@ -60,8 +60,8 @@ bool VelocityColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
 void VelocityColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                          KeyboardLayout* layout) {
 	// Restore previously set Velocity
-	vDisplay = velocity32;
-	layout->velocity = (velocity32 + kHalfStep) >> kVelModShift;
+	vDisplay = storedVelocity;
+	layout->velocity = (storedVelocity + kHalfStep) >> kVelModShift;
 };
 
 void VelocityColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
@@ -72,13 +72,14 @@ void VelocityColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTime
 		display->displayPopup(layout->velocity);
 	}
 	else if (!pad.padPressHeld || FlashStorage::keyboardFunctionsVelocityGlide) {
-		velocity32 = velocityMin + pad.y * velocityStep;
-		vDisplay = velocity32;
-		layout->velocity = (velocity32 + kHalfStep) >> kVelModShift;
+		// short press or momentary velocity is off, latch the display velocity from the ON press
+		storedVelocity = vDisplay;
+		layout->velocity = (storedVelocity + kHalfStep) >> kVelModShift;
 	}
 	else {
-		vDisplay = velocity32;
-		layout->velocity = (velocity32 + kHalfStep) >> kVelModShift;
+		// revert to previous value
+		vDisplay = storedVelocity;
+		layout->velocity = (storedVelocity + kHalfStep) >> kVelModShift;
 	}
 };
 } // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/ui/keyboard/column_controls/velocity.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/velocity.h
@@ -23,7 +23,7 @@ namespace deluge::gui::ui::keyboard::controls {
 
 class VelocityColumn : public ControlColumn {
 public:
-	VelocityColumn(uint8_t velocity) : vDisplay(velocity), velocity32(velocity << kVelModShift){};
+	VelocityColumn(uint8_t velocity) : vDisplay(velocity), storedVelocity(velocity << kVelModShift){};
 
 	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
 	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;
@@ -37,7 +37,7 @@ private:
 	uint32_t velocityMax = 127 << kVelModShift;
 	uint32_t velocityMin = 15 << kVelModShift;
 	uint32_t velocityStep = (velocityMax - velocityMin) / 7;
-	uint32_t velocity32;
+	uint32_t storedVelocity;
 	uint32_t vDisplay;
 };
 

--- a/src/deluge/gui/ui/keyboard/column_controls/velocity.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/velocity.h
@@ -23,7 +23,8 @@ namespace deluge::gui::ui::keyboard::controls {
 
 class VelocityColumn : public ControlColumn {
 public:
-	VelocityColumn(uint8_t velocity) : vDisplay(velocity), storedVelocity(velocity << kVelModShift){};
+	explicit VelocityColumn(uint8_t velocity)
+	    : vDisplay(velocity << kVelModShift), storedVelocity(velocity << kVelModShift){};
 
 	void renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) override;
 	bool handleVerticalEncoder(int8_t pad, int32_t offset) override;

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -72,6 +72,18 @@ KeyboardScreen::KeyboardScreen() {
 static const uint32_t padActionUIModes[] = {UI_MODE_AUDITIONING, UI_MODE_RECORD_COUNT_IN,
                                             0}; // Careful - this is referenced in two places // I'm always careful ;)
 
+void KeyboardScreen::killColumnSwitchKey(int32_t column) {
+	if (column != kDisplayWidth && column != kDisplayWidth + 1) {
+		return;
+	}
+	for (auto& pressedPad : pressedPads) {
+		// kill the pad so it doesn't get used on release or hold
+		if (pressedPad.x == column && pressedPad.y == 7) {
+			pressedPad.dead = true;
+			return;
+		}
+	}
+}
 ActionResult KeyboardScreen::padAction(int32_t x, int32_t y, int32_t velocity) {
 	if (sdRoutineLock && !allowSomeUserActionsEvenWhenInCardRoutine) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE; // Allow some of the time when in card routine.
@@ -588,9 +600,8 @@ ActionResult KeyboardScreen::horizontalEncoderAction(int32_t offset) {
 	    offset, (Buttons::isShiftButtonPressed() && isUIModeWithinRange(padActionUIModes)));
 
 	if (isUIModeWithinRange(padActionUIModes)) {
-		// ignore the change?
-		//		evaluateActiveNotes();
-		//		updateActiveNotes();
+		evaluateActiveNotes();
+		updateActiveNotes();
 	}
 
 	requestRendering();

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -588,8 +588,9 @@ ActionResult KeyboardScreen::horizontalEncoderAction(int32_t offset) {
 	    offset, (Buttons::isShiftButtonPressed() && isUIModeWithinRange(padActionUIModes)));
 
 	if (isUIModeWithinRange(padActionUIModes)) {
-		evaluateActiveNotes();
-		updateActiveNotes();
+		// ignore the change?
+		//		evaluateActiveNotes();
+		//		updateActiveNotes();
 	}
 
 	requestRendering();

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.h
@@ -56,6 +56,8 @@ public:
 
 	inline void requestRendering() { uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF); }
 
+	void killColumnSwitchKey(int32_t column);
+
 	// ui
 	UIType getUIType() { return UIType::KEYBOARD_SCREEN; }
 

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -77,6 +77,7 @@ void ColumnControlsKeyboard::evaluatePads(PressedPad presses[kMaxNumKeyboardPadP
 		// in note columns
 		if (pressed.x == LEFT_COL) {
 			if (pressed.active) {
+				// if holding multiple will be left as the last button pressed
 				leftColHeld = pressed.y;
 			}
 			if (!pressed.dead) {
@@ -291,6 +292,7 @@ bool ColumnControlsKeyboard::horizontalEncoderHandledByColumns(int32_t offset, b
 		                                 : prevControlFunction(state.leftColFunc, state.rightColFunc);
 		display->displayPopup(functionNames[state.leftColFunc]);
 		state.leftCol = state.getColumnForFunc(state.leftColFunc);
+		keyboardScreen.killColumnSwitchKey(LEFT_COL);
 		return true;
 	}
 	else if (rightColHeld == 7 && offset) {
@@ -300,6 +302,7 @@ bool ColumnControlsKeyboard::horizontalEncoderHandledByColumns(int32_t offset, b
 		display->displayPopup(functionNames[state.rightColFunc]);
 		state.rightCol = state.getColumnForFunc(state.rightColFunc);
 		state.rightColSetAtRuntime = true;
+		keyboardScreen.killColumnSwitchKey(RIGHT_COL);
 		return true;
 	}
 	return false;

--- a/src/deluge/gui/ui/keyboard/notes_state.h
+++ b/src/deluge/gui/ui/keyboard/notes_state.h
@@ -34,6 +34,8 @@ struct PressedPad : Cartesian {
 	bool active;
 	// all evaluatePads wil be called at least once with pad.active == false on release. Following
 	// that, dead will be set to true to avoid repeatedly processing releases.
+	// exception - if the pad is "used up" by switching keyboard columns it will be set dead immediately to prevent
+	// processing its release, while still being set as active
 	bool dead;
 };
 


### PR DESCRIPTION
Fix a bug where releasing a pad recalculated the display value, leading to changes when the display value was different between calculations. Now releasing always latches the value set during the press. 

Fix a bug where releasing the top pad after changing columns caused the new column to treat that as a release. Fixed by setting that pad as "dead" when it's used to change columns so no release is processed

Fix #2155 

Fix velocity column initialization to make display match the held value

Fix #2156 (just the definitely buggy part)
