### PR TITLE
Cleanup decimal rendering

### DIFF
--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -165,7 +165,7 @@ void Decimal::drawPixelsForOled() {
 	// draw remaining digits
 	hid::display::OLED::main.drawString(buffer, stringStartX, 20, digitWidth, kTextHugeSizeY, 0, 128, true);
 	// draw cursor
-	hid::display::OLED::setupBlink(ourDigitStartX, digitWidth, 40, 44, movingCursor);
+	hid::display::OLED::setupBlink(ourDigitStartX + 1, digitWidth - 2, 41, 42, movingCursor);
 }
 
 void Decimal::drawActualValue(bool justDidHorizontalScroll) {

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -141,20 +141,30 @@ void Decimal::drawPixelsForOled() {
 		editingChar--;
 	}
 
+	int32_t digitWidth = kTextHugeSpacingX;
+	int32_t periodWidth = digitWidth / 2;
+	int32_t stringWidth = digitWidth * length + (numDecimalPlaces ? periodWidth : 0);
+	int32_t stringStartX = (OLED_MAIN_WIDTH_PIXELS - stringWidth) >> 1;
+	int32_t ourDigitStartX = stringStartX + editingChar * digitWidth;
+
+	// for values with decimal digits showing
 	if (numDecimalPlaces) {
 		int32_t numCharsBeforeDecimalPoint = length - numDecimalPlaces;
-		memmove(&buffer[numCharsBeforeDecimalPoint + 1], &buffer[numCharsBeforeDecimalPoint], numDecimalPlaces + 1);
-		buffer[numCharsBeforeDecimalPoint] = '.';
-		length++;
+		// draw digits before period
+		hid::display::OLED::main.drawString(std::string_view(buffer, numCharsBeforeDecimalPoint), stringStartX, 20,
+		                                    digitWidth, kTextHugeSizeY, 0, 128, true);
+		// draw period
+		hid::display::OLED::main.drawString(".", stringStartX + numCharsBeforeDecimalPoint * digitWidth, 20,
+		                                    periodWidth, kTextHugeSizeY, 0, 128, true);
+		// modify properties so that the remaining digits and the cursor get drawn correctly
+		std::memmove(buffer, buffer + numCharsBeforeDecimalPoint, sizeof(buffer) - numCharsBeforeDecimalPoint);
+		stringStartX += numCharsBeforeDecimalPoint * digitWidth + periodWidth;
+		if (editingChar > numCharsBeforeDecimalPoint)
+			ourDigitStartX -= periodWidth;
 	}
-
-	int32_t digitWidth = kTextHugeSpacingX;
-	int32_t stringWidth = digitWidth * length;
-	int32_t stringStartX = (OLED_MAIN_WIDTH_PIXELS - stringWidth) >> 1;
-
+	// draw remaining digits
 	hid::display::OLED::main.drawString(buffer, stringStartX, 20, digitWidth, kTextHugeSizeY, 0, 128, true);
-
-	int32_t ourDigitStartX = stringStartX + editingChar * digitWidth;
+	// draw cursor
 	hid::display::OLED::setupBlink(ourDigitStartX, digitWidth, 40, 44, movingCursor);
 }
 

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -152,7 +152,7 @@ void Decimal::drawPixelsForOled() {
 	int32_t stringWidth = digitWidth * length;
 	int32_t stringStartX = (OLED_MAIN_WIDTH_PIXELS - stringWidth) >> 1;
 
-	hid::display::OLED::main.drawString(buffer, stringStartX, 20, digitWidth, kTextHugeSizeY);
+	hid::display::OLED::main.drawString(buffer, stringStartX, 20, digitWidth, kTextHugeSizeY, 0, 128, true);
 
 	int32_t ourDigitStartX = stringStartX + editingChar * digitWidth;
 	hid::display::OLED::setupBlink(ourDigitStartX, digitWidth, 40, 44, movingCursor);


### PR DESCRIPTION
### Changes
- Fix #2858 (revert to c1.1 monospaced rendering for decimals)
- Render period at half-width
- Resize cursor, make it not touch digits

![IMG_2496](https://github.com/user-attachments/assets/34e5a13d-0a09-4d0c-92dc-25b66a4c0cd5)
_c1.1_

![IMG_2494](https://github.com/user-attachments/assets/18ee4325-a9bf-408f-834e-d50dd89ca58e)
_new_