### PR TITLE
chore: delete empty InstrumentClipMinder::opened

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -717,7 +717,6 @@ void KeyboardScreen::exitAuditionMode() {
 bool KeyboardScreen::opened() {
 	focusRegained();
 	openedInBackground();
-	InstrumentClipMinder::opened();
 	return true;
 }
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -129,8 +129,6 @@ bool InstrumentClipView::opened() {
 
 	openedInBackground();
 
-	InstrumentClipMinder::opened();
-
 	focusRegained();
 
 	return true;

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -322,9 +322,6 @@ void InstrumentClipMinder::setLedStates() {
 	playbackHandler.setLedStates();
 }
 
-void InstrumentClipMinder::opened() {
-}
-
 void InstrumentClipMinder::focusRegained() {
 	view.focusRegained();
 	view.setActiveModControllableTimelineCounter(getCurrentInstrumentClip());

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -49,7 +49,6 @@ public:
 	static void drawMIDIControlNumber(int32_t controlNumber, bool automationExists);
 	static bool makeCurrentClipActiveOnInstrumentIfPossible(ModelStack* modelStack);
 	bool changeOutputType(OutputType newOutputType);
-	void opened();
 
 	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas);
 


### PR DESCRIPTION
This hook was completely unused, so delete it and its callsites