### PR TITLE
Fix for grains constantly clearing their buffer

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -1155,7 +1155,7 @@ void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, i
 		disableGrain();
 	}
 	else if (modFXTypeNow == ModFXType::GRAIN) {
-		if (anySoundComingIn) {
+		if (anySoundComingIn && !grainFX) {
 			enableGrain();
 		}
 	}


### PR DESCRIPTION
The root cause is that the globalfx re enabled the grain in every render cycle as they recreate the fx just in case

This is a bad idea for performance and the root cause of clicks when enabling fx so the allocations should be moved out of the render cycle entirely but that will be a future PR

Fix #2937 