### PR TITLE
Bugfix - leave space for params saved as attributes

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2410,7 +2410,7 @@ void InstrumentClip::writeDataToFile(Serializer& writer, Song* song) {
 	}
 
 	if (output->type == OutputType::KIT) {
-		writer.writeOpeningTag("kitParams");
+		writer.writeOpeningTagBeginning("kitParams");
 		GlobalEffectableForClip::writeParamAttributesToFile(writer, &paramManager, true);
 		writer.writeOpeningTagEnd();
 		GlobalEffectableForClip::writeParamTagsToFile(writer, &paramManager, true);


### PR DESCRIPTION
Fix #2710 

The kit param xml tag was being closed on write, so the params expecting to be read as attributes get skipped looking for the next "<"