### PR TITLE
Fix #2463 Drumrandomizer ignore mac dot files

### DIFF
--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1301,7 +1301,7 @@ void getThingFilename(char const* thingName, int16_t currentSlot, int8_t current
 }
 
 bool isAudioFilename(char const* filename) {
-	if (*filename == '.') {
+	if (filename[0] == '.') {
 		return false;
 	}
 	char* dotPos = strrchr(filename, '.');

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1301,9 +1301,11 @@ void getThingFilename(char const* thingName, int16_t currentSlot, int8_t current
 }
 
 bool isAudioFilename(char const* filename) {
+	if (*filename == '.') {
+		return false;
+	}
 	char* dotPos = strrchr(filename, '.');
-	return (dotPos != 0
-	        && (!strcasecmp(dotPos, ".WAV") || !strcasecmp(dotPos, ".AIF") || !strcasecmp(dotPos, ".AIFF")));
+	return (!strcasecmp(dotPos, ".WAV") || !strcasecmp(dotPos, ".AIF") || !strcasecmp(dotPos, ".AIFF"));
 }
 
 bool isAiffFilename(char const* filename) {


### PR DESCRIPTION
Fix #2463

isAudioFilename now correctly rejects filenames starting with dot

(isAifffile was not changed because it is used in a different context)