### PR TITLE
Performance/improve render caching, fix unitialized variable use

### DIFF
--- a/src/deluge/processing/render_wave.h
+++ b/src/deluge/processing/render_wave.h
@@ -114,7 +114,7 @@ startRenderingASyncLabel:                                                       
 	}
 
 #define SETUP_FOR_APPLYING_AMPLITUDE_WITH_VECTORS()                                                                    \
-	int32x4_t amplitudeVector;                                                                                         \
+	int32x4_t amplitudeVector{0};                                                                                      \
 	setupAmplitudeVector(0) setupAmplitudeVector(1) setupAmplitudeVector(2) setupAmplitudeVector(3)                    \
 	    int32x4_t amplitudeIncrementVector = vdupq_n_s32(amplitudeIncrement << 1);
 

--- a/src/deluge/processing/vector_rendering_function.h
+++ b/src/deluge/processing/vector_rendering_function.h
@@ -31,8 +31,8 @@
 // Renders 4 wave values (a "vector") together in one go.
 #define waveRenderingFunctionGeneral()                                                                                 \
 	{                                                                                                                  \
-		uint32x4_t readValue;                                                                                          \
-		uint16x4_t strength2;                                                                                          \
+		uint32x4_t readValue{0};                                                                                       \
+		uint16x4_t strength2{0};                                                                                       \
                                                                                                                        \
 		/* Need to use a macro rather than a for loop here, otherwise won't compile with less than O2. */              \
 		waveRenderingFunctionGeneralForLoop(0) waveRenderingFunctionGeneralForLoop(1)                                  \
@@ -72,8 +72,8 @@
 // Renders 4 wave values (a "vector") together in one go - special case for pulse waves with variable width.
 #define waveRenderingFunctionPulse()                                                                                   \
 	{                                                                                                                  \
-		int16x4_t rshiftedA, rshiftedB;                                                                                \
-		uint32x4_t readValueA, readValueB;                                                                             \
+		int16x4_t rshiftedA{0}, rshiftedB{0};                                                                          \
+		uint32x4_t readValueA{0}, readValueB{0};                                                                       \
                                                                                                                        \
 		int32_t rshiftAmount = (32 - tableSizeMagnitude - 16);                                                         \
                                                                                                                        \

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -1059,7 +1059,7 @@ uint32_t WaveTable::render(int32_t* __restrict__ outputBuffer, int32_t numSample
 	WaveTableBand* bandHere = (WaveTableBand*)bands.getElementAddress(bHere);
 
 	// If we're an actual wave table with more than one cycle...
-	if (numCycles > 1) {
+	if (numCycles > 1) [[likely]] {
 		int32_t numSamplesLeftToDo = numSamples;
 
 		// Haven't yet investigated why, but we do need to use the "rounded" multiply functions here, otherwise get a


### PR DESCRIPTION
Significant improvement in voices by tagging likely/unlikely branches. Can likely improve a lot more by caching some repeated checks. 

Also removes rendering directly to the output buffer - the extra time to check and set up for that is worse than an extra memcpy

Fixes a bug where stereo wavefolding used the non-anti aliased fold function

same before as here - #2199

Synth after:
<img width="841" alt="image" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/46945c19-6321-4a2a-b9eb-d7ee90aa98c4">

Multisample after:

<img width="788" alt="image" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/5e2ffc2e-4c9e-4151-9534-ab8e7418784c">
