### PR TITLE
Release 1.1 - Update midi follow feedback for kit drum selection

### DIFF
--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -66,12 +66,13 @@ public:
 
 	void handleReceivedCC(ModelStackWithTimelineCounter& modelStack, Clip* clip, int32_t ccNumber, int32_t value);
 
+	Clip* getSelectedOrActiveClip();
+
 private:
 	// initialize
 	void init();
 	void initMapping(int32_t mapping[kDisplayWidth][kDisplayHeight]);
 
-	Clip* getSelectedOrActiveClip();
 	Clip* getSelectedClip();
 	Clip* getActiveClip(ModelStack* modelStack);
 


### PR DESCRIPTION
Added one additional scenario where Midi Follow Feedback should be sent:

- when you've selected a kit clip for midi follow control and you're not currently in that kit clip (e.g. in song view), and affect entire is disabled in that kit clip, changing drum selection will necessitate sending updated midi feedback to advise controller of the changed kit drum selection context