### PR TITLE
fix bug in SourceSelection: don't set s to temporary values

### DIFF
--- a/src/deluge/gui/menu_item/source_selection.cpp
+++ b/src/deluge/gui/menu_item/source_selection.cpp
@@ -200,10 +200,9 @@ void SourceSelection::selectEncoderAction(int32_t offset) {
 			newValue = ((newValue % kNumPatchSources) + kNumPatchSources) % kNumPatchSources;
 		}
 
-		s = sourceMenuContents[newValue];
+	} while (!sourceIsAllowed(sourceMenuContents[newValue]));
 
-	} while (!sourceIsAllowed(s));
-
+	s = sourceMenuContents[newValue];
 	this->setValue(newValue);
 
 	if (display->haveOLED()) {


### PR DESCRIPTION
- If we were on OLED, and last allowable modulation source was highlighted, but there were non-allowed ones after it, trying to scroll further would bail out with with SourceSelection::s set to a non-allowed value even though we had an allowed on selected.

  Solution is to set s only after we've found a legal value: in event of the bailout we retain the previous legal value.

- fixes #2312