### PR TITLE
Release 1.2 - Bugfix MIDI Follow Feedback - Only send feedback for clip context

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1625,15 +1625,18 @@ void View::sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam, 
 		    midiEngine.midiFollowChannelType[util::to_underlying(midiEngine.midiFollowFeedbackChannelType)]
 		        .channelOrZone;
 		if (channel != MIDI_CHANNEL_NONE) {
-			if (modelStackWithParam && modelStackWithParam->autoParam) {
-				params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-				int32_t ccNumber = midiFollow.getCCFromParam(kind, modelStackWithParam->paramId);
-				if (ccNumber != MIDI_CC_NONE) {
-					midiFollow.sendCCForMidiFollowFeedback(channel, ccNumber, knobPos);
+			// check if we're dealing with a clip context param (don't send feedback for song params)
+			if (isClipContext()) {
+				if (modelStackWithParam && modelStackWithParam->autoParam) {
+					params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+					int32_t ccNumber = midiFollow.getCCFromParam(kind, modelStackWithParam->paramId);
+					if (ccNumber != MIDI_CC_NONE) {
+						midiFollow.sendCCForMidiFollowFeedback(channel, ccNumber, knobPos);
+					}
 				}
-			}
-			else {
-				midiFollow.sendCCWithoutModelStackForMidiFollowFeedback(channel, isAutomation);
+				else {
+					midiFollow.sendCCWithoutModelStackForMidiFollowFeedback(channel, isAutomation);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix bug with midi follow feedback where it would send midi follow feedback when adjusting song params, feedback code now checks that the context for feedback is the clip context

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2164