### PR TITLE
bugfix: don't make a copy of the SampleHolderForClip

### DIFF
--- a/src/deluge/gui/menu_item/audio_clip/transpose.h
+++ b/src/deluge/gui/menu_item/audio_clip/transpose.h
@@ -26,7 +26,7 @@ class Transpose final : public Decimal, public MenuItemWithCCLearning {
 public:
 	using Decimal::Decimal;
 	void readCurrentValue() override {
-		auto sampleHolder = getCurrentAudioClip()->sampleHolder;
+		auto& sampleHolder = getCurrentAudioClip()->sampleHolder;
 		this->setValue(computeCurrentValueForTranspose(sampleHolder.transpose, sampleHolder.cents));
 	}
 	void writeCurrentValue() override {


### PR DESCRIPTION
- This causes a crash when entering master transpose menu of an audio clip.