### PR TITLE
Fixed out-of-bounds array access when writing long string to OLED, e.…

### DIFF
--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -756,7 +756,9 @@ void OLED::popupText(char const* text, bool persistent, PopupType type) {
 	}
 
 	for (int32_t l = 0; l < textLineBreakdown.numLines; l++) {
-		if (textPixelY >= OLED_MAIN_HEIGHT_PIXELS) continue;
+		if (textPixelY >= OLED_MAIN_HEIGHT_PIXELS) {
+			continue;
+		}
 		int32_t textPixelX = (OLED_MAIN_WIDTH_PIXELS - textLineBreakdown.lineWidths[l]) >> 1;
 		popup.drawString(std::string_view{textLineBreakdown.lines[l], textLineBreakdown.lineLengths[l]}, textPixelX,
 		                 textPixelY, kTextSpacingX, kTextSpacingY);

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -756,6 +756,7 @@ void OLED::popupText(char const* text, bool persistent, PopupType type) {
 	}
 
 	for (int32_t l = 0; l < textLineBreakdown.numLines; l++) {
+		if (textPixelY >= OLED_MAIN_HEIGHT_PIXELS) continue;
 		int32_t textPixelX = (OLED_MAIN_WIDTH_PIXELS - textLineBreakdown.lineWidths[l]) >> 1;
 		popup.drawString(std::string_view{textLineBreakdown.lines[l], textLineBreakdown.lineLengths[l]}, textPixelX,
 		                 textPixelY, kTextSpacingX, kTextSpacingY);


### PR DESCRIPTION
…g. a drum with a very long name. Could lead to freeze.

Cherry-picked from commit 456387b188116e76f22d0c3ebc95fab6d8d5f70f