### PR TITLE
Bugfix/arranger recording

### DIFF
--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -308,7 +308,8 @@ void AudioClip::processCurrentPos(ModelStackWithTimelineCounter* modelStack, uin
 	// If at pos 0, that's the only place where anything really important happens: play the Sample
 	// also play it if we're auto extending and we just did that
 	if (!lastProcessedPos || lastProcessedPos == nextSampleRestartPos) {
-		if (getCurrentlyRecordingLinearly()) {
+		// original length is only 0 when recording into arranger, in which case we don't want to loop
+		if (getCurrentlyRecordingLinearly() && originalLength != 0) {
 			nextSampleRestartPos = lastProcessedPos + originalLength;
 			// make sure we come back here later
 			if (originalLength < playbackHandler.swungTicksTilNextEvent) {

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -629,7 +629,11 @@ void PlaybackHandler::actionTimerTick() {
 
 	// Do any swung ticks up to and including now.
 	// Warning - this could do a song swap and reset a bunch of stuff
-	while (lastSwungTickActioned + swungTicksTilNextEvent <= lastTimerTickActioned) {
+	while (lastSwungTickActioned + swungTicksTilNextEvent < lastTimerTickActioned) {
+		actionSwungTick();
+	}
+	// avoid infinite loop when swung ticks til next event is 0 (e.g. something wants to be rechecked next render)
+	if (lastSwungTickActioned + swungTicksTilNextEvent == lastTimerTickActioned) {
 		actionSwungTick();
 	}
 


### PR DESCRIPTION
Fix #2513 

Fixes a loop that could be infinite 

Change audio looping to avoid setting next tick to 0 when not necessary 