### PR TITLE
Fix saving of reverb hpf / lpf to song

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 #### <ins>FM Synth Filters</ins>
 - Added filters in FM synth mode. They're set to OFF by default, enable by changing them to any other mode using the menu or db/oct shortcut.
 
+#### <ins>Reverb</ins>
+- Fixed bug with Reverb HPF not saving to / loading from the Song
+
 ### MIDI
 
 #### <ins>Sysex</ins>

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -172,6 +172,7 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	// Setup reverb temp variables
 	reverbRoomSize = (float)30 / 50;
 	reverbDamp = (float)36 / 50;
+	reverbHPF = 0;
 	reverbLPF = (float)50 / 50;
 	reverbWidth = 1;
 	reverbPan = 0;
@@ -1137,16 +1138,19 @@ weAreInArrangementEditorOrInClipInstance:
 	uint32_t roomSize = AudioEngine::reverb.getRoomSize() * (uint32_t)2147483648u;
 	uint32_t damping = AudioEngine::reverb.getDamping() * (uint32_t)2147483648u;
 	uint32_t width = AudioEngine::reverb.getWidth() * (uint32_t)2147483648u;
+	uint32_t hpf = AudioEngine::reverb.getHPF() * (uint32_t)2147483648u;
 	uint32_t lpf = AudioEngine::reverb.getLPF() * (uint32_t)2147483648u;
 
 	roomSize = std::min(roomSize, (uint32_t)2147483647);
 	damping = std::min(damping, (uint32_t)2147483647);
 	width = std::min(width, (uint32_t)2147483647);
+	hpf = std::min(hpf, (uint32_t)2147483647);
 	lpf = std::min(lpf, (uint32_t)2147483647);
 
 	writer.writeAttribute("roomSize", roomSize);
 	writer.writeAttribute("dampening", damping);
 	writer.writeAttribute("width", width);
+	writer.writeAttribute("hpf", hpf);
 	writer.writeAttribute("lpf", lpf);
 	writer.writeAttribute("pan", AudioEngine::reverbPan);
 	writer.writeAttribute("model", util::to_underlying(model));
@@ -1358,6 +1362,14 @@ Error Song::readFromFile(Deserializer& reader) {
 						}
 						reverbWidth = (float)widthInt / 2147483648u;
 						reader.exitTag("width");
+					}
+					else if (!strcmp(tagName, "hpf")) {
+						reverbHPF = (float)reader.readTagOrAttributeValueInt() / 2147483648u;
+						reader.exitTag("hpf");
+					}
+					else if (!strcmp(tagName, "lpf")) {
+						reverbLPF = (float)reader.readTagOrAttributeValueInt() / 2147483648u;
+						reader.exitTag("lpf");
 					}
 					else if (!strcmp(tagName, "pan")) {
 						reverbPan = reader.readTagOrAttributeValueInt();

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -396,6 +396,7 @@ public:
 	// Reverb params to be stored here between loading and song being made the active one
 	dsp::Reverb::Model model;
 	float reverbRoomSize;
+	float reverbHPF;
 	float reverbLPF;
 	float reverbDamp;
 	float reverbWidth;


### PR DESCRIPTION
Added missing code to write reverb HPF to song and read reverb HPF / LPF from song file

If the HPF fix is good, I will cherry pick it manually to 1.2 because LPF is not part of 1.2

Fix #2817 
Fix #2818