### PR TITLE
Handle first pad released when two pads are held. Fixes #2693 (#2865)

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1046,6 +1046,10 @@ void SessionView::clipPressEnded() {
 	// the right model stack with param (otherwise midi follow mode will think you're still in a clip)
 	selectedClipYDisplay = 255;
 	clipWasSelectedWithShift = false;
+	// Cancel copying clip
+	if (gridFirstPressedX != -1 && gridFirstPressedY != -1 && gridSecondPressedX != -1 && gridSecondPressedY != -1) {
+		display->popupTextTemporary("COPY CANCELED");
+	}
 	gridResetPresses();
 
 	currentUIMode = UI_MODE_NONE;
@@ -3888,6 +3892,7 @@ ActionResult SessionView::gridHandlePadsEdit(int32_t x, int32_t y, int32_t on, C
 			performActionOnPadRelease = false;
 			gridSecondPressedX = x;
 			gridSecondPressedY = y;
+			display->popupText("COPY CLIPS");
 		}
 	}
 	// Release


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/2693 where the "COPY CLIPS" popup would stay on the screen when trying to copy a clip in grid mode and releasing the source-pad first, and in some instances when switching grid view modes while holding two pads. Also fixes inconsistent popups when copying.

Makes existing behavior more explicit: releasing the first pad of two held pads cancels copying. This should be added to the documentation.

https://github.com/user-attachments/assets/64fad287-4d88-48fa-847b-b4f78b524f0f

_spelling has been updated to "canceled" (common American spelling) since taking this video_