### PR TITLE
Bugfix/respect record arming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added `VELOCITY VIEW`, accessible from `AUTOMATION VIEW OVERVIEW` by pressing the `VELOCITY` shortcut, from `AUTOMATION VIEW EDITOR` by pressing `SHIFT OR AUDITION PAD + VELOCITY` or from `INSTRUMENT CLIP VIEW` by pressing `AUDITION PAD + VELOCITY`. 
   - Velocity View enables you to edit the velocities and other parameters of notes in a single note row using a similar interface to `AUTOMATION VIEW`.
 - Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW` and `INSTRUMENT STEMS` while in `ARRANGER VIEW`. Press `SAVE + RECORD` to start exporting stems. Press `BACK` to cancel stem exporting and stop recording and playback.
+- Fixed a bug where instruments and kits wouldn't respect record arming state. They no longer record when not armed
 
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -160,7 +160,6 @@ public:
 
 	bool isPendingOverdub;
 	bool isUnfinishedAutoOverdub;
-	bool armedForRecording;
 	bool wasWantingToDoLinearRecordingBeforeCountIn; // Only valid during a count-in
 	OverDubType overdubNature;
 

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1043,10 +1043,10 @@ void Kit::receivedNoteForDrum(ModelStackWithTimelineCounter* modelStack, MIDIDev
 
 	bool recordingNoteOnEarly = false;
 
-	bool shouldRecordNoteOn = shouldRecordNotes && instrumentClip
-	                          && currentSong->isClipActive(instrumentClip); // Even if this comes out as false here,
-	                                                                        // there are some special cases below where
-	                                                                        // we might insist on making it true
+	bool shouldRecordNoteOn = shouldRecordNotes && instrumentClip && currentSong->isClipActive(instrumentClip)
+	                          && instrumentClip->armedForRecording; // Even if this comes out as false here,
+	                                                                // there are some special cases below where
+	                                                                // we might insist on making it true
 	// If MIDIDrum, outputting same note, then don't additionally do thru
 	if (doingMidiThru && thisDrum->type == DrumType::MIDI && ((MIDIDrum*)thisDrum)->channel == channel
 	    && ((MIDIDrum*)thisDrum)->note == note) {

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -139,7 +139,7 @@ void MelodicInstrument::receivedNote(ModelStackWithTimelineCounter* modelStack, 
 				if (instrumentClip) {
 
 					// If we wanna record...
-					if (shouldRecordNotes) {
+					if (shouldRecordNotes && instrumentClip->armedForRecording) {
 
 						bool forcePos0 = false;
 

--- a/src/deluge/model/timeline_counter.h
+++ b/src/deluge/model/timeline_counter.h
@@ -49,4 +49,5 @@ public:
 	virtual void instrumentBeenEdited() {}
 
 	ParamManagerForTimeline paramManager;
+	bool armedForRecording{true};
 };

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -111,7 +111,8 @@ void AutoParam::setCurrentValueInResponseToUserInput(int32_t value, ModelStackWi
 	if (isPlaying) {
 
 		// If recording...
-		if (playbackHandler.recording != RecordingMode::OFF && modelStack->timelineCounterIsSet()) {
+		if (playbackHandler.recording != RecordingMode::OFF && modelStack->timelineCounterIsSet()
+		    && modelStack->getTimelineCounter()->armedForRecording) {
 
 			// If in record mode and shift button held down, delete automation
 			if (Buttons::isShiftButtonPressed()) {


### PR DESCRIPTION
Non audio clips let you toggle the record arming state but didn't do anything with it. This bugfix has them respect their arming state while recording