### PR TITLE
refactor/test: extract is-same-note logic from InstrumentClipView

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -68,6 +68,7 @@
 #include "model/note/copied_note_row.h"
 #include "model/note/note.h"
 #include "model/note/note_row.h"
+#include "model/scale/utils.h"
 #include "model/settings/runtime_feature_settings.h"
 #include "model/song/song.h"
 #include "modulation/automation/auto_param.h"
@@ -4106,8 +4107,7 @@ int32_t InstrumentClipView::setupForEnteringScaleMode(int32_t newRootNote, int32
 		// If there's a root-note (or its octave) currently onscreen, pin animation to that
 		for (int32_t i = 0; i < kDisplayHeight; i++) {
 			int32_t thisNote = getCurrentInstrumentClip()->getYNoteFromYDisplay(i, currentSong);
-			// If it's the root note...
-			if ((int32_t)std::abs(newRootNote - thisNote) % 12 == 0) {
+			if (isSameNote(newRootNote, thisNote)) {
 				pinAnimationToYDisplay = i;
 				pinAnimationToYNote = thisNote;
 				goto doneLookingForRootNoteOnScreen;
@@ -4218,8 +4218,7 @@ int32_t InstrumentClipView::setupForExitingScaleMode() {
 	bool foundRootNoteOnScreen = false;
 	for (int32_t i = 0; i < kDisplayHeight; i++) {
 		int32_t yNote = getCurrentInstrumentClip()->getYNoteFromYDisplay(i, currentSong);
-		// If it's the root note...
-		if ((int32_t)std::abs(currentSong->rootNote - yNote) % 12 == 0) {
+		if (isSameNote(currentSong->rootNote, yNote)) {
 			scrollAdjust = yNote - i - getCurrentInstrumentClip()->yScroll;
 			foundRootNoteOnScreen = true;
 			break;
@@ -4477,7 +4476,7 @@ drawNormally:
 			if (currentUIMode == UI_MODE_SCALE_MODE_BUTTON_PRESSED) {
 				if (flashDefaultRootNoteOn) {
 					int32_t yNote = getCurrentInstrumentClip()->getYNoteFromYDisplay(yDisplay, currentSong);
-					if ((uint16_t)(yNote - defaultRootNote + 120) % (uint8_t)12 == 0) {
+					if (isSameNote(yNote, defaultRootNote)) {
 						thisColour = rowColour[yDisplay];
 						return;
 					}
@@ -4488,7 +4487,7 @@ drawNormally:
 				{
 					// If this is the root note, indicate
 					int32_t yNote = getCurrentInstrumentClip()->getYNoteFromYDisplay(yDisplay, currentSong);
-					if ((uint16_t)(yNote - currentSong->rootNote + 120) % (uint8_t)12 == 0) {
+					if (isSameNote(yNote, currentSong->rootNote)) {
 						thisColour = rowColour[yDisplay];
 					}
 					else {

--- a/src/deluge/model/scale/utils.cpp
+++ b/src/deluge/model/scale/utils.cpp
@@ -1,0 +1,5 @@
+#include "model/scale/utils.h"
+
+bool isSameNote(int16_t a, int16_t b) {
+	return (a - b) % 12 == 0;
+}

--- a/src/deluge/model/scale/utils.h
+++ b/src/deluge/model/scale/utils.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <cstdint>
+
+/** Determines if two semitone values refer to the same chromatic note.
+ */
+bool isSameNote(int16_t a, int16_t b);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -34,6 +34,8 @@ file(GLOB_RECURSE deluge_SOURCES
         ../../src/deluge/modulation/lfo.cpp
         # For value scaling
         ../../src/deluge/gui/menu_item/value_scaling.cpp
+        # For scale utilities
+        ../../src/deluge/model/scale/utils.cpp
 )
 
 add_executable(UnitTests RunAllTests.cpp scheduler_tests.cpp lfo_tests.cpp scale_tests.cpp value_scaling_tests.cpp)

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -1,5 +1,6 @@
 #include "CppUTest/TestHarness.h"
 #include "model/scale/note_set.h"
+#include "model/scale/utils.h"
 
 TEST_GROUP(NoteSetTest){};
 
@@ -34,4 +35,31 @@ TEST(NoteSetTest, count) {
 	CHECK(notes.count() == 1);
 	notes.fill();
 	CHECK(notes.count() == 12);
+}
+
+TEST_GROUP(UtilTest){};
+
+TEST(UtilTest, isSameNote) {
+	// Exhaustive test for a reasonable input range
+	for (int a = -200; a <= 200; a++) {
+		for (int b = -200; b <= 200; b++) {
+			// Different variations in the codebase that were replaced by isSameNote()
+			int legacy1 = (int32_t)std::abs(a - b) % 12 == 0;
+			int legacy2 = (uint16_t)(a - b + 120) % (uint8_t)12 == 0;
+			bool same = isSameNote(a, b);
+			// The first variation matches always.
+			CHECK_EQUAL(legacy1, same);
+			// The second variation returns bogus values if (a-b+120) goes negative,
+			// due to the cast to u16.
+			if (a - b + 120 >= 0) {
+				CHECK_EQUAL(legacy2, same);
+			}
+		}
+	}
+	// Explicit demo of the legacy2 code misbehaving: both numbers are 2 modulo 12.
+	int a = 2;
+	int b = 146;
+	int legacy2 = (uint16_t)(a - b + 120) % (uint8_t)12 == 0;
+	CHECK(!legacy2);
+	CHECK(isSameNote(a, b));
 }


### PR DESCRIPTION
- There were a couple of variations, both seemingly needlessly complex, and the second one buggy. Test case includes the verbatim versions of the old code, and demonstrates bug.
- Drop a couple of comments that aren't needed given a descriptive function name.
