### PR TITLE
Bugfix/keep audio recording track through synth change

### DIFF
--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -219,6 +219,7 @@ public:
 		}
 		return false;
 	}
+	Output* getOutputRecordingThis() { return outputRecordingThisOutput; }
 
 protected:
 	virtual Clip* createNewClipForArrangementRecording(ModelStack* modelStack) = 0;

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3296,6 +3296,8 @@ void Song::replaceInstrument(Instrument* oldOutput, Instrument* newOutput, bool 
 		((MelodicInstrument*)oldOutput)->midiInput.clear();
 	}
 
+	Output* outputRecordingOldOutput = oldOutput->getOutputRecordingThis();
+
 	outputClipInstanceListIsCurrentlyInvalid = true;
 
 	// Tell all the Clips to change their Instrument.
@@ -3372,7 +3374,9 @@ traverseClips:
 
 	// Put the newInstrument into the master list
 	*prevPointer = newOutput;
-
+	if (outputRecordingOldOutput) {
+		((AudioOutput*)outputRecordingOldOutput)->setOutputRecordingFrom(newOutput, true);
+	}
 	AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 }
 


### PR DESCRIPTION
Related to #2519, keep the synth track monitoring via the audio track when changed if applicable