### PR TITLE
Fix issue of SCW not loading as wavetable oscType if oscType was already set as Wavetable

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -869,8 +869,8 @@ doLoadAsWaveTable:
 
 		// Or if we want to first try doing it as a Sample (not a WaveTable)...
 		else {
-doLoadAsSample:
 			numTypesTried++;
+doLoadAsSample:
 
 			/*
 			// If multiple Ranges, then forbid the changing from WaveTable to Sample.


### PR DESCRIPTION
When osc1type is already set to WAVETABLE, from having loaded another SCW before, if you try to load another SCW into the synth, it will follow an erroneous path through the source code that leads to operation failing and falling back to SAMPLE, instead of WAVETABLE.

To cherry pick