### PR TITLE
fix rounding in audio engine, fix optimization bug in scheduler

### DIFF
--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -345,7 +345,6 @@ bool TaskManager::yield(RunCondition until, double timeout) {
 		startClock();
 	}
 #if !IN_UNIT_TESTS
-	D_PRINTLN("yielding");
 	GeneralMemoryAllocator::get().checkStack("ensure resizeable space");
 #endif
 	auto yieldingTask = &list[currentID];
@@ -382,9 +381,6 @@ bool TaskManager::yield(RunCondition until, double timeout) {
 		auto finishTime = getSecondsFromStart();
 		yieldingTask->lastCallTime = finishTime; // hack so it won't get called again immediately
 	}
-#if !IN_UNIT_TESTS
-	D_PRINTLN("done yielding");
-#endif
 	return (getSecondsFromStart() < timeNow + timeout);
 }
 

--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -149,7 +149,7 @@ struct TaskManager {
 	double getLastRunTimeforCurrentTask();
 
 private:
-	TaskID currentID{std::numeric_limits<TaskID>::max()};
+	TaskID currentID{0};
 	// for time tracking with rollover
 	double lastTime{0};
 	double runningTime{0};
@@ -344,8 +344,8 @@ bool TaskManager::yield(RunCondition until, double timeout) {
 	if (!running) {
 		startClock();
 	}
-	D_PRINTLN("yielding");
 #if !IN_UNIT_TESTS
+	D_PRINTLN("yielding");
 	GeneralMemoryAllocator::get().checkStack("ensure resizeable space");
 #endif
 	auto yieldingTask = &list[currentID];
@@ -382,7 +382,9 @@ bool TaskManager::yield(RunCondition until, double timeout) {
 		auto finishTime = getSecondsFromStart();
 		yieldingTask->lastCallTime = finishTime; // hack so it won't get called again immediately
 	}
+#if !IN_UNIT_TESTS
 	D_PRINTLN("done yielding");
+#endif
 	return (getSecondsFromStart() < timeNow + timeout);
 }
 

--- a/src/OSLikeStuff/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler.cpp
@@ -18,10 +18,13 @@
 #include "task_scheduler.h"
 
 #include "io/debug/log.h"
-#include "memory/general_memory_allocator.h"
 #include "util/container/static_vector.hpp"
 #include <algorithm>
 #include <iostream>
+
+#if !IN_UNIT_TESTS
+#include "memory/general_memory_allocator.h"
+#endif
 
 extern "C" {
 #include "RZA1/ostm/ostm.h"
@@ -342,8 +345,9 @@ bool TaskManager::yield(RunCondition until, double timeout) {
 		startClock();
 	}
 	D_PRINTLN("yielding");
+#if !IN_UNIT_TESTS
 	GeneralMemoryAllocator::get().checkStack("ensure resizeable space");
-
+#endif
 	auto yieldingTask = &list[currentID];
 	auto yieldingID = currentID;
 	bool taskRemoved = false;

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -58,8 +58,8 @@ void GeneralMemoryAllocator::checkStack(char const* caller) {
 	int32_t distance = (int32_t)&a - (uint32_t)&program_stack_start;
 	if (distance < closestDistance) {
 		closestDistance = distance;
-		D_PRINT("%d bytes in stack %d free bytes in stack at %x", (uint32_t)&program_stack_end - (int32_t)&a, distance,
-		        caller);
+		D_PRINTLN("%d bytes in stack %d free bytes in stack at %s", (uint32_t)&program_stack_end - (int32_t)&a,
+		          distance, caller);
 
 		if (distance < 200) {
 			FREEZE_WITH_ERROR("E338");
@@ -94,7 +94,7 @@ void* GeneralMemoryAllocator::allocExternal(uint32_t requiredSize) {
 	void* address = regions[MEMORY_REGION_EXTERNAL].alloc(requiredSize, false, NULL);
 	lock = false;
 	if (!address) {
-		// FREEZE_WITH_ERROR("M998");
+		FREEZE_WITH_ERROR("M998");
 		return nullptr;
 	}
 	return address;

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -94,7 +94,7 @@ void* GeneralMemoryAllocator::allocExternal(uint32_t requiredSize) {
 	void* address = regions[MEMORY_REGION_EXTERNAL].alloc(requiredSize, false, NULL);
 	lock = false;
 	if (!address) {
-		FREEZE_WITH_ERROR("M998");
+		// FREEZE_WITH_ERROR("M998");
 		return nullptr;
 	}
 	return address;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -464,7 +464,7 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 /// set the direness level and cull any voices
 inline void setDireness(size_t numSamples) { // Consider direness and culling - before increasing the number of samples
 	// number of samples it took to do the last render
-	int32_t dspTime = (getLastRunTimeforCurrentTask() * 44100.);
+	auto dspTime = (int32_t)(getLastRunTimeforCurrentTask() * 44100.);
 	size_t nonDSP = numSamples - dspTime;
 	// we don't care about the number that were rendered in the last go, only the ones taken by the first routine call
 	numSamples = std::max<int32_t>(dspTime - (int32_t)(numRoutines * numSamples), 0);

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -464,10 +464,10 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 /// set the direness level and cull any voices
 inline void setDireness(size_t numSamples) { // Consider direness and culling - before increasing the number of samples
 	// number of samples it took to do the last render
-	auto dspTime = (size_t)(getLastRunTimeforCurrentTask() * 44100.);
+	int32_t dspTime = (getLastRunTimeforCurrentTask() * 44100.);
 	size_t nonDSP = numSamples - dspTime;
 	// we don't care about the number that were rendered in the last go, only the ones taken by the first routine call
-	numSamples = dspTime - numRoutines * numSamples;
+	numSamples = std::max<int32_t>(dspTime - (int32_t)(numRoutines * numSamples), 0);
 
 	// don't smooth this - used for other decisions as well
 	if (numSamples >= direnessThreshold) {

--- a/src/deluge/util/container/static_vector.hpp
+++ b/src/deluge/util/container/static_vector.hpp
@@ -858,9 +858,8 @@ public:
 	}
 
 	/// Copy assignment.
-	constexpr static_vector&
-	operator=(static_vector const& other) noexcept(noexcept(clear())
-	                                               && noexcept(insert(begin(), other.begin(), other.end())))
+	constexpr static_vector& operator=(static_vector const& other) noexcept(
+	    noexcept(clear()) && noexcept(insert(begin(), other.begin(), other.end())))
 	requires std::assignable_from<reference, const_reference>
 	{
 		// nothin to assert: size of other cannot exceed capacity
@@ -871,9 +870,8 @@ public:
 	}
 
 	/// Move assignment.
-	constexpr static_vector&
-	operator=(static_vector&& other) noexcept(noexcept(clear())
-	                                          and noexcept(move_insert(begin(), other.begin(), other.end())))
+	constexpr static_vector& operator=(static_vector&& other) noexcept(
+	    noexcept(clear()) and noexcept(move_insert(begin(), other.begin(), other.end())))
 	requires std::move_constructible<value_type>
 	{
 		// nothin to assert: size of other cannot exceed capacity

--- a/src/deluge/util/container/static_vector.hpp
+++ b/src/deluge/util/container/static_vector.hpp
@@ -53,6 +53,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
+#include <algorithm>
 #include <array>
 #include <cstddef>     // for size_t
 #include <cstdint>     // for fixed-width integer types
@@ -857,8 +858,9 @@ public:
 	}
 
 	/// Copy assignment.
-	constexpr static_vector& operator=(static_vector const& other) noexcept(
-	    noexcept(clear()) && noexcept(insert(begin(), other.begin(), other.end())))
+	constexpr static_vector&
+	operator=(static_vector const& other) noexcept(noexcept(clear())
+	                                               && noexcept(insert(begin(), other.begin(), other.end())))
 	requires std::assignable_from<reference, const_reference>
 	{
 		// nothin to assert: size of other cannot exceed capacity
@@ -869,8 +871,9 @@ public:
 	}
 
 	/// Move assignment.
-	constexpr static_vector& operator=(static_vector&& other) noexcept(
-	    noexcept(clear()) and noexcept(move_insert(begin(), other.begin(), other.end())))
+	constexpr static_vector&
+	operator=(static_vector&& other) noexcept(noexcept(clear())
+	                                          and noexcept(move_insert(begin(), other.begin(), other.end())))
 	requires std::move_constructible<value_type>
 	{
 		// nothin to assert: size of other cannot exceed capacity

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,9 @@ if (WIN32 AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Gcc")
     set(CPPUTEST_PLATFORM VisualCpp)
 endif()
 
+set(DELUGE_C_STANDARD 23)
+set(DELUGE_CXX_STANDARD 23)
+
 enable_testing()
 #needs to support -m32 since the memory tests assume a 32 bit architecture
 if (UNIX AND NOT APPLE)


### PR DESCRIPTION
Conversion and rounding to size_t in audio engine sometimes resulted in culling a voice due to a falsely high sample count

At O2 GCC sometimes optimized the check for counting a task's stats away since it can only be modified through the indirect function call, mark it volatile to fix it