### PR TITLE
Fix some ub

### DIFF
--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -84,6 +84,9 @@ void ActionLogger::deleteLastAction() {
 
 Action* ActionLogger::getNewAction(ActionType newActionType, ActionAddition addToExistingIfPossible) {
 
+	if (!currentSong) {
+		return nullptr;
+	}
 	deleteLog(AFTER);
 
 	// If not on a View, not allowed!

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -246,7 +246,7 @@ void Song::setupDefault() {
 
 	seedRandom();
 
-	setBPM(defaultTempoMenu.getRandomValueInRange(), false);
+	setBPMInner(defaultTempoMenu.getRandomValueInRange(), false);
 	swingAmount = defaultSwingAmountMenu.getRandomValueInRange() - 50;
 	key.rootNote = defaultKeyMenu.getRandomValueInRange();
 

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -1954,7 +1954,9 @@ bool Session::areAnyClipsArmed() {
 // I wish we could easily just do this to the Clips that need it, but we don't store an easy list of just the Clips
 // affected by each Action. This is only to be called if playbackHandler.isEitherClockActive().
 void Session::reversionDone() {
-
+	if (!currentSong) {
+		return;
+	}
 	for (Clip* clip : AllClips::everywhere(currentSong)) {
 		if (currentSong->isClipActive(clip)) {
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -187,7 +187,7 @@ LiveInputBuffer* liveInputBuffers[3];
 uint16_t lastRoutineTime;
 
 std::array<StereoSample, SSI_TX_BUFFER_NUM_SAMPLES> renderingBuffer __attribute__((aligned(CACHE_LINE_SIZE)));
-std::array<int32_t, SSI_TX_BUFFER_NUM_SAMPLES> reverbBuffer __attribute__((aligned(CACHE_LINE_SIZE)));
+std::array<int32_t, 2 * SSI_TX_BUFFER_NUM_SAMPLES> reverbBuffer __attribute__((aligned(CACHE_LINE_SIZE)));
 
 StereoSample* renderingBufferOutputPos = renderingBuffer.begin();
 StereoSample* renderingBufferOutputEnd = renderingBuffer.begin();


### PR DESCRIPTION
Fixes the reverb buffer not being large enough for a full render window and some issues with referencing currentSong before its set

I believe this resolves the crash but I'm not certain, might just be hiding. I have verified that both issues do cause crashes though - the reverb buffer causes the SPI selection to get stuck with the OLED deselected and the null currentSong dereference overwrites random areas of memory to write clip meta data

Fix #2351 
Fix #2369