### PR TITLE
render audio more often in sd routine

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -986,7 +986,7 @@ extern "C" void yieldingRoutineForSD(RunCondition until) {
 	yield(until);
 	sdRoutineLock = false;
 }
-enum class UIStage { UItimer, oled, readEnc, readButtons, renderUI };
+enum class UIStage { oled, readEnc, readButtons };
 /// this function is used as a busy wait loop for long SD reads, and while swapping songs
 extern "C" void routineForSD(void) {
 
@@ -1002,15 +1002,10 @@ extern "C" void routineForSD(void) {
 
 	sdRoutineLock = true;
 	ignoreForStats();
-	static UIStage step = UIStage::UItimer;
+	static UIStage step = UIStage::oled;
 	AudioEngine::logAction("from routineForSD()");
 	AudioEngine::routine();
 	switch (step) {
-
-	case UIStage::UItimer:
-		uiTimerManager.routine();
-		step = UIStage::oled;
-		break;
 	case UIStage::oled:
 		if (display->haveOLED()) {
 			oledRoutine();
@@ -1025,11 +1020,7 @@ extern "C" void routineForSD(void) {
 		break;
 	case UIStage::readButtons:
 		readButtonsAndPads();
-		step = UIStage::renderUI;
-		break;
-	case UIStage::renderUI:
-		doAnyPendingUIRendering();
-		step = UIStage::UItimer;
+		step = UIStage::oled;
 		break;
 	}
 

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -986,7 +986,7 @@ extern "C" void yieldingRoutineForSD(RunCondition until) {
 	yield(until);
 	sdRoutineLock = false;
 }
-
+enum class UIStage { UItimer, oled, readEnc, readButtons, renderUI };
 /// this function is used as a busy wait loop for long SD reads, and while swapping songs
 extern "C" void routineForSD(void) {
 
@@ -1002,20 +1002,36 @@ extern "C" void routineForSD(void) {
 
 	sdRoutineLock = true;
 	ignoreForStats();
+	static UIStage step = UIStage::UItimer;
 	AudioEngine::logAction("from routineForSD()");
 	AudioEngine::routine();
+	switch (step) {
 
-	uiTimerManager.routine();
-
-	if (display->haveOLED()) {
-		oledRoutine();
+	case UIStage::UItimer:
+		uiTimerManager.routine();
+		step = UIStage::oled;
+		break;
+	case UIStage::oled:
+		if (display->haveOLED()) {
+			oledRoutine();
+		}
+		PIC::flush();
+		step = UIStage::readEnc;
+		break;
+	case UIStage::readEnc:
+		encoders::readEncoders();
+		encoders::interpretEncoders(true);
+		step = UIStage::readButtons;
+		break;
+	case UIStage::readButtons:
+		readButtonsAndPads();
+		step = UIStage::renderUI;
+		break;
+	case UIStage::renderUI:
+		doAnyPendingUIRendering();
+		step = UIStage::UItimer;
+		break;
 	}
-	PIC::flush();
-
-	encoders::readEncoders();
-	encoders::interpretEncoders(true);
-	readButtonsAndPads();
-	doAnyPendingUIRendering();
 
 	sdRoutineLock = false;
 }


### PR DESCRIPTION
Partially fix #2549 (makes it much less annoying)

Strips all non essential calls out of the sd routine and changes it to run an audio routine in between all other calls remaining. This makes the crackle while saving a lot quiter but in heavy songs it still occurs. 

The scheduler is doing "too good" a job at scheduling long calls at times when the audio render isn't necessary before they finish. As a result we can be in a state where the sd routine call in file creation/moving lines up poorly with when audio rendering is needed and crackles still happen (it needed much less timing precision pre scheduler as the overhead was a lot higher). Fortunately this is largely exclusive to saving songs as the SDRoutine has already been replaced with yields in most other cases