### PR TITLE
Bugfix/ Remove stale delete popup in 7SEG sample browser menu

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -193,6 +193,9 @@ void SampleBrowser::possiblySetUpBlinking() {
 void SampleBrowser::focusRegained() {
 	// displayCurrentFilename();
 	indicator_leds::setLedState(IndicatorLED::SAVE, false); // In case returning from delete-file context menu
+	if (display->have7SEG()) {
+		displayText(); // In case returning from delete-file context menu
+	}
 }
 
 void SampleBrowser::folderContentsReady(int32_t entryDirection) {


### PR DESCRIPTION
Fixed bug where "DELE" would continue flashing on 7SEG display when exiting delete-file context menu back into the sample browser

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1052

@ok-reza 