### PR TITLE
Handle first pad released when two pads are held. Fixes #2693

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4128,7 +4128,7 @@ ActionResult SessionView::gridHandlePadsLaunch(int32_t x, int32_t y, int32_t on,
 	// Release first pad, while two pads are held
 	if (!on && x == gridFirstPressedX && y == gridFirstPressedY && gridSecondPressedX != -1
 	    && gridSecondPressedY != -1) {
-		display->popupTextTemporary("COPY CANCELLED");
+		display->popupTextTemporary("COPY CANCELED");
 	}
 
 	if (FlashStorage::gridAllowGreenSelection) {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4125,6 +4125,12 @@ ActionResult SessionView::gridHandlePadsLaunch(int32_t x, int32_t y, int32_t on,
 		return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 	}
 
+	// Release first pad, while two pads are held
+	if (!on && x == gridFirstPressedX && y == gridFirstPressedY && gridSecondPressedX != -1 && gridSecondPressedY != -1) {
+		gridResetPresses(true, true);
+		display->popupTextTemporary("COPY CANCELLED");
+	}
+
 	if (FlashStorage::gridAllowGreenSelection) {
 		return gridHandlePadsLaunchWithSelection(x, y, on, clip);
 	}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4127,7 +4127,6 @@ ActionResult SessionView::gridHandlePadsLaunch(int32_t x, int32_t y, int32_t on,
 
 	// Release first pad, while two pads are held
 	if (!on && x == gridFirstPressedX && y == gridFirstPressedY && gridSecondPressedX != -1 && gridSecondPressedY != -1) {
-		gridResetPresses(true, true);
 		display->popupTextTemporary("COPY CANCELLED");
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3925,6 +3925,7 @@ ActionResult SessionView::gridHandlePadsEdit(int32_t x, int32_t y, int32_t on, C
 			performActionOnPadRelease = false;
 			gridSecondPressedX = x;
 			gridSecondPressedY = y;
+			display->popupText("COPY CLIPS");
 		}
 	}
 	// Release
@@ -3949,6 +3950,10 @@ ActionResult SessionView::gridHandlePadsEdit(int32_t x, int32_t y, int32_t on, C
 					}
 					return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 				}
+			}
+			// Release first pad, while two pads are held
+			else if (gridSecondPressedX != -1 && gridSecondPressedY != -1) {
+				display->popupTextTemporary("COPY CANCELED");
 			}
 
 			clipPressEnded();

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4126,7 +4126,8 @@ ActionResult SessionView::gridHandlePadsLaunch(int32_t x, int32_t y, int32_t on,
 	}
 
 	// Release first pad, while two pads are held
-	if (!on && x == gridFirstPressedX && y == gridFirstPressedY && gridSecondPressedX != -1 && gridSecondPressedY != -1) {
+	if (!on && x == gridFirstPressedX && y == gridFirstPressedY && gridSecondPressedX != -1
+	    && gridSecondPressedY != -1) {
 		display->popupTextTemporary("COPY CANCELLED");
 	}
 


### PR DESCRIPTION
Fixes #2693 where the "COPY CLIPS" popup would stay on the screen, when trying to copy a clip in grid mode and releasing the source-pad first.

This makes existing behavior more explicit: releasing the first pad of two held pads cancels copying. This should be added to the documentation.

https://github.com/user-attachments/assets/64fad287-4d88-48fa-847b-b4f78b524f0f

Bug existed only in launch-mode. Behavior in edit-mode does not match behavior in launch-mode yet. Code needs some restructuring to avoid duplicate code, but this could possibly be merged as is.