### PR TITLE
Bugfix/freeze_while_booting

### DIFF
--- a/src/deluge/hid/matrix/matrix_driver.cpp
+++ b/src/deluge/hid/matrix/matrix_driver.cpp
@@ -76,6 +76,10 @@ ActionResult MatrixDriver::padAction(int32_t x, int32_t y, int32_t velocity) {
 #if ENABLE_MATRIX_DEBUG
 	D_PRINT("UI=%s,PAD_X=%d,PAD_Y=%d,VEL=%d", getCurrentUI()->getName(), x, y, velocity);
 #endif
+	auto ui = getCurrentUI();
+	if (ui == nullptr) {
+		return ActionResult::DEALT_WITH; // only happens when booting
+	}
 	ActionResult result = getCurrentUI()->padAction(x, y, velocity);
 	if (result == ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;


### PR DESCRIPTION
ui hasn't loaded  when the busy wait routine is first called yet if the user presses a pad while the flash is still being accessed

Fix #2629 