### PR TITLE
Bugfix/rendering of tempo and scale on OLED display in song and arranger views

### DIFF
--- a/src/deluge/gui/l10n/english.json
+++ b/src/deluge/gui/l10n/english.json
@@ -797,10 +797,6 @@
 
         "STRING_FOR_MIDILOOPBACK": "MIDI Loopback",
 
-        "STRING_FOR_SONG_VIEW": "Song",
-
-        "STRING_FOR_ARRANGER_VIEW": "Arranger",
-
         "STRING_FOR_KIT_GLOBAL_FX": "Kit FX",
         "STRING_FOR_PITCH": "Pitch",
 

--- a/src/deluge/gui/l10n/g_english.cpp
+++ b/src/deluge/gui/l10n/g_english.cpp
@@ -737,8 +737,6 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_PERFORM_DEFAULTS_LOADED, "Defaults Loaded"},
         {STRING_FOR_PERFORM_DEFAULTS_SAVED, "Defaults Saved"},
         {STRING_FOR_MIDILOOPBACK, "MIDI Loopback"},
-        {STRING_FOR_SONG_VIEW, "Song"},
-        {STRING_FOR_ARRANGER_VIEW, "Arranger"},
         {STRING_FOR_KIT_GLOBAL_FX, "Kit FX"},
         {STRING_FOR_PITCH, "Pitch"},
         {STRING_FOR_FOLLOW_TITLE, "Midi-Follow"},

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -813,18 +813,6 @@ enum class String : size_t {
 	STRING_FOR_PERFORM_DEFAULTS_LOADED,
 	STRING_FOR_PERFORM_DEFAULTS_SAVED,
 
-	/* Strings Specifically for Song View
-	 * session_view.cpp
-	 */
-
-	STRING_FOR_SONG_VIEW,
-
-	/* Strings Specifically for Arranger View
-	 * arranger_view.cpp
-	 */
-
-	STRING_FOR_ARRANGER_VIEW,
-
 	/* Strings for Kit Global FX Menu*/
 
 	STRING_FOR_KIT_GLOBAL_FX,

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1997,7 +1997,7 @@ void SessionView::renderViewDisplay(char const* viewString) {
 	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 #endif
 
-	canvas.drawStringCentred(viewString, yPos, kTextSpacingX, kTextSpacingY);
+	canvas.drawString(viewString, 0, yPos, kTextSpacingX, kTextSpacingY);
 
 	DEF_STACK_STRING_BUF(tempoBPM, 10);
 	lastDisplayedTempo = currentSong->calculateBPM();
@@ -2045,12 +2045,18 @@ void SessionView::displayTempoBPM(deluge::hid::display::oled_canvas::Canvas& can
                                   bool clearArea) {
 	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 
+	int32_t metronomeIconSpacingX = 7 + 3;
+
 	if (clearArea) {
-		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 6), OLED_MAIN_TOPMOST_PIXEL,
-		                      OLED_MAIN_WIDTH_PIXELS, yPos + kTextSpacingY);
+		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 6) - metronomeIconSpacingX,
+		                      OLED_MAIN_TOPMOST_PIXEL, OLED_MAIN_WIDTH_PIXELS - 1, yPos + kTextSpacingY);
 	}
 
 	canvas.drawStringAlignRight(tempoBPM.c_str(), yPos, kTextSpacingX, kTextSpacingY);
+
+	int32_t stringLength = tempoBPM.size();
+	int32_t metronomeIconStartX = OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * stringLength) - metronomeIconSpacingX;
+	canvas.drawGraphicMultiLine(deluge::hid::display::OLED::metronomeIcon, metronomeIconStartX, yPos, 7);
 }
 
 void SessionView::displayCurrentRootNoteAndScaleName(deluge::hid::display::oled_canvas::Canvas& canvas,
@@ -2059,7 +2065,7 @@ void SessionView::displayCurrentRootNoteAndScaleName(deluge::hid::display::oled_
 	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 32;
 
 	if (clearArea) {
-		canvas.clearAreaExact(0, yPos, OLED_MAIN_WIDTH_PIXELS, yPos + kTextSpacingY);
+		canvas.clearAreaExact(0, yPos, OLED_MAIN_WIDTH_PIXELS - 1, yPos + kTextSpacingY);
 	}
 
 	canvas.drawString(rootNoteAndScaleName.c_str(), 0, yPos, kTextSpacingX, kTextSpacingY);

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2046,7 +2046,7 @@ void SessionView::displayTempoBPM(deluge::hid::display::oled_canvas::Canvas& can
 	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 
 	if (clearArea) {
-		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 5), OLED_MAIN_TOPMOST_PIXEL,
+		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 7), OLED_MAIN_TOPMOST_PIXEL,
 		                      OLED_MAIN_WIDTH_PIXELS, yPos + kTextSpacingY);
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1865,8 +1865,7 @@ void SessionView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) 
 		view.displayOutputName(getCurrentClip()->output, true, getCurrentClip());
 	}
 	else if (currentUI != &performanceSessionView) {
-		renderViewDisplay(currentUI == &arrangerView ? l10n::get(l10n::String::STRING_FOR_ARRANGER_VIEW)
-		                                             : l10n::get(l10n::String::STRING_FOR_SONG_VIEW));
+		renderViewDisplay();
 	}
 
 	if (playbackHandler.isEitherClockActive()) {
@@ -1987,7 +1986,7 @@ void SessionView::displayRepeatsTilLaunch() {
 }
 
 /// render session view display on opening
-void SessionView::renderViewDisplay(char const* viewString) {
+void SessionView::renderViewDisplay() {
 	deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 	hid::display::OLED::clearMainImage();
 
@@ -1997,17 +1996,15 @@ void SessionView::renderViewDisplay(char const* viewString) {
 	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 #endif
 
-	canvas.drawString(viewString, 0, yPos, kTextSpacingX, kTextSpacingY);
-
 	DEF_STACK_STRING_BUF(tempoBPM, 10);
 	lastDisplayedTempo = currentSong->calculateBPM();
 	playbackHandler.getTempoStringForOLED(lastDisplayedTempo, tempoBPM);
 	displayTempoBPM(canvas, tempoBPM, false);
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
-	yPos = OLED_MAIN_TOPMOST_PIXEL + 31;
+	yPos = OLED_MAIN_TOPMOST_PIXEL + 30;
 #else
-	yPos = OLED_MAIN_TOPMOST_PIXEL + 18;
+	yPos = OLED_MAIN_TOPMOST_PIXEL + 17;
 #endif
 
 	char const* name;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2046,7 +2046,7 @@ void SessionView::displayTempoBPM(deluge::hid::display::oled_canvas::Canvas& can
 	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 
 	if (clearArea) {
-		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 7), OLED_MAIN_TOPMOST_PIXEL,
+		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 5), OLED_MAIN_TOPMOST_PIXEL,
 		                      OLED_MAIN_WIDTH_PIXELS, yPos + kTextSpacingY);
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2046,7 +2046,7 @@ void SessionView::displayTempoBPM(deluge::hid::display::oled_canvas::Canvas& can
 	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
 
 	if (clearArea) {
-		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 5), OLED_MAIN_TOPMOST_PIXEL,
+		canvas.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - (kTextSpacingX * 6), OLED_MAIN_TOPMOST_PIXEL,
 		                      OLED_MAIN_WIDTH_PIXELS, yPos + kTextSpacingY);
 	}
 

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -161,7 +161,7 @@ private:
 	void commandChangeLayout(int8_t offset);
 
 private:
-	void renderViewDisplay(char const* viewString);
+	void renderViewDisplay();
 	void sectionPadAction(uint8_t y, bool on);
 	void clipPressEnded();
 	void drawSectionRepeatNumber();

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1988,9 +1988,9 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 oledDrawString:
 			deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 #if OLED_MAIN_HEIGHT_PIXELS == 64
-			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 31;
+			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 30;
 #else
-			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 18;
+			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 17;
 #endif
 
 			int32_t textSpacingX = kTextTitleSpacingX;

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -130,6 +130,16 @@ const uint8_t OLED::submenuArrowIcon[] = {
     0b00000000, //<
 };
 
+const uint8_t OLED::metronomeIcon[] = {
+    0b11100000, //<
+    0b11011100, //<
+    0b11000011, //<
+    0b11100001, //<
+    0b11010011, //<
+    0b11011000, //<
+    0b11100100, //<
+};
+
 #if ENABLE_TEXT_OUTPUT
 uint16_t renderStartTime;
 #endif

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -134,6 +134,8 @@ const uint8_t OLED::submenuArrowIcon[] = {
 uint16_t renderStartTime;
 #endif
 
+bool drawnPermanentPopup = false;
+
 void OLED::clearMainImage() {
 #if ENABLE_TEXT_OUTPUT
 	renderStartTime = *TCNT[TIMER_SYSTEM_FAST];
@@ -143,6 +145,7 @@ void OLED::clearMainImage() {
 	stopScrollingAnimation();
 	main.clear();
 	markChanged();
+	drawnPermanentPopup = false;
 }
 
 void moveAreaUpCrude(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, int32_t delta, ImageStore image) {
@@ -342,6 +345,10 @@ bool OLED::isPopupPresent() {
 }
 bool OLED::isPopupPresentOfType(PopupType type) {
 	return oledPopupWidth && popupType == type;
+}
+
+bool OLED::isPermanentPopupPresent() {
+	return drawnPermanentPopup;
 }
 
 void copyRowWithMask(uint8_t destMask, uint8_t sourceRow[], uint8_t destRow[], int32_t minX, int32_t maxX) {
@@ -646,6 +653,8 @@ void OLED::drawPermanentPopupLookingText(char const* text) {
 		                textPixelY, kTextSpacingX, kTextSpacingY);
 		textPixelY += kTextSpacingY;
 	}
+
+	drawnPermanentPopup = true;
 }
 
 void OLED::popupText(char const* text, bool persistent, PopupType type) {

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -101,6 +101,7 @@ public:
 	static const uint8_t checkedBoxIcon[];
 	static const uint8_t uncheckedBoxIcon[];
 	static const uint8_t submenuArrowIcon[];
+	static const uint8_t metronomeIcon[];
 
 	void removeWorkingAnimation() override;
 	void timerRoutine() override;

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -55,6 +55,7 @@ public:
 	static void popupText(char const* text, bool persistent = false, PopupType type = PopupType::GENERAL);
 	static bool isPopupPresent();
 	static bool isPopupPresentOfType(PopupType type = PopupType::GENERAL);
+	static bool isPermanentPopupPresent();
 
 	static void displayWorkingAnimation(char const* word);
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5768,7 +5768,7 @@ void Song::displayCurrentRootNoteAndScaleName() {
 		UI* currentUI = getCurrentUI();
 		bool isSessionView = (currentUI == &sessionView || currentUI == &arrangerView);
 		// only display pop-up if we're using 7SEG or we're not currently in Song / Arranger View
-		if (isSessionView) {
+		if (isSessionView && !deluge::hid::display::OLED::isPermanentPopupPresent()) {
 			sessionView.displayCurrentRootNoteAndScaleName(deluge::hid::display::OLED::main, popupMsg, true);
 			deluge::hid::display::OLED::markChanged();
 			return;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2249,7 +2249,7 @@ float PlaybackHandler::calculateBPM(float timePerInternalTick) {
 }
 
 void PlaybackHandler::getTempoStringForOLED(float tempoBPM, StringBuf& buffer) {
-	if (currentSong->timePerTimerTickBig <= ((uint64_t)kMinTimePerTimerTick << 32)) {
+	if (tempoBPM >= 9999.5) {
 		buffer.append("FAST");
 	}
 	else {

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2253,7 +2253,8 @@ void PlaybackHandler::getTempoStringForOLED(float tempoBPM, StringBuf& buffer) {
 		buffer.append("FAST");
 	}
 	else {
-		buffer.appendFloat(tempoBPM, 1, 1);
+		int32_t numDecimalPlaces = tempoBPM >= 1000 ? 0 : 1;
+		buffer.appendFloat(tempoBPM, numDecimalPlaces, numDecimalPlaces);
 	}
 }
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2263,7 +2263,8 @@ void PlaybackHandler::displayTempoBPM(float tempoBPM) {
 	if (display->haveOLED()) {
 		UI* currentUI = getCurrentUI();
 		// if we're currently in song or arranger view, we'll render tempo on the display instead of a popup
-		if (currentUI == &sessionView || currentUI == &arrangerView) {
+		if ((currentUI == &sessionView || currentUI == &arrangerView)
+		    && !deluge::hid::display::OLED::isPermanentPopupPresent()) {
 			sessionView.lastDisplayedTempo = tempoBPM;
 			getTempoStringForOLED(tempoBPM, text);
 			sessionView.displayTempoBPM(deluge::hid::display::OLED::main, text, true);

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2253,8 +2253,8 @@ void PlaybackHandler::getTempoStringForOLED(float tempoBPM, StringBuf& buffer) {
 		buffer.append("FAST");
 	}
 	else {
-		int32_t numDecimalPlaces = tempoBPM >= 1000 ? 0 : 1;
-		buffer.appendFloat(tempoBPM, numDecimalPlaces, numDecimalPlaces);
+		int32_t numDecimalPlaces = tempoBPM >= 1000 ? 0 : 2;
+		buffer.appendFloat(tempoBPM, 0, numDecimalPlaces);
 	}
 }
 


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2568

- **Tempo rendering glitch:** Area being cleared was only 5 characters wide which was previously valid when Tempo didn't show a decimal place but didn't work when showing tempo values that are >= 1000. Fixed this by not rendering decimal places for tempo's >= 1000.
- **Update display of tempo's >= 9999.5:** on OLED when tempo is >= 9999.5, the display will show "FAST" to ensure that excessively big tempo's do not overlap with other text on the display.
- **Update display of tempo's < 1000**: on OLED tempo's less than 1000 will show up to 2 decimal places
- **Display tempo / scale pop-up when permanent pop-up is present:** Added a flag to indicate when a permanent pop-up is rendered on OLED display. Whenever there is a permanent pop-up, display tempo/transpose pop-up instead, otherwise updated tempo/scale info won't be legible / distort the permanent pop-up image / will be overwritten by the permanent pop-up (e.g. when it's a constantly refreshing loops remaining popup)
- **Display metronome icon before tempo**: metronome icon is now rendered before the tempo value
- **Removed Song and Arranger from Display**
- **Fixed vertical alignment of song and preset name on display**