### PR TITLE
Disallow new clip instance on different row

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1273,15 +1273,8 @@ void ArrangerView::editPadAction(int32_t x, int32_t y, bool on) {
 
 			// Already pressing - length edit
 			else if (currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW) {
-
-				if (y != yPressedEffective) {
-					if (!pressedClipInstanceIsInValidPosition) {
-						return;
-					}
-					return createNewClipInstance(output, x, y, squareStart, squareEnd, xScroll);
-				}
-
-				if (x > xPressed) {
+				// Only when pressing on the same row, and to the right of the currently held pad
+				if (y != yPressedEffective && x > xPressed) {
 					adjustClipInstanceLength(output, xPressed, y, squareStart, squareEnd);
 				}
 			}


### PR DESCRIPTION
In current Arranger behavior, when creating or editing a clip instance, a bunch of checks are performed when releasing a pad. (Such as: stop stutter, create white clip for white clip instance.) But, when holding/editing a clip instance, the code allows you to create a new clip instance on a different row with a new press. In code this releases your press on the first clip instance, but as there's no physical pad release, the safety checks in the "releasing pad" code are not run.

We could implement the checks for this situation as well, but I'm personally not seeing any merit in having this even be possible - why would you even want to be holding a clip instance while creating another one on a different row? I'd much rather ignore the second press on a different row altogether. The only change for the user is that you can no longer create a new clip instance while holding a clip instance, which is an edge-case anyway.

Keeping this as a draft until #2886 is handled to avoid clashes