### PR TITLE
Bugfix - Automation View - Remove audio clip timestretching / Adjust audio clip length without time stretching

### DIFF
--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -51,6 +51,7 @@ public:
 	void setClipLengthEqualToSampleLength();
 	void adjustLoopLength(int32_t newLength);
 	ActionResult horizontalEncoderAction(int32_t offset) override;
+	ActionResult editClipLengthWithoutTimestretching(int32_t offset);
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
 	ActionResult timerCallback() override;
 	uint32_t getMaxLength() override;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1773,7 +1773,7 @@ ActionResult AutomationView::buttonAction(hid::Button b, bool on, bool inCardRou
 	}
 
 	// Horizontal encoder button
-	// Not relevant for audio clip or arranger view
+	// Not relevant for arranger view
 	else if (b == X_ENC) {
 		if (handleHorizontalEncoderButtonAction(on, isAudioClip)) {
 			goto passToOthers;
@@ -2057,12 +2057,24 @@ void AutomationView::handleCVButtonAction(OutputType outputType, bool on) {
 
 // called by button action if b == X_ENC
 bool AutomationView::handleHorizontalEncoderButtonAction(bool on, bool isAudioClip) {
-	if (isAudioClip || onArrangerView) {
+	if (onArrangerView) {
+		return true;
+	}
+	else if (isAudioClip) {
+		// removing time stretching by re-calculating clip length based on length of audio sample
+		if (on && Buttons::isButtonPressed(deluge::hid::button::Y_ENC) && currentUIMode == UI_MODE_NONE) {
+			audioClipView.setClipLengthEqualToSampleLength();
+			return false;
+		}
+		// if shift is pressed then we're resizing the clip without time stretching
+		else if (Buttons::isShiftButtonPressed()) {
+			return false;
+		}
 		return true;
 	}
 	// If user wants to "multiply" Clip contents
-	if (on && Buttons::isShiftButtonPressed() && !isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)
-	    && !onAutomationOverview()) {
+	else if (on && Buttons::isShiftButtonPressed() && !isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)
+	         && !onAutomationOverview()) {
 		if (isNoUIModeActive()) {
 			// Zoom to max if we weren't already there...
 			if (!zoomToMax()) {
@@ -3621,10 +3633,12 @@ getOut:
 	}
 }
 
-// horizontal encoder action
-// using this to shift automations left / right
-// using this to zoom in / out
-// using this to adjust velocity in note editor
+// horizontal encoder actions:
+// scroll left / right
+// zoom in / out
+// adjust clip length
+// shift automations left / right
+// adjust velocity in note editor
 ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 	if (sdRoutineLock) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE; // Just be safe - maybe not necessary
@@ -3731,10 +3745,16 @@ ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 		return ActionResult::DEALT_WITH;
 	}
 
+	// Shift and x pressed - edit length of audio clip without timestretching
+	else if (getCurrentClip()->type == ClipType::AUDIO && isNoUIModeActive()
+	         && Buttons::isButtonPressed(deluge::hid::button::X_ENC) && Buttons::isShiftButtonPressed()) {
+		ActionResult result = audioClipView.editClipLengthWithoutTimestretching(offset);
+		return result;
+	}
+
 	// Or, let parent deal with it
 	else {
 		ActionResult result = ClipView::horizontalEncoderAction(offset);
-		uiNeedsRendering(this);
 		return result;
 	}
 }

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -270,7 +270,7 @@ uint32_t ClipView::changeClipLength(int32_t offset, uint32_t oldLength, Action*&
 
 			if (!scrollRightToEndOfLengthIfNecessary(newLength)) {
 doReRender:
-				uiNeedsRendering(this, 0xFFFFFFFF, 0);
+				uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0);
 			}
 		}
 	}

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -35,7 +35,7 @@ void TimelineView::scrollFinished() {
 	exitUIMode(UI_MODE_HORIZONTAL_SCROLL);
 	// Needed because sometimes we initiate a scroll before reverting an Action, so we need to
 	// properly render again afterwards
-	uiNeedsRendering(this, 0xFFFFFFFF, 0);
+	uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0);
 }
 
 // Virtual function


### PR DESCRIPTION
Bugfix - Audio Clip Automation View

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2595

Add ability to remove audio clip timestretching / Adjust audio clip length without timestretching using audio clip button combos while in audio clip automation view

Fixed a rendering bug also with audio clip automation view which would cause flashing of the underlying audio clip waveform while scrolling