### PR TITLE
init audio file manager when sd read successfully

### DIFF
--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -68,6 +68,15 @@ AudioFileManager::AudioFileManager() {
 	}
 }
 
+void AudioFileManager::firstCardRead() {
+	if (cardReadOnce) {
+		cardReinserted();
+	}
+	else {
+		init();
+	}
+}
+
 void AudioFileManager::init() {
 
 	clusterBeingLoaded = NULL;
@@ -1246,23 +1255,9 @@ void AudioFileManager::slowRoutine() {
 
 	// If we know the card's been ejected...
 	if (cardEjected) {
-		// If it's still ejected, get out
-		if (!storageManager.checkSDPresent()) {
-			return;
-
-			// Otherwise, see if we can get it
-		}
-		else {
-			Error error = storageManager.initSD();
-			if (error == Error::NONE) {
-				cardEjected = false;
-				if (cardReadOnce) {
-					cardReinserted();
-				}
-				else {
-					init();
-				}
-			}
+		Error error = storageManager.initSD();
+		if (error == Error::NONE) {
+			cardEjected = false;
 		}
 	}
 

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -112,8 +112,8 @@ public:
 
 	ClusterPriorityQueue loadingQueue;
 
-	uint32_t clusterSize;
-	uint32_t clusterSizeAtBoot;
+	uint32_t clusterSize{32768};
+	uint32_t clusterSizeAtBoot{0};
 	int32_t clusterSizeMagnitude;
 
 	uint32_t clusterObjectSize;
@@ -133,6 +133,7 @@ public:
 
 	int32_t highestUsedAudioRecordingNumber[kNumAudioRecordingFolders];
 	bool highestUsedAudioRecordingNumberNeedsReChecking[kNumAudioRecordingFolders];
+	void firstCardRead();
 
 private:
 	void setClusterSize(uint32_t newSize);

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -251,6 +251,7 @@ Error StorageManager::initSD() {
 		return error; //<
 	});
 	if (success) {
+		audioFileManager.firstCardRead(); // tell the audio file manager that we have a new card
 		return Error::NONE;
 	}
 	return Error::SD_CARD;


### PR DESCRIPTION
Instead of trying to init the file manager in a seperate loop just tie it to the fatfs mount, so that we never read with incorrect cluster sizes