### PR TITLE
Fix: initialize scale to -1 and don't revert to it

### DIFF
--- a/src/deluge/gui/ui/keyboard/column_controls/scale_mode.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/scale_mode.cpp
@@ -65,6 +65,9 @@ bool ScaleModeColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
 void ScaleModeColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                           KeyboardLayout* layout) {
 	// Restore previously set scale
+	if (previousScale == -1) {
+		return;
+	}
 	if (keyboardScreen.setScale(previousScale)) {
 		for (int32_t y = 0; y < kDisplayHeight; ++y) {
 			if (scaleModes[y] == previousScale) {

--- a/src/deluge/gui/ui/keyboard/column_controls/scale_mode.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/scale_mode.h
@@ -35,7 +35,7 @@ public:
 
 private:
 	int32_t currentScalePad = -1;
-	int32_t previousScale = currentSong->getCurrentPresetScale();
+	int32_t previousScale = -1;
 	uint8_t scaleModes[8] = {0, 1, 2, 3, 4, 5, 6, 7};
 };
 


### PR DESCRIPTION
Fix #2171 

We got lucky this didn't cause boot crashes but it might at some point in the future, this was a null ptr dereference and later a virtual function call