### PR TITLE
refactor: arp sequence length value scaling

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/sequence_length.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/sequence_length.h
@@ -25,12 +25,12 @@ class SequenceLength final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		auto* current_clip = getCurrentInstrumentClip();
-		int64_t value = (int64_t)current_clip->arpeggiatorSequenceLength;
-		this->setValue((value * kMaxMenuValue + 2147483648) >> 32);
+		this->setValue(
+		    computeCurrentValueForArpMidiCvRatchetsOrRhythm(getCurrentInstrumentClip()->arpeggiatorSequenceLength));
 	}
 	void writeCurrentValue() override {
-		getCurrentInstrumentClip()->arpeggiatorSequenceLength = (uint32_t)this->getValue() * 85899345;
+		getCurrentInstrumentClip()->arpeggiatorSequenceLength =
+		    computeFinalValueForArpMidiCvRatchetsOrRhythm(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -38,6 +38,20 @@
 /// - unpatched_param::Pan
 /// - unpatched_param::UnpatchedParam
 ///
+/// Done, but current value == final value so no function
+/// - arpeggiator::ArpMpeVelocity
+/// - arpeggiator::Mode
+/// - arpeggiator::NoteMode
+/// - arpeggiator::NoteModeFromOctave
+/// - arpeggiator::OctaveMode
+/// - arpeggiator::OctaveModeToNote
+/// - arpeggiator::Octaves
+/// - arpeggiator::PresetMode
+///
+/// Special cases:
+/// - arpeggiator::Sync - uses syncTypeAndLevelToMenuOption() to pack two values,
+///   and menuOptionToSyncType|Level() to unpack them.
+///
 /// As stuff is extraced and turns out to be functionally identical the dupes
 /// should be eliminated.
 ///


### PR DESCRIPTION
- same math as ratchets and rhythm. Not changing the name, because I don't have a good accurate alternative that isn't too unvieldy right now.

- mark bunch of menu classes value scaling as "done":
  - identity scaling: Mode, NoteMode, NoteModeFromOctave, ArpMpeVelocity, OctaveMode, Octaves, PresetMode
  - pre-existing special functions: Sync