### PR TITLE
Bugfix/don't apply dac gain to output resampling

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -150,7 +150,7 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 		compressor.reset();
 	}
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
-		recorder->feedAudio((int32_t*)globalEffectableBuffer, numSamples, true);
+		recorder->feedAudio((int32_t*)globalEffectableBuffer, numSamples, false);
 	}
 	addAudio(globalEffectableBuffer, outputBuffer, numSamples);
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2430,7 +2430,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	}
 
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
-		recorder->feedAudio(soundBuffer, numSamples, true);
+		recorder->feedAudio(soundBuffer, numSamples, false);
 	}
 	addAudio((StereoSample*)soundBuffer, outputBuffer, numSamples);
 


### PR DESCRIPTION
Applying the gain makes the output recordings much louder than they should be and requires the recording audio clip to have a volume of 12 to retain volume