### PR TITLE
fix bug with modulating sustain causing clicks

### DIFF
--- a/src/deluge/modulation/envelope.h
+++ b/src/deluge/modulation/envelope.h
@@ -48,4 +48,5 @@ public:
 
 private:
 	void setState(EnvelopeStage newState);
+	int32_t smoothedSustain{0};
 };


### PR DESCRIPTION
Fixes an annoying bug where modulating sustain with expression leads to clicks by adding smoothing on the sustain value