### PR TITLE
Bugfix - Make community features sync scaling menu a regular setting menu and not a toggle

### DIFF
--- a/src/deluge/gui/menu_item/runtime_feature/settings.cpp
+++ b/src/deluge/gui/menu_item/runtime_feature/settings.cpp
@@ -35,7 +35,7 @@ SettingToggle menuCatchNotes(RuntimeFeatureSettingType::CatchNotes);
 SettingToggle menuDeleteUnusedKitRows(RuntimeFeatureSettingType::DeleteUnusedKitRows);
 SettingToggle menuAltGoldenKnobDelayParams(RuntimeFeatureSettingType::AltGoldenKnobDelayParams);
 SettingToggle menuQuantizedStutterRate(RuntimeFeatureSettingType::QuantizedStutterRate);
-SettingToggle menuSyncScalingAction(RuntimeFeatureSettingType::SyncScalingAction);
+Setting menuSyncScalingAction(RuntimeFeatureSettingType::SyncScalingAction);
 DevSysexSetting menuDevSysexAllowed(RuntimeFeatureSettingType::DevSysexAllowed);
 SettingToggle menuHighlightIncomingNotes(RuntimeFeatureSettingType::HighlightIncomingNotes);
 SettingToggle menuDisplayNornsLayout(RuntimeFeatureSettingType::DisplayNornsLayout);


### PR DESCRIPTION
Made the community features sync scaling action menu a regular setting menu and not a toggle menu as it's not a regular toggle