### PR TITLE
Add Vibrato and Sidechain Patch Cables Grid Shortcuts to Automation View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > To find a detailed list of how to use each feature, check here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/community_features.md)
 
+## c1.3.0
+
+### User Interface
+
+- Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
+
 ## c1.2.0 Chopin
 
 ### Sound Engine

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -776,7 +776,8 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 			if (!onArrangerView
 			    && ((outputType == OutputType::SYNTH || (outputType == OutputType::KIT && !getAffectEntire()))
 			        && ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-			            || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)))) {
+			            || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+			            || params::isPatchCableShortcut(xDisplay, yDisplay)))) {
 
 				if (patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
 					modelStackWithParam =
@@ -795,6 +796,14 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 					modelStackWithParam = getModelStackWithParamForClip(
 					    modelStackWithTimelineCounter, clip, unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay],
 					    params::Kind::UNPATCHED_SOUND);
+				}
+
+				else if (params::isPatchCableShortcut(xDisplay, yDisplay)) {
+					ParamDescriptor paramDescriptor;
+					params::getPatchCableFromShortcut(xDisplay, yDisplay, &paramDescriptor);
+
+					modelStackWithParam = getModelStackWithParamForClip(
+					    modelStackWithTimelineCounter, clip, paramDescriptor.data, params::Kind::PATCH_CABLE);
 				}
 			}
 
@@ -1575,12 +1584,8 @@ void AutomationView::getAutomationParameterName(Clip* clip, OutputType outputTyp
 				source2 = paramDescriptor.getTopLevelSource();
 			}
 
-			if (source2 == PatchSource::NONE) {
-				parameterName.append(getSourceDisplayNameForOLED(lastSelectedPatchSource));
-			}
-			else {
-				parameterName.append(sourceToStringShort(lastSelectedPatchSource));
-			}
+			parameterName.append(sourceToStringShort(lastSelectedPatchSource));
+
 			if (display->haveOLED()) {
 				parameterName.append(" -> ");
 			}
@@ -2567,7 +2572,8 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	             || (outputType == OutputType::KIT && !getAffectEntire() && ((Kit*)output)->selectedDrum
 	                 && ((Kit*)output)->selectedDrum->type == DrumType::SOUND))
 	         && ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-	             || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID))) {
+	             || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+	             || params::isPatchCableShortcut(xDisplay, yDisplay))) {
 		// don't allow automation of portamento in kit's
 		if ((outputType == OutputType::KIT)
 		    && (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] == params::UNPATCHED_PORTAMENTO)) {
@@ -2580,13 +2586,21 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 			clip->lastSelectedParamKind = params::Kind::PATCHED;
 			clip->lastSelectedParamID = patchedParamShortcuts[xDisplay][yDisplay];
 		}
-
 		else if (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID) {
 			clip->lastSelectedParamKind = params::Kind::UNPATCHED_SOUND;
 			clip->lastSelectedParamID = unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay];
 		}
+		else if (params::isPatchCableShortcut(xDisplay, yDisplay)) {
+			ParamDescriptor paramDescriptor;
+			params::getPatchCableFromShortcut(xDisplay, yDisplay, &paramDescriptor);
+			clip->lastSelectedParamKind = params::Kind::PATCH_CABLE;
+			clip->lastSelectedParamID = paramDescriptor.data;
+			clip->lastSelectedPatchSource = paramDescriptor.getBottomLevelSource();
+		}
 
-		getLastSelectedNonGlobalParamArrayPosition(clip);
+		if (clip->lastSelectedParamKind != params::Kind::PATCH_CABLE) {
+			getLastSelectedNonGlobalParamArrayPosition(clip);
+		}
 	}
 
 	// if you are in arranger, an audio clip, or a kit clip with affect entire enabled

--- a/src/deluge/modulation/params/param.cpp
+++ b/src/deluge/modulation/params/param.cpp
@@ -23,20 +23,20 @@
 
 namespace deluge::modulation::params {
 
-bool isParamBipolar(params::Kind kind, int32_t paramID) {
-	return (kind == params::Kind::PATCH_CABLE) || isParamPan(kind, paramID) || isParamPitch(kind, paramID);
+bool isParamBipolar(Kind kind, int32_t paramID) {
+	return (kind == Kind::PATCH_CABLE) || isParamPan(kind, paramID) || isParamPitch(kind, paramID);
 }
 
-bool isParamPan(params::Kind kind, int32_t paramID) {
-	return (kind == params::Kind::PATCHED && paramID == LOCAL_PAN)
-	       || (kind == params::Kind::UNPATCHED_GLOBAL && paramID == UNPATCHED_PAN);
+bool isParamPan(Kind kind, int32_t paramID) {
+	return (kind == Kind::PATCHED && paramID == LOCAL_PAN)
+	       || (kind == Kind::UNPATCHED_GLOBAL && paramID == UNPATCHED_PAN);
 }
 
-bool isParamArpRhythm(params::Kind kind, int32_t paramID) {
-	return (kind == params::Kind::UNPATCHED_SOUND && paramID == UNPATCHED_ARP_RHYTHM);
+bool isParamArpRhythm(Kind kind, int32_t paramID) {
+	return (kind == Kind::UNPATCHED_SOUND && paramID == UNPATCHED_ARP_RHYTHM);
 }
 
-bool isParamPitch(params::Kind kind, int32_t paramID) {
+bool isParamPitch(Kind kind, int32_t paramID) {
 	if (kind == Kind::PATCHED) {
 		return (paramID == LOCAL_PITCH_ADJUST) || (paramID == LOCAL_OSC_A_PITCH_ADJUST)
 		       || (paramID == LOCAL_OSC_B_PITCH_ADJUST) || (paramID == LOCAL_MODULATOR_0_PITCH_ADJUST)
@@ -50,16 +50,53 @@ bool isParamPitch(params::Kind kind, int32_t paramID) {
 	}
 }
 
-bool isParamStutter(params::Kind kind, int32_t paramID) {
-	return (kind == params::Kind::UNPATCHED_GLOBAL || kind == params::Kind::UNPATCHED_SOUND)
+bool isParamStutter(Kind kind, int32_t paramID) {
+	return (kind == Kind::UNPATCHED_GLOBAL || kind == Kind::UNPATCHED_SOUND)
 	       && static_cast<UnpatchedShared>(paramID) == UNPATCHED_STUTTER_RATE;
 }
 
-bool isParamQuantizedStutter(params::Kind kind, int32_t paramID) {
+bool isParamQuantizedStutter(Kind kind, int32_t paramID) {
 	if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::QuantizedStutterRate) != RuntimeFeatureStateToggle::On) {
 		return false;
 	}
 	return isParamStutter(kind, paramID);
+}
+
+bool isVibratoPatchCableShortcut(int32_t xDisplay, int32_t yDisplay) {
+	if (xDisplay == 6 && yDisplay == 2) {
+		return true;
+	}
+	return false;
+}
+
+bool isSidechainPatchCableShortcut(int32_t xDisplay, int32_t yDisplay) {
+	if (xDisplay == 10 && yDisplay == 2) {
+		return true;
+	}
+	return false;
+}
+
+bool isPatchCableShortcut(int32_t xDisplay, int32_t yDisplay) {
+	// vibrato shortcut
+	if (isVibratoPatchCableShortcut(xDisplay, yDisplay)) {
+		return true;
+	}
+	// sidechain volume ducking shortcut
+	else if (isSidechainPatchCableShortcut(xDisplay, yDisplay)) {
+		return true;
+	}
+	return false;
+}
+
+void getPatchCableFromShortcut(int32_t xDisplay, int32_t yDisplay, ParamDescriptor* paramDescriptor) {
+	// vibrato shortcut
+	if (isVibratoPatchCableShortcut(xDisplay, yDisplay)) {
+		paramDescriptor->setToHaveParamAndSource(LOCAL_PITCH_ADJUST, PatchSource::LFO_GLOBAL);
+	}
+	// sidechain volume ducking shortcut
+	else if (isSidechainPatchCableShortcut(xDisplay, yDisplay)) {
+		paramDescriptor->setToHaveParamAndSource(GLOBAL_VOLUME_POST_REVERB_SEND, PatchSource::SIDECHAIN);
+	}
 }
 
 char const* getPatchedParamShortName(ParamType type) {

--- a/src/deluge/modulation/params/param.h
+++ b/src/deluge/modulation/params/param.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "modulation/params/param_descriptor.h"
 #include "util/misc.h"
 #include <algorithm>
 #include <cstdint>
@@ -240,6 +241,11 @@ bool isParamPitch(Kind kind, int32_t paramID);
 bool isParamArpRhythm(Kind kind, int32_t paramID);
 bool isParamStutter(Kind kind, int32_t paramID);
 bool isParamQuantizedStutter(Kind kind, int32_t paramID);
+
+bool isVibratoPatchCableShortcut(int32_t xDisplay, int32_t yDisplay);
+bool isSidechainPatchCableShortcut(int32_t xDisplay, int32_t yDisplay);
+bool isPatchCableShortcut(int32_t xDisplay, int32_t yDisplay);
+void getPatchCableFromShortcut(int32_t xDisplay, int32_t yDisplay, ParamDescriptor* paramDescriptor);
 
 char const* getPatchedParamDisplayName(int32_t p);
 /// Get the short version of a param name, for use in the OLED mod matrix display (maximum 10 characters)


### PR DESCRIPTION
Added Vibrato and Sidechain patch cables to the Automation View Overview grid and grid shortcuts.

Also shortened patch source name shown on OLED display for patch cables in automation view

Requested here https://github.com/SynthstromAudible/DelugeFirmware/discussions/2497