### PR TITLE
Bugfix/ensure file paths are unique in both temp and main folders

### DIFF
--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -265,7 +265,9 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 	if (error != Error::NONE) {
 		return error;
 	}
-
+	// this caches the last used numbers in the main folders to avoid repeated reads. This is probably good there since
+	// some people have hundreds of recordings, but it's unnecessary for song specific folders since the number of
+	// recordings will be much smaller
 	if (highestUsedAudioRecordingNumberNeedsReChecking[folderID]) {
 
 		FRESULT result = f_opendir(&staticDIR, audioRecordingFolderNames[folderID]);
@@ -320,7 +322,7 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		}
 	}
 
-	// default to putting it in the normal spot if the song isn't named
+	// default to putting it in the main folder if the song isn't named
 	if (songName->isEmpty()) {
 		error = filePath->concatenate("/REC");
 		if (error != Error::NONE) {
@@ -335,24 +337,47 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 			return error;
 		}
 		highestUsedAudioRecordingNumber[folderID]++;
+
+		if (doingTempFolder) {
+			error =
+			    tempFilePathForRecording->concatenate(&filePath->get()[strlen(audioRecordingFolderNames[folderID])]);
+			if (error != Error::NONE) {
+				return error;
+			}
+		}
 	}
+	// otherwise file it under the song name
 	else {
 		char namedPath[255]{0};
-		snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_000.wav", filePath->get(), songName->get(), channelName);
-		int i = 1;
-		while (StorageManager::fileExists(namedPath)) {
+		char tempPath[255]{0};
+		int i = 0;
+		bool changed = true;
+		// iterate through the main and temp folders until we find a path that's free in both
+		while (changed) {
+			changed = false;
 			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath->get(), songName->get(), channelName,
 			         i);
-			i++;
+			while (StorageManager::fileExists(namedPath)) {
+				snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath->get(), songName->get(),
+				         channelName, i);
+				i++;
+				changed = true;
+			}
+			snprintf(tempPath, sizeof(tempPath), "%s/%s/%s_%03d.wav", tempFilePathForRecording->get(), songName->get(),
+			         channelName, i);
+
+			while (StorageManager::fileExists(tempPath)) {
+				snprintf(tempPath, sizeof(tempPath), "%s/%s/%s_%03d.wav", tempFilePathForRecording->get(),
+				         songName->get(), channelName, i);
+				i++;
+				changed = true;
+			}
 		}
 		error = filePath->set(namedPath);
 		if (error != Error::NONE) {
 			return error;
 		}
-	}
-
-	if (doingTempFolder) {
-		error = tempFilePathForRecording->concatenate(&filePath->get()[strlen(audioRecordingFolderNames[folderID])]);
+		error = tempFilePathForRecording->set(tempPath);
 		if (error != Error::NONE) {
 			return error;
 		}

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -100,6 +100,8 @@ public:
 	Error setupAlternateAudioFilePath(String* newPath, int32_t dirPathLength, String* oldPath);
 	Error setupAlternateAudioFileDir(String* newPath, char const* rootDir, String* songFilenameWithoutExtension);
 	bool loadingQueueHasAnyLowestPriorityElements();
+	/// If songname isn't supplied the file is placed in the main recording folder and named as samples/folder/REC###.
+	/// If song and channel are supplied then it's placed in samples/folder/song/channel_###
 	Error getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
 	                                      AudioRecordingFolder folder, uint32_t* getNumber, const char* channelName,
 	                                      String* songName);


### PR DESCRIPTION
Make sure that the file number to be used is unique in both the temp and main folder

Fixes a bug where numbers could get reused as the files hadn't been moved out of temp yet and the name generator only checked the main folders, causing samples to be overwritten when the song was saved