### PR TITLE
Windows configuration for VS code

### DIFF
--- a/IDE_Configs/vscode/c_cpp_properties.json
+++ b/IDE_Configs/vscode/c_cpp_properties.json
@@ -52,7 +52,32 @@
         "${default}"
       ],
       "compileCommands": "${workspaceFolder}/build/compile_commands.json"
-    }
+    },
+    {
+        "name": "Windows",
+        "includePath": [
+          "src/**",
+          "${default}"
+        ],
+        "compilerPath": "${workspaceFolder}/toolchain/v16/win32-x86_64/arm-none-eabi-gcc/bin/arm-none-eabi-gcc",
+        "compilerArgs": [
+          "-mcpu=cortex-a9",
+          "-marm",
+          "-mthumb-interwork",
+          "-mlittle-endian",
+          "-mfloat-abi=hard",
+          "-mfpu=neon",
+          "-DHAVE_OLED=1"
+        ],
+        "cStandard": "gnu17",
+        "cppStandard": "gnu++20",
+        "intelliSenseMode": "gcc-arm",
+        "defines": [
+          "HAVE_OLED=1",
+          "${default}"
+        ],
+        "compileCommands": "${workspaceFolder}/build/compile_commands.json"
+      }
   ],
   "version": 4
 }

--- a/IDE_Configs/vscode/tasks.json
+++ b/IDE_Configs/vscode/tasks.json
@@ -91,6 +91,9 @@
 			"label": "Format source",
 			"problemMatcher": [],
 			"command": "./dbt",
+			"windows": {
+				"command": "./dbt.cmd",
+			},
 			"args": [
 				"format",
 			]


### PR DESCRIPTION
- There's still something funny about building from within VS Code: near the end I get complaints about missing temp object files which appear in deluge.map, but build still seems to succeed. The same complaints do not appear when building from within Git Bash.