### PR TITLE
Fixed bug with compBlend

### DIFF
--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -698,7 +698,7 @@ doReadPatchedParam:
 			}
 			else if (!strcmp(tagName, "compBlend")) {
 				q31_t masterCompressorBlend = reader.readTagOrAttributeValueInt();
-				compressor.setRelease(masterCompressorBlend);
+				compressor.setBlend(masterCompressorBlend);
 				reader.exitTag("compBlend");
 			}
 			else {


### PR DESCRIPTION
Fixed bug where compressor blend value was not being loaded from saved song

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2914