### PR TITLE
Start Arranger Playback from Scroll Position while in Cross Screen Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ use the TRACK menu to select the specific track to record from
   - This change only applies to `SONG GRID VIEW` and NOT `SONG ROW VIEW`  
 - Updated Fonts and Character Spacing on OLED to provide a more refined and polished user experience.
 - Added ability to scroll `KEYBOARD VIEW` horizontally using `<>` while editing Param values in the menu.
+- Changed the behaviour of the `PLAY` button while in `ARRANGER VIEW` with `CROSS SCREEN AUTO SCROLL MODE` active. Pressing `PLAY` while playback is off will now start playback from the current scroll position.
 
 ### Keyboard View Improvements
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -289,13 +289,16 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 	decideOnCurrentPlaybackMode(); // Must be done up here - we reference currentPlaybackMode a bit below
 
 	// Allow playback to start from current scroll if holding down <> knob
+	// or if you're in arranger view and in cross screen auto scrolling mode
 	int32_t newPos = 0;
+	RootUI* rootUI = getRootUI();
+	bool isArrangerView = rootUI == &arrangerView;
 	if (Buttons::isButtonPressed(deluge::hid::button::X_ENC)
-	    || (getRootUI() == &arrangerView && recording == RecordingMode::NORMAL)) {
+	    || (isArrangerView && (recording == RecordingMode::NORMAL || currentSong->arrangerAutoScrollModeActive))) {
 
 		int32_t navSys;
-		if (getRootUI()) {
-			if (auto* timelineView = getRootUI()->toTimelineView()) {
+		if (rootUI) {
+			if (auto* timelineView = rootUI->toTimelineView()) {
 				navSys = timelineView->getNavSysId();
 			}
 		}
@@ -315,8 +318,7 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 
 	// See if we want a count-in
 	if (allowCountIn && !doingTempolessRecord && recording == RecordingMode::NORMAL && countInBars
-	    && (!currentUIMode || currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON)
-	    && getCurrentUI() == getRootUI()) {
+	    && (!currentUIMode || currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) && getCurrentUI() == rootUI) {
 
 		ticksLeftInCountIn = currentSong->getBarLength() * countInBars;
 		currentVisualCountForCountIn = 0; // Reset it. In a moment it'll display as 4 - 12.


### PR DESCRIPTION
Changed the behaviour of the `PLAY` button while in `ARRANGER VIEW` with `CROSS SCREEN AUTO SCROLL MODE` active. Pressing `PLAY` while playback is off will now start playback from the current scroll position.