### PR TITLE
Bugfix/make activeClip private, fix associated bugs

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -275,7 +275,7 @@ void KeyboardScreen::updateActiveNotes() {
 		}
 
 		// Ensure the note the user is trying to sound isn't already sounding
-		NoteRow* noteRow = ((InstrumentClip*)activeInstrument->activeClip)->getNoteRowForYNote(newNote);
+		NoteRow* noteRow = ((InstrumentClip*)activeInstrument->getActiveClip())->getNoteRowForYNote(newNote);
 		if (noteRow) {
 			if (noteRow->soundingStatus == STATUS_SEQUENCED_NOTE) {
 				continue;
@@ -369,7 +369,7 @@ void KeyboardScreen::updateActiveNotes() {
 
 void KeyboardScreen::noteOff(ModelStack& modelStack, Instrument& activeInstrument, bool clipIsActiveOnInstrument,
                              int32_t note) {
-	NoteRow* noteRow = (static_cast<InstrumentClip*>(activeInstrument.activeClip))->getNoteRowForYNote(note);
+	NoteRow* noteRow = (static_cast<InstrumentClip*>(activeInstrument.getActiveClip()))->getNoteRowForYNote(note);
 	if (noteRow) {
 		if (noteRow->soundingStatus == STATUS_SEQUENCED_NOTE) {
 			return; // Note was activated by sequence

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -1005,7 +1005,7 @@ giveUsedError:
 	}
 	else {
 		currentSong->instrumentSwapped(newInstrument);
-		view.setActiveModControllableTimelineCounter(newInstrument->activeClip);
+		view.setActiveModControllableTimelineCounter(newInstrument->getActiveClip());
 	}
 
 	instrumentToReplace = newInstrument;

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -654,13 +654,13 @@ drawNormally:
 
 ModelStackWithNoteRow* ArrangerView::getNoteRowForAudition(ModelStack* modelStack, Kit* kit) {
 
-	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(kit->activeClip);
+	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(kit->getActiveClip());
 
 	ModelStackWithNoteRow* modelStackWithNoteRow;
 
-	if (kit->activeClip) {
+	if (kit->getActiveClip()) {
 
-		InstrumentClip* instrumentClip = (InstrumentClip*)kit->activeClip;
+		InstrumentClip* instrumentClip = (InstrumentClip*)kit->getActiveClip();
 		modelStackWithNoteRow = instrumentClip->getNoteRowForDrumName(modelStackWithTimelineCounter, "SNAR");
 		if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
 			if (kit->selectedDrum) {
@@ -885,8 +885,8 @@ doNewPress:
 
 			beginAudition(output);
 
-			if (output->activeClip) {
-				view.setActiveModControllableTimelineCounter(output->activeClip);
+			if (output->getActiveClip()) {
+				view.setActiveModControllableTimelineCounter(output->getActiveClip());
 			}
 			else {
 				view.setActiveModControllableWithoutTimelineCounter(output->toModControllable(),
@@ -1165,9 +1165,9 @@ void ArrangerView::outputDeactivated(Output* output) {
 	output->stopAnyAuditioning(modelStack);
 
 	if (arrangement.hasPlaybackActive()) {
-		if (output->activeClip && !output->recordingInArrangement) {
-			output->activeClip->expectNoFurtherTicks(currentSong);
-			output->activeClip->activeIfNoSolo = false;
+		if (output->getActiveClip() && !output->recordingInArrangement) {
+			output->getActiveClip()->expectNoFurtherTicks(currentSong);
+			output->getActiveClip()->activeIfNoSolo = false;
 		}
 	}
 }
@@ -1629,7 +1629,7 @@ justGetOut:
 								// Crucial that we do this not long after calling setInstrument, in case this is the
 								// first Clip with the Instrument and we just grabbed the backedUpParamManager for it,
 								// which it might go and look for again if the audio routine was called in the interim
-								if (!output->activeClip) {
+								if (!output->getActiveClip()) {
 									output->setActiveClip(modelStack);
 								}
 
@@ -2468,7 +2468,7 @@ void ArrangerView::navigateThroughPresets(int32_t offset) {
 
 	outputsOnScreen[yPressedEffective] = output;
 
-	view.setActiveModControllableTimelineCounter(output->activeClip);
+	view.setActiveModControllableTimelineCounter(output->getActiveClip());
 
 	AudioEngine::routineWithClusterLoading();
 
@@ -2501,7 +2501,7 @@ void ArrangerView::changeOutputType(OutputType newOutputType) {
 	indicator_leds::setLedState(IndicatorLED::MIDI, false);
 	indicator_leds::setLedState(IndicatorLED::CV, false);
 	view.displayOutputName(newInstrument);
-	view.setActiveModControllableTimelineCounter(newInstrument->activeClip);
+	view.setActiveModControllableTimelineCounter(newInstrument->getActiveClip());
 
 	beginAudition(newInstrument);
 }
@@ -3082,7 +3082,7 @@ void ArrangerView::graphicsRoutine() {
 
 void ArrangerView::notifyActiveClipChangedOnOutput(Output* output) {
 	if (currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION && outputsOnScreen[yPressedEffective] == output) {
-		view.setActiveModControllableTimelineCounter(output->activeClip);
+		view.setActiveModControllableTimelineCounter(output->getActiveClip());
 	}
 }
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3355,13 +3355,13 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 		else {
 			// Kit
 			if (isKit) {
-				noteRowOnActiveClip = ((InstrumentClip*)output->activeClip)->getNoteRowForDrum(drum);
+				noteRowOnActiveClip = ((InstrumentClip*)output->getActiveClip())->getNoteRowForDrum(drum);
 			}
 
 			// Non-kit
 			else {
 				int32_t yNote = clip->getYNoteFromYDisplay(yDisplay, currentSong);
-				noteRowOnActiveClip = ((InstrumentClip*)output->activeClip)->getNoteRowForYNote(yNote);
+				noteRowOnActiveClip = ((InstrumentClip*)output->getActiveClip())->getNoteRowForYNote(yNote);
 			}
 		}
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3009,10 +3009,10 @@ void InstrumentClipView::sendAuditionNote(bool on, uint8_t yDisplay, uint8_t vel
 
 			if (drum) {
 
-				if (getCurrentClip() != instrument->activeClip) {
-					modelStackWithTimelineCounter->setTimelineCounter(instrument->activeClip);
+				if (getCurrentClip() != instrument->getActiveClip()) {
+					modelStackWithTimelineCounter->setTimelineCounter(instrument->getActiveClip());
 					modelStackWithNoteRow =
-					    ((InstrumentClip*)instrument->activeClip)
+					    ((InstrumentClip*)instrument->getActiveClip())
 					        ->getNoteRowForDrum(modelStackWithTimelineCounter, drum); // On *active* clip!
 					if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
 						return;
@@ -3415,7 +3415,7 @@ void InstrumentClipView::setSelectedDrum(Drum* drum, bool shouldRedrawStuff, Kit
 		// make sure we're dealing with the same clip that this kit is a part of
 		// if you selected a clip and then sent a midi note to a kit that is part of a different clip, well
 		// we don't need to do anything here because we're in a different clip
-		if (clip == kit->activeClip) {
+		if (clip == kit->getActiveClip()) {
 			// let's make sure that that the output type for that clip is a kit
 			//(if for some strange reason you changed the drum selection for a hibernated instrument...)
 			if (clip->output->type == OutputType::KIT) {
@@ -3713,13 +3713,13 @@ NoteRow* InstrumentClipView::getNoteRowOnActiveClip(int32_t yDisplay, Instrument
 	else {
 		// Kit
 		if (instrument->type == OutputType::KIT) {
-			noteRowOnActiveClip = ((InstrumentClip*)instrument->activeClip)->getNoteRowForDrum(drum);
+			noteRowOnActiveClip = ((InstrumentClip*)instrument->getActiveClip())->getNoteRowForDrum(drum);
 		}
 
 		// Non-kit
 		else {
 			int32_t yNote = getCurrentInstrumentClip()->getYNoteFromYDisplay(yDisplay, currentSong);
-			noteRowOnActiveClip = ((InstrumentClip*)instrument->activeClip)->getNoteRowForYNote(yNote);
+			noteRowOnActiveClip = ((InstrumentClip*)instrument->getActiveClip())->getNoteRowForYNote(yNote);
 		}
 	}
 	return noteRowOnActiveClip;
@@ -5579,14 +5579,14 @@ void InstrumentClipView::modEncoderAction(int32_t whichModEncoder, int32_t offse
 
 		if (kit->selectedDrum && kit->selectedDrum->type != DrumType::SOUND) {
 
-			if (ALPHA_OR_BETA_VERSION && !kit->activeClip) {
+			if (ALPHA_OR_BETA_VERSION && !kit->getActiveClip()) {
 				FREEZE_WITH_ERROR("E381");
 			}
 
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-			    modelStack->addTimelineCounter(kit->activeClip);
+			    modelStack->addTimelineCounter(kit->getActiveClip());
 			ModelStackWithNoteRow* modelStackWithNoteRow =
-			    ((InstrumentClip*)kit->activeClip)
+			    ((InstrumentClip*)kit->getActiveClip())
 			        ->getNoteRowForDrum(modelStackWithTimelineCounter,
 			                            kit->selectedDrum); // The NoteRow probably doesn't get referred to...
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -588,7 +588,7 @@ doActualSimpleChange:
 								Instrument* newInstrument = currentSong->changeOutputType(instrument, newOutputType);
 								if (newInstrument) {
 									view.displayOutputName(newInstrument);
-									view.setActiveModControllableTimelineCounter(newInstrument->activeClip);
+									view.setActiveModControllableTimelineCounter(newInstrument->getActiveClip());
 								}
 							}
 							break;
@@ -1237,7 +1237,7 @@ void SessionView::commandChangeClipPreset(int8_t offset) {
 			Output* oldOutput = clip->output;
 			Output* newOutput = currentSong->navigateThroughPresetsForInstrument(oldOutput, offset);
 			if (oldOutput != newOutput) {
-				view.setActiveModControllableTimelineCounter(newOutput->activeClip);
+				view.setActiveModControllableTimelineCounter(newOutput->getActiveClip());
 				requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 			}
 			break;
@@ -1648,7 +1648,7 @@ doGetInstrument:
 	}
 
 	// Possibly want to set this as the active Clip...
-	if (!newClip->output->activeClip) {
+	if (!newClip->output->getActiveClip()) {
 		newClip->output->setActiveClip(modelStackWithTimelineCounter);
 	}
 
@@ -3008,8 +3008,8 @@ Clip* SessionView::gridCreateClipInTrack(Output* targetOutput) {
 		}
 	}
 
-	if (sourceClip == nullptr && targetOutput->activeClip != nullptr) {
-		sourceClip = targetOutput->activeClip;
+	if (sourceClip == nullptr && targetOutput->getActiveClip() != nullptr) {
+		sourceClip = targetOutput->getActiveClip();
 	}
 
 	if (sourceClip == nullptr) {
@@ -3074,7 +3074,7 @@ bool SessionView::gridCreateNewTrackForClip(OutputType type, InstrumentClip* cli
 		currentSong->addOutput(clip->output);
 	}
 
-	if (!clip->output->activeClip) {
+	if (!clip->output->getActiveClip()) {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
 
@@ -3226,7 +3226,7 @@ Clip* SessionView::gridCreateClip(uint32_t targetSection, Output* targetOutput, 
 	}
 
 	// Set to active for new tracks
-	if (targetOutput == nullptr && !newClip->output->activeClip) {
+	if (targetOutput == nullptr && !newClip->output->getActiveClip()) {
 		newClip->output->setActiveClip(modelStack);
 	}
 	// set it active in the song
@@ -3863,7 +3863,7 @@ const uint32_t SessionView::gridTrackCount() {
 	uint32_t count = 0;
 	Output* currentTrack = currentSong->firstOutput;
 	while (currentTrack != nullptr) {
-		if (currentTrack->activeClip != nullptr) {
+		if (currentTrack->getActiveClip() != nullptr) {
 			++count;
 		}
 		currentTrack = currentTrack->next;
@@ -3894,7 +3894,7 @@ uint32_t SessionView::gridTrackIndexFromTrack(Output* track, uint32_t maxTrack) 
 		if (ptrOutput == track) {
 			return ((maxTrack - 1) - reverseOutputIndex);
 		}
-		if (ptrOutput->activeClip != nullptr) {
+		if (ptrOutput->getActiveClip() != nullptr) {
 			++reverseOutputIndex;
 		}
 	}
@@ -3905,7 +3905,7 @@ Output* SessionView::gridTrackFromIndex(uint32_t trackIndex, uint32_t maxTrack) 
 	uint32_t count = 0;
 	Output* currentTrack = currentSong->firstOutput;
 	while (currentTrack != nullptr) {
-		if (currentTrack->activeClip != nullptr) {
+		if (currentTrack->getActiveClip() != nullptr) {
 			if (((maxTrack - 1) - count) == trackIndex) {
 				return currentTrack;
 			}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -654,7 +654,7 @@ isMPEZone:
 				newBendRanges[BEND_RANGE_FINGER_LEVEL] = fromDevice->mpeZoneBendRanges[zone][BEND_RANGE_FINGER_LEVEL];
 
 				if (newBendRanges[BEND_RANGE_FINGER_LEVEL]) {
-					InstrumentClip* clip = (InstrumentClip*)instrumentPressedForMIDILearn->activeClip;
+					InstrumentClip* clip = (InstrumentClip*)instrumentPressedForMIDILearn->getActiveClip();
 					if (!clip || !clip->hasAnyPitchExpressionAutomationOnNoteRows()) {
 						if (paramManager) { // Could be NULL, e.g. for CVInstruments with no Clips
 							ExpressionParamSet* expressionParams = paramManager->getOrCreateExpressionParamSet();
@@ -754,7 +754,7 @@ void View::clearMelodicInstrumentMonoExpressionIfPossible() {
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithParamCollection* modelStack =
 			    setupModelStackWithSong(modelStackMemory, currentSong)
-			        ->addTimelineCounter(instrumentPressedForMIDILearn->activeClip) // Could be NULL
+			        ->addTimelineCounter(instrumentPressedForMIDILearn->getActiveClip()) // Could be NULL
 			        ->addOtherTwoThingsButNoNoteRow(instrumentPressedForMIDILearn->toModControllable(), paramManager)
 			        ->addParamCollection(expressionParams, expressionParamsSummary);
 
@@ -2288,7 +2288,7 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 		// If we want to "replace" the old Instrument, we can instead sneakily just modify its channel
 		if (shouldReplaceWholeInstrument) {
 			if (playbackHandler.isEitherClockActive()) {
-				clip->output->activeClip->expectNoFurtherTicks(modelStack->song);
+				clip->output->getActiveClip()->expectNoFurtherTicks(modelStack->song);
 			}
 
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -125,7 +125,7 @@ Clip* MidiFollow::getSelectedOrActiveClip() {
 		if (clip) {
 			Output* output = clip->output;
 			if (output) {
-				clip = output->activeClip;
+				clip = output->getActiveClip();
 			}
 		}
 	}
@@ -185,7 +185,7 @@ Clip* MidiFollow::getActiveClip(ModelStack* modelStack) {
 	if (currentClip && (currentClip->type == ClipType::INSTRUMENT)) {
 		if (currentClip->output) {
 			InstrumentClipMinder::makeCurrentClipActiveOnInstrumentIfPossible(modelStack);
-			return currentClip->output->activeClip;
+			return currentClip->output->getActiveClip();
 		}
 	}
 	return nullptr;

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -768,8 +768,8 @@ void AudioClip::unassignVoiceSample(bool wontBeUsedAgain) {
 void AudioClip::expectNoFurtherTicks(Song* song, bool actuallySoundChange) {
 
 	// If it's actually another Clip, that we're recording into the arranger...
-	if (output->activeClip && output->activeClip->beingRecordedFromClip == this) {
-		output->activeClip->expectNoFurtherTicks(song, actuallySoundChange);
+	if (output->getActiveClip() && output->getActiveClip()->beingRecordedFromClip == this) {
+		output->getActiveClip()->expectNoFurtherTicks(song, actuallySoundChange);
 		return;
 	}
 

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -122,6 +122,8 @@ protected:
 	bool cloneOutput(ModelStackWithTimelineCounter* modelStack) override;
 
 private:
+	AudioClip* nextClipInSection;
+	void removeClipFromSection(AudioClip* clip);
 	void detachAudioClipFromOutput(Song* song, bool shouldRetainLinksToOutput, bool shouldTakeParamManagerWith = false);
 	LoopType getLoopingType(ModelStackWithTimelineCounter const* modelStack);
 };

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -206,7 +206,7 @@ bool Clip::isArrangementOnlyClip() const {
 }
 
 bool Clip::isActiveOnOutput() {
-	return (output->activeClip == this);
+	return (output->getActiveClip() == this);
 }
 
 // Note: it's now the caller's job to increment currentPos before calling this! But we check here whether it's looped
@@ -455,8 +455,8 @@ void Clip::setPosForParamManagers(ModelStackWithTimelineCounter* modelStack, boo
 }
 
 Clip* Clip::getClipToRecordTo() {
-	if (output->activeClip && output->activeClip->beingRecordedFromClip == this) {
-		return output->activeClip;
+	if (output->getActiveClip() && output->getActiveClip()->beingRecordedFromClip == this) {
+		return output->getActiveClip();
 	}
 	else {
 		return this;
@@ -901,7 +901,7 @@ yesMakeItActive:
 	else {
 		// In any case, we want the newInstrument to have an activeClip, and if it doesn't yet have one, the supplied
 		// Clip makes a perfect candidate
-		if (!newOutput->activeClip) {
+		if (!newOutput->getActiveClip()) {
 			goto yesMakeItActive;
 		}
 	}
@@ -1057,8 +1057,8 @@ bool Clip::possiblyCloneForArrangementRecording(ModelStackWithTimelineCounter* m
 	if (playbackHandler.recording == RecordingMode::ARRANGEMENT && playbackHandler.isEitherClockActive()
 	    && !isArrangementOnlyClip() && modelStack->song->isClipActive(this)) {
 
-		if (output->activeClip && output->activeClip->beingRecordedFromClip == this) {
-			modelStack->setTimelineCounter(output->activeClip);
+		if (output->getActiveClip() && output->getActiveClip()->beingRecordedFromClip == this) {
+			modelStack->setTimelineCounter(output->getActiveClip());
 		}
 
 		else {

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1144,8 +1144,8 @@ void InstrumentClip::resumePlayback(ModelStackWithTimelineCounter* modelStack, b
 void InstrumentClip::expectNoFurtherTicks(Song* song, bool actuallySoundChange) {
 
 	// If it's actually another Clip, that we're recording into the arranger...
-	if (output->activeClip && output->activeClip->beingRecordedFromClip == this) {
-		output->activeClip->expectNoFurtherTicks(song, actuallySoundChange);
+	if (output->getActiveClip() && output->getActiveClip()->beingRecordedFromClip == this) {
+		output->getActiveClip()->expectNoFurtherTicks(song, actuallySoundChange);
 		return;
 	}
 
@@ -1736,7 +1736,7 @@ Error InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelStack
 	// If newInstrument has no activeClip, we must set that right now before the audio routine is called - otherwise it
 	// won't be able to find its ParamManager. This prevents a crash if we just navigated this Clip into this Instrument
 	// and it already existed and had no Clips
-	if (!newInstrument->activeClip) {
+	if (!newInstrument->getActiveClip()) {
 		newInstrument->setActiveClip(modelStack, PgmChangeSend::NEVER);
 	}
 

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -91,7 +91,7 @@ Error ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) {
 			}
 		}
 
-		if (!clip->output->activeClip) {
+		if (!clip->output->getActiveClip()) {
 			clip->output->setActiveClip(
 			    modelStackWithTimelineCounter); // Must do this to avoid E170 error. If Instrument has no
 			                                    // backedUpParamManager, it must have an activeClip

--- a/src/deluge/model/instrument/cv_instrument.cpp
+++ b/src/deluge/model/instrument/cv_instrument.cpp
@@ -98,23 +98,27 @@ bool CVInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmC
 	bool clipChanged = NonAudioInstrument::setActiveClip(modelStack, maySendMIDIPGMs);
 
 	if (clipChanged) {
-		ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
-		ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
-		if (expressionParams) {
-			monophonicPitchBendValue = expressionParams->params[0].getCurrentValue();
+		if (modelStack) {
 
-			cachedBendRanges[BEND_RANGE_MAIN] = expressionParams->bendRanges[BEND_RANGE_MAIN];
-			cachedBendRanges[BEND_RANGE_FINGER_LEVEL] = expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL];
+			ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
+			ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
+			if (expressionParams) {
+				monophonicPitchBendValue = expressionParams->params[0].getCurrentValue();
+
+				cachedBendRanges[BEND_RANGE_MAIN] = expressionParams->bendRanges[BEND_RANGE_MAIN];
+				cachedBendRanges[BEND_RANGE_FINGER_LEVEL] = expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL];
+			}
+			else {
+				monophonicPitchBendValue = 0;
+			}
 		}
 		else {
 			monophonicPitchBendValue = 0;
-			// TODO: grab bend ranges here too - when we've moved them to the ParamManager?
 		}
-
-		updatePitchBendOutput(
-		    false); // Don't change the CV output voltage right now (we could, but this Clip-change might come with a
-		            // note that's going to sound "now" anyway...)
-		            // - but make it so the next note which sounds will have our new correct bend value / range.
+		// Don't change the CV output voltage right now (we could, but this Clip-change might come with a
+		// note that's going to sound "now" anyway...)
+		// - but make it so the next note which sounds will have our new correct bend value / range.
+		updatePitchBendOutput(false);
 	}
 
 	return clipChanged;

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -170,8 +170,8 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 		}
 	}
 	else if (type == OutputType::CV) {
-		if (activeClip) {
-			newParamManager.cloneParamCollectionsFrom(&activeClip->paramManager, false,
+		if (getActiveClip()) {
+			newParamManager.cloneParamCollectionsFrom(&getActiveClip()->paramManager, false,
 			                                          true); // Because we want the bend ranges
 		}
 	}

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -246,27 +246,41 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimens
 }
 
 bool MIDIInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs) {
+	bool shouldSendPGMs;
+	if (modelStack) {
+		InstrumentClip* newInstrumentClip = (InstrumentClip*)modelStack->getTimelineCounter();
+		InstrumentClip* oldInstrumentClip = (InstrumentClip*)activeClip;
 
-	InstrumentClip* newInstrumentClip = (InstrumentClip*)modelStack->getTimelineCounter();
-	InstrumentClip* oldInstrumentClip = (InstrumentClip*)activeClip;
-
-	bool shouldSendPGMs = (maySendMIDIPGMs != PgmChangeSend::NEVER && activeClip && activeClip != newInstrumentClip
-	                       && (newInstrumentClip->midiPGM != oldInstrumentClip->midiPGM
-	                           || newInstrumentClip->midiSub != oldInstrumentClip->midiSub
-	                           || newInstrumentClip->midiBank != oldInstrumentClip->midiBank));
-
+		shouldSendPGMs = (maySendMIDIPGMs != PgmChangeSend::NEVER && activeClip && activeClip != newInstrumentClip
+		                  && (newInstrumentClip->midiPGM != oldInstrumentClip->midiPGM
+		                      || newInstrumentClip->midiSub != oldInstrumentClip->midiSub
+		                      || newInstrumentClip->midiBank != oldInstrumentClip->midiBank));
+	}
+	else {
+		shouldSendPGMs = false;
+	}
 	bool clipChanged = NonAudioInstrument::setActiveClip(modelStack, maySendMIDIPGMs);
 
 	if (shouldSendPGMs) {
 		sendMIDIPGM();
 	}
 	if (clipChanged) {
-		ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
-		ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
-		if (expressionParams) {
-			cachedBendRanges[BEND_RANGE_MAIN] = expressionParams->bendRanges[BEND_RANGE_MAIN];
-			cachedBendRanges[BEND_RANGE_FINGER_LEVEL] = expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL];
-			ratio = float(cachedBendRanges[BEND_RANGE_FINGER_LEVEL]) / float(cachedBendRanges[BEND_RANGE_MAIN]);
+		if (modelStack) {
+			ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
+			ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
+			if (expressionParams) {
+				cachedBendRanges[BEND_RANGE_MAIN] = expressionParams->bendRanges[BEND_RANGE_MAIN];
+				cachedBendRanges[BEND_RANGE_FINGER_LEVEL] = expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL];
+				ratio = float(cachedBendRanges[BEND_RANGE_FINGER_LEVEL]) / float(cachedBendRanges[BEND_RANGE_MAIN]);
+			}
+		}
+		else {
+			allNotesOff();
+			for (int i = 0; i < kNumExpressionDimensions; i++) {
+				lastMonoExpression[i] = 0;
+				lastCombinedPolyExpression[i] = 0;
+				sendMonophonicExpressionEvent(i);
+			}
 		}
 	}
 

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -51,7 +51,11 @@ void Output::setupWithoutActiveClip(ModelStack* modelStack) {
 
 // Returns whether Clip changed from before
 bool Output::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs) {
-
+	if (!modelStack) {
+		activeClip = nullptr;
+		inValidState = false;
+		return true;
+	}
 	Clip* newClip = (Clip*)modelStack->getTimelineCounter();
 
 	bool clipChanged = (activeClip != newClip);
@@ -547,6 +551,10 @@ void Output::endArrangementPlayback(Song* song, int32_t actualEndPos, uint32_t t
 	}
 
 	endAnyArrangementRecording(song, actualEndPos, timeRemainder);
+}
+
+Clip* Output::getActiveClip() const {
+	return activeClip;
 }
 
 /*

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -49,7 +49,7 @@ public:
 	virtual ~Output();
 
 	ClipInstanceVector clipInstances;
-	Clip* activeClip;
+	[[nodiscard]] Clip* getActiveClip() const;
 	String name; // Contains the display name as the user sees it.
 	             // E.g. on numeric Deluge, SYNT000 will be just "0". Definitely no leading zeros, so not "000".
 	             // On OLED Deluge I thiiink SYNT000 would be "SYNT000"?
@@ -162,4 +162,6 @@ public:
 
 protected:
 	virtual Clip* createNewClipForArrangementRecording(ModelStack* modelStack) = 0;
+
+	Clip* activeClip;
 };

--- a/src/deluge/playback/mode/arrangement.cpp
+++ b/src/deluge/playback/mode/arrangement.cpp
@@ -164,10 +164,10 @@ void Arrangement::doTickForward(int32_t posIncrement) {
 				}
 
 				// Tick forward the Clip being recorded to
-				output->activeClip->lastProcessedPos += posIncrement;
+				output->getActiveClip()->lastProcessedPos += posIncrement;
 				ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-				    modelStack->addTimelineCounter(output->activeClip);
-				output->activeClip->processCurrentPos(modelStackWithTimelineCounter, posIncrement);
+				    modelStack->addTimelineCounter(output->getActiveClip());
+				output->getActiveClip()->processCurrentPos(modelStackWithTimelineCounter, posIncrement);
 			}
 
 			else {
@@ -300,8 +300,8 @@ notRecording:
 
 justDoArp:
 			int32_t posForArp;
-			if (output->activeClip && output->activeClip->activeIfNoSolo) {
-				posForArp = output->activeClip->lastProcessedPos;
+			if (output->getActiveClip() && output->getActiveClip()->activeIfNoSolo) {
+				posForArp = output->getActiveClip()->lastProcessedPos;
 			}
 			else {
 				posForArp = lastProcessedPos;
@@ -466,7 +466,7 @@ void Arrangement::reversionDone() {
 }
 
 bool Arrangement::isOutputAvailable(Output* output) {
-	if (!playbackHandler.playbackState || !output->activeClip) {
+	if (!playbackHandler.playbackState || !output->getActiveClip()) {
 		return true;
 	}
 

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -262,8 +262,8 @@ void Session::doLaunch(bool isFillLaunch) {
 
 			Output* output = clip->output;
 
-			if (isFillLaunch && clip->launchStyle == LaunchStyle::FILL && output->activeClip
-			    && output->activeClip->launchStyle != LaunchStyle::FILL) {
+			if (isFillLaunch && clip->launchStyle == LaunchStyle::FILL && output->getActiveClip()
+			    && output->getActiveClip()->launchStyle != LaunchStyle::FILL) {
 				/* There's a non fill clip already on this output, don't launch */
 				clip->armState = ArmState::OFF;
 				continue;
@@ -1769,8 +1769,8 @@ void Session::scheduleFillClip(Clip* clip) {
 			// and if closer than the fill clip length, do immediate launch */
 			// if (launchEventAtSwungTickCount < playbackHandler.getActualSwungTickCount() + clip->getMaxLength()) {
 			if (fillStartTime < playbackHandler.getActualSwungTickCount()) {
-				if (clip->output->activeClip) {
-					if (clip->output->activeClip->launchStyle == LaunchStyle::FILL) {
+				if (clip->output->getActiveClip()) {
+					if (clip->output->getActiveClip()->launchStyle == LaunchStyle::FILL) {
 						/* A fill clip is already here, steal the output */
 					}
 					else {
@@ -1834,7 +1834,7 @@ void Session::scheduleFillClips(uint8_t section) {
 		if (thisClip->section == section && thisClip->launchStyle == LaunchStyle::FILL) {
 
 			Output* output = thisClip->output;
-			if (output->activeClip && output->activeClip->launchStyle != LaunchStyle::FILL) {
+			if (output->getActiveClip() && output->getActiveClip()->launchStyle != LaunchStyle::FILL) {
 				/* Some non-fill already has this output. We can't steal it.*/
 				continue;
 			}
@@ -2153,8 +2153,8 @@ traverseClips:
 			continue;
 		}
 
-		if (clip->output->activeClip && clip->output->activeClip->beingRecordedFromClip == clip) {
-			clip = clip->output->activeClip;
+		if (clip->output->getActiveClip() && clip->output->getActiveClip()->beingRecordedFromClip == clip) {
+			clip = clip->output->getActiveClip();
 		}
 
 		ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
@@ -2317,8 +2317,8 @@ void Session::doTickForward(int32_t posIncrement) {
 				continue;
 			}
 
-			if (clip->output->activeClip && clip->output->activeClip->beingRecordedFromClip == clip) {
-				clip = clip->output->activeClip;
+			if (clip->output->getActiveClip() && clip->output->getActiveClip()->beingRecordedFromClip == clip) {
+				clip = clip->output->getActiveClip();
 			}
 
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
@@ -2351,8 +2351,8 @@ void Session::doTickForward(int32_t posIncrement) {
 	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
 
 		int32_t posForArp;
-		if (thisOutput->activeClip && currentSong->isClipActive(thisOutput->activeClip)) {
-			posForArp = thisOutput->activeClip->lastProcessedPos;
+		if (thisOutput->getActiveClip() && currentSong->isClipActive(thisOutput->getActiveClip())) {
+			posForArp = thisOutput->getActiveClip()->lastProcessedPos;
 		}
 		else {
 			posForArp = playbackHandler.lastSwungTickActioned;
@@ -2492,7 +2492,7 @@ doAssertThisClip:
 }
 
 bool Session::isOutputAvailable(Output* output) {
-	if (!playbackHandler.playbackState || !output->activeClip) {
+	if (!playbackHandler.playbackState || !output->getActiveClip()) {
 		return true;
 	}
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2691,7 +2691,7 @@ void PlaybackHandler::noteMessageReceived(MIDIDevice* fromDevice, bool on, int32
 		if (!on || currentSong->isOutputActiveInArrangement(thisOutput)) {
 
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-			    modelStack->addTimelineCounter(thisOutput->activeClip);
+			    modelStack->addTimelineCounter(thisOutput->getActiveClip());
 			// Output is a MIDI instrument, kit, or melodic instrument
 			// Midi instruments will hand control to NonAudioInstrument which inherits from melodic
 			thisOutput->offerReceivedNote(modelStackWithTimelineCounter, fromDevice, on, channel, note, velocity,
@@ -2807,7 +2807,7 @@ void PlaybackHandler::pitchBendReceived(MIDIDevice* fromDevice, uint8_t channel,
 	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
 
 		ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-		    modelStack->addTimelineCounter(thisOutput->activeClip);
+		    modelStack->addTimelineCounter(thisOutput->getActiveClip());
 
 		bool usedForParam = false;
 
@@ -2881,10 +2881,10 @@ void PlaybackHandler::midiCCReceived(MIDIDevice* fromDevice, uint8_t channel, ui
 		// If it has an activeClip... (Hmm, interesting, we don't allow MIDI control of params when no activeClip? Yeah
 		// this checks out, as the various offerReceivedCCToLearnedParams()'s require a timelineCounter, but this seems
 		// restrictive for the user...)
-		if (thisOutput->activeClip) {
+		if (thisOutput->getActiveClip()) {
 
 			ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-			    modelStack->addTimelineCounter(thisOutput->activeClip);
+			    modelStack->addTimelineCounter(thisOutput->getActiveClip());
 
 			if (!isMPE) {
 				// See if it's learned to a parameter
@@ -2923,7 +2923,7 @@ void PlaybackHandler::aftertouchReceived(MIDIDevice* fromDevice, int32_t channel
 	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
 
 		ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
-		    modelStack->addTimelineCounter(thisOutput->activeClip);
+		    modelStack->addTimelineCounter(thisOutput->getActiveClip());
 
 		thisOutput->offerReceivedAftertouch(modelStackWithTimelineCounter, fromDevice, channel, value, noteCode,
 		                                    doingMidiThru);

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -394,7 +394,7 @@ bool AudioOutput::wantsToBeginArrangementRecording() {
 
 bool AudioOutput::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs) {
 	if (activeClip
-	    && (activeClip != modelStack->getTimelineCounter()
+	    && (!modelStack || activeClip != modelStack->getTimelineCounter()
 	        || (playbackHandler.playbackState && currentPlaybackMode == &arrangement))) {
 		((AudioClip*)activeClip)->unassignVoiceSample(false);
 	}

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "model/clip/audio_clip.h"
 #include "model/global_effectable/global_effectable_for_clip.h"
 #include "model/output.h"
 #include "modulation/envelope.h"

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -252,23 +252,26 @@ bool SoundInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, P
 	bool clipChanged = MelodicInstrument::setActiveClip(modelStack, maySendMIDIPGMs);
 
 	if (clipChanged) {
-		ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
-		patcher.performInitialPatching(this, paramManager);
 		AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 
-		// Grab mono expression params
-		ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
-		if (expressionParams) {
-			for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
-				monophonicExpressionValues[i] = expressionParams->params[i].getCurrentValue();
+		if (modelStack) {
+			ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
+			patcher.performInitialPatching(this, paramManager);
+
+			// Grab mono expression params
+			ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
+			if (expressionParams) {
+				for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
+					monophonicExpressionValues[i] = expressionParams->params[i].getCurrentValue();
+				}
 			}
-		}
-		else {
-			for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
-				monophonicExpressionValues[i] = 0;
+			else {
+				for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
+					monophonicExpressionValues[i] = 0;
+				}
 			}
+			whichExpressionSourcesChangedAtSynthLevel = (1 << kNumExpressionDimensions) - 1;
 		}
-		whichExpressionSourcesChangedAtSynthLevel = (1 << kNumExpressionDimensions) - 1;
 	}
 	return clipChanged;
 }


### PR DESCRIPTION
Makes activeClip private to enforce getter/setter use

Fix bugs where activeClip could be changed without updating the external state

Fix bugs when activeClip is set to null without telling the output

Update all setActiveClip methods to handle null pointers