### PR TITLE
Fix bug with entering && exiting perf view from arranger view

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -406,6 +406,7 @@ doActualSimpleChange:
 
 	else if (b == KEYBOARD) {
 		if (on && currentUIMode == UI_MODE_NONE) {
+			performanceSessionView.timeKeyboardShortcutPress = AudioEngine::audioSampleTimer;
 			changeRootUI(&performanceSessionView);
 		}
 	}

--- a/src/deluge/gui/views/performance_session_view.cpp
+++ b/src/deluge/gui/views/performance_session_view.cpp
@@ -930,10 +930,15 @@ ActionResult PerformanceSessionView::buttonAction(deluge::hid::Button b, bool on
 		}
 		else {
 			// if you released the keyboard button and it was held for longer than hold time
-			// switch back to session view (it just peeks performance view)
+			// switch back to arranger or session view (it just peeks performance view)
 			if (((AudioEngine::audioSampleTimer - timeKeyboardShortcutPress) >= FlashStorage::holdTime)) {
 				releaseViewOnExit(modelStack);
-				changeRootUI(&sessionView);
+				if (currentSong->lastClipInstanceEnteredStartPos != -1) {
+					changeRootUI(&arrangerView);
+				}
+				else {
+					changeRootUI(&sessionView);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2878

Fixed bug with entering and exiting performance view from arranger view