### PR TITLE
Feature/overdub in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 - Added blend control to compressors
 - Added ability to record from a specific track's output. Set an audio clips input to TRACK, then in the audio clip menu
 use the TRACK menu to select the specific track to record from
+  - To hear the instrument through the audio clip's FX set the input to TRACK (FX)
 - Added filters in FM synth mode. They're set to OFF by default, enable by changing them to any other mode using the menu or db/oct shortcut.
+- Audio clips with monitoring (or FX) active in grid mode now support in place overdub using the global midi loop/layer commands
 
 ### User Interface
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -239,7 +239,8 @@ as the micromonsta and the dreadbox nymphes.
 #### 3.17 - Select Audio Clip Source from Audio Clip Menu
 - ([#1531]) Added ability to select audio source from within an Audio Clip by opening the Audio Clip Sound Menu (`SHIFT` + `SELECT`) and Selecting the `AUDIO SOURCE` menu
   - Not included in c1.1.0
-- ([#2371]) Source can now also be set to a specific track on the deluge. This enables an additional TRACK menu to choose which track to record from.
+- ([#2371]) Source can now also be set to a specific track on the deluge. This enables an additional TRACK menu to choose 
+which track to record from. To run the instrument through the audio clip's FX choose the FX PROCESSING option
 
 #### 3.18 - Set Audio Clip Length Equal to Sample Length
 - ([#1542]) Added new shortcut to set the length of an audio clip to the same length as its sample at the current tempo. This functionally removes timestretching until the Audio Clip length or Song tempo is changed. 
@@ -422,6 +423,15 @@ Here is a list of features that have been added to the firmware as a list, group
         4. The new clip that was just created will be selected and start recording at the beginning of the next bar
         5. You can press `RECORD` to stop recording or press that new clip to stop recording.
         6. Repeat steps as required.
+- ([#2421]) Allow true overdubbing for grid audio clips
+  - Traditional guitar style looping is now possible for audio clips in grid mode. To use it monitoring must be active 
+  - The loop will capture all fx in the audio clip (e.g. it's recording at the end of the signal chain) and then reset the fx
+  - LOOP will begin an auto extending overdub. The initial sample will loop and the clip will extend as you keep playing
+  - Pressing LOOP again will end recording quantized to the original length (e.g. LOOPing on a 1-bar clip will quantize to 1 bar)
+    - This works similarly to increasing loop length on an EDP style looper but without needing to set it in advance 
+  - LAYER will continuously layer over the existing audio without extending the loop
+    - This works like an overdub on a pedal style looper
+  - Only the midi loop commands work at this time but loop controls will be added to grid down the road
 
 #### 4.1.6 - Performance View
 
@@ -1458,6 +1468,7 @@ different firmware
 [#2367]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2367
 
 [#2385]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2385
+[#2421]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2421
 
 [#2429]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2429
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -637,6 +637,7 @@ enum class ArmState {
 	OFF,
 	ON_NORMAL, // Arming to stop or start normally, or to stop soloing
 	ON_TO_SOLO,
+	ON_TO_RECORD,
 };
 
 constexpr int32_t kNumProbabilityValues = 20;

--- a/src/deluge/gui/context_menu/audio_input_selector.h
+++ b/src/deluge/gui/context_menu/audio_input_selector.h
@@ -18,8 +18,7 @@
 #pragma once
 
 #include "gui/context_menu/context_menu.h"
-
-class AudioOutput;
+#include "processing/audio_output.h"
 
 namespace deluge::gui::context_menu {
 

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -777,7 +777,7 @@ removeLoadingAnimationAndGetOut:
 		int32_t oldLength = clip->loopLength;
 
 		clip->loopLength = newLength;
-
+		clip->originalLength = newLength;
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 		clip->lengthChanged(modelStack, oldLength);

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -308,7 +308,8 @@ void AudioClip::processCurrentPos(ModelStackWithTimelineCounter* modelStack, uin
 	}
 
 	// If at pos 0, that's the only place where anything really important happens: play the Sample
-	if (!lastProcessedPos) {
+	// also play it if we're auto extending and we just did that
+	if (!(lastProcessedPos % originalLength)) {
 
 		// If there is a sample, play it
 		if (sampleHolder.audioFile && !((Sample*)sampleHolder.audioFile)->unplayable) {
@@ -830,6 +831,8 @@ void AudioClip::expectNoFurtherTicks(Song* song, bool actuallySoundChange) {
 // May change the TimelineCounter in the modelStack if new Clip got created
 void AudioClip::posReachedEnd(ModelStackWithTimelineCounter* modelStack) {
 
+	if (!isEmpty()) {}
+
 	Clip::posReachedEnd(modelStack);
 
 	// If recording from session to arranger...
@@ -1266,8 +1269,8 @@ void AudioClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack,
 				abortRecording();
 			}
 		}
-
-		else if (sampleHolder.audioFile) {
+		// with overdubs these could both be true
+		if (sampleHolder.audioFile) {
 			// we're not actually deleting the song, but we don't want to keep this sample cached since we can't get it
 			// back anyway
 			unassignVoiceSample(true);

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "model/clip/audio_clip.h"
+#include "clip.h"
 #include "definitions_cxx.hpp"
 #include "dsp/timestretch/time_stretcher.h"
 #include "gui/views/automation_view.h"
@@ -137,7 +138,7 @@ void AudioClip::abortRecording() {
 }
 
 bool AudioClip::wantsToBeginLinearRecording(Song* song) {
-	return (Clip::wantsToBeginLinearRecording(song) && (!sampleHolder.audioFile || doTrueOverdubs)
+	return (Clip::wantsToBeginLinearRecording(song) && (!sampleHolder.audioFile || !shouldCloneForOverdubs())
 	        && ((AudioOutput*)output)->inputChannel > AudioInputChannel::NONE);
 }
 
@@ -275,7 +276,7 @@ ramError:
 
 bool AudioClip::cloneOutput(ModelStackWithTimelineCounter* modelStack) {
 	// don't clone for loop commands in red mode
-	if (!overdubsShouldCloneOutput || doTrueOverdubs) {
+	if (!overdubsShouldCloneOutput) {
 		return false;
 	}
 

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -111,7 +111,6 @@ Error AudioClip::clone(ModelStackWithTimelineCounter* modelStack, bool shouldFla
 void AudioClip::copyBasicsFrom(Clip const* otherClip) {
 	Clip::copyBasicsFrom(otherClip);
 	overdubsShouldCloneOutput = ((AudioClip*)otherClip)->overdubsShouldCloneOutput;
-	doTrueOverdubs = ((AudioClip*)otherClip)->doTrueOverdubs;
 }
 
 void AudioClip::abortRecording() {

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -307,8 +307,14 @@ void AudioClip::processCurrentPos(ModelStackWithTimelineCounter* modelStack, uin
 
 	// If at pos 0, that's the only place where anything really important happens: play the Sample
 	// also play it if we're auto extending and we just did that
-	if (!(lastProcessedPos) || (getCurrentlyRecordingLinearly() && !(lastProcessedPos % originalLength))) {
-
+	if (!lastProcessedPos || lastProcessedPos == nextSampleRestartPos) {
+		if (getCurrentlyRecordingLinearly()) {
+			nextSampleRestartPos = lastProcessedPos + originalLength;
+			// make sure we come back here later
+			if (originalLength < playbackHandler.swungTicksTilNextEvent) {
+				playbackHandler.swungTicksTilNextEvent = originalLength;
+			}
+		}
 		// If there is a sample, play it
 		if (sampleHolder.audioFile && !((Sample*)sampleHolder.audioFile)->unplayable) {
 

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -99,9 +99,9 @@ public:
 
 	WaveformRenderData renderData;
 
-	SampleRecorder* recorder; // Will be set to NULL right at the end of the loop's recording, even though the
-	                          // SampleRecorder itself will usually persist slightly longer
-
+	SampleRecorder* recorder;      // Will be set to NULL right at the end of the loop's recording, even though the
+	                               // SampleRecorder itself will usually persist slightly longer
+	SampleRecorder* inputRecorder; // for sampling + saving the raw input if doing true overdubs
 	int32_t attack;
 
 	VoicePriority voicePriority;
@@ -126,4 +126,6 @@ private:
 	void removeClipFromSection(AudioClip* clip);
 	void detachAudioClipFromOutput(Song* song, bool shouldRetainLinksToOutput, bool shouldTakeParamManagerWith = false);
 	LoopType getLoopingType(ModelStackWithTimelineCounter const* modelStack);
+	bool doTrueOverdubs{true};
+	bool recordPostFX{true};
 };

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -57,6 +57,7 @@ public:
 	void quantizeLengthForArrangementRecording(ModelStackWithTimelineCounter* modelStack, int32_t lengthSoFar,
 	                                           uint32_t timeRemainder, int32_t suggestedLength,
 	                                           int32_t alternativeLongerLength) override;
+	bool shouldCloneForOverdubs() override { return !doTrueOverdubs; };
 	Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) override;
 	int64_t getSamplesFromTicks(int32_t ticks);
 	void unassignVoiceSample(bool wontBeUsedAgain);

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -107,10 +107,9 @@ public:
 	String outputNameWhileLoading; // Only valid while loading
 
 	WaveformRenderData renderData;
-
-	SampleRecorder* recorder;      // Will be set to NULL right at the end of the loop's recording, even though the
-	                               // SampleRecorder itself will usually persist slightly longer
-	SampleRecorder* inputRecorder; // for sampling + saving the raw input if doing true overdubs
+	// TODO: For looping without monitoring we'll need a second recorder plus maybe a second sample player?
+	SampleRecorder* recorder; // Will be set to NULL right at the end of the loop's recording, even though the
+	                          // SampleRecorder itself will usually persist slightly longer
 	int32_t attack;
 
 	VoicePriority voicePriority;
@@ -135,5 +134,4 @@ private:
 	void removeClipFromSection(AudioClip* clip);
 	void detachAudioClipFromOutput(Song* song, bool shouldRetainLinksToOutput, bool shouldTakeParamManagerWith = false);
 	LoopType getLoopingType(ModelStackWithTimelineCounter const* modelStack);
-	bool recordPostFX{true};
 };

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -87,7 +87,7 @@ public:
 	Error readFromFile(Deserializer& reader, Song* song) override;
 	void writeDataToFile(Serializer& writer, Song* song) override;
 	char const* getXMLTag() override { return "audioClip"; }
-
+	int32_t nextSampleRestartPos;
 	SampleControls sampleControls;
 
 	SampleHolderForClip sampleHolder;

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -722,6 +722,7 @@ void Clip::readTagFromFile(Deserializer& reader, char const* tagName, Song* song
 	else if (!strcmp(tagName, "trackLength") || !strcmp(tagName, "length")) {
 		loopLength = reader.readTagOrAttributeValueInt();
 		loopLength = std::max((int32_t)1, loopLength);
+		originalLength = loopLength; // it's 0 otherwise, which is fine except for audio clips
 		*readAutomationUpToPos = loopLength;
 	}
 
@@ -1170,4 +1171,9 @@ void Clip::incrementPos(ModelStackWithTimelineCounter* modelStack, int32_t numTi
 		numTicks = -numTicks;
 	}
 	lastProcessedPos += numTicks;
+}
+void Clip::setupOverdubInPlace() {
+	originalLength = loopLength;
+	armState = ArmState::ON_TO_RECORD;
+	isPendingOverdub = true;
 }

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -1172,8 +1172,10 @@ void Clip::incrementPos(ModelStackWithTimelineCounter* modelStack, int32_t numTi
 	}
 	lastProcessedPos += numTicks;
 }
-void Clip::setupOverdubInPlace() {
+void Clip::setupOverdubInPlace(OverDubType type) {
 	originalLength = loopLength;
 	armState = ArmState::ON_TO_RECORD;
-	isPendingOverdub = true;
+	// This is used to indicate a cloned overdub clip that doesn't have anything in it, not overdub in place
+	isPendingOverdub = false;
+	overdubNature = type;
 }

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -19,9 +19,16 @@
 
 #include "definitions_cxx.hpp"
 #include "gui/colour/colour.h"
+#include "gui/views/audio_clip_view.h"
+#include "gui/waveform/waveform_render_data.h"
 #include "io/midi/learned_midi.h"
+#include "model/clip/clip.h"
+#include "model/sample/sample_controls.h"
+#include "model/sample/sample_holder_for_clip.h"
+#include "model/sample/sample_playback_guide.h"
 #include "model/timeline_counter.h"
 #include "modulation/params/param.h"
+#include "util/d_string.h"
 #include <cstdint>
 
 class Song;
@@ -38,6 +45,7 @@ class Serializer;
 class Deserializer;
 
 class Clip : public TimelineCounter {
+
 public:
 	Clip(ClipType newType);
 	~Clip() override;
@@ -104,8 +112,10 @@ public:
 	bool opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounter* modelStack, bool* newOutputCreated,
 	                                              int32_t buttonPressLatency);
 	virtual Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) = 0;
-	virtual bool shouldCloneForOverdubs() { return false; };
-	void setupOverdubInPlace();
+	virtual bool shouldCloneForOverdubs() {
+		return true;
+	}; // instrument version of in place overdub doesn't quite work so never do it for those
+	void setupOverdubInPlace(OverDubType type);
 	virtual bool getCurrentlyRecordingLinearly() = 0;
 	virtual bool currentlyScrollableAndZoomable() = 0;
 	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,
@@ -219,4 +229,5 @@ protected:
 	Error solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
 	                          Clip* favourClipForCloningParamManager = NULL);
 	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {}
+	bool doTrueOverdubs{true};
 };

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -104,6 +104,8 @@ public:
 	bool opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounter* modelStack, bool* newOutputCreated,
 	                                              int32_t buttonPressLatency);
 	virtual Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) = 0;
+	virtual bool shouldCloneForOverdubs() { return false; };
+	void setupOverdubInPlace();
 	virtual bool getCurrentlyRecordingLinearly() = 0;
 	virtual bool currentlyScrollableAndZoomable() = 0;
 	virtual void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -112,9 +112,12 @@ public:
 	bool opportunityToBeginSessionLinearRecording(ModelStackWithTimelineCounter* modelStack, bool* newOutputCreated,
 	                                              int32_t buttonPressLatency);
 	virtual Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) = 0;
+
+	/// returns whether the clip needs to be cloned for overdubs (old style) or will actually overdub its audio like a
+	/// normal looper
 	virtual bool shouldCloneForOverdubs() {
-		return true;
-	}; // instrument version of in place overdub doesn't quite work so never do it for those
+		return true; // instrument version of in place overdub doesn't quite work so never do it for now
+	};
 	void setupOverdubInPlace(OverDubType type);
 	virtual bool getCurrentlyRecordingLinearly() = 0;
 	virtual bool currentlyScrollableAndZoomable() = 0;
@@ -229,5 +232,4 @@ protected:
 	Error solicitParamManager(Song* song, ParamManager* newParamManager = NULL,
 	                          Clip* favourClipForCloningParamManager = NULL);
 	virtual void pingpongOccurred(ModelStackWithTimelineCounter* modelStack) {}
-	bool doTrueOverdubs{true};
 };

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -150,7 +150,8 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 		compressor.reset();
 	}
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
-		recorder->feedAudio((int32_t*)globalEffectableBuffer, numSamples, false);
+		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
+		recorder->feedAudio((int32_t*)globalEffectableBuffer, numSamples, true, 2);
 	}
 	addAudio(globalEffectableBuffer, outputBuffer, numSamples);
 

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -861,7 +861,8 @@ void SampleRecorder::finishCapturing() {
 
 // Only call this after checking that status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING
 // Watch out - this could be called during SD writing - including during cardRoutine() for this class!
-void SampleRecorder::feedAudio(int32_t* __restrict__ inputAddress, int32_t numSamples, bool applyGain) {
+void SampleRecorder::feedAudio(int32_t* __restrict__ inputAddress, int32_t numSamples, bool applyGain,
+                               uint8_t gainToApply) {
 
 	do {
 		int32_t numSamplesThisCycle = numSamples;
@@ -951,7 +952,7 @@ doFinishCapturing:
 				do {
 					int32_t rxL = *inputAddress;
 					if (applyGain) {
-						rxL = lshiftAndSaturate<5>(rxL);
+						rxL = lshiftAndSaturateUnknown(rxL, gainToApply);
 					}
 
 					char* __restrict__ readPos = (char*)&rxL + 1;
@@ -988,7 +989,7 @@ doFinishCapturing:
 					if (recordingNumChannels == 2) {
 						int32_t rxR = *(inputAddress + 1);
 						if (applyGain) {
-							rxR = lshiftAndSaturate<5>(rxR);
+							rxR = lshiftAndSaturateUnknown(rxR, gainToApply);
 						}
 
 						readPos = (char*)&rxR + 1;

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -52,6 +52,7 @@ SampleRecorder::~SampleRecorder() {
 	if (sample != nullptr) {
 		detachSample();
 	}
+	outputRecordingFrom->removeRecorder();
 }
 
 // This can be called when this SampleRecorder is destructed routinely - or earlier if we've aborted and the sample file

--- a/src/deluge/model/sample/sample_recorder.h
+++ b/src/deluge/model/sample/sample_recorder.h
@@ -51,7 +51,7 @@ public:
 	Error setup(int32_t newNumChannels, AudioInputChannel newMode, bool newKeepingReasons,
 	            bool shouldRecordExtraMargins, AudioRecordingFolder newFolderID, int32_t buttonPressLatency,
 	            Output* outputRecordingFrom);
-	void feedAudio(int32_t* inputAddress, int32_t numSamples, bool applyGain = false);
+	void feedAudio(int32_t* inputAddress, int32_t numSamples, bool applyGain = false, uint8_t gainToApply = 5);
 	Error cardRoutine();
 	void endSyncedRecording(int32_t buttonLatencyForTempolessRecording);
 	bool inputLooksDifferential();

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5314,7 +5314,8 @@ Clip* Song::createPendingNextOverdubBelowClip(Clip* clip, int32_t clipIndex, Ove
 	if (anyClipsSoloing) {
 		return NULL;
 	}
-	if (clip->shouldCloneForOverdubs()) {
+	// if we're in rows or the clip can't support in place overdub then use the traditional deluge cloning looper
+	if (sessionLayout == SessionLayoutType::SessionLayoutTypeRows || clip->shouldCloneForOverdubs()) {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, this);
 
@@ -5334,7 +5335,7 @@ Clip* Song::createPendingNextOverdubBelowClip(Clip* clip, int32_t clipIndex, Ove
 		}
 	}
 	else {
-		clip->setupOverdubInPlace();
+		clip->setupOverdubInPlace(newOverdubNature);
 	}
 
 	return newClip;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5259,6 +5259,11 @@ bool Song::deletePendingOverdubs(Output* onlyWithOutput, int32_t* originalClipIn
 
 			anyDeleted = true;
 		}
+		// this isn't actually deleting, but it is clearing a pending overdub which is what matters for the caller
+		else if (clip->armState == ArmState::ON_TO_RECORD) {
+			clip->armState = ArmState::OFF;
+			anyDeleted = true;
+		}
 	}
 	D_PRINTLN("Deleted pending overdubs");
 	return anyDeleted;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5322,7 +5322,7 @@ Clip* Song::createPendingNextOverdubBelowClip(Clip* clip, int32_t clipIndex, Ove
 
 	Clip* newClip = clip->cloneAsNewOverdub(modelStackWithTimelineCounter, newOverdubNature);
 
-	if (newClip) {
+	if (newClip && newClip != clip) {
 		newClip->overdubNature = newOverdubNature;
 		sessionClips.insertClipAtIndex(newClip, clipIndex);
 		if (clipIndex != songViewYScroll) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -375,7 +375,6 @@ void Session::doLaunch(bool isFillLaunch) {
 				clip->setPos(modelStackWithTimelineCounter, 0, false);
 
 				giveClipOpportunityToBeginLinearRecording(clip, c, 0);
-				output = clip->output; // A new Output may have been created as recording began
 
 				// If that caused it to be armed *again*...
 				if (clip->armState == ArmState::ON_NORMAL) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -368,8 +368,13 @@ void Session::doLaunch(bool isFillLaunch) {
 				}
 			}
 
-			// If armed to stop
-			else if (clip->armState != ArmState::OFF && !isFillLaunch) {
+			// start up an overdub
+			else if (clip->armState == ArmState::ON_TO_RECORD) {
+				giveClipOpportunityToBeginLinearRecording(clip, c, 0);
+			}
+			// If armed to stop (these mean stop normally or end soloing respectively)
+			else if ((clip->armState == ArmState::ON_NORMAL || clip->armState == ArmState::ON_TO_SOLO)
+			         && !isFillLaunch) {
 
 				clip->armState = ArmState::OFF;
 

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -371,6 +371,10 @@ void Session::doLaunch(bool isFillLaunch) {
 
 			// start up an overdub
 			else if (clip->armState == ArmState::ON_TO_RECORD) {
+				if (clip->getCurrentlyRecordingLinearly()) {
+					clip->finishLinearRecording(modelStackWithTimelineCounter, nullptr);
+					stoppedLinearRecording = true;
+				}
 				clip->armState = ArmState::OFF;
 				clip->setPos(modelStackWithTimelineCounter, 0, false);
 

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
-#include "model/clip/audio_clip.h"
 #include "model/global_effectable/global_effectable_for_clip.h"
 #include "model/output.h"
 #include "modulation/envelope.h"

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2430,7 +2430,8 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	}
 
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
-		recorder->feedAudio(soundBuffer, numSamples, false);
+		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
+		recorder->feedAudio(soundBuffer, numSamples, true, 2);
 	}
 	addAudio((StereoSample*)soundBuffer, outputBuffer, numSamples);
 


### PR DESCRIPTION
Add a new overdub method for audio clips based on resampling their output. This allows for more traditional looper workflows. LOOP command auto extends and the existing sample loops as you play. LAYER does not auto extend but continues adding layers. This is functionally the same as the existing clip cloning method but avoids weirdness in the grid by staying on a single output. 

I've elected to not use this new method in rows mode for old times sake and so that people who like the individual clip per layer approach can continue to use it.

Exclusively works in grid mode for audio outputs with monitoring right now (midi controller required). There's some work to do to enable it for outputs without monitoring (namely adding the input to the rendered audio, and therefore recording pre effects) but this basic usecase of recording post fx and with monitoring on is fully functional

This is largely ready to extend to instrument clips as well - the missing feature is automatically copying the previous clip contents as the loop extends so it's disabled until that's done. Turning it on now just leads to the existing clip playing once and then auto extending with blank space. 

