### PR TITLE
Stop sending early clocks

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -629,7 +629,9 @@ void PlaybackHandler::actionTimerTickPart2() {
 			uint64_t fractionLastTimerTick = lastTimerTickActioned * analogOutTicksPer;
 			uint64_t fractionNextAnalogOutTick = (lastTriggerClockOutTickDone + 1) * internalTicksPer;
 
-			if (fractionNextAnalogOutTick <= fractionLastTimerTick) {
+			// if we've fallen behind the timer ticks somehow then scheduling won't work properly so output immediately
+			// otherwise set it to be done by the audio engine
+			if (fractionNextAnalogOutTick < fractionLastTimerTick) {
 				doTriggerClockOutTick();
 				fractionNextAnalogOutTick += internalTicksPer;
 			}
@@ -646,8 +648,9 @@ void PlaybackHandler::actionTimerTickPart2() {
 			uint64_t fractionLastTimerTick = lastTimerTickActioned * midiClockOutTicksPer;
 
 			uint64_t fractionNextMIDIClockOutTick = (lastMIDIClockOutTickDone + 1) * internalTicksPer;
-
-			if (fractionNextMIDIClockOutTick <= fractionLastTimerTick) {
+			// if we've fallen behind the timer ticks somehow then scheduling won't work properly so output immediately
+			// otherwise set it to be done by the audio engine
+			if (fractionNextMIDIClockOutTick < fractionLastTimerTick) {
 				doMIDIClockOutTick();
 				fractionNextMIDIClockOutTick += midiClockOutTicksPer;
 			}


### PR DESCRIPTION
Fixes a bug which caused midi clocks to be sent immediately rather than at a properly scheduled time. When a clock tick is exactly corresponds to an internal tick this comparison is equal but the tick still needs to be scheduled in the future for accurate timing

With this fix all ticks are within 1ms of the correct time, which is the best possible timing on USB 1.1


fix #2305 