### PR TITLE
move logic from Song::getCurrentPresetScale() to NoteSet

### DIFF
--- a/src/deluge/model/scale/note_set.cpp
+++ b/src/deluge/model/scale/note_set.cpp
@@ -1,4 +1,5 @@
 #include "model/scale/note_set.h"
+#include "model/scale/preset_scales.h"
 
 NoteSet::NoteSet(std::initializer_list<uint8_t> notes) : bits{0} {
 	for (uint8_t note : notes) {
@@ -55,3 +56,41 @@ void NoteSet::applyChanges(int8_t changes[12]) {
 	newSet.add(0);
 	bits = newSet.bits;
 }
+
+uint8_t NoteSet::presetScaleId() const {
+	for (int32_t p = 0; p < NUM_PRESET_SCALES; p++) {
+		if (*this == presetScaleNotes[p]) {
+			return p;
+		}
+	}
+	return CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
+}
+
+#ifdef IN_UNIT_TESTS
+const TestString StringFrom(const NoteSet& set) {
+	// We print out as chromatic notes across C, even though NoteSet does _not_ specify the root.
+	// This is just easier to read and think about when debugging.
+	std::string out;
+	static const char* names[12] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
+	out.append("NoteSet(");
+	bool first = true;
+	for (int i = 0; i < NoteSet::size; i++) {
+		if (set.has(i)) {
+			if (!first) {
+				out.append(", ");
+			}
+			else {
+				first = false;
+			}
+			out.append(names[i]);
+		}
+	}
+	out.append(")");
+	return TestString(out);
+}
+
+std::ostream& operator<<(std::ostream& output, const NoteSet& set) {
+	output << StringFrom(set).asCharString();
+	return output;
+}
+#endif

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -56,9 +56,16 @@ public:
 	/** Returns the highest note that has been added to the NoteSet.
 	 */
 	uint8_t highest() const { return 15 - std::countl_zero(bits); }
+	/** If this is a preset scale, returns the preset scale id.
+	 *
+	 * Otherwise returns CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES
+	 */
+	uint8_t presetScaleId() const;
 	/** Returns number of notes in the NoteSet.
 	 */
 	int count() const { return std::popcount(bits); }
+	/** True if two NoteSets are identical. */
+	bool operator==(const NoteSet& other) const { return bits == other.bits; }
 	/** Size of NoteSet, ie. the maximum number of notes it can hold.
 	 */
 	static const int8_t size = 12;
@@ -66,3 +73,23 @@ public:
 private:
 	uint16_t bits;
 };
+
+#ifdef IN_UNIT_TESTS
+// For CppUTest CHECK_EQUAL() and debugging convenience
+
+#include <iostream>
+#include <string>
+
+std::ostream& operator<<(std::ostream& output, const NoteSet& set);
+
+class TestString {
+public:
+	TestString(std::string string_) : string(string_) {}
+	const char* asCharString() const { return string.c_str(); }
+
+private:
+	std::string string;
+};
+
+const TestString StringFrom(const NoteSet&);
+#endif

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3043,31 +3043,8 @@ int32_t Song::setPresetScale(int32_t newScale) {
 	return newScale;
 }
 
-// Returns CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES if no preset matches current notes
-int32_t Song::getCurrentPresetScale() {
-	if (key.modeNotes.count() > 7) {
-		return CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
-	}
-
-	int32_t numPresetScales = NUM_PRESET_SCALES;
-	for (int32_t p = 0; p < numPresetScales; p++) {
-		for (int32_t n = 1; n < 7; n++) {
-			int32_t newNote = presetScaleNotes[p][n];
-			if (newNote == 0) {
-				continue;
-			}
-			if (key.modeNotes[n] != newNote) {
-				goto notThisOne;
-			}
-		}
-
-		// If we're here, must be this one!
-		return p;
-
-notThisOne: {}
-	}
-
-	return CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES;
+int8_t Song::getCurrentPresetScale() {
+	return key.modeNotes.presetScaleId();
 }
 
 // What does this do exactly, again?

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -114,7 +114,8 @@ public:
 	void displayCurrentRootNoteAndScaleName();
 	const char* getScaleName(int32_t scale);
 	int32_t cycleThroughScales();
-	int32_t getCurrentPresetScale();
+	// Returns CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES if no preset matches current notes
+	int8_t getCurrentPresetScale();
 	int32_t setPresetScale(int32_t newScale);
 	void setTempoFromNumSamples(double newTempoSamples, bool shouldLogAction);
 	void setupDefault();

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,6 +41,7 @@ file(GLOB_RECURSE deluge_SOURCES
         ../../src/deluge/model/scale/musical_key.cpp
         ../../src/deluge/model/scale/note_set.cpp
         ../../src/deluge/model/scale/utils.cpp
+        ../../src/deluge/model/scale/preset_scales.cpp
         # For clip iterator tests
         ../../src/deluge/model/song/clip_iterators.cpp
         # For sync tests

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -1,6 +1,7 @@
 #include "CppUTest/TestHarness.h"
 #include "model/scale/musical_key.h"
 #include "model/scale/note_set.h"
+#include "model/scale/preset_scales.h"
 #include "model/scale/utils.h"
 
 TEST_GROUP(NoteSetTest){};
@@ -94,6 +95,18 @@ TEST(NoteSetTest, applyChanges) {
 	CHECK_EQUAL(4, a.count());
 }
 
+TEST(NoteSetTest, equality) {
+	NoteSet a;
+	NoteSet b;
+	CHECK(a == b);
+	a.add(0);
+	CHECK(a != b);
+}
+
+TEST(NoteSetTest, checkEqualAllowed) {
+	CHECK_EQUAL(NoteSet(), NoteSet());
+}
+
 TEST(NoteSetTest, subscript1) {
 	NoteSet a;
 	for (int i = 0; i < NoteSet::size; i++) {
@@ -146,6 +159,12 @@ TEST(NoteSetTest, subscript3) {
 	CHECK_EQUAL(7, a[5]);
 	CHECK_EQUAL(9, a[6]);
 	CHECK_EQUAL(11, a[7]);
+}
+
+TEST(NoteSetTest, presetScaleId) {
+	CHECK_EQUAL(MAJOR_SCALE, presetScaleNotes[MAJOR_SCALE].presetScaleId());
+	CHECK_EQUAL(MINOR_SCALE, presetScaleNotes[MINOR_SCALE].presetScaleId());
+	CHECK_EQUAL(CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES, NoteSet().presetScaleId());
 }
 
 TEST_GROUP(MusicalKeyTest){};


### PR DESCRIPTION
- added NoteSet::operator==()
- added NoteSet::operator<<() #ifdef IN_UNIT_TESTS
- added StringFrom as required by CppUTest
