### PR TITLE
Move files to SETTINGS folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 
 ### MIDI
 
+#### <ins>SETTINGS SD card folder</ins>
+- A new folder has been created in the root of the SD card titled `SETTINGS`
+- The following files which were previously saved in the root of the SD card have been moved to the `SETTINGS` folder: `MIDIDevices.XML`, `MIDIFollow.XML`, `PerformanceView.XML` and `CommunityFeatures.XML`.
+
 #### <ins>Learn</ins>
 - Added new `MIDI LEARN` menu to the `SONG` menu. In `Song Grid View` this menu enables you to learn `Clip/Section Launch`. In `Song Row View` this menu enables you to learn the `Clip/Section Launch` and `Instrument`.
   - While in this menu, you just need to `hold a clip / section` and send midi to learn that clip / section. If you press the `clip / section` again you will unlearn it.
@@ -312,7 +316,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to access the `AUTOMATION VIEW EDITOR` for that specific Patch Cable / Modulation Depth.
   - You can also use the `SELECT ENCODER` while in the `AUTOMATION VIEW EDITOR` to scroll to any patch cables that exist.
 - Updated `AUTOMATION VIEW EDITOR` to allow you to edit Bipolar params according to their Bipolar nature. E.g. positive values are shown in the top four pads, negative value in the bottom four pads, and the middle value (0) is shown by not lighting up any pads.
-- Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset file `MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the Automation Overview and with the shortcut combos (e.g. `SHIFT` + `SHORTCUT PAD`).
+- Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset file `MIDI_DEVICES/MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the Automation Overview and with the shortcut combos (e.g. `SHIFT` + `SHORTCUT PAD`).
 - Updated `AUTOMATION VIEW` to move the `INTERPOLATION` shortcut to the `INTERPOLATION` pad in the first column of the Deluge grid (second pad from the top). Toggle interpolation on/off using `SHIFT` + `INTERPOLATION` shortcut pad. The Interpolation shortcut pad will blink to indicate that interpolation is enabled.
 - Updated `AUTOMATION VIEW` to move the `PAD SELECTION MODE` shortcut to the `WAVEFORM` pad in the first column of the Deluge grid (very top left pad). Toggle pad selection mode on/off using `SHIFT` + `WAVEFORM` shortcut pad. The Waveform shortcut pad will blink to indicate that pad selection mode is enabled.  
 - Updated `AUTOMATION VIEW` to provide access to `SETTINGS` menu (`SHIFT` + press `SELECT`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 #### <ins>SETTINGS SD card folder</ins>
 - A new folder has been created in the root of the SD card titled `SETTINGS`
 - The following files which were previously saved in the root of the SD card have been moved to the `SETTINGS` folder: `MIDIDevices.XML`, `MIDIFollow.XML`, `PerformanceView.XML` and `CommunityFeatures.XML`.
+  - Note: if you revert back to an earlier firmware, you will need to move these files back to the root of the SD card so that they can be loaded.
 
 #### <ins>Learn</ins>
 - Added new `MIDI LEARN` menu to the `SONG` menu. In `Song Grid View` this menu enables you to learn `Clip/Section Launch`. In `Song Row View` this menu enables you to learn the `Clip/Section Launch` and `Instrument`.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -511,12 +511,12 @@ Here is a list of features that have been added to the firmware as a list, group
             - Short press pads (< 100ms by default) in a column to change the value until you press the pad again (resetting it to the value before the pad was pressed)
             - Quickly clear all held values by pressing `HORIZONTAL ENCODER ◀︎▶︎` + `BACK` (resetting FX values back to their previous state)
         - Editing mode to edit the FX values assigned to each pad and the parameter assigned to each FX column
-        - Save defaults as PerformanceView.xml file
+        - Save defaults to `SETTINGS/PerformanceView.XML` file
             - Adjustable default Values assigned to each FX column via `VALUE` editing mode or PerformanceView.xml
             - Adjustable default Param assigned to each FX column via `PARAM` editing mode or PerformanceView.xml
             - Adjustable default "held pad" settings for each FX column via Performance View or PerformanceView.xml (
               simply change a held pad in Performance View and save the layout to save the layout with the held pads).
-        - Load defaults from PerformanceView.xml file
+        - Load defaults from `SETTINGS/PerformanceView.XML` file
 
 ### 4.1.7 - Added Master Chromatic Transpose of All Scale Mode Instrument Clips
 
@@ -780,7 +780,7 @@ to each individual note onset. ([#1978])
                         3) go back to the automation overview;
     - ([#1083]) Updated the Automation Overview and grid shortcuts in automation view for MIDI clips to match the grid
       shortcut cc mappings for MIDI Follow. So if you want to change what CC's map to what grid shortcuts in the
-      Automation View for MIDI Clips, you would need to edit the MIDIFollow.XML template for MIDI Follow mode.
+      Automation View for MIDI Clips, you would need to edit the `SETTINGS/MIDIFollow.XML` template for MIDI Follow mode.
     - ([#1156]) Change interpolation shortcut + Provide better integration with Deluge menu system and consistency with
       Select encoder usage.
         - Updated `AUTOMATION VIEW` to move the Interpolation shortcut to the Interpolation pad in the first column of
@@ -1232,8 +1232,9 @@ for the Lumi Keys Studio Edition, described below.
 ## 5. Community Features Menu (aka Runtime Settings)
 
 In the main menu of the Deluge (accessed by pressing both "SHIFT" + the "SELECT" encoder) there is
-the `COMMUNITY FEATURES` (OLED) or `FEAT` (7SEG) entry which allows you to turn features on and off as needed. Here is a
-list of all options as listed in OLED and 7SEG displays and what they do:
+the `COMMUNITY FEATURES` (OLED) or `FEAT` (7SEG) entry which allows you to turn features on and off as needed. Here is a list of all options as listed in OLED and 7SEG displays and what they do:
+
+Note: these settings are saved to `SETTINGS/CommunityFeatures.XML` on your SD card.
 
 * `Drum Randomizer (DRUM)`
     * When On, the "AUDITION + RANDOM" shortcut is enabled.

--- a/docs/features/midi_follow_mode.md
+++ b/docs/features/midi_follow_mode.md
@@ -10,13 +10,13 @@ Master MIDI follow mode whereby after setting a master MIDI follow channel for S
 
 Comes with a MIDI feedback mode to send updated parameter values on the MIDI follow feedback channel for mapped MIDI cc's. Feedback is sent whenever you change context on the deluge and whenever parameter values for the active context are changed.
 
-Comes with an XML file (MIDIFollow.XML) with default CC to Deluge parameter mappings. You can customize this XML file to map CC's differently as required.
+Comes with an XML file (`SETTINGS/MIDIFollow.XML`) with default CC to Deluge parameter mappings. You can customize this XML file to map CC's differently as required.
 
 **Simple summary:** 
 - Set your follow and feedback channel(s)
 - Set your MIDI Controller(s) to the same channel(s)
 - Set a root note for your kits
-- Confirm that your controller cc's are mapped to the parameters you want (via MIDIFollow.XML)
+- Confirm that your controller cc's are mapped to the parameters you want (via `SETTINGS/MIDIFollow.XML`)
 - Play and control the deluge instruments and parameters with ease!
 
 **No more re-learning your MIDI controllers every time you start a new song, add new clips or change instrument presets.**
@@ -83,7 +83,7 @@ The parameters are controlled only in the current context.
 - In other words it checks what context you’re in and controls the parameters of that context.
 
 #### Default MIDI CC Mappings
-A default set of MIDI CC # to Deluge Parameter mappings has been created for MIDI Follow Mode. When you launch the Deluge after installing the firmware with MIDI Follow Mode, an XML file will be created to the root folder of the SD card titled "MIDIFollow.XML"
+A default set of MIDI CC # to Deluge Parameter mappings has been created for MIDI Follow Mode. When you launch the Deluge after installing the firmware with MIDI Follow Mode, an XML file will be created in the `SETTINGS` folder in the root of the SD card titled `MIDIFollow.XML`
 
 The default mappings have taken into account standard MIDI CC to parameter mappings and usages. It has also taken into account reserving of MIDI CC's for future Deluge functionality / feature implementations.
 
@@ -98,14 +98,14 @@ Here are the MIDI CC #'s that have been reserved for other purposes:
 ![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/f076d9c8-d25f-4d13-a631-be552f84d7c8)
 
 #### Adjust MIDI CC Mappings
-MIDI CC mappings for MIDI Follow Mode are saved to the root of your SD card in an XML file called MIDIFollow.XML
+MIDI CC mappings for MIDI Follow Mode are saved to the `SETTINGS` folder in the root of your SD card in an XML file called `MIDIFollow.XML`
 
-Within MIDIFollow.XML, all Parameters that can mapped to a MIDI CC are listed. The MIDI CC value is enclosed between a Parameter XML tag - e.g. `<lpfFrequency>74</lpfFrequency>` indicates that MIDI CC 74 is mapped to the LPF Frequency parameter. Conversely when a value of 255 is entered (e.g. `<hpfFrequency>255</hpfFrequency>`) it indicates that no MIDI CC value has been mapped to that parameter.
+Within `MIDIFollow.XML`, all Parameters that can mapped to a MIDI CC are listed. The MIDI CC value is enclosed between a Parameter XML tag - e.g. `<lpfFrequency>74</lpfFrequency>` indicates that MIDI CC 74 is mapped to the LPF Frequency parameter. Conversely when a value of 255 is entered (e.g. `<hpfFrequency>255</hpfFrequency>`) it indicates that no MIDI CC value has been mapped to that parameter.
 
 ![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/1ae66f8b-1627-4e2f-a05d-fd7a8c73b62f)
-You can manually edit the MIDIFollow.XML to enter your MIDI CC mappings to each Parameter. 
+You can manually edit the `MIDIFollow.XML` to enter your MIDI CC mappings to each Parameter. 
 
-The defaults from MIDIFollow.XML are loaded automatically when you start the Deluge so you can begin controlling the deluge with your MIDI controller right away. 
+The defaults from `MIDIFollow.XML` are loaded automatically when you start the Deluge so you can begin controlling the deluge with your MIDI controller right away. 
 
 Note: A parameter can only be mapped to one MIDI CC. Conversely, a MIDI CC can be mapped to multiple parameters.
 

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -55,7 +55,8 @@ using deluge::modulation::params::kNoParamID;
 using namespace deluge;
 using namespace gui;
 
-#define PERFORM_DEFAULTS_XML "PerformanceView.XML"
+#define SETTINGS_FOLDER "SETTINGS"
+#define PERFORM_DEFAULTS_XML "SETTINGS/PerformanceView.XML"
 #define PERFORM_DEFAULTS_TAG "defaults"
 #define PERFORM_DEFAULTS_FXVALUES_TAG "defaultFXValues"
 #define PERFORM_DEFAULTS_PARAM_TAG "param"
@@ -1840,8 +1841,22 @@ void PerformanceSessionView::readDefaultsFromFile() {
 	// PerformanceView.XML
 	bool success = StorageManager::fileExists(PERFORM_DEFAULTS_XML, &fp);
 	if (!success) {
-		loadDefaultLayout();
-		return;
+		// since we changed the file path for the PerformanceView.XML in c1.3, it's possible
+		// that a PerformanceView file may exists in the root of the SD card
+		// if so, let's move it to the new SETTINGS folder (but first make sure folder exists)
+		FRESULT result = f_mkdir(SETTINGS_FOLDER);
+		if (result == FR_OK || result == FR_EXIST) {
+			result = f_rename("PerformanceView.XML", PERFORM_DEFAULTS_XML);
+			if (result == FR_OK) {
+				// this means we moved it
+				// now let's open it
+				success = StorageManager::fileExists(PERFORM_DEFAULTS_XML, &fp);
+			}
+		}
+		if (!success) {
+			loadDefaultLayout();
+			return;
+		}
 	}
 
 	//<defaults>

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -208,7 +208,8 @@ void MIDIDevice::readFromFile(Deserializer& reader) {
 	}
 }
 
-void MIDIDevice::writeDefinitionAttributesToFile(Serializer& writer) { // These only go into MIDIDEVICES.XML.
+// These only go into SETTINGS/MIDIDevices.XML
+void MIDIDevice::writeDefinitionAttributesToFile(Serializer& writer) {
 	if (hasDefaultVelocityToLevelSet()) {
 		writer.writeAttribute("defaultVolumeVelocitySensitivity", defaultVelocityToLevel);
 	}

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -134,10 +134,12 @@ public:
 	int32_t incomingSysexPos = 0;
 
 protected:
-	virtual void writeReferenceAttributesToFile(
-	    Serializer& writer) = 0; // These go both into MIDIDEVICES.XML and also any song/preset
-	                             // files where there's a reference to this Device.
-	void writeDefinitionAttributesToFile(Serializer& writer); // These only go into MIDIDEVICES.XML.
+	// These go both into SETTINGS/MIDIDevices.XML and also any song/preset
+	// files where there's a reference to this Device.
+	virtual void writeReferenceAttributesToFile(Serializer& writer) = 0;
+
+	// These only go into SETTINGS/MIDIDevices.XML
+	void writeDefinitionAttributesToFile(Serializer& writer);
 };
 
 class MIDIDeviceUSB : public MIDIDevice {

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -24,7 +24,8 @@
 #include <cstring>
 #include <string_view>
 
-#define RUNTIME_FEATURE_SETTINGS_FILE "CommunityFeatures.XML"
+#define SETTINGS_FOLDER "SETTINGS"
+#define RUNTIME_FEATURE_SETTINGS_FILE "SETTINGS/CommunityFeatures.XML"
 #define TAG_RUNTIME_FEATURE_SETTINGS "runtimeFeatureSettings"
 #define TAG_RUNTIME_FEATURE_SETTING "setting"
 #define TAG_RUNTIME_FEATURE_SETTING_ATTR_NAME "name"
@@ -191,10 +192,24 @@ void RuntimeFeatureSettings::init() {
 
 void RuntimeFeatureSettings::readSettingsFromFile() {
 	FilePointer fp;
-
+	// CommunityFeatures.XML
 	bool success = StorageManager::fileExists(RUNTIME_FEATURE_SETTINGS_FILE, &fp);
 	if (!success) {
-		return;
+		// since we changed the file path for the CommunityFeatures.XML in c1.3, it's possible
+		// that a CommunityFeatures file may exists in the root of the SD card
+		// if so, let's move it to the new SETTINGS folder (but first make sure folder exists)
+		FRESULT result = f_mkdir(SETTINGS_FOLDER);
+		if (result == FR_OK || result == FR_EXIST) {
+			result = f_rename("CommunityFeatures.XML", RUNTIME_FEATURE_SETTINGS_FILE);
+			if (result == FR_OK) {
+				// this means we moved it
+				// now let's open it
+				success = StorageManager::fileExists(RUNTIME_FEATURE_SETTINGS_FILE, &fp);
+			}
+		}
+		if (!success) {
+			return;
+		}
 	}
 
 	Error error = StorageManager::openXMLFile(&fp, smDeserializer, TAG_RUNTIME_FEATURE_SETTINGS);


### PR DESCRIPTION
- A new folder has been created in the root of the SD card titled `SETTINGS`
- The following files which were previously saved in the root of the SD card have been moved to the `SETTINGS` folder: `MIDIDevices.XML`, `MIDIFollow.XML`, `PerformanceView.XML` and `CommunityFeatures.XML`.

<img width="231" alt="Screenshot 2024-10-27 at 12 19 00 PM" src="https://github.com/user-attachments/assets/0ee1e83a-be2f-451d-873f-6f1cde6aab31">