### PR TITLE
Render more menu's as toggles + Render checkbox and arrow icons

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -906,10 +906,12 @@ constexpr int32_t kOLEDMenuNumOptionsVisible = (OLED_HEIGHT_CHARS - 1);
 constexpr int32_t kConsoleImageHeight = (OLED_MAIN_HEIGHT_PIXELS);
 constexpr int32_t kConsoleImageNumRows = (OLED_MAIN_HEIGHT_PIXELS >> 3);
 
-constexpr int32_t kTextSpacingX = 6;
-constexpr int32_t kTextSpacingY = 9;
+// non-title characters
+constexpr int32_t kTextSpacingX = 6; // the width of a character (5 px) + the space after it (1 px)
+constexpr int32_t kTextSpacingY = 9; // the height of a character (7 px) + the space above (1px) and below it (1px)
 constexpr int32_t kTextSizeYUpdated = 7;
 
+// title characters
 constexpr int32_t kTextTitleSpacingX = 9;
 constexpr int32_t kTextTitleSizeY = 10;
 

--- a/src/deluge/gui/menu_item/arpeggiator/mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/mode.h
@@ -62,5 +62,11 @@ public:
 		    l10n::getView(STRING_FOR_ARP), //<
 		};
 	}
+
+	// flag this selection menu as a toggle menu so we can use a checkbox to toggle value
+	bool isToggle() override { return true; }
+
+	// don't enter menu on select button press
+	bool shouldEnterSubmenu() override { return false; }
 };
 } // namespace deluge::gui::menu_item::arpeggiator

--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -69,5 +69,7 @@ void MenuItem::drawItemsForOled(std::span<std::string_view> options, const int32
 void MenuItem::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
-	image.drawString("  >", xPixel, yPixel, kTextSpacingX, kTextSpacingY);
+	// push the start x over so it aligns with the right most character drawn for param value menus
+	int32_t startX = xPixel + kTextSpacingX * 2 - 1;
+	image.drawGraphicMultiLine(deluge::hid::display::OLED::submenuArrowIcon, startX, yPixel, 7);
 }

--- a/src/deluge/gui/menu_item/menu_item.cpp
+++ b/src/deluge/gui/menu_item/menu_item.cpp
@@ -66,10 +66,10 @@ void MenuItem::drawItemsForOled(std::span<std::string_view> options, const int32
 }
 
 // renders the default sub menu item type ("  >")
-void MenuItem::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+void MenuItem::renderSubmenuItemTypeForOled(int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
-	// push the start x over so it aligns with the right most character drawn for param value menus
-	int32_t startX = xPixel + kTextSpacingX * 2 - 1;
+	int32_t startX = getSubmenuItemTypeRenderIconStart();
+
 	image.drawGraphicMultiLine(deluge::hid::display::OLED::submenuArrowIcon, startX, yPixel, 7);
 }

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -248,8 +248,23 @@ public:
 	virtual bool shouldEnterSubmenu() { return true; }
 
 	/// @brief Handle rendering of submenu item types
-	virtual int32_t getSubmenuItemTypeRenderLength() { return (3 + (kTextSpacingX * 3) + kTextSpacingX); }
-	virtual void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel);
+	// length = spacing before (6 pixels)
+	//			+ width of 3 characters (3 * 6 pixels - to accomodate rendering of 3 digit param values)
+	//          + spacing after (3 pixels)
+	// spacing before is to ensure that menu item text doesn't overlap and can scroll
+	// length = 6 pixels before + (3 characters * 6 pixels per character) + 3 pixels after
+	virtual int32_t getSubmenuItemTypeRenderLength() { return (3 + (3 * kTextSpacingX) + 3); }
+	// push the start x over so it aligns with the right most character drawn for param value menus
+	// startX = end pixel of menu item string + 3px spacing after it + spacing for 2 characters +
+	// 			shift icon left 1 pixel (it's 1px wider than a regular character)
+	virtual int32_t getSubmenuItemTypeRenderIconStart() { return (OLED_MAIN_WIDTH_PIXELS - 3 - kTextSpacingX - 1); }
+	// push the start x over 3 characters which is the spacing between the end of the menu item text and the first
+	// value character drawn
+	virtual int32_t getSubmenuItemTypeRenderValueStart() {
+		return (OLED_MAIN_WIDTH_PIXELS - getSubmenuItemTypeRenderLength() + 3);
+	}
+	// render the submenu item type (icon or value)
+	virtual void renderSubmenuItemTypeForOled(int32_t yPixel);
 
 	/// @}
 };

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -248,7 +248,7 @@ public:
 	virtual bool shouldEnterSubmenu() { return true; }
 
 	/// @brief Handle rendering of submenu item types
-	// length = spacing before (6 pixels)
+	// length = spacing before (3 pixels)
 	//			+ width of 3 characters (3 * 6 pixels - to accomodate rendering of 3 digit param values)
 	//          + spacing after (3 pixels)
 	// spacing before is to ensure that menu item text doesn't overlap and can scroll

--- a/src/deluge/gui/menu_item/patched_param/integer.cpp
+++ b/src/deluge/gui/menu_item/patched_param/integer.cpp
@@ -56,7 +56,7 @@ int32_t Integer::getFinalValue() {
 	return computeFinalValueForStandardMenuItem(this->getValue());
 }
 
-void Integer::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+void Integer::renderSubmenuItemTypeForOled(int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
 	DEF_STACK_STRING_BUF(paramValue, 10);
@@ -68,7 +68,9 @@ void Integer::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
 	// pad value string so it's 3 characters long
 	padStringTo(stringForSubmenuItemType, 3);
 
-	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
+	int32_t startX = getSubmenuItemTypeRenderIconStart();
+
+	image.drawString(stringForSubmenuItemType, startX, yPixel, kTextSpacingX, kTextSpacingY);
 }
 
 } // namespace deluge::gui::menu_item::patched_param

--- a/src/deluge/gui/menu_item/patched_param/integer.h
+++ b/src/deluge/gui/menu_item/patched_param/integer.h
@@ -58,7 +58,7 @@ public:
 	};
 
 	// renders param value in submenus after the item name
-	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+	void renderSubmenuItemTypeForOled(int32_t yPixel) override;
 
 	int32_t getParamValue() {
 		readCurrentValue();

--- a/src/deluge/gui/menu_item/runtime_feature/setting.h
+++ b/src/deluge/gui/menu_item/runtime_feature/setting.h
@@ -36,4 +36,15 @@ private:
 	friend class Settings;
 	uint32_t currentSettingIndex;
 };
+
+class SettingToggle : public Setting {
+public:
+	using Setting::Setting;
+
+	// flag this selection menu as a toggle menu so we can use a checkbox to toggle value
+	bool isToggle() override { return true; }
+
+	// don't enter menu on select button press
+	bool shouldEnterSubmenu() override { return false; }
+};
 } // namespace deluge::gui::menu_item::runtime_feature

--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -27,25 +27,25 @@ extern deluge::gui::menu_item::runtime_feature::Setting runtimeFeatureSettingMen
 namespace deluge::gui::menu_item::runtime_feature {
 
 // Generic menu item instances
-Setting menuDrumRandomizer(RuntimeFeatureSettingType::DrumRandomizer);
-Setting menuFineTempo(RuntimeFeatureSettingType::FineTempoKnob);
-Setting menuQuantize(RuntimeFeatureSettingType::Quantize);
-Setting menuPatchCableResolution(RuntimeFeatureSettingType::PatchCableResolution);
-Setting menuCatchNotes(RuntimeFeatureSettingType::CatchNotes);
-Setting menuDeleteUnusedKitRows(RuntimeFeatureSettingType::DeleteUnusedKitRows);
-Setting menuAltGoldenKnobDelayParams(RuntimeFeatureSettingType::AltGoldenKnobDelayParams);
-Setting menuQuantizedStutterRate(RuntimeFeatureSettingType::QuantizedStutterRate);
-Setting menuSyncScalingAction(RuntimeFeatureSettingType::SyncScalingAction);
+SettingToggle menuDrumRandomizer(RuntimeFeatureSettingType::DrumRandomizer);
+SettingToggle menuFineTempo(RuntimeFeatureSettingType::FineTempoKnob);
+SettingToggle menuQuantize(RuntimeFeatureSettingType::Quantize);
+SettingToggle menuPatchCableResolution(RuntimeFeatureSettingType::PatchCableResolution);
+SettingToggle menuCatchNotes(RuntimeFeatureSettingType::CatchNotes);
+SettingToggle menuDeleteUnusedKitRows(RuntimeFeatureSettingType::DeleteUnusedKitRows);
+SettingToggle menuAltGoldenKnobDelayParams(RuntimeFeatureSettingType::AltGoldenKnobDelayParams);
+SettingToggle menuQuantizedStutterRate(RuntimeFeatureSettingType::QuantizedStutterRate);
+SettingToggle menuSyncScalingAction(RuntimeFeatureSettingType::SyncScalingAction);
 DevSysexSetting menuDevSysexAllowed(RuntimeFeatureSettingType::DevSysexAllowed);
-Setting menuHighlightIncomingNotes(RuntimeFeatureSettingType::HighlightIncomingNotes);
-Setting menuDisplayNornsLayout(RuntimeFeatureSettingType::DisplayNornsLayout);
+SettingToggle menuHighlightIncomingNotes(RuntimeFeatureSettingType::HighlightIncomingNotes);
+SettingToggle menuDisplayNornsLayout(RuntimeFeatureSettingType::DisplayNornsLayout);
 ShiftIsSticky menuShiftIsSticky{};
-Setting menuLightShiftLed(RuntimeFeatureSettingType::LightShiftLed);
-Setting menuEnableGrainFX(RuntimeFeatureSettingType::EnableGrainFX);
-Setting menuEnableDxShortcuts(RuntimeFeatureSettingType::EnableDxShortcuts);
+SettingToggle menuLightShiftLed(RuntimeFeatureSettingType::LightShiftLed);
+SettingToggle menuEnableGrainFX(RuntimeFeatureSettingType::EnableGrainFX);
+SettingToggle menuEnableDxShortcuts(RuntimeFeatureSettingType::EnableDxShortcuts);
 EmulatedDisplay menuEmulatedDisplay{};
-Setting menuEnableKeyboardViewSidebarMenuExit(RuntimeFeatureSettingType::EnableKeyboardViewSidebarMenuExit);
-Setting menuEnableLaunchEventPlayhead(RuntimeFeatureSettingType::EnableLaunchEventPlayhead);
+SettingToggle menuEnableKeyboardViewSidebarMenuExit(RuntimeFeatureSettingType::EnableKeyboardViewSidebarMenuExit);
+SettingToggle menuEnableLaunchEventPlayhead(RuntimeFeatureSettingType::EnableLaunchEventPlayhead);
 
 std::array<MenuItem*, RuntimeFeatureSettingType::MaxElement - kNonTopLevelSettings> subMenuEntries{
     &menuDrumRandomizer,

--- a/src/deluge/gui/menu_item/runtime_feature/shift_is_sticky.h
+++ b/src/deluge/gui/menu_item/runtime_feature/shift_is_sticky.h
@@ -21,9 +21,9 @@
 #include "model/settings/runtime_feature_settings.h"
 
 namespace deluge::gui::menu_item::runtime_feature {
-class ShiftIsSticky final : public Setting {
+class ShiftIsSticky final : public SettingToggle {
 public:
-	ShiftIsSticky() : Setting(RuntimeFeatureSettingType::ShiftIsSticky) {}
+	ShiftIsSticky() : SettingToggle(RuntimeFeatureSettingType::ShiftIsSticky) {}
 
 	void writeCurrentValue() override;
 };

--- a/src/deluge/gui/menu_item/selection.cpp
+++ b/src/deluge/gui/menu_item/selection.cpp
@@ -45,10 +45,10 @@ void Selection::displayToggleValue() {
 void Selection::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
+	// push the start x over so it aligns with the right most character drawn for param value menus
+	int32_t startX = xPixel + kTextSpacingX * 2 - 1;
+
 	if (isToggle()) {
-		// the icon is the equivalent of 1 character width so need to push the start x over so it aligns with the ">"
-		// icon
-		int32_t startX = xPixel + kTextSpacingX * 2 - 1;
 		if (getToggleValue()) {
 			image.drawGraphicMultiLine(deluge::hid::display::OLED::checkedBoxIcon, startX, yPixel, 7);
 		}
@@ -57,9 +57,7 @@ void Selection::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
 		}
 	}
 	else {
-		std::string stringForSubmenuItemType;
-		stringForSubmenuItemType.append("  >");
-		image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
+		image.drawGraphicMultiLine(deluge::hid::display::OLED::submenuArrowIcon, startX, yPixel, 7);
 	}
 }
 

--- a/src/deluge/gui/menu_item/selection.cpp
+++ b/src/deluge/gui/menu_item/selection.cpp
@@ -2,6 +2,7 @@
 #include "gui/menu_item/menu_item.h"
 #include "gui/ui/sound_editor.h"
 #include "hid/display/display.h"
+#include "hid/display/oled.h"
 
 namespace deluge::gui::menu_item {
 void Selection::drawValue() {
@@ -29,4 +30,36 @@ void Selection::drawPixelsForOled() {
 	MenuItem::drawItemsForOled(std::span{getOptions().data(), getOptions().size()}, selectedOption,
 	                           soundEditor.menuCurrentScroll);
 }
+
+// renders check box on OLED and dot on 7seg
+void Selection::displayToggleValue() {
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+	else {
+		drawName();
+	}
+}
+
+// handles rendering of the community features menu items that are identified as toggles
+void Selection::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+
+	std::string stringForSubmenuItemType;
+
+	if (isToggle()) {
+		if (getToggleValue()) {
+			stringForSubmenuItemType.append("[x]");
+		}
+		else {
+			stringForSubmenuItemType.append("[ ]");
+		}
+	}
+	else {
+		stringForSubmenuItemType.append("  >");
+	}
+
+	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
+}
+
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/selection.cpp
+++ b/src/deluge/gui/menu_item/selection.cpp
@@ -42,11 +42,10 @@ void Selection::displayToggleValue() {
 }
 
 // handles rendering of the community features menu items that are identified as toggles
-void Selection::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+void Selection::renderSubmenuItemTypeForOled(int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
-	// push the start x over so it aligns with the right most character drawn for param value menus
-	int32_t startX = xPixel + kTextSpacingX * 2 - 1;
+	int32_t startX = getSubmenuItemTypeRenderIconStart();
 
 	if (isToggle()) {
 		if (getToggleValue()) {

--- a/src/deluge/gui/menu_item/selection.cpp
+++ b/src/deluge/gui/menu_item/selection.cpp
@@ -45,21 +45,22 @@ void Selection::displayToggleValue() {
 void Selection::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
-	std::string stringForSubmenuItemType;
-
 	if (isToggle()) {
+		// the icon is the equivalent of 1 character width so need to push the start x over so it aligns with the ">"
+		// icon
+		int32_t startX = xPixel + kTextSpacingX * 2 - 1;
 		if (getToggleValue()) {
-			stringForSubmenuItemType.append("[x]");
+			image.drawGraphicMultiLine(deluge::hid::display::OLED::checkedBoxIcon, startX, yPixel, 7);
 		}
 		else {
-			stringForSubmenuItemType.append("[ ]");
+			image.drawGraphicMultiLine(deluge::hid::display::OLED::uncheckedBoxIcon, startX, yPixel, 7);
 		}
 	}
 	else {
+		std::string stringForSubmenuItemType;
 		stringForSubmenuItemType.append("  >");
+		image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
 	}
-
-	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/selection.h
+++ b/src/deluge/gui/menu_item/selection.h
@@ -32,5 +32,38 @@ public:
 
 	void drawPixelsForOled() override;
 	size_t size() override { return this->getOptions().size(); }
+
+	virtual bool isToggle() { return false; }
+
+	void displayToggleValue();
+
+	// renders toggle item type in submenus after the item name
+	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+
+	// toggles boolean ON / OFF
+	void toggleValue() {
+		readCurrentValue();
+		setValue(!getValue());
+		writeCurrentValue();
+	};
+
+	// handles changing bool setting without entering menu and updating the display
+	MenuItem* selectButtonPress() override {
+		toggleValue();
+		displayToggleValue();
+		return (MenuItem*)0xFFFFFFFF; // no navigation
+	}
+
+	// get's toggle status for rendering checkbox on OLED
+	bool getToggleValue() {
+		readCurrentValue();
+		return this->getValue();
+	}
+
+	// get's toggle status for rendering dot on 7SEG
+	uint8_t shouldDrawDotOnName() override {
+		readCurrentValue();
+		return this->getValue() ? 3 : 255;
+	}
 };
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/selection.h
+++ b/src/deluge/gui/menu_item/selection.h
@@ -38,7 +38,7 @@ public:
 	void displayToggleValue();
 
 	// renders toggle item type in submenus after the item name
-	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+	void renderSubmenuItemTypeForOled(int32_t yPixel) override;
 
 	// toggles boolean ON / OFF
 	void toggleValue() {

--- a/src/deluge/gui/menu_item/selection.h
+++ b/src/deluge/gui/menu_item/selection.h
@@ -62,8 +62,13 @@ public:
 
 	// get's toggle status for rendering dot on 7SEG
 	uint8_t shouldDrawDotOnName() override {
-		readCurrentValue();
-		return this->getValue() ? 3 : 255;
+		if (isToggle()) {
+			readCurrentValue();
+			return this->getValue() ? 3 : 255;
+		}
+		else {
+			return 255;
+		}
 	}
 };
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -95,7 +95,7 @@ void Submenu::drawSubmenuItemsForOled(std::span<MenuItem*> options, const int32_
 		image.drawString(menuItem->getName(), kTextSpacingX, yPixel, kTextSpacingX, kTextSpacingY, 0, endX);
 
 		// draw the menu item type after the menu item string
-		menuItem->renderSubmenuItemTypeForOled(endX + kTextSpacingX, yPixel);
+		menuItem->renderSubmenuItemTypeForOled(yPixel);
 
 		// if you've selected a menu item, invert the area to show that it is selected
 		// and setup scrolling in case that menu item is too long to display fully

--- a/src/deluge/gui/menu_item/toggle.cpp
+++ b/src/deluge/gui/menu_item/toggle.cpp
@@ -74,11 +74,10 @@ void Toggle::displayToggleValue() {
 	}
 }
 
-void Toggle::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+void Toggle::renderSubmenuItemTypeForOled(int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
-	// push the start x over so it aligns with the right most character drawn for param value menus
-	int32_t startX = xPixel + kTextSpacingX * 2 - 1;
+	int32_t startX = getSubmenuItemTypeRenderIconStart();
 
 	if (getToggleValue()) {
 		image.drawGraphicMultiLine(deluge::hid::display::OLED::checkedBoxIcon, startX, yPixel, 7);

--- a/src/deluge/gui/menu_item/toggle.cpp
+++ b/src/deluge/gui/menu_item/toggle.cpp
@@ -77,16 +77,14 @@ void Toggle::displayToggleValue() {
 void Toggle::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
-	std::string stringForSubmenuItemType;
-
+	// the icon is the equivalent of 1 character width so need to push the start x over so it aligns with the ">" icon
+	int32_t startX = xPixel + kTextSpacingX * 2 - 1;
 	if (getToggleValue()) {
-		stringForSubmenuItemType.append("[x]");
+		image.drawGraphicMultiLine(deluge::hid::display::OLED::checkedBoxIcon, startX, yPixel, 7);
 	}
 	else {
-		stringForSubmenuItemType.append("[ ]");
+		image.drawGraphicMultiLine(deluge::hid::display::OLED::uncheckedBoxIcon, startX, yPixel, 7);
 	}
-
-	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/toggle.cpp
+++ b/src/deluge/gui/menu_item/toggle.cpp
@@ -77,8 +77,9 @@ void Toggle::displayToggleValue() {
 void Toggle::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
-	// the icon is the equivalent of 1 character width so need to push the start x over so it aligns with the ">" icon
+	// push the start x over so it aligns with the right most character drawn for param value menus
 	int32_t startX = xPixel + kTextSpacingX * 2 - 1;
+
 	if (getToggleValue()) {
 		image.drawGraphicMultiLine(deluge::hid::display::OLED::checkedBoxIcon, startX, yPixel, 7);
 	}

--- a/src/deluge/gui/menu_item/toggle.h
+++ b/src/deluge/gui/menu_item/toggle.h
@@ -18,7 +18,7 @@ public:
 	bool shouldEnterSubmenu() override { return false; }
 
 	// renders toggle item type in submenus after the item name
-	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+	void renderSubmenuItemTypeForOled(int32_t yPixel) override;
 
 	// toggles boolean ON / OFF
 	void toggleValue() {

--- a/src/deluge/gui/menu_item/unpatched_param.cpp
+++ b/src/deluge/gui/menu_item/unpatched_param.cpp
@@ -81,7 +81,7 @@ uint32_t UnpatchedParam::getParamIndex() {
 	return this->getP();
 }
 
-void UnpatchedParam::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) {
+void UnpatchedParam::renderSubmenuItemTypeForOled(int32_t yPixel) {
 	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
 
 	DEF_STACK_STRING_BUF(paramValue, 10);
@@ -93,7 +93,9 @@ void UnpatchedParam::renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel
 	// pad value string so it's 3 characters long
 	padStringTo(stringForSubmenuItemType, 3);
 
-	image.drawString(stringForSubmenuItemType, xPixel, yPixel, kTextSpacingX, kTextSpacingY);
+	int32_t startX = getSubmenuItemTypeRenderValueStart();
+
+	image.drawString(stringForSubmenuItemType, startX, yPixel, kTextSpacingX, kTextSpacingY);
 }
 
 // ---------------------------------------

--- a/src/deluge/gui/menu_item/unpatched_param.h
+++ b/src/deluge/gui/menu_item/unpatched_param.h
@@ -58,7 +58,7 @@ public:
 	ModelStackWithAutoParam* getModelStack(void* memory) final;
 
 	// renders param value in submenus after the item name
-	void renderSubmenuItemTypeForOled(int32_t xPixel, int32_t yPixel) override;
+	void renderSubmenuItemTypeForOled(int32_t yPixel) override;
 
 	int32_t getParamValue() {
 		readCurrentValue();

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -120,6 +120,16 @@ const uint8_t OLED::uncheckedBoxIcon[] = {
     0b11111110, //<
 };
 
+const uint8_t OLED::submenuArrowIcon[] = {
+    0b00000000, //<
+    0b00000000, //<
+    0b01000100, //<
+    0b00101000, //<
+    0b00010000, //<
+    0b00000000, //<
+    0b00000000, //<
+};
+
 #if ENABLE_TEXT_OUTPUT
 uint16_t renderStartTime;
 #endif

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -100,6 +100,26 @@ const uint8_t OLED::lockIcon[] = {
     0b11111000, //<
 };
 
+const uint8_t OLED::checkedBoxIcon[] = {
+    0b11111110, //<
+    0b10000010, //<
+    0b10011010, //<
+    0b10110010, //<
+    0b10011010, //<
+    0b10001100, //<
+    0b11100110, //<
+};
+
+const uint8_t OLED::uncheckedBoxIcon[] = {
+    0b11111110, //<
+    0b10000010, //<
+    0b10000010, //<
+    0b10000010, //<
+    0b10000010, //<
+    0b10000010, //<
+    0b11111110, //<
+};
+
 #if ENABLE_TEXT_OUTPUT
 uint16_t renderStartTime;
 #endif

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -99,6 +99,7 @@ public:
 	static const uint8_t lockIcon[];
 	static const uint8_t checkedBoxIcon[];
 	static const uint8_t uncheckedBoxIcon[];
+	static const uint8_t submenuArrowIcon[];
 
 	void removeWorkingAnimation() override;
 	void timerRoutine() override;

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -97,6 +97,8 @@ public:
 	static const uint8_t downArrowIcon[];
 	static const uint8_t rightArrowIcon[];
 	static const uint8_t lockIcon[];
+	static const uint8_t checkedBoxIcon[];
+	static const uint8_t uncheckedBoxIcon[];
 
 	void removeWorkingAnimation() override;
 	void timerRoutine() override;


### PR DESCRIPTION
- Some selection class menu's are actually toggles (e.g. most in community features, arp mode).

  This PR enables those selection class menu's to behave like toggles and thus display a checkbox (on OLED) and dot (on 7SEG)

- Replaced ascii checkbox "[ ]" and arrow ">" with a check box and arrow icons.

- Refactored logic for calculating render start x pixel position for rendering icons and param values