### PR TITLE
remove mpe zone auto learn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.
 - Allow changing MPE y output to CC1 to support more synths
+- Removed MPE zone auto learn as a huge source of midi bugs, MPE must now be configured in the menu
 
 ## c1.1.1 Beethoven
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -549,8 +549,6 @@ void View::instrumentMidiLearnPadPressed(bool on, Instrument* instrument) {
 		deleteMidiCommandOnRelease = true;
 		learnedThing = &instrument->midiInput;
 		instrumentPressedForMIDILearn = instrument;
-		highestMIDIChannelSeenWhileLearning = -1;
-		lowestMIDIChannelSeenWhileLearning = 16;
 	}
 
 	else if (thingPressedForMidiLearn == MidiLearn::INSTRUMENT_INPUT) {
@@ -669,43 +667,6 @@ isMPEZone:
 
 			// Or if we don't already know this is an MPE zone...
 			else {
-				if (learnedThing->device == fromDevice) {
-
-					if (channelOrZone > highestMIDIChannelSeenWhileLearning) {
-						highestMIDIChannelSeenWhileLearning = channelOrZone;
-					}
-					if (channelOrZone < lowestMIDIChannelSeenWhileLearning) {
-						lowestMIDIChannelSeenWhileLearning = channelOrZone;
-					}
-
-					// If multiple channels seen, that's a shortcut for setting up MPE zones for the device in question
-					// note - I think this leads to confusion more than any deliberate use
-					if (highestMIDIChannelSeenWhileLearning != lowestMIDIChannelSeenWhileLearning) {
-						if (lowestMIDIChannelSeenWhileLearning == 1) {
-							fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeLowerZoneLastMemberChannel =
-							    highestMIDIChannelSeenWhileLearning;
-							fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].moveUpperZoneOutOfWayOfLowerZone();
-							channelOrZone = MIDI_CHANNEL_MPE_LOWER_ZONE;
-							MIDIDeviceManager::anyChangesToSave = true;
-							goto isMPEZone;
-						}
-						else if (highestMIDIChannelSeenWhileLearning == 14) {
-							fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].mpeUpperZoneLastMemberChannel =
-							    lowestMIDIChannelSeenWhileLearning;
-							fromDevice->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].moveLowerZoneOutOfWayOfUpperZone();
-							channelOrZone = MIDI_CHANNEL_MPE_UPPER_ZONE;
-							MIDIDeviceManager::anyChangesToSave = true;
-							goto isMPEZone;
-						}
-					}
-				}
-
-				else { // Or if different device...
-					   // Reset our assumptions about MPE
-					highestMIDIChannelSeenWhileLearning = channelOrZone;
-					lowestMIDIChannelSeenWhileLearning = channelOrZone;
-				}
-
 				// If still here, it's not MPE. Now that we know that, see if we want to apply a stored bend range for
 				// the input MIDI channel of the device
 				newBendRanges[BEND_RANGE_MAIN] = fromDevice->inputChannels[channelOrZone].bendRange;
@@ -771,11 +732,10 @@ void View::ccReceivedForMIDILearn(MIDIDevice* fromDevice, int32_t channel, int32
 		if (thingPressedForMidiLearn == MidiLearn::INSTRUMENT_INPUT) {
 
 			// Special case for MIDIInstruments - CCs can learn the input MIDI channel
-			// note - I think this is probably the source of a lot of bugs around MPE
 			if (getCurrentOutputType() == OutputType::MIDI_OUT) {
 
 				// But only if user hasn't already started learning MPE stuff... Or regular note-ons...
-				if (highestMIDIChannelSeenWhileLearning < lowestMIDIChannelSeenWhileLearning) {
+				if (learnedThing->channelOrZone == MIDI_CHANNEL_NONE) {
 					learnedThing->device = fromDevice;
 					learnedThing->channelOrZone = channel;
 					getCurrentInstrument()->beenEdited(false);

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -104,9 +104,6 @@ public:
 	bool midiLearnFlashOn;
 	bool shouldSaveSettingsAfterMidiLearn;
 
-	int8_t highestMIDIChannelSeenWhileLearning;
-	int8_t lowestMIDIChannelSeenWhileLearning;
-
 	LearnedMIDI* learnedThing;
 	Instrument* instrumentPressedForMIDILearn;
 	Drum* drumPressedForMIDILearn;


### PR DESCRIPTION
This is a huge source of bugs - the vast majority of midi issues in the facebook group and discord come from mpe zones getting set accidentally

As they're automatically set to match real MPE controllers via NRPN it's not super useful, so just disable the auto learning. Can still be set in the menu for devices that don't use NRPN, and I think a one time setup cost for people using MPE is better than causing bugs for people who don't

Example - #1162