### PR TITLE
Show correct string for dimension and disabled modfx

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -202,9 +202,7 @@ char const* GlobalEffectable::getModFXTypeDisplayName() {
 	auto modTypeCount = kNumModFXTypes;
 
 	modFXType_ = static_cast<ModFXType>(util::to_underlying(modFXType_) % modTypeCount);
-	if (modFXType_ == ModFXType::NONE) {
-		modFXType_ = static_cast<ModFXType>(1);
-	}
+
 	return modfx::modFXToString(modFXType_);
 }
 
@@ -236,10 +234,7 @@ bool GlobalEffectable::modEncoderButtonAction(uint8_t whichModEncoder, bool on,
 		if (whichModEncoder == 1) {
 			if (on) {
 				auto modTypeCount = kNumModFXTypes;
-				modFXType_ = static_cast<ModFXType>((util::to_underlying(modFXType_) + 1) % modTypeCount);
-				if (modFXType_ == ModFXType::NONE) {
-					modFXType_ = static_cast<ModFXType>(1);
-				}
+				setModFXType(static_cast<ModFXType>((util::to_underlying(modFXType_) + 1) % modTypeCount));
 				ensureModFXParamIsValid();
 
 				// if mod button is pressed, update mod button pop up
@@ -1230,12 +1225,14 @@ const char* modFXToString(ModFXType type) {
 		return l10n::get(STRING_FOR_CHORUS);
 	case ModFXType::CHORUS_STEREO:
 		return l10n::get(STRING_FOR_STEREO_CHORUS);
+	case ModFXType::DIMENSION:
+		return l10n::get(STRING_FOR_DIMENSION);
 	case ModFXType::GRAIN:
 		return l10n::get(STRING_FOR_GRAIN);
 	case ModFXType::WARBLE:
 		return l10n::get(STRING_FOR_WARBLE);
 	default:
-		return l10n::get(STRING_FOR_NONE);
+		return l10n::get(STRING_FOR_DISABLED);
 	}
 }
 } // namespace modfx


### PR DESCRIPTION
Fix #2935 

Also adds disabled to the gold knob press cycle so that you don't need to use the shortcut to disable modfx