### PR TITLE
fix possible infinite loop

### DIFF
--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3699,7 +3699,8 @@ goAgain:
 			// Otherwise, then yes, we want to look at the next note along (left).
 			else {
 				i--;
-				goto goAgain;
+				if (i > -effectiveLength)
+					goto goAgain;
 			}
 		}
 	}


### PR DESCRIPTION
You can get into an infinite loop while monitoring MPE without recording where the note row has no notes, so it continues to search backwards forever