### PR TITLE
clean up bpm functions, remove float comparison

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2019,7 +2019,7 @@ void SessionView::renderViewDisplay() {
 #endif
 
 	DEF_STACK_STRING_BUF(tempoBPM, 10);
-	lastDisplayedTempo = currentSong->calculateBPM();
+	lastDisplayedTempo = playbackHandler.calculateBPM(playbackHandler.getTimePerInternalTickFloat());
 	playbackHandler.getTempoStringForOLED(lastDisplayedTempo, tempoBPM);
 	displayTempoBPM(canvas, tempoBPM, false);
 
@@ -2336,12 +2336,15 @@ void SessionView::graphicsRoutine() {
 void SessionView::displayPotentialTempoChange(UI* ui) {
 	// check UI in case graphics routine is called while we're in another UI (e.g. menu)
 	if (getCurrentUI() == ui) {
-		float tempo = currentSong->calculateBPM();
-		if (tempo != lastDisplayedTempo) {
+		float tempo = playbackHandler.calculateBPMForDisplay();
+		float diff = std::abs(tempo - lastDisplayedTempo);
+		// always catch manual adjustments, limit rate of others
+		if (diff > 0.5) {
 			DEF_STACK_STRING_BUF(tempoBPM, 10);
 			playbackHandler.getTempoStringForOLED(tempo, tempoBPM);
 			displayTempoBPM(deluge::hid::display::OLED::main, tempoBPM, true);
 			deluge::hid::display::OLED::markChanged();
+			lastDisplayedTempo = tempo;
 		}
 	}
 }

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -433,8 +433,13 @@ public:
 	// Tempo automation
 	void clearTempoAutomation();
 	void updateBPMFromAutomation();
+	
 	float calculateBPM() {
 		float timePerTimerTick = getTimePerTimerTickFloat();
+		return calculateBPM(timePerTimerTick);
+	}
+	float calculateBPM(float timePerTimerTick) {
+
 		if (insideWorldTickMagnitude > 0) {
 			timePerTimerTick *= ((uint32_t)1 << (insideWorldTickMagnitude));
 		}

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -433,7 +433,7 @@ public:
 	// Tempo automation
 	void clearTempoAutomation();
 	void updateBPMFromAutomation();
-	
+
 	float calculateBPM() {
 		float timePerTimerTick = getTimePerTimerTickFloat();
 		return calculateBPM(timePerTimerTick);

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2265,12 +2265,16 @@ void PlaybackHandler::displayTempoFromParams(int32_t magnitude, int8_t whichValu
 }
 
 void PlaybackHandler::commandDisplayTempo() {
-	float bpm = calculateBPM(getTimePerInternalTickFloat());
+	float bpm = calculateBPMForDisplay();
 	displayTempoBPM(bpm);
+}
+// takes into account incoming clock sync
+float PlaybackHandler::calculateBPMForDisplay() {
+	return calculateBPM(getTimePerInternalTickFloat());
 }
 
 float PlaybackHandler::calculateBPM(float timePerInternalTick) {
-	return currentSong->calculateBPM();
+	return currentSong->calculateBPM(timePerInternalTick);
 }
 
 void PlaybackHandler::getTempoStringForOLED(float tempoBPM, StringBuf& buffer) {

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -229,6 +229,8 @@ public:
 
 	void tryLoopCommand(GlobalMIDICommand command);
 
+	float calculateBPMForDisplay();
+
 private:
 	uint32_t timerTicksToOutputTicks(uint32_t timerTicks);
 


### PR DESCRIPTION
Fix #2736 

@seangoodvibes fysa comparing floats for equality doesn't work, they'll never compare equal unless they've been created, stored, and processed in literally identical ways (and sometimes not even then) 