### PR TITLE
Remove trailing whitespace in docs folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,17 +48,17 @@
 - Updated mechanism for creating New Clips in New Tracks in `SONG GRID VIEW` and `SONG ROW VIEW`.
   - The default clip type for new clips created can be configured in `SETTINGS > DEFAULTS > UI > CLIP TYPE > NEW CLIP TYPE` menu.
     - You can also configure whether the clip type for the next clip type you create should default to the last clip type you created. This helps with fast creation of multiple clips of the same type. You can enable this default setting in the `SETTINGS > DEFAULTS > UI > CLIP TYPE > USE LAST CLIP TYPE` menu.
-    - NOTE for `SONG ROW VIEW`: The default clip type / last clip type setting cannot be used with CV clips and Audio clips in Song Row View. If you set the default to CV or Audio or enable use of the last clip type (and the last clip type is a CV or Audio Clip), then it will create a Synth clip by default. 
+    - NOTE for `SONG ROW VIEW`: The default clip type / last clip type setting cannot be used with CV clips and Audio clips in Song Row View. If you set the default to CV or Audio or enable use of the last clip type (and the last clip type is a CV or Audio Clip), then it will create a Synth clip by default.
 
 #### <ins>Audio Clips</ins>
-- Added audio output modes, and changed audio clip monitoring to be seperate from source selection. Monitoring is now on 
+- Added audio output modes, and changed audio clip monitoring to be seperate from source selection. Monitoring is now on
 when the output is a SAMPLER or a LOOPER, chosen by turning the select knob in an audio clip.
 
 #### <ins>Instrument Clip View</ins>
 
 ##### Pad Rendering
-- Note velocity is now displayed in clips using colour intensities. The note head (the bright part) 
-now stands out from the tail in proportion to its velocity. At velocity 127 it is identical to official, 
+- Note velocity is now displayed in clips using colour intensities. The note head (the bright part)
+now stands out from the tail in proportion to its velocity. At velocity 127 it is identical to official,
 at velocity 0 it would look the same as its tail (but you can't have 0 velocity).
 
 ##### Scale Mode
@@ -74,7 +74,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
   - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid.
   - Hold a note row audition pad and press the select encoder to enter the note row editor menu. While in the note row editor menu, the selected note row's audition pad will blink. You can select other note row's by pressing the note row audition pad or by scrolling with the vertical encoder.
   - The iteration is now also customizable with custom iteration steps. If you scroll the iteration parameter all the way to the right, you will see the `CUSTOM` option. If you click the `SELECT` encoder, a new menu will appear to select the `DIVISOR` parameter (you can select from 1 to 8), and also as many `ITERATION #` toggles as `DIVISOR` is set, to allow you to activate or deactivate each iteration step.
-  
+
 ##### Recording
 - Enabled seamless linear recording of drone notes using audition pads or external midi.
   - When linear recording to a clip, you can seamlessly record a drone note using the audition pads or from external midi by continuing to audition / send a note until the linear recording stops. After linear recording stops, you can stop auditioning / send a note off and the drone note will persist without any breaks or re-triggering.
@@ -88,7 +88,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
   - Press `SELECT` to enter the `CV Instrument Menu`
   - Enter the  `CV 2 Source (CV2)` submenu
   - Select from `OFF, Y, Aftertouch, Velocity`
-  
+
 ##### MIDI Clips
 - Added ability to rename MIDI CC's in MIDI clips. Changes are saved by Instrument (e.g. per MIDI channel). Changes can be saved to a `MIDI preset`, with the `Song`, or to a `MIDI device definition file`. See documentation on [MIDI Device Definition Files](docs/features/midi_device_definition_files.md) for more info.
 - Added MIDI CC numbers and labels to `Gold (Mod) Encoder` popups.
@@ -124,7 +124,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
   - While in this menu, you just need to `hold a clip / section` and send midi to learn that clip / section. If you press the `clip / section` again you will unlearn it.
 - Added ability to `Midi Learn Instruments` and `Select the Audio Source for Audio Clips` in `Song Grid View Green Mode` by moving `Midi Learn Clip/Section Launch` actions to the `MIDI LEARN` menu mentioned above.
 - `Midi Learned Note Input for the Whole Kit` now persists between Kit preset changes.
-- Fixed unexpected behaviour for `Synth` and `Kit` clips that would cause `MIDI LEARNED PARAMS` to get lost when changing presets for Synth / Kits. 
+- Fixed unexpected behaviour for `Synth` and `Kit` clips that would cause `MIDI LEARNED PARAMS` to get lost when changing presets for Synth / Kits.
   - Note: for `Kit` clips it will migrate midi learn for `Kit Affect Entire` params only.
 - Added new learnable global command `LOAD NEXT SONG`, which when received while playing, it will queue to load the next song within the folder of the current song.
 
@@ -220,7 +220,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added new `ACTIONS` menu in the `Audio Clip Sound Menu` (Press `SELECT`).
 
 ##### Timestretching
-- Added new shortcut to set the length of an audio clip to the same length as its sample at the current tempo. This functionally removes timestretching until the Audio Clip length or Song tempo is changed. 
+- Added new shortcut to set the length of an audio clip to the same length as its sample at the current tempo. This functionally removes timestretching until the Audio Clip length or Song tempo is changed.
   - Press `▼︎▲︎` + `◀︎▶︎` to set the Audio Clip length equal to the length of the audio sample.
     - This action is also available in the `Audio Clip Sound Menu` (Press `SELECT`) by Selecting the `ACTIONS` menu and Pressing `SELECT` on the `Set Clip Length to Sample Length` action.
   - Press `SHIFT` + `◀︎▶︎` + `turn ◀︎▶︎` to adjust the audio clip's length independent of timestretching.
@@ -230,11 +230,11 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 ##### General
 - Added ability to sync LFO2. Where LFO1 syncs relative to the grid, LFO2 syncs relative to individual notes.
 - Added ability to set `CLIP NAMES`. MIDI, SYNTH and KIT clips can now be named. When in a the clip view, press `SHIFT` + `NAME` and enter the name of the clip. For KIT, its important to activate `AFFECT ENTIRE` to name the KIT clip. When on ARRANGER view with an OLED display, you are now able to scroll through the clip names when holding a clip pad and turning `SELECT` encoder.
-- Fixed a bug where pressing `UNDO` in a `KIT` could cause the `SELECTED DRUM` to change but not update the `GOLD KNOBS` so that they now control that updated kit row.  
+- Fixed a bug where pressing `UNDO` in a `KIT` could cause the `SELECTED DRUM` to change but not update the `GOLD KNOBS` so that they now control that updated kit row.
 - Fixed a bug where you could not turn `RECORDING OFF` while auditioning a note in an `INSTRUMENT CLIP`. With this fix you can now record drone notes when using `LINEAR RECORDING`.
 
 ##### Velocity View
-- Added `VELOCITY VIEW`, accessible from `AUTOMATION VIEW OVERVIEW` by pressing the `VELOCITY` shortcut, from `AUTOMATION VIEW EDITOR` by pressing `SHIFT OR AUDITION PAD + VELOCITY` or from `INSTRUMENT CLIP VIEW` by pressing `AUDITION PAD + VELOCITY`. 
+- Added `VELOCITY VIEW`, accessible from `AUTOMATION VIEW OVERVIEW` by pressing the `VELOCITY` shortcut, from `AUTOMATION VIEW EDITOR` by pressing `SHIFT OR AUDITION PAD + VELOCITY` or from `INSTRUMENT CLIP VIEW` by pressing `AUDITION PAD + VELOCITY`.
   - Velocity View enables you to edit the velocities and other parameters of notes in a single note row using a similar interface to `AUTOMATION VIEW`.
 
 ##### Scales
@@ -270,13 +270,13 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
     - If you just a tap a pad quickly to create a new clip, it will create that new clip using either the default clip type or the last clip type you created (if you enable this).
     - If you press and hold a pad, you can choose a different type to create in a number of ways:
       - by turning the select encoder to switch between the various clip types. You can create that clip type by pressing on the select encoder or letting go of the pad.
-      - by pressing one of the clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV`). 
+      - by pressing one of the clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV`).
       - If you let go of the pad without selecting a different type, it will create the clip using the last create type (or the last selected type if you changed selection using select encoder).
-    - If you press `BACK` before releasing a pad or selecting a clip type, it will cancel the clip creation.  
+    - If you press `BACK` before releasing a pad or selecting a clip type, it will cancel the clip creation.
     - These changes only apply to `SONG GRID VIEW` and NOT `SONG ROW VIEW`
 
 ##### Converting Empty Instrument Clips to Audio Clips
-- To convert an empty Instrument Clip to an Audio Clip, you will now use the `CLIP SETTINGS` menu described above. 
+- To convert an empty Instrument Clip to an Audio Clip, you will now use the `CLIP SETTINGS` menu described above.
 
 ##### Loop and Layering Loop Pads
 - Added community feature toggle `Grid View Loop Pads (LOOP)` to illuminate two pads (Red and Magenta) in the `GRID VIEW` sidebar for triggering the `LOOP` (Red) and `LAYERING LOOP` (Magenta) global MIDI commands to make it easier for you to loop in `GRID VIEW` without a MIDI controller.
@@ -309,8 +309,8 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added ability to scroll `KEYBOARD VIEW` horizontally using `<>` while editing Param values in the menu.
 
 ##### Chord Layouts
-- New `CHORDS` keyboard layout. The `CHORD` keyboard provides easy building and playing of in-scale chords. The `CHORD` keyboard provides two modes, a `ROW` mode, inspired by the Launchpad Pro, and a `COLUMN` mode, inspired by some of the features in the OXI one and others. 
-- New `CHORD LIBRARY` keyboard layout. `CHORD LIBRARY` keyboard is a library of chords split up into columns, where each column belongs to a specific root note. Going up and down the columns will play different chords of the same root note. Voicings can also be changed with pressing a pad and pressing the `◀︎▶︎` encoder and turning it. 
+- New `CHORDS` keyboard layout. The `CHORD` keyboard provides easy building and playing of in-scale chords. The `CHORD` keyboard provides two modes, a `ROW` mode, inspired by the Launchpad Pro, and a `COLUMN` mode, inspired by some of the features in the OXI one and others.
+- New `CHORD LIBRARY` keyboard layout. `CHORD LIBRARY` keyboard is a library of chords split up into columns, where each column belongs to a specific root note. Going up and down the columns will play different chords of the same root note. Voicings can also be changed with pressing a pad and pressing the `◀︎▶︎` encoder and turning it.
 - As the UI and implementation is still experimental, a community setting has to be activated to access the `CHORD`  and `CHORD LIBRARY` keyboards.
 
 ##### Kits
@@ -345,20 +345,20 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added an adapted version of the reverb found in Émilie Gillet's Mutable Instruments Rings module. Switch between reverb types within the new `MODEL` sub-menu under `SOUND > FX > REVERB`.
     - This `MUTABLE` reverb model has been set as the default reverb model for new songs. Old songs will respect the reverb model used with those songs.
 
-#### <ins>Compressors</ins>      
+#### <ins>Compressors</ins>
 - Added compressors to synths, kits, audio clips, and kit rows. The compressor can be enabled and edited from their respective menus.
 - Compressor behavior has been changed to reduce clipping. Songs made with community release 1.0.x may need to have their volume manually adjusted to compensate. This is done via affect entire in song/arranger mode, or by entering the `SONG MENU` by pressing `SELECT` in Song View and navigating to  `MASTER > VOLUME`
 
 #### <ins>Polyphony / Voice Count </ins>
 - Added new `Max Voices (VCNT)` menu which lets you configure the Maximum number of Voices for a Polyphonic instrument
-- Updated default `Max Voices` for new synth's to `8 voices`. Old synths for which a max number of voices has not been configured will default to `16 voices`. 
+- Updated default `Max Voices` for new synth's to `8 voices`. Old synths for which a max number of voices has not been configured will default to `16 voices`.
 
 ### User Interface
 
 #### <ins>General</ins>
 - Added a feature which saves user-defined pad brightness level and restores it at startup. `SETTINGS>DEFAULTS>PAD BRIGHTNESS`
 - Added new `High CPU Usage Indicator`. The `PLAY` button button will blink when deluge CPU usage is high which indicates that synth voices / sample playback may be culled.
-  - To activate the feature, press `SHIFT` + `SELECT` : `MENU > DEFAULTS > HIGH CPU INDICATOR`.  
+  - To activate the feature, press `SHIFT` + `SELECT` : `MENU > DEFAULTS > HIGH CPU INDICATOR`.
 - Added new default menu to set the length of time to register a `Hold Press` for use with `Sticky Shift`, `Performance View`, and the `Keyboard Sidebar Layouts.`
   - Set the default Hold Press time by accessing `SETTINGS > DEFAULTS > HOLD PRESS TIME`
 - Fixed numerous bugs, including some crash bugs, around the display of `QUANTIZED STUTTER`.
@@ -375,14 +375,14 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added parameter names (including mod matrix / patch cable mappings) to Mod (Gold) Encoder popups.
 - `ARRANGER VIEW` and `SONG VIEW` now display the name of the current view on the screen.
 - The 12TET note name is now displayed along with the MIDI note number.
-- Added a new community setting which allows emulating the 7SEG style on the OLED display. When set to `TOGGLE` press `SHIFT`+`LEARN/INPUT`+`AFFECT ENTIRE` to switch to the emulated 7SEG display. 
+- Added a new community setting which allows emulating the 7SEG style on the OLED display. When set to `TOGGLE` press `SHIFT`+`LEARN/INPUT`+`AFFECT ENTIRE` to switch to the emulated 7SEG display.
 - Fixed several cases where popups could get stuck open.
 - Fixed a number of minor rendering bugs.
 
 #### <ins>Mod (Gold Encoders)</ins>
 - Added Mod Button popups to display the current Mod (Gold) Encoder context (e.g. LPF/HPF Mode, Delay Mode and Type, Reverb Room Size, Compressor Mode, ModFX Type and Param).
-- Mod (Gold) Encoders learned to the Mod Matrix can now access the full range of the Mod Matrix / Patch Cable parameters (Values from -50 to +50 where previously only 0 to +50 were accesible via Mod (Gold) Encoders).  
-- Mod (Gold) Encoder LED indicators are now bipolar for bipolar params (e.g. `PAN`, `PITCH`, Patch Cables). Positive values illuminate the top two LEDs. Negative values illuminate the bottom two LEDs. The middle value doesn't light up any LEDs. 
+- Mod (Gold) Encoders learned to the Mod Matrix can now access the full range of the Mod Matrix / Patch Cable parameters (Values from -50 to +50 where previously only 0 to +50 were accesible via Mod (Gold) Encoders).
+- Mod (Gold) Encoder LED indicators are now bipolar for bipolar params (e.g. `PAN`, `PITCH`, Patch Cables). Positive values illuminate the top two LEDs. Negative values illuminate the bottom two LEDs. The middle value doesn't light up any LEDs.
 
 #### <ins>Startup Song</ins>
 - Added feature to automatically load song projects at startup.
@@ -393,14 +393,14 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 #### <ins>Performance View</ins>
 - Added `PERFORMANCE VIEW`, accessible in Song View by pressing the Keyboard button. Allows quick control of Song Global FX.
 
-#### <ins>Automation View</ins>  
+#### <ins>Automation View</ins>
 - Added `AUTOMATION VIEW` for Audio Clips and Arranger View.
 - Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to access the `AUTOMATION VIEW EDITOR` for that specific Patch Cable / Modulation Depth.
   - You can also use the `SELECT ENCODER` while in the `AUTOMATION VIEW EDITOR` to scroll to any patch cables that exist.
 - Updated `AUTOMATION VIEW EDITOR` to allow you to edit Bipolar params according to their Bipolar nature. E.g. positive values are shown in the top four pads, negative value in the bottom four pads, and the middle value (0) is shown by not lighting up any pads.
 - Updated `AUTOMATION VIEW` for MIDI Clips to load the Parameter to CC mappings from the `MIDI FOLLOW MODE` preset file `SETTINGS/MIDIFollow.XML`. These Parameter to CC mappings are used as the quick access MIDI CC shortcuts dislayed in the Automation Overview and with the shortcut combos (e.g. `SHIFT` + `SHORTCUT PAD`).
 - Updated `AUTOMATION VIEW` to move the `INTERPOLATION` shortcut to the `INTERPOLATION` pad in the first column of the Deluge grid (second pad from the top). Toggle interpolation on/off using `SHIFT` + `INTERPOLATION` shortcut pad. The Interpolation shortcut pad will blink to indicate that interpolation is enabled.
-- Updated `AUTOMATION VIEW` to move the `PAD SELECTION MODE` shortcut to the `WAVEFORM` pad in the first column of the Deluge grid (very top left pad). Toggle pad selection mode on/off using `SHIFT` + `WAVEFORM` shortcut pad. The Waveform shortcut pad will blink to indicate that pad selection mode is enabled.  
+- Updated `AUTOMATION VIEW` to move the `PAD SELECTION MODE` shortcut to the `WAVEFORM` pad in the first column of the Deluge grid (very top left pad). Toggle pad selection mode on/off using `SHIFT` + `WAVEFORM` shortcut pad. The Waveform shortcut pad will blink to indicate that pad selection mode is enabled.
 - Updated `AUTOMATION VIEW` to provide access to `SETTINGS` menu (`SHIFT` + press `SELECT`)
 - Updated `AUTOMATION VIEW` to provide access to the `SOUND` menu (press `SELECT`)
 - Updated automatable parameter editing menus (accessed via `SOUND` menu or `SHIFT + PARAMETER SHORTCUT`) to provide the ability to access the `AUTOMATION VIEW EDITOR` directly from the parameter menu. While in the parameter menu press `CLIP` (if you are in a clip) or `SONG` (if you are in arranger) to open the `AUTOMATION VIEW EDITOR` for that respective parameter or patch cable.
@@ -439,7 +439,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added Synth/MIDI/CV clip configuration of note row play direction. Hold `AUDITION` while entering the `PLAY DIRECTION` menu to set the play direction for the selected note row. While in the note row play direction menu, you can select other note rows to quickly set the play directiom for multiple note rows.
 
 ##### Midi
-- Added ability to save and load MIDI presets. They end up in a new folder named MIDI.  
+- Added ability to save and load MIDI presets. They end up in a new folder named MIDI.
 
 ##### Kits
 - Added a `KIT FX MENU` to KITS which allows you to customize the AFFECT ENTIRE KIT parameters with greater control.   Accessible in `KIT CLIP VIEW` by pressing `SELECT` with `AFFECT ENTIRE` enabled.
@@ -470,13 +470,13 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Added support for 5 and 6 note scales.
 - Added 8 new built-in scales: Melodic Minor, Hungarian Minor, Marva (Indian), Arabian, Whole Tone, Blues, Pentatonic Minor, Hirajoshi.
 
-#### <ins>Clip Launch Modes</ins>  
-- Added `ONCE CLIP` launch mode, which allows a clip to play just once when launched and then mute itself. Settable in Song's `ROWS VIEW` by holding the `MUTE` pad of a row and then pressing `SELECT`. 
+#### <ins>Clip Launch Modes</ins>
+- Added `ONCE CLIP` launch mode, which allows a clip to play just once when launched and then mute itself. Settable in Song's `ROWS VIEW` by holding the `MUTE` pad of a row and then pressing `SELECT`.
 
 #### <ins>Note Probability</ins>
 - Added `NOT FILL` note probability. Similar to the `FILL` probability but only plays when the `FILL` button is *not* pressed. When the `SYNC-SCALING` button is held, `NOT FILL` notes will be highlighted in red color, as opposed to blue for `FILL` notes.
 
-#### <ins>Note Copy/Paste</ins>  
+#### <ins>Note Copy/Paste</ins>
 - Added support for copy/paste of single rows.
 - Added support for notes to `PASTE GENTLY` which pastes notes without removing old ones.
 
@@ -490,7 +490,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Fixed CC74 on the MPE master channel behaving like an expression event.
 
 #### <ins>Learn</ins>
-- Added MIDI learning of `SONG` and `KIT AFFECT ENTIRE` params.  
+- Added MIDI learning of `SONG` and `KIT AFFECT ENTIRE` params.
 - Added MIDI learn for kits, allowing a whole kit to be learnt to the same midi channel at once. The incoming note is the first row, and increasing notes (chromatically) go to the next rows.
 - Added support for learning Program Change methods for most global commands.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -94,7 +94,7 @@ The following requirements must be fulfilled for a Pull request to be mergable t
 * All project files, especially source files need to have a compatible license with the project.
   See [LICENSE](../LICENSE).
 * There is no written standard on code guidelines yet but please make your code match the existing style as much as possible.
-* Exception: the old code uses GOTOs and single returns heavily - new C++ code should favour other flow control methods 
+* Exception: the old code uses GOTOs and single returns heavily - new C++ code should favour other flow control methods
   and early returns instead, the old code is a result of the project's roots in C.
 * Clang Format runs on CI following the config in .clang-format. As there are slight differences between versions, we
   provide a command "./dbt format" to run the CI version exactly, which should gaurantee that your PR passes the checks
@@ -204,22 +204,22 @@ need to use in the command to authenticate with the Deluge.
 The `loadfw` command should automatically identify the correct MIDI port, as long as you are connected directly via USB.
 
 The first time you run it, the command will ask you for the key code you from the Deluge menu. The code is cached in
-`.deluge_hex_key` file in the DelugeFirmware directory, if it changes delete the file to have `loadfw` ask again for the key. 
+`.deluge_hex_key` file in the DelugeFirmware directory, if it changes delete the file to have `loadfw` ask again for the key.
 
 More instructions available via:
 `./dbt loadfw -h`
 
-**NOTE:** loadfw *can not* flash the new firmware to the permanent memory of the Deluge. 
+**NOTE:** loadfw *can not* flash the new firmware to the permanent memory of the Deluge.
 It is only loaded to RAM and then executed. Consequences:
 * **Good:** After switching off and on again, Deluge will boot from the last firmware flashed to permanent memory *from the SD card*.
 This is great for development, because if your changes crash the Deluge, just switch it off and on again and you are instantly back to the last
 (hopefully stable) version that was flashed from SD card.
 * **Meh**: If you want to keep your updated firmware on the Deluge persistently, i.e. surviving a power cycle, you *have to* physically copy it to your SD card
 and update it as described in https://github.com/SynthstromAudible/DelugeFirmware/wiki#updating-firmware
-* **Possibly bad:** *In rare cases* the firmware can behave differently when uploaded via loadfw than when actually flashed from SD card. 
+* **Possibly bad:** *In rare cases* the firmware can behave differently when uploaded via loadfw than when actually flashed from SD card.
 While this should only be relevant when changing low-level code executed at boot time,
 **please** always verify that your firmware also works when actually flashed from SD card,
-especially before making a pull request (ask me how I know...). 
+especially before making a pull request (ask me how I know...).
 
 ### Printing debug log messages on the console
 
@@ -263,28 +263,28 @@ This is a sample of the output:
 
 ### Deluge Crash Reader Discord Bot
 
-If deluge crashes, there is a colorful pixelated image that gets displayed across the main pads and sidebar. In case 
-of a CPU fault or C++ exception, the handler will print the last link register address and as many pointers to the code 
-section it can find in the stack data. The main pads display 4 32-bit numbers which are the addresses. Every color block 
+If deluge crashes, there is a colorful pixelated image that gets displayed across the main pads and sidebar. In case
+of a CPU fault or C++ exception, the handler will print the last link register address and as many pointers to the code
+section it can find in the stack data. The main pads display 4 32-bit numbers which are the addresses. Every color block
 is one address. Each pad is a bit, 1 is lit, 0 is unlit. The most significant bit is at the lower left corner
-of the color block, and the least significant bit is at the top right. Each column is one byte, reading along a single 
-column from bottom row to top row first, then incrementing to the next column from left to right. Rotating Deluge 90 
-degrees to the right makes it easy to read and enter the bytes into Windows calculator. However, we have created a 
+of the color block, and the least significant bit is at the top right. Each column is one byte, reading along a single
+column from bottom row to top row first, then incrementing to the next column from left to right. Rotating Deluge 90
+degrees to the right makes it easy to read and enter the bytes into Windows calculator. However, we have created a
 Deluge Crash Reader Discord Bot which can decode the addresses for you from a picture of the pads.
 
 The red sidebar is the first 4 chars of commit ID. Pink color in main pads means it's from ARM USR mode. Blue would be
-SYS mode. Stack pointers will alternate green and light blue. 
+SYS mode. Stack pointers will alternate green and light blue.
 
-The Deluge Crash Reader Discord Bot uses image recognition to decode the pad lights for you if you post a picture of 
-your Deluge to the nightly-testing channel on the Deluge Discord. Take a photo of your deluge, make sure all the pad 
-LEDs are inside the photo, then post it in the channel, and the robot should output the decoded addresses and the 
+The Deluge Crash Reader Discord Bot uses image recognition to decode the pad lights for you if you post a picture of
+your Deluge to the nightly-testing channel on the Deluge Discord. Take a photo of your deluge, make sure all the pad
+LEDs are inside the photo, then post it in the channel, and the robot should output the decoded addresses and the
 command used to investigate the addresses.
 
 For example, after posting a picture, the Deluge Crash Reader might output a message similar to this:
 
-Thanks for the image @username!, try running  
-I couldn't find a recent matching commit for `0x714a`  
-`arm-none-eabi-addr2line -Capife build/Release/deluge.elf 0x200a2f5b 0x200f3100 0x200fe6c1 0x2006dfe7 `  
+Thanks for the image @username!, try running
+I couldn't find a recent matching commit for `0x714a`
+`arm-none-eabi-addr2line -Capife build/Release/deluge.elf 0x200a2f5b 0x200f3100 0x200fe6c1 0x2006dfe7 `
 
 Then run the command that Deluge Crash Reader Bot outputs. This outputs the latest stack trace before hard crashing.
 (If you're on Windows and using VS Code, try running `.\dbt.cmd shell` first in your terminal.)

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -6,7 +6,7 @@ Goal of the DelugeFirmware community is to produce high quality firmware applica
 
 ## Development strategy
 
-In order to give everyone in the project clear expectations and transparency on what is going on, all development is organized in the form of Pull requests. This ensures visibility on the ongoing activities and prevents intransparent internal changes from disrupting community work. 
+In order to give everyone in the project clear expectations and transparency on what is going on, all development is organized in the form of Pull requests. This ensures visibility on the ongoing activities and prevents intransparent internal changes from disrupting community work.
 
 There is no official roamdap or project activities, instead all contributors are welcome to participate in the discussion and planning process as outlined in the [contribution guidelines](CONTRIBUTING.md). Members of the community can build informal working groups to achieve greater goals and work on them in the form of collaborative Pull requests.
 
@@ -21,7 +21,7 @@ There are `nightly` releases covering all changes of the day as well as stable `
 
 `community` (stable) releases:
 * Community releases will be done in a three months cycle at the end of January, April, July and October
-* Before every release a special release candidate branch is created from the community branch at that time. This branch only merges bugfixes and no new features from the community branch. 
+* Before every release a special release candidate branch is created from the community branch at that time. This branch only merges bugfixes and no new features from the community branch.
 * Until release, users and developers can test the release candidate and make sure it is of high quality for the final release on GitHub Releases tagged as `community`.
 
 ## What to expect and when to expect it

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -27,8 +27,8 @@ back up your SD card!
 ## 2. UI Changes from Official
 
 #### 2.1 Velocity Rendering
-- Note velocity is now displayed in clips using colour intensities. The note head (the bright part) 
-now stands out from the tail in proportion to its velocity. At velocity 127 it is identical to official, 
+- Note velocity is now displayed in clips using colour intensities. The note head (the bright part)
+now stands out from the tail in proportion to its velocity. At velocity 127 it is identical to official,
 at velocity 0 it would look the same as its tail (but you can't have 0 velocity).
 
 
@@ -53,7 +53,7 @@ Here is a list of general improvements that have been made, ordered from newest 
   converts poly y-axis to mod wheel and poly pitch bend to an average monophonic pitch bend. For y axis and aftertouch
   the highest value wins.
 
-- ([#2343]) Allow converting output Y axis to mod wheel (cc1) to support synths with a limited MPE implementation, such 
+- ([#2343]) Allow converting output Y axis to mod wheel (cc1) to support synths with a limited MPE implementation, such
 as the micromonsta and the dreadbox nymphes.
 
 #### 3.3 - MIDI
@@ -74,7 +74,7 @@ as the micromonsta and the dreadbox nymphes.
 
   **2. `PICKUP`:** The Deluge will ignore changes to its internal encoder position/Parameter value until the MIDI
   encoder/Fader's position is equal to the Deluge encoder position. After which the MIDI encoder/Fader will move in sync
-  with the Deluge. 
+  with the Deluge.
     - Note: this mode will behave like the `JUMP` mode when you are recording or step editing automation.
 
   **3. `SCALE`:** The Deluge will increase/decrease its internal encoder position/Parameter value relative to the change
@@ -113,7 +113,7 @@ as the micromonsta and the dreadbox nymphes.
           go up a tone, and after that a D5 will go up an octave, or a D3 will go down etc.
     - **Limitation** Just as with setting transposition from the encoders, a new transpose event will cut off currently
       playing notes. If this is done from a MIDI clip, it can cut off notes right at the start so they are never heard.
-      Clip playback ensures transpose clips play first to affect new notes starting at the same position correctly, 
+      Clip playback ensures transpose clips play first to affect new notes starting at the same position correctly,
       but any already sounding notes will be stopped.
 
 - ([#889]) `Master MIDI Follow Mode` whereby after setting a master MIDI follow channel for Synth/MIDI/CV clips, Kit
@@ -269,8 +269,8 @@ as the micromonsta and the dreadbox nymphes.
 #### 3.18 - Select Audio Clip Source and Monitoring
 - ([#1531]) Added ability to select audio source from within an Audio Clip by opening the Audio Clip Sound Menu (`SHIFT` + `SELECT`) and Selecting the `AUDIO SOURCE` menu
   - Not included in c1.1.0
-- ([#2371]) Source can now also be set to a specific track on the deluge. This enables an additional TRACK menu to choose 
-which track to record from. The source can also be selected by pressing a clip's pad while in the audio source selection menu. 
+- ([#2371]) Source can now also be set to a specific track on the deluge. This enables an additional TRACK menu to choose
+which track to record from. The source can also be selected by pressing a clip's pad while in the audio source selection menu.
 - ([#2702]) Monitoring is now set by the audio output mode. This is done by turning the select encoder
 
     - Player: Monitoring is off, overdubs work by cloning. This is intended to be used for playing a static audio file or recording without monitoring.
@@ -280,14 +280,14 @@ which track to record from. The source can also be selected by pressing a clip's
     - Looper: Monitoring is on and remains on. Overdubs do a real overdub in place. This is intended for live looping or use as an fx processor
 
 #### 3.19 - Set Audio Clip Length Equal to Sample Length
-- ([#1542]) Added new shortcut to set the length of an audio clip to the same length as its sample at the current tempo. This functionally removes timestretching until the Audio Clip length or Song tempo is changed. 
+- ([#1542]) Added new shortcut to set the length of an audio clip to the same length as its sample at the current tempo. This functionally removes timestretching until the Audio Clip length or Song tempo is changed.
   - Press `▼︎▲︎` + `◀︎▶︎` to set the Audio Clip length equal to the length of the audio sample.
     - This action is also available in the `Audio Clip Sound Menu` (Press `SELECT`) by Selecting the `ACTIONS` menu and Pressing `SELECT` on the `Set Clip Length to Sample Length` action.
   - Press `SHIFT` + `◀︎▶︎` + `turn ◀︎▶︎` to adjust the audio clip's length independent of timestretching.
 
 #### 3.20 - Sample Slice Default Mode
 
-- ([#1589]) Added a new default setting that controls which playback mode new slices of a kit will get. 
+- ([#1589]) Added a new default setting that controls which playback mode new slices of a kit will get.
 -  To change the setting, press `SHIFT` + `SELECT` : `MENU > DEFAULTS > SAMPLE SLICE MODE`.
 - every new slice in a kit using the slicer will now get one of the modes by default
   -  `CUT`, `ONCE`, `LOOP`, `STRETCH`
@@ -337,7 +337,7 @@ which track to record from. The source can also be selected by pressing a clip's
     - If you just a tap a pad quickly to create a new clip, it will create that new clip using either the default clip type or the last clip type you created (if you enable this).
     - If you press and hold a pad, you can choose a different type to create in a number of ways:
       - by turning the select encoder to switch between the various clip types. You can create that clip type by pressing on the select encoder or letting go of the pad.
-      - by pressing one of the clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV`). 
+      - by pressing one of the clip type buttons (e.g. `SYNTH`, `KIT`, `MIDI`, `CV`).
       - If you let go of the pad without selecting a different type, it will create the clip using the last create type (or the last selected type if you changed selection using select encoder).
     - If you press `BACK` before releasing a pad or selecting a clip type, it will cancel the clip creation.
 - These changes only apply to `SONG GRID VIEW` and NOT `SONG ROW VIEW`
@@ -346,7 +346,7 @@ which track to record from. The source can also be selected by pressing a clip's
 - ([#2299]) Holding a clip in `SONG GRID VIEW` or the status pad for a clip in `SONG ROW VIEW` and pressing `SELECT` brings up a `CLIP SETTINGS` menu.
 - If you open the menu with with an `INSTRUMENT CLIP` selected, then the menu will give you three options:
   1) `Convert to Audio`: Press select on this option to convert the selected `instrument clip` into an `audio clip`. The menu will exit after converting the clip.
-    - Note: for `SONG ROW VIEW`, you can still convert an empty instrument clip to an audio clip the regular way by holding a pad for that clip in the main grid and pressing select.  
+    - Note: for `SONG ROW VIEW`, you can still convert an empty instrument clip to an audio clip the regular way by holding a pad for that clip in the main grid and pressing select.
   2) `Clip Mode`: Press select on this option to enter the `Clip Mode` menu so you can change the Clip Mode between `INFINITE`, `FILL` and `ONCE`.
   3) `Clip Name`: Press select on this option to enter the `Clip Name` UI to set the name for the clip.
 - If you open the menu with an `AUDIO CLIP` selected, then the menu will give two options: `Clip Mode` and `Clip Name`.
@@ -360,7 +360,7 @@ which track to record from. The source can also be selected by pressing a clip's
 #### 3.31 Added ability to Start / Restart Playback from Specific Clip Pad in Arranger View
 - ([#2615]) Added ability to start / restart arrangement playback from the clip pad you're holding in arranger view.
   - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
-  
+
 #### 3.32 Added Song New Midi Learn Menu
 - ([#2645]) Added new `MIDI LEARN` menu to the `SONG` menu. In `Song Grid View` this menu enables you to learn `Clip/Section Launch`. In `Song Row View` this menu enables you to learn the `Clip/Section Launch` and `Instrument`.
   - While in this menu, you just need to `hold a clip / section` and send midi to learn that clip / section. If you press the `clip / section` again you will unlearn it.
@@ -368,7 +368,7 @@ which track to record from. The source can also be selected by pressing a clip's
 #### 3.33 Updated UI for Creating New Clips in Song Row View
 - ([#2716]) The default clip type for new clips created can be configured in `SETTINGS > DEFAULTS > UI > CLIP TYPE > NEW CLIP TYPE` menu.
     - You can also configure whether the clip type for the next clip type you create should default to the last clip type you created. This helps with fast creation of multiple clips of the same type. You can enable this default setting in the `SETTINGS > DEFAULTS > UI > CLIP TYPE > USE LAST CLIP TYPE` menu.
-    - NOTE: The default clip type / last clip type setting cannot be used with CV clips and Audio clips in Song Row View. If you set the default to CV or Audio or enable use of the last clip type (and the last clip type is a CV or Audio Clip), then it will create a Synth clip by default. 
+    - NOTE: The default clip type / last clip type setting cannot be used with CV clips and Audio clips in Song Row View. If you set the default to CV or Audio or enable use of the last clip type (and the last clip type is a CV or Audio Clip), then it will create a Synth clip by default.
         - This is because Audio Clips cannot currently be converted to other clip types and thus you will be stuck with only being able to create Audio Clips (unless you change the default and/or disable use of last clip type). The same applies to CV clips, which after two CV clips created, would prevent you from creating other clips (unless you change the default and/or disable use of last clip type).
 
 #### 3.34 Threshold Recording
@@ -385,7 +385,7 @@ which track to record from. The source can also be selected by pressing a clip's
 #### 3.35 Polyphony / Voice Count
 - ([#1824]) Added new `Max Voices (VCNT)` menu which lets you configure the Maximum number of Voices for a Polyphonic instrument, accessible by pressing `SELECT` in a `Synth clip` or `Kit clip with a Sound Drum selected and Affect Entire Off` under the `VOICE (VOIC)` menu.
   - This menu is also accessible from the `VOICE (VOIC) > Polyphony Type (POLY)` type menu by selecting `Polyphonic` and pressing `SELECT`
-- Updated default `Max Voices` for new synth's to `8 voices`. Old synths for which a max number of voices has not been configured will default to `16 voices`. 
+- Updated default `Max Voices` for new synth's to `8 voices`. Old synths for which a max number of voices has not been configured will default to `16 voices`.
 
 ## 4. New Features Added
 
@@ -400,7 +400,7 @@ Here is a list of features that have been added to the firmware as a list, group
   -related gold encoder (`FULL` mode). The top LED will become a compression meter. Clicking the `REVERB`-related lower
   gold encoder will cycle through additional params: `RATIO` (displays ratio), `ATTACK` & `RELEASE` (shown in
   milliseconds) and Sidechain `HPF` (shown in Hz). The sidechain HPF is useful to remove some bass from the compressor
-  level detection, which sounds like an increase in bass allowed through the compression. There is also a blend control 
+  level detection, which sounds like an increase in bass allowed through the compression. There is also a blend control
   to allow parallel compression.
 
     - `ATTACK`: 0ms - 63ms
@@ -412,7 +412,7 @@ Here is a list of features that have been added to the firmware as a list, group
     - `RATIO`: 2:1 - 256:1
 
     - `THRESHOLD`: 0 - 50
-  
+
     - `BLEND` : 0-100%
 - ([#1173]) In clip view, the settings are available under the COMPRESSOR menu entry. The same parameters exist there.
   In kits there is both a per row compressor, accessed through the menu when affect entire is off, and a kit compressor
@@ -426,7 +426,7 @@ Here is a list of features that have been added to the firmware as a list, group
 #### 4.1.3 - Fill Clips and Once Clips
 
 - ([#196] and [#1018]) Holding a clip in `SONG GRID VIEW` or the status pad for a clip in `SONG ROW VIEW` and pressing `SELECT` brings up a `CLIP SETTINGS` menu. In this menu, you will find a submenu for `CLIP MODE`.
-  
+
   The `CLIP MODE` menu enables you the set the following launch style options for a clip:
     - **`INFINITE (INF)`** - the default Deluge launch style.
     - **`Fill (FILL)`** - Fill clip.
@@ -471,7 +471,7 @@ Here is a list of features that have been added to the firmware as a list, group
             - `Default active mode:` "Selection" allows changing the mode as described below, all other settings will
               always make mode snap back to the configured one (default Selection)
             - `Select in green mode:` Enabling this will make allow holding clips in green (launch) mode to change their
-              parameters like in blue mode, tradeoff is arming is executed on finger up (default on). 
+              parameters like in blue mode, tradeoff is arming is executed on finger up (default on).
                 - In addition, with this mode enabled, if you hold a clip and press the clip button you will enter that clip.
             - `Empty pad unarm:` Enabling will make pressing empty pads in a track unarm all playing tracks in that
               track (default off)
@@ -505,11 +505,11 @@ Here is a list of features that have been added to the firmware as a list, group
         5. You can press `RECORD` to stop recording or press that new clip to stop recording.
         6. Repeat steps as required.
 - ([#2421]) Allow true overdubbing for grid audio clips
-  - Traditional guitar style looping is now possible for audio clips in grid mode. To use it monitoring must be active 
+  - Traditional guitar style looping is now possible for audio clips in grid mode. To use it monitoring must be active
   - The loop will capture all fx in the audio clip (e.g. it's recording at the end of the signal chain) and then reset the fx
   - LOOP will begin an auto extending overdub. The initial sample will loop and the clip will extend as you keep playing
   - Pressing LOOP again will end recording quantized to the original length (e.g. LOOPing on a 1-bar clip will quantize to 1 bar)
-    - This works similarly to increasing loop length on an EDP style looper but without needing to set it in advance 
+    - This works similarly to increasing loop length on an EDP style looper but without needing to set it in advance
   - LAYER will continuously layer over the existing audio without extending the loop
     - This works like an overdub on a pedal style looper
   - Only the midi loop commands work at this time but loop controls will be added to grid down the road
@@ -574,11 +574,11 @@ Here is a list of features that have been added to the firmware as a list, group
 ### 4.1.9 - Song macros
 
 Macros are a way to quickly switch playing clips without needing to go into song view.
-From song view, open the `SONG MENU` and enter the `CONFIGURE MACROS` menu to edit macros. 
+From song view, open the `SONG MENU` and enter the `CONFIGURE MACROS` menu to edit macros.
 
-There are 8 macro slots shown in the left sidebar. 
+There are 8 macro slots shown in the left sidebar.
 
-To assign a macro, first select a macro slot and then press a clip in the grid. 
+To assign a macro, first select a macro slot and then press a clip in the grid.
 
 Pressing the same clip multiple time cycles though different modes:
 
@@ -591,9 +591,9 @@ After assigning a clip to a slot, you can press the macro slot to see what clip 
 
 Inside a `CLIP TIMELINE VIEW`, hold `SONG` button and press the `LEFT SIDEBAR` to launch a macro.
 
-In `KEYBOARD VIEW`, macros are available as a sidebar control. 
+In `KEYBOARD VIEW`, macros are available as a sidebar control.
 
-`SHIFT` makes the launch immediate just like in song view. 
+`SHIFT` makes the launch immediate just like in song view.
 
 `AFFECT ENTIRE` + `CLIP MACRO` can be used to jump to edit the clip.
 
@@ -622,9 +622,9 @@ In `KEYBOARD VIEW`, macros are available as a sidebar control.
 
 #### 4.2.4 - Warbler Effect
 
-- ([#2712]) New Warble fx, which provides randomly warbling pitch shifting and delays to simulate things from a tape reel 
-warbling up to getting chewed up by the machine and spat back out. It's essentially a flanger/chorus/whatever based modulation 
-abomination that makes super cool lofi warbley noises. It essentially consists of two things, a randomly drifting vibrato 
+- ([#2712]) New Warble fx, which provides randomly warbling pitch shifting and delays to simulate things from a tape reel
+warbling up to getting chewed up by the machine and spat back out. It's essentially a flanger/chorus/whatever based modulation
+abomination that makes super cool lofi warbley noises. It essentially consists of two things, a randomly drifting vibrato
 and a comb filter. Controls are the normal rate/depth/feedback/offset.
 
     - To make a tape warble type thing set rate to 15ish, depth to 5-10, feedback 0-2 and offset at 25
@@ -636,7 +636,7 @@ and a comb filter. Controls are the normal rate/depth/feedback/offset.
     - Turning feedback up makes it get super weird
 
     - Turning offset up adds phasing (unless feedback is 0, in which case it does nothing)
-  
+
 #### 4.2.5 - Grain FX
 
 - ([#363] and [#2815]) New `GRAIN` added to Mod FX.
@@ -815,7 +815,7 @@ to each individual note onset. ([#1978])
           press Clip (if you are in a clip) or Song (if you are in arranger) to open the `AUTOMATION VIEW EDITOR` while you are still in the menu. You will be able to interact with the grid to edit automation for the current parameter / patch cable selected in the menu.
     - ([#1374]) Added `AUTOMATION VIEW` for `PATCH CABLES / MODULATION DEPTH`. Simply enter the modulation menu that displays `SOURCE -> DESTINATION` and then press `CLIP` to access the `AUTOMATION VIEW EDITOR` for that specific Patch Cable / Modulation Depth.
       - ([#1607]) You can also use the `SELECT ENCODER` while in the `AUTOMATION VIEW EDITOR` to scroll to any patch cables that exist.
-    - ([#1456]) Added an in-between-layer in the Deluge menu system to be able to access and interact with the `AUTOMATION VIEW EDITOR` while you are still in the menu from the regular `ARRANGER / CLIP VIEW`. When you exit the menu you will be returned to the View you were in prior to entering the menu. Press Clip (if you are in a clip) or Song (if you are in arranger) to temporarily open the `AUTOMATION VIEW EDITOR` while you are still in the menu.    
+    - ([#1456]) Added an in-between-layer in the Deluge menu system to be able to access and interact with the `AUTOMATION VIEW EDITOR` while you are still in the menu from the regular `ARRANGER / CLIP VIEW`. When you exit the menu you will be returned to the View you were in prior to entering the menu. Press Clip (if you are in a clip) or Song (if you are in arranger) to temporarily open the `AUTOMATION VIEW EDITOR` while you are still in the menu.
     - ([#1480]) As a follow-up to [#1374] which enabled enabled patch cables to be edited in Automation View, the Automation Editor has now been modified to display param values according to whether the Param is bipolar or not. If it's a bipolar param, the grid will light up as follows:
       - Middle value = no pads lit up
       - Positive value = top 4 pads lit up according to position in middle to maximum value rnage
@@ -823,7 +823,7 @@ to each individual note onset. ([#1978])
       - Note: per the functionality added in [#887] mentioned above, you can set a param to the middle value by pressing the two pads in a column or you can use the fine tuning method with the gold encoders in or out of pad selection mode by selecting a pad and turning gold encoder.
       - To make it easier to set the middle value, functionality has been added to blink the LED indicators when you reach the middle value and it also makes it more difficult to turn the knob past the middle value as it currently did outside automation view editor.
     - ([#1898] [#2136]) Change pad selection mode shortcut.
-      - Updated `AUTOMATION VIEW` to move `PAD SELECTION MODE` shortcut to the `WAVEFORM` pad in the first column of the Deluge grid (very top left pad). Toggle pad selection mode on/off using `SHIFT` + `WAVEFORM` shortcut pad. The Waveform shortcut pad will blink to indicate that pad selection mode is enabled.    
+      - Updated `AUTOMATION VIEW` to move `PAD SELECTION MODE` shortcut to the `WAVEFORM` pad in the first column of the Deluge grid (very top left pad). Toggle pad selection mode on/off using `SHIFT` + `WAVEFORM` shortcut pad. The Waveform shortcut pad will blink to indicate that pad selection mode is enabled.
 
 #### 4.3.6 - Set Probability By Row
 
@@ -1039,17 +1039,17 @@ to each individual note onset. ([#1978])
       messages from norns.
     - The functionality of the grid changes with each norns script.
 
-  **1.** Connect Deluge to norns with a USB cable for MIDI.  
+  **1.** Connect Deluge to norns with a USB cable for MIDI.
   **2.** Install [Midigrid](https://llllllll.co/t/midigrid-use-launchpads-midi-grid-controllers-with-norns/42336/) on
-  your norns, turn on the mod, set to 128 grid size.  
+  your norns, turn on the mod, set to 128 grid size.
   **3.** Turn on two features in the `COMMUNITY FEATURES` menu (via `SETTINGS > COMMUNITY FEATURES`): "Highlight
-  Incoming Notes" (HIGH) and "Norns Layout" (NORN) both set to ON.  
+  Incoming Notes" (HIGH) and "Norns Layout" (NORN) both set to ON.
   **4.** Create a MIDI clip on Deluge by pressing `MIDI` button in Clip View. Set MIDI output for the clip to channel 16
-  by turning the `SELECT` encoder.  
+  by turning the `SELECT` encoder.
   **5.** Select the keyboard layout on the MIDI clip. Press and hold keyboard button and turn `SELECT` encoder to
-  select "Norns Layout" (NORN).  
+  select "Norns Layout" (NORN).
   **6.** Select a [script](https://norns.community/) on norns that supports grid controls (awake, boingg,
-  rudiments, ... ).  
+  rudiments, ... ).
   **7.** The grid LEDs should light up indicating that norns is sending MIDI notes out on channel 16 to Deluge. Press a
   pad to see a change on norns indicating Deluge is sending MIDI notes out on channel 16.
 
@@ -1249,7 +1249,7 @@ as an oscillator type within the subtractive engine, so it can be combined with 
   - To save the `MIDI CC` labels to a `MIDI Device Definition File`, hold `Save` + Press down on either `Gold (Mod) Encoder`. It will ask you to enter a file name. Press `Select`, `Enter on the Keyboard` or `Save` to save the file.
   - To load the `MIDI CC` labels from a `MIDI Device Definition File`, hold `Load` + Press down on either `Gold (Mod) Encoder`. It will ask you to select a file. Press `Select`, `Enter on the Keyboard` or `Load` to load the file.
   - Saving or Loading a `MIDI Device Definition File` will link that file to the current MIDI Instrument in the current song. If you save the song or save the current midi instrument as a preset, the song file and midi instrument preset file will include a file path to the `MIDI Device Definition File`. If you re-load the song or re-load the midi instrument preset, it will load information from the linked `MIDI Device Definition File`.
-  - You can unlink a Song or Midi Instrument preset from the a `MIDI Device Definition File` via the `MIDI > Device Definition (DEVI)` menu. You will need to re-save the song and/or preset to save the changes. 
+  - You can unlink a Song or Midi Instrument preset from the a `MIDI Device Definition File` via the `MIDI > Device Definition (DEVI)` menu. You will need to re-save the song and/or preset to save the changes.
   - You can also manually unlink the song file / preset file from the `MIDI Device Definition File` by searching for `definitionFile`. You should see `name="***"` right under it. Do not delete the name line from the preset. Instead replace the name with `name=""`
   - You can also use the `MIDI > Device Definition` menu as another way to link / load a `MIDI Device Definition File`. When clicking on the `File Linked (LINK)` setting, it will prompt you to select a `MIDI Device Definition File` to load. After successfully loading the file, the file name will be displayed (on OLED only) below the `File Linked` setting.
 

--- a/docs/dev/getting_started.md
+++ b/docs/dev/getting_started.md
@@ -66,14 +66,14 @@ Built files output to subdirectories named after the configuration (e.g. `build/
 
 #### Build configurations:
 
-* `debug` - build selected target with debugging support (including debugging symbols and different optimizations) 
+* `debug` - build selected target with debugging support (including debugging symbols and different optimizations)
 * `release` - build selected target with optimizations for release.
 
-#### Build arguments: 
+#### Build arguments:
 
 * `-S` or `--no-status` - this disables the `ninja` status line while building. Output from compilation commands (such as warnings and errors) will still be printed.
 * `-v` or `--verbose` - this prints greater level of detail to the console (i.e. exactly the compiler/linker commands called)
-* `-c` or `--clean-first` - clean before building 
+* `-c` or `--clean-first` - clean before building
 
 #### CMake custom arguments
 

--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -1,6 +1,6 @@
 # Description
 
-Automation View is a new view that complements the existing Arranger and Clip Views. 
+Automation View is a new view that complements the existing Arranger and Clip Views.
 - The Automation Arranger View is accessed from within Arranger View by pressing the Shift + Song buttons
     - Note: the automation arranger view editor for a specific parameter can be accessed directly from the arranger song menu for that parameter (e.g. the one you would access by pressing on select encoder or by using the shift + shortcut buttom combo) by pressing the Song button while in the parameter value.
 - The Automation Clip View is accessed from within the Clip View by pressing the Clip button
@@ -111,7 +111,7 @@ Automation View can also be accessed from the Sound menu for any automatable par
 
 Some additional things to note:
 
-- If you are in Automation Clip View and transition to Song/Arranger View, the Deluge will remember that on a per Clip basis. This means that when you transition back to a Clip it will re-load the Automation Clip View if you were in that view previously. 
+- If you are in Automation Clip View and transition to Song/Arranger View, the Deluge will remember that on a per Clip basis. This means that when you transition back to a Clip it will re-load the Automation Clip View if you were in that view previously.
 
 > **Note:** This information is saved with the song.
 
@@ -134,7 +134,7 @@ The Automation Overview **will:**
 > **Note:** While in the automation overview, if you hit play, record and then record in Master FX automations using the Mod Encoder (Gold Knobs), the automation overview grid will update to show you that those parameters are now automated by highlighted the corresponding pads on the grid white. Note: the update will happen after you turn record off.
 
 - be quickly accessible at any time from within the Automation Arranger View by pressing affect entire
-- be quickly accessible at any time from within the Automation Clip View by holding shift + clip, audition + clip, or affect entire. 
+- be quickly accessible at any time from within the Automation Clip View by holding shift + clip, audition + clip, or affect entire.
 
 > **Note 1:** The Automation Overview will also be displayed if you change clip types (e.g. from Synth to MIDI).
 
@@ -172,7 +172,7 @@ You can select the Parameter that you want to edit in four ways:
 3. From the menu by selecting a parameter for editing and then pressing song (if you're in arranger) or clip (if you're in a clip)
 4. By pressing shift + the shortcut pad corresponding to the parameter you want to edit
 
-Once you select a Parameter in the Automation Clip View, it will be remembered and stored on a per clip basis unless you go back to the Automation Overview. This means that if you are editing a Parameter and go back to the regular Clip View, Song View or Arranger View, when you transition back to the Automation Clip View it will open the last Parameter that you were editing in the Automation Editor. Similarly if you were last on the Automation Overview it will remember that. 
+Once you select a Parameter in the Automation Clip View, it will be remembered and stored on a per clip basis unless you go back to the Automation Overview. This means that if you are editing a Parameter and go back to the regular Clip View, Song View or Arranger View, when you transition back to the Automation Clip View it will open the last Parameter that you were editing in the Automation Editor. Similarly if you were last on the Automation Overview it will remember that.
 
 > **Note:** This information is saved with the song.
 
@@ -193,9 +193,9 @@ The Automation Editor **will:**
 - enable you to use either of the Mod Encoders (gold knobs) to quickly change the parameter value of the parameter in focus. The knobs automatically map to the selected parameter and you can use either knob (eliminating the guess work about which knob to turn).
 - enable you to quickly change parameters in focus for editing by turning select or using shift + shortcut pad or going back to automation overview using affect entire or shift/audition pad + clip
 - enable you to view the current parameter value setting for the parameters that are currently automatable.
-- illuminate each pad row according to the current value within the range of 0-128. E.g. bottom pad = 0-16, then 17-32, 33-48, 49-64, 65-80, 81-96, 97-112, 113-128) 
+- illuminate each pad row according to the current value within the range of 0-128. E.g. bottom pad = 0-16, then 17-32, 33-48, 49-64, 65-80, 81-96, 97-112, 113-128)
 > **Update** The values displayed in automation view have been updated to display the same value range displayed in the menu's for consistency across the Deluge UI. So instead of displaying 0 - 128, it now displays 0 - 50. Calculations in automation view are still being done based on the 0 - 128 range, but the display converts it to the 0 - 50 range.
-- edit new or existing parameter automations on a per step basis, at any zoom level across the entire timeline. Each row in a step column corresponds to a range of values in the parameter value range (0-128) (see above). If you press the bottom row, the value will be set to 0. if you press the top row, the value will be set to 128. Pressing the rows in between increments/decrements the value by 18.29 (e.g. 0, 18, 37, 55, 73, 91, 110, 128). 
+- edit new or existing parameter automations on a per step basis, at any zoom level across the entire timeline. Each row in a step column corresponds to a range of values in the parameter value range (0-128) (see above). If you press the bottom row, the value will be set to 0. if you press the top row, the value will be set to 128. Pressing the rows in between increments/decrements the value by 18.29 (e.g. 0, 18, 37, 55, 73, 91, 110, 128).
 > **Update** The values displayed in automation view have been updated to display the same value range displayed in the menu's for consistency across the Deluge UI. So instead of displaying 0 - 128, it now displays 0 - 50. Calculations in automation view are still being done based on the 0 - 128 range, but the display converts it to the 0 - 50 range.
 
 <img width="297" alt="Screenshot 2024-03-16 at 5 13 50 PM" src="https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/3d5dded1-efc2-4cb6-ad07-df2942fdc66e">
@@ -207,7 +207,7 @@ The Automation Editor **will:**
 > You can set the value to 0 by pressing and holding the two middle pads.
 >
 > The LED indicators for the mod encoders have been updated to show the full -50 to +50 range as well.
-> 
+>
 > This diagram shows the updated value ranges for the pads when automating a patch cable / modulation depth.
 
 <img width="293" alt="Screenshot 2024-03-16 at 5 07 36 PM" src="https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/e6f853f7-56bc-4102-8cc3-9b5a86bd4bfb">
@@ -221,20 +221,20 @@ The Automation Editor **will:**
 
 ![IMG_5827](https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/890970a0-2496-40e9-926c-9a9bd5697c0a)
 
-- enable you to fine tune the parameter automation values set by pressing and holding on a pad (or multiple pads) in a grid column and turning either of the Mod Encoders (Gold Knobs) (the value will increase/decrease relative to the current parameter value corresponding to the pad(s) you are holding). 
+- enable you to fine tune the parameter automation values set by pressing and holding on a pad (or multiple pads) in a grid column and turning either of the Mod Encoders (Gold Knobs) (the value will increase/decrease relative to the current parameter value corresponding to the pad(s) you are holding).
 
 > **Note 1:** you can also fine tune your long multi-step automations with the Mod Encoders (Gold Knobs).
 >
-> You have the ability to fine tune a long press's start and end values which automatically adjusts the interpolation between those values (without needing to enter the pad selection mode). 
-> 
+> You have the ability to fine tune a long press's start and end values which automatically adjusts the interpolation between those values (without needing to enter the pad selection mode).
+>
 > Simply enter a long press and while continuing to hold the first pad in the long press, turn the gold knobs to adjust the start and end values of the long press.
-> 
-> When refining a long presses start/end values, each gold knob is used separately to adjust the start/end position values. 
-> 
-> The bottom left gold knob is used to adjust the start value. 
-> 
+>
+> When refining a long presses start/end values, each gold knob is used separately to adjust the start/end position values.
+>
+> The bottom left gold knob is used to adjust the start value.
+>
 > The top right gold knob is used to adjust the end value.
-> 
+>
 > In a long press, you will also note that the LED indicators change to show the current value of the start and end position. Once you've let go of the long press, the LED indicators reset back to the parameters overall current value.
 
 > **Note 2:** the existing master FX section is disabled in the automation editor and can only be accessed if you go back to the Automation Overview, Arranger View, Clip View, or open the keyboard screen. When you turn either of Mod Encoders (Gold Knobs) it will display the parameter value between 0 and 128 on the screen of the current parameter being edited (not the parameter selected in the master FX section).
@@ -245,31 +245,31 @@ The Automation Editor **will:**
 
 ![image](https://github.com/seangoodvibes/DelugeFirmware/assets/138174805/1e4b3653-c1a1-4d21-bfa0-826df378b063)
 
-> In pad selection mode, you cannot edit the automation grid by pressing on the pads. 
-> 
-> With a single or multi pad (long) press you select the pad(s) to edit. 
-> 
+> In pad selection mode, you cannot edit the automation grid by pressing on the pads.
+>
+> With a single or multi pad (long) press you select the pad(s) to edit.
+>
 > A cursor is displayed on the grid to identify the single or multiple pads you've selected. Seeing the cursor means you are in pad selection mode.
-> 
+>
 > Once you've made your pad selection, you can use the gold knobs to tweak the value of the singular pad or the value of the start/end pads in a long press.
-> 
+>
 > When one pad is selected, one cursor is displayed on the grid and both led indicators show the value for that pad (cursor position).
-> 
+>
 > When two pads are selected, two cursors are displayed on the grid and the lower led indicator shows the value of the left pad (left cursor), and the upper led indicator shows the value of the right pad (right cursor).
-> 
+>
 > With this mode you can also press on each pad to see its current value without changing its value.
 >
 > **Note 1:** if you've entered a long press and wish to see the value of each column in the long press, you will need to press and hold any pad in the column you wish to query.
 >
 > **Note 2:** if you've entered a long press and wish to switch back to a single press, you can do so by quickly pressing a pad in any column (e.g. don't hold it).
 
-- enable you to lay down longer automations with interpolation 
+- enable you to lay down longer automations with interpolation
 
 > **Note:** Interpolation only has an effect if you are entering a "long automation press." (see below). that is to say: you press and hold one pad and then press a second pad.
 
 > **Note:** If an automation value has been entered with the interpolation setting turned on and then subsequently the interpolation setting is turned off, the automation value will not be affected unless you to re-enter it.
 
-- enable you to lay down automations without interpolation (parameter values change in a step ladder fashion). 
+- enable you to lay down automations without interpolation (parameter values change in a step ladder fashion).
 
 > **Note:** If an automation value has been entered with the interpolation setting turned off and then subsequently the interpolation setting is turned on, the automation value will not be affected unless you to re-enter it.
 
@@ -323,9 +323,9 @@ These default settings are found in the `Settings` Menu under `Defaults/Automati
 
 ### Interpolation
 
-Interpolation does not change existing behaviour. This toggle is only used in the new Automation View. 
+Interpolation does not change existing behaviour. This toggle is only used in the new Automation View.
 
-This sets the default value for the Interpolation setting in the Automation View. 
+This sets the default value for the Interpolation setting in the Automation View.
 
 > **Note:** This default value is loaded every time you enter the Automation View.
 

--- a/docs/features/chord_keyboard.md
+++ b/docs/features/chord_keyboard.md
@@ -6,7 +6,7 @@ Two new chord focused keyboards as an additional keyboard options.
 
 The first `CHORD` keyboard is a layout that facilitates the creation and exploration of chords within a scale. It offers two modes, Column mode (providing in-scale harmonically similar chords for substitutions) and Row Mode (based largely on the Launchpad Pro's chord mode that spreads notes out on a row to allow users to build and play interesting chords across the rows).
 
-The second `CHORD LIBRARY` keyboard is a library of chords where each column is a note (chromatic, all 12 notes), with chords laid out vertically within each column. 
+The second `CHORD LIBRARY` keyboard is a library of chords where each column is a note (chromatic, all 12 notes), with chords laid out vertically within each column.
 
 ### Community Feature Setting
 
@@ -27,18 +27,18 @@ The Chord Keyboard Layout is designed to facilitate the creation and exploration
 
 #### Column Mode
 
-This mode arranges harmonically similar chords vertically. Chords in the same column can often be substituted for each other to explore different harmonic flavors. For example, if you are in a major scale, the first column will contain various options for the I chord, the second column will contain various options for the ii chord, and so on. 
+This mode arranges harmonically similar chords vertically. Chords in the same column can often be substituted for each other to explore different harmonic flavors. For example, if you are in a major scale, the first column will contain various options for the I chord, the second column will contain various options for the ii chord, and so on.
 
 #### Row Mode
 
 Based largely on the Launchpad Pro, with the notes spread out horizontally across the pads to allow users to build and play interesting chords across the rows. Generally simpler and more standard intervals for chords are on the left and less standard ones on the right.
- 
+
 Each row starts from the next scale degree up or down, and then moving across the pads, the intervals are the following in scale intervals (if a 3rd up from a scale degree is a major 3rd, it will be a major 3rd in the row, if it is a minor 3rd, it will be a minor 3rd in the row).
   - Root, 5th, 3rd + Octave (Compound 3rd), 7th + Octave (Compound 7th), 5th + Octave (Compound 5th), 3rd + 2 * Octave (Double Compound 3rd), 2nd + 2 * Octave (Double Compound 2nd), 6th + Octave (Compound 6th), Octave, 5th, 7th, 3rd - Octave, 2nd
   - The final column is a triad based on the Root of the row with 5th, Compound 3rd above it.
-  
+
 **As the Chord Keyboard is still in development, the intervals chosen for each row are not final and may change in the future. We welcome feedback on the intervals chosen for each row.**
-    
+
 
 ### Color Coding
 
@@ -60,7 +60,7 @@ turning either `◀︎▶︎` or  `▼︎▲︎` will move up or down by scale d
 Because the Chord Keyboard has more features than other keyboard layouts, controls are embedded into the two rightmost columns of the main grid. Currently it includes controls for switching between Row Mode and Column Mode, with more features planned for the future.
   - At the top of the rightmost main grid column, you can select the current mode (`ROW` and `COLUMN`) by pressing the corresponding pad. It defaults to Column Mode.
     - In addition, you can use `SHIFT` + `◀︎▶︎` to also cycle through the `ROW` and `COLUMN` mode.
-    
+
 
 ### Scale Considerations
 
@@ -83,7 +83,7 @@ Each column is a different color with the colors repeating on the octave. This i
 In scale mode, the chords with notes entirely within the scale are highlighted, while the chords with notes outside the scale are dimmed.
 
 When out of scale mode, the final 2 columns change colors each 8 chords you scroll up to help you keep track of where you are in the layout as you scroll up and down. Other than these columns, the column of the root note of the key you are in is highlighted, while the all other columns are dimmed.
-  
+
 #### Controls
 
 Turning `◀︎▶︎` scrolls through the scale, allowing you to raise or lower the chords. Turning `▼︎▲︎` scrolls up or down to access more chords.
@@ -104,8 +104,8 @@ In the interest of brevity, and to display as much of the chord name as possible
   - Diminished: `DIM`
   - Augmented: `AUG`
   - suspended: `SUS`
-  
+
 Then the chord would be followed by any additional information such as the extension (7, 9, 11, 13) or alterations (b5, #5, b9, #9, #11, b13). Finally, if the chord has a well known nickname, it may be included as well.
 
 So for example, a C Major chord would be displayed as `CM`, a C Minor chord would be displayed as `C-`, and a C Diminished chord would be displayed as `CDIM`. A C Dominant 7 chord would be displayed as `C7`, a C Minor 7 Flat 5 chord would be displayed as `C-7FLAT5`.
-  
+

--- a/docs/features/dx_synth.md
+++ b/docs/features/dx_synth.md
@@ -57,9 +57,9 @@ unless it was manually set to something else.
 
 When the Keyboard view is active, the first 6 rows of the sidebar shows the operators as green for a carrier and blue for a modulator.
 
-1. Taping a single pad in isolation lets you switch an operator on or off. 
+1. Taping a single pad in isolation lets you switch an operator on or off.
 
-2. Pressing Shift+coloured pad opens the editor for that operator. 
+2. Pressing Shift+coloured pad opens the editor for that operator.
 - The first press of Shift+colored pad selects the level parameter.
 - Pressing Shift+coloured pad again select the COARSE tuning parameter.
 

--- a/docs/features/looping_in_grid_view.md
+++ b/docs/features/looping_in_grid_view.md
@@ -34,7 +34,7 @@ To use the technique shown in the video above, you must follow these steps:
 This technique requires the following:
 - you have created a clip
 - you have selected that clip by pressing and holding it from grid view or by entering it
-- you are able to use the Global MIDI Commands: `LOOP` or `LAYERING LOOP` by either using the Grid Loop/Layering Loop pads or by sending the Loop/Layering Loop Global MIDI Commands using an external controller. 
+- you are able to use the Global MIDI Commands: `LOOP` or `LAYERING LOOP` by either using the Grid Loop/Layering Loop pads or by sending the Loop/Layering Loop Global MIDI Commands using an external controller.
 
 To enable the Grid Loop/Layering Loop pads, enable `Grid View Loop Pads (LOOP)` in the `Community Features menu`.
  - When On, two pads (Red and Magenta) in the GRID VIEW sidebar will be illuminated and enable you to trigger the LOOP (Red) and LAYERING LOOP (Magenta) global MIDI commands to make it easier for you to loop in GRID VIEW without a MIDI controller.

--- a/docs/features/midi_device_definition_files.md
+++ b/docs/features/midi_device_definition_files.md
@@ -46,7 +46,7 @@ A `MIDI Device Definition File` is saved on the SD Card in the folder path: `MID
 
 #### Load with the Song
 
-When you load a song for which MIDI CC name changes were previously saved, those name changes will be re-loaded. 
+When you load a song for which MIDI CC name changes were previously saved, those name changes will be re-loaded.
 
 If you linked the Song to a `MIDI Device Definition File`, then the changes will be loaded from that definition file.
 
@@ -54,7 +54,7 @@ If the Song is not linked to a definition file, then the name changes will be lo
 
 #### Load from Midi Preset
 
-When you load a MIDI preset for which MIDI cc name changes were previously saved, those name changes will be re-loaded. 
+When you load a MIDI preset for which MIDI cc name changes were previously saved, those name changes will be re-loaded.
 
 If you linked the preset to a `MIDI Device Definition File`, then the changes will be loaded from that definition file.
 
@@ -68,7 +68,7 @@ Saving or Loading a `MIDI Device Definition File` will link that file to the cur
 
 ### Linking / Unlinking a MIDI Device Definition File
 
-You can unlink a Song or Midi Instrument preset from the a `MIDI Device Definition File` via the `MIDI > Device Definition (DEVI)` menu. You will need to re-save the song and/or preset to save the changes. 
+You can unlink a Song or Midi Instrument preset from the a `MIDI Device Definition File` via the `MIDI > Device Definition (DEVI)` menu. You will need to re-save the song and/or preset to save the changes.
 
 You can also manually unlink the song file / preset file from the `MIDI Device Definition File` by searching for `definitionFile`. You should see `name="***"` right under it. Do not delete the name line from the preset. Instead replace the name with `name=""`
 
@@ -80,9 +80,9 @@ You can also use the `MIDI > Device Definition` menu as another way to link / lo
 
 Firstly, when you load a `MIDI Device Definition File`, the song will become linked to that file. If you wish to make changes to the cc labels, you will need to either:
 
-A) unlink the song from the `MIDI Device Definition File` and make changes to the labels and save them to the song, 
+A) unlink the song from the `MIDI Device Definition File` and make changes to the labels and save them to the song,
 
-or 
+or
 
 B) you will need to save those label changes back to a `MIDI Device Definition File` and save the song so that it reloads from that file.
 
@@ -118,7 +118,7 @@ TLDR steps:
 5. Save song
 ```
 
-If you loaded a song and loaded a `MIDI Device Definition File` and now want to make changes to CC Labels, or you just started making changes as part of that song, you can save those changes back to the same or a new `MIDI Device Definition File`. 
+If you loaded a song and loaded a `MIDI Device Definition File` and now want to make changes to CC Labels, or you just started making changes as part of that song, you can save those changes back to the same or a new `MIDI Device Definition File`.
 
 After you have saved the changes to the `MIDI Device Definition File`, you will need to Save the song and/or MIDI preset to link the Song / Preset to that `MIDI Device Definition File`.
 

--- a/docs/features/midi_follow_mode.md
+++ b/docs/features/midi_follow_mode.md
@@ -12,7 +12,7 @@ Comes with a MIDI feedback mode to send updated parameter values on the MIDI fol
 
 Comes with an XML file (`SETTINGS/MIDIFollow.XML`) with default CC to Deluge parameter mappings. You can customize this XML file to map CC's differently as required.
 
-**Simple summary:** 
+**Simple summary:**
 - Set your follow and feedback channel(s)
 - Set your MIDI Controller(s) to the same channel(s)
 - Set a root note for your kits
@@ -106,9 +106,9 @@ MIDI CC mappings for MIDI Follow Mode are saved to the `SETTINGS` folder in the 
 Within `MIDIFollow.XML`, all Parameters that can mapped to a MIDI CC are listed. The MIDI CC value is enclosed between a Parameter XML tag - e.g. `<lpfFrequency>74</lpfFrequency>` indicates that MIDI CC 74 is mapped to the LPF Frequency parameter. Conversely when a value of 255 is entered (e.g. `<hpfFrequency>255</hpfFrequency>`) it indicates that no MIDI CC value has been mapped to that parameter.
 
 ![image](https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/1ae66f8b-1627-4e2f-a05d-fd7a8c73b62f)
-You can manually edit the `MIDIFollow.XML` to enter your MIDI CC mappings to each Parameter. 
+You can manually edit the `MIDIFollow.XML` to enter your MIDI CC mappings to each Parameter.
 
-The defaults from `MIDIFollow.XML` are loaded automatically when you start the Deluge so you can begin controlling the deluge with your MIDI controller right away. 
+The defaults from `MIDIFollow.XML` are loaded automatically when you start the Deluge so you can begin controlling the deluge with your MIDI controller right away.
 
 Note: A parameter can only be mapped to one MIDI CC. Conversely, a MIDI CC can be mapped to multiple parameters.
 
@@ -126,9 +126,9 @@ Note: if the MIDI CC being received is for a Parameter that cannot be controlled
 
 ## Re-cap of functionality
 
-1. Added new MIDI submenu for MIDI-Follow where you can: 
+1. Added new MIDI submenu for MIDI-Follow where you can:
 
-- Set up to three MIDI Follow Channels and Devices 
+- Set up to three MIDI Follow Channels and Devices
 - Set the MIDI Follow Root Note for Kits
 - Enable or Disable MIDI Follow Param Pop-up's
 - Enable or Disable MIDI Follow Feedback by setting/unsetting the MIDI Follow Feedback Channel
@@ -150,7 +150,7 @@ If you experience MIDI stutter / lag while using MIDI follow mode, you may need 
 
 Things you can try:
 
-1) Disable MIDI Feedback altogether by setting the MIDI Feedback Channel to NONE in the following sub-menu: MIDI > MIDI-FOLLOW > FEEDBACK > CHANNEL 
+1) Disable MIDI Feedback altogether by setting the MIDI Feedback Channel to NONE in the following sub-menu: MIDI > MIDI-FOLLOW > FEEDBACK > CHANNEL
 
 2) Disable MIDI Automation Feedback. Set the following menu to Disabled: MIDI > MIDI-FOLLOW > FEEDBACK > AUTOMATION FEEDBACK
 

--- a/docs/features/note_noterow_editor.md
+++ b/docs/features/note_noterow_editor.md
@@ -12,17 +12,17 @@ To edit fill, you need to access the new note and note row editor menu's.
 
 ### Enter Note Editor Menu
 
-Hold a note and press the select encoder to enter the note editor menu. 
+Hold a note and press the select encoder to enter the note editor menu.
 
-The note you were holding will be the note selected when you enter the note editor. 
+The note you were holding will be the note selected when you enter the note editor.
 
 If playback is off, you will hear what that note sounds like. You can toggle whether you want to hear / not hear the note by pressing the note again.
 
 ### Selecting a Note
 
-While in the note editor menu, the selected note will blink. 
+While in the note editor menu, the selected note will blink.
 
-You can select another note by pressing the note on the grid. 
+You can select another note by pressing the note on the grid.
 
 You can vertical scroll, horizontal scroll, and zoom in / out to find a note you want to edit.
 
@@ -51,7 +51,7 @@ You can exit the menu by pressing BACK to back out or you can press the greyed o
 
 ### Enter Note Row Editor Menu
 
-Hold a note row audition pad and press the select encoder to enter the note row editor menu. 
+Hold a note row audition pad and press the select encoder to enter the note row editor menu.
 
 The note row you were holding will be the note row selected when you enter the note row editor.
 
@@ -59,7 +59,7 @@ While in the Note Row Editor Menu, the audition pads will not sound. They will f
 
 ### Selecting A Note Row
 
-While in the note row editor menu, the selected note row audition pad will blink. 
+While in the note row editor menu, the selected note row audition pad will blink.
 
 You can select other note row's by:
 - pressing the note row audition pad

--- a/docs/features/performance_view.md
+++ b/docs/features/performance_view.md
@@ -41,10 +41,10 @@ Specifications:
 
 > Enter using `SHIFT` + `KEYBOARD` button
 
-or 
+or
 
 > Enter using the menu
-> 
+>
 > - Enter `VALUE EDITING MODE` by pressing down on the `SELECT` Encoder to open up the Perform FX Menu
 > - In the Perform FX menu, select the `EDITING MODE` sub menu and press down on Select Encoder to enter the menu
 > - Change Editing Mode to `VALUE` and press down on the `SELECT` Encoder to enter `VALUE EDITING MODE`
@@ -63,10 +63,10 @@ Value Editing Mode:
 
 > Enter using `SHIFT` + `KEYBOARD` button. You will need to cycle passed the Value Editing Mode to enter the Param Editing Mode.
 
-or 
+or
 
 > Enter using the menu
-> 
+>
 > - Enter `PARAM EDITING MODE` by pressing down on the `SELECT` Encoder to open up the Perform FX Menu
 > - In the Perform FX menu, select the `EDITING MODE` sub menu and press down on Select Encoder to enter the menu
 > - Change Editing Mode to `PARAM`

--- a/docs/features/stem_export.md
+++ b/docs/features/stem_export.md
@@ -10,7 +10,7 @@ Now with one quick action you can start a stem export job, walk away from your D
 
 ## Stems Folder
 
-Stems get exported to a new `SAMPLES/STEMS/` folder. 
+Stems get exported to a new `SAMPLES/STEMS/` folder.
 
 Within the `STEMS` folder, when exporting stems, a folder with the `SONG NAME` is created if it does not already exist. Unsaved songs are saved with the song name `UNSAVED`. Thus, you will have a new folder named `SAMPLES/STEMS/SONG NAME/`.
 
@@ -25,7 +25,7 @@ Stem's are given a meaningful name in the following format:
 `ClipType_ExportType_PresetName_FileNumber.WAV`
 
 > For example:
-> 
+>
 > SYNTH_CLIP_PRESETNAME_000.WAV
 > SYNTH_TRACK_PRESETNAME_000.WAV
 > ARRANGEMENT.WAV
@@ -65,7 +65,7 @@ Stem's are given a meaningful name in the following format:
 
 ### Normalization
 - Normalization is off by default. Normalization sets the peak of the recorded stems to be at 0dB (as loud as possible without distorting).
-  - Normalization can be turned on in the stem export configuration menu located at: `SONG\EXPORT STEMS\CONFIGURE EXPORT\NORMALIZATION`  
+  - Normalization can be turned on in the stem export configuration menu located at: `SONG\EXPORT STEMS\CONFIGURE EXPORT\NORMALIZATION`
 
 ### Song FX
 - Song FX are excluded by default. They can be included in the stem export configuration menu located at: `SONG\EXPORT STEMS\CONFIGURE EXPORT\SONG FX`
@@ -83,7 +83,7 @@ Stem's are given a meaningful name in the following format:
 
 ## Stem Export Menu
 
-A new `EXPORT STEMS` menu has been added to the `SONG` menu accessible in Song and Arranger Views. 
+A new `EXPORT STEMS` menu has been added to the `SONG` menu accessible in Song and Arranger Views.
 
 This menu allows you to start a stem export and configure various settings related to the stem export.
 
@@ -115,11 +115,11 @@ For heavy arrangements, if you encounter the above issue, we recommend turning o
 
 The problem is due to memory filling up faster when using `Offline Rendering` compared to `Online (Live) Rendering`. We hope to find a solution for this problem as soon as possible.
 
-#### Scenario: Special characters in the track name 
+#### Scenario: Special characters in the track name
 
 One user reported that they were unable to export a track even though the stem export indicated that the track had been exported.
 
-Solution: 
+Solution:
 
 Check that the track name doesn't have any special characters. In this case, the user had a track called << Organ >>. Removing the characters "<< >>" and just naming the track "Organ" allowed the track to be exported.
 

--- a/docs/features/velocity_view.md
+++ b/docs/features/velocity_view.md
@@ -1,6 +1,6 @@
 ## **Feature: Automation View Note Velocity Editor**
 
-New Note Velocity Editing View that has been added as part of the existing Automation View implementation so that you can edit the velocities and other parameters of notes in a single note row. 
+New Note Velocity Editing View that has been added as part of the existing Automation View implementation so that you can edit the velocities and other parameters of notes in a single note row.
 
 <img width="605" alt="Screenshot 2024-06-05 at 11 34 47 AM" src="https://github.com/SynthstromAudible/DelugeFirmware/assets/138174805/c0a1577c-5a10-4511-ab2e-1c40b3cb3d64">
 
@@ -22,7 +22,7 @@ New Note Velocity Editing View that has been added as part of the existing Autom
 - Add Note / Adjust Velocity Using Grid:
   - Press grid to set/adjust velocities of existing notes and add note (if no note exists)
 - Set a Velocity Ramp:
-  - Press and hold two grid note pads to set a velocity ramp between the two notes. 
+  - Press and hold two grid note pads to set a velocity ramp between the two notes.
   - Note: for this to work, you must first press a pad that has a note in it and then press a second pad that has a note in it. if the second pad has no note already in it, it will set a tail instead for the first note pad pressed (or if it's a drum sound, like a kick, it will just add another note in the position of the second pad press).
 - Remove Note:
   - Short press top velocity pad in a note column to remove note
@@ -46,7 +46,7 @@ New Note Velocity Editing View that has been added as part of the existing Autom
 - Change selected note row length by:
    - Holding Audition pad + Turning horizontal encoder <>
    - Note: does not work if you have selected a note
-- Clear notes in selected note row by: 
+- Clear notes in selected note row by:
    - Holding horizontal encoder <> + pressing Back
    - Note: does not work if you have selected a note
 - Rotate Note Row by:
@@ -57,5 +57,5 @@ New Note Velocity Editing View that has been added as part of the existing Autom
    - Enabling Quantize community feature
    - Hold audition pad + press and turn tempo encoder to set quantize / humanize %
 - Cross Screen Editing:
-    - Press cross screen while in the Velocity Note Editor to edit notes across multiple screens. 
-    - Note: you can only toggle cross screen editing if the clip has multiple screens OR the current note row selected has multiple screens. 
+    - Press cross screen while in the Velocity Note Editor to edit notes across multiple screens.
+    - Note: you can only toggle cross screen editing if the clip has multiple screens OR the current note row selected has multiple screens.

--- a/docs/menu_hierarchies.md
+++ b/docs/menu_hierarchies.md
@@ -20,7 +20,7 @@ The Settings menu contains the following menu hierarchy:
 	- CV Output 2 (OUT2)
 		- Volts per Octave (VOLT)
 		- Transpose (TRAN)
-</details>		
+</details>
 <details><summary>Gate</summary>
 
 	- Gate Output 1 (OUT1)
@@ -41,7 +41,7 @@ The Settings menu contains the following menu hierarchy:
 <details><summary>Trigger Clock (TCLO)</summary>
 
 	- Input (IN)
-		- PPQN 
+		- PPQN
 		- Auto-Start (AUTO)
 			- Disabled (ON)
 			- Enabled (OFF)
@@ -117,7 +117,7 @@ The Settings menu contains the following menu hierarchy:
 					- Upper Zone (UPPE)
 				- Out
 					- Lower Zone (LOWE)
-					- Upper Zone (UPPE)				
+					- Upper Zone (UPPE)
 			- Velocity (VELO)
 			- Clock (CLK)
 				- Disabled (OFF)
@@ -129,13 +129,13 @@ The Settings menu contains the following menu hierarchy:
 					- Upper Zone (UPPE)
 				- Out
 					- Lower Zone (LOWE)
-					- Upper Zone (UPPE)				
+					- Upper Zone (UPPE)
 			- Velocity (VELO)
 			- Clock (CLK)
 				- Disabled (OFF)
 				- Enabled (ON)
 </details>
-				
+
 <details><summary>Defaults (DEFA)</summary>
 
 	- UI
@@ -292,7 +292,7 @@ NOTE: These options can change depending on how your default resolution is set
 			- Amber (AMBE)
 			- White (WHIT)
 			- Pink
-		- Soloed 
+		- Soloed
 			- Red
 			- Green (GREE)
 			- Blue
@@ -309,15 +309,15 @@ NOTE: These options can change depending on how your default resolution is set
 	- Disabled (OFF)
 	- Conditional (COND)
 	- Enabled (ON)
-</details>	
-	
+</details>
+
 <details><summary>Play-Cursor (CURS)</summary>
 
 	- Fast
 	- Disabled (OFF)
 	- Slow
-</details>	
-	
+</details>
+
 <details><summary>Recording (RECO)</summary>
 
 	- Count-in (COUN)
@@ -503,7 +503,7 @@ The Song menu contains the following menu hierarchy:
 			- Analog (ANA)
 		- Sync
 		NOTE: These options can change depending on how your default resolution is set
-				
+
 			- Off
 			- 2-Bar
 			- 1-Bar
@@ -545,7 +545,7 @@ The Song menu contains the following menu hierarchy:
 		- Pan
 		- Reverb Sidechain (SIDE)
 			- Volume Ducking (VOLU)
-	
+
 	- Mod-FX (MODU)
 		- Type
 			- Disabled (OFF)
@@ -568,7 +568,7 @@ The Song menu contains the following menu hierarchy:
 </details>
 <details><summary>Swing Interval (SWII)</summary></details>
 <details><summary>Active Scales</summary>
-	
+
 	- Major (MAJO)
 	- Minor (MINO)
 	- Dorian (DORI)
@@ -641,7 +641,7 @@ The Perform FX menu contains the following menu hierarchy:
 <details><summary>FX</summary>
 
 	- See Song menu hierarchy above for break-down of FX menu
-</details>		
+</details>
 
 </details>
 
@@ -698,7 +698,7 @@ The Sound menu contains the following menu hierarchy:
 			- 16th-DTTED
 			- 32nd-DTTED
 			- 64th-DTTED
-			- 128th-DTTED	
+			- 128th-DTTED
 	- Rate
 	- Gate
 	- Octaves (OCTA)
@@ -782,7 +782,7 @@ The Sound menu contains the following menu hierarchy:
 			- Analog (ANA)
 		- Sync
 		NOTE: These options can change depending on how your default resolution is set
-				
+
 			- Off
 			- 2-Bar
 			- 1-Bar
@@ -824,7 +824,7 @@ The Sound menu contains the following menu hierarchy:
 		- Pan
 		- Reverb Sidechain (SIDE)
 			- Volume Ducking (VOLU)
-	
+
 	- Mod-FX (MODU)
 		- Type
 			- Disabled (OFF)
@@ -853,7 +853,7 @@ The Sound menu contains the following menu hierarchy:
 	- Volume Ducking (VOLU)
 	- Sync
 	NOTE: These options can change depending on how your default resolution is set
-				
+
 		- Off
 		- 2-Bar
 		- 1-Bar
@@ -881,11 +881,11 @@ The Sound menu contains the following menu hierarchy:
 		- 16th-DTTED
 		- 32nd-DTTED
 		- 64th-DTTED
-		- 128th-DTTED		
+		- 128th-DTTED
 	- Attack (ATTA)
 	- Release (RELE)
 	- Shape (TYPE)
-</details>	
+</details>
 <details><summary>Oscillator 1 (OSC1) </summary>
 
 	- Type
@@ -923,7 +923,7 @@ The Sound menu contains the following menu hierarchy:
 	- Speed (SPEE) - if Sample type selected
 	- Pulse Width (PULS) - if any type except Sample or Input is selected
 	- Retrigger Phase (RETR) - if any type except Sample is selected
-</details>	
+</details>
 <details><summary>Oscillator 2 (OSC2) </summary>
 
 	- Type
@@ -964,14 +964,14 @@ The Sound menu contains the following menu hierarchy:
 		- Disabled (OFF)
 		- Enabled (ON)
 	- Retrigger Phase (RETR) - if any type except Sample is selected
-</details>	
+</details>
 <details><summary>Envelope 1 (ENV1) </summary>
 
 	- Attack (ATTA)
 	- Decay (DECA)
 	- Sustain (SUST)
 	- Release (RELE)
-</details>	
+</details>
 <details><summary>Envelope 2 (ENV2) </summary>
 
 	- Attack (ATTA)
@@ -991,7 +991,7 @@ The Sound menu contains the following menu hierarchy:
 	- Rate
 	- Sync
 	NOTE: These options can change depending on how your default resolution is set
-				
+
 		- Off
 		- 2-Bar
 		- 1-Bar
@@ -1019,7 +1019,7 @@ The Sound menu contains the following menu hierarchy:
 		- 16th-DTTED
 		- 32nd-DTTED
 		- 64th-DTTED
-		- 128th-DTTED	
+		- 128th-DTTED
 </details>
 <details><summary>LFO2 </summary>
 
@@ -1030,7 +1030,7 @@ The Sound menu contains the following menu hierarchy:
 		- Saw
 		- S&H (S H)
 		- Random Walk (RWLK)
-	- Rate	
+	- Rate
 </details>
 <details><summary>Voice (VOIC) </summary>
 
@@ -1130,7 +1130,7 @@ The Kit FX menu contains the following menu hierarchy:
 			- Analog (ANA)
 		- Sync
 		NOTE: These options can change depending on how your default resolution is set
-				
+
 			- Off
 			- 2-Bar
 			- 1-Bar
@@ -1172,7 +1172,7 @@ The Kit FX menu contains the following menu hierarchy:
 		- Pan
 		- Reverb Sidechain (SIDE)
 			- Volume Ducking (VOLU)
-	
+
 	- Mod-FX (MODU)
 		- Type
 			- Disabled (OFF)
@@ -1198,7 +1198,7 @@ The Kit FX menu contains the following menu hierarchy:
 	- Volume Ducking (VOLU)
 	- Sync
 	NOTE: These options can change depending on how your default resolution is set
-				
+
 		- Off
 		- 2-Bar
 		- 1-Bar
@@ -1226,11 +1226,11 @@ The Kit FX menu contains the following menu hierarchy:
 		- 16th-DTTED
 		- 32nd-DTTED
 		- 64th-DTTED
-		- 128th-DTTED		
+		- 128th-DTTED
 	- Attack (ATTA)
 	- Release (RELE)
 	- Shape (TYPE)
-</details>	
+</details>
 
 </details>
 
@@ -1287,7 +1287,7 @@ The MIDI menu contains the following menu hierarchy:
 			- 16th-DTTED
 			- 32nd-DTTED
 			- 64th-DTTED
-			- 128th-DTTED	
+			- 128th-DTTED
 	- Rate
 	- Gate
 	- Octaves (OCTA)
@@ -1331,7 +1331,7 @@ The MIDI menu contains the following menu hierarchy:
 	- MPE
 		- Disabled (OFF)
 		- Enabled (ON)
-</details>	
+</details>
 <details><summary>Play Direction (DIRE) </summary>
 
 	- Forward
@@ -1384,7 +1384,7 @@ The CV menu contains the following menu hierarchy:
 			- 16th-DTTED
 			- 32nd-DTTED
 			- 64th-DTTED
-			- 128th-DTTED	
+			- 128th-DTTED
 	- Rate
 	- Gate
 	- Octaves (OCTA)
@@ -1456,29 +1456,29 @@ The Note Editor menu contains the following menu hierarchy:
 
 	- 1 OF 2 (1OF2)
 	- 2 OF 2 (2OF2)
- 
+
 	- 1 OF 3 (1OF3)
 	- 2 OF 3 (2OF3)
 	- 3 OF 3 (3OF3)
-    
+
 	- 1 OF 4 (1OF4)
 	- 2 OF 4 (2OF4)
 	- 3 OF 4 (3OF4)
 	- 4 OF 4 (4OF4)
-	
+
 	- 1 OF 5 (1OF5)
 	- 2 OF 5 (2OF5)
 	- 3 OF 5 (3OF5)
 	- 4 OF 5 (4OF5)
 	- 5 OF 5 (5OF5)
-     
+
 	- 1 OF 6 (1OF6)
 	- 2 OF 6 (2OF6)
 	- 3 OF 6 (3OF6)
 	- 4 OF 6 (4OF6)
 	- 5 OF 6 (5OF6)
 	- 6 OF 6 (6OF6)
-   
+
 	- 1 OF 7 (1OF7)
 	- 2 OF 7 (2OF7)
 	- 3 OF 7 (3OF7)
@@ -1486,7 +1486,7 @@ The Note Editor menu contains the following menu hierarchy:
 	- 5 OF 7 (5OF7)
 	- 6 OF 7 (6OF7)
 	- 7 OF 7 (7OF7)
-    
+
 	- 1 OF 8 (1OF8)
 	- 2 OF 8 (2OF8)
 	- 3 OF 8 (3OF8)
@@ -1532,29 +1532,29 @@ The Note Row Editor menu contains the following menu hierarchy:
 
 	- 1 OF 2 (1OF2)
 	- 2 OF 2 (2OF2)
- 
+
 	- 1 OF 3 (1OF3)
 	- 2 OF 3 (2OF3)
 	- 3 OF 3 (3OF3)
-    
+
 	- 1 OF 4 (1OF4)
 	- 2 OF 4 (2OF4)
 	- 3 OF 4 (3OF4)
 	- 4 OF 4 (4OF4)
-	
+
 	- 1 OF 5 (1OF5)
 	- 2 OF 5 (2OF5)
 	- 3 OF 5 (3OF5)
 	- 4 OF 5 (4OF5)
 	- 5 OF 5 (5OF5)
-     
+
 	- 1 OF 6 (1OF6)
 	- 2 OF 6 (2OF6)
 	- 3 OF 6 (3OF6)
 	- 4 OF 6 (4OF6)
 	- 5 OF 6 (5OF6)
 	- 6 OF 6 (6OF6)
-   
+
 	- 1 OF 7 (1OF7)
 	- 2 OF 7 (2OF7)
 	- 3 OF 7 (3OF7)
@@ -1562,7 +1562,7 @@ The Note Row Editor menu contains the following menu hierarchy:
 	- 5 OF 7 (5OF7)
 	- 6 OF 7 (6OF7)
 	- 7 OF 7 (7OF7)
-    
+
 	- 1 OF 8 (1OF8)
 	- 2 OF 8 (2OF8)
 	- 3 OF 8 (3OF8)
@@ -1678,7 +1678,7 @@ The Audio Clip menu contains the following menu hierarchy:
 			- Analog (ANA)
 		- Sync
 		NOTE: These options can change depending on how your default resolution is set
-				
+
 			- Off
 			- 2-Bar
 			- 1-Bar
@@ -1720,7 +1720,7 @@ The Audio Clip menu contains the following menu hierarchy:
 		- Pan
 		- Reverb Sidechain (SIDE)
 			- Volume Ducking (VOLU)
-	
+
 	- Mod-FX (MODU)
 		- Type
 			- Disabled (OFF)
@@ -1747,7 +1747,7 @@ The Audio Clip menu contains the following menu hierarchy:
 	- Volume Ducking (VOLU)
 	- Sync
 	NOTE: These options can change depending on how your default resolution is set
-				
+
 		- Off
 		- 2-Bar
 		- 1-Bar
@@ -1775,11 +1775,11 @@ The Audio Clip menu contains the following menu hierarchy:
 		- 16th-DTTED
 		- 32nd-DTTED
 		- 64th-DTTED
-		- 128th-DTTED		
+		- 128th-DTTED
 	- Attack (ATTA)
 	- Release (RELE)
 	- Shape (TYPE)
-</details>	
+</details>
 <details><summary>Sample (SAMP) </summary>
 
 	- File Browser (FILE)

--- a/docs/ux_principles.md
+++ b/docs/ux_principles.md
@@ -4,7 +4,7 @@
 The Deluge is a standalone instrument that also works as a controller/sequencer. It has two core features which set it apart from the competition:
 
 * Tracks can be smoothly changed from the internal synths to midi/cv and back again
-* It features a linear arranger 
+* It features a linear arranger
 
 These features should be maintained and any new features must not impact them
 
@@ -13,12 +13,12 @@ The deluge is not a computer, and should not feel like you're operating one. Dir
 
 ## Guidelines
 
-* Favour explicitness 
+* Favour explicitness
     - Parameters describe their action on the waveform, not their result on the final sound
     - A user who understands synthesis should immediately be able to edit the deluge
 * Favour simplicity
     - Menus should never feel mandatory
-    - Make the shortcuts and gold knob system feel like a feature and not a hindrance 
+    - Make the shortcuts and gold knob system feel like a feature and not a hindrance
     - The OLED screen is a bonus, not a requirement
 * Favour performance
     - Entire parameter ranges should be useful and scaled for quick editing


### PR DESCRIPTION
Mechanical removal of trailing whitespace in all files under /docs