### PR TITLE
Enhancement/ Play and Restart Arranger From Held Pad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### User Interface
 
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
+- Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
+  - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
 
 ## c1.2.0 Chopin
 
@@ -70,8 +72,6 @@ use the TRACK menu to select the specific track to record from
 - CLIP NAMES. MIDI, SYNTH & KIT clips can now be named. When entered the clip view, press `SHIFT` + `NAME` and enter the name of the clip. For KIT, its important to activate `AFFECT ENTIRE` to name the KIT clip. When on ARRANGER view, you are now able to scroll through the clip names when holding a pad.
 - Fixed bug where you wouldn't enter drum creator to select a drum sample when creating a new kit in the `KIT VELOCITY KEYBOARD VIEW`.
 - Fixed a bug where pressing `UNDO` in a `KIT` could cause the `SELECTED DRUM` to change but not update the `GOLD KNOBS` so that they now control that updated kit row.
-- Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
-  - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
 
 ### Keyboard View Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 ### User Interface
 
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
+- Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
+  - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
 
 ## c1.2.0 Chopin
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@
 ### User Interface
 
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
-- Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
-  - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
 
 ## c1.2.0 Chopin
 
@@ -72,6 +70,8 @@ use the TRACK menu to select the specific track to record from
 - CLIP NAMES. MIDI, SYNTH & KIT clips can now be named. When entered the clip view, press `SHIFT` + `NAME` and enter the name of the clip. For KIT, its important to activate `AFFECT ENTIRE` to name the KIT clip. When on ARRANGER view, you are now able to scroll through the clip names when holding a pad.
 - Fixed bug where you wouldn't enter drum creator to select a drum sample when creating a new kit in the `KIT VELOCITY KEYBOARD VIEW`.
 - Fixed a bug where pressing `UNDO` in a `KIT` could cause the `SELECTED DRUM` to change but not update the `GOLD KNOBS` so that they now control that updated kit row.
+- Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
+  - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
 
 ### Keyboard View Improvements
 

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -309,6 +309,10 @@ which track to record from. To run the instrument through the audio clip's FX ch
 - ([#2299]) `HOLDING PAD FOR THE CLIP` + `PRESSING SELECT` in `SONG GRID VIEW` will now always open the `CLIP MODE` menu so you can change the Clip Mode between `INFINITE`, `FILL` and `ONCE`.
 - This change only applies to `SONG GRID VIEW` and NOT `SONG ROW VIEW`
 
+### 3.29 Added ability to Start / Restart Playback from Specific Clip Pad in Arranger View
+- ([#2615]) Added ability to start / restart arrangement playback from the clip pad you're holding in arranger view.
+  - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
+
 ## 4. New Features Added
 
 Here is a list of features that have been added to the firmware as a list, grouped by category:
@@ -1496,6 +1500,8 @@ different firmware
 [#2429]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2429
 
 [#2475]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2475
+
+[#2615]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2475
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/automation_view.md
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -97,6 +97,8 @@ ArrangerView::ArrangerView() {
 	lastInteractedPos = -1;
 	lastInteractedSection = 0;
 	lastInteractedClipInstance = nullptr;
+
+	lastInteractedArrangementPos = -1;
 }
 
 void ArrangerView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
@@ -1249,6 +1251,7 @@ void ArrangerView::editPadAction(int32_t x, int32_t y, bool on) {
 			// No previous press
 			if (currentUIMode == UI_MODE_NONE) {
 				createNewClipInstance(output, x, y, squareStart, squareEnd, xScroll);
+				lastInteractedArrangementPos = squareStart;
 			}
 
 			// Already pressing - length edit

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -114,6 +114,8 @@ public:
 	uint8_t lastInteractedSection;
 	ClipInstance* lastInteractedClipInstance;
 
+	int32_t lastInteractedArrangementPos;
+
 	int32_t lastTickSquare;
 
 	int32_t xScrollWhenPlaybackStarted;

--- a/src/deluge/playback/mode/arrangement.cpp
+++ b/src/deluge/playback/mode/arrangement.cpp
@@ -351,6 +351,10 @@ void Arrangement::resetPlayPos(int32_t newPos, bool doingComplete, int32_t butto
 	playbackStartedAtPos = newPos;
 	lastProcessedPos = newPos;
 	arrangerView.xScrollWhenPlaybackStarted = currentSong->xScroll[NAVIGATION_ARRANGEMENT];
+	// if you were holding a clip pad and doing a reset,
+	// it can be easy to accidentally delete or enter the clip
+	// setting this to false prevents that
+	arrangerView.actionOnDepress = false;
 
 	if (currentSong->paramManager.mightContainAutomation()) {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -202,12 +202,24 @@ void PlaybackHandler::playButtonPressed(int32_t buttonPressLatency) {
 		    (accessibility && Buttons::isButtonPressed(deluge::hid::button::CROSS_SCREEN_EDIT))
 		    || (!accessibility && Buttons::isButtonPressed(deluge::hid::button::X_ENC));
 
-		// If holding <> encoder down...
-		if (isRestartShortcutPressed) {
+		bool isArrangementPadPressed = isArrangerView && isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW);
+		// placeholders:
+		// isSongPadPressed = restart playhead in song view
+		// isClipPadPressed = restart playhead in clip view
 
+		bool isSequencerPadPressed = isArrangementPadPressed; // add isSongPadPressed and isClipPadPressed here
+
+		// If holding restart shortcut down...
+		// or holding pad in arranger view (and eventually song and clip views)
+		if (isRestartShortcutPressed || isSequencerPadPressed) {
 			// If wanting to switch into arranger...
 			if (currentPlaybackMode == &session && isArrangerView) {
-				arrangementPosToStartAtOnSwitch = currentSong->xScroll[NAVIGATION_ARRANGEMENT];
+				if (isArrangementPadPressed) {
+					arrangementPosToStartAtOnSwitch = arrangerView.lastInteractedArrangementPos;
+				}
+				else {
+					arrangementPosToStartAtOnSwitch = currentSong->xScroll[NAVIGATION_ARRANGEMENT];
+				}
 				session.armForSwitchToArrangement();
 				if (display->haveOLED()) {
 					renderUIsForOled();
@@ -220,7 +232,6 @@ void PlaybackHandler::playButtonPressed(int32_t buttonPressLatency) {
 
 			// Otherwise, if internal clock, restart playback
 			else {
-
 				if (isInternalClockActive() && recording != RecordingMode::ARRANGEMENT) {
 					forceResetPlayPos(currentSong);
 				}
@@ -326,15 +337,29 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 	bool isRestartShortcutPressed = (accessibility && Buttons::isButtonPressed(deluge::hid::button::CROSS_SCREEN_EDIT))
 	                                || (!accessibility && Buttons::isButtonPressed(deluge::hid::button::X_ENC));
 
-	/*
-	Allow playback to start from current scroll if:
-	    1) horizontal encoder (<>) or cross screen is held and alternative playback start behaviour is disabled or
-	restarting playback 2) or horizontal encoder (<>) or cross screen is not held and alternative playback start
-	behaviour is enabled 3) or if you're in arranger view and in cross screen auto scrolling mode
-	*/
-	if ((isRestartShortcutPressed && (!alternativePlaybackStartBehaviour || restartingPlayback))
-	    || (!isRestartShortcutPressed && alternativePlaybackStartBehaviour)
-	    || (isArrangerView && (recording == RecordingMode::NORMAL || currentSong->arrangerAutoScrollModeActive))) {
+	bool useArrangementScrollPosition =
+	    isArrangerView && (recording == RecordingMode::NORMAL || currentSong->arrangerAutoScrollModeActive);
+
+	bool isArrangementPadPressed = isArrangerView && isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW);
+	// placeholders:
+	// isSongPadPressed = restart playhead in song view
+	// isClipPadPressed = restart playhead in clip view
+
+	bool useScrollPosition = isRestartShortcutPressed || useArrangementScrollPosition;
+
+	bool useSpecificPosition = isArrangementPadPressed; // add isSongPadPressed and isClipPadPressed here
+
+	// 	  Allow playback to start from current scroll if:
+	//    1) horizontal encoder (<>) or cross screen is held and alternative playback start behaviour
+	//		 is disabled or restarting playback;
+	//	  2) or horizontal encoder (<>) or cross screen is not held and alternative playback start behaviour is enabled;
+	//	  3) or if you're in arranger view and in normal recording mode
+	//	  4) or if you're in arranger view and in cross screen auto scrolling mode;
+
+	// 	  Allow playback to start from specific position if:
+	//	  1) you're in arranger view and holding a pad in the arrangement
+
+	if (useScrollPosition || useSpecificPosition) {
 
 		int32_t navSys;
 		if (rootUI) {
@@ -346,7 +371,12 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 			navSys = NAVIGATION_CLIP; // Keyboard view will cause this case
 		}
 
-		newPos = currentSong->xScroll[navSys];
+		if (isArrangementPadPressed) {
+			newPos = arrangerView.lastInteractedArrangementPos;
+		}
+		else {
+			newPos = currentSong->xScroll[navSys];
+		}
 	}
 
 	// See if we're gonna do a tempoless record

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2401,7 +2401,7 @@ void PlaybackHandler::resyncInternalTicksToInputTicks(Song* song) {
 }
 
 // This is that special MIDI command for Todd T
-void PlaybackHandler::forceResetPlayPos(Song* song) {
+void PlaybackHandler::forceResetPlayPos(Song* song, bool restartingPlayback) {
 	if (playbackState) {
 
 		endPlayback();
@@ -2411,7 +2411,7 @@ void PlaybackHandler::forceResetPlayPos(Song* song) {
 		}
 
 		else {
-			setupPlaybackUsingInternalClock(0, false, true);
+			setupPlaybackUsingInternalClock(0, false, restartingPlayback);
 		}
 	}
 }
@@ -2661,7 +2661,7 @@ bool PlaybackHandler::tryGlobalMIDICommands(MIDIDevice* device, int32_t channel,
 			switch (command) {
 			case GlobalMIDICommand::PLAYBACK_RESTART:
 				if (recording != RecordingMode::ARRANGEMENT) {
-					forceResetPlayPos(currentSong);
+					forceResetPlayPos(currentSong, true);
 				}
 				break;
 

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -74,7 +74,7 @@ public:
 	bool isCurrentlyRecording();
 	void positionPointerReceived(uint8_t data1, uint8_t data2);
 	void doSongSwap(bool preservePlayPosition = false);
-	void forceResetPlayPos(Song* song);
+	void forceResetPlayPos(Song* song, bool restartingPlayback = false);
 	void expectEvent();
 	void setMidiInClockEnabled(bool newValue);
 	int32_t getActualArrangementRecordPos();


### PR DESCRIPTION
Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.

https://github.com/user-attachments/assets/adc8b653-5c73-4fe2-942f-58c894bac0a1


