### PR TITLE
Docs: Warn about "dangers" of loadfw in contributing.md and when using loadfw

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -215,7 +215,7 @@ It is only loaded to RAM and then executed. Consequences:
 This is great for development, because if your changes crash the Deluge, just switch it off and on again and you are instantly back to the last
 (hopefully stable) version that was flashed from SD card.
 * **Meh**: If you want to keep your updated firmware on the Deluge persistently, i.e. surviving a power cycle, you *have to* physically copy it to your SD card
-and update it as desrcibed in https://github.com/SynthstromAudible/DelugeFirmware/wiki#updating-firmware
+and update it as described in https://github.com/SynthstromAudible/DelugeFirmware/wiki#updating-firmware
 * **Possibly bad:** *In rare cases* the firmware can behave differently when uploaded via loadfw than when actually flashed from SD card. 
 While this should only be relevant when changing low-level code executed at boot time,
 **please** always verify that your firmware also works when actually flashed from SD card,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -214,9 +214,9 @@ It is only loaded to RAM and then executed. This has three consequences:
 * **Good:** After switching the Deluge off, it will re-boot with the last firmware flashed to permanent memory *from the SD card*.
 This is great for development, because if your update crashes the Deluge, you just need to switch off and on again and are back to the last
 (hopefully stable) version that you flashed from SD card.
-* **meh**: If you want to keep your updated firmware on the Deluge persistently, i.e. surviving a power cycle, you *have to* load it from SD card at boot.
-Loadfw can not do that.
-* **(possibly) bad:** The fact that loadfw updates the firmware on an already running Deluge, instead of truly rebooting it from powered-off state means that:
+* **Meh**: If you want to keep your updated firmware on the Deluge persistently, i.e. surviving a power cycle, you *have to* physically copy it to your SD card
+and update it at boot, as desrcibed in https://github.com/SynthstromAudible/DelugeFirmware/wiki#updating-firmware
+* **Possibly bad:** The fact that loadfw updates the firmware on an already running Deluge, instead of truly rebooting it from powered-off state means that:
 The firmware *might* behave differently than when actually flashed from SD card. 
 While this should only be relevant when changing low-level code executed at boot time,
 **please** always verify that your firmware also works when actually flashed from SD card,

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -210,14 +210,17 @@ More instructions available via:
 `./dbt loadfw -h`
 
 **NOTE:** loadfw *does not* flash the new firmware to the permanent memory of the Deluge. 
-It is only loaded to RAM and then executed *as if* booting from flash memory.
-This is great for development, because if your update crashes the Deluge, 
-you just need to switch off and on again and are back to the (hopefully stable) version that you flashed from your SD card earlier. But...
-
-**NOTE:** The fact that this effectively "hijacks" an already running device, instead of truly rebooting it from powered-off state means that:
+It is only loaded to RAM and then executed. This has three consequences:
+* **Good:** After switching the Deluge off, it will re-boot with the last firmware flashed to permanent memory *from the SD card*.
+This is great for development, because if your update crashes the Deluge, you just need to switch off and on again and are back to the last
+(hopefully stable) version that you flashed from SD card.
+* **meh**: If you want to keep your updated firmware on the Deluge persistently, i.e. surviving a power cycle, you *have to* load it from SD card at boot.
+Loadfw can not do that.
+* **(possibly) bad:** The fact that loadfw updates the firmware on an already running Deluge, instead of truly rebooting it from powered-off state means that:
 The firmware *might* behave differently than when actually flashed from SD card. 
-Although this mainly applies when changing low-level stuff happening at boot time,
-**please** always verify that your firmware also works when actually flashed from SD card before making a pull request (ask me how I know...). 
+While this should only be relevant when changing low-level code executed at boot time,
+**please** always verify that your firmware also works when actually flashed from SD card,
+especially before making a pull request (ask me how I know...). 
 
 ### Printing debug log messages on the console
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -209,15 +209,15 @@ The first time you run it, the command will ask you for the key code you from th
 More instructions available via:
 `./dbt loadfw -h`
 
-**NOTE:** The uploaded firmware is *not* flashed to the permanent memory of the Deluge. 
+**NOTE:** loadfw *does not* flash the new firmware to the permanent memory of the Deluge. 
 It is only loaded to RAM and then executed *as if* booting from flash memory.
 This is great for development, because if your update crashes the Deluge, 
 you just need to switch off and on again and are back to the (hopefully stable) version that you flashed from your SD card earlier. But...
 
 **NOTE:** The fact that this effectively "hijacks" an already running device, instead of truly rebooting it from powered-off state means that:
 The firmware *might* behave differently than when actually flashed from SD card. 
-This mainly applies when changing low-level stuff happening at boot time.
-**Please** *always* verify that your firmware also works when actually flashed from SD card before making a pull request. 
+Although this mainly applies when changing low-level stuff happening at boot time,
+**please** always verify that your firmware also works when actually flashed from SD card before making a pull request (ask me how I know...). 
 
 ### Printing debug log messages on the console
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -185,7 +185,7 @@ a variety of possible debug hardware.
 If you'd like to use our suggested config, just copy the folder from IDE_configs/vscode to .vscode in the repo root.
 .vscode itself is gitignored so you can modify it as needed to fit your desired workflow later.
 
-### Flashing the firmware via USB (loadfw)
+### Loading new firmware via USB (loadfw)
 
 To use this feature, you will need to first flash a build via the SD card that has been built with `ENABLE_SYSEX_LOAD=YES`.
 
@@ -208,6 +208,16 @@ The first time you run it, the command will ask you for the key code you from th
 
 More instructions available via:
 `./dbt loadfw -h`
+
+**NOTE:** The uploaded firmware is *not* flashed to the permanent memory of the Deluge. 
+It is only loaded to RAM and then executed *as if* booting from flash memory.
+This is great for development, because if your update crashes the Deluge, 
+you just need to switch off and on again and are back to the (hopefully stable) version that you flashed from your SD card earlier. But...
+
+**NOTE:** The fact that this effectively "hijacks" an already running device, instead of truly rebooting it from powered-off state means that:
+The firmware *might* behave differently than when actually flashed from SD card. 
+This mainly applies when changing low-level stuff happening at boot time.
+**Please** *always* verify that your firmware also works when actually flashed from SD card before making a pull request. 
 
 ### Printing debug log messages on the console
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -209,15 +209,14 @@ The first time you run it, the command will ask you for the key code you from th
 More instructions available via:
 `./dbt loadfw -h`
 
-**NOTE:** loadfw *does not* flash the new firmware to the permanent memory of the Deluge. 
-It is only loaded to RAM and then executed. This has three consequences:
-* **Good:** After switching the Deluge off, it will re-boot with the last firmware flashed to permanent memory *from the SD card*.
-This is great for development, because if your update crashes the Deluge, you just need to switch off and on again and are back to the last
-(hopefully stable) version that you flashed from SD card.
+**NOTE:** loadfw *can not* flash the new firmware to the permanent memory of the Deluge. 
+It is only loaded to RAM and then executed. Consequences:
+* **Good:** After switching off and on again, Deluge will boot from the last firmware flashed to permanent memory *from the SD card*.
+This is great for development, because if your changes crash the Deluge, just switch it off and on again and you are instantly back to the last
+(hopefully stable) version that was flashed from SD card.
 * **Meh**: If you want to keep your updated firmware on the Deluge persistently, i.e. surviving a power cycle, you *have to* physically copy it to your SD card
-and update it at boot, as desrcibed in https://github.com/SynthstromAudible/DelugeFirmware/wiki#updating-firmware
-* **Possibly bad:** The fact that loadfw updates the firmware on an already running Deluge, instead of truly rebooting it from powered-off state means that:
-The firmware *might* behave differently than when actually flashed from SD card. 
+and update it as desrcibed in https://github.com/SynthstromAudible/DelugeFirmware/wiki#updating-firmware
+* **Possibly bad:** *In rare cases* the firmware can behave differently when uploaded via loadfw than when actually flashed from SD card. 
 While this should only be relevant when changing low-level code executed at boot time,
 **please** always verify that your firmware also works when actually flashed from SD card,
 especially before making a pull request (ask me how I know...). 

--- a/scripts/tasks/task-loadfw.py
+++ b/scripts/tasks/task-loadfw.py
@@ -6,6 +6,10 @@ import itertools
 import rtmidi
 import os
 
+advisory = """
+NOTE: Firmware might behave slightly differently when using loadfw than when flashed from SD card.
+Please remember to test flashing your firmware version via SD card before opening a pull request.
+"""
 
 def argparser():
     parser = argparse.ArgumentParser(
@@ -137,6 +141,8 @@ def load_fw(output, handshake, file, delay_ms=2, output_to_file=False):
 
     sysex_data = make_sysex_messages(binary, handshake)
 
+    print(advisory)
+    
     if output_to_file:
         with open(output, "wb") as f:
             text = f"Writing SysEx File '{f.name}': "

--- a/scripts/tasks/task-loadfw.py
+++ b/scripts/tasks/task-loadfw.py
@@ -11,6 +11,7 @@ NOTE: Firmware might behave slightly differently when using loadfw than when fla
 Please remember to test flashing your firmware version via SD card before opening a pull request.
 """
 
+
 def argparser():
     parser = argparse.ArgumentParser(
         prog="loadfw",
@@ -142,7 +143,7 @@ def load_fw(output, handshake, file, delay_ms=2, output_to_file=False):
     sysex_data = make_sysex_messages(binary, handshake)
 
     print(advisory)
-    
+
     if output_to_file:
         with open(output, "wb") as f:
             text = f"Writing SysEx File '{f.name}': "


### PR DESCRIPTION
Chainloading firmware via loadfw is **not** fully equivalent to flashing it from SD card and actually rebooting, especially in relation to low-level hardware stuff that happens at boot time... 

Not really surprising, and I should have known, but AFAIK not explicitly stated anywhere.

As penance for ( #2611 #2627 ) I put a warning about this in the docs as well as in the screen output of loadfw itself, to save others (and quite possibly myself) from embarrassment in the future...
