### PR TITLE
Enhancement/ Enable seamless drone linear recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@
 - Added new note and note row editor menu's to edit note and note row parameters.
   - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid.
   - Hold a note row audition pad and press the select encoder to enter the note row editor menu. While in the note row editor menu, the select note row audition pad will blink. You can select other note row's by pressing the note row audition pad.
+  
+##### Recording
+- Enabled seamless linear recording of drone notes using audition pads or external midi.
+  - When linear recording to a clip, you can seamlessly record a drone note using the audition pads or from external midi by continuing to audition / send a note until the linear recording stops. After linear recording stops, you can stop auditioning / send a note off and the drone note will persist without any breaks or re-triggering.
 
 ### MIDI
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -3581,9 +3581,10 @@ doSilentAudition:
 				instrumentClipView.auditionPadIsPressed[yDisplay] = 0;
 				instrumentClipView.lastAuditionedVelocityOnScreen[yDisplay] = 255;
 
-				// Stop the note sounding - but only if a sequenced note isn't in fact being played
-				// here.
-				if (!noteRowOnActiveClip || noteRowOnActiveClip->soundingStatus == STATUS_OFF) {
+				// Stop the note sounding - but only if a sequenced note isn't in fact being played here.
+				// Or if it's drone note, end auditioning to transfer the note's sustain to the sequencer
+				if (!noteRowOnActiveClip || noteRowOnActiveClip->soundingStatus == STATUS_OFF
+				    || noteRowOnActiveClip->isDroning(modelStackWithNoteRowOnCurrentClip->getLoopLength())) {
 					instrumentClipView.sendAuditionNote(false, yDisplay, 64, 0);
 				}
 			}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4039,7 +4039,7 @@ ActionResult InstrumentClipView::auditionPadAction(int32_t velocity, int32_t yDi
 
 	// Or if auditioning this NoteRow just finished...
 	else {
-		finishAuditioningRow(yDisplay, noteRowOnActiveClip);
+		finishAuditioningRow(yDisplay, modelStackWithNoteRowOnCurrentClip, noteRowOnActiveClip);
 	}
 
 	if (doRender) {
@@ -4332,13 +4332,16 @@ void InstrumentClipView::potentiallyRefreshNoteRowMenu() {
 
 // sub-function of AuditionPadAction
 // pad is released, end previous audition pad press
-void InstrumentClipView::finishAuditioningRow(int32_t yDisplay, NoteRow* noteRowOnActiveClip) {
+void InstrumentClipView::finishAuditioningRow(int32_t yDisplay, ModelStackWithNoteRow* modelStack,
+                                              NoteRow* noteRowOnActiveClip) {
 	if (auditionPadIsPressed[yDisplay]) {
 		auditionPadIsPressed[yDisplay] = 0;
 		lastAuditionedVelocityOnScreen[yDisplay] = 255;
 
 		// Stop the note sounding - but only if a sequenced note isn't in fact being played here.
-		if (!noteRowOnActiveClip || noteRowOnActiveClip->soundingStatus == STATUS_OFF) {
+		// Or if it's drone note, end auditioning to transfer the note's sustain to the sequencer
+		if (!noteRowOnActiveClip || noteRowOnActiveClip->soundingStatus == STATUS_OFF
+		    || noteRowOnActiveClip->isDroning(modelStack->getLoopLength())) {
 			sendAuditionNote(false, yDisplay, 64, 0);
 		}
 	}

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -342,7 +342,7 @@ private:
 	int32_t getVelocityToSound(int32_t velocity);
 	bool startAuditioningRow(int32_t velocity, int32_t yDisplay, bool shiftButtonDown, bool isKit,
 	                         NoteRow* noteRowOnActiveClip, Drum* drum);
-	void finishAuditioningRow(int32_t yDisplay, NoteRow* noteRowOnActiveClip);
+	void finishAuditioningRow(int32_t yDisplay, ModelStackWithNoteRow* modelStack, NoteRow* noteRowOnActiveClip);
 };
 
 extern InstrumentClipView instrumentClipView;

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -4296,6 +4296,12 @@ void InstrumentClip::finishLinearRecording(ModelStackWithTimelineCounter* modelS
 					// front than any previous Clip-lengthening that took place.
 
 					lastNote->setLength(loopLength - lastNote->pos);
+
+					// if we just recorded a drone note, transfer the note to the sequencer
+					// so that we can stop auditioning / sending midi and note will continue sustaining
+					if (thisNoteRow->isDroning(loopLength)) {
+						thisNoteRow->soundingStatus = STATUS_SEQUENCED_NOTE;
+					}
 				}
 
 				// And, that'll be the last Note we need to deal with

--- a/src/deluge/model/note/note.h
+++ b/src/deluge/model/note/note.h
@@ -48,7 +48,7 @@ public:
 	inline void setFill(int32_t newFill) { fill = newFill; }
 
 	inline int32_t getFill() { return fill; }
-	
+
 	inline bool isDrone(int32_t effectiveLength) { return (pos == 0 && length == effectiveLength); }
 
 	//	void writeToFile();

--- a/src/deluge/model/note/note.h
+++ b/src/deluge/model/note/note.h
@@ -48,6 +48,8 @@ public:
 	inline void setFill(int32_t newFill) { fill = newFill; }
 
 	inline int32_t getFill() { return fill; }
+	
+	inline bool isDrone(int32_t effectiveLength) { return (pos == 0 && length == effectiveLength); }
 
 	//	void writeToFile();
 	int32_t length;

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -2168,9 +2168,8 @@ noFurtherNotes:
 
 			if (!notes.getNumElements()) {
 stopNote:
-				stopCurrentlyPlayingNote(
-				    modelStack, true,
-				    thisNote); // Ideally (but optionally) supply the note, so lift-velocity can be used
+				// Ideally (but optionally) supply the note, so lift-velocity can be used
+				stopCurrentlyPlayingNote(modelStack, true, thisNote);
 			}
 			else {
 
@@ -2224,7 +2223,7 @@ stopNote:
 				if (ticksTilNextNoteEvent <= 0) {
 
 					// If it's a droning, full-length note...
-					if (thisNote->pos == 0 && thisNote->length == effectiveLength) {
+					if (thisNote->isDrone(effectiveLength)) {
 
 						// If it's a cut-mode sample, though, we want it to stop, so it can get retriggered
 						// again from the start. Same for time-stretching - although those can loop themselves,
@@ -4417,6 +4416,19 @@ void NoteRow::setSequenceDirectionMode(ModelStackWithNoteRow* modelStack, Sequen
 			}
 		}
 	}
+}
+
+/// check to see if this note row has only one note and that note is a drone note
+/// drone note = note at position 0 with length equal to the note row's length
+bool NoteRow::isDroning(int32_t effectiveLength) {
+	int32_t numNotes = notes.getNumElements();
+	if (numNotes == 1) {
+		Note* note = notes.getElement(0);
+		if (note->isDrone(effectiveLength)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 /*

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -236,6 +236,8 @@ public:
 	void setSequenceDirectionMode(ModelStackWithNoteRow* modelStack, SequenceDirection newMode);
 	bool isAuditioning(ModelStackWithNoteRow* modelStack);
 
+	bool isDroning(int32_t effectiveLength);
+
 private:
 	void playNote(bool, ModelStackWithNoteRow* modelStack, Note*, int32_t ticksLate = 0, uint32_t samplesLate = 0,
 	              bool noteMightBeConstant = false, PendingNoteOnList* pendingNoteOnList = NULL);


### PR DESCRIPTION
When linear recording to a clip, you can seamlessly record a drone note using the audition pads or from external midi by continuing to audition / send a note until the linear recording stops. After linear recording stops, you can stop auditioning / send a note off and the drone note will persist without any breaks or re-triggering.

https://github.com/user-attachments/assets/8cc69c16-e1fc-41c4-9270-64622cde6277

