### PR TITLE
Fix: Don't blink cross screen button in audio clip view

### DIFF
--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -83,6 +83,7 @@ void AudioClipView::focusRegained() {
 	ClipView::focusRegained();
 	endMarkerVisible = false;
 	indicator_leds::setLedState(IndicatorLED::BACK, false);
+	indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
 	view.focusRegained();
 	view.setActiveModControllableTimelineCounter(getCurrentClip());
 


### PR DESCRIPTION
When entering audio clip from grid view, the cross screen button which was blinking in grid view (to indicate that it's an audio clip) was persisting after entering the clip. Fix by setting the led to false when you've entered the audio clip view.