### PR TITLE
Bugfix: Block converting non empty output to/from kit type

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -542,8 +542,8 @@ changeOutputType:
 
 					// don't allow clip type change if clip is not empty
 					// only impose this restriction if switching to/from kit clip
-					if (((getCurrentOutputType() == OutputType::KIT) || (newOutputType == OutputType::KIT))
-					    && !instrumentClip->isEmpty()) {
+					if (((instrument->type == OutputType::KIT) || (newOutputType == OutputType::KIT))
+					    && (!clip->isEmpty() || !clip->output->isEmpty())) {
 						return ActionResult::DEALT_WITH;
 					}
 


### PR DESCRIPTION
Blocked converting clip to/from kit if the output for that clip is not empty

fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2427