### PR TITLE
Bugfix/ scale offset bug caused by modding on octaves

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -82,8 +82,9 @@ void KeyboardLayoutChord::evaluatePadsColumn(PressedPad pressed) {
 	KeyboardStateChord& state = getState().chord;
 
 	NoteSet& scaleNotes = getScaleNotes();
-	int32_t octaveDisplacement = (pressed.x) / scaleNotes.count();
-	int32_t steps = getScaleSteps(pressed.x, scaleNotes);
+	// We use the floor function to round down to the nearest octave instead of truncating
+	int32_t octaveDisplacement = (int32_t) floor(float(pressed.x + state.scaleOffset) / scaleNotes.count());
+	int32_t steps = scaleNotes[mod(pressed.x + state.scaleOffset, scaleNotes.count())];
 	int32_t root = getRootNote() + state.noteOffset + steps;
 
 	NoteSet scaleMode = scaleNotes.modulateByOffset(kOctaveSize - steps);
@@ -245,9 +246,9 @@ void KeyboardLayoutChord::drawChordName(int16_t noteCode, const char* chordName,
 uint8_t KeyboardLayoutChord::noteFromCoordsRow(int32_t x, int32_t y, int32_t root, NoteSet& scaleNotes,
                                                uint8_t scaleNoteCount) {
 	KeyboardStateChord& state = getState().chord;
-	int32_t octaveDisplacement = state.autoVoiceLeading ? 0 : (y + scaleSteps[x]) / scaleNoteCount;
-	// int32_t steps = scaleNotes[(y + scaleSteps[x]) % scaleNoteCount];
-	int32_t steps = getScaleSteps(y + scaleSteps[x], scaleNotes);
+	// We use the floor function to round down to the nearest octave instead of truncating
+	int32_t octaveDisplacement = state.autoVoiceLeading ? 0 : (int32_t) floor(float(y + scaleSteps[x] + state.scaleOffset) / scaleNoteCount);
+	int32_t steps = scaleNotes[mod(y + scaleSteps[x] + state.scaleOffset, scaleNoteCount)];
 	return root + steps + octaveDisplacement * kOctaveSize;
 }
 

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -83,7 +83,7 @@ void KeyboardLayoutChord::evaluatePadsColumn(PressedPad pressed) {
 
 	NoteSet& scaleNotes = getScaleNotes();
 	// We use the floor function to round down to the nearest octave instead of truncating
-	int32_t octaveDisplacement = (int32_t) floor(float(pressed.x + state.scaleOffset) / scaleNotes.count());
+	int32_t octaveDisplacement = (int32_t)floor(float(pressed.x + state.scaleOffset) / scaleNotes.count());
 	int32_t steps = scaleNotes[mod(pressed.x + state.scaleOffset, scaleNotes.count())];
 	int32_t root = getRootNote() + state.noteOffset + steps;
 
@@ -247,7 +247,8 @@ uint8_t KeyboardLayoutChord::noteFromCoordsRow(int32_t x, int32_t y, int32_t roo
                                                uint8_t scaleNoteCount) {
 	KeyboardStateChord& state = getState().chord;
 	// We use the floor function to round down to the nearest octave instead of truncating
-	int32_t octaveDisplacement = state.autoVoiceLeading ? 0 : (int32_t) floor(float(y + scaleSteps[x] + state.scaleOffset) / scaleNoteCount);
+	int32_t octaveDisplacement =
+	    state.autoVoiceLeading ? 0 : (int32_t)floor(float(y + scaleSteps[x] + state.scaleOffset) / scaleNoteCount);
 	int32_t steps = scaleNotes[mod(y + scaleSteps[x] + state.scaleOffset, scaleNoteCount)];
 	return root + steps + octaveDisplacement * kOctaveSize;
 }

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.h
@@ -67,10 +67,6 @@ private:
 	void evaluatePadsRow(PressedPad pressed);
 	void evaluatePadsColumn(PressedPad pressed);
 	void drawChordName(int16_t noteCode, const char* chordName = "", const char* voicingName = "");
-	inline int32_t getScaleSteps(int32_t i, NoteSet& scaleNotes) {
-		KeyboardStateChord& state = getState().chord;
-		return scaleNotes[mod(i + state.scaleOffset, scaleNotes.count())];
-	}
 
 	Scale lastScale = NO_SCALE;
 


### PR DESCRIPTION
# Summary

Fixes a bug where the horizontal encoder, which controls scale offset (switching scale modes), would drop down octaves weirdly instead of continuing up and down. This was caused by it using the `scaleOffset` attribute % `scaleNotes.count()`, but not taking into account how many octaves it should go up or down.