### PR TITLE
Bugfix/dont count stats if the audio routine doesn't run

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -302,7 +302,7 @@ void TaskManager::setNextRunTimeforCurrentTask(double seconds) {
 void TaskManager::runTask(TaskID id) {
 	countThisTask = true;
 	auto timeNow = getSecondsFromStart();
-    double startTime = timeNow;
+	double startTime = timeNow;
 	// this includes ISR time as well as the scheduler's own time, such as calculating and printing stats
 	overhead += timeNow - list[currentID].lastFinishTime;
 	currentID = id;
@@ -314,14 +314,14 @@ void TaskManager::runTask(TaskID id) {
 		removeTask(id);
 	}
 	else {
-        if (countThisTask) {
+		if (countThisTask) {
 #if SCHEDULER_DETAILED_STATS
-        currentTask->latency.update(startTime - currentTask->lastCallTime);
+			currentTask->latency.update(startTime - currentTask->lastCallTime);
 #endif
-        currentTask->lastCallTime = startTime;
-        currentTask->lastFinishTime = timeNow;
-		double runtime = (currentTask->lastFinishTime - currentTask->lastCallTime);
-		cpuTime += runtime;
+			currentTask->lastCallTime = startTime;
+			currentTask->lastFinishTime = timeNow;
+			double runtime = (currentTask->lastFinishTime - currentTask->lastCallTime);
+			cpuTime += runtime;
 
 			currentTask->durationStats.update(runtime);
 			currentTask->totalTime += runtime;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -953,6 +953,7 @@ void routine() {
 
 	if (audioRoutineLocked) {
 		logAction("AudioDriver::routine locked");
+        ignoreForStats();
 		return; // Prevents this from being called again from inside any e.g. memory allocation routines that get
 		        // called from within this!
 	}

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -953,7 +953,7 @@ void routine() {
 
 	if (audioRoutineLocked) {
 		logAction("AudioDriver::routine locked");
-        ignoreForStats();
+		ignoreForStats();
 		return; // Prevents this from being called again from inside any e.g. memory allocation routines that get
 		        // called from within this!
 	}


### PR DESCRIPTION
Should fix #2247

Fixes a bug where calling the audio routine while it was locked out still "counted" for call frequency, leading to occasional drops in audio call frequency at low cpu load

Before:
![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/6aa352b3-5d8f-493b-ae5f-b8d2dc4ab485)


After:
![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/52469396/bc47d2d0-7b38-407b-ae73-a3bc3a961882)

