### PR TITLE
Bugfix/load sample to empty row

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3643,7 +3643,7 @@ Drum* InstrumentClipView::getAuditionedDrum(int32_t velocity, int32_t yDisplay, 
 	}
 
 	// If NoteRow doesn't exist here, we'll see about creating one
-	else {
+	if (drum == nullptr) {
 		// But not if we're actually not on this screen
 		if (getCurrentUI() != this) {
 			return drum;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3642,7 +3642,7 @@ Drum* InstrumentClipView::getAuditionedDrum(int32_t velocity, int32_t yDisplay, 
 		drum = modelStackWithNoteRowOnCurrentClip->getNoteRow()->drum;
 	}
 
-	// If NoteRow doesn't exist here, we'll see about creating one
+	// If drum or noterow doesn't exist here, we'll see about creating one
 	if (drum == nullptr) {
 		// But not if we're actually not on this screen
 		if (getCurrentUI() != this) {


### PR DESCRIPTION
Fix edge case where having a note row without a drum blocked drums getting created

Fix #2346