### PR TITLE
Update Stem Export Folder Path and File Names

### DIFF
--- a/docs/features/stem_export.md
+++ b/docs/features/stem_export.md
@@ -12,9 +12,11 @@ Now with one quick action you can start a stem export job, walk away from your D
 
 Stems get exported to a new `SAMPLES/STEMS/` folder. 
 
-Within the `STEMS` folder, a folder with the `SONG NAME` is created for each stem export job which contains all the WAV file recordings. 
+Within the `STEMS` folder, when exporting stems, a folder with the `SONG NAME` is created if it does not already exist. Unsaved songs are saved with the song name `UNSAVED`. Thus, you will have a new folder named `SAMPLES/STEMS/SONG NAME/`.
 
-If the same SONG is exported more than once, a 5 digit number incremental number is appended to that song's folder name.
+Within the `SONG NAME` folder, a folder for the type of export (e.g. `ARRANGER` or `SONG`) is created for each stem export job which contains all the WAV file recordings.
+
+If the same SONG and EXPORT TYPE is exported more than once, a 2 digit number incremental number is appended to that export type's folder name (e.g. ARRANGER## or SONG##).
 
 ## Stem File Names
 
@@ -24,8 +26,8 @@ Stem's are given a meaningful name in the following format:
 
 > For example:
 > 
-> SYNTH_CLIP_PRESETNAME_00000.WAV
-> SYNTH_TRACK_PRESETNAME_00000.WAV
+> SYNTH_CLIP_PRESETNAME_000.WAV
+> SYNTH_TRACK_PRESETNAME_000.WAV
 
 ## Shortcuts to Start/Stop Stem Exporting
 

--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -69,6 +69,8 @@ StemExport::StemExport() {
 	includeSongFX = false;
 
 	timePlaybackStopped = 0xFFFFFFFF;
+
+	lastFolderNameForStemExport.clear();
 }
 
 /// starts stem export process which includes setting up UI mode, timer, and preparing

--- a/src/deluge/processing/stem_export/stem_export.h
+++ b/src/deluge/processing/stem_export/stem_export.h
@@ -81,7 +81,7 @@ public:
 	Error getUnusedStemRecordingFilePath(String* filePath, AudioRecordingFolder folder);
 	Error getUnusedStemRecordingFolderPath(String* filePath, AudioRecordingFolder folder);
 	int32_t highestUsedStemFolderNumber;
-	String lastSongNameForStemExport;
+	String lastFolderNameForStemExport;
 	void setWavFileNameForStemExport(StemExportType type, Output* output, int32_t fileNumber);
 	String wavFileNameForStemExport;
 	bool wavFileNameForStemExportSet;


### PR DESCRIPTION
### Description

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2564

> Currently we export stems to the following file path:
> 
> SAMPLES/STEMS/SONGNAME#####/FILENAME#####.WAV
> 
> The agreed upon change is to export stems to a single Song folder with no number incrementing after the Song name
> 
> Within each folder there will two folders for Arranger and Song exports
> 
> Arranger and Song exports will have a 2 digit number appended to the end for incremental stem exports
> 
> File names within each Arranger and Song folder will have a 3 digit number appended to them representing the unique ID of the track or clip being exported
> 
> Thus the stem file path will change to the following:
> 
> SAMPLES/STEMS/SONGNAME/ARRANGER##/FILENAME###.WAV
> 
> SAMPLES/STEMS/SONGNAME/SONG##/FILENAME###.WAV
> 
> In the future, when kit drum exporting is added, a KIT## folder will be added underneath ARRANGER## or SONG## depending on the type of exporting being done (eg is it being done from arranger, from song view or from within a kit clip)
> 
> So we would have the following file paths for Kit drums:
> 
> SAMPLES/STEMS/SONGNAME/ARRANGER##/KIT##/FILENAME###.WAV
>
> SAMPLES/STEMS/SONGNAME/SONG##/KIT##/FILENAME###.WAV