### PR TITLE
backport clip renaming logic

### DIFF
--- a/src/deluge/gui/ui/rename/rename_clipname_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clipname_ui.cpp
@@ -84,9 +84,9 @@ ActionResult RenameClipNameUI::buttonAction(deluge::hid::Button b, bool on, bool
 
 void RenameClipNameUI::enterKeyPress() {
 
-	// If actually changing it...
+	// Don't allow duplicate names on clips of a single output.
 	if (!clip->clipName.equalsCaseIrrespective(&enteredText)) {
-		if (currentSong->getAudioOutputFromName(&enteredText)) {
+		if (clip->output->getClipFromName(&enteredText)) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
 		}

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -53,6 +53,15 @@ Output::~Output() {
 	}
 }
 
+Clip* Output::getClipFromName(String* name) {
+	for (Clip* clip : AllClips::everywhere(currentSong)) {
+		if (clip->output == this && clip->clipName.equalsCaseIrrespective(name)) {
+			return clip;
+		}
+	}
+	return NULL;
+}
+
 void Output::setupWithoutActiveClip(ModelStack* modelStack) {
 	inValidState = true;
 }

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -135,6 +135,8 @@ public:
 	virtual void getThingWithMostReverb(Sound** soundWithMostReverb, ParamManager** paramManagerWithMostReverb,
 	                                    GlobalEffectableForClip** globalEffectableWithMostReverb,
 	                                    int32_t* highestReverbAmountFound) {}
+	/// If there's a clip matching the name on this output, returns it.
+	Clip* getClipFromName(String* name);
 
 	/// Pitch bend is available in the mod matrix as X and shouldn't be learned to params anymore (post 4.0)
 	virtual bool offerReceivedPitchBendToLearnedParams(MIDIDevice* fromDevice, uint8_t channel, uint8_t data1,


### PR DESCRIPTION
- Allow multiple clips to share a name as long as they're all on different outputs. From https://github.com/SynthstromAudible/DelugeFirmware/pull/3046

- move Song::getClipFromName() to Output, so that we actually check the right thing -- previously if tracks 1 & 2 both have a clip named A, the check might find the clip from track 2, allowing a duplicate name on track 1. From https://github.com/SynthstromAudible/DelugeFirmware/pull/3056