### PR TITLE
Update clip compressor menu to show decimals

### DIFF
--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -129,7 +129,7 @@ public:
 	q31_t getSidechain() { return sideChainKnobPos; }
 
 	/// Get the current sidechain cutoff frequency in hertz.
-	[[nodiscard]] inline constexpr int32_t getSidechainForDisplay() const { return fc_hz; }
+	[[nodiscard]] inline constexpr float getSidechainForDisplay() const { return fc_hz; }
 
 	/// Set the sidechain cutoff frequency from a full-scale (0 to 2^31) integer.
 	///

--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -69,10 +69,7 @@ public:
 	[[nodiscard]] inline constexpr q31_t getAttack() const { return attackKnobPos; }
 
 	/// Get the current attack time constant in MS for a 3db change
-	///
-	/// @todo This currently rounds (down) to the nearest millisecond, it would probably be nice to expose at least a
-	/// little more of the underlying precsision.
-	[[nodiscard]] inline constexpr int32_t getAttackMS() const { return attackMS; }
+	[[nodiscard]] inline constexpr float getAttackMS() const { return attackMS; }
 
 	/// Set the attack time constant from a full-scale (0 to 2^31) number.
 	///
@@ -87,11 +84,9 @@ public:
 
 	/// Get the current release time constant in terms of the full knob range (0 to 2^31)
 	[[nodiscard]] inline constexpr q31_t getRelease() const { return releaseKnobPos; }
+
 	/// Get the current release time constant in MS for a 3db change
-	///
-	/// @todo This currently rounds (down) to the nearest millisecond, it would probably be nice to expose at least a
-	/// little more of the underlying precsision.
-	[[nodiscard]] inline constexpr int32_t getReleaseMS() const { return releaseMS; }
+	[[nodiscard]] inline constexpr float getReleaseMS() const { return releaseMS; }
 
 	/// Set the release time constant from a full-scale (0 to 2^31) number.
 	///
@@ -117,11 +112,8 @@ public:
 	/// Get the current ratio as a full-scale (0 to 2^31) number
 	[[nodiscard]] inline constexpr q31_t getRatio() const { return ratioKnobPos; }
 
-	/// Get the current ratio as an integer
-	///
-	/// @todo Thsi currently rounds (down) to the nearest integer, it would be nice to expose at least a little more of
-	/// the underlying precision.
-	[[nodiscard]] inline constexpr int32_t getRatioForDisplay() const { return ratio; }
+	/// Get the current ratio as a float
+	[[nodiscard]] inline constexpr float getRatioForDisplay() const { return ratio; }
 
 	/// Set the ratio based on a full-scale (0 to 2^31) number.
 	///

--- a/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
+++ b/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "definitions_cxx.hpp"
+#include "gui/menu_item/decimal.h"
 #include "gui/menu_item/integer.h"
 #include "gui/ui/sound_editor.h"
 #include "model/mod_controllable/mod_controllable_audio.h"
@@ -7,9 +8,9 @@
 #include "util/fixedpoint.h"
 
 namespace deluge::gui::menu_item::audio_compressor {
-class Attack final : public Integer {
+class Attack final : public DecimalWithoutScrolling {
 public:
-	using Integer::Integer;
+	using DecimalWithoutScrolling::DecimalWithoutScrolling;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getAttack();
 		this->setValue(value >> 24);
@@ -21,13 +22,13 @@ public:
 			soundEditor.currentModControllable->compressor.setAttack(knobPos);
 		}
 	}
-	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getAttackMS(); }
+	float getDisplayValue() override { return soundEditor.currentModControllable->compressor.getAttackMS(); }
 	const char* getUnit() override { return " MS"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
-class Release final : public Integer {
+class Release final : public DecimalWithoutScrolling {
 public:
-	using Integer::Integer;
+	using DecimalWithoutScrolling::DecimalWithoutScrolling;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getRelease();
 		this->setValue(value >> 24);
@@ -39,13 +40,13 @@ public:
 			soundEditor.currentModControllable->compressor.setRelease(knobPos);
 		}
 	}
-	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getReleaseMS(); }
+	float getDisplayValue() override { return soundEditor.currentModControllable->compressor.getReleaseMS(); }
 	const char* getUnit() override { return " MS"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
-class Ratio final : public Integer {
+class Ratio final : public DecimalWithoutScrolling {
 public:
-	using Integer::Integer;
+	using DecimalWithoutScrolling::DecimalWithoutScrolling;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getRatio();
 		this->setValue(value >> 24);
@@ -57,7 +58,7 @@ public:
 			soundEditor.currentModControllable->compressor.setRatio(knobPos);
 		}
 	}
-	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getRatioForDisplay(); }
+	float getDisplayValue() override { return soundEditor.currentModControllable->compressor.getRatioForDisplay(); }
 	const char* getUnit() override { return " : 1"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };

--- a/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
+++ b/src/deluge/gui/menu_item/audio_compressor/compressor_values.h
@@ -23,8 +23,9 @@ public:
 		}
 	}
 	float getDisplayValue() override { return soundEditor.currentModControllable->compressor.getAttackMS(); }
-	const char* getUnit() override { return " MS"; }
+	const char* getUnit() override { return "MS"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
+	[[nodiscard]] int32_t getNumDecimalPlaces() const final { return 2; }
 };
 class Release final : public DecimalWithoutScrolling {
 public:
@@ -41,8 +42,9 @@ public:
 		}
 	}
 	float getDisplayValue() override { return soundEditor.currentModControllable->compressor.getReleaseMS(); }
-	const char* getUnit() override { return " MS"; }
+	const char* getUnit() override { return "MS"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
+	[[nodiscard]] int32_t getNumDecimalPlaces() const final { return 1; }
 };
 class Ratio final : public DecimalWithoutScrolling {
 public:
@@ -61,10 +63,11 @@ public:
 	float getDisplayValue() override { return soundEditor.currentModControllable->compressor.getRatioForDisplay(); }
 	const char* getUnit() override { return " : 1"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
+	[[nodiscard]] int32_t getNumDecimalPlaces() const final { return 2; }
 };
-class SideHPF final : public Integer {
+class SideHPF final : public DecimalWithoutScrolling {
 public:
-	using Integer::Integer;
+	using DecimalWithoutScrolling::DecimalWithoutScrolling;
 	void readCurrentValue() override {
 		auto value = (uint64_t)soundEditor.currentModControllable->compressor.getSidechain();
 		this->setValue(value >> 24);
@@ -76,11 +79,10 @@ public:
 			soundEditor.currentModControllable->compressor.setSidechain(knobPos);
 		}
 	}
-	int32_t getDisplayValue() override {
-		return soundEditor.currentModControllable->compressor.getSidechainForDisplay();
-	}
-	const char* getUnit() override { return " HZ"; }
+	float getDisplayValue() override { return soundEditor.currentModControllable->compressor.getSidechainForDisplay(); }
+	const char* getUnit() override { return "HZ"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
+	[[nodiscard]] int32_t getNumDecimalPlaces() const final { return 2; }
 };
 class Blend final : public Integer {
 public:
@@ -100,7 +102,7 @@ public:
 		}
 	}
 	int32_t getDisplayValue() override { return soundEditor.currentModControllable->compressor.getBlendForDisplay(); }
-	const char* getUnit() override { return " %"; }
+	const char* getUnit() override { return "%"; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxKnobPos; }
 };
 } // namespace deluge::gui::menu_item::audio_compressor

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -191,4 +191,35 @@ void Decimal::drawActualValue(bool justDidHorizontalScroll) {
 	                 false); // blinkImmediately
 }
 
+void DecimalWithoutScrolling::selectEncoderAction(int32_t offset) {
+	this->setValue(this->getValue() + offset);
+	int32_t maxValue = getMaxValue();
+	if (this->getValue() > maxValue) {
+		this->setValue(maxValue);
+	}
+	else {
+		int32_t minValue = getMinValue();
+		if (this->getValue() < minValue) {
+			this->setValue(minValue);
+		}
+	}
+
+	Number::selectEncoderAction(offset);
+}
+
+void DecimalWithoutScrolling::drawDecimal(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
+	char buffer[12];
+	intToString(getDisplayValue(), buffer, 1);
+	strncat(buffer, getUnit(), 4);
+	deluge::hid::display::OLED::main.drawStringCentred(buffer, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
+}
+
+void DecimalWithoutScrolling::drawPixelsForOled() {
+	drawDecimal(kTextHugeSpacingX, kTextHugeSizeY, 18);
+}
+
+void DecimalWithoutScrolling::drawActualValue(bool justDidHorizontalScroll) {
+	display->setTextAsNumber(std::round(getDisplayValue()));
+}
+
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -208,8 +208,9 @@ void DecimalWithoutScrolling::selectEncoderAction(int32_t offset) {
 }
 
 void DecimalWithoutScrolling::drawDecimal(int32_t textWidth, int32_t textHeight, int32_t yPixel) {
+	int32_t numDecimalPlaces = getNumDecimalPlaces();
 	char buffer[12];
-	intToString(getDisplayValue(), buffer, 1);
+	floatToString(getDisplayValue(), buffer, numDecimalPlaces, numDecimalPlaces);
 	strncat(buffer, getUnit(), 4);
 	deluge::hid::display::OLED::main.drawStringCentred(buffer, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
 }
@@ -219,7 +220,17 @@ void DecimalWithoutScrolling::drawPixelsForOled() {
 }
 
 void DecimalWithoutScrolling::drawActualValue(bool justDidHorizontalScroll) {
-	display->setTextAsNumber(std::round(getDisplayValue()));
+	int32_t dotPos;
+	float displayValue = getDisplayValue();
+	int32_t numDecimalPlaces = displayValue > 100 ? 1 : 2;
+	char buffer[12];
+	floatToString(displayValue, buffer, numDecimalPlaces, numDecimalPlaces);
+	if (numDecimalPlaces) {
+		dotPos = 3 - numDecimalPlaces;
+	}
+	else {
+		dotPos = 255;
+	}
+	display->setText(buffer, dotPos);
 }
-
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/decimal.h
+++ b/src/deluge/gui/menu_item/decimal.h
@@ -25,7 +25,7 @@ class Decimal : public Number {
 public:
 	using Number::Number;
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override;
-	void selectEncoderAction(int32_t offset) final;
+	void selectEncoderAction(int32_t offset) override;
 	void horizontalEncoderAction(int32_t offset) override;
 
 protected:
@@ -33,13 +33,30 @@ protected:
 	[[nodiscard]] virtual int32_t getNumDecimalPlaces() const = 0;
 	[[nodiscard]] virtual int32_t getDefaultEditPos() const { return 2; }
 
-	void drawPixelsForOled() override;
+	virtual void drawPixelsForOled() override;
 
 	// 7Seg Only
 	virtual void drawActualValue(bool justDidHorizontalScroll = false);
 
 private:
 	void scrollToGoodPos();
+};
+
+class DecimalWithoutScrolling : public Decimal {
+	using Decimal::Decimal;
+
+public:
+	void selectEncoderAction(int32_t offset) override;
+	void horizontalEncoderAction(int32_t offset) override { return; }
+
+protected:
+	virtual float getDisplayValue() { return this->getValue(); }
+	virtual const char* getUnit() { return ""; }
+
+	void drawPixelsForOled() override;
+	void drawDecimal(int32_t textWidth, int32_t textHeight, int32_t yPixel);
+	// 7Seg Only
+	void drawActualValue(bool justDidHorizontalScroll = false) override;
 };
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2053,7 +2053,8 @@ doCutModFXTail:
 					default:
 						waitSamplesModfx = (90 * 441);
 					}
-					int32_t waitSamples = std::max(waitSamplesModfx, compressor.getReleaseMS() * 44);
+					int32_t waitSamples =
+					    std::max(waitSamplesModfx, static_cast<int32_t>(compressor.getReleaseMS() * 44));
 					startSkippingRenderingAtTime = AudioEngine::audioSampleTimer + waitSamples;
 				}
 


### PR DESCRIPTION
Added decimals to clip compressor menu's for Ratio, Attack, Release, HPF

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2483