### PR TITLE
Bugfix / arranger performance view playback restart behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,10 @@ use the TRACK menu to select the specific track to record from
 - CLIP NAMES. MIDI, SYNTH & KIT clips can now be named. When entered the clip view, press `SHIFT` + `NAME` and enter the name of the clip. For KIT, its important to activate `AFFECT ENTIRE` to name the KIT clip. When on ARRANGER view, you are now able to scroll through the clip names when holding a pad.
 - Fixed bug where you wouldn't enter drum creator to select a drum sample when creating a new kit in the `KIT VELOCITY KEYBOARD VIEW`.
 - Fixed a bug where pressing `UNDO` in a `KIT` could cause the `SELECTED DRUM` to change but not update the `GOLD KNOBS` so that they now control that updated kit row.
+- Updated Arranger View clip rendering. Clip's are now rendered more simply which should also increase Arranger View performance, especially when using cross screen mode. Clip's are now rendered as follows:
+  - The clip head (the first pad where the clip is placed in the arrangement) is rendered the clip colour brightly.
+  - The clip loop points (the pad's where the clip, if extended past it's length will loop) are rendered the clip colour but dimly.
+  - The clip tails (pad's between clip head and loop points) are rendered the clip's colour but dimly and blurred.
 
 ### Keyboard View Improvements
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -210,6 +210,15 @@ PerformanceSessionView::PerformanceSessionView() {
 	}
 }
 
+int32_t PerformanceSessionView::getNavSysId() const {
+	if (currentSong->lastClipInstanceEnteredStartPos != -1) {
+		return NAVIGATION_ARRANGEMENT;
+	}
+	else {
+		return NAVIGATION_CLIP;
+	}
+}
+
 void PerformanceSessionView::initPadPress(PadPress& padPress) {
 	padPress.isActive = false;
 	padPress.xDisplay = kNoSelection;

--- a/src/deluge/gui/views/performance_session_view.h
+++ b/src/deluge/gui/views/performance_session_view.h
@@ -68,6 +68,8 @@ public:
 	// ui
 	UIType getUIType() { return UIType::PERFORMANCE_SESSION; }
 	const char* getName() { return "performance_session_view"; }
+	[[nodiscard]] int32_t getNavSysId() const override;
+
 	// rendering
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
 	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true) override;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -25,6 +25,7 @@
 #include "gui/ui/ui.h"
 #include "gui/ui_timer_manager.h"
 #include "gui/views/arranger_view.h"
+#include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
 #include "gui/views/performance_session_view.h"
 #include "gui/views/session_view.h"
@@ -194,7 +195,8 @@ void PlaybackHandler::playButtonPressed(int32_t buttonPressLatency) {
 
 		bool isArrangerView =
 		    rootUI == &arrangerView
-		    || (rootUI == &performanceSessionView && currentSong->lastClipInstanceEnteredStartPos != -1);
+		    || (rootUI == &performanceSessionView && currentSong->lastClipInstanceEnteredStartPos != -1)
+		    || (rootUI == &automationView && automationView.onArrangerView);
 
 		bool isRestartShortcutPressed =
 		    (accessibility && Buttons::isButtonPressed(deluge::hid::button::CROSS_SCREEN_EDIT))
@@ -311,7 +313,8 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 	RootUI* rootUI = getRootUI();
 
 	bool isArrangerView = rootUI == &arrangerView
-	                      || (rootUI == &performanceSessionView && currentSong->lastClipInstanceEnteredStartPos != -1);
+	                      || (rootUI == &performanceSessionView && currentSong->lastClipInstanceEnteredStartPos != -1)
+	                      || (rootUI == &automationView && automationView.onArrangerView);
 
 	bool alternativePlaybackStartBehaviour =
 	    runtimeFeatureSettings.get(RuntimeFeatureSettingType::AlternativePlaybackStartBehaviour)

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -190,6 +190,12 @@ void PlaybackHandler::playButtonPressed(int32_t buttonPressLatency) {
 		bool accessibility = runtimeFeatureSettings.get(RuntimeFeatureSettingType::AccessibilityShortcuts)
 		                     == RuntimeFeatureStateToggle::On;
 
+		RootUI* rootUI = getRootUI();
+
+		bool isArrangerView =
+		    rootUI == &arrangerView
+		    || (rootUI == &performanceSessionView && currentSong->lastClipInstanceEnteredStartPos != -1);
+
 		bool isRestartShortcutPressed =
 		    (accessibility && Buttons::isButtonPressed(deluge::hid::button::CROSS_SCREEN_EDIT))
 		    || (!accessibility && Buttons::isButtonPressed(deluge::hid::button::X_ENC));
@@ -198,7 +204,7 @@ void PlaybackHandler::playButtonPressed(int32_t buttonPressLatency) {
 		if (isRestartShortcutPressed) {
 
 			// If wanting to switch into arranger...
-			if (currentPlaybackMode == &session && getCurrentUI() == &arrangerView) {
+			if (currentPlaybackMode == &session && isArrangerView) {
 				arrangementPosToStartAtOnSwitch = currentSong->xScroll[NAVIGATION_ARRANGEMENT];
 				session.armForSwitchToArrangement();
 				if (display->haveOLED()) {
@@ -304,7 +310,8 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 
 	RootUI* rootUI = getRootUI();
 
-	bool isArrangerView = rootUI == &arrangerView;
+	bool isArrangerView = rootUI == &arrangerView
+	                      || (rootUI == &performanceSessionView && currentSong->lastClipInstanceEnteredStartPos != -1);
 
 	bool alternativePlaybackStartBehaviour =
 	    runtimeFeatureSettings.get(RuntimeFeatureSettingType::AlternativePlaybackStartBehaviour)


### PR DESCRIPTION
The playback restart changes made for arranger view were not carrying over to arranger performance view

This was due to:
- arranger performance view not being recognized as an "arranger view"
- performance view was also not returning the correct NavSysId previously which would mean it would not restart arranger from the right scroll position