### PR TITLE
Fix default numRepeats for sections, for old songs before the addition of 12 extra sections

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1337,7 +1337,7 @@ Error Song::readFromFile(Deserializer& reader) {
 	char const* tagName;
 
 	for (int32_t s = 0; s < kMaxNumSections; s++) {
-		sections[s].numRepetitions = -1;
+		sections[s].numRepetitions = 0;
 	}
 	for (int32_t y = 0; y < 8; y++) {
 		sessionMacros[y].kind = NO_MACRO;


### PR DESCRIPTION
Fixes https://github.com/SynthstromAudible/DelugeFirmware/issues/3022

For songs which have only 12 sections in the XML (before 12 extra sections were added, it is better to initialize them to 0 (Repeats: Infinite), instead of -1 (Launch non-exclusively), so when the song is saved with the new firmware, the numRepeats value is saved as 0 and not -1