### PR TITLE
Updated UI for creating clips in new tracks in grid view + bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,13 @@ use the TRACK menu to select the specific track to record from
 - Submenus on OLED are rendered with a ">" at the end to indicate that it is a submenu.
 - Added ability to `AUTOMATE TEMPO` in arranger view
 - Added new mechanism for creating New Clips in New Tracks in `SONG GRID VIEW` and updated the button used to Create Audio Clips in `SONG GRID VIEW` from the `SELECT ENCODER` to the `CROSS SCREEN BUTTON`.
-  - When you press a pad in a new track, a popup will appear asking you to confirm the type of clip you wish to create. By default it will select the last clip type you created as the clip type to create. It will tell you on the display what that clip type is. 
-    - If you just a tap a pad quickly to create a new clip, it will create that new clip using the last clip type.
-    - If you press and hold a pad, you can choose a different type by pressing one of the `BLINKING` clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV` or `CROSS SCREEN` (for Audio Clips)). If you let go of the pad without selecting a different type, it will create the clip using the last selected clip type.
-    - If you press `BACK` before releasing a pad or selecting a clip type, it will cancel the clip creation.    
+  - When you press a pad in a new track, a menu will appear asking you to confirm the type of clip you wish to create. By default it will select the last clip type you created as the clip type to create. The clip type selected to be created is shown on the display and is also indicated by the clip type button that is blinking.
+    - If you just a tap a pad quickly to create a new clip, it will create that new clip using the last created clip type.
+    - If you press and hold a pad, you can choose a different type to create in a number of ways:
+      - by turning the select encoder to switch between the various clip types. You can create that clip type by pressing on the select encoder or letting go of the pad.
+      - by pressing one of the clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV` or `CROSS SCREEN` (for Audio Clips)). 
+      - If you let go of the pad without selecting a different type, it will create the clip using the last create type (or the last selected type if you changed selection using select encoder).
+    - If you press `BACK` before releasing a pad or selecting a clip type, it will cancel the clip creation.  
     - These changes only apply to `SONG GRID VIEW` and NOT `SONG ROW VIEW`
 - Updated the `SONG GRID VIEW` shortcut of `HOLDING PAD FOR THE CLIP` + `CROSS SCREEN BUTTON` to convert an Empty `INSTRUMENT CLIP` to an `AUDIO CLIP`.
   - This replaces the previous shortcut of `HOLDING PAD FOR THE CLIP` + `SELECT ENCODER`.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -294,9 +294,12 @@ which track to record from. To run the instrument through the audio clip's FX ch
 
 #### 3.27 Updated UI for Creating New Clips in New Tracks in Song Grid View
 - ([#2429]) Added new mechanism for creating New Clips in New Tracks in `SONG GRID VIEW` and updated the button used to Create Audio Clips in `SONG GRID VIEW` from the `SELECT ENCODER` to the `CROSS SCREEN BUTTON`.
-  - When you press a pad in a new track, a popup will appear asking you to confirm the type of clip you wish to create. By default it will select the last clip type you created as the clip type to create. It will tell you on the display what that clip type is. 
-    - If you just a tap a pad quickly to create a new clip, it will create that new clip using the last clip type.
-    - If you press and hold a pad, you can choose a different type by pressing one of the `BLINKING` clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV` or `CROSS SCREEN` (for Audio Clips)). If you let go of the pad without selecting a different type, it will create the clip using the last selected clip type.
+  - When you press a pad in a new track, a menu will appear asking you to confirm the type of clip you wish to create. By default it will select the last clip type you created as the clip type to create. The clip type selected to be created is shown on the display and is also indicated by the clip type button that is blinking.
+    - If you just a tap a pad quickly to create a new clip, it will create that new clip using the last created clip type.
+    - If you press and hold a pad, you can choose a different type to create in a number of ways:
+      - by turning the select encoder to switch between the various clip types. You can create that clip type by pressing on the select encoder or letting go of the pad.
+      - by pressing one of the clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV` or `CROSS SCREEN` (for Audio Clips)). 
+      - If you let go of the pad without selecting a different type, it will create the clip using the last create type (or the last selected type if you changed selection using select encoder).
     - If you press `BACK` before releasing a pad or selecting a clip type, it will cancel the clip creation.
 - Updated the `SONG GRID VIEW` shortcut of `HOLDING PAD FOR THE CLIP` + `CROSS SCREEN BUTTON` to convert an Empty `INSTRUMENT CLIP` to an `AUDIO CLIP`.
   - This replaces the previous shortcut of `HOLDING PAD FOR THE CLIP` + `SELECT ENCODER`.

--- a/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
@@ -1,0 +1,176 @@
+
+
+#include "gui/context_menu/clip_settings/new_clip_type.h"
+#include "definitions_cxx.hpp"
+#include "gui/l10n/l10n.h"
+#include "gui/ui/root_ui.h"
+#include "gui/ui/ui.h"
+#include "gui/views/session_view.h"
+#include "hid/button.h"
+#include "hid/display/display.h"
+#include <cstddef>
+
+namespace deluge::gui::context_menu::clip_settings {
+
+constexpr size_t kNumValues = 5;
+
+NewClipType newClipType{};
+
+char const* NewClipType::getTitle() {
+	static char const* title = "New Clip Type";
+	return title;
+}
+
+Sized<char const**> NewClipType::getOptions() {
+	using enum l10n::String;
+	static const char* optionsls[] = {
+	    "Audio", // audio
+	    "Synth", // synth
+	    "Kit",   // kit
+	    "MIDI",  // midi
+	    "CV",    // cv
+	};
+	return {optionsls, kNumValues};
+}
+
+bool NewClipType::setupAndCheckAvailability() {
+	currentUIMode = UI_MODE_CREATING_CLIP;
+
+	updateSelectedOption();
+
+	indicator_leds::blinkLed(IndicatorLED::BACK);
+
+	if (display->haveOLED()) {
+		scrollPos = currentOption;
+	}
+
+	return true;
+}
+
+void NewClipType::updateSelectedOption() {
+	switch (toCreate) {
+	case OutputType::AUDIO:
+		currentOption = 0;
+		break;
+	case OutputType::SYNTH:
+		currentOption = 1;
+		break;
+	case OutputType::KIT:
+		currentOption = 2;
+		break;
+	case OutputType::MIDI_OUT:
+		currentOption = 3;
+		break;
+	case OutputType::CV:
+		currentOption = 4;
+		break;
+	default:
+		break;
+	}
+	blinkLedForOption(currentOption);
+}
+
+void NewClipType::selectEncoderAction(int8_t offset) {
+	int32_t optionSelectedBeforeEncoderAction = currentOption;
+	ContextMenu::selectEncoderAction(offset);
+	if (currentOption != optionSelectedBeforeEncoderAction) {
+		disableLedForOption(optionSelectedBeforeEncoderAction);
+		updateOutputToCreate();
+		blinkLedForOption(currentOption);
+	}
+}
+
+void NewClipType::updateOutputToCreate() {
+	if (currentOption == 0) {
+		toCreate = OutputType::AUDIO;
+	}
+	else if (currentOption == 1) {
+		toCreate = OutputType::SYNTH;
+	}
+	else if (currentOption == 2) {
+		toCreate = OutputType::KIT;
+	}
+	else if (currentOption == 3) {
+		toCreate = OutputType::MIDI_OUT;
+	}
+	else if (currentOption == 4) {
+		toCreate = OutputType::CV;
+	}
+}
+
+bool NewClipType::acceptCurrentOption() {
+	deluge::hid::Button b;
+	using namespace deluge::hid::button;
+
+	if (currentOption == 0) {
+		b = CROSS_SCREEN_EDIT;
+	}
+	else if (currentOption == 1) {
+		b = SYNTH;
+	}
+	else if (currentOption == 2) {
+		b = KIT;
+	}
+	else if (currentOption == 3) {
+		b = MIDI;
+	}
+	else if (currentOption == 4) {
+		b = CV;
+	}
+
+	sessionView.clipCreationButtonPressed(b, 1, sdRoutineLock); // let the grid handle this
+
+	return true;
+}
+ActionResult NewClipType::padAction(int32_t x, int32_t y, int32_t on) {
+	ActionResult result = sessionView.padAction(x, y, on); // let the grid handle this
+
+	display->setNextTransitionDirection(-1);
+	close();
+
+	return result;
+}
+
+ActionResult NewClipType::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+	using namespace deluge::hid::button;
+
+	if (b == SELECT_ENC) {
+		acceptCurrentOption();
+	}
+	else {
+		sessionView.clipCreationButtonPressed(b, on, inCardRoutine); // let the grid handle this
+	}
+
+	display->setNextTransitionDirection(-1);
+	close();
+
+	return ActionResult::DEALT_WITH;
+}
+
+LED NewClipType::getLedFromOption(int32_t option) {
+	if (option == 0) {
+		return IndicatorLED::CROSS_SCREEN_EDIT;
+	}
+	else if (option == 1) {
+		return IndicatorLED::SYNTH;
+	}
+	else if (option == 2) {
+		return IndicatorLED::KIT;
+	}
+	else if (option == 3) {
+		return IndicatorLED::MIDI;
+	}
+	else {
+		return IndicatorLED::CV;
+	}
+}
+
+void NewClipType::disableLedForOption(int32_t option) {
+	indicator_leds::setLedState(getLedFromOption(option), false, false);
+}
+
+void NewClipType::blinkLedForOption(int32_t option) {
+	indicator_leds::blinkLed(getLedFromOption(option));
+}
+
+} // namespace deluge::gui::context_menu::clip_settings

--- a/src/deluge/gui/context_menu/clip_settings/new_clip_type.h
+++ b/src/deluge/gui/context_menu/clip_settings/new_clip_type.h
@@ -1,0 +1,44 @@
+/*
+ * ContextMenu\Clip_Settings\New_Clip_Type.h
+ *
+ *  Created on: 4 Aug 2024
+ *      Author: Sean
+ */
+
+#pragma once
+
+#include "gui/context_menu/context_menu.h"
+#include "hid/led/indicator_leds.h"
+
+using namespace indicator_leds;
+
+namespace deluge::gui::context_menu::clip_settings {
+
+class NewClipType final : public ContextMenu {
+
+public:
+	NewClipType() = default;
+	void selectEncoderAction(int8_t offset) override;
+	bool setupAndCheckAvailability();
+	bool canSeeViewUnderneath() override { return true; }
+	bool acceptCurrentOption() override; // If returns false, will cause UI to exit
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
+	void updateSelectedOption();
+	void updateOutputToCreate();
+
+	LED getLedFromOption(int32_t option);
+	void disableLedForOption(int32_t option);
+	void blinkLedForOption(int32_t option);
+
+	OutputType toCreate = OutputType::AUDIO;
+
+	/// Title
+	char const* getTitle() override;
+
+	/// Options
+	Sized<const char**> getOptions() override;
+	ActionResult padAction(int32_t x, int32_t y, int32_t on) override;
+};
+
+extern NewClipType newClipType;
+} // namespace deluge::gui::context_menu::clip_settings

--- a/src/deluge/gui/context_menu/context_menu.cpp
+++ b/src/deluge/gui/context_menu/context_menu.cpp
@@ -19,6 +19,7 @@
 
 #include "definitions_cxx.hpp"
 #include "extern.h"
+#include "gui/ui/ui.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
 #include "hid/led/indicator_leds.h"

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1592,8 +1592,7 @@ Error setPresetOrNextUnlaunchedOne(InstrumentClip* clip, OutputType outputType, 
 			ModelStackWithTimelineCounter* modelStack =
 			    setupModelStackWithSong(modelStackMemory, currentSong)->addTimelineCounter(clip);
 
-			clip->assignDrumsToNoteRows(modelStack); // Does a setupPatching() for each Drum
-			clip->yScroll = 0;
+			clip->setupAsNewKitClipIfNecessary(modelStack);
 		}
 	}
 	else {

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -54,6 +54,7 @@ public:
 
 	const char* getName() { return "session_view"; }
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
+	ActionResult clipCreationButtonPressed(hid::Button i, bool on, bool routine);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
 	ActionResult horizontalEncoderAction(int32_t offset);
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine);
@@ -130,8 +131,8 @@ public:
 	UIType getUIType() { return UIType::SESSION; }
 
 	Clip* createNewClip(OutputType outputType, int32_t yDisplay);
-	Clip* newClipToCreate;
-	bool createClip = false;
+	bool createClip{false};
+	OutputType lastTypeCreated{OutputType::AUDIO};
 
 	// Grid macros config mode
 	void enterMacrosConfigMode();
@@ -219,8 +220,6 @@ private:
 	int32_t gridFirstPressedY = -1;
 	int32_t gridSecondPressedX = -1;
 	int32_t gridSecondPressedY = -1;
-	bool creatingClip{false};
-	OutputType lastTypeCreated{OutputType::AUDIO};
 	inline bool gridSecondPadInactive() { return (gridSecondPressedX == -1 && gridSecondPressedY == -1); }
 
 	inline void gridResetPresses(bool first = true, bool second = true) {
@@ -269,7 +268,6 @@ private:
 		}
 	}
 	void setupTrackCreation() const;
-	ActionResult clipCreationButtonPressed(hid::Button i, bool on, bool routine);
 	void exitTrackCreation();
 };
 


### PR DESCRIPTION
When you press a pad in an empty track column, a menu will appear asking you to confirm the clip type you wish to create

The last created clip type is displayed as the current selection in the menu when it opens

You can change the selection using the select encoder

You can confirm selection of the clip type to create by:
- pressing on select encoder
- letting go of the pad you're holding
- or pressing one of the clip type buttons

Back cancels out of the menu and does not create a clip

If you do not create a clip, the next time the menu opens it will open will the last created clip as the selection

You can short press a pad to quickly create the last created clip type

---

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2482 bug where new kit clip's weren't getting setup properly