### PR TITLE
[DRAFT] Polish/ Clip Settings Menu - Blink Selected Clip Pad

### DIFF
--- a/src/deluge/gui/context_menu/clip_settings/clip_settings.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/clip_settings.cpp
@@ -4,6 +4,7 @@
 #include "gui/l10n/l10n.h"
 #include "gui/ui/rename/rename_clipname_ui.h"
 #include "gui/ui/root_ui.h"
+#include "gui/ui_timer_manager.h"
 #include "gui/views/session_view.h"
 #include "hid/display/display.h"
 #include "model/clip/clip.h"
@@ -42,6 +43,13 @@ bool ClipSettingsMenu::setupAndCheckAvailability() {
 	return true;
 }
 
+void ClipSettingsMenu::focusRegained() {
+	// blink the pad of the clip we've selected for this menu
+	soundEditor.setupShortcutBlink(clipX, clipY, 10);
+	soundEditor.blinkShortcut();
+	ContextMenu::focusRegained();
+}
+
 void ClipSettingsMenu::selectEncoderAction(int8_t offset) {
 	ContextMenu::selectEncoderAction(offset);
 }
@@ -62,6 +70,9 @@ bool ClipSettingsMenu::acceptCurrentOption() {
 			openUI(&launchStyle);
 		}
 		else {
+			// disable shortcut blinking in the rename UI because you don't see
+			// the clip pad on the grid
+			uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 			currentUIMode = UI_MODE_NONE;
 			renameClipNameUI.clip = clip;
 			openUI(&renameClipNameUI);

--- a/src/deluge/gui/context_menu/clip_settings/clip_settings.h
+++ b/src/deluge/gui/context_menu/clip_settings/clip_settings.h
@@ -14,8 +14,11 @@ public:
 	bool setupAndCheckAvailability();
 	bool canSeeViewUnderneath() override { return true; }
 	bool acceptCurrentOption() override; // If returns false, will cause UI to exit
+	void focusRegained() override;
 
 	Clip* clip = nullptr;
+	int32_t clipX = -1;
+	int32_t clipY = -1;
 
 	/// Title
 	char const* getTitle() override;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -505,6 +505,8 @@ moveAfterClipInstance:
 					requestRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 					if (clip != nullptr) {
 						context_menu::clip_settings::clipSettings.clip = clip;
+						context_menu::clip_settings::clipSettings.clipX = gridFirstPressedX;
+						context_menu::clip_settings::clipSettings.clipY = gridFirstPressedY;
 						context_menu::clip_settings::clipSettings.setupAndCheckAvailability();
 						openUI(&context_menu::clip_settings::clipSettings);
 					}


### PR DESCRIPTION
Just some nice polish for the clip settings menu to identify menu context

While in the Clip Settings menu in grid view (which is accessed by holding an existing clip pad and pressing select), the pad for the clip selected for that menu will blink