### PR TITLE
Fix bug with persist midi learn

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -41,6 +41,7 @@
 #include "model/consequence/consequence_clip_existence.h"
 #include "model/instrument/cv_instrument.h"
 #include "model/instrument/midi_instrument.h"
+#include "model/mod_controllable/mod_controllable_audio.h"
 #include "model/sample/sample_recorder.h"
 #include "model/scale/preset_scales.h"
 #include "model/scale/scale_change.h"
@@ -3312,7 +3313,7 @@ void Song::replaceInstrument(Instrument* oldOutput, Instrument* newOutput, bool 
 	// if we're replacing the same output type
 	if (newOutput->type == oldOutput->type) {
 		// exclude MIDI and CV instruments from this
-		// only sound instruments have a midi knob array
+		// only audio instruments have a midi knob array
 		if (newOutput->type == OutputType::SYNTH || newOutput->type == OutputType::KIT) {
 			// Migrate any midi learned params for synth and kit clip preset changes
 			// For kit clips it will migrate only kit affect entire midi learned params
@@ -3321,14 +3322,15 @@ void Song::replaceInstrument(Instrument* oldOutput, Instrument* newOutput, bool 
 			// - you midi learn a controller to that clip's params
 			// - you then go to change the preset for that clip
 			// - you expect that you can continue controlling the same params for the new preset
-			Sound* oldSound = (Sound*)oldOutput->toModControllable();
-			if (oldSound) {
-				int32_t numKnobs = oldSound->midiKnobArray.getNumElements();
+			ModControllableAudio* oldModControllableAudio = (ModControllableAudio*)oldOutput->toModControllable();
+			if (oldModControllableAudio) {
+				int32_t numKnobs = oldModControllableAudio->midiKnobArray.getNumElements();
 				if (numKnobs) {
-					Sound* newSound = (Sound*)newOutput->toModControllable();
-					newSound->midiKnobArray.cloneFrom(&oldSound->midiKnobArray);
-					oldSound->midiKnobArray.deleteAtIndex(0, numKnobs);
-					oldSound->ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(this);
+					ModControllableAudio* newModControllableAudio =
+					    (ModControllableAudio*)newOutput->toModControllable();
+					newModControllableAudio->midiKnobArray.cloneFrom(&oldModControllableAudio->midiKnobArray);
+					oldModControllableAudio->midiKnobArray.deleteAtIndex(0, numKnobs);
+					oldModControllableAudio->ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(this);
 				}
 			}
 		}

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3311,21 +3311,25 @@ void Song::replaceInstrument(Instrument* oldOutput, Instrument* newOutput, bool 
 
 	// if we're replacing the same output type
 	if (newOutput->type == oldOutput->type) {
-		// Migrate any midi learned params for synth and kit clip preset changes
-		// For kit clips it will migrate only kit affect entire midi learned params
-		// Scenario:
-		// - you create a clip
-		// - you midi learn a controller to that clip's params
-		// - you then go to change the preset for that clip
-		// - you expect that you can continue controlling the same params for the new preset
-		Sound* oldSound = (Sound*)oldOutput->toModControllable();
-		if (oldSound) {
-			int32_t numKnobs = oldSound->midiKnobArray.getNumElements();
-			if (numKnobs) {
-				Sound* newSound = (Sound*)newOutput->toModControllable();
-				newSound->midiKnobArray.cloneFrom(&oldSound->midiKnobArray);
-				oldSound->midiKnobArray.deleteAtIndex(0, numKnobs);
-				oldSound->ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(this);
+		// exclude MIDI and CV instruments from this
+		// only sound instruments have a midi knob array
+		if (newOutput->type == OutputType::SYNTH || newOutput->type == OutputType::KIT) {
+			// Migrate any midi learned params for synth and kit clip preset changes
+			// For kit clips it will migrate only kit affect entire midi learned params
+			// Scenario:
+			// - you create a clip
+			// - you midi learn a controller to that clip's params
+			// - you then go to change the preset for that clip
+			// - you expect that you can continue controlling the same params for the new preset
+			Sound* oldSound = (Sound*)oldOutput->toModControllable();
+			if (oldSound) {
+				int32_t numKnobs = oldSound->midiKnobArray.getNumElements();
+				if (numKnobs) {
+					Sound* newSound = (Sound*)newOutput->toModControllable();
+					newSound->midiKnobArray.cloneFrom(&oldSound->midiKnobArray);
+					oldSound->midiKnobArray.deleteAtIndex(0, numKnobs);
+					oldSound->ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(this);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Logic for persisting midi knob array between preset changes should only apply to synth and kit instruments.

This fixes a crash that happens when trying to load a midi preset.