### PR TITLE
scale mapper

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -38,6 +38,7 @@
 #include "model/note/note.h"
 #include "model/scale/note_set.h"
 #include "model/scale/preset_scales.h"
+#include "model/scale/scale_change.h"
 #include "model/scale/utils.h"
 #include "model/song/song.h"
 #include "modulation/midi/midi_param.h"
@@ -1243,8 +1244,7 @@ RGB InstrumentClip::getMainColourFromY(int32_t yNote, int8_t noteRowColourOffset
 	return RGB::fromHue((yNote + colourOffset + noteRowColourOffset) * -8 / 3);
 }
 
-void InstrumentClip::replaceMusicalMode(uint8_t numModeNotes, int8_t changes[12],
-                                        ModelStackWithTimelineCounter* modelStack) {
+void InstrumentClip::replaceMusicalMode(const ScaleChange& changes, ModelStackWithTimelineCounter* modelStack) {
 	if (!isScaleModeClip()) {
 		return;
 	}

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -76,7 +76,7 @@ public:
 	void resumePlayback(ModelStackWithTimelineCounter* modelStack, bool mayMakeSound = true) override;
 	void setPos(ModelStackWithTimelineCounter* modelStack, int32_t newPos,
 	            bool useActualPosForParamManagers = true) override;
-	void replaceMusicalMode(uint8_t numModeNotes, int8_t changes[], ModelStackWithTimelineCounter* modelStack);
+	void replaceMusicalMode(const ScaleChange& changes, ModelStackWithTimelineCounter* modelStack);
 	void seeWhatNotesWithinOctaveArePresent(NoteSet&, int32_t, Song* song, bool deleteEmptyNoteRows = true);
 	void transpose(int32_t, ModelStackWithTimelineCounter* modelStack);
 	void nudgeNotesVertically(int32_t direction, VerticalNudgeType, ModelStackWithTimelineCounter* modelStack);

--- a/src/deluge/model/scale/musical_key.cpp
+++ b/src/deluge/model/scale/musical_key.cpp
@@ -8,11 +8,6 @@ MusicalKey::MusicalKey() {
 	rootNote = 0;
 }
 
-void MusicalKey::applyChanges(int8_t changes[12]) {
-	modeNotes.applyChanges(changes);
-	rootNote += changes[0];
-}
-
 uint8_t MusicalKey::intervalOf(int32_t noteCode) const {
 	return mod(noteCode - rootNote, 12);
 }

--- a/src/deluge/model/scale/musical_key.h
+++ b/src/deluge/model/scale/musical_key.h
@@ -16,8 +16,7 @@ public:
 	 * -1 if the noteCode is note in key.
 	 */
 	int8_t degreeOf(int32_t nodeCode) const;
-	void applyChanges(int8_t changes[12]);
-	// TODO: make these priviate later, and maybe rename modeNotes
+	// TODO: make these private later, and maybe rename modeNotes
 	NoteSet modeNotes;
 	int16_t rootNote;
 };

--- a/src/deluge/model/scale/note_set.cpp
+++ b/src/deluge/model/scale/note_set.cpp
@@ -41,6 +41,15 @@ int8_t NoteSet::operator[](uint8_t index) const {
 	return note;
 }
 
+int8_t NoteSet::highestNotIn(NoteSet other) const {
+	for (int8_t i = highest(); i >= 0; i--) {
+		if (has(i) && !other.has(i)) {
+			return i;
+		}
+	}
+	return -1;
+}
+
 int8_t NoteSet::degreeOf(uint8_t note) const {
 	if (has(note)) {
 		// Mask everything before the note

--- a/src/deluge/model/scale/note_set.cpp
+++ b/src/deluge/model/scale/note_set.cpp
@@ -63,20 +63,6 @@ int8_t NoteSet::degreeOf(uint8_t note) const {
 	}
 }
 
-void NoteSet::applyChanges(int8_t changes[12]) {
-	NoteSet newSet;
-	uint8_t n = 1;
-	for (int note = 1; note < 12; note++) {
-		if (has(note)) {
-			// n'th degree has semitone t, compute
-			// the transpose and save to new noteset
-			newSet.add(note + changes[n++] - changes[0]);
-		}
-	}
-	newSet.add(0);
-	bits = newSet.bits;
-}
-
 uint8_t NoteSet::presetScaleId() const {
 	for (int32_t p = 0; p < NUM_PRESET_SCALES; p++) {
 		if (*this == presetScaleNotes[p]) {

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -27,6 +27,9 @@ public:
 	/** Add a note to NoteSet.
 	 */
 	void add(int8_t note) { bits = 0xfff & (bits | (1 << note)); }
+	/** Remove a note to NoteSet.
+	 */
+	void remove(int8_t note) { bits = 0xfff & (bits & ~(1 << note)); }
 	/** Returns true if note is part of the NoteSet.
 	 */
 	bool has(int8_t note) const { return (bits >> note) & 1; }

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -64,6 +64,11 @@ public:
 	/** Returns the highest note that has been added to the NoteSet.
 	 */
 	uint8_t highest() const { return 15 - std::countl_zero(bits); }
+	/** Returns the highest note present in this NoteSet not present in the other.
+	 *
+	 * Returns -1 if there are no notes present unused in the other NoteSet..
+	 */
+	int8_t highestNotIn(NoteSet used) const;
 	/** If this is a preset scale, returns the preset scale id.
 	 *
 	 * Otherwise returns CUSTOM_SCALE_WITH_MORE_THAN_7_NOTES

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -64,6 +64,8 @@ public:
 	/** Removes all semitones from the NoteSet.
 	 */
 	void clear() { bits = 0; }
+	/** Returns true if the NoteSet is empty */
+	bool isEmpty() const { return bits == 0; }
 	/** Returns the highest note that has been added to the NoteSet.
 	 */
 	uint8_t highest() const { return 15 - std::countl_zero(bits); }

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -107,6 +107,8 @@ private:
 	uint16_t bits;
 };
 
+const uint8_t kMaxScaleSize = NoteSet::size;
+
 #ifdef IN_UNIT_TESTS
 // For CppUTest CHECK_EQUAL() and debugging convenience
 

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -50,14 +50,6 @@ public:
 	 * This is the scale degree of the note if the NoteSet represents a scale and has a root.
 	 */
 	int8_t degreeOf(uint8_t note) const;
-	/** Applies changes specified by the array.
-	 *
-	 * Each element of the array describes a semitone offset
-	 * to a scale degree.
-	 *
-	 * Root offset is applied relative to the other notes.
-	 */
-	void applyChanges(int8_t changes[12]);
 	/** Marks all semitones as being part of the NoteSet.
 	 */
 	void fill() { bits = 0xfff; }

--- a/src/deluge/model/scale/scale_change.cpp
+++ b/src/deluge/model/scale/scale_change.cpp
@@ -1,0 +1,13 @@
+#include "model/scale/scale_change.h"
+#include "model/scale/note_set.h"
+
+NoteSet ScaleChange::applyTo(NoteSet notes) const {
+	NoteSet newSet;
+	for (int i = 0; i < source.count(); i++) {
+		uint8_t note = source[i];
+		if (notes.has(note)) {
+			newSet.add(note + degreeOffset[i]);
+		}
+	}
+	return newSet;
+}

--- a/src/deluge/model/scale/scale_change.h
+++ b/src/deluge/model/scale/scale_change.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "model/scale/note_set.h"
+
+class ScaleChange {
+public:
+	/** The source scale to which the ScaleChange applies.
+	 */
+	NoteSet source;
+	/** Returns the number of semitones for a scale degree offset.
+	 */
+	int8_t operator[](uint8_t degree) const { return degreeOffset[degree]; }
+	int8_t& operator[](uint8_t degree) { return degreeOffset[degree]; }
+	/** Transposes a NoteSet according to the ScaleChange.
+	 *
+	 * For each scale degree of source, if the note exists in the
+	 * notes, applies the semitone offset from the corresponding
+	 * scale degree.
+	 *
+	 * If the NoteSet is not a subset of oldScale, all bets are off.
+	 */
+	NoteSet applyTo(NoteSet notes) const;
+
+private:
+	int8_t degreeOffset[kMaxScaleSize] = {0};
+};

--- a/src/deluge/model/scale/scale_mapper.cpp
+++ b/src/deluge/model/scale/scale_mapper.cpp
@@ -1,0 +1,160 @@
+#include "model/scale/scale_mapper.h"
+#include "definitions.h"
+
+bool oops(const char* msg) {
+#ifdef IN_UNIT_TESTS
+	std::cerr << "conputeChangeFrom failed with " << msg << std::endl;
+#else
+	FREEZE_WITH_ERROR(msg);
+#endif
+	return false;
+}
+
+bool ScaleMapper::computeChangeFrom(NoteSet notes, NoteSet sourceScale, NoteSet targetScale, ScaleChange& changes) {
+	if (notes.scaleSize() > targetScale.scaleSize() || !notes.isSubsetOf(sourceScale)) {
+		return oops("SM01");
+	}
+	changes.source = sourceScale;
+	// If we've previously converted from a scale with different size, this is the scale in which we
+	// arrived at current scale size before converting to whatever scale we're in now. If we don't have
+	// a different scale size in our history, this is same as source scale.
+	NoteSet initialScale = initialTransitionScale(sourceScale);
+	// Compute changes[] needed to go from into transition scale.
+	computeInitialChanges(sourceScale, initialScale, changes);
+	// Tranform notes into the transition scale.
+	NoteSet transitionNotes = changes.applyTo(notes);
+	// If we've added new notes not part of a previous transition, we need to flush out
+	// the earlier transitions: they're no longer valid.
+	if (!transitionNotes.isSubsetOf(lastTransitionNotes)) {
+		flushTransitionScaleStore(initialScale);
+	}
+
+	NoteSet transitionScale = initialScale;
+	// Step the transition scale until it is the same size as target scale.
+	uint8_t size = transitionScale.count();
+	while (size != targetScale.count()) {
+		// Each step should only add or remove one note from the scale: we don't need
+		// to think about changes[] because the notes aren't _moving_, which is alo why
+		// we don't need to update transitionNotes.
+		transitionScale = nextTransitionScale(transitionNotes, transitionScale, targetScale);
+		uint8_t newSize = transitionScale.count();
+		if (newSize == size) {
+			// Bail out if we don't make progesss.
+			return oops("SM02");
+		}
+		else {
+			size = newSize;
+		}
+	}
+	// Store the final transition notes, so we know if we need to flush the transition scale store.
+	lastTransitionNotes = transitionNotes;
+
+	// Now compute the changes needed to go from transitionScale of correct size to the target
+	// scale.
+	computeFinalChanges(initialScale, transitionScale, targetScale, changes);
+	return true;
+}
+
+NoteSet ScaleMapper::initialTransitionScale(NoteSet sourceScale) {
+	uint8_t size = sourceScale.count();
+	NoteSet mode = transitionScaleStore[size];
+	if (mode.isEmpty()) {
+		mode = transitionScaleStore[size] = sourceScale;
+	}
+	return mode;
+}
+
+void ScaleMapper::computeInitialChanges(NoteSet sourceScale, NoteSet initialScale, ScaleChange& changes) {
+	// Zero the root offset
+	changes[0] = 0;
+	uint8_t size = sourceScale.count();
+	// Set the semitone offsets to go from source to the initial transition scale
+	for (uint8_t degree = 1; degree < size; degree++) {
+		changes[degree] = initialScale[degree] - sourceScale[degree];
+	}
+	// Zero out the tail end.
+	for (uint8_t degree = size; degree < NoteSet::size; degree++) {
+		changes[degree] = 0;
+	}
+}
+
+void ScaleMapper::flushTransitionScaleStore(NoteSet initialScale) {
+	for (int i = 0; i < kMaxScaleSize; i++) {
+		transitionScaleStore[i].clear();
+	}
+	transitionScaleStore[initialScale.count()] = initialScale;
+}
+
+void ScaleMapper::computeFinalChanges(NoteSet initialScale, NoteSet transitionScale, NoteSet targetScale,
+                                      ScaleChange& changes) {
+	// Initial scale has the same number of scale degrees as actual source scale.
+	//
+	// Transition scale may have more or less scale degrees, but if the same _note_ is present in
+	// both init and transition, it refers to the same source scale degree.
+	//
+	// Target scale has the same number of scale degrees as transition.
+	//
+	// Bit of debugging prints left out in commented form. This function is a key place to instrument
+	// if you want to understand what's going on.
+	/*
+	    std::cerr << "source=" << source << std::endl;
+	    std::cerr << "transition=" << transition << std::endl;
+	    std::cerr << "target=" << target << std::endl;
+	*/
+	for (uint8_t sourceDegree = 1; sourceDegree < initialScale.count(); sourceDegree++) {
+		uint8_t sourceNote = initialScale[sourceDegree];
+		if (transitionScale.has(sourceNote)) {
+			uint8_t transitionDegree = transitionScale.degreeOf(sourceNote);
+			uint8_t targetNote = targetScale[transitionDegree];
+			// NoteSet x, y; x.add(sourceNote); y.add(targetNote);
+			// std::cerr << "mapping degree " << (int)sourceDegree << " to " << (int)transitionDegree << " as " << x <<
+			// " -> " << y << std::endl;
+			changes[sourceDegree] += targetNote - sourceNote;
+		}
+	}
+}
+
+NoteSet ScaleMapper::nextTransitionScale(NoteSet notes, NoteSet transitionScale, NoteSet targetScale) {
+	uint8_t ss = transitionScale.count();
+	uint8_t ts = targetScale.count();
+	uint8_t next = ss;
+	if (ss > ts) {
+		next = ss - 1;
+	}
+	else if (ts > ss) {
+		next = ss + 1;
+	}
+	NoteSet nextScale = transitionScaleStore[next];
+	if (nextScale.isEmpty()) {
+		// No transition mode for this size, let's make one up.
+		nextScale = transitionScale;
+		if (ss > ts) {
+			// Drop an unused note.
+			//
+			// *** We can drop any note that isn't in notes. ***
+			//
+			// It is better to drop high notes than low notes: the lower
+			// you drop the more likely you are to change the function of
+			// other notes. (You're still going to change the function regularly,
+			// but _sometimes_ this will avoid it.)
+			//
+			// Another trick is to try to pick notes that aren't used in
+			// the target scale either: this way we're more likely to preserve
+			// intervals. (We're still going to change intervals, but _sometimes_
+			// this will avoid it.)
+			int8_t inNeither = nextScale.highestNotIn(notes | targetScale);
+			if (inNeither < 0) {
+				nextScale.remove(nextScale.highestNotIn(notes));
+			}
+			else {
+				nextScale.remove(inNeither);
+			}
+		}
+		else if (ss < ts) {
+			// Add highest note of target scale we don't already have.
+			nextScale.add(targetScale.highestNotIn(transitionScale));
+		}
+		transitionScaleStore[next] = nextScale;
+	}
+	return nextScale;
+}

--- a/src/deluge/model/scale/scale_mapper.h
+++ b/src/deluge/model/scale/scale_mapper.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "model/scale/note_set.h"
+#include "model/scale/scale_change.h"
+#include "util/const_functions.h"
+
+#include <cstdint>
+
+#if IN_UNIT_TESTS
+#include <iostream>
+#endif
+
+class ScaleMapper {
+public:
+	/** With notes being currently in use, compute ScaleChange to go from sourceScale to targetScale.
+	 *
+	 * In production code freezes with error if the scale change cannot be computed, for testing
+	 * purposes returns false.
+	 *
+	 * The computed ScaleChanges are such that as long as no new notes are added, all transitions
+	 * are reversible.
+	 */
+	bool computeChangeFrom(NoteSet notes, NoteSet sourceScale, NoteSet targetScale, ScaleChange& changes);
+
+private:
+	/** Stores the transition notes from the last computed scale change.
+	 */
+	NoteSet lastTransitionNotes;
+	/** Indexes 0-11 store the transition scales for the corresponding scale size - 1.
+	 *
+	 * Note: we include 12 tone scales both for simplicity, and in order to support 12-tone scales with
+	 * bent notes.
+	 */
+	NoteSet transitionScaleStore[kMaxScaleSize];
+	NoteSet initialTransitionScale(NoteSet sourceScale);
+	void computeInitialChanges(NoteSet sourceScale, NoteSet initialScale, ScaleChange& changes);
+	void flushTransitionScaleStore(NoteSet initialScale);
+	void computeFinalChanges(NoteSet initialScale, NoteSet transitionScale, NoteSet targetScale, ScaleChange& changes);
+	NoteSet nextTransitionScale(NoteSet notes, NoteSet transitionScale, NoteSet targetScale);
+};

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -26,6 +26,8 @@
 #include "model/output.h"
 #include "model/scale/musical_key.h"
 #include "model/scale/note_set.h"
+#include "model/scale/scale_change.h"
+#include "model/scale/scale_mapper.h"
 #include "model/sync.h"
 #include "model/timeline_counter.h"
 #include "modulation/params/param.h"
@@ -95,7 +97,7 @@ public:
 	void addMajorDependentModeNotes(uint8_t i, bool preferHigher, NoteSet& notesWithinOctavePresent);
 	void changeMusicalMode(uint8_t yVisualWithinOctave, int8_t change);
 	void rotateMusicalMode(int8_t change);
-	void replaceMusicalMode(int8_t changes[], bool affectMIDITranspose);
+	void replaceMusicalMode(const ScaleChange& changes, bool affectMIDITranspose);
 	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode);
 	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode, const MusicalKey& key);
 	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode);
@@ -395,8 +397,7 @@ public:
 	uint8_t chordMem[kDisplayHeight][MAX_NOTES_CHORD_MEM] = {0};
 
 private:
-	uint8_t indexLastUnusedScaleDegreeFrom7To6 = 0;
-	uint8_t indexLastUnusedScaleDegreeFrom6To5 = 0;
+	ScaleMapper scaleMapper;
 	bool fillModeActive;
 	Clip* currentClip = nullptr;
 	Clip* previousClip = nullptr; // for future use, maybe finding an instrument clip or something

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -43,6 +43,8 @@ file(GLOB_RECURSE deluge_SOURCES
         ../../src/deluge/model/scale/preset_scales.cpp
         ../../src/deluge/model/scale/utils.cpp
         ../../src/deluge/model/scale/preset_scales.cpp
+        ../../src/deluge/model/scale/scale_change.cpp
+        ../../src/deluge/model/scale/scale_mapper.cpp
         # For clip iterator tests
         ../../src/deluge/model/song/clip_iterators.cpp
         # For sync tests

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -180,6 +180,13 @@ TEST(NoteSetTest, checkEqualAllowed) {
 	CHECK_EQUAL(NoteSet(), NoteSet());
 }
 
+TEST(NoteSetTest, isEmpty) {
+	NoteSet a;
+	CHECK_EQUAL(true, a.isEmpty());
+	a.add(0);
+	CHECK_EQUAL(false, a.isEmpty());
+}
+
 TEST(NoteSetTest, subscript1) {
 	NoteSet a;
 	for (int i = 0; i < NoteSet::size; i++) {

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -242,6 +242,26 @@ TEST(NoteSetTest, subscript4) {
 	CHECK_EQUAL(7, a[1]);
 }
 
+TEST(NoteSetTest, remove) {
+	NoteSet a;
+	for (int i = 0; i < 12; i++) {
+		a.remove(i);
+		CHECK_EQUAL(0, a.count());
+	}
+	a.fill();
+	for (int i = 0; i < 12; i++) {
+		CHECK_EQUAL(true, a.has(i));
+		a.remove(i);
+		CHECK_EQUAL(false, a.has(i));
+	}
+	a.fill();
+	for (int i = 11; i >= 0; i--) {
+		CHECK_EQUAL(true, a.has(i));
+		a.remove(i);
+		CHECK_EQUAL(false, a.has(i));
+	}
+}
+
 TEST(NoteSetTest, presetScaleId) {
 	CHECK_EQUAL(MAJOR_SCALE, presetScaleNotes[MAJOR_SCALE].presetScaleId());
 	CHECK_EQUAL(MINOR_SCALE, presetScaleNotes[MINOR_SCALE].presetScaleId());

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -330,6 +330,47 @@ TEST(NoteSetTest, toImpliedScale) {
 	CHECK_EQUAL(presetScaleNotes[MAJOR_SCALE], NoteSet({11}).toImpliedScale());
 }
 
+TEST(NoteSetTest, highestNotIn) {
+	// A is aways the receiver and B the argument in these tests.
+	NoteSet a;
+	NoteSet b;
+	// First the edge cases: empty or full notesets
+	//
+	//    A     B      result
+	//    empty empty  -1
+	//    empty full   -1
+	//    full  empty  11
+	//    full  full   -1
+	//
+	a.clear();
+	b.clear();
+	CHECK_EQUAL(-1, a.highestNotIn(b));
+	a.clear();
+	b.fill();
+	CHECK_EQUAL(-1, a.highestNotIn(b));
+	a.fill();
+	b.clear();
+	CHECK_EQUAL(11, a.highestNotIn(b));
+	a.fill();
+	b.fill();
+	CHECK_EQUAL(-1, a.highestNotIn(b));
+	// Major scale in A, one less note in B
+	uint8_t major[] = {0, 2, 4, 5, 7, 9, 11};
+	a.fromScaleNotes(major);
+	for (int i = 0; i < sizeof(major); i++) {
+		b.fromScaleNotes(major);
+		b.remove(major[i]);
+		CHECK_EQUAL(major[i], a.highestNotIn(b));
+	}
+	// Major scale in A, three missing notes in B
+	a.fromScaleNotes(major);
+	b.fromScaleNotes(major);
+	b.remove(4);
+	b.remove(7);
+	b.remove(11);
+	CHECK_EQUAL(11, a.highestNotIn(b));
+}
+
 TEST_GROUP(MusicalKeyTest){};
 
 TEST(MusicalKeyTest, ctor) {

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -117,21 +117,6 @@ TEST(NoteSetTest, addUntrusted) {
 	CHECK_EQUAL(3, a.count());
 }
 
-TEST(NoteSetTest, applyChanges) {
-	NoteSet a;
-	a.add(0);
-	a.add(2);
-	a.add(4);
-	a.add(5);
-	int8_t changes[12] = {-1, -1, +1, +2, 0, 0, 0, 0, 0, 0, 0, 0};
-	a.applyChanges(changes);
-	CHECK_EQUAL(0, a[0]);
-	CHECK_EQUAL(2, a[1]);
-	CHECK_EQUAL(6, a[2]);
-	CHECK_EQUAL(8, a[3]);
-	CHECK_EQUAL(4, a.count());
-}
-
 TEST(NoteSetTest, degreeOfBasic) {
 	NoteSet a;
 	a.add(0);


### PR DESCRIPTION
Best reviewed one commit at a time.

## NoteSet additions

- isEmpty()
- remove()
- highestNotIn() 

## ScaleMapper and ScaleChange classes

- ScaleMapper produces ScaleChanges, and remembers decisions done, so reversing the changes done works.

- ScaleChange wraps the kind of changes[] array we've previously had, and also retain information about the source scale, allowing it to be applied to notes without additional information.

## integrating ScaleChange and ScaleMapper

- ScaleMapper.computeChangeFrom() replaces guts of Song::setPresetScale()
- NoteSet:: and MusicalKey::applyChanges() replaced by ScaleChange::applyTo()
