### PR TITLE
Add New Clip Type Menu and Remove Yellow Grid Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ use the TRACK menu to select the specific track to record from
 - Added new shortcut to remove timestretching from an audio clip and shorten / extend an audio clip without timestretching. 
   - Press `▼︎▲︎` + `◀︎▶︎` to set the Audio Clip length equal to the length of the audio sample. This will effectively remove timestretching from the audio sample.
   - Press `SHIFT` + `◀︎▶︎` + `turn ◀︎▶︎` to shorten / lengthen the audio clip without timestretching.
-- Added new `YELLOW GRID MODE` which allows you configure the clip type between `DEFAULT`, `FILL`, and `ONCE` by holding on a clip pad and pressing `SELECT`. In this mode, while clips are inactive, the clip pads are highlighted different colours to indicate the current clip type.
 - The maximum zoom level for timelines has been increased. Now, the maximum zoom is the point the point where the entire timeline is represented by a single grid cell.
 - Added ability to sync LFO2. Where LFO1 syncs relative to the grid, LFO2 syncs relative to individual notes.
 - Added `VELOCITY VIEW`, accessible from `AUTOMATION VIEW OVERVIEW` by pressing the `VELOCITY` shortcut, from `AUTOMATION VIEW EDITOR` by pressing `SHIFT OR AUDITION PAD + VELOCITY` or from `INSTRUMENT CLIP VIEW` by pressing `AUDITION PAD + VELOCITY`. 
@@ -32,8 +31,13 @@ use the TRACK menu to select the specific track to record from
  - OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu.
  - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.
 - Submenu's on OLED for automatable parameters (e.g. LPF Frequency) render the current parameter value at the end. You still need to click on `SELECT` to edit the parameters value / edit modulation depth and patch cables.
- - All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
- - Added ability to automate tempo in arranger view
+- All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
+- Added ability to automate tempo in arranger view
+- Added `NEW CLIP TYPE` menu that opens on creation of a `NEW CLIP` in `SONG VIEW` which enables you to select the type of clip before the clip is created.
+  - In `SONG (GRID) VIEW`, this menu will only appear when you add a `NEW CLIP` to a `NEW TRACK` (empty column).
+  - This menu will not appear if you are cloning clips (e.g. pressing one clip and then pressing an empty pad).
+- Removed the `SONG VIEW` shortcut of Pressing `CLIP` + `SELECT` to convert an Empty `INSTRUMENT CLIP` to an `AUDIO CLIP`. 
+- Pressing `CLIP` + `SELECT` in `SONG VIEW` will now always open the `LAUNCH STYLE` menu so you can change the Clip launch style between `DEFAULT`, `FILL` and `ONCE`.
 
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -291,6 +291,15 @@ as the micromonsta and the dreadbox nymphes.
  - Submenu's on OLED for automatable parameters (e.g. LPF Frequency) render the current parameter value at the end. You still need to click on `SELECT` to edit the parameters value / edit modulation depth and patch cables.
  - All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
 
+#### 3.27 Updated UI for Creating New Clips in New Tracks in Song View
+- ([#2299]) Added `NEW CLIP TYPE` menu that opens on creation of a `NEW CLIP` in `SONG VIEW` which enables you to select the type of clip before the clip is created.
+  - In `SONG (GRID) VIEW`, this menu will only appear when you add a `NEW CLIP` to a `NEW TRACK` (empty column).
+  - This menu will not appear if you are cloning clips (e.g. pressing one clip and then pressing an empty pad).
+- Removed the `SONG VIEW` shortcut of Pressing `CLIP` + `SELECT` to convert an Empty `INSTRUMENT CLIP` to an `AUDIO CLIP`. 
+
+#### 3.28 Updated UI for Setting Clip Launch Style in Song View
+- ([#2299]) Pressing `CLIP` + `SELECT` in `SONG VIEW` will now always open the `LAUNCH STYLE` menu so you can change the Clip launch style between `DEFAULT`, `FILL` and `ONCE`.
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -329,12 +338,11 @@ Here is a list of features that have been added to the firmware as a list, group
 
 #### 4.1.3 - Fill Clips and Once Clips
 
-- ([#196] and [#1018]) In Song View (Rows mode), holding the status pad (mute pad) for a clip and pressing `SELECT`
-  brings up a clip type selection menu. For Grid Mode there is a dedicated Config Mode in which this menu can be
-  reached, see `Yellow Mode` in [Grid View](#415grid-view).
+- ([#196] and [#1018]) In Song View (Rows mode), holding a clip or the status pad (mute pad) for a clip and pressing `SELECT`
+  brings up a `LAUNCH STYLE` menu. For Grid Mode, only holding a clip and pressing `SELECT` will bring up the `LAUNCH STYLE` menu. 
   
-  The options are:
-    - **`Default (DEFA)`** - the default Deluge clip type.
+  The `LAUNCH STYLE` menu enables you the set the following launch style options for a clip:
+    - **`Default (DEFA)`** - the default Deluge launch style.
     - **`Fill (FILL)`** - Fill clip.
         - When inactive it appears orange on the status pads in rows view, or in Config Mode in grid view.
         - When active it will appear green.
@@ -401,16 +409,6 @@ Here is a list of features that have been added to the firmware as a list, group
             - Track color can be changed by holding any populated clip in a column and rotating `▼︎▲︎`. For fine changes
               to the color press `▼︎▲︎` while turning it.
             - Section pads (left sidebar column) will allow changing repeat count while held
-        - `Yellow mode`
-            - Clips can be configured by holding their pad and pressing the Select encoder to reach the launch style
-              menu, see [Fill Clips and Once Clips](#413fill-clips-and-once-clips)
-            - Pad colour in yellow mode indicates the clip type:
-              - If inactive
-                  - Fill clips are dim orange by default
-                  - Once clips are dim purple by default.
-                  - Normal clips are dull grey.
-              - Active clips are green, or whatever colour is set for active pads.
-              - The colours can be changed in `SETTINGS > PADS > COLOURS > FILL/ONCE`
 - ([#970]) Streamline recording new clips while Deluge is playing
     - This assumes the Deluge is in Grid mode, you are in Green mode, the Deluge is Playing, and Recording is enabled.
     - To use this feature you will need to enable it in the menu:
@@ -1390,6 +1388,8 @@ different firmware
 [#2174]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2166
 
 [#2260]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2260
+
+[#2299]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2299
 
 [#2315]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2315
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -229,6 +229,9 @@ enum class AutomationParamType : uint8_t {
 	NOTE_VELOCITY,
 };
 
+// BEWARE! Something in Kit loading or InstrumentClip::changeOutputType() is sensitive to output type order. There's a
+// lot of casting to and from indexes, and the issue is non-obvious, but moving AUDIO first causes new song + pressing
+// kit to crash in changeOutputType()
 enum class OutputType : uint8_t {
 	SYNTH,
 	KIT,

--- a/src/deluge/gui/context_menu/clip_settings/launch_style.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/launch_style.cpp
@@ -1,6 +1,6 @@
 
 
-#include "gui/context_menu/launch_style.h"
+#include "gui/context_menu/clip_settings/launch_style.h"
 #include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
 #include "gui/ui/root_ui.h"
@@ -8,7 +8,7 @@
 #include "model/clip/clip.h"
 #include <cstddef>
 
-namespace deluge::gui::context_menu {
+namespace deluge::gui::context_menu::clip_settings {
 
 constexpr size_t kNumValues = 3;
 
@@ -45,4 +45,4 @@ void LaunchStyle::selectEncoderAction(int8_t offset) {
 	clip->launchStyle = static_cast<::LaunchStyle>(this->currentOption);
 }
 
-} // namespace deluge::gui::context_menu
+} // namespace deluge::gui::context_menu::clip_settings

--- a/src/deluge/gui/context_menu/clip_settings/launch_style.h
+++ b/src/deluge/gui/context_menu/clip_settings/launch_style.h
@@ -1,5 +1,5 @@
 /*
- * ContextMenuLaunchStyle.h
+ * ContextMenu\Clip_Settings\Launch_Style.h
  *
  *  Created on: 11 Jun 2023
  *      Author: Robin
@@ -11,7 +11,7 @@
 
 class Clip;
 
-namespace deluge::gui::context_menu {
+namespace deluge::gui::context_menu::clip_settings {
 
 class LaunchStyle final : public ContextMenu {
 
@@ -21,7 +21,7 @@ public:
 	bool setupAndCheckAvailability();
 	bool canSeeViewUnderneath() override { return true; }
 
-	Clip* clip;
+	Clip* clip = nullptr;
 
 	/// Title
 	char const* getTitle() override;
@@ -31,4 +31,4 @@ public:
 };
 
 extern LaunchStyle launchStyle;
-} // namespace deluge::gui::context_menu
+} // namespace deluge::gui::context_menu::clip_settings

--- a/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
@@ -1,0 +1,109 @@
+
+
+#include "gui/context_menu/clip_settings/new_clip_type.h"
+#include "definitions_cxx.hpp"
+#include "gui/l10n/l10n.h"
+#include "gui/ui/root_ui.h"
+#include "gui/views/session_view.h"
+#include "hid/display/display.h"
+#include <cstddef>
+
+namespace deluge::gui::context_menu::clip_settings {
+
+constexpr size_t kNumValues = 5;
+
+NewClipType newClipType{};
+
+char const* NewClipType::getTitle() {
+	static char const* title = "New Clip Type";
+	return title;
+}
+
+Sized<char const**> NewClipType::getOptions() {
+	using enum l10n::String;
+	static const char* optionsls[] = {
+	    "Audio", // audio
+	    "Synth", // synth
+	    "Kit",   // kit
+	    "MIDI",  // midi
+	    "CV",    // cv
+	};
+	return {optionsls, kNumValues};
+}
+
+bool NewClipType::setupAndCheckAvailability() {
+	currentUIMode = UI_MODE_NONE;
+
+	this->currentOption = scrollPos = 0; // start at the top of the menu
+
+	return true;
+}
+
+void NewClipType::selectEncoderAction(int8_t offset) {
+	ContextMenu::selectEncoderAction(offset);
+}
+
+bool NewClipType::acceptCurrentOption() {
+	int32_t selection = this->currentOption;
+	OutputType outputType = OutputType::NONE;
+	if (selection == 0) {
+		outputType = OutputType::AUDIO;
+	}
+	else if (selection == 1) {
+		outputType = OutputType::SYNTH;
+	}
+	else if (selection == 2) {
+		outputType = OutputType::KIT;
+	}
+	else if (selection == 3) {
+		outputType = OutputType::MIDI_OUT;
+	}
+	else if (selection == 4) {
+		outputType = OutputType::CV;
+	}
+	sessionView.newClipToCreate = sessionView.createNewClip(outputType, yDisplay);
+	return false; // so you exit out of the context menu
+}
+
+ActionResult NewClipType::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+	using namespace deluge::hid::button;
+
+	if (inCardRoutine) {
+		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+	}
+
+	if (b == SYNTH) {
+		if (on) {
+			sessionView.newClipToCreate = sessionView.createNewClip(OutputType::SYNTH, yDisplay);
+		}
+	}
+
+	else if (b == KIT) {
+		if (on) {
+			sessionView.newClipToCreate = sessionView.createNewClip(OutputType::KIT, yDisplay);
+		}
+	}
+
+	else if (b == MIDI) {
+		if (on) {
+			sessionView.newClipToCreate = sessionView.createNewClip(OutputType::MIDI_OUT, yDisplay);
+		}
+	}
+
+	else if (b == CV) {
+		if (on) {
+			sessionView.newClipToCreate = sessionView.createNewClip(OutputType::CV, yDisplay);
+		}
+	}
+
+	else {
+		return ContextMenu::buttonAction(b, on, inCardRoutine);
+	}
+
+	display->setNextTransitionDirection(-1);
+	close();
+
+	return ActionResult::DEALT_WITH;
+}
+
+} // namespace deluge::gui::context_menu::clip_settings

--- a/src/deluge/gui/context_menu/clip_settings/new_clip_type.h
+++ b/src/deluge/gui/context_menu/clip_settings/new_clip_type.h
@@ -1,0 +1,34 @@
+/*
+ * ContextMenu\Clip_Settings\New_Clip_Type.h
+ *
+ *  Created on: 4 Aug 2024
+ *      Author: Sean
+ */
+
+#pragma once
+
+#include "gui/context_menu/context_menu.h"
+
+namespace deluge::gui::context_menu::clip_settings {
+
+class NewClipType final : public ContextMenu {
+
+public:
+	NewClipType() = default;
+	void selectEncoderAction(int8_t offset) override;
+	bool setupAndCheckAvailability();
+	bool canSeeViewUnderneath() override { return true; }
+	bool acceptCurrentOption() override; // If returns false, will cause UI to exit
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
+
+	int32_t yDisplay = -1;
+
+	/// Title
+	char const* getTitle() override;
+
+	/// Options
+	Sized<const char**> getOptions() override;
+};
+
+extern NewClipType newClipType;
+} // namespace deluge::gui::context_menu::clip_settings

--- a/src/deluge/gui/context_menu/context_menu.h
+++ b/src/deluge/gui/context_menu/context_menu.h
@@ -32,7 +32,7 @@ public:
 
 	void focusRegained() override;
 	void selectEncoderAction(int8_t offset) override;
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) final;
+	virtual ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	void drawCurrentOption();
 	virtual bool isCurrentOptionAvailable() { return true; }
 	virtual bool acceptCurrentOption() { return false; } // If returns false, will cause UI to exit

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -124,7 +124,7 @@ enum class String : size_t {
 	STRING_FOR_MIX_POST_FX,
 	STRING_FOR_TRACK,
 
-	// gui/context_menu/launch_style.cpp
+	// gui/context_menu/clip_settings/launch_style.cpp
 	STRING_FOR_DEFAULT_LAUNCH,
 	STRING_FOR_FILL_LAUNCH,
 	STRING_FOR_ONCE_LAUNCH,

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -20,7 +20,7 @@
 #include "dsp/compressor/rms_feedback.h"
 #include "gui/colour/colour.h"
 #include "gui/colour/palette.h"
-#include "gui/context_menu/launch_style.h"
+#include "gui/context_menu/clip_settings/launch_style.h"
 #include "gui/menu_item/unpatched_param.h"
 #include "gui/ui/menus.h"
 #include "gui/ui/ui.h"

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -24,13 +24,14 @@
 
 class Editor;
 class InstrumentClip;
+class AudioClip;
 class Clip;
 class ModelStack;
+class ModelStackWithTimelineCounter;
 
 enum SessionGridMode : uint8_t {
 	SessionGridModeEdit,
 	SessionGridModeLaunch,
-	SessionGridModeConfig,
 	SessionGridModeMaxElement // Keep as boundary
 };
 
@@ -123,6 +124,9 @@ public:
 	// ui
 	UIType getUIType() { return UIType::SESSION; }
 
+	Clip* createNewClip(OutputType outputType, int32_t yDisplay);
+	Clip* newClipToCreate;
+
 private:
 	// These and other (future) commandXXX methods perform actions triggered by HID, but contain
 	// no dispatch logic.
@@ -139,11 +143,18 @@ private:
 	void clipPressEnded();
 	void drawSectionRepeatNumber();
 	void beginEditingSectionRepeatsNum();
-	Clip* createNewInstrumentClip(int32_t yDisplay);
 	void goToArrangementEditor();
-	void replaceInstrumentClipWithAudioClip(Clip* clip);
 	void rowNeedsRenderingDependingOnSubMode(int32_t yDisplay);
 	void setCentralLEDStates();
+
+	Clip* createNewAudioClip(int32_t yDisplay);
+	Clip* createNewInstrumentClip(OutputType outputType, int32_t yDisplay);
+
+	bool createNewTrackForAudioClip(AudioClip* newClip);
+	bool createNewTrackForInstrumentClip(OutputType type, InstrumentClip* clip, bool copyDrumsFromClip);
+
+	bool insertAndResyncNewClip(Clip* newClip, int32_t yDisplay);
+	void resyncNewClip(Clip* newClip, ModelStackWithTimelineCounter* modelStackWithTimelineCounter);
 
 	// Members regarding rendering different layouts
 private:
@@ -168,7 +179,6 @@ private:
 	ActionResult gridHandlePadsLaunch(int32_t x, int32_t y, int32_t on, Clip* clip);
 	ActionResult gridHandlePadsLaunchImmediate(int32_t x, int32_t y, int32_t on, Clip* clip);
 	ActionResult gridHandlePadsLaunchWithSelection(int32_t x, int32_t y, int32_t on, Clip* clip);
-	ActionResult gridHandlePadsConfig(int32_t x, int32_t y, int32_t on, Clip* clip);
 	void gridHandlePadsLaunchToggleArming(Clip* clip, bool immediate);
 
 	ActionResult gridHandleScroll(int32_t offsetX, int32_t offsetY);
@@ -200,10 +210,11 @@ private:
 
 	Clip* gridCloneClip(Clip* sourceClip);
 	Clip* gridCreateClipInTrack(Output* targetOutput);
-	bool gridCreateNewTrackForClip(OutputType type, InstrumentClip* clip, bool copyDrumsFromClip);
-	InstrumentClip* gridCreateClipWithNewTrack(OutputType type);
+	AudioClip* gridCreateAudioClipWithNewTrack();
+	InstrumentClip* gridCreateInstrumentClipWithNewTrack(OutputType type);
 	Clip* gridCreateClip(uint32_t targetSection, Output* targetOutput = nullptr, Clip* sourceClip = nullptr);
 	void gridClonePad(uint32_t sourceX, uint32_t sourceY, uint32_t targetX, uint32_t targetY);
+	void setupNewClip(Clip* newClip);
 
 	void gridStartSection(uint32_t section, bool instant);
 	void gridToggleClipPlay(Clip* clip, bool instant);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -22,7 +22,7 @@
 #include "extern.h"
 #include "gui/colour/colour.h"
 #include "gui/context_menu/clear_song.h"
-#include "gui/context_menu/launch_style.h"
+#include "gui/context_menu/clip_settings/launch_style.h"
 #include "gui/l10n/l10n.h"
 #include "gui/menu_item/colour.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
@@ -2488,7 +2488,7 @@ void View::instrumentChanged(ModelStackWithTimelineCounter* modelStack, Instrume
 	}
 }
 
-RGB View::getClipMuteSquareColour(Clip* clip, RGB thisColour, bool whiteInactivePads, bool allowMIDIFlash) {
+RGB View::getClipMuteSquareColour(Clip* clip, RGB thisColour, bool allowMIDIFlash) {
 
 	if (currentUIMode == UI_MODE_VIEWING_RECORD_ARMING && clip && clip->armedForRecording) {
 		if (blinkOn) {
@@ -2535,17 +2535,8 @@ RGB View::getClipMuteSquareColour(Clip* clip, RGB thisColour, bool whiteInactive
 				thisColour = menu_item::onceColourMenu.getRGB(); // colours::red_orange;
 				break;
 			default:
-
-				if (whiteInactivePads) {
-					// If grid view + config mode requests it,
-					// Use white to avoid a screen full of red pads
-					// Grid mode itself dims these colours to grey
-					thisColour = colours::white;
-				}
-				else {
-					// If it's stopped, red.
-					thisColour = menu_item::stoppedColourMenu.getRGB();
-				}
+				// If it's stopped, red.
+				thisColour = menu_item::stoppedColourMenu.getRGB();
 			}
 		}
 		else {
@@ -2587,13 +2578,13 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 				clip->armedForRecording = true;
 				if (clip->type == ClipType::AUDIO) {
 					((AudioClip*)clip)->overdubsShouldCloneOutput = false;
-					defaultAudioClipOverdubOutputCloning = 0;
+					currentSong->defaultAudioClipOverdubOutputCloning = 0;
 				}
 			}
 			else {
 				if (clip->type == ClipType::AUDIO && !((AudioClip*)clip)->overdubsShouldCloneOutput) {
 					((AudioClip*)clip)->overdubsShouldCloneOutput = true;
-					defaultAudioClipOverdubOutputCloning = 1;
+					currentSong->defaultAudioClipOverdubOutputCloning = 1;
 					break; // No need to reassess greyout
 				}
 				else {
@@ -2619,7 +2610,7 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 	case UI_MODE_HOLDING_STATUS_PAD:
 		if (on) {
 			enterUIMode(UI_MODE_HOLDING_STATUS_PAD);
-			context_menu::launchStyle.clip = clip;
+			context_menu::clip_settings::launchStyle.clip = clip;
 			sessionView.performActionOnPadRelease = false; // Even though there's a chance we're not in session view
 			session.toggleClipStatus(clip, NULL, Buttons::isShiftButtonPressed(), kInternalButtonPressLatency);
 		}

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -92,8 +92,7 @@ public:
 	void drawOutputNameFromDetails(OutputType outputType, int32_t slot, int32_t subSlot, char const* name,
 	                               bool editedByUser, bool doBlink, Clip* clip = NULL);
 	void endMIDILearn();
-	[[nodiscard]] RGB getClipMuteSquareColour(Clip* clip, RGB thisColour, bool whiteInactivePads = false,
-	                                          bool allowMIDIFlash = true);
+	[[nodiscard]] RGB getClipMuteSquareColour(Clip* clip, RGB thisColour, bool allowMIDIFlash = true);
 	ActionResult clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfInSessionView = -1);
 	void flashPlayEnable();
 	void flashPlayDisable();

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5249,8 +5249,6 @@ void Song::swapClips(Clip* newClip, Clip* oldClip, int32_t clipIndex) {
 	deleteClipObject(oldClip);
 }
 
-int8_t defaultAudioClipOverdubOutputCloning = -1; // -1 means no default set
-
 Clip* Song::replaceInstrumentClipWithAudioClip(Clip* oldClip, int32_t clipIndex) {
 
 	// Allocate memory for audio clip

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -396,9 +396,11 @@ public:
 	uint8_t chordMemNoteCount[kDisplayHeight] = {0};
 	uint8_t chordMem[kDisplayHeight][MAX_NOTES_CHORD_MEM] = {0};
 
+	// Tempo automation
 	void clearTempoAutomation();
-
 	void updateBPMFromAutomation();
+
+	int8_t defaultAudioClipOverdubOutputCloning = -1; // -1 means no default set
 
 private:
 	ScaleMapper scaleMapper;
@@ -423,4 +425,3 @@ private:
 
 extern Song* currentSong;
 extern Song* preLoadedSong;
-extern int8_t defaultAudioClipOverdubOutputCloning;


### PR DESCRIPTION
## Description

Added new clip type context menu that opens on creation of a new clip in song view which enables you to select the type of clip before the clip is created, removing the need to create a synth clip and then change its type afterwards.

This frees up the press clip and press select encoder shortcut to be used to selecting the clips launch style.

Removed grid view yellow mode (from https://github.com/SynthstromAudible/DelugeFirmware/pull/1494) because you can now select clip launch style in all grid view modes.

## Usage: 

Add new clip by pressing an empty row or adding a clip to an empty column in grid view.

A menu will open enabling you to select the type of clip that you wish to create. The options are:

1. Audio clip
2. Synth clip
3. Kit clip
4. MIDI clip
5. CV clip

Select the type by scrolling to it in the menu and pressing the select encoder to create a clip with that type.

Alternatively, while the menu is open, you can also select Synth/Kit/MIDI/CV by pressing the corresponding deluge buttons.

If you exit the menu (by pressing back or pressing the grid) then no clip will be created.
