### PR TITLE
Fix alignment issue for interpolator

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 
 FetchContent_Declare(argon
   GIT_REPOSITORY https://github.com/stellar-aria/argon
-  GIT_TAG 67ba8399c5c6b939c2b34be5746ad0d2676418d2
+  GIT_TAG dc020d017579ba17c7bbe7f92e0c042673a0e330
 )
 FetchContent_MakeAvailable(argon)
 

--- a/src/deluge/dsp/interpolate/interpolate.cpp
+++ b/src/deluge/dsp/interpolate/interpolate.cpp
@@ -36,8 +36,8 @@ StereoSample Interpolator::interpolate(size_t channels, int32_t whichKernel, uin
 
 	Argon<int32_t> multiplied = 0;
 	for (size_t i = 0; i < kernelVector.size(); ++i) {
-		multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetLow(), interpolation_buffer_l_[i * 2]);
-		multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetHigh(), interpolation_buffer_l_[(i * 2) + 1]);
+		multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetLow(), ArgonHalf<int16_t>::Load(&interpolation_buffer_l_[i * 8]));
+		multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetHigh(), ArgonHalf<int16_t>::Load(&interpolation_buffer_l_[(i * 8) + 4]));
 	}
 
 	ArgonHalf<int32_t> twosies = multiplied.GetHigh() + multiplied.GetLow();
@@ -48,8 +48,8 @@ StereoSample Interpolator::interpolate(size_t channels, int32_t whichKernel, uin
 
 		Argon<int32_t> multiplied = 0;
 		for (size_t i = 0; i < kernelVector.size(); ++i) {
-			multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetLow(), interpolation_buffer_r_[i * 2]);
-			multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetHigh(), interpolation_buffer_r_[(i * 2) + 1]);
+			multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetLow(), ArgonHalf<int16_t>::Load(&interpolation_buffer_r_[i * 8]));
+			multiplied = multiplied.MultiplyAddLong(kernelVector[i].GetHigh(), ArgonHalf<int16_t>::Load(&interpolation_buffer_r_[(i * 8) + 4]));
 		}
 
 		ArgonHalf<int32_t> twosies = multiplied.GetHigh() + multiplied.GetLow();
@@ -64,9 +64,9 @@ StereoSample Interpolator::interpolateLinear(size_t channels, uint32_t phase) {
 	int16_t strength2 = phase >> 9;
 	int16_t strength1 = std::numeric_limits<int16_t>::max() - strength2; // inverse
 
-	output.l = (interpolation_buffer_l_[0][1] * strength1) + (interpolation_buffer_l_[0][0] * strength2);
+	output.l = (interpolation_buffer_l_[1] * strength1) + (interpolation_buffer_l_[0] * strength2);
 	if (channels == 2) {
-		output.r = (interpolation_buffer_r_[0][1] * strength1) + (interpolation_buffer_r_[0][0] * strength2);
+		output.r = (interpolation_buffer_r_[1] * strength1) + (interpolation_buffer_r_[0] * strength2);
 	}
 	return output;
 }

--- a/src/deluge/dsp/interpolate/interpolate.h
+++ b/src/deluge/dsp/interpolate/interpolate.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "definitions_cxx.hpp"
 #include "deluge/dsp/stereo_sample.h"
-#include <arm_neon_shim.h>
 #include <array>
 #include <cstdint>
 
@@ -9,22 +8,22 @@ extern const int16_t windowedSincKernel[][17][16];
 
 namespace deluge::dsp {
 class Interpolator {
-	using buffer_t = std::array<int16x4_t, kInterpolationMaxNumSamples / 4>;
+	using buffer_t = std::array<int16_t, kInterpolationMaxNumSamples>;
 
 public:
 	Interpolator() = default;
 	StereoSample interpolate(size_t channels, int32_t whichKernel, uint32_t oscPos);
 	StereoSample interpolateLinear(size_t channels, uint32_t oscPos);
 
-	constexpr int16_t& bufferL(size_t idx) { return interpolation_buffer_l_[idx / 4][idx % 4]; }
-	constexpr int16_t& bufferR(size_t idx) { return interpolation_buffer_r_[idx / 4][idx % 4]; }
+	constexpr int16_t& bufferL(size_t idx) { return interpolation_buffer_l_[idx]; }
+	constexpr int16_t& bufferR(size_t idx) { return interpolation_buffer_r_[idx]; }
 
 	constexpr void pushL(int16_t value) {
 #pragma unroll
 		for (int32_t i = kInterpolationMaxNumSamples - 1; i >= 1; i--) {
 			bufferL(i) = bufferL(i - 1);
 		}
-		interpolation_buffer_l_[0][0] = value;
+		interpolation_buffer_l_[0] = value;
 	}
 
 	inline void pushR(int16_t value) {
@@ -32,7 +31,7 @@ public:
 		for (int32_t i = kInterpolationMaxNumSamples - 1; i >= 1; i--) {
 			bufferR(i) = bufferR(i - 1);
 		}
-		interpolation_buffer_r_[0][0] = value;
+		interpolation_buffer_r_[0] = value;
 	}
 
 	constexpr void jumpForward(size_t num_samples) {
@@ -44,7 +43,7 @@ public:
 	}
 
 private:
-	buffer_t interpolation_buffer_l_{};
-	buffer_t interpolation_buffer_r_{};
+	buffer_t interpolation_buffer_l_;
+	buffer_t interpolation_buffer_r_;
 };
 } // namespace deluge::dsp

--- a/src/deluge/dsp/interpolate/interpolate.h
+++ b/src/deluge/dsp/interpolate/interpolate.h
@@ -7,43 +7,39 @@
 extern const int16_t windowedSincKernel[][17][16];
 
 namespace deluge::dsp {
-class Interpolator {
+struct Interpolator {
 	using buffer_t = std::array<int16_t, kInterpolationMaxNumSamples>;
 
-public:
 	Interpolator() = default;
 	StereoSample interpolate(size_t channels, int32_t whichKernel, uint32_t oscPos);
 	StereoSample interpolateLinear(size_t channels, uint32_t oscPos);
 
-	constexpr int16_t& bufferL(size_t idx) { return interpolation_buffer_l_[idx]; }
-	constexpr int16_t& bufferR(size_t idx) { return interpolation_buffer_r_[idx]; }
-
 	constexpr void pushL(int16_t value) {
 #pragma unroll
 		for (int32_t i = kInterpolationMaxNumSamples - 1; i >= 1; i--) {
-			bufferL(i) = bufferL(i - 1);
+			buffer_l[i] = buffer_l[i - 1];
 		}
-		interpolation_buffer_l_[0] = value;
+		buffer_l[0] = value;
 	}
 
 	inline void pushR(int16_t value) {
 #pragma unroll
 		for (int32_t i = kInterpolationMaxNumSamples - 1; i >= 1; i--) {
-			bufferR(i) = bufferR(i - 1);
+			buffer_r[i] = buffer_r[i - 1];
 		}
-		interpolation_buffer_r_[0] = value;
+		buffer_r[0] = value;
 	}
 
 	constexpr void jumpForward(size_t num_samples) {
 #pragma unroll
 		for (int32_t i = kInterpolationMaxNumSamples - 1; i >= num_samples; i--) {
-			bufferL(i) = bufferL(i - num_samples);
-			bufferR(i) = bufferR(i - num_samples);
+			buffer_l[i] = buffer_l[i - num_samples];
+			buffer_r[i] = buffer_r[i - num_samples];
 		}
 	}
 
-private:
-	buffer_t interpolation_buffer_l_;
-	buffer_t interpolation_buffer_r_;
+	// These are the state buffers
+	buffer_t buffer_l;
+	buffer_t buffer_r;
 };
 } // namespace deluge::dsp

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -992,7 +992,8 @@ void SampleLowLevelReader::readSamplesResampled(int32_t** __restrict__ oscBuffer
 					if (numChannels == 2) {
 						while (true) {
 							interpolator_.buffer_l[numSamplesToJumpForward] = sourceL;
-							interpolator_.buffer_r[numSamplesToJumpForward] = *(int16_t*)(currentPlayPosNow + byteDepth);
+							interpolator_.buffer_r[numSamplesToJumpForward] =
+							    *(int16_t*)(currentPlayPosNow + byteDepth);
 							currentPlayPosNow += jumpAmount;
 							if (!numSamplesToJumpForward) {
 								goto skipFirstSmooth;

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -450,8 +450,8 @@ void SampleLowLevelReader::fillInterpolationBufferRetrospectively(Sample* sample
 	if (clusters[0] == nullptr) {
 		// zero and return ASAP
 		for (int32_t i = startI; i < bufferSize; i++) {
-			interpolator_.bufferL(i) = 0;
-			interpolator_.bufferR(i) = 0;
+			interpolator_.buffer_l[i] = 0;
+			interpolator_.buffer_r[i] = 0;
 		}
 		return;
 	}
@@ -466,17 +466,17 @@ void SampleLowLevelReader::fillInterpolationBufferRetrospectively(Sample* sample
 
 		// If there was valid audio data there...
 		if (bytesPastClusterStart >= 0) {
-			interpolator_.bufferL(i) = *(int16_t*)(thisPlayPos + 2);
+			interpolator_.buffer_l[i] = *(int16_t*)(thisPlayPos + 2);
 
 			if (sample->numChannels == 2) {
-				interpolator_.bufferR(i) = *(int16_t*)(thisPlayPos + 2 + sample->byteDepth);
+				interpolator_.buffer_r[i] = *(int16_t*)(thisPlayPos + 2 + sample->byteDepth);
 			}
 		}
 
 		// Or if not, just write zeros
 		else {
-			interpolator_.bufferL(i) = 0;
-			interpolator_.bufferR(i) = 0;
+			interpolator_.buffer_l[i] = 0;
+			interpolator_.buffer_r[i] = 0;
 		}
 	}
 }
@@ -488,8 +488,8 @@ bool SampleLowLevelReader::fillInterpolationBufferForward(SamplePlaybackGuide* g
 	if (clusters[0] == nullptr) {
 		// zero and exit fast
 		for (int32_t i = numSpacesToFill - 1; i >= 0; i--) {
-			interpolator_.bufferL(i) = 0;
-			interpolator_.bufferR(i) = 0;
+			interpolator_.buffer_l[i] = 0;
+			interpolator_.buffer_r[i] = 0;
 			currentPlayPos++;
 			if ((uint32_t)currentPlayPos >= interpolationBufferSize) {
 				return false;
@@ -502,17 +502,17 @@ bool SampleLowLevelReader::fillInterpolationBufferForward(SamplePlaybackGuide* g
 	for (int32_t i = numSpacesToFill - 1; i >= 0; i--) {
 		bool stillGoing = changeClusterIfNecessary(guide, sample, loopingAtLowLevel, priorityRating);
 		if (!stillGoing) {
-			interpolator_.bufferL(i) = 0;
-			interpolator_.bufferR(i) = 0;
+			interpolator_.buffer_l[i] = 0;
+			interpolator_.buffer_r[i] = 0;
 			currentPlayPos++;
 			if ((uint32_t)currentPlayPos >= interpolationBufferSize) {
 				return false;
 			}
 		}
 
-		interpolator_.bufferL(i) = *(int16_t*)(currentPlayPos + 2);
+		interpolator_.buffer_l[i] = *(int16_t*)(currentPlayPos + 2);
 		if (sample->numChannels == 2) {
-			interpolator_.bufferR(i) = *(int16_t*)(currentPlayPos + 2 + sample->byteDepth);
+			interpolator_.buffer_r[i] = *(int16_t*)(currentPlayPos + 2 + sample->byteDepth);
 		}
 
 		// And move forward one more
@@ -607,9 +607,9 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 				int32_t offset = difference >> 1;
 
 				for (int32_t i = 0; i < interpolationBufferSize; i++) {
-					interpolator_.bufferL(i) = interpolator_.bufferL(i + offset);
+					interpolator_.buffer_l[i] = interpolator_.buffer_l[i + offset];
 					if (sample->numChannels == 2) {
-						interpolator_.bufferR(i) = interpolator_.bufferR(i + offset);
+						interpolator_.buffer_r[i] = interpolator_.buffer_r[i + offset];
 					}
 				}
 
@@ -639,9 +639,9 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 				int32_t offset = difference >> 1;
 
 				for (int32_t i = 0; i < interpolationBufferSizeLastTime; i++) {
-					interpolator_.bufferL(i + offset) = interpolator_.bufferL(i);
+					interpolator_.buffer_l[i + offset] = interpolator_.buffer_l[i];
 					if (sample->numChannels == 2) {
-						interpolator_.bufferR(i + offset) = interpolator_.bufferR(i);
+						interpolator_.buffer_r[i + offset] = interpolator_.buffer_r[i];
 					}
 				}
 
@@ -654,9 +654,9 @@ bool SampleLowLevelReader::considerUpcomingWindow(SamplePlaybackGuide* guide, Sa
 
 				// If still here, fill far end with zeros. Not perfect, but it'll do.
 				for (int32_t i = (interpolationBufferSize - offset); i < interpolationBufferSize; i++) {
-					interpolator_.bufferL(i) = 0;
+					interpolator_.buffer_l[i] = 0;
 					if (sample->numChannels == 2) {
-						interpolator_.bufferR(i) = 0;
+						interpolator_.buffer_r[i] = 0;
 					}
 				}
 
@@ -909,29 +909,29 @@ void SampleLowLevelReader::jumpForwardLinear(int32_t numChannels, int32_t byteDe
 
 		if (numChannels == 2) {
 			if (numSamplesToJumpForward >= 2) {
-				interpolator_.bufferL(1) = *(int16_t*)(currentPlayPos + 2);
-				interpolator_.bufferR(1) = *(int16_t*)(currentPlayPos + 2 + byteDepth);
+				interpolator_.buffer_l[1] = *(int16_t*)(currentPlayPos + 2);
+				interpolator_.buffer_r[1] = *(int16_t*)(currentPlayPos + 2 + byteDepth);
 				currentPlayPos += jumpAmount;
 			}
 			else {
-				interpolator_.bufferL(1) = interpolator_.bufferL(0);
-				interpolator_.bufferR(1) = interpolator_.bufferR(0);
+				interpolator_.buffer_l[1] = interpolator_.buffer_l[0];
+				interpolator_.buffer_r[1] = interpolator_.buffer_r[0];
 			}
-			interpolator_.bufferR(0) = *(int16_t*)(currentPlayPos + 2 + byteDepth);
+			interpolator_.buffer_r[0] = *(int16_t*)(currentPlayPos + 2 + byteDepth);
 		}
 
 		else {
 			if (numSamplesToJumpForward >= 2) {
-				interpolator_.bufferL(1) = *(int16_t*)(currentPlayPos + 2);
+				interpolator_.buffer_l[1] = *(int16_t*)(currentPlayPos + 2);
 				currentPlayPos += jumpAmount;
 			}
 			else {
-				interpolator_.bufferL(1) = interpolator_.bufferL(0);
+				interpolator_.buffer_l[1] = interpolator_.buffer_l[0];
 			}
 		}
 
 		// Putting these down here did speed things up!
-		interpolator_.bufferL(0) = *(int16_t*)(currentPlayPos + 2);
+		interpolator_.buffer_l[0] = *(int16_t*)(currentPlayPos + 2);
 		currentPlayPos += jumpAmount;
 	}
 }
@@ -991,8 +991,8 @@ void SampleLowLevelReader::readSamplesResampled(int32_t** __restrict__ oscBuffer
 
 					if (numChannels == 2) {
 						while (true) {
-							interpolator_.bufferL(numSamplesToJumpForward) = sourceL;
-							interpolator_.bufferR(numSamplesToJumpForward) = *(int16_t*)(currentPlayPosNow + byteDepth);
+							interpolator_.buffer_l[numSamplesToJumpForward] = sourceL;
+							interpolator_.buffer_r[numSamplesToJumpForward] = *(int16_t*)(currentPlayPosNow + byteDepth);
 							currentPlayPosNow += jumpAmount;
 							if (!numSamplesToJumpForward) {
 								goto skipFirstSmooth;
@@ -1005,7 +1005,7 @@ void SampleLowLevelReader::readSamplesResampled(int32_t** __restrict__ oscBuffer
 					else {
 						while (true) {
 							currentPlayPosNow += jumpAmount;
-							interpolator_.bufferL(numSamplesToJumpForward) = sourceL;
+							interpolator_.buffer_l[numSamplesToJumpForward] = sourceL;
 							if (!numSamplesToJumpForward) {
 								goto skipFirstSmooth;
 							}

--- a/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
@@ -185,8 +185,8 @@ void LivePitchShifterPlayHead::fillInterpolationBuffer(LiveInputBuffer* liveInpu
 			int32_t pos = (uint32_t)(rawBufferReadPos - i) & (kInputRawBufferSize - 1);
 
 			interpolator_.buffer_r[i - 1] = (pos < liveInputBuffer->numRawSamplesProcessed)
-			                                   ? liveInputBuffer->rawBuffer[pos * numChannels + 1] >> 16
-			                                   : 0;
+			                                    ? liveInputBuffer->rawBuffer[pos * numChannels + 1] >> 16
+			                                    : 0;
 		}
 	}
 }

--- a/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter_play_head.cpp
@@ -78,9 +78,9 @@ void LivePitchShifterPlayHead::render(int32_t* __restrict__ outputBuffer, int32_
 				interpolator_.jumpForward(numSamplesToJumpForward);
 
 				while (numSamplesToJumpForward--) {
-					interpolator_.bufferL(numSamplesToJumpForward) = rawBuffer[rawBufferReadPos * numChannels] >> 16;
+					interpolator_.buffer_l[numSamplesToJumpForward] = rawBuffer[rawBufferReadPos * numChannels] >> 16;
 					if (numChannels == 2) {
-						interpolator_.bufferR(numSamplesToJumpForward) = rawBuffer[rawBufferReadPos * 2 + 1] >> 16;
+						interpolator_.buffer_r[numSamplesToJumpForward] = rawBuffer[rawBufferReadPos * 2 + 1] >> 16;
 					}
 
 					rawBufferReadPos = (rawBufferReadPos + 1) & (kInputRawBufferSize - 1);
@@ -175,7 +175,7 @@ void LivePitchShifterPlayHead::fillInterpolationBuffer(LiveInputBuffer* liveInpu
 	for (int32_t i = 1; i <= kInterpolationMaxNumSamples; i++) {
 		int32_t pos = (uint32_t)(rawBufferReadPos - i) & (kInputRawBufferSize - 1);
 
-		interpolator_.bufferL(i - 1) =
+		interpolator_.buffer_l[i - 1] =
 		    (pos < liveInputBuffer->numRawSamplesProcessed) ? liveInputBuffer->rawBuffer[pos * numChannels] >> 16 : 0;
 	}
 
@@ -184,7 +184,7 @@ void LivePitchShifterPlayHead::fillInterpolationBuffer(LiveInputBuffer* liveInpu
 		for (int32_t i = 1; i <= kInterpolationMaxNumSamples; i++) {
 			int32_t pos = (uint32_t)(rawBufferReadPos - i) & (kInputRawBufferSize - 1);
 
-			interpolator_.bufferR(i - 1) = (pos < liveInputBuffer->numRawSamplesProcessed)
+			interpolator_.buffer_r[i - 1] = (pos < liveInputBuffer->numRawSamplesProcessed)
 			                                   ? liveInputBuffer->rawBuffer[pos * numChannels + 1] >> 16
 			                                   : 0;
 		}

--- a/src/deluge/processing/live/live_pitch_shifter_play_head.h
+++ b/src/deluge/processing/live/live_pitch_shifter_play_head.h
@@ -31,10 +31,7 @@ enum class PlayHeadMode {
 	RAW_DIRECT,
 };
 
-class LivePitchShifterPlayHead {
-public:
-	LivePitchShifterPlayHead();
-	~LivePitchShifterPlayHead();
+struct LivePitchShifterPlayHead {
 	void render(int32_t* outputBuffer, int32_t numSamples, int32_t numChannels, int32_t phaseIncrement,
 	            int32_t amplitude, int32_t amplitudeIncrement, int32_t* repitchedBuffer, int32_t* rawBuffer,
 	            int32_t whichKernel, int32_t interpolationBufferSize);


### PR DESCRIPTION
Changes the backing storage for the interpolator to int16_t and simplifies buffer access due to this