### PR TITLE
setup dx7 synth properly when setup via osc type menu

### DIFF
--- a/src/deluge/gui/menu_item/osc/type.h
+++ b/src/deluge/gui/menu_item/osc/type.h
@@ -34,7 +34,7 @@ public:
 	Type(l10n::String name, l10n::String title_format_str) : Selection(name), FormattedTitle(title_format_str){};
 	void beginSession(MenuItem* navigatedBackwardFrom) override { Selection::beginSession(navigatedBackwardFrom); }
 
-	bool mayUseDx() { return !soundEditor.editingKit(); }
+	bool mayUseDx() { return !soundEditor.editingKit() && soundEditor.currentSourceIndex == 0; }
 
 	void readCurrentValue() override {
 		int32_t rawVal = (int32_t)soundEditor.currentSource->oscType;


### PR DESCRIPTION
follow up to #3004

- only setup dx7 on source1.
- the ENV1 release should be set to 50 to let the DX7:s internal envelopes release phase play out (yes, we still do voice culling properly when the dx7 envelopes end)
- The VEL-> master volume patch cable should not be used as dx7 handles velocity per operator and this additional global patch cable will throw off loaded patches which are properly velocity calibrated internally.