### PR TITLE
Performance/note on speed

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -826,7 +826,7 @@ skipDoingSumTo100:
 			}
 
 			// Otherwise...
-			else {
+			else [[unlikely]] {
 				int32_t probability = pendingNoteOnList.pendingNoteOns[i].probability & 127;
 
 				// If it's an iteration dependence...
@@ -894,7 +894,7 @@ doNewProbability:
 				}
 			}
 
-			if (conditionPassed) {
+			if (conditionPassed) [[likely]] {
 				sendPendingNoteOn(modelStack, &pendingNoteOnList.pendingNoteOns[i]);
 			}
 			else {

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -185,7 +185,7 @@ bool Voice::noteOn(ModelStackWithVoice* modelStack, int32_t newNoteCodeBeforeArp
 	// Porta
 	if (sound->polyphonic != PolyphonyMode::LEGATO
 	    && paramManager->getUnpatchedParamSet()->getValue(params::UNPATCHED_PORTAMENTO) != -2147483648
-	    && sound->lastNoteCode != -2147483648) {
+	    && sound->lastNoteCode != -2147483648) [[unlikely]] {
 		setupPorta(sound);
 	}
 
@@ -223,7 +223,7 @@ bool Voice::noteOn(ModelStackWithVoice* modelStack, int32_t newNoteCodeBeforeArp
 		guides[s].audioFileHolder = NULL;
 
 		bool sourceEverActive = modelStack->checkSourceEverActive(s);
-		if (sourceEverActive) {
+		if (sourceEverActive) [[likely]] {
 			guides[s].noteOffReceived = false;
 			guides[s].sequenceSyncLengthTicks = 0; // That's the default - may get overwritten below
 
@@ -279,7 +279,7 @@ activenessDetermined:
 
 		bool sourceEverActive = modelStack->checkSourceEverActive(s);
 
-		if (!sourceEverActive) {
+		if (!sourceEverActive) [[unlikely]] {
 			continue;
 		}
 
@@ -311,7 +311,7 @@ activenessDetermined:
 				bool success =
 				    unisonParts[u].sources[s].noteOn(this, source, &guides[s], samplesLate, sound->oscRetriggerPhase[s],
 				                                     resetEnvelopes, sound->synthMode, velocity);
-				if (!success) {
+				if (!success) [[unlikely]] {
 					return false; // This shouldn't really ever happen I don't think really...
 				}
 			}

--- a/src/deluge/model/voice/voice_unison_part_source.cpp
+++ b/src/deluge/model/voice/voice_unison_part_source.cpp
@@ -47,7 +47,7 @@ bool VoiceUnisonPartSource::noteOn(Voice* voice, Source* source, VoiceSamplePlay
 
 		if (!voiceSample) { // We might actually already have one, and just be restarting this voice
 			voiceSample = AudioEngine::solicitVoiceSample();
-			if (!voiceSample) {
+			if (!voiceSample) [[unlikely]] {
 				return false;
 			}
 		}
@@ -70,7 +70,7 @@ bool VoiceUnisonPartSource::noteOn(Voice* voice, Source* source, VoiceSamplePlay
 	        || source->oscType == OscType::INPUT_R || source->oscType == OscType::INPUT_STEREO)) {
 		// oscPos = 0;
 	}
-	else if (synthMode != SynthMode::FM && source->oscType == OscType::DX7) {
+	else if (synthMode != SynthMode::FM && source->oscType == OscType::DX7) [[unlikely]] {
 		if (!dxVoice) { // We might actually already have one, and just be restarting this voice
 			dxVoice = getDxEngine()->solicitDxVoice();
 			if (!dxVoice)

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -148,7 +148,7 @@ void Arpeggiator::noteOn(ArpeggiatorSettings* settings, int32_t noteCode, int32_
 	ArpNote* arpNoteAsPlayed;
 
 	int32_t notesKey = notes.search(noteCode, GREATER_OR_EQUAL);
-	if (notesKey < notes.getNumElements()) {
+	if (notesKey < notes.getNumElements()) [[unlikely]] {
 		arpNote = (ArpNote*)notes.getElementAddress(notesKey);
 		if (arpNote->inputCharacteristics[util::to_underlying(MIDICharacteristic::NOTE)] == noteCode) {
 			noteExists = true;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -112,8 +112,8 @@ int16_t zeroMPEValues[kNumExpressionDimensions] = {0, 0, 0};
 namespace AudioEngine {
 // statically allocate some of these to reduce allocations
 constexpr int32_t kNumVoicesStatic = 48;
-constexpr int32_t kNumVoiceSamplesStatic = 24;
-constexpr int32_t kNumTimeStretchersStatic = 24;
+constexpr int32_t kNumVoiceSamplesStatic = 48;
+constexpr int32_t kNumTimeStretchersStatic = 48;
 
 // used for culling. This can be high now since it's decoupled from the time between renders, and
 // will spill into a second render and output if needed so as long as we always render 128 samples in under 128/44100
@@ -1377,7 +1377,7 @@ void disposeOfVoice(Voice* voice) {
 }
 
 VoiceSample* solicitVoiceSample() {
-	if (firstUnassignedVoiceSample) {
+	if (firstUnassignedVoiceSample) [[likely]] {
 		VoiceSample* toReturn = firstUnassignedVoiceSample;
 		firstUnassignedVoiceSample = firstUnassignedVoiceSample->nextUnassigned;
 		return toReturn;


### PR DESCRIPTION
Improve the speed of note ons by marking the happy path (no arp, no probability, no failures as happy to improve caching

Lower the impact of note ons by not rendering the voice in the same window that the note was created in

Combine for a 10%ish reduction in window size during note ons for synth voices, both changes are about half of that independently. Multisamples are improved enough to play an extra voice in the same render length. 

Synth before (66 default voice note ons):
<img width="807" alt="image" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/a6b4b5a8-4d3d-4350-9181-35f26c2cdb65">

After:
<img width="834" alt="image" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/b9e191de-0c2d-4403-971d-2d8bd226bea4">

Multisample before (29 multisampled piano note ons):
<img width="804" alt="image" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/f54d419d-a727-4759-b3e4-363eff67d8e5">

Multisample after:

<img width="809" alt="image" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/2a950fe0-17d8-48ad-b420-9d2bd8450a2d">
