### PR TITLE
bugfix automation view shortcut blinking

### DIFF
--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -150,6 +150,9 @@ public:
 	AutomationParamType automationParamType;
 	bool getAffectEntire() override;
 
+	// public so action logger can access it
+	void resetShortcutBlinking();
+
 private:
 	// button action functions
 	void handleSessionButtonAction(Clip* clip, bool on);
@@ -332,7 +335,6 @@ private:
 	                                                    int32_t offset);
 
 	void blinkShortcuts();
-	void resetShortcutBlinking();
 	void resetParameterShortcutBlinking();
 
 	bool parameterShortcutBlinking;

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -604,6 +604,7 @@ currentClipSwitchedOver:
 	}
 
 	else if (whichAnimation == Animation::EXIT_AUTOMATION_VIEW) {
+		automationView.resetShortcutBlinking();
 		if (getCurrentClip()->type == ClipType::INSTRUMENT) {
 			changeRootUI(&instrumentClipView);
 		}


### PR DESCRIPTION
Fixed bug where if you exit automation view using "undo" the shortcut's that were blinking in automation view would continue to blink in note view.

fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3028