### PR TITLE
refactor: simplify call sites of nudgeNotesVertically()

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3697,9 +3697,8 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 		else if (!currentUIMode && outputType != OutputType::KIT) {
 			actionLogger.deleteAllLogs();
 
-			clip->nudgeNotesVertically(
-			    offset, Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE,
-			    modelStack);
+			auto nudgeType = Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE;
+			clip->nudgeNotesVertically(offset, nudgeType, modelStack);
 
 			instrumentClipView.recalculateColours();
 			uiNeedsRendering(this, 0, 0xFFFFFFFF);

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3697,21 +3697,10 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 		else if (!currentUIMode && outputType != OutputType::KIT) {
 			actionLogger.deleteAllLogs();
 
-			offset = std::min((int32_t)1, std::max((int32_t)-1, offset));
+			clip->nudgeNotesVertically(
+			    offset, Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE,
+			    modelStack);
 
-			// If shift button not pressed, transpose whole octave
-			if (!Buttons::isShiftButtonPressed()) {
-				// If in scale mode, an octave takes numModeNotes rows while in chromatic mode it takes
-				// 12 rows
-				clip->nudgeNotesVertically(offset * (clip->isScaleModeClip() ? modelStack->song->numModeNotes : 12),
-				                           modelStack);
-			}
-			// Otherwise, transpose single row position
-			else {
-				// Transpose just one row up or down (if not in scale mode, then it's a semitone, and if
-				// in scale mode, it's the next note in the scale)¬
-				clip->nudgeNotesVertically(offset, modelStack);
-			}
 			instrumentClipView.recalculateColours();
 			uiNeedsRendering(this, 0, 0xFFFFFFFF);
 			if (inNoteEditor()) {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4595,9 +4595,8 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
 			InstrumentClip* clip = getCurrentInstrumentClip();
-			clip->nudgeNotesVertically(
-			    offset, Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE,
-			    modelStack);
+			auto nudgeType = Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE;
+			clip->nudgeNotesVertically(offset, nudgeType, modelStack);
 
 			recalculateColours();
 			uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4594,22 +4594,11 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
-			InstrumentClip* instrumentClip = getCurrentInstrumentClip();
+			InstrumentClip* clip = getCurrentInstrumentClip();
+			clip->nudgeNotesVertically(
+			    offset, Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE,
+			    modelStack);
 
-			offset = std::min((int32_t)1, std::max((int32_t)-1, offset));
-
-			// If shift button not pressed, transpose whole octave
-			if (!Buttons::isShiftButtonPressed()) {
-				// If in scale mode, an octave takes numModeNotes rows while in chromatic mode it takes 12 rows
-				instrumentClip->nudgeNotesVertically(
-				    offset * (instrumentClip->isScaleModeClip() ? modelStack->song->numModeNotes : 12), modelStack);
-			}
-			// Otherwise, transpose single row position
-			else {
-				// Transpose just one row up or down (if not in scale mode, then it's a semitone, and if in scale
-				// mode, it's the next note in the scale)¬
-				instrumentClip->nudgeNotesVertically(offset, modelStack);
-			}
 			recalculateColours();
 			uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 		}

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1319,10 +1319,27 @@ void InstrumentClip::transpose(int32_t semitones, ModelStackWithTimelineCounter*
 	colourOffset -= semitones;
 }
 
-void InstrumentClip::nudgeNotesVertically(int32_t change, ModelStackWithTimelineCounter* modelStack) {
-	// Note: the usage of this method is limited to no more than an octave of "change"
-	//  ideally used by the "hold and turn vertical encoder"
-	//  and "shift + hold and turn vertical encoder" shorcuts within clip
+void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType type,
+                                          ModelStackWithTimelineCounter* modelStack) {
+	// This method is limited to no more than an octave of "change", currently used
+	// by the "hold and turn vertical encoder" and "shift + hold and turn vertical
+	// encoder" shorcuts.
+
+	if (!direction) {
+		// It's not clear if we ever get "zero" as direction of change, but let's
+		// make sure we behave sensibly in that case as well.
+		return;
+	}
+
+	int32_t change = direction > 0 ? 1 : -1;
+	if (type == VerticalNudgeType::OCTAVE) {
+		if (isScaleModeClip()) {
+			change *= modelStack->song->numModeNotes;
+		}
+		else {
+			change *= 12;
+		}
+	}
 
 	// Make sure no notes sounding
 	stopAllNotesPlaying(modelStack);

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -53,6 +53,8 @@ struct PendingNoteOn;
 
 extern uint8_t undefinedColour[];
 
+enum class VerticalNudgeType { ROW, OCTAVE };
+
 class InstrumentClip final : public Clip {
 public:
 	InstrumentClip(Song* song = NULL);
@@ -78,7 +80,7 @@ public:
 	void replaceMusicalMode(uint8_t numModeNotes, int8_t changes[], ModelStackWithTimelineCounter* modelStack);
 	void seeWhatNotesWithinOctaveArePresent(NoteSet&, int32_t, Song* song, bool deleteEmptyNoteRows = true);
 	void transpose(int32_t, ModelStackWithTimelineCounter* modelStack);
-	void nudgeNotesVertically(int32_t, ModelStackWithTimelineCounter* modelStack);
+	void nudgeNotesVertically(int32_t, VerticalNudgeType, ModelStackWithTimelineCounter* modelStack);
 	void expectNoFurtherTicks(Song* song, bool actuallySoundChange = true) override;
 	Error clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false) const override;
 	NoteRow* createNewNoteRowForYVisual(int32_t, Song* song);

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -80,7 +80,7 @@ public:
 	void replaceMusicalMode(uint8_t numModeNotes, int8_t changes[], ModelStackWithTimelineCounter* modelStack);
 	void seeWhatNotesWithinOctaveArePresent(NoteSet&, int32_t, Song* song, bool deleteEmptyNoteRows = true);
 	void transpose(int32_t, ModelStackWithTimelineCounter* modelStack);
-	void nudgeNotesVertically(int32_t, VerticalNudgeType, ModelStackWithTimelineCounter* modelStack);
+	void nudgeNotesVertically(int32_t direction, VerticalNudgeType, ModelStackWithTimelineCounter* modelStack);
 	void expectNoFurtherTicks(Song* song, bool actuallySoundChange = true) override;
 	Error clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false) const override;
 	NoteRow* createNewNoteRowForYVisual(int32_t, Song* song);


### PR DESCRIPTION
- Move the "how many rows do we shift"-logic to the function instead of duplicating it on call sites: instead pass in an enum indicating the kind of nudge requested.

- Interpret the integer argument as direction instead of a count, making it explicit we're either moving by one row or octave.