### PR TITLE
Fix stem export with song fx

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -810,7 +810,7 @@ enum class AudioInputChannel {
 	MIX,
 	OUTPUT,
 	SPECIFIC_OUTPUT,
-	OFFLINE_OUTPUT,
+	OFFLINE_OUTPUT, // special output only used with offline stem exporting
 };
 
 constexpr AudioInputChannel AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION = AudioInputChannel::MIX;

--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -810,6 +810,7 @@ enum class AudioInputChannel {
 	MIX,
 	OUTPUT,
 	SPECIFIC_OUTPUT,
+	OFFLINE_OUTPUT,
 };
 
 constexpr AudioInputChannel AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION = AudioInputChannel::MIX;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -642,6 +642,16 @@ void renderAudioForStemExport(size_t numSamples) {
 		renderSongFX(numSamples);
 	}
 
+	// If we're recording final output for offline stem export with song FX
+	// Check if we have a recorder
+	SampleRecorder* recorder = audioRecorder.recorder;
+	if (recorder && recorder->mode == AudioInputChannel::OFFLINE_OUTPUT) {
+		// continue feeding audio if we're not finished recording
+		if (recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
+			recorder->feedAudio((int32_t*)renderingBuffer.data(), numSamples, true);
+		}
+	}
+
 	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), numSamples);
 
 	doMonitoring = false;

--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -152,8 +152,20 @@ void StemExport::startOutputRecordingUntilLoopEndAndSilence() {
 	timeThereWasLastSomeActivity = 0xFFFFFFFF;
 	playbackHandler.playButtonPressed(kInternalButtonPressLatency);
 	if (playbackHandler.isEitherClockActive()) {
-		audioRecorder.beginOutputRecording(AudioRecordingFolder::STEMS, AudioInputChannel::MIX, writeLoopEndPos(),
-		                                   allowNormalization);
+		// default - record the MIX (before SongFX)
+		AudioInputChannel channel = AudioInputChannel::MIX;
+		// if we want to record stems with SongFX
+		if (includeSongFX) {
+			// special input channel for offline rendering
+			if (renderOffline) {
+				channel = AudioInputChannel::OFFLINE_OUTPUT;
+			}
+			// record output for live rendering
+			else {
+				channel = AudioInputChannel::OUTPUT;
+			}
+		}
+		audioRecorder.beginOutputRecording(AudioRecordingFolder::STEMS, channel, writeLoopEndPos(), allowNormalization);
 		if (audioRecorder.recordingSource > AudioInputChannel::NONE) {
 			stopRecording = true;
 		}


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2866

- [x] Export song FX with live rendering by using AudioInputSource::OUTPUT
- [x] Export song FX with offline rendering by using AudioInputSource::OFFLINE_OUTPUT