### PR TITLE
Fix - Migrate midi learned params between synth and kit clip preset changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added new `MIDI LEARN` menu to the `SONG` menu. In `Song Grid View` this menu enables you to learn `Clip/Section Launch`. In `Song Row View` this menu enables you to learn the `Clip/Section Launch` and `Instrument`.
   - While in this menu, you just need to `hold a clip / section` and send midi to learn that clip / section. If you press the `clip / section` again you will unlearn it.
 - Added ability to `Midi Learn Instruments` and `Select the Audio Source for Audio Clips` in `Song Grid View Green Mode` by moving `Midi Learn Clip/Section Launch` actions to the `MIDI LEARN` menu mentioned above.
+- Fixed unexpected behaviour for `Synth` and `Kit` clips that would cause `MIDI LEARNED PARAMS` to get lost when changing presets for Synth / Kits. 
+  - Note: for `Kit` clips it will migrate midi learn for `Kit Affect Entire` params only.
 
 ## c1.2.0 Chopin
 


### PR DESCRIPTION
Fixed unexpected behaviour for `Synth` and `Kit` clips that would cause `MIDI LEARNED PARAMS` to get lost when changing presets for Synth / Kits

This fix makes this scenario now work as expected:

- you create a clip
- you midi learn a controller to that clip's params
- you then go to change the preset for that clip
- you expect that you can continue controlling the same params for the new preset