### PR TITLE
Bugfix - enable large cluster sizes consistently

### DIFF
--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -894,9 +894,7 @@ void AudioFileManager::testQueue() {
 
 // Caller must initialize() the Cluster after getting it from this function
 Cluster* AudioFileManager::allocateCluster(ClusterType type, bool shouldAddReasons, void* dontStealFromThing) {
-	if (!cardReadOnce) {
-		FREEZE_WITH_ERROR("M006");
-	}
+	cardReadOnce = true; // even if it hasn't been we're now commited to the cluster size
 	void* clusterMemory = GeneralMemoryAllocator::get().allocStealable(clusterObjectSize, dontStealFromThing);
 	if (!clusterMemory) {
 		return NULL;

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -78,6 +78,7 @@ void AudioFileManager::init() {
 
 		D_PRINTLN("clusterSize  %d clusterSizeMagnitude  %d", clusterSize, clusterSizeMagnitude);
 		cardEjected = false;
+		cardReadOnce = true;
 	}
 
 	else {
@@ -893,7 +894,9 @@ void AudioFileManager::testQueue() {
 
 // Caller must initialize() the Cluster after getting it from this function
 Cluster* AudioFileManager::allocateCluster(ClusterType type, bool shouldAddReasons, void* dontStealFromThing) {
-
+	if (!cardReadOnce) {
+		FREEZE_WITH_ERROR("M006");
+	}
 	void* clusterMemory = GeneralMemoryAllocator::get().allocStealable(clusterObjectSize, dontStealFromThing);
 	if (!clusterMemory) {
 		return NULL;
@@ -1255,7 +1258,12 @@ void AudioFileManager::slowRoutine() {
 			Error error = storageManager.initSD();
 			if (error == Error::NONE) {
 				cardEjected = false;
-				cardReinserted();
+				if (cardReadOnce) {
+					cardReinserted();
+				}
+				else {
+					init();
+				}
 			}
 		}
 	}

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -118,6 +118,7 @@ public:
 
 	uint32_t clusterObjectSize;
 
+	bool cardReadOnce{false};
 	bool cardEjected;
 	bool cardDisabled;
 


### PR DESCRIPTION
If an SD card has a cluster size over 32kb and the audio file init is first ran before the card is ready Deluge will refuse to load any samples as the cluster size has increased.

Fixed by adding a flag for whether we've successfully initialized and initializing instead of calling card reinserted if we haven't

For the edge case of starting a recording (which needs a cluster) before an SD card has been read just set the flag to true on the first allocation