### PR TITLE
Fix scheduler perf dropping after 128 seconds

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -118,7 +118,7 @@ struct TaskManager {
 	std::array<SortedTask, kMaxTasks> sortedList;
 	uint8_t numActiveTasks = 0;
 	uint8_t numRegisteredTasks = 0;
-	double mustEndBefore = 128; // use for testing or I guess if you want a second temporary task manager?
+	double mustEndBefore = -1; // use for testing or I guess if you want a second temporary task manager?
 	bool running{false};
 	double cpuTime{0};
 	double overhead{0};
@@ -173,6 +173,7 @@ void TaskManager::createSortedList() {
 	}
 }
 
+// deadline < 0 means no deadline
 TaskID TaskManager::chooseBestTask(double deadline) {
 	double currentTime = getSecondsFromStart();
 	double nextFinishTime = currentTime;
@@ -192,7 +193,7 @@ TaskID TaskManager::chooseBestTask(double deadline) {
 			return sortedList[i].task;
 		}
 		if (timeToCall < currentTime || maxTimeToCall < nextFinishTime) {
-			if (currentTime + t->durationStats.average < deadline) {
+			if (deadline < 0 || currentTime + t->durationStats.average < deadline) {
 
 				if (s->priority < bestPriority && t->handle) {
 					if (timeSinceFinish > s->backOffPeriod) {
@@ -385,6 +386,9 @@ void TaskManager::start(double duration) {
 	double lastLoop = startTime;
 	if (duration != 0) {
 		mustEndBefore = startTime + duration;
+	}
+	else {
+		mustEndBefore = -1;
 	}
 
 	while (duration == 0 || getSecondsFromStart() < startTime + duration) {


### PR DESCRIPTION
Currently, there is a massive increase in scheduler overhead happening after roughly 128 seconds after boot up. As an example, here is scheduler stats before and after when the deluge is idle in an empty song:

```
Before (typical numbers):

task_scheduler.cpp:451: Dumping task manager stats: (min/ average/ max)
task_scheduler.cpp:470: Load: 84.20 Average Duration: 13.628 Times Called: 340283, Task: audio routine
task_scheduler.cpp:470: Load: 1.59 Average Duration: 5.730 Times Called: 19062, Task: read encoders
......
task_scheduler.cpp:478: Working time: 55.94, Overhead: 44.20. Total running time: 120.00 seconds

After (typical numbers):
task_scheduler.cpp:451: Dumping task manager stats: (min/ average/ max)
task_scheduler.cpp:470: Load: 58.62 Average Duration: 33.665 Times Called: 18188, Task: audio routine
task_scheduler.cpp:470: Load: 4.59 Average Duration: 4.393 Times Called: 9922, Task: read encoders
....
task_scheduler.cpp:478: Working time: 10.06, Overhead: 89.94. Total running time: 140.00 seconds

```

After chasing a few false ends (I was convinced it was a rollover related bug, as rolltime is 128.86 seconds), there is a bug in chooseBestTask() as the deadline is not being setup anymore, which leads to the default value of `double mustEndBefore = 128;` being unchanged. after this, most logic in chooseBestTask stops working as intended. 

To fix it, add a proper check for running the scheduler without deadline.