### PR TITLE
[HOLD] check max times and avoid blocking in the same pass through task list

### DIFF
--- a/src/OSLikeStuff/scheduler_api.h
+++ b/src/OSLikeStuff/scheduler_api.h
@@ -45,7 +45,7 @@ typedef int8_t TaskID;
 /// @param backOffTime Minimum time from completing the task to calling it again in seconds.
 /// @param targetTimeBetweenCalls Desired time between calls to the task, including the runtime for the task itself.
 uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, double targetTimeBetweenCalls,
-                         double maxTimeBetweenCalls, const char* name);
+                         double maxTimeBetweenCalls, const char* name, bool reentrant);
 
 /// Add a task to run once, aiming to run at current time + timeToWait and worst case run at timeToWait*10
 uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name);

--- a/src/OSLikeStuff/task_scheduler/task.h
+++ b/src/OSLikeStuff/task_scheduler/task.h
@@ -46,6 +46,7 @@ struct StatBlock {
 struct TaskSchedule {
 	// 0 is highest priority
 	uint8_t priority;
+	bool reentrant;
 	// time to wait between return and calling the function again
 	Time backOffPeriod;
 	// target time between function calls
@@ -67,7 +68,7 @@ struct Task {
 	Task(TaskHandle _handle, uint8_t _priority, Time timeNow, Time _timeToWait, const char* _name)
 	    : handle(_handle), lastCallTime(timeNow), removeAfterUse(true), name(_name) {
 
-		schedule = TaskSchedule{_priority, _timeToWait, _timeToWait, _timeToWait * 2};
+		schedule = TaskSchedule{_priority, false, _timeToWait, _timeToWait, _timeToWait * 2};
 	}
 	// makes a repeating task
 	Task(TaskHandle task, TaskSchedule _schedule, const char* _name) : handle(task), schedule(_schedule), name(_name) {}
@@ -76,7 +77,7 @@ struct Task {
 	    : handle(task), state(State::BLOCKED), condition(_condition), removeAfterUse(true), name(_name) {
 
 		// good to go as soon as it's marked as runnable
-		schedule = {priority, 0, 0, 0};
+		schedule = {priority, false, 0, 0, 0};
 	}
 
 	void updateNextTimes(Time startTime, Time runtime) {

--- a/src/OSLikeStuff/task_scheduler/task.h
+++ b/src/OSLikeStuff/task_scheduler/task.h
@@ -102,16 +102,16 @@ struct Task {
 		return false;
 	}
 
-	[[nodiscard]] bool isReady(Time currentTime) const { return state == State::READY && isReleased(currentTime); };
-	[[nodiscard]] bool isRunnable() const { return state == State::READY; }
+	[[nodiscard]] bool isReady(Time currentTime) const { return isRunnable() && isReleased(currentTime); };
+	[[nodiscard]] bool isRunnable() const { return (handle != nullptr) && state == State::READY; }
 	[[nodiscard]] bool isReleased(Time currentTime) const {
-		return currentTime - lastFinishTime > schedule.backOffPeriod;
+		return currentTime - lastCallTime > schedule.backOffPeriod;
 	}
 	TaskHandle handle{nullptr};
 	TaskSchedule schedule{0, 0, 0, 0};
 	Time idealCallTime{0};
 	Time latestCallTime{0};
-	Time lastCallTime{0};
+	Time lastCallTime{-1};
 	Time lastFinishTime{0};
 
 	StatBlock durationStats;

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -281,7 +281,6 @@ void TaskManager::start(Time duration) {
 				printStats();
 			}
 		}
-
 	}
 }
 void TaskManager::startClock() {

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -66,7 +66,7 @@ TaskID TaskManager::chooseBestTask(Time deadline) {
 			continue;
 		}
 		// ensure every routine is within its target
-		if (currentTime > t->lastCallTime + s->maxInterval) {
+		if (currentTime > t->lastCallTime + s->maxInterval && t->isReady(currentTime)) {
 			return sortedList[i].task;
 		}
 		if (t->idealCallTime < currentTime && currentTime + t->durationStats.average < latestFinishTime) {
@@ -87,7 +87,7 @@ TaskID TaskManager::chooseBestTask(Time deadline) {
 		for (int i = (numActiveTasks - 1); i >= 0; i--) {
 			struct Task* t = &list[sortedList[i].task];
 			struct TaskSchedule* s = &t->schedule;
-			if (currentTime + t->durationStats.max < latestFinishTime
+			if (currentTime + t->durationStats.average < latestFinishTime
 			    && currentTime - t->lastFinishTime > s->targetInterval && t->isReady(currentTime)) {
 				return sortedList[i].task;
 			}
@@ -95,7 +95,7 @@ TaskID TaskManager::chooseBestTask(Time deadline) {
 		// then look based on min time just to avoid busy waiting
 		for (int i = (numActiveTasks - 1); i >= 0; i--) {
 			struct Task* t = &list[sortedList[i].task];
-			if (currentTime + t->durationStats.max < latestFinishTime && t->isReady(currentTime)) {
+			if (currentTime + t->durationStats.average < latestFinishTime && t->isReady(currentTime)) {
 				return sortedList[i].task;
 			}
 		}

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -177,8 +177,11 @@ void TaskManager::runTask(TaskID id) {
 	overhead += timeNow - lastFinishTime;
 	currentID = id;
 	auto currentTask = &list[currentID];
-
+	if (!currentTask->schedule.reentrant) {
+		currentTask->state = State::QUEUED;
+	}
 	currentTask->handle();
+	currentTask->state = State::READY;
 	timeNow = getSecondsFromStart();
 	Time runtime = (timeNow - startTime);
 	cpuTime += runtime;

--- a/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
@@ -23,9 +23,9 @@ void setNextRunTimeforCurrentTask(double seconds) {
 }
 
 uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, double targetTimeBetweenCalls,
-                         double maxTimeBetweenCalls, const char* name) {
+                         double maxTimeBetweenCalls, const char* name, bool reentrant) {
 	return taskManager.addRepeatingTask(
-	    task, TaskSchedule{priority, backOffTime, targetTimeBetweenCalls, maxTimeBetweenCalls}, name);
+	    task, TaskSchedule{priority, reentrant, backOffTime, targetTimeBetweenCalls, maxTimeBetweenCalls}, name);
 }
 uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name) {
 	return taskManager.addOnceTask(task, priority, timeToWait, name);

--- a/src/OSLikeStuff/timers_interrupts/clock_type.h
+++ b/src/OSLikeStuff/timers_interrupts/clock_type.h
@@ -37,6 +37,7 @@ public:
 	constexpr Time operator+(Time r) { return time + r.time; }
 	constexpr Time operator-(Time r) { return time - r.time; }
 	constexpr Time operator*(int r) { return time * r; }
+	constexpr Time operator*(double r) { return time * r; }
 	auto operator<=>(const Time&) const = default;
 	constexpr Time& operator+=(const Time& r) {
 		time = time + r.time;

--- a/src/OSLikeStuff/timers_interrupts/clock_type.h
+++ b/src/OSLikeStuff/timers_interrupts/clock_type.h
@@ -5,7 +5,8 @@
 extern "C" {
 #endif
 
-#include <math.h>
+#include "math.h"
+#include "stdint.h"
 #define DELUGE_CLOCKS_PER 33330000
 #define DELUGE_CLOCKS_PERf 33330000.
 #define ONE_OVER_CLOCK (1 / DELUGE_CLOCKS_PERf)

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -573,12 +573,13 @@ void registerTasks() {
 
 	// 0-9: High priority (10 for dyn tasks)
 	uint8_t p = 0;
-	addRepeatingTask(&(AudioEngine::routine), p++, 0.00001, 16 / 44100., 24 / 44100., "audio  routine");
+	addRepeatingTask(&(AudioEngine::routine), p++, 16 / 44100., 32 / 44100., 64 / 44100., "audio  routine");
 	// this one runs quickly and frequently to check for encoder changes
 	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders");
 	// formerly part of audio routine, updates midi and clock
-	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 2 / 44100., 16 / 44100, 32 / 44100., "playback routine");
-	addRepeatingTask([]() { audioFileManager.loadAnyEnqueuedClusters(128, false); }, p++, 0.00001, 0.00001, 0.00002,
+	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 16 / 44100., 32 / 44100, 64 / 44100.,
+	                 "playback routine");
+	addRepeatingTask([]() { audioFileManager.loadAnyEnqueuedClusters(128, false); }, p++, 0.0001, 0.0001, 0.001,
 	                 "load clusters");
 	// handles sd card recorders
 	// named "slow" but isn't actually, it handles audio recording setup

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -573,48 +573,51 @@ void registerTasks() {
 
 	// 0-9: High priority (10 for dyn tasks)
 	uint8_t p = 0;
-	addRepeatingTask(&(AudioEngine::routine), p++, 16 / 44100., 32 / 44100., 64 / 44100., "audio  routine");
+	addRepeatingTask(&(AudioEngine::routine), p++, 16 / 44100., 32 / 44100., 64 / 44100., "audio  routine", false);
 	// this one runs quickly and frequently to check for encoder changes
-	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders");
+	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders", true);
 	// formerly part of audio routine, updates midi and clock
-	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 16 / 44100., 32 / 44100, 64 / 44100.,
-	                 "playback routine");
+	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 16 / 44100., 32 / 44100, 64 / 44100., "playback routine",
+	                 true);
 	addRepeatingTask([]() { audioFileManager.loadAnyEnqueuedClusters(128, false); }, p++, 0.0001, 0.0001, 0.001,
-	                 "load clusters");
+	                 "load clusters", true);
 	// handles sd card recorders
 	// named "slow" but isn't actually, it handles audio recording setup
-	addRepeatingTask(&AudioEngine::slowRoutine, p++, 0.001, 0.005, 0.05, "audio slow");
-	addRepeatingTask(&(readButtonsAndPadsOnce), p++, 0.005, 0.005, 0.01, "buttons and pads");
+	addRepeatingTask(&AudioEngine::slowRoutine, p++, 0.001, 0.005, 0.05, "audio slow", true);
+	addRepeatingTask(&(readButtonsAndPadsOnce), p++, 0.005, 0.005, 0.01, "buttons and pads", true);
 
 	// 11-19: Medium priority (20 for dyn tasks)
 	p = 11;
-	addRepeatingTask([]() { encoders::interpretEncoders(true); }, p++, 0.005, 0.005, 0.01, "interpret encoders fast");
+	addRepeatingTask([]() { encoders::interpretEncoders(true); }, p++, 0.005, 0.005, 0.01, "interpret encoders fast",
+	                 true);
 	// 30 Hz update desired?
-	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI");
+	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI", true);
 	// this one actually actions them
-	addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow");
+	addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
+	                 true);
 
 	// Check for and handle queued SysEx traffic
-	addRepeatingTask([]() { smSysex::handleNextSysEx(); }, p++, 0.0002, 0.0002, 0.01, "Handle pending SysEx traffic.");
+	addRepeatingTask([]() { smSysex::handleNextSysEx(); }, p++, 0.0002, 0.0002, 0.01, "Handle pending SysEx traffic.",
+	                 true);
 
 	// 21-29: Low priority (30 for dyn tasks)
 	p = 21;
 	// these ones are actually "slow" -> file manager just checks if an sd card has been inserted, audio recorder checks
 	// if recordings are finished
-	addRepeatingTask([]() { audioFileManager.slowRoutine(); }, p++, 0.1, 0.1, 0.2, "audio file slow");
-	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "audio recorder slow");
+	addRepeatingTask([]() { audioFileManager.slowRoutine(); }, p++, 0.1, 0.1, 0.2, "audio file slow", true);
+	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "audio recorder slow", true);
 	// formerly part of cluster loading (why? no idea), actions undo/redo midi commands
-	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "playback routine");
+	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "playback routine", true);
 	// 31-39: Idle priority (40 for dyn tasks)
 	p = 31;
-	addRepeatingTask(&(PIC::flush), p++, 0.001, 0.001, 0.02, "PIC flush");
+	addRepeatingTask(&(PIC::flush), p++, 0.001, 0.001, 0.02, "PIC flush", true);
 	if (hid::display::have_oled_screen) {
-		addRepeatingTask(&(oledRoutine), p++, 0.01, 0.01, 0.02, "oled routine");
+		addRepeatingTask(&(oledRoutine), p++, 0.01, 0.01, 0.02, "oled routine", true);
 	}
 	// needs to be called very frequently,
 	// handles animations and checks on the timers for any infrequent actions
 	// long term this should probably be made into an idle task
-	addRepeatingTask([]() { uiTimerManager.routine(); }, p++, 0.0001, 0.0007, 0.01, "ui routine");
+	addRepeatingTask([]() { uiTimerManager.routine(); }, p++, 0.0001, 0.0007, 0.01, "ui routine", true);
 
 	// addRepeatingTask([]() { AudioEngine::routineWithClusterLoading(true); }, 0, 1 / 44100., 16 / 44100., 32 / 44100.,
 	// true); addRepeatingTask(&(AudioEngine::routine), 0, 16 / 44100., 64 / 44100., true);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2419,6 +2419,7 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 			                     volumePostFX >> 1, sideChainHitPending, !isClipActiveNow, isClipActiveNow);
 		}
 		ENABLE_INTERRUPTS();
+		yield([]() { return true; });
 #if DO_AUDIO_LOG
 		char buf[64];
 		snprintf(buf, sizeof(buf), "complete: %s", output->name.get());

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2419,7 +2419,7 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 			                     volumePostFX >> 1, sideChainHitPending, !isClipActiveNow, isClipActiveNow);
 		}
 		ENABLE_INTERRUPTS();
-		yield([]() { return true; });
+
 #if DO_AUDIO_LOG
 		char buf[64];
 		snprintf(buf, sizeof(buf), "complete: %s", output->name.get());

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -3259,9 +3259,9 @@ storePhase:
 	}
 }
 
-bool Voice::doFastRelease(uint32_t releaseIncrement) {
+bool Voice::forceNormalRelease() {
 	if (doneFirstRender) {
-		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, releaseIncrement);
+		envelopes[0].unconditionalRelease(EnvelopeStage::RELEASE);
 		return true;
 	}
 
@@ -3271,9 +3271,9 @@ bool Voice::doFastRelease(uint32_t releaseIncrement) {
 	}
 }
 
-bool Voice::forceNormalRelease() {
+bool Voice::doFastRelease(uint32_t releaseIncrement) {
 	if (doneFirstRender) {
-		envelopes[0].unconditionalRelease();
+		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, releaseIncrement);
 		return true;
 	}
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -485,9 +485,9 @@ inline void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 
 		int32_t numSamplesOverLimit = numSamples - numSamplesLimit;
 		// If it's real dire, do a proper immediate cull
-		if (numSamplesOverLimit >= 20) {
+		if (numSamplesOverLimit >= 32) {
 
-			numToCull = (numSamplesOverLimit >> 3);
+			numToCull = (numSamplesOverLimit / 32);
 
 			// leave at least 7 - below this point culling won't save us
 			// if they can't load their sample in time they'll stop the same way anyway
@@ -689,7 +689,7 @@ void renderAudio(size_t numSamples) {
 
 		currentSong->renderAudio(renderingBuffer.data(), numSamples, reverbBuffer.data(), sideChainHitPending);
 	}
-
+	yield([]() { return true; }); // let something else run if it needs to
 	renderReverb(numSamples);
 
 	renderSamplePreview(numSamples);
@@ -1098,6 +1098,7 @@ void routine() {
 			}
 		}
 	}
+	bypassCulling = false;
 	audioRoutineLocked = false;
 }
 

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -1331,6 +1331,7 @@ void AudioFileManager::loadAnyEnqueuedClusters(int32_t maxNum, bool mayProcessUs
 		        // the card right now
 	}
 	if (AudioEngine::audioRoutineLocked) {
+		ignoreForStats();
 		return; // Not sure if this should be neccesary?
 	}
 

--- a/tests/unit/mocks/timer_mocks.cpp
+++ b/tests/unit/mocks/timer_mocks.cpp
@@ -55,10 +55,16 @@ void passMockTime(double seconds) {
 	mockTimers[1] += ticks;
 }
 
+void passMockTimeMin() {
+	uint32_t ticks = 1;
+	mockTimers[0] += ticks;
+	mockTimers[1] += ticks;
+}
+
 // returns ticks at the rate the deluge clock would generate them
 uint32_t getTimerValue(int timerNo) {
 	/// this ensures that the mocked time keeps advancing
-	passMockTime(0.0000001);
+	passMockTimeMin();
 	auto now = std::chrono::steady_clock::now();
 	if (mockTimeIntervals) {
 		return mockTimers[timerNo];

--- a/tests/unit/mocks/timer_mocks.h
+++ b/tests/unit/mocks/timer_mocks.h
@@ -4,8 +4,7 @@
 
 #ifndef DELUGE_TIMER_MOCKS_H
 #define DELUGE_TIMER_MOCKS_H
-
-#endif // DELUGE_TIMER_MOCKS_H
 extern "C" {
 void passMockTime(double seconds);
 }
+#endif // DELUGE_TIMER_MOCKS_H

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -153,10 +153,10 @@ TEST(Scheduler, yield) {
 
 TEST(Scheduler, removeWithPriZero) {
 	mock().clear();
-	mock().expectNCalls((0.01 - 0.002) / 0.001 - 1, "sleep_50ns");
+	mock().expectNCalls((0.01 - 0.002) / 0.001, "sleep_50ns");
 	mock().expectNCalls(2, "sleep_2ms");
 	// every 1ms sleep for 50ns and 10ns
-	addRepeatingTask(sleep_50ns, 0, 0.0099, 0.0099, 0.001, "sleep 50ns");
+	addRepeatingTask(sleep_50ns, 0, 0.00099, 0.00099, 0.001, "sleep 50ns");
 
 	addOnceTask(sleep_2ms, 11, 0.002, "sleep 2 ms");
 

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -29,18 +29,18 @@ struct SelfRemoving {
 };
 
 void sleep_50ns() {
+
 	mock().actualCall("sleep_50ns");
-	uint32_t now = getTimerValue(0);
 	passMockTime(0.00005);
 }
 void sleep_20ns() {
+
 	mock().actualCall("sleep_20ns");
-	uint32_t now = getTimerValue(0);
 	passMockTime(0.00002);
 }
 void sleep_2ms() {
+
 	mock().actualCall("sleep_2ms");
-	uint32_t now = getTimerValue(0);
 	passMockTime(0.002);
 }
 
@@ -156,10 +156,10 @@ TEST(Scheduler, removeWithPriZero) {
 	mock().expectNCalls((0.01 - 0.002) / 0.001 - 1, "sleep_50ns");
 	mock().expectNCalls(2, "sleep_2ms");
 	// every 1ms sleep for 50ns and 10ns
-	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep 50ns");
-	addRepeatingTask([]() { passMockTime(0.00001); }, 0, 0.001, 0.001, 0.001, "mock time");
+	addRepeatingTask(sleep_50ns, 0, 0.0099, 0.0099, 0.001, "sleep 50ns");
+
 	addOnceTask(sleep_2ms, 11, 0.002, "sleep 2 ms");
-	addRepeatingTask([]() { passMockTime(0.00003); }, 0, 0.001, 0.001, 0.001, "mock time");
+
 	addOnceTask(sleep_2ms, 11, 0.009, "sleep 2ms");
 	// run the scheduler for 10ms
 	taskManager.start(0.01);


### PR DESCRIPTION
By going in priority order in the first pass (instead of inverse priority) the blocking logic can be made much simpler. Now it just walks through the tasks, if the task is ready and finishes before the latestFinishTime it's set as the next one to run and the latestFinishTime is updated to the last finish time that won't interfere with its start time 