### PR TITLE
Fix bug with display for kit automation overview

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1844,13 +1844,6 @@ ActionResult AutomationView::buttonAction(hid::Button b, bool on, bool inCardRou
 		handleSelectEncoderButtonAction(on);
 	}
 
-	// when you press affect entire, the parameter selection needs to reset
-	else if (on && b == AFFECT_ENTIRE) {
-		initParameterSelection();
-		blinkShortcuts();
-		goto passToOthers;
-	}
-
 	else {
 passToOthers:
 		// if you're entering settings menu
@@ -1880,6 +1873,13 @@ passToOthers:
 		}
 		if (result == ActionResult::NOT_DEALT_WITH) {
 			result = ClipView::buttonAction(b, on, inCardRoutine);
+		}
+
+		// when you press affect entire, the parameter selection needs to reset
+		// do this here because affect entire state may have just changed
+		if (on && b == AFFECT_ENTIRE) {
+			initParameterSelection();
+			blinkShortcuts();
 		}
 
 		return result;


### PR DESCRIPTION
There was a bug in the automation overview for kits when affect entire is disabled and no drum is selected

the display would show "Select Affect Entire / Drum" even after pressing affect entire.

it was happening because the affect entire state was being changed after the display had already refreshed

moving the display refresh after the affect entire state is changed fixes this