### PR TITLE
change chord interval storage from int32 to int8

### DIFF
--- a/src/deluge/gui/ui/keyboard/chords.cpp
+++ b/src/deluge/gui/ui/keyboard/chords.cpp
@@ -51,17 +51,17 @@ ChordQuality getChordQuality(NoteSet& notes) {
 
 ChordList::ChordList()
     : chords{
-        kEmptyChord, kMajor,  kMinor,  k6,      k2,   k69,      kSus2,    kSus4,   k7,         k7Sus4,      k7Sus2,
-        kM7,         kMinor7, kMinor2, kMinor4, kDim, kFullDim, kAug,     kMinor6, kMinorMaj7, kMinor7b5,   kMinor9b5,
-        kMinor7b5b9, k9,      kM9,     kMinor9, k11,  kM11,     kMinor11, k13,     kM13,       kM13Sharp11, kMinor13,
-    } {
+          kEmptyChord, kMajor,  kMinor,  k6,      k2,   k69,      kSus2,    kSus4,   k7,         k7Sus4,      k7Sus2,
+          kM7,         kMinor7, kMinor2, kMinor4, kDim, kFullDim, kAug,     kMinor6, kMinorMaj7, kMinor7b5,   kMinor9b5,
+          kMinor7b5b9, k9,      kM9,     kMinor9, k11,  kM11,     kMinor11, k13,     kM13,       kM13Sharp11, kMinor13,
+      } {
 }
 
-Voicing ChordList::getChordVoicing(int32_t chordNo) {
+Voicing ChordList::getChordVoicing(int8_t chordNo) {
 	// Check if chord number is valid
 	chordNo = validateChordNo(chordNo);
 
-	int32_t voicingNo = voicingOffset[chordNo];
+	int8_t voicingNo = voicingOffset[chordNo];
 	bool valid;
 	if (voicingNo <= 0) {
 		return chords[chordNo].voicings[0];
@@ -91,28 +91,28 @@ Voicing ChordList::getChordVoicing(int32_t chordNo) {
 	return chords[chordNo].voicings[0];
 }
 
-void ChordList::adjustChordRowOffset(int32_t offset) {
+void ChordList::adjustChordRowOffset(int8_t offset) {
 	if (offset > 0) {
-		chordRowOffset = std::min<int32_t>(kOffScreenChords, chordRowOffset + offset);
+		chordRowOffset = std::min<int8_t>(kOffScreenChords, chordRowOffset + offset);
 	}
 	else {
-		chordRowOffset = std::max<int32_t>(0, chordRowOffset + offset);
+		chordRowOffset = std::max<int8_t>(0, chordRowOffset + offset);
 	}
 }
 
-void ChordList::adjustVoicingOffset(int32_t chordNo, int32_t offset) {
+void ChordList::adjustVoicingOffset(int8_t chordNo, int8_t offset) {
 	// Check if chord number is valid
 	chordNo = validateChordNo(chordNo);
 
 	if (offset > 0) {
-		voicingOffset[chordNo] = std::min<int32_t>(kUniqueVoicings - 1, voicingOffset[chordNo] + offset);
+		voicingOffset[chordNo] = std::min<int8_t>(kUniqueVoicings - 1, voicingOffset[chordNo] + offset);
 	}
 	else {
-		voicingOffset[chordNo] = std::max<int32_t>(0, voicingOffset[chordNo] + offset);
+		voicingOffset[chordNo] = std::max<int8_t>(0, voicingOffset[chordNo] + offset);
 	}
 }
 
-int32_t ChordList::validateChordNo(int32_t chordNo) {
+int8_t ChordList::validateChordNo(int8_t chordNo) {
 	if (chordNo < 0) {
 		D_PRINTLN("Chord number is negative, returning chord 0");
 		chordNo = 0;

--- a/src/deluge/gui/ui/keyboard/chords.cpp
+++ b/src/deluge/gui/ui/keyboard/chords.cpp
@@ -51,10 +51,10 @@ ChordQuality getChordQuality(NoteSet& notes) {
 
 ChordList::ChordList()
     : chords{
-          kEmptyChord, kMajor,  kMinor,  k6,      k2,   k69,      kSus2,    kSus4,   k7,         k7Sus4,      k7Sus2,
-          kM7,         kMinor7, kMinor2, kMinor4, kDim, kFullDim, kAug,     kMinor6, kMinorMaj7, kMinor7b5,   kMinor9b5,
-          kMinor7b5b9, k9,      kM9,     kMinor9, k11,  kM11,     kMinor11, k13,     kM13,       kM13Sharp11, kMinor13,
-      } {
+        kEmptyChord, kMajor,  kMinor,  k6,      k2,   k69,      kSus2,    kSus4,   k7,         k7Sus4,      k7Sus2,
+        kM7,         kMinor7, kMinor2, kMinor4, kDim, kFullDim, kAug,     kMinor6, kMinorMaj7, kMinor7b5,   kMinor9b5,
+        kMinor7b5b9, k9,      kM9,     kMinor9, k11,  kM11,     kMinor11, k13,     kM13,       kM13Sharp11, kMinor13,
+    } {
 }
 
 Voicing ChordList::getChordVoicing(int8_t chordNo) {

--- a/src/deluge/gui/ui/keyboard/chords.h
+++ b/src/deluge/gui/ui/keyboard/chords.h
@@ -23,10 +23,10 @@
 #include <array>
 // #include <vector>
 
-constexpr int32_t kMaxChordKeyboardSize = 7;
-constexpr int32_t kUniqueVoicings = 4;
-constexpr int32_t kUniqueChords = 33;
-constexpr int32_t kOffScreenChords = kUniqueChords - kDisplayHeight;
+constexpr int8_t kMaxChordKeyboardSize = 7;
+constexpr int8_t kUniqueVoicings = 4;
+constexpr int8_t kUniqueChords = 33;
+constexpr int8_t kOffScreenChords = kUniqueChords - kDisplayHeight;
 
 namespace deluge::gui::ui::keyboard {
 
@@ -44,40 +44,40 @@ enum class ChordQuality {
 ChordQuality getChordQuality(NoteSet& notes);
 
 // Interval offsets for convenience
-const int32_t NONE = INT32_MAX;
-const int32_t ROOT = 0;
-const int32_t MIN2 = 1;
-const int32_t MAJ2 = 2;
-const int32_t MIN3 = 3;
-const int32_t MAJ3 = 4;
-const int32_t P4 = 5;
-const int32_t AUG4 = 6;
-const int32_t DIM5 = 6;
-const int32_t P5 = 7;
-const int32_t AUG5 = 8;
-const int32_t MIN6 = 8;
-const int32_t MAJ6 = 9;
-const int32_t DIM7 = 9;
-const int32_t MIN7 = 10;
-const int32_t DOM7 = 10;
-const int32_t MAJ7 = 11;
-const int32_t OCT = kOctaveSize;
-const int32_t MIN9 = MIN2 + OCT;
-const int32_t MAJ9 = MAJ2 + OCT;
-const int32_t MIN10 = MIN3 + OCT;
-const int32_t MAJ10 = MAJ3 + OCT;
-const int32_t P11 = P4 + OCT;
-const int32_t AUG11 = AUG4 + OCT;
-const int32_t DIM12 = DIM5 + OCT;
-const int32_t P12 = P5 + OCT;
-const int32_t MIN13 = MIN6 + OCT;
-const int32_t MAJ13 = MAJ6 + OCT;
-const int32_t MIN14 = MIN7 + OCT;
-const int32_t MAJ14 = MAJ7 + OCT;
+const int8_t NONE = INT8_MAX;
+const int8_t ROOT = 0;
+const int8_t MIN2 = 1;
+const int8_t MAJ2 = 2;
+const int8_t MIN3 = 3;
+const int8_t MAJ3 = 4;
+const int8_t P4 = 5;
+const int8_t AUG4 = 6;
+const int8_t DIM5 = 6;
+const int8_t P5 = 7;
+const int8_t AUG5 = 8;
+const int8_t MIN6 = 8;
+const int8_t MAJ6 = 9;
+const int8_t DIM7 = 9;
+const int8_t MIN7 = 10;
+const int8_t DOM7 = 10;
+const int8_t MAJ7 = 11;
+const int8_t OCT = kOctaveSize;
+const int8_t MIN9 = MIN2 + OCT;
+const int8_t MAJ9 = MAJ2 + OCT;
+const int8_t MIN10 = MIN3 + OCT;
+const int8_t MAJ10 = MAJ3 + OCT;
+const int8_t P11 = P4 + OCT;
+const int8_t AUG11 = AUG4 + OCT;
+const int8_t DIM12 = DIM5 + OCT;
+const int8_t P12 = P5 + OCT;
+const int8_t MIN13 = MIN6 + OCT;
+const int8_t MAJ13 = MAJ6 + OCT;
+const int8_t MIN14 = MIN7 + OCT;
+const int8_t MAJ14 = MAJ7 + OCT;
 
 /// @brief A voicing is a set of offsets from the root note of a chord
 struct Voicing {
-	int32_t offsets[kMaxChordKeyboardSize];
+	int8_t offsets[kMaxChordKeyboardSize];
 	const char* supplementalName = "";
 };
 
@@ -147,17 +147,17 @@ public:
 	 * @param chordNo The index of the chord
 	 * @return The voicing
 	 */
-	Voicing getChordVoicing(int32_t chordNo);
+	Voicing getChordVoicing(int8_t chordNo);
 
-	void adjustChordRowOffset(int32_t offset);
-	void adjustVoicingOffset(int32_t chordNo, int32_t offset);
+	void adjustChordRowOffset(int8_t offset);
+	void adjustVoicingOffset(int8_t chordNo, int8_t offset);
 
 	Chord chords[kUniqueChords];
-	int32_t voicingOffset[kUniqueChords] = {0};
-	uint32_t chordRowOffset = 0;
+	int8_t voicingOffset[kUniqueChords] = {0};
+	uint8_t chordRowOffset = 0;
 
 private:
-	int32_t validateChordNo(int32_t chordNo);
+	int8_t validateChordNo(int8_t chordNo);
 };
 
 } // namespace deluge::gui::ui::keyboard


### PR DESCRIPTION
Reduces the size of the chord arrays in memory by 20kb or so