### PR TITLE
Fix note and note row editor menu entering for midi and cv drums

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1387,7 +1387,8 @@ bool SoundEditor::setup(Clip* clip, const MenuItem* item, int32_t sourceIndex) {
 						newArpSettings = &((SoundDrum*)selectedDrum)->arpSettings;
 					}
 					else {
-						if (item != &sequenceDirectionMenu) {
+						if (item != &sequenceDirectionMenu && item != &noteEditorRootMenu
+						    && item != &noteRowEditorRootMenu) {
 							if (selectedDrum->type == DrumType::MIDI) {
 								indicator_leds::indicateAlertOnLed(IndicatorLED::MIDI);
 							}
@@ -1441,13 +1442,7 @@ bool SoundEditor::setup(Clip* clip, const MenuItem* item, int32_t sourceIndex) {
 			actionLogger.deleteAllLogs();
 
 			if (clip->type == ClipType::INSTRUMENT) {
-				if (currentUIMode == UI_MODE_NOTES_PRESSED) {
-					newItem = &noteEditorRootMenu;
-				}
-				else if (currentUIMode == UI_MODE_AUDITIONING) {
-					newItem = &noteRowEditorRootMenu;
-				}
-				else if (outputType == OutputType::MIDI_OUT) {
+				if (outputType == OutputType::MIDI_OUT) {
 					soundEditorRootMenuMIDIOrCV.title = l10n::String::STRING_FOR_MIDI_INST_MENU_TITLE;
 doMIDIOrCV:
 					newItem = &soundEditorRootMenuMIDIOrCV;
@@ -1471,11 +1466,8 @@ doMIDIOrCV:
 			}
 		}
 		else {
-			if ((currentUI == &performanceView) && !Buttons::isShiftButtonPressed()) {
-				newItem = &soundEditorRootMenuPerformanceView;
-			}
-			else if ((currentUI == &sessionView || currentUI == &arrangerView || currentUI == &automationView)
-			         && !Buttons::isShiftButtonPressed()) {
+			if ((currentUI == &sessionView || currentUI == &arrangerView || currentUI == &automationView)
+			    && !Buttons::isShiftButtonPressed()) {
 				newItem = &soundEditorRootMenuSongView;
 			}
 			else {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3045,7 +3045,7 @@ bool InstrumentClipView::enterNoteEditor() {
 		dontDeleteNotesOnDepress();
 		display->setNextTransitionDirection(1);
 		InstrumentClip* clip = getCurrentInstrumentClip();
-		if (soundEditor.setup(clip)) {
+		if (soundEditor.setup(clip, &noteEditorRootMenu)) {
 			// if it's a kit with affect entire enabled, toggle it off when entering note editor
 			if (clip->output->type == OutputType::KIT) {
 				if (clip->affectEntire) {
@@ -3203,7 +3203,7 @@ bool InstrumentClipView::enterNoteRowEditor() {
 		if (modelStackWithNoteRow->getNoteRowAllowNull()) {
 			display->setNextTransitionDirection(1);
 			InstrumentClip* clip = getCurrentInstrumentClip();
-			if (soundEditor.setup(clip)) {
+			if (soundEditor.setup(clip, &noteRowEditorRootMenu)) {
 				// if it's a kit with affect entire enabled, toggle it off when entering note row editor
 				if (clip->output->type == OutputType::KIT) {
 					if (clip->affectEntire) {

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -869,8 +869,9 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 
 			if (!defaultEditingMode) {
 				display->setNextTransitionDirection(1);
-				soundEditor.setup(nullptr, &soundEditorRootMenuPerformanceView);
-				openUI(&soundEditor);
+				if (soundEditor.setup(nullptr, &soundEditorRootMenuPerformanceView)) {
+					openUI(&soundEditor);
+				}
 			}
 		}
 	}

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -869,7 +869,7 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 
 			if (!defaultEditingMode) {
 				display->setNextTransitionDirection(1);
-				soundEditor.setup();
+				soundEditor.setup(nullptr, &soundEditorRootMenuPerformanceView);
 				openUI(&soundEditor);
 			}
 		}


### PR DESCRIPTION
Fixed bug with entering note and note row editor menu's for midi and cv kit drums

Cleaned up menu entry code for performance view as well

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3094