### PR TITLE
Fix alternative playback start behaviour in nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,9 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 
 #### <ins>General</ins>
 - The maximum zoom level for timelines has been increased. Now, the maximum zoom is the point the point where the entire timeline is represented by a single grid cell.
+- Added community feature toggle `Alternative Playback Start Behaviour (STAR)` to change the behaviour of playback start shortcuts as follows:
+  - With playback off, pressing `PLAY` will start playback from the current grid scroll position
+  - With playback off, pressing `HORIZONTAL ENCODER ◀︎▶︎` + `PLAY` will start playback from the start of the arrangement or clip
 
 #### <ins>Menu UI Improvements</ins>
 - For toggle (ON/OFF) menus, you can now view and toggle the ON/OFF status without entering the menu by simply pressing on the `SELECT` encoder while the menu is selected.

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -168,7 +168,7 @@ doEndMidiLearnPressSession:
 				// Otherwise, normal - tap tempo, but not during record count in
 				else if (currentUIMode == UI_MODE_NONE) {
 					bool useNormalTapTempoBehaviour =
-					    (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AlternativePlaybackStartBehaviour)
+					    (runtimeFeatureSettings.get(RuntimeFeatureSettingType::AlternativeTapTempoBehaviour)
 					     == RuntimeFeatureStateToggle::Off);
 					playbackHandler.tapTempoButtonPress(useNormalTapTempoBehaviour);
 				}

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -59,7 +59,7 @@ public:
 	void playButtonPressed(int32_t buttonPressLatency);
 	void recordButtonPressed();
 	void setupPlaybackUsingInternalClock(int32_t buttonPressLatencyForTempolessRecord = 0, bool allowCountIn = true,
-	                                     bool restartingPlayback = false);
+	                                     bool restartingPlayback = false, bool restartingPlaybackAtBeginning = false);
 	void setupPlaybackUsingExternalClock(bool switchingFromInternalClock = false, bool fromContinueCommand = false);
 	void setupPlayback(int32_t newPlaybackState, int32_t playFromPos, bool doOneLastAudioRoutineCall = false,
 	                   bool shouldShiftAccordingToClipInstance = true,
@@ -74,7 +74,7 @@ public:
 	bool isCurrentlyRecording();
 	void positionPointerReceived(uint8_t data1, uint8_t data2);
 	void doSongSwap(bool preservePlayPosition = false);
-	void forceResetPlayPos(Song* song, bool restartingPlayback = false);
+	void forceResetPlayPos(Song* song, bool restartingPlaybackAtBeginning = false);
 	void expectEvent();
 	void setMidiInClockEnabled(bool newValue);
 	int32_t getActualArrangementRecordPos();


### PR DESCRIPTION
The alternative playback start behaviour community feature stopped working in the nightly build after a refactoring which removed logic that handled what to do if the toggle was enabled and handled

Fixed alternative playback start behaviour by cleaning up logic, re-adding the toggle handling, and making it code more explicit and easier to understand/follow in PlaybackHandler::setupPlaybackUsingInternalClock

Re-added change log entry for alternative playback start behaviour that was accidentally removed

Also fixed mistake with alternativeTapTempoBehaviour toggle