### PR TITLE
use local paths in docs so that releases don't point to HEAD docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Deluge Community Firmware Change Log
 
-> To find a detailed list of how to use each feature, check here: [Community Features](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/community_features.md)
+> To find a detailed list of how to use each feature, check here: [Community Features](docs/community_features.md)
 
 ## c1.3.0
 
@@ -366,7 +366,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 - Fixed several bugs with pad grid rendering.
 
 #### <ins>Documentation</ins>
-- Created a new menu hierarchies document that documents the Deluge menu structure for OLED and 7SEG and can be used as a reference for navigating the various menu's. See: [Menu Hierarchies](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/menu_hierarchies.md)
+- Created a new menu hierarchies document that documents the Deluge menu structure for OLED and 7SEG and can be used as a reference for navigating the various menu's. See: [Menu Hierarchies](docs/menu_hierarchies.md)
 
 #### <ins>Menu UI Improvements</ins>
 - Holding back now fully exits the menu

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -13,7 +13,7 @@ about released versions can be found here:
 - [1.1.x (Beethoven)](https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.1/docs/community_features.md)
 - [1.0.x (Amadeus)](https://github.com/SynthstromAudible/DelugeFirmware/blob/release/1.0/docs/community_features.md)
 
-For more detailed version information, see the [changelog](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/CHANGELOG.md).
+For more detailed version information, see the [changelog](../CHANGELOG.md).
 
 Reference the 'Community Features Menu' section at the end of this document to understand what each entry is and their
 7SEG abbreviations.
@@ -1662,22 +1662,22 @@ different firmware
 
 [#2990]: https://github.com/SynthstromAudible/DelugeFirmware/pull/2990
 
-[Automation View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/automation_view.md
+[Automation View Documentation]: features/automation_view.md
 
-[Velocity View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/velocity_view.md
+[Velocity View Documentation]: features/velocity_view.md
 
-[Performance View Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/performance_view.md
+[Performance View Documentation]: features/performance_view.md
 
-[MIDI Follow Mode Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/midi_follow_mode.md
+[MIDI Follow Mode Documentation]: features/midi_follow_mode.md
 
-[MIDI Follow Mode Loopy Pro Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/loopy_pro
+[MIDI Follow Mode Loopy Pro Template]: ../contrib/midi_follow/loopy_pro
 
-[MIDI Follow Mode Touch OSC Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/touch_osc
+[MIDI Follow Mode Touch OSC Template]: ../contrib/midi_follow/touch_osc
 
-[DX7 Synth Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/dx_synth.md
+[DX7 Synth Documentation]: features/dx_synth.md
 
-[Audio Export Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/audio_export.md
+[Stem Export Documentation]: features/stem_export.md
 
-[Chord Keyboard Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/chord_keyboard.md
+[Chord Keyboard Documentation]: features/chord_keyboard.md
 
-[Note / Note Row Editor Documentation]: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/features/note_noterow_editor.md
+[Note / Note Row Editor Documentation]: features/note_noterow_editor.md


### PR DESCRIPTION
This swaps out the absolute GitHub paths for doc links in the .md files, instead using local paths. This prevents a release branch's docs from pointing to the current community HEAD docs, which may differ