### PR TITLE
refactor: split SessionView::SelectEncoderAction() into parts

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1161,7 +1161,7 @@ void SessionView::drawSectionRepeatNumber() {
 	}
 }
 
-void SessionView::action_changeSectionRepeats(int8_t offset) {
+void SessionView::commandChangeSectionRepeats(int8_t offset) {
 	if (performActionOnSectionPadRelease) {
 		beginEditingSectionRepeatsNum();
 	}
@@ -1178,7 +1178,7 @@ void SessionView::action_changeSectionRepeats(int8_t offset) {
 	}
 }
 
-void SessionView::action_changeClipPreset(int8_t offset) {
+void SessionView::commandChangeClipPreset(int8_t offset) {
 	performActionOnPadRelease = false;
 
 	if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
@@ -1221,7 +1221,7 @@ void SessionView::action_changeClipPreset(int8_t offset) {
 	}
 }
 
-void SessionView::action_changeCurrentSectionRepeats(int8_t offset) {
+void SessionView::commandChangeCurrentSectionRepeats(int8_t offset) {
 	if (session.hasPlaybackActive()) {
 		if (session.launchEventAtSwungTickCount) {
 			editNumRepeatsTilLaunch(offset);
@@ -1232,26 +1232,26 @@ void SessionView::action_changeCurrentSectionRepeats(int8_t offset) {
 	}
 }
 
-void SessionView::action_changeLayout(int8_t offset) {
+void SessionView::commandChangeLayout(int8_t offset) {
 	return selectLayout(offset);
 }
 
 void SessionView::selectEncoderAction(int8_t offset) {
 	switch (currentUIMode) {
 	case UI_MODE_HOLDING_SECTION_PAD:
-		return action_changeSectionRepeats(offset);
+		return commandChangeSectionRepeats(offset);
 	case UI_MODE_CLIP_PRESSED_IN_SONG_VIEW:
-		return action_changeClipPreset(offset);
+		return commandChangeClipPreset(offset);
 	case UI_MODE_NONE:
 		if (sessionButtonActive) {
 			// TODO: this "held button consumed so no action on release" -logic really needs
 			// to be abstracted somehow. Maybe something like Button::consumeButtonPress() which
 			// removes it from buttonState[] and causes the button-up not to trigger an action?
 			sessionButtonUsed = true;
-			return action_changeLayout(offset);
+			return commandChangeLayout(offset);
 		}
 		else {
-			return action_changeCurrentSectionRepeats(offset);
+			return commandChangeCurrentSectionRepeats(offset);
 		}
 	}
 }

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1161,77 +1161,97 @@ void SessionView::drawSectionRepeatNumber() {
 	}
 }
 
+void SessionView::action_changeSectionRepeats(int8_t offset) {
+	if (performActionOnSectionPadRelease) {
+		beginEditingSectionRepeatsNum();
+	}
+	else {
+		int16_t* numRepetitions = &currentSong->sections[sectionPressed].numRepetitions;
+		*numRepetitions += offset;
+		if (*numRepetitions > 9999) {
+			*numRepetitions = 9999;
+		}
+		else if (*numRepetitions < -1) {
+			*numRepetitions = -1;
+		}
+		drawSectionRepeatNumber();
+	}
+}
+
+void SessionView::action_changeClipPreset(int8_t offset) {
+	performActionOnPadRelease = false;
+
+	if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
+		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_RECORDING_TO_ARRANGEMENT));
+		return;
+	}
+
+	Clip* clip = getClipForLayout();
+
+	if (clip == nullptr) {
+		return;
+	}
+
+	if (clip->type == ClipType::INSTRUMENT) {
+		char modelStackMemory[MODEL_STACK_MAX_SIZE];
+		ModelStackWithTimelineCounter* modelStack =
+		    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, clip);
+
+		switch (currentSong->sessionLayout) {
+		case SessionLayoutType::SessionLayoutTypeRows: {
+			view.navigateThroughPresetsForInstrumentClip(offset, modelStack, true);
+			break;
+		}
+		case SessionLayoutType::SessionLayoutTypeGrid: {
+			Output* oldOutput = clip->output;
+			Output* newOutput = currentSong->navigateThroughPresetsForInstrument(oldOutput, offset);
+			if (oldOutput != newOutput) {
+				view.setActiveModControllableTimelineCounter(newOutput->activeClip);
+				requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
+			}
+			break;
+		}
+		}
+	}
+	else {
+		// This moves clips around uncomfortably and we have a track for every Audio anyway
+		if (currentSong->sessionLayout != SessionLayoutType::SessionLayoutTypeGrid) {
+			view.navigateThroughAudioOutputsForAudioClip(offset, (AudioClip*)clip, true);
+		}
+	}
+}
+
+void SessionView::action_changeCurrentSectionRepeats(int8_t offset) {
+	if (session.hasPlaybackActive()) {
+		if (session.launchEventAtSwungTickCount) {
+			editNumRepeatsTilLaunch(offset);
+		}
+		else if (offset == 1) {
+			session.userWantsToArmNextSection(1);
+		}
+	}
+}
+
+void SessionView::action_changeLayout(int8_t offset) {
+	return selectLayout(offset);
+}
+
 void SessionView::selectEncoderAction(int8_t offset) {
-	if (currentUIMode == UI_MODE_HOLDING_SECTION_PAD) {
-		if (performActionOnSectionPadRelease) {
-			beginEditingSectionRepeatsNum();
+	switch (currentUIMode) {
+	case UI_MODE_HOLDING_SECTION_PAD:
+		return action_changeSectionRepeats(offset);
+	case UI_MODE_CLIP_PRESSED_IN_SONG_VIEW:
+		return action_changeClipPreset(offset);
+	case UI_MODE_NONE:
+		if (sessionButtonActive) {
+			// TODO: this "held button consumed so no action on release" -logic really needs
+			// to be abstracted somehow. Maybe something like Button::consumeButtonPress() which
+			// removes it from buttonState[] and causes the button-up not to trigger an action?
+			sessionButtonUsed = true;
+			return action_changeLayout(offset);
 		}
 		else {
-			int16_t* numRepetitions = &currentSong->sections[sectionPressed].numRepetitions;
-			*numRepetitions += offset;
-			if (*numRepetitions > 9999) {
-				*numRepetitions = 9999;
-			}
-			else if (*numRepetitions < -1) {
-				*numRepetitions = -1;
-			}
-			drawSectionRepeatNumber();
-		}
-	}
-	else if (currentUIMode == UI_MODE_CLIP_PRESSED_IN_SONG_VIEW) {
-		performActionOnPadRelease = false;
-
-		if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
-			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_RECORDING_TO_ARRANGEMENT));
-			return;
-		}
-
-		Clip* clip = getClipForLayout();
-
-		if (clip == nullptr) {
-			return;
-		}
-
-		if (clip->type == ClipType::INSTRUMENT) {
-			char modelStackMemory[MODEL_STACK_MAX_SIZE];
-			ModelStackWithTimelineCounter* modelStack =
-			    setupModelStackWithTimelineCounter(modelStackMemory, currentSong, clip);
-
-			switch (currentSong->sessionLayout) {
-			case SessionLayoutType::SessionLayoutTypeRows: {
-				view.navigateThroughPresetsForInstrumentClip(offset, modelStack, true);
-				break;
-			}
-			case SessionLayoutType::SessionLayoutTypeGrid: {
-				Output* oldOutput = clip->output;
-				Output* newOutput = currentSong->navigateThroughPresetsForInstrument(oldOutput, offset);
-				if (oldOutput != newOutput) {
-					view.setActiveModControllableTimelineCounter(newOutput->activeClip);
-					requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
-				}
-				break;
-			}
-			}
-		}
-		else {
-			// This moves clips around uncomfortably and we have a track for every Audio anyway
-			if (currentSong->sessionLayout != SessionLayoutType::SessionLayoutTypeGrid) {
-				view.navigateThroughAudioOutputsForAudioClip(offset, (AudioClip*)clip, true);
-			}
-		}
-	}
-	else if (currentUIMode == UI_MODE_NONE && sessionButtonActive) {
-		sessionButtonUsed = true;
-		selectLayout(offset);
-	}
-	else if (currentUIMode == UI_MODE_NONE) {
-		if (session.hasPlaybackActive()) {
-			if (session.launchEventAtSwungTickCount) {
-				editNumRepeatsTilLaunch(offset);
-			}
-			else if (offset == 1) {
-				session.userWantsToArmNextSection(1);
-			}
+			return action_changeCurrentSectionRepeats(offset);
 		}
 	}
 }

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -122,6 +122,13 @@ public:
 	UIType getUIType() { return UIType::SESSION_VIEW; }
 
 private:
+	// selectEncoderAction() ..actions
+	void action_changeSectionRepeats(int8_t offset);
+	void action_changeClipPreset(int8_t offset);
+	void action_changeCurrentSectionRepeats(int8_t offset);
+	void action_changeLayout(int8_t offset);
+
+private:
 	void renderViewDisplay(char const* viewString);
 	void sectionPadAction(uint8_t y, bool on);
 	void clipPressEnded();

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -122,11 +122,14 @@ public:
 	UIType getUIType() { return UIType::SESSION_VIEW; }
 
 private:
-	// selectEncoderAction() ..actions
-	void action_changeSectionRepeats(int8_t offset);
-	void action_changeClipPreset(int8_t offset);
-	void action_changeCurrentSectionRepeats(int8_t offset);
-	void action_changeLayout(int8_t offset);
+	// These and other (future) commandXXX methods perform actions triggered by HID, but contain
+	// no dispatch logic.
+	//
+	// selectEncoderAction() triggered commands
+	void commandChangeSectionRepeats(int8_t offset);
+	void commandChangeClipPreset(int8_t offset);
+	void commandChangeCurrentSectionRepeats(int8_t offset);
+	void commandChangeLayout(int8_t offset);
 
 private:
 	void renderViewDisplay(char const* viewString);

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -1,6 +1,6 @@
 #include "CppUTest/TestHarness.h"
-#include "model/scale/note_set.h"
 #include "model/scale/musical_key.h"
+#include "model/scale/note_set.h"
 #include "model/scale/utils.h"
 
 TEST_GROUP(NoteSetTest){};


### PR DESCRIPTION
- each distinct action has its own function, with action_ prefix

- use switch to dispatch on the UI mode for more clarity