### PR TITLE
Add Horizontal Scrolling of Keyboard View while in Param editing menu's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,13 +33,14 @@ use the TRACK menu to select the specific track to record from
  - 7SEG renders a dot at the end of the menu item to show current ON/OFF status. Selecting that menu with select encoder will toggle the dot as opposed to entering the menu.
 - Submenu's on OLED for automatable parameters (e.g. LPF Frequency) render the current parameter value at the end. You still need to click on `SELECT` to edit the parameters value / edit modulation depth and patch cables.
 - All other submenu's on OLED are rendered with a ">" at the end to indicate that it is a submenu.
-- Added ability to automate tempo in arranger view
+- Added ability to `AUTOMATE TEMPO` in arranger view
 - Added `NEW CLIP TYPE` menu that opens on creation of a `NEW CLIP` in `SONG VIEW` which enables you to select the type of clip before the clip is created.
   - In `SONG (GRID) VIEW`, this menu will only appear when you add a `NEW CLIP` to a `NEW TRACK` (empty column).
   - This menu will not appear if you are cloning clips (e.g. pressing one clip and then pressing an empty pad).
 - Removed the `SONG VIEW` shortcut of `HOLDING PAD FOR THE CLIP` + `PRESSING SELECT` to convert an Empty `INSTRUMENT CLIP` to an `AUDIO CLIP`. 
 - `HOLDING PAD FOR THE CLIP` + `PRESSING SELECT` in `SONG VIEW` will now always open the `CLIP MODE` menu so you can change the Clip Mode between `INFINITE`, `FILL` and `ONCE`.
 - Updated Fonts and Character Spacing on OLED to provide a more refined and polished user experience.
+- Added ability to scroll `KEYBOARD VIEW` horizontally using `<>` while editing Param values in the menu.
 
 ### MIDI
 - Added Universal SysEx Identity response, including firmware version.

--- a/src/deluge/gui/menu_item/automation/automation.cpp
+++ b/src/deluge/gui/menu_item/automation/automation.cpp
@@ -173,10 +173,4 @@ void Automation::selectAutomationViewParameter(bool clipMinder) {
 	}
 }
 
-void Automation::horizontalEncoderAction(int32_t offset) {
-	if (getRootUI() == &automationView) {
-		automationView.horizontalEncoderAction(offset);
-	}
-}
-
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/automation/automation.h
+++ b/src/deluge/gui/menu_item/automation/automation.h
@@ -33,6 +33,5 @@ public:
 	virtual ModelStackWithAutoParam* getModelStackWithParam(void* memory) = 0;
 	virtual PatchSource getPatchSource() { return PatchSource::NONE; }
 	void selectAutomationViewParameter(bool clipMinder);
-	void horizontalEncoderAction(int32_t offset);
 };
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/param.cpp
+++ b/src/deluge/gui/menu_item/param.cpp
@@ -18,6 +18,7 @@
 #include "param.h"
 #include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
+#include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/view.h"
@@ -42,7 +43,13 @@ ActionResult Param::buttonAction(deluge::hid::Button b, bool on, bool inCardRout
 }
 
 void Param::horizontalEncoderAction(int32_t offset) {
-	Automation::horizontalEncoderAction(offset);
+	RootUI* rootUI = getRootUI();
+	if (rootUI == &automationView) {
+		automationView.horizontalEncoderAction(offset);
+	}
+	else if (rootUI == &keyboardScreen) {
+		keyboardScreen.horizontalEncoderAction(offset);
+	}
 }
 
 ModelStackWithAutoParam* Param::getModelStackWithParam(void* memory) {

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -20,6 +20,7 @@
 #include "deluge/model/settings/runtime_feature_settings.h"
 #include "gui/l10n/l10n.h"
 #include "gui/menu_item/menu_item.h"
+#include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/view.h"
@@ -253,7 +254,13 @@ void PatchCableStrength::horizontalEncoderAction(int32_t offset) {
 	// or you're holding down the horizontal encoder because you want to zoom in/out
 	// if this is the case, then you can potentially engage scrolling/zooming of the underlying automation view
 	if (currentEditPos == soundEditor.numberEditPos) {
-		Automation::horizontalEncoderAction(offset);
+		RootUI* rootUI = getRootUI();
+		if (rootUI == &automationView) {
+			automationView.horizontalEncoderAction(offset);
+		}
+		else if (rootUI == &keyboardScreen) {
+			keyboardScreen.horizontalEncoderAction(offset);
+		}
 	}
 }
 

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -48,6 +48,8 @@ void PatchCableStrength::beginSession(MenuItem* navigatedBackwardFrom) {
 
 	preferBarDrawing =
 	    (runtimeFeatureSettings.get(RuntimeFeatureSettingType::PatchCableResolution) == RuntimeFeatureStateToggle::Off);
+
+	delayHorizontalScrollUntil = 0;
 }
 
 void PatchCableStrength::renderOLED() {
@@ -254,13 +256,21 @@ void PatchCableStrength::horizontalEncoderAction(int32_t offset) {
 	// or you're holding down the horizontal encoder because you want to zoom in/out
 	// if this is the case, then you can potentially engage scrolling/zooming of the underlying automation view
 	if (currentEditPos == soundEditor.numberEditPos) {
-		RootUI* rootUI = getRootUI();
-		if (rootUI == &automationView) {
-			automationView.horizontalEncoderAction(offset);
+		if (delayHorizontalScrollUntil == 0) {
+			delayHorizontalScrollUntil = AudioEngine::audioSampleTimer + kShortPressTime;
 		}
-		else if (rootUI == &keyboardScreen) {
-			keyboardScreen.horizontalEncoderAction(offset);
+		else if (AudioEngine::audioSampleTimer > delayHorizontalScrollUntil) {
+			RootUI* rootUI = getRootUI();
+			if (rootUI == &automationView) {
+				automationView.horizontalEncoderAction(offset);
+			}
+			else if (rootUI == &keyboardScreen) {
+				keyboardScreen.horizontalEncoderAction(offset);
+			}
 		}
+	}
+	else {
+		delayHorizontalScrollUntil = 0;
 	}
 }
 

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -57,6 +57,9 @@ public:
 
 	virtual ModelStackWithAutoParam* getModelStackWithParam(void* memory);
 
+	/// Used when scrolling horizontally to briefly catch on min / max decimal number edit position
+	uint32_t delayHorizontalScrollUntil = 0;
+
 protected:
 	bool preferBarDrawing = false;
 	ModelStackWithAutoParam* getModelStack(void* memory, bool allowCreation = false);


### PR DESCRIPTION
Added horizontal scrolling for keyboard view while in Param and Patch Cable editing menu's

Behaves the same as with horizontal scrolling when automation menu view is open

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2386