### PR TITLE
Bugfix - Display bars / 16th notes remaining + Launch playhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 - Fixed a bug where instruments and kits wouldn't respect record arming state. They no longer record when not armed
 - A white playhead is now rendered in Song Grid and Performance Views that let's you know when a clip or section launch event is scheduled to occur. The playhead only renders the last 16 notes before a launch event.
   - Note: this playhead can be turned off in the Community Features submenu titled: `Enable Launch Event Playhead (PLAY)`
-- The display now shows the number of Bars (or Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
+- The display now shows the number of Bars (or Quarter Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
 - For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.
  - OLED renders a checkbox that shows current ON/OFF status. Selecting that menu with select encoder will toggle the checkbox as opposed to entering the menu.
  - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -279,7 +279,7 @@ as the micromonsta and the dreadbox nymphes.
   - Note: this playhead can be turned off in the Community Features submenu titled: `Enable Launch Event Playhead (PLAY)`
 
 #### 3.25 Display Number of Bars / Notes Remaining until Clip / Section Launch Event
-- ([#2315]) The display now shows the number of Bars (or Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
+- ([#2315]) The display now shows the number of Bars (or Quarter Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
 
 #### 3.26 Updated UI for Interacting with Toggle Menu's and Sub Menu's
 - ([#2345]) For toggle (ON/OFF) menu's, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -654,7 +654,6 @@ void PerformanceSessionView::renderOLED(deluge::hid::display::oled_canvas::Canva
 }
 
 void PerformanceSessionView::redrawNumericDisplay() {
-	renderViewDisplay();
 	sessionView.redrawNumericDisplay();
 }
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2142,15 +2142,14 @@ int32_t SessionView::displayLoopsRemainingPopup() {
 	if (sixteenthNotesRemaining > 0) {
 		DEF_STACK_STRING_BUF(popupMsg, 40);
 		if (sixteenthNotesRemaining > 16) {
-			int32_t barsRemaining = static_cast<int32_t>(std::round(static_cast<float>(sixteenthNotesRemaining) / 16));
+			int32_t barsRemaining = ((sixteenthNotesRemaining - 1) / 16) + 1;
 			if (display->haveOLED()) {
 				popupMsg.append("Bars Remaining: ");
 			}
 			popupMsg.appendInt(barsRemaining);
 		}
 		else {
-			int32_t quarterNotesRemaining =
-			    static_cast<int32_t>(std::round(static_cast<float>(sixteenthNotesRemaining) / 4));
+			int32_t quarterNotesRemaining = ((sixteenthNotesRemaining - 1) / 4) + 1;
 			if (display->haveOLED()) {
 				popupMsg.append("Beats Remaining: ");
 			}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2136,24 +2136,25 @@ void SessionView::graphicsRoutine() {
 	PadLEDs::setTickSquares(tickSquares, colours);
 }
 
-/// display number of bars or notes remaining until a launch event
+/// display number of bars or quarter notes remaining until a launch event
 int32_t SessionView::displayLoopsRemainingPopup() {
 	int32_t sixteenthNotesRemaining = session.getNumSixteenthNotesRemainingTilLaunch();
 	if (sixteenthNotesRemaining > 0) {
-		int32_t barsRemaining = sixteenthNotesRemaining / 16;
-
 		DEF_STACK_STRING_BUF(popupMsg, 40);
 		if (sixteenthNotesRemaining > 16) {
+			int32_t barsRemaining = static_cast<int32_t>(std::round(static_cast<float>(sixteenthNotesRemaining) / 16));
 			if (display->haveOLED()) {
 				popupMsg.append("Bars Remaining: ");
 			}
 			popupMsg.appendInt(barsRemaining);
 		}
 		else {
+			int32_t quarterNotesRemaining =
+			    static_cast<int32_t>(std::round(static_cast<float>(sixteenthNotesRemaining) / 4));
 			if (display->haveOLED()) {
-				popupMsg.append("Notes Remaining: ");
+				popupMsg.append("Beats Remaining: ");
 			}
-			popupMsg.appendInt(sixteenthNotesRemaining);
+			popupMsg.appendInt(quarterNotesRemaining);
 		}
 		if (display->haveOLED()) {
 			deluge::hid::display::OLED::clearMainImage();

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -700,6 +700,12 @@ int32_t Session::getNumSixteenthNotesRemainingTilLaunch() {
 	float ticksRemaining = static_cast<float>(launchEventAtSwungTickCount - playbackHandler.lastSwungTickActioned
 	                                          - playbackHandler.getNumSwungTicksInSinceLastActionedSwungTick());
 	float sixteenthNotesRemaining = std::round(ticksRemaining / currentSong->getSixteenthNoteLength());
+	// if there is more than 1 repeat remaining, we need to adjust the number of sixteenth notes remaining
+	// as number of ticksRemaining is only accurate for 1 repeat
+	if (numRepeatsTilLaunch > 1) {
+		sixteenthNotesRemaining += (((numRepeatsTilLaunch - 1) * currentArmedLaunchLengthForOneRepeat)
+		                            / currentSong->getSixteenthNoteLength());
+	}
 	return static_cast<int32_t>(sixteenthNotesRemaining);
 }
 

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -709,10 +709,6 @@ int32_t Session::getNumSixteenthNotesRemainingTilLaunch() {
 	return static_cast<int32_t>(sixteenthNotesRemaining);
 }
 
-int32_t Session::getNumBarsRemainingTilLaunch() {
-	return getNumSixteenthNotesRemainingTilLaunch() / 16;
-}
-
 void Session::scheduleFillEvent(Clip* clip, int64_t atTickCount) {
 	clip->fillEventAtTickCount = atTickCount;
 	int32_t ticksTilFillEvent = atTickCount - playbackHandler.lastSwungTickActioned;

--- a/src/deluge/playback/mode/session.h
+++ b/src/deluge/playback/mode/session.h
@@ -34,7 +34,6 @@ public:
 	void doLaunch(bool isFillLaunch);
 	void scheduleLaunchTiming(int64_t atTickCount, int32_t numRepeatsUntil, int32_t armedLaunchLengthForOneRepeat);
 	int32_t getNumSixteenthNotesRemainingTilLaunch();
-	int32_t getNumBarsRemainingTilLaunch();
 	void scheduleFillEvent(Clip* clip, int64_t atTickCount);
 	void cancelAllLaunchScheduling();
 	void launchSchedulingMightNeedCancelling();


### PR DESCRIPTION
Fixed couple bugs:
- Repeats remaining wasn't displaying on 7SEG when turning select encoder (fix #2301)
- Bars / 16th notes remaining and corresponding playhead rendered in grid and performance view was not correctly accounting for number of repeats remaining (fix #2352)