### PR TITLE
Revert pr's causing nightly crash on boot

### DIFF
--- a/src/RZA1/spibsc/spibsc_Deluge_setup.c
+++ b/src/RZA1/spibsc/spibsc_Deluge_setup.c
@@ -39,7 +39,6 @@
  */
 
 #include "RZA1/cpu_specific.h"
-#include "RZA1/gpio/gpio.h"
 #include "RZA1/spibsc/r_spibsc_flash_api.h"
 #include "RZA1/spibsc/r_spibsc_ioset_api.h"
 #include "RZA1/spibsc/spibsc.h"
@@ -50,12 +49,7 @@
 
 void initSPIBSC()
 {
-    setPinMux(4, 2, 2);
-    setPinMux(4, 3, 2);
-    setPinMux(4, 4, 2);
-    setPinMux(4, 5, 2);
-    setPinMux(4, 6, 2);
-    setPinMux(4, 7, 2);
+
     // We've switched back to doing just 1-bit.
     // setPinMux(4, 2, 2);
     // setPinMux(4, 3, 2);

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -65,6 +65,7 @@
 #include "storage/storage_manager.h"
 #include "task_scheduler.h"
 #include "util/misc.h"
+#include "util/pack.h"
 #include <stdlib.h>
 
 #if AUTOMATED_TESTER_ENABLED
@@ -656,21 +657,17 @@ void mainLoop() {
 #endif
 	}
 }
-
-bool checkOLED() {
+extern "C" int32_t deluge_main(void) {
 	// Piggyback off of bootloader DMA setup.
 	uint32_t oledSPIDMAConfig = (0b1101000 | (OLED_SPI_DMA_CHANNEL & 7));
 	bool have_oled = ((DMACn(OLED_SPI_DMA_CHANNEL).CHCFG_n & oledSPIDMAConfig) == oledSPIDMAConfig);
-	return have_oled;
-}
 
-void initPads(bool have_oled) {
-
+	// Give the PIC some startup instructions
 	if (have_oled) {
 		PIC::enableOLED();
 	}
 
-	PIC::setDebounce(20); // Set debounce time (mS)
+	PIC::setDebounce(20); // Set debounce time (mS) to...
 
 	PadLEDs::setRefreshTime(23);
 	PIC::setMinInterruptInterval(8);
@@ -679,46 +676,50 @@ void initPads(bool have_oled) {
 	PIC::setUARTSpeed();
 	PIC::flush();
 
-	PIC::setupForPads();
-}
+	functionsInit();
 
-void initAnalogIO() {
+#if AUTOMATED_TESTER_ENABLED
+	AutomatedTester::init();
+#endif
+
+	currentPlaybackMode = &session;
+
 	setOutputState(BATTERY_LED.port, BATTERY_LED.pin, 1); // Switch it off (1 is off for open-drain)
-	setPinAsOutput(BATTERY_LED.port, BATTERY_LED.pin);
+	setPinAsOutput(BATTERY_LED.port, BATTERY_LED.pin);    // Battery LED control
 
 	setOutputState(SYNCED_LED.port, SYNCED_LED.pin, 0); // Switch it off
-	setPinAsOutput(SYNCED_LED.port, SYNCED_LED.pin);
+	setPinAsOutput(SYNCED_LED.port, SYNCED_LED.pin);    // Synced LED
 
+	// Codec control
 	setPinAsOutput(CODEC.port, CODEC.pin);
 	setOutputState(CODEC.port, CODEC.pin, 0); // Switch it off
 
+	// Speaker / amp control
 	setPinAsOutput(SPEAKER_ENABLE.port, SPEAKER_ENABLE.pin);
 	setOutputState(SPEAKER_ENABLE.port, SPEAKER_ENABLE.pin, 0); // Switch it off
 
-	setPinAsInput(HEADPHONE_DETECT.port, HEADPHONE_DETECT.pin);
-	setPinAsInput(LINE_IN_DETECT.port, LINE_IN_DETECT.pin);
-	setPinAsInput(MIC_DETECT.port, MIC_DETECT.pin);
+	setPinAsInput(HEADPHONE_DETECT.port, HEADPHONE_DETECT.pin); // Headphone detect
+	setPinAsInput(LINE_IN_DETECT.port, LINE_IN_DETECT.pin);     // Line in detect
+	setPinAsInput(MIC_DETECT.port, MIC_DETECT.pin);             // Mic detect
 
-	setPinMux(VOLT_SENSE.port, VOLT_SENSE.pin, 1);
+	setPinMux(VOLT_SENSE.port, VOLT_SENSE.pin, 1); // Analog input for voltage sense
 
+	// Trigger clock input
 	setPinMux(ANALOG_CLOCK_IN.port, ANALOG_CLOCK_IN.pin, 2);
 
+	// Line out detect pins
 	setPinAsInput(LINE_OUT_DETECT_L.port, LINE_OUT_DETECT_L.pin);
 	setPinAsInput(LINE_OUT_DETECT_R.port, LINE_OUT_DETECT_R.pin);
 
-	// Setup audio output on SSI0
-	ssiInit(0, 1);
-}
-
-void init_OLED_and_CV(bool have_oled) {
+	// SPI for CV
 	R_RSPI_Create(SPI_CHANNEL_CV,
 	              have_oled ? 10000000 // Higher than this would probably work... but let's stick to the OLED
 	                                   // datasheet's spec of 100ns (10MHz).
 	                        : 30000000,
 	              0, 32);
 	R_RSPI_Start(SPI_CHANNEL_CV);
-	setPinMux(SPI_CLK.port, SPI_CLK.pin, 3);
-	setPinMux(SPI_MOSI.port, SPI_MOSI.pin, 3);
+	setPinMux(SPI_CLK.port, SPI_CLK.pin, 3);   // CLK
+	setPinMux(SPI_MOSI.port, SPI_MOSI.pin, 3); // MOSI
 
 	if (have_oled) {
 		// If OLED sharing SPI channel, have to manually control SSL pin.
@@ -727,21 +728,61 @@ void init_OLED_and_CV(bool have_oled) {
 
 		setupSPIInterrupts();
 		oledDMAInit();
-		setupOLED();
+		setupOLED(); // Set up OLED now
 		display = new deluge::hid::display::OLED;
 	}
 	else {
-		setPinMux(SPI_SSL.port, SPI_SSL.pin, 3);
+		setPinMux(SPI_SSL.port, SPI_SSL.pin, 3); // SSL
 		display = new deluge::hid::display::SevenSegment;
 	}
-
 	// remember the physical display type
 	deluge::hid::display::have_oled_screen = have_oled;
-}
 
-void maybeFactoryReset() {
-	PIC::requestFirmwareVersion();
-	PIC::resendButtonStates();
+	// Setup audio output on SSI0
+	ssiInit(0, 1);
+
+#if RECORD_TEST_MODE == 1
+	makeTestRecording();
+#endif
+
+	encoders::init();
+
+#if TEST_GENERAL_MEMORY_ALLOCATION
+	GeneralMemoryAllocator::get().test();
+#endif
+
+	init_crc_table();
+
+	// Setup for gate output
+	cvEngine.init();
+
+	// Wait for PIC Uart to flush out. Could this help Ron R with his Deluge sometimes not booting? (No probably wasn't
+	// that.) Otherwise didn't seem necessary.
+	PIC::waitForFlush();
+
+	PIC::setupForPads();
+	setOutputState(CODEC.port, CODEC.pin, 1); // Enable codec
+
+	AudioEngine::init();
+
+#if HARDWARE_TEST_MODE
+	ramTestLED();
+#endif
+
+	audioFileManager.init();
+
+	// Setup SPIBSC. Crucial that this only be done now once everything else is running, because I've injected graphics
+	// and audio routines into the SPIBSC wait routines, so that has to be running
+	setPinMux(4, 2, 2);
+	setPinMux(4, 3, 2);
+	setPinMux(4, 4, 2);
+	setPinMux(4, 5, 2);
+	setPinMux(4, 6, 2);
+	setPinMux(4, 7, 2);
+	initSPIBSC(); // This will run the audio routine! Ideally, have external RAM set up by now.
+
+	PIC::requestFirmwareVersion(); // Request PIC firmware version
+	PIC::resendButtonStates();     // Tell PIC to re-send button states
 	PIC::flush();
 
 	// Check if the user is holding down the select knob to do a factory reset
@@ -788,10 +829,56 @@ void maybeFactoryReset() {
 			return 0;
 		}
 	});
-}
+
+	FlashStorage::readSettings();
+
+	runtimeFeatureSettings.init();
+
+	if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::EmulatedDisplay)
+	    == RuntimeFeatureStateEmulatedDisplay::OnBoot) {
+		deluge::hid::display::swapDisplayType();
+	}
+
+	usbLock = 1;
+	openUSBHost();
+
+	// If nothing was plugged in to us as host, we'll go peripheral
+	// Ideally I'd like to repeatedly switch between host and peripheral mode anytime there's no USB connection.
+	// To do that, I'd really need to know at any point in time whether the user had just made a connection, just then,
+	// that hadn't fully initialized yet. I think I sorta have that for host, but not for peripheral yet.
+	if (!anythingInitiallyAttachedAsUSBHost) {
+		D_PRINTLN("switching from host to peripheral");
+		closeUSBHost();
+		openUSBPeripheral();
+	}
+
+	usbLock = 0;
+
+	// Hopefully we can read these files now
+	runtimeFeatureSettings.readSettingsFromFile();
+	MIDIDeviceManager::readDevicesFromFile();
+	midiFollow.readDefaultsFromFile();
+	PadLEDs::setBrightnessLevel(FlashStorage::defaultPadBrightness);
+	setupBlankSong(); // we always need to do this
+	addConditionalTask(setupStartupSong, 100, isCardReady, "load startup song");
+
+#ifdef TEST_VECTOR
+	NoteVector noteVector;
+	noteVector.test();
+#endif
+
+#ifdef TEST_VECTOR_SEARCH_MULTIPLE
+	NoteVector noteVector;
+	noteVector.testSearchMultiple();
+#endif
+
+#ifdef TEST_VECTOR_DUPLICATES
+	NoteVector noteVector;
+	noteVector.testDuplicates();
+#endif
 
 #ifdef TEST_SD_WRITE
-void testSdWrite() {
+
 	FIL fil; // File object
 	FATFS fs;
 	DIR dp;
@@ -808,8 +895,7 @@ void testSdWrite() {
 		int32_t fileSize = (uint32_t)getNoise() % 1000000;
 
 		char fileName[20];
-		strcpy(fileName, "TEST/");
-		intToString(fileNumber, &fileName[5], 4);
+		strcpy(fineName, "TEST/") intToString(fileNumber, &fileName[5], 4);
 		strcat(fileName, ".TXT");
 
 		result = f_open(&fil, fileName, FA_CREATE_ALWAYS | FA_WRITE);
@@ -836,95 +922,14 @@ void testSdWrite() {
 
 		count++;
 	}
-}
-#endif // TEST_SD_WRITE
-
-void initUSB() {
-	usbLock = 1;
-	openUSBHost();
-	// If nothing was plugged in to us as host, we'll go peripheral
-	// Ideally I'd like to repeatedly switch between host and peripheral mode anytime there's no USB connection.
-	// To do that, I'd really need to know at any point in time whether the user had just made a connection, just then,
-	// that hadn't fully initialized yet. I think I sorta have that for host, but not for peripheral yet.
-	if (!anythingInitiallyAttachedAsUSBHost) {
-		D_PRINTLN("switching from host to peripheral");
-		closeUSBHost();
-		openUSBPeripheral();
-	}
-
-	usbLock = 0;
-}
-
-void loadSettings() {
-	maybeFactoryReset(); // Check if the user is holding down the select knob to do a factory reset
-
-	FlashStorage::readSettings();
-
-	runtimeFeatureSettings.init();
-
-	if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::EmulatedDisplay)
-	    == RuntimeFeatureStateEmulatedDisplay::OnBoot) {
-		deluge::hid::display::swapDisplayType();
-	}
-
-	// Hopefully we can read these files now
-	runtimeFeatureSettings.readSettingsFromFile();
-	MIDIDeviceManager::readDevicesFromFile();
-	midiFollow.readDefaultsFromFile();
-	PadLEDs::setBrightnessLevel(FlashStorage::defaultPadBrightness);
-}
-
-extern "C" int32_t deluge_main(void) {
-
-	// HARDWARE SETUP
-
-	bool have_oled = checkOLED(); // Detects OLED Screen by DMA settings
-
-	initPads(have_oled); // Handled by PIC Microcontroller
-
-	initAnalogIO(); // General Purpose (GPIO) pins: analog (line, mic, headphone) ports, battery monitoring, some leds
-
-	encoders::init(); // Rotary encoders also handled by GPIO pins
-
-	init_OLED_and_CV(have_oled); // OLED and CV share an SPI (serial peripheral interface) channel
-
-	cvEngine.init(have_oled); // CV setup
-
-	initSPIBSC(); // Set up "serial flash memory". Old comment indicating this also runs audio seems wrong/outdated
-
-	// INIT AUDIO AND MIDI
-
-	makeParameterRangeConstants(); // Do at compile-time? Constexpr? (not for performance but for tidyness...)
-
-	currentPlaybackMode = &session; // ?
-
-	setOutputState(CODEC.port, CODEC.pin, 1); // Enable Audio Output
-
-	AudioEngine::init();
-
-	audioFileManager.init();
-
-	initUSB(); // USB MIDI: If nothing was plugged in to us as host, we'll go peripheral
-
-	// LOAD STUFF
-
-	loadSettings(); // Load User Settings from Flash and SD Card, reset to defaults if requested
-
-	setupBlankSong(); // we always need to do this
-
-	addConditionalTask(setupStartupSong, 100, isCardReady, "load startup song");
-
-	// PREPARE FOR MAIN LOOP
+#endif
 
 	inputRoutine();
 
 	uiTimerManager.setTimer(TimerName::GRAPHICS_ROUTINE, 50);
 
-	sdRoutineLock = false; // Allow SD routine to start happening
-
-	// START MAIN LOOP
-
 	D_PRINTLN("going into main loop");
+	sdRoutineLock = false; // Allow SD routine to start happening
 
 #ifdef USE_TASK_MANAGER
 	registerTasks();

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -46,7 +46,7 @@ CVEngine::CVEngine() {
 	mostRecentSwitchOffTimeOfPendingNoteOn = 0;
 }
 
-void CVEngine::init(bool have_oled) {
+void CVEngine::init() {
 	// As instructed by the AD DAC's datasheet, do the weird "linearity" routine
 	/*
 	IO::setOutputState(6, 13, 0);
@@ -55,7 +55,7 @@ void CVEngine::init(bool have_oled) {
 	SPI::send(1, 0);
 	IO::setOutputState(6, 13, 1);
 */
-	if (have_oled) {
+	if (display->haveOLED()) {
 		enqueueCVMessage(SPI_CHANNEL_CV, 0b00000101000000100000000000000000); // LIN = 1
 	}
 	else {
@@ -70,7 +70,7 @@ void CVEngine::init(bool have_oled) {
 	SPI::send(1, 0);
 	IO::setOutputState(6, 13, 1);
 	*/
-	if (have_oled) {
+	if (display->haveOLED()) {
 		enqueueCVMessage(SPI_CHANNEL_CV, 0b00000101000000000000000000000000); // LIN = 0
 	}
 	else {

--- a/src/deluge/processing/engines/cv_engine.h
+++ b/src/deluge/processing/engines/cv_engine.h
@@ -55,7 +55,7 @@ public:
 class CVEngine {
 public:
 	CVEngine();
-	void init(bool have_oled);
+	void init();
 	void sendNote(bool on, uint8_t channel, int16_t note = -32768);
 	void setGateType(uint8_t whichGate, GateType value);
 	void setCVVoltsPerOctave(uint8_t channel, uint8_t value);

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -154,7 +154,7 @@ int32_t getParamNeutralValue(int32_t p) {
 	}
 }
 
-void makeParameterRangeConstants() {
+void functionsInit() {
 
 	for (int32_t p = 0; p < kNumParams; p++) {
 		paramRanges[p] = getParamRange(p);

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -43,7 +43,7 @@ extern uint8_t subModeToReturnTo;
 extern int32_t paramRanges[];
 extern int32_t paramNeutralValues[];
 
-void makeParameterRangeConstants();
+void functionsInit();
 
 char const* getThingName(OutputType outputType);
 char const* getOutputTypeName(OutputType outputType, int32_t channel);

--- a/src/deluge/util/pack.c
+++ b/src/deluge/util/pack.c
@@ -239,9 +239,7 @@ void init_crc_table(void) {
 static uint32_t update_crc(uint32_t crc, uint8_t* buf, int len) {
 	uint32_t c = crc;
 	int n;
-	if (crc_table[0] == 0) {
-		init_crc_table();
-	}
+
 	for (n = 0; n < len; n++) {
 		c = crc_table[(c ^ buf[n]) & 0xff] ^ (c >> 8);
 	}


### PR DESCRIPTION
Revert PR's #2611 and #2627

#2611 introduced a crash bug in the nightly firmware. #2627 tried to fix it but it didn't work entirely.

FYI @M0R172 @m-m-adams 