### PR TITLE
Keep arranger clip instance length same after change

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -2494,34 +2494,9 @@ void ArrangerView::selectEncoderAction(int8_t offset) {
 			                      clipInstance->clip, NULL);
 		}
 
-		int32_t newLength;
-
-		// No newClip means this will become a white clip
-		if (!newClip) {
-			// which will have the same length as the original clip instance
-			newLength = desiredLength;
-		}
-
-		else {
-			// choosing a section clip will reset the clip instance length to the length of that section clip
-			newLength = newClip->loopLength;
-		}
-
-		// Make sure it's not too long
-		ClipInstance* nextClipInstance = output->clipInstances.getElement(pressedClipInstanceIndex + 1);
-		if (nextClipInstance) {
-			int32_t maxLength = nextClipInstance->pos - clipInstance->pos;
-
-			if (newLength > maxLength) {
-				newLength = maxLength;
-			}
-		}
-		if (newLength > kMaxSequenceLength - clipInstance->pos) {
-			newLength = kMaxSequenceLength - clipInstance->pos;
-		}
 		// log action
 		Action* action = actionLogger.getNewAction(ActionType::CLIP_INSTANCE_EDIT, ActionAddition::ALLOWED);
-		clipInstance->change(action, output, clipInstance->pos, newLength, newClip);
+		clipInstance->change(action, output, clipInstance->pos, desiredLength, newClip);
 		// notify the arrangement that this clip instance will be added
 		arrangement.rowEdited(output, clipInstance->pos, clipInstance->pos + clipInstance->length, NULL, clipInstance);
 

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -113,6 +113,7 @@ public:
 	ClipInstance* lastInteractedClipInstance;
 
 	int32_t lastInteractedArrangementPos;
+	bool creatingNewClipInstance = false;
 
 	int32_t lastTickSquare{};
 


### PR DESCRIPTION
Fix #2877 

This deletes a bunch of safety-checks for the length of the new clip-instance
As we're taking the length from a valid clip-instance, we already know the length is valid