### PR TITLE
Bugfix/audio track recording with null output

### DIFF
--- a/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
+++ b/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
@@ -32,6 +32,9 @@ public:
 		if (audioOutputBeingEdited->outputRecordingFrom) {
 			outputIndex = currentSong->getOutputIndex(audioOutputBeingEdited->outputRecordingFrom);
 		}
+		else {
+			outputIndex = 0;
+		}
 		numOutputs = currentSong->getNumOutputs();
 		if (display->haveOLED()) {
 			renderUIsForOled();

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -51,6 +51,7 @@ void AudioOutput::cloneFrom(ModControllableAudio* other) {
 	GlobalEffectableForClip::cloneFrom(other);
 
 	inputChannel = ((AudioOutput*)other)->inputChannel;
+	outputRecordingFrom = ((AudioOutput*)other)->outputRecordingFrom;
 }
 
 void AudioOutput::renderOutput(ModelStack* modelStack, StereoSample* outputBuffer, StereoSample* outputBufferEnd,

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1579,7 +1579,11 @@ errorAfterAllocation:
 		return NULL;
 	}
 
-	if (mode == AudioInputChannel::SPECIFIC_OUTPUT && outputRecordingFrom) {
+	if (mode == AudioInputChannel::SPECIFIC_OUTPUT) {
+		if (!outputRecordingFrom) {
+			D_PRINTLN("Specific output recorder with no output provided");
+			goto errorAfterAllocation;
+		}
 		bool success = outputRecordingFrom->addRecorder(newRecorder);
 		if (!success) {
 			D_PRINTLN("Tried to attach to an occupied output");


### PR DESCRIPTION
When an audio output is cloned it could have its source set as internal but the internal recorder would still be null

Fix menu display if that happens, and fix cloning so it doesn't happen