### PR TITLE
create path for new recordings

### DIFF
--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -183,6 +183,7 @@ gotError:
 			if (audioFile->type == AudioFileType::SAMPLE) {
 				// If this is a recording which still exists at its temporary location, move the file
 				if (!((Sample*)audioFile)->tempFilePathForRecording.isEmpty()) {
+					bdsm.buildPathToFile(audioFile->filePath.get());
 					FRESULT result =
 					    f_rename(((Sample*)audioFile)->tempFilePathForRecording.get(), audioFile->filePath.get());
 					if (result == FR_OK) {
@@ -192,10 +193,8 @@ gotError:
 						// We at least need to warn the user that although the main file save was (hopefully soon to be)
 						// successful, something's gone wrong
 						anyErrorMovingTempFiles = true;
-						/*
-						D_PRINTLN("rename failed.  %d %s %s", result, ((Sample*)sample)->tempFilePathForRecording.get(),
-						sample->filePath.get());
-						*/
+						D_PRINTLN("rename failed.  %d %s %s", result,
+						          ((Sample*)audioFile)->tempFilePathForRecording.get(), audioFile->filePath.get());
 					}
 				}
 			}

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -222,6 +222,8 @@ public:
 
 	bool fileExists(char const* pathName);
 	bool fileExists(char const* pathName, FilePointer* fp);
+	/// takes a full path/to/file.text and makes sure the directories exist
+	bool buildPathToFile(const char* fileName);
 
 	bool checkSDPresent();
 	bool checkSDInitialized();


### PR DESCRIPTION
Fix bug reported on discord

fatfs move fails if the directory to move to doesn't exist, so add a function to the storage manager that creates the path if needed and call that first