### PR TITLE
Enable l2 instruction cache only

### DIFF
--- a/src/RZA1/cache/cache.c
+++ b/src/RZA1/cache/cache.c
@@ -240,9 +240,10 @@ void L2CacheFlushAll(void)
 void L2CacheEnable(void)
 {
     L2C.REG2_INT_CLEAR   = 0x000001FFuL; /* Clear the reg2_int_raw_status register */
-    L2C.REG9_D_LOCKDOWN0 = 0x00000000uL;
-
-    L2C.REG1_CONTROL = 0x00000001uL; /* Enable L2 cache */
+    L2C.REG9_D_LOCKDOWN0 = 0xFFFFFFFFuL; // lock the data cache - we need a lot of work around invalidating it with DMA
+                                         // before it can be used
+    L2C.REG9_I_LOCKDOWN0 = 0x00000000uL; // unlock the instruction cache
+    L2C.REG1_CONTROL     = 0x00000001uL; /* Enable L2 cache */
 }
 
 /******************************************************************************
@@ -254,6 +255,13 @@ void L2CacheEnable(void)
 void L2CacheDisable(void)
 {
     L2C.REG1_CONTROL = 0x00000000uL; /* Disable L2 cache */
+}
+
+void L2CacheInit(void)
+{
+    L2CacheDisable();
+    L2CacheFlushAll();
+    L2CacheEnable();
 }
 
 /* End of File */

--- a/src/RZA1/cache/cache.h
+++ b/src/RZA1/cache/cache.h
@@ -64,7 +64,7 @@ void L2CacheInit(void);
 void L2CacheFlushAll(void);
 void L2CacheEnable(void);
 void L2CacheDisable(void);
-
+void L2CacheInit(void);
 extern void R_CACHE_L1Init(void);
 
 #endif /* CACHE_H */

--- a/src/RZA1/compiler/asm/access.S
+++ b/src/RZA1/compiler/asm/access.S
@@ -130,6 +130,7 @@ enable_mmu:
     MRC  p15, 0, r0, c1, c0, 0     /* Read CP15 System Control register (SCTLR) */
     BIC  r0, r0, #(0x1 << 12)             /* Clear I bit 12 to disable I Cache */
     BIC  r0, r0, #(0x1 <<  2)             /* Clear C bit  2 to disable D Cache */
+    BIC  r0, r0, #(0x1 <<  1)          /* Clear C bit  1 to disable btac Cache */
     BIC  r0, r0, #0x2       /* Clear A bit 1 to disable alignment fault check */
     ORR  r0, r0, #0x1      /* Set M bit 1 to enable MMU before scatter loading */
     MCR  p15, 0, r0, c1, c0, 0            /* Write CP15 System Control register */


### PR DESCRIPTION
Mild speedup with no downsides, the instruction cache doesn't have the same invalidation problems with DMA as the data cache. 

Data cache is a future problem