### PR TITLE
Bug fix - go up a level when pressing select in selection and toggle menu's

### DIFF
--- a/src/deluge/gui/menu_item/selection.h
+++ b/src/deluge/gui/menu_item/selection.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "gui/menu_item/enumeration.h"
+#include "gui/ui/sound_editor.h"
 #include "util/containers.h"
 #include <string_view>
 
@@ -47,11 +48,20 @@ public:
 		writeCurrentValue();
 	};
 
-	// handles changing bool setting without entering menu and updating the display
+	// handles toggling a "toggle" selection menu from sub-menu level
+	// or handles going back up a level after making a selection from within selection menu
 	MenuItem* selectButtonPress() override {
-		toggleValue();
-		displayToggleValue();
-		return NO_NAVIGATION;
+		// this is true if you open a selection menu using grid shortcut
+		// or you enter a selection menu that isn't a toggle
+		if (soundEditor.getCurrentMenuItem() == this) {
+			return nullptr; // go up a level
+		}
+		// you're toggling selection menu from submenu level
+		else {
+			toggleValue();
+			displayToggleValue();
+			return NO_NAVIGATION;
+		}
 	}
 
 	// get's toggle status for rendering checkbox on OLED

--- a/src/deluge/gui/menu_item/toggle.h
+++ b/src/deluge/gui/menu_item/toggle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "gui/ui/sound_editor.h"
 #include "value.h"
 
 namespace deluge::gui::menu_item {
@@ -27,11 +28,19 @@ public:
 		writeCurrentValue();
 	};
 
-	// handles changing bool setting without entering menu and updating the display
+	// handles toggling a "toggle" menu from sub-menu level
+	// or handles going back up a level after making a selection from within toggle menu
 	MenuItem* selectButtonPress() override {
-		toggleValue();
-		displayToggleValue();
-		return NO_NAVIGATION; // no navigation
+		// this is true if you open a toggle menu using grid shortcut
+		if (soundEditor.getCurrentMenuItem() == this) {
+			return nullptr; // go up a level
+		}
+		// you're toggling toggle menu from submenu level
+		else {
+			toggleValue();
+			displayToggleValue();
+			return NO_NAVIGATION;
+		}
 	}
 
 	// get's toggle status for rendering checkbox on OLED


### PR DESCRIPTION
Fixed bug where pressing select encoder within a selection menu or toggle menu would not go back up a level and would toggle between the first two selection options.