### PR TITLE
Refactor interpolation system

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 
 FetchContent_Declare(argon
   GIT_REPOSITORY https://github.com/stellar-aria/argon
-  GIT_TAG 724f1be90d8f1a08750d65bda72e51108f1d3619
+  GIT_TAG 67ba8399c5c6b939c2b34be5746ad0d2676418d2
 )
 FetchContent_MakeAvailable(argon)
 

--- a/src/deluge/dsp/interpolate/interpolate.h
+++ b/src/deluge/dsp/interpolate/interpolate.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "definitions_cxx.hpp"
+#include "deluge/dsp/stereo_sample.h"
 #include <arm_neon_shim.h>
 #include <array>
 #include <cstdint>
@@ -7,13 +8,19 @@
 extern const int16_t windowedSincKernel[][17][16];
 
 namespace deluge::dsp {
+class Interpolator {
+	using buffer_t = std::array<int16x4_t, kInterpolationMaxNumSamples / 4>;
 
-std::array<int32_t, 2>
-interpolate(std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer, size_t channels,
-            int32_t whichKernel, uint32_t oscPos);
+public:
+	Interpolator() = default;
+	StereoSample interpolate(size_t channels, int32_t whichKernel, uint32_t oscPos);
+	StereoSample interpolateLinear(size_t channels, uint32_t oscPos);
 
-std::array<int32_t, 2>
-interpolateLinear(std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer,
-                  size_t channels, int32_t whichKernel, uint32_t oscPos);
+	int16_t& bufferL(size_t idx) { return interpolation_buffer_l_[idx >> 3][idx & 3]; } // divide by 4, modulo 4
+	int16_t& bufferR(size_t idx) { return interpolation_buffer_r_[idx >> 3][idx & 3]; } // divide by 4, modulo 4
 
+private:
+	buffer_t interpolation_buffer_l_{};
+	buffer_t interpolation_buffer_r_{};
+};
 } // namespace deluge::dsp

--- a/src/deluge/dsp/interpolate/interpolate.h
+++ b/src/deluge/dsp/interpolate/interpolate.h
@@ -7,9 +7,13 @@
 extern const int16_t windowedSincKernel[][17][16];
 
 namespace deluge::dsp {
-void interpolate(int32_t* sampleRead, int32_t numChannelsNow, int32_t whichKernel, uint32_t oscPos,
-                 std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer);
-void interpolateLinear(int32_t* sampleRead, int32_t numChannelsNow, int32_t whichKernel, uint32_t oscPos,
-                       std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer);
+
+std::array<int32_t, 2>
+interpolate(std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer, size_t channels,
+            int32_t whichKernel, uint32_t oscPos);
+
+std::array<int32_t, 2>
+interpolateLinear(std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer,
+                  size_t channels, int32_t whichKernel, uint32_t oscPos);
 
 } // namespace deluge::dsp

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "dsp/interpolate/interpolate.h"
+#include <cstdint>
 #pragma GCC push_options
 #pragma GCC target("fpu=neon")
 
@@ -1080,8 +1081,7 @@ void SampleLowLevelReader::readSamplesResampled(int32_t** __restrict__ oscBuffer
 			}
 
 skipFirstSmooth:
-			int32_t sampleRead[2];
-			deluge::dsp::interpolate(sampleRead, numChannels, whichKernel, oscPos, interpolationBuffer);
+			auto sampleRead = deluge::dsp::interpolate(interpolationBuffer, numChannels, whichKernel, oscPos);
 
 			int32_t existingValueL = *oscBufferPosNow;
 
@@ -1141,8 +1141,7 @@ skipFirstSmooth:
 			}
 
 skipFirstLinear:
-			int32_t sampleRead[2];
-			deluge::dsp::interpolateLinear(sampleRead, numChannels, whichKernel, oscPos, interpolationBuffer);
+			auto sampleRead = deluge::dsp::interpolateLinear(interpolationBuffer, numChannels, whichKernel, oscPos);
 
 			int32_t existingValueL = *oscBufferPosNow;
 

--- a/src/deluge/model/sample/sample_low_level_reader.h
+++ b/src/deluge/model/sample/sample_low_level_reader.h
@@ -20,6 +20,7 @@
 #include "arm_neon_shim.h"
 
 #include "definitions_cxx.hpp"
+#include "dsp/interpolate/interpolate.h"
 #include <array>
 #include <cstdint>
 #define REASSESSMENT_ACTION_STOP_OR_LOOP 0
@@ -96,7 +97,7 @@ public:
 	uint8_t reassessmentAction;
 	int8_t interpolationBufferSizeLastTime; // 0 if was previously switched off
 
-	std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2> interpolationBuffer;
+	deluge::dsp::Interpolator interpolator_;
 
 	Cluster* clusters[kNumClustersLoadedAhead];
 

--- a/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
@@ -83,20 +83,19 @@ void LivePitchShifterPlayHead::render(int32_t* __restrict__ outputBuffer, int32_
 				}
 
 				for (int32_t i = kInterpolationMaxNumSamples - 1; i >= numSamplesToJumpForward; i--) {
-					interpolationBuffer[0][0][i] = interpolationBuffer[0][0][i - numSamplesToJumpForward];
+					interpolator_.bufferL(i) = interpolator_.bufferL(i - numSamplesToJumpForward);
 				}
 
 				if (numChannels == 2) {
 					for (int32_t i = kInterpolationMaxNumSamples - 1; i >= numSamplesToJumpForward; i--) {
-						interpolationBuffer[1][0][i] = interpolationBuffer[1][0][i - numSamplesToJumpForward];
+						interpolator_.bufferR(i) = interpolator_.bufferR(i - numSamplesToJumpForward);
 					}
 				}
 
 				while (numSamplesToJumpForward--) {
-					interpolationBuffer[0][0][numSamplesToJumpForward] =
-					    rawBuffer[rawBufferReadPos * numChannels] >> 16;
+					interpolator_.bufferL(numSamplesToJumpForward) = rawBuffer[rawBufferReadPos * numChannels] >> 16;
 					if (numChannels == 2) {
-						interpolationBuffer[1][0][numSamplesToJumpForward] = rawBuffer[rawBufferReadPos * 2 + 1] >> 16;
+						interpolator_.bufferR(numSamplesToJumpForward) = rawBuffer[rawBufferReadPos * 2 + 1] >> 16;
 					}
 
 					rawBufferReadPos = (rawBufferReadPos + 1) & (kInputRawBufferSize - 1);
@@ -105,16 +104,15 @@ void LivePitchShifterPlayHead::render(int32_t* __restrict__ outputBuffer, int32_
 
 			amplitude += amplitudeIncrement;
 
-			std::array<int32_t, 2> sampleRead =
-			    (interpolationBufferSize > 2)
-			        ? deluge::dsp::interpolate(interpolationBuffer, numChannels, whichKernel, oscPos)
-			        : deluge::dsp::interpolateLinear(interpolationBuffer, numChannels, whichKernel, oscPos);
+			StereoSample sampleRead = (interpolationBufferSize > 2)
+			                              ? interpolator_.interpolate(numChannels, whichKernel, oscPos)
+			                              : interpolator_.interpolateLinear(numChannels, oscPos);
 
-			*outputBuffer += multiply_32x32_rshift32_rounded(sampleRead[0], amplitude) << 5;
+			*outputBuffer += multiply_32x32_rshift32_rounded(sampleRead.l, amplitude) << 5;
 			outputBuffer++;
 
 			if (numChannels == 2) {
-				*outputBuffer += multiply_32x32_rshift32_rounded(sampleRead[1], amplitude) << 5;
+				*outputBuffer += multiply_32x32_rshift32_rounded(sampleRead.r, amplitude) << 5;
 				outputBuffer++;
 			}
 		} while (outputBuffer != outputBufferEnd);
@@ -186,14 +184,21 @@ int32_t LivePitchShifterPlayHead::getNumRawSamplesBehindInput(LiveInputBuffer* l
 	}
 }
 
+/// @param numChannels a value between 0 and 1
 void LivePitchShifterPlayHead::fillInterpolationBuffer(LiveInputBuffer* liveInputBuffer, int32_t numChannels) {
-	for (int32_t c = 0; c < numChannels; c++) {
-		for (int32_t i = 1; i <= kInterpolationMaxNumSamples; i++) {
-			int32_t pos = (uint32_t)(rawBufferReadPos - i) & (kInputRawBufferSize - 1);
+	for (int32_t i = 0; i < kInterpolationMaxNumSamples; ++i) {
+		int32_t pos = (uint32_t)(rawBufferReadPos - (i + 1)) & (kInputRawBufferSize - 1);
 
-			interpolationBuffer[c][0][i - 1] = (pos < liveInputBuffer->numRawSamplesProcessed)
-			                                       ? liveInputBuffer->rawBuffer[pos * numChannels + c] >> 16
-			                                       : 0;
+		interpolator_.bufferL(i) =
+		    (pos < liveInputBuffer->numRawSamplesProcessed) ? liveInputBuffer->rawBuffer[pos * numChannels] >> 16 : 0;
+	}
+	if (numChannels == 2) {
+		for (int32_t i = 0; i < kInterpolationMaxNumSamples; ++i) {
+			int32_t pos = (uint32_t)(rawBufferReadPos - (i + 1)) & (kInputRawBufferSize - 1);
+
+			interpolator_.bufferR(i) = (pos < liveInputBuffer->numRawSamplesProcessed)
+			                               ? liveInputBuffer->rawBuffer[pos * numChannels + 1] >> 16
+			                               : 0;
 		}
 	}
 }

--- a/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
@@ -105,13 +105,10 @@ void LivePitchShifterPlayHead::render(int32_t* __restrict__ outputBuffer, int32_
 
 			amplitude += amplitudeIncrement;
 
-			int32_t sampleRead[2];
-			if (interpolationBufferSize > 2) {
-				deluge::dsp::interpolate(sampleRead, numChannels, whichKernel, oscPos, interpolationBuffer);
-			}
-			else {
-				deluge::dsp::interpolateLinear(sampleRead, numChannels, whichKernel, oscPos, interpolationBuffer);
-			}
+			std::array<int32_t, 2> sampleRead =
+			    (interpolationBufferSize > 2)
+			        ? deluge::dsp::interpolate(interpolationBuffer, numChannels, whichKernel, oscPos)
+			        : deluge::dsp::interpolateLinear(interpolationBuffer, numChannels, whichKernel, oscPos);
 
 			*outputBuffer += multiply_32x32_rshift32_rounded(sampleRead[0], amplitude) << 5;
 			outputBuffer++;

--- a/src/deluge/processing/live/live_pitch_shifter_play_head.h
+++ b/src/deluge/processing/live/live_pitch_shifter_play_head.h
@@ -19,6 +19,7 @@
 
 #include "arm_neon_shim.h"
 #include "definitions_cxx.hpp"
+#include "dsp/interpolate/interpolate.h"
 #include <array>
 
 class LivePitchShifter;
@@ -52,7 +53,7 @@ public:
 	int32_t rawBufferReadPos;
 	uint32_t oscPos;
 
-	std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2> interpolationBuffer;
+	deluge::dsp::Interpolator interpolator_;
 
 	uint32_t percPos;
 };


### PR DESCRIPTION
Uses Argon to simplify DSP interpolation functions, and converts the entire thing to a proper class.