### PR TITLE
Updating cross-links in developer documentation

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,8 +51,8 @@ appreciated.
 * Code reviews are intended to increase quality and should not go into nitpicking, please remember
   the [Code of Conduct](CODE_OF_CONDUCT.md).
 * Final decisions about merging of Pull requests is up to the code owners, see [Governance](GOVERNANCE.md).
-* If you have a contribution to make then review the [Guidelines for Repository Contributions](/docs/dev/guidelines.md). 
+* If you have a contribution to make then review the [Guidelines for Repository Contributions](dev/guidelines.md). 
 
 ## Additional Developer Resources
 
-* Access more developer resources in [Additional Information](/docs/dev/additional_info.md).
+* Access more developer resources in [Additional Information](dev/additional_info.md).

--- a/docs/dev/SysExProtocolNotes.md
+++ b/docs/dev/SysExProtocolNotes.md
@@ -48,4 +48,4 @@ The file routines work with Uint8Array objects. The assumption is that we have a
 
 ## Additional Developer Resources
 
-* Access more developer resources in [Additional Information](/docs/dev/additional_info.md).
+* Access more developer resources in [Additional Information](additional_info.md).

--- a/docs/dev/additional_info.md
+++ b/docs/dev/additional_info.md
@@ -1,11 +1,11 @@
 ## Additional Information
 Developers will want to review these resources:
 
-* [Getting Started with Deluge Development](/docs/dev/getting_started.md)
-* [Guidelines for Repository Contributions](/docs/dev/guidelines.md)
-* [Developer Tools](/docs/dev/tools.md)
-* [Deluge UX Principles](/docs/dev/ux_principles.md)
-* [SYSEX Protocol Notes](/docs/dev/SysExProtocolNotes.md)
+* [Getting Started with Deluge Development](getting_started.md)
+* [Guidelines for Repository Contributions](guidelines.md)
+* [Developer Tools](tools.md)
+* [Deluge UX Principles](ux_principles.md)
+* [SYSEX Protocol Notes](SysExProtocolNotes.md)
 
 There are a lot more resources that help you getting started in the repository [Wiki](https://github.com/SynthstromAudible/DelugeFirmware/wiki) including but not limited to:
 

--- a/docs/dev/getting_started.md
+++ b/docs/dev/getting_started.md
@@ -82,4 +82,4 @@ Any additional arguments to CMake may be transparently passed via `dbt build`. P
 
 ## Additional Developer Resources
 
-* Access more developer resources in [Additional Information](/docs/dev/additional_info.md).
+* Access more developer resources in [Additional Information](additional_info.md).

--- a/docs/dev/guidelines.md
+++ b/docs/dev/guidelines.md
@@ -124,4 +124,4 @@ project by:
 
 ## Additional Developer Resources
 
-* Access more developer resources in [Additional Information](/docs/dev/additional_info.md).
+* Access more developer resources in [Additional Information](additional_info.md).

--- a/docs/dev/tools.md
+++ b/docs/dev/tools.md
@@ -121,4 +121,4 @@ Then run the command that Deluge Crash Reader Bot outputs. This outputs the late
 
 ## Additional Developer Resources
 
-* Access more developer resources in [Additional Information](/docs/dev/additional_info.md).
+* Access more developer resources in [Additional Information](additional_info.md).

--- a/docs/dev/ux_principles.md
+++ b/docs/dev/ux_principles.md
@@ -47,4 +47,4 @@ This is a subset of issues where the current UX does not fully align with the pr
 
 ## Additional Information
 
-* Access more developer resources in [Additional Information](/docs/dev/additional_info.md)
+* Access more developer resources in [Additional Information](additional_info.md)


### PR DESCRIPTION
So that links work in doxygen documentation.