### PR TITLE
print error messages

### DIFF
--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -1178,6 +1178,7 @@ void OLED::displayError(Error error) {
 		break;
 	}
 	displayPopup(message);
+	D_PRINTLN(message);
 }
 
 } // namespace deluge::hid::display

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -692,5 +692,6 @@ void SevenSegment::displayError(Error error) {
 		break;
 	}
 	SevenSegment::displayPopup(message);
+	D_PRINTLN(message);
 }
 } // namespace deluge::hid::display


### PR DESCRIPTION
Just a dev convenience thing, log error messages in case the popup is replaced too quickly to read them