### PR TITLE
test/refactor: arpgeggiator::midi_cv::Rate values roundtrip

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
@@ -25,16 +25,10 @@ class Rate final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		this->setValue(
-		    (((int64_t)getCurrentInstrumentClip()->arpeggiatorRate + 2147483648) * kMaxMenuValue + 2147483648) >> 32);
+		this->setValue(computeCurrentValueForArpMidiCvRate(getCurrentInstrumentClip()->arpeggiatorRate));
 	}
 	void writeCurrentValue() override {
-		if (this->getValue() == kMidMenuValue) {
-			getCurrentInstrumentClip()->arpeggiatorRate = 0;
-		}
-		else {
-			getCurrentInstrumentClip()->arpeggiatorRate = (uint32_t)this->getValue() * 85899345 - 2147483648;
-		}
+		getCurrentInstrumentClip()->arpeggiatorRate = computeFinalValueForArpMidiCvRate(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -23,6 +23,10 @@ int32_t computeCurrentValueForArpMidiCvRatchets(uint32_t value) {
 	return ((int64_t)value * kMaxMenuValue + 2147483648) >> 32;
 }
 
+int32_t computeCurrentValueForArpMidiCvRate(int32_t value) {
+	return computeCurrentValueForStandardMenuItem(value);
+}
+
 int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 	if (value == kMaxMenuValue) {
 		return 2147483647;
@@ -79,4 +83,13 @@ int32_t computeFinalValueForArpMidiCvGate(int32_t value) {
 
 uint32_t computeFinalValueForArpMidiCvRatchets(int32_t value) {
 	return (uint32_t)value * 85899345;
+}
+
+int32_t computeFinalValueForArpMidiCvRate(int32_t value) {
+	if (value == kMidMenuValue) {
+		return 0;
+	}
+	else {
+		return (uint32_t)value * 85899345 - 2147483648;
+	}
 }

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -29,6 +29,7 @@
 /// - arpeggiator::midi_cv::Gate
 /// - arpeggiator::midi_cv::RatchetAmount
 /// - arpeggiator::midi_cv::RatchetProbability
+/// - arpeggiator::midi_cv::Rate
 /// - osc::PulseWidth
 /// - patched_param::Integer
 /// - patched_param::Pan
@@ -76,6 +77,10 @@ int32_t computeFinalValueForPan(int32_t value);
  *
  * This roundtrips with the final value math despite not
  * being it's proper inverse.
+ *
+ * This is exactly the same as the "standard" version, but
+ * has a wrapper for clarity, because the final value compuation
+ * is different.
  */
 int32_t computeCurrentValueForArpMidiCvGate(int32_t value);
 
@@ -84,6 +89,9 @@ int32_t computeCurrentValueForArpMidiCvGate(int32_t value);
  * This is presumably to have the gate go down even at 50: the values
  * produced create a 2.5ms gate down period between 16th arp notes at Gate=50,
  * which exactly matches the gate down period between regular 16h notes.
+ *
+ * NOTE: computeFinalValueForArpMidiRate() is _almost_ but not quite
+ * the same: this one returns -23 for zero, that one returns 0.
  */
 int32_t computeFinalValueForArpMidiCvGate(int32_t value);
 
@@ -101,3 +109,23 @@ int32_t computeCurrentValueForArpMidiCvRatchets(uint32_t value);
  * Note UNSIGNED output!
  */
 uint32_t computeFinalValueForArpMidiCvRatchets(int32_t value);
+
+/** Scales INT32_MIN-INT32_MAX range to 0-50 for display.
+ *
+ * This roundtrips with the final value math despite being
+ * not being it's proper inverse.
+ *
+ * This is exactly the same as the "standard" version, but
+ * has a wrapper for clarity, because the final value compuation
+ * is different.
+ */
+int32_t computeCurrentValueForArpMidiCvRate(int32_t value);
+
+/** Scales 0-50 range to INT32_MIN-(INT32_MAX-45) for storage and use.
+ *
+ * arpeggiator::midi_cv::Rate uses this, it is not obvious why, though.
+ *
+ * NOTE: computeFinalValueForArpMidiGate() is _almost_ but not quite
+ * the same: this one returns 0 for 0, whereas that one does not.
+ */
+int32_t computeFinalValueForArpMidiCvRate(int32_t value);

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -54,6 +54,9 @@ TEST(ValueScalingTest, arpMidiCvGateValueScaling) {
 	// See computeFinalValueForArpMidiCvGate()'s comment for possible
 	// motivation.
 	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueForArpMidiCvGate(50));
+	// while 50 doesn't quite get to INT32_MAX, make sure the current value math
+	// behaves well on the whole range
+	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvGate(INT32_MAX));
 }
 
 TEST(ValueScalingTest, arpMidiCvRatchetValueScaling) {
@@ -68,4 +71,18 @@ TEST(ValueScalingTest, arpMidiCvRatchetValueScaling) {
 	// while 50 doesn't quite get to UINT32_MAX, make sure the current value math
 	// behaves well on the whole range
 	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvRatchets(UINT32_MAX));
+}
+
+TEST(ValueScalingTest, arpMidiCvRate) {
+	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
+		int32_t finalValue = computeFinalValueForArpMidiCvRate(i);
+		int32_t currentValue = computeCurrentValueForArpMidiCvRate(finalValue);
+		CHECK_EQUAL(i, currentValue);
+	}
+	CHECK_EQUAL(INT32_MIN, computeFinalValueForArpMidiCvRate(0));
+	CHECK_EQUAL(0, computeFinalValueForArpMidiCvRate(25));
+	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueForArpMidiCvRate(50));
+	// while 50 doesn't quite get to INT32_MAX, make sure the current value math
+	// behaves well on the whole range
+	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvRate(INT32_MAX));
 }


### PR DESCRIPTION
- Pull out the guts for testing: the current value math is identical to standard, so share the machinery, but the final value computation produces numbers that are slightly smaller near the max values, and needs to remain distinct. The user-provided values roundtrip despite the asymmetry.

- Note similarity with the Gate value scaling: tantalizingly close, but not identical, so not sharing code right now.