### PR TITLE
Revert "Fix midi devices menu out of bounds crash"

### DIFF
--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -29,7 +29,7 @@ extern deluge::gui::menu_item::midi::Device midiDeviceMenu;
 
 namespace deluge::gui::menu_item::midi {
 
-static constexpr int32_t lowestDeviceNum = -3;
+static constexpr int32_t lowestDeviceNum = -4;
 
 void Devices::beginSession(MenuItem* navigatedBackwardFrom) {
 	bool found = false;
@@ -90,7 +90,7 @@ void Devices::selectEncoderAction(int32_t offset) {
 		if (offset >= 0) {
 			int32_t d = this->getValue();
 			int32_t numSeen = 1;
-			while (d > lowestDeviceNum) {
+			while (d > -4) {
 				d--;
 				if (d == currentScroll) {
 					break;
@@ -111,8 +111,8 @@ void Devices::selectEncoderAction(int32_t offset) {
 	drawValue();
 }
 
-MIDICable* Devices::getCable(int32_t deviceIndex) {
-	if (deviceIndex < lowestDeviceNum || deviceIndex >= MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
+MIDIDevice* Devices::getDevice(int32_t deviceIndex) {
+	if (deviceIndex < -3 || deviceIndex >= MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
 		D_PRINTLN("impossible device request");
 		return nullptr;
 	}


### PR DESCRIPTION
Reverts SynthstromAudible/DelugeFirmware#2974