### PR TITLE
Revert "Bugfix/replace routine with cluster loading"

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -459,9 +459,6 @@ int32_t getNumVoices() {
 }
 
 void routineWithClusterLoading(bool mayProcessUserActionsBetween) {
-	// just yield to run some stuff (probably audio and cluster loading based on their priorities)
-	yieldWithTimeout([]() { return false; }, 0.0002);
-	return;
 	logAction("AudioDriver::routineWithClusterLoading");
 
 	routineBeenCalled = false;


### PR DESCRIPTION
Reverts SynthstromAudible/DelugeFirmware#3087 since some of these aren't safe to replace