### PR TITLE
Bugfix/usb midi dropped messages

### DIFF
--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -19,6 +19,7 @@
 #include "device.h"
 #include "gui/ui/sound_editor.h"
 #include "hid/display/display.h"
+#include "io/debug/log.h"
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_device_manager.h"
 #include "util/container/static_vector.hpp"
@@ -85,16 +86,17 @@ void Devices::selectEncoderAction(int32_t offset) {
 		if (this->getValue() < currentScroll) {
 			currentScroll = this->getValue();
 		}
-
+		//
 		if (offset >= 0) {
 			int32_t d = this->getValue();
 			int32_t numSeen = 1;
-			while (true) {
+			while (d >= -4) {
 				d--;
 				if (d == currentScroll) {
 					break;
 				}
-				if (!getDevice(d)->connectionFlags) {
+				auto device = getDevice(d);
+				if (!(device && device->connectionFlags)) {
 					continue;
 				}
 				numSeen++;
@@ -152,7 +154,7 @@ void Devices::drawPixelsForOled() {
 	size_t row = 0;
 	while (row < kOLEDMenuNumOptionsVisible && device_idx < MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
 		MIDIDevice* device = getDevice(device_idx);
-		if (device->connectionFlags != 0u) {
+		if (device && device->connectionFlags != 0u) {
 			itemNames.push_back(device->getDisplayName());
 			if (device_idx == this->getValue()) {
 				selectedRow = static_cast<int32_t>(row);

--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -90,7 +90,7 @@ void Devices::selectEncoderAction(int32_t offset) {
 		if (offset >= 0) {
 			int32_t d = this->getValue();
 			int32_t numSeen = 1;
-			while (d >= -4) {
+			while (d > -4) {
 				d--;
 				if (d == currentScroll) {
 					break;
@@ -112,6 +112,10 @@ void Devices::selectEncoderAction(int32_t offset) {
 }
 
 MIDIDevice* Devices::getDevice(int32_t deviceIndex) {
+	if (deviceIndex < -4 || deviceIndex >= MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
+		D_PRINTLN("impossible device request");
+		return nullptr;
+	}
 	switch (deviceIndex) {
 	case -4: {
 		return &MIDIDeviceManager::dinMIDIPorts;

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -685,6 +685,10 @@ bool ConnectedUSBMIDIDevice::consumeSendData() {
 	if (g_usb_usbmode == USB_HOST) {
 		// many devices do not accept more than 64 bytes of data at a time
 		// likely this can be inferred from the device metadata somehow?
+
+		// some seem to take even less, especially with hubs involved. The hydrasynth seems to only respond to a max of
+		// 2 messages per transfer, the third gets blocked. For MPE this leads to ignoring note ons as the x and y
+		// resets are sent before the note on
 		max_size = MIDI_SEND_BUFFER_LEN_INNER_HOST;
 	}
 
@@ -704,6 +708,20 @@ void ConnectedUSBMIDIDevice::setup() {
 	numBytesReceived = 0;
 
 	// default to only a single port
+	maxPortConnected = 0;
+}
+ConnectedUSBMIDIDevice::ConnectedUSBMIDIDevice() {
+	currentlyWaitingToReceive = 0;
+	sq = 0;
+	canHaveMIDISent = 0;
+	numBytesReceived = 0;
+	memset(receiveData, 0, 64);
+	memset(dataSendingNow, 0, MIDI_SEND_BUFFER_LEN_INNER * 4);
+	numBytesSendingNow = 0;
+	memset(sendDataRingBuf, 0, MIDI_SEND_BUFFER_LEN_RING);
+	ringBufWriteIdx = 0;
+	ringBufReadIdx = 0;
+
 	maxPortConnected = 0;
 }
 

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -36,7 +36,8 @@ struct MIDIDeviceUSB;
 // NOTE: increasing this even more doesn't work.
 // Looks like a hardware limitation (maybe we more in FS mode)?
 #define MIDI_SEND_BUFFER_LEN_INNER 32
-#define MIDI_SEND_BUFFER_LEN_INNER_HOST 16
+// Seems to be the max for a hydrasynth on a usb hub?
+#define MIDI_SEND_BUFFER_LEN_INNER_HOST 2
 
 // MUST be an exact power of two
 #define MIDI_SEND_BUFFER_LEN_RING 1024
@@ -61,6 +62,7 @@ struct MIDIDeviceUSB;
 class ConnectedUSBMIDIDevice {
 public:
 	MIDIDeviceUSB* device[4]; // If NULL, then no device is connected here
+	ConnectedUSBMIDIDevice();
 	void bufferMessage(uint32_t fullMessage);
 	void setup();
 

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -36,7 +36,8 @@ struct MIDIDeviceUSB;
 // NOTE: increasing this even more doesn't work.
 // Looks like a hardware limitation (maybe we more in FS mode)?
 #define MIDI_SEND_BUFFER_LEN_INNER 32
-// Seems to be the max for a hydrasynth on a usb hub?
+// Seems to be the max for a hydrasynth on a usb hub? We should figure out how to find this from the device config but I
+// haven't seen anything below this yet. Widi bud's can do 3, both do fine at 16 without a hub involved
 #define MIDI_SEND_BUFFER_LEN_INNER_HOST 2
 
 // MUST be an exact power of two


### PR DESCRIPTION
Fixes some bugs around hosting multiple devices. The menu still doesn't look right (scrolling up gets weird) but it no longer crashes. Some issues with hubs and packing multiple midi messages into one USB packet are fixed by lowering our max size significantly, but that doesn't affect anything other than hubs and this seems to work fine.

I think the real downside would come from sending big sysex packets to a hosted device. We don't have any way to do that at the moment so it can be a future problem.

@bfredl fyi in case this impacts the sysex stuff

fix #2580 
fix #2476 