### PR TITLE
fix sharpening/flattening scale notes

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -643,6 +643,7 @@ void Song::rotateMusicalMode(int8_t change) {
 		}
 	}
 
+	changes.target = changes.applyTo(changes.source);
 	replaceMusicalMode(changes, false);
 }
 
@@ -673,6 +674,7 @@ void Song::changeMusicalMode(uint8_t yVisualWithinOctave, int8_t change) {
 	ScaleChange changes;
 	changes.source = key.modeNotes;
 	changes[yVisualWithinOctave] += change;
+	changes.target = changes.applyTo(changes.source);
 
 	replaceMusicalMode(changes, true);
 }


### PR DESCRIPTION
- ScaleChange was missing the target scale, used to figure out a possible y-adjustment. Fixes #3038.

- Same issue in rotateMusicalScale(), used from Song::transposeAllScaleModeClips, which might be causing #2936.
