### PR TITLE
Bugfix (c1.1.1) - save load midi preset in keyboard view

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -535,8 +535,8 @@ ActionResult KeyboardScreen::buttonAction(deluge::hid::Button b, bool on, bool i
 		}
 	}
 
-	else if (b == MIDI) {
-		if (on && currentUIMode == UI_MODE_NONE) {
+	else if (b == MIDI && currentUIMode == UI_MODE_NONE) {
+		if (on) {
 			if (changeOutputType(OutputType::MIDI_OUT)) {
 				selectLayout(0);
 			}

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -543,8 +543,8 @@ ActionResult KeyboardScreen::buttonAction(deluge::hid::Button b, bool on, bool i
 		}
 	}
 
-	else if (b == CV) {
-		if (on && currentUIMode == UI_MODE_NONE) {
+	else if (b == CV && currentUIMode == UI_MODE_NONE) {
+		if (on) {
 			if (changeOutputType(OutputType::CV)) {
 				selectLayout(0);
 			}


### PR DESCRIPTION
Fixed bug where you couldnt save or load a midi preset while in keyboard view