### PR TITLE
view: move responsibility for triplets LED to UI classes

### DIFF
--- a/src/deluge/gui/ui/root_ui.h
+++ b/src/deluge/gui/ui/root_ui.h
@@ -34,7 +34,6 @@ public:
 	virtual uint32_t getGreyedOutRowsNotRepresentingOutput(Output* output) { return 0; }
 	virtual void noteRowChanged(InstrumentClip* clip, NoteRow* noteRow) {}
 	virtual void playbackEnded() {}
-	virtual bool isTimelineView() { return false; }
 	virtual void clipNeedsReRendering(Clip* clip) {}
 	virtual void sampleNeedsReRendering(Sample* sample) {}
 	virtual void midiLearnFlash() {}

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -143,11 +143,6 @@ RootUI* getRootUI() {
 	return (RootUI*)uiNavigationHierarchy[0];
 }
 
-bool rootUIIsTimelineView() {
-	RootUI* rootUI = getRootUI();
-	return (rootUI && rootUI->isTimelineView());
-}
-
 bool currentUIIsClipMinderScreen() {
 	UI* currentUI = getCurrentUI();
 	return (currentUI && currentUI->toClipMinder());

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -22,9 +22,10 @@
 #include "hid/button.h"
 #include "hid/display/oled_canvas/canvas.h"
 
-class RootUI;
 class ClipMinder;
 class MIDIDevice;
+class RootUI;
+class TimelineView;
 
 extern uint32_t currentUIMode;
 extern bool pendingUIRenderingLock;
@@ -115,6 +116,12 @@ public:
 	/// Convert this clip to a clip minder. Returns true for views which manage a single clip,
 	/// false for song level views
 	virtual ClipMinder* toClipMinder() { return NULL; }
+
+	/// \brief Convert this view to a TimelineView
+	///
+	/// \return \c nullptr if the view is not a TimelineView, otherwise \c this cast to a TimelineView
+	virtual TimelineView* toTimelineView() { return nullptr; }
+
 	virtual void scrollFinished() {}
 	virtual const char* getName() { return "UI"; }
 	virtual bool pcReceivedForMidiLearn(MIDIDevice* fromDevice, int32_t channel, int32_t program) { return false; }
@@ -166,7 +173,6 @@ bool isUIOpen(UI* ui);
 void setRootUILowLevel(UI* newUI);
 void swapOutRootUILowLevel(UI* newUI);
 void nullifyUIs();
-bool rootUIIsTimelineView();
 bool currentUIIsClipMinderScreen();
 bool rootUIIsClipMinderScreen();
 std::pair<uint32_t, uint32_t> getUIGreyoutColsAndRows();

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -21,6 +21,7 @@
 #include "gui/views/view.h"
 #include "hid/buttons.h"
 #include "hid/display/display.h"
+#include "hid/led/indicator_leds.h"
 #include "hid/led/pad_leds.h"
 #include "model/settings/runtime_feature_settings.h"
 #include "model/song/song.h"
@@ -391,7 +392,11 @@ void TimelineView::tripletsButtonPressed() {
 		currentSong->tripletsLevel = currentSong->xZoom[getNavSysId()] * 4 / 3;
 	}
 	uiNeedsRendering(this, 0xFFFFFFFF, 0);
-	view.setTripletsLedState();
+	setTripletsLEDState();
+}
+
+void TimelineView::setTripletsLEDState() {
+	indicator_leds::setLedState(IndicatorLED::TRIPLETS, inTripletsView());
 }
 
 int32_t TimelineView::getPosFromSquare(int32_t square, int32_t xScroll, uint32_t xZoom) const {

--- a/src/deluge/gui/views/timeline_view.h
+++ b/src/deluge/gui/views/timeline_view.h
@@ -30,6 +30,8 @@ public:
 
 	void scrollFinished();
 
+	TimelineView* toTimelineView() final { return this; }
+
 	const char* getName() { return "timeline_view"; }
 	virtual uint32_t getMaxZoom() = 0;
 	virtual bool calculateZoomPinSquares(uint32_t oldScroll, uint32_t newScroll, uint32_t newZoom,
@@ -40,7 +42,6 @@ public:
 
 	virtual void tellMatrixDriverWhichRowsContainSomethingZoomable() {
 	} // SessionView doesn't have this because it does this a different way. Sorry, confusing I know
-	bool isTimelineView() { return true; }
 
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	void displayZoomLevel(bool justPopup = false);
@@ -58,6 +59,7 @@ public:
 	bool scrollLeftIfTooFarRight(int32_t maxLength);
 
 	void tripletsButtonPressed();
+	void setTripletsLEDState();
 
 	[[nodiscard]] int32_t getPosFromSquare(int32_t square, int32_t localScroll = -1) const;
 	[[nodiscard]] int32_t getPosFromSquare(int32_t square, int32_t xScroll, uint32_t xZoom) const;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -112,7 +112,9 @@ View::View() {
 
 void View::focusRegained() {
 	uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
-	setTripletsLedState();
+	if (auto* timeline = getCurrentUI()->toTimelineView()) {
+		timeline->setTripletsLEDState();
+	}
 
 	indicator_leds::setLedState(IndicatorLED::LOAD, false);
 	indicator_leds::setLedState(IndicatorLED::SAVE, false);
@@ -123,13 +125,6 @@ void View::focusRegained() {
 	renderedVUMeter = false;
 	cachedMaxYDisplayForVUMeterL = 255;
 	cachedMaxYDisplayForVUMeterR = 255;
-}
-
-void View::setTripletsLedState() {
-	RootUI* rootUI = getRootUI();
-
-	indicator_leds::setLedState(IndicatorLED::TRIPLETS,
-	                            rootUI->isTimelineView() && ((TimelineView*)rootUI)->inTripletsView());
 }
 
 extern GlobalMIDICommand pendingGlobalMIDICommandNumClustersWritten;
@@ -940,7 +935,7 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				    modelStackWithParam->modControllable->allowNoteTails(tempModelStack->addSoundFlags());
 
 				if (noteTailsAllowedBefore != noteTailsAllowedAfter) {
-					if (getRootUI() && getRootUI()->isTimelineView()) {
+					if (getRootUI() && getRootUI()->toTimelineView() != nullptr) {
 						uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0);
 					}
 				}

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -47,11 +47,11 @@ class Kit;
 // A view is where the user can interact with the pads - song view, Clip view, automation view and keyboard view.
 // (Is that still a good description? This class is a bit of a mishmash of poorly organised code, sorry.)
 
+/// Assorted utilities for manging the user interface.
 class View {
 public:
 	View();
 	void focusRegained();
-	void setTripletsLedState();
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	void setTimeBaseScaleLedState();
 	void setLedStates();

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -712,7 +712,9 @@ currentClipSwitchedOver:
 			else if (getCurrentUI() == &sessionView) {
 				sessionView.setLedStates();
 			}
-			view.setTripletsLedState();
+			if (auto* timelineView = getCurrentUI()->toTimelineView()) {
+				timelineView->setTripletsLEDState();
+			}
 		}
 	}
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -289,8 +289,10 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 	    || (getRootUI() == &arrangerView && recording == RecordingMode::NORMAL)) {
 
 		int32_t navSys;
-		if (getRootUI() && getRootUI()->isTimelineView()) {
-			navSys = ((TimelineView*)getRootUI())->getNavSysId();
+		if (getRootUI()) {
+			if (auto* timelineView = getRootUI()->toTimelineView()) {
+				navSys = timelineView->getNavSysId();
+			}
 		}
 		else {
 			navSys = NAVIGATION_CLIP; // Keyboard view will cause this case


### PR DESCRIPTION
Cleans up a bunch of random stuff that was blindly casting RootUIs and UIs to TimelineViews