### PR TITLE
Make default value of writeJsonFlag = false. (Fixes 2910), for real.

### DIFF
--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -67,7 +67,7 @@ JsonSerializer smJsonSerializer;
 JsonDeserializer smJsonDeserializer;
 FileDeserializer* activeDeserializer = &smDeserializer;
 
-const bool writeJsonFlag = true;
+const bool writeJsonFlag = false;
 
 Serializer& GetSerializer() {
 	if (writeJsonFlag) {


### PR DESCRIPTION
Issue 2910 had a SYNTH file being written out as Json. That should not be happening at this time. Turns out the writeJsonFlag was defaulting to true. Must have been a missed change in an earlier merge.