### PR TITLE
Set colour intensity proportional to note velocity for easier editing

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2347,6 +2347,7 @@ void InstrumentClipView::adjustVelocity(int32_t velocityChange) {
 
 			gridSquareInfo[editPadPresses[i].yDisplay][editPadPresses[i].xDisplay].averageVelocity =
 			    editPadPresses[i].intendedVelocity;
+			uiNeedsRendering(this, 1 << editPadPresses[i].yDisplay, 0);
 		}
 	}
 

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -1960,7 +1960,7 @@ void NoteRow::renderRow(TimelineView* editorScreen, RGB rowColour, RGB rowTailCo
 			// Or if Note starts exactly on square...
 			else if (note && note->pos == squareStartPos) {
 				drewNote = true;
-				pixel = rowColour;
+				pixel = RGB::blend(rowColour, rowTailColour, note->velocity << 9);
 				if (occupancyMask) {
 					occupancyMask[xDisplay] = 64;
 				}


### PR DESCRIPTION
Makes the note velocity editor more useful by making velocities visible at a glance. Low velocity notes get closer to the tail colour and only max velocity notes show as the full note on colour

