### PR TITLE
Fixed bug with probability value popup

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2969,24 +2969,21 @@ multiplePresses:
 void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) {
 	char buffer[(display->haveOLED()) ? 29 : 5];
 
-	// Probability dependence
-	if (probability <= kNumProbabilityValues) {
-		if (display->haveOLED()) {
-			sprintf(buffer, "Probability %d%%", probability * 5);
-			if (prevBase) {
-				strcat(buffer, " latching");
-			}
-		}
-		if (display->have7SEG()) {
-			intToString(probability * 5, buffer);
-		}
+	// if it's a latching probability, remove latching from value
+	if (probability > kNumProbabilityValues) {
+		probability &= 127;
 	}
 
 	if (display->haveOLED()) {
+		sprintf(buffer, "Probability %d%%", probability * 5);
+		if (prevBase) {
+			strcat(buffer, " latching");
+		}
 		display->popupText(buffer, PopupType::PROBABILITY);
 	}
 	else {
-		display->displayPopup(buffer, 0, true, prevBase ? 3 : 255, 1, PopupType::PROBABILITY);
+		intToString(probability * 5, buffer);
+		display->setText(buffer, true, prevBase ? 3 : 255);
 	}
 }
 


### PR DESCRIPTION
Fixed bug with probability value popup

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2980

Cleaned up the pop-up logic using the same logic we use in the probability menu code