### PR TITLE
Bugfix/Update rendering of preset names

### DIFF
--- a/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
+++ b/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
@@ -57,9 +57,42 @@ public:
 		}
 	}
 	void drawPixelsForOled() override {
-		char const* text = audioOutputBeingEdited->getOutputRecordingFrom()->name.get();
-		deluge::hid::display::OLED::main.drawStringCentred(text, 20 + OLED_MAIN_TOPMOST_PIXEL, kTextBigSpacingX,
-		                                                   kTextBigSizeY);
+		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+
+		// track
+		Output* output = currentSong->getOutputFromIndex(outputIndex);
+
+		// track type
+		OutputType outputType = output->type;
+
+		// for midi instruments, get the channel
+		int32_t channel;
+		if (outputType == OutputType::MIDI_OUT) {
+			Instrument* instrument = (Instrument*)output;
+			channel = ((NonAudioInstrument*)instrument)->channel;
+		}
+
+		char const* outputTypeText = getOutputTypeName(outputType, channel);
+
+		// draw the track type
+		canvas.drawStringCentred(outputTypeText, OLED_MAIN_TOPMOST_PIXEL + 14, kTextSpacingX, kTextSpacingY);
+
+		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 28;
+
+		// draw the track name
+		char const* name = audioOutputBeingEdited->getOutputRecordingFrom()->name.get();
+
+		int32_t stringLengthPixels = canvas.getStringWidthInPixels(name, kTextTitleSizeY);
+
+		if (stringLengthPixels <= OLED_MAIN_WIDTH_PIXELS) {
+			canvas.drawStringCentred(name, yPos, kTextTitleSpacingX, kTextTitleSizeY);
+		}
+		else {
+			canvas.drawString(name, 0, yPos, kTextTitleSpacingX, kTextTitleSizeY);
+			deluge::hid::display::OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos,
+			                                              yPos + kTextTitleSizeY, kTextTitleSpacingX, kTextTitleSizeY,
+			                                              false);
+		}
 	}
 
 	void drawFor7seg() {

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -1535,7 +1535,7 @@ doneMoving:
 		if (toReturn.error != Error::NONE) {
 			goto emptyFileItemsAndReturn;
 		}
-		view.drawOutputNameFromDetails(outputType, 0, 0, newName.get(), false, doBlink);
+		view.drawOutputNameFromDetails(outputType, 0, 0, newName.get(), newName.isEmpty(), false, doBlink);
 	}
 
 	if (display->haveOLED()) {

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -484,6 +484,7 @@ void AutomationView::focusRegained() {
 		if (clip->type == ClipType::AUDIO) {
 			indicator_leds::setLedState(IndicatorLED::BACK, false);
 			indicator_leds::setLedState(IndicatorLED::AFFECT_ENTIRE, true);
+			indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
 			view.focusRegained();
 			view.setActiveModControllableTimelineCounter(clip);
 		}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2015,18 +2015,15 @@ void SessionView::renderViewDisplay() {
 		name = currentSong->name.get();
 	}
 
-	int32_t textSpacingX = kTextTitleSpacingX;
-	int32_t textSpacingY = kTextTitleSizeY;
+	int32_t stringLengthPixels = canvas.getStringWidthInPixels(name, kTextTitleSizeY);
 
-	int32_t textLength = strlen(name);
-	int32_t stringLengthPixels = textLength * textSpacingX;
 	if (stringLengthPixels <= OLED_MAIN_WIDTH_PIXELS) {
-		canvas.drawStringCentred(name, yPos, textSpacingX, textSpacingY);
+		canvas.drawStringCentred(name, yPos, kTextTitleSpacingX, kTextTitleSizeY);
 	}
 	else {
-		canvas.drawString(name, 0, yPos, textSpacingX, textSpacingY);
-		deluge::hid::display::OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos, yPos + textSpacingY,
-		                                              textSpacingX, textSpacingY, false);
+		canvas.drawString(name, 0, yPos, kTextTitleSpacingX, kTextTitleSizeY);
+		deluge::hid::display::OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos, yPos + kTextTitleSizeY,
+		                                              kTextTitleSpacingX, kTextTitleSizeY, false);
 	}
 
 	yPos = OLED_MAIN_TOPMOST_PIXEL + 32;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1857,12 +1857,13 @@ void View::displayOutputName(Output* output, bool doBlink, Clip* clip) {
 		}
 	}
 
-	drawOutputNameFromDetails(output->type, channel, channelSuffix, output->name.get(), editedByUser, doBlink, clip);
+	drawOutputNameFromDetails(output->type, channel, channelSuffix, output->name.get(), output->name.isEmpty(),
+	                          editedByUser, doBlink, clip);
 	deluge::hid::display::OLED::markChanged();
 }
 
 void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int32_t channelSuffix, char const* name,
-                                     bool editedByUser, bool doBlink, Clip* clip) {
+                                     bool isNameEmpty, bool editedByUser, bool doBlink, Clip* clip) {
 	if (doBlink) {
 		using namespace indicator_leds;
 		LED led;
@@ -1938,34 +1939,7 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 		hid::display::OLED::clearMainImage();
 
-		char const* outputTypeText;
-		switch (outputType) {
-		case OutputType::SYNTH:
-			outputTypeText = "Synth";
-			break;
-		case OutputType::KIT:
-			outputTypeText = "Kit";
-			break;
-		case OutputType::MIDI_OUT:
-			if (channel < 16) {
-				outputTypeText = "MIDI";
-			}
-			else if (channel == MIDI_CHANNEL_MPE_LOWER_ZONE || channel == MIDI_CHANNEL_MPE_UPPER_ZONE) {
-				outputTypeText = "MPE";
-			}
-			else {
-				outputTypeText = "Internal";
-			}
-			break;
-		case OutputType::CV:
-			outputTypeText = "CV / gate";
-			break;
-		case OutputType::AUDIO:
-			outputTypeText = "Audio";
-			break;
-		default:
-			__builtin_unreachable();
-		}
+		char const* outputTypeText = getOutputTypeName(outputType, channel);
 
 #if OLED_MAIN_HEIGHT_PIXELS == 64
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
@@ -1978,7 +1952,7 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 	char buffer[12];
 	char const* nameToDraw = nullptr;
 
-	if (name && name[0]) {
+	if (!isNameEmpty) {
 		if (display->haveOLED()) {
 			nameToDraw = name;
 oledDrawString:
@@ -1989,18 +1963,16 @@ oledDrawString:
 			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 17;
 #endif
 
-			int32_t textSpacingX = kTextTitleSpacingX;
-			int32_t textSpacingY = kTextTitleSizeY;
+			int32_t stringLengthPixels = canvas.getStringWidthInPixels(nameToDraw, kTextTitleSizeY);
 
-			int32_t textLength = strlen(name);
-			int32_t stringLengthPixels = textLength * textSpacingX;
 			if (stringLengthPixels <= OLED_MAIN_WIDTH_PIXELS) {
-				canvas.drawStringCentred(nameToDraw, yPos, textSpacingX, textSpacingY);
+				canvas.drawStringCentred(nameToDraw, yPos, kTextTitleSpacingX, kTextTitleSizeY);
 			}
 			else {
-				canvas.drawString(nameToDraw, 0, yPos, textSpacingX, textSpacingY);
-				deluge::hid::display::OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos,
-				                                              yPos + textSpacingY, textSpacingX, textSpacingY, false);
+				canvas.drawString(nameToDraw, 0, yPos, kTextTitleSpacingX, kTextTitleSizeY);
+				deluge::hid::display::OLED::setupSideScroller(0, nameToDraw, 0, OLED_MAIN_WIDTH_PIXELS, yPos,
+				                                              yPos + kTextTitleSizeY, kTextTitleSpacingX,
+				                                              kTextTitleSizeY, false);
 			}
 
 			if (clip) {

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -90,7 +90,7 @@ public:
 	void navigateThroughAudioOutputsForAudioClip(int32_t offset, AudioClip* clip, bool doBlink = false);
 	bool changeOutputType(OutputType newOutputType, ModelStackWithTimelineCounter* modelStack, bool doBlink = false);
 	void drawOutputNameFromDetails(OutputType outputType, int32_t slot, int32_t subSlot, char const* name,
-	                               bool editedByUser, bool doBlink, Clip* clip = NULL);
+	                               bool isNameEmpty, bool editedByUser, bool doBlink, Clip* clip = NULL);
 	void endMIDILearn();
 	[[nodiscard]] RGB getClipMuteSquareColour(Clip* clip, RGB thisColour, bool allowMIDIFlash = true);
 	ActionResult clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfInSessionView = -1);

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -560,6 +560,31 @@ char const* getThingName(OutputType outputType) {
 	}
 }
 
+char const* getOutputTypeName(OutputType outputType, int32_t channel) {
+	switch (outputType) {
+	case OutputType::SYNTH:
+		return "Synth";
+	case OutputType::KIT:
+		return "Kit";
+	case OutputType::MIDI_OUT:
+		if (channel < 16) {
+			return "MIDI";
+		}
+		else if (channel == MIDI_CHANNEL_MPE_LOWER_ZONE || channel == MIDI_CHANNEL_MPE_UPPER_ZONE) {
+			return "MPE";
+		}
+		else {
+			return "Internal";
+		}
+	case OutputType::CV:
+		return "CV / gate";
+	case OutputType::AUDIO:
+		return "Audio";
+	default:
+		return "None";
+	}
+}
+
 void byteToHex(uint8_t number, char* buffer) {
 	buffer[0] = halfByteToHexChar(number >> 4);
 	buffer[1] = halfByteToHexChar(number & 15);

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -46,6 +46,7 @@ extern int32_t paramNeutralValues[];
 void functionsInit();
 
 char const* getThingName(OutputType outputType);
+char const* getOutputTypeName(OutputType outputType, int32_t channel);
 
 // bits must be *less* than 32! I.e. 31 or less
 [[gnu::always_inline]] inline int32_t signed_saturate_operand_unknown(int32_t val, int32_t bits) {


### PR DESCRIPTION
Updated rendering of preset names in Song View / Clip View / and in the Track Selection menu of Audio Clips

Fixes some weird scroll issues with song / preset names while in song / arranger / clip views.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2581