### PR TITLE
Bugfix/remount filesystem

### DIFF
--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -1254,7 +1254,7 @@ copy7ToMe:
 void AudioFileManager::slowRoutine() {
 
 	// If we know the card's been ejected...
-	if (cardEjected) {
+	if (cardEjected && !sdRoutineLock) {
 		Error error = storageManager.initSD();
 		if (error == Error::NONE) {
 			cardEjected = false;

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -238,6 +238,7 @@ Error StorageManager::initSD() {
 	// If we know the SD card is still initialised, no need to actually initialise
 	DSTATUS status = disk_status(SD_PORT);
 	if ((status & STA_NOINIT) == 0) {
+		auto _ = fileSystemStuff.fileSystem.mount(0); // check that it's mounted but don't block if not
 		return Error::NONE;
 	}
 

--- a/src/fatfs/fatfs.cpp
+++ b/src/fatfs/fatfs.cpp
@@ -142,7 +142,7 @@ std::expected<bool, Error> Filesystem::mount(BYTE opt, char const* path) {
   if (error == FR_NOT_READY && opt == 1) {
     return false;
   }
-// need a marker to say we have no filesystem
+// at this point we'd have no filesystem, but the only possible error is an invalid path and our null string is valid
   return std::unexpected(FatFS::Error(error));
 }
 

--- a/src/fatfs/fatfs.cpp
+++ b/src/fatfs/fatfs.cpp
@@ -142,6 +142,7 @@ std::expected<bool, Error> Filesystem::mount(BYTE opt, char const* path) {
   if (error == FR_NOT_READY && opt == 1) {
     return false;
   }
+// need a marker to say we have no filesystem
   return std::unexpected(FatFS::Error(error));
 }
 

--- a/src/fatfs/ff.c
+++ b/src/fatfs/ff.c
@@ -3656,8 +3656,11 @@ FRESULT f_mount (
 	int vol;
 	FRESULT res;
 	const TCHAR *rp = path;
-cfs = FatFs[vol];
-if (cfs && opt==0) return FR_OK;/* Pointer to fs object */
+        /* Pointer to fs object */
+        cfs = FatFs[vol];
+        if (cfs && opt==0) {
+          return FR_OK; //this is a dirty hack, only works because we're never doing a delayed mount over a different filesystem
+        }
 	/* Get logical drive number */
 	vol = get_ldnumber(&rp);
 	if (vol < 0) return FR_INVALID_DRIVE;

--- a/src/fatfs/ff.c
+++ b/src/fatfs/ff.c
@@ -3372,7 +3372,7 @@ static UINT find_volume (	/* Returns BS status found in the hosting drive */
 /*-----------------------------------------------------------------------*/
 /* Determine logical drive number and mount the volume if needed         */
 /*-----------------------------------------------------------------------*/
-
+// safe to call repeatedly, caches whether it's initialized already
 static FRESULT mount_volume (	/* FR_OK(0): successful, !=0: an error occurred */
 	const TCHAR** path,			/* Pointer to pointer to the path name (drive number) */
 	FATFS** rfs,				/* Pointer to pointer to the found filesystem object */
@@ -3657,12 +3657,10 @@ FRESULT f_mount (
 	FRESULT res;
 	const TCHAR *rp = path;
 
-
 	/* Get logical drive number */
 	vol = get_ldnumber(&rp);
 	if (vol < 0) return FR_INVALID_DRIVE;
 	cfs = FatFs[vol];					/* Pointer to fs object */
-
 	if (cfs) {
 #if FF_FS_LOCK != 0
 		clear_lock(cfs);

--- a/src/fatfs/ff.c
+++ b/src/fatfs/ff.c
@@ -461,7 +461,7 @@ typedef struct {
 #if FF_VOLUMES < 1 || FF_VOLUMES > 10
 #error Wrong FF_VOLUMES setting
 #endif
-static FATFS* FatFs[FF_VOLUMES];	/* Pointer to the filesystem objects (logical drives) */
+static FATFS* FatFs[FF_VOLUMES] = {0};	/* Pointer to the filesystem objects (logical drives) */
 static WORD Fsid;					/* Filesystem mount ID */
 
 #if FF_FS_RPATH != 0
@@ -3656,11 +3656,12 @@ FRESULT f_mount (
 	int vol;
 	FRESULT res;
 	const TCHAR *rp = path;
-
+cfs = FatFs[vol];
+if (cfs && opt==0) return FR_OK;/* Pointer to fs object */
 	/* Get logical drive number */
 	vol = get_ldnumber(&rp);
 	if (vol < 0) return FR_INVALID_DRIVE;
-	cfs = FatFs[vol];					/* Pointer to fs object */
+
 	if (cfs) {
 #if FF_FS_LOCK != 0
 		clear_lock(cfs);


### PR DESCRIPTION
This shouldn't be necessary - in case the FS fails to mount this ensures it remounts later, but it can't fail the first time so the memory is probably being corrupted by something else

In any case this now remounts the filesystem if it doesn't appear mounted which is better than locking out the SD card
