### PR TITLE
fix first build after clean

### DIFF
--- a/src/deluge/CMakeLists.txt
+++ b/src/deluge/CMakeLists.txt
@@ -21,6 +21,10 @@ add_dependencies(deluge deluge_menus)
 
 target_sources(deluge PUBLIC
   ${deluge_SOURCES}
+  # Add strings-sources explicitly: since they're build artefacts clean nukes them,
+  # and if they're not there in the first place then the source glob won't find them,
+  # and they only get generated not built.
+  ${deluge_strings_SOURCES}
 )
 
 target_include_directories(deluge PUBLIC


### PR DESCRIPTION
- Clean nukes the g_english.cpp & friends, so the glob won't see them, The dependency on deluge_strings still generates them, but for them to be built they need to be in place before the source glob. Just moving the add_dependency() earlier is not enoough: they're not generated until the build is running, and by that time we need the sources list already.