### PR TITLE
Bugfix MIDI CC processing for parameter editing / automation recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,14 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 #### <ins>Loopback</ins>
 - Removed `MIDI LOOPBACK` feature as it included a number of bugs that could not be easily fixed in the feature's current state. This feature may be re-designed and re-introduced in the future when an implementation can be found that does not introduce bugs.
 
+#### <ins>Takeover</ins>
+- Fixed a couple bugs with the `MIDI TAKEOVER` modes `PICKUP` and `SCALE` which did not work properly when recording automation and when editing automated parameters.
+
+#### <ins>Follow</ins>
+- Fixed a couple bugs with `MIDI FOLLOW`:
+  - You can now edit parameters while step editing (e.g. holding a note)
+  - If you enable `MIDI Follow Feedback Automation` the Deluge will now send feedback when step editing
+
 ### User Interface
 
 #### <ins>General</ins>

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -66,7 +66,7 @@ as the micromonsta and the dreadbox nymphes.
 
 - ([#147]) Allows CCs to be learnt to the global commands (play, stop, loop, fill, etc.)
 
-- ([#170]) A new `TAKEOVER` submenu was created in the `MIDI` settings menu which consists of three modes that can be
+- ([#170]) A new `TAKEOVER` submenu was created in the `MIDI` settings menu which consists of four modes that can be
   selected from. This mode affects how the Deluge handles MIDI input for learned CC controls:
 
   **1. `JUMP`:** This is the default mode for the Deluge. As soon as a MIDI encoder/Fader position is changed, the
@@ -74,12 +74,14 @@ as the micromonsta and the dreadbox nymphes.
 
   **2. `PICKUP`:** The Deluge will ignore changes to its internal encoder position/Parameter value until the MIDI
   encoder/Fader's position is equal to the Deluge encoder position. After which the MIDI encoder/Fader will move in sync
-  with the Deluge.
+  with the Deluge. 
+    - Note: this mode will behave like the `JUMP` mode when you are recording or step editing automation.
 
   **3. `SCALE`:** The Deluge will increase/decrease its internal encoder position/Parameter value relative to the change
   of the MIDI encoder/Fader position and the amount of "runway" remaining on the MIDI controller. Once the MIDI
   controller reaches its maximum or minimum position, the MIDI encoder/Fader will move in sync with the Deluge. The
   Deluge value will always decrease/increase in the same direction as the MIDI controller.
+    - Note: this mode will behave like the `JUMP` mode when you are recording or step editing automation.
 
   **4. `RELATIVE`:** The Deluge will increase/decrease its internal encoder position/Parameter value using the relative value changes (offset) sent by the controller. The controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
 

--- a/docs/features/midi_follow_mode.md
+++ b/docs/features/midi_follow_mode.md
@@ -39,6 +39,7 @@ To use MIDI follow mode, you will need to configure the various MIDI Follow Mode
   - You can choose MIDI Follow Channel A/B/C or NONE. Thus, when you update MIDI Follow Channel A/B/C it will automatically update the channel used for MIDI Feedback.
       - Note: if no Channel has been set, MIDI Feedback will be Disabled
 - In the MIDI-Follow > Feedback > Automation Feedback submenu, Enable or Disable MIDI follow feedback for automated parameters and set the rate at which feedback for automated parameters is sent
+  - With Automation Feedback enabled, the Deluge will also send feedback while you are holding a note (e.g. step editing automation). This will override the sending of automation feedback until you release the note.
 - In the MIDI-Follow > Feedback > Filter Responses submenu, Enable or Disable filtering of responses received within 1 second of sending a MIDI feedback value update.
 
 ### **Input Device Differentiation**

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1840,6 +1840,13 @@ void View::setModRegion(uint32_t pos, uint32_t length, int32_t noteRowId) {
 		// activeModControllable might not be a Sound, but in that case, the pointer's not going to get used
 	}
 	setKnobIndicatorLevels();
+
+	// midi follow and midi feedback enabled
+	// re-send midi cc's because learned parameter values may have changed
+	// don't send if midi follow feedback automation is disabled
+	if (midiEngine.midiFollowFeedbackAutomation != MIDIFollowFeedbackAutomationMode::DISABLED) {
+		sendMidiFollowFeedback(nullptr, kNoSelection, true);
+	}
 }
 
 void View::pretendModKnobsUntouchedForAWhile() {

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -461,8 +461,8 @@ void MidiFollow::sendNoteToClip(MIDICable& cable, Clip* clip, MIDIMatchType matc
 /// called from playback handler
 /// determines whether a midi cc received is midi follow relevant
 /// and should be routed to the active context for further processing
-void MidiFollow::midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru,
-                                ModelStack* modelStack) {
+void MidiFollow::midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t ccNumber, uint8_t ccValue,
+                                bool* doingMidiThru, ModelStack* modelStack) {
 	MIDIMatchType match = checkMidiFollowMatch(cable, channel);
 	if (match != MIDIMatchType::NO_MATCH) {
 		// obtain clip for active context (for params that's only for the active mod controllable stack)
@@ -497,8 +497,10 @@ void MidiFollow::midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t ccNum
 				if (modelStack) {
 					auto modelStackWithTimelineCounter = modelStack->addTimelineCounter(clip);
 
-					// See if it's learned to a parameter
-					handleReceivedCC(*modelStackWithTimelineCounter, clip, ccNumber, value);
+					if (modelStackWithTimelineCounter) {
+						// See if it's learned to a parameter
+						handleReceivedCC(*modelStackWithTimelineCounter, clip, ccNumber, ccValue);
+					}
 				}
 			}
 		}
@@ -509,13 +511,13 @@ void MidiFollow::midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t ccNum
 			if (modelStackWithTimelineCounter) {
 				if (clip->output->type == OutputType::KIT) {
 					Kit* kit = (Kit*)clip->output;
-					kit->receivedCCForKit(modelStackWithTimelineCounter, cable, match, channel, ccNumber, value,
+					kit->receivedCCForKit(modelStackWithTimelineCounter, cable, match, channel, ccNumber, ccValue,
 					                      doingMidiThru, clip);
 				}
 				else {
 					MelodicInstrument* melodicInstrument = (MelodicInstrument*)clip->output;
-					melodicInstrument->receivedCC(modelStackWithTimelineCounter, cable, match, channel, ccNumber, value,
-					                              doingMidiThru);
+					melodicInstrument->receivedCC(modelStackWithTimelineCounter, cable, match, channel, ccNumber,
+					                              ccValue, doingMidiThru);
 				}
 			}
 		}
@@ -527,7 +529,25 @@ void MidiFollow::midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t ccNum
 /// this function works by first checking the active context to see if there is an active clip
 /// to determine if the cc intends to control a song level or clip level parameter
 void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithTimelineCounter, Clip* clip,
-                                  int32_t ccNumber, int32_t value) {
+                                  int32_t ccNumber, int32_t ccValue) {
+
+	int32_t modPos = 0;
+	int32_t modLength = 0;
+	bool isStepEditing = false;
+
+	if (modelStackWithTimelineCounter.timelineCounterIsSet()) {
+		TimelineCounter* timelineCounter = modelStackWithTimelineCounter.getTimelineCounter();
+
+		// Only if this exact TimelineCounter is having automation step-edited, we can set the value for just a
+		// region.
+		if (view.modLength && timelineCounter == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+			modPos = view.modPos;
+			modLength = view.modLength;
+			isStepEditing = true;
+		}
+
+		timelineCounter->possiblyCloneForArrangementRecording(&modelStackWithTimelineCounter);
+	}
 
 	// loop through the grid to see if any parameters have been learned to the ccNumber received
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
@@ -539,16 +559,25 @@ void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithT
 				                           midiEngine.midiFollowDisplayParam);
 				// check if model stack is valid
 				if (modelStackWithParam && modelStackWithParam->autoParam) {
+					int32_t currentValue;
+
 					// get current value
-					int32_t oldValue =
-					    modelStackWithParam->autoParam->getValuePossiblyAtPos(view.modPos, modelStackWithParam);
+					if (isStepEditing) {
+						currentValue =
+						    modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
+					}
+					else {
+						currentValue = modelStackWithParam->autoParam->getCurrentValue();
+					}
 
 					// convert current value to knobPos to compare to cc value being received
 					int32_t knobPos =
-					    modelStackWithParam->paramCollection->paramValueToKnobPos(oldValue, modelStackWithParam);
+					    modelStackWithParam->paramCollection->paramValueToKnobPos(currentValue, modelStackWithParam);
 
-					// calculate new knob position based on value received and deluge current value
-					int32_t newKnobPos = MidiTakeover::calculateKnobPos(knobPos, value, nullptr, true, ccNumber);
+					// calculate new knob position based on cc value received and deluge current value
+					int32_t newKnobPos =
+					    MidiTakeover::calculateKnobPos(knobPos, ccValue, nullptr, true, ccNumber, isStepEditing);
+
 					// is the cc being received for the same value as the current knob pos? If so, do nothing
 					if (newKnobPos != knobPos) {
 						// Convert the New Knob Position to a Parameter Value
@@ -556,8 +585,8 @@ void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithT
 						    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
 
 						// Set the new Parameter Value for the MIDI Learned Parameter
-						modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam,
-						                                                          view.modPos, view.modLength);
+						modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, modPos,
+						                                                          modLength);
 
 						// check if you're currently editing the same learned param in automation view or
 						// performance view if so, you will need to refresh the automation editor grid or the
@@ -619,6 +648,27 @@ void MidiFollow::sendCCWithoutModelStackForMidiFollowFeedback(int32_t channel, b
 
 	// check that model stack is valid
 	if (modelStackWithTimelineCounter) {
+		int32_t modPos = 0;
+		bool isStepEditing = false;
+
+		if (modelStackWithTimelineCounter->timelineCounterIsSet()) {
+			TimelineCounter* timelineCounter = modelStackWithTimelineCounter->getTimelineCounter();
+
+			// Only if this exact TimelineCounter is having automation step-edited, we can send the value for just a
+			// region.
+			if (view.modLength
+			    && timelineCounter == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+
+				// don't send automation feedback if you're step editing
+				if (isAutomation) {
+					return;
+				}
+
+				modPos = view.modPos;
+				isStepEditing = true;
+			}
+		}
+
 		// loop through the grid to see if any parameters have been learned
 		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 			for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
@@ -629,9 +679,15 @@ void MidiFollow::sendCCWithoutModelStackForMidiFollowFeedback(int32_t channel, b
 					// check that model stack is valid
 					if (modelStackWithParam && modelStackWithParam->autoParam) {
 						if (!isAutomation || (isAutomation && modelStackWithParam->autoParam->isAutomated())) {
+							int32_t currentValue;
 							// obtain current value of the learned parameter
-							int32_t currentValue =
-							    modelStackWithParam->autoParam->getValuePossiblyAtPos(view.modPos, modelStackWithParam);
+							if (isStepEditing) {
+								currentValue =
+								    modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
+							}
+							else {
+								currentValue = modelStackWithParam->autoParam->getCurrentValue();
+							}
 
 							// convert current value to a knob position
 							int32_t knobPos = modelStackWithParam->paramCollection->paramValueToKnobPos(

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -44,7 +44,7 @@ public:
 	                         bool* doingMidiThru, bool shouldRecordNotesNowNow, ModelStack* modelStack);
 	void sendNoteToClip(MIDICable& cable, Clip* clip, MIDIMatchType match, bool on, int32_t channel, int32_t note,
 	                    int32_t velocity, bool* doingMidiThru, bool shouldRecordNotesNowNow, ModelStack* modelStack);
-	void midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru,
+	void midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t ccNumber, uint8_t ccValue, bool* doingMidiThru,
 	                    ModelStack* modelStack);
 	void pitchBendReceived(MIDICable& cable, uint8_t channel, uint8_t data1, uint8_t data2, bool* doingMidiThru,
 	                       ModelStack* modelStack);
@@ -66,7 +66,7 @@ public:
 	void sendCCWithoutModelStackForMidiFollowFeedback(int32_t channel, bool isAutomation = false);
 	void sendCCForMidiFollowFeedback(int32_t channel, int32_t ccNumber, int32_t knobPos);
 
-	void handleReceivedCC(ModelStackWithTimelineCounter& modelStack, Clip* clip, int32_t ccNumber, int32_t value);
+	void handleReceivedCC(ModelStackWithTimelineCounter& modelStack, Clip* clip, int32_t ccNumber, int32_t ccValue);
 
 private:
 	// initialize

--- a/src/deluge/io/midi/midi_takeover.h
+++ b/src/deluge/io/midi/midi_takeover.h
@@ -22,6 +22,6 @@
 #include "modulation/params/param_set.h"
 
 namespace MidiTakeover {
-int32_t calculateKnobPos(int32_t knobPos, int32_t value, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
-                         int32_t ccNumber = MIDI_CC_NONE);
+int32_t calculateKnobPos(int32_t knobPos, int32_t ccValue, MIDIKnob* knob = nullptr, bool doingMidiFollow = false,
+                         int32_t ccNumber = MIDI_CC_NONE, bool isStepEditing = false);
 } // namespace MidiTakeover

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -96,7 +96,8 @@ TEST(Scheduler, scheduleConditional) {
 	mock().clear();
 	mock().expectNCalls(1, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns");
+	addConditionalTask(
+	    sleep_50ns, 0, []() { return true; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -106,7 +107,8 @@ TEST(Scheduler, scheduleConditionalDoesntRun) {
 	mock().clear();
 	mock().expectNCalls(0, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns");
+	addConditionalTask(
+	    sleep_50ns, 0, []() { return false; }, "sleep 50ns");
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2921
Fix https://github.com/SynthstromAudible/DelugeFirmware/discussions/2919

Description: Fixed how midi cc's received are handled

- If editing a step (e.g. holding the step) -> use MIDITakeover mode jump to set value at that step to the midi CC value received

- if recording and not holding a step -> use MIDITakeover mode jump to set current value to the midi CC value received

- Fixed MIDITakeover bug where it was not using the current parameter value when a parameter had been automated which resulted in an inability to change the current value when using MIDITakeover modes Pickup or Scale

- Fixed MIDIFollow bug which did not allow you to step edit

- Fixed MIDIFollow feedback bug which would send values other than the current value

- Fixed MIDIFollow feedback bug which would not send feedback when step editing (holding a note). It will now send feedback if you have enabled MIDI Follow Feedback Automation

- Added a ModelStackWithTimelineCounter nullptr sanity check to MIDIFollow

+ some minor cleanup of variable names