### PR TITLE
Bugfix/moving clip to grid

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -155,10 +155,16 @@ void ArrangerView::moveClipToSession() {
 
 		goToSongView();
 
-		currentUIMode = UI_MODE_CLIP_PRESSED_IN_SONG_VIEW;
-		sessionView.selectedClipYDisplay = yPressedEffective;
-		sessionView.selectedClipPressYDisplay = yPressedActual;
-		sessionView.selectedClipPressXDisplay = xPressed;
+		if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeRows) {
+			currentUIMode = UI_MODE_CLIP_PRESSED_IN_SONG_VIEW;
+			sessionView.selectedClipYDisplay = yPressedEffective;
+			sessionView.selectedClipPressYDisplay = yPressedActual;
+			sessionView.selectedClipPressXDisplay = xPressed;
+		}
+		else {
+			currentUIMode = UI_MODE_NONE;
+		}
+
 		sessionView.performActionOnPadRelease = false;
 		view.setActiveModControllableTimelineCounter(clip);
 	}


### PR DESCRIPTION
This left you stuck in the UI mode for holding a clip in rows mode since in the grid the clip you moved is unlikely to be under your finger

If switching to grid just set the UI mode to none instead

Fix #1907 
