### PR TITLE
more explicit type for scale indexes / ids

### DIFF
--- a/src/deluge/gui/ui/keyboard/column_controls/scale_mode.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/scale_mode.cpp
@@ -25,7 +25,7 @@ using namespace deluge::gui::ui::keyboard::layout;
 namespace deluge::gui::ui::keyboard::controls {
 
 void ScaleModeColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column) {
-	int32_t currentScale = currentSong->getCurrentPresetScale();
+	Scale currentScale = currentSong->getCurrentScale();
 	uint8_t otherChannels = 0;
 	for (int32_t y = 0; y < kDisplayHeight; ++y) {
 		bool mode_selected = scaleModes[y] == currentScale;
@@ -41,13 +41,11 @@ void ScaleModeColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], i
 }
 
 bool ScaleModeColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
-	int32_t newScale = scaleModes[pad];
+	Scale newScale = scaleModes[pad];
 	bool newScaleNotSelectedYet = true;
 	while (newScaleNotSelectedYet) {
-		newScale = (newScale + offset) % NUM_PRESET_SCALES;
-		if (newScale < 0) {
-			newScale = NUM_PRESET_SCALES - 1;
-		}
+		// TODO: support USER_SCALE here.
+		newScale = static_cast<Scale>(mod(newScale + offset, NUM_PRESET_SCALES));
 		bool scaleFoundInPads = false;
 		for (int32_t y = 0; y < kDisplayHeight; ++y) {
 			if (scaleModes[y] == newScale) {
@@ -66,7 +64,7 @@ bool ScaleModeColumn::handleVerticalEncoder(int8_t pad, int32_t offset) {
 void ScaleModeColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
                                           KeyboardLayout* layout) {
 	// Restore previously set scale
-	if (previousScale == -1) {
+	if (previousScale == NO_SCALE) {
 		return;
 	}
 	if (keyboardScreen.setScale(previousScale)) {
@@ -82,7 +80,7 @@ void ScaleModeColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelSt
 void ScaleModeColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
                                 KeyboardLayout* layout) {
 	if (pad.active) {
-		previousScale = currentSong->getCurrentPresetScale();
+		previousScale = currentSong->getCurrentScale();
 		if (keyboardScreen.setScale(scaleModes[pad.y])) {
 			currentScalePad = pad.y;
 		}

--- a/src/deluge/gui/ui/keyboard/column_controls/scale_mode.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/scale_mode.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "gui/ui/keyboard/column_controls/control_column.h"
+#include "model/scale/preset_scales.h"
 #include "model/song/song.h"
 
 namespace deluge::gui::ui::keyboard::controls {
@@ -35,8 +36,9 @@ public:
 
 private:
 	int32_t currentScalePad = -1;
-	int32_t previousScale = -1;
-	uint8_t scaleModes[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+	Scale previousScale = NO_SCALE;
+	Scale scaleModes[8] = {MAJOR_SCALE,  MINOR_SCALE,      DORIAN_SCALE,  PHRYGIAN_SCALE,
+	                       LYDIAN_SCALE, MIXOLYDIAN_SCALE, LOCRIAN_SCALE, MELODIC_MINOR_SCALE};
 };
 
 } // namespace deluge::gui::ui::keyboard::controls

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -181,7 +181,7 @@ ActionResult InstrumentClipView::commandLearnUserScale() {
 		commandEnterScaleMode();
 	}
 	NoteSet notes = currentSong->notesInScaleModeClips();
-	currentSong->setScale(notes);
+	currentSong->setScaleNotes(notes);
 	recalculateColours();
 	uiNeedsRendering(this);
 	// Hook point for specificMidiDevice

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -525,14 +525,13 @@ void InstrumentClipMinder::drawActualNoteCode(int16_t noteCode) {
 }
 
 void InstrumentClipMinder::cycleThroughScales() {
-	int32_t newScale = currentSong->cycleThroughScales();
-	displayScaleName(newScale);
+	displayScaleName(currentSong->cycleThroughScales());
 }
 
 // Returns if the scale could be changed or not
-bool InstrumentClipMinder::setScale(int32_t newScale) {
-	int32_t result = currentSong->setPresetScale(newScale);
-	if (result == CANT_CHANGE_SCALE) {
+bool InstrumentClipMinder::setScale(Scale newScale) {
+	auto result = currentSong->setScale(newScale);
+	if (result == NO_SCALE) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CANT_CHANGE_SCALE));
 		return false;
 	}
@@ -542,12 +541,12 @@ bool InstrumentClipMinder::setScale(int32_t newScale) {
 	}
 }
 
-void InstrumentClipMinder::displayScaleName(uint8_t scale) {
+void InstrumentClipMinder::displayScaleName(Scale scale) {
 	display->displayPopup(getScaleName(scale));
 }
 
 void InstrumentClipMinder::displayCurrentScaleName() {
-	displayScaleName(currentSong->getCurrentPresetScale());
+	displayScaleName(currentSong->getCurrentScale());
 }
 
 // Returns whether currentClip is now active on Output / Instrument

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -530,7 +530,7 @@ void InstrumentClipMinder::cycleThroughScales() {
 
 // Returns if the scale could be changed or not
 bool InstrumentClipMinder::setScale(Scale newScale) {
-	auto result = currentSong->setScale(newScale);
+	Scale result = currentSong->setScale(newScale);
 	if (result == NO_SCALE) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CANT_CHANGE_SCALE));
 		return false;

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -21,6 +21,8 @@
 #include "hid/button.h"
 #include "hid/display/oled_canvas/canvas.h"
 #include "model/clip/clip_minder.h"
+#include "model/scale/preset_scales.h"
+
 #include <cstdint>
 
 class InstrumentClip;
@@ -42,8 +44,8 @@ public:
 	void calculateDefaultRootNote();
 	void drawActualNoteCode(int16_t noteCode);
 	void cycleThroughScales();
-	bool setScale(int32_t newScale);
-	void displayScaleName(uint8_t scale);
+	bool setScale(Scale newScale);
+	void displayScaleName(Scale scale);
 	void displayCurrentScaleName();
 	void selectEncoderAction(int32_t offset);
 	static void drawMIDIControlNumber(int32_t controlNumber, bool automationExists);

--- a/src/deluge/model/scale/note_set.cpp
+++ b/src/deluge/model/scale/note_set.cpp
@@ -63,15 +63,6 @@ int8_t NoteSet::degreeOf(uint8_t note) const {
 	}
 }
 
-uint8_t NoteSet::scaleId() const {
-	for (int32_t p = 0; p < NUM_PRESET_SCALES; p++) {
-		if (*this == presetScaleNotes[p]) {
-			return p;
-		}
-	}
-	return NUM_PRESET_SCALES;
-}
-
 NoteSet NoteSet::operator|(const NoteSet& other) {
 	NoteSet newSet = other;
 	newSet.bits |= bits;

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -66,11 +66,6 @@ public:
 	 * Returns -1 if there are no notes present unused in the other NoteSet..
 	 */
 	int8_t highestNotIn(NoteSet used) const;
-	/** If this is a preset scale, returns the preset scale id / index.
-	 *
-	 * Otherwise returns NUM_PRESET_SCALES.
-	 */
-	uint8_t scaleId() const;
 	/** Returns number of notes in the NoteSet.
 	 */
 	int count() const { return std::popcount(bits); }

--- a/src/deluge/model/scale/preset_scales.cpp
+++ b/src/deluge/model/scale/preset_scales.cpp
@@ -13,10 +13,10 @@ const NoteSet presetScaleNotes[NUM_PRESET_SCALES] = {
 #undef DEF
 };
 
-const char* getScaleName(uint8_t scale) {
+const char* getScaleName(Scale scale) {
 	// Not using l10n since USER and ERR are <= 4 characters, and
 	// keeing this disentangled from l10n makes testing easier.
-	if (scale == NUM_PRESET_SCALES) {
+	if (scale == USER_SCALE) {
 		return "USER";
 	}
 	else if (scale < NUM_PRESET_SCALES) {
@@ -25,4 +25,17 @@ const char* getScaleName(uint8_t scale) {
 	else {
 		return "ERR";
 	}
+}
+
+Scale getScale(NoteSet notes) {
+	for (int32_t p = 0; p < NUM_PRESET_SCALES; p++) {
+		if (notes == presetScaleNotes[p]) {
+			return static_cast<Scale>(p);
+		}
+	}
+	return USER_SCALE;
+}
+
+bool isUserScale(NoteSet notes) {
+	return USER_SCALE == getScale(notes);
 }

--- a/src/deluge/model/scale/preset_scales.h
+++ b/src/deluge/model/scale/preset_scales.h
@@ -13,7 +13,7 @@
  * See OFFSET_6|5_NOTE_SCALE for how to deal with that.
  *
  * The actual definitions expand this macro, picking the thing they need:
- * - enum PresetScale
+ * - enum Scale
  * - presetScaleNames
  * - presetScaleNotes
  *

--- a/src/deluge/model/scale/preset_scales.h
+++ b/src/deluge/model/scale/preset_scales.h
@@ -13,7 +13,7 @@
  * See OFFSET_6|5_NOTE_SCALE for how to deal with that.
  *
  * The actual definitions expand this macro, picking the thing they need:
- * - enum PresetScales
+ * - enum PresetScale
  * - presetScaleNames
  * - presetScaleNotes
  *
@@ -66,18 +66,20 @@
 	/* HIRA Hirajoshi (matches Launchpad scale) */                                                                     \
 	DEF(HIRAJOSHI_SCALE, "HIRAJOSHI", DEF_NOTES(0, 2, 3, 7, 8))
 
-#define FIRST_6_NOTE_SCALE_INDEX WHOLE_TONE_SCALE
-#define FIRST_5_NOTE_SCALE_INDEX PENTATONIC_MINOR_SCALE
-
 /** Indexes into presetScaleNames and presetScaleNotes -arrays, and total
  *  number of preset scales.
  */
-enum PresetScales {
+enum Scale {
 #define DEF(id, name, notes) id,
 	DEF_SCALES()
 #undef DEF
-	    NUM_PRESET_SCALES
+	    NUM_PRESET_SCALES,
+	USER_SCALE = NUM_PRESET_SCALES,
+	NO_SCALE = 255
 };
+
+#define FIRST_6_NOTE_SCALE_INDEX WHOLE_TONE_SCALE
+#define FIRST_5_NOTE_SCALE_INDEX PENTATONIC_MINOR_SCALE
 
 extern const NoteSet presetScaleNotes[NUM_PRESET_SCALES];
 extern std::array<char const*, NUM_PRESET_SCALES> presetScaleNames;
@@ -86,7 +88,6 @@ extern std::array<char const*, NUM_PRESET_SCALES> presetScaleNames;
 // arrays!
 #define OFFICIAL_FIRMWARE_RANDOM_SCALE_INDEX 7
 #define OFFICIAL_FIRMWARE_NONE_SCALE_INDEX 8
-#define CANT_CHANGE_SCALE 255
 #define PRESET_SCALE_RANDOM 254
 #define PRESET_SCALE_NONE 255
 // These offsets allow us to introduce new 7, 6 and 5 note scales in between the existing
@@ -95,4 +96,8 @@ extern std::array<char const*, NUM_PRESET_SCALES> presetScaleNames;
 #define OFFSET_6_NOTE_SCALE 64
 #define OFFSET_5_NOTE_SCALE 128
 
-const char* getScaleName(uint8_t scale);
+const char* getScaleName(Scale scale);
+
+Scale getScale(NoteSet notes);
+
+bool isUserScale(NoteSet notes);

--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -260,10 +260,10 @@ TEST(NoteSetTest, remove) {
 	}
 }
 
-TEST(NoteSetTest, scaleId) {
-	CHECK_EQUAL(MAJOR_SCALE, presetScaleNotes[MAJOR_SCALE].scaleId());
-	CHECK_EQUAL(MINOR_SCALE, presetScaleNotes[MINOR_SCALE].scaleId());
-	CHECK_EQUAL(NUM_PRESET_SCALES, NoteSet().scaleId());
+TEST(NoteSetTest, getScale) {
+	CHECK_EQUAL(MAJOR_SCALE, getScale(presetScaleNotes[MAJOR_SCALE]));
+	CHECK_EQUAL(MINOR_SCALE, getScale(presetScaleNotes[MINOR_SCALE]));
+	CHECK_EQUAL(USER_SCALE, getScale(NoteSet()));
 }
 
 TEST(NoteSetTest, majorness) {


### PR DESCRIPTION
- enum PresetScales -> enum Scale
   - added explicit Scale::USER_SCALE
   - CANT_CHANGE_SCALE -> NO_SCALE
- Renaming for clarity:
  - Song::getCurrentPresetScale() -> Song::getCurrentScale()
  - Song::setScale() -> Song::setScaleNotes()
  - Song::setPresetScale() -> Song::setScale()
  - Song::userScale -> Song::userScaleNotes
- new toplevel functions dealing with enum Scale:
  - NoteSet::scaleId() -> getScale(), to avoid circular dep with the
    explicit type.
  - isUserScale()
- delete dead declaration: Song::addMajorDependentModeNotes()
- group Song methods working on scales a bit, and document them
