### PR TITLE
[DRAFT] Feature: Add Automated Stem Exporting for Kit Rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Added ability to sync LFO2. Where LFO1 syncs relative to the grid, LFO2 syncs relative to individual notes.
 - Added `VELOCITY VIEW`, accessible from `AUTOMATION VIEW OVERVIEW` by pressing the `VELOCITY` shortcut, from `AUTOMATION VIEW EDITOR` by pressing `SHIFT OR AUDITION PAD + VELOCITY` or from `INSTRUMENT CLIP VIEW` by pressing `AUDITION PAD + VELOCITY`. 
   - Velocity View enables you to edit the velocities and other parameters of notes in a single note row using a similar interface to `AUTOMATION VIEW`.
-- Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW` and `INSTRUMENT STEMS` while in `ARRANGER VIEW`. Press `SAVE + RECORD` to start exporting stems. Press `BACK` to cancel stem exporting and stop recording and playback.
+- Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW`,  `INSTRUMENT STEMS` while in `ARRANGER VIEW` and `DRUM STEMS` while in `KIT CLIP VIEW`. Press `SAVE + RECORD` to start exporting stems. Press `BACK` to cancel stem exporting and stop recording and playback.
 
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -267,8 +267,7 @@ Here is a list of general improvements that have been made, ordered from newest 
 #### 3.23 Automated Stem Exporting
 
 - For a detailed description of this feature as well the button shortcuts/combos, please refer to the feature documentation: [Stem Export Documentation]
-- ([#2260]) Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW` and `INSTRUMENT STEMS` while in `ARRANGER VIEW`. Press `SAVE + RECORD` to start exporting stems. Press `BACK` to cancel stem exporting and stop recording and playback.
-  - Note: in Arranger, any instruments that are muted will be excluded from the Instrument Stem Export
+- ([#2260], [#2285]) Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW`,  `INSTRUMENT STEMS` while in `ARRANGER VIEW` and `DRUM STEMS` while in `KIT CLIP VIEW`. Press `SAVE + RECORD` to start exporting stems. Press `BACK` to cancel stem exporting and stop recording and playback.
 
 ## 4. New Features Added
 
@@ -1367,6 +1366,8 @@ different firmware
 [#2174]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2166
 
 [#2260]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2260
+
+[#2285]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2285
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/automation_view.md
 

--- a/docs/features/stem_export.md
+++ b/docs/features/stem_export.md
@@ -46,7 +46,7 @@ For Drum exports, the stem's are given the following format for the file name:
 - Note 3: Instruments, Clips and Drums that are `EMPTY` (e.g. they have no Notes or Audio Files) are excluded from the stem export
 - Note 4: In Arranger View, any Instruments that are `MUTED` are excluded from the stem export
 - Note 5: In Kits, any Drums that are `MUTED` are excluded from the stem export.
-- `(NOT WORKING YET)` Note 6: Drum Stems are exported without Kit Affect Entire FX applied
+- Note 6: Drum Stems are exported without Kit Affect Entire FX applied (except for the Kit Affect Entire Pitch Adjustment which is still applied)
 
 ### Cancelling Stem Export
 

--- a/docs/features/stem_export.md
+++ b/docs/features/stem_export.md
@@ -4,9 +4,9 @@ https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/044efe71-ac
 
 ## Description
 
-Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW` and `INSTRUMENT STEMS` while in `ARRANGER VIEW`. Press `SAVE + RECORD` to start exporting stems.
+Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW`,  `INSTRUMENT STEMS` while in `ARRANGER VIEW` and `DRUM STEMS` while in `KIT CLIP VIEW`. Press `SAVE + RECORD` to start exporting stems.
 
-Now with one quick action you can start a stem export job, walk away from your Deluge and come back with a bunch of stems for all your clips and arranger instruments.
+Now with one quick action you can start a stem export job, walk away from your Deluge and come back with a bunch of stems for all your clips, arranger instruments, and kit drums.
 
 ## Stems Folder
 
@@ -27,14 +27,26 @@ Stem's are given a meaningful name in the following format:
 > SYNTH_CLIP_PRESETNAME_00000.WAV
 > SYNTH_TRACK_PRESETNAME_00000.WAV
 
+For Drum exports, the stem's are given the following format for the file name:
+
+`ClipType_ExportType_PresetName_DrumName_FileNumber.WAV`
+
+> For example:
+> 
+> KIT_DRUM_003 TR-909_KICK_00000.WAV
+
 ## Shortcuts to Start/Stop Stem Exporting
 
 ### Starting Stem Export
 
 - Hold `SAVE` + Press `RECORD` while Playback and Record are disabled to launch Stem Export process
 - When the stem export is finished, a dialog will appear on the display that tells you that the stem export process has finished. Press `SELECT`, `BACK` or any `PAD` on the grid to exit the dialog.
-- Note 1: In Arranger View, any Instruments that are `MUTED` will be excluded from the stem export.
-- Note 2: Stems are exported without Master (Song) FX applied
+- Note 1: Stems are exported without Master (Song) FX applied
+- Note 2: MIDI and CV Instruments, Clips, and Drums are excluded from the stem export
+- Note 3: Instruments, Clips and Drums that are `EMPTY` (e.g. they have no Notes or Audio Files) are excluded from the stem export
+- Note 4: In Arranger View, any Instruments that are `MUTED` are excluded from the stem export
+- Note 5: In Kits, any Drums that are `MUTED` are excluded from the stem export.
+- `(NOT WORKING YET)` Note 6: Drum Stems are exported without Kit Affect Entire FX applied
 
 ### Cancelling Stem Export
 
@@ -49,3 +61,5 @@ https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/77bb8dfc-8b
 https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/c48d0ab8-656f-427a-99c0-f7c4076b06ca
 
 https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/c00e69c6-96a6-4b25-94ed-abcf1a0088f4
+
+https://github.com/user-attachments/assets/b1fd6408-ea5b-4c6d-b5ca-09f73c62ab69

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -240,6 +240,7 @@ enum class OutputType : uint8_t {
 enum class StemExportType : uint8_t {
 	CLIP,
 	TRACK,
+	DRUM,
 };
 
 enum class ThingType : uint8_t {

--- a/src/deluge/gui/context_menu/stem_export/cancel_stem_export.cpp
+++ b/src/deluge/gui/context_menu/stem_export/cancel_stem_export.cpp
@@ -48,8 +48,6 @@ Sized<char const**> CancelStemExport::getOptions() {
 }
 
 bool CancelStemExport::acceptCurrentOption() {
-	using enum l10n::String;
-
 	stemExport.stopStemExportProcess();
 
 	return false; // return false so you exit out of the context menu

--- a/src/deluge/gui/context_menu/stem_export/done_stem_export.cpp
+++ b/src/deluge/gui/context_menu/stem_export/done_stem_export.cpp
@@ -47,8 +47,6 @@ Sized<char const**> DoneStemExport::getOptions() {
 }
 
 bool DoneStemExport::acceptCurrentOption() {
-	using enum l10n::String;
-
 	return false; // return false so you exit out of the context menu
 }
 } // namespace deluge::gui::context_menu

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -22,7 +22,6 @@
 #include "gui/colour/colour.h"
 #include "gui/context_menu/audio_input_selector.h"
 #include "gui/context_menu/stem_export/cancel_stem_export.h"
-#include "gui/context_menu/stem_export/done_stem_export.h"
 #include "gui/menu_item/colour.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/load/load_instrument_preset_ui.h"

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -19,6 +19,7 @@
 #include "definitions_cxx.hpp"
 #include "extern.h"
 #include "gui/colour/colour.h"
+#include "gui/context_menu/stem_export/cancel_stem_export.h"
 #include "gui/l10n/l10n.h"
 #include "gui/menu_item/colour.h"
 #include "gui/menu_item/file_selector.h"
@@ -82,6 +83,7 @@
 #include "processing/engines/cv_engine.h"
 #include "processing/sound/sound_drum.h"
 #include "processing/sound/sound_instrument.h"
+#include "processing/stem_export/stem_export.h"
 #include "storage/audio/audio_file_holder.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/multi_range/multi_range.h"
@@ -350,6 +352,31 @@ doOther:
 				cancelAllAuditioning();
 
 				enterDrumCreator(modelStackWithNoteRow, true);
+			}
+		}
+	}
+
+	// trigger stem export when pressing record while holding save
+	else if (b == RECORD && currentUIMode == UI_MODE_HOLDING_SAVE_BUTTON) {
+		if (on && getCurrentOutputType() == OutputType::KIT) {
+			if (playbackHandler.isEitherClockActive() || playbackHandler.recording != RecordingMode::OFF) {
+				display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CANT_EXPORT_STEMS));
+			}
+			else {
+				stemExport.startStemExportProcess(StemExportType::DRUM);
+				return ActionResult::DEALT_WITH;
+			}
+		}
+	}
+
+	// cancel stem export process
+	else if (b == BACK && stemExport.processStarted) {
+		if (on) {
+			bool available = context_menu::cancelStemExport.setupAndCheckAvailability();
+
+			if (available) {
+				display->setNextTransitionDirection(1);
+				openUI(&context_menu::cancelStemExport);
 			}
 		}
 	}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -24,7 +24,6 @@
 #include "gui/context_menu/audio_input_selector.h"
 #include "gui/context_menu/launch_style.h"
 #include "gui/context_menu/stem_export/cancel_stem_export.h"
-#include "gui/context_menu/stem_export/done_stem_export.h"
 #include "gui/menu_item/colour.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/load/load_instrument_preset_ui.h"

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -142,6 +142,7 @@ public:
 	// vu meter rendering
 	bool displayVUMeter;
 	bool potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]);
+	int32_t getMaxYDisplayForVUMeter(float level);
 
 	void getParameterNameFromModEncoder(int32_t whichModEncoder, char* parameterName);
 
@@ -153,7 +154,6 @@ private:
 	void clearMelodicInstrumentMonoExpressionIfPossible();
 
 	// vu meter rendering
-	int32_t getMaxYDisplayForVUMeter(float level);
 	int32_t cachedMaxYDisplayForVUMeterL;
 	int32_t cachedMaxYDisplayForVUMeterR;
 	void renderVUMeter(int32_t maxYDisplay, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth]);

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -44,6 +44,7 @@ Clip::Clip(ClipType newType) : type(newType) {
 	armState = ArmState::OFF;
 	activeIfNoSolo = true;
 	activeIfNoSoloBeforeStemExport = activeIfNoSolo;
+	exportStem = false;
 	wasActiveBefore = false; // Want to set this default in case a Clip was created during playback
 
 	section = 0;

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -155,8 +155,9 @@ public:
 	ArmState armState;
 	bool activeIfNoSolo;
 	bool activeIfNoSoloBeforeStemExport; // Used by stem export to restore previous state
-	bool wasActiveBefore;                // A temporary thing used by Song::doLaunch()
-	bool gotInstanceYet;                 // For use only while loading song
+	bool exportStem; // Used by stem export to flag if this note row should be exported
+	bool wasActiveBefore; // A temporary thing used by Song::doLaunch()
+	bool gotInstanceYet;  // For use only while loading song
 
 	bool isPendingOverdub;
 	bool isUnfinishedAutoOverdub;

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -155,9 +155,9 @@ public:
 	ArmState armState;
 	bool activeIfNoSolo;
 	bool activeIfNoSoloBeforeStemExport; // Used by stem export to restore previous state
-	bool exportStem; // Used by stem export to flag if this note row should be exported
-	bool wasActiveBefore; // A temporary thing used by Song::doLaunch()
-	bool gotInstanceYet;  // For use only while loading song
+	bool exportStem;                     // Used by stem export to flag if this note row should be exported
+	bool wasActiveBefore;                // A temporary thing used by Song::doLaunch()
+	bool gotInstanceYet;                 // For use only while loading song
 
 	bool isPendingOverdub;
 	bool isUnfinishedAutoOverdub;

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -46,6 +46,7 @@
 #include "playback/mode/arrangement.h"
 #include "processing/engines/cv_engine.h"
 #include "processing/sound/sound_instrument.h"
+#include "processing/stem_export/stem_export.h"
 #include "util/lookuptables/lookuptables.h"
 #include <cstring>
 
@@ -99,6 +100,9 @@ void InstrumentClipMinder::selectEncoderAction(int32_t offset) {
 }
 
 void InstrumentClipMinder::redrawNumericDisplay() {
+	if (stemExport.processStarted) {
+		return;
+	}
 	if (display->have7SEG()) {
 		if (getCurrentUI()->toClipMinder()) { // Seems a redundant check now? Maybe? Or not?
 			view.displayOutputName(getCurrentOutput(), false);
@@ -107,6 +111,10 @@ void InstrumentClipMinder::redrawNumericDisplay() {
 }
 
 void InstrumentClipMinder::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
+	if (stemExport.processStarted) {
+		stemExport.displayStemExportProgressOLED(StemExportType::DRUM);
+		return;
+	}
 	view.displayOutputName(getCurrentOutput(), false);
 }
 

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -68,6 +68,5 @@ protected:
 
 	virtual bool willRenderAsOneChannelOnlyWhichWillNeedCopying() { return false; }
 
-private:
 	bool renderedLastTime;
 };

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -658,7 +658,7 @@ void Kit::renderOutput(ModelStack* modelStack, StereoSample* outputBuffer, Stere
 
 	// if you're exporting drum stems
 	// render kit row without kit affect entire FX (but leave in kit affect entire pitch adjustment)
-	if (stemExport.processStarted && (stemExport.currentStemExportType == StemExportType::DRUM)) {
+	if (stemExport.processStarted && (stemExport.currentStemExportType == StemExportType::DRUM)) [[unlikely]] {
 		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 
 		int32_t pitchAdjust =

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -656,8 +656,9 @@ void Kit::renderOutput(ModelStack* modelStack, StereoSample* outputBuffer, Stere
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(activeClip);
 	// Beware - modelStackWithThreeMainThings might have a NULL timelineCounter
 
+	// if you're exporting drum stems
 	// render kit row without kit affect entire FX (but leave in kit affect entire pitch adjustment)
-	if (stemExport.processStarted) {
+	if (stemExport.processStarted && (stemExport.currentStemExportType == StemExportType::DRUM)) {
 		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 
 		int32_t pitchAdjust =

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -58,6 +58,7 @@ NoteRow::NoteRow(int16_t newY) {
 	probabilityValue = kNumProbabilityValues;
 	loopLengthIfIndependent = 0;
 	sequenceDirectionMode = SequenceDirection::OBEY_PARENT;
+	exportStem = false;
 }
 
 NoteRow::~NoteRow() {

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -119,6 +119,7 @@ public:
 
 	int16_t y; // This has to be at the top
 	bool muted;
+	bool mutedBeforeStemExport;
 
 	int32_t loopLengthIfIndependent; // 0 means obeying parent
 	int32_t lastProcessedPosIfIndependent;

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -156,6 +156,9 @@ public:
 	/// compared with the time since this NoteRow started (i.e., time from the end during reversed playback).
 	uint32_t ignoreNoteOnsBefore_;
 
+	/// flag used for stem exporting to indicate if this note row's stem should be exported
+	bool exportStem;
+
 	int32_t getDefaultProbability(ModelStackWithNoteRow* ModelStack);
 	int32_t attemptNoteAdd(int32_t pos, int32_t length, int32_t velocity, int32_t probability,
 	                       ModelStackWithNoteRow* modelStack, Action* action);

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -31,6 +31,7 @@
 Output::Output(OutputType newType) : type(newType) {
 	mutedInArrangementMode = false;
 	mutedInArrangementModeBeforeStemExport = mutedInArrangementMode;
+	exportStem = true;
 	soloingInArrangementMode = false;
 	activeClip = NULL;
 	inValidState = false;

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -58,6 +58,7 @@ public:
 	const OutputType type;
 	bool mutedInArrangementMode;
 	bool mutedInArrangementModeBeforeStemExport; // Used by stem export to restore previous state
+	bool exportStem; // Used by stem export to flag if this output should be exported
 	bool soloingInArrangementMode;
 	bool inValidState;
 	bool wasCreatedForAutoOverdub;

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -58,7 +58,7 @@ public:
 	const OutputType type;
 	bool mutedInArrangementMode;
 	bool mutedInArrangementModeBeforeStemExport; // Used by stem export to restore previous state
-	bool exportStem; // Used by stem export to flag if this output should be exported
+	bool exportStem;                             // Used by stem export to flag if this output should be exported
 	bool soloingInArrangementMode;
 	bool inValidState;
 	bool wasCreatedForAutoOverdub;

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -38,6 +38,7 @@
 #include "processing/engines/audio_engine.h"
 #include "processing/engines/cv_engine.h"
 #include "processing/sound/sound_instrument.h"
+#include "processing/stem_export/stem_export.h"
 #include <string.h>
 // #include <algorithm>
 #include "gui/ui/load/load_song_ui.h"
@@ -2263,6 +2264,16 @@ traverseClips:
 }
 
 void Session::doTickForward(int32_t posIncrement) {
+	// if we're exporting clip stems in song or inside a clip (e.g. not arrangement tracks)
+	// we want to export up to length of the longest sequence in the clip (clip or note row loop length)
+	// when we reach longest loop length, we stop playback and allow recording to continue until silence
+	if (stemExport.processStarted && stemExport.currentStemExportType != StemExportType::TRACK) {
+		if (stemExport.checkForLoopEnd()) {
+			// if true, then we've already processed the full sequence and we've stopped playback
+			// return as there is nothing else to process
+			return;
+		}
+	}
 
 	if (launchEventAtSwungTickCount) {
 		int32_t ticksTilLaunchEvent = launchEventAtSwungTickCount - playbackHandler.lastSwungTickActioned;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -501,7 +501,13 @@ void PlaybackHandler::endPlayback() {
 
 	// Or if not doing a song swap, some UI stuff to do
 	else {
-		if (wasRecordingArrangement) {
+		// if we're exporting stems, just turn recording mode off
+		// we don't want to stop active clip instances because we want to let tails ring out
+		if (stemExport.processStarted) {
+			recording = RecordingMode::OFF;
+			view.setModLedStates();
+		}
+		else if (wasRecordingArrangement) {
 			currentSong->endInstancesOfActiveClips(getActualArrangementRecordPos(), true);
 			recording = RecordingMode::OFF;
 			view.setModLedStates();

--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -23,6 +23,7 @@
 #include "gui/l10n/l10n.h"
 #include "gui/ui/audio_recorder.h"
 #include "gui/views/arranger_view.h"
+#include "gui/views/view.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
 #include "hid/led/indicator_leds.h"
@@ -33,6 +34,7 @@
 #include "playback/mode/arrangement.h"
 #include "playback/mode/session.h"
 #include "playback/playback_handler.h"
+#include "processing/engines/audio_engine.h"
 #include "storage/audio/audio_file_manager.h"
 #include "task_scheduler.h"
 #include <new>
@@ -51,6 +53,7 @@ StemExport stemExport{};
 StemExport::StemExport() {
 	currentStemExportType = StemExportType::CLIP;
 	processStarted = false;
+	stopOutputRecordingAtSilence = false;
 
 	highestUsedStemFolderNumber = -1;
 	wavFileNameForStemExportSet = false;
@@ -77,24 +80,27 @@ void StemExport::startStemExportProcess(StemExportType stemExportType) {
 	audioFileManager.highestUsedAudioRecordingNumber[util::to_underlying(AudioRecordingFolder::STEMS)] = -1;
 	enterUIMode(UI_MODE_STEM_EXPORT);
 
+	// so that we can reset vertical scroll position
+	int32_t elementsProcessed = 0;
+
 	// export stems
 	if (stemExportType == StemExportType::CLIP) {
-		exportClipStems(stemExportType);
+		elementsProcessed = exportClipStems(stemExportType);
 	}
 	else if (stemExportType == StemExportType::TRACK) {
-		exportInstrumentStems(stemExportType);
+		elementsProcessed = exportInstrumentStems(stemExportType);
 	}
 	else if (stemExportType == StemExportType::DRUM) {
-		exportDrumStems(stemExportType);
+		elementsProcessed = exportDrumStems(stemExportType);
 	}
 
 	// if process wasn't cancelled, then we got here because we finished
 	// exporting all the stems, so let's finish up
 	if (processStarted) {
-		finishStemExportProcess(stemExportType);
+		finishStemExportProcess(stemExportType, elementsProcessed);
 	}
 	else {
-		updateScrollPosition(stemExportType, totalNumStemsToExport);
+		updateScrollPosition(stemExportType, elementsProcessed);
 	}
 
 	// turn off recording if it's still on
@@ -116,41 +122,90 @@ void StemExport::stopStemExportProcess() {
 }
 
 /// Simulate pressing record and play in order to trigger resampling of out output that ends when loop ends
-void StemExport::startOutputRecordingUntilLoopEnd() {
+void StemExport::startOutputRecordingUntilLoopEndAndSilence() {
 	playbackHandler.playButtonPressed(kInternalButtonPressLatency);
 	if (playbackHandler.isEitherClockActive()) {
 		audioRecorder.beginOutputRecording();
 		if (audioRecorder.recordingSource > AudioInputChannel::NONE) {
-			currentPlaybackMode->stopOutputRecordingAtLoopEnd();
+			stopOutputRecordingAtSilence = true;
 		}
 	}
 }
 
 /// simulate pressing record and then play to stop output-recording and playback immediately
 void StemExport::stopOutputRecordingAndPlayback() {
-	if (audioRecorder.isCurrentlyResampling()) {
-		audioRecorder.endRecordingSoon(kInternalButtonPressLatency);
-	}
 	if (playbackHandler.isEitherClockActive()) {
 		playbackHandler.playButtonPressed(kInternalButtonPressLatency);
 	}
 	highestUsedStemFolderNumber++;
 }
 
+/// if we're exporting clip stems in song or inside a clip (e.g. not arrangement tracks)
+/// we want to export up to length of the longest sequence in the clip (clip or note row loop length)
+/// when we reach longest loop length, we stop playback and allow recording to continue until silence
+bool StemExport::checkForLoopEnd() {
+	int32_t loopLength = loopLengthToStopStemExport;
+
+	int32_t currentPos =
+	    playbackHandler.lastSwungTickActioned + playbackHandler.getNumSwungTicksInSinceLastActionedSwungTick();
+
+	/*	DEF_STACK_STRING_BUF(popupMsg, 40);
+	    popupMsg.append("Current Pos: ");
+	    popupMsg.appendInt(currentPos);
+	    popupMsg.append("/n");
+	    popupMsg.append("Length: ");
+	    popupMsg.appendInt(loopLength);
+	    display->displayPopup(popupMsg.c_str());*/
+
+	if (currentPos == loopLength) {
+		playbackHandler.endPlayback();
+		return true;
+	}
+	return false;
+}
+
+/// if playback has stopped, we want to check for silence so we can stop recording
+void StemExport::checkForSilence() {
+	if (!playbackHandler.isEitherClockActive() && playbackHandler.recording == RecordingMode::OFF) {
+		int32_t maxYDisplayForVUMeterL = view.getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.l);
+		int32_t maxYDisplayForVUMeterR = view.getMaxYDisplayForVUMeter(AudioEngine::approxRMSLevel.r);
+
+		// if silence is found and you are currently resampling, stop recording soon
+		if ((maxYDisplayForVUMeterL == 255 && maxYDisplayForVUMeterR == 255)) {
+			audioRecorder.endRecordingSoon();
+			stopOutputRecordingAtSilence = false;
+		}
+	}
+}
+
 /// disarms and prepares all the instruments so that they can be exported
-void StemExport::disarmAllInstrumentsForStemExport() {
+int32_t StemExport::disarmAllInstrumentsForStemExport() {
 	// when we begin stem export, we haven't exported any instruments yet, so initialize these variables
 	numStemsExported = 0;
-
+	totalNumStemsToExport = 0;
 	// when we trigger stem export, we don't know how many instruments there are yet
 	// so get the number and store it so we only need to ping getNumElements once
-	totalNumStemsToExport = currentSong->getNumOutputs();
+	int32_t totalNumOutputs = currentSong->getNumOutputs();
 
-	if (totalNumStemsToExport) {
+	if (totalNumOutputs) {
 		// iterate through all the instruments to disable all the recording relevant flags
-		for (int32_t idxOutput = 0; idxOutput < totalNumStemsToExport; ++idxOutput) {
+		for (int32_t idxOutput = 0; idxOutput < totalNumOutputs; ++idxOutput) {
 			Output* output = currentSong->getOutputFromIndex(idxOutput);
 			if (output) {
+				/* export output stem if all these conditions are met:
+				    1) the output is not muted in arranger
+				    2) the output is not empty (it has clips with notes in them)
+				    3) the output type is not MIDI or CV
+				*/
+				OutputType outputType = output->type;
+				if (!output->mutedInArrangementMode && !output->isEmpty(false) && outputType != OutputType::MIDI_OUT
+				    && outputType != OutputType::CV) {
+					output->exportStem = true;
+					totalNumStemsToExport++;
+				}
+				else {
+					output->exportStem = false;
+				}
 				output->mutedInArrangementModeBeforeStemExport = output->mutedInArrangementMode;
 				output->mutedInArrangementMode = true;
 				output->recordingInArrangement = false;
@@ -159,13 +214,14 @@ void StemExport::disarmAllInstrumentsForStemExport() {
 			}
 		}
 	}
+	return totalNumOutputs;
 }
 
 /// set instrument mutes back to their previous state (before exporting stems)
-void StemExport::restoreAllInstrumentMutes() {
-	if (totalNumStemsToExport) {
+void StemExport::restoreAllInstrumentMutes(int32_t totalNumOutputs) {
+	if (totalNumOutputs) {
 		// iterate through all the instruments to restore previous mute states
-		for (int32_t idxOutput = 0; idxOutput < totalNumStemsToExport; ++idxOutput) {
+		for (int32_t idxOutput = 0; idxOutput < totalNumOutputs; ++idxOutput) {
 			Output* output = currentSong->getOutputFromIndex(idxOutput);
 			if (output) {
 				output->mutedInArrangementMode = output->mutedInArrangementModeBeforeStemExport;
@@ -177,18 +233,17 @@ void StemExport::restoreAllInstrumentMutes() {
 /// iterates through all instruments, arming one instrument at a time for recording
 /// simulates the button combo action of pressing record + play twice to enable resample
 /// and stop recording at the end of the arrangement
-void StemExport::exportInstrumentStems(StemExportType stemExportType) {
+int32_t StemExport::exportInstrumentStems(StemExportType stemExportType) {
 	// prepare all the instruments for stem export
-	disarmAllInstrumentsForStemExport();
+	int32_t totalNumOutputs = disarmAllInstrumentsForStemExport();
 
-	if (totalNumStemsToExport) {
+	if (totalNumOutputs) {
 		// now we're going to iterate through all instruments to find the ones that should be exported
-		for (int32_t idxOutput = totalNumStemsToExport - 1; idxOutput >= 0; --idxOutput) {
+		for (int32_t idxOutput = totalNumOutputs - 1; idxOutput >= 0; --idxOutput) {
 			Output* output = currentSong->getOutputFromIndex(idxOutput);
 			if (output) {
-				bool started = startCurrentStemExport(stemExportType, output, output->type,
-				                                      output->mutedInArrangementMode, idxOutput, output->isEmpty(false),
-				                                      output->mutedInArrangementModeBeforeStemExport);
+				bool started = startCurrentStemExport(stemExportType, output, output->mutedInArrangementMode, idxOutput,
+				                                      output->exportStem);
 
 				if (!started) {
 					// skip this stem and move to the next one
@@ -197,7 +252,13 @@ void StemExport::exportInstrumentStems(StemExportType stemExportType) {
 
 				// wait until recording is done and playback is turned off
 				yield([]() {
-					return !(audioRecorder.recordingSource > AudioInputChannel::NONE
+					// if you haven't found silence yet and playback has stopped
+					// check for silence so you can stop recording
+					if (stemExport.stopOutputRecordingAtSilence) {
+						stemExport.checkForSilence();
+					}
+					return !(playbackHandler.recording != RecordingMode::OFF
+					         || audioRecorder.recordingSource > AudioInputChannel::NONE
 					         || playbackHandler.isEitherClockActive());
 				});
 
@@ -212,24 +273,39 @@ void StemExport::exportInstrumentStems(StemExportType stemExportType) {
 	}
 
 	// set instrument mutes back to their previous state (before exporting stems)
-	restoreAllInstrumentMutes();
+	restoreAllInstrumentMutes(totalNumOutputs);
+
+	return totalNumOutputs;
 }
 
 /// disarms and prepares all the clips so that they can be exported
-void StemExport::disarmAllClipsForStemExport() {
+int32_t StemExport::disarmAllClipsForStemExport() {
 	// when we begin stem export, we haven't exported any clips yet, so initialize these variables
 	numStemsExported = 0;
+	totalNumStemsToExport = 0;
 	currentSong->xScroll[NAVIGATION_CLIP] = 0;
 
 	// when we trigger stem export, we don't know how many clips there are yet
 	// so get the number and store it so we only need to ping getNumElements once
-	totalNumStemsToExport = currentSong->sessionClips.getNumElements();
+	int32_t totalNumClips = currentSong->sessionClips.getNumElements();
 
-	if (totalNumStemsToExport) {
+	if (totalNumClips) {
 		// iterate through all clips to disable all the recording relevant flags
-		for (int32_t idxClip = 0; idxClip < totalNumStemsToExport; ++idxClip) {
+		for (int32_t idxClip = 0; idxClip < totalNumClips; ++idxClip) {
 			Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
 			if (clip) {
+				/* export clip stem if all these conditions are met:
+				    1) the clip is not empty (it has notes in it)
+				    2) the output type is not MIDI or CV
+				*/
+				OutputType outputType = clip->output->type;
+				if (!clip->isEmpty(false) && outputType != OutputType::MIDI_OUT && outputType != OutputType::CV) {
+					clip->exportStem = true;
+					totalNumStemsToExport++;
+				}
+				else {
+					clip->exportStem = false;
+				}
 				clip->activeIfNoSoloBeforeStemExport = clip->activeIfNoSolo;
 				clip->activeIfNoSolo = false;
 				clip->armState = ArmState::OFF;
@@ -238,13 +314,14 @@ void StemExport::disarmAllClipsForStemExport() {
 			}
 		}
 	}
+	return totalNumClips;
 }
 
 /// set clip mutes back to their previous state (before exporting stems)
-void StemExport::restoreAllClipMutes() {
-	if (totalNumStemsToExport) {
+void StemExport::restoreAllClipMutes(int32_t totalNumClips) {
+	if (totalNumClips) {
 		// iterate through all clips to restore previous mute states
-		for (int32_t idxClip = 0; idxClip < totalNumStemsToExport; ++idxClip) {
+		for (int32_t idxClip = 0; idxClip < totalNumClips; ++idxClip) {
 			Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
 			if (clip) {
 				clip->activeIfNoSolo = clip->activeIfNoSoloBeforeStemExport;
@@ -253,20 +330,43 @@ void StemExport::restoreAllClipMutes() {
 	}
 }
 
+/// for clip export, gets length of longest note row that isn't empty
+/// we will use this length to record that clip until longest note row is fully recorded
+void StemExport::getLoopLengthOfLongestNotEmptyNoteRow(Clip* clip) {
+	loopLengthToStopStemExport = clip->loopLength;
+
+	if (clip->type == ClipType::INSTRUMENT) {
+		InstrumentClip* instrumentClip = (InstrumentClip*)clip;
+		int32_t totalNumNoteRows = instrumentClip->noteRows.getNumElements();
+		if (totalNumNoteRows) {
+			// iterate through all the note rows to find the longest one
+			for (int32_t idxNoteRow = 0; idxNoteRow < totalNumNoteRows; ++idxNoteRow) {
+				NoteRow* thisNoteRow = instrumentClip->noteRows.getElement(idxNoteRow);
+				if (thisNoteRow && (thisNoteRow->loopLengthIfIndependent > loopLengthToStopStemExport)
+				    && !thisNoteRow->hasNoNotes()) {
+					loopLengthToStopStemExport = thisNoteRow->loopLengthIfIndependent;
+				}
+			}
+		}
+	}
+}
+
 /// iterates through all clips, arming one clip at a time for recording
 /// simulates the button combo action of pressing record + play twice to enable resample
 /// and stop recording at the end of the clip's loop length
-void StemExport::exportClipStems(StemExportType stemExportType) {
+int32_t StemExport::exportClipStems(StemExportType stemExportType) {
 	// prepare all the clips for stem export
-	disarmAllClipsForStemExport();
+	int32_t totalNumClips = disarmAllClipsForStemExport();
 
-	if (totalNumStemsToExport) {
+	if (totalNumClips) {
 		// now we're going to iterate through all clips to find the ones that should be exported
-		for (int32_t idxClip = totalNumStemsToExport - 1; idxClip >= 0; --idxClip) {
+		for (int32_t idxClip = totalNumClips - 1; idxClip >= 0; --idxClip) {
 			Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
 			if (clip) {
-				bool started = startCurrentStemExport(stemExportType, clip->output, clip->output->type,
-				                                      clip->activeIfNoSolo, idxClip, clip->isEmpty(false));
+				getLoopLengthOfLongestNotEmptyNoteRow(clip);
+
+				bool started = startCurrentStemExport(stemExportType, clip->output, clip->activeIfNoSolo, idxClip,
+				                                      clip->exportStem);
 
 				if (!started) {
 					// skip this stem and move to the next one
@@ -275,7 +375,13 @@ void StemExport::exportClipStems(StemExportType stemExportType) {
 
 				// wait until recording is done and playback is turned off
 				yield([]() {
-					return !(audioRecorder.recordingSource > AudioInputChannel::NONE
+					// if you haven't found silence yet and playback has stopped
+					// check for silence so you can stop recording
+					if (stemExport.stopOutputRecordingAtSilence) {
+						stemExport.checkForSilence();
+					}
+					return !(playbackHandler.recording != RecordingMode::OFF
+					         || audioRecorder.recordingSource > AudioInputChannel::NONE
 					         || playbackHandler.isEitherClockActive());
 				});
 
@@ -290,42 +396,60 @@ void StemExport::exportClipStems(StemExportType stemExportType) {
 	}
 
 	// set clip mutes back to their previous state (before exporting stems)
-	restoreAllClipMutes();
+	restoreAllClipMutes(totalNumClips);
+
+	return totalNumClips;
 }
 
 /// disarms and prepares all the drums so that they can be exported
-void StemExport::disarmAllDrumsForStemExport() {
+int32_t StemExport::disarmAllDrumsForStemExport() {
 	// when we begin stem export, we haven't exported any drums yet, so initialize these variables
 	numStemsExported = 0;
+	totalNumStemsToExport = 0;
 
 	InstrumentClip* clip = getCurrentInstrumentClip();
+	OutputType outputType = clip->output->type;
 
 	// when we trigger stem export, we don't know how many drums there are yet
 	// so get the number and store it so we only need to ping getNumElements once
-	totalNumStemsToExport = clip->noteRows.getNumElements();
+	int32_t totalNumNoteRows = clip->noteRows.getNumElements();
 
-	if (totalNumStemsToExport) {
+	if (totalNumNoteRows) {
 		// iterate through all the drums to disable all the recording relevant flags
-		for (int32_t idxNoteRow = 0; idxNoteRow < totalNumStemsToExport; ++idxNoteRow) {
+		for (int32_t idxNoteRow = 0; idxNoteRow < totalNumNoteRows; ++idxNoteRow) {
 			NoteRow* thisNoteRow = clip->noteRows.getElement(idxNoteRow);
 			if (thisNoteRow) {
+				/* export drum stem if all these conditions are met:
+				    1) the note row is not muted
+				    2) the note row is not empty (it has notes)
+				    3) it has a drum assigned to it
+				    4) the drum assigned to it is a sound drum
+				*/
+				if (!thisNoteRow->muted && !thisNoteRow->hasNoNotes() && thisNoteRow->drum
+				    && thisNoteRow->drum->type == DrumType::SOUND) {
+					thisNoteRow->exportStem = true;
+					totalNumStemsToExport++;
+				}
+				else {
+					thisNoteRow->exportStem = false;
+				}
 				thisNoteRow->mutedBeforeStemExport = thisNoteRow->muted;
 				thisNoteRow->muted = true;
 			}
 		}
 	}
+
+	return totalNumNoteRows;
 }
 
 /// set drum mutes back to their previous state (before exporting stems)
-void StemExport::restoreAllDrumMutes() {
-	if (totalNumStemsToExport) {
-		// iterate through all the drums to restore previous mute states
-		InstrumentClip* clip = getCurrentInstrumentClip();
-		for (int32_t idxNoteRow = 0; idxNoteRow < totalNumStemsToExport; ++idxNoteRow) {
-			NoteRow* thisNoteRow = clip->noteRows.getElement(idxNoteRow);
-			if (thisNoteRow) {
-				thisNoteRow->muted = thisNoteRow->mutedBeforeStemExport;
-			}
+void StemExport::restoreAllDrumMutes(int32_t totalNumNoteRows) {
+	// iterate through all the drums to restore previous mute states
+	InstrumentClip* clip = getCurrentInstrumentClip();
+	for (int32_t idxNoteRow = 0; idxNoteRow < totalNumNoteRows; ++idxNoteRow) {
+		NoteRow* thisNoteRow = clip->noteRows.getElement(idxNoteRow);
+		if (thisNoteRow) {
+			thisNoteRow->muted = thisNoteRow->mutedBeforeStemExport;
 		}
 	}
 }
@@ -333,27 +457,32 @@ void StemExport::restoreAllDrumMutes() {
 /// iterates through all drums, arming one drum at a time for recording
 /// simulates the button combo action of pressing record + play twice to enable resample
 /// and stop recording at the end of the arrangement
-void StemExport::exportDrumStems(StemExportType stemExportType) {
+int32_t StemExport::exportDrumStems(StemExportType stemExportType) {
+	// need to disarm all the other clips so that we can export just this kit clip
+	int32_t totalNumClips = disarmAllClipsForStemExport();
 	// prepare all the drums for stem export
-	disarmAllDrumsForStemExport();
+	int32_t totalNumNoteRows = disarmAllDrumsForStemExport();
 
-	if (totalNumStemsToExport) {
+	if (totalNumNoteRows) {
 		// now we're going to iterate through all drums to find the ones that should be exported
 		InstrumentClip* clip = getCurrentInstrumentClip();
 		Output* output = clip->output;
 		OutputType outputType = output->type;
-		for (int32_t idxNoteRow = totalNumStemsToExport - 1; idxNoteRow >= 0; --idxNoteRow) {
+		for (int32_t idxNoteRow = totalNumNoteRows - 1; idxNoteRow >= 0; --idxNoteRow) {
 			NoteRow* thisNoteRow = clip->noteRows.getElement(idxNoteRow);
 			if (thisNoteRow) {
-				bool isEmpty = true;
-				// for stem export purposes, a note row is not empty if it has notes and is assigned a sound drum
-				if (!thisNoteRow->hasNoNotes() && thisNoteRow->drum && thisNoteRow->drum->type == DrumType::SOUND) {
-					isEmpty = false;
+				clip->activeIfNoSolo = true; // unmute clip
+
+				// set the loop length that drum stem export should be stopped at
+				if (thisNoteRow && thisNoteRow->loopLengthIfIndependent) {
+					loopLengthToStopStemExport = thisNoteRow->loopLengthIfIndependent;
+				}
+				else {
+					loopLengthToStopStemExport = clip->loopLength;
 				}
 
-				bool started =
-				    startCurrentStemExport(stemExportType, output, output->type, thisNoteRow->muted, idxNoteRow,
-				                           isEmpty, thisNoteRow->mutedBeforeStemExport, (SoundDrum*)thisNoteRow->drum);
+				bool started = startCurrentStemExport(stemExportType, output, thisNoteRow->muted, idxNoteRow,
+				                                      thisNoteRow->exportStem, (SoundDrum*)thisNoteRow->drum);
 
 				if (!started) {
 					// skip this stem and move to the next one
@@ -362,7 +491,13 @@ void StemExport::exportDrumStems(StemExportType stemExportType) {
 
 				// wait until recording is done and playback is turned off
 				yield([]() {
-					return !(audioRecorder.recordingSource > AudioInputChannel::NONE
+					// if you haven't found silence yet and playback has stopped
+					// check for silence so you can stop recording
+					if (stemExport.stopOutputRecordingAtSilence) {
+						stemExport.checkForSilence();
+					}
+					return !(playbackHandler.recording != RecordingMode::OFF
+					         || audioRecorder.recordingSource > AudioInputChannel::NONE
 					         || playbackHandler.isEitherClockActive());
 				});
 
@@ -377,20 +512,19 @@ void StemExport::exportDrumStems(StemExportType stemExportType) {
 	}
 
 	// set drum mutes back to their previous state (before exporting stems)
-	restoreAllDrumMutes();
+	restoreAllDrumMutes(totalNumNoteRows);
+	// set clip mutes back to their previous state (before exporting stems)
+	restoreAllClipMutes(totalNumClips);
+
+	return totalNumNoteRows;
 }
 
-bool StemExport::startCurrentStemExport(StemExportType stemExportType, Output* output, OutputType outputType,
-                                        bool& muteState, int32_t indexNumber, bool isEmpty, bool isMuted,
-                                        SoundDrum* drum) {
+bool StemExport::startCurrentStemExport(StemExportType stemExportType, Output* output, bool& muteState,
+                                        int32_t indexNumber, bool exportStem, SoundDrum* drum) {
 	updateScrollPosition(stemExportType, indexNumber + 1);
 
 	// exclude empty clips / outputs, muted outputs (arranger), MIDI and CV outputs
-	if (isEmpty || isMuted || outputType == OutputType::MIDI_OUT || outputType == OutputType::CV) {
-		// updated number of stems exported (even though we didn't actually export anything)
-		// so that we know we processed this stem
-		numStemsExported++;
-
+	if (!exportStem) {
 		return false;
 	}
 
@@ -409,8 +543,8 @@ bool StemExport::startCurrentStemExport(StemExportType stemExportType, Output* o
 	// set wav file name for stem to be exported
 	setWavFileNameForStemExport(stemExportType, output, indexNumber, drum);
 
-	// start resampling which ends when end of clip is reached
-	stemExport.startOutputRecordingUntilLoopEnd();
+	// start resampling which ends when end of clip is reached and audio is silent
+	startOutputRecordingUntilLoopEndAndSilence();
 
 	// we haven't exported all the clips yet
 	// so display the number of clips we've exported so far
@@ -438,7 +572,7 @@ void StemExport::finishCurrentStemExport(StemExportType stemExportType, bool& mu
 
 // if we know how many stems to export, we can check if we've already exported all the
 // stems and are therefore done and should exit out of the stem export UI mode
-void StemExport::finishStemExportProcess(StemExportType stemExportType) {
+void StemExport::finishStemExportProcess(StemExportType stemExportType, int32_t elementsProcessed) {
 	// the only other UI we could be in is the context menu, so let's get out of that
 	if (inContextMenu()) {
 		display->setNextTransitionDirection(-1);
@@ -459,7 +593,7 @@ void StemExport::finishStemExportProcess(StemExportType stemExportType) {
 	highestUsedStemFolderNumber++;
 
 	// reset scroll position
-	updateScrollPosition(stemExportType, totalNumStemsToExport);
+	updateScrollPosition(stemExportType, elementsProcessed);
 
 	processStarted = false;
 

--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -49,6 +49,7 @@ using namespace gui;
 StemExport stemExport{};
 
 StemExport::StemExport() {
+	currentStemExportType = StemExportType::CLIP;
 	processStarted = false;
 
 	highestUsedStemFolderNumber = -1;
@@ -61,6 +62,7 @@ StemExport::StemExport() {
 /// starts stem export process which includes setting up UI mode, timer, and preparing
 /// instruments / clips for exporting
 void StemExport::startStemExportProcess(StemExportType stemExportType) {
+	currentStemExportType = stemExportType;
 	processStarted = true;
 
 	// exit save UI mode and turn off save button LED

--- a/src/deluge/processing/stem_export/stem_export.h
+++ b/src/deluge/processing/stem_export/stem_export.h
@@ -18,10 +18,12 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "processing/sound/sound_drum.h"
 #include "util/d_string.h"
 #include <cstdint>
 
 class Output;
+class SoundDrum;
 
 class StemExport {
 public:
@@ -44,9 +46,14 @@ public:
 	void exportClipStems(StemExportType stemExportType);
 	void restoreAllClipMutes();
 
+	// export drums
+	void disarmAllDrumsForStemExport();
+	void exportDrumStems(StemExportType stemExportType);
+	void restoreAllDrumMutes();
+
 	// start exporting
 	bool startCurrentStemExport(StemExportType stemExportType, Output* output, OutputType outputType, bool& muteState,
-	                            int32_t fileNumber, bool isEmpty, bool isMuted = false);
+	                            int32_t fileNumber, bool isEmpty, bool isMuted = false, SoundDrum* drum = nullptr);
 
 	// finish exporting
 	void finishCurrentStemExport(StemExportType stemExportType, bool& muteState);
@@ -65,7 +72,8 @@ public:
 	Error getUnusedStemRecordingFolderPath(String* filePath, AudioRecordingFolder folder);
 	int32_t highestUsedStemFolderNumber;
 	String lastSongNameForStemExport;
-	void setWavFileNameForStemExport(StemExportType type, Output* output, int32_t fileNumber);
+	void setWavFileNameForStemExport(StemExportType type, Output* output, int32_t fileNumber,
+	                                 SoundDrum* drum = nullptr);
 	String wavFileNameForStemExport;
 	bool wavFileNameForStemExportSet;
 

--- a/src/deluge/processing/stem_export/stem_export.h
+++ b/src/deluge/processing/stem_export/stem_export.h
@@ -32,33 +32,38 @@ public:
 	// start & stop process
 	void startStemExportProcess(StemExportType stemExportType);
 	void stopStemExportProcess();
-	void startOutputRecordingUntilLoopEnd();
+	void startOutputRecordingUntilLoopEndAndSilence();
 	void stopOutputRecordingAndPlayback();
+	bool checkForLoopEnd();
+	void checkForSilence();
 	bool processStarted;
+	bool stopOutputRecordingAtSilence;
 	StemExportType currentStemExportType;
 
 	// export instruments
-	void disarmAllInstrumentsForStemExport();
-	void exportInstrumentStems(StemExportType stemExportType);
-	void restoreAllInstrumentMutes();
+	int32_t disarmAllInstrumentsForStemExport();
+	int32_t exportInstrumentStems(StemExportType stemExportType);
+	void restoreAllInstrumentMutes(int32_t totalNumOutputs);
 
 	// export clips
-	void disarmAllClipsForStemExport();
-	void exportClipStems(StemExportType stemExportType);
-	void restoreAllClipMutes();
+	int32_t disarmAllClipsForStemExport();
+	int32_t exportClipStems(StemExportType stemExportType);
+	void restoreAllClipMutes(int32_t totalNumClips);
+	void getLoopLengthOfLongestNotEmptyNoteRow(Clip* clip);
+	int32_t loopLengthToStopStemExport;
 
 	// export drums
-	void disarmAllDrumsForStemExport();
-	void exportDrumStems(StemExportType stemExportType);
-	void restoreAllDrumMutes();
+	int32_t disarmAllDrumsForStemExport();
+	int32_t exportDrumStems(StemExportType stemExportType);
+	void restoreAllDrumMutes(int32_t totalNumNoteRows);
 
 	// start exporting
-	bool startCurrentStemExport(StemExportType stemExportType, Output* output, OutputType outputType, bool& muteState,
-	                            int32_t fileNumber, bool isEmpty, bool isMuted = false, SoundDrum* drum = nullptr);
+	bool startCurrentStemExport(StemExportType stemExportType, Output* output, bool& muteState, int32_t fileNumber,
+	                            bool exportStem, SoundDrum* drum = nullptr);
 
 	// finish exporting
 	void finishCurrentStemExport(StemExportType stemExportType, bool& muteState);
-	void finishStemExportProcess(StemExportType stemExportType);
+	void finishStemExportProcess(StemExportType stemExportType, int32_t elementsProcessed);
 	void updateScrollPosition(StemExportType stemExportType, int32_t indexNumber);
 
 	// export status

--- a/src/deluge/processing/stem_export/stem_export.h
+++ b/src/deluge/processing/stem_export/stem_export.h
@@ -35,6 +35,7 @@ public:
 	void startOutputRecordingUntilLoopEnd();
 	void stopOutputRecordingAndPlayback();
 	bool processStarted;
+	StemExportType currentStemExportType;
 
 	// export instruments
 	void disarmAllInstrumentsForStemExport();


### PR DESCRIPTION
# Automated Stem Export for Kit Rows

<img width="429" alt="Screenshot 2024-07-11 at 9 00 16 PM" src="https://github.com/user-attachments/assets/b08ac109-a7bc-4b67-8c48-67ffd0afcadd">

https://github.com/user-attachments/assets/b1fd6408-ea5b-4c6d-b5ca-09f73c62ab69

## Description

Added Stem Export for Kit Rows using the same shortcut as in Song and Arranger (Hold Save + Press Record)

Exports each kit row individually without Kit Affect Entire FX applied (except for the Kit Affect Entire Pitch Adjustment which is still applied)

Muted kit rows, kit rows with no notes, and kit rows that are MIDI or CV drums are excluded from the export.

Stems are labelled as a "Drum" and include the Drum Name.