### PR TITLE
[DRAFT] browser: try to keep selected item on the middle row

### DIFF
--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -132,7 +132,6 @@ protected:
 
 	static int32_t fileIndexSelected; // If -1, we have not selected any real file/folder. Maybe there are no files, or
 	                                  // maybe we're typing a new name.
-	static int32_t scrollPosVertical;
 	static int32_t
 	    numCharsInPrefix; // Only used for deciding Drum names within Kit. Oh and initial text scroll position.
 	static bool qwertyVisible;


### PR DESCRIPTION
* Highlight should now be on the the first line for the first file, and on the last line for the last file.

* This is done by getting rid of scrollPosVertical and inferring it based on the fileIndexSelected. ...but browser.cpp is messy, and the assumptions that make this work are probably brittle.

* Fixes #2767, hopefully.