### PR TITLE
Bugfix - handle audition pad action in clip rename UI

### DIFF
--- a/src/deluge/gui/ui/rename/rename_clipname_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clipname_ui.cpp
@@ -19,7 +19,7 @@
 #include "definitions_cxx.hpp"
 #include "extern.h"
 #include "gui/l10n/l10n.h"
-#include "gui/views/arranger_view.h"
+#include "gui/views/instrument_clip_view.h"
 #include "hid/buttons.h"
 #include "hid/display/display.h"
 #include "hid/led/pad_leds.h"
@@ -106,17 +106,24 @@ bool RenameClipNameUI::exitUI() {
 
 ActionResult RenameClipNameUI::padAction(int32_t x, int32_t y, int32_t on) {
 
+	// Audition pad
+	if (x == kDisplayWidth + 1) {
+		return instrumentClipView.padAction(x, y, on);
+	}
+
 	// Main pad
-	if (x < kDisplayWidth) {
+	else if (x < kDisplayWidth) {
 		return QwertyUI::padAction(x, y, on);
 	}
 
 	// Otherwise, exit
-	if (on && !currentUIMode) {
-		if (sdRoutineLock) {
-			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+	else {
+		if (on && !currentUIMode) {
+			if (sdRoutineLock) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			}
+			exitUI();
 		}
-		exitUI();
 	}
 
 	return ActionResult::DEALT_WITH;
@@ -126,5 +133,5 @@ ActionResult RenameClipNameUI::verticalEncoderAction(int32_t offset, bool inCard
 	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(deluge::hid::button::X_ENC)) {
 		return ActionResult::DEALT_WITH;
 	}
-	return arrangerView.verticalEncoderAction(offset, inCardRoutine);
+	return instrumentClipView.verticalEncoderAction(offset, inCardRoutine);
 }

--- a/src/deluge/gui/ui/rename/rename_clipname_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clipname_ui.cpp
@@ -29,13 +29,10 @@
 RenameClipNameUI renameClipNameUI{};
 
 RenameClipNameUI::RenameClipNameUI() {
+	title = "Clip Name";
 }
 
 bool RenameClipNameUI::opened() {
-	if (display->haveOLED()) {
-
-		title = "Clip Name";
-	}
 	bool success = QwertyUI::opened();
 	if (!success) {
 		return false;

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -31,7 +31,7 @@
 RenameDrumUI renameDrumUI{};
 
 RenameDrumUI::RenameDrumUI() {
-	title = "Rename item";
+	title = "Drum Name";
 }
 
 bool RenameDrumUI::opened() {

--- a/src/deluge/gui/ui/rename/rename_output_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_output_ui.cpp
@@ -29,17 +29,10 @@
 RenameOutputUI renameOutputUI{};
 
 RenameOutputUI::RenameOutputUI() {
+	title = "Track Name";
 }
 
 bool RenameOutputUI::opened() {
-	if (display->haveOLED()) {
-		if (output->type == OutputType::AUDIO) {
-			title = "Rename track";
-		}
-		else {
-			title = "Rename instrument";
-		}
-	}
 	bool success = QwertyUI::opened();
 	if (!success) {
 		return false;


### PR DESCRIPTION
Fixed bug where you could get stuck in the UI_MODE_AUDITIONING state which blocks you from using the clip rename UI

Basically just took the exact same implementation used in the RenameDrumUI class

Also fixed what looked like a mistake in referencing arranger view in the vertical encoder action function

Also for consistency sake, renamed the titles for the rename drum and rename track UI's to "Drum Name" and "Track Name" respectively.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2557