### PR TITLE
refactor: value scaling for tranpose-menu items

### DIFF
--- a/src/deluge/gui/menu_item/audio_clip/transpose.h
+++ b/src/deluge/gui/menu_item/audio_clip/transpose.h
@@ -26,14 +26,12 @@ class Transpose final : public Decimal, public MenuItemWithCCLearning {
 public:
 	using Decimal::Decimal;
 	void readCurrentValue() override {
-		this->setValue(getCurrentAudioClip()->sampleHolder.transpose * 100 + getCurrentAudioClip()->sampleHolder.cents);
+		auto sampleHolder = getCurrentAudioClip()->sampleHolder;
+		this->setValue(computeCurrentValueForTranspose(sampleHolder.transpose, sampleHolder.cents));
 	}
 	void writeCurrentValue() override {
-		int32_t currentValue = this->getValue() + 25600;
-
-		int32_t semitones = (currentValue + 50) / 100;
-		int32_t cents = currentValue - semitones * 100;
-		int32_t transpose = semitones - 256;
+		int32_t transpose, cents;
+		computeFinalValuesForTranspose(this->getValue(), &transpose, &cents);
 
 		auto& sampleHolder = getCurrentAudioClip()->sampleHolder;
 		sampleHolder.transpose = transpose;

--- a/src/deluge/gui/menu_item/cv/transpose.h
+++ b/src/deluge/gui/menu_item/cv/transpose.h
@@ -32,16 +32,14 @@ public:
 	[[nodiscard]] int32_t getNumDecimalPlaces() const override { return 2; }
 
 	void readCurrentValue() override {
-		this->setValue((int32_t)cvEngine.cvChannels[soundEditor.currentSourceIndex].transpose * 100
-		               + cvEngine.cvChannels[soundEditor.currentSourceIndex].cents);
+		this->setValue(computeCurrentValueForTranspose(cvEngine.cvChannels[soundEditor.currentSourceIndex].transpose,
+		                                               cvEngine.cvChannels[soundEditor.currentSourceIndex].cents));
 	}
 
 	void writeCurrentValue() override {
-		int32_t currentValue = this->getValue() + 25600;
-
-		int32_t semitones = (currentValue + 50) / 100;
-		int32_t cents = currentValue - semitones * 100;
-		cvEngine.setCVTranspose(soundEditor.currentSourceIndex, semitones - 256, cents);
+		int32_t transpose, cents;
+		computeFinalValuesForTranspose(this->getValue(), &transpose, &cents);
+		cvEngine.setCVTranspose(soundEditor.currentSourceIndex, transpose, cents);
 	}
 };
 } // namespace deluge::gui::menu_item::cv

--- a/src/deluge/gui/menu_item/modulator/transpose.h
+++ b/src/deluge/gui/menu_item/modulator/transpose.h
@@ -29,20 +29,19 @@ public:
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	void readCurrentValue() override {
-		this->setValue((int32_t)soundEditor.currentSound->modulatorTranspose[soundEditor.currentSourceIndex] * 100
-		               + soundEditor.currentSound->modulatorCents[soundEditor.currentSourceIndex]);
+		this->setValue(computeCurrentValueForTranspose(
+		    soundEditor.currentSound->modulatorTranspose[soundEditor.currentSourceIndex],
+		    soundEditor.currentSound->modulatorCents[soundEditor.currentSourceIndex]));
 	}
 
 	void writeCurrentValue() override {
-		int32_t currentValue = this->getValue() + 25600;
-
-		int32_t semitones = (currentValue + 50) / 100;
-		int32_t cents = currentValue - semitones * 100;
+		int32_t transpose, cents;
+		computeFinalValuesForTranspose(this->getValue(), &transpose, &cents);
 
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithSoundFlags* modelStack = soundEditor.getCurrentModelStack(modelStackMemory)->addSoundFlags();
 
-		soundEditor.currentSound->setModulatorTranspose(soundEditor.currentSourceIndex, semitones - 256, modelStack);
+		soundEditor.currentSound->setModulatorTranspose(soundEditor.currentSourceIndex, transpose, modelStack);
 		soundEditor.currentSound->setModulatorCents(soundEditor.currentSourceIndex, cents, modelStack);
 	}
 

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -40,16 +40,13 @@ public:
 			transpose = soundEditor.currentSource->transpose;
 			cents = soundEditor.currentSource->cents;
 		}
-		this->setValue(transpose * 100 + cents);
+		this->setValue(computeCurrentValueForTranspose(transpose, cents));
 	}
 
 	void writeCurrentValue() override {
-		int32_t currentValue = this->getValue() + 25600;
+		int32_t transpose, cents;
+		computeFinalValuesForTranspose(this->getValue(), &transpose, &cents);
 
-		int32_t semitones = (currentValue + 50) / 100;
-		int32_t cents = currentValue - semitones * 100;
-
-		int32_t transpose = semitones - 256;
 		if ((soundEditor.currentMultiRange != nullptr) && soundEditor.currentSound->getSynthMode() != SynthMode::FM
 		    && soundEditor.currentSource->oscType == OscType::SAMPLE) {
 			(static_cast<MultisampleRange*>(soundEditor.currentMultiRange))->sampleHolder.transpose = transpose;

--- a/src/deluge/gui/menu_item/value_scaling.cpp
+++ b/src/deluge/gui/menu_item/value_scaling.cpp
@@ -61,3 +61,14 @@ int32_t computeFinalValueForPan(int32_t value) {
 uint32_t computeFinalValueForArpMidiCvRatchetsOrRhythm(int32_t value) {
 	return (uint32_t)value * 85899345;
 }
+
+int32_t computeCurrentValueForTranspose(int32_t transpose, int32_t cents) {
+	return transpose * 100 + cents;
+}
+
+void computeFinalValuesForTranspose(int32_t value, int32_t* transpose, int32_t* cents) {
+	int32_t currentValue = value + 25600;
+	int32_t semitones = (currentValue + 50) / 100;
+	*cents = currentValue - semitones * 100;
+	*transpose = semitones - 256;
+}

--- a/src/deluge/gui/menu_item/value_scaling.h
+++ b/src/deluge/gui/menu_item/value_scaling.h
@@ -25,17 +25,20 @@
 ///     -> computeFinalValueForSomeClass()
 ///
 /// Done:
-/// - audio_compressor::CompParam
-/// - audio_clip::Attack
 /// - arpeggiator::midi_cv::Gate
 /// - arpeggiator::midi_cv::RatchetAmount
 /// - arpeggiator::midi_cv::RatchetProbability
 /// - arpeggiator::midi_cv::Rate
 /// - arpeggiator::midi_cv::Rhythm
+/// - audio_compressor::CompParam
+/// - audio_clip::Attack
+/// - cv::Transpose
+/// - modulator::Transpose
 /// - osc::PulseWidth
 /// - patched_param::Integer
 /// - patched_param::Pan
 /// - reverb::Pan
+/// - sample::Transpose
 /// - unpatched_param::Pan
 /// - unpatched_param::UnpatchedParam
 ///
@@ -49,6 +52,8 @@
 /// - arpeggiator::Octaves
 /// - arpeggiator::PresetMode
 /// - audio_clip::Reverse
+/// - midi::Transpose
+/// - MasterTranspose
 ///
 /// Special cases:
 /// - arpeggiator::Sync - uses syncTypeAndLevelToMenuOption() to pack two values,
@@ -112,3 +117,6 @@ int32_t computeCurrentValueForArpMidiCvRatchetsOrRhythm(uint32_t value);
  * See comment in the current value computation above for more.
  */
 uint32_t computeFinalValueForArpMidiCvRatchetsOrRhythm(int32_t value);
+
+int32_t computeCurrentValueForTranspose(int32_t transpose, int32_t cents);
+void computeFinalValuesForTranspose(int32_t current, int32_t* transpose, int32_t* cents);

--- a/tests/unit/value_scaling_tests.cpp
+++ b/tests/unit/value_scaling_tests.cpp
@@ -58,3 +58,18 @@ TEST(ValueScalingTest, arpMidiCvRatchetOrRhytmValueScaling) {
 	// behaves well on the whole range
 	CHECK_EQUAL(50, computeCurrentValueForArpMidiCvRatchetsOrRhythm(UINT32_MAX));
 }
+
+TEST(ValueScalingTest, transpose) {
+	for (int i = -9600; i <= 9600; i++) {
+		int32_t transpose, cents;
+		computeFinalValuesForTranspose(i, &transpose, &cents);
+		int32_t current = computeCurrentValueForTranspose(transpose, cents);
+		CHECK_EQUAL(i, current);
+	}
+	CHECK_EQUAL(0, computeCurrentValueForTranspose(0, 0));
+	CHECK_EQUAL(110, computeCurrentValueForTranspose(1, 10));
+	int32_t transpose, cents;
+	computeFinalValuesForTranspose(110, &transpose, &cents);
+	CHECK_EQUAL(1, transpose);
+	CHECK_EQUAL(10, cents);
+}


### PR DESCRIPTION
- audio_clip::Transpose, cv::Transpose, modulator::Transpose, and sample::Transpose all use the same logic

- midi::Transpose and MasterTranspose use unity scaling