### PR TITLE
Update pad selection mode instructions in automation_view.md

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -184,7 +184,7 @@ The Automation Editor **will:**
 
 ![image](https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/1e4b3653-c1a1-4d21-bfa0-826df378b063)
 
-> Pad selection mode is accessed by pressing on either of the mod encoder buttons
+> Pad selection mode is accessed by pressing shift + waveform
 > 
 > In pad selection mode, you cannot edit the automation grid by pressing on the pads. 
 > 


### PR DESCRIPTION
The instructions for entering pad selection mode were out of date. The image of button shortcuts still needs edited though