### PR TITLE
Bugfix performance view stutter getting stuck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### User Interface
 
 - Added `BASS FREQUENCY` and `TREBLE FREQUENCY` parameters to the list of assignable parameters in `PERFORMANCE VIEW`.
+- Fixed `PERFORMANCE VIEW` bug where stutter pad could get stuck in active state which should not be possible.
 
 ## c1.1.0 Beethoven
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -1045,10 +1045,10 @@ void PerformanceSessionView::normalPadAction(ModelStackWithThreeMainThings* mode
 	}
 	// releasing a pad
 	else {
-		// if releasing a pad with "held" status shortly after being given that status
+		// if releasing stutter pad
+		// or releasing a pad with "held" status shortly after being given that status
 		// or releasing a pad that was not in "held" status but was a longer press and release
-		if ((params::isParamStutter(lastSelectedParamKind, lastSelectedParamID) && lastPadPress.isActive
-		     && lastPadPress.yDisplay == yDisplay)
+		if (params::isParamStutter(lastSelectedParamKind, lastSelectedParamID)
 		    || (fxPress[xDisplay].padPressHeld
 		        && ((AudioEngine::audioSampleTimer - fxPress[xDisplay].timeLastPadPress) < FlashStorage::holdTime))
 		    || ((fxPress[xDisplay].previousKnobPosition != kNoSelection) && (fxPress[xDisplay].yDisplay == yDisplay)


### PR DESCRIPTION
Cherry picking since forgot to add cherry pick label

Fixed bug where stutter pad could get stuck in active state which should not be possible

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2373