### PR TITLE
fix: mute voices when switching between dx7 presets

### DIFF
--- a/src/deluge/gui/menu_item/dx/cartridge.cpp
+++ b/src/deluge/gui/menu_item/dx/cartridge.cpp
@@ -97,6 +97,7 @@ void DxCartridge::readValueAgain() {
 
 	DxPatch* patch = soundEditor.currentSource->ensureDxPatch();
 	pd->unpackProgram(patch->params, currentValue);
+	soundEditor.currentSound->unassignAllVoices();
 	Instrument* instrument = getCurrentInstrument();
 	if (instrument->type == OutputType::SYNTH && !instrument->existsOnCard) {
 		char name[11];


### PR DESCRIPTION
Switching the dx7 patch while voices are playing leads to an inconsistent sound which neither matches the previous patch nor the new one and this is not useful when auditioning patches. Muting existing voices is a better behavior, and is consistent with the behavior when switching between some oscillator types and samples.