### PR TITLE
Bugfix change drum selection from keyboard view

### DIFF
--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -516,6 +516,19 @@ ActionResult KeyboardScreen::buttonAction(deluge::hid::Button b, bool on, bool i
 			bool result;
 			if (Buttons::isShiftButtonPressed()) {
 				result = createNewInstrument(OutputType::KIT);
+
+				// enter drum creator to select drum sample when creating new kit
+				if (result) {
+					char modelStackMemory[MODEL_STACK_MAX_SIZE];
+					ModelStackWithTimelineCounter* modelStack =
+						currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+
+					NoteRow* noteRow = getCurrentInstrumentClip()->noteRows.getElement(0);
+
+					ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(0, noteRow);
+
+					instrumentClipView.enterDrumCreator(modelStackWithNoteRow);
+				}
 			}
 			else {
 				result = changeOutputType(OutputType::KIT);

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -521,7 +521,7 @@ ActionResult KeyboardScreen::buttonAction(deluge::hid::Button b, bool on, bool i
 				if (result) {
 					char modelStackMemory[MODEL_STACK_MAX_SIZE];
 					ModelStackWithTimelineCounter* modelStack =
-						currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+					    currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
 					NoteRow* noteRow = getCurrentInstrumentClip()->noteRows.getElement(0);
 

--- a/src/deluge/gui/ui/keyboard/layout/velocity_drums.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/velocity_drums.cpp
@@ -17,6 +17,7 @@
 
 #include "gui/ui/keyboard/layout/velocity_drums.h"
 #include "hid/display/display.h"
+#include "model/instrument/kit.h"
 #include "util/functions.h"
 #include <stdint.h>
 
@@ -55,6 +56,14 @@ void KeyboardLayoutVelocityDrums::evaluatePads(PressedPad presses[kMaxNumKeyboar
 					currentNotesState.notes[noteOnIdx].velocity = velocity;
 					noteOnTimes[noteOnIdx] = thisOnTime;
 				}
+			}
+
+			// if this note was recently pressed, set it as the selected drum
+			if (isShortPress(noteOnTimes[noteOnIdx])) {
+				InstrumentClip* clip = getCurrentInstrumentClip();
+				Kit* thisKit = (Kit*)clip->output;
+				Drum* thisDrum = thisKit->getDrumFromNoteCode(clip, note);
+				instrumentClipView.setSelectedDrum(thisDrum);
 			}
 		}
 	}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3533,7 +3533,7 @@ void InstrumentClipView::setSelectedDrum(Drum* drum, bool shouldRedrawStuff, Kit
 			if (clip->output->type == OutputType::KIT) {
 				// are we currently in the instrument clip UI?
 				// if yes, we may need to refresh it (main pads and / or sidebar)
-				if (currentUI == &instrumentClipView || currentUI == &automationView) {
+				if (currentUI == &instrumentClipView || currentUI == &automationView || currentUI == &keyboardScreen) {
 					bool affectEntire = ((InstrumentClip*)clip)->affectEntire;
 
 					// don't reset mod controllable when affect entire is enabled because mod controllable is
@@ -3560,11 +3560,11 @@ void InstrumentClipView::setSelectedDrum(Drum* drum, bool shouldRedrawStuff, Kit
 					// or automation clip view (with affect entire enabled)
 					// or just auditioning the same drum selection
 					// redraw sidebar
-					else {
+					else if (currentUI != &keyboardScreen) {
 						renderingNeededRegardlessOfUI(0, 0xFFFFFFFF);
 					}
 				}
-				else {
+				else if (getRootUI() != &keyboardScreen) {
 					// Some other top-level view currently, don't overwrite the active ModControllable but do
 					// request rendering
 					renderingNeededRegardlessOfUI(0, 0xFFFFFFFF);

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -229,6 +229,9 @@ public:
 	void setRowProbability(int32_t offset);
 	void editNoteRepeat(int32_t offset);
 
+	// public so you can enter drum creator from keyboard view when creating a new kit
+	void enterDrumCreator(ModelStackWithNoteRow* modelStack, bool doRecording = false);
+
 private:
 	bool doneAnyNudgingSinceFirstEditPadPress;
 	bool offsettingNudgeNumberDisplay;
@@ -251,7 +254,6 @@ private:
 	Drum* flipThroughAvailableDrums(int32_t newOffset, Drum* drum, bool mayBeNone = false);
 	NoteRow* createNewNoteRowForKit(ModelStackWithTimelineCounter* modelStack, int32_t yDisplay,
 	                                int32_t* getIndex = NULL);
-	void enterDrumCreator(ModelStackWithNoteRow* modelStack, bool doRecording = false);
 	void displayProbability(uint8_t probability, bool prevBase);
 	void copyNotes();
 	void pasteNotes(bool overwriteExisting);

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -153,6 +153,8 @@ public:
 	                                                         deluge::modulation::params::Kind paramKind,
 	                                                         bool useMenuStack);
 
+	Drum* getDrumFromNoteCode(InstrumentClip* clip, int32_t noteCode);
+
 protected:
 	bool isKit() { return true; }
 
@@ -164,5 +166,4 @@ private:
 	void removeDrumFromLinkedList(Drum* drum);
 	void drumRemoved(Drum* drum);
 	void possiblySetSelectedDrumAndRefreshUI(Drum* thisDrum);
-	Drum* getDrumFromNoteCode(InstrumentClip* clip, int32_t noteCode);
 };


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2069

Pressing drum pads in kit keyboard view will now update the drum selection so that you can edit parameters of each drum directly from the kit keyboard view