### PR TITLE
Bugfix VU meter rendering

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -3012,8 +3012,7 @@ void ArrangerView::graphicsRoutine() {
 		}
 	}
 
-	// if we're not currently selecting a clip
-	if (!getClipForSelection() && view.potentiallyRenderVUMeter(PadLEDs::image)) {
+	if (view.potentiallyRenderVUMeter(PadLEDs::image)) {
 		PadLEDs::sendOutSidebarColours();
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1987,8 +1987,7 @@ void SessionView::graphicsRoutine() {
 		}
 	}
 
-	// if we're not currently selecting a clip
-	if (!getClipForLayout() && view.potentiallyRenderVUMeter(PadLEDs::image)) {
+	if (view.potentiallyRenderVUMeter(PadLEDs::image)) {
 		PadLEDs::sendOutSidebarColours();
 	}
 
@@ -2932,8 +2931,12 @@ void SessionView::gridRenderActionModes(int32_t y, RGB image[][kDisplayWidth + k
 bool SessionView::gridRenderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
 
-	// We currently assume sidebar is rendered after main pads
-	memset(image, 0, sizeof(RGB) * kDisplayHeight * (kDisplayWidth + kSideBarWidth));
+	// Clear just the main pads
+	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+		for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+			image[yDisplay][xDisplay] = {0, 0, 0};
+		}
+	}
 
 	// Iterate over all clips and render them where they are
 	auto trackCount = gridTrackCount();

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1614,8 +1614,15 @@ void View::displayAutomation() {
 /// and the current mod button selected is the volume/pan button
 /// render VU meter on the grid
 bool View::potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]) {
-	if (displayVUMeter && view.activeModControllableModelStack.modControllable
-	    && *activeModControllableModelStack.modControllable->getModKnobMode() == 0) {
+	// if VU meter is toggled on and
+	// 1) mod controllable is active and we've selected the level / pan mod knob button
+	// or
+	// 2) we've pressed a clip while vu meter was active
+	// then let's continue to render VU meter
+	if (displayVUMeter
+	    && ((activeModControllableModelStack.modControllable
+	         && *activeModControllableModelStack.modControllable->getModKnobMode() == 0)
+	        || (isClipContext() && renderedVUMeter))) {
 		PadLEDs::renderingLock = true;
 
 		// get max Y display that would be rendered based on AudioEngine::approxRMSLevel


### PR DESCRIPTION
Fixed a couple bugs around VU meter rendering:

- VU meter would stop rendering previously when you selected a clip in song or arranger view

- VU meter would flash when a clip was being launched in grid view

Fix #2321