### PR TITLE
bigger dots on emulated 7-segment display

### DIFF
--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -642,7 +642,7 @@ void OLED::renderEmulated7Seg(const std::array<uint8_t, kNumericDisplayLength>& 
 		}
 
 		if (display[i] & (1 << 7)) {
-			main.invertArea(ix + 22, 2, 42, 43);
+			main.invertArea(ix + 21, 3, 41, 43);
 		}
 	}
 	markChanged();


### PR DESCRIPTION
- 3x3 px instead of 2x2. The old is probably closer to the actual 7-seg display, but white on black makes it looks like a spec of dust.