### PR TITLE
follow-up to loosening clip-naming restrictions

### DIFF
--- a/src/deluge/gui/ui/rename/rename_clip_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.cpp
@@ -86,8 +86,7 @@ void RenameClipUI::enterKeyPress() {
 
 	// Don't allow duplicate names on clips of a single output.
 	if (!clip->name.equalsCaseIrrespective(&enteredText)) {
-		Clip* other = currentSong->getClipFromName(&enteredText);
-		if (other && other->output == clip->output) {
+		if (clip->output->getClipFromName(&enteredText)) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
 		}

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -53,6 +53,15 @@ Output::~Output() {
 	}
 }
 
+Clip* Output::getClipFromName(String* name) {
+	for (Clip* clip : AllClips::everywhere(currentSong)) {
+		if (clip->output == this && clip->name.equalsCaseIrrespective(name)) {
+			return clip;
+		}
+	}
+	return NULL;
+}
+
 void Output::setupWithoutActiveClip(ModelStack* modelStack) {
 	inValidState = true;
 }

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -136,6 +136,8 @@ public:
 	virtual void getThingWithMostReverb(Sound** soundWithMostReverb, ParamManager** paramManagerWithMostReverb,
 	                                    GlobalEffectableForClip** globalEffectableWithMostReverb,
 	                                    int32_t* highestReverbAmountFound) {}
+	/// If there's a clip matching the name on this output, returns it.
+	Clip* getClipFromName(String* name);
 
 	/// Pitch bend is available in the mod matrix as X and shouldn't be learned to params anymore (post 4.0)
 	virtual bool offerReceivedPitchBendToLearnedParams(MIDICable& cable, uint8_t channel, uint8_t data1, uint8_t data2,

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3577,17 +3577,6 @@ AudioOutput* Song::getAudioOutputFromName(String* name) {
 	return NULL;
 }
 
-// used with the renameClipUI class to check if you're trying to rename a clip to the same name
-// as another clip
-Clip* Song::getClipFromName(String* name) {
-	for (Clip* clip : AllClips::everywhere(this)) {
-		if (clip->name.equalsCaseIrrespective(name)) {
-			return clip;
-		}
-	}
-	return NULL;
-}
-
 // You can put name as NULL if it's MIDI or CV
 Instrument* Song::getInstrumentFromPresetSlot(OutputType outputType, int32_t channel, int32_t channelSuffix,
                                               char const* name, char const* dirPath, bool searchHibernating,

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -167,7 +167,6 @@ public:
 	                                        char const* name, char const* dirPath, bool searchHibernatingToo = true,
 	                                        bool searchNonHibernating = true);
 	AudioOutput* getAudioOutputFromName(String* name);
-	Clip* getClipFromName(String* name);
 	void setupPatchingForAllParamManagers();
 	void replaceInstrument(Instrument* oldInstrument, Instrument* newInstrument, bool keepNoteRowsWithMIDIInput = true);
 	void stopAllMIDIAndGateNotesPlaying();


### PR DESCRIPTION
- move Song::getClipFromName() to Output, so that we actually check the right thing -- previously if tracks 1 & 2 both have a clip named A, the check might find the clip from track 2, allowing a duplicate name on track 1.