### PR TITLE
Add a new simple delay

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 
 FetchContent_Declare(argon
   GIT_REPOSITORY https://github.com/stellar-aria/argon
-  GIT_TAG 724f1be90d8f1a08750d65bda72e51108f1d3619
+  GIT_TAG c19a93d3228d74782c1d17e6bc0b1acb74001aff
 )
 FetchContent_MakeAvailable(argon)
 

--- a/src/deluge/dsp/blocks/gain_ramp.cpp
+++ b/src/deluge/dsp/blocks/gain_ramp.cpp
@@ -1,0 +1,54 @@
+#include "gain_ramp.hpp"
+#include "argon/store.hpp"
+
+namespace deluge::dsp::blocks {
+
+void GainRamp::processBlock(const std::span<float> in, std::span<float> out) const {
+	float single_step = (end_ - start_) / static_cast<float>(in.size() - 1);
+
+	// NEON-accelerated version
+	Argon<float> current = Argon<float>{start_}.MultiplyAdd(single_step, {0.f, 1.f, 2.f, 3.f});
+
+	size_t vec_size = in.size() & ~(Argon<float>::lanes - 1);
+	Argon<float> step = single_step * Argon<float>::lanes;
+
+	for (size_t i = 0; i < vec_size; i += Argon<float>::lanes) {
+		auto in_sample = Argon<float>::Load(&in[i]); // Load four mono samples
+		auto out_sample = in_sample * current;       // Apply gain
+		out_sample.StoreTo(&out[i]);                 // Store four mono samples
+		current = current + step;                    // Move to next segment of ramp
+	}
+
+	// Do remainder that don't fit the vector width
+	float single_current = current[1];
+	for (size_t i = vec_size; i < in.size(); ++i) {
+		out[i] = in[i] * single_current;
+		single_current += single_step;
+	}
+}
+
+void GainRamp::processBlock(std::span<StereoFloatSample> in, std::span<StereoFloatSample> out) {
+	float single_step = (end_ - start_) / static_cast<float>(in.size() - 1);
+
+	Argon<float> current = Argon<float>{start_}.MultiplyAdd(single_step, {0.f, 1.f, 2.f, 3.f});
+
+	size_t vec_size = in.size() & ~(Argon<float>::lanes - 1);
+	Argon<float> step = single_step * Argon<float>::lanes;
+
+	for (size_t i = 0; i < vec_size; i += Argon<float>::lanes) {
+		auto [in_sample_l, in_sample_r] = Argon<float>::LoadInterleaved<2>(&in[i].l); // Load four stereo samples
+		Argon<float> out_sample_l = in_sample_l * current;                            // Apply gain
+		Argon<float> out_sample_r = in_sample_r * current;                            // Apply gain
+		argon::store_interleaved<2>(&out[i].l, out_sample_l, out_sample_r);           // Store four stereo samples
+		current = current + step;                                                     // Move to next segment of ramp
+	}
+
+	// Do remainder that don't fit the vector width
+	float single_current = current[1];
+	for (size_t i = vec_size; i < in.size(); ++i) {
+		out[i].l = in[i].l * single_current;
+		out[i].r = in[i].r * single_current;
+		single_current += single_step;
+	}
+}
+} // namespace deluge::dsp::blocks

--- a/src/deluge/dsp/blocks/gain_ramp.hpp
+++ b/src/deluge/dsp/blocks/gain_ramp.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "dsp/stereo_sample.h"
+#include <argon.hpp>
+
+namespace deluge::dsp::blocks {
+class GainRamp {
+public:
+	GainRamp(float start, float end) : start_{start}, end_{end} {}
+
+	void processBlock(std::span<float> in, std::span<float> out) const;
+	void processBlock(std::span<StereoFloatSample> in, std::span<StereoFloatSample> out);
+
+	[[nodiscard]] constexpr float start() const { return start_; }
+	[[nodiscard]] constexpr float end() const { return end_; }
+
+private:
+	float start_;
+	float end_;
+};
+} // namespace deluge::dsp::blocks

--- a/src/deluge/dsp/delay/delay_buffer.h
+++ b/src/deluge/dsp/delay/delay_buffer.h
@@ -29,9 +29,9 @@ constexpr ptrdiff_t delaySpaceBetweenReadAndWrite = 20;
 
 class DelayBuffer {
 public:
-	constexpr static size_t kMaxSize = 88200;
+	constexpr static size_t kMaxSize = 88200; // 2 seconds
 	constexpr static size_t kMinSize = 1;
-	constexpr static size_t kNeutralSize = 16384;
+	constexpr static size_t kNeutralSize = 16384; // (1 << 14) ??
 
 	DelayBuffer() = default;
 	~DelayBuffer() { discard(); }

--- a/src/deluge/dsp/delay/simple/buffer.hpp
+++ b/src/deluge/dsp/delay/simple/buffer.hpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2024 Katherine Whitlock
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "dsp/blocks/gain_ramp.hpp"
+#include "dsp/interpolate/interpolate.h"
+#include <argon.hpp>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace deluge::dsp::delay::simple {
+
+/**
+ * @brief This class is essentially a fractional delay line/FIFO-queue combined with a circular buffer.
+ */
+template <size_t max_delay>
+class Buffer {
+public:
+	static_assert(Argon<float>::lanes == 4);
+	Buffer(size_t size) : size_(size) {}
+	~Buffer() = default;
+
+	constexpr void Reset() { idx_ = 0; }
+	constexpr void Clear() { raw_buffer_.fill(0); }
+
+	constexpr void Write(size_t index, const float sample, float feedback = 0.f) {
+		buffer_[index] = sample + (buffer_[index] * feedback);
+	}
+
+	constexpr void WriteSIMD(Argon<float> sample, Argon<float> feedback) {
+		// No wraparound, so we can do this with NEON
+		if (idx_ < size_ - 4) [[likely]] {
+			// reverse so that "oldest" sample is at highest index
+			feedback = feedback.Reverse();
+			sample = sample.Reverse();
+
+			auto old_sample = Argon<float>::Load(&buffer_[idx_]);
+			auto new_sample = sample.MultiplyAdd(old_sample, feedback); // sample + (old * feedback)
+			new_sample.StoreTo(&buffer_[idx_]);
+			idx_ = 0;
+			return;
+		}
+
+		// Wraparound, but on the doubleword boundary
+		if (idx_ == size_ - 2) {
+			// do "low" half (oldest samples)
+			ArgonHalf<float> feedback_low = feedback.GetLow().Reverse();
+			ArgonHalf<float> sample_low = sample.GetLow().Reverse();
+			auto old_sample_low = ArgonHalf<float>::Load(&buffer_[idx_]);
+			sample_low.MultiplyAdd(old_sample_low, feedback_low).StoreTo(&buffer_[idx_]);
+
+			// do "high" half (newest samples)
+			ArgonHalf<float> feedback_high = sample.GetHigh().Reverse();
+			ArgonHalf<float> sample_high = sample.GetHigh().Reverse();
+			auto old_sample_high = ArgonHalf<float>::Load(buffer_.data());
+			sample_high.MultiplyAdd(old_sample_high, feedback_high).StoreTo(buffer_.data());
+			idx_ = 2;
+			return;
+		}
+
+		// Wraparound case in the middle of a doubleword, need to do each lane indivdually :(
+		for (size_t lane = 0; lane < Argon<float>::lanes; ++lane) {
+			Write(idx_, sample[lane], feedback[lane]);
+			Advance();
+		}
+	}
+
+	///@brief Advance the Rec/Play heads by \p count samples
+	constexpr void Advance(size_t count = 1) {
+		// must be signed so that the result can be negative
+		idx_ += count;
+		if (idx_ >= size_) {
+			idx_ = 0;
+		}
+	}
+
+	[[nodiscard]] constexpr float Read(size_t integral = 0) const { return buffer_[wrap(idx_ + integral)]; }
+
+	[[nodiscard]] constexpr float ReadFractional(float index) const {
+		return InterpolateHermiteTable(buffer_, wrap(idx_ + index));
+	}
+
+	[[nodiscard]] constexpr Argon<float> ReadSIMD(size_t integral = 0) const {
+		auto read_idx = idx_ + integral;
+
+		// can read using quadword without wrap
+		if (read_idx < size_ - 4) [[likely]] {
+			return Argon<float>::Load(&buffer_[read_idx]);
+		}
+
+		// can read using doubleword
+		if (read_idx == size_ - 2) [[unlikely]] {
+			return Argon<float>{ArgonHalf<float>::Load(&buffer_[size_ - 2]), ArgonHalf<float>::Load(buffer_.data())};
+		}
+
+		// basically a LoadGather, without the writebacck
+		return Argon<float>::GenerateWithIndex([read_idx, this](uint32_t offset) {
+			auto lane_index = read_idx + offset;
+			if (lane_index >= size_) {
+				lane_index -= size_;
+			}
+			return buffer_[lane_index];
+		});
+	}
+
+	[[nodiscard]] constexpr Argon<float> ReadFractionalSIMD(Argon<float> index) const {
+		auto index_integral = index.ConvertTo<uint32_t>() + static_cast<uint32_t>(idx_);
+		Argon<float> index_fractional = index - index_integral.ConvertTo<float>();
+
+		// Fast wraparound: do a comparison against the length to get a vector of bitmasks, bitwise-and them with the
+		// vector of the length so that only the lanes _over_ that length are populated, then subtract that from the
+		// original set of indices
+		index_integral = index_integral - (Argon<uint32_t>(size_) & (index_integral >= size_));
+
+		return InterpolateHermiteTableSIMD<float>(buffer_, index_integral, index_fractional);
+	}
+
+	///@brief Prepares the buffer for fractional read via Hermite interpolation without needing to wrap the indices
+	void PrepForInterpolate() {
+		buffer_[-1] = buffer_[size_ - 1];
+		buffer_[size_] = buffer_[0];
+		buffer_[size_ + 1] = buffer_[1];
+	}
+
+	template <size_t othersize>
+	void RepitchCopyFrom(Buffer<othersize>& origin) {
+		if (size() == origin.size()) [[unlikely]] {
+			const size_t read_pos = origin.pos();
+			if (read_pos == 0) {
+				std::copy(origin.buffer_.begin(), origin.buffer_.end(), buffer_.begin());
+				return;
+			}
+
+			// copy over in two halves: pos to end, start to pos;
+			auto first_half_size = origin.size() - read_pos;
+			std::copy(&origin.buffer_[read_pos], &origin.buffer_[origin.size()], buffer_.data());
+			std::copy(&origin.buffer_[0], &origin.buffer_[read_pos], &buffer_[first_half_size]);
+			return;
+		}
+
+		// prep the other for fractional read
+		origin.PrepForInterpolate();
+
+		// repitch copy via Hermite interpolation
+		const float step = origin.size() / size_; // ratio
+		const Argon<float> step_simd = step * 4;
+
+		// main loop
+		Argon<float> pos = Argon{step} * Argon{0.f, 1.f, 2.f, 3.f};
+		for (size_t idx = 0; idx < (size_ & ~0b11); idx += 4) {
+			// You might think that reading the first sample (x = 0) causes a problem,
+			// as it's using an invalid sample for the x-1 value. However, because there's
+			// no fractional component for the first sample, the interpolation samples are
+			// disregarded via multiplication by 0 (the fractional coefficients),
+			// leaving us with simply y = x0
+
+			origin.ReadFractionalSIMD(pos).StoreTo(&buffer_[idx + 1]);
+			pos = pos + step_simd;
+		}
+
+		// tail loop
+		float tail_pos = pos[1]; // same as pos[0] + step
+		for (size_t idx = (size_ & ~0b11); idx < size_; ++idx) {
+			buffer_[idx + 1] = origin.ReadFractional(tail_pos);
+			tail_pos += step;
+		}
+	}
+
+	/**
+	 * @brief Copy from one buffer to another, retaining only the most recent samples (discard oldest)
+	 */
+	template <size_t othersize>
+	void CopyFrom(const Buffer<othersize>& origin) {
+		// The chunk of newest samples from the current write head to the end, is longer
+		// than the new buffer, so we don't need to copy in segments
+		if (origin.pos() >= size()) {
+			// copies n newest samples to an n-sized buffer
+			std::copy(&origin.buffer_[origin.pos() - size()], &origin.buffer_[origin.pos()], buffer_.begin());
+			return;
+		}
+
+		size_t wrap_size = size() - origin.pos();
+		std::copy(&origin.buffer_[origin.size() - wrap_size], &origin.buffer_[origin.size()], buffer_.begin());
+		std::copy(&origin.buffer_[0], &origin.buffer_[origin.size()], &buffer_[wrap_size]);
+	}
+
+	void ApplyGainRamp(blocks::GainRamp gain_ramp) {
+		const float start = gain_ramp.start();
+		const float end = gain_ramp.end();
+
+		const float breakpoint = end - ((end - start) * (pos() / size()));
+
+		std::span first_block{buffer_.data(), pos()};
+		blocks::GainRamp{breakpoint, start}.processBlock(first_block, first_block);
+
+		std::span second_block{&buffer_[pos()], &buffer_[size()]};
+		blocks::GainRamp{end, breakpoint}.processBlock(second_block, second_block);
+	}
+
+	[[nodiscard]] constexpr size_t size() const { return size_; }
+	constexpr void set_size(size_t size) { size_ = size; }
+	[[nodiscard]] constexpr size_t pos() const { return idx_; }
+
+private:
+	[[nodiscard]] constexpr size_t wrap(size_t index) const {
+		if (index >= size_) {
+			return index - size_;
+		}
+		return index;
+	}
+
+	std::array<float, max_delay + 3> raw_buffer_{}; // + 3 for hermite samples (two lookahead, one lookbehind)
+	std::span<float> buffer_{&raw_buffer_[1], max_delay};
+
+	size_t size_;
+
+	size_t idx_ = 0;
+};
+} // namespace deluge::dsp::delay::simple

--- a/src/deluge/dsp/delay/simple/delay.cpp
+++ b/src/deluge/dsp/delay/simple/delay.cpp
@@ -1,0 +1,1 @@
+#include "delay.hpp"

--- a/src/deluge/dsp/delay/simple/delay.hpp
+++ b/src/deluge/dsp/delay/simple/delay.hpp
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2024 Katherine Whitlock
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include "argon/vectorize.hpp"
+#include "buffer.hpp"
+#include "definitions_cxx.hpp"
+#include "dsp/blocks/gain_ramp.hpp"
+#include "dsp/interpolate/parameter.hpp"
+#include "dsp/stereo_sample.h"
+#include "model/types.hpp"
+#include "util/fixedpoint.h"
+#include <argon.hpp>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace deluge::dsp::delay::simple {
+
+// A simple digital delay inspired by Ableton's Delay
+class Delay {
+
+	constexpr static size_t kNumSecsDelayMax = 5;
+	constexpr static size_t kNumSamplesMainDelay = (5 * kSampleRate);
+	constexpr static size_t kNumSamplesMax =
+	    kNumSamplesMainDelay + (kNumSamplesMainDelay / 3.f); // 6.666 seconds maximum
+public:
+	enum class Mode {
+		Repitch,
+		Fade,
+		Jump,
+	};
+
+	enum class ChannelMode {
+		Sync, // beat-synced
+		Time, // strict timing
+	};
+	struct ChannelConfig {
+		ChannelMode mode;
+		Milliseconds duration;   // ms for time, beat divisions for sync, internally stored as ms
+		Percentage<float> nudge; // up to 0.33 (33%)
+
+		// Comparison ops
+		bool operator==(const ChannelConfig& b) const {
+			return mode == b.mode && duration == b.duration && nudge == b.nudge;
+		}
+		bool operator!=(const ChannelConfig& b) const {
+			return mode != b.mode || duration != b.duration || nudge != b.nudge;
+		}
+	};
+
+	struct Config {
+		bool channel_link = true; // uses first config for all settings
+		ChannelConfig l_channel;  // stereo
+		ChannelConfig r_channel;
+		Percentage<float> feedback = 0.5f; // 50% for linear decay rate by default
+		bool freeze = false; // disables new input and feedback, cycling the current buffer contents infinitely
+
+		// Standard 2 param bandpass
+		Frequency<float> filter_cutoff = 1000.f; // Hz
+		QFactor<float> filter_width = 9.0f;      // Q
+
+		// Mod block
+		Frequency<float> lfo_rate = 0.5f;
+		Percentage<float> lfo_filter_depth = 0.f;
+		// float lfo_time_depth = 0.f;
+
+		bool ping_pong = false;
+
+		Percentage<float> dry_wet = 0.5f;
+	};
+
+	void setConfig(const Config& config) { config_ = config; }
+	void processBlock(std::span<q31_t> buffer) {
+		interpolated::Parameter feedback{old_config_.feedback.value, config_.feedback.value, buffer.size()};
+
+		interpolated::Parameter filter_cutoff{old_config_.filter_cutoff.value, config_.filter_cutoff.value,
+		                                      buffer.size()};
+		interpolated::Parameter filter_width{old_config_.filter_width.value, config_.filter_width.value, buffer.size()};
+
+		interpolated::Parameter lfo_rate{old_config_.lfo_rate.value, config_.lfo_rate.value, buffer.size()};
+		interpolated::Parameter lfo_filter_depth{old_config_.lfo_filter_depth.value, config_.lfo_filter_depth.value,
+		                                         buffer.size()};
+		// interpolated::Parameter lfo_time_depth{old_config_.lfo_time_depth, new_config_.lfo_time_depth,
+		// buffer.size()};
+
+		interpolated::Parameter dry_wet{old_config_.dry_wet.value, config_.dry_wet.value, buffer.size()};
+
+		// l channel config has changed, so swap
+		if (old_config_.l_channel != config_.l_channel) {
+			auto& old_buffer = bufferLeft();
+			swapBufferLeft();
+			auto& new_buffer = bufferLeft();
+
+			new_buffer.set_size(config_.l_channel.duration                                                    // main
+			                    + static_cast<size_t>(config_.l_channel.duration * config_.l_channel.nudge)); // nudge
+
+			if (mode_ == Mode::Repitch) {
+				new_buffer.RepitchCopyFrom(old_buffer);
+			}
+			else if (mode_ == Mode::Fade) {
+				new_buffer.CopyFrom(old_buffer);
+				new_buffer.ApplyGainRamp(blocks::GainRamp{1.f, 0.f});
+			}
+			// Jump discards delay state
+		}
+
+		if (old_config_.r_channel != config_.r_channel) {
+			// r channel config has changed, so swap
+			auto& old_buffer = bufferRight();
+			swapBufferRight();
+			auto& new_buffer = bufferRight();
+
+			new_buffer.set_size(config_.r_channel.duration                                                    // main
+			                    + static_cast<size_t>(config_.r_channel.duration * config_.r_channel.nudge)); // nudge
+
+			if (mode_ == Mode::Repitch) {
+				new_buffer.RepitchCopyFrom(old_buffer);
+			}
+			else if (mode_ == Mode::Fade) {
+				new_buffer.CopyFrom(old_buffer);
+				new_buffer.ApplyGainRamp(blocks::GainRamp{1.f, 0.f});
+			}
+			// Jump discards delay state
+		}
+
+		// when the buffer is frozen, no writing is peformed, only advancement of the rec/play head
+		if (config_.freeze) {
+			for (auto& [left, right] : argon::vectorize_interleaved<2, int32_t>(buffer)) {
+				left = bufferLeft().ReadSIMD().ConvertTo<q31_t, 31>(); // To Q31
+				bufferLeft().Advance(4);
+
+				right = bufferRight().ReadSIMD().ConvertTo<q31_t, 31>(); // To Q31
+				bufferRight().Advance(4);
+			}
+			return;
+		}
+
+		// Otherwise...
+		for (auto& [left, right] : argon::vectorize_interleaved<2, int32_t>(buffer)) {
+			feedback.Next();
+			filter_cutoff.Next();
+			filter_width.Next();
+			lfo_rate.Next();
+			lfo_filter_depth.Next();
+			dry_wet.Next();
+		}
+		old_config_ = config_;
+	}
+
+	void process(std::array<Argon<int32_t>, 2> samples) {}
+
+	std::pair<Buffer<kNumSamplesMax>&, Buffer<kNumSamplesMax>&> buffers() { return {bufferLeft(), bufferRight()}; }
+
+	Buffer<kNumSamplesMax>& bufferLeft() { return l_buffers_[l_buffer_idx_]; }
+
+	Buffer<kNumSamplesMax>& bufferRight() { return l_buffers_[l_buffer_idx_]; }
+
+private:
+	void swapBufferLeft() { l_buffer_idx_ = !l_buffer_idx_; }
+	void swapBufferRight() { r_buffer_idx_ = !r_buffer_idx_; }
+
+	constexpr size_t calcBufferSize(size_t time_ms) {
+		return (time_ms * kSampleRate) / 1000; // divide by 1000 due to ms (i.e. * 0.001)
+	}
+
+	std::array<Buffer<kNumSamplesMax>, 2> l_buffers_; // 3D array.
+	std::array<Buffer<kNumSamplesMax>, 2> r_buffers_; // 3D array.
+
+	size_t l_buffer_idx_ = 0; // Which buffer is currently selected. This is used for
+	size_t r_buffer_idx_ = 0; // when the delay time changes and how to handle it depending on mode
+
+	// config
+	Config old_config_;
+	Config config_;
+
+	Mode mode_ = Mode::Repitch;
+};
+} // namespace deluge::dsp::delay::simple

--- a/src/deluge/dsp/dx/aligned_buf.h
+++ b/src/deluge/dsp/dx/aligned_buf.h
@@ -20,7 +20,8 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
+#include <cstdint>
 
 template <typename T, size_t size, size_t alignment = 16>
 class AlignedBuf {

--- a/src/deluge/dsp/filter/filter.cpp
+++ b/src/deluge/dsp/filter/filter.cpp
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU General Public License along with this program.
  * If not, see <https://www.gnu.org/licenses/>.
  */
+#include "definitions.h"
 #include "util/fixedpoint.h"
 namespace deluge::dsp::filter {
 q31_t blendBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2] = {0};

--- a/src/deluge/dsp/granular/GranularProcessor.cpp
+++ b/src/deluge/dsp/granular/GranularProcessor.cpp
@@ -24,6 +24,7 @@
 #include "model/mod_controllable/mod_controllable.h"
 #include "modulation/lfo.h"
 #include "playback/playback_handler.h"
+#include "processing/engines/audio_engine.h"
 
 void GranularProcessor::setWrapsToShutdown() {
 

--- a/src/deluge/dsp/interpolate/interpolate.h
+++ b/src/deluge/dsp/interpolate/interpolate.h
@@ -1,9 +1,10 @@
 #pragma once
 #include "definitions_cxx.hpp"
-#include <arm_neon_shim.h>
+#include "dsp/interpolate/interpolate.h"
+#include <argon.hpp>
 #include <array>
 #include <cstdint>
-
+#include <span>
 extern const int16_t windowedSincKernel[][17][16];
 
 namespace deluge::dsp {
@@ -11,5 +12,96 @@ void interpolate(int32_t* sampleRead, int32_t numChannelsNow, int32_t whichKerne
                  std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer);
 void interpolateLinear(int32_t* sampleRead, int32_t numChannelsNow, int32_t whichKernel, uint32_t oscPos,
                        std::array<std::array<int16x4_t, kInterpolationMaxNumSamples / 4>, 2>& interpolationBuffer);
+
+template <typename T = float>
+constexpr T InterpolateLinear(const T x_0, const T x_1, float fractional) {
+	return static_cast<T>(x_0 + ((x_1 - x_0) * fractional));
+}
+
+template <typename T = float, typename U = float>
+constexpr T InterpolateHermite(const T x_m1, const T x_0, const T x_1, const T x_2, U fractional) {
+	const T c = (x_1 - x_m1) * 0.5f;
+	const T v = x_0 - x_1;
+	const T w = c + v;
+	const T a = w + v + ((x_2 - x_0) * 0.5f);
+	const T b_neg = w + a;
+	return (((((a * fractional) - b_neg) * fractional) + c) * fractional) + x_0;
+}
+
+template <typename T>
+inline float InterpolateHermiteTable(std::span<T> table, float index) {
+	auto index_integral = static_cast<size_t>(index);
+	float index_fractional = index - static_cast<float>(index_integral);
+
+	const T x_m1 = table[index_integral - 1];
+	const T x_0 = table[index_integral + 0];
+	const T x_1 = table[index_integral + 1];
+	const T x_2 = table[index_integral + 2];
+	return InterpolateHermite(x_m1, x_0, x_1, x_2, index_fractional);
+}
+
+/// @brief Transpose a 4x4 matrix comprised of an array of vectors
+/// {a, b, c, d}    {a, e, i, m}
+/// {e, f, g, h} -> {b, f, j, n}
+/// {i, j, k, l} -> {c, g, k, o}
+/// {m, n, o, p}    {d, h, l, p}
+template <typename T>
+std::array<Argon<T>, 4> transpose(Argon<T> r_0, Argon<T> r_1, Argon<T> r_2, Argon<T> r_3) {
+	// {a, b, c, d}    {a, e, c, g}
+	// {e, f, g, h} -> {b, f, d, h}
+	// {i, j, k, l} -> {i, j, k, l}
+	// {m, n, o, p}    {m, n, o, p}
+	std::tie(r_0, r_1) = r_0.TransposeWith(r_1);
+
+	// {a, e, c, g}    {a, e, c, g}
+	// {b, f, d, h} -> {b, f, d, h}
+	// {i, j, k, l} -> {i, m, k, o}
+	// {m, n, o, p}    {j, n, l, p}
+	std::tie(r_2, r_3) = r_2.TransposeWith(r_3);
+
+	// {a, e, c, g}    {a, e, i, m}
+	// {b, f, d, h} -> {b, f, d, h}
+	// {i, m, k, o} -> {c, g, k, o}
+	// {j, n, l, p}    {j, n, l, p}
+	std::tie(r_0, r_2) =
+	    std::make_tuple(r_0.GetLow().CombineWith(r_2.GetLow()), r_0.GetHigh().CombineWith(r_2.GetHigh()));
+
+	// {a, e, i, m}    {a, e, i, m}
+	// {b, f, d, h} -> {b, f, j, n}
+	// {c, g, k, o} -> {c, g, k, o}
+	// {j, n, l, p}    {d, h, l, p}
+	std::tie(r_1, r_3) =
+	    std::make_tuple(r_1.GetLow().CombineWith(r_3.GetLow()), r_1.GetHigh().CombineWith(r_3.GetHigh()));
+
+	return std::array{r_0, r_1, r_2, r_3};
+}
+
+template <typename T>
+inline Argon<T> InterpolateHermiteTableSIMD(std::span<T> table, Argon<uint32_t> index_integral,
+                                            Argon<float> index_fractional) {
+	index_integral = index_integral - 1;
+
+	// writeback incurred
+	std::array index_integral_arr = index_integral.to_array();
+
+	// x_m1 = { l0[-1], l1[-1], l2[-1], l3[-1] }
+	// x_0  = { l0[0],  l1[0],  l2[0],  l3[0]  }
+	// x_1  = { l0[1],  l1[1],  l2[1],  l3[1]  }
+	// x_2  = { l0[2],  l1[2],  l2[2],  l3[2]  }
+	auto [x_m1, x_0, x_1, x_2] = transpose(            //<
+	    Argon<T>::Load(&table[index_integral_arr[0]]), // {l0[-1], l0[0], l0[1], l0[2]}
+	    Argon<T>::Load(&table[index_integral_arr[1]]), // {l1[-1], l1[0], l1[1], l1[2]}
+	    Argon<T>::Load(&table[index_integral_arr[2]]), // {l2[-1], l2[0], l2[1], l2[2]}
+	    Argon<T>::Load(&table[index_integral_arr[3]])  // {l3[-1], l3[0], l3[1], l3[2]}
+	);
+	return InterpolateHermite(x_m1, x_0, x_1, x_2, index_fractional);
+}
+
+template <typename T>
+inline Argon<T> InterpolateHermiteTableSIMD(std::span<T> table, Argon<float> index) {
+	auto index_integral = index.ConvertTo<uint32_t>();
+	Argon<float> index_fractional = index - index_integral.ConvertTo<float>();
+	return InterpolateHermiteTableSIMD<T>(table, index_integral, index_fractional);
+}
 
 } // namespace deluge::dsp

--- a/src/deluge/dsp/interpolate/interpolated_value.hpp
+++ b/src/deluge/dsp/interpolate/interpolated_value.hpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2024 Katherine Whitlock
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <cmath>
+#include <cstddef>
+
+enum class InterpolationType {
+	Linear,
+	Multiplicative,
+};
+
+template <typename T, InterpolationType U = InterpolationType::Linear>
+class InterpolatedValue {
+public:
+	constexpr InterpolatedValue(T value) { Init(value, value, 1); }
+
+	constexpr InterpolatedValue(T value, T target_value, size_t num_steps) { Init(value, target_value, num_steps); }
+
+	constexpr void Init(T value, T target_value, size_t num_steps) {
+		orig_value_ = value;
+		value_ = value;
+		target_value_ = target_value;
+		num_steps_ = num_steps;
+		increment_ = is_interpolating() ? calc_increment() : identity_increment();
+	}
+
+	constexpr float Next() {
+		if (is_interpolating()) {
+			if constexpr (U == InterpolationType::Linear) {
+				value_ += increment_;
+			}
+			else if constexpr (U == InterpolationType::Multiplicative) {
+				value_ *= increment_;
+			}
+		}
+		return value_;
+	}
+
+	constexpr void Reset(float sample_rate, float ramp_length_in_seconds) {
+		Reset(static_cast<size_t>(std::floor(ramp_length_in_seconds * sample_rate)));
+	}
+
+	constexpr void Reset(size_t num_steps) {
+		num_steps_ = num_steps;
+		value_ = orig_value_;
+		increment_ = calc_increment();
+	}
+
+	constexpr void Set(T target_value, size_t num_steps) {
+		target_value_ = target_value;
+		num_steps_ = num_steps;
+		increment_ = (is_interpolating()) ? calc_increment() : identity_increment();
+	}
+
+	constexpr void Set(T value) { set_current_and_target(value); }
+
+	[[nodiscard]] constexpr T value() const { return value_; }
+	[[nodiscard]] constexpr T target() const { return target_value_; }
+	[[nodiscard]] constexpr bool is_interpolating() const { return (value_ != target_value_); }
+
+private:
+	constexpr void set_steps(size_t num_steps) {
+		num_steps_ = num_steps;
+		if (is_interpolating()) {
+			increment_ = calc_increment();
+		}
+	}
+
+	constexpr void set_target(T target_value) {
+		target_value_ = target_value;
+		increment_ = calc_increment();
+	}
+
+	constexpr void set_current_and_target(T value) {
+		value_ = value;
+		target_value_ = value;
+	}
+
+	[[nodiscard]] constexpr T calc_increment() const {
+		auto num_steps_f = static_cast<float>(num_steps_);
+		if constexpr (U == InterpolationType::Linear) {
+			return (target_value_ - value_) / num_steps_f;
+		}
+		else if constexpr (U == InterpolationType::Multiplicative) {
+			return std::exp((std::log(std::abs(target_value_)) - std::log(std::abs(value_))) / num_steps_f);
+		}
+	}
+
+	constexpr T identity_increment() {
+		if constexpr (U == InterpolationType::Linear) {
+			return T{0};
+		}
+		else if constexpr (U == InterpolationType::Multiplicative) {
+			return T{1};
+		}
+	}
+
+	T value_ = 0;
+	T orig_value_ = 0;
+	T target_value_ = 0;
+	float increment_ = 0.f;
+	size_t num_steps_ = 1;
+};

--- a/src/deluge/dsp/interpolate/parameter.hpp
+++ b/src/deluge/dsp/interpolate/parameter.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include <cstddef>
+
+namespace deluge::dsp::interpolated {
+class Parameter {
+public:
+	Parameter(float& state, float new_value, size_t size)
+	    : state_(state), value_(new_value), increment_((new_value - state) / static_cast<float>(size)) {}
+
+	constexpr float Next() {
+		value_ += increment_;
+		return value_;
+	}
+
+	constexpr float subsample(float t) { return value_ + (increment_ * t); }
+
+private:
+	float& state_;
+	float value_;
+	float increment_;
+};
+} // namespace deluge::dsp::interpolated

--- a/src/deluge/model/types.hpp
+++ b/src/deluge/model/types.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include "util/fixedpoint.h"
+#include <ratio>
+#include <string_view>
+
+template <typename T>
+struct Value {
+	T value = 0;
+	operator T() { return value; }
+	auto operator<=>(const Value<T>& o) const = default;
+};
+
+template <typename T>
+struct Frequency : Value<T> {
+	Frequency() : Value<T>() {}
+	Frequency(T value) : Value<T>{value} {}
+	static constexpr std::string_view unit = "Hz";
+};
+
+template <typename T>
+struct Percentage;
+
+template <>
+struct Percentage<float> : Value<float> {
+	static constexpr std::string_view unit = "%";
+
+	Percentage() = default;
+	Percentage(float value) : Value<float>{value} {}
+	Percentage(float value, float lower_bound, float upper_bound)
+	    : Value<float>{value}, lower_bound{lower_bound}, upper_bound{upper_bound} {}
+
+	float lower_bound = 0.f;
+	float upper_bound = 1.f;
+};
+
+template <>
+struct Percentage<q31_t> : Value<q31_t> {
+	static constexpr std::string_view unit = "%";
+
+	Percentage() = default;
+	Percentage(q31_t value) : Value<q31_t>{value} {}
+	Percentage(q31_t value, q31_t lower_bound, q31_t upper_bound)
+	    : Value<q31_t>{value}, lower_bound{lower_bound}, upper_bound{upper_bound} {}
+
+	Percentage(float value) : Value<q31_t>{q31_from_float(value)} {}
+	Percentage(float value, float lower_bound, float upper_bound)
+	    : Value<q31_t>{q31_from_float(value)}, lower_bound{q31_from_float(lower_bound)},
+	      upper_bound{q31_from_float(upper_bound)} {}
+
+	q31_t lower_bound = q31_from_float(0.f);
+	q31_t upper_bound = q31_from_float(1.f);
+};
+
+template <typename T>
+struct QFactor : Value<T> {
+	QFactor(T value) : Value<T>{value} {}
+};
+
+struct Milliseconds : Value<int32_t> {
+	static constexpr std::string_view unit = "ms";
+};

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -16,7 +16,9 @@
  */
 #pragma once
 
+#include <arm_neon.h>
 #include <cstdint>
+
 // signed 31 fractional bits (e.g. one would be 1<<31 but can't be represented)
 using q31_t = int32_t;
 
@@ -147,3 +149,39 @@ inline int32_t clz(uint32_t input) {
 	return __builtin_clz(input);
 }
 #endif
+
+using q63_t = int64_t;
+
+///@brief Clips Q63 to Q31 values.
+constexpr q31_t clip_q63(q63_t x) {
+	if ((q31_t)(x >> 32) != ((q31_t)x >> 31)) {
+		return ((0x7FFFFFFF ^ ((q31_t)(x >> 63))));
+	}
+	else {
+		return (q31_t)x;
+	}
+}
+
+constexpr q31_t q31_from_float(float x) {
+	return clip_q63((q63_t)(x * 2147483648.0f));
+}
+
+constexpr int32x4_t q31_from_float(float32x4_t x) {
+	return vcvtq_n_s32_f32(x, 31);
+}
+
+constexpr int32x2_t q31_from_float(float32x2_t x) {
+	return vcvt_n_s32_f32(x, 31);
+}
+
+constexpr float q31_to_float(q31_t x) {
+	return (float)x / 2147483648.0f;
+}
+
+constexpr float32x4_t q31_to_float(int32x4_t x) {
+	return vcvtq_n_f32_s32(x, 31);
+}
+
+constexpr float32x2_t q31_to_float(int32x2_t x) {
+	return vcvt_n_f32_s32(x, 31);
+}


### PR DESCRIPTION
This is a new digital delay inspired by the generic digital delay found in just about every DAW, particularly Ableton.

Differences from the original delay:
- Simpler architecture
- Repitch occurs on modification of the delay length, not at the insertion (i.e. at playback, not at record)
- NEON acceleration throughout