### PR TITLE
Fix perf view bugs with keyboard button handling

### DIFF
--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -725,6 +725,12 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithThreeMainThings* modelStack = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
+	// if we press keyboard button while in performance view, reset time keyboard shortcut was pressed
+	// so we don't accidentally leave performance view on release of keyboard button
+	if (b == KEYBOARD && on) {
+		timeKeyboardShortcutPress = 0;
+	}
+
 	// Clip-view button
 	if (b == CLIP_VIEW) {
 		if (on && ((currentUIMode == UI_MODE_NONE) || isUIModeActive(UI_MODE_STUTTERING))
@@ -927,7 +933,7 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 				}
 			}
 		}
-		else {
+		else if (timeKeyboardShortcutPress != 0) {
 			// if you released the keyboard button and it was held for longer than hold time
 			// switch back to arranger or session view (it just peeks performance view)
 			if (((AudioEngine::audioSampleTimer - timeKeyboardShortcutPress) >= FlashStorage::holdTime)) {
@@ -1667,17 +1673,14 @@ void PerformanceView::updateLayoutChangeStatus() {
 		}
 	}
 
-	if (defaultEditingMode) {
-		if (anyChangesToSave) {
-			indicator_leds::blinkLed(IndicatorLED::SAVE);
-		}
-		else {
-			indicator_leds::setLedState(IndicatorLED::SAVE, false);
-		}
+	if (defaultEditingMode && anyChangesToSave) {
+		indicator_leds::blinkLed(IndicatorLED::SAVE);
 	}
 	else {
 		indicator_leds::setLedState(IndicatorLED::SAVE, false);
 	}
+
+	indicator_leds::setLedState(IndicatorLED::LOAD, false);
 
 	return;
 }


### PR DESCRIPTION
Fixed the following bugs in performance view with the handling of keyboard button release:

1) holding save + keyboard would exit performance view on keyboard button release

2) holding load + keyboard would exit performance view on keyboard button release

3) holding load + keyboard and releasing load first would keep the load button led lit

4) shift + keyboard would exit performance view instead of allow you to enter value editing / param editing modes