### PR TITLE
Hotfix for song swap crashing

### DIFF
--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -416,7 +416,10 @@ gotErrorAfterCreatingSong:
 		AudioEngine::logAction("waiting for samples");
 #ifdef USE_TASK_MANAGER
 		// make sure we don't get stuck
-		yield([]() { return currentUIMode != UI_MODE_LOADING_SONG_UNESSENTIAL_SAMPLES_ARMED; });
+		yield([]() {
+			return currentUIMode != UI_MODE_LOADING_SONG_UNESSENTIAL_SAMPLES_ARMED
+			       && currentUIMode != UI_MODE_LOADING_SONG_UNESSENTIAL_SAMPLES_UNARMED;
+		});
 #else
 		// If any more waiting required before the song swap actually happens, do that
 		while (currentUIMode != UI_MODE_LOADING_SONG_NEW_SONG_PLAYING) {


### PR DESCRIPTION
Switching to a song without samples instantly crashes by not waiting until the swap happens. Fix to check that condition too