### PR TITLE
use newline='\n' in generate.py

### DIFF
--- a/src/deluge/gui/l10n/generate.py
+++ b/src/deluge/gui/l10n/generate.py
@@ -51,7 +51,7 @@ def main():
     args = parser.parse_args()
 
     with open(args.input) as inf:
-        with open(args.output, "w") as outf:
+        with open(args.output, "w", newline="\n") as outf:
             process(inf, outf)
 
 


### PR DESCRIPTION
- Without it Python writes \n as \r\n on Windows, which *works*, but leads git to consider the file dirty.