### PR TITLE
Double number of session mode sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
 - Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
   - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
 
+#### <ins>Session Mode</ins>
+- Doubled the number of Session Mode sections from 12 to 24.
+
 #### <ins>Song Grid View</ins>
 
 ##### Entering Clips

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -453,7 +453,7 @@ constexpr int32_t kNumericDisplayLength = 4;
 constexpr size_t kNumGoldKnobIndicatorLEDs = 4;
 constexpr int32_t kMaxGoldKnobIndicatorLEDValue = kMaxKnobPos / 4;
 
-constexpr int32_t kMaxNumSections = 12;
+constexpr int32_t kMaxNumSections = 24;
 
 constexpr int32_t kNumPhysicalModKnobs = 2;
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1546,7 +1546,7 @@ void SessionView::drawSectionSquare(uint8_t yDisplay, RGB thisImage[]) {
 		}
 
 		else {
-			thisColour = RGB::fromHue(defaultClipGroupColours[clip->section]);
+			thisColour = defaultClipSectionColours[clip->section];
 
 			// If user assigning MIDI controls and has this section selected, flash to half brightness
 			if (view.midiLearnFlashOn && currentSong
@@ -3145,8 +3145,7 @@ bool SessionView::gridRenderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 			auto section = gridSectionFromY(y);
 			RGB& ptrSectionColour = image[y][sectionColumnIndex];
 
-			ptrSectionColour = RGB::fromHue(defaultClipGroupColours[gridSectionFromY(y)]);
-			ptrSectionColour = ptrSectionColour.adjust(255, 2);
+			ptrSectionColour = defaultClipSectionColours[gridSectionFromY(y)];
 
 			if (view.midiLearnFlashOn && gridModeActive == SessionGridModeLaunch) {
 				// MIDI colour if necessary

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -41,10 +41,6 @@ extern float getTransitionProgress();
 
 constexpr uint32_t kGridHeight = kDisplayHeight;
 
-// Clip Group colours
-extern const uint8_t numDefaultClipGroupColours;
-extern const uint8_t defaultClipGroupColours[];
-
 class SessionView final : public ClipNavigationTimelineView {
 public:
 	SessionView();

--- a/src/deluge/model/clip/clip_instance.cpp
+++ b/src/deluge/model/clip/clip_instance.cpp
@@ -20,6 +20,7 @@
 #include "model/action/action.h"
 #include "model/clip/instrument_clip.h"
 #include "model/consequence/consequence_clip_instance_change.h"
+#include "playback/mode/session.h"
 #include "util/functions.h"
 #include <new>
 
@@ -32,7 +33,7 @@ RGB ClipInstance::getColour() {
 		return RGB::monochrome(128);
 	}
 
-	return RGB::fromHue(defaultClipGroupColours[clip->section]);
+	return defaultClipSectionColours[clip->section];
 }
 
 void ClipInstance::change(Action* action, Output* output, int32_t newPos, int32_t newLength, Clip* newClip) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -58,6 +58,32 @@ enum class LaunchStatus {
 	LAUNCH_ALONG_WITH_EXISTING_LAUNCHING,
 };
 
+using namespace deluge::gui::colours;
+const Colour defaultClipSectionColours[] = {RGB::fromHue(102), // bright light blue
+                                            RGB::fromHue(168), // bright dark pink
+                                            RGB::fromHue(24),  // bright light orange
+                                            RGB::fromHue(84),  // bright turquoise
+                                            red,
+                                            lime,
+                                            blue,
+                                            RGB::fromHue(12),  // bright dark orange
+                                            RGB::fromHue(147), // bright purple
+                                            yellow,
+                                            green,
+                                            RGB::fromHue(157), // bright magenta
+                                            pastel::blue,
+                                            pink_full,
+                                            pastel::orange,
+                                            pastel::green,
+                                            pink.forTail(),
+                                            lime.forTail(),
+                                            cyan.forTail(),
+                                            orange.forTail(),
+                                            purple.forTail(),
+                                            pastel::yellow.forTail(),
+                                            green.forTail(),
+                                            magenta.forTail()};
+
 Session::Session() {
 	cancelAllLaunchScheduling();
 	lastSectionArmed = 255;

--- a/src/deluge/playback/mode/session.h
+++ b/src/deluge/playback/mode/session.h
@@ -17,6 +17,7 @@
 
 #pragma once
 #include "definitions_cxx.hpp"
+#include "gui/colour/colour.h"
 #include "playback/mode/playback_mode.h"
 
 class InstrumentClip;
@@ -107,3 +108,4 @@ private:
 };
 
 extern Session session;
+extern const deluge::gui::colours::Colour defaultClipSectionColours[];

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -667,9 +667,6 @@ const int16_t windowedSincKernelBasicForWavetableBetweenCycles[] = {
 const uint8_t noteCodeToNoteLetter[12] = {67, 67, 68, 68, 69, 70, 70, 71, 71, 65, 65, 66};
 const bool noteCodeIsSharp[12] = {0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0};
 
-
-const uint8_t defaultClipGroupColours[] = {102, 168, 24, 84, 186, 36, 126, 12, 147, 48, 72, 157};
-
 /**
  * @brief How iterance is encoded:
  *

--- a/src/deluge/util/lookuptables/lookuptables.h
+++ b/src/deluge/util/lookuptables/lookuptables.h
@@ -135,8 +135,6 @@ const uint8_t presetReverbRoomSize[NUM_PRESET_REVERBS] = {16, 30, 44};
 const uint8_t presetReverbDamping[NUM_PRESET_REVERBS] = {29, 36, 45};
 extern deluge::l10n::String presetReverbNames[NUM_PRESET_REVERBS];
 
-extern const uint8_t defaultClipGroupColours[];
-
 extern const uint8_t noteCodeToNoteLetter[];
 extern const bool noteCodeIsSharp[];
 


### PR DESCRIPTION
Doubled the number of sections that can be created in the Session Views (Row and Grid) from 12 to 24.