### PR TITLE
Feature - make all expression automatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 
 ##### Automation View
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
+- Added ability to automate all Expression parameters (X - Pitchbend, Y - Modwheel, Z - Channel Pressure / Aftertouch)
 
 ##### Note / Note Row Probability, Iterance, Fill
 - Enhanced existing note probability, iteration and fill function functionality by enabling you to use each type independently. This means that you can now apply probability to iteration and fill and you can also apply iteration to fill. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 
 ##### Automation View
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
-- Added ability to automate all Expression parameters (X - Pitchbend, Y - Modwheel, Z - Channel Pressure / Aftertouch)
+- Added ability to automate all Monophonic (Channel) Expression parameters (X - Pitch Bend, Y - Mod Wheel, Z - Channel Pressure / Aftertouch) in Synth / Kit Row (with Affect Entire Off) / MIDI / CV
 
 ##### Note / Note Row Probability, Iterance, Fill
 - Enhanced existing note probability, iteration and fill function functionality by enabling you to use each type independently. This means that you can now apply probability to iteration and fill and you can also apply iteration to fill. 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -36,9 +36,9 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **Portamento**
 > - **Stutter** Rate
 > - **Compressor** Threshold
-> - **Expression** X (Pitchbend)
-> - **Expression** Y (Modwheel)
-> - **Expression** Z (Channel Pressure / Aftertouch)
+> - **Mono Expression** X (Pitch Bend)
+> - **Mono Expression** Y (Mod Wheel)
+> - **Mono Expression** Z (Channel Pressure / Aftertouch)
 
 >You can also edit any patch cables that are created
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -12,7 +12,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 
 1. Automatable Clip View Parameters for Synths and Kits with a row selected and affect entire DISABLED
 
->The 60 parameters that can be edited are:
+>The 63 parameters that can be edited are:
 >
 > - **Master** Level, Pitch, Pan
 > - **LPF** Frequency, Resonance, Morph
@@ -36,6 +36,9 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **Portamento**
 > - **Stutter** Rate
 > - **Compressor** Threshold
+> - **Expression** X (Pitchbend)
+> - **Expression** Y (Modwheel)
+> - **Expression** Z (Channel Pressure / Aftertouch)
 
 >You can also edit any patch cables that are created
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1576,8 +1576,7 @@ void AutomationView::renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputTyp
 
 // get's the name of the Parameter being edited so it can be displayed on the screen
 void AutomationView::getAutomationParameterName(Clip* clip, OutputType outputType, StringBuf& parameterName) {
-	if (onArrangerView || outputType == OutputType::SYNTH || outputType == OutputType::KIT
-	    || outputType == OutputType::AUDIO) {
+	if (outputType != OutputType::MIDI_OUT) {
 		params::Kind lastSelectedParamKind = params::Kind::NONE;
 		int32_t lastSelectedParamID = kNoSelection;
 		PatchSource lastSelectedPatchSource = PatchSource::NONE;
@@ -1618,7 +1617,7 @@ void AutomationView::getAutomationParameterName(Clip* clip, OutputType outputTyp
 			parameterName.append(getParamDisplayName(lastSelectedParamKind, lastSelectedParamID));
 		}
 	}
-	else if (outputType == OutputType::MIDI_OUT) {
+	else {
 		if (clip->lastSelectedParamID == CC_NUMBER_NONE) {
 			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_PARAM));
 		}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -119,7 +119,7 @@ const uint32_t mutePadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITION
 
 const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_RECORD_COUNT_IN, 0};
 
-constexpr int32_t kNumNonGlobalParamsForAutomation = 60;
+constexpr int32_t kNumNonGlobalParamsForAutomation = 63;
 constexpr int32_t kNumGlobalParamsForAutomation = 26;
 constexpr int32_t kParamNodeWidth = 3;
 
@@ -208,6 +208,12 @@ const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutom
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE},
     // Compressor Threshold
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_COMPRESSOR_THRESHOLD},
+    // Mono Expression: X - Pitch Bend
+    {params::Kind::EXPRESSION, Expression::X_PITCH_BEND},
+    // Mono Expression: Y - Mod Wheel
+    {params::Kind::EXPRESSION, Expression::Y_SLIDE_TIMBRE},
+    // Mono Expression: Z - Channel Pressure
+    {params::Kind::EXPRESSION, Expression::Z_PRESSURE},
 }};
 
 // global FX - sorted in the order that Parameters are scrolled through on the display
@@ -609,8 +615,7 @@ AutomationSubType AutomationView::getAutomationSubType() {
 }
 
 // rendering
-bool AutomationView::possiblyRefreshAutomationEditorGrid(Clip* clip, deluge::modulation::params::Kind paramKind,
-                                                         int32_t paramID) {
+bool AutomationView::possiblyRefreshAutomationEditorGrid(Clip* clip, params::Kind paramKind, int32_t paramID) {
 	bool doRefreshGrid = false;
 	if (clip && !automationView.onArrangerView) {
 		if ((clip->lastSelectedParamID == paramID) && (clip->lastSelectedParamKind == paramKind)) {
@@ -1611,7 +1616,7 @@ void AutomationView::getAutomationParameterName(Clip* clip, OutputType outputTyp
 				parameterName.append(display->haveOLED() ? " -> " : " - ");
 			}
 
-			parameterName.append(modulation::params::getPatchedParamShortName(lastSelectedParamID));
+			parameterName.append(params::getPatchedParamShortName(lastSelectedParamID));
 		}
 		else {
 			parameterName.append(getParamDisplayName(lastSelectedParamKind, lastSelectedParamID));
@@ -2581,7 +2586,7 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	         // selected a single sound drum
 	         || ((outputType == OutputType::KIT && !getAffectEntire() && ((Kit*)output)->selectedDrum
 	              && ((Kit*)output)->selectedDrum->type == DrumType::SOUND))) {
-		uint32_t paramID = deluge::modulation::params::expressionParamFromShortcut(xDisplay, yDisplay);
+		uint32_t paramID = params::expressionParamFromShortcut(xDisplay, yDisplay);
 		clip->lastSelectedParamID = paramID;
 		clip->lastSelectedParamKind = params::Kind::EXPRESSION;
 	}
@@ -4777,7 +4782,9 @@ void AutomationView::getLastSelectedParamShortcut(Clip* clip) {
 				    || (clip->lastSelectedParamKind == params::Kind::UNPATCHED_SOUND
 				        && unpatchedNonGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)
 				    || (clip->lastSelectedParamKind == params::Kind::UNPATCHED_GLOBAL
-				        && unpatchedGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)) {
+				        && unpatchedGlobalParamShortcuts[x][y] == clip->lastSelectedParamID)
+				    || (clip->lastSelectedParamKind == params::Kind::EXPRESSION
+				        && params::expressionParamFromShortcut(x, y) == clip->lastSelectedParamID)) {
 					clip->lastSelectedParamShortcutX = x;
 					clip->lastSelectedParamShortcutY = y;
 					paramShortcutFound = true;

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1701,6 +1701,9 @@ ModelStackWithAutoParam* Kit::getModelStackWithParamForKitRow(ModelStackWithTime
 				else if (paramKind == deluge::modulation::params::Kind::PATCH_CABLE) {
 					modelStackWithParam = modelStackWithThreeMainThings->getPatchCableAutoParamFromId(paramID);
 				}
+				else if (paramKind == params::Kind::EXPRESSION) {
+					modelStackWithParam = modelStackWithThreeMainThings->getExpressionAutoParamFromID(paramID);
+				}
 			}
 		}
 	}

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -744,6 +744,10 @@ ModelStackWithAutoParam* MelodicInstrument::getModelStackWithParam(ModelStackWit
 		else if (paramKind == deluge::modulation::params::Kind::PATCH_CABLE) {
 			modelStackWithParam = modelStackWithThreeMainThings->getPatchCableAutoParamFromId(paramID);
 		}
+		else if (paramKind == deluge::modulation::params::Kind::EXPRESSION) {
+
+			modelStackWithParam = modelStackWithThreeMainThings->getExpressionAutoParamFromID(paramID);
+		}
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -259,3 +259,16 @@ ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchCableAutoParamFr
 	}
 	return modelStackWithParam;
 }
+
+ModelStackWithAutoParam* ModelStackWithThreeMainThings::getExpressionAutoParamFromID(int32_t newParamId) {
+	if (newParamId >= kNumExpressionDimensions) {
+		return addParamCollectionAndId(nullptr, nullptr, 0)->addAutoParam(nullptr); // "No param"
+	}
+
+	paramManager->ensureExpressionParamSetExists(); // Allowed to fail
+	ParamCollectionSummary* summary = paramManager->getExpressionParamSetSummary();
+	ModelStackWithParamId* modelStackWithParamId =
+	    addParamCollectionAndId(summary->paramCollection, summary, newParamId);
+
+	return summary->paramCollection->getAutoParamFromId(modelStackWithParamId, true);
+}

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -246,6 +246,7 @@ public:
 
 	inline ModelStackWithSoundFlags* addSoundFlags() const;
 	inline ModelStackWithSoundFlags* addDummySoundFlags() const;
+	ModelStackWithAutoParam* getExpressionAutoParamFromID(int32_t newParamId);
 };
 
 class ModelStackWithParamCollection : public ModelStackWithThreeMainThings {

--- a/src/deluge/modulation/params/param.cpp
+++ b/src/deluge/modulation/params/param.cpp
@@ -609,6 +609,18 @@ constexpr ParamType fileStringToParamConst(Kind kind, char const* name, bool all
 ParamType fileStringToParam(Kind kind, char const* name, bool allowPatched) {
 	return fileStringToParamConst(kind, name, allowPatched);
 }
+uint32_t expressionParamFromShortcut(int x, int y) {
+	if (x == 14 && y == 7) {
+		return X_PITCH_BEND;
+	}
+	else if (x == 15 && y == 0) {
+		return Z_PRESSURE;
+	}
+	else if (x == 15 && y == 7) {
+		return Y_SLIDE_TIMBRE;
+	}
+	return kNoParamID;
+}
 
 constexpr bool validateParams() {
 	bool m = true;

--- a/src/deluge/modulation/params/param.cpp
+++ b/src/deluge/modulation/params/param.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "modulation/params/param.h"
+#include "definitions_cxx.hpp"
 #include "gui/l10n/l10n.h"
 #include "gui/l10n/strings.h"
 #include "model/settings/runtime_feature_settings.h"
@@ -24,7 +25,8 @@
 namespace deluge::modulation::params {
 
 bool isParamBipolar(Kind kind, int32_t paramID) {
-	return (kind == Kind::PATCH_CABLE) || isParamPan(kind, paramID) || isParamPitch(kind, paramID);
+	return (kind == Kind::PATCH_CABLE) || isParamPan(kind, paramID) || isParamPitch(kind, paramID)
+	       || isParamPitchBend(kind, paramID);
 }
 
 bool isParamPan(Kind kind, int32_t paramID) {
@@ -48,6 +50,10 @@ bool isParamPitch(Kind kind, int32_t paramID) {
 	else {
 		return false;
 	}
+}
+
+bool isParamPitchBend(Kind kind, int32_t paramID) {
+	return (kind == Kind::EXPRESSION && paramID == Expression::X_PITCH_BEND);
 }
 
 bool isParamStutter(Kind kind, int32_t paramID) {

--- a/src/deluge/modulation/params/param.cpp
+++ b/src/deluge/modulation/params/param.cpp
@@ -242,6 +242,15 @@ char const* getParamDisplayName(Kind kind, int32_t p) {
 		return l10n::get(NAMES[p]);
 	}
 
+	if (kind == Kind::EXPRESSION && p < kNumExpressionDimensions) {
+		static l10n::String const NAMES[kNumExpressionDimensions] = {
+		    [Expression::X_PITCH_BEND] = STRING_FOR_PITCH_BEND,
+		    [Expression::Y_SLIDE_TIMBRE] = STRING_FOR_MOD_WHEEL,
+		    [Expression::Z_PRESSURE] = STRING_FOR_CHANNEL_PRESSURE,
+		};
+		return l10n::get(NAMES[p]);
+	}
+
 	constexpr ParamType unc = UNPATCHED_NUM_SHARED;
 
 	if (kind == Kind::UNPATCHED_SOUND && p < util::to_underlying(UNPATCHED_SOUND_MAX_NUM)) {

--- a/src/deluge/modulation/params/param.h
+++ b/src/deluge/modulation/params/param.h
@@ -338,4 +338,5 @@ const uint32_t unpatchedGlobalParamShortcuts[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID          , kNoParamID            , kNoParamID                , kNoParamID                  , kNoParamID				   , kNoParamID			   		 	, kNoParamID            , kNoParamID}};
 // clang-format on
 
+uint32_t expressionParamFromShortcut(int x, int y);
 } // namespace deluge::modulation::params

--- a/src/deluge/modulation/params/param.h
+++ b/src/deluge/modulation/params/param.h
@@ -238,6 +238,7 @@ static_assert(kMaxNumUnpatchedParams < STATIC_START, "Error: Too many UNPATCHED 
 bool isParamBipolar(Kind kind, int32_t paramID);
 bool isParamPan(Kind kind, int32_t paramID);
 bool isParamPitch(Kind kind, int32_t paramID);
+bool isParamPitchBend(Kind kind, int32_t paramID);
 bool isParamArpRhythm(Kind kind, int32_t paramID);
 bool isParamStutter(Kind kind, int32_t paramID);
 bool isParamQuantizedStutter(Kind kind, int32_t paramID);


### PR DESCRIPTION
Allows automating x/y/z expression for all instrument types (midi/cv/synth/single sound drum)

CV expression doesn't do anything without the other PR but its harmless

@seangoodvibes I refactored some of automation view to streamline the checks and make them readable