### PR TITLE
[DRAFT] Feature/ Add midi cc labels + midi cc #'s / name's to mod encoder popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@
 ##### Synth/Kit Clips
 - Added Auto-Load feature to sample browser, so you can load the sounds to the instrument as you preview them. Auto-Load can be engaged while in sample browser, if you press the `Load` button.
 
+##### MIDI Clips
+- Added ability to rename MIDI CC's in MIDI clips. Changed are saved by Instrument (e.g. per MIDI channel). Changes can be saved to a MIDI preset and with the song.
+  - To rename a `MIDI CC`, enter `Automation View` and select the CC you wish to rename using the `Select Encoder`.
+  - With the `MIDI CC` selected, press down either `Gold (Mod) Encoder` and then press the `Name` grid shortcut to open the `MIDI CC Renaming UI`. Enter a new name and press `Select` or `Enter`.
+  - The new `MIDI CC` name will be immediately visible in `Automation View` and you can assign that CC to a `Gold Knob` in the MIDI clip and it will show that name when you press down on the `Gold (Mod) Encoder`.
+- Added MIDI CC numbers and labels to `Gold (Mod) Encoder` popups.
+
 ### MIDI
 
 #### <ins>Learn</ins>

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -1182,6 +1182,13 @@ as an oscillator type within the subtractive engine, so it can be combined with 
 - ([#1390]) Allows saving and loading midi presets. They end up in a new folder named MIDI.
   - Note: The information that is saved is the MIDI channel selection, and the assignments of CC parameters to golden knobs.
 
+#### 4.7.2 - Save/Load MIDI CC Labels
+
+- ([#2721]) Added ability to rename MIDI CC's in MIDI clips. Changed are saved by Instrument (e.g. per MIDI channel). Changes can be saved to a MIDI preset and with the song.
+  - To rename a `MIDI CC`, enter `Automation View` and select the CC you wish to rename using the `Select Encoder`.
+  - With the `MIDI CC` selected, press down either `Gold (Mod) Encoder` and then press the `Name` grid shortcut to open the `MIDI CC Renaming UI`. Enter a new name and press `Select` or `Enter`.
+  - The new `MIDI CC` name will be immediately visible in `Automation View` and you can assign that CC to a `Gold Knob` in the MIDI clip and it will show that name when you press down on the `Gold (Mod) Encoder`.
+
 ### 4.8 Audio Clip View - Features
 
 #### 4.8.1 - Shift Clip
@@ -1553,6 +1560,8 @@ different firmware
 [#2712]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2712
 
 [#2716]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2716
+
+[#2721]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2721
 
 [Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/automation_view.md
 

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -213,7 +213,8 @@ enum class UIType : uint8_t {
 	SLICER,
 	SOUND_EDITOR,
 	TIMELINE,
-	RENAME_CLIPNAME,
+	RENAME_CLIP,
+	RENAME_MIDI_CC,
 	NONE = 255,
 };
 

--- a/src/deluge/gui/context_menu/clip_settings/clip_settings.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/clip_settings.cpp
@@ -2,7 +2,7 @@
 #include "definitions_cxx.hpp"
 #include "gui/context_menu/clip_settings/launch_style.h"
 #include "gui/l10n/l10n.h"
-#include "gui/ui/rename/rename_clipname_ui.h"
+#include "gui/ui/rename/rename_clip_ui.h"
 #include "gui/ui/root_ui.h"
 #include "gui/views/session_view.h"
 #include "hid/display/display.h"
@@ -63,8 +63,8 @@ bool ClipSettingsMenu::acceptCurrentOption() {
 		}
 		else {
 			currentUIMode = UI_MODE_NONE;
-			renameClipNameUI.clip = clip;
-			openUI(&renameClipNameUI);
+			renameClipUI.clip = clip;
+			openUI(&renameClipUI);
 		}
 		return true;
 	}

--- a/src/deluge/gui/ui/rename/rename_clip_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.cpp
@@ -15,30 +15,30 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-#include "gui/ui/rename/rename_output_ui.h"
+#include "gui/ui/rename/rename_clip_ui.h"
 #include "definitions_cxx.hpp"
 #include "extern.h"
 #include "gui/l10n/l10n.h"
-#include "gui/views/arranger_view.h"
+#include "gui/views/instrument_clip_view.h"
 #include "hid/buttons.h"
 #include "hid/display/display.h"
 #include "hid/led/pad_leds.h"
 #include "model/output.h"
 #include "model/song/song.h"
 
-RenameOutputUI renameOutputUI{};
+RenameClipUI renameClipUI{};
 
-RenameOutputUI::RenameOutputUI() {
-	title = "Track Name";
+RenameClipUI::RenameClipUI() {
+	title = "Clip Name";
 }
 
-bool RenameOutputUI::opened() {
+bool RenameClipUI::opened() {
 	bool success = QwertyUI::opened();
 	if (!success) {
 		return false;
 	}
 
-	enteredText.set(&output->name);
+	enteredText.set(&clip->name);
 
 	displayText();
 
@@ -47,12 +47,12 @@ bool RenameOutputUI::opened() {
 	return true;
 }
 
-bool RenameOutputUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
+bool RenameClipUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*cols = 0b11;
 	return true;
 }
 
-ActionResult RenameOutputUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+ActionResult RenameClipUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 	using namespace deluge::hid::button;
 
 	// Back button
@@ -82,34 +82,27 @@ ActionResult RenameOutputUI::buttonAction(deluge::hid::Button b, bool on, bool i
 	return ActionResult::DEALT_WITH;
 }
 
-void RenameOutputUI::enterKeyPress() {
-
-	if (enteredText.isEmpty()) {
-		return;
-	}
+void RenameClipUI::enterKeyPress() {
 
 	// If actually changing it...
-	if (!output->name.equalsCaseIrrespective(&enteredText)) {
-		// if this is an audio output
-		// don't let user set a name that is a duplicate of another name that has been set for another audio output
-		// Sean: do we only want to do this for audio output's?
-		if (currentSong->getAudioOutputFromName(&enteredText)) {
+	if (!clip->name.equalsCaseIrrespective(&enteredText)) {
+		// don't let user set a name that is a duplicate of another name that has been set for another clip
+		if (currentSong->getClipFromName(&enteredText)) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
 		}
 	}
-
-	output->name.set(&enteredText);
+	clip->name.set(&enteredText);
 	exitUI();
 }
 
-bool RenameOutputUI::exitUI() {
+bool RenameClipUI::exitUI() {
 	display->setNextTransitionDirection(-1);
 	close();
 	return true;
 }
 
-ActionResult RenameOutputUI::padAction(int32_t x, int32_t y, int32_t on) {
+ActionResult RenameClipUI::padAction(int32_t x, int32_t y, int32_t on) {
 
 	// Main pad
 	if (x < kDisplayWidth) {
@@ -127,6 +120,6 @@ ActionResult RenameOutputUI::padAction(int32_t x, int32_t y, int32_t on) {
 	return ActionResult::DEALT_WITH;
 }
 
-ActionResult RenameOutputUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
+ActionResult RenameClipUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
 	return ActionResult::DEALT_WITH;
 }

--- a/src/deluge/gui/ui/rename/rename_clip_ui.h
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.h
@@ -23,9 +23,9 @@
 class Output;
 class Clip;
 
-class RenameClipNameUI final : public RenameUI {
+class RenameClipUI final : public RenameUI {
 public:
-	RenameClipNameUI();
+	RenameClipUI();
 	bool opened();
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
@@ -36,12 +36,12 @@ public:
 	Clip* clip;
 
 	// ui
-	UIType getUIType() { return UIType::RENAME_CLIPNAME; }
-	const char* getName() { return "rename_clipname_ui"; }
+	UIType getUIType() { return UIType::RENAME_CLIP; }
+	const char* getName() { return "rename_clip_ui"; }
 	bool exitUI() override;
 
 protected:
 	void enterKeyPress();
 };
 
-extern RenameClipNameUI renameClipNameUI;
+extern RenameClipUI renameClipUI;

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -96,6 +96,7 @@ void RenameDrumUI::enterKeyPress() {
 
 	// If actually changing it...
 	if (!getDrum()->name.equalsCaseIrrespective(&enteredText)) {
+		// don't let user set a name that is a duplicate of another name that has been set for another drum
 		if (getCurrentKit()->getDrumFromName(enteredText.get())) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
@@ -114,32 +115,22 @@ bool RenameDrumUI::exitUI() {
 
 ActionResult RenameDrumUI::padAction(int32_t x, int32_t y, int32_t on) {
 
-	// Audition pad
-	if (x == kDisplayWidth + 1) {
-		return instrumentClipView.padAction(x, y, on);
-	}
-
 	// Main pad
-	else if (x < kDisplayWidth) {
+	if (x < kDisplayWidth) {
 		return QwertyUI::padAction(x, y, on);
 	}
 
 	// Otherwise, exit
-	else {
-		if (on && !currentUIMode) {
-			if (sdRoutineLock) {
-				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-			}
-			exitUI();
+	if (on && !currentUIMode) {
+		if (sdRoutineLock) {
+			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
+		exitUI();
 	}
 
 	return ActionResult::DEALT_WITH;
 }
 
 ActionResult RenameDrumUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(deluge::hid::button::X_ENC)) {
-		return ActionResult::DEALT_WITH;
-	}
-	return instrumentClipView.verticalEncoderAction(offset, inCardRoutine);
+	return ActionResult::DEALT_WITH;
 }

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
@@ -45,13 +45,19 @@ bool RenameMidiCCUI::opened() {
 
 	// if we're not dealing with a real cc number
 	// then don't allow user to edit the name
-	if (cc < 0 || cc >= kNumRealCCNumbers) {
+	if (cc < 0 || cc == CC_EXTERNAL_MOD_WHEEL || cc >= kNumRealCCNumbers) {
 		return false;
 	}
 
 	MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
 
-	midiInstrument->getNameFromCC(cc, &enteredText);
+	String* name = midiInstrument->getNameFromCC(cc);
+	if (name) {
+		enteredText.set(name);
+	}
+	else {
+		enteredText.clear();
+	}
 
 	displayText();
 
@@ -102,10 +108,9 @@ void RenameMidiCCUI::enterKeyPress() {
 	int32_t cc = clip->lastSelectedParamID;
 
 	// If actually changing it...
-	String name;
-	midiInstrument->getNameFromCC(cc, &name);
+	String* name = midiInstrument->getNameFromCC(cc);
 
-	if (!name.equalsCaseIrrespective(&enteredText)) {
+	if (name && !name->equalsCaseIrrespective(&enteredText)) {
 		// don't let user set a name that is a duplicate of another name that has been set for another cc
 		if (midiInstrument->getCCFromName(&enteredText) != 255) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2019-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/ui/rename/rename_ui.h"
+#include "hid/button.h"
+
+class Output;
+class Clip;
+
+class RenameMidiCCUI final : public RenameUI {
+public:
+	RenameMidiCCUI();
+	bool opened();
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
+	ActionResult padAction(int32_t x, int32_t y, int32_t velocity);
+	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine);
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows);
+
+	// ui
+	UIType getUIType() { return UIType::RENAME_MIDI_CC; }
+	const char* getName() { return "rename_midi_cc_ui"; }
+	bool exitUI() override;
+
+protected:
+	void enterKeyPress();
+};
+
+extern RenameMidiCCUI renameMidiCCUI;

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -11,7 +11,7 @@
 #include "gui/ui/audio_recorder.h"
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
-#include "gui/ui/rename/rename_clipname_ui.h"
+#include "gui/ui/rename/rename_clip_ui.h"
 #include "gui/ui/rename/rename_drum_ui.h"
 #include "gui/ui/rename/rename_output_ui.h"
 #include "gui/ui/sample_marker_editor.h"
@@ -1686,8 +1686,8 @@ bool SoundEditor::handleClipName() {
 		if (output->type == OutputType::SYNTH || output->type == OutputType::MIDI_OUT
 		    || output->type == OutputType::KIT && getRootUI()->getAffectEntire()) {
 			if (clip) {
-				renameClipNameUI.clip = clip;
-				openUI(&renameClipNameUI);
+				renameClipUI.clip = clip;
+				openUI(&renameClipUI);
 				return true;
 			}
 		}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1619,20 +1619,19 @@ void AutomationView::getAutomationParameterName(Clip* clip, OutputType outputTyp
 		}
 		else {
 			MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
-			String name;
+			bool appendedName = false;
 
 			if (clip->lastSelectedParamID >= 0 && clip->lastSelectedParamID < kNumRealCCNumbers) {
-				midiInstrument->getNameFromCC(clip->lastSelectedParamID, &name);
-			}
-			else {
-				name.clear();
+				String* name = midiInstrument->getNameFromCC(clip->lastSelectedParamID);
+				// if we have a name for this midi cc set by the user, display that instead of the cc number
+				if (name && !name->isEmpty()) {
+					parameterName.append(name->get());
+					appendedName = true;
+				}
 			}
 
-			// if we have a name for this midi cc set by the user, display that instead of the cc number
-			if (!name.isEmpty()) {
-				parameterName.append(name.get());
-			}
-			else {
+			// if we don't have a midi cc name set, draw CC number instead
+			if (!appendedName) {
 				if (display->haveOLED()) {
 					parameterName.append("CC ");
 					parameterName.appendInt(clip->lastSelectedParamID);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -28,7 +28,7 @@
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/load/load_instrument_preset_ui.h"
 #include "gui/ui/menus.h"
-#include "gui/ui/rename/rename_clipname_ui.h"
+#include "gui/ui/rename/rename_clip_ui.h"
 #include "gui/ui/rename/rename_drum_ui.h"
 #include "gui/ui/sample_marker_editor.h"
 #include "gui/ui/save/save_kit_row_ui.h"

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1044,6 +1044,7 @@ void View::potentiallyMakeItHarderToTurnKnob(int32_t whichModEncoder, ModelStack
 void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32_t newKnobPos, PatchSource source1,
                                        PatchSource source2) {
 	DEF_STACK_STRING_BUF(popupMsg, 40);
+	bool appendedName = true;
 
 	// On OLED, display the name of the parameter on the first line of the popup
 	if (display->haveOLED()) {
@@ -1057,14 +1058,48 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 				popupMsg.append("-> ");
 			}
 			popupMsg.append(modulation::params::getPatchedParamShortName(paramID));
-			popupMsg.append(": ");
+		}
+		else if (getCurrentOutputType() == OutputType::MIDI_OUT) {
+			MIDIInstrument* midiInstrument = (MIDIInstrument*)getCurrentOutput();
+			String name;
+
+			if (kind == params::Kind::EXPRESSION) {
+				if (paramID == X_PITCH_BEND) {
+					popupMsg.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
+				}
+				else if (paramID == Z_PRESSURE) {
+					popupMsg.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
+				}
+				else if (paramID == Y_SLIDE_TIMBRE) {
+					// in mono expression this is mod wheel, and y-axis is not directly controllable
+					popupMsg.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
+				}
+			}
+			else if (paramID >= 0 && paramID < kNumRealCCNumbers) {
+				midiInstrument->getNameFromCC(paramID, &name);
+				if (!name.isEmpty()) {
+					popupMsg.append(name.get());
+				}
+				else {
+					popupMsg.append("CC ");
+					popupMsg.appendInt(paramID);
+				}
+			}
+			else {
+				appendedName = false;
+			}
 		}
 		else {
 			const char* name = getParamDisplayName(kind, paramID);
 			if (name != l10n::get(l10n::String::STRING_FOR_NONE)) {
 				popupMsg.append(name);
-				popupMsg.append(": ");
 			}
+			else {
+				appendedName = false;
+			}
+		}
+		if (appendedName) {
+			popupMsg.append(": ");
 		}
 	}
 
@@ -1971,12 +2006,12 @@ oledDrawString:
 			}
 
 			if (clip) {
-				if (!clip->clipName.isEmpty()) {
+				if (!clip->name.isEmpty()) {
 					yPos = yPos + 14;
-					canvas.drawStringCentred(clip->clipName.get(), yPos, kTextSpacingX, kTextSpacingY);
-					deluge::hid::display::OLED::setupSideScroller(1, clip->clipName.get(), 0, OLED_MAIN_WIDTH_PIXELS,
-					                                              yPos, yPos + kTextSpacingY, kTextSpacingX,
-					                                              kTextSpacingY, false);
+					canvas.drawStringCentred(clip->name.get(), yPos, kTextSpacingX, kTextSpacingY);
+					deluge::hid::display::OLED::setupSideScroller(1, clip->name.get(), 0, OLED_MAIN_WIDTH_PIXELS, yPos,
+					                                              yPos + kTextSpacingY, kTextSpacingX, kTextSpacingY,
+					                                              false);
 				}
 			}
 		}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1061,8 +1061,6 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 		}
 		else if (getCurrentOutputType() == OutputType::MIDI_OUT) {
 			MIDIInstrument* midiInstrument = (MIDIInstrument*)getCurrentOutput();
-			String name;
-
 			if (kind == params::Kind::EXPRESSION) {
 				if (paramID == X_PITCH_BEND) {
 					popupMsg.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
@@ -1076,9 +1074,9 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 				}
 			}
 			else if (paramID >= 0 && paramID < kNumRealCCNumbers) {
-				midiInstrument->getNameFromCC(paramID, &name);
-				if (!name.isEmpty()) {
-					popupMsg.append(name.get());
+				String* name = midiInstrument->getNameFromCC(paramID);
+				if (name && !name->isEmpty()) {
+					popupMsg.append(name->get());
 				}
 				else {
 					popupMsg.append("CC ");

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -236,7 +236,7 @@ void AudioClip::finishLinearRecording(ModelStackWithTimelineCounter* modelStack,
 
 	recorder = NULL;
 
-	clipName.set(sampleHolder.filePath.get());
+	name.set(sampleHolder.filePath.get());
 }
 
 Clip* AudioClip::cloneAsNewOverdub(ModelStackWithTimelineCounter* modelStackOldClip, OverDubType newOverdubNature) {
@@ -1212,7 +1212,7 @@ Error AudioClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 
 void AudioClip::loadSample(bool mayActuallyReadFile) {
 	Error error = sampleHolder.loadFile(sampleControls.reversed, false, mayActuallyReadFile);
-	clipName.set(sampleHolder.filePath.get());
+	name.set(sampleHolder.filePath.get());
 	if (error != Error::NONE) {
 		display->displayError(error);
 	}
@@ -1290,7 +1290,7 @@ void AudioClip::clear(Action* action, ModelStackWithTimelineCounter* modelStack,
 
 			sampleHolder.filePath.clear();
 			sampleHolder.setAudioFile(NULL);
-			clipName.set("");
+			name.set("");
 		}
 
 		renderData.xScroll = -1;

--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -221,7 +221,7 @@ public:
 	virtual bool renderSidebar(uint32_t whichRows = 0, RGB image[][kDisplayWidth + kSideBarWidth] = nullptr,
 	                           uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth] = nullptr) = 0;
 	// Setup the name per clip on session/song/grid view and to be selectable on the arranger
-	String clipName;
+	String name;
 
 protected:
 	virtual void posReachedEnd(ModelStackWithTimelineCounter* modelStack); // May change the TimelineCounter in the

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2307,7 +2307,7 @@ Error InstrumentClip::setAudioInstrument(Instrument* newInstrument, Song* song, 
 
 void InstrumentClip::writeDataToFile(Serializer& writer, Song* song) {
 
-	writer.writeAttribute("clipName", clipName.get());
+	writer.writeAttribute("clipName", name.get());
 	writer.writeAttribute("inKeyMode", inScaleMode);
 	writer.writeAttribute("yScroll", yScroll);
 	writer.writeAttribute("yScrollKeyboard", keyboardState.isomorphic.scrollOffset);
@@ -2498,7 +2498,7 @@ someError:
 		int32_t temp;
 
 		if (!strcmp(tagName, "clipName")) {
-			reader.readTagOrAttributeValueString(&clipName);
+			reader.readTagOrAttributeValueString(&name);
 		}
 		else if (!strcmp(tagName, "inKeyMode")) {
 			inScaleMode = reader.readTagOrAttributeValueInt();

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -135,22 +135,20 @@ void InstrumentClipMinder::drawMIDIControlNumber(int32_t controlNumber, bool aut
 	}
 	else {
 		MIDIInstrument* midiInstrument = (MIDIInstrument*)getCurrentOutput();
-
-		String name;
+		bool appendedName = false;
 
 		if (controlNumber >= 0 && controlNumber < kNumRealCCNumbers) {
-			midiInstrument->getNameFromCC(controlNumber, &name);
-		}
-		else {
-			name.clear();
+			String* name = midiInstrument->getNameFromCC(controlNumber);
+			// if we have a name for this midi cc set by the user, display that instead of the cc number
+			if (name && !name->isEmpty()) {
+				buffer.append(name->get());
+				doScroll = name->getLength() > 4 ? true : false;
+				appendedName = true;
+			}
 		}
 
-		// if we have a name for this midi cc set by the user, display that instead of the cc number
-		if (!name.isEmpty()) {
-			buffer.append(name.get());
-			doScroll = name.getLength() > 4 ? true : false;
-		}
-		else {
+		// if we don't have a midi cc name set, draw CC number instead
+		if (!appendedName) {
 			if (display->haveOLED()) {
 				buffer.append("CC ");
 				buffer.appendInt(controlNumber);

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -1176,12 +1176,12 @@ int32_t MIDIInstrument::getCCFromName(String* name) {
 	return 255;
 }
 
-void MIDIInstrument::getNameFromCC(int32_t cc, String* name) {
+String* MIDIInstrument::getNameFromCC(int32_t cc) {
 	if (cc >= 0 && cc < kNumRealCCNumbers) {
-		name->set(&ccNames[cc]);
+		return &ccNames[cc];
 	}
 	else {
-		name->clear();
+		return nullptr;
 	}
 }
 

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -47,10 +47,9 @@ public:
 	                                     ParamManagerForTimeline* paramManager = nullptr);
 
 	// cc names
-	String ccNames[kNumRealCCNumbers];
 	Error readCCNamesFromFile();
 	int32_t getCCFromName(String* name);
-	void getNameFromCC(int32_t cc, String* name);
+	String* getNameFromCC(int32_t cc);
 	void setNameForCC(int32_t cc, String* name);
 
 	void sendMIDIPGM();
@@ -123,4 +122,5 @@ private:
 	void outputAllMPEValuesOnMemberChannel(int16_t const* mpeValuesToUse, int32_t outputMemberChannel);
 	Error readMIDIParamFromFile(Deserializer& reader, int32_t readAutomationUpToPos,
 	                            MIDIParamCollection* midiParamCollection, int8_t* getCC = NULL);
+	String ccNames[kNumRealCCNumbers];
 };

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -45,6 +45,14 @@ public:
 	bool readTagFromFile(Deserializer& reader, char const* tagName);
 	Error readModKnobAssignmentsFromFile(int32_t readAutomationUpToPos,
 	                                     ParamManagerForTimeline* paramManager = nullptr);
+
+	// cc names
+	String ccNames[kNumRealCCNumbers];
+	Error readCCNamesFromFile();
+	int32_t getCCFromName(String* name);
+	void getNameFromCC(int32_t cc, String* name);
+	void setNameForCC(int32_t cc, String* name);
+
 	void sendMIDIPGM();
 
 	void sendNoteToInternal(bool on, int32_t note, uint8_t velocity, uint8_t channel);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3503,12 +3503,25 @@ void Song::markAllInstrumentsAsEdited() {
 	}
 }
 
+// used with the renameOutputUI class to check if you're trying to rename an output to the same
+// name as another output
 AudioOutput* Song::getAudioOutputFromName(String* name) {
 	for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
 		if (thisOutput->type == OutputType::AUDIO) {
 			if (thisOutput->name.equalsCaseIrrespective(name)) {
 				return (AudioOutput*)thisOutput;
 			}
+		}
+	}
+	return NULL;
+}
+
+// used with the renameClipUI class to check if you're trying to rename a clip to the same name
+// as another clip
+Clip* Song::getClipFromName(String* name) {
+	for (Clip* clip : AllClips::everywhere(this)) {
+		if (clip->name.equalsCaseIrrespective(name)) {
+			return clip;
 		}
 	}
 	return NULL;

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -167,6 +167,7 @@ public:
 	                                        char const* name, char const* dirPath, bool searchHibernatingToo = true,
 	                                        bool searchNonHibernating = true);
 	AudioOutput* getAudioOutputFromName(String* name);
+	Clip* getClipFromName(String* name);
 	void setupPatchingForAllParamManagers();
 	void replaceInstrument(Instrument* oldInstrument, Instrument* newInstrument, bool keepNoteRowsWithMIDIInput = true);
 	void stopAllMIDIAndGateNotesPlaying();


### PR DESCRIPTION
- Cleaned up rename UI classes
- Added ability to rename MIDI CC's in MIDI clips. Changed are saved by Instrument (e.g. per MIDI channel). Changes can be saved to a MIDI preset and with the song.
  - To rename a `MIDI CC`, enter `Automation View` and select the CC you wish to rename using the `Select Encoder`.
  - With the `MIDI CC` selected, press down either `Gold (Mod) Encoder` and then press the `Name` grid shortcut to open the `MIDI CC Renaming UI`. Enter a new name and press `Select` or `Enter`.
  - The new `MIDI CC` name will be immediately visible in `Automation View` and you can assign that CC to a `Gold Knob` in the MIDI clip and it will show that name when you press down on the `Gold (Mod) Encoder`.
- Added MIDI CC numbers and labels to `Gold (Mod) Encoder` popups.