### PR TITLE
refactor: audio clip attack value scaling

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
@@ -29,7 +29,7 @@ public:
 		this->setValue(computeCurrentValueForStandardMenuItem(getCurrentInstrumentClip()->arpeggiatorGate));
 	}
 	void writeCurrentValue() override {
-		getCurrentInstrumentClip()->arpeggiatorGate = computeFinalValueForSemiStandardMenuItem(this->getValue());
+		getCurrentInstrumentClip()->arpeggiatorGate = computeFinalValueWithoutRoundingToOne(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
@@ -29,7 +29,7 @@ public:
 		this->setValue(computeCurrentValueForStandardMenuItem(getCurrentInstrumentClip()->arpeggiatorGate));
 	}
 	void writeCurrentValue() override {
-		getCurrentInstrumentClip()->arpeggiatorGate = computeFinalValueWithoutRoundingToOne(this->getValue());
+		getCurrentInstrumentClip()->arpeggiatorGate = computeFinalValueForStandardMenuItem(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/gate.h
@@ -26,10 +26,10 @@ class Gate final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		this->setValue(computeCurrentValueForArpMidiCvGate(getCurrentInstrumentClip()->arpeggiatorGate));
+		this->setValue(computeCurrentValueForStandardMenuItem(getCurrentInstrumentClip()->arpeggiatorGate));
 	}
 	void writeCurrentValue() override {
-		getCurrentInstrumentClip()->arpeggiatorGate = computeFinalValueForArpMidiCvGate(this->getValue());
+		getCurrentInstrumentClip()->arpeggiatorGate = computeFinalValueForSemiStandardMenuItem(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rate.h
@@ -25,10 +25,10 @@ class Rate final : public Integer {
 public:
 	using Integer::Integer;
 	void readCurrentValue() override {
-		this->setValue(computeCurrentValueForArpMidiCvRate(getCurrentInstrumentClip()->arpeggiatorRate));
+		this->setValue(computeCurrentValueForStandardMenuItem(getCurrentInstrumentClip()->arpeggiatorRate));
 	}
 	void writeCurrentValue() override {
-		getCurrentInstrumentClip()->arpeggiatorRate = computeFinalValueForArpMidiCvRate(this->getValue());
+		getCurrentInstrumentClip()->arpeggiatorRate = computeFinalValueForStandardMenuItem(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/gui/menu_item/audio_clip/attack.h
+++ b/src/deluge/gui/menu_item/audio_clip/attack.h
@@ -25,10 +25,10 @@ public:
 	using Integer::Integer;
 
 	void readCurrentValue() override {
-		this->setValue((((int64_t)getCurrentAudioClip()->attack + 2147483648) * kMaxMenuValue + 2147483648) >> 32);
+		this->setValue(computeCurrentValueForSemiStandardMenuItem(getCurrentAudioClip()->attack));
 	}
 	void writeCurrentValue() override {
-		getCurrentAudioClip()->attack = (uint32_t)this->getValue() * 85899345 - 2147483648;
+		getCurrentAudioClip()->attack = computeFinalValueForSemiStandardMenuItem(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };

--- a/src/deluge/gui/menu_item/audio_clip/attack.h
+++ b/src/deluge/gui/menu_item/audio_clip/attack.h
@@ -25,10 +25,10 @@ public:
 	using Integer::Integer;
 
 	void readCurrentValue() override {
-		this->setValue(computeCurrentValueForSemiStandardMenuItem(getCurrentAudioClip()->attack));
+		this->setValue(computeCurrentValueWithoutRoundingToOne(getCurrentAudioClip()->attack));
 	}
 	void writeCurrentValue() override {
-		getCurrentAudioClip()->attack = computeFinalValueForSemiStandardMenuItem(this->getValue());
+		getCurrentAudioClip()->attack = computeFinalValueWithoutRoundingToOne(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };

--- a/src/deluge/gui/menu_item/audio_clip/attack.h
+++ b/src/deluge/gui/menu_item/audio_clip/attack.h
@@ -25,10 +25,10 @@ public:
 	using Integer::Integer;
 
 	void readCurrentValue() override {
-		this->setValue(computeCurrentValueWithoutRoundingToOne(getCurrentAudioClip()->attack));
+		this->setValue(computeCurrentValueForStandardMenuItem(getCurrentAudioClip()->attack));
 	}
 	void writeCurrentValue() override {
-		getCurrentAudioClip()->attack = computeFinalValueWithoutRoundingToOne(this->getValue());
+		getCurrentAudioClip()->attack = computeCurrentValueForStandardMenuItem(this->getValue());
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuValue; }
 };

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -16,16 +16,13 @@ int32_t computeCurrentValueForPan(int32_t value) {
 	return ((int64_t)value * (kMaxMenuRelativeValue * 2) + 2147483648) >> 32;
 }
 
-int32_t computeCurrentValueForArpMidiCvGate(int32_t value) {
-	return computeCurrentValueForStandardMenuItem(value);
-}
-
 int32_t computeCurrentValueForArpMidiCvRatchetsOrRhythm(uint32_t value) {
 	return ((int64_t)value * kMaxMenuValue + 2147483648) >> 32;
 }
 
-int32_t computeCurrentValueForArpMidiCvRate(int32_t value) {
-	return computeCurrentValueForStandardMenuItem(value);
+int32_t computeFinalValueForSemiStandardMenuItem(int32_t value) {
+	// (2147483648 / kMidMenuValue) == 85899345
+	return (uint32_t)value * 85899345 - 2147483648;
 }
 
 int32_t computeFinalValueForStandardMenuItem(int32_t value) {
@@ -36,20 +33,7 @@ int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 		return -2147483648;
 	}
 	else {
-		return (uint32_t)value * (2147483648 / kMidMenuValue) - 2147483648;
-	}
-}
-
-int32_t computeFinalValueForCompParam(int32_t value) {
-	// comp params aren't set up for negative inputs - this is the same as osc pulse width
-	if (value == kMaxMenuValue) {
-		return 2147483647;
-	}
-	else if (value == kMinMenuValue) {
-		return 0;
-	}
-	else {
-		return (uint32_t)value * (2147483648 / kMidMenuValue) >> 1;
+		return computeFinalValueForSemiStandardMenuItem(value);
 	}
 }
 
@@ -78,10 +62,6 @@ int32_t computeFinalValueForPan(int32_t value) {
 	}
 }
 
-int32_t computeFinalValueForArpMidiCvGate(int32_t value) {
-	return (uint32_t)value * 85899345 - 2147483648;
-}
-
 uint32_t computeFinalValueForArpMidiCvRatchetsOrRhythm(int32_t value) {
 	return (uint32_t)value * 85899345;
 }
@@ -91,6 +71,6 @@ int32_t computeFinalValueForArpMidiCvRate(int32_t value) {
 		return 0;
 	}
 	else {
-		return (uint32_t)value * 85899345 - 2147483648;
+		return computeFinalValueForSemiStandardMenuItem(value);
 	}
 }

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -20,7 +20,7 @@ int32_t computeCurrentValueForArpMidiCvRatchetsOrRhythm(uint32_t value) {
 	return ((int64_t)value * kMaxMenuValue + 2147483648) >> 32;
 }
 
-int32_t computeFinalValueForSemiStandardMenuItem(int32_t value) {
+int32_t computeFinalValueWithoutRoundingToOne(int32_t value) {
 	// (2147483648 / kMidMenuValue) == 85899345
 	return (uint32_t)value * 85899345 - 2147483648;
 }
@@ -33,7 +33,7 @@ int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 		return -2147483648;
 	}
 	else {
-		return computeFinalValueForSemiStandardMenuItem(value);
+		return computeFinalValueWithoutRoundingToOne(value);
 	}
 }
 
@@ -71,6 +71,6 @@ int32_t computeFinalValueForArpMidiCvRate(int32_t value) {
 		return 0;
 	}
 	else {
-		return computeFinalValueForSemiStandardMenuItem(value);
+		return computeFinalValueWithoutRoundingToOne(value);
 	}
 }

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -20,11 +20,6 @@ int32_t computeCurrentValueForArpMidiCvRatchetsOrRhythm(uint32_t value) {
 	return ((int64_t)value * kMaxMenuValue + 2147483648) >> 32;
 }
 
-int32_t computeFinalValueWithoutRoundingToOne(int32_t value) {
-	// (2147483648 / kMidMenuValue) == 85899345
-	return (uint32_t)value * 85899345 - 2147483648;
-}
-
 int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 	if (value == kMaxMenuValue) {
 		return 2147483647;
@@ -33,7 +28,8 @@ int32_t computeFinalValueForStandardMenuItem(int32_t value) {
 		return -2147483648;
 	}
 	else {
-		return computeFinalValueWithoutRoundingToOne(value);
+		// (2147483648 / kMidMenuValue) == 85899345
+		return (uint32_t)value * 85899345 - 2147483648;
 	}
 }
 
@@ -64,13 +60,4 @@ int32_t computeFinalValueForPan(int32_t value) {
 
 uint32_t computeFinalValueForArpMidiCvRatchetsOrRhythm(int32_t value) {
 	return (uint32_t)value * 85899345;
-}
-
-int32_t computeFinalValueForArpMidiCvRate(int32_t value) {
-	if (value == kMidMenuValue) {
-		return 0;
-	}
-	else {
-		return computeFinalValueWithoutRoundingToOne(value);
-	}
 }

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -26,6 +26,7 @@
 ///
 /// Done:
 /// - audio_compressor::CompParam
+/// - audio_clip::Attack
 /// - arpeggiator::midi_cv::Gate
 /// - arpeggiator::midi_cv::RatchetAmount
 /// - arpeggiator::midi_cv::RatchetProbability
@@ -47,6 +48,7 @@
 /// - arpeggiator::OctaveModeToNote
 /// - arpeggiator::Octaves
 /// - arpeggiator::PresetMode
+/// - audio_clip::Reverse
 ///
 /// Special cases:
 /// - arpeggiator::Sync - uses syncTypeAndLevelToMenuOption() to pack two values,
@@ -72,6 +74,31 @@ int32_t computeCurrentValueForStandardMenuItem(int32_t value);
  */
 int32_t computeFinalValueForStandardMenuItem(int32_t value);
 
+/** Scales INT32_MIN-INT32_MAX range to 0-50 for display.
+ *
+ * This roundtrips with the final value math despite being not being it's
+ * proper inverse.
+ *
+ * Thin wrapper for clarity.
+ */
+inline int32_t computeCurrentValueForSemiStandardMenuItem(int32_t value) {
+	return computeCurrentValueForStandardMenuItem(value);
+}
+
+/** Scales 0-50 range to INT32_MIN-(INT32_MAX-45) for storage and use.
+ *
+ * It is unclear when this is used intentionally, and when by accident.
+ *
+ * - arpeggiator::midi_cv::Gate: possibly so that gate
+ *   will momentarily go down even at 50: the values produced create a 2.5ms
+ *   gate down period between 16th arp notes at Gate=50, which exactly matches
+ *   the gate down period between regular 16h notes.
+ *
+ * NOTE: computeFinalValueForArpMidiRate() is _almost_ but not quite
+ * the same: this one returns -23 for zero, that one returns 0.
+ */
+int32_t computeFinalValueForSemiStandardMenuItem(int32_t value);
+
 /** Scales 0-INT32_MAX range to 0-50 for display.
  */
 int32_t computeCurrentValueForHalfPrecisionMenuItem(int32_t value);
@@ -87,28 +114,6 @@ int32_t computeCurrentValueForPan(int32_t value);
 /** Scales -25 to 25 range to INT32_MIN-INT32_MAX for storage and use.
  */
 int32_t computeFinalValueForPan(int32_t value);
-
-/** Scales INT32_MIN-INT32_MAX range to 0-50 for display.
- *
- * This roundtrips with the final value math despite not
- * being it's proper inverse.
- *
- * This is exactly the same as the "standard" version, but
- * has a wrapper for clarity, because the final value compuation
- * is different.
- */
-int32_t computeCurrentValueForArpMidiCvGate(int32_t value);
-
-/** Scales 0-50 range to INT32_MIN-(INT32_MAX-45) for storage and use.
- *
- * This is presumably to have the gate go down even at 50: the values
- * produced create a 2.5ms gate down period between 16th arp notes at Gate=50,
- * which exactly matches the gate down period between regular 16h notes.
- *
- * NOTE: computeFinalValueForArpMidiRate() is _almost_ but not quite
- * the same: this one returns -23 for zero, that one returns 0.
- */
-int32_t computeFinalValueForArpMidiCvGate(int32_t value);
 
 /** Scales UINT32 range to 0-50 for display.
  *
@@ -138,17 +143,17 @@ uint32_t computeFinalValueForArpMidiCvRatchetsOrRhythm(int32_t value);
  * This roundtrips with the final value math despite being
  * not being it's proper inverse.
  *
- * This is exactly the same as the "standard" version, but
- * has a wrapper for clarity, because the final value compuation
- * is different.
+ * Thin wrapper for clarity.
  */
-int32_t computeCurrentValueForArpMidiCvRate(int32_t value);
+inline int32_t computeCurrentValueForArpMidiCvRate(int32_t value) {
+	return computeCurrentValueForStandardMenuItem(value);
+}
 
 /** Scales 0-50 range to INT32_MIN-(INT32_MAX-45) for storage and use.
  *
  * arpeggiator::midi_cv::Rate uses this, it is not obvious why, though.
  *
- * NOTE: computeFinalValueForArpMidiGate() is _almost_ but not quite
- * the same: this one returns 0 for 0, whereas that one does not.
+ * NOTE: computeFinalValueForSemiStandardMenuItem() is _almost_ but not quite
+ * the same: this one returns 0 for kMidMenuValue, whereas that one does not.
  */
 int32_t computeFinalValueForArpMidiCvRate(int32_t value);

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -87,12 +87,8 @@ inline int32_t computeCurrentValueForSemiStandardMenuItem(int32_t value) {
 
 /** Scales 0-50 range to INT32_MIN-(INT32_MAX-45) for storage and use.
  *
- * It is unclear when this is used intentionally, and when by accident.
- *
- * - arpeggiator::midi_cv::Gate: possibly so that gate
- *   will momentarily go down even at 50: the values produced create a 2.5ms
- *   gate down period between 16th arp notes at Gate=50, which exactly matches
- *   the gate down period between regular 16h notes.
+ * Current assumption is that this is an accident. TODO: figure out how
+ * replace this with the standard value computation without changing sounds.
  *
  * NOTE: computeFinalValueForArpMidiRate() is _almost_ but not quite
  * the same: this one returns -23 for zero, that one returns 0.

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -81,7 +81,7 @@ int32_t computeFinalValueForStandardMenuItem(int32_t value);
  *
  * Thin wrapper for clarity.
  */
-inline int32_t computeCurrentValueForSemiStandardMenuItem(int32_t value) {
+inline int32_t computeCurrentValueWithoutRoundingToOne(int32_t value) {
 	return computeCurrentValueForStandardMenuItem(value);
 }
 
@@ -93,7 +93,7 @@ inline int32_t computeCurrentValueForSemiStandardMenuItem(int32_t value) {
  * NOTE: computeFinalValueForArpMidiRate() is _almost_ but not quite
  * the same: this one returns -23 for zero, that one returns 0.
  */
-int32_t computeFinalValueForSemiStandardMenuItem(int32_t value);
+int32_t computeFinalValueWithoutRoundingToOne(int32_t value);
 
 /** Scales 0-INT32_MAX range to 0-50 for display.
  */
@@ -149,7 +149,7 @@ inline int32_t computeCurrentValueForArpMidiCvRate(int32_t value) {
  *
  * arpeggiator::midi_cv::Rate uses this, it is not obvious why, though.
  *
- * NOTE: computeFinalValueForSemiStandardMenuItem() is _almost_ but not quite
+ * NOTE: computeFinalValueWithoutRoundingToOne() is _almost_ but not quite
  * the same: this one returns 0 for kMidMenuValue, whereas that one does not.
  */
 int32_t computeFinalValueForArpMidiCvRate(int32_t value);

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -74,27 +74,6 @@ int32_t computeCurrentValueForStandardMenuItem(int32_t value);
  */
 int32_t computeFinalValueForStandardMenuItem(int32_t value);
 
-/** Scales INT32_MIN-INT32_MAX range to 0-50 for display.
- *
- * This roundtrips with the final value math despite being not being it's
- * proper inverse.
- *
- * Thin wrapper for clarity.
- */
-inline int32_t computeCurrentValueWithoutRoundingToOne(int32_t value) {
-	return computeCurrentValueForStandardMenuItem(value);
-}
-
-/** Scales 0-50 range to INT32_MIN-(INT32_MAX-45) for storage and use.
- *
- * Current assumption is that this is an accident. TODO: figure out how
- * replace this with the standard value computation without changing sounds.
- *
- * NOTE: computeFinalValueForArpMidiRate() is _almost_ but not quite
- * the same: this one returns -23 for zero, that one returns 0.
- */
-int32_t computeFinalValueWithoutRoundingToOne(int32_t value);
-
 /** Scales 0-INT32_MAX range to 0-50 for display.
  */
 int32_t computeCurrentValueForHalfPrecisionMenuItem(int32_t value);
@@ -133,23 +112,3 @@ int32_t computeCurrentValueForArpMidiCvRatchetsOrRhythm(uint32_t value);
  * See comment in the current value computation above for more.
  */
 uint32_t computeFinalValueForArpMidiCvRatchetsOrRhythm(int32_t value);
-
-/** Scales INT32_MIN-INT32_MAX range to 0-50 for display.
- *
- * This roundtrips with the final value math despite being
- * not being it's proper inverse.
- *
- * Thin wrapper for clarity.
- */
-inline int32_t computeCurrentValueForArpMidiCvRate(int32_t value) {
-	return computeCurrentValueForStandardMenuItem(value);
-}
-
-/** Scales 0-50 range to INT32_MIN-(INT32_MAX-45) for storage and use.
- *
- * arpeggiator::midi_cv::Rate uses this, it is not obvious why, though.
- *
- * NOTE: computeFinalValueWithoutRoundingToOne() is _almost_ but not quite
- * the same: this one returns 0 for kMidMenuValue, whereas that one does not.
- */
-int32_t computeFinalValueForArpMidiCvRate(int32_t value);

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -1,6 +1,6 @@
 #include "CppUTest/TestHarness.h"
-#include "model/scale/note_set.h"
 #include "model/scale/musical_key.h"
+#include "model/scale/note_set.h"
 #include "model/scale/utils.h"
 
 TEST_GROUP(NoteSetTest){};

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -19,6 +19,26 @@ TEST(ValueScalingTest, standardMenuItemValueScaling) {
 	CHECK_EQUAL(INT32_MAX, computeFinalValueForStandardMenuItem(50));
 }
 
+TEST(ValueScalingTest, semiStandardValueScaling) {
+	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
+		int32_t finalValue = computeFinalValueForSemiStandardMenuItem(i);
+		int32_t currentValue = computeCurrentValueForStandardMenuItem(finalValue);
+		CHECK_EQUAL(i, currentValue);
+	}
+	CHECK_EQUAL(INT32_MIN, computeFinalValueForSemiStandardMenuItem(0));
+	CHECK_EQUAL(-23, computeFinalValueForSemiStandardMenuItem(25));
+	// As seen here, we diverge _slightly_ from the standard
+	// menu item scaling when computing final values, despite roundtripping
+	// and using the identical current value computation.
+	//
+	// See computeFinalValueForSemiStandardMenuItem()'s comment for possible
+	// motivation.
+	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueForSemiStandardMenuItem(50));
+	// while 50 doesn't quite get to INT32_MAX, make sure the current value math
+	// behaves well on the whole range
+	CHECK_EQUAL(50, computeCurrentValueForStandardMenuItem(INT32_MAX));
+}
+
 TEST(ValueScalingTest, HalfPrecisionValueScaling) {
 	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
 		int32_t finalValue = computeFinalValueForHalfPrecisionMenuItem(i);
@@ -39,26 +59,6 @@ TEST(ValueScalingTest, panValueScaling) {
 	CHECK_EQUAL(INT32_MIN, computeFinalValueForPan(-25));
 	CHECK_EQUAL(0, computeFinalValueForPan(0));
 	CHECK_EQUAL(INT32_MAX, computeFinalValueForPan(25));
-}
-
-TEST(ValueScalingTest, arpMidiCvGateValueScaling) {
-	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
-		int32_t finalValue = computeFinalValueForArpMidiCvGate(i);
-		int32_t currentValue = computeCurrentValueForArpMidiCvGate(finalValue);
-		CHECK_EQUAL(i, currentValue);
-	}
-	CHECK_EQUAL(INT32_MIN, computeFinalValueForArpMidiCvGate(0));
-	CHECK_EQUAL(-23, computeFinalValueForArpMidiCvGate(25));
-	// As seen here, we diverge _slightly_ from the standard
-	// menu item scaling when computing final values, despite roundtripping
-	// and using the identical current value computation.
-	//
-	// See computeFinalValueForArpMidiCvGate()'s comment for possible
-	// motivation.
-	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueForArpMidiCvGate(50));
-	// while 50 doesn't quite get to INT32_MAX, make sure the current value math
-	// behaves well on the whole range
-	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvGate(INT32_MAX));
 }
 
 TEST(ValueScalingTest, consistentArpAndMenuMaxValues) {

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -19,26 +19,6 @@ TEST(ValueScalingTest, standardMenuItemValueScaling) {
 	CHECK_EQUAL(INT32_MAX, computeFinalValueForStandardMenuItem(50));
 }
 
-TEST(ValueScalingTest, withoutRoundingToOne) {
-	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
-		int32_t finalValue = computeFinalValueWithoutRoundingToOne(i);
-		int32_t currentValue = computeCurrentValueForStandardMenuItem(finalValue);
-		CHECK_EQUAL(i, currentValue);
-	}
-	CHECK_EQUAL(INT32_MIN, computeFinalValueWithoutRoundingToOne(0));
-	CHECK_EQUAL(-23, computeFinalValueWithoutRoundingToOne(25));
-	// As seen here, we diverge _slightly_ from the standard
-	// menu item scaling when computing final values, despite roundtripping
-	// and using the identical current value computation.
-	//
-	// See computeFinalValueWithoutRoundingToOne()'s comment for possible
-	// motivation.
-	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueWithoutRoundingToOne(50));
-	// while 50 doesn't quite get to INT32_MAX, make sure the current value math
-	// behaves well on the whole range
-	CHECK_EQUAL(50, computeCurrentValueForStandardMenuItem(INT32_MAX));
-}
-
 TEST(ValueScalingTest, HalfPrecisionValueScaling) {
 	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
 		int32_t finalValue = computeFinalValueForHalfPrecisionMenuItem(i);
@@ -79,18 +59,4 @@ TEST(ValueScalingTest, arpMidiCvRatchetOrRhytmValueScaling) {
 	// while 50 doesn't quite get to UINT32_MAX, make sure the current value math
 	// behaves well on the whole range
 	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvRatchetsOrRhythm(UINT32_MAX));
-}
-
-TEST(ValueScalingTest, arpMidiCvRate) {
-	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
-		int32_t finalValue = computeFinalValueForArpMidiCvRate(i);
-		int32_t currentValue = computeCurrentValueForArpMidiCvRate(finalValue);
-		CHECK_EQUAL(i, currentValue);
-	}
-	CHECK_EQUAL(INT32_MIN, computeFinalValueForArpMidiCvRate(0));
-	CHECK_EQUAL(0, computeFinalValueForArpMidiCvRate(25));
-	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueForArpMidiCvRate(50));
-	// while 50 doesn't quite get to INT32_MAX, make sure the current value math
-	// behaves well on the whole range
-	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvRate(INT32_MAX));
 }

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -19,21 +19,21 @@ TEST(ValueScalingTest, standardMenuItemValueScaling) {
 	CHECK_EQUAL(INT32_MAX, computeFinalValueForStandardMenuItem(50));
 }
 
-TEST(ValueScalingTest, semiStandardValueScaling) {
+TEST(ValueScalingTest, withoutRoundingToOne) {
 	for (int i = kMinMenuValue; i <= kMaxMenuValue; i++) {
-		int32_t finalValue = computeFinalValueForSemiStandardMenuItem(i);
+		int32_t finalValue = computeFinalValueWithoutRoundingToOne(i);
 		int32_t currentValue = computeCurrentValueForStandardMenuItem(finalValue);
 		CHECK_EQUAL(i, currentValue);
 	}
-	CHECK_EQUAL(INT32_MIN, computeFinalValueForSemiStandardMenuItem(0));
-	CHECK_EQUAL(-23, computeFinalValueForSemiStandardMenuItem(25));
+	CHECK_EQUAL(INT32_MIN, computeFinalValueWithoutRoundingToOne(0));
+	CHECK_EQUAL(-23, computeFinalValueWithoutRoundingToOne(25));
 	// As seen here, we diverge _slightly_ from the standard
 	// menu item scaling when computing final values, despite roundtripping
 	// and using the identical current value computation.
 	//
-	// See computeFinalValueForSemiStandardMenuItem()'s comment for possible
+	// See computeFinalValueWithoutRoundingToOne()'s comment for possible
 	// motivation.
-	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueForSemiStandardMenuItem(50));
+	CHECK_EQUAL(INT32_MAX - 45, computeFinalValueWithoutRoundingToOne(50));
 	// while 50 doesn't quite get to INT32_MAX, make sure the current value math
 	// behaves well on the whole range
 	CHECK_EQUAL(50, computeCurrentValueForStandardMenuItem(INT32_MAX));


### PR DESCRIPTION
- fix wrong value in computeFinalValueForArpMidiCvRate() comment

- math is same as in with arp::midi_cv::Gate, rename the shared logic to compute(Current|Final)ValueForSemiStandardMenuItem().

- move the thin wrappers to be inline functions

- delete dead code: computeFinalValueForCompParam()