### PR TITLE
[DRAFT] Update OLED to stop scrolling during playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ when the output is a SAMPLER or a LOOPER, chosen by turning the select knob in a
 
 #### <ins>OLED Display Improvements</ins>
 - Updated OLED display for `SONG VIEW` and `ARRANGER VIEW` to display the Song Name, Current Tempo and Current Root Note and Scale Name.
+- Updated OLED display to stop scrolling `SONG` / `PRESET` names while playback is running.
 
 #### <ins>Stem Export</ins>
 - Added `STEM EXPORT`, an automated process for exporting `CLIP STEMS` while in `SONG VIEW` and `INSTRUMENT STEMS` while in `ARRANGER VIEW`. Press `SAVE + RECORD` to start exporting stems. Press `BACK` to cancel stem exporting and stop recording and playback.

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2046,7 +2046,7 @@ void SessionView::renderViewDisplay() {
 	else {
 		canvas.drawString(name, 0, yPos, kTextTitleSpacingX, kTextTitleSizeY);
 		deluge::hid::display::OLED::setupSideScroller(0, name, 0, OLED_MAIN_WIDTH_PIXELS, yPos, yPos + kTextTitleSizeY,
-		                                              kTextTitleSpacingX, kTextTitleSizeY, false);
+		                                              kTextTitleSpacingX, kTextTitleSizeY, false, false);
 	}
 
 	yPos = OLED_MAIN_TOPMOST_PIXEL + 32;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1970,7 +1970,7 @@ oledDrawString:
 				canvas.drawString(nameToDraw, 0, yPos, kTextTitleSpacingX, kTextTitleSizeY);
 				deluge::hid::display::OLED::setupSideScroller(0, nameToDraw, 0, OLED_MAIN_WIDTH_PIXELS, yPos,
 				                                              yPos + kTextTitleSizeY, kTextTitleSpacingX,
-				                                              kTextTitleSizeY, false);
+				                                              kTextTitleSizeY, false, false);
 			}
 
 			if (clip) {
@@ -1979,7 +1979,7 @@ oledDrawString:
 					canvas.drawStringCentred(clip->clipName.get(), yPos, kTextSpacingX, kTextSpacingY);
 					deluge::hid::display::OLED::setupSideScroller(1, clip->clipName.get(), 0, OLED_MAIN_WIDTH_PIXELS,
 					                                              yPos, yPos + kTextSpacingY, kTextSpacingX,
-					                                              kTextSpacingY, false);
+					                                              kTextSpacingY, false, false);
 				}
 			}
 		}

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -64,7 +64,8 @@ public:
 
 	static void stopScrollingAnimation();
 	static void setupSideScroller(int32_t index, std::string_view text, int32_t startX, int32_t endX, int32_t startY,
-	                              int32_t endY, int32_t textSpacingX, int32_t textSizeY, bool doHighlight);
+	                              int32_t endY, int32_t textSpacingX, int32_t textSizeY, bool doHighlight,
+	                              bool scrollDuringPlayback = true);
 	static void drawPermanentPopupLookingText(char const* text);
 
 	/// Call this after doing any rendering work so the next trip through the UI rendering loop actually sends the image


### PR DESCRIPTION
Updated OLED display to stop scrolling song names (in session/arranger) and preset names (in clip views) while playback is running

- [ ] Scroll once before stopping scroll