### PR TITLE
Bugfix Midi Follow Crash on Song Swap

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -371,6 +371,14 @@ int32_t MidiFollow::getCCFromParam(params::Kind paramKind, int32_t paramID) {
 /// used to store the clip's for each note received so that note off's can be sent to the right clip
 PLACE_SDRAM_DATA Clip* clipForLastNoteReceived[kMaxMIDIValue + 1] = {0};
 
+/// initializes the clipForLastNoteReceived array
+/// called when swapping songs to make sure that you aren't using clips from the old song
+void MidiFollow::clearStoredClips() {
+	for (int32_t i = 0; i <= 127; i++) {
+		clipForLastNoteReceived[i] = nullptr;
+	}
+}
+
 /// removes a specific clip pointer from the clipForLastNoteReceived array
 /// if a clip is deleted, it should be removed from this array to ensure note off's don't get sent
 /// to delete clips

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -51,6 +51,7 @@ public:
 	void aftertouchReceived(MIDIDevice* fromDevice, int32_t channel, int32_t value, int32_t noteCode,
 	                        bool* doingMidiThru, ModelStack* modelStack);
 
+	void clearStoredClips();
 	void removeClip(Clip* clip);
 
 	// midi CC mappings

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1252,6 +1252,7 @@ void PlaybackHandler::doSongSwap(bool preservePlayPosition) {
 
 	// Swap stuff over
 	AudioEngine::unassignAllVoices(true);
+	midiFollow.clearStoredClips(); // need to clear clip pointers stored for previous song
 	currentSong = preLoadedSong;
 	AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 	preLoadedSong = NULL;


### PR DESCRIPTION
Fixed a bug where deluge would crash if you were still sending a note using midi follow while swapping songs.