### PR TITLE
Fix bug with the first audio file recorded

### DIFF
--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -303,6 +303,8 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		highestUsedAudioRecordingNumberNeedsReChecking[folderID] = false;
 	}
 
+	highestUsedAudioRecordingNumber[folderID]++;
+
 	D_PRINTLN("new file: --------------  %d", highestUsedAudioRecordingNumber[folderID]);
 
 	error = filePath->set(audioRecordingFolderNames[folderID]);
@@ -336,7 +338,6 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		if (error != Error::NONE) {
 			return error;
 		}
-		highestUsedAudioRecordingNumber[folderID]++;
 
 		if (doingTempFolder) {
 			error =


### PR DESCRIPTION
Fixed bug where first recording would fail because it wasn't incrementing the last file path saved (so when it would go to create the file it would fail because the file already exists and recording would get aborted)

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2633