### PR TITLE
task manager: allow speedy handling of sysex messages when possible

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -572,7 +572,7 @@ void registerTasks() {
 	// this one runs quickly and frequently to check for encoder changes
 	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders");
 	// formerly part of audio routine, updates midi and clock
-	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 8 / 44100., 16 / 44100, 32 / 44100., "playback routine");
+	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 2 / 44100., 16 / 44100, 32 / 44100., "playback routine");
 	addRepeatingTask([]() { audioFileManager.loadAnyEnqueuedClusters(128, false); }, p++, 0.00001, 0.00001, 0.00002,
 	                 "load clusters");
 	// handles sd card recorders


### PR DESCRIPTION
The loading time of firmware over USB regressed in 149d907 From ~2.5 seconds to ~6.1 seconds (regardless if debug or release build). This restores the old performance.

It seems to be enough to _allow_ `playbackHandler.routine()` to run more often without increasing the target time, so this should have no negative effects when there is contention with other tasks, I guess.