### PR TITLE
refactor: replace Song::modeNotes and numModeNotes with a NoteSet

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout.h
+++ b/src/deluge/gui/ui/keyboard/layout.h
@@ -24,6 +24,7 @@
 #include "model/clip/instrument_clip.h"
 #include "model/instrument/instrument.h"
 #include "model/note/note_row.h"
+#include "model/scale/note_set.h"
 #include "model/song/song.h"
 
 constexpr uint8_t kMaxNumKeyboardPadPresses = 10;
@@ -36,8 +37,6 @@ enum class RequiredScaleMode : uint8_t {
 	Enabled = 2,
 };
 
-constexpr uint8_t kModesArraySize = kOctaveSize;
-typedef uint8_t ModesArray[kModesArraySize];
 typedef uint8_t NoteHighlightIntensity[kHighestKeyboardNote];
 
 class KeyboardLayout {
@@ -85,9 +84,9 @@ protected:
 	/// Song root note can be in any octave, layouts get the normalized one
 	inline int16_t getRootNote() { return (currentSong->rootNote % kOctaveSize); }
 	inline bool getScaleModeEnabled() { return getCurrentInstrumentClip()->inScaleMode; }
-	inline uint8_t getScaleNoteCount() { return currentSong->numModeNotes; }
+	inline uint8_t getScaleNoteCount() { return currentSong->modeNotes.count(); }
 
-	inline ModesArray& getScaleNotes() { return currentSong->modeNotes; }
+	inline NoteSet& getScaleNotes() { return currentSong->modeNotes; }
 
 	inline uint8_t getDefaultVelocity() { return getCurrentInstrument()->defaultVelocity; }
 

--- a/src/deluge/gui/ui/keyboard/layout/in_key.h
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "gui/ui/keyboard/layout/column_controls.h"
+#include "model/scale/note_set.h"
 
 namespace deluge::gui::ui::keyboard::layout {
 
@@ -50,7 +51,7 @@ private:
 	}
 
 	inline uint16_t noteFromPadIndex(uint16_t padIndex) {
-		ModesArray& scaleNotes = getScaleNotes();
+		NoteSet& scaleNotes = getScaleNotes();
 		uint8_t scaleNoteCount = getScaleNoteCount();
 
 		uint8_t octave = padIndex / scaleNoteCount;
@@ -59,7 +60,7 @@ private:
 	}
 
 	inline uint16_t padIndexFromNote(uint16_t note) {
-		ModesArray& scaleNotes = getScaleNotes();
+		NoteSet& scaleNotes = getScaleNotes();
 		uint8_t scaleNoteCount = getScaleNoteCount();
 		int16_t rootNote = getRootNote();
 

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -20,6 +20,7 @@
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/sound_editor.h"
 #include "hid/display/display.h"
+#include "model/scale/note_set.h"
 #include "model/settings/runtime_feature_settings.h"
 #include "util/functions.h"
 
@@ -103,7 +104,7 @@ void KeyboardLayoutIsomorphic::renderPads(RGB image[][kDisplayWidth + kSideBarWi
 	// Precreate list of all scale notes per octave
 	NoteSet octaveScaleNotes;
 	if (getScaleModeEnabled()) {
-		ModesArray& scaleNotes = getScaleNotes();
+		NoteSet& scaleNotes = getScaleNotes();
 		for (uint8_t idx = 0; idx < getScaleNoteCount(); ++idx) {
 			octaveScaleNotes.add(scaleNotes[idx]);
 		}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3359,9 +3359,9 @@ int32_t InstrumentClipView::getYVisualFromYDisplay(int32_t yDisplay) {
 int32_t InstrumentClipView::getYVisualWithinOctaveFromYDisplay(int32_t yDisplay) {
 	int32_t yVisual = getYVisualFromYDisplay(yDisplay);
 	int32_t yVisualRelativeToRoot = yVisual - currentSong->rootNote;
-	int32_t yVisualWithinOctave = yVisualRelativeToRoot % currentSong->numModeNotes;
+	int32_t yVisualWithinOctave = yVisualRelativeToRoot % currentSong->modeNotes.count();
 	if (yVisualWithinOctave < 0) {
-		yVisualWithinOctave += currentSong->numModeNotes;
+		yVisualWithinOctave += currentSong->modeNotes.count();
 	}
 	return yVisualWithinOctave;
 }

--- a/src/deluge/io/midi/device_specific/midi_device_lumi_keys.cpp
+++ b/src/deluge/io/midi/device_specific/midi_device_lumi_keys.cpp
@@ -38,7 +38,7 @@ void MIDIDeviceLumiKeys::hookOnConnected() {
 	uint8_t upperZoneLastChannel = this->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel;
 	uint8_t lowerZoneLastChannel = this->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel;
 
-	Scale currentScale = determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes, currentSong->numModeNotes);
+	Scale currentScale = determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes);
 
 	if (lowerZoneLastChannel != 0 || upperZoneLastChannel != 15) {
 		setMIDIMode(MIDIMode::MPE);
@@ -78,7 +78,7 @@ void MIDIDeviceLumiKeys::hookOnChangeRootNote() {
 }
 
 void MIDIDeviceLumiKeys::hookOnChangeScale() {
-	Scale scale = determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes, currentSong->numModeNotes);
+	Scale scale = determineScaleAndRootNoteOffsetFromNotes(currentSong->modeNotes);
 	setScale(scale);
 }
 
@@ -236,11 +236,10 @@ void MIDIDeviceLumiKeys::setRootNote(int16_t rootNote) {
 }
 
 // Efficient binary comparison of notes to Lumi builtin scales
-MIDIDeviceLumiKeys::Scale MIDIDeviceLumiKeys::determineScaleAndRootNoteOffsetFromNotes(uint8_t* modeNotes,
-                                                                                       uint8_t noteCount) {
+MIDIDeviceLumiKeys::Scale MIDIDeviceLumiKeys::determineScaleAndRootNoteOffsetFromNotes(NoteSet& modeNotes) {
 	// Turn notes in octave into 12 bit binary
 	uint16_t noteInt = 0;
-	for (uint8_t note = 0; note < noteCount; note++) {
+	for (uint8_t note = 0; note < modeNotes.count(); note++) {
 		noteInt |= 1 << modeNotes[note];
 	}
 	// Compare with Lumis pre-built binary list of scales

--- a/src/deluge/io/midi/device_specific/midi_device_lumi_keys.h
+++ b/src/deluge/io/midi/device_specific/midi_device_lumi_keys.h
@@ -19,6 +19,7 @@
 
 #include "gui/colour/colour.h"
 #include "io/midi/midi_device.h"
+#include "model/scale/note_set.h"
 
 #define MIDI_DEVICE_LUMI_KEYS_VP_COUNT 1
 
@@ -158,7 +159,7 @@ private:
 	void setMPEZone(MPEZone mpeZone);
 	void setMPENumChannels(uint8_t numChannels);
 	void setRootNote(int16_t rootNote);
-	Scale determineScaleAndRootNoteOffsetFromNotes(uint8_t* modeNotes, uint8_t noteCount);
+	Scale determineScaleAndRootNoteOffsetFromNotes(NoteSet& modeNotes);
 	void setScale(Scale scale);
 	void setColour(ColourZone zone, RGB rgb);
 };

--- a/src/deluge/io/midi/midi_transpose.cpp
+++ b/src/deluge/io/midi/midi_transpose.cpp
@@ -42,7 +42,7 @@ void doTranspose(bool on, int32_t newNoteOrCC) {
 				else {
 					octaves = (semitones / 12);
 				}
-				int32_t steps = octaves * currentSong->numModeNotes + indexInMode;
+				int32_t steps = octaves * currentSong->modeNotes.count() + indexInMode;
 
 				currentSong->transposeAllScaleModeClips(steps, false);
 

--- a/src/deluge/model/action/action.h
+++ b/src/deluge/model/action/action.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "model/scale/note_set.h"
 #include <cstdint>
 
 class Consequence;
@@ -107,8 +108,7 @@ public:
 	int32_t yScrollArranger[2];
 	int32_t xZoomArranger[2];
 
-	uint8_t modeNotes[2][12];
-	uint8_t numModeNotes[2];
+	NoteSet modeNotes[2];
 
 	// And a few more snapshot-things here only store one state - at the time of the action, because the action could
 	// not change these things

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -187,8 +187,7 @@ traverseClips:
 		newAction->xScrollArranger[BEFORE] = currentSong->xScroll[NAVIGATION_ARRANGEMENT];
 		newAction->xZoomArranger[BEFORE] = currentSong->xZoom[NAVIGATION_ARRANGEMENT];
 
-		newAction->numModeNotes[BEFORE] = currentSong->numModeNotes;
-		memcpy(newAction->modeNotes[BEFORE], currentSong->modeNotes, sizeof(currentSong->modeNotes));
+		newAction->modeNotes[BEFORE] = currentSong->modeNotes;
 
 		newAction->tripletsOn = currentSong->tripletsOn;
 		newAction->tripletsLevel = currentSong->tripletsLevel;
@@ -246,8 +245,7 @@ traverseClips2:
 	newAction->xScrollArranger[AFTER] = currentSong->xScroll[NAVIGATION_ARRANGEMENT];
 	newAction->xZoomArranger[AFTER] = currentSong->xZoom[NAVIGATION_ARRANGEMENT];
 
-	newAction->numModeNotes[AFTER] = currentSong->numModeNotes;
-	memcpy(newAction->modeNotes[AFTER], currentSong->modeNotes, sizeof(currentSong->modeNotes));
+	newAction->modeNotes[AFTER] = currentSong->modeNotes;
 }
 
 void ActionLogger::recordUnautomatedParamChange(ModelStackWithAutoParam const* modelStack, ActionType actionType) {
@@ -530,8 +528,7 @@ traverseClips:
 		currentSong->arrangementYScroll = action->yScrollArranger[time];
 
 		// Musical Scale
-		currentSong->numModeNotes = action->numModeNotes[time];
-		memcpy(currentSong->modeNotes, action->modeNotes[time], sizeof(currentSong->modeNotes));
+		currentSong->modeNotes = action->modeNotes[time];
 
 		// Other stuff
 		// currentSong->modKnobMode = action->modKnobModeSongView;

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -36,6 +36,7 @@
 #include "model/instrument/cv_instrument.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/note/note.h"
+#include "model/scale/note_set.h"
 #include "model/song/song.h"
 #include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
@@ -1114,8 +1115,7 @@ ModelStackWithNoteRow* InstrumentClip::getOrCreateNoteRowForYNote(int32_t yNote,
 						action->addConsequence(newConsequence);
 					}
 
-					action->numModeNotes[AFTER] = modelStack->song->numModeNotes;
-					memcpy(action->modeNotes[AFTER], modelStack->song->modeNotes, sizeof(modelStack->song->modeNotes));
+					action->modeNotes[AFTER] = modelStack->song->modeNotes;
 				}
 			}
 
@@ -1334,7 +1334,7 @@ void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 	int32_t change = direction > 0 ? 1 : -1;
 	if (type == VerticalNudgeType::OCTAVE) {
 		if (isScaleModeClip()) {
-			change *= modelStack->song->numModeNotes;
+			change *= modelStack->song->modeNotes.count();
 		}
 		else {
 			change *= 12;
@@ -1356,7 +1356,7 @@ void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 		// Scale clip, transpose by scale note jumps
 
 		// wanting to change a full octave
-		if (std::abs(change) == modelStack->song->numModeNotes) {
+		if (std::abs(change) == modelStack->song->modeNotes.count()) {
 			int32_t changeInSemitones = (change > 0) ? 12 : -12;
 			for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
 				NoteRow* thisNoteRow = noteRows.getElement(i);
@@ -1372,13 +1372,13 @@ void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 				int32_t changeInSemitones = 0;
 				int32_t yNoteWithinOctave = modelStack->song->getYNoteWithinOctaveFromYNote(thisNoteRow->getNoteCode());
 				int32_t oldModeNoteIndex = 0;
-				for (; oldModeNoteIndex < modelStack->song->numModeNotes; oldModeNoteIndex++) {
+				for (; oldModeNoteIndex < modelStack->song->modeNotes.count(); oldModeNoteIndex++) {
 					if (modelStack->song->modeNotes[oldModeNoteIndex] == yNoteWithinOctave) {
 						break;
 					}
 				}
-				int32_t newModeNoteIndex =
-				    (oldModeNoteIndex + change + modelStack->song->numModeNotes) % modelStack->song->numModeNotes;
+				int32_t newModeNoteIndex = (oldModeNoteIndex + change + modelStack->song->modeNotes.count())
+				                           % modelStack->song->modeNotes.count();
 
 				int32_t s = 0;
 				if ((change > 0 && newModeNoteIndex > oldModeNoteIndex)

--- a/src/deluge/model/scale/note_set.cpp
+++ b/src/deluge/model/scale/note_set.cpp
@@ -1,0 +1,61 @@
+#include "model/scale/note_set.h"
+
+void NoteSet::addUntrusted(uint8_t note) {
+	// Constrain added note to be strictly increasing, and < 12.
+	//
+	// Used when reading mode notes from song files, and other
+	// untrusted sources.
+	if (count() > 0 && note <= highest()) {
+		note = highest() + 1;
+	}
+	if (note > 11) {
+		note = 11;
+	}
+	add(note);
+}
+
+uint8_t NoteSet::operator[](uint8_t index) const {
+	// Shift out the root note bit, ie. scale degree zero. We don't
+	// actually check it it's set, because counting scale degrees
+	// doesn't make sense if the root is not set.
+	uint16_t wip = bits >> 1;
+	uint8_t note = 0;
+	while (index--) {
+		if (!wip) {
+			// The desired degree does not exist.
+			return 0;
+		}
+		// For each subsequent scale degree, find the number
+		// of semitones, increment the note counter
+		// and shift out the bit.
+		uint8_t step = std::countr_zero(wip) + 1;
+		wip >>= step;
+		note += step;
+	}
+	// Return the note
+	return note;
+}
+
+void NoteSet::fromScaleNotes(const uint8_t scaleNotes[7]) {
+	clear();
+	for (int32_t n = 0; n < 7; n++) {
+		int32_t newNote = scaleNotes[n];
+		// Non-diatonic scales have trailing zero notes
+		// but adding zero to the set again doesn't hurt.
+		add(newNote);
+	}
+}
+
+void NoteSet::applyChanges(int8_t changes[12]) {
+	NoteSet newSet;
+	uint8_t n = 1;
+	for (int note = 1; note < 12; note++) {
+		if (has(note)) {
+			// n'th degree has semitone t, compute
+			// the transpose and save to new noteset
+			newSet.add(note + changes[n++] - changes[0]);
+		}
+	}
+	newSet.add(0);
+	bits = newSet.bits;
+}

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -14,17 +14,51 @@
  *
  * The class is just a thin wrapper around a integer bitfield.
  * First 12 bits represent semitones. Last 4 bits curretly are unused,
- * but there is no range checking. Only currently required set-operations
- * are implemented, to keep things simple and avoid bloat. More should be
- * added as required.
+ * but there is no range checking.
  */
 class NoteSet {
 public:
 	NoteSet() : bits(0) {}
+	/** Add a note to NoteSet.
+	 */
 	void add(int8_t note) { bits = 0xfff & (bits | (1 << note)); }
-	void fill() { bits = 0xfff; }
-	int count() { return std::popcount(bits); }
+	/** Returns true if note is part of the NoteSet.
+	 */
 	bool has(int8_t note) const { return (bits >> note) & 1; }
+	/** Like add(), but ensures note is in range and higher than previous notes.
+	 */
+	void addUntrusted(uint8_t note);
+	/** Return the note at specified scale degree as semitone offset from root.
+	 *
+	 * Ie. if a NoteSet has add(0), add(1), add(4), and optionally higher notes
+	 * added, notesSet[2] will return 4.
+	 */
+	uint8_t operator[](uint8_t index) const;
+	/** Clears existing notes and adds notes from the scaleNotes[] array.
+	 */
+	void fromScaleNotes(const uint8_t scaleNotes[7]);
+	/** Applies changes specified by the array.
+	 *
+	 * Each element of the array describes a semitone offset
+	 * to a scale degree.
+	 *
+	 * Root offset is applied relative to the other notes.
+	 */
+	void applyChanges(int8_t changes[12]);
+	/** Marks all semitones as being part of the NoteSet.
+	 */
+	void fill() { bits = 0xfff; }
+	/** Removes all semitones from the NoteSet.
+	 */
+	void clear() { bits = 0; }
+	/** Returns the highest note that has been added to the NoteSet.
+	 */
+	uint8_t highest() const { return 15 - std::countl_zero(bits); }
+	/** Returns number of notes in the NoteSet.
+	 */
+	int count() const { return std::popcount(bits); }
+	/** Size of NoteSet, ie. the maximum number of notes it can hold.
+	 */
 	static const int8_t size = 12;
 
 private:

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -90,7 +90,6 @@ public:
 	void transposeAllScaleModeClips(int32_t offset, bool chromatic);
 	bool anyScaleModeClips();
 	void setRootNote(int32_t newRootNote, InstrumentClip* clipToAvoidAdjustingScrollFor = NULL);
-	void addModeNote(uint8_t modeNote);
 	void addMajorDependentModeNotes(uint8_t i, bool preferHigher, NoteSet& notesWithinOctavePresent);
 	bool yNoteIsYVisualWithinOctave(int32_t yNote, int32_t yVisualWithinOctave);
 	uint8_t getYNoteWithinOctaveFromYNote(int32_t yNote);
@@ -98,9 +97,9 @@ public:
 	void rotateMusicalMode(int8_t change);
 	void replaceMusicalMode(int8_t changes[], bool affectMIDITranspose);
 	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode);
-	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode, int16_t root, uint8_t nModeNotes, uint8_t mNotes[]);
+	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode, int16_t root, NoteSet& mNotes);
 	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode);
-	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode, int16_t root, uint8_t nModeNotes, uint8_t mNotes[]);
+	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode, int16_t root, NoteSet& mNotes);
 	bool mayMoveModeNote(int16_t yVisualWithinOctave, int8_t newOffset);
 	bool modeContainsYNote(int32_t yNote);
 	ParamManagerForTimeline* findParamManagerForDrum(Kit* kit, Drum* drum, Clip* stopTraversalAtClip = NULL);
@@ -185,8 +184,7 @@ public:
 	Section sections[kMaxNumSections];
 
 	// Scales
-	uint8_t modeNotes[12];
-	uint8_t numModeNotes;
+	NoteSet modeNotes;
 	int16_t rootNote;
 
 	uint16_t slot;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -34,7 +34,8 @@ file(GLOB_RECURSE deluge_SOURCES
         ../../src/deluge/modulation/lfo.cpp
         # For value scaling
         ../../src/deluge/gui/menu_item/value_scaling.cpp
-        # For scale utilities
+        # For scale tests
+        ../../src/deluge/model/scale/note_set.cpp
         ../../src/deluge/model/scale/utils.cpp
 )
 

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -37,6 +37,118 @@ TEST(NoteSetTest, count) {
 	CHECK(notes.count() == 12);
 }
 
+TEST(NoteSetTest, clear) {
+	NoteSet notes;
+	notes.add(1);
+	notes.add(2);
+	CHECK_EQUAL(2, notes.count());
+	notes.clear();
+	CHECK_EQUAL(0, notes.count());
+}
+
+TEST(NoteSetTest, highest) {
+	NoteSet notes;
+	notes.add(0);
+	CHECK_EQUAL(0, notes.highest());
+	notes.add(1);
+	CHECK_EQUAL(1, notes.highest());
+	notes.add(7);
+	CHECK_EQUAL(7, notes.highest());
+	notes.add(11);
+	CHECK_EQUAL(11, notes.highest());
+}
+
+TEST(NoteSetTest, addUntrusted) {
+	NoteSet a;
+	a.addUntrusted(0);
+	a.addUntrusted(0);
+	a.addUntrusted(12);
+	CHECK_EQUAL(0, a[0]);
+	CHECK_EQUAL(1, a[1]);
+	CHECK_EQUAL(11, a[2]);
+	CHECK_EQUAL(3, a.count());
+}
+
+TEST(NoteSetTest, fromScaleNotes) {
+	NoteSet a;
+	uint8_t scale[7] = {0, 2, 4, 6, 0, 0, 0};
+	a.fromScaleNotes(scale);
+	CHECK_EQUAL(0, a[0]);
+	CHECK_EQUAL(2, a[1]);
+	CHECK_EQUAL(4, a[2]);
+	CHECK_EQUAL(6, a[3]);
+	CHECK_EQUAL(4, a.count());
+}
+
+TEST(NoteSetTest, applyChanges) {
+	NoteSet a;
+	a.add(0);
+	a.add(2);
+	a.add(4);
+	a.add(5);
+	int8_t changes[12] = {-1, -1, +1, +2, 0, 0, 0, 0, 0, 0, 0, 0};
+	a.applyChanges(changes);
+	CHECK_EQUAL(0, a[0]);
+	CHECK_EQUAL(2, a[1]);
+	CHECK_EQUAL(6, a[2]);
+	CHECK_EQUAL(8, a[3]);
+	CHECK_EQUAL(4, a.count());
+}
+
+TEST(NoteSetTest, subscript1) {
+	NoteSet a;
+	for (int i = 0; i < NoteSet::size; i++) {
+		CHECK_EQUAL(0, a[i]);
+	}
+}
+
+TEST(NoteSetTest, subscript2) {
+	NoteSet a;
+	a.add(0);
+	a.add(2);
+	a.add(4);
+	a.add(5);
+	a.add(7);
+	a.add(9);
+	a.add(11);
+	CHECK_EQUAL(0, a[0]);
+	CHECK_EQUAL(2, a[1]);
+	CHECK_EQUAL(4, a[2]);
+	CHECK_EQUAL(5, a[3]);
+	CHECK_EQUAL(7, a[4]);
+	CHECK_EQUAL(9, a[5]);
+	CHECK_EQUAL(11, a[6]);
+	a.add(1);
+	CHECK_EQUAL(0, a[0]);
+	CHECK_EQUAL(1, a[1]);
+	CHECK_EQUAL(2, a[2]);
+	CHECK_EQUAL(4, a[3]);
+	CHECK_EQUAL(5, a[4]);
+	CHECK_EQUAL(7, a[5]);
+	CHECK_EQUAL(9, a[6]);
+	CHECK_EQUAL(11, a[7]);
+}
+
+TEST(NoteSetTest, subscript3) {
+	NoteSet a;
+	a.add(0);
+	a.add(2);
+	a.add(4);
+	a.add(5);
+	a.add(7);
+	a.add(9);
+	a.add(11);
+	a.add(1);
+	CHECK_EQUAL(0, a[0]);
+	CHECK_EQUAL(1, a[1]);
+	CHECK_EQUAL(2, a[2]);
+	CHECK_EQUAL(4, a[3]);
+	CHECK_EQUAL(5, a[4]);
+	CHECK_EQUAL(7, a[5]);
+	CHECK_EQUAL(9, a[6]);
+	CHECK_EQUAL(11, a[7]);
+}
+
 TEST_GROUP(UtilTest){};
 
 TEST(UtilTest, isSameNote) {


### PR DESCRIPTION
- NoteSet::operator[] gets note value of a scale degree.
- NoteSet::fromScaleNotes() constructs a NoteSet from scale notes.
- NoteSet::applyChanges() applies an array of scale degree semitone offsets.
- NoteSet::addUntrusted() implements safeguards that loading from song file uses.
- NoteSet::clear() clears a set.
- NoteSet::highest() returns the highest note in the set.