### PR TITLE
Bugfix (c1.1.1) - Fix Performance View Save-Load UI Mode Bug

### DIFF
--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -785,6 +785,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 		if (on) {
 			savePerformanceViewLayout();
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_PERFORM_DEFAULTS_SAVED));
+			exitUIMode(UI_MODE_HOLDING_SAVE_BUTTON);
 		}
 	}
 
@@ -794,6 +795,7 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 			loadPerformanceViewLayout();
 			renderViewDisplay();
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_PERFORM_DEFAULTS_LOADED));
+			exitUIMode(UI_MODE_HOLDING_LOAD_BUTTON);
 		}
 	}
 


### PR DESCRIPTION
Fixed bug where you can get stuck in holding Save/Load button UI mode when trying to save/load performance view layout

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2215