### PR TITLE
[DRAFT] Feature/ Add Panic Button to Stop All Notes and Sound + Send MIDI All Notes Off Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Sound Engine
 - Added a Warbler fx and a warble LFO to synths/kits/kit rows/song/audio clips
+- Added panic button to stop playback and all sound and notes. Press `SHIFT` + `PLAY`.
+  - Note: for any active `MIDI and CV Instrument Clips` this will also send an `All Notes Off` (CC#123) message.
 
 ### User Interface
 

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -143,6 +143,13 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 			considerCrossScreenReleaseForCrossScreenMode = true;
 		}
 	}
+	// panic button, this button combo will no longer do anything else
+	else if (b == PLAY && isShiftButtonPressed()) {
+		if (currentSong) {
+			currentSong->panicStopAllSound();
+		}
+		goto dealtWith;
+	}
 
 	result = getCurrentUI()->buttonAction(b, on, inCardRoutine);
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -3364,6 +3364,10 @@ void InstrumentClip::stopAllNotesForMIDIOrCV(ModelStackWithTimelineCounter* mode
 
 	// And then we still need this but in case any notes have been sent out via audition, or I guess being echoed thru
 
+	sendAllNotesOffForMIDIOrCV();
+}
+
+void InstrumentClip::sendAllNotesOffForMIDIOrCV() {
 	// CV - easy
 	if (output->type == OutputType::CV) {
 		cvEngine.sendNote(false, ((CVInstrument*)output)->channel);

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -199,6 +199,7 @@ public:
 	int32_t getDistanceToNextNote(Note* givenNote, ModelStackWithNoteRow* modelStack);
 	void reGetParameterAutomation(ModelStackWithTimelineCounter* modelStack) override;
 	void stopAllNotesForMIDIOrCV(ModelStackWithTimelineCounter* modelStack);
+	void sendAllNotesOffForMIDIOrCV();
 	void sendMIDIPGM();
 	void noteRemovedFromMode(int32_t yNoteWithinOctave, Song* song);
 	void clear(Action* action, ModelStackWithTimelineCounter* modelStack, bool clearAutomation,

--- a/src/deluge/model/drum/drum.h
+++ b/src/deluge/model/drum/drum.h
@@ -90,4 +90,6 @@ public:
 	void getCombinedExpressionInputs(int16_t* combined);
 
 	virtual ModControllable* toModControllable() { return NULL; }
+
+	virtual void stopDelay() {}
 };

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -1127,6 +1127,10 @@ Delay::State GlobalEffectable::createDelayWorkingState(ParamManager& paramManage
 	return delayWorkingState;
 }
 
+void GlobalEffectable::stopDelay() {
+	delay.discardBuffers();
+}
+
 void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, int32_t numSamples,
                                                     int32_t* postFXVolume, ParamManager* paramManager,
                                                     const Delay::State& delayWorkingState, bool grainHadInput) {

--- a/src/deluge/model/global_effectable/global_effectable.h
+++ b/src/deluge/model/global_effectable/global_effectable.h
@@ -57,6 +57,7 @@ public:
 	                                 int32_t readAutomationUpToPos);
 	Delay::State createDelayWorkingState(ParamManager& paramManager, bool shouldLimitDelayFeedback = false,
 	                                     bool soundComingIn = true);
+	void stopDelay();
 	bool isEditingComp() override { return editingComp; }
 	int32_t getKnobPosForNonExistentParam(int32_t whichModEncoder, ModelStackWithAutoParam* modelStack) override;
 	ActionResult modEncoderActionForNonExistentParam(int32_t offset, int32_t whichModEncoder,

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -171,6 +171,10 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	}
 }
 
+void GlobalEffectableForClip::stopDelay() {
+	GlobalEffectable::stopDelay();
+}
+
 int32_t GlobalEffectableForClip::getSidechainVolumeAmountAsPatchCableDepth(ParamManager* paramManager) {
 	int32_t sidechainVolumeParam = paramManager->getUnpatchedParamSet()->getValue(params::UNPATCHED_SIDECHAIN_VOLUME);
 	return (sidechainVolumeParam >> 2) + 536870912;

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -59,6 +59,7 @@ protected:
 	                  StereoSample* outputBuffer, int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
 	                  int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive,
 	                  OutputType outputType, SampleRecorder* recorder);
+	void stopDelay();
 
 	virtual bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
 	                                           StereoSample* globalEffectableBuffer, int32_t* bufferToTransferTo,

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -515,6 +515,16 @@ void Kit::cutAllSound() {
 	}
 }
 
+void Kit::stopDelay() {
+	// stop kit affect entire delay
+	GlobalEffectableForClip::stopDelay();
+
+	// stop delay at drum level
+	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
+		thisDrum->stopDelay();
+	}
+}
+
 // Beware - unlike usual, modelStack, a ModelStackWithThreeMainThings*,  might have a NULL timelineCounter
 bool Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
                                         int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -45,6 +45,7 @@ public:
 
 	Error loadAllAudioFiles(bool mayActuallyReadFiles) override;
 	void cutAllSound() override;
+	void stopDelay() override;
 	void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
 	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                  bool shouldLimitDelayFeedback, bool isClipActive) override;

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -113,6 +113,7 @@ public:
 	virtual void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
 	                          int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                          bool shouldLimitDelayFeedback, bool isClipActive) = 0;
+	virtual void stopDelay() {}
 
 	virtual void setupWithoutActiveClip(ModelStack* modelStack);
 	virtual bool setActiveClip(

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -170,6 +170,8 @@ public:
 	void setupPatchingForAllParamManagers();
 	void replaceInstrument(Instrument* oldInstrument, Instrument* newInstrument, bool keepNoteRowsWithMIDIInput = true);
 	void stopAllMIDIAndGateNotesPlaying();
+	void sendAllNotesOffForMIDIOrCV();
+	void stopAllDelay();
 	void stopAllAuditioning();
 	void deleteOrHibernateOutput(Output* output);
 	Instrument* getNonAudioInstrumentToSwitchTo(OutputType newOutputType, Availability availabilityRequirement,
@@ -446,6 +448,9 @@ public:
 	}
 
 	int8_t defaultAudioClipOverdubOutputCloning = -1; // -1 means no default set
+
+	// Panic button
+	void panicStopAllSound();
 
 private:
 	ScaleMapper scaleMapper;

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -305,6 +305,10 @@ void AudioOutput::cutAllSound() {
 	}
 }
 
+void AudioOutput::stopDelay() {
+	GlobalEffectableForClip::stopDelay();
+}
+
 void AudioOutput::getThingWithMostReverb(Sound** soundWithMostReverb,
                                          ParamManagerForTimeline** paramManagerWithMostReverb, Kit** kitWithMostReverb,
                                          int32_t* highestReverbAmountFound) {

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -46,6 +46,7 @@ public:
 	uint8_t* getModKnobMode() { return &modKnobMode; }
 
 	void cutAllSound();
+	void stopDelay();
 	void getThingWithMostReverb(Sound** soundWithMostReverb, ParamManagerForTimeline** paramManagerWithMostReverb,
 	                            Kit** kitWithMostReverb, int32_t* highestReverbAmountFound);
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2473,6 +2473,10 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	doParamLPF(numSamples, modelStackWithSoundFlags);
 }
 
+void Sound::stopDelay() {
+	delay.discardBuffers();
+}
+
 // This is virtual, and gets extended by drums!
 void Sound::setSkippingRendering(bool newSkipping) {
 	skippingRendering = newSkipping;

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -148,6 +148,7 @@ public:
 	            int32_t* reverbBuffer, int32_t sideChainHitPending, int32_t reverbAmountAdjust = 134217728,
 	            bool shouldLimitDelayFeedback = false, int32_t pitchAdjust = kMaxSampleValue,
 	            SampleRecorder* recorder = nullptr);
+	void stopDelay();
 	void unassignAllVoices();
 
 	void ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(Song* song) final; // Song may be NULL

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -229,3 +229,7 @@ void SoundDrum::drumWontBeRenderedForAWhile() {
 ArpeggiatorBase* SoundDrum::getArp() {
 	return &arpeggiator;
 }
+
+void SoundDrum::stopDelay() {
+	Sound::stopDelay();
+}

--- a/src/deluge/processing/sound/sound_drum.h
+++ b/src/deluge/processing/sound/sound_drum.h
@@ -64,4 +64,6 @@ public:
 	ArpeggiatorBase* getArp();
 	ArpeggiatorSettings* getArpSettings(InstrumentClip* clip = NULL) { return &arpSettings; }
 	void resetTimeEnteredState();
+
+	void stopDelay() override;
 };

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -87,6 +87,10 @@ void SoundInstrument::cutAllSound() {
 	Sound::unassignAllVoices();
 }
 
+void SoundInstrument::stopDelay() {
+	Sound::stopDelay();
+}
+
 void SoundInstrument::renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos,
                                    int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
                                    int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive) {

--- a/src/deluge/processing/sound/sound_instrument.h
+++ b/src/deluge/processing/sound/sound_instrument.h
@@ -38,6 +38,7 @@ public:
 	void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
 	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                  bool shouldLimitDelayFeedback, bool isClipActive);
+	void stopDelay();
 
 	// A timelineCounter is required
 	void offerReceivedCCToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t ccNumber, uint8_t value,


### PR DESCRIPTION
Added panic button to stop playback and all sound and notes. Press `SHIFT` + `PLAY`.
  - Note: for any active `MIDI and CV Instrument Clips` this will also send an `All Notes Off` message.