### PR TITLE
Bugfix gold knobs don't reflect selected drum when doing an undo action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ use the TRACK menu to select the specific track to record from
   - `HORIZONTAL ENCODER ◀︎▶︎` + `PLAY` is changed to `CROSS SCREEN` + `PLAY`
 - Added community feature toggle `Grid View Loop Pads (LOOP)` to illuminate two pads (Red and Magenta) in the `GRID VIEW` sidebar for triggering the `LOOP` (Red) and `LAYERING LOOP` (Magenta) global MIDI commands to make it easier for you to loop in `GRID VIEW` without a MIDI controller.
 - CLIP NAMES. MIDI, SYNTH & KIT clips can now be named. When entered the clip view, press `SHIFT` + `NAME` and enter the name of the clip. For KIT, its important to activate `AFFECT ENTIRE` to name the KIT clip. When on ARRANGER view, you are now able to scroll through the clip names when holding a pad.
+- Fixed a bug where pressing `UNDO` in a `KIT` could cause the `SELECTED DRUM` to change but not update the `GOLD KNOBS` so that they now control that updated kit row.
 
 ### Keyboard View Improvements
 

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -481,11 +481,17 @@ void ActionLogger::revertAction(Action* action, bool updateVisually, bool doNavi
 
 						if (clip->output->type == OutputType::KIT) {
 							Kit* kit = (Kit*)clip->output;
+							Drum* currentSelectedDrum = kit->selectedDrum;
 							if (action->clipStates[i].selectedDrumIndex == -1) {
 								kit->selectedDrum = NULL;
 							}
 							else {
 								kit->selectedDrum = kit->getDrumFromIndex(action->clipStates[i].selectedDrumIndex);
+							}
+							// if affect entire is disabled and we've updated drum selection
+							// need to update the mod controllable context that the gold knobs are editing
+							if (!instrumentClip->affectEntire && currentSelectedDrum != kit->selectedDrum) {
+								view.setActiveModControllableTimelineCounter(instrumentClip);
 							}
 						}
 					}


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2141

When doing an undo action that causes the selected drum to change, we need to also update the gold knob context so that they are editing the updated drum selection