### PR TITLE
Improved cmake and debug configs for clion

### DIFF
--- a/IDE_Configs/clion/cmake.xml
+++ b/IDE_Configs/clion/cmake.xml
@@ -9,6 +9,20 @@
           </envs>
         </ADDITIONAL_GENERATION_ENVIRONMENT>
       </configuration>
+      <configuration PROFILE_NAME="RelWithDebInfo" ENABLED="true" GENERATION_DIR="build" CONFIG_NAME="RelWithDebInfo" GENERATION_OPTIONS="-DCMAKE_TOOLCHAIN_FILES=scripts/cmake/CMakeToolchainDeluge.cmake --no-warn-unused-cli -G &quot;Ninja Multi-Config&quot;">
+        <ADDITIONAL_GENERATION_ENVIRONMENT>
+          <envs>
+            <env name="DELUGE_FW_ROOT" value="$PROJECT_DIR$" />
+          </envs>
+        </ADDITIONAL_GENERATION_ENVIRONMENT>
+      </configuration>
+      <configuration PROFILE_NAME="Release" ENABLED="true" GENERATION_DIR="build" CONFIG_NAME="Release" GENERATION_OPTIONS="-DCMAKE_TOOLCHAIN_FILES=scripts/cmake/CMakeToolchainDeluge.cmake --no-warn-unused-cli -G &quot;Ninja Multi-Config&quot;">
+        <ADDITIONAL_GENERATION_ENVIRONMENT>
+          <envs>
+            <env name="DELUGE_FW_ROOT" value="$PROJECT_DIR$" />
+          </envs>
+        </ADDITIONAL_GENERATION_ENVIRONMENT>
+      </configuration>
     </configurations>
   </component>
 </project>

--- a/IDE_Configs/clion/runConfigurations/Flash and debug.run.xml
+++ b/IDE_Configs/clion/runConfigurations/Flash and debug.run.xml
@@ -1,0 +1,10 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Flash and debug" type="com.jetbrains.cidr.embedded.customgdbserver.type" factoryName="com.jetbrains.cidr.embedded.customgdbserver.factory" PROGRAM_PARAMS="-device R7S721020 -speed 50000 -endian little -if swd -port 3333 -nogui -nohalt" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" WORKING_DIR="file://$PROJECT_DIR$" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Deluge" TARGET_NAME="deluge" CONFIG_NAME="Debug" version="1" RUN_TARGET_PROJECT_NAME="Deluge" RUN_TARGET_NAME="deluge">
+    <custom-gdb-server version="1" gdb-connect="localhost:3333" executable="JLinkGDBServer" warmup-ms="0" download-type="ALWAYS" reset-cmd="monitor reset" reset-type="BEFORE_DOWNLOAD">
+      <debugger kind="GDB">$PROJECT_DIR$/toolchain/v13/darwin-arm64/arm-none-eabi-gcc/bin/arm-none-eabi-gdb</debugger>
+    </custom-gdb-server>
+    <method v="2">
+      <option name="CLION.COMPOUND.BUILD" enabled="true" />
+    </method>
+  </configuration>
+</component>


### PR DESCRIPTION
CLion got better embedded gdb functionality this year so I've updated the configs to use it with cmake profiles for one click switching between debug types

This still leaves the pre existing dbt based ones in the default, they also work but don't integrate with clion as nicely