### PR TITLE
Bugfix/cross screen mode button handling

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -223,8 +223,8 @@ ActionResult ArrangerView::buttonAction(deluge::hid::Button b, bool on, bool inC
 	// Cross-screen button
 	else if (b == CROSS_SCREEN_EDIT) {
 		if (!on && currentUIMode == UI_MODE_NONE) {
-			// if cross screen button wasn't held
-			if (isShortPress(Buttons::timeCrossScreenButtonPressed)) {
+			// if another button wasn't pressed while cross screen was held
+			if (Buttons::considerCrossScreenReleaseForCrossScreenMode) {
 				currentSong->arrangerAutoScrollModeActive = !currentSong->arrangerAutoScrollModeActive;
 				indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, currentSong->arrangerAutoScrollModeActive);
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1948,8 +1948,8 @@ void AutomationView::handleClipButtonAction(bool on, bool isAudioClip) {
 // call by button action if b == CROSS_SCREEN_EDIT
 void AutomationView::handleCrossScreenButtonAction(bool on) {
 	if (!on && currentUIMode == UI_MODE_NONE) {
-		// if cross screen button wasn't held
-		if (isShortPress(Buttons::timeCrossScreenButtonPressed)) {
+		// if another button wasn't pressed while cross screen was held
+		if (Buttons::considerCrossScreenReleaseForCrossScreenMode) {
 			if (onArrangerView) {
 				currentSong->arrangerAutoScrollModeActive = !currentSong->arrangerAutoScrollModeActive;
 				indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, currentSong->arrangerAutoScrollModeActive);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -369,8 +369,8 @@ doOther:
 	// Wrap edit button
 	else if (b == CROSS_SCREEN_EDIT) {
 		if (!on && currentUIMode == UI_MODE_NONE) {
-			// if cross screen button wasn't held
-			if (isShortPress(Buttons::timeCrossScreenButtonPressed)) {
+			// if another button wasn't pressed while cross screen was held
+			if (Buttons::considerCrossScreenReleaseForCrossScreenMode) {
 				if (inCardRoutine) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 				}

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -38,7 +38,6 @@ namespace Buttons {
 
 bool recordButtonPressUsedUp;
 uint32_t timeRecordButtonPressed;
-uint32_t timeCrossScreenButtonPressed;
 /**
  * AudioEngine::audioSampleTimer value at which the shift button was pressed. Used to distinguish between short and
  * long shift presses, for sticky keys.
@@ -60,9 +59,14 @@ bool shiftCurrentlyStuck = false;
 bool shiftHasChangedSinceLastCheck;
 /**
  * Flag that represents whether another button was pressed while shift was held, and therefore we should ignore the
- * release of the shift for the purposes of enabling sticky keys.
+ * release of the shift for the purposes of toggling sticky shift.
  */
 bool considerShiftReleaseForSticky;
+/**
+ * Flag that represents whether another button was pressed while cross screen was held, and therefore we should ignore
+ * the release of the cross screen for the purposes of toggling cross screen mode.
+ */
+bool considerCrossScreenReleaseForCrossScreenMode;
 
 bool buttonStates[NUM_BUTTON_COLS + 1][NUM_BUTTON_ROWS]; // The extra col is for "fake" buttons
 
@@ -86,10 +90,13 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 #if ENABLE_MATRIX_DEBUG
 	D_PRINT("UI=%s, Button=%s, On=%d", getCurrentUI()->getName(), getButtonName(b), on);
 #endif
-	// If the user presses a different button while holding shift, don't consider the shift press for the purposes of
-	// enabling sticky keys.
 	if (on) {
+		// If the user presses a different button while holding shift, don't consider the shift press for the purposes
+		// of toggling sticky shift.
 		considerShiftReleaseForSticky = false;
+		// If the user presses a different button while holding cross screen, don't consider the cross screen press for
+		// for the purposes of toggling cross screen mode
+		considerCrossScreenReleaseForCrossScreenMode = false;
 	}
 
 	ActionResult result;
@@ -132,7 +139,8 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 	}
 	else if (b == CROSS_SCREEN_EDIT) {
 		if (on) {
-			timeCrossScreenButtonPressed = AudioEngine::audioSampleTimer;
+			// The next release has a chance of toggling cross screen mode
+			considerCrossScreenReleaseForCrossScreenMode = true;
 		}
 	}
 

--- a/src/deluge/hid/buttons.h
+++ b/src/deluge/hid/buttons.h
@@ -42,5 +42,5 @@ void clearShiftSticky();
 bool shiftHasChanged();
 
 extern bool recordButtonPressUsedUp;
-extern uint32_t timeCrossScreenButtonPressed;
+extern bool considerCrossScreenReleaseForCrossScreenMode;
 } // namespace Buttons


### PR DESCRIPTION
Cross screen button will now toggle cross screen mode on / off as long as you don't press another button while holding the cross screen button

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2556