### PR TITLE
Rewrite ClusterPriorityQueue to use STL containers instead of custom ResizeableArray

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,6 @@ add_compile_options(
 
     # C++ stuff
     $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
-    $<$<COMPILE_LANGUAGE:CXX>:-fno-exceptions>
     $<$<COMPILE_LANGUAGE:CXX>:-fno-use-cxa-atexit>
     $<$<COMPILE_LANGUAGE:CXX>:-fno-threadsafe-statics>
 
@@ -269,9 +268,6 @@ set(NMDUMP_FILE $<CONFIG>/deluge${EXECUTABLE_VERSION_SUFFIX}.nmdump)
 
 # add link options to generate memory map
 target_link_options(deluge PUBLIC
-
-    # use newlib nano
-    --specs=nano.specs
 
     -T ${PROJECT_SOURCE_DIR}/linker_script_rz_a1l.ld
     LINKER:-Map=${MAP_FILE}

--- a/linker_script_rz_a1l.ld
+++ b/linker_script_rz_a1l.ld
@@ -336,10 +336,9 @@ SECTIONS
   /DISCARD/ :
   {
     libc.a ( * )
-	libc_nano.a ( * )
     libm.a ( * )
     libgcc.a ( * )
-    libstdc++_nano.a ( * )
+    libstdc++.a ( * )
   }
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_path(SET SHARED_INCLUDE ${CMAKE_CURRENT_LIST_DIR})
 
-target_sources(deluge PUBLIC main.c resetprg.c c_lib_alternatives.S sys_stubs.c)
+target_sources(deluge PUBLIC main.c resetprg.c c_lib_alternatives.S malloc.c terminate.cpp)
 
 add_subdirectory(OSLikeStuff)
 add_subdirectory(deluge)

--- a/src/cpp_handler.cpp
+++ b/src/cpp_handler.cpp
@@ -1,0 +1,3 @@
+//
+// Created by Mark Adams on 2024-12-18.
+//

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -1096,7 +1096,7 @@ void TimeStretcher::rememberPercCacheCluster(Cluster* cluster) {
 		return;
 	}
 
-	audioFileManager.addReasonToCluster(cluster);
+	cluster->addReason();
 
 	if (percCacheClustersNearby[0]) {
 		audioFileManager.removeReasonFromCluster(percCacheClustersNearby[0],

--- a/src/deluge/memory/fallback_allocator.h
+++ b/src/deluge/memory/fallback_allocator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "memory/general_memory_allocator.h"
+#include "util/exceptions.h"
 #include <cstddef>
 extern "C" {
 void abort(void); // this is defined in reset_handler.S
@@ -22,18 +23,15 @@ public:
 	template <typename U>
 	constexpr fallback_allocator(const fallback_allocator<U>&) noexcept {};
 
-	[[nodiscard]] T* allocate(std::size_t n) noexcept {
+	[[nodiscard]] T* allocate(std::size_t n) noexcept(false) {
 		if (n == 0) {
 			return nullptr;
 		}
 		void* addr = GeneralMemoryAllocator::get().allocExternal(n * sizeof(T));
-		// cpp specifies we should throw. Given that we don't have excpetions
-		// we are obligated to freeze
-		// c++ wil NOT check for nullptr before calling constructors on the return address
 		if (addr != nullptr) {
 			return static_cast<T*>(addr);
 		}
-		abort();
+		throw deluge::exception::BAD_ALLOC;
 	}
 
 	void deallocate(T* p, std::size_t n) { GeneralMemoryAllocator::get().deallocExternal(p); }

--- a/src/deluge/memory/fast_allocator.h
+++ b/src/deluge/memory/fast_allocator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "memory/general_memory_allocator.h"
+#include "util/exceptions.h"
 #include <cstddef>
 extern "C" {
 void abort(void); // this is defined in reset_handler.S
@@ -13,38 +14,38 @@ namespace deluge::memory {
  * @tparam T The type to allocate for
  */
 template <typename T>
-class fallback_allocator {
+class fast_allocator {
 public:
 	using value_type = T;
 
-	constexpr fallback_allocator() noexcept = default;
+	constexpr fast_allocator() noexcept = default;
 
 	template <typename U>
-	constexpr fallback_allocator(const fallback_allocator<U>&) noexcept {};
+	constexpr fast_allocator(const fast_allocator<U>&) noexcept {};
 
-	[[nodiscard]] T* allocate(std::size_t n) noexcept {
+	[[nodiscard]] T* allocate(std::size_t n) noexcept(false) {
 		if (n == 0) {
 			return nullptr;
 		}
-		void* addr = GeneralMemoryAllocator::get().allocExternal(n * sizeof(T));
+		void* addr = GeneralMemoryAllocator::get().allocMaxSpeed(n * sizeof(T));
 		// cpp specifies we should throw. Given that we don't have excpetions
 		// we are obligated to freeze
 		// c++ wil NOT check for nullptr before calling constructors on the return address
 		if (addr != nullptr) {
 			return static_cast<T*>(addr);
 		}
-		abort();
+		throw deluge::exception::BAD_ALLOC;
 	}
 
-	void deallocate(T* p, std::size_t n) { GeneralMemoryAllocator::get().deallocExternal(p); }
+	void deallocate(T* p, std::size_t n) { GeneralMemoryAllocator::get().dealloc(p); }
 
 	template <typename U>
-	bool operator==(const deluge::memory::fallback_allocator<U>& o) {
+	bool operator==(const fast_allocator<U>& o) {
 		return true;
 	}
 
 	template <typename U>
-	bool operator!=(const deluge::memory::fallback_allocator<U>& o) {
+	bool operator!=(const fast_allocator<U>& o) {
 		return false;
 	}
 };

--- a/src/deluge/memory/fast_allocator.h
+++ b/src/deluge/memory/fast_allocator.h
@@ -28,9 +28,6 @@ public:
 			return nullptr;
 		}
 		void* addr = GeneralMemoryAllocator::get().allocMaxSpeed(n * sizeof(T));
-		// cpp specifies we should throw. Given that we don't have excpetions
-		// we are obligated to freeze
-		// c++ wil NOT check for nullptr before calling constructors on the return address
 		if (addr != nullptr) {
 			return static_cast<T*>(addr);
 		}

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -1695,7 +1695,7 @@ void Sample::convertDataOnAnyClustersIfNecessary() {
 			if (cluster) {
 
 				// Add reason in case it would get stolen
-				audioFileManager.addReasonToCluster(cluster);
+				cluster->addReason();
 
 				cluster->convertDataIfNecessary();
 

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -163,10 +163,8 @@ void Sample::markAsUnloadable() {
 	// If any Clusters in the load-queue, remove them from there
 	for (int32_t c = 0; c < clusters.getNumElements(); c++) {
 		Cluster* cluster = clusters.getElement(c)->cluster;
-		if (cluster) {
-			if (audioFileManager.loadingQueue.removeIfPresent(cluster)) {
-				// TODO: what's going to happen to this cluster now?
-			}
+		if (cluster != nullptr) {
+			audioFileManager.loadingQueue.erase(*cluster);
 		}
 	}
 }

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -191,7 +191,7 @@ justEnqueue:
 			}
 		}
 
-		audioFileManager.addReasonToCluster(cluster);
+		cluster->addReason();
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on V4.0.x have been getting E341.
 		if (cluster && cluster->numReasonsToBeLoaded <= 0) {

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -1284,7 +1284,7 @@ void SampleLowLevelReader::cloneFrom(SampleLowLevelReader* other, bool stealReas
 				other->clusters[l] = NULL;
 			}
 			else {
-				audioFileManager.addReasonToCluster(clusters[l]);
+				clusters[l]->addReason();
 			}
 		}
 	}

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -960,7 +960,7 @@ Cluster* AudioFileManager::allocateCluster(ClusterType type, bool shouldAddReaso
 	cluster->type = type;
 
 	if (shouldAddReasons) {
-		addReasonToCluster(cluster);
+		cluster->addReason();
 	}
 
 	return cluster;
@@ -1008,8 +1008,8 @@ bool AudioFileManager::loadCluster(Cluster* cluster, int32_t minNumReasonsAfter)
 	}
 #endif
 
-	addReasonToCluster(cluster); // So that it can't accidentally hit 0 reasons while we're loading it, cos then it
-	                             // might get deallocated.
+	cluster->addReason(); // So that it can't accidentally hit 0 reasons while we're loading it, cos then it
+	                      // might get deallocated.
 
 	if (false) {
 getOutEarly:
@@ -1376,8 +1376,8 @@ performActionsAndGetOut:
 			cluster = &loadingQueue.front();
 			loadingQueue.pop();
 			if (cluster->numReasonsToBeLoaded > 0) {
-			break;
-		}
+				break;
+			}
 			cluster->~Cluster();
 			deallocateCluster(cluster);
 		}
@@ -1438,16 +1438,6 @@ performActionsAndGetOut:
 // after it's freshly allocated
 Error AudioFileManager::enqueueCluster(Cluster* cluster, uint32_t priorityRating) {
 	return loadingQueue.push(*cluster, priorityRating);
-}
-
-void AudioFileManager::addReasonToCluster(Cluster* cluster) {
-	// If it's going to cease to be zero, it's become unavailable
-	if (cluster->numReasonsToBeLoaded == 0) {
-		cluster->remove();
-		//*cluster->getAnyReasonsPointer() = reasonType;
-	}
-
-	cluster->numReasonsToBeLoaded++;
 }
 
 void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* errorCode, bool deletingSong) {

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -93,7 +93,6 @@ public:
 	Error enqueueCluster(Cluster* cluster, uint32_t priorityRating = 0xFFFFFFFF);
 	bool loadCluster(Cluster* cluster, int32_t minNumReasonsAfter = 0);
 	void loadAnyEnqueuedClusters(int32_t maxNum = 128, bool mayProcessUserActionsBetween = false);
-	void addReasonToCluster(Cluster* cluster);
 	void removeReasonFromCluster(Cluster* cluster, char const* errorCode, bool deletingSong = false);
 	void testQueue();
 

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -234,7 +234,8 @@ bool Cluster::mayBeStolen(void* thingNotToStealFrom) {
 }
 
 void Cluster::addReason() {
-	// If it's going to cease to be zero, it's become unavailable
+	// If it's going to cease to be zero, it's become unavailable,
+	// so remove it from the stealables queue
 	if (this->numReasonsToBeLoaded == 0) {
 		this->remove();
 	}

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -232,3 +232,12 @@ bool Cluster::mayBeStolen(void* thingNotToStealFrom) {
 	}
 	return true;
 }
+
+void Cluster::addReason() {
+	// If it's going to cease to be zero, it's become unavailable
+	if (this->numReasonsToBeLoaded == 0) {
+		this->remove();
+	}
+
+	this->numReasonsToBeLoaded++;
+}

--- a/src/deluge/storage/cluster/cluster.h
+++ b/src/deluge/storage/cluster/cluster.h
@@ -34,6 +34,7 @@ public:
 	bool mayBeStolen(void* thingNotToStealFrom);
 	void steal(char const* errorCode);
 	StealableQueue getAppropriateQueue();
+	void addReason();
 
 	ClusterType type;
 	int8_t numReasonsHeldBySampleRecorder;

--- a/src/deluge/storage/cluster/cluster_priority_queue.cpp
+++ b/src/deluge/storage/cluster/cluster_priority_queue.cpp
@@ -31,15 +31,7 @@ Error ClusterPriorityQueue::push(Cluster& cluster, uint32_t priority) {
 
 	try {
 		priority_map_.insert({priority, &cluster});
-	} catch (deluge::exception e) {
-		if (e == deluge::exception::BAD_ALLOC) {
-			return Error::INSUFFICIENT_RAM;
-		}
-		freezeWithError("EXPQ");
-	}
-
-	try {
-		queued_clusters_.insert({&cluster, priority});
+		queued_clusters_[&cluster] = priority;
 	} catch (deluge::exception e) {
 		if (e == deluge::exception::BAD_ALLOC) {
 			return Error::INSUFFICIENT_RAM;

--- a/src/deluge/storage/cluster/cluster_priority_queue.cpp
+++ b/src/deluge/storage/cluster/cluster_priority_queue.cpp
@@ -16,56 +16,35 @@
  */
 
 #include "storage/cluster/cluster_priority_queue.h"
+#include "definitions.h"
 #include "definitions_cxx.hpp"
+#include "util/exceptions.h"
+#include <cstdlib>
 
 class Cluster;
 
-ClusterPriorityQueue::ClusterPriorityQueue()
-    : OrderedResizeableArrayWith32bitKey(sizeof(PriorityQueueElement), 32, 31) {
-}
-
 // Returns error
-Error ClusterPriorityQueue::add(Cluster* cluster, uint32_t priorityRating) {
-	int32_t i = insertAtKey((int32_t)cluster);
-	if (i == -1) {
-		return Error::INSUFFICIENT_RAM;
+Error ClusterPriorityQueue::push(Cluster& cluster, uint32_t priority) {
+	if (auto search = queued_clusters_.find(&cluster); search != queued_clusters_.end()) {
+		priority_map_.erase({search->second, &cluster});
 	}
 
-	PriorityQueueElement* element = (PriorityQueueElement*)getElementAddress(i);
-	element->priorityRating = priorityRating;
-	element->cluster = cluster;
+	try {
+		priority_map_.insert({priority, &cluster});
+	} catch (deluge::exception e) {
+		if (e == deluge::exception::BAD_ALLOC) {
+			return Error::INSUFFICIENT_RAM;
+		}
+		freezeWithError("EXPQ");
+	}
+
+	try {
+		queued_clusters_.insert({&cluster, priority});
+	} catch (deluge::exception e) {
+		if (e == deluge::exception::BAD_ALLOC) {
+			return Error::INSUFFICIENT_RAM;
+		}
+		freezeWithError("EXPQ");
+	}
 	return Error::NONE;
-}
-
-Cluster* ClusterPriorityQueue::grabHead() {
-	if (!numElements) {
-		return NULL;
-	}
-	Cluster* toReturn = ((PriorityQueueElement*)getElementAddress(0))->cluster;
-	deleteAtIndex(0);
-	return toReturn;
-}
-
-// Returns whether it was present
-bool ClusterPriorityQueue::removeIfPresent(Cluster* cluster) {
-	for (int32_t i = 0; i < numElements; i++) {
-		PriorityQueueElement* element = (PriorityQueueElement*)getElementAddress(i);
-		if (element->cluster == cluster) {
-			deleteAtIndex(i);
-			return true;
-		}
-	}
-
-	return false;
-}
-
-bool ClusterPriorityQueue::checkPresent(Cluster* cluster) {
-	for (int32_t i = 0; i < numElements; i++) {
-		PriorityQueueElement* element = (PriorityQueueElement*)getElementAddress(i);
-		if (element->cluster == cluster) {
-			return true;
-		}
-	}
-
-	return false;
 }

--- a/src/deluge/storage/cluster/cluster_priority_queue.cpp
+++ b/src/deluge/storage/cluster/cluster_priority_queue.cpp
@@ -36,7 +36,7 @@ Error ClusterPriorityQueue::push(Cluster& cluster, uint32_t priority) {
 		if (e == deluge::exception::BAD_ALLOC) {
 			return Error::INSUFFICIENT_RAM;
 		}
-		freezeWithError("EXPQ");
+		FREEZE_WITH_ERROR("EXPQ");
 	}
 	return Error::NONE;
 }

--- a/src/deluge/storage/cluster/cluster_priority_queue.h
+++ b/src/deluge/storage/cluster/cluster_priority_queue.h
@@ -19,6 +19,7 @@
 
 #include "util/containers.h"
 #include <cstdint>
+#include <limits>
 
 class Cluster;
 
@@ -50,7 +51,7 @@ public:
 	/* This is currently a consequence of how priorities are calculated (using full 32bits) next-gen getPriorityRating
 	 * should return an int32_t */
 	constexpr bool hasAnyLowestPriority() const {
-		return !priority_map_.empty() && priority_map_.rbegin()->first == static_cast<uint32_t>(-1);
+		return !priority_map_.empty() && priority_map_.rbegin()->first == std::numeric_limits<uint32_t>::max();
 	}
 
 private:

--- a/src/deluge/storage/cluster/cluster_priority_queue.h
+++ b/src/deluge/storage/cluster/cluster_priority_queue.h
@@ -30,25 +30,21 @@ public:
 
 	Error push(Cluster& cluster, uint32_t priorityRating);
 	constexpr Cluster& front() const { return *priority_map_.begin()->second; }
-	constexpr Cluster& back() const { return *priority_map_.rbegin()->second; }
 
 	constexpr void pop() {
 		auto it = priority_map_.begin();
-		Cluster* cluster = it->second;
 		priority_map_.erase(it);
-		queued_clusters_.erase(cluster);
+		queued_clusters_.erase(it->second);
 	}
 
 	constexpr bool empty() const { return queued_clusters_.empty() || priority_map_.empty(); }
-	constexpr bool contains(Cluster& cluster) const { return queued_clusters_.contains(&cluster); }
 	constexpr size_t erase(Cluster& cluster) {
-		if (!queued_clusters_.contains(&cluster)) {
-			return 0;
+		if (auto search = queued_clusters_.find(&cluster); search != queued_clusters_.end()) {
+			priority_map_.erase({search->second, &cluster});
+			queued_clusters_.erase(&cluster);
+			return 1;
 		}
-		Priority priority = queued_clusters_[&cluster];
-		priority_map_.erase({priority, &cluster});
-		queued_clusters_.erase(&cluster);
-		return 1;
+		return 0;
 	}
 
 	/* This is currently a consequence of how priorities are calculated (using full 32bits) next-gen getPriorityRating

--- a/src/deluge/util/containers.h
+++ b/src/deluge/util/containers.h
@@ -1,10 +1,13 @@
 #pragma once
 #include "memory/fallback_allocator.h"
+#include "memory/fast_allocator.h"
 #include <deque>
 #include <forward_list>
+#include <functional>
 #include <list>
 #include <map>
 #include <queue>
+#include <set>
 #include <stack>
 #include <unordered_map>
 #include <vector>
@@ -49,4 +52,21 @@ using stack = std::stack<T, deque<T, Alloc>>;
 // Queue
 template <typename T, typename Alloc = memory::fallback_allocator<T>>
 using queue = std::queue<T, deque<T, Alloc>>;
+
+// Vector (resizeable variable-length array, unknown size)
+template <typename T>
+using fast_vector = std::vector<T, memory::fast_allocator<T>>;
+
+template <typename T>
+using fast_priority_queue = std::priority_queue<T, fast_vector<T>>;
+
+template <class T, class Compare = std::less<T>>
+using fast_set = std::set<T, Compare, memory::fast_allocator<T>>;
+
+template <typename Key, typename T, class Compare = std::less<Key>>
+using fast_multimap = std::multimap<Key, T, Compare, memory::fast_allocator<std::pair<const Key, T>>>;
+
+template <typename Key, typename T, class Compare = std::equal_to<Key>>
+using fast_unordered_map =
+    std::unordered_map<Key, T, std::hash<Key>, Compare, memory::fast_allocator<std::pair<const Key, T>>>;
 } // namespace deluge

--- a/src/deluge/util/exceptions.h
+++ b/src/deluge/util/exceptions.h
@@ -2,6 +2,6 @@
 
 namespace deluge {
 enum class exception {
-	BAD_ALLOC
+	BAD_ALLOC,
 };
 }

--- a/src/deluge/util/exceptions.h
+++ b/src/deluge/util/exceptions.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace deluge {
+enum class exception {
+	BAD_ALLOC
+};
+}

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -1,0 +1,13 @@
+
+#include <stddef.h>
+
+extern void* delugeAlloc(unsigned int requiredSize, bool mayUseOnChipRam);
+extern void delugeDealloc(void* address);
+
+void *malloc(size_t size){
+	return delugeAlloc(size, true);
+}
+
+void free(void* addr) {
+	delugeDealloc(addr);
+}

--- a/src/malloc.c
+++ b/src/malloc.c
@@ -4,7 +4,7 @@
 extern void* delugeAlloc(unsigned int requiredSize, bool mayUseOnChipRam);
 extern void delugeDealloc(void* address);
 
-void *malloc(size_t size){
+void* malloc(size_t size) {
 	return delugeAlloc(size, true);
 }
 

--- a/src/sys_stubs.c
+++ b/src/sys_stubs.c
@@ -1,55 +1,52 @@
-// this is no longer needed - switched to non allocating sprintf, and calling the abort handler on c++ throw
-// remains as a repo of information for implementing these in the future, and to help troubleshoot link failures
-// in the future - e.g. if _sbrk is required, it can be uncommented to finish compilation and find out what's
-// including it
+#include <sys/stat.h>
 
 // this stub fails to allocate - needed for libc malloc
 // Take advantage of that to ensure anything which allocates will fail to link
-// void* _sbrk(int incr) {
-// 	return (void*)-1;
-// }
+void* _sbrk(int incr) {
+	return (void*)-1;
+}
 
-// // needed for libc abort, raise, return from main
-// void _exit(int status) {
-// 	// halt execution
-// 	__asm("BKPT #0");
-// 	__builtin_unreachable();
-// }
+// needed for libc abort, raise, return from main
+void _exit(int status) {
+	// halt execution
+	__asm("BKPT #0");
+	__builtin_unreachable();
+}
 
-// // needed for libc abort
-// void _kill(int pid, int sig) {
-// 	return;
-// }
+// needed for libc abort
+void _kill(int pid, int sig) {
+	return;
+}
 
-// // needed for libc abort
-// int _getpid(void) {
-// 	return -1;
-// }
+// needed for libc abort
+int _getpid(void) {
+	return -1;
+}
 
-// // needed for stdio, files
-//  int _close(int file) {
-//  	return -1;
-//  }
+// needed for stdio, files
+int _close(int file) {
+	return -1;
+}
 
 // return character oriented (not block)
-// int _fstat(int file, struct stat* st) {
-// 	st->st_mode = S_IFCHR;
-// 	return 0;
-// }
+int _fstat(int file, struct stat* st) {
+	st->st_mode = S_IFCHR;
+	return 0;
+}
 
 // return character oriented
-// int _isatty(int file) {
-// 	return 1;
-// }
+int _isatty(int file) {
+	return 1;
+}
 
-// int _lseek(int file, int ptr, int dir) {
-// 	return 0;
-// }
-// // write nothing - note these will loop infinitely with newlib
-// int _write(int file, char* ptr, int len) {
-// 	return 0;
-// }
-// // read nothing
-// int _read(int file, char* ptr, int len) {
-// 	return 0;
-// }
+int _lseek(int file, int ptr, int dir) {
+	return 0;
+}
+// write nothing - note these will loop infinitely with newlib
+int _write(int file, char* ptr, int len) {
+	return 0;
+}
+// read nothing
+int _read(int file, char* ptr, int len) {
+	return 0;
+}

--- a/src/sys_stubs.c
+++ b/src/sys_stubs.c
@@ -1,15 +1,17 @@
+#include "definitions.h"
 #include <sys/stat.h>
 
 // this stub fails to allocate - needed for libc malloc
 // Take advantage of that to ensure anything which allocates will fail to link
 void* _sbrk(int incr) {
+	FREEZE_WITH_ERROR("SBRK");
 	return (void*)-1;
 }
 
 // needed for libc abort, raise, return from main
 void _exit(int status) {
 	// halt execution
-	__asm("BKPT #0");
+	FREEZE_WITH_ERROR("EXIT");
 	__builtin_unreachable();
 }
 

--- a/src/sys_stubs.c
+++ b/src/sys_stubs.c
@@ -1,6 +1,10 @@
 #include "definitions.h"
 #include <sys/stat.h>
 
+// this is not included in the build but remains as a repo of information for implementing these in the future,
+// and to help troubleshoot link failures in the future - e.g. if _sbrk is required, it can be added to
+// finish compilation and find out what's including it
+
 // this stub fails to allocate - needed for libc malloc
 // Take advantage of that to ensure anything which allocates will fail to link
 void* _sbrk(int incr) {

--- a/src/terminate.cpp
+++ b/src/terminate.cpp
@@ -1,0 +1,11 @@
+#include "definitions.h"
+#include <exception>
+
+[[noreturn]] void Terminate() noexcept {
+	FREEZE_WITH_ERROR("TERM");
+	__builtin_unreachable();
+}
+
+namespace __cxxabiv1 {
+std::terminate_handler __terminate_handler = Terminate;
+}


### PR DESCRIPTION
This replaces the current implementation with a much simpler and easier to reason about implementation based on a std::map and a std::set

Impact:
- Switching from newlib-nano to newlib and enabling exceptions increases size by about ~~70k~~ 20k
- Performance impact is negligible
- Attempting to link against sbrk/malloc now no longer results in a link-time error, instead a runtime error. I don't think this is a problem in practice, since the errors should get reported and tracked down before each release.