### PR TITLE
Refactor Sine Oscillator

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -3,10 +3,8 @@ cmake_policy(SET CMP0135 NEW)
 include(FetchContent)
 
 FetchContent_Declare(argon
-  #GIT_REPOSITORY https://github.com/stellar-aria/argon
-  #GIT_TAG caa7cd8056351d4fea353c1e572fa62e04a49971
-  URL https://github.com/stellar-aria/argon/archive/refs/tags/v0.1.0.tar.gz
-  URL_HASH MD5=2cbc9a803e52ded736f1e28eca8b14aa
+  GIT_REPOSITORY https://github.com/stellar-aria/argon
+  GIT_TAG 4c4aa8ae891b29ed926309cb15ae6bddc38d7895
 )
 FetchContent_MakeAvailable(argon)
 

--- a/src/deluge/dsp/CMakeLists.txt
+++ b/src/deluge/dsp/CMakeLists.txt
@@ -30,6 +30,7 @@ set_target_properties(deluge_dsp
 target_link_libraries(deluge_dsp PRIVATE
     NE10
     eyalroz_printf
+    argon
 )
 
 target_compile_definitions(deluge_dsp PUBLIC

--- a/src/deluge/dsp/oscillators/sine_osc.h
+++ b/src/deluge/dsp/oscillators/sine_osc.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "deluge/util/misc.h"
-#include <arm_neon.h>
+#include <argon.hpp>
 #include <array>
 #include <cstdint>
 
@@ -25,45 +25,38 @@ public:
 		return value + diff * strength2;
 	}
 
-	static inline int32x4_t getSineVector(uint32_t* thisPhase, uint32_t phaseIncrement) {
+	// Test and verified to be identical to original function 11/22/24
+	static inline Argon<int32_t> getSineVector(uint32_t* thisPhase, uint32_t phaseIncrement) {
+		// create a vector containing a ramp of incrementing phases:
+		// {phase + (phaseIncrement * 1), phase + (phaseIncrement * 2), phase + (phaseIncrement * 3), phase +
+		// (phaseIncrement * 4)}
+		auto phaseVector = Argon<uint32_t>::LoadCopy(thisPhase).MultiplyAdd(uint32x4_t{1, 2, 3, 4}, phaseIncrement);
+		*thisPhase = *thisPhase + phaseIncrement * 4;
 
-		int16x4_t strength2;
-		uint32x4_t readValue;
-
-		for (int32_t i = 0; i < 4; i++) {
-			*thisPhase += phaseIncrement;
-			int32_t whichValue = *thisPhase >> (32 - kSineTableSizeMagnitude);
-			strength2[i] = (*thisPhase >> (32 - 16 - kSineTableSizeMagnitude + 1)) & 32767;
-
-			uint32_t readOffset = whichValue << 1;
-
-			readValue[i] = *(uint32_t*)&sineWaveDiff[readOffset];
-		}
-
-		int32x4_t enlargedValue1 = vreinterpretq_s32_u32(vshlq_n_u32(readValue, 16));
-		int16x4_t diffValue = vshrn_n_s32(vreinterpretq_s32_u32(readValue), 16);
-
-		return vqdmlal_s16(enlargedValue1, strength2, diffValue);
+		return render(phaseVector);
 	}
 
-	static inline int32x4_t doFMVector(uint32x4_t phaseVector, uint32x4_t phaseShift) {
-
-		uint32x4_t finalPhase = vaddq_u32(phaseVector, vshlq_n_u32(phaseShift, 8));
-
-		uint32x4_t readValue{0};
-		util::constexpr_for<0, 4, 1>([&]<int i>() {
-			uint32_t readOffsetNow = (vgetq_lane_u32(finalPhase, i) >> (32 - kSineTableSizeMagnitude)) << 1;
-			uint32_t* thisReadAddress = (uint32_t*)&sineWaveDiff[readOffsetNow];
-			readValue = vld1q_lane_u32(thisReadAddress, readValue, i);
-		});
-
-		int16x4_t strength2 =
-		    vreinterpret_s16_u16(vshr_n_u16(vshrn_n_u32(finalPhase, (32 - 16 - kSineTableSizeMagnitude)), 1));
-
-		int32x4_t enlargedValue1 = vreinterpretq_s32_u32(vshlq_n_u32(readValue, 16));
-		int16x4_t diffValue = vshrn_n_s32(vreinterpretq_s32_u32(readValue), 16);
-
-		return vqdmlal_s16(enlargedValue1, strength2, diffValue);
+	// Test and verified to be identical to original function 11/22/24
+	static inline Argon<int32_t> doFMVector(Argon<uint32_t> phaseVector, Argon<uint32_t> phaseShift) {
+		return render(phaseVector + (phaseShift << 8));
 	}
+
+private:
+	static inline Argon<int32_t> render(Argon<uint32_t> phase) {
+		// interpolation fractional component
+		ArgonHalf<int16_t> strength2 = phase.ShiftRightNarrow<32 - 16 - kSineTableSizeMagnitude + 1>()
+		                                   .BitwiseAnd(std::numeric_limits<int16_t>::max())
+		                                   .As<int16_t>();
+
+		// multiply by 2 due to interleave. i.e. sin(x) is actually table[x * 2]
+		Argon<uint32_t> indices = (phase >> (32 - kSineTableSizeMagnitude)) << 1;
+
+		//  load our two relevent table components
+		auto [sine, diff] = ArgonHalf<int16_t>::LoadGatherInterleaved<2>(sineWaveDiff.data(), indices);
+
+		// Essentially a MultiplyAddFixedPoint, but without the reduction back down to q31
+		return sine.ShiftLeftLong<16>().MultiplyDoubleAddSaturateLong(diff, strength2);
+	}
+
 }; // namespace deluge::dsp
 } // namespace deluge::dsp

--- a/src/deluge/dsp/reverb/mutable/cosine_oscillator.hpp
+++ b/src/deluge/dsp/reverb/mutable/cosine_oscillator.hpp
@@ -12,7 +12,7 @@ public:
 	enum class Mode { APPROX, EXACT };
 
 	template <Mode mode = Mode::APPROX>
-	constexpr DualCosineOscillator(std::initializer_list<float> frequencies) : frequencies_(frequencies) {
+	constexpr DualCosineOscillator(std::array<float, 2> frequencies) : frequencies_(frequencies) {
 		Init<mode>();
 	}
 	~DualCosineOscillator() = default;
@@ -24,9 +24,9 @@ public:
 	}
 
 	inline void InitApproximate() {
-		argon::Neon64<float> sign = 16.0f;
-		argon::Neon64<float> frequencies = frequencies_;
-		frequencies.each_lane([&](float& frequency, int i) {
+		ArgonHalf<float> sign = 16.0f;
+		ArgonHalf<float> frequencies = frequencies_;
+		frequencies.each_lane_with_index([&](float& frequency, int i) {
 			frequency -= 0.25f;
 			if (frequency < 0.0f) {
 				frequency = -frequency;
@@ -47,10 +47,10 @@ public:
 		y_1 = 0.5f;
 	}
 
-	[[nodiscard]] inline argon::Neon64<float> values() const { return y_0 + 0.5f; }
+	[[nodiscard]] inline ArgonHalf<float> values() const { return y_0 + 0.5f; }
 
-	inline argon::Neon64<float> Next() {
-		argon::Neon64<float> temp = y_1;
+	inline ArgonHalf<float> Next() {
+		ArgonHalf<float> temp = y_1;
 		y_1 = iir_coefficient_ * y_1 - y_0;
 		y_0 = temp;
 		return temp + 0.5f;
@@ -71,9 +71,9 @@ private:
 		Start();
 	}
 
-	argon::Neon64<float> frequencies_;
-	argon::Neon64<float> y_0;
-	argon::Neon64<float> y_1;
-	argon::Neon64<float> iir_coefficient_;
-	argon::Neon64<float> initial_amplitude_;
+	ArgonHalf<float> frequencies_;
+	ArgonHalf<float> y_0;
+	ArgonHalf<float> y_1;
+	ArgonHalf<float> iir_coefficient_;
+	ArgonHalf<float> initial_amplitude_;
 };

--- a/src/deluge/dsp/reverb/mutable/fx_engine.hpp
+++ b/src/deluge/dsp/reverb/mutable/fx_engine.hpp
@@ -28,7 +28,7 @@ enum LFOIndex { LFO_1, LFO_2 };
 
 class FxEngine {
 public:
-	FxEngine(std::span<float> signal, std::initializer_list<float> lfo_freqs)
+	FxEngine(std::span<float> signal, std::array<float, 2> lfo_freqs)
 	    : buffer_(signal), mask(buffer_.size() - 1), lfo_{lfo_freqs} {};
 	~FxEngine() = default;
 


### PR DESCRIPTION
- Upgrades Argon library and dependent code (Reverb's dual cosine lfo)
- Rewrites and simplifies core sine oscillator vector functions using Argon library.
