### PR TITLE
Fix perf view stutter latching bug

### DIFF
--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -1365,8 +1365,8 @@ void PerformanceView::resetFXColumn(ModelStackWithThreeMainThings* modelStack, i
 /// reset press info and stutter when exiting performance view
 /// exit out of default editing mode
 void PerformanceView::releaseViewOnExit(ModelStackWithThreeMainThings* modelStack) {
-	resetPadPressInfo();
 	releaseStutter(modelStack);
+	resetPadPressInfo();
 	defaultEditingMode = false;
 	editingParam = false;
 }


### PR DESCRIPTION
Fixed bug where stutter could get latched if stutter pad is pressed in performance view while exiting performance view

fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3080