### PR TITLE
Allow adjusting iterance with select encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,10 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added ability to automate all Monophonic (Channel) Expression parameters (X - Pitch Bend, Y - Mod Wheel, Z - Channel Pressure / Aftertouch) in Synth / Kit Row (with Affect Entire Off) / MIDI / CV
 
 ##### Note / Note Row Probability, Iterance, Fill
-- Enhanced existing note probability, iteration and fill function functionality by enabling you to use each type independently. This means that you can now apply probability to iteration and fill and you can also apply iteration to fill. 
-  - Holding a note / note row and turning the select encoder now only changes probability.
-  - To edit note / note row iteration and fill settings you need to access the new note and note row editor menu's.
+- Enhanced existing note probability, iteration and fill function functionality by enabling you to use each type independently. This means that you can now apply probability to iteration and fill and you can also apply iteration to fill.
+  - To edit probability, hold a note / audition pad and turn the select encoder to the left to display current probability value / set new probability value.
+  - To edit iterance, hold a note / audition pad and turn the select encoder to the right to display current iterance value / set new iterance value.
+  - To edit fill, you need to access the new note and note row editor menu's.
 - Added new note and note row editor menu's to edit note and note row parameters.
   - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid.
   - Hold a note row audition pad and press the select encoder to enter the note row editor menu. While in the note row editor menu, the selected note row's audition pad will blink. You can select other note row's by pressing the note row audition pad or by scrolling with the vertical encoder.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -945,8 +945,9 @@ to each individual note onset. ([#1978])
 #### 4.3.10 - Enhanced Note Probability, Iterance and Fill
 
 - ([#2641]) Enhanced existing note probability, iteration and fill function functionality by enabling you to use each type independently. This means that you can now apply probability to iteration and fill and you can also apply iteration to fill.
-  - Holding a note / note row and turning the select encoder now only changes probability.
-  - To edit note / note row iteration and fill settings you need to access the new note and note row editor menu's.
+  - To edit probability, hold a note / audition pad and turn the select encoder to the left to display current probability value / set new probability value.
+  - To edit iterance, hold a note / audition pad and turn the select encoder to the right to display current iterance value / set new iterance value.
+  - To edit fill, you need to access the new note and note row editor menu's.
 
 #### 4.3.11 - Added New Note and Note Row Editor Menu's
 - For a detailed description of this feature as well the button shortcuts/combos, please refer to the feature documentation: [Note / Note Row Editor Documentation]

--- a/docs/features/note_noterow_editor.md
+++ b/docs/features/note_noterow_editor.md
@@ -2,9 +2,11 @@
 
 Enhanced existing note probability, iteration and fill function functionality by enabling you to use each type independently. This means that you can now apply probability to iteration and fill and you can also apply iteration to fill.
 
-Holding a note / note row and turning the select encoder now only changes probability.
+To edit probability, hold a note / audition pad and turn the select encoder to the left to display current probability value / set new probability value.
 
-To edit note / note row iteration and fill settings you need to access the new note and note row editor menu's.
+To edit iterance, hold a note / audition pad and turn the select encoder to the right to display current iterance value / set new iterance value.
+
+To edit fill, you need to access the new note and note row editor menu's.
 
 ## Note Editor Menu
 

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -310,6 +310,7 @@ private:
 	// note functions
 	void nudgeNotes(int32_t offset);
 	void displayProbability(uint8_t probability, bool prevBase);
+	void displayIterance(uint8_t iterance, bool prevBase);
 
 	// note row functions
 	void copyNotes();

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -18,6 +18,8 @@ enum class PopupType {
 	LOADING,
 	/// Popup shown when editing note or row probability.
 	PROBABILITY,
+	/// Popup shown when editing note or row iterance.
+	ITERANCE,
 	/// Swing amount and interval
 	SWING,
 	/// Tempo


### PR DESCRIPTION
Re-enabled editing note / note row iterance using note / audition pad + turning select encoder

- To edit probability, hold a note / audition pad and turn the select encoder to the left to display current probability value / set new probability value.

- To edit iterance, hold a note / audition pad and turn the select encoder to the right to display current iterance value / set new iterance value.