### PR TITLE
Bugfix: Typo prevented loading debug build via "loadfw debug"

### DIFF
--- a/scripts/tasks/task-loadfw.py
+++ b/scripts/tasks/task-loadfw.py
@@ -171,7 +171,7 @@ def find_binary(build):
     id = build.upper()
     if id == "RELEASE":
         return "build/Release/deluge.bin"
-    if id == "DBEUG":
+    if id == "DEBUG":
         return "build/Debug/deluge.bin"
     if id == "RELWITHDEBINFO":
         return "build/RelWithDebInfo/deluge.bin"


### PR DESCRIPTION
Found out why "loadfw debug" did not work...

Fix typo in task-loadfw.py preventing "loadfw debug" (DBEUG->DEBUG)