### PR TITLE
Update the link for automation view documentation in community_features

### DIFF
--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -1363,9 +1363,9 @@ different firmware
 
 [#2260]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2260
 
-[Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.1/docs/features/automation_view.md
+[Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/automation_view.md
 
-[Velocity View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/velocity_view.md
+[Velocity View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/velocity_view.md
 
 [Performance View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/performance_view.md
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -1363,7 +1363,7 @@ different firmware
 
 [#2260]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2260
 
-[Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/automation_view.md
+[Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.1/docs/features/automation_view.md
 
 [Velocity View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/features/velocity_view.md
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -279,7 +279,7 @@ The Automation Editor **will:**
 - enable you to record in automations live with either of the Mod Encoders (Gold Knobs) so that you can see your automations displayed on the grid
 - display the current parameter being edited on the grid by flashing the parameter shortcut pad white. you can also see the name of the parameter you are editing by holding shift + pressing the flashing shortcut pad to see the parameter name on the screen. Note: for 7seg, you will only cc the MIDI CC # on the screen, not the parameter names in a Synth or Kit as the names are too complicated to abbreviate for a 7seg display and they are not currently shown in the sound editor).
 - enable you to quickly turn interpolation on/off by using the shift + interpolation shortcut (the interpolation shortcut pad is the interpolation pad in the first column of the grid, second from the top). The interpolation shortcut pad will blink every few seconds to remind you that interpolation is on.
-- delete automation for the current parameter being edited using shift + press on either of the Mod Encoders (Gold Knobs)
+- delete automation for the current parameter being edited using shift + press on either of the Mod Encoders (Gold Knobs). You can also delete automation for the current parameter being edited by pressing down on Horizontal Encoder at the same time as pressing the Back button.
 
 > **Note:** When automation is deleted, the Parameter's value is reset to the current value in the Sound Editor. E.g. if an automation playing back and you deleted it mid playback, the parameter value would be set to the last played back value. Or if you just edited the automation by pressing on the grid, the last value would be the value corresponding to the last pad you pressed.
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -446,11 +446,11 @@ These are the main button shortcuts/combos that will be used in the Automation C
 
 ## Automation Overview
 
-![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/108d68d6-b11e-431d-9910-454e1905eb7f)
+![Automation Overview Shortcuts](https://github.com/user-attachments/assets/a2a58c06-f094-49dc-913c-b32ac4137b34)
 
 ## Automation Editor
 
-![image](https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/7c80679a-199e-482f-bfcd-7cb9bc48c623)
+![Automation Editor Shortcuts](https://github.com/user-attachments/assets/eff8f5d7-46dd-46da-b114-72b79ffdb076)
 
 ## Additional Shortcut Combos for Automation Arranger View
 


### PR DESCRIPTION
The link for automation view documentation was out of date

Update automation view shortcut pictures as well:

![Automation Overview Shortcuts](https://github.com/user-attachments/assets/a2a58c06-f094-49dc-913c-b32ac4137b34)

![Automation Editor Shortcuts](https://github.com/user-attachments/assets/eff8f5d7-46dd-46da-b114-72b79ffdb076)
