### PR TITLE
Set recording name according to the source

### DIFF
--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -24,6 +24,7 @@
 #include "memory/general_memory_allocator.h"
 #include "model/clip/audio_clip.h"
 #include "model/sample/sample.h"
+#include "model/song/song.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/stem_export/stem_export.h"
 #include "storage/audio/audio_file_manager.h"
@@ -386,7 +387,7 @@ aborted:
 			}
 			else {
 				error = audioFileManager.getUnusedAudioRecordingFilePath(&filePath, &tempFilePathForRecording, folderID,
-				                                                         &audioFileNumber);
+				                                                         &audioFileNumber, mode, &currentSong->name);
 			}
 			if (status == RecorderStatus::ABORTED) {
 				goto aborted; // In case aborted during

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -386,8 +386,20 @@ aborted:
 				error = stemExport.getUnusedStemRecordingFilePath(&filePath, folderID);
 			}
 			else {
+				const char* name;
+				if (mode < AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION && !AudioEngine::lineInPluggedIn) {
+					if (AudioEngine::micPluggedIn) {
+						name = "ExtMic";
+					}
+					else {
+						name = "IntMic";
+					}
+				}
+				else {
+					name = inputChannelToString(mode);
+				}
 				error = audioFileManager.getUnusedAudioRecordingFilePath(&filePath, &tempFilePathForRecording, folderID,
-				                                                         &audioFileNumber, mode, &currentSong->name);
+				                                                         &audioFileNumber, name, &currentSong->name);
 			}
 			if (status == RecorderStatus::ABORTED) {
 				goto aborted; // In case aborted during

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -342,7 +342,7 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		snprintf(namedPath, sizeof(namedPath), "%s/%s/%s.wav", filePath->get(), songName->get(), channelName);
 		int i = 1;
 		while (storageManager.fileExists(namedPath)) {
-			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%d.wav", filePath->get(), songName->get(), channelName, i);
+			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath->get(), songName->get(), channelName, i);
 		}
 		error = filePath->set(namedPath);
 		if (error != Error::NONE) {

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -302,8 +302,6 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		highestUsedAudioRecordingNumberNeedsReChecking[folderID] = false;
 	}
 
-	highestUsedAudioRecordingNumber[folderID]++;
-
 	D_PRINTLN("new file: --------------  %d", highestUsedAudioRecordingNumber[folderID]);
 
 	error = filePath->set(audioRecordingFolderNames[folderID]);
@@ -337,6 +335,7 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		if (error != Error::NONE) {
 			return error;
 		}
+		highestUsedAudioRecordingNumber[folderID]++;
 	}
 	else {
 		char namedPath[255]{0};
@@ -344,10 +343,10 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		         inputChannelToString(recordingFrom));
 		int i = 1;
 		while (storageManager.fileExists(namedPath)) {
-			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s%d.wav", filePath->get(), songName->get(),
+			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%d.wav", filePath->get(), songName->get(),
 			         inputChannelToString(recordingFrom), i);
 		}
-		error = filePath->concatenate(namedPath);
+		error = filePath->set(namedPath);
 		if (error != Error::NONE) {
 			return error;
 		}

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -259,7 +259,7 @@ void AudioFileManager::deleteAnyTempRecordedSamplesFromMemory() {
 // the card access.
 Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
                                                         AudioRecordingFolder folder, uint32_t* getNumber,
-                                                        AudioInputChannel recordingFrom, String* songName) {
+                                                        const char* channelName, String* songName) {
 	const auto folderID = util::to_underlying(folder);
 
 	Error error = storageManager.initSD();
@@ -339,12 +339,10 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 	}
 	else {
 		char namedPath[255]{0};
-		snprintf(namedPath, sizeof(namedPath), "%s/%s/%s.wav", filePath->get(), songName->get(),
-		         inputChannelToString(recordingFrom));
+		snprintf(namedPath, sizeof(namedPath), "%s/%s/%s.wav", filePath->get(), songName->get(), channelName);
 		int i = 1;
 		while (storageManager.fileExists(namedPath)) {
-			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%d.wav", filePath->get(), songName->get(),
-			         inputChannelToString(recordingFrom), i);
+			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%d.wav", filePath->get(), songName->get(), channelName, i);
 		}
 		error = filePath->set(namedPath);
 		if (error != Error::NONE) {

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -339,10 +339,11 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 	}
 	else {
 		char namedPath[255]{0};
-		snprintf(namedPath, sizeof(namedPath), "%s/%s/%s.wav", filePath->get(), songName->get(), channelName);
+		snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_000.wav", filePath->get(), songName->get(), channelName);
 		int i = 1;
 		while (storageManager.fileExists(namedPath)) {
-			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath->get(), songName->get(), channelName, i);
+			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath->get(), songName->get(), channelName,
+			         i);
 		}
 		error = filePath->set(namedPath);
 		if (error != Error::NONE) {

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -101,7 +101,8 @@ public:
 	Error setupAlternateAudioFileDir(String* newPath, char const* rootDir, String* songFilenameWithoutExtension);
 	bool loadingQueueHasAnyLowestPriorityElements();
 	Error getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
-	                                      AudioRecordingFolder folder, uint32_t* getNumber);
+	                                      AudioRecordingFolder folder, uint32_t* getNumber,
+	                                      AudioInputChannel recordingFrom, String* songName);
 	void deleteAnyTempRecordedSamplesFromMemory();
 	void deleteUnusedAudioFileFromMemory(AudioFile* audioFile, int32_t i);
 	void deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile* audioFile);

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -101,8 +101,8 @@ public:
 	Error setupAlternateAudioFileDir(String* newPath, char const* rootDir, String* songFilenameWithoutExtension);
 	bool loadingQueueHasAnyLowestPriorityElements();
 	Error getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
-	                                      AudioRecordingFolder folder, uint32_t* getNumber,
-	                                      AudioInputChannel recordingFrom, String* songName);
+	                                      AudioRecordingFolder folder, uint32_t* getNumber, const char* channelName,
+	                                      String* songName);
 	void deleteAnyTempRecordedSamplesFromMemory();
 	void deleteUnusedAudioFileFromMemory(AudioFile* audioFile, int32_t i);
 	void deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile* audioFile);


### PR DESCRIPTION
Close #821 

Sets the filename according to the input source (left/right/balanced/mix/output) and the current song name to enable finding the recordings more easily later