### PR TITLE
Update grid view clip creation UI + Bugfix

### DIFF
--- a/tests/unit/scale_tests.cpp
+++ b/tests/unit/scale_tests.cpp
@@ -392,10 +392,10 @@ TEST(NoteSetTest, highestNotIn) {
 TEST(NoteSetTest, modulateByOffset) {
 	NoteSet notes = NoteSet({0, 1, 4, 11});
 	NoteSet modulated = notes.modulateByOffset(3);
-	CHECK_EQUAL(2, modulated[0]);  // wrapped around 11 + 3 % 12 = 2
-	CHECK_EQUAL(3, modulated[1]);  // 0 + 3 % 12 = 3
-	CHECK_EQUAL(4, modulated[2]);  // 1 + 3 % 12 = 4
-	CHECK_EQUAL(7, modulated[3]);  // 4 + 3 % 12 = 7
+	CHECK_EQUAL(2, modulated[0]); // wrapped around 11 + 3 % 12 = 2
+	CHECK_EQUAL(3, modulated[1]); // 0 + 3 % 12 = 3
+	CHECK_EQUAL(4, modulated[2]); // 1 + 3 % 12 = 4
+	CHECK_EQUAL(7, modulated[3]); // 4 + 3 % 12 = 7
 }
 
 TEST_GROUP(MusicalKeyTest){};


### PR DESCRIPTION
Updated UI for creating clips in new tracks in grid view by only blinking the clip pad corresponding to the clip that is going to be created

Fixed bug where you could get stuck in the clip pressed / copy mode UI when trying to create more than 2 CV clips