### PR TITLE
yield instead since this is now broken

### DIFF
--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -24,6 +24,7 @@
 #include "model/sample/sample_recorder.h"
 #include "model/voice/voice_sample.h"
 #include "processing/engines/audio_engine.h"
+#include "scheduler_api.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 #include "storage/multi_range/multisample_range.h"
@@ -554,8 +555,8 @@ cantReadData:
 			if (nextCluster) {
 				audioFileManager.removeReasonFromCluster(nextCluster, "9700");
 			}
-
-			AudioEngine::routineWithClusterLoading(); // -----------------------------------
+			// just yield to run a single thing (probably audio)
+			yield([]() { return true; });
 		}
 	}
 


### PR DESCRIPTION
There's a bunch of other spots where this is probably causing problems, but this one specifically is only in the UI so it's safe to cherry pick to the RC. I'll do a follow up PR removing routineWithClusterLoading more generally but I'm not sure if there would be side effects somewhere, it seems to get called during big song operations too 