### PR TITLE
Refactor AudioFileManager and Sample::RawDataType

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -746,16 +746,6 @@ constexpr int32_t kDifferenceLPFPoles = 2;
 constexpr int32_t kInterpolationMaxNumSamples = 16;
 constexpr int32_t kInterpolationMaxNumSamplesMagnitude = 4;
 
-enum class ClusterType {
-	EMPTY,
-	Sample,
-	GENERAL_MEMORY,
-	SAMPLE_CACHE,
-	PERC_CACHE_FORWARDS,
-	PERC_CACHE_REVERSED,
-	OTHER,
-};
-
 enum PlayHead {
 	PLAY_HEAD_OLDER,
 	PLAY_HEAD_NEWER,

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -1035,7 +1035,7 @@ extern "C" void sdCardInserted(void) {
 }
 
 extern "C" void sdCardEjected(void) {
-	audioFileManager.cardEjected = true;
+	audioFileManager.setCardEjected();
 }
 
 extern "C" void loadAnyEnqueuedClustersRoutine() {

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -1276,9 +1276,9 @@ removeReasonsFromSamplesAndGetOut:
 
 		filePath.concatenateAtPos(staticFNO.fname, dirWithSlashLength);
 
-		Sample* newSample = (Sample*)audioFileManager.getAudioFileFromFilename(
-		    &filePath, true, &error, &thisFilePointer,
-		    AudioFileType::SAMPLE); // We really want to be able to pass a file pointer in here
+		// We really want to be able to pass a file pointer in here
+		auto* newSample = static_cast<Sample*>(
+		    audioFileManager.getAudioFileFromFilename(filePath, true, &error, &thisFilePointer, AudioFileType::SAMPLE));
 		if (error != Error::NONE || !newSample) {
 			f_closedir(&staticDIR);
 			goto removeReasonsFromSamplesAndGetOut;

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -401,8 +401,8 @@ fail:
 			goto gotErrorAfterCreatingSong;
 		}
 
-		error = audioFileManager.setupAlternateAudioFileDir(&audioFileManager.alternateAudioFileLoadPath,
-		                                                    currentDir.get(), &currentFilenameWithoutExtension);
+		error = audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath,
+		                                                    currentDir.get(), currentFilenameWithoutExtension);
 		if (error != Error::NONE) {
 			goto gotErrorAfterCreatingSong;
 		}
@@ -464,8 +464,8 @@ gotErrorAfterCreatingSong:
 		goto gotErrorAfterCreatingSong;
 	}
 
-	error = audioFileManager.setupAlternateAudioFileDir(&audioFileManager.alternateAudioFileLoadPath, currentDir.get(),
-	                                                    &currentFilenameWithoutExtension);
+	error = audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath, currentDir.get(),
+	                                                    currentFilenameWithoutExtension);
 	if (error != Error::NONE) {
 		goto gotErrorAfterCreatingSong;
 	}

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -166,7 +166,7 @@ gotError:
 	}
 
 	error =
-	    audioFileManager.setupAlternateAudioFileDir(&newSongAlternatePath, currentDir.get(), &filenameWithoutExtension);
+	    audioFileManager.setupAlternateAudioFileDir(newSongAlternatePath, currentDir.get(), filenameWithoutExtension);
 	if (error != Error::NONE) {
 		goto gotError;
 	}
@@ -312,8 +312,8 @@ gotError:
 					// Normally, the filePath will be in the SAMPLES folder, which our name-condensing system was
 					// designed for...
 					if (!memcasecmp(audioFile->filePath.get(), "SAMPLES/", 8)) {
-						error = audioFileManager.setupAlternateAudioFilePath(&newSongAlternatePath, dirPathLengthNew,
-						                                                     &audioFile->filePath);
+						error = audioFileManager.setupAlternateAudioFilePath(newSongAlternatePath, dirPathLengthNew,
+						                                                     audioFile->filePath);
 						if (error != Error::NONE) {
 failAfterOpeningSourceFile:
 							activeDeserializer->closeWriter();
@@ -361,7 +361,7 @@ failAfterOpeningSourceFile:
 					while (true) {
 						UINT bytesRead;
 						result = f_read(&activeDeserializer->readFIL, activeDeserializer->fileClusterBuffer,
-						                audioFileManager.clusterSize, &bytesRead);
+						                Cluster::size, &bytesRead);
 						if (result) {
 							D_PRINTLN("read fail");
 fail3:
@@ -379,7 +379,7 @@ fail3:
 							goto fail3;
 						}
 
-						if (bytesRead < audioFileManager.clusterSize) {
+						if (bytesRead < Cluster::size) {
 							break; // Stop - file clearly ended part-way through cluster
 						}
 					}

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -192,7 +192,7 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 Error Instrument::setupDefaultAudioFileDir() {
 	char const* dirPathChars = dirPath.get();
 	Error error =
-	    audioFileManager.setupAlternateAudioFileDir(&audioFileManager.alternateAudioFileLoadPath, dirPathChars, &name);
+	    audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath, dirPathChars, name);
 	if (error != Error::NONE) {
 		return error;
 	}

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -135,7 +135,7 @@ void Sample::deletePercCache(bool beingDestructed) {
 						FREEZE_WITH_ERROR("E137");
 					}
 
-					audioFileManager.deallocateCluster(percCacheClusters[reversed][c]);
+					Cluster::dealloc(*percCacheClusters[reversed][c]);
 					// Don't bother actually setting our pointer to NULL, cos we're about to deallocate that memory
 					// anyway
 				}
@@ -218,7 +218,7 @@ SampleCache* Sample::getOrCreateCache(SampleHolder* sampleHolder, int32_t phaseI
 		return NULL; // If cache would be more than 32MB, assume that it wouldn't be very useful to cache it
 	}
 
-	int32_t numClusters = ((lengthInBytesCached - 1) >> audioFileManager.clusterSizeMagnitude) + 1;
+	int32_t numClusters = ((lengthInBytesCached - 1) >> Cluster::size_magnitude) + 1;
 
 	void* memory =
 	    GeneralMemoryAllocator::get().allocLowSpeed(sizeof(SampleCache) + (numClusters - 1) * sizeof(Cluster*));
@@ -297,11 +297,11 @@ Error Sample::fillPercCache(TimeStretcher* timeStretcher, int32_t startPosSample
 	int32_t lengthInSamplesAfterReduction = ((lengthInSamples - 1) >> kPercBufferReductionMagnitude) + 1;
 	lengthInSamplesAfterReduction = std::max(lengthInSamplesAfterReduction, 1_i32); // Can't allocate less than 1 byte
 
-	bool percCacheDoneWithClusters = (lengthInSamplesAfterReduction >= (audioFileManager.clusterSize >> 1));
+	bool percCacheDoneWithClusters = (lengthInSamplesAfterReduction >= (Cluster::size >> 1));
 
 	if (percCacheDoneWithClusters) {
 		if (!percCacheClusters[reversed]) {
-			numPercCacheClusters = ((lengthInSamplesAfterReduction - 1) >> audioFileManager.clusterSizeMagnitude)
+			numPercCacheClusters = ((lengthInSamplesAfterReduction - 1) >> Cluster::size_magnitude)
 			                       + 1; // Stores this number for the future too
 			int32_t memorySize = numPercCacheClusters * sizeof(Cluster*);
 			percCacheClusters[reversed] = (Cluster**)GeneralMemoryAllocator::get().allocMaxSpeed(memorySize);
@@ -384,8 +384,8 @@ doReturnNoError:
 			// here.
 			int32_t percClusterIndexStart;
 			if (percCacheDoneWithClusters) {
-				percClusterIndexStart = (uint32_t)startPosSamples
-				                        >> (audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude);
+				percClusterIndexStart =
+				    (uint32_t)startPosSamples >> (Cluster::size_magnitude + kPercBufferReductionMagnitude);
 				if (ALPHA_OR_BETA_VERSION && percClusterIndexStart >= numPercCacheClusters) {
 					FREEZE_WITH_ERROR("E138");
 				}
@@ -394,8 +394,7 @@ doReturnNoError:
 				if (!clusterHere) {
 
 					// That's actually allowed if we're right at the start of that cluster. But otherwise...
-					if (startPosSamples
-					    & ((1 << audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude) - 1)) {
+					if (startPosSamples & ((1 << Cluster::size_magnitude + kPercBufferReductionMagnitude) - 1)) {
 						// If Cluster has been stolen, the zones should have been updated, so we shouldn't be here
 						D_PRINTLN("startPosSamples: %d", startPosSamples);
 						FREEZE_WITH_ERROR("E139");
@@ -419,9 +418,8 @@ doReturnNoError:
 					// I think the fact that we subtract playDirection here means that we look at the cluster for the
 					// very last existing sample, so even if we've actually filled up right up to the cluster boundary
 					// but not allocated a next one, it should be fine, ya know?
-					int32_t percClusterIndexEnd =
-					    (uint32_t)(endPosSamples - playDirection)
-					    >> (audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude);
+					int32_t percClusterIndexEnd = (uint32_t)(endPosSamples - playDirection)
+					                              >> (Cluster::size_magnitude + kPercBufferReductionMagnitude);
 					if (percClusterIndexEnd != percClusterIndexStart) {
 #if ALPHA_OR_BETA_VERSION
 						if (percClusterIndexEnd >= numPercCacheClusters) {
@@ -524,7 +522,7 @@ doLoading:
 
 		int32_t numSamplesThisClusterReadWrite = numSamples;
 
-		int32_t sourceClusterIndex = sourceBytePos >> audioFileManager.clusterSizeMagnitude;
+		int32_t sourceClusterIndex = sourceBytePos >> Cluster::size_magnitude;
 
 		if (sourceClusterIndex >= getFirstClusterIndexWithNoAudioData()
 		    || sourceClusterIndex
@@ -534,8 +532,7 @@ doLoading:
 
 		uint8_t* percCacheNow;
 		if (percCacheDoneWithClusters) {
-			int32_t percClusterIndex =
-			    startPosSamples >> (audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude);
+			int32_t percClusterIndex = startPosSamples >> (Cluster::size_magnitude + kPercBufferReductionMagnitude);
 			if (ALPHA_OR_BETA_VERSION && percClusterIndex >= numPercCacheClusters) {
 				FREEZE_WITH_ERROR("E136");
 			}
@@ -545,8 +542,8 @@ doLoading:
 				//  are definitely a high priority to keep, but because doing so would probably alter our
 				//  percCacheZones, which we're currently working with, which could really muck things up. Scenario only
 				//  discovered Jan 2021.
-				percCacheClusters[reversed][percClusterIndex] = audioFileManager.allocateCluster(
-				    reversed ? ClusterType::PERC_CACHE_REVERSED : ClusterType::PERC_CACHE_FORWARDS, false,
+				percCacheClusters[reversed][percClusterIndex] = Cluster::alloc(
+				    reversed ? Cluster::Type::PERC_CACHE_REVERSED : Cluster::Type::PERC_CACHE_FORWARDS, false,
 				    this); // Doesn't add reason. Call to rememberPercCacheCluster() below will
 				if (!percCacheClusters[reversed][percClusterIndex]) {
 					error = Error::INSUFFICIENT_RAM;
@@ -559,16 +556,15 @@ doLoading:
 
 			timeStretcher->rememberPercCacheCluster(percCacheClusters[reversed][percClusterIndex]);
 
-			percCacheNow = (uint8_t*)percCacheClusters[reversed][percClusterIndex]->data
-			               - (percClusterIndex * audioFileManager.clusterSize);
+			percCacheNow =
+			    (uint8_t*)percCacheClusters[reversed][percClusterIndex]->data - (percClusterIndex * Cluster::size);
 
-			int32_t posWithinPercClusterBig =
-			    startPosSamples & ((audioFileManager.clusterSize << kPercBufferReductionMagnitude) - 1);
+			int32_t posWithinPercClusterBig = startPosSamples & ((Cluster::size << kPercBufferReductionMagnitude) - 1);
 
 			// Bytes and samples are the same for the dest Cluster
 			int32_t samplesLeftThisDestCluster =
 			    reversed ? (posWithinPercClusterBig + 1)
-			             : ((audioFileManager.clusterSize << kPercBufferReductionMagnitude) - posWithinPercClusterBig);
+			             : ((Cluster::size << kPercBufferReductionMagnitude) - posWithinPercClusterBig);
 			numSamplesThisClusterReadWrite = std::min(numSamplesThisClusterReadWrite, samplesLeftThisDestCluster);
 		}
 
@@ -583,12 +579,11 @@ doLoading:
 			goto getOut;
 		}
 
-		int32_t bytePosWithinCluster = sourceBytePos & (audioFileManager.clusterSize - 1);
+		int32_t bytePosWithinCluster = sourceBytePos & (Cluster::size - 1);
 
 		// Ok, how many samples can we load right now?
-		int32_t bytesLeftThisSourceCluster =
-		    reversed ? (bytePosWithinCluster + bytesPerSample)
-		             : (audioFileManager.clusterSize - bytePosWithinCluster + bytesPerSample - 1);
+		int32_t bytesLeftThisSourceCluster = reversed ? (bytePosWithinCluster + bytesPerSample)
+		                                              : (Cluster::size - bytePosWithinCluster + bytesPerSample - 1);
 		int32_t bytesWeWantToRead = numSamplesThisClusterReadWrite * bytesPerSample;
 		if (bytesWeWantToRead > bytesLeftThisSourceCluster + bytesPerSample) {
 			numSamplesThisClusterReadWrite = bytesLeftThisSourceCluster / bytesPerSample;
@@ -790,7 +785,7 @@ bool Sample::getAveragesForCrossfade(int32_t* totals, int32_t startBytePos, int3
 				FREEZE_WITH_ERROR("E432"); // Was "GGGG". Sven may have gotten.
 			}
 
-			int32_t whichCluster = readByte >> audioFileManager.clusterSizeMagnitude;
+			int32_t whichCluster = readByte >> Cluster::size_magnitude;
 			if (ALPHA_OR_BETA_VERSION
 			    && (whichCluster < getFirstClusterIndexWithAudioData()
 			        || whichCluster >= getFirstClusterIndexWithNoAudioData())) {
@@ -802,12 +797,12 @@ bool Sample::getAveragesForCrossfade(int32_t* totals, int32_t startBytePos, int3
 				return false;
 			}
 
-			int32_t bytePosWithinCluster = readByte & (audioFileManager.clusterSize - 1);
+			int32_t bytePosWithinCluster = readByte & (Cluster::size - 1);
 			int32_t numSamplesThisRead = numSamplesLeftThisAverage;
 
-			int32_t bytesLeftThisCluster =
-			    (playDirection == -1) ? (bytePosWithinCluster + bytesPerSample)
-			                          : (audioFileManager.clusterSize - bytePosWithinCluster + bytesPerSample - 1);
+			int32_t bytesLeftThisCluster = (playDirection == -1)
+			                                   ? (bytePosWithinCluster + bytesPerSample)
+			                                   : (Cluster::size - bytePosWithinCluster + bytesPerSample - 1);
 			int32_t bytesWeWantToRead = numSamplesThisRead * bytesPerSample;
 			if (bytesWeWantToRead > bytesLeftThisCluster) {
 				numSamplesThisRead = (uint32_t)bytesLeftThisCluster / (uint8_t)bytesPerSample;
@@ -865,33 +860,33 @@ uint8_t* Sample::prepareToReadPercCache(int32_t pixellatedPos, int32_t playDirec
 
 	// Or if Cluster-based perc cache...
 	else {
-		int32_t ourCluster = pixellatedPos >> audioFileManager.clusterSizeMagnitude;
+		int32_t ourCluster = pixellatedPos >> Cluster::size_magnitude;
 		if (ALPHA_OR_BETA_VERSION && !percCacheClusters[reversed][ourCluster]) {
 			FREEZE_WITH_ERROR("E142");
 		}
 
-		int32_t earliestCluster = *earliestPixellatedPos >> audioFileManager.clusterSizeMagnitude;
+		int32_t earliestCluster = *earliestPixellatedPos >> Cluster::size_magnitude;
 		;
-		int32_t latestCluster = *latestPixellatedPos >> audioFileManager.clusterSizeMagnitude;
+		int32_t latestCluster = *latestPixellatedPos >> Cluster::size_magnitude;
 
 		// Constrain to Cluster boundaries. This will theoretically hurt the sound a tiny bit... once every 90 seconds.
 		// No one will ever know
 		if (earliestCluster < ourCluster) {
-			*earliestPixellatedPos = ourCluster << audioFileManager.clusterSizeMagnitude;
+			*earliestPixellatedPos = ourCluster << Cluster::size_magnitude;
 		}
 		else if (earliestCluster > ourCluster) {
-			*earliestPixellatedPos = ((ourCluster + 1) << audioFileManager.clusterSizeMagnitude) - 1;
+			*earliestPixellatedPos = ((ourCluster + 1) << Cluster::size_magnitude) - 1;
 		}
 
 		if (latestCluster < ourCluster) {
-			*latestPixellatedPos = ourCluster << audioFileManager.clusterSizeMagnitude;
+			*latestPixellatedPos = ourCluster << Cluster::size_magnitude;
 		}
 		else if (latestCluster > ourCluster) {
-			*latestPixellatedPos = ((ourCluster + 1) << audioFileManager.clusterSizeMagnitude) - 1;
+			*latestPixellatedPos = ((ourCluster + 1) << Cluster::size_magnitude) - 1;
 		}
 
 		// Fudge an address to send back
-		return (uint8_t*)percCacheClusters[reversed][ourCluster]->data - (ourCluster * audioFileManager.clusterSize);
+		return (uint8_t*)percCacheClusters[reversed][ourCluster]->data - (ourCluster * Cluster::size);
 	}
 }
 
@@ -899,12 +894,12 @@ void Sample::percCacheClusterStolen(Cluster* cluster) {
 	LOCK_ENTRY
 
 	D_PRINTLN("percCacheClusterStolen -----------------------------------------------------------!!");
-	int32_t reversed = (cluster->type == ClusterType::PERC_CACHE_REVERSED);
+	int32_t reversed = (cluster->type == Cluster::Type::PERC_CACHE_REVERSED);
 	int32_t playDirection = reversed ? -1 : 1;
 	int32_t comparison = reversed ? GREATER_OR_EQUAL : LESS;
 
 #if ALPHA_OR_BETA_VERSION
-	if (cluster->type != ClusterType::PERC_CACHE_FORWARDS && cluster->type != ClusterType::PERC_CACHE_REVERSED) {
+	if (cluster->type != Cluster::Type::PERC_CACHE_FORWARDS && cluster->type != Cluster::Type::PERC_CACHE_REVERSED) {
 		FREEZE_WITH_ERROR("E149");
 	}
 	if (!percCacheClusters[reversed]) {
@@ -925,10 +920,8 @@ void Sample::percCacheClusterStolen(Cluster* cluster) {
 
 	// TODO: while inside this, don't allow further editing to percCacheZones[reversed]
 
-	int32_t leftBorder = cluster->clusterIndex
-	                     << (audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude);
-	int32_t rightBorder = (cluster->clusterIndex + 1)
-	                      << (audioFileManager.clusterSizeMagnitude + kPercBufferReductionMagnitude);
+	int32_t leftBorder = cluster->clusterIndex << (Cluster::size_magnitude + kPercBufferReductionMagnitude);
+	int32_t rightBorder = (cluster->clusterIndex + 1) << (Cluster::size_magnitude + kPercBufferReductionMagnitude);
 
 	int32_t laterBorder = reversed ? (leftBorder - 1) : rightBorder;
 	int32_t earlierBorder = reversed ? (rightBorder - 1) : leftBorder;
@@ -1011,12 +1004,12 @@ deleteThatOneToo:
 }
 
 int32_t Sample::getFirstClusterIndexWithAudioData() {
-	return audioDataStartPosBytes >> audioFileManager.clusterSizeMagnitude;
+	return audioDataStartPosBytes >> Cluster::size_magnitude;
 }
 
 int32_t Sample::getFirstClusterIndexWithNoAudioData() {
 	uint32_t clusterIndex =
-	    ((audioDataStartPosBytes + audioDataLengthBytes - 1) >> audioFileManager.clusterSizeMagnitude) + 1; // Rounds up
+	    ((audioDataStartPosBytes + audioDataLengthBytes - 1) >> Cluster::size_magnitude) + 1; // Rounds up
 	if (clusterIndex > clusters.getNumElements()) {
 		clusterIndex = clusters.getNumElements();
 	}
@@ -1337,7 +1330,7 @@ startAgain:
 
 	// Load the sample into memory
 	int32_t currentOffset = beginningOffsetForPitchDetection;
-	uint32_t currentClusterIndex = currentOffset >> audioFileManager.clusterSizeMagnitude;
+	uint32_t currentClusterIndex = currentOffset >> Cluster::size_magnitude;
 	int32_t writeIndex = 0;
 
 	Cluster* cluster =
@@ -1369,7 +1362,7 @@ continueWhileLoop:
 			nextCluster = clusters.getElement(currentClusterIndex + 1)
 			                  ->getCluster(this, currentClusterIndex + 1, CLUSTER_LOAD_IMMEDIATELY);
 			if (!nextCluster) {
-				audioFileManager.removeReasonFromCluster(cluster, "imcwn4o");
+				audioFileManager.removeReasonFromCluster(*cluster, "imcwn4o");
 				D_PRINTLN("failed to load next");
 				goto getOut;
 			}
@@ -1387,8 +1380,7 @@ continueWhileLoop:
 			count++;
 
 			int32_t individualSampleValue =
-			    *(int32_t*)&cluster->data[(currentOffset & (audioFileManager.clusterSize - 1)) - 4 + byteDepth]
-			    & bitMask;
+			    *(int32_t*)&cluster->data[(currentOffset & (Cluster::size - 1)) - 4 + byteDepth] & bitMask;
 			thisValue += (individualSampleValue >> lengthDoublingsNow);
 
 			currentOffset += byteDepth;
@@ -1398,13 +1390,13 @@ continueWhileLoop:
 				goto doneReading;
 			}
 
-			uint32_t newClusterIndex = currentOffset >> audioFileManager.clusterSizeMagnitude;
+			uint32_t newClusterIndex = currentOffset >> Cluster::size_magnitude;
 
 			// If passed Cluster end...
 			if (newClusterIndex != currentClusterIndex) {
 				currentClusterIndex = newClusterIndex;
 
-				audioFileManager.removeReasonFromCluster(cluster, "hset");
+				audioFileManager.removeReasonFromCluster(*cluster, "hset");
 				cluster = nextCluster;
 				nextCluster = NULL; // It'll soon get filled
 			}
@@ -1457,9 +1449,9 @@ continueWhileLoop:
 	}
 
 doneReading:
-	audioFileManager.removeReasonFromCluster(cluster, "kncd");
-	if (nextCluster) {
-		audioFileManager.removeReasonFromCluster(nextCluster, "ljpp");
+	audioFileManager.removeReasonFromCluster(*cluster, "kncd");
+	if (nextCluster != nullptr) {
+		audioFileManager.removeReasonFromCluster(*nextCluster, "ljpp");
 	}
 
 	// If we didn't find any sound...
@@ -1692,14 +1684,14 @@ void Sample::convertDataOnAnyClustersIfNecessary() {
 	if (rawDataFormat) {
 		for (int32_t c = getFirstClusterIndexWithAudioData(); c < getFirstClusterIndexWithNoAudioData(); c++) {
 			Cluster* cluster = clusters.getElement(c)->cluster;
-			if (cluster) {
+			if (cluster != nullptr) {
 
 				// Add reason in case it would get stolen
 				cluster->addReason();
 
 				cluster->convertDataIfNecessary();
 
-				audioFileManager.removeReasonFromCluster(cluster, "E231");
+				audioFileManager.removeReasonFromCluster(*cluster, "E231");
 			}
 		}
 	}

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -135,7 +135,7 @@ void Sample::deletePercCache(bool beingDestructed) {
 						FREEZE_WITH_ERROR("E137");
 					}
 
-					Cluster::dealloc(*percCacheClusters[reversed][c]);
+					percCacheClusters[reversed][c]->destroy();
 					// Don't bother actually setting our pointer to NULL, cos we're about to deallocate that memory
 					// anyway
 				}
@@ -542,7 +542,7 @@ doLoading:
 				//  are definitely a high priority to keep, but because doing so would probably alter our
 				//  percCacheZones, which we're currently working with, which could really muck things up. Scenario only
 				//  discovered Jan 2021.
-				percCacheClusters[reversed][percClusterIndex] = Cluster::alloc(
+				percCacheClusters[reversed][percClusterIndex] = Cluster::create(
 				    reversed ? Cluster::Type::PERC_CACHE_REVERSED : Cluster::Type::PERC_CACHE_FORWARDS, false,
 				    this); // Doesn't add reason. Call to rememberPercCacheCluster() below will
 				if (!percCacheClusters[reversed][percClusterIndex]) {

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -65,7 +65,7 @@ Sample::Sample()
 	audioDataLengthBytes = 0;
 	audioDataStartPosBytes = 0;
 	lengthInSamples = 0;
-	rawDataFormat = RAW_DATA_FINE;
+	rawDataFormat = RawDataFormat::NATIVE;
 	midiNote = MIDI_NOTE_UNSET;
 	partOfFolderBeingLoaded = false;
 
@@ -1681,7 +1681,7 @@ doneReading:
 }
 
 void Sample::convertDataOnAnyClustersIfNecessary() {
-	if (rawDataFormat) {
+	if (rawDataFormat != RawDataFormat::NATIVE) {
 		for (int32_t c = getFirstClusterIndexWithAudioData(); c < getFirstClusterIndexWithNoAudioData(); c++) {
 			Cluster* cluster = clusters.getElement(c)->cluster;
 			if (cluster != nullptr) {

--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -74,22 +74,22 @@ public:
 	int32_t getValueSpan();
 	void finalizeAfterLoad(uint32_t fileSize);
 
-	inline void convertOneData(int32_t* value) {
+	inline q31_t convertOneData(int32_t value) {
 		// Floating point
 		if (rawDataFormat == RAW_DATA_FLOAT)
-			*value = q31_from_float(std::bit_cast<float>(value));
+			return q31_from_float(std::bit_cast<float>(value));
 
 		// Or endianness swap
 		else if (rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_32) {
-			*value = swapEndianness32(*value);
+			return swapEndianness32(value);
 		}
 
 		else if (rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_16) {
-			*value = swapEndianness2x16(*value);
+			return swapEndianness2x16(value);
 		}
 
 		else if (rawDataFormat == RAW_DATA_UNSIGNED_8) {
-			*value ^= 0x80808080;
+			return value ^ 0x80808080;
 		}
 	}
 

--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -26,10 +26,11 @@
 #include "util/fixedpoint.h"
 #include "util/functions.h"
 #include <bit>
+#include <cstdint>
 
 #define SAMPLE_DO_LOCKS (ALPHA_OR_BETA_VERSION)
 
-enum class RawDataFormat {
+enum class RawDataFormat : uint8_t {
 	NATIVE = 0,
 	FLOAT = 1,
 	UNSIGNED_8 = 2,

--- a/src/deluge/model/sample/sample_cache.cpp
+++ b/src/deluge/model/sample/sample_cache.cpp
@@ -96,7 +96,7 @@ void SampleCache::unlinkClusters(int32_t startAtIndex, bool beingDestructed) {
 			FREEZE_WITH_ERROR("E167");
 		}
 
-		Cluster::dealloc(*clusters[i]);
+		clusters[i]->destroy();
 
 		if (ALPHA_OR_BETA_VERSION && !beingDestructed) {
 			clusters[i] = nullptr;
@@ -149,7 +149,7 @@ bool SampleCache::setupNewCluster(int32_t clusterIndex) {
 #endif
 
 	// Do not add reasons, and don't steal from this SampleCache
-	clusters[clusterIndex] = Cluster::alloc(Cluster::Type::SAMPLE_CACHE, false, this);
+	clusters[clusterIndex] = Cluster::create(Cluster::Type::SAMPLE_CACHE, false, this);
 	if (!clusters[clusterIndex]) { // If that allocation failed...
 		D_PRINTLN("allocation fail");
 		return false;

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -41,7 +41,7 @@ SampleCluster::~SampleCluster() {
 			FREEZE_WITH_ERROR("E036");
 		}
 #endif
-		Cluster::dealloc(*cluster);
+		cluster->destroy();
 	}
 }
 
@@ -83,7 +83,7 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 		}
 
 		// D_PRINTLN("loading");
-		cluster = Cluster::alloc(); // Adds 1 reason
+		cluster = Cluster::create(); // Adds 1 reason
 
 		if (!cluster) {
 			D_PRINTLN("couldn't allocate");
@@ -151,7 +151,7 @@ justEnqueue:
 				// Or if it was a must-load-now...
 				// Free and remove our link to the unloaded Cluster - otherwise the next time we try to load it, it'd
 				// still exist but never get enqueued for loading
-				Cluster::dealloc(*cluster); // This removes the 1 reason that it'd still have
+				cluster->destroy(); // This removes the 1 reason that it'd still have
 
 				if (error != nullptr) {
 					// TODO: get actual error. Although sometimes it'd just be a "can't do it now

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -41,7 +41,7 @@ SampleCluster::~SampleCluster() {
 			FREEZE_WITH_ERROR("E036");
 		}
 #endif
-		audioFileManager.deallocateCluster(cluster);
+		Cluster::dealloc(*cluster);
 	}
 }
 
@@ -83,7 +83,7 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 		}
 
 		// D_PRINTLN("loading");
-		cluster = audioFileManager.allocateCluster(); // Adds 1 reason
+		cluster = Cluster::alloc(); // Adds 1 reason
 
 		if (!cluster) {
 			D_PRINTLN("couldn't allocate");
@@ -97,7 +97,7 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 		if (cluster->numReasonsToBeLoaded != 1) {
 			FREEZE_WITH_ERROR("i005"); // Diversifying Qui's E341. It should actually be exactly 1
 		}
-		if (cluster->type != ClusterType::Sample) {
+		if (cluster->type != Cluster::Type::SAMPLE) {
 			FREEZE_WITH_ERROR("E256"); // Cos I got E236
 		}
 #endif
@@ -115,12 +115,13 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 		if (loadInstruction == CLUSTER_ENQUEUE) {
 justEnqueue:
 
-			if (ALPHA_OR_BETA_VERSION && cluster->type != ClusterType::Sample) {
+			if (ALPHA_OR_BETA_VERSION && cluster->type != Cluster::Type::SAMPLE) {
 				FREEZE_WITH_ERROR("E236"); // Cos Chris F got an E205
 			}
 
-			audioFileManager.enqueueCluster(
-			    cluster, priorityRating); // TODO: If that fails, it'll just get awkwardly forgotten about
+			// TODO: If that fails, it'll just get awkwardly forgotten about
+			audioFileManager.loadingQueue.push(*cluster, priorityRating);
+
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
 			if (cluster && cluster->numReasonsToBeLoaded <= 0) {
 				FREEZE_WITH_ERROR("i027"); // Diversifying Ron R's i004, which was diversifying Qui's E341
@@ -133,10 +134,10 @@ justEnqueue:
 
 			// cluster has (at least?) one reason - added above
 
-			if (ALPHA_OR_BETA_VERSION && cluster->type != ClusterType::Sample) {
+			if (ALPHA_OR_BETA_VERSION && cluster->type != Cluster::Type::SAMPLE) {
 				FREEZE_WITH_ERROR("E234"); // Cos Chris F got an E205
 			}
-			bool result = audioFileManager.loadCluster(cluster, 1);
+			bool result = audioFileManager.loadCluster(*cluster, 1);
 
 			// If that didn't work...
 			if (!result) {
@@ -150,7 +151,7 @@ justEnqueue:
 				// Or if it was a must-load-now...
 				// Free and remove our link to the unloaded Cluster - otherwise the next time we try to load it, it'd
 				// still exist but never get enqueued for loading
-				audioFileManager.deallocateCluster(cluster); // This removes the 1 reason that it'd still have
+				Cluster::dealloc(*cluster); // This removes the 1 reason that it'd still have
 
 				if (error != nullptr) {
 					// TODO: get actual error. Although sometimes it'd just be a "can't do it now

--- a/src/deluge/model/sample/sample_holder.cpp
+++ b/src/deluge/model/sample/sample_holder.cpp
@@ -66,10 +66,10 @@ void SampleHolder::beenClonedFrom(SampleHolder const* other, bool reversed) {
 
 void SampleHolder::unassignAllClusterReasons(bool beingDestructed) {
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
-		if (clustersForStart[l]) {
-			audioFileManager.removeReasonFromCluster(clustersForStart[l], "E123");
+		if (clustersForStart[l] != nullptr) {
+			audioFileManager.removeReasonFromCluster(*clustersForStart[l], "E123");
 			if (!beingDestructed) {
-				clustersForStart[l] = NULL;
+				clustersForStart[l] = nullptr;
 			}
 		}
 	}
@@ -190,9 +190,9 @@ void SampleHolder::claimClusterReasons(bool reversed, int32_t clusterLoadInstruc
 void SampleHolder::claimClusterReasonsForMarker(Cluster** clusters, uint32_t startPlaybackAtByte, int32_t playDirection,
                                                 int32_t clusterLoadInstruction) {
 
-	int32_t clusterIndex = startPlaybackAtByte >> audioFileManager.clusterSizeMagnitude;
+	int32_t clusterIndex = startPlaybackAtByte >> Cluster::size_magnitude;
 
-	uint32_t posWithinCluster = startPlaybackAtByte & (audioFileManager.clusterSize - 1);
+	uint32_t posWithinCluster = startPlaybackAtByte & (Cluster::size - 1);
 
 	// Set up new temp list
 	Cluster* newClusters[kNumClustersLoadedAhead];
@@ -235,8 +235,8 @@ void SampleHolder::claimClusterReasonsForMarker(Cluster** clusters, uint32_t sta
 
 	// Replace old list
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
-		if (clusters[l]) {
-			audioFileManager.removeReasonFromCluster(clusters[l], "E146");
+		if (clusters[l] != nullptr) {
+			audioFileManager.removeReasonFromCluster(*clusters[l], "E146");
 		}
 		clusters[l] = newClusters[l];
 	}

--- a/src/deluge/model/sample/sample_holder_for_voice.cpp
+++ b/src/deluge/model/sample/sample_holder_for_voice.cpp
@@ -45,7 +45,7 @@ SampleHolderForVoice::~SampleHolderForVoice() {
 	// overriding of that virtual function won't happen as we've already been destructed!
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
 		if (clustersForLoopStart[l]) {
-			audioFileManager.removeReasonFromCluster(clustersForLoopStart[l], "E247");
+			audioFileManager.removeReasonFromCluster(*clustersForLoopStart[l], "E247");
 		}
 	}
 }
@@ -54,10 +54,10 @@ void SampleHolderForVoice::unassignAllClusterReasons(bool beingDestructed) {
 	SampleHolder::unassignAllClusterReasons(beingDestructed);
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
 		if (clustersForLoopStart[l]) {
-			audioFileManager.removeReasonFromCluster(clustersForLoopStart[l],
-			                                         "E320"); // Happened to me while auto-pilot testing, I think
+			// Happened to me while auto-pilot testing, I think
+			audioFileManager.removeReasonFromCluster(*clustersForLoopStart[l], "E320");
 			if (!beingDestructed) {
-				clustersForLoopStart[l] = NULL;
+				clustersForLoopStart[l] = nullptr;
 			}
 		}
 	}
@@ -95,8 +95,7 @@ void SampleHolderForVoice::claimClusterReasons(bool reversed, int32_t clusterLoa
 
 	else if (((Sample*)audioFile)->clusters.getNumElements() <= 4) {
 		// claim the next few reasons for the sample instead since we can keep it all cached
-		int32_t nextClusterStartByte =
-		    ((Sample*)audioFile)->audioDataStartPosBytes + audioFileManager.clusterSizeMagnitude << 1;
+		int32_t nextClusterStartByte = ((Sample*)audioFile)->audioDataStartPosBytes + Cluster::size_magnitude << 1;
 
 		claimClusterReasonsForMarker(clustersForLoopStart, nextClusterStartByte, playDirection, clusterLoadInstruction);
 	}
@@ -105,8 +104,8 @@ void SampleHolderForVoice::claimClusterReasons(bool reversed, int32_t clusterLoa
 	else {
 		for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
 			if (clustersForLoopStart[l]) {
-				audioFileManager.removeReasonFromCluster(clustersForLoopStart[l], "E246");
-				clustersForLoopStart[l] = NULL;
+				audioFileManager.removeReasonFromCluster(*clustersForLoopStart[l], "E246");
+				clustersForLoopStart[l] = nullptr;
 			}
 		}
 	}

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -15,21 +15,16 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include "model/sample/sample_low_level_reader.h"
 #include "dsp/interpolate/interpolate.h"
-#pragma GCC push_options
-#pragma GCC target("fpu=neon")
-
 #include "dsp/timestretch/time_stretcher.h"
 #include "hid/display/display.h"
 #include "io/debug/log.h"
 #include "model/sample/sample.h"
-#include "model/sample/sample_low_level_reader.h"
 #include "model/voice/voice.h"
 #include "model/voice/voice_sample_playback_guide.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
-
-#include "arm_neon.h"
 
 SampleLowLevelReader::SampleLowLevelReader() {
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {

--- a/src/deluge/model/sample/sample_playback_guide.cpp
+++ b/src/deluge/model/sample/sample_playback_guide.cpp
@@ -56,7 +56,7 @@ int32_t SamplePlaybackGuide::getFinalClusterIndex(Sample* sample, bool obeyMarke
 		finalBytePos = endPlaybackAtByteNow + sample->byteDepth * sample->numChannels;
 	}
 
-	return finalBytePos >> audioFileManager.clusterSizeMagnitude;
+	return finalBytePos >> Cluster::size_magnitude;
 }
 
 void SamplePlaybackGuide::setupPlaybackBounds(bool reversed) {

--- a/src/deluge/model/sample/sample_reader.cpp
+++ b/src/deluge/model/sample/sample_reader.cpp
@@ -18,6 +18,7 @@
 #include "model/sample/sample_reader.h"
 #include "definitions_cxx.hpp"
 #include "model/sample/sample.h"
+#include "storage/audio/audio_file.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 
@@ -38,14 +39,15 @@ Error SampleReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t num
 }
 
 Error SampleReader::readNewCluster() {
-	if (currentCluster) {
-		audioFileManager.removeReasonFromCluster(currentCluster, "E031");
+	if (currentCluster != nullptr) {
+		audioFileManager.removeReasonFromCluster(*currentCluster, "E031");
 	}
 
-	currentCluster = ((Sample*)audioFile)
-	                     ->clusters.getElement(currentClusterIndex)
-	                     ->getCluster((Sample*)audioFile, currentClusterIndex, CLUSTER_LOAD_IMMEDIATELY);
-	if (!currentCluster) {
+	auto& sampleFile = static_cast<Sample&>(*audioFile);
+
+	currentCluster = sampleFile.clusters.getElement(currentClusterIndex)
+	                     ->getCluster(&sampleFile, currentClusterIndex, CLUSTER_LOAD_IMMEDIATELY);
+	if (currentCluster == nullptr) {
 		return Error::SD_CARD; // Failed to load cluster from card
 	}
 	return Error::NONE;

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -74,7 +74,7 @@ void SampleRecorder::detachSample() {
 			}
 			cluster->numReasonsHeldBySampleRecorder--;
 
-			audioFileManager.removeReasonFromCluster(cluster, "E257");
+			audioFileManager.removeReasonFromCluster(*cluster, "E257");
 		}
 	}
 
@@ -97,7 +97,7 @@ void SampleRecorder::detachSample() {
 		}
 		cluster->numReasonsHeldBySampleRecorder--;
 
-		audioFileManager.removeReasonFromCluster(cluster, "E249");
+		audioFileManager.removeReasonFromCluster(*cluster, "E249");
 		firstUnwrittenClusterIndex++;
 	}
 
@@ -228,7 +228,7 @@ gotError:
 	recordMin = 2147483647;
 
 	writePos = currentRecordCluster->data;
-	clusterEndPos = &currentRecordCluster->data[audioFileManager.clusterSize];
+	clusterEndPos = &currentRecordCluster->data[Cluster::size];
 
 	numSamplesBeenRunning = 0;
 	numSamplesCaptured = 0;
@@ -363,7 +363,7 @@ aborted:
 #endif
 
 			if (haveAddedSampleToArray) { // We only add it to the array when the file is created.
-				audioFileManager.deleteUnusedAudioFileFromMemoryIndexUnknown(sample);
+				audioFileManager.deleteUnusedAudioFileFromMemoryIndexUnknown(*sample);
 			}
 
 			sample = NULL; // So we don't try to detach it again when we're destructed
@@ -445,7 +445,7 @@ aborted:
 				else {
 					name = inputChannelToString(mode);
 				}
-				error = audioFileManager.getUnusedAudioRecordingFilePath(&filePath, &tempFilePathForRecording, folderID,
+				error = audioFileManager.getUnusedAudioRecordingFilePath(filePath, &tempFilePathForRecording, folderID,
 				                                                         &audioFileNumber, name, &currentSong->name);
 			}
 			if (status == RecorderStatus::ABORTED) {
@@ -568,7 +568,7 @@ Error SampleRecorder::writeOneCompletedCluster() {
 	                              // called, and we need to be counting this cluster as "written", as in too late for it
 	                              // to be modified (by writing a final length to it)
 
-	Error error = writeCluster(writingClusterIndex, audioFileManager.clusterSize);
+	Error error = writeCluster(writingClusterIndex, Cluster::size);
 
 	// We no longer have a reason to require this Cluster to be kept in memory
 	if (!keepingReasonsForFirstClusters || writingClusterIndex >= kNumClustersLoadedAhead) {
@@ -582,7 +582,7 @@ Error SampleRecorder::writeOneCompletedCluster() {
 		}
 		cluster->numReasonsHeldBySampleRecorder--;
 
-		audioFileManager.removeReasonFromCluster(cluster, "E015");
+		audioFileManager.removeReasonFromCluster(*cluster, "E015");
 	}
 
 	// If there was an error, we can only return now after removing that reason, because we'd already incremented
@@ -644,7 +644,7 @@ Error SampleRecorder::finalizeRecordedFile() {
 			}
 			currentRecordCluster->numReasonsHeldBySampleRecorder--;
 
-			audioFileManager.removeReasonFromCluster(currentRecordCluster, "E047");
+			audioFileManager.removeReasonFromCluster(*currentRecordCluster, "E047");
 		}
 		currentRecordClusterIndex++; // We've finished with that cluster
 		currentRecordCluster = NULL; // But currentRecordClusterIndex now refers to a cluster that'll never exist
@@ -769,7 +769,7 @@ Error SampleRecorder::finalizeRecordedFile() {
 				}
 				cluster->numReasonsHeldBySampleRecorder--;
 
-				audioFileManager.removeReasonFromCluster(cluster, "E026");
+				audioFileManager.removeReasonFromCluster(*cluster, "E026");
 			}
 		}
 	}
@@ -837,7 +837,7 @@ Error SampleRecorder::createNextCluster() {
 	                             // remain NULL to indicate that we never created one
 
 	// If this new cluster would actually put us past the 4GB limit...
-	if (currentRecordClusterIndex >= (1 << (MAX_FILE_SIZE_MAGNITUDE - audioFileManager.clusterSizeMagnitude))) {
+	if (currentRecordClusterIndex >= (1 << (MAX_FILE_SIZE_MAGNITUDE - Cluster::size_magnitude))) {
 
 		// See if we actually already had any bytes to write into that new cluster we can't have...
 		int32_t bytesTilClusterEnd = (uint32_t)clusterEndPos - (uint32_t)writePos;
@@ -874,7 +874,7 @@ Error SampleRecorder::createNextCluster() {
 	currentRecordCluster->numReasonsHeldBySampleRecorder++;
 
 	// Copy those extra bytes from the end of the old record cluster to the start of the new cluster
-	memcpy(currentRecordCluster->data, &oldRecordCluster->data[audioFileManager.clusterSize],
+	memcpy(currentRecordCluster->data, &oldRecordCluster->data[Cluster::size],
 	       5); // 5 is the max number of bytes we could have overshot
 
 	int32_t bytesOvershot = (uint32_t)writePos - (uint32_t)clusterEndPos;
@@ -883,7 +883,7 @@ Error SampleRecorder::createNextCluster() {
 	    true; // I think this is ok - mark it as loaded even though we're yet to record into it
 
 	writePos = (char*)&currentRecordCluster->data[bytesOvershot];
-	clusterEndPos = (char*)&currentRecordCluster->data[audioFileManager.clusterSize];
+	clusterEndPos = (char*)&currentRecordCluster->data[Cluster::size];
 
 	return Error::NONE;
 }
@@ -1215,7 +1215,7 @@ void SampleRecorder::setExtraBytesOnPreviousCluster(Cluster* currentCluster, int
 
 	// It might have since been deallocated, which is just fine. But if not...
 	if (prevCluster) {
-		memcpy(&prevCluster->data[audioFileManager.clusterSize], currentCluster->data, 5);
+		memcpy(&prevCluster->data[Cluster::size], currentCluster->data, 5);
 	}
 }
 
@@ -1235,8 +1235,7 @@ Error SampleRecorder::alterFile(MonitoringAction action, int32_t lshiftAmount, u
 	// Bug hunting - newly gotten Cluster
 	currentReadCluster->numReasonsHeldBySampleRecorder++;
 
-	int32_t numClustersBeforeAction =
-	    ((idealFileSizeBeforeAction - 1) >> audioFileManager.clusterSizeMagnitude) + 1; // Rounds up
+	int32_t numClustersBeforeAction = ((idealFileSizeBeforeAction - 1) >> Cluster::size_magnitude) + 1; // Rounds up
 	if (ALPHA_OR_BETA_VERSION && numClustersBeforeAction > sample->clusters.getNumElements()) {
 		FREEZE_WITH_ERROR("E286");
 	}
@@ -1254,7 +1253,7 @@ Error SampleRecorder::alterFile(MonitoringAction action, int32_t lshiftAmount, u
 			}
 			currentReadCluster->numReasonsHeldBySampleRecorder--;
 
-			audioFileManager.removeReasonFromCluster(currentReadCluster, "E017");
+			audioFileManager.removeReasonFromCluster(*currentReadCluster, "E017");
 			return Error::SD_CARD;
 		}
 
@@ -1293,9 +1292,9 @@ Error SampleRecorder::alterFile(MonitoringAction action, int32_t lshiftAmount, u
 	char* readPos = &currentReadCluster->data[sample->audioDataStartPosBytes];
 	char* writePos = &currentWriteCluster->data[sample->audioDataStartPosBytes];
 
-	uint32_t bytesFinalCluster = idealFileSizeBeforeAction & (audioFileManager.clusterSize - 1);
+	uint32_t bytesFinalCluster = idealFileSizeBeforeAction & (Cluster::size - 1);
 	if (bytesFinalCluster == 0) {
-		bytesFinalCluster = audioFileManager.clusterSize;
+		bytesFinalCluster = Cluster::size;
 	}
 
 	uint32_t count = 0;
@@ -1337,7 +1336,7 @@ Error SampleRecorder::alterFile(MonitoringAction action, int32_t lshiftAmount, u
 
 		// If need to advance write-head past the end of a cluster, then we'll write that current cluster to disk
 		// and carry on
-		int32_t writeOvershot = (uint32_t)writePos - (uint32_t)&currentWriteCluster->data[audioFileManager.clusterSize];
+		int32_t writeOvershot = (uint32_t)writePos - (uint32_t)&currentWriteCluster->data[Cluster::size];
 		if (writeOvershot >= 0) {
 
 			// If reached very end of file, break
@@ -1360,13 +1359,12 @@ Error SampleRecorder::alterFile(MonitoringAction action, int32_t lshiftAmount, u
 			}
 
 			// Write the Cluster we just finished processing to card
-			DRESULT result =
-			    disk_write(0, (BYTE*)currentWriteCluster->data, sdAddress, audioFileManager.clusterSize >> 9);
+			DRESULT result = disk_write(0, (BYTE*)currentWriteCluster->data, sdAddress, Cluster::size >> 9);
 
 			// Grab any overshot / extra bytes from the end of the Cluster we just finished...
 			uint8_t extraBytes[5]; // 5 is the max number of bytes we could have overshot
 			if (writeOvershot) {
-				memcpy(extraBytes, &currentWriteCluster->data[audioFileManager.clusterSize], writeOvershot);
+				memcpy(extraBytes, &currentWriteCluster->data[Cluster::size], writeOvershot);
 			}
 
 			// And from the Cluster we just finished, give the Cluster *before that* the extra bytes from its start
@@ -1380,7 +1378,7 @@ Error SampleRecorder::alterFile(MonitoringAction action, int32_t lshiftAmount, u
 			}
 			currentWriteCluster->numReasonsHeldBySampleRecorder--;
 
-			audioFileManager.removeReasonFromCluster(currentWriteCluster, "E023");
+			audioFileManager.removeReasonFromCluster(*currentWriteCluster, "E023");
 			currentWriteCluster = NULL;
 
 			// If write operation failed, now's the time to get out
@@ -1394,7 +1392,7 @@ writeFailed:
 				}
 				currentReadCluster->numReasonsHeldBySampleRecorder--;
 
-				audioFileManager.removeReasonFromCluster(currentReadCluster, "E024");
+				audioFileManager.removeReasonFromCluster(*currentReadCluster, "E024");
 
 				if (nextReadCluster) {
 					// Some bug-hunting
@@ -1403,7 +1401,7 @@ writeFailed:
 					}
 					nextReadCluster->numReasonsHeldBySampleRecorder--;
 
-					audioFileManager.removeReasonFromCluster(nextReadCluster, "E025");
+					audioFileManager.removeReasonFromCluster(*nextReadCluster, "E025");
 				}
 				return Error::SD_CARD;
 			}
@@ -1444,11 +1442,11 @@ writeFailed:
 		}
 
 		// Advance read-head. We read one Cluster ahead, so we can access its "extra bytes"
-		if (readPos >= &currentReadCluster->data[audioFileManager.clusterSize]) {
+		if (readPos >= &currentReadCluster->data[Cluster::size]) {
 
 			D_PRINTLN("read advance");
 
-			int32_t overshot = (uint32_t)readPos - (uint32_t)&currentReadCluster->data[audioFileManager.clusterSize];
+			int32_t overshot = (uint32_t)readPos - (uint32_t)&currentReadCluster->data[Cluster::size];
 
 			// Some bug-hunting
 			if (!currentReadCluster->numReasonsHeldBySampleRecorder) {
@@ -1456,7 +1454,7 @@ writeFailed:
 			}
 			currentReadCluster->numReasonsHeldBySampleRecorder--;
 
-			audioFileManager.removeReasonFromCluster(currentReadCluster, "E020");
+			audioFileManager.removeReasonFromCluster(*currentReadCluster, "E020");
 			currentReadClusterIndex++;
 			currentReadCluster = nextReadCluster;
 
@@ -1475,7 +1473,7 @@ writeFailed:
 					}
 					currentReadCluster->numReasonsHeldBySampleRecorder--;
 
-					audioFileManager.removeReasonFromCluster(currentReadCluster, "E021");
+					audioFileManager.removeReasonFromCluster(*currentReadCluster, "E021");
 
 					// Some bug-hunting
 					if (!currentWriteCluster->numReasonsHeldBySampleRecorder) {
@@ -1483,7 +1481,7 @@ writeFailed:
 					}
 					currentWriteCluster->numReasonsHeldBySampleRecorder--;
 
-					audioFileManager.removeReasonFromCluster(currentWriteCluster, "E022");
+					audioFileManager.removeReasonFromCluster(*currentWriteCluster, "E022");
 					currentWriteCluster = NULL;
 					return Error::SD_CARD;
 				}
@@ -1507,7 +1505,7 @@ writeFailed:
 	}
 	currentReadCluster->numReasonsHeldBySampleRecorder--;
 
-	audioFileManager.removeReasonFromCluster(currentReadCluster, "E018");
+	audioFileManager.removeReasonFromCluster(*currentReadCluster, "E018");
 	// We know that finishedAlteringFile must be NULL
 
 	currentWriteCluster->loaded = true;
@@ -1520,7 +1518,7 @@ writeFailed:
 		setExtraBytesOnPreviousCluster(currentWriteCluster, currentWriteClusterIndex);
 
 		uint32_t numSectorsToWrite = ((bytesToWriteFinalCluster - 1) >> 9) + 1;
-		if (numSectorsToWrite > (audioFileManager.clusterSize >> 9)) {
+		if (numSectorsToWrite > (Cluster::size >> 9)) {
 			FREEZE_WITH_ERROR("E239");
 		}
 
@@ -1542,8 +1540,8 @@ writeFailed:
 		}
 		currentWriteCluster->numReasonsHeldBySampleRecorder--;
 
-		audioFileManager.removeReasonFromCluster(currentWriteCluster, "E019");
-		currentWriteCluster = NULL;
+		audioFileManager.removeReasonFromCluster(*currentWriteCluster, "E019");
+		currentWriteCluster = nullptr;
 
 		// If writing disk failed, above, we've now removed that "reason", so we can get out
 		if (result) {
@@ -1578,7 +1576,7 @@ writeFailed:
 		}
 		currentWriteCluster->numReasonsHeldBySampleRecorder--;
 
-		audioFileManager.removeReasonFromCluster(currentWriteCluster, "E238");
+		audioFileManager.removeReasonFromCluster(*currentWriteCluster, "E238");
 		currentWriteCluster = NULL;
 	}
 
@@ -1590,7 +1588,7 @@ Error SampleRecorder::truncateFileDownToSize(uint32_t newFileSize) {
 
 	// Update the Sample object to indicate the correct size. Do this before we risk errors below
 
-	uint64_t numClustersAfterAction = ((newFileSize - 1) >> audioFileManager.clusterSizeMagnitude) + 1;
+	uint64_t numClustersAfterAction = ((newFileSize - 1) >> Cluster::size_magnitude) + 1;
 
 	int32_t numToDelete = sample->clusters.getNumElements() - numClustersAfterAction;
 	if (numToDelete > 0) {

--- a/src/deluge/storage/Deserializer.cpp
+++ b/src/deluge/storage/Deserializer.cpp
@@ -71,8 +71,8 @@ XMLDeserializer::XMLDeserializer() {
 void XMLDeserializer::reset() {
 	resetReader();
 	// Prep to read first Cluster shortly
-	fileReadBufferCurrentPos = audioFileManager.clusterSize;
-	currentReadBufferEndPos = audioFileManager.clusterSize;
+	fileReadBufferCurrentPos = Cluster::size;
+	currentReadBufferEndPos = Cluster::size;
 
 	song_firmware_version = FirmwareVersion{FirmwareVersion::Type::OFFICIAL, {}};
 

--- a/src/deluge/storage/JsonDeserializer.cpp
+++ b/src/deluge/storage/JsonDeserializer.cpp
@@ -68,8 +68,8 @@ void JsonDeserializer::reset() {
 	resetReader();
 	if (!memoryBased) {
 		// Prep to read first Cluster shortly
-		fileReadBufferCurrentPos = audioFileManager.clusterSize;
-		currentReadBufferEndPos = audioFileManager.clusterSize;
+		fileReadBufferCurrentPos = Cluster::size;
+		currentReadBufferEndPos = Cluster::size;
 	}
 	song_firmware_version = FirmwareVersion{FirmwareVersion::Type::OFFICIAL, {}};
 

--- a/src/deluge/storage/audio/audio_file_holder.cpp
+++ b/src/deluge/storage/audio/audio_file_holder.cpp
@@ -46,7 +46,7 @@ Error AudioFileHolder::loadFile(bool reversed, bool manuallySelected, bool mayAc
 
 	Error error;
 	AudioFile* newAudioFile = audioFileManager.getAudioFileFromFilename(
-	    &filePath, mayActuallyReadFile, &error, filePointer, audioFileType, makeWaveTableWorkAtAllCosts);
+	    filePath, mayActuallyReadFile, &error, filePointer, audioFileType, makeWaveTableWorkAtAllCosts);
 
 	// If we found it...
 	if (newAudioFile) {

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -936,8 +936,9 @@ bool AudioFileManager::loadCluster(Cluster& cluster, int32_t minNumReasonsAfter)
 	}
 #endif
 
-	cluster.addReason(); // So that it can't accidentally hit 0 reasons while we're loading it, cos then it
-	                     // might get deallocated.
+	// So that it can't accidentally hit 0 reasons while we're loading it,
+	// cos then it might get deallocated.
+	cluster.addReason();
 
 	if (false) {
 getOutEarly:
@@ -1306,7 +1307,7 @@ performActionsAndGetOut:
 			if (cluster->numReasonsToBeLoaded > 0) {
 				break;
 			}
-			Cluster::dealloc(*cluster);
+			cluster->destroy();
 		}
 
 		// no more clusters to load, so exit

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -58,14 +58,8 @@ extern uint8_t currentlyAccessingCard;
 AudioFileManager audioFileManager{};
 
 AudioFileManager::AudioFileManager() {
-	cardDisabled = false;
-	alternateLoadDirStatus = AlternateLoadDirStatus::NONE_SET;
-	thingTypeBeingLoaded = ThingType::NONE;
-
-	for (int32_t i = 0; i < kNumAudioRecordingFolders; i++) {
-		highestUsedAudioRecordingNumber[i] = -1;
-		highestUsedAudioRecordingNumberNeedsReChecking[i] = true;
-	}
+	highestUsedAudioRecordingNumber.fill(-1);
+	highestUsedAudioRecordingNumberNeedsReChecking.set();
 }
 
 void AudioFileManager::firstCardRead() {
@@ -79,34 +73,23 @@ void AudioFileManager::firstCardRead() {
 
 void AudioFileManager::init() {
 
-	clusterBeingLoaded = NULL;
+	clusterBeingLoaded = nullptr;
 
 	Error error = StorageManager::initSD();
 	if (error == Error::NONE) {
-		setClusterSize(fileSystem.csize * 512);
+		Cluster::setSize(fileSystem.csize * 512);
 
-		D_PRINTLN("clusterSize  %d clusterSizeMagnitude  %d", clusterSize, clusterSizeMagnitude);
+		D_PRINTLN("Cluster::size  %d clusterSizeMagnitude  %d", Cluster::size, Cluster::size_magnitude);
 		cardEjected = false;
 		cardReadOnce = true;
 	}
 
 	else {
-		clusterSize = 32768;
-		clusterSizeMagnitude = 15;
+		Cluster::setSize(Cluster::kSizeFAT16Max);
 		cardEjected = true;
 	}
 
-	clusterSizeAtBoot = clusterSize;
-
-	clusterObjectSize = sizeof(Cluster) + clusterSize;
-}
-
-void AudioFileManager::setClusterSize(uint32_t newSize) {
-	clusterSize = newSize;
-	clusterSizeMagnitude = 9;
-	while ((clusterSize >> clusterSizeMagnitude) > 1) {
-		clusterSizeMagnitude++;
-	}
+	clusterSizeAtBoot = Cluster::size;
 }
 
 void AudioFileManager::cardReinserted() {
@@ -117,7 +100,7 @@ void AudioFileManager::cardReinserted() {
 	}
 
 	// If cluster size has increased, we're in trouble
-	if (fileSystem.csize * 512 > clusterSize) {
+	if (fileSystem.csize * 512 > Cluster::size) {
 
 		// But, if it's still not as big as it was when we booted up, that's still manageable
 		if (fileSystem.csize * 512 <= clusterSizeAtBoot) {
@@ -131,7 +114,7 @@ void AudioFileManager::cardReinserted() {
 
 	// If cluster size decreased, we have to stop all current samples from ever sounding again. Pretty big trouble
 	// really...
-	else if (fileSystem.csize * 512 < clusterSize) {
+	else if (fileSystem.csize * 512 < Cluster::size) {
 
 clusterSizeChangedButItsOk:
 		D_PRINTLN("cluster size changed, and smaller than original so it's ok");
@@ -142,7 +125,7 @@ clusterSizeChangedButItsOk:
 
 			// If AudioFile isn't used currently, take this opportunity to remove it from memory
 			if (!thisAudioFile->numReasonsToBeLoaded) {
-				deleteUnusedAudioFileFromMemory(thisAudioFile, e);
+				deleteUnusedAudioFileFromMemory(*thisAudioFile, e);
 				e--;
 			}
 
@@ -155,7 +138,7 @@ clusterSizeChangedButItsOk:
 		}
 
 		// That was all a pain, but now we can update the cluster size
-		setClusterSize(fileSystem.csize * 512);
+		Cluster::setSize(fileSystem.csize * 512);
 	}
 
 	// Or if cluster size stayed the same...
@@ -167,7 +150,7 @@ clusterSizeChangedButItsOk:
 
 			// If Sample isn't used currently, take this opportunity to remove it from memory
 			if (!thisAudioFile->numReasonsToBeLoaded) {
-				deleteUnusedAudioFileFromMemory(thisAudioFile, e);
+				deleteUnusedAudioFileFromMemory(*thisAudioFile, e);
 				e--;
 			}
 
@@ -247,7 +230,7 @@ void AudioFileManager::deleteAnyTempRecordedSamplesFromMemory() {
 				// We may have deleted several, so do make sure we go and re-check from 0
 				highestUsedAudioRecordingNumber[util::to_underlying(AudioRecordingFolder::CLIPS)] = -1;
 
-				deleteUnusedAudioFileFromMemory(audioFile, e);
+				deleteUnusedAudioFileFromMemory(*audioFile, e);
 				e--;
 			}
 		}
@@ -256,7 +239,7 @@ void AudioFileManager::deleteAnyTempRecordedSamplesFromMemory() {
 
 // Oi, don't even think about modifying this to take a Sample* pointer - cos the whole Sample could get deleted during
 // the card access.
-Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
+Error AudioFileManager::getUnusedAudioRecordingFilePath(String& filePath, String* tempFilePathForRecording,
                                                         AudioRecordingFolder folder, uint32_t* getNumber,
                                                         const char* channelName, String* songName) {
 	const auto folderID = util::to_underlying(folder);
@@ -307,7 +290,7 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 
 	D_PRINTLN("new file: --------------  %d", highestUsedAudioRecordingNumber[folderID]);
 
-	error = filePath->set(audioRecordingFolderNames[folderID]);
+	error = filePath.set(audioRecordingFolderNames[folderID]);
 	if (error != Error::NONE) {
 		return error;
 	}
@@ -326,22 +309,21 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 
 	// default to putting it in the main folder if the song isn't named
 	if (songName->isEmpty()) {
-		error = filePath->concatenate("/REC");
+		error = filePath.concatenate("/REC");
 		if (error != Error::NONE) {
 			return error;
 		}
-		error = filePath->concatenateInt(highestUsedAudioRecordingNumber[folderID], 5);
+		error = filePath.concatenateInt(highestUsedAudioRecordingNumber[folderID], 5);
 		if (error != Error::NONE) {
 			return error;
 		}
-		error = filePath->concatenate(".WAV");
+		error = filePath.concatenate(".WAV");
 		if (error != Error::NONE) {
 			return error;
 		}
 
 		if (doingTempFolder) {
-			error =
-			    tempFilePathForRecording->concatenate(&filePath->get()[strlen(audioRecordingFolderNames[folderID])]);
+			error = tempFilePathForRecording->concatenate(&filePath.get()[strlen(audioRecordingFolderNames[folderID])]);
 			if (error != Error::NONE) {
 				return error;
 			}
@@ -356,10 +338,10 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 		// iterate through the main and temp folders until we find a path that's free in both
 		while (changed) {
 			changed = false;
-			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath->get(), songName->get(), channelName,
+			snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath.get(), songName->get(), channelName,
 			         i);
 			while (StorageManager::fileExists(namedPath)) {
-				snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath->get(), songName->get(),
+				snprintf(namedPath, sizeof(namedPath), "%s/%s/%s_%03d.wav", filePath.get(), songName->get(),
 				         channelName, i);
 				i++;
 				changed = true;
@@ -376,7 +358,7 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String* filePath, String
 				}
 			}
 		}
-		error = filePath->set(namedPath);
+		error = filePath.set(namedPath);
 		if (error != Error::NONE) {
 			return error;
 		}
@@ -411,13 +393,13 @@ bool AudioFileManager::tryToDeleteAudioFileFromMemoryIfItExists(char const* file
 		}
 
 		// Ok, it's unused. Delete it.
-		deleteUnusedAudioFileFromMemory(audioFile, i);
+		deleteUnusedAudioFileFromMemory(*audioFile, i);
 	}
 	return true; // We're fine - it got deleted
 }
 
-void AudioFileManager::deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile* audioFile) {
-	int32_t i = audioFiles.searchForExactObject(audioFile);
+void AudioFileManager::deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile& audioFile) {
+	int32_t i = audioFiles.searchForExactObject(&audioFile);
 	if (i < 0) {
 #if ALPHA_OR_BETA_VERSION
 		FREEZE_WITH_ERROR("E401"); // Leo got. And me! But now I've solved.
@@ -428,14 +410,14 @@ void AudioFileManager::deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile* au
 	}
 }
 
-void AudioFileManager::deleteUnusedAudioFileFromMemory(AudioFile* audioFile, int32_t i) {
+void AudioFileManager::deleteUnusedAudioFileFromMemory(AudioFile& audioFile, int32_t i) {
 
 	// Remove AudioFile from memory
 	audioFiles.removeElement(i);
 	// audioFile->remove(); // Remove from the unused AudioFiles list, where this already must have been. Actually
 	// no, the destructor does this anyway.
-	audioFile->~AudioFile();
-	delugeDealloc(audioFile);
+	audioFile.~AudioFile();
+	delugeDealloc(&audioFile);
 }
 
 bool AudioFileManager::ensureEnoughMemoryForOneMoreAudioFile() {
@@ -443,20 +425,20 @@ bool AudioFileManager::ensureEnoughMemoryForOneMoreAudioFile() {
 	return audioFiles.ensureEnoughSpaceAllocated(1);
 }
 
-Error AudioFileManager::setupAlternateAudioFileDir(String* newPath, char const* rootDir,
-                                                   String* songFilenameWithoutExtension) {
+Error AudioFileManager::setupAlternateAudioFileDir(String& newPath, char const* rootDir,
+                                                   String& songFilenameWithoutExtension) {
 
-	Error error = newPath->set(rootDir);
+	Error error = newPath.set(rootDir);
 	if (error != Error::NONE) {
 		return error;
 	}
 
-	error = newPath->concatenate("/");
+	error = newPath.concatenate("/");
 	if (error != Error::NONE) {
 		return error;
 	}
 
-	error = newPath->concatenate(songFilenameWithoutExtension);
+	error = newPath.concatenate(&songFilenameWithoutExtension);
 	if (error != Error::NONE) {
 		return error;
 	}
@@ -464,8 +446,8 @@ Error AudioFileManager::setupAlternateAudioFileDir(String* newPath, char const* 
 	return Error::NONE;
 }
 
-Error AudioFileManager::setupAlternateAudioFilePath(String* newPath, int32_t dirPathLength, String* oldPath) {
-	Error error = newPath->concatenateAtPos(&oldPath->get()[8], dirPathLength); // The [8] skips us past "SAMPLES/"
+Error AudioFileManager::setupAlternateAudioFilePath(String& newPath, int32_t dirPathLength, String& oldPath) {
+	Error error = newPath.concatenateAtPos(&oldPath.get()[8], dirPathLength); // The [8] skips us past "SAMPLES/"
 	if (error != Error::NONE) {
 		return error;
 	}
@@ -473,13 +455,13 @@ Error AudioFileManager::setupAlternateAudioFilePath(String* newPath, int32_t dir
 	int32_t pos = dirPathLength;
 
 	while (true) {
-		char const* newPathChars = newPath->get();
+		char const* newPathChars = newPath.get();
 		char const* slashAddress = strchr(&newPathChars[pos], '/');
 		if (!slashAddress) {
 			break;
 		}
 		int32_t slashPos = (uint32_t)slashAddress - (uint32_t)newPathChars;
-		Error error = newPath->setChar('_', slashPos);
+		Error error = newPath.setChar('_', slashPos);
 		if (error != Error::NONE) {
 			return error;
 		}
@@ -489,7 +471,7 @@ Error AudioFileManager::setupAlternateAudioFilePath(String* newPath, int32_t dir
 	return Error::NONE;
 }
 
-AudioFile* AudioFileManager::getAudioFileFromFilename(String* filePath, bool mayReadCard, Error* error,
+AudioFile* AudioFileManager::getAudioFileFromFilename(String& filePath, bool mayReadCard, Error* error,
                                                       FilePointer* suppliedFilePointer, AudioFileType type,
                                                       bool makeWaveTableWorkAtAllCosts) {
 
@@ -499,7 +481,7 @@ AudioFile* AudioFileManager::getAudioFileFromFilename(String* filePath, bool may
 
 	// See if it's already in memory.
 	bool foundExact;
-	int32_t audioFileI = audioFiles.search(filePath->get(), GREATER_OR_EQUAL, &foundExact);
+	int32_t audioFileI = audioFiles.search(filePath.get(), GREATER_OR_EQUAL, &foundExact);
 
 	// If that basic search by the file's "normal" path already found it, then great.
 	if (foundExact) {
@@ -518,7 +500,7 @@ successfullyFoundInMemory:
 doTryOffset:
 			AudioFile* foundAudioFile2 = (AudioFile*)audioFiles.getElement(audioFileI + tryOffset);
 
-			if (foundAudioFile2->type == type && !strcasecmp(filePath->get(), foundAudioFile2->filePath.get())) {
+			if (foundAudioFile2->type == type && !strcasecmp(filePath.get(), foundAudioFile2->filePath.get())) {
 				return foundAudioFile2;
 			}
 		}
@@ -593,7 +575,7 @@ waveTableCloneError:
 		// filePath if needed (pretty unlikely scenario).
 		else {
 			if (!backedUpFilePath.isEmpty()) {
-				filePath->set(&backedUpFilePath);
+				filePath.set(&backedUpFilePath);
 			}
 		}
 	}
@@ -612,7 +594,7 @@ waveTableCloneError:
 				if (*error != Error::NONE) {
 					goto tryLoadingFromCard;
 				}
-				char const* fileName = getFileNameFromEndOfPath(filePath->get());
+				char const* fileName = getFileNameFromEndOfPath(filePath.get());
 				*error = searchPath.concatenate(fileName);
 				if (*error != Error::NONE) {
 					goto tryLoadingFromCard;
@@ -622,8 +604,8 @@ waveTableCloneError:
 				if (foundExact) {
 					// Tiny bit cheeky, but we're going to update the file path actually stored in the AudioFile to
 					// reflect this alternate location, which will no longer be considered alternate.
-					backedUpFilePath.set(filePath); // First we back up the original filePath.
-					filePath->set(&searchPath);
+					backedUpFilePath.set(&filePath); // First we back up the original filePath.
+					filePath.set(&searchPath);
 					goto successfullyFoundInMemory;
 				}
 			}
@@ -676,11 +658,11 @@ tryAlternateDoesExist:
 			// We'll first try the long file name, which contains all the folder names from the original path. This
 			// is how collect-media saves look - for Songs. But, if that original path didn't begin with "SAMPLES/",
 			// we can't do that.
-			if (memcasecmp(filePath->get(), "SAMPLES/", 8)) {
+			if (memcasecmp(filePath.get(), "SAMPLES/", 8)) {
 				goto tryNextAlternate;
 			}
 
-			*error = setupAlternateAudioFilePath(&proposedFileName, 0, filePath);
+			*error = setupAlternateAudioFilePath(proposedFileName, 0, filePath);
 			if (*error != Error::NONE) {
 				return nullptr; // This is to generate just the name of the file - not an entire path with folders -
 				                // despite the function being called ...Path.
@@ -705,7 +687,7 @@ tryNextAlternate:
 					// folder names. This allows users to copy files into folders for instruments more easily, and
 					// have them load.
 					alreadyTriedSecondAlternate = true;
-					char const* fileName = getFileNameFromEndOfPath(filePath->get());
+					char const* fileName = getFileNameFromEndOfPath(filePath.get());
 					*error = proposedFileName.set(fileName);
 					if (*error != Error::NONE) {
 						return NULL;
@@ -738,7 +720,7 @@ tryNextAlternate:
 				// Special rule for loading presets with files in their dedicated "alternate" folder: must update
 				// the AudioFile's filePath to point to that alternate location - and then treat them as normal (not
 				// alternate).
-				filePath->set(&usingAlternateLocation);
+				filePath.set(&usingAlternateLocation);
 				usingAlternateLocation.clear();
 			}
 		}
@@ -746,7 +728,7 @@ tryNextAlternate:
 		// Otherwise, try the regular file path
 		else {
 tryRegular:
-			result = f_open(&smDeserializer.readFIL, filePath->get(), FA_READ);
+			result = f_open(&smDeserializer.readFIL, filePath.get(), FA_READ);
 
 			// If that didn't work, try the alternate load directory, if we didn't already and it potentially exists
 			if (result != FR_OK) {
@@ -790,7 +772,7 @@ cantLoadFile:
 		goto cantLoadFile;
 	}
 
-	uint32_t numClusters = ((effectiveFilePointer.objsize - 1) >> clusterSizeMagnitude) + 1;
+	uint32_t numClusters = ((effectiveFilePointer.objsize - 1) >> Cluster::size_magnitude) + 1;
 
 	int32_t memorySizeNeeded = (type == AudioFileType::SAMPLE) ? sizeof(Sample) : sizeof(WaveTable);
 
@@ -823,13 +805,13 @@ ramError:
 		reader = new (readerMemory) WaveTableReader;
 	}
 
-	audioFile->filePath.set(filePath);
+	audioFile->filePath.set(&filePath);
 	audioFile->loadedFromAlternatePath.set(&usingAlternateLocation);
 
 	reader->currentClusterIndex = -1;
 	reader->audioFile = audioFile;
 	reader->fileSize = effectiveFilePointer.objsize;
-	reader->byteIndexWithinCluster = clusterSize;
+	reader->byteIndexWithinCluster = Cluster::size;
 
 	// If Sample, we go directly to god-mode and get the cluster addresses.
 	if (type == AudioFileType::SAMPLE) {
@@ -887,8 +869,9 @@ ramError:
 
 ensureSafeThenCheckError:
 	if (type == AudioFileType::SAMPLE) {
-		if (((SampleReader*)reader)->currentCluster) {
-			removeReasonFromCluster(((SampleReader*)reader)->currentCluster, "E030");
+		auto& sampleReader = static_cast<SampleReader&>(*reader);
+		if (sampleReader.currentCluster) {
+			removeReasonFromCluster(*sampleReader.currentCluster, "E030");
 		}
 	}
 	else {
@@ -915,65 +898,9 @@ audioFileError:
 	return audioFile;
 }
 
-void AudioFileManager::testQueue() {
-
-	/*
-	Cluster* loadedSampleChunk = queues[LOADED_SAMPLE_CHUNK_ALLOCATION_QUEUE_NORMAL].first;
-	while (loadedSampleChunk != &queues[LOADED_SAMPLE_CHUNK_ALLOCATION_QUEUE_NORMAL].endNode) {
-
-
-	    if (loadedSampleChunk->nextAvailableLoadedSampleChunk ==
-	&queues[LOADED_SAMPLE_CHUNK_ALLOCATION_QUEUE_NORMAL].endNode
-	            && queues[LOADED_SAMPLE_CHUNK_ALLOCATION_QUEUE_NORMAL].endNode.prevAvailableLoadedSampleChunkPointer
-	!= &loadedSampleChunk->nextAvailableLoadedSampleChunk) { D_PRINTLN("error ---------------------------------");
-	        D_PRINT(loadedSampleChunk->sample->fileName);
-	        D_PRINT(", part ");
-	        D_PRINTLN(loadedSampleChunk->chunkIndex);
-	        return;
-	    }
-
-	    if (loadedSampleChunk->nextAvailableLoadedSampleChunk->prevAvailableLoadedSampleChunkPointer !=
-	&loadedSampleChunk->nextAvailableLoadedSampleChunk) { D_PRINTLN("abc ---------------------------------");
-	        D_PRINT(loadedSampleChunk->sample->fileName);
-	        D_PRINT(", part ");
-	        D_PRINTLN(loadedSampleChunk->chunkIndex);
-	        return;
-	    }
-
-	    loadedSampleChunk = loadedSampleChunk->nextAvailableLoadedSampleChunk;
-	}
-
-	D_PRINTLN("queue ok -----------------------");
-	*/
-}
-
-// Caller must initialize() the Cluster after getting it from this function
-Cluster* AudioFileManager::allocateCluster(ClusterType type, bool shouldAddReasons, void* dontStealFromThing) {
-	cardReadOnce = true; // even if it hasn't been we're now commited to the cluster size
-	void* clusterMemory = GeneralMemoryAllocator::get().allocStealable(clusterObjectSize, dontStealFromThing);
-	if (!clusterMemory) {
-		return NULL;
-	}
-
-	Cluster* cluster = new (clusterMemory) Cluster();
-
-	cluster->type = type;
-
-	if (shouldAddReasons) {
-		cluster->addReason();
-	}
-
-	return cluster;
-}
-
-void AudioFileManager::deallocateCluster(Cluster* cluster) {
-	cluster->~Cluster(); // Removes reasons, and / or from stealable list
-	delugeDealloc(cluster);
-}
-
 #define REPORT_LOAD_TIME 0
 
-bool AudioFileManager::loadCluster(Cluster* cluster, int32_t minNumReasonsAfter) {
+bool AudioFileManager::loadCluster(Cluster& cluster, int32_t minNumReasonsAfter) {
 
 	if (currentlyAccessingCard) {
 		return false; // Could happen if we're trying to render a waveform but we're actually already inside the SD
@@ -981,24 +908,25 @@ bool AudioFileManager::loadCluster(Cluster* cluster, int32_t minNumReasonsAfter)
 	}
 
 	// I don't think these should happen...
-	if (clusterBeingLoaded) {
+	if (clusterBeingLoaded != nullptr) {
 		return false;
 	}
+
 	if (AudioEngine::audioRoutineLocked) {
 		return false;
 	}
 
-	clusterBeingLoaded = cluster;
+	clusterBeingLoaded = &cluster;
 	minNumReasonsForClusterBeingLoaded = minNumReasonsAfter + 1;
 
-	Sample* sample = cluster->sample;
+	Sample* sample = cluster.sample;
 
-	if (cluster->type != ClusterType::Sample) {
+	if (cluster.type != Cluster::Type::SAMPLE) {
 		FREEZE_WITH_ERROR("E205"); // Chris F got this, so gonna leave checking in release build
 	}
 
 #if ALPHA_OR_BETA_VERSION
-	if (cluster->numReasonsToBeLoaded <= 0) {
+	if (cluster.numReasonsToBeLoaded <= 0) {
 		// Ok, I think we know there's at least 1 reason at the point this function's called, because
 		FREEZE_WITH_ERROR("E204");
 	}
@@ -1008,38 +936,38 @@ bool AudioFileManager::loadCluster(Cluster* cluster, int32_t minNumReasonsAfter)
 	}
 #endif
 
-	cluster->addReason(); // So that it can't accidentally hit 0 reasons while we're loading it, cos then it
-	                      // might get deallocated.
+	cluster.addReason(); // So that it can't accidentally hit 0 reasons while we're loading it, cos then it
+	                     // might get deallocated.
 
 	if (false) {
 getOutEarly:
-		clusterBeingLoaded = NULL;
+		clusterBeingLoaded = nullptr;
 		removeReasonFromCluster(cluster, "E033");
 		return false;
 	}
 
-	int32_t clusterIndex = cluster->clusterIndex;
+	int32_t clusterIndex = cluster.clusterIndex;
 
-	int32_t numSectors = clusterSize >> 9;
+	int32_t numSectors = Cluster::size >> 9;
 
 	// If this is the last Cluster, and we do know what the audio data length is...
 	if (sample->audioDataLengthBytes && sample->audioDataLengthBytes != 0x8FFFFFFFFFFFFFFF) {
 		uint32_t audioDataEndPosBytes = sample->audioDataLengthBytes + sample->audioDataStartPosBytes;
-		uint32_t startByteThisCluster = clusterIndex << clusterSizeMagnitude;
+		uint32_t startByteThisCluster = clusterIndex << Cluster::size_magnitude;
 		int32_t bytesToRead = audioDataEndPosBytes - startByteThisCluster;
 		if (bytesToRead <= 0) {
 			D_PRINTLN("fail thing"); // Shouldn't really still happen
 			goto getOutEarly;
 		}
-		if (bytesToRead < clusterSize) {
+		if (bytesToRead < Cluster::size) {
 			numSectors = ((bytesToRead - 1) >> 9) + 1;
 		}
 		// Otherwise, just leave it at the normal number of sectors
 	}
 
 #if ALPHA_OR_BETA_VERSION
-	if ((uint32_t)cluster->data & 0b11) {
-		D_PRINTLN("SD read address misaligned by  %d", (int32_t)((uint32_t)cluster->data & 0b11));
+	if ((uint32_t)cluster.data & 0b11) {
+		D_PRINTLN("SD read address misaligned by  %d", (int32_t)((uint32_t)cluster.data & 0b11));
 	}
 #endif
 
@@ -1050,17 +978,17 @@ getOutEarly:
 #endif
 
 #if ALPHA_OR_BETA_VERSION
-	if (cluster->type != ClusterType::Sample) {
+	if (cluster.type != Cluster::Type::SAMPLE) {
 		FREEZE_WITH_ERROR("i023"); // Happened to me while thrash testing with reduced RAM
 	}
 
-	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter + 1) {
+	if (cluster.numReasonsToBeLoaded < minNumReasonsAfter + 1) {
 		FREEZE_WITH_ERROR("i039"); // It's +1 because we haven't removed this function's "reason" yet.
 	}
 #endif
 
 	DRESULT result = disk_read_without_streaming_first(
-	    SD_PORT, (BYTE*)cluster->data, sample->clusters.getElement(cluster->clusterIndex)->sdAddress, numSectors);
+	    SD_PORT, (BYTE*)cluster.data, sample->clusters.getElement(cluster.clusterIndex)->sdAddress, numSectors);
 
 #if REPORT_LOAD_TIME
 	uint16_t endTime = MTU2.TCNT_0;
@@ -1072,27 +1000,27 @@ getOutEarly:
 #endif
 
 #if ALPHA_OR_BETA_VERSION
-	if (cluster->type != ClusterType::Sample) {
+	if (cluster.type != Cluster::Type::SAMPLE) {
 		FREEZE_WITH_ERROR("E207");
 	}
-	if (!cluster->sample) {
+	if (cluster.sample == nullptr) {
 		FREEZE_WITH_ERROR("E208");
 	}
 
-	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter + 1) {
+	if (cluster.numReasonsToBeLoaded < minNumReasonsAfter + 1) {
 		FREEZE_WITH_ERROR("i038"); // It's +1 because we haven't removed this function's "reason" yet.
 	}
 #endif
 
 	// If that failed, get out
-	if (result) {
+	if (result != 0u) {
 		goto getOutEarly;
 	}
 
-	cluster->convertDataIfNecessary();
+	cluster.convertDataIfNecessary();
 
 #if ALPHA_OR_BETA_VERSION
-	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter + 1) {
+	if (cluster.numReasonsToBeLoaded < minNumReasonsAfter + 1) {
 		FREEZE_WITH_ERROR("i040"); // It's +1 because we haven't removed this function's "reason" yet.
 	}
 #endif
@@ -1101,12 +1029,12 @@ getOutEarly:
 
 	// Give extra bytes to previous Cluster
 	if (clusterIndex > 0) {
-		Cluster* prevCluster = sample->clusters.getElement(cluster->clusterIndex - 1)->cluster;
+		Cluster* prevCluster = sample->clusters.getElement(cluster.clusterIndex - 1)->cluster;
 
 		if (prevCluster && prevCluster->loaded) {
 
 			// We first copy our first 7 bytes from here to the end of the prev Cluster...
-			memcpy(&prevCluster->data[clusterSize], cluster->data, 7);
+			memcpy(&prevCluster->data[Cluster::size], cluster.data, 7);
 
 			// If 24-bit wrong-endian data...
 			if (sample->rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_24) {
@@ -1115,13 +1043,13 @@ getOutEarly:
 				// them, do so now...
 				if (!prevCluster->extraBytesAtEndConverted) {
 
-					uint32_t bytesBeforeStartOfCluster = clusterIndex * clusterSize - sample->audioDataStartPosBytes;
+					uint32_t bytesBeforeStartOfCluster = clusterIndex * Cluster::size - sample->audioDataStartPosBytes;
 					int32_t bytesUnconvertedBeforeCluster = bytesBeforeStartOfCluster % 3;
 					if (bytesUnconvertedBeforeCluster) {
 
 						// There'll be one word in there which hasn't yet been converted. Do it now. (We've probably
 						// just copied over the next one and a bit, which already was converted)
-						int32_t startPos = clusterSize - bytesUnconvertedBeforeCluster;
+						int32_t startPos = Cluster::size - bytesUnconvertedBeforeCluster;
 						uint8_t* thisNumber = (uint8_t*)&prevCluster->data[startPos];
 
 						uint8_t temp = thisNumber[0];
@@ -1130,7 +1058,7 @@ getOutEarly:
 
 						// And now, copy 2 bytes back to this Cluster (that's the maximum that the float could have
 						// been overhanging the boundary)
-						memcpy(cluster->data, &prevCluster->data[clusterSize], 2);
+						memcpy(cluster.data, &prevCluster->data[Cluster::size], 2);
 					}
 
 					prevCluster->extraBytesAtEndConverted = true;
@@ -1149,26 +1077,25 @@ getOutEarly:
 
 						// There'll be one word in there which hasn't yet been converted. Do it now. (We've probably
 						// also just moved over the next one too, which already was converted)
-						int32_t startPos = clusterSize - 4 + misalignment;
-						int32_t* thisNumber = (int32_t*)&prevCluster->data[startPos];
-						sample->convertOneData(thisNumber);
+						int32_t startPos = Cluster::size - 4 + misalignment;
+						sample->convertOneData(prevCluster->data[startPos]);
 
 						// And now, copy 3 bytes back to this Cluster (that's the maximum that the float could have
 						// been overhanging the boundary)
-						memcpy(cluster->data, &prevCluster->data[clusterSize], 3);
+						memcpy(cluster.data, &prevCluster->data[Cluster::size], 3);
 					}
 
 					prevCluster->extraBytesAtEndConverted = true;
 				}
 			}
 
-			cluster->extraBytesAtStartConverted = true;
+			cluster.extraBytesAtStartConverted = true;
 		}
 	}
 
 	// Grab extra bytes from next Cluster
 	if (clusterIndex < sample->clusters.getNumElements() - 1) {
-		Cluster* nextCluster = sample->clusters.getElement(cluster->clusterIndex + 1)->cluster;
+		Cluster* nextCluster = sample->clusters.getElement(cluster.clusterIndex + 1)->cluster;
 
 		if (nextCluster && nextCluster->loaded) {
 
@@ -1176,7 +1103,7 @@ getOutEarly:
 			if (sample->rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_24) {
 
 				uint32_t bytesBeforeStartOfNextCluster =
-				    (clusterIndex + 1) * clusterSize - sample->audioDataStartPosBytes;
+				    (clusterIndex + 1) * Cluster::size - sample->audioDataStartPosBytes;
 				int32_t bytesUnconvertedBeforeNextCluster = bytesBeforeStartOfNextCluster % 3;
 
 				// If one word missed conversion...
@@ -1186,19 +1113,19 @@ getOutEarly:
 					if (!nextCluster->extraBytesAtStartConverted) {
 
 						// We first copy the next Cluster first 7 bytes to the end of this Cluster
-						memcpy(&cluster->data[clusterSize], nextCluster->data, 7);
+						memcpy(&cluster.data[Cluster::size], nextCluster->data, 7);
 					}
 
 					// Or, if we *had* previously converted the first bytes of the next Cluster...
 					else {
 
 						// Grab the unconverted bytes back from where we backed them up to
-						memcpy(&cluster->data[clusterSize], nextCluster->firstThreeBytesPreDataConversion, 2);
+						memcpy(&cluster.data[Cluster::size], nextCluster->firstThreeBytesPreDataConversion, 2);
 					}
 
 					// There'll be one word in there which hasn't yet been converted. Do it now. (We've probably
 					// just copied over the next one and a bit, which already was converted)
-					uint8_t* thisNumber = (uint8_t*)&cluster->data[clusterSize - bytesUnconvertedBeforeNextCluster];
+					uint8_t* thisNumber = (uint8_t*)&cluster.data[Cluster::size - bytesUnconvertedBeforeNextCluster];
 
 					uint8_t temp = thisNumber[0];
 					thisNumber[0] = thisNumber[2];
@@ -1210,7 +1137,7 @@ getOutEarly:
 
 						// And now, copy 2 bytes back to the next Cluster (that's the maximum that the 24-bit
 						// int32_t could have been overhanging the boundary)
-						memcpy(nextCluster->data, &cluster->data[clusterSize], 2);
+						memcpy(nextCluster->data, &cluster.data[Cluster::size], 2);
 					}
 
 					// Or, if we *had* previously converted the first bytes of the next Cluster...
@@ -1230,21 +1157,21 @@ getOutEarly:
 
 				// If one word missed conversion...
 				if (misalignment) {
-					int32_t startPos = clusterSize - 4 + misalignment;
-					int32_t* thisNumber = (int32_t*)&cluster->data[startPos];
+					int32_t startPos = Cluster::size - 4 + misalignment;
+					int32_t& thisNumber = *reinterpret_cast<int32_t*>(&cluster.data[startPos]);
 
 					// If we had't previously converted the first couple of bytes of the next Cluster, do so now...
 					if (!nextCluster->extraBytesAtStartConverted) {
 
 						// We first copy the next Cluster first 7 bytes to the end of this Cluster
-						memcpy(&cluster->data[clusterSize], nextCluster->data, 7);
+						memcpy(&cluster.data[Cluster::size], nextCluster->data, 7);
 
 						// There'll be one word in there which hasn't yet been converted from float. Do it now
 						sample->convertOneData(thisNumber);
 
 						// And now, copy 3 bytes back to the next Cluster (that's the maximum that the float could
 						// have been overhanging the boundary)
-						memcpy(nextCluster->data, &cluster->data[clusterSize], 3);
+						memcpy(nextCluster->data, &cluster.data[Cluster::size], 3);
 
 						nextCluster->extraBytesAtStartConverted = true;
 					}
@@ -1253,7 +1180,7 @@ getOutEarly:
 					else {
 
 						// Grab the unconverted bytes back from where we backed them up to
-						memcpy(&cluster->data[clusterSize], nextCluster->firstThreeBytesPreDataConversion, 3);
+						memcpy(&cluster.data[Cluster::size], nextCluster->firstThreeBytesPreDataConversion, 3);
 
 						// There'll be one word in there which hasn't yet been converted from float. Do it now
 						sample->convertOneData(thisNumber);
@@ -1271,23 +1198,23 @@ getOutEarly:
 			else {
 copy7ToMe:
 				// We copy the next Cluster's first 7 bytes to the end of this Cluster
-				memcpy(&cluster->data[clusterSize], nextCluster->data, 7);
+				memcpy(&cluster.data[Cluster::size], nextCluster->data, 7);
 			}
 
-			cluster->extraBytesAtEndConverted = true;
+			cluster.extraBytesAtEndConverted = true;
 		}
 	}
 
-	cluster->loaded = true;
+	cluster.loaded = true;
 
 	clusterBeingLoaded = NULL;
 	removeReasonFromCluster(cluster, "E034");
 
 #if ALPHA_OR_BETA_VERSION
-	if (cluster->numReasonsToBeLoaded < minNumReasonsAfter) {
+	if (cluster.numReasonsToBeLoaded < minNumReasonsAfter) {
 		FREEZE_WITH_ERROR("i037");
 	}
-	if (cluster->sample->clusters.getElement(cluster->clusterIndex)->cluster != cluster) {
+	if (cluster.sample->clusters.getElement(cluster.clusterIndex)->cluster != &cluster) {
 		FREEZE_WITH_ERROR("E438");
 	}
 #endif
@@ -1378,8 +1305,7 @@ performActionsAndGetOut:
 			if (cluster->numReasonsToBeLoaded > 0) {
 				break;
 			}
-			cluster->~Cluster();
-			deallocateCluster(cluster);
+			Cluster::dealloc(*cluster);
 		}
 
 		// no more clusters to load, so exit
@@ -1390,12 +1316,12 @@ performActionsAndGetOut:
 		// cluster has at least 1 "reason". If it didn't, it would have been removed from the load-queue
 
 		// Do the actual loading
-		if (cluster->type != ClusterType::Sample) {
+		if (cluster->type != Cluster::Type::SAMPLE) {
 			FREEZE_WITH_ERROR("E235"); // Cos Chris F got an E205
 		}
 
 		allowSomeUserActionsEvenWhenInCardRoutine = true; // Sorry!!
-		bool success = loadCluster(cluster);
+		bool success = loadCluster(*cluster);
 		allowSomeUserActionsEvenWhenInCardRoutine = false;
 
 		// If that didn't work, presumably because the SD card got ejected...
@@ -1411,11 +1337,12 @@ performActionsAndGetOut:
 			// re-inserts the card
 			else {
 
-				if (cluster->type != ClusterType::Sample) {
+				if (cluster->type != Cluster::Type::SAMPLE) {
 					FREEZE_WITH_ERROR("E237"); // Cos Chris F got an E205
 				}
 
-				enqueueCluster(cluster); // TODO: If that fails, it'll just get awkwardly forgotten about
+				// TODO: If that fails, it'll just get awkwardly forgotten about
+				loadingQueue.push(*cluster, 0xFFFFFFFF); // lowest priority
 
 				// Also, return now. Normally we stay here til there's nothing left in the load-queue, but now that
 				// would leave us in an infinite loop!
@@ -1434,50 +1361,44 @@ performActionsAndGetOut:
 #endif
 }
 
-// Currently there's no risk of trying to enqueue a cluster multiple times, because this function only gets called
-// after it's freshly allocated
-Error AudioFileManager::enqueueCluster(Cluster* cluster, uint32_t priorityRating) {
-	return loadingQueue.push(*cluster, priorityRating);
-}
+void AudioFileManager::removeReasonFromCluster(Cluster& cluster, char const* errorCode, bool deletingSong) {
+	cluster.numReasonsToBeLoaded--;
 
-void AudioFileManager::removeReasonFromCluster(Cluster* cluster, char const* errorCode, bool deletingSong) {
-	cluster->numReasonsToBeLoaded--;
-
-	if (cluster == clusterBeingLoaded && cluster->numReasonsToBeLoaded < minNumReasonsForClusterBeingLoaded) {
+	if (&cluster == clusterBeingLoaded && cluster.numReasonsToBeLoaded < minNumReasonsForClusterBeingLoaded) {
 		FREEZE_WITH_ERROR("E041"); // Sven got this!
 	}
 
 	// If it's now zero, it's become available
-	if (cluster->numReasonsToBeLoaded == 0) {
+	if (cluster.numReasonsToBeLoaded == 0) {
 
 		// Bug hunting
-		if (ALPHA_OR_BETA_VERSION && cluster->numReasonsHeldBySampleRecorder) {
+		if (ALPHA_OR_BETA_VERSION && cluster.numReasonsHeldBySampleRecorder) {
 			FREEZE_WITH_ERROR("E364");
 		}
 
 		// If it's still in the load queue, remove it from there. (We know that it isn't in the process of being
 		// loaded right now because that would have added a "reason", so we wouldn't be here.) also do this on song
 		// swap
-		if (loadingQueue.erase(*cluster) || deletingSong) {
+		if (loadingQueue.erase(cluster) || deletingSong) {
 
 			// Tell its Cluster to forget it exists
-			cluster->sample->clusters.getElement(cluster->clusterIndex)->cluster = NULL;
+			cluster.sample->clusters.getElement(cluster.clusterIndex)->cluster = NULL;
 
-			deallocateCluster(cluster); // It contains nothing, so completely recycle it
+			delete &cluster; // It contains nothing, so completely recycle it
 		}
 
 		else {
-			GeneralMemoryAllocator::get().putStealableInAppropriateQueue(
-			    cluster); // It contains data we may want at some future point, so file it away
+			// It contains data we may want at some future point, so file it away
+			GeneralMemoryAllocator::get().putStealableInAppropriateQueue(&cluster);
 		}
 
 		//*cluster->getAnyReasonsPointer() = ANY_REASONS_NO;
 	}
 
-	else if (cluster->numReasonsToBeLoaded < 0) {
+	else if (cluster.numReasonsToBeLoaded < 0) {
 #if ALPHA_OR_BETA_VERSION
-		if (cluster->sample) { // "Should" always be true...
-			D_PRINTLN("reason remains on cluster of sample:  %d", cluster->sample->filePath.get());
+		if (cluster.sample != nullptr) { // "Should" always be true...
+			D_PRINTLN("reason remains on cluster of sample:  %d", cluster.sample->filePath.get());
 		}
 		FREEZE_WITH_ERROR(errorCode);
 #else

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -18,16 +18,16 @@
 #pragma once
 #include "definitions_cxx.hpp"
 #include "storage/audio/audio_file_vector.h"
+#include "storage/cluster/cluster.h"
 #include "storage/cluster/cluster_priority_queue.h"
+#include <array>
 #include <cstdint>
-#include <stdint.h>
 
 extern "C" {
 #include "fatfs/ff.h"
 }
 
 class Sample;
-class Cluster;
 class SampleCache;
 class String;
 class SampleRecorder;
@@ -86,63 +86,57 @@ public:
 	AudioFileVector audioFiles;
 
 	void init();
-	AudioFile* getAudioFileFromFilename(String* fileName, bool mayReadCard, Error* error, FilePointer* filePointer,
+	AudioFile* getAudioFileFromFilename(String& fileName, bool mayReadCard, Error* error, FilePointer* filePointer,
 	                                    AudioFileType type, bool makeWaveTableWorkAtAllCosts = false);
-	Cluster* allocateCluster(ClusterType type = ClusterType::Sample, bool shouldAddReasons = true,
-	                         void* dontStealFromThing = NULL);
-	Error enqueueCluster(Cluster* cluster, uint32_t priorityRating = 0xFFFFFFFF);
-	bool loadCluster(Cluster* cluster, int32_t minNumReasonsAfter = 0);
+	bool loadCluster(Cluster& cluster, int32_t minNumReasonsAfter = 0);
 	void loadAnyEnqueuedClusters(int32_t maxNum = 128, bool mayProcessUserActionsBetween = false);
-	void removeReasonFromCluster(Cluster* cluster, char const* errorCode, bool deletingSong = false);
-	void testQueue();
+	void removeReasonFromCluster(Cluster& cluster, char const* errorCode, bool deletingSong = false);
 
 	bool ensureEnoughMemoryForOneMoreAudioFile();
 
 	void slowRoutine();
-	void deallocateCluster(Cluster* cluster);
-	Error setupAlternateAudioFilePath(String* newPath, int32_t dirPathLength, String* oldPath);
-	Error setupAlternateAudioFileDir(String* newPath, char const* rootDir, String* songFilenameWithoutExtension);
+
+	Error setupAlternateAudioFilePath(String& newPath, int32_t dirPathLength, String& oldPath);
+	Error setupAlternateAudioFileDir(String& newPath, char const* rootDir, String& songFilenameWithoutExtension);
 	bool loadingQueueHasAnyLowestPriorityElements();
 	/// If songname isn't supplied the file is placed in the main recording folder and named as samples/folder/REC###.
 	/// If song and channel are supplied then it's placed in samples/folder/song/channel_###
-	Error getUnusedAudioRecordingFilePath(String* filePath, String* tempFilePathForRecording,
+	Error getUnusedAudioRecordingFilePath(String& filePath, String* tempFilePathForRecording,
 	                                      AudioRecordingFolder folder, uint32_t* getNumber, const char* channelName,
 	                                      String* songName);
 	void deleteAnyTempRecordedSamplesFromMemory();
-	void deleteUnusedAudioFileFromMemory(AudioFile* audioFile, int32_t i);
-	void deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile* audioFile);
+	void deleteUnusedAudioFileFromMemory(AudioFile& audioFile, int32_t i);
+	void deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile& audioFile);
 	bool tryToDeleteAudioFileFromMemoryIfItExists(char const* filePath);
 
 	void thingBeginningLoading(ThingType newThingType);
 	void thingFinishedLoading();
 
+	void setCardRead() { cardReadOnce = true; }
+	void setCardEjected() { cardEjected = true; }
+
 	ClusterPriorityQueue loadingQueue;
-
-	uint32_t clusterSize{32768};
-	uint32_t clusterSizeAtBoot{0};
-	int32_t clusterSizeMagnitude;
-
-	uint32_t clusterObjectSize;
-
-	bool cardReadOnce{false};
-	bool cardEjected;
-	bool cardDisabled;
 
 	Cluster* clusterBeingLoaded;
 	int32_t minNumReasonsForClusterBeingLoaded; // Only valid when clusterBeingLoaded is set. And this exists for bug
 	                                            // hunting only.
 
 	String alternateAudioFileLoadPath;
-	AlternateLoadDirStatus alternateLoadDirStatus;
-	ThingType thingTypeBeingLoaded;
+	AlternateLoadDirStatus alternateLoadDirStatus = AlternateLoadDirStatus::NONE_SET;
+	ThingType thingTypeBeingLoaded = ThingType::NONE;
 	DIR alternateLoadDir;
 
-	int32_t highestUsedAudioRecordingNumber[kNumAudioRecordingFolders];
-	bool highestUsedAudioRecordingNumberNeedsReChecking[kNumAudioRecordingFolders];
+	std::array<int32_t, kNumAudioRecordingFolders> highestUsedAudioRecordingNumber;
+	std::bitset<kNumAudioRecordingFolders> highestUsedAudioRecordingNumberNeedsReChecking;
 	void firstCardRead();
 
 private:
-	void setClusterSize(uint32_t newSize);
+	bool cardReadOnce{false};
+	bool cardEjected;
+	bool cardDisabled = false;
+
+	uint32_t clusterSizeAtBoot{0};
+
 	void cardReinserted();
 	int32_t readBytes(char* buffer, int32_t num, int32_t* byteIndexWithinCluster, Cluster** currentCluster,
 	                  uint32_t* currentClusterIndex, uint32_t fileSize, Sample* sample);

--- a/src/deluge/storage/audio/audio_file_reader.cpp
+++ b/src/deluge/storage/audio/audio_file_reader.cpp
@@ -41,19 +41,19 @@ void AudioFileReader::jumpForwardToBytePos(uint32_t newPos) {
 }
 
 uint32_t AudioFileReader::getBytePos() {
-	return byteIndexWithinCluster + currentClusterIndex * audioFileManager.clusterSize;
+	return byteIndexWithinCluster + currentClusterIndex * Cluster::size;
 }
 
 Error AudioFileReader::advanceClustersIfNecessary() {
 
-	int32_t numClustersToAdvance = byteIndexWithinCluster >> audioFileManager.clusterSizeMagnitude;
+	int32_t numClustersToAdvance = byteIndexWithinCluster >> Cluster::size_magnitude;
 
 	if (!numClustersToAdvance) {
 		return Error::NONE;
 	}
 
 	currentClusterIndex += numClustersToAdvance;
-	byteIndexWithinCluster &= audioFileManager.clusterSize - 1;
+	byteIndexWithinCluster &= Cluster::size - 1;
 
 	return readNewCluster();
 }

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -37,7 +37,7 @@ void Cluster::setSize(size_t size) {
 	Cluster::size_magnitude = 32 - __builtin_clz(size) - 1;
 }
 
-Cluster* Cluster::alloc(Cluster::Type type, bool shouldAddReasons, void* dontStealFromThing) {
+Cluster* Cluster::create(Cluster::Type type, bool shouldAddReasons, void* dontStealFromThing) {
 	audioFileManager.setCardRead(); // even if it hasn't been we're now commited to the cluster size
 	void* memory = GeneralMemoryAllocator::get().allocStealable(sizeof(Cluster) + Cluster::size, dontStealFromThing);
 	if (memory == nullptr) {
@@ -55,9 +55,9 @@ Cluster* Cluster::alloc(Cluster::Type type, bool shouldAddReasons, void* dontSte
 	return cluster;
 }
 
-void Cluster::dealloc(Cluster& cluster) {
-	cluster.~Cluster(); // Removes reasons, and / or from stealable list
-	delugeDealloc(&cluster);
+void Cluster::destroy() {
+	this->~Cluster(); // Removes reasons, and / or from stealable list
+	delugeDealloc(this);
 }
 
 /**

--- a/src/deluge/storage/cluster/cluster.h
+++ b/src/deluge/storage/cluster/cluster.h
@@ -17,9 +17,11 @@
 
 #pragma once
 
+#include "definitions.h"
 #include "definitions_cxx.hpp"
 #include "memory/general_memory_allocator.h"
 #include "memory/stealable.h"
+#include <array>
 #include <cstdint>
 
 class Sample;
@@ -60,15 +62,19 @@ public:
 	void addReason();
 
 	Cluster::Type type;
-	int8_t numReasonsHeldBySampleRecorder;
-	bool extraBytesAtStartConverted;
-	bool extraBytesAtEndConverted;
-	int32_t numReasonsToBeLoaded;
-	Sample* sample;
-	uint32_t clusterIndex;
-	SampleCache* sampleCache;
+	uint32_t clusterIndex = 0;
+
+	int32_t numReasonsToBeLoaded = 0;
+	int8_t numReasonsHeldBySampleRecorder = 0;
+
+	bool extraBytesAtStartConverted = false;
+	bool extraBytesAtEndConverted = false;
+
+	Sample* sample = nullptr;
+	SampleCache* sampleCache = nullptr;
+
 	char firstThreeBytesPreDataConversion[3];
-	bool loaded;
+	bool loaded = false;
 
 	// MUST BE THE LAST TWO MEMBERS
 	char dummy[CACHE_LINE_SIZE];

--- a/src/deluge/storage/cluster/cluster.h
+++ b/src/deluge/storage/cluster/cluster.h
@@ -28,8 +28,9 @@ class Sample;
 class SampleCluster;
 class SampleCache;
 
-// Please see explanation of Clusters and SD card streaming at the top of AudioFileManager.h
-
+/// Header data for a cluster. The actual cluster data is expected to be in the same allocation, after this class
+/// member. To correctly allocate an instance of this class, you must also allocate Cluster::size bytes with enough
+/// padding to safely absorb an offset of at least CACHE_LINE_SIZE.
 class Cluster final : public Stealable {
 public:
 	constexpr static size_t kSizeFAT16Max = 32768;
@@ -43,10 +44,9 @@ public:
 		OTHER,
 	};
 
-	static Cluster* alloc(Cluster::Type type = Cluster::Type::SAMPLE, bool shouldAddReasons = true,
-	                      void* dontStealFromThing = nullptr);
-
-	static void dealloc(Cluster& cluster);
+	static Cluster* create(Cluster::Type type = Cluster::Type::SAMPLE, bool shouldAddReasons = true,
+	                       void* dontStealFromThing = nullptr);
+	void destroy();
 
 	static size_t size;
 	static size_t size_magnitude;

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -731,8 +731,8 @@ FileReader::~FileReader() {
 
 void FileReader::resetReader() {
 	if (!memoryBased) {
-		fileReadBufferCurrentPos = audioFileManager.clusterSize;
-		currentReadBufferEndPos = audioFileManager.clusterSize;
+		fileReadBufferCurrentPos = Cluster::size;
+		currentReadBufferEndPos = Cluster::size;
 	}
 	else {
 		fileReadBufferCurrentPos = 0;
@@ -751,7 +751,7 @@ bool FileReader::readFileClusterIfNecessary() {
 		return !reachedBufferEnd;
 	}
 	// Load next Cluster if necessary
-	if (fileReadBufferCurrentPos >= audioFileManager.clusterSize) {
+	if (fileReadBufferCurrentPos >= Cluster::size) {
 		readCount = 0;
 		bool result = readFileCluster();
 		if (!result) {
@@ -775,7 +775,7 @@ bool FileReader::readFileCluster() {
 		return true;
 	}
 
-	FRESULT result = f_read(&readFIL, (UINT*)fileClusterBuffer, audioFileManager.clusterSize, &currentReadBufferEndPos);
+	FRESULT result = f_read(&readFIL, (UINT*)fileClusterBuffer, Cluster::size, &currentReadBufferEndPos);
 	if (result) {
 		return false;
 	}

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -137,7 +137,7 @@ void dft_r2c(ne10_fft_cpx_int32_t* __restrict__ out, int32_t const* __restrict__
 #define SHOULD_DISCARD_WAVETABLE_DATA_WITH_INSUFFICIENT_HF_CONTENT 0
 
 Error WaveTable::setup(Sample* sample, int32_t rawFileCycleSize, uint32_t audioDataStartPosBytes,
-                       uint32_t audioDataLengthBytes, int32_t byteDepth, int32_t rawDataFormat,
+                       uint32_t audioDataLengthBytes, int32_t byteDepth, RawDataFormat rawDataFormat,
                        WaveTableReader* reader) {
 	AudioEngine::logAction("WaveTable::setup");
 
@@ -360,10 +360,10 @@ gotError5:
 	uint32_t startedBandsYet = 0;
 
 	bool swappingEndianness =
-	    (rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_32 || rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_24
-	     || rawDataFormat == RAW_DATA_ENDIANNESS_WRONG_16);
+	    (rawDataFormat == RawDataFormat::ENDIANNESS_WRONG_32 || rawDataFormat == RawDataFormat::ENDIANNESS_WRONG_24
+	     || rawDataFormat == RawDataFormat::ENDIANNESS_WRONG_16);
 
-	bool needToMisalignData = (rawDataFormat == RAW_DATA_FINE || rawDataFormat == RAW_DATA_UNSIGNED_8);
+	bool needToMisalignData = (rawDataFormat == RawDataFormat::NATIVE || rawDataFormat == RawDataFormat::UNSIGNED_8);
 
 	// For each wave cycle...
 	for (int32_t cycleIndex = 0; cycleIndex < numCycles; cycleIndex++) {
@@ -420,7 +420,7 @@ gotError5:
 			// Macro setup for below
 #define CONVERT_AND_STORE_SAMPLE                                                                                       \
 	{                                                                                                                  \
-		if (rawDataFormat == RAW_DATA_FLOAT) {                                                                         \
+		if (rawDataFormat == RawDataFormat::FLOAT) {                                                                   \
 			value32 = q31_from_float(std::bit_cast<float>(value32));                                                   \
 		}                                                                                                              \
 		else {                                                                                                         \
@@ -428,7 +428,7 @@ gotError5:
 				value32 = swapEndianness32(value32);                                                                   \
 			}                                                                                                          \
 			value32 &= bitMask;                                                                                        \
-			if (rawDataFormat == RAW_DATA_UNSIGNED_8) {                                                                \
+			if (rawDataFormat == RawDataFormat::UNSIGNED_8) {                                                          \
 				value32 += (1 << 31);                                                                                  \
 			}                                                                                                          \
 		}                                                                                                              \

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -516,8 +516,10 @@ gotError5:
 			// If we're less than one sample from the end of the cluster...
 			if (byteIndexWithinCluster > Cluster::size - byteDepth) {
 				bytesOverlappingFromLastCluster = *(uint32_t*)source;
-				byteIndexWithinCluster -= Cluster::size; // Might end up negative, indicating that we've
-				                                         // got a sample overlapping the cluster boundary
+
+				// A negative value here indicates that the start of the next sample is within the current cluster
+				byteIndexWithinCluster -= Cluster::size;
+
 				clusterIndex++;
 			}
 		} while (sourceBytesLeftToCopyThisCycle > 0);

--- a/src/deluge/storage/wave_table/wave_table.h
+++ b/src/deluge/storage/wave_table/wave_table.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "model/sample/sample.h"
 #include "storage/audio/audio_file.h"
 #include "storage/wave_table/wave_table_band_data.h"
 #include "util/container/array/ordered_resizeable_array.h"
@@ -48,8 +49,8 @@ public:
 	                uint32_t resetterDivideByPhaseIncrement, uint32_t retriggerPhase, int32_t waveIndex,
 	                int32_t waveIndexIncrement);
 	Error setup(Sample* sample, int32_t nativeNumSamplesPerCycle = 0, uint32_t audioDataStartPosBytes = 0,
-	            uint32_t audioDataLengthBytes = 0, int32_t byteDepth = 0, int32_t rawDataFormat = 0,
-	            WaveTableReader* reader = NULL);
+	            uint32_t audioDataLengthBytes = 0, int32_t byteDepth = 0,
+	            RawDataFormat rawDataFormat = RawDataFormat::NATIVE, WaveTableReader* reader = nullptr);
 	void deleteAllBandsAndData();
 	void bandDataBeingStolen(WaveTableBandData* bandData);
 

--- a/src/deluge/storage/wave_table/wave_table_band_data.cpp
+++ b/src/deluge/storage/wave_table/wave_table_band_data.cpp
@@ -43,7 +43,7 @@ void WaveTableBandData::steal(char const* errorCode) {
 	waveTable->bandDataBeingStolen(this);
 
 	// Delete the WaveTable from memory - deallocating all other BandDatas and everything.
-	audioFileManager.deleteUnusedAudioFileFromMemoryIndexUnknown(waveTable);
+	audioFileManager.deleteUnusedAudioFileFromMemoryIndexUnknown(*waveTable);
 }
 
 StealableQueue WaveTableBandData::getAppropriateQueue() {

--- a/src/deluge/storage/wave_table/wave_table_reader.cpp
+++ b/src/deluge/storage/wave_table/wave_table_reader.cpp
@@ -39,8 +39,7 @@ Error WaveTableReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t 
 Error WaveTableReader::readNewCluster() {
 
 	UINT bytesRead;
-	FRESULT result =
-	    f_read(&smDeserializer.readFIL, smDeserializer.fileClusterBuffer, audioFileManager.clusterSize, &bytesRead);
+	FRESULT result = f_read(&smDeserializer.readFIL, smDeserializer.fileClusterBuffer, Cluster::size, &bytesRead);
 	if (result) {
 		return Error::SD_CARD; // Failed to load cluster from card
 	}


### PR DESCRIPTION
Moves most of AudioFileManager's member functions to using references for non-nullable values, and migrates some code to Cluster where it operates (Cluster::alloc, Cluster::dealloc, Cluster::size, etc.). Also convert's sample RAW_DATA values to an enum class.