### PR TITLE
maybe fix arranger bug, definitely fix automation freeze at low tempo

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -249,7 +249,7 @@ void Song::setupDefault() {
 
 	seedRandom();
 
-	setBPMInner(defaultTempoMenu.getRandomValueInRange(), false);
+	setBPM(defaultTempoMenu.getRandomValueInRange(), false);
 	swingAmount = defaultSwingAmountMenu.getRandomValueInRange() - 50;
 	key.rootNote = defaultKeyMenu.getRandomValueInRange();
 
@@ -1969,6 +1969,10 @@ loadOutput:
 	}
 
 	setTimePerTimerTick(newTimePerTimerTick);
+
+	// make sure the bpm param matches the ticks in case something went wrong? ref issue 2455, possible cause is invalid
+	// tempo param
+	setBPM(calculateBPM(), false);
 
 	// Ensure all arranger-only Clips have their section as 255
 	for (int32_t t = 0; t < arrangementOnlyClips.getNumElements(); t++) {
@@ -5776,8 +5780,9 @@ ModelStackWithAutoParam* Song::getModelStackWithParam(ModelStackWithThreeMainThi
 	return modelStackWithParam;
 }
 void Song::updateBPMFromAutomation() {
+	// There seems to be a param manager bug where it occasionally reports unautomated params as 0 so just ignore that
 	int32_t currentTempo = currentSong->paramManager.getUnpatchedParamSet()->getValue(params::UNPATCHED_TEMPO);
-	if (currentTempo != intBPM) {
+	if (currentTempo && currentTempo != intBPM) {
 		setBPMInner((float)currentTempo / 100, false);
 		intBPM = currentTempo;
 	}

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -435,6 +435,17 @@ public:
 	// Tempo automation
 	void clearTempoAutomation();
 	void updateBPMFromAutomation();
+	float calculateBPM() {
+		float timePerTimerTick = getTimePerTimerTickFloat();
+		if (insideWorldTickMagnitude > 0) {
+			timePerTimerTick *= ((uint32_t)1 << (insideWorldTickMagnitude));
+		}
+		float tempoBPM = (float)110250 / timePerTimerTick;
+		if (insideWorldTickMagnitude < 0) {
+			tempoBPM *= ((uint32_t)1 << (-insideWorldTickMagnitude));
+		}
+		return tempoBPM;
+	}
 
 	int8_t defaultAudioClipOverdubOutputCloning = -1; // -1 means no default set
 
@@ -453,7 +464,7 @@ private:
 	void setupClipIndexesForSaving();
 	void setBPMInner(float tempoBPM, bool shouldLogAction);
 	void clearTempoAutomation(float tempoBPM);
-	int32_t intBPM;
+	int32_t intBPM{0};
 };
 
 extern Song* currentSong;

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -199,7 +199,8 @@ investigatePrevNode:
 			// everywhere from here to the next node - we don't need to preserve the "original" value in any part of
 			// that region because it's going to get overridden any time another note is inserted into it, anyway. And
 			// we want our value to last as long as possible, for the note's release-tail.
-			if (doMPEMode) {
+			// might as well do this for when the ticks are longer than 0.2s too
+			if (doMPEMode || ticksToClear == 0) {
 				leftI = setNodeAtPos(livePos, value, reversed || shouldInterpolateRegionStart);
 				if (leftI == -1) {
 					goto getOut;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2004,7 +2004,7 @@ void PlaybackHandler::commandEditTempoCoarse(int8_t offset) {
 }
 
 void PlaybackHandler::commandEditTempoFine(int8_t offset) {
-	int32_t tempoBPM = calculateBPM(currentSong->getTimePerTimerTickFloat()) + 0.5;
+	int32_t tempoBPM = calculateBPM(currentSong->getTimePerTimerTickFloat()) + 0.5f;
 	tempoBPM += offset;
 	if (tempoBPM > 0) {
 		currentSong->setBPM(tempoBPM, true);
@@ -2202,15 +2202,7 @@ void PlaybackHandler::commandDisplayTempo() {
 }
 
 float PlaybackHandler::calculateBPM(float timePerInternalTick) {
-	float timePerTimerTick = timePerInternalTick;
-	if (currentSong->insideWorldTickMagnitude > 0) {
-		timePerTimerTick *= ((uint32_t)1 << (currentSong->insideWorldTickMagnitude));
-	}
-	float tempoBPM = (float)110250 / timePerTimerTick;
-	if (currentSong->insideWorldTickMagnitude < 0) {
-		tempoBPM *= ((uint32_t)1 << (-currentSong->insideWorldTickMagnitude));
-	}
-	return tempoBPM;
+	return currentSong->calculateBPM();
 }
 
 void PlaybackHandler::displayTempoBPM(float tempoBPM) {

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -192,7 +192,7 @@ public:
 	bool subModeAllowsRecording();
 
 	void songSelectReceived(uint8_t songId);
-	float calculateBPM(float timePerInternalTick);
+	static float calculateBPM(float timePerInternalTick);
 	void switchToArrangement();
 	void switchToSession();
 	void finishTempolessRecording(bool startPlaybackAgain, int32_t buttonLatencyForTempolessRecord,
@@ -245,7 +245,6 @@ private:
 	uint32_t skipMidiClocks;
 
 	void resetTimePerInternalTickMovingAverage();
-	void getCurrentTempoParams(int32_t* magnitude, int8_t* whichValue);
 	void displayTempoFromParams(int32_t magnitude, int8_t whichValue);
 	void displayTempoBPM(float tempoBPM);
 	void getAnalogOutTicksToInternalTicksRatio(uint32_t* internalTicksPer, uint32_t* analogOutTicksPer);


### PR DESCRIPTION
2455 cause is unknown since I can't reproduce it but I found some spots where a tempo of 0 could plausibly get set 

Fix #2455

2466 freezes when trying to homogenize a zero length region. This is caused by recording any automation under 5 bpm. Fixed by just using the "mpe mode" instead which skips the clear

Fix #2466 
