### PR TITLE
Bugfix - ensure selected submenu item is relevant

### DIFF
--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -52,6 +52,7 @@ public:
 	/// @brief 	Indicates if the menu-like object should wrap-around. Destined to be virtualized.
 	///         At the moment implements the legacy behaviour of wrapping on 7seg but not on OLED.
 	bool wrapAround();
+	bool ensureCurrentItemIsRelevant();
 
 	deluge::vector<MenuItem*> items;
 	typename decltype(items)::iterator current_item_;


### PR DESCRIPTION
sometimes when you refresh a menu, a menu item may become not relevant anymore depending on the context

for example, refreshing the custom note iterance menu when selecting a different note with a different divisor

this fix ensures that when the menu is refreshed that only a relevant menu item is selected