### PR TITLE
Allow ColumnControlsKeyboards to opt out of sidebar columns

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -145,7 +145,7 @@ void KeyboardLayoutChord::drawChordName(int16_t noteCode, const char* chordName,
 }
 
 bool KeyboardLayoutChord::allowSidebarType(ColumnControlFunction sidebarType) {
-	if ((sidebarType == ColumnControlFunction::CHORD) || (sidebarType == ColumnControlFunction::DX) ||
+	if ((sidebarType == ColumnControlFunction::CHORD) ||
 	    // TODO, when scales for chord keyboard are implemented, add this back in
 	    (sidebarType == ColumnControlFunction::SCALE_MODE)) {
 		return false;

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -145,12 +145,9 @@ void KeyboardLayoutChord::drawChordName(int16_t noteCode, const char* chordName,
 }
 
 bool KeyboardLayoutChord::allowSidebarType(ColumnControlFunction sidebarType) {
-	if (
-		(sidebarType == ColumnControlFunction::CHORD) ||
-		(sidebarType == ColumnControlFunction::DX) ||
-		// TODO, when scales for chord keyboard are implemented, add this back in
-		(sidebarType == ColumnControlFunction::SCALE_MODE)
-	) {
+	if ((sidebarType == ColumnControlFunction::CHORD) || (sidebarType == ColumnControlFunction::DX) ||
+	    // TODO, when scales for chord keyboard are implemented, add this back in
+	    (sidebarType == ColumnControlFunction::SCALE_MODE)) {
 		return false;
 	}
 	return true;

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -58,6 +58,9 @@ void KeyboardLayoutChord::evaluatePads(PressedPad presses[kMaxNumKeyboardPadPres
 }
 
 void KeyboardLayoutChord::handleVerticalEncoder(int32_t offset) {
+	if (verticalEncoderHandledByColumns(offset)) {
+		return;
+	}
 	KeyboardStateChord& state = getState().chord;
 
 	state.chordList.adjustChordRowOffset(offset);
@@ -66,6 +69,9 @@ void KeyboardLayoutChord::handleVerticalEncoder(int32_t offset) {
 
 void KeyboardLayoutChord::handleHorizontalEncoder(int32_t offset, bool shiftEnabled,
                                                   PressedPad presses[kMaxNumKeyboardPadPresses], bool encoderPressed) {
+	if (horizontalEncoderHandledByColumns(offset, shiftEnabled)) {
+		return;
+	}
 	KeyboardStateChord& state = getState().chord;
 
 	if (encoderPressed) {
@@ -137,4 +143,17 @@ void KeyboardLayoutChord::drawChordName(int16_t noteCode, const char* chordName,
 		display->setScrollingText(fullChordName, 0);
 	}
 }
+
+bool KeyboardLayoutChord::allowSidebarType(ColumnControlFunction sidebarType) {
+	if (
+		(sidebarType == ColumnControlFunction::CHORD) ||
+		(sidebarType == ColumnControlFunction::DX) ||
+		// TODO, when scales for chord keyboard are implemented, add this back in
+		(sidebarType == ColumnControlFunction::SCALE_MODE)
+	) {
+		return false;
+	}
+	return true;
+}
+
 } // namespace deluge::gui::ui::keyboard::layout

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -112,10 +112,10 @@ void KeyboardLayoutChord::renderPads(RGB image[][kDisplayWidth + kSideBarWidth])
 			// We also use different colors for the rows to help with navigation
 			if (chordNo % 4 == 0) {
 				int32_t rowNo = chordNo / 4;
-				image[y][x] = noteColours[rowNo % kOctaveSize];
+				image[y][x] = noteColours[rowNo % noteColours.size()];
 			}
 			else {
-				image[y][x] = noteColours[x];
+				image[y][x] = noteColours[x % noteColours.size()];
 			}
 		}
 	}

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -96,7 +96,7 @@ void KeyboardLayoutChord::precalculate() {
 	KeyboardStateChord& state = getState().chord;
 
 	// Pre-Buffer colours for next renderings
-	for (int32_t i = 0; i < (kChordColumns); ++i) {
+	for (int32_t i = 0; i < noteColours.size(); ++i) {
 		noteColours[i] = getNoteColour(((state.noteOffset + i) % state.rowInterval) * state.rowColorMultiplier);
 	}
 }

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -96,7 +96,7 @@ void KeyboardLayoutChord::precalculate() {
 	KeyboardStateChord& state = getState().chord;
 
 	// Pre-Buffer colours for next renderings
-	for (int32_t i = 0; i < (kOctaveSize + kDisplayWidth); ++i) {
+	for (int32_t i = 0; i < (kChordColumns); ++i) {
 		noteColours[i] = getNoteColour(((state.noteOffset + i) % state.rowInterval) * state.rowColorMultiplier);
 	}
 }

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
@@ -39,7 +39,6 @@ public:
 
 	void renderPads(RGB image[][kDisplayWidth + kSideBarWidth]) override;
 
-
 	char const* name() override { return "Chord"; }
 	bool supportsInstrument() override { return true; }
 	bool supportsKit() override { return false; }

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
@@ -21,13 +21,13 @@
 #include "definitions.h"
 #include "gui/ui/keyboard/chords.h"
 #include "gui/ui/keyboard/layout/column_controls.h"
+#include <array>
 
 namespace deluge::gui::ui::keyboard::layout {
 
 /// @brief Represents a keyboard layout for chord-based input.
 class KeyboardLayoutChord : public ColumnControlsKeyboard {
 public:
-	// KeyboardLayoutChord() {}
 	KeyboardLayoutChord() = default;
 	~KeyboardLayoutChord() override = default;
 
@@ -52,7 +52,7 @@ private:
 	void drawChordName(int16_t noteCode, const char* chordName, const char* voicingName = "");
 	inline uint8_t noteFromCoords(int32_t x) { return getState().chord.noteOffset + x; }
 
-	RGB noteColours[kOctaveSize];
+	std::array<RGB, kOctaveSize> noteColours;
 };
 
 }; // namespace deluge::gui::ui::keyboard::layout

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
@@ -27,6 +27,7 @@ namespace deluge::gui::ui::keyboard::layout {
 /// @brief Represents a keyboard layout for chord-based input.
 class KeyboardLayoutChord : public ColumnControlsKeyboard {
 public:
+	// KeyboardLayoutChord() {}
 	KeyboardLayoutChord() = default;
 	~KeyboardLayoutChord() override = default;
 
@@ -38,7 +39,6 @@ public:
 
 	void renderPads(RGB image[][kDisplayWidth + kSideBarWidth]) override;
 
-	void drawChordName(int16_t noteCode, const char* chordName, const char* voicingName = "");
 
 	char const* name() override { return "Chord"; }
 	bool supportsInstrument() override { return true; }
@@ -46,19 +46,11 @@ public:
 
 	RequiredScaleMode requiredScaleMode() override { return RequiredScaleMode::Disabled; }
 
-	uint8_t chordSemitoneOffsets[kMaxChordKeyboardSize] = {0};
+protected:
+	bool allowSidebarType(ColumnControlFunction sidebarType) override;
 
 private:
-	inline uint16_t padIndexFromCoords(int32_t x, int32_t y) {
-		return getState().chord.noteOffset + x + y * getState().chord.rowInterval;
-	}
-
-	void offsetPads(int32_t offset, bool shiftEnabled);
-
-	// A modified version of noteCodeToString
-	// Because sometimes the note name is not displayed correctly
-	// and we need to add a null terminator to the note name string
-	// TODO: work out how to fix this with the noteCodeToString function
+	void drawChordName(int16_t noteCode, const char* chordName, const char* voicingName = "");
 	inline uint8_t noteFromCoords(int32_t x) { return getState().chord.noteOffset + x; }
 
 	RGB noteColours[kOctaveSize];

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -130,18 +130,18 @@ void ColumnControlsKeyboard::handleHorizontalEncoder(int32_t offset, bool shiftE
 	horizontalEncoderHandledByColumns(offset, shiftEnabled);
 }
 
-ColumnControlFunction nextControlFunction(ColumnControlFunction cur, ColumnControlFunction skip) {
+ColumnControlFunction ColumnControlsKeyboard::nextControlFunction(ColumnControlFunction cur, ColumnControlFunction skip) {
 	bool has_dx = (getCurrentDxPatch() != nullptr);
 	auto out = cur;
 	while (true) {
 		out = static_cast<ColumnControlFunction>((out + 1) % COL_CTRL_FUNC_MAX);
-		if (out != skip && (has_dx || out != DX)) {
+		if (out != skip && (has_dx || out != DX) && allowSidebarType(out)) {
 			return out;
 		}
 	}
 }
 
-ColumnControlFunction prevControlFunction(ColumnControlFunction cur, ColumnControlFunction skip) {
+ColumnControlFunction ColumnControlsKeyboard::prevControlFunction(ColumnControlFunction cur, ColumnControlFunction skip) {
 	bool has_dx = (getCurrentDxPatch() != nullptr);
 	auto out = cur;
 	while (true) {
@@ -149,7 +149,7 @@ ColumnControlFunction prevControlFunction(ColumnControlFunction cur, ColumnContr
 		if (out < 0) {
 			out = static_cast<ColumnControlFunction>(COL_CTRL_FUNC_MAX - 1);
 		}
-		if (out != skip && (has_dx || out != DX)) {
+		if (out != skip && (has_dx || out != DX) && allowSidebarType(out)) {
 			return out;
 		}
 	}
@@ -187,7 +187,7 @@ void ColumnControlsKeyboard::checkNewInstrument(Instrument* newInstrument) {
 	}
 }
 
-ColumnControlFunction stepControlFunction(int32_t offset, ColumnControlFunction cur, ColumnControlFunction skip) {
+ColumnControlFunction ColumnControlsKeyboard::stepControlFunction(int32_t offset, ColumnControlFunction cur, ColumnControlFunction skip) {
 	return (offset > 0) ? nextControlFunction(cur, skip) : prevControlFunction(cur, skip);
 }
 

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -130,7 +130,8 @@ void ColumnControlsKeyboard::handleHorizontalEncoder(int32_t offset, bool shiftE
 	horizontalEncoderHandledByColumns(offset, shiftEnabled);
 }
 
-ColumnControlFunction ColumnControlsKeyboard::nextControlFunction(ColumnControlFunction cur, ColumnControlFunction skip) {
+ColumnControlFunction ColumnControlsKeyboard::nextControlFunction(ColumnControlFunction cur,
+                                                                  ColumnControlFunction skip) {
 	bool has_dx = (getCurrentDxPatch() != nullptr);
 	auto out = cur;
 	while (true) {
@@ -141,7 +142,8 @@ ColumnControlFunction ColumnControlsKeyboard::nextControlFunction(ColumnControlF
 	}
 }
 
-ColumnControlFunction ColumnControlsKeyboard::prevControlFunction(ColumnControlFunction cur, ColumnControlFunction skip) {
+ColumnControlFunction ColumnControlsKeyboard::prevControlFunction(ColumnControlFunction cur,
+                                                                  ColumnControlFunction skip) {
 	bool has_dx = (getCurrentDxPatch() != nullptr);
 	auto out = cur;
 	while (true) {
@@ -187,7 +189,8 @@ void ColumnControlsKeyboard::checkNewInstrument(Instrument* newInstrument) {
 	}
 }
 
-ColumnControlFunction ColumnControlsKeyboard::stepControlFunction(int32_t offset, ColumnControlFunction cur, ColumnControlFunction skip) {
+ColumnControlFunction ColumnControlsKeyboard::stepControlFunction(int32_t offset, ColumnControlFunction cur,
+                                                                  ColumnControlFunction skip) {
 	return (offset > 0) ? nextControlFunction(cur, skip) : prevControlFunction(cur, skip);
 }
 

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.h
@@ -78,6 +78,7 @@ public:
 
 	int8_t leftColHeld = -1;
 	int8_t rightColHeld = -1;
+
 protected:
 	// Subclasses can override this to allow or disallow certain ControlColumn types
 	virtual bool allowSidebarType(ColumnControlFunction sidebarType) { return true; };

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.h
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.h
@@ -28,9 +28,6 @@ constexpr int32_t kMinIsomorphicRowInterval = 1;
 constexpr int32_t kMaxIsomorphicRowInterval = 16;
 constexpr uint32_t kHalfStep = 0x7FFFFF;
 
-ColumnControlFunction nextControlFunction(ColumnControlFunction cur, ColumnControlFunction skip);
-ColumnControlFunction prevControlFunction(ColumnControlFunction cur, ColumnControlFunction skip);
-
 enum BeatRepeat {
 	NO_BEAT_REPEAT = 0,
 	DOT_EIGHT,
@@ -69,6 +66,10 @@ public:
 	bool verticalEncoderHandledByColumns(int32_t offset);
 	bool horizontalEncoderHandledByColumns(int32_t offset, bool shiftEnabled);
 
+	ColumnControlFunction nextControlFunction(ColumnControlFunction cur, ColumnControlFunction skip);
+	ColumnControlFunction prevControlFunction(ColumnControlFunction cur, ColumnControlFunction skip);
+	ColumnControlFunction stepControlFunction(int32_t offset, ColumnControlFunction cur, ColumnControlFunction skip);
+
 	virtual void renderSidebarPads(RGB image[][kDisplayWidth + kSideBarWidth]) override;
 
 	void checkNewInstrument(Instrument* newInstrument) override;
@@ -77,6 +78,9 @@ public:
 
 	int8_t leftColHeld = -1;
 	int8_t rightColHeld = -1;
+protected:
+	// Subclasses can override this to allow or disallow certain ControlColumn types
+	virtual bool allowSidebarType(ColumnControlFunction sidebarType) { return true; };
 };
 
 }; // namespace deluge::gui::ui::keyboard::layout


### PR DESCRIPTION
A keyboard subclass can override allowSidebarType to skip certain sidebar cols.

Encountering bug where if Chord Keyboard has default constructor, then changing sidebar col after entering chord keyboard with cause a crash, but if using an empty constructor will cause a crash when changing to in-key keyboard after entering the chord keyboard