### PR TITLE
Bugfix/recording from audio and kit tracks

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -112,7 +112,7 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	}
 	q31_t compThreshold = unpatchedParams->getValue(params::UNPATCHED_COMPRESSOR_THRESHOLD);
 	compressor.setThreshold(compThreshold);
-	static StereoSample globalEffectableBuffer[SSI_TX_BUFFER_NUM_SAMPLES] __attribute__((aligned(CACHE_LINE_SIZE)));
+	StereoSample globalEffectableBuffer[SSI_TX_BUFFER_NUM_SAMPLES] __attribute__((aligned(CACHE_LINE_SIZE)));
 
 	memset(globalEffectableBuffer, 0, sizeof(StereoSample) * numSamples);
 


### PR DESCRIPTION
remove static and render onto stack since we can have nested global effectables