### PR TITLE
Bugfix/restore synth output if audio monitoring track is deleted

### DIFF
--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -45,6 +45,9 @@ AudioOutput::AudioOutput() : Output(OutputType::AUDIO) {
 }
 
 AudioOutput::~AudioOutput() {
+	if (outputRecordingFrom) {
+		outputRecordingFrom->setRenderingToAudioOutput(false, nullptr);
+	}
 }
 
 void AudioOutput::cloneFrom(ModControllableAudio* other) {


### PR DESCRIPTION
Fix #2517 