### PR TITLE
Fix twitchy BPM display during playback w/external clock

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2311,7 +2311,7 @@ void PlaybackHandler::getTempoStringForOLED(float tempoBPM, StringBuf& buffer) {
 		buffer.append("FAST");
 	}
 	else {
-		int32_t numDecimalPlaces = tempoBPM >= 1000 ? 0 : 2;
+		int32_t numDecimalPlaces = (tempoBPM >= 1000 || isExternalClockActive()) ? 0 : 2;
 		buffer.appendFloat(tempoBPM, 0, numDecimalPlaces);
 	}
 }


### PR DESCRIPTION
Before this fix, when Ableton is clock master and Deluge is slave, the BPM display during playback will twitch wildly because its displaying fluctuating pulses and calculating in realtime the BPM displayed with precision of 1/100 BPM. This fix rounds this number to an integer.