### PR TITLE
Update pad greyout for Song Macro Config Mode

### DIFF
--- a/src/deluge/gui/context_menu/configure_song_macros.cpp
+++ b/src/deluge/gui/context_menu/configure_song_macros.cpp
@@ -31,6 +31,12 @@ namespace deluge::gui::context_menu {
 
 ConfigureSongMacros configureSongMacros{};
 
+bool ConfigureSongMacros::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
+	*cols = 0x01; // Only mode (audition) column
+	*rows = 0x0;
+	return true;
+}
+
 char const* ConfigureSongMacros::getTitle() {
 	using enum l10n::String;
 	return l10n::get(STRING_FOR_CONFIGURE_SONG_MACROS_SHORT);

--- a/src/deluge/gui/context_menu/configure_song_macros.h
+++ b/src/deluge/gui/context_menu/configure_song_macros.h
@@ -34,6 +34,7 @@ public:
 	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 	ActionResult horizontalEncoderAction(int32_t offset) override;
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
 };
 
 extern ConfigureSongMacros configureSongMacros;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2941,7 +2941,7 @@ void SessionView::renderLayoutChange(bool displayPopup) {
 		currentSong->songGridScrollY = 0;
 	}
 
-	requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
+	requestRendering(&sessionView, 0xFFFFFFFF, 0xFFFFFFFF);
 	view.flashPlayEnable();
 }
 
@@ -2955,7 +2955,7 @@ void SessionView::selectSpecificLayout(SessionLayoutType layout) {
 		renderLayoutChange(false);
 	}
 	else {
-		requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
+		requestRendering(&sessionView, 0xFFFFFFFF, 0xFFFFFFFF);
 		view.flashPlayEnable();
 	}
 }


### PR DESCRIPTION
Updated pad greyout for Song Macro Config Mode. All pads except for the furthest right column remain bright indicating to the user that they can interact with those pads.