### PR TITLE
refactoring: iterators replacing almost all traverseClips-gotos

### DIFF
--- a/src/deluge/model/action/action.cpp
+++ b/src/deluge/model/action/action.cpp
@@ -32,6 +32,7 @@
 #include "model/consequence/consequence_param_change.h"
 #include "model/model_stack.h"
 #include "model/note/note.h"
+#include "model/song/clip_iterators.h"
 #include "model/song/song.h"
 #include "processing/engines/audio_engine.h"
 #include "storage/audio/audio_file_manager.h"
@@ -323,14 +324,9 @@ void Action::updateYScrollClipViewAfter(InstrumentClip* clip) {
 		return;
 	}
 
+	// NOTE: i ranges over over all clips, not just instrument clips!
 	int32_t i = 0;
-
-	// For each Clip in session and arranger
-	ClipArray* clipArray = &currentSong->sessionClips;
-traverseClips:
-	for (int32_t c = 0; c < clipArray->getNumElements(); c++) {
-		Clip* thisClip = clipArray->getClipAtIndex(c);
-
+	for (Clip* thisClip : AllClips::everywhere(currentSong)) {
 		if (thisClip->type == ClipType::INSTRUMENT) {
 
 			if (!clip || thisClip == clip) {
@@ -340,9 +336,5 @@ traverseClips:
 		}
 
 		i++;
-	}
-	if (clipArray != &currentSong->arrangementOnlyClips) {
-		clipArray = &currentSong->arrangementOnlyClips;
-		goto traverseClips;
 	}
 }

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -593,6 +593,7 @@ int32_t MIDIInstrument::moveAutomationToDifferentCC(int32_t offset, int32_t whic
 	// For each Clip in session and arranger for specific Output (that Output is "this")
 	int32_t numElements = modelStack->song->sessionClips.getNumElements();
 	bool doingArrangementClips = false;
+	// TODO: Should use AllClips, but less obvious so later.
 traverseClips:
 	for (int32_t c = 0; c < numElements; c++) {
 		Clip* clip;

--- a/src/deluge/model/song/clip_iterators.cpp
+++ b/src/deluge/model/song/clip_iterators.cpp
@@ -1,0 +1,99 @@
+#include "model/song/clip_iterators.h"
+
+ClipIteratorBase::ClipIteratorBase(ClipArray* array_, uint32_t index_, ClipArray* nextArray_,
+                                   std::optional<ClipType> clipType_)
+    : array(array_), nextArray(nextArray_), index(index_), clipType(clipType_) {
+	// handle case of first array empty on initialization, or first element being
+	// wrong type
+	index--;
+	next();
+}
+
+ClipIteratorBase& ClipIteratorBase::operator++() {
+	next();
+	return *this;
+}
+ClipIteratorBase ClipIteratorBase::operator++(int) {
+	ClipIteratorBase pre = *this;
+	next();
+	return pre;
+}
+
+void ClipIteratorBase::deleteClip(InstrumentRemoval instrumentRemoval) {
+	Clip* clip = array->getClipAtIndex(index);
+	currentSong->deleteClipObject(clip, false, instrumentRemoval);
+	// This shifts all others down by one.
+	array->deleteAtIndex(index);
+	// By decreementing the index and doing next we force the type filter
+	// to run again. We don't actually need to loop backwards -- only
+	// forwards.
+	index--;
+	next();
+}
+
+void ClipIteratorBase::next() {
+	for (;;) {
+		index++;
+		if (index >= array->getNumElements() && nextArray) {
+			array = nextArray;
+			nextArray = nullptr;
+			index = 0;
+		}
+		if (index >= array->getNumElements()) {
+			// end
+			return;
+		}
+		if (!clipType.has_value() || clipType.value() == array->getClipAtIndex(index)->type) {
+			// valid clip for this iteration
+			return;
+		}
+	}
+}
+
+AllClips AllClips::everywhere(Song* song) {
+	return AllClips(&song->sessionClips, &song->arrangementOnlyClips);
+}
+
+AllClips AllClips::inSession(Song* song) {
+	return AllClips(&song->sessionClips, nullptr);
+}
+
+AllClips AllClips::inArrangementOnly(Song* song) {
+	return AllClips(&song->arrangementOnlyClips, nullptr);
+}
+
+ClipIterator<Clip> AllClips::begin() {
+	return ClipIterator<Clip>(first, 0, second, {});
+}
+
+ClipIterator<Clip> AllClips::end() {
+	ClipArray* last = second ? second : first;
+	int32_t n = last ? last->getNumElements() : 0;
+	return ClipIterator<Clip>(last, n, nullptr, {});
+}
+
+InstrumentClips InstrumentClips::everywhere(Song* song) {
+	return InstrumentClips(&song->sessionClips, &song->arrangementOnlyClips);
+}
+
+ClipIterator<InstrumentClip> InstrumentClips::begin() {
+	return ClipIterator<InstrumentClip>(first, 0, second, ClipType::INSTRUMENT);
+}
+
+ClipIterator<InstrumentClip> InstrumentClips::end() {
+	ClipArray* last = second ? second : first;
+	return ClipIterator<InstrumentClip>(last, last->getNumElements(), nullptr, ClipType::INSTRUMENT);
+}
+
+AudioClips AudioClips::everywhere(Song* song) {
+	return AudioClips(&song->sessionClips, &song->arrangementOnlyClips);
+}
+
+ClipIterator<AudioClip> AudioClips::begin() {
+	return ClipIterator<AudioClip>(first, 0, second, ClipType::AUDIO);
+}
+
+ClipIterator<AudioClip> AudioClips::end() {
+	ClipArray* last = second ? second : first;
+	return ClipIterator<AudioClip>(last, last->getNumElements(), nullptr, ClipType::AUDIO);
+}

--- a/src/deluge/model/song/clip_iterators.h
+++ b/src/deluge/model/song/clip_iterators.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+#include "definitions_cxx.hpp"
+
+#ifdef IN_UNIT_TESTS
+#include "clip_iterator_mocks.h"
+#else
+#include "deluge.h"
+#include "model/clip/clip.h"
+#include "model/clip/clip_array.h"
+#include "model/song/song.h"
+#endif
+
+// This is an incomplete iterator, missing operator*() and operator->(): the templated iterators inherit
+// from this and implement just those for minimal template bloat.
+class ClipIteratorBase {
+public:
+	__attribute__((noinline))
+	ClipIteratorBase(ClipArray* array_, uint32_t index_, ClipArray* nextArray_, std::optional<ClipType> clipType_);
+	__attribute__((noinline)) ClipIteratorBase& operator++();
+	__attribute__((noinline)) ClipIteratorBase operator++(int);
+	/** Deletes the clip pointed to by the iterator and advances it. */
+	__attribute__((noinline)) void deleteClip(InstrumentRemoval instrumentRemoval);
+	__attribute__((noinline)) friend bool operator==(const ClipIteratorBase& a, const ClipIteratorBase& b) {
+		return (a.array == b.array) && (a.index == b.index) && (a.clipType == b.clipType);
+	}
+	__attribute__((noinline)) friend bool operator!=(const ClipIteratorBase& a, const ClipIteratorBase& b) {
+		return (a.array != b.array) || (a.index != b.index) || (a.clipType != b.clipType);
+	}
+
+private:
+	__attribute__((noinline)) void next();
+
+protected:
+	ClipArray* array;
+	ClipArray* nextArray;
+	int32_t index;
+	std::optional<ClipType> clipType;
+};
+
+template <typename ClipClass>
+class ClipIterator : public ClipIteratorBase {
+public:
+	using ClipIteratorBase::ClipIteratorBase;
+	ClipClass*& operator*() { return *(ClipClass**)array->getElementAddress(index); }
+	ClipClass** operator->() { return (ClipClass**)array->getElementAddress(index); }
+};
+
+class ClipSet {
+protected:
+	ClipSet(ClipArray* first_, ClipArray* second_) : first(first_), second(second_) {}
+	ClipArray* first;
+	ClipArray* second;
+};
+
+class AllClips : ClipSet {
+public:
+	/** Constructs an iterable for all Clips in session and arranger. */
+	static AllClips everywhere(Song* song);
+	/** Constructs an iterable for all Clips in session. */
+	static AllClips inSession(Song* song);
+	/** Constructs an iterable for all Clips in arranger only. */
+	static AllClips inArrangementOnly(Song* song);
+	ClipIterator<Clip> begin();
+	ClipIterator<Clip> end();
+
+private:
+	using ClipSet::ClipSet;
+};
+
+class InstrumentClips : ClipSet {
+public:
+	/** Constructs an iterable for all InstrumentClips in session and arranger. */
+	static InstrumentClips everywhere(Song* song);
+	ClipIterator<InstrumentClip> begin();
+	ClipIterator<InstrumentClip> end();
+
+private:
+	using ClipSet::ClipSet;
+};
+
+class AudioClips : ClipSet {
+public:
+	/** Constructs an iterable for all AudioClips in session and arranger. */
+	static AudioClips everywhere(Song* song);
+	ClipIterator<AudioClip> begin();
+	ClipIterator<AudioClip> end();
+
+private:
+	using ClipSet::ClipSet;
+};

--- a/src/deluge/model/song/clip_iterators.h
+++ b/src/deluge/model/song/clip_iterators.h
@@ -18,21 +18,21 @@
 // from this and implement just those for minimal template bloat.
 class ClipIteratorBase {
 public:
-	__attribute__((noinline))
-	ClipIteratorBase(ClipArray* array_, uint32_t index_, ClipArray* nextArray_, std::optional<ClipType> clipType_);
-	__attribute__((noinline)) ClipIteratorBase& operator++();
-	__attribute__((noinline)) ClipIteratorBase operator++(int);
+	[[gnu::noinline]] ClipIteratorBase(ClipArray* array_, uint32_t index_, ClipArray* nextArray_,
+	                                   std::optional<ClipType> clipType_);
+	[[gnu::noinline]] ClipIteratorBase& operator++();
+	[[gnu::noinline]] ClipIteratorBase operator++(int);
 	/** Deletes the clip pointed to by the iterator and advances it. */
-	__attribute__((noinline)) void deleteClip(InstrumentRemoval instrumentRemoval);
-	__attribute__((noinline)) friend bool operator==(const ClipIteratorBase& a, const ClipIteratorBase& b) {
+	[[gnu::noinline]] void deleteClip(InstrumentRemoval instrumentRemoval);
+	[[gnu::noinline]] friend bool operator==(const ClipIteratorBase& a, const ClipIteratorBase& b) {
 		return (a.array == b.array) && (a.index == b.index) && (a.clipType == b.clipType);
 	}
-	__attribute__((noinline)) friend bool operator!=(const ClipIteratorBase& a, const ClipIteratorBase& b) {
+	[[gnu::noinline]] friend bool operator!=(const ClipIteratorBase& a, const ClipIteratorBase& b) {
 		return (a.array != b.array) || (a.index != b.index) || (a.clipType != b.clipType);
 	}
 
 private:
-	__attribute__((noinline)) void next();
+	[[gnu::noinline]] void next();
 
 protected:
 	ClipArray* array;

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -32,6 +32,7 @@
 #include "model/clip/instrument_clip_minder.h"
 #include "model/drum/drum.h"
 #include "model/note/note_row.h"
+#include "model/song/clip_iterators.h"
 #include "model/song/song.h"
 #include "playback/playback_handler.h"
 #include "processing/engines/audio_engine.h"
@@ -1940,12 +1941,7 @@ bool Session::areAnyClipsArmed() {
 // affected by each Action. This is only to be called if playbackHandler.isEitherClockActive().
 void Session::reversionDone() {
 
-	// For each Clip in session and arranger
-	ClipArray* clipArray = &currentSong->sessionClips;
-traverseClips:
-	for (int32_t c = 0; c < clipArray->getNumElements(); c++) {
-		Clip* clip = clipArray->getClipAtIndex(c);
-
+	for (Clip* clip : AllClips::everywhere(currentSong)) {
 		if (currentSong->isClipActive(clip)) {
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
@@ -1954,10 +1950,6 @@ traverseClips:
 			clip->reGetParameterAutomation(modelStackWithTimelineCounter);
 			clip->expectEvent();
 		}
-	}
-	if (clipArray != &currentSong->arrangementOnlyClips) {
-		clipArray = &currentSong->arrangementOnlyClips;
-		goto traverseClips;
 	}
 }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -38,9 +38,18 @@ file(GLOB_RECURSE deluge_SOURCES
         ../../src/deluge/model/scale/musical_key.cpp
         ../../src/deluge/model/scale/note_set.cpp
         ../../src/deluge/model/scale/utils.cpp
+        # For clip iterator tests
+        ../../src/deluge/model/song/clip_iterators.cpp
 )
 
-add_executable(UnitTests RunAllTests.cpp scheduler_tests.cpp lfo_tests.cpp scale_tests.cpp value_scaling_tests.cpp)
+add_executable(UnitTests
+        RunAllTests.cpp
+        scheduler_tests.cpp
+        lfo_tests.cpp
+        scale_tests.cpp
+        value_scaling_tests.cpp
+        clip_iterator_tests.cpp
+)
 add_test(NAME UnitTests
         COMMAND UnitTests)
 target_sources(UnitTests PRIVATE ${deluge_SOURCES})

--- a/tests/unit/clip_iterator_tests.cpp
+++ b/tests/unit/clip_iterator_tests.cpp
@@ -1,0 +1,249 @@
+#include "CppUTest/TestHarness.h"
+#include "model/song/clip_iterators.h"
+
+Song testSong;
+Song* currentSong = &testSong;
+
+const int nSessionClips = 10;
+Clip sessionClips[nSessionClips];
+
+const int nArrangementOnlyClips = 4;
+Clip arrangementOnlyClips[nArrangementOnlyClips];
+
+const int nInstrumentClips = 11;
+const int nAudioClips = 3;
+
+void useSessionClips() {
+	for (int i = 0; i < nSessionClips; i++) {
+		sessionClips[i].id = i;
+		if (i == 4 || i == 7) {
+			sessionClips[i].type = ClipType::AUDIO;
+		}
+		else {
+			sessionClips[i].type = ClipType::INSTRUMENT;
+		}
+		testSong.sessionClips.push(&sessionClips[i]);
+	}
+}
+
+void useArrangementOnlyClips() {
+	for (int i = 0; i < nArrangementOnlyClips; i++) {
+		arrangementOnlyClips[i].id = i + nSessionClips;
+		if (i == 2) {
+			arrangementOnlyClips[i].type = ClipType::AUDIO;
+		}
+		else {
+			arrangementOnlyClips[i].type = ClipType::INSTRUMENT;
+		}
+		testSong.arrangementOnlyClips.push(&arrangementOnlyClips[i]);
+	}
+}
+
+TEST_GROUP(ClipIteratorTests){void setup(){testSong.clear();
+}
+}
+;
+
+TEST(ClipIteratorTests, noClips) {
+	for (Clip* clip : AllClips::everywhere(currentSong)) {
+		FAIL("no 1");
+	}
+	for (Clip* clip : AllClips::inSession(currentSong)) {
+		FAIL("no 2");
+	}
+	for (Clip* clip : AllClips::inArrangementOnly(currentSong)) {
+		FAIL("no 3");
+	}
+}
+
+TEST(ClipIteratorTests, sessionClips_everywhereIterator) {
+	useSessionClips();
+	int n = 0;
+	for (Clip* clip : AllClips::everywhere(currentSong)) {
+		CHECK_EQUAL(n, clip->id);
+		if (n == 4 || n == 7) {
+			CHECK(ClipType::AUDIO == clip->type);
+		}
+		else {
+			CHECK(ClipType::INSTRUMENT == clip->type);
+		}
+		n++;
+	}
+	CHECK_EQUAL(nSessionClips, n);
+}
+
+TEST(ClipIteratorTests, sessionClips_sessionIterator) {
+	useSessionClips();
+	int n = 0;
+	for (Clip* clip : AllClips::inSession(currentSong)) {
+		CHECK_EQUAL(n, clip->id);
+		if (n == 4 || n == 7) {
+			CHECK(ClipType::AUDIO == clip->type);
+		}
+		else {
+			CHECK(ClipType::INSTRUMENT == clip->type);
+		}
+		n++;
+	}
+	CHECK_EQUAL(nSessionClips, n);
+}
+
+TEST(ClipIteratorTests, sessionClips_arrangementIterator) {
+	useSessionClips();
+	for (Clip* clip : AllClips::inArrangementOnly(currentSong)) {
+		(void)clip;
+		FAIL("no");
+	}
+}
+
+TEST(ClipIteratorTests, arrangementClips_everywhereIterator) {
+	useArrangementOnlyClips();
+	int n = 0;
+	for (Clip* clip : AllClips::everywhere(currentSong)) {
+		CHECK_EQUAL(n + nSessionClips, clip->id);
+		if (clip->id == 12) {
+			CHECK(ClipType::AUDIO == clip->type);
+		}
+		else {
+			CHECK(ClipType::INSTRUMENT == clip->type);
+		}
+		n++;
+	}
+	CHECK_EQUAL(nArrangementOnlyClips, n);
+}
+
+TEST(ClipIteratorTests, arrangementClips_arrangementIterator) {
+	useArrangementOnlyClips();
+	int n = 0;
+	for (Clip* clip : AllClips::inArrangementOnly(currentSong)) {
+		CHECK_EQUAL(n + nSessionClips, clip->id);
+		if (clip->id == 12) {
+			CHECK(ClipType::AUDIO == clip->type);
+		}
+		else {
+			CHECK(ClipType::INSTRUMENT == clip->type);
+		}
+		n++;
+	}
+	CHECK_EQUAL(nArrangementOnlyClips, n);
+}
+
+TEST(ClipIteratorTests, arrangementClips_sessionIterator) {
+	useArrangementOnlyClips();
+	int n = 0;
+	for (Clip* clip : AllClips::inSession(currentSong)) {
+		(void)clip;
+		FAIL("no");
+	}
+}
+
+TEST(ClipIteratorTests, allClips_everywhereIterator) {
+	useSessionClips();
+	useArrangementOnlyClips();
+	int n = 0;
+	for (Clip* clip : AllClips::everywhere(currentSong)) {
+		CHECK_EQUAL(n, clip->id);
+		if (clip->id == 4 || clip->id == 7 || clip->id == 12) {
+			CHECK(ClipType::AUDIO == clip->type);
+		}
+		else {
+			CHECK(ClipType::INSTRUMENT == clip->type);
+		}
+		n++;
+	}
+	CHECK_EQUAL(nSessionClips + nArrangementOnlyClips, n);
+}
+
+TEST(ClipIteratorTests, allClips_sessionIterator) {
+	useSessionClips();
+	useArrangementOnlyClips();
+	int n = 0;
+	for (Clip* clip : AllClips::inSession(currentSong)) {
+		CHECK_EQUAL(n, clip->id);
+		if (clip->id == 4 || clip->id == 7) {
+			CHECK(ClipType::AUDIO == clip->type);
+		}
+		else {
+			CHECK(ClipType::INSTRUMENT == clip->type);
+		}
+		n++;
+	}
+	CHECK_EQUAL(nSessionClips, n);
+}
+
+TEST(ClipIteratorTests, allClips_arrangementIterator) {
+	useSessionClips();
+	useArrangementOnlyClips();
+	int n = 0;
+	for (Clip* clip : AllClips::inArrangementOnly(currentSong)) {
+		CHECK_EQUAL(n + nSessionClips, clip->id);
+		if (clip->id == 12) {
+			CHECK(ClipType::AUDIO == clip->type);
+		}
+		else {
+			CHECK(ClipType::INSTRUMENT == clip->type);
+		}
+		n++;
+	}
+	CHECK_EQUAL(nArrangementOnlyClips, n);
+}
+
+TEST(ClipIteratorTests, instrumentClips) {
+	useSessionClips();
+	useArrangementOnlyClips();
+	int n = 0;
+	for (InstrumentClip* clip : InstrumentClips::everywhere(currentSong)) {
+		CHECK(ClipType::INSTRUMENT == clip->type);
+		n++;
+	}
+	CHECK_EQUAL(nInstrumentClips, n);
+}
+
+TEST(ClipIteratorTests, instrumentClips_firstElementsWrongType) {
+	useSessionClips();
+	sessionClips[0].type = ClipType::AUDIO;
+	useArrangementOnlyClips();
+	arrangementOnlyClips[0].type = ClipType::AUDIO;
+	int n = 0;
+	for (InstrumentClip* clip : InstrumentClips::everywhere(currentSong)) {
+		CHECK(ClipType::INSTRUMENT == clip->type);
+		n++;
+	}
+	CHECK_EQUAL(nInstrumentClips - 2, n);
+}
+
+TEST(ClipIteratorTests, audioClips) {
+	useSessionClips();
+	useArrangementOnlyClips();
+	int n = 0;
+	for (AudioClip* clip : AudioClips::everywhere(currentSong)) {
+		CHECK(ClipType::AUDIO == clip->type);
+		n++;
+	}
+	CHECK_EQUAL(nAudioClips, n);
+}
+
+TEST(ClipIteratorTests, deleteClip) {
+	useSessionClips();
+	useArrangementOnlyClips();
+	AllClips all = AllClips::everywhere(currentSong);
+	int n = 0;
+	for (auto it = all.begin(); it != all.end();) {
+		Clip* clip = *it;
+		if (clip->type == ClipType::INSTRUMENT) {
+			it.deleteClip(InstrumentRemoval::NONE);
+			CHECK_EQUAL(true, clip->deleted);
+			n++;
+		}
+		else {
+			it++;
+		}
+	}
+	CHECK_EQUAL(nInstrumentClips, n);
+	int k = 0;
+	for (Clip* clip : all) {
+		CHECK(ClipType::AUDIO == clip->type);
+		k++;
+	}
+	CHECK_EQUAL(nAudioClips, k);
+}

--- a/tests/unit/mocks/clip_iterator_mocks.h
+++ b/tests/unit/mocks/clip_iterator_mocks.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "definitions_cxx.hpp"
+
+#include <cstdint>
+#include <vector>
+
+class Clip {
+public:
+	Clip(int id_ = -1) : id(id_) {}
+	int id;
+	ClipType type = ClipType::INSTRUMENT;
+	bool deleted = false;
+};
+
+class InstrumentClip : public Clip {};
+
+class AudioClip : public Clip {};
+
+class ClipArray {
+public:
+	Clip** getElementAddress(int32_t index) { return &data[index]; }
+	Clip* getClipAtIndex(int32_t index) { return data[index]; }
+	int32_t getNumElements() { return data.size(); }
+	void deleteAtIndex(int32_t index) {
+		for (int32_t i = index; i < data.size() - 1; i++) {
+			data[i] = data[i + 1];
+		}
+		data.pop_back();
+	}
+	void clear() { data.clear(); }
+	void push(Clip* clip) { data.push_back(clip); }
+
+private:
+	std::vector<Clip*> data;
+};
+
+class Song {
+public:
+	void deleteClipObject(Clip* clip, bool x, InstrumentRemoval removal) {
+		(void)x;
+		(void)removal;
+		clip->deleted = true;
+	}
+	void clear() {
+		sessionClips.clear();
+		arrangementOnlyClips.clear();
+	}
+	ClipArray sessionClips;
+	ClipArray arrangementOnlyClips;
+};
+
+extern Song* currentSong;

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -1,6 +1,6 @@
 #include "CppUTest/TestHarness.h"
-#include "model/scale/note_set.h"
 #include "model/scale/musical_key.h"
+#include "model/scale/note_set.h"
 #include "model/scale/utils.h"
 
 TEST_GROUP(NoteSetTest){};

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -4,8 +4,6 @@
 #include "gui/menu_item/value_scaling.h"
 #include "modulation/arpeggiator_rhythms.h"
 
-#include <iostream>
-
 TEST_GROUP(ValueScalingTest){};
 
 TEST(ValueScalingTest, standardMenuItemValueScaling) {


### PR DESCRIPTION
- AllClips, InstrumentClips, and Audioclips -classes are iterators across different sets of clips. Their instances are built using static ::everywhere(), ::inSession(), and ::inArrangementOnly() methods. Examples:

      for (Clip* clip : AllClips::inSession(currentSong)) { ... }

      for (InstrumentClip* clip : InstrumentClips::everywhere(currentSong)) { ... }

- This does away with the most gotos and casts - or rather, moves the casts to the iterators.

- Some gotos remain: in Output-related functions there's an entirely different logic for iterating over "all clips in session and arranger for specific output", that uses sound->clipInstances for arrangement-only clips. The reason isn't obvious, and neither is it clear if that code can be directly replaced with the new iterators.

- Tests are probably the most questionable part here, since there's a minor #ifdef leakage into the application code, in order to avoid pulling Song, Clip, etc as dependencies.

- Codesize 1706264 on release build is a bit disappointing vs tip of community at 1705776 -- this was intended to be neutral or positive change, but maybe not too bad considering the improved clarity.