### PR TITLE
Fix LaunchStyle setting

### DIFF
--- a/src/deluge/gui/context_menu/clip_settings/launch_style.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/launch_style.cpp
@@ -12,14 +12,14 @@ namespace deluge::gui::context_menu::clip_settings {
 
 constexpr size_t kNumValues = 3;
 
-LaunchStyle launchStyle{};
+LaunchStyleMenu launchStyle{};
 
-char const* LaunchStyle::getTitle() {
+char const* LaunchStyleMenu::getTitle() {
 	static char const* title = "Clip Mode";
 	return title;
 }
 
-Sized<char const**> LaunchStyle::getOptions() {
+Sized<char const**> LaunchStyleMenu::getOptions() {
 	using enum l10n::String;
 	static const char* optionsls[] = {
 	    l10n::get(STRING_FOR_DEFAULT_LAUNCH),
@@ -29,7 +29,7 @@ Sized<char const**> LaunchStyle::getOptions() {
 	return {optionsls, kNumValues};
 }
 
-bool LaunchStyle::setupAndCheckAvailability() {
+bool LaunchStyleMenu::setupAndCheckAvailability() {
 	currentUIMode = UI_MODE_NONE;
 	this->currentOption = static_cast<int32_t>(clip->launchStyle);
 
@@ -40,7 +40,7 @@ bool LaunchStyle::setupAndCheckAvailability() {
 	return true;
 }
 
-void LaunchStyle::selectEncoderAction(int8_t offset) {
+void LaunchStyleMenu::selectEncoderAction(int8_t offset) {
 	ContextMenu::selectEncoderAction(offset);
 	clip->launchStyle = static_cast<::LaunchStyle>(this->currentOption);
 }

--- a/src/deluge/gui/context_menu/clip_settings/launch_style.h
+++ b/src/deluge/gui/context_menu/clip_settings/launch_style.h
@@ -13,10 +13,10 @@ class Clip;
 
 namespace deluge::gui::context_menu::clip_settings {
 
-class LaunchStyle final : public ContextMenu {
+class LaunchStyleMenu final : public ContextMenu {
 
 public:
-	LaunchStyle() = default;
+	LaunchStyleMenu() = default;
 	void selectEncoderAction(int8_t offset) override;
 	bool setupAndCheckAvailability();
 	bool canSeeViewUnderneath() override { return true; }
@@ -30,5 +30,5 @@ public:
 	Sized<const char**> getOptions() override;
 };
 
-extern LaunchStyle launchStyle;
+extern LaunchStyleMenu launchStyle;
 } // namespace deluge::gui::context_menu::clip_settings


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/2542
To cherry pick

There was some conflict with LaunchStyle menu and LaunchStyle enum being called the same and used in the same class. By renaming the menu to something different it seems to fix the issue