### PR TITLE
always skip multi-range select if there's only one option

### DIFF
--- a/src/deluge/gui/menu_item/file_selector.cpp
+++ b/src/deluge/gui/menu_item/file_selector.cpp
@@ -72,6 +72,6 @@ MenuPermission FileSelector::checkPermissionToBeginSession(ModControllableAudio*
 		return MenuPermission::NO;
 	}
 
-	return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, false, currentRange);
+	return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, currentRange);
 }
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/osc/audio_recorder.h
+++ b/src/deluge/gui/menu_item/osc/audio_recorder.h
@@ -56,7 +56,7 @@ public:
 
 		Sound* sound = static_cast<Sound*>(modControllable);
 
-		return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, false, currentRange);
+		return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, currentRange);
 	}
 };
 } // namespace deluge::gui::menu_item::osc

--- a/src/deluge/gui/menu_item/sample/loop_point.cpp
+++ b/src/deluge/gui/menu_item/sample/loop_point.cpp
@@ -47,7 +47,7 @@ MenuPermission LoopPoint::checkPermissionToBeginSession(ModControllableAudio* mo
 	Sound* sound = static_cast<Sound*>(modControllable);
 
 	MenuPermission permission =
-	    soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, true, currentRange);
+	    soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, currentRange);
 
 	// Before going ahead, make sure a Sample is loaded
 	if (permission == MenuPermission::YES) {

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -78,7 +78,7 @@ public:
 			return MenuPermission::YES;
 		}
 
-		return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, true, currentRange);
+		return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, whichThing, currentRange);
 	}
 
 	bool isRangeDependent() override { return true; }

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1559,7 +1559,6 @@ void SoundEditor::setCurrentMultiRange(int32_t i) {
 }
 
 MenuPermission SoundEditor::checkPermissionToBeginSessionForRangeSpecificParam(Sound* sound, int32_t whichThing,
-                                                                               bool automaticallySelectIfOnlyOne,
                                                                                ::MultiRange** previouslySelectedRange) {
 
 	Source* source = &sound->sources[whichThing];
@@ -1570,7 +1569,13 @@ MenuPermission SoundEditor::checkPermissionToBeginSessionForRangeSpecificParam(S
 		return MenuPermission::NO;
 	}
 
-	if (soundEditor.editingKit() || (automaticallySelectIfOnlyOne && source->ranges.getNumElements() == 1)) {
+	// NOTE: This function used to have automaticallySelectIfOnlyOne-parameter, for which FileSelector
+	// and AudioRecorder passed false, and and which was checked in the second half of the OR below.
+	//
+	// Since there was only one option to select, and there was no available reasoning for these exceptions,
+	// that parameter was removed in 2024-08. If there's new weirdness with FileSelector or AudioRecorder,
+	// then we've discovered the reason for the exceptions... and if not, then the UX is slightly smoother.
+	if (soundEditor.editingKit() || (source->ranges.getNumElements() == 1)) {
 		*previouslySelectedRange = firstRange;
 		return MenuPermission::YES;
 	}

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -136,7 +136,6 @@ public:
 	void setCurrentMultiRange(int32_t i);
 	void possibleChangeToCurrentRangeDisplay();
 	MenuPermission checkPermissionToBeginSessionForRangeSpecificParam(Sound* sound, int32_t whichThing,
-	                                                                  bool automaticallySelectIfOnlyOne,
 	                                                                  MultiRange** previouslySelectedRange);
 	void setupExclusiveShortcutBlink(int32_t x, int32_t y);
 	void setShortcutsVersion(int32_t newVersion);


### PR DESCRIPTION
- `checkPermissionToBeginSessionForRangeSpecificParam()` used to have an `automaticallySelectIfOnlyOne`-argument, which did exactly what it says on the tin.

- That function was called by 4 MenuItems, 2 of which passed true, and 2 of which passed false:
  - `FileSelector` & `AudioRecorder`: false
  - `LoopPoint` & `sample::Transpose`: true

- Only time this code has been touched by community was code-reorg by Kate, and there's no clear reason for the different usages.

- This commit removes that argument, and behaves as if it was always true. Either we'll find out why, or the UX is slightly smoother.