### PR TITLE
loosen restrictions on clip names

### DIFF
--- a/src/deluge/gui/ui/rename/rename_clip_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.cpp
@@ -84,10 +84,10 @@ ActionResult RenameClipUI::buttonAction(deluge::hid::Button b, bool on, bool inC
 
 void RenameClipUI::enterKeyPress() {
 
-	// If actually changing it...
+	// Don't allow duplicate names on clips of a single output.
 	if (!clip->name.equalsCaseIrrespective(&enteredText)) {
-		// don't let user set a name that is a duplicate of another name that has been set for another clip
-		if (currentSong->getClipFromName(&enteredText)) {
+		Clip* other = currentSong->getClipFromName(&enteredText);
+		if (other && other->output == clip->output) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
 		}


### PR DESCRIPTION
- Allow multiple clips to share a name as long as they're all on different outputs.