### PR TITLE
Fix highlighting in browser

### DIFF
--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -131,7 +131,10 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 		highlightStartX = 0;
 	}
 	else {
-		highlightStartX = xPixel + kTextSpacingX * scrollAmount - 1;
+		// if we're at the beginning of the string, we want to show an extra inverted pixel before
+		// if we're somewhere inside the string, we want to start highlight right on the character
+		int32_t startAdjustment = scrollAmount ? 0 : 1;
+		highlightStartX = xPixel + kTextSpacingX * scrollAmount - startAdjustment;
 	}
 	int32_t highlightWidth = xPixelMax - highlightStartX;
 


### PR DESCRIPTION
Fixed where inverted highlighting starts in preset browser when you're scrolled over into a string using <>

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2766