### PR TITLE
Feature/filter fm synths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added blend control to compressors
 - Added ability to record from a specific track's output. Set an audio clips input to TRACK, then in the audio clip menu
 use the TRACK menu to select the specific track to record from
+- Added filters in FM synth mode. They're set to OFF by default, enable by changing them to any other mode using the menu or db/oct shortcut.
 
 ### User Interface
 

--- a/src/deluge/gui/menu_item/filter/hpf_freq.h
+++ b/src/deluge/gui/menu_item/filter/hpf_freq.h
@@ -21,10 +21,9 @@
 
 namespace deluge::gui::menu_item::filter {
 
-class HPFFreq final : public patched_param::IntegerNonFM {
+class HPFFreq final : public patched_param::Integer {
 public:
-	using patched_param::IntegerNonFM::IntegerNonFM;
-
+	using patched_param::Integer::Integer;
 	// 7Seg ONLY
 	void drawValue() override {
 		if (this->getValue() == kMinMenuValue
@@ -33,7 +32,7 @@ public:
 			display->setText(l10n::get(l10n::String::STRING_FOR_DISABLED));
 		}
 		else {
-			patched_param::IntegerNonFM::drawValue();
+			patched_param::Integer::drawValue();
 		}
 	}
 };

--- a/src/deluge/gui/menu_item/filter/hpf_mode.h
+++ b/src/deluge/gui/menu_item/filter/hpf_mode.h
@@ -39,11 +39,8 @@ public:
 		    l10n::getView(STRING_FOR_SVF_BAND),
 		    l10n::getView(STRING_FOR_SVF_NOTCH),
 		    l10n::getView(STRING_FOR_HPLADDER),
+		    l10n::getView(STRING_FOR_NONE),
 		};
-	}
-	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
-		Sound* sound = static_cast<Sound*>(modControllable);
-		return ((sound == nullptr) || sound->synthMode != ::SynthMode::FM);
 	}
 };
 } // namespace deluge::gui::menu_item::filter

--- a/src/deluge/gui/menu_item/filter/lpf_freq.h
+++ b/src/deluge/gui/menu_item/filter/lpf_freq.h
@@ -20,9 +20,9 @@
 #include "modulation/patch/patch_cable_set.h"
 
 namespace deluge::gui::menu_item::filter {
-class LPFFreq final : public patched_param::IntegerNonFM {
+class LPFFreq final : public patched_param::Integer {
 public:
-	using patched_param::IntegerNonFM::IntegerNonFM;
+	using patched_param::Integer::Integer;
 
 	// 7Seg ONLY
 	void drawValue() override {
@@ -32,7 +32,7 @@ public:
 			display->setText(l10n::get(l10n::String::STRING_FOR_DISABLED));
 		}
 		else {
-			patched_param::IntegerNonFM::drawValue();
+			patched_param::Integer::drawValue();
 		}
 	}
 };

--- a/src/deluge/gui/menu_item/filter/lpf_mode.h
+++ b/src/deluge/gui/menu_item/filter/lpf_mode.h
@@ -26,19 +26,30 @@ namespace deluge::gui::menu_item::filter {
 class LPFMode final : public Selection {
 public:
 	using Selection::Selection;
-	void readCurrentValue() override { this->setValue<::FilterMode>(soundEditor.currentModControllable->lpfMode); }
-	void writeCurrentValue() override { soundEditor.currentModControllable->lpfMode = this->getValue<::FilterMode>(); }
+	void readCurrentValue() override {
+		// Off is located past the HPFLadder, which isn't an option for the low pass filter (should it be?)
+		int32_t selection = util::to_underlying(soundEditor.currentModControllable->lpfMode);
+		this->setValue(std::min(selection, kNumLPFModes));
+	}
+	void writeCurrentValue() override {
+		int32_t selection = this->getValue();
+		FilterMode mode;
+		// num lpf modes counts off but there's HPF modes in the middle
+		if (selection >= kNumLPFModes) {
+			mode = FilterMode::OFF;
+		}
+		else {
+			mode = static_cast<FilterMode>(selection);
+		}
+		soundEditor.currentModControllable->lpfMode = mode;
+	}
 	deluge::vector<std::string_view> getOptions() override {
 		using enum l10n::String;
 		return {
 		    l10n::getView(STRING_FOR_12DB_LADDER), l10n::getView(STRING_FOR_24DB_LADDER),
 		    l10n::getView(STRING_FOR_DRIVE),       l10n::getView(STRING_FOR_SVF_BAND),
-		    l10n::getView(STRING_FOR_SVF_NOTCH),
+		    l10n::getView(STRING_FOR_SVF_NOTCH),   l10n::getView(STRING_FOR_NONE),
 		};
-	}
-	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
-		Sound* sound = static_cast<Sound*>(modControllable);
-		return ((sound == nullptr) || sound->synthMode != ::SynthMode::FM);
 	}
 };
 } // namespace deluge::gui::menu_item::filter

--- a/src/deluge/gui/menu_item/filter/morph.h
+++ b/src/deluge/gui/menu_item/filter/morph.h
@@ -21,10 +21,10 @@
 using namespace deluge::dsp::filter;
 namespace deluge::gui::menu_item::filter {
 
-class FilterMorph final : public patched_param::IntegerNonFM {
+class FilterMorph final : public patched_param::Integer {
 public:
-	using patched_param::IntegerNonFM::IntegerNonFM;
-	FilterMorph(l10n::String newName, int32_t newP, bool hpf) : IntegerNonFM{newName, newP}, hpf{hpf} {}
+	using patched_param::Integer::Integer;
+	FilterMorph(l10n::String newName, int32_t newP, bool hpf) : Integer{newName, newP}, hpf{hpf} {}
 	[[nodiscard]] std::string_view getName() const override {
 		using enum l10n::String;
 		auto filt = SpecificFilter(hpf ? soundEditor.currentModControllable->hpfMode

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2935,6 +2935,9 @@ void Sound::setSynthMode(SynthMode value, Song* song) {
 				}
 			}
 		}
+		// switch the filters off so they don't render unless deliberately enabled
+		lpfMode = FilterMode::OFF;
+		hpfMode = FilterMode::OFF;
 	}
 
 	// ... and switching *from* FM...
@@ -2945,6 +2948,13 @@ void Sound::setSynthMode(SynthMode value, Song* song) {
 				modKnobs[f][0].paramDescriptor.setToHaveParamOnly(params::LOCAL_LPF_RESONANCE);
 				modKnobs[f][1].paramDescriptor.setToHaveParamOnly(params::LOCAL_LPF_FREQ);
 			}
+		}
+		// switch the filters back on if needed
+		if (lpfMode == FilterMode::OFF) {
+			lpfMode = FilterMode::TRANSISTOR_24DB;
+		}
+		if (hpfMode == FilterMode::OFF) {
+			hpfMode = FilterMode::HPLADDER;
 		}
 	}
 }

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3078,7 +3078,7 @@ bool Sound::anyNoteIsOn() {
 }
 
 bool Sound::hasFilters() {
-	return (getSynthMode() != SynthMode::FM);
+	return (lpfMode != FilterMode::OFF || hpfMode != FilterMode::OFF);
 }
 
 void Sound::readParamsFromFile(Deserializer& reader, ParamManagerForTimeline* paramManager,

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3119,6 +3119,12 @@ Error Sound::readFromFile(Deserializer& reader, ModelStackWithModControllable* m
 		}
 	}
 
+	// old FM patches can have a filter mode saved in them even though it wouldn't have rendered at the time
+	if (synthMode == SynthMode::FM && reader.getFirmwareVersion() < FirmwareVersion::community({1, 2, 0})) {
+		hpfMode = FilterMode::OFF;
+		lpfMode = FilterMode::OFF;
+	}
+
 	// If we actually got a paramManager, we can do resonance compensation on it
 	if (paramManager.containsAnyMainParamCollections()) {
 		if (smDeserializer.firmware_version < FirmwareVersion::official({1, 2, 0})) {

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -137,6 +137,7 @@ public:
 	virtual char const* readNextCharsOfTagOrAttributeValue(int32_t numChars) = 0;
 	virtual Error readTagOrAttributeValueString(String* string) = 0;
 	virtual void exitTag(char const* exitTagName = NULL) = 0;
+	virtual FirmwareVersion getFirmwareVersion() = 0;
 };
 
 class XMLDeserializer : public Deserializer {
@@ -163,6 +164,7 @@ public:
 	                  bool ignoreIncorrectFirmware = false);
 
 	StorageManager* msd;
+	FirmwareVersion getFirmwareVersion() override { return firmware_version; }
 
 public:
 	UINT currentReadBufferEndPos;


### PR DESCRIPTION
Enable filter in FM synths

Filter modes are set to off when an FM synth is created or loaded from an old file to avoid issues with loading old songs and synths