### PR TITLE
Fix typo in English localization file

### DIFF
--- a/src/deluge/gui/l10n/english.json
+++ b/src/deluge/gui/l10n/english.json
@@ -283,7 +283,7 @@
         "STRING_FOR_ERROR_CREATING_MULTISAMPLED_INSTRUMENT": "Error creating multisampled instrument",
         "STRING_FOR_CLIP_IS_RECORDING": "Clip is recording",
         "STRING_FOR_AUDIO_FILE_IS_USED_IN_CURRENT_SONG": "Audio file is used in current song",
-        "STRING_FOR_CAN_ONLY_USE_SLICER_FOR_BRAND_NEW_KIT": "Can only user slicer for brand-new kit",
+        "STRING_FOR_CAN_ONLY_USE_SLICER_FOR_BRAND_NEW_KIT": "Can only use slicer for brand-new kit",
         "STRING_FOR_TEMP_FOLDER_CANT_BE_BROWSED": "TEMP folder can't be browsed",
         "STRING_FOR_UNLOADED_PARTS": "Can't return to current song, as parts have been unloaded",
         "STRING_FOR_SD_CARD_ERROR": "SD card error",

--- a/src/deluge/gui/l10n/g_english.cpp
+++ b/src/deluge/gui/l10n/g_english.cpp
@@ -245,7 +245,7 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_ERROR_CREATING_MULTISAMPLED_INSTRUMENT, "Error creating multisampled instrument"},
         {STRING_FOR_CLIP_IS_RECORDING, "Clip is recording"},
         {STRING_FOR_AUDIO_FILE_IS_USED_IN_CURRENT_SONG, "Audio file is used in current song"},
-        {STRING_FOR_CAN_ONLY_USE_SLICER_FOR_BRAND_NEW_KIT, "Can only user slicer for brand-new kit"},
+        {STRING_FOR_CAN_ONLY_USE_SLICER_FOR_BRAND_NEW_KIT, "Can only use slicer for brand-new kit"},
         {STRING_FOR_TEMP_FOLDER_CANT_BE_BROWSED, "TEMP folder can't be browsed"},
         {STRING_FOR_UNLOADED_PARTS, "Can't return to current song, as parts have been unloaded"},
         {STRING_FOR_SD_CARD_ERROR, "SD card error"},


### PR DESCRIPTION
This pull request fixes a typo in the English localization file. The string "Can only user slicer for brand-new kit" has been corrected to "Can only use slicer for brand-new kit".

PS: I know it is a small contribution but I just got the Deluge (loving it), saw this typo and couldn't resist contributing. 