### PR TITLE
[DRAFT] MIDI Queuing - De-prioritize sending of MIDI Automation and Feedback

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -153,6 +153,23 @@ enum class MidiLearn : uint8_t {
 	DRUM_INPUT,
 };
 
+enum class MidiSendType : uint8_t {
+	NONE,
+	CLOCK,
+	START,
+	STOP,
+	CONTINUE,
+	POSITION_POINTER,
+	BANK,
+	SUB_BANK,
+	PROGRAM_CHANGE,
+	NOTE,
+	EXPRESSION,
+	CC,
+	AUTOMATION,
+	FEEDBACK,
+};
+
 constexpr size_t kMinTimePerTimerTick = 1;
 constexpr int32_t kNumInputTicksToAverageTime = 24;
 constexpr int32_t kNumInputTicksToAllowTempoTargeting =

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -63,14 +63,15 @@ public:
 	MidiEngine();
 
 	void sendNote(MIDISource source, bool on, int32_t note, uint8_t velocity, uint8_t channel, int32_t filter);
-	void sendCC(MIDISource source, int32_t channel, int32_t cc, int32_t value, int32_t filter);
+	void sendCC(MIDISource source, int32_t channel, int32_t cc, int32_t value, int32_t filter,
+	            MidiSendType type = MidiSendType::NONE);
 	bool checkIncomingSerialMidi();
 	void checkIncomingUsbMidi();
 
 	void checkIncomingUsbSysex(uint8_t const* message, int32_t ip, int32_t d, int32_t cable);
 
 	void sendMidi(MIDISource source, uint8_t statusType, uint8_t channel, uint8_t data1 = 0, uint8_t data2 = 0,
-	              int32_t filter = kMIDIOutputFilterNoMPE, bool sendUSB = true);
+	              int32_t filter = kMIDIOutputFilterNoMPE, bool sendUSB = true, MidiSendType type = MidiSendType::NONE);
 	void sendClock(MIDISource source, bool sendUSB = true, int32_t howMany = 1);
 	void sendStart(MIDISource source);
 	void sendStop(MIDISource source);

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -659,7 +659,7 @@ void MidiFollow::sendCCForMidiFollowFeedback(int32_t channel, int32_t ccNumber, 
 
 		int32_t midiOutputFilter = midiInput.channelOrZone;
 
-		midiEngine.sendCC(this, channel, ccNumber, knobPos + kKnobPosOffset, midiOutputFilter);
+		midiEngine.sendCC(this, channel, ccNumber, knobPos + kKnobPosOffset, midiOutputFilter, MidiSendType::FEEDBACK);
 
 		timeLastCCSent[ccNumber] = AudioEngine::audioSampleTimer;
 	}

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -230,7 +230,7 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimens
 		int32_t newValue = std::clamp<int32_t>(polyPart + monoPart, 0, 127);
 		// send CC1 for monophonic expression - monophonic synths won't do anything useful with CC74
 
-		midiEngine.sendCC(this, masterChannel, CC_EXTERNAL_MOD_WHEEL, newValue, channel);
+		midiEngine.sendCC(this, masterChannel, CC_EXTERNAL_MOD_WHEEL, newValue, channel, MidiSendType::EXPRESSION);
 		break;
 	}
 	case Z_PRESSURE: {
@@ -848,7 +848,7 @@ void MIDIInstrument::outputAllMPEValuesOnMemberChannel(int16_t const* mpeValuesT
 	{ // Y
 		int32_t outputValue7 = mpeValuesToUse[1] >> 9;
 		mpeOutputMemberChannels[outputMemberChannel].lastYAndZValuesSent[0] = outputValue7;
-		midiEngine.sendCC(this, outputMemberChannel, outputMPEY, outputValue7 + 64, channel);
+		midiEngine.sendCC(this, outputMemberChannel, outputMPEY, outputValue7 + 64, channel, MidiSendType::EXPRESSION);
 	}
 
 	{ // Z
@@ -1022,7 +1022,7 @@ void MIDIInstrument::polyphonicExpressionEventPostArpeggiator(int32_t value32, i
 		case 1: { // Y
 			int32_t value7 = value32 >> 25;
 			mpeOutputMemberChannels[memberChannel].lastYAndZValuesSent[0] = value7;
-			midiEngine.sendCC(this, memberChannel, outputMPEY, value7 + 64, channel);
+			midiEngine.sendCC(this, memberChannel, outputMPEY, value7 + 64, channel, MidiSendType::EXPRESSION);
 			break;
 		}
 

--- a/src/deluge/modulation/midi/midi_param_collection.cpp
+++ b/src/deluge/modulation/midi/midi_param_collection.cpp
@@ -197,7 +197,8 @@ void MIDIParamCollection::sendMIDI(MIDISource source, int32_t masterChannel, int
 	}
 	int32_t newValueSmall = (newValue + roundingAmountToAdd) >> rShift;
 
-	midiEngine.sendCC(source, masterChannel, cc, newValueSmall + 64, midiOutputFilter); // TODO: get master channel
+	midiEngine.sendCC(source, masterChannel, cc, newValueSmall + 64, midiOutputFilter,
+	                  MidiSendType::AUTOMATION); // TODO: get master channel
 }
 
 // For MIDI CCs, which prior to V2.0 did interpolation


### PR DESCRIPTION
Background:

I got a message from someone using midi follow that mentioned that they are unable to use Midi Follow with Feedback together with sending Note data to external synths because it can result in notes getting delayed as the midi feedback info is getting sent out in bulk.

This brought me back to our discussion around building a midi queue system.

So what I started doing is creating a new enum to capture the "type" of midi message being sent.

Then I wanted to do something simple and focus on de-prioritizing the sending of Automation and Feedback types of midi data

So I thought of using the Yield function to do something like this where it waits until other messages have been processed before processing Automation or Feedback messages.