### PR TITLE
Update mod button popup for Delay Sync

### DIFF
--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1747,7 +1747,7 @@ void ModControllableAudio::displayDelaySettings(bool on) {
 				popupMsg.append("Type: ");
 				popupMsg.append(getDelaySyncTypeDisplayName());
 
-				popupMsg.append("\nLevel: ");
+				popupMsg.append("\nSync: ");
 				char displayName[30];
 				getDelaySyncLevelDisplayName(displayName);
 				popupMsg.append(displayName);


### PR DESCRIPTION
Updated mod button popup for Delay Sync so that it shows the word Sync instead of Level