### PR TITLE
Bugfix probability editing on 7seg

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2983,7 +2983,7 @@ void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) 
 	}
 	else {
 		intToString(probability * 5, buffer);
-		display->setText(buffer, true, prevBase ? 3 : 255);
+		display->displayPopup(buffer, 0, true, prevBase ? 3 : 255, 1, PopupType::PROBABILITY);
 	}
 }
 


### PR DESCRIPTION
Fixed 7seg only bug which didnt let you edit note probability by holding note / audition pad and turning select encoder left