### PR TITLE
[DRAFT] Update Instrument Clip View to Allow changing scale && root note with select encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,10 @@
 ##### Synth/Kit Clips
 - Added Auto-Load feature to sample browser, so you can load the sounds to the instrument as you preview them. Auto-Load can be engaged while in sample browser, if you press the `Load` button.
 
+##### Scales
+- Added new way to change `SCALE` in non-kit instrument clips: Hold `SCALE` and press `SELECT`
+- Added new way to change scale `ROOT NOTE` in non-kit instument clips: Hold `SCALE` and turn `SELECT`
+
 ### MIDI
 
 #### <ins>Learn</ins>

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1434,9 +1434,13 @@ void InstrumentClipView::selectEncoderAction(int8_t offset) {
 		toggleScaleModeOnButtonRelease = false;
 		int32_t newRootNote = ((currentSong->key.rootNote + kOctaveSize) + offset) % kOctaveSize;
 		setupChangingOfRootNote(newRootNote);
+		
 		recalculateColours();
 		uiNeedsRendering(this);
 		currentSong->displayCurrentRootNoteAndScaleName();
+		
+		// Hook point for specificMidiDevice
+		iterateAndCallSpecificDeviceHook(MIDIDeviceUSBHosted::Hook::HOOK_ON_CHANGE_ROOT_NOTE);
 	}
 
 	// Or, normal option - trying to change Instrument presets

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -81,7 +81,7 @@ public:
 	/// Learn notes from current clip + scale mode clips as USER scale.
 	/// Enters scale mode if wasn't in it already. LEARN + SCALE.
 	ActionResult commandLearnUserScale();
-	/// Cycle through preset scales. SHIFT + SCALE in scale mode.
+	/// Cycle through preset scales. SHIFT + SCALE (or SCALE + SELECT) in scale mode
 	ActionResult commandCycleThroughScales();
 	/// Flash the current root note. Part of SCALE down.
 	ActionResult commandFlashRootNote();


### PR DESCRIPTION
Added the following commands to instrument clip view that were added previously to keyboard view.

- Added new way to change `SCALE` in non-kit instrument clips: Hold `SCALE` and press `SELECT`
- Added new way to change scale `ROOT NOTE` in non-kit instument clips: Hold `SCALE` and turn `SELECT`

To do:
- [ ] After changing root note, it should scroll the grid so that you're no longer seeing out of scale note rows