### PR TITLE
Fix - Allow turning off fill mode while audio recording to kit row

### DIFF
--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -261,6 +261,10 @@ ActionResult AudioRecorder::buttonAction(deluge::hid::Button b, bool on, bool in
 	using namespace deluge::hid::button;
 
 	if (!on) {
+		// allow turning off fill mode if it was active while entering audio recorder
+		if (b == SYNC_SCALING && currentSong->isFillModeActive()) {
+			return getRootUI()->buttonAction(b, on, inCardRoutine);
+		}
 		return ActionResult::NOT_DEALT_WITH;
 	}
 


### PR DESCRIPTION
Allow turning off fill mode while in audio recorder in case you turned it on before you entered audio recorder and want to turn it off while you're in audio recorder.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2901