### PR TITLE
Use VCVT for Q31 conversions

### DIFF
--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -23,6 +23,7 @@
 #include "storage/audio/audio_file.h"
 #include "util/container/array/ordered_resizeable_array.h"
 #include "util/container/array/ordered_resizeable_array_with_multi_word_key.h"
+#include "util/fixedpoint.h"
 #include "util/functions.h"
 
 #define SAMPLE_DO_LOCKS (ALPHA_OR_BETA_VERSION)
@@ -76,7 +77,7 @@ public:
 	inline void convertOneData(int32_t* value) {
 		// Floating point
 		if (rawDataFormat == RAW_DATA_FLOAT)
-			convertFloatToIntAtMemoryLocation((uint32_t*)value);
+			*value = q31_from_float(std::bit_cast<float>(value));
 
 		// Or endianness swap
 		else if (rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_32) {

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -30,6 +30,7 @@
 #include "storage/cluster/cluster.h"
 #include "storage/storage_manager.h"
 #include "storage/wave_table/wave_table_reader.h"
+#include "util/fixedpoint.h"
 #include <new>
 
 extern int32_t oscSyncRenderingBuffer[];
@@ -420,7 +421,7 @@ gotError5:
 #define CONVERT_AND_STORE_SAMPLE                                                                                       \
 	{                                                                                                                  \
 		if (rawDataFormat == RAW_DATA_FLOAT) {                                                                         \
-			value32 = floatBitPatternToInt(value32);                                                                   \
+			value32 = q31_from_float(std::bit_cast<float>(value32));                                                   \
 		}                                                                                                              \
 		else {                                                                                                         \
 			if (swappingEndianness) {                                                                                  \

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -111,11 +111,15 @@ inline int32_t clz(uint32_t input) {
 	return out;
 }
 
+///@brief Convert from a float to a q31 value, saturating above 1.0
+///@note VFP instruction - 1 cycle for issue, 4 cycles result latency
 static inline q31_t q31_from_float(float value) {
 	asm("vcvt.f32.s32 %0, %0, #31" : "=t"(value) : "t"(value));
 	return std::bit_cast<q31_t>(value);
 }
 
+///@brief Convert from a q31 to a float
+///@note VFP instruction - 1 cycle for issue, 4 cycles result latency
 static inline float q31_to_float(q31_t value) {
 	asm("vcvt.s32.f32 %0, %0, #31" : "=t"(value) : "t"(value));
 	return std::bit_cast<float>(value);

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -229,47 +229,6 @@ char const* sourceToStringShort(PatchSource source);
 int32_t shiftVolumeByDB(int32_t oldValue, float offset);
 int32_t quickLog(uint32_t input);
 
-[[gnu::always_inline]] constexpr void convertFloatToIntAtMemoryLocation(uint32_t* pos) {
-
-	//*(int32_t*)pos = *(float*)pos * 2147483648;
-
-	uint32_t readValue = *(uint32_t*)pos;
-	int32_t exponent = (int32_t)((readValue >> 23) & 255) - 127;
-
-	int32_t outputValue = (exponent >= 0) ? 2147483647 : (uint32_t)((readValue << 8) | 0x80000000) >> (-exponent);
-
-	// Sign bit
-	if (readValue >> 31)
-		outputValue = -outputValue;
-
-	*pos = outputValue;
-}
-
-[[gnu::always_inline]] constexpr int32_t floatToInt(float theFloat) {
-	uint32_t readValue = std::bit_cast<uint32_t>(theFloat);
-	int32_t exponent = (int32_t)((readValue >> 23) & 255) - 127;
-
-	int32_t outputValue = (exponent >= 0) ? 2147483647 : (uint32_t)((readValue << 8) | 0x80000000) >> (-exponent);
-
-	// Sign bit
-	if (readValue >> 31)
-		outputValue = -outputValue;
-
-	return outputValue;
-}
-
-[[gnu::always_inline]] constexpr int32_t floatBitPatternToInt(uint32_t readValue) {
-	int32_t exponent = (int32_t)((readValue >> 23) & 255) - 127;
-
-	int32_t outputValue = (exponent >= 0) ? 2147483647 : (uint32_t)((readValue << 8) | 0x80000000) >> (-exponent);
-
-	// Sign bit
-	if (readValue >> 31)
-		outputValue = -outputValue;
-
-	return outputValue;
-}
-
 int32_t interpolateTable(uint32_t input, int32_t numBitsInInput, const uint16_t* table, int32_t numBitsInTableSize = 8);
 uint32_t interpolateTableInverse(int32_t tableValueBig, int32_t numBitsInLookupOutput, const uint16_t* table,
                                  int32_t numBitsInTableSize = 8);


### PR DESCRIPTION
Current code compiles to about 17 ALU instructions, versus the single VCVT with a writeback latency of 4 cycles.
Godbolt: https://godbolt.org/z/ohcTeEGvo