### PR TITLE
Feature - looper and sampler types for audio outputs

### DIFF
--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -28,27 +28,15 @@ namespace deluge::gui::context_menu {
 
 enum class AudioInputSelector::Value {
 	OFF,
-
 	LEFT,
-	LEFT_ECHO,
-
 	RIGHT,
-	RIGHT_ECHO,
-
 	STEREO,
-	STEREO_ECHO,
-
 	BALANCED,
-	BALANCED_ECHO,
-
 	MASTER,
-
 	OUTPUT,
-
 	TRACK,
-	TRACK_FX,
 };
-constexpr size_t kNumValues = 13;
+constexpr size_t kNumValues = 8;
 
 AudioInputSelector audioInputSelector{};
 
@@ -60,19 +48,9 @@ char const* AudioInputSelector::getTitle() {
 Sized<const char**> AudioInputSelector::getOptions() {
 	using enum l10n::String;
 	static const char* options[] = {
-	    l10n::get(STRING_FOR_DISABLED),
-	    l10n::get(STRING_FOR_LEFT_INPUT),
-	    l10n::get(STRING_FOR_LEFT_INPUT_MONITORING),
-	    l10n::get(STRING_FOR_RIGHT_INPUT),
-	    l10n::get(STRING_FOR_RIGHT_INPUT_MONITORING),
-	    l10n::get(STRING_FOR_STEREO_INPUT),
-	    l10n::get(STRING_FOR_STEREO_INPUT_MONITORING),
-	    l10n::get(STRING_FOR_BALANCED_INPUT),
-	    l10n::get(STRING_FOR_BALANCED_INPUT_MONITORING),
-	    l10n::get(STRING_FOR_MIX_PRE_FX),
-	    l10n::get(STRING_FOR_MIX_POST_FX),
-	    l10n::get(STRING_FOR_TRACK),
-	    l10n::get(STRING_FOR_TRACK_WITH_FX),
+	    l10n::get(STRING_FOR_DISABLED),     l10n::get(STRING_FOR_LEFT_INPUT),     l10n::get(STRING_FOR_RIGHT_INPUT),
+	    l10n::get(STRING_FOR_STEREO_INPUT), l10n::get(STRING_FOR_BALANCED_INPUT), l10n::get(STRING_FOR_MIX_PRE_FX),
+	    l10n::get(STRING_FOR_MIX_POST_FX),  l10n::get(STRING_FOR_TRACK),
 	};
 	return {options, kNumValues};
 }
@@ -115,9 +93,6 @@ bool AudioInputSelector::setupAndCheckAvailability() {
 
 	currentOption = static_cast<int32_t>(valueOption);
 
-	if (audioOutput->echoing) {
-		currentOption += 1;
-	}
 	scrollPos = currentOption;
 	return true;
 }
@@ -134,31 +109,22 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 
 	ContextMenu::selectEncoderAction(offset);
 
-	audioOutput->echoing = false;
-
 	auto valueOption = static_cast<Value>(currentOption);
 
 	switch (valueOption) {
-	case Value::LEFT_ECHO:
-		audioOutput->echoing = true;
+
 	case Value::LEFT:
 		audioOutput->inputChannel = AudioInputChannel::LEFT;
 		break;
 
-	case Value::RIGHT_ECHO:
-		audioOutput->echoing = true;
 	case Value::RIGHT:
 		audioOutput->inputChannel = AudioInputChannel::RIGHT;
 		break;
 
-	case Value::STEREO_ECHO:
-		audioOutput->echoing = true;
 	case Value::STEREO:
 		audioOutput->inputChannel = AudioInputChannel::STEREO;
 		break;
 
-	case Value::BALANCED_ECHO:
-		audioOutput->echoing = true;
 	case Value::BALANCED:
 		audioOutput->inputChannel = AudioInputChannel::BALANCED;
 		break;
@@ -172,11 +138,7 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 		break;
 	case Value::TRACK:
 		audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
-		audioOutput->setOutputRecordingFrom(currentSong->getOutputFromIndex(0), false);
-		break;
-	case Value::TRACK_FX:
-		audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
-		audioOutput->setOutputRecordingFrom(currentSong->getOutputFromIndex(0), true);
+		audioOutput->setOutputRecordingFrom(currentSong->getOutputFromIndex(0));
 		break;
 
 	default:

--- a/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
+++ b/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
@@ -48,7 +48,7 @@ public:
 		outputIndex += offset;
 		outputIndex = std::clamp<int32_t>(outputIndex, 0, numOutputs - 1);
 		auto newRecordingFrom = currentSong->getOutputFromIndex(outputIndex);
-		audioOutputBeingEdited->setOutputRecordingFrom(newRecordingFrom, audioOutputBeingEdited->echoing);
+		audioOutputBeingEdited->setOutputRecordingFrom(newRecordingFrom);
 		if (display->haveOLED()) {
 			renderUIsForOled();
 		}

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -661,8 +661,9 @@ void AudioClipView::selectEncoderAction(int8_t offset) {
 	if (currentUIMode) {
 		return;
 	}
-
-	view.navigateThroughAudioOutputsForAudioClip(offset, getCurrentAudioClip());
+	auto ao = (AudioOutput*)getCurrentAudioClip()->output;
+	ao->scrollAudioOutputMode(offset);
+	renderUIsForOled();
 }
 
 void AudioClipView::setClipLengthEqualToSampleLength() {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1271,10 +1271,9 @@ void SessionView::commandChangeClipPreset(int8_t offset) {
 		}
 	}
 	else {
-		// This moves clips around uncomfortably and we have a track for every Audio anyway
-		if (currentSong->sessionLayout != SessionLayoutType::SessionLayoutTypeGrid) {
-			view.navigateThroughAudioOutputsForAudioClip(offset, (AudioClip*)clip, true);
-		}
+		auto ao = (AudioOutput*)clip->output;
+		ao->scrollAudioOutputMode(offset);
+		renderUIsForOled();
 	}
 }
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1843,7 +1843,7 @@ char const* View::getReverbPresetDisplayName(int32_t preset) {
 }
 
 void View::displayOutputName(Output* output, bool doBlink, Clip* clip) {
-	int32_t channel, channelSuffix;
+	int32_t channel{0}, channelSuffix{0};
 	bool editedByUser = true;
 	if (output->type != OutputType::AUDIO) {
 		Instrument* instrument = (Instrument*)output;
@@ -1857,6 +1857,9 @@ void View::displayOutputName(Output* output, bool doBlink, Clip* clip) {
 			channel = ((NonAudioInstrument*)instrument)->channel;
 			break;
 		}
+	}
+	else {
+		channel = static_cast<int32_t>(((AudioOutput*)output)->mode);
 	}
 
 	drawOutputNameFromDetails(output->type, channel, channelSuffix, output->name.get(), output->name.isEmpty(),

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -22,6 +22,7 @@
 #include "hid/button.h"
 #include "model/model_stack.h"
 #include "modulation/params/param.h"
+#include "processing/audio_output.h"
 #include <cstdint>
 
 class InstrumentClip;

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -220,6 +220,11 @@ void AudioClip::finishLinearRecording(ModelStackWithTimelineCounter* modelStack,
 	if (!isEmpty()) {
 		clear(nullptr, modelStack, true, true);
 	}
+	auto ao = (AudioOutput*)output;
+	// if we're a sampler then turn off monitoring
+	if (ao->mode == AudioOutputMode::sampler) {
+		ao->mode = AudioOutputMode::player;
+	}
 	originalLength = loopLength;
 	sampleHolder.filePath.set(&recorder->sample->filePath);
 	sampleHolder.setAudioFile(recorder->sample, sampleControls.reversed, true,

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -62,10 +62,7 @@ public:
 
 	// we can only do in place overdubs if input monitoring is on right now, recording input seperately might come later
 	// if we're in rows mode then use the old cloning method instead
-	bool shouldCloneForOverdubs() override {
-		return currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeRows
-		       || !(((AudioOutput*)output)->echoing);
-	};
+	bool shouldCloneForOverdubs() override { return ((AudioOutput*)output)->mode != AudioOutputMode::looper; };
 	Clip* cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStack, OverDubType newOverdubNature) override;
 	int64_t getSamplesFromTicks(int32_t ticks);
 	void unassignVoiceSample(bool wontBeUsedAgain);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2140,7 +2140,7 @@ skipInstance:
 		if (thisOutput->type == OutputType::AUDIO) {
 			auto ao = (AudioOutput*)thisOutput;
 			if (ao->inputChannel == AudioInputChannel::SPECIFIC_OUTPUT) {
-				ao->setOutputRecordingFrom(getOutputFromIndex(ao->outputRecordingFromIndex), ao->echoing);
+				ao->setOutputRecordingFrom(getOutputFromIndex(ao->outputRecordingFromIndex));
 			}
 		}
 		// If saved before V2.1, set sample-based synth instruments to linear interpolation, cos that's how it was
@@ -3375,7 +3375,7 @@ traverseClips:
 	// Put the newInstrument into the master list
 	*prevPointer = newOutput;
 	if (outputRecordingOldOutput) {
-		((AudioOutput*)outputRecordingOldOutput)->setOutputRecordingFrom(newOutput, true);
+		((AudioOutput*)outputRecordingOldOutput)->setOutputRecordingFrom(newOutput);
 	}
 	AudioEngine::mustUpdateReverbParamsBeforeNextRender = true;
 }

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -21,8 +21,17 @@
 #include "model/global_effectable/global_effectable_for_clip.h"
 #include "model/output.h"
 #include "modulation/envelope.h"
+#include "util/container/enum_to_string_map.hpp"
 
 class ModelStackWithTimelineCounter;
+
+/// Player: plays back a file or samples from input without monitoring
+/// Sampler: Monitoring is enabled but disabled after recording. Overdubbing creates a new clip.
+/// Looper/FX: monitoring always enabled. Overdubbing overdubs the existing audio
+enum class AudioOutputMode : uint8_t { player, sampler, looper };
+constexpr int kNumAudioOutputModes = 3;
+AudioOutputMode stringToAOMode(char const* string);
+char const* aoModeToString(AudioOutputMode mode);
 
 class AudioOutput final : public Output, public GlobalEffectableForClip {
 public:
@@ -42,36 +51,36 @@ public:
 
 	void resetEnvelope();
 
-	ModControllable* toModControllable() { return this; }
-	uint8_t* getModKnobMode() { return &modKnobMode; }
+	ModControllable* toModControllable() override { return this; }
+	uint8_t* getModKnobMode() override { return &modKnobMode; }
 
-	void cutAllSound();
+	void cutAllSound() override;
 	void getThingWithMostReverb(Sound** soundWithMostReverb, ParamManagerForTimeline** paramManagerWithMostReverb,
 	                            Kit** kitWithMostReverb, int32_t* highestReverbAmountFound);
 
-	Error readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos);
-	bool writeDataToFile(Serializer& writer, Clip* clipForSavingOutputOnly, Song* song);
-	void deleteBackedUpParamManagers(Song* song);
+	Error readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos) override;
+	bool writeDataToFile(Serializer& writer, Clip* clipForSavingOutputOnly, Song* song) override;
+	void deleteBackedUpParamManagers(Song* song) override;
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack,
 	                   PgmChangeSend maySendMIDIPGMs = PgmChangeSend::ONCE) override;
-	bool isSkippingRendering();
-	Output* toOutput() { return this; }
+	bool isSkippingRendering() override;
+	Output* toOutput() override { return this; }
 	void getThingWithMostReverb(Sound** soundWithMostReverb, ParamManager** paramManagerWithMostReverb,
 	                            GlobalEffectableForClip** globalEffectableWithMostReverb,
-	                            int32_t* highestReverbAmountFound);
+	                            int32_t* highestReverbAmountFound) override;
 
 	// A TimelineCounter is required
 	void offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,
-	                                    ModelStackWithTimelineCounter* modelStack) {
+	                                    ModelStackWithTimelineCounter* modelStack) override {
 		ModControllableAudio::offerReceivedCCToLearnedParamsForClip(fromDevice, channel, ccNumber, value, modelStack);
 	}
 	bool offerReceivedPitchBendToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1, uint8_t data2,
-	                                           ModelStackWithTimelineCounter* modelStack) {
+	                                           ModelStackWithTimelineCounter* modelStack) override {
 		return ModControllableAudio::offerReceivedPitchBendToLearnedParams(fromDevice, channel, data1, data2,
 		                                                                   modelStack);
 	}
 
-	char const* getXMLTag() { return "audioTrack"; }
+	char const* getXMLTag() override { return "audioTrack"; }
 
 	Envelope envelope;
 
@@ -86,29 +95,36 @@ public:
 	/// accurate through those changes.
 	///
 	/// int16 so it packs nicely with `echoing` below
-	int16_t outputRecordingFromIndex{-1}; // int16 so it fits with the bool and because that should be enough outputs
-	/// When true, this output is monitoring its input.
-	///
-	/// Does not get copied when this Output is cloned, as that would result in undesirable doubling of the monitored
-	/// audio.
-	bool echoing;
+	int16_t outputRecordingFromIndex{-1}; // int16 so it fits with the bool and mode
+
+	AudioOutputMode mode{AudioOutputMode::player};
 
 	Output* getOutputRecordingFrom() { return outputRecordingFrom; }
-	void clearRecordingFrom() override { setOutputRecordingFrom(nullptr, false); }
-	void setOutputRecordingFrom(Output* toRecordfrom, bool monitoring) {
+	void clearRecordingFrom() override { setOutputRecordingFrom(nullptr); }
+	void setOutputRecordingFrom(Output* toRecordfrom) {
+		if (toRecordfrom == this) {
+			// can happen from bad save files
+			return;
+		}
 		if (outputRecordingFrom) {
 			outputRecordingFrom->setRenderingToAudioOutput(false, nullptr);
 		}
 		outputRecordingFrom = toRecordfrom;
 		if (outputRecordingFrom) {
-			outputRecordingFrom->setRenderingToAudioOutput(monitoring, this);
+			// If we are a SAMPLER or a LOOPER then we're monitoring the audio, so tell the other output that we're in
+			// charge of rendering
+			outputRecordingFrom->setRenderingToAudioOutput(mode != AudioOutputMode::player, this);
 		}
-		echoing = monitoring;
 	}
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
 	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,
 	                                                bool affectEntire, bool useMenuStack);
+	void scrollAudioOutputMode(int offset) {
+		auto modeInt = util::to_underlying(mode);
+		modeInt = (modeInt + offset) % kNumAudioOutputModes;
+		mode = static_cast<AudioOutputMode>(modeInt);
+	}
 
 protected:
 	Clip* createNewClipForArrangementRecording(ModelStack* modelStack);

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -26,6 +26,7 @@
 #include "hid/display/display.h"
 #include "hid/encoders.h"
 #include "modulation/arpeggiator.h"
+#include "processing/audio_output.h"
 #include "processing/sound/sound.h"
 #include <cmath>
 #include <string.h>
@@ -578,8 +579,19 @@ char const* getOutputTypeName(OutputType outputType, int32_t channel) {
 		}
 	case OutputType::CV:
 		return "CV / gate";
-	case OutputType::AUDIO:
+	case OutputType::AUDIO: {
+		auto mode = static_cast<AudioOutputMode>(channel);
+		switch (mode) {
+
+		case AudioOutputMode::player:
+			return "Audio Player";
+		case AudioOutputMode::sampler:
+			return "Audio Sampler";
+		case AudioOutputMode::looper:
+			return "Audio Looper";
+		}
 		return "Audio";
+	}
 	default:
 		return "None";
 	}


### PR DESCRIPTION
Creates modes for audio clips, player, sample and looper. Modes are changed by turning select in an audio clip view or while holding an audio clip in song view.

Player: Monitoring is off, overdubs work by cloning. This is intended to be used for playing a static audio file or recording without monitoring.

Sampler: Monitoring is on, monitoring turns off after recording, overdubs work by cloning. This is intended to be used for sampling from an ongoing audio stream where you only want to hear the part you're looping afterwards

Looper: Monitoring is on and remains on. Overdubs do a real overdub in place. This is intended for live looping or use as an fx processor

I've slightly modified copying as well - if the clip is empty then it works the same way as current copying (target clip becomes a player), if the clip has contents then the original clip becomes a player and the new clip takes its sampler/looper settings. This makes copying an output to make new loops much smoother

Removed: Moving a clip to another output from rows view. This didn't do anything useful in rows view (can't change section of the clip or move it to an output that already has a clip in the section) and it's still possible from arranger. 