### PR TITLE
Update submenu rendering for toggle's and automatable param's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
 - For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.
  - OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu.
  - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.
-- Submenu's on OLED are now rendered with a ">" at the end to indicate that it is a submenu.
+- Submenu's on OLED for automatable parameters (e.g. LPF Frequency) render the current parameter value at the end. You still need to click on `SELECT` to edit the parameters value / edit modulation depth and patch cables.
+ - All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
 
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - A white playhead is now rendered in Song Grid and Performance Views that let's you know when a clip or section launch event is scheduled to occur. The playhead only renders the last 16 notes before a launch event.
   - Note: this playhead can be turned off in the Community Features submenu titled: `Enable Launch Event Playhead (PLAY)`
 - The display now shows the number of Bars (or Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
+- For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.
+ - OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu.
+ - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.
+- Submenu's on OLED are now rendered with a ">" at the end to indicate that it is a submenu.
 
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -282,11 +282,11 @@ as the micromonsta and the dreadbox nymphes.
 - ([#2315]) The display now shows the number of Bars (or Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
 
 #### 3.26 Updated UI for Interacting with Toggle Menu's and Sub Menu's
-- ([#2331]) For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.
+- ([#2345]) For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.
  - OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu.
  - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.
-- ([#2339]) Submenu's on OLED for automatable parameters (e.g. LPF Frequency) render the current parameter value at the end. You still need to click on `SELECT` to edit the parameters value / edit modulation depth and patch cables.
- - ([#2331]) All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
+ - Submenu's on OLED for automatable parameters (e.g. LPF Frequency) render the current parameter value at the end. You still need to click on `SELECT` to edit the parameters value / edit modulation depth and patch cables.
+ - All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
 
 ## 4. New Features Added
 
@@ -1394,9 +1394,9 @@ different firmware
 
 [#2330]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2330
 
-[#2331]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2331
-
 [#2343]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2343
+
+[#2345]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2345
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/automation_view.md
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -285,7 +285,8 @@ as the micromonsta and the dreadbox nymphes.
 - ([#2331]) For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.
  - OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu.
  - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.
- - Submenu's on OLED are also now rendered with a ">" at the end to indicate that it is a submenu.
+- ([#2339]) Submenu's on OLED for automatable parameters (e.g. LPF Frequency) render the current parameter value at the end. You still need to click on `SELECT` to edit the parameters value / edit modulation depth and patch cables.
+ - ([#2331]) All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
 
 ## 4. New Features Added
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -281,6 +281,12 @@ as the micromonsta and the dreadbox nymphes.
 #### 3.25 Display Number of Bars / Notes Remaining until Clip / Section Launch Event
 - ([#2315]) The display now shows the number of Bars (or Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
 
+#### 3.26 Updated UI for Interacting with Toggle Menu's and Sub Menu's
+- ([#2331]) For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.
+ - OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu.
+ - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.
+ - Submenu's on OLED are also now rendered with a ">" at the end to indicate that it is a submenu.
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -1386,6 +1392,8 @@ different firmware
 [#2327]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2327
 
 [#2330]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2330
+
+[#2331]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2331
 
 [#2343]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2343
 

--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -64,3 +64,10 @@ void MenuItem::drawItemsForOled(std::span<std::string_view> options, const int32
 		}
 	}
 }
+
+// renders the default sub menu item type ("  >")
+void MenuItem::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+
+	image.drawString("  >", xPixel, yPixel, kTextSpacingX, kTextSpacingY);
+}

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -247,5 +247,9 @@ public:
 	/// @brief Check if selecting this menu item (with select encoder) should enter a submenu
 	virtual bool shouldEnterSubmenu() { return true; }
 
+	/// @brief Handle rendering of submenu item types
+	virtual int32_t getSubmenuItemTypeRenderLength() { return (3 + (kTextSpacingX * 3) + kTextSpacingX); }
+	virtual void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel);
+
 	/// @}
 };

--- a/src/deluge/gui/menu_item/patched_param/integer.cpp
+++ b/src/deluge/gui/menu_item/patched_param/integer.cpp
@@ -19,6 +19,7 @@
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/view.h"
+#include "hid/display/oled.h"
 #include "model/clip/clip.h"
 #include "model/song/song.h"
 #include "modulation/automation/auto_param.h"
@@ -53,6 +54,21 @@ void Integer::writeCurrentValue() {
 
 int32_t Integer::getFinalValue() {
 	return computeFinalValueForStandardMenuItem(this->getValue());
+}
+
+void Integer::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+
+	DEF_STACK_STRING_BUF(paramValue, 10);
+	paramValue.appendInt(getParamValue());
+
+	std::string stringForSubmenuItemType;
+	stringForSubmenuItemType.append(paramValue.c_str());
+
+	// pad value string so it's 3 characters long
+	padStringTo(stringForSubmenuItemType, 3);
+
+	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
 }
 
 } // namespace deluge::gui::menu_item::patched_param

--- a/src/deluge/gui/menu_item/patched_param/integer.h
+++ b/src/deluge/gui/menu_item/patched_param/integer.h
@@ -57,6 +57,14 @@ public:
 		MenuItemWithCCLearning::learnKnob(fromDevice, whichKnob, modKnobMode, midiChannel);
 	};
 
+	// renders param value in submenus after the item name
+	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+
+	int32_t getParamValue() {
+		readCurrentValue();
+		return getValue();
+	}
+
 protected:
 	void readCurrentValue() override;
 	void writeCurrentValue() final;

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -48,6 +48,7 @@ public:
 	void learnProgramChange(MIDIDevice* fromDevice, int32_t channel, int32_t programNumber);
 	bool learnNoteOn(MIDIDevice* fromDevice, int32_t channel, int32_t noteCode) final;
 	void drawPixelsForOled() override;
+	void drawSubmenuItemsForOled(std::span<MenuItem*> options, const int32_t selectedOption);
 
 	deluge::vector<MenuItem*> items;
 	typename decltype(items)::iterator current_item_;

--- a/src/deluge/gui/menu_item/toggle.cpp
+++ b/src/deluge/gui/menu_item/toggle.cpp
@@ -63,4 +63,30 @@ void Toggle::drawPixelsForOled() {
 		}
 	}
 }
+
+// renders check box on OLED and dot on 7seg
+void Toggle::displayToggleValue() {
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+	else {
+		drawName();
+	}
+}
+
+void Toggle::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+
+	std::string stringForSubmenuItemType;
+
+	if (getToggleValue()) {
+		stringForSubmenuItemType.append("[x]");
+	}
+	else {
+		stringForSubmenuItemType.append("[ ]");
+	}
+
+	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
+}
+
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/toggle.h
+++ b/src/deluge/gui/menu_item/toggle.h
@@ -12,6 +12,39 @@ public:
 
 	virtual void drawValue();
 	void drawPixelsForOled();
+	void displayToggleValue();
+
+	// don't enter menu on select button press
+	bool shouldEnterSubmenu() override { return false; }
+
+	// renders toggle item type in submenus after the item name
+	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+
+	// toggles boolean ON / OFF
+	void toggleValue() {
+		readCurrentValue();
+		setValue(!getValue());
+		writeCurrentValue();
+	};
+
+	// handles changing bool setting without entering menu and updating the display
+	MenuItem* selectButtonPress() override {
+		toggleValue();
+		displayToggleValue();
+		return (MenuItem*)0xFFFFFFFF; // no navigation
+	}
+
+	// get's toggle status for rendering checkbox on OLED
+	bool getToggleValue() {
+		readCurrentValue();
+		return this->getValue();
+	}
+
+	// get's toggle status for rendering dot on 7SEG
+	uint8_t shouldDrawDotOnName() override {
+		readCurrentValue();
+		return this->getValue() ? 3 : 255;
+	}
 };
 
 /// the toggle pointer passed to this class must be valid for as long as the menu exists

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -20,6 +20,7 @@
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/view.h"
+#include "hid/display/oled.h"
 #include "model/clip/clip.h"
 #include "model/clip/instrument_clip.h"
 #include "model/model_stack.h"
@@ -78,6 +79,21 @@ deluge::modulation::params::Kind UnpatchedParam::getParamKind() {
 
 uint32_t UnpatchedParam::getParamIndex() {
 	return this->getP();
+}
+
+void UnpatchedParam::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+
+	DEF_STACK_STRING_BUF(paramValue, 10);
+	paramValue.appendInt(getParamValue());
+
+	std::string stringForSubmenuItemType;
+	stringForSubmenuItemType.append(paramValue.c_str());
+
+	// pad value string so it's 3 characters long
+	padStringTo(stringForSubmenuItemType, 3);
+
+	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
 }
 
 // ---------------------------------------

--- a/src/deluge/gui/menu_item/unpatched_param.h
+++ b/src/deluge/gui/menu_item/unpatched_param.h
@@ -57,6 +57,14 @@ public:
 	ParamSet* getParamSet() final;
 	ModelStackWithAutoParam* getModelStack(void* memory) final;
 
+	// renders param value in submenus after the item name
+	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+
+	int32_t getParamValue() {
+		readCurrentValue();
+		return getValue();
+	}
+
 protected:
 	virtual int32_t getFinalValue();
 };

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -29,6 +29,7 @@
 #include <bit>
 #include <cstdint>
 #include <cstring>
+#include <string>
 
 class UI;
 
@@ -127,6 +128,13 @@ template <uint8_t lshift>
 }
 
 char* replace_char(const char* str, char find, char replace);
+
+/// pads a string up to a num of characters if the current string size is shorter than num
+[[gnu::always_inline]] constexpr void padStringTo(std::string& str, const size_t num) {
+	if (num > str.size()) {
+		str.insert(0, num - str.size(), ' ');
+	}
+}
 
 int32_t stringToInt(char const* string);
 int32_t stringToUIntOrError(char const* mem);


### PR DESCRIPTION
## Update Toggle Menu's

Updated UI for interacting with toggle (ON/OFF) menu's on OLED and 7SEG
- OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu
- 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.

https://github.com/user-attachments/assets/cb03129e-304c-446a-88eb-05bed36c8cfe

https://github.com/user-attachments/assets/623e3187-d088-4db6-b63f-589e7ac9b51b

## Update Param Menu's

Renders the current value for all automatable unpatched / patched parameters while in the menu

https://github.com/user-attachments/assets/eac94bcc-798d-4d32-8d1d-8b90d69667da

## Update Submenu's

Submenu's are also now rendered with a ">" at the end to indicate that it is a submenu.

## Outstanding

There are a couple edge case menu's (e.g. CV / Gate Output, Community Features) that do not inherit these changes but I think those can be addressed as part of a separate PR as they are built differently (they don't use the submenu class).