### PR TITLE
[DRAFT] Step recording in keyboard view

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.h
@@ -50,6 +50,7 @@ public:
 	void flashDefaultRootNote();
 	void openedInBackground();
 	void exitAuditionMode();
+	void stepRecordAdvance();
 
 	uint8_t highlightedNotes[kHighestKeyboardNote] = {0};
 	uint8_t nornsNotes[kHighestKeyboardNote] = {0};

--- a/src/deluge/gui/ui/keyboard/notes_state.h
+++ b/src/deluge/gui/ui/keyboard/notes_state.h
@@ -48,6 +48,7 @@ struct NoteState {
 	int16_t mpeValues[3] = {0};
 	/// Generated notes will only create sound and not be used for interaction (e.g. setting root note)
 	bool generatedNote = false;
+	bool stepRec = false;
 };
 
 // Always needs to be 0 currently for the math to math

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -4687,6 +4687,30 @@ doHomogenize:
 	}
 }
 
+bool InstrumentClip::stepRecordNoteOn(ModelStackWithNoteRow* modelStack, int32_t velocity,
+                                      int32_t xZoom) {
+
+	NoteRow* noteRow = modelStack->getNoteRow();
+
+	int32_t effectiveLength = modelStack->getLoopLength();
+	if (stepRecordingPos >= effectiveLength) {
+		display->displayPopup("oopsie");
+	}
+
+	int32_t probability = noteRow->getDefaultProbability(modelStack);
+	// Don't supply Action, cos sin tan
+	return noteRow->attemptNoteAdd(stepRecordingPos, xZoom, velocity, probability, modelStack, nullptr);
+}
+
+void InstrumentClip::stepRecordAdvance( int32_t xZoom) {
+	stepRecordingPos += xZoom;
+	// TODO: expand instead?
+	if (stepRecordingPos >= getLoopLength()) {
+		stepRecordingPos = 0;
+	}
+}
+
+
 void InstrumentClip::recordNoteOff(ModelStackWithNoteRow* modelStack, int32_t velocity) {
 
 	if (!allowNoteTails(modelStack)) {
@@ -4765,6 +4789,13 @@ void InstrumentClip::incrementPos(ModelStackWithTimelineCounter* modelStack, int
 				thisNoteRow->lastProcessedPosIfIndependent += movement;
 			}
 		}
+	}
+}
+
+void InstrumentClip::toggleStepRecording() {
+	isStepRecording = !isStepRecording;
+	if (isStepRecording) {
+		stepRecordingPos = 0;
 	}
 }
 

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -109,6 +109,9 @@ public:
 	                  int16_t const* mpeValuesOrNull = NULL, int32_t fromMIDIChannel = MIDI_CHANNEL_NONE);
 	void recordNoteOff(ModelStackWithNoteRow* modelStack, int32_t velocity = kDefaultLiftValue);
 
+	bool stepRecordNoteOn(ModelStackWithNoteRow* modelStack, int32_t velocity, int32_t xZoom);
+	void stepRecordAdvance(int32_t xZoom);
+
 	void copyBasicsFrom(Clip const* otherClip) override;
 
 	ArpeggiatorSettings arpSettings; // Not valid for Kits
@@ -156,6 +159,10 @@ public:
 	uint8_t midiPGM;  // 128 means none
 
 	OutputType outputTypeWhileLoading; // For use only while loading song
+
+	bool isStepRecording = false;
+	int32_t stepRecordingPos = 0;
+	void toggleStepRecording();
 
 	void lengthChanged(ModelStackWithTimelineCounter* modelStack, int32_t oldLength, Action* action = NULL) override;
 	NoteRow* createNewNoteRowForKit(ModelStackWithTimelineCounter* modelStack, bool atStart, int32_t* getIndex = NULL);

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -1061,6 +1061,29 @@ modifyNote:
 	((InstrumentClip*)modelStack->getTimelineCounter())->expectEvent();
 }
 
+void NoteRow::stepRecordExtend(uint32_t noteOffPos, ModelStackWithNoteRow* modelStack) {
+	if (!notes.getNumElements()) {
+		return;
+	}
+
+	int32_t effectiveLength = modelStack->getLoopLength();
+
+	int32_t i = notes.search(noteOffPos, LESS);
+	bool wrapping = (i == -1 || i == notes.getNumElements());
+	if (wrapping) {
+		// if wrapping, do something quite lazy:p
+		return;
+	}
+
+	// TODO: anyhow keep track of next note we might be crashing into?
+	Note *note = notes.getElement(i);
+	int32_t newLength = noteOffPos - note->pos;
+	if (newLength <= 0) {
+		return;
+	}
+	note->setLength(newLength);
+}
+
 void NoteRow::complexSetNoteLength(Note* thisNote, uint32_t newLength, ModelStackWithNoteRow* modelStack,
                                    Action* action) {
 

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -178,6 +178,7 @@ public:
 	void trimToLength(uint32_t newLength, ModelStackWithNoteRow* modelStack, Action* action);
 	void trimNoteDataToNewClipLength(uint32_t newLength, InstrumentClip* clip, Action* action, int32_t noteRowId);
 	void recordNoteOff(uint32_t pos, ModelStackWithNoteRow* modelStack, Action* action, int32_t velocity);
+	void stepRecordExtend(uint32_t noteOffPos, ModelStackWithNoteRow* modelStack);
 	int8_t getColourOffset(InstrumentClip* clip);
 	void rememberDrumName();
 	void shiftHorizontally(int32_t amount, ModelStackWithNoteRow* modelStack, bool shiftAutomation,


### PR DESCRIPTION
Clip timeline view is good for step recording melody and chords within ~one octave but I often wish I could enter notes at steps from multiple octaves in the the keyboard view without changing to the different workflow of (quantized) live recording.

To (de)activate in keyboard view: record+select
Enter notes or chords
Add rest or prolong currently held note/chord: AFFECT ENTIRE

- [ ] make undo behavior coherent (maybe also restore cursor)
- [ ] change step length independently of zoom level