### PR TITLE
Bitsets for exressionSources

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -7179,8 +7179,7 @@ void InstrumentClipView::reportNoteOffForMPEEditing(ModelStackWithNoteRow* model
 		ModelStackWithParamCollection* modelStackWithParamCollection =
 		    modelStack->addOtherTwoThingsAutomaticallyGivenNoteRow()->addParamCollection(mpeParams, mpeParamsSummary);
 
-		for (int32_t expressionDimension = 0; expressionDimension < kNumExpressionDimensions;
-		     expressionDimension++) {
+		for (int32_t expressionDimension = 0; expressionDimension < kNumExpressionDimensions; expressionDimension++) {
 			AutoParam* param = &mpeParams->params[expressionDimension];
 
 			ModelStackWithAutoParam* modelStackWithAutoParam =

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -7119,15 +7119,15 @@ void InstrumentClipView::reportMPEInitialValuesForNoteEditing(ModelStackWithNote
 			    modelStack->addOtherTwoThingsAutomaticallyGivenNoteRow()->addParamCollection(mpeParams,
 			                                                                                 mpeParamsSummary);
 
-			for (int32_t whichExpressionDimension = 0; whichExpressionDimension < kNumExpressionDimensions;
-			     whichExpressionDimension++) {
-				mpeValuesAtHighestPressure[0][whichExpressionDimension] = mpeValues[whichExpressionDimension];
+			for (int32_t expressionDimension = 0; expressionDimension < kNumExpressionDimensions;
+			     expressionDimension++) {
+				mpeValuesAtHighestPressure[0][expressionDimension] = mpeValues[expressionDimension];
 			}
 		}
 	}
 }
 
-void InstrumentClipView::reportMPEValueForNoteEditing(int32_t whichExpressionimension, int32_t value) {
+void InstrumentClipView::reportMPEValueForNoteEditing(int32_t expressionDimension, int32_t value) {
 
 	// If time to move record along...
 	uint32_t timeSince = AudioEngine::audioSampleTimer - mpeRecordLastUpdateTime;
@@ -7140,13 +7140,13 @@ void InstrumentClipView::reportMPEValueForNoteEditing(int32_t whichExpressionime
 	}
 
 	// Always keep track of the "current" pressure value, so we can decide whether to be recording the other values.
-	if (whichExpressionimension == 2) {
+	if (expressionDimension == 2) {
 		mpeMostRecentPressure = value >> 16;
 	}
 
 	// And if we're still at max pressure, then yeah, record those other values.
 	if (mpeMostRecentPressure >= mpeValuesAtHighestPressure[0][2]) {
-		mpeValuesAtHighestPressure[0][whichExpressionimension] = value >> 16;
+		mpeValuesAtHighestPressure[0][expressionDimension] = value >> 16;
 	}
 
 	dontDeleteNotesOnDepress(); // We know the caller is also manually editing the AutoParam now too - this counts
@@ -7179,14 +7179,14 @@ void InstrumentClipView::reportNoteOffForMPEEditing(ModelStackWithNoteRow* model
 		ModelStackWithParamCollection* modelStackWithParamCollection =
 		    modelStack->addOtherTwoThingsAutomaticallyGivenNoteRow()->addParamCollection(mpeParams, mpeParamsSummary);
 
-		for (int32_t whichExpressionDimension = 0; whichExpressionDimension < kNumExpressionDimensions;
-		     whichExpressionDimension++) {
-			AutoParam* param = &mpeParams->params[whichExpressionDimension];
+		for (int32_t expressionDimension = 0; expressionDimension < kNumExpressionDimensions;
+		     expressionDimension++) {
+			AutoParam* param = &mpeParams->params[expressionDimension];
 
 			ModelStackWithAutoParam* modelStackWithAutoParam =
-			    modelStackWithParamCollection->addAutoParam(whichExpressionDimension, param);
+			    modelStackWithParamCollection->addAutoParam(expressionDimension, param);
 
-			int32_t newValue = (int32_t)mpeValuesAtHighestPressure[t][whichExpressionDimension] << 16;
+			int32_t newValue = (int32_t)mpeValuesAtHighestPressure[t][expressionDimension] << 16;
 
 			param->setValueForRegion(view.modPos, view.modLength, newValue, modelStackWithAutoParam);
 		}

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -161,7 +161,7 @@ public:
 	void modEncoderAction(int32_t whichModEncoder, int32_t offset) override;
 	ClipMinder* toClipMinder() override { return this; }
 	void reportMPEInitialValuesForNoteEditing(ModelStackWithNoteRow* modelStack, int16_t const* mpeValues);
-	void reportMPEValueForNoteEditing(int32_t whichExpressionDimension, int32_t value);
+	void reportMPEValueForNoteEditing(int32_t expressionDimension, int32_t value);
 	void reportNoteOffForMPEEditing(ModelStackWithNoteRow* modelStack);
 	void dontDeleteNotesOnDepress();
 

--- a/src/deluge/model/drum/drum.cpp
+++ b/src/deluge/model/drum/drum.cpp
@@ -111,8 +111,8 @@ void Drum::expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelS
 			goto justSend;
 		}
 
-		bool success = noteRow->recordPolyphonicExpressionEvent(modelStackWithNoteRow, combinedValue,
-		                                                        expressionDimension, true);
+		bool success =
+		    noteRow->recordPolyphonicExpressionEvent(modelStackWithNoteRow, combinedValue, expressionDimension, true);
 		if (!success) {
 			goto justSend;
 		}

--- a/src/deluge/model/drum/drum.cpp
+++ b/src/deluge/model/drum/drum.cpp
@@ -86,15 +86,15 @@ void Drum::getCombinedExpressionInputs(int16_t* combined) {
 }
 
 void Drum::expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelStack, int16_t newValue,
-                                           int32_t whichExpressionimension, int32_t level) {
+                                           int32_t expressionDimension, int32_t level) {
 
 	// Ok we have to first combine the expression inputs that the user might have sent at both MPE/polyphonic/finger
 	// level, *and* at channel/instrument level. Yes, we combine these here at the input before the data gets recorded
 	// or sounded, because unlike for Instruments, we're a Drum, and all we have is the NoteRow level to store this
 	// stuff.
-	lastExpressionInputsReceived[level][whichExpressionimension] = newValue >> 8; // Store value
+	lastExpressionInputsReceived[level][expressionDimension] = newValue >> 8; // Store value
 	int32_t combinedValue =
-	    (int32_t)newValue + ((int32_t)lastExpressionInputsReceived[!level][whichExpressionimension] << 8);
+	    (int32_t)newValue + ((int32_t)lastExpressionInputsReceived[!level][expressionDimension] << 8);
 	combinedValue = lshiftAndSaturate<16>(combinedValue);
 
 	expressionValueChangesMustBeDoneSmoothly = true;
@@ -112,7 +112,7 @@ void Drum::expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelS
 		}
 
 		bool success = noteRow->recordPolyphonicExpressionEvent(modelStackWithNoteRow, combinedValue,
-		                                                        whichExpressionimension, true);
+		                                                        expressionDimension, true);
 		if (!success) {
 			goto justSend;
 		}
@@ -121,7 +121,7 @@ void Drum::expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelS
 	// Or if not recording, just sound the change ourselves here (as opposed to the AutoParam doing it).
 	else {
 justSend:
-		expressionEvent(combinedValue, whichExpressionimension); // Virtual function
+		expressionEvent(combinedValue, expressionDimension); // Virtual function
 	}
 
 	expressionValueChangesMustBeDoneSmoothly = false;

--- a/src/deluge/model/drum/drum.h
+++ b/src/deluge/model/drum/drum.h
@@ -85,8 +85,8 @@ public:
 	bool readDrumTagFromFile(Deserializer& reader, char const* tagName);
 	void recordNoteOnEarly(int32_t velocity, bool noteTailsAllowed);
 	void expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelStack, int16_t newValue,
-	                                     int32_t whichExpressionimension, int32_t level);
-	virtual void expressionEvent(int32_t newValue, int32_t whichExpressionimension) {}
+	                                     int32_t expressionDimension, int32_t level);
+	virtual void expressionEvent(int32_t newValue, int32_t expressionDimension) {}
 	void getCombinedExpressionInputs(int16_t* combined);
 
 	virtual ModControllable* toModControllable() { return NULL; }

--- a/src/deluge/model/drum/midi_drum.cpp
+++ b/src/deluge/model/drum/midi_drum.cpp
@@ -123,19 +123,19 @@ int8_t MIDIDrum::modEncoderAction(ModelStackWithThreeMainThings* modelStack, int
 	return -64;
 }
 
-void MIDIDrum::expressionEvent(int32_t newValue, int32_t whichExpressionDimension) {
+void MIDIDrum::expressionEvent(int32_t newValue, int32_t expressionDimension) {
 
 	// Aftertouch only
-	if (whichExpressionDimension == 2) {
+	if (expressionDimension == 2) {
 		int32_t value7 = newValue >> 24;
 		midiEngine.sendPolyphonicAftertouch(this, channel, value7, note, kMIDIOutputFilterNoMPE);
 	}
 }
 
-void MIDIDrum::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+void MIDIDrum::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
                                                         int32_t channelOrNoteNumber,
                                                         MIDICharacteristic whichCharacteristic) {
 	// Because this is a Drum, we disregard the noteCode (which is what channelOrNoteNumber always is in our case - but
 	// yeah, that's all irrelevant.
-	expressionEvent(newValue, whichExpressionDimension);
+	expressionEvent(newValue, expressionDimension);
 }

--- a/src/deluge/model/drum/midi_drum.h
+++ b/src/deluge/model/drum/midi_drum.h
@@ -35,9 +35,9 @@ public:
 
 	int8_t modEncoderAction(ModelStackWithThreeMainThings* modelStack, int8_t offset, uint8_t whichModEncoder);
 
-	void expressionEvent(int32_t newValue, int32_t whichExpressionDimension);
+	void expressionEvent(int32_t newValue, int32_t expressionDimension);
 
-	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
 	                                              int32_t channelOrNoteNumber, MIDICharacteristic whichCharacteristic);
 
 	uint8_t note;

--- a/src/deluge/model/instrument/cv_instrument.cpp
+++ b/src/deluge/model/instrument/cv_instrument.cpp
@@ -45,28 +45,28 @@ void CVInstrument::noteOffPostArp(int32_t noteCodePostArp, int32_t oldMIDIChanne
 }
 
 void CVInstrument::polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,
-                                                            int32_t whichExpressionDimension, ArpNote* arpNote) {
+                                                            int32_t expressionDimension, ArpNote* arpNote) {
 	if (cvEngine.isNoteOn(getPitchChannel(), noteCodeAfterArpeggiation)) {
-		if (!whichExpressionDimension) { // Pitch bend only, handles different polyphonic vs mpe pitch scales
+		if (!expressionDimension) { // Pitch bend only, handles different polyphonic vs mpe pitch scales
 			polyPitchBendValue = newValue;
 			updatePitchBendOutput();
 		}
 		else {
 			// send the combined mono and poly expression
-			lastCombinedPolyExpression[whichExpressionDimension] = newValue;
-			sendMonophonicExpressionEvent(whichExpressionDimension);
+			lastCombinedPolyExpression[expressionDimension] = newValue;
+			sendMonophonicExpressionEvent(expressionDimension);
 		}
 	}
 }
 
-void CVInstrument::monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDimension) {
-	if (!whichExpressionDimension) { // Pitch bend only
+void CVInstrument::monophonicExpressionEvent(int32_t newValue, int32_t expressionDimension) {
+	if (!expressionDimension) { // Pitch bend only
 		monophonicPitchBendValue = newValue;
 		updatePitchBendOutput();
 	}
 	else {
-		lastMonoExpression[whichExpressionDimension] = newValue;
-		sendMonophonicExpressionEvent(whichExpressionDimension);
+		lastMonoExpression[expressionDimension] = newValue;
+		sendMonophonicExpressionEvent(expressionDimension);
 	}
 }
 

--- a/src/deluge/model/instrument/cv_instrument.h
+++ b/src/deluge/model/instrument/cv_instrument.h
@@ -35,10 +35,10 @@ public:
 	void noteOnPostArp(int32_t noteCodePostArp, ArpNote* arpNote);
 	void noteOffPostArp(int32_t noteCode, int32_t oldMIDIChannel, int32_t velocity);
 	void polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,
-	                                              int32_t whichExpressionDmiension, ArpNote* arpNote);
+	                                              int32_t expressionDmiension, ArpNote* arpNote);
 	bool writeDataToFile(Serializer& writer, Clip* clipForSavingOutputOnly, Song* song);
 	bool readTagFromFile(Deserializer& reader, const char* tagName) override;
-	void monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDmiension);
+	void monophonicExpressionEvent(int32_t newValue, int32_t expressionDmiension);
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs);
 	void setupWithoutActiveClip(ModelStack* modelStack);
 	static int32_t navigateChannels(int oldChannel, int offset) {

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -673,7 +673,7 @@ bool expressionValueChangesMustBeDoneSmoothly = false; // Wee bit of a workaroun
 // no NoteRow for the note
 // - but we still want to cause a sound change in response to the message.
 void MelodicInstrument::polyphonicExpressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelStack,
-                                                                  int32_t newValue, int32_t whichExpressionDimension,
+                                                                  int32_t newValue, int32_t expressionDimension,
                                                                   int32_t channelOrNoteNumber,
                                                                   MIDICharacteristic whichCharacteristic) {
 	expressionValueChangesMustBeDoneSmoothly = true;
@@ -699,7 +699,7 @@ void MelodicInstrument::polyphonicExpressionEventPossiblyToRecord(ModelStackWith
 				NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
 				if (noteRow) {
 					bool success = noteRow->recordPolyphonicExpressionEvent(modelStackWithNoteRow, newValue,
-					                                                        whichExpressionDimension, false);
+					                                                        expressionDimension, false);
 					if (success) {
 						continue;
 					}
@@ -707,7 +707,7 @@ void MelodicInstrument::polyphonicExpressionEventPossiblyToRecord(ModelStackWith
 
 				// If still here, that didn't work, so just send it without recording.
 				polyphonicExpressionEventOnChannelOrNote(
-				    newValue, whichExpressionDimension,
+				    newValue, expressionDimension,
 				    arpNote->inputCharacteristics[util::to_underlying(MIDICharacteristic::NOTE)],
 				    MIDICharacteristic::NOTE);
 			}
@@ -716,7 +716,7 @@ void MelodicInstrument::polyphonicExpressionEventPossiblyToRecord(ModelStackWith
 
 	// Or if not recording, just sound the change ourselves here (as opposed to the AutoParam doing it).
 	else {
-		polyphonicExpressionEventOnChannelOrNote(newValue, whichExpressionDimension, channelOrNoteNumber,
+		polyphonicExpressionEventOnChannelOrNote(newValue, expressionDimension, channelOrNoteNumber,
 		                                         whichCharacteristic);
 	}
 

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -75,11 +75,11 @@ public:
 	                                      ModelStackWithTimelineCounter* modelStack) override;
 
 	void polyphonicExpressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelStack, int32_t newValue,
-	                                               int32_t whichExpressionDimension, int32_t channelOrNoteNumber,
+	                                               int32_t expressionDimension, int32_t channelOrNoteNumber,
 	                                               MIDICharacteristic whichCharacteristic);
 	ArpeggiatorSettings* getArpSettings(InstrumentClip* clip = nullptr);
 
-	virtual void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+	virtual void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
 	                                                      int32_t channelOrNoteNumber,
 	                                                      MIDICharacteristic whichCharacteristic) = 0;
 

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -204,19 +204,19 @@ int32_t MIDIInstrument::getOutputMasterChannel() {
 	}
 }
 
-void MIDIInstrument::monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDimension) {
-	lastMonoExpression[whichExpressionDimension] = newValue;
-	sendMonophonicExpressionEvent(whichExpressionDimension);
+void MIDIInstrument::monophonicExpressionEvent(int32_t newValue, int32_t expressionDimension) {
+	lastMonoExpression[expressionDimension] = newValue;
+	sendMonophonicExpressionEvent(expressionDimension);
 }
 
-void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimension) {
+void MIDIInstrument::sendMonophonicExpressionEvent(int32_t expressionDimension) {
 
 	int32_t masterChannel = getOutputMasterChannel();
 
-	switch (whichExpressionDimension) {
+	switch (expressionDimension) {
 	case X_PITCH_BEND: {
-		int32_t newValue = add_saturation(lastCombinedPolyExpression[whichExpressionDimension],
-		                                  lastMonoExpression[whichExpressionDimension]);
+		int32_t newValue = add_saturation(lastCombinedPolyExpression[expressionDimension],
+		                                  lastMonoExpression[expressionDimension]);
 		int32_t valueSmall = (newValue >> 18) + 8192;
 		midiEngine.sendPitchBend(this, masterChannel, valueSmall & 127, valueSmall >> 7, getChannel());
 		break;
@@ -227,8 +227,8 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimens
 		// this means that without sending CC1 on the master channel poly expression below 64 will
 		// send as mod wheel 0. However this is better than the alternative of sending erroneous values
 		// because the sound engine initializes MPE-Y as 0 (e.g. a CC value of 64)
-		int32_t polyPart = (lastCombinedPolyExpression[whichExpressionDimension] >> 24);
-		int32_t monoPart = lastMonoExpression[whichExpressionDimension] >> 24;
+		int32_t polyPart = (lastCombinedPolyExpression[expressionDimension] >> 24);
+		int32_t monoPart = lastMonoExpression[expressionDimension] >> 24;
 		int32_t newValue = std::clamp<int32_t>(polyPart + monoPart, 0, 127);
 		// send CC1 for monophonic expression - monophonic synths won't do anything useful with CC74
 
@@ -236,8 +236,8 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t whichExpressionDimens
 		break;
 	}
 	case Z_PRESSURE: {
-		int32_t newValue = add_saturation(lastCombinedPolyExpression[whichExpressionDimension],
-		                                  lastMonoExpression[whichExpressionDimension])
+		int32_t newValue = add_saturation(lastCombinedPolyExpression[expressionDimension],
+		                                  lastMonoExpression[expressionDimension])
 		                   >> 24;
 		midiEngine.sendChannelAftertouch(this, masterChannel, newValue, getChannel());
 		break;
@@ -1064,14 +1064,14 @@ uint8_t const shiftAmountsFrom16Bit[] = {2, 9, 8};
 // well use the 32-bit version here. Although, could it have even got more than 14 bits of meaningful value in the first
 // place?
 void MIDIInstrument::polyphonicExpressionEventPostArpeggiator(int32_t value32, int32_t noteCodeAfterArpeggiation,
-                                                              int32_t whichExpressionDimension, ArpNote* arpNote) {
+                                                              int32_t expressionDimension, ArpNote* arpNote) {
 	int32_t channel = getChannel();
 	if (sendsToInternal()) {
 		// Do nothing
 	}
 	// If we don't have MPE output...
 	else if (!sendsToMPE()) {
-		if (whichExpressionDimension == 2) {
+		if (expressionDimension == 2) {
 			if (!collapseAftertouch) {
 				// We can only send Z - and that's as polyphonic aftertouch
 				midiEngine.sendPolyphonicAftertouch(this, channel, value32 >> 24, noteCodeAfterArpeggiation,
@@ -1079,11 +1079,11 @@ void MIDIInstrument::polyphonicExpressionEventPostArpeggiator(int32_t value32, i
 				return;
 			}
 			else {
-				combineMPEtoMono(value32, whichExpressionDimension);
+				combineMPEtoMono(value32, expressionDimension);
 			}
 		}
 		else if (collapseMPE) {
-			combineMPEtoMono(value32, whichExpressionDimension);
+			combineMPEtoMono(value32, expressionDimension);
 		}
 	}
 
@@ -1102,7 +1102,7 @@ void MIDIInstrument::polyphonicExpressionEventPostArpeggiator(int32_t value32, i
 				ArpNote* lookingAtArpNote = (ArpNote*)arpeggiator.notes.getElementAddress(n);
 				if (lookingAtArpNote->outputMemberChannel == memberChannel) {
 					numNotesFound++;
-					mpeValuesSum += lookingAtArpNote->mpeValues[whichExpressionDimension];
+					mpeValuesSum += lookingAtArpNote->mpeValues[expressionDimension];
 				}
 			}
 
@@ -1110,10 +1110,10 @@ void MIDIInstrument::polyphonicExpressionEventPostArpeggiator(int32_t value32, i
 			if (numNotesFound > 1) {
 				int32_t averageValue16 = mpeValuesSum / numNotesFound;
 
-				int32_t averageValue7Or14 = averageValue16 >> shiftAmountsFrom16Bit[whichExpressionDimension];
+				int32_t averageValue7Or14 = averageValue16 >> shiftAmountsFrom16Bit[expressionDimension];
 				int32_t lastValue7Or14 =
-				    whichExpressionDimension
-				        ? mpeOutputMemberChannels[memberChannel].lastYAndZValuesSent[whichExpressionDimension - 1]
+				    expressionDimension
+				        ? mpeOutputMemberChannels[memberChannel].lastYAndZValuesSent[expressionDimension - 1]
 				        : mpeOutputMemberChannels[memberChannel].lastXValueSent;
 
 				// If there's been no actual change, don't send anything
@@ -1126,7 +1126,7 @@ void MIDIInstrument::polyphonicExpressionEventPostArpeggiator(int32_t value32, i
 			}
 		}
 
-		switch (whichExpressionDimension) {
+		switch (expressionDimension) {
 		case 0: { // X
 			int32_t value14 = (value32 >> 18);
 			mpeOutputMemberChannels[memberChannel].lastXValueSent = value14;
@@ -1154,7 +1154,7 @@ void MIDIInstrument::polyphonicExpressionEventPostArpeggiator(int32_t value32, i
 	}
 }
 
-void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t whichExpressionDimension) {
+void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t expressionDimension) {
 
 	ParamManager* paramManager = getParamManager(NULL);
 	if (paramManager) {
@@ -1178,7 +1178,7 @@ void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t whichExpressionDi
 
 			numNotesFound++;
 
-			int32_t value = lookingAtArpNote->mpeValues[whichExpressionDimension];
+			int32_t value = lookingAtArpNote->mpeValues[expressionDimension];
 			mpeValuesSum += value;
 			mpeValuesMax = std::max(mpeValuesMax, value);
 		}
@@ -1186,7 +1186,7 @@ void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t whichExpressionDi
 		// If there in fact are multiple notes sharing the channel, to combine...
 		if (numNotesFound >= 1) {
 			int32_t averageValue16;
-			if (whichExpressionDimension == 0) {
+			if (expressionDimension == 0) {
 				averageValue16 = mpeValuesSum / numNotesFound;
 			}
 			else {
@@ -1195,16 +1195,16 @@ void MIDIInstrument::combineMPEtoMono(int32_t value32, int32_t whichExpressionDi
 
 			value32 = averageValue16 << 16;
 		}
-		if (whichExpressionDimension == 0) {
+		if (expressionDimension == 0) {
 			// this can be bigger than 2^31
 			float fbend = value32 * ratio;
 			// casting down will truncate
 			value32 = (int32_t)fbend;
 		}
 		// if it's changed, we need to update the outputs
-		if (value32 != lastCombinedPolyExpression[whichExpressionDimension]) {
-			lastCombinedPolyExpression[whichExpressionDimension] = value32;
-			sendMonophonicExpressionEvent(whichExpressionDimension);
+		if (value32 != lastCombinedPolyExpression[expressionDimension]) {
+			lastCombinedPolyExpression[expressionDimension] = value32;
+			sendMonophonicExpressionEvent(expressionDimension);
 		}
 	}
 }

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -215,8 +215,8 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t expressionDimension) 
 
 	switch (expressionDimension) {
 	case X_PITCH_BEND: {
-		int32_t newValue = add_saturation(lastCombinedPolyExpression[expressionDimension],
-		                                  lastMonoExpression[expressionDimension]);
+		int32_t newValue =
+		    add_saturation(lastCombinedPolyExpression[expressionDimension], lastMonoExpression[expressionDimension]);
 		int32_t valueSmall = (newValue >> 18) + 8192;
 		midiEngine.sendPitchBend(this, masterChannel, valueSmall & 127, valueSmall >> 7, getChannel());
 		break;
@@ -236,9 +236,9 @@ void MIDIInstrument::sendMonophonicExpressionEvent(int32_t expressionDimension) 
 		break;
 	}
 	case Z_PRESSURE: {
-		int32_t newValue = add_saturation(lastCombinedPolyExpression[expressionDimension],
-		                                  lastMonoExpression[expressionDimension])
-		                   >> 24;
+		int32_t newValue =
+		    add_saturation(lastCombinedPolyExpression[expressionDimension], lastMonoExpression[expressionDimension])
+		    >> 24;
 		midiEngine.sendChannelAftertouch(this, masterChannel, newValue, getChannel());
 		break;
 	}

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -124,14 +124,14 @@ public:
 
 protected:
 	void polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,
-	                                              int32_t whichExpressionDimension, ArpNote* arpNote);
+	                                              int32_t expressionDimension, ArpNote* arpNote);
 	void noteOnPostArp(int32_t noteCodePostArp, ArpNote* arpNote);
 	void noteOffPostArp(int32_t noteCodePostArp, int32_t oldMIDIChannel, int32_t velocity);
-	void monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDimension);
+	void monophonicExpressionEvent(int32_t newValue, int32_t expressionDimension);
 
 private:
-	void sendMonophonicExpressionEvent(int32_t whichExpressionDimension);
-	void combineMPEtoMono(int32_t value32, int32_t whichExpressionDimension);
+	void sendMonophonicExpressionEvent(int32_t expressionDimension);
+	void combineMPEtoMono(int32_t value32, int32_t expressionDimension);
 	void outputAllMPEValuesOnMemberChannel(int16_t const* mpeValuesToUse, int32_t outputMemberChannel);
 	Error readMIDIParamFromFile(Deserializer& reader, int32_t readAutomationUpToPos,
 	                            MIDIParamCollection* midiParamCollection, int8_t* getCC = NULL);

--- a/src/deluge/model/instrument/non_audio_instrument.cpp
+++ b/src/deluge/model/instrument/non_audio_instrument.cpp
@@ -152,8 +152,7 @@ lookAtArpNote:
 			}
 
 			// Send this even if arp is on and this note isn't currently sounding: its release might still be
-			polyphonicExpressionEventPostArpeggiator(newValue, noteCodeAfterArpeggiation, expressionDimension,
-			                                         arpNote);
+			polyphonicExpressionEventPostArpeggiator(newValue, noteCodeAfterArpeggiation, expressionDimension, arpNote);
 		}
 	}
 	// Traverse also notesAsPlayed so those get updated mpeValues too, in case noteMode is changed to AsPlayed

--- a/src/deluge/model/instrument/non_audio_instrument.cpp
+++ b/src/deluge/model/instrument/non_audio_instrument.cpp
@@ -101,7 +101,7 @@ void NonAudioInstrument::sendNote(ModelStackWithThreeMainThings* modelStack, boo
 }
 
 // Inherit / overrides from both MelodicInstrument and ModControllable
-void NonAudioInstrument::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+void NonAudioInstrument::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
                                                                   int32_t channelOrNoteNumber,
                                                                   MIDICharacteristic whichCharacteristic) {
 	ArpeggiatorSettings* settings = getArpSettings();
@@ -130,7 +130,7 @@ lookAtArpNote:
 			// note-on-post-arp. I realise this is potentially frequent writing when it's only going to be read
 			// occasionally, but since we're already this far (the Instrument being notified), it's hardly any extra
 			// work.
-			arpNote->mpeValues[whichExpressionDimension] = newValue >> 16;
+			arpNote->mpeValues[expressionDimension] = newValue >> 16;
 
 			int32_t noteCodeBeforeArpeggiation =
 			    arpNote->inputCharacteristics[util::to_underlying(MIDICharacteristic::NOTE)];
@@ -152,7 +152,7 @@ lookAtArpNote:
 			}
 
 			// Send this even if arp is on and this note isn't currently sounding: its release might still be
-			polyphonicExpressionEventPostArpeggiator(newValue, noteCodeAfterArpeggiation, whichExpressionDimension,
+			polyphonicExpressionEventPostArpeggiator(newValue, noteCodeAfterArpeggiation, expressionDimension,
 			                                         arpNote);
 		}
 	}
@@ -165,7 +165,7 @@ lookAtArpNote:
 			// note-on-post-arp. I realise this is potentially frequent writing when it's only going to be read
 			// occasionally, but since we're already this far (the Instrument being notified), it's hardly any extra
 			// work.
-			arpNote->mpeValues[whichExpressionDimension] = newValue >> 16;
+			arpNote->mpeValues[expressionDimension] = newValue >> 16;
 
 			int32_t noteCodeBeforeArpeggiation =
 			    arpNote->inputCharacteristics[util::to_underlying(MIDICharacteristic::NOTE)];

--- a/src/deluge/model/instrument/non_audio_instrument.h
+++ b/src/deluge/model/instrument/non_audio_instrument.h
@@ -40,8 +40,8 @@ public:
 	int32_t doTickForwardForArp(ModelStack* modelStack, int32_t currentPos) final;
 	ParamManager* getParamManager(Song* song) final;
 
-	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
-	                                              int32_t channelOrNote, MIDICharacteristic whichCharacteristic) final;
+	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension, int32_t channelOrNote,
+	                                              MIDICharacteristic whichCharacteristic) final;
 
 	void beenEdited(bool shouldMoveToEmptySlot) {} // Probably don't need this anymore...
 

--- a/src/deluge/model/instrument/non_audio_instrument.h
+++ b/src/deluge/model/instrument/non_audio_instrument.h
@@ -40,7 +40,7 @@ public:
 	int32_t doTickForwardForArp(ModelStack* modelStack, int32_t currentPos) final;
 	ParamManager* getParamManager(Song* song) final;
 
-	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
 	                                              int32_t channelOrNote, MIDICharacteristic whichCharacteristic) final;
 
 	void beenEdited(bool shouldMoveToEmptySlot) {} // Probably don't need this anymore...
@@ -62,7 +62,7 @@ public:
 
 protected:
 	virtual void polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,
-	                                                      int32_t whichExpressionDimension, ArpNote* arpNote) = 0;
+	                                                      int32_t expressionDimension, ArpNote* arpNote) = 0;
 	// for tracking mono expression output
 	int32_t lastMonoExpression[3]{0};
 	int32_t lastCombinedPolyExpression[3]{0};

--- a/src/deluge/model/mod_controllable/mod_controllable.h
+++ b/src/deluge/model/mod_controllable/mod_controllable.h
@@ -61,10 +61,10 @@ public:
 		return ActionResult::NOT_DEALT_WITH;
 	}
 	virtual bool allowNoteTails(ModelStackWithSoundFlags* modelStack, bool disregardSampleLoop = false) { return true; }
-	virtual void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+	virtual void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
 	                                                      int32_t channelOrNoteNumber,
 	                                                      MIDICharacteristic whichCharacteristic) {}
-	virtual void monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDimension) {}
+	virtual void monophonicExpressionEvent(int32_t newValue, int32_t expressionDimension) {}
 
 protected:
 	/// What kind of unpatched parameters this ModControllable uses.

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -4370,7 +4370,7 @@ needToDoIt:
 
 // Returns whether success.
 bool NoteRow::recordPolyphonicExpressionEvent(ModelStackWithNoteRow* modelStack, int32_t newValueBig,
-                                              int32_t whichExpressionDimension, bool forDrum) {
+                                              int32_t expressionDimension, bool forDrum) {
 
 	uint32_t livePos = modelStack->getLivePos();
 	if (livePos < ignoreNoteOnsBefore_) {
@@ -4384,11 +4384,11 @@ bool NoteRow::recordPolyphonicExpressionEvent(ModelStackWithNoteRow* modelStack,
 		return false;
 	}
 
-	AutoParam* param = &mpeParams->params[whichExpressionDimension];
+	AutoParam* param = &mpeParams->params[expressionDimension];
 
 	ModelStackWithAutoParam* modelStackWithAutoParam =
 	    modelStack->addOtherTwoThingsAutomaticallyGivenNoteRow()->addParam(mpeParams, mpeParamsSummary,
-	                                                                       whichExpressionDimension, param);
+	                                                                       expressionDimension, param);
 
 	// Only if this exact TimelineCounter and NoteRow is having automation step-edited, we can set the value for
 	// just a region.
@@ -4398,7 +4398,7 @@ bool NoteRow::recordPolyphonicExpressionEvent(ModelStackWithNoteRow* modelStack,
 
 		// As well as just setting values now, InstrumentClipView keeps a record, for in case the user then
 		// releases the note, in which case we'll want the values from when they pressed hardest etc.
-		instrumentClipView.reportMPEValueForNoteEditing(whichExpressionDimension, newValueBig);
+		instrumentClipView.reportMPEValueForNoteEditing(expressionDimension, newValueBig);
 
 		// And also, set the values now, for in case they're instead gonna stop editing the note before
 		// releasing this MIDI note.

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -234,7 +234,7 @@ public:
 	                             bool shouldJustDeleteNodes = false);
 	SequenceDirection getEffectiveSequenceDirectionMode(ModelStackWithNoteRow const* modelStack);
 	bool recordPolyphonicExpressionEvent(ModelStackWithNoteRow* modelStackWithNoteRow, int32_t newValueBig,
-	                                     int32_t whichExpressionDimension, bool forDrum);
+	                                     int32_t expressionDimension, bool forDrum);
 	void setSequenceDirectionMode(ModelStackWithNoteRow* modelStack, SequenceDirection newMode);
 	bool isAuditioning(ModelStackWithNoteRow* modelStack);
 

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -54,7 +54,6 @@ public:
 	// choose where the Patcher looks for them
 	int32_t sourceValues[kNumPatchSources];
 
-
 	std::bitset<kNumExpressionDimensions> expressionSourcesCurrentlySmoothing;
 	std::bitset<kNumExpressionDimensions> expressionSourcesFinalValueChanged;
 	int32_t localExpressionSourceValuesBeforeSmoothing[kNumExpressionDimensions];

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -55,8 +55,8 @@ public:
 	int32_t sourceValues[kNumPatchSources];
 
 
-	std::bitset<kNumExpressionDimensions> whichExpressionSourcesCurrentlySmoothing;
-	std::bitset<kNumExpressionDimensions> whichExpressionSourcesFinalValueChanged;
+	std::bitset<kNumExpressionDimensions> expressionSourcesCurrentlySmoothing;
+	std::bitset<kNumExpressionDimensions> expressionSourcesFinalValueChanged;
 	int32_t localExpressionSourceValuesBeforeSmoothing[kNumExpressionDimensions];
 
 	Envelope envelopes[kNumEnvelopes];
@@ -143,5 +143,5 @@ private:
 	                             int32_t* lastFeedbackValue, int32_t amplitudeIncrement);
 	bool areAllUnisonPartsInactive(ModelStackWithVoice* modelStackWithVoice);
 	void setupPorta(Sound* sound);
-	int32_t combineExpressionValues(Sound* sound, int32_t whichExpressionDimension);
+	int32_t combineExpressionValues(Sound* sound, int32_t expressionDimension);
 };

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -25,6 +25,7 @@
 #include "modulation/lfo.h"
 #include "modulation/params/param.h"
 #include "modulation/patch/patcher.h"
+#include <bitset>
 
 class StereoSample;
 class ModelStackWithVoice;
@@ -53,6 +54,9 @@ public:
 	// choose where the Patcher looks for them
 	int32_t sourceValues[kNumPatchSources];
 
+
+	std::bitset<kNumExpressionDimensions> whichExpressionSourcesCurrentlySmoothing;
+	std::bitset<kNumExpressionDimensions> whichExpressionSourcesFinalValueChanged;
 	int32_t localExpressionSourceValuesBeforeSmoothing[kNumExpressionDimensions];
 
 	Envelope envelopes[kNumEnvelopes];
@@ -76,8 +80,6 @@ public:
 
 	bool doneFirstRender;
 	bool previouslyIgnoredNoteOff;
-	uint8_t whichExpressionSourcesCurrentlySmoothing;
-	uint8_t whichExpressionSourcesFinalValueChanged;
 
 	uint32_t orderSounded;
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -146,7 +146,7 @@ Sound::Sound() : patcher(&patchableInfoForSound) {
 	                                                  + params::UNPATCHED_SAMPLE_RATE_REDUCTION);
 	modKnobs[7][0].paramDescriptor.setToHaveParamOnly(params::UNPATCHED_START + params::UNPATCHED_BITCRUSHING);
 	voicePriority = VoicePriority::MEDIUM;
-	whichExpressionSourcesChangedAtSynthLevel = 0;
+	whichExpressionSourcesChangedAtSynthLevel.reset();
 
 	skippingRendering = true;
 	startSkippingRenderingAtTime = 0;
@@ -2434,7 +2434,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	postReverbVolumeLastTime = postReverbVolume;
 
 	sourcesChanged = 0;
-	whichExpressionSourcesChangedAtSynthLevel = 0;
+	whichExpressionSourcesChangedAtSynthLevel.reset();
 	for (int i = 0; i < kNumSources; i++) {
 		sources[i].dxPatchChanged = false;
 	}

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -146,7 +146,7 @@ Sound::Sound() : patcher(&patchableInfoForSound) {
 	                                                  + params::UNPATCHED_SAMPLE_RATE_REDUCTION);
 	modKnobs[7][0].paramDescriptor.setToHaveParamOnly(params::UNPATCHED_START + params::UNPATCHED_BITCRUSHING);
 	voicePriority = VoicePriority::MEDIUM;
-	whichExpressionSourcesChangedAtSynthLevel.reset();
+	expressionSourcesChangedAtSynthLevel.reset();
 
 	skippingRendering = true;
 	startSkippingRenderingAtTime = 0;
@@ -2434,7 +2434,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	postReverbVolumeLastTime = postReverbVolume;
 
 	sourcesChanged = 0;
-	whichExpressionSourcesChangedAtSynthLevel.reset();
+	expressionSourcesChangedAtSynthLevel.reset();
 	for (int i = 0; i < kNumSources; i++) {
 		sources[i].dxPatchChanged = false;
 	}

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -120,7 +120,7 @@ public:
 
 	bool skippingRendering;
 
-	std::bitset<kNumExpressionDimensions> whichExpressionSourcesChangedAtSynthLevel;
+	std::bitset<kNumExpressionDimensions> expressionSourcesChangedAtSynthLevel;
 
 	// I really didn't want to store these here, since they're stored in the ParamManager, but.... complications! Always
 	// 0 for Drums - that was part of the problem - a Drum's main ParamManager's expression data has been sent to the

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -30,6 +30,7 @@
 #include "modulation/sidechain/sidechain.h"
 #include "processing/source.h"
 #include "util/misc.h"
+#include <bitset>
 
 struct CableGroup;
 class StereoSample;
@@ -119,7 +120,7 @@ public:
 
 	bool skippingRendering;
 
-	uint8_t whichExpressionSourcesChangedAtSynthLevel;
+	std::bitset<kNumExpressionDimensions> whichExpressionSourcesChangedAtSynthLevel;
 
 	// I really didn't want to store these here, since they're stored in the ParamManager, but.... complications! Always
 	// 0 for Drums - that was part of the problem - a Drum's main ParamManager's expression data has been sent to the

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -107,9 +107,9 @@ void SoundDrum::noteOff(ModelStackWithThreeMainThings* modelStack, int32_t veloc
 
 extern bool expressionValueChangesMustBeDoneSmoothly;
 
-void SoundDrum::expressionEvent(int32_t newValue, int32_t whichExpressionDimension) {
+void SoundDrum::expressionEvent(int32_t newValue, int32_t expressionDimension) {
 
-	int32_t s = whichExpressionDimension + util::to_underlying(PatchSource::X);
+	int32_t s = expressionDimension + util::to_underlying(PatchSource::X);
 
 	// sourcesChanged |= 1 << s; // We'd ideally not want to apply this to all voices though...
 
@@ -128,15 +128,15 @@ void SoundDrum::expressionEvent(int32_t newValue, int32_t whichExpressionDimensi
 	// Must update MPE values in Arp too - useful either if it's on, or if we're in true monophonic mode - in either
 	// case, we could need to suddenly do a note-on for a different note that the Arp knows about, and need these MPE
 	// values.
-	arpeggiator.arpNote.mpeValues[whichExpressionDimension] = newValue >> 16;
+	arpeggiator.arpNote.mpeValues[expressionDimension] = newValue >> 16;
 }
 
-void SoundDrum::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+void SoundDrum::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
                                                          int32_t channelOrNoteNumber,
                                                          MIDICharacteristic whichCharacteristic) {
 	// Because this is a Drum, we disregard the noteCode (which is what channelOrNoteNumber always is in our case - but
 	// yeah, that's all irrelevant.
-	expressionEvent(newValue, whichExpressionDimension);
+	expressionEvent(newValue, expressionDimension);
 }
 
 void SoundDrum::unassignAllVoices() {

--- a/src/deluge/processing/sound/sound_drum.h
+++ b/src/deluge/processing/sound/sound_drum.h
@@ -57,8 +57,8 @@ public:
 	void drumWontBeRenderedForAWhile();
 	ModControllable* toModControllable() { return this; }
 
-	void expressionEvent(int32_t newValue, int32_t whichExpressionDimension);
-	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+	void expressionEvent(int32_t newValue, int32_t expressionDimension);
+	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
 	                                              int32_t channelOrNoteNumber, MIDICharacteristic whichCharacteristic);
 
 	ArpeggiatorBase* getArp();

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -274,7 +274,7 @@ bool SoundInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, P
 					monophonicExpressionValues[i] = 0;
 				}
 			}
-			whichExpressionSourcesChangedAtSynthLevel = (1 << kNumExpressionDimensions) - 1;
+			whichExpressionSourcesChangedAtSynthLevel.set();
 		}
 	}
 	return clipChanged;
@@ -297,7 +297,7 @@ void SoundInstrument::setupWithoutActiveClip(ModelStack* modelStack) {
 	for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
 		monophonicExpressionValues[i] = 0;
 	}
-	whichExpressionSourcesChangedAtSynthLevel = (1 << kNumExpressionDimensions) - 1;
+	whichExpressionSourcesChangedAtSynthLevel.set();
 
 	Instrument::setupWithoutActiveClip(modelStack);
 }
@@ -317,7 +317,7 @@ void SoundInstrument::deleteBackedUpParamManagers(Song* song) {
 extern bool expressionValueChangesMustBeDoneSmoothly;
 
 void SoundInstrument::monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDimension) {
-	whichExpressionSourcesChangedAtSynthLevel |= 1 << whichExpressionDimension;
+	whichExpressionSourcesChangedAtSynthLevel[whichExpressionDimension] = true;
 	monophonicExpressionValues[whichExpressionDimension] = newValue;
 }
 

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -274,7 +274,7 @@ bool SoundInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, P
 					monophonicExpressionValues[i] = 0;
 				}
 			}
-			whichExpressionSourcesChangedAtSynthLevel.set();
+			expressionSourcesChangedAtSynthLevel.set();
 		}
 	}
 	return clipChanged;
@@ -297,7 +297,7 @@ void SoundInstrument::setupWithoutActiveClip(ModelStack* modelStack) {
 	for (int32_t i = 0; i < kNumExpressionDimensions; i++) {
 		monophonicExpressionValues[i] = 0;
 	}
-	whichExpressionSourcesChangedAtSynthLevel.set();
+	expressionSourcesChangedAtSynthLevel.set();
 
 	Instrument::setupWithoutActiveClip(modelStack);
 }
@@ -316,19 +316,19 @@ void SoundInstrument::deleteBackedUpParamManagers(Song* song) {
 
 extern bool expressionValueChangesMustBeDoneSmoothly;
 
-void SoundInstrument::monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDimension) {
-	whichExpressionSourcesChangedAtSynthLevel[whichExpressionDimension] = true;
-	monophonicExpressionValues[whichExpressionDimension] = newValue;
+void SoundInstrument::monophonicExpressionEvent(int32_t newValue, int32_t expressionDimension) {
+	expressionSourcesChangedAtSynthLevel[expressionDimension] = true;
+	monophonicExpressionValues[expressionDimension] = newValue;
 }
 
 // Alternative to what's in the NonAudioInstrument:: implementation, which would almost work here, but we cut corner for
 // Sound by avoiding going through the Arp and just talk directly to the Voices. (Despite my having made it now actually
 // need to talk to the Arp too, as below...) Note, this virtual function actually overrides/implements from two base
 // classes - MelodicInstrument and ModControllable.
-void SoundInstrument::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+void SoundInstrument::polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
                                                                int32_t channelOrNoteNumber,
                                                                MIDICharacteristic whichCharacteristic) {
-	int32_t s = whichExpressionDimension + util::to_underlying(PatchSource::X);
+	int32_t s = expressionDimension + util::to_underlying(PatchSource::X);
 
 	// sourcesChanged |= 1 << s; // We'd ideally not want to apply this to all voices though...
 
@@ -363,14 +363,14 @@ void SoundInstrument::polyphonicExpressionEventOnChannelOrNote(int32_t newValue,
 lookAtArpNote:
 		ArpNote* arpNote = (ArpNote*)arpeggiator.notes.getElementAddress(n);
 		if (arpNote->inputCharacteristics[util::to_underlying(whichCharacteristic)] == channelOrNoteNumber) {
-			arpNote->mpeValues[whichExpressionDimension] = newValue >> 16;
+			arpNote->mpeValues[expressionDimension] = newValue >> 16;
 		}
 	}
 	// Traverse also notesAsPlayed so those get updated mpeValues too, in case noteMode is changed to AsPlayed
 	for (n = 0; n < arpeggiator.notesAsPlayed.getNumElements(); n++) {
 		ArpNote* arpNote = (ArpNote*)arpeggiator.notesAsPlayed.getElementAddress(n);
 		if (arpNote->inputCharacteristics[util::to_underlying(whichCharacteristic)] == channelOrNoteNumber) {
-			arpNote->mpeValues[whichExpressionDimension] = newValue >> 16;
+			arpNote->mpeValues[expressionDimension] = newValue >> 16;
 		}
 	}
 }

--- a/src/deluge/processing/sound/sound_instrument.h
+++ b/src/deluge/processing/sound/sound_instrument.h
@@ -57,9 +57,9 @@ public:
 	void setupPatching(ModelStackWithTimelineCounter* modelStack);
 
 	void deleteBackedUpParamManagers(Song* song);
-	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t whichExpressionDimension,
+	void polyphonicExpressionEventOnChannelOrNote(int32_t newValue, int32_t expressionDimension,
 	                                              int32_t channelOrNoteNumber, MIDICharacteristic whichCharacteristic);
-	void monophonicExpressionEvent(int32_t newValue, int32_t whichExpressionDimension);
+	void monophonicExpressionEvent(int32_t newValue, int32_t expressionDimension);
 
 	void sendNote(ModelStackWithThreeMainThings* modelStack, bool isOn, int32_t noteCode, int16_t const* mpeValues,
 	              int32_t fromMIDIChannel, uint8_t velocity, uint32_t sampleSyncLength, int32_t ticksLate,


### PR DESCRIPTION
Changes the use of bit-packed uint8_t for bitfield variables relating to expressionSource status to use std::bitset instead.

Also: mechanically renames whichExpressionSources... variables to be expressionSources... for clarity and brevity.

The two commits can be reviewed independently for simplicity's sake.