### PR TITLE
save when audition pressed while save held

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1599,6 +1599,8 @@ possiblyAuditionPad:
 
 				bool isKit = (instrument->type == OutputType::KIT);
 				if (isKit) {
+					// this is fine - since it's a kit we don't need the song, it's only used to check scale for
+					// instrument clips
 					NoteRow* noteRow =
 					    getCurrentInstrumentClip()->getNoteRowOnScreen(y, nullptr, nullptr); // On *current* clip!
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1557,7 +1557,7 @@ possiblyAuditionPad:
 		if (x == kDisplayWidth + 1) {
 
 			// "Learning" to this audition pad:
-			if (isUIModeActiveExclusively(UI_MODE_MIDI_LEARN)) {
+			if (isUIModeActiveExclusively(UI_MODE_MIDI_LEARN)) [[unlikely]] {
 				if (getCurrentUI() == this) {
 					if (sdRoutineLock) {
 						return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -1577,7 +1577,7 @@ possiblyAuditionPad:
 			}
 
 			// Changing the scale:
-			else if (isUIModeActiveExclusively(UI_MODE_SCALE_MODE_BUTTON_PRESSED)) {
+			else if (isUIModeActiveExclusively(UI_MODE_SCALE_MODE_BUTTON_PRESSED)) [[unlikely]] {
 				if (sdRoutineLock) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 				}
@@ -1594,7 +1594,7 @@ possiblyAuditionPad:
 					}
 				}
 			}
-			else if (currentUIMode == UI_MODE_HOLDING_SAVE_BUTTON && velocity) {
+			else if (currentUIMode == UI_MODE_HOLDING_SAVE_BUTTON && velocity) [[unlikely]] {
 				Instrument* instrument = getCurrentInstrument();
 
 				bool isKit = (instrument->type == OutputType::KIT);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1594,6 +1594,23 @@ possiblyAuditionPad:
 					}
 				}
 			}
+			else if (currentUIMode == UI_MODE_HOLDING_SAVE_BUTTON && velocity) {
+				Instrument* instrument = getCurrentInstrument();
+
+				bool isKit = (instrument->type == OutputType::KIT);
+				if (isKit) {
+					NoteRow* noteRow =
+					    getCurrentInstrumentClip()->getNoteRowOnScreen(y, nullptr, nullptr); // On *current* clip!
+
+					if (noteRow && noteRow->drum && noteRow->drum->type == DrumType::SOUND) {
+						auto* drum = static_cast<SoundDrum*>(noteRow->drum);
+						currentUIMode = UI_MODE_NONE;
+						indicator_leds::setLedState(IndicatorLED::SAVE, false);
+						saveKitRowUI.setup(static_cast<SoundDrum*>(drum), &noteRow->paramManager);
+						openUI(&saveKitRowUI);
+					}
+				}
+			}
 
 			// Actual basic audition pad press:
 			else if (!velocity || isUIModeWithinRange(auditionPadActionUIModes)) {

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -963,6 +963,7 @@ ModelStackWithNoteRow* InstrumentClip::getNoteRowOnScreen(int32_t yDisplay, Mode
 	return modelStack->addNoteRow(noteRowId, noteRow);
 }
 
+/// can be called with null song if the clip is a kit
 NoteRow* InstrumentClip::getNoteRowOnScreen(int32_t yDisplay, Song* song, int32_t* getIndex) {
 	// Kit
 	if (output->type == OutputType::KIT) {


### PR DESCRIPTION
Makes saving a kit row work in the same direction as saving synths and kits (save+row) 