### PR TITLE
setup dx7 when dx oscillator selected

### DIFF
--- a/src/deluge/gui/menu_item/osc/type.h
+++ b/src/deluge/gui/menu_item/osc/type.h
@@ -34,7 +34,7 @@ public:
 	Type(l10n::String name, l10n::String title_format_str) : Selection(name), FormattedTitle(title_format_str){};
 	void beginSession(MenuItem* navigatedBackwardFrom) override { Selection::beginSession(navigatedBackwardFrom); }
 
-	bool mayUseDx() { return soundEditor.currentSource->dxPatch != nullptr; }
+	bool mayUseDx() { return !soundEditor.editingKit(); }
 
 	void readCurrentValue() override {
 		int32_t rawVal = (int32_t)soundEditor.currentSource->oscType;
@@ -67,6 +67,7 @@ public:
 		}
 
 		soundEditor.currentSource->setOscType(newValue);
+
 		if (oldValue == OscType::SQUARE || newValue == OscType::SQUARE) {
 			soundEditor.currentSound->setupPatchingForAllParamManagers(currentSong);
 		}

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -284,6 +284,9 @@ doChangeType:
 	}
 
 	oscType = newType;
+	if (oscType == OscType::DX7) {
+		ensureDxPatch();
+	}
 }
 
 DxPatch* Source::ensureDxPatch() {


### PR DESCRIPTION
Remove the need for the custom 1 plus synth shortcut by just setting up the dx7 engine if an oscillator is set to dx7

I think we should cherry pick this since it's tiny and makes the DX7 a lot more usable