### PR TITLE
refactor: extract stutterer code from ModControllableAudio

### DIFF
--- a/src/deluge/model/fx/README.md
+++ b/src/deluge/model/fx/README.md
@@ -1,0 +1,7 @@
+# FX
+
+FX classes are between the application and the DSP. They have access to params via a
+ParamManager, but don't know anything about settings, UI or the larger application state.
+
+No shared interface yet, but maybe one day.
+

--- a/src/deluge/model/fx/stutterer.cpp
+++ b/src/deluge/model/fx/stutterer.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "model/fx/stutterer.h"
+#include "dsp/stereo_sample.h"
+#include "modulation/params/param_manager.h"
+#include "modulation/params/param_set.h"
+
+namespace params = deluge::modulation::params;
+
+Stutterer stutterer{};
+
+void Stutterer::initParams(ParamManager* paramManager) {
+	paramManager->getUnpatchedParamSet()->params[params::UNPATCHED_STUTTER_RATE].setCurrentValueBasicForSetup(0);
+}
+
+int32_t Stutterer::getStutterRate(ParamManager* paramManager, int32_t magnitude, uint32_t timePerTickInverse) {
+	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+	int32_t paramValue = unpatchedParams->getValue(params::UNPATCHED_STUTTER_RATE);
+
+	// Quantized Stutter diff
+	// Convert to knobPos (range -64 to 64) for easy operation
+	int32_t knobPos = unpatchedParams->paramValueToKnobPos(paramValue, nullptr);
+	// Add diff "lastQuantizedKnobDiff" (this value will be set if Quantized Stutter is On, zero if not so this will be
+	// a no-op)
+	knobPos = knobPos + lastQuantizedKnobDiff;
+	// Avoid the param to go beyond limits
+	if (knobPos < -64) {
+		knobPos = -64;
+	}
+	else if (knobPos > 64) {
+		knobPos = 64;
+	}
+	// Convert back to value range
+	paramValue = unpatchedParams->knobPosToParamValue(knobPos, nullptr);
+
+	int32_t rate =
+	    getFinalParameterValueExp(paramNeutralValues[params::GLOBAL_DELAY_RATE], cableToExpParamShortcut(paramValue));
+
+	if (sync != 0) {
+		rate = multiply_32x32_rshift32(rate, timePerTickInverse);
+
+		// Limit to the biggest number we can store...
+		int32_t lShiftAmount = sync + 6 - magnitude;
+		int32_t limit = 2147483647 >> lShiftAmount;
+		rate = std::min(rate, limit);
+		rate <<= lShiftAmount;
+	}
+	return rate;
+}
+
+Error Stutterer::beginStutter(void* source, ParamManagerForTimeline* paramManager, bool quantize, int32_t magnitude,
+                              uint32_t timePerTickInverse) {
+	if (quantize) {
+		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+		int32_t paramValue = unpatchedParams->getValue(params::UNPATCHED_STUTTER_RATE);
+		int32_t knobPos = unpatchedParams->paramValueToKnobPos(paramValue, nullptr);
+		if (knobPos < -39) {
+			knobPos = -16; // 4ths
+		}
+		else if (knobPos < -14) {
+			knobPos = -8; // 8ths
+		}
+		else if (knobPos < 14) {
+			knobPos = 0; // 16ths
+		}
+		else if (knobPos < 39) {
+			knobPos = 8; // 32nds
+		}
+		else {
+			knobPos = 16; // 64ths
+		}
+		// Save current values for later recovering them
+		valueBeforeStuttering = paramValue;
+		lastQuantizedKnobDiff = knobPos;
+		isQuantized = true;
+
+		// When stuttering, we center the value at 0, so the center is the reference for the stutter rate that we
+		// selected just before pressing the knob and we use the lastQuantizedKnobDiff value to calculate the relative
+		// (real) value
+		unpatchedParams->params[params::UNPATCHED_STUTTER_RATE].setCurrentValueBasicForSetup(0);
+	}
+
+	// You'd think I should apply "false" here, to make it not add extra space to the buffer, but somehow this seems to
+	// sound as good if not better (in terms of ticking / crackling)...
+	Error error = buffer.init(getStutterRate(paramManager, magnitude, timePerTickInverse), 0, true);
+	if (error == Error::NONE) {
+		status = Status::RECORDING;
+		sizeLeftUntilRecordFinished = buffer.size();
+		stutterSource = source;
+	}
+	return error;
+}
+
+void Stutterer::processStutter(StereoSample* audio, int32_t numSamples, ParamManager* paramManager, int32_t magnitude,
+                               uint32_t timePerTickInverse) {
+	StereoSample* audioEnd = audio + numSamples;
+
+	StereoSample* thisSample = audio;
+
+	int32_t rate = getStutterRate(paramManager, magnitude, timePerTickInverse);
+
+	buffer.setupForRender(rate);
+
+	if (status == Status::RECORDING) {
+
+		do {
+
+			int32_t strength1;
+			int32_t strength2;
+
+			// First, tick it along, as if we were reading from it
+
+			// Non-resampling tick-along
+			if (buffer.isNative()) {
+				buffer.clearAndMoveOn();
+				sizeLeftUntilRecordFinished--;
+
+				// buffer.writeNative(thisSample->l, thisSample->r);
+			}
+
+			// Or, resampling tick-along
+			else {
+				// Move forward, and clear buffer as we go
+				strength2 = buffer.advance([&] {
+					buffer.clearAndMoveOn(); //<
+					sizeLeftUntilRecordFinished--;
+				});
+				strength1 = 65536 - strength2;
+
+				// buffer.writeResampled(thisSample->l, thisSample->r, strength1, strength2,
+				// &delayBufferSetup);
+			}
+
+			buffer.write(*thisSample, strength1, strength2);
+
+		} while (++thisSample != audioEnd);
+
+		// If we've finished recording, remember to play next time instead
+		if (sizeLeftUntilRecordFinished < 0) {
+			status = Status::PLAYING;
+		}
+	}
+
+	else { // PLAYING
+
+		do {
+			int32_t strength1;
+			int32_t strength2;
+
+			// Non-resampling read
+			if (buffer.isNative()) {
+				buffer.moveOn();
+				thisSample->l = buffer.current().l;
+				thisSample->r = buffer.current().r;
+			}
+
+			// Or, resampling read
+			else {
+				// Move forward
+				strength2 = buffer.advance([&] {
+					buffer.moveOn(); //<
+				});
+				strength1 = 65536 - strength2;
+
+				StereoSample* nextPos = &buffer.current() + 1;
+				if (nextPos == buffer.end()) {
+					nextPos = buffer.begin();
+				}
+				StereoSample& fromDelay1 = buffer.current();
+				StereoSample& fromDelay2 = *nextPos;
+
+				thisSample->l = (multiply_32x32_rshift32(fromDelay1.l, strength1 << 14)
+				                 + multiply_32x32_rshift32(fromDelay2.l, strength2 << 14))
+				                << 2;
+				thisSample->r = (multiply_32x32_rshift32(fromDelay1.r, strength1 << 14)
+				                 + multiply_32x32_rshift32(fromDelay2.r, strength2 << 14))
+				                << 2;
+			}
+		} while (++thisSample != audioEnd);
+	}
+}
+
+// paramManager is optional - if you don't send it, it won't change the stutter rate
+void Stutterer::endStutter(ParamManagerForTimeline* paramManager) {
+	buffer.discard();
+	status = Status::OFF;
+
+	bool automationOccurred = false;
+
+	if (paramManager) {
+
+		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+
+		if (isQuantized) {
+			// Sset back the value it had just before stuttering so orange LEDs are redrawn.
+			unpatchedParams->params[params::UNPATCHED_STUTTER_RATE].setCurrentValueBasicForSetup(valueBeforeStuttering);
+		}
+		else {
+			// Regular Stutter FX (if below middle value, reset it back to middle)
+			// Normally we shouldn't call this directly, but it's ok because automation isn't allowed for stutter anyway
+			if (unpatchedParams->getValue(params::UNPATCHED_STUTTER_RATE) < 0) {
+				unpatchedParams->params[params::UNPATCHED_STUTTER_RATE].setCurrentValueBasicForSetup(0);
+			}
+		}
+	}
+	// Reset temporary and diff values for Quantized stutter
+	lastQuantizedKnobDiff = 0;
+	valueBeforeStuttering = 0;
+	stutterSource = nullptr;
+}

--- a/src/deluge/model/fx/stutterer.h
+++ b/src/deluge/model/fx/stutterer.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2016-2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "dsp/delay/delay_buffer.h"
+#include <cstdint>
+
+class ParamManagerForTimeline;
+class ParamManager;
+class StereoSample;
+
+class Stutterer {
+public:
+	Stutterer() = default;
+	static void initParams(ParamManager* paramManager);
+	inline bool isStuttering(void* source) { return stutterSource == source; }
+	// These calls are slightly awkward with the magniture & timePerTickInverse, but that's the price for not depending
+	// on currentSong and playbackhandler...
+	[[nodiscard]] Error beginStutter(void* source, ParamManagerForTimeline* paramManager, bool quantize,
+	                                 int32_t magnitude, uint32_t timePerTickInverse);
+	void processStutter(StereoSample* buffer, int32_t numSamples, ParamManager* paramManager, int32_t magnitude,
+	                    uint32_t timePerTickInverse);
+	void endStutter(ParamManagerForTimeline* paramManager = nullptr);
+
+private:
+	enum class Status {
+		OFF,
+		RECORDING,
+		PLAYING,
+	};
+	int32_t getStutterRate(ParamManager* paramManager, int32_t magnitude, uint32_t timePerTickInverse);
+	DelayBuffer buffer;
+	Status status = Status::OFF;
+	// TODO: This is currently unused! It's set to 7 initially, and never modified. Either we should set it depending
+	// on sync, or get rid of it entirely.
+	uint8_t sync = 7;
+	bool isQuantized = false;
+	int32_t sizeLeftUntilRecordFinished = 0;
+	int32_t valueBeforeStuttering = 0;
+	int32_t lastQuantizedKnobDiff = 0;
+	/// This functions as cookie, allowing different users to know who is currently stuttering, so only those who
+	/// are will send audio here.
+	void* stutterSource = nullptr;
+};
+
+// There's only one stutter effect active at a time, so we have a global stutterer to save memory.
+extern Stutterer stutterer;

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -21,25 +21,13 @@
 #include "dsp/compressor/rms_feedback.h"
 #include "dsp/delay/delay.h"
 #include "hid/button.h"
+#include "model/fx/stutterer.h"
 #include "model/mod_controllable/filters/filter_config.h"
 #include "model/mod_controllable/mod_controllable.h"
 #include "modulation/lfo.h"
 #include "modulation/midi/midi_knob_array.h"
 #include "modulation/params/param_descriptor.h"
 #include "modulation/sidechain/sidechain.h"
-
-#define STUTTERER_STATUS_OFF 0
-#define STUTTERER_STATUS_RECORDING 1
-#define STUTTERER_STATUS_PLAYING 2
-
-struct Stutterer {
-	DelayBuffer buffer;
-	uint8_t status;
-	uint8_t sync;
-	int32_t sizeLeftUntilRecordFinished;
-	int32_t valueBeforeStuttering;
-	int32_t lastQuantizedKnobDiff;
-};
 
 struct Grain {
 	int32_t length;     // in samples 0=OFF
@@ -155,8 +143,6 @@ public:
 	bool grainLastTickCountIsZero;
 	bool grainInitialized;
 
-	Stutterer stutterer;
-
 	uint32_t lowSampleRatePos;
 	uint32_t highSampleRatePos;
 	StereoSample lastSample;
@@ -171,7 +157,6 @@ public:
 protected:
 	void processFX(StereoSample* buffer, int32_t numSamples, ModFXType modFXType, int32_t modFXRate, int32_t modFXDepth,
 	               const Delay::State& delayWorkingState, int32_t* postFXVolume, ParamManager* paramManager);
-	int32_t getStutterRate(ParamManager* paramManager);
 	void switchDelayPingPong();
 	void switchDelayAnalog();
 	void switchDelaySyncType();

--- a/src/deluge/model/settings/runtime_feature_settings.h
+++ b/src/deluge/model/settings/runtime_feature_settings.h
@@ -90,6 +90,7 @@ public:
 
 	// Traded type safety for option values for code simplicity and size, use enum from above to compare
 	inline uint32_t get(RuntimeFeatureSettingType type) { return settings[type].value; };
+	inline bool isOn(RuntimeFeatureSettingType type) { return get(type) == RuntimeFeatureStateToggle::On; }
 
 	/**
 	 * Set a runtime feature setting.

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2004,7 +2004,7 @@ void Sound::reassessRenderSkippingStatus(ModelStackWithSoundFlags* modelStack, b
 	ArpeggiatorSettings* arpSettings = getArpSettings();
 
 	bool skippingStatusNow =
-	    ((numVoicesAssigned == 0) && (delay.repeatsUntilAbandon == 0u) && (stutterer.status == 0u)
+	    ((numVoicesAssigned == 0) && (delay.repeatsUntilAbandon == 0u) && !stutterer.isStuttering(this)
 	     && ((arpSettings == nullptr) || !getArp()->hasAnyInputNotesActive() || arpSettings->mode == ArpMode::OFF));
 
 	if (skippingStatusNow != skippingRendering) {


### PR DESCRIPTION
- Leave all UI-related code in ModControllableAudio, so Stutterer only depends on ParamManager. That dependency makes DPS a bad place for it, though, so add a new model/fx directory. Radical experiment: README.md file in the directory explaining the intent. (Planning to split move more stuff there to simplify ModControllableAudio further.)

- Looks like Stutterer::sync is unused. Didn't delete because it's not obvious if it _should_ be used, or if it's a remnant.

- Since there's only one stutter effect at a time, move the Stutterer memory to a global instance - only invocations remain in ModControllable audio. One Stutterer is 76 bytes, which is nothing, but a song can easily have 20 ModControllableAudio instances, which comes to 1520 bytes of memory, which is already worth saving. (If there are ever multiple stutter instances needed, this is very easy to undo.)