### PR TITLE
clang-tidy readability-implicit-bool-conversion

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -238,7 +238,8 @@ bool isShortPress(uint32_t pressTime) {
 
 bool readButtonsAndPads() {
 
-	if ((usbInitializationPeriodComplete == 0u) && (int32_t)(AudioEngine::audioSampleTimer - timeUSBInitializationEnds) >= 0) {
+	if ((usbInitializationPeriodComplete == 0u)
+	    && (int32_t)(AudioEngine::audioSampleTimer - timeUSBInitializationEnds) >= 0) {
 		usbInitializationPeriodComplete = 1;
 	}
 

--- a/src/deluge/dsp/delay/delay.cpp
+++ b/src/deluge/dsp/delay/delay.cpp
@@ -95,7 +95,7 @@ void Delay::setupWorkingState(Delay::State& workingState, uint32_t timePerIntern
 	// Set some stuff up that we need before we make some decisions
 	// BUG: we want to be able to reduce the 256 to 1, but for some reason, the
 	// patching engine spits out 112 even when this should be 0...
-	bool mightDoDelay = (workingState.delayFeedbackAmount >= 256 && (anySoundComingIn || repeatsUntilAbandon));
+	bool mightDoDelay = (workingState.delayFeedbackAmount >= 256 && (anySoundComingIn || (repeatsUntilAbandon != 0u)));
 
 	if (mightDoDelay) {
 
@@ -188,7 +188,7 @@ void Delay::hasWrapped() {
 	}
 
 	repeatsUntilAbandon--;
-	if (!repeatsUntilAbandon) {
+	if (repeatsUntilAbandon == 0u) {
 		// D_PRINTLN("discarding");
 		discardBuffers();
 	}

--- a/src/deluge/dsp/dx/EngineMkI.cpp
+++ b/src/deluge/dsp/dx/EngineMkI.cpp
@@ -81,7 +81,7 @@ inline int32_t mkiSin(int32_t phase, uint16_t env) {
 	uint16_t expVal = sinLog(phase >> (22 - SINLOG_BITDEPTH)) + (env);
 	// int16_t expValShow = expVal;
 
-	const bool isSigned = expVal & NEGATIVE_BIT;
+	const bool isSigned = (expVal & NEGATIVE_BIT) != 0;
 	expVal &= ~NEGATIVE_BIT;
 
 	const uint16_t SINEXP_FILTER = 0x3FF;

--- a/src/deluge/dsp/dx/dx7note.cpp
+++ b/src/deluge/dsp/dx/dx7note.cpp
@@ -141,7 +141,7 @@ int32_t DxVoice::osc_freq(int logFreq_for_detune, int mode, int coarse, int fine
 		logfreq += detuneRatio * logFreq_for_detune * (detune - 7 + random_scaled);
 
 		logfreq += coarsemul[coarse & 31];
-		if (fine) {
+		if (fine != 0) {
 			// (1 << 24) / log(2)
 			logfreq += (int32_t)floor(24204406.323123 * log(1 + 0.01 * fine) + 0.5);
 		}
@@ -263,11 +263,11 @@ void DxVoice::init(DxPatch& newp, int midinote, int velocity) {
 	pitchenv_.set(pitchenv_p());
 
 	// TODO: in LFO sync mode it would be best with LFO per voice
-	if (patch[141]) {
+	if (patch[141] != 0u) {
 		newp.lfo_phase = (1U << 31) - 1;
 	}
 
-	if (patch[136]) {
+	if (patch[136] != 0u) {
 		oscSync();
 	}
 	else {
@@ -354,7 +354,7 @@ bool DxVoice::compute(int32_t* buf, int n, int base_pitch, const DxPatch* ctrls,
 			// int32_t gain = pow(2, 10 + level * (1.0 / (1 << 24)));
 
 			int mode = patch[off + 17];
-			if (mode)
+			if (mode != 0)
 				params[op].freq = Freqlut::lookup(basepitch_[op]);
 			else
 				params[op].freq = Freqlut::lookup(basepitch_[op] + pitch_mod);

--- a/src/deluge/dsp/dx/dx7note.h
+++ b/src/deluge/dsp/dx/dx7note.h
@@ -41,7 +41,7 @@ public:
 
 	uint8_t params[156];
 	FmCore* core;
-	bool opSwitch(int op) const { return (params[155] >> op) & 1; }
+	bool opSwitch(int op) const { return ((((params[155] >> op) & 1) != 0) != 0) != 0; }
 	void setOpSwitch(int op, bool on) { params[155] = (params[155] & ~(1 << op)) | (on ? 1 : 0) * (1 << op); }
 	uint8_t engineMode;
 

--- a/src/deluge/dsp/dx/dx7note.h
+++ b/src/deluge/dsp/dx/dx7note.h
@@ -41,7 +41,7 @@ public:
 
 	uint8_t params[156];
 	FmCore* core;
-	bool opSwitch(int op) const { return ((((params[155] >> op) & 1) != 0) != 0) != 0; }
+	bool opSwitch(int op) const { return ((params[155] >> op) & 1) != 0; }
 	void setOpSwitch(int op, bool on) { params[155] = (params[155] & ~(1 << op)) | (on ? 1 : 0) * (1 << op); }
 	uint8_t engineMode;
 

--- a/src/deluge/dsp/dx/engine.cpp
+++ b/src/deluge/dsp/dx/engine.cpp
@@ -57,7 +57,7 @@ DxVoice* DxEngine::solicitDxVoice() {
 	}
 #endif
 	void* memory = allocMaxSpeed(sizeof(DxVoice));
-	if (!memory)
+	if (memory == nullptr)
 		return nullptr;
 
 	return new (memory) DxVoice();

--- a/src/deluge/dsp/dx/env.cpp
+++ b/src/deluge/dsp/dx/env.cpp
@@ -51,7 +51,7 @@ void Env::init(const EnvParams& p, int ol, int rate_scaling) {
 
 int32_t Env::getsample(const EnvParams& p, int n, int extra_rate) {
 #ifdef ACCURATE_ENVELOPE
-	if (staticcount_) {
+	if (staticcount_ != 0) {
 		staticcount_ -= n;
 		if (staticcount_ <= 0) {
 			staticcount_ = 0;
@@ -61,7 +61,7 @@ int32_t Env::getsample(const EnvParams& p, int n, int extra_rate) {
 #endif
 
 	if (ix_ < 3 || ((ix_ < 4) && !down_)) {
-		if (staticcount_) {
+		if (staticcount_ != 0) {
 			;
 		}
 		else if (rising_) {

--- a/src/deluge/dsp/fft/fft_config_manager.cpp
+++ b/src/deluge/dsp/fft/fft_config_manager.cpp
@@ -27,7 +27,7 @@ ne10_fft_r2c_cfg_int32_t getConfig(int32_t magnitude) {
 	if (magnitude > FFT_CONFIG_MAX_MAGNITUDE)
 		return NULL;
 
-	if (!configs[magnitude]) {
+	if (configs[magnitude] == nullptr) {
 		// Allocates and sets up. And we'll just never deallocate.
 		configs[magnitude] = ne10_fft_alloc_r2c_int32(1 << magnitude);
 	}

--- a/src/deluge/dsp/granular/GranularProcessor.cpp
+++ b/src/deluge/dsp/granular/GranularProcessor.cpp
@@ -142,7 +142,7 @@ StereoSample GranularProcessor::processOneGrainSample(StereoSample* currentSampl
 			    grains[i].counter <= (grains[i].length >> 1)
 			        ? grains[i].counter * grains[i].volScale
 			        : grains[i].volScaleMax - (grains[i].counter - (grains[i].length >> 1)) * grains[i].volScale;
-			int32_t delta = grains[i].counter * (grains[i].rev == 1 ? -1 : 1);
+			int32_t delta = grains[i].counter * (static_cast<int>(grains[i].rev) == 1 ? -1 : 1);
 			if (grains[i].pitch != 1024) {
 				delta = ((delta * grains[i].pitch) >> 10);
 			}
@@ -303,7 +303,7 @@ GranularProcessor::GranularProcessor() {
 void GranularProcessor::getBuffer() {
 	if (grainBuffer == nullptr) {
 		void* grainBufferMemory = GeneralMemoryAllocator::get().allocStealable(sizeof(GrainBuffer));
-		if (grainBufferMemory) {
+		if (grainBufferMemory != nullptr) {
 			grainBuffer = new (grainBufferMemory) GrainBuffer(this);
 		}
 		else {}
@@ -336,7 +336,7 @@ GranularProcessor::GranularProcessor(const GranularProcessor& other) {
 	getBuffer();
 }
 void GranularProcessor::startSkippingRendering() {
-	if (grainBuffer) {
+	if (grainBuffer != nullptr) {
 		grainBuffer->inUse = false;
 	}
 }

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -950,8 +950,9 @@ optForDirectReading:
 
 #else
 	// If no one's reading from the buffer anymore, stop filling it
-	if ((buffer != nullptr) && !olderHeadReadingFromBuffer) { // olderHeadReadingFromBuffer will always be false - we set it above,
-		                                         // at the start
+	if ((buffer != nullptr)
+	    && !olderHeadReadingFromBuffer) { // olderHeadReadingFromBuffer will always be false - we set it above,
+		                                  // at the start
 		delugeDealloc(buffer);
 		buffer = nullptr;
 		D_PRINTLN("abandoning buffer!!!!!!!!!!!!!!!!");
@@ -1149,7 +1150,8 @@ void TimeStretcher::setupCrossfadeFromCache(SampleCache* cache, int32_t cacheByt
 	int32_t bytePosWithinCluster = cacheBytePos & (Cluster::size - 1);
 
 	Cluster* cacheCluster = cache->getCluster(cachedClusterIndex);
-	if (ALPHA_OR_BETA_VERSION && (cacheCluster == nullptr)) { // If it got stolen - but we should have already detected this above
+	if (ALPHA_OR_BETA_VERSION
+	    && (cacheCluster == nullptr)) { // If it got stolen - but we should have already detected this above
 		FREEZE_WITH_ERROR("E178");
 	}
 	int32_t* __restrict__ readPos = (int32_t*)&cacheCluster->data[bytePosWithinCluster - 4 + kCacheByteDepth];

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -950,9 +950,8 @@ optForDirectReading:
 
 #else
 	// If no one's reading from the buffer anymore, stop filling it
-	if ((buffer != nullptr)
-	    && !olderHeadReadingFromBuffer) { // olderHeadReadingFromBuffer will always be false - we set it above,
-		                                  // at the start
+	if ((buffer != nullptr) && !olderHeadReadingFromBuffer) { // olderHeadReadingFromBuffer will always be false - we
+		                                                      // set it above, at the start
 		delugeDealloc(buffer);
 		buffer = nullptr;
 		D_PRINTLN("abandoning buffer!!!!!!!!!!!!!!!!");

--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -150,9 +150,9 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 }
 // if they're in session view and press a clip's pad, record from that output
 ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
-	if (on && getUIUpOneLevel() == &sessionView) {
+	if ((on != 0) && getUIUpOneLevel() == &sessionView) {
 		auto track = (&sessionView)->getOutputFromPad(x, y);
-		if (track && track->type != OutputType::MIDI_OUT && track->type != OutputType::CV) {
+		if ((track != nullptr) && track->type != OutputType::MIDI_OUT && track->type != OutputType::CV) {
 			audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
 			audioOutput->setOutputRecordingFrom(track);
 			display->popupTextTemporary(track->name.get());
@@ -161,7 +161,7 @@ ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 			currentOption = scrollPos;
 			renderUIsForOled();
 		}
-		else if (track) {
+		else if (track != nullptr) {
 			display->popupTextTemporary("Can't record MIDI or CV!");
 		}
 

--- a/src/deluge/gui/context_menu/clear_song.cpp
+++ b/src/deluge/gui/context_menu/clear_song.cpp
@@ -70,7 +70,7 @@ void ClearSong::focusRegained() {
 }
 
 bool ClearSong::acceptCurrentOption() {
-	if (playbackHandler.playbackState
+	if ((playbackHandler.playbackState != 0u)
 	    && (playbackHandler.isInternalClockActive() || currentPlaybackMode == &arrangement)) {
 
 		playbackHandler.endPlayback();
@@ -97,7 +97,7 @@ bool ClearSong::acceptCurrentOption() {
 	preLoadedSong->ensureAtLeastOneSessionClip(); // Will load a synth preset from SD card
 
 	playbackHandler.doSongSwap(playbackHandler.isEitherClockActive());
-	if (toDelete) {
+	if (toDelete != nullptr) {
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Song();
 		delugeDealloc(toDealloc);

--- a/src/deluge/gui/context_menu/clip_settings/clip_settings.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/clip_settings.cpp
@@ -71,7 +71,7 @@ bool ClipSettingsMenu::acceptCurrentOption() {
 }
 
 ActionResult ClipSettingsMenu::padAction(int32_t x, int32_t y, int32_t on) {
-	if (on) {
+	if (on != 0) {
 		return ContextMenu::padAction(x, y, on);
 	}
 	else {                                      // this would happen if you release pad after entering the menu

--- a/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
@@ -125,7 +125,7 @@ bool NewClipType::acceptCurrentOption() {
 		b = CV;
 	}
 
-	sessionView.clipCreationButtonPressed(b, 1, sdRoutineLock); // let the grid handle this
+	sessionView.clipCreationButtonPressed(b, true, sdRoutineLock); // let the grid handle this
 
 	return true;
 }

--- a/src/deluge/gui/context_menu/context_menu.cpp
+++ b/src/deluge/gui/context_menu/context_menu.cpp
@@ -205,7 +205,7 @@ void ContextMenu::drawCurrentOption() {
 }
 
 ActionResult ContextMenu::padAction(int32_t x, int32_t y, int32_t on) {
-	if (on && isUIModeWithinRange(buttonAndPadActionUIModes)) {
+	if ((on != 0) && isUIModeWithinRange(buttonAndPadActionUIModes)) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/context_menu/delete_file.cpp
+++ b/src/deluge/gui/context_menu/delete_file.cpp
@@ -90,7 +90,7 @@ bool DeleteFile::acceptCurrentOption() {
 	else if (toDelete->instrumentAlreadyInSong) {
 		display->displayPopup(l10n::get(STRING_FOR_ERROR_PRESET_IN_USE));
 	}
-	else if (toDelete->instrument) {
+	else if (toDelete->instrument != nullptr) {
 		// it has an instrument, it's not on the card, it's not in use, let's remove it
 		browser->currentFileDeleted();
 	}

--- a/src/deluge/gui/context_menu/overwrite_file.cpp
+++ b/src/deluge/gui/context_menu/overwrite_file.cpp
@@ -47,7 +47,7 @@ bool OverwriteFile::acceptCurrentOption() {
 }
 ActionResult OverwriteFile::padAction(int32_t x, int32_t y, int32_t on) {
 	// enter key press. Overwrite is only relevant in places where a qwerty keyboard is showing so no need to check
-	if (on && y == kQwertyHomeRow && x >= 14 && x < 16) {
+	if ((on != 0) && y == kQwertyHomeRow && x >= 14 && x < 16) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/context_menu/save_song_or_instrument.cpp
+++ b/src/deluge/gui/context_menu/save_song_or_instrument.cpp
@@ -79,13 +79,13 @@ bool SaveSongOrInstrument::isCurrentOptionAvailable() {
 
 	switch (currentOption) {
 	case 0: // Collect media
-		return (isUIOpen(&saveSongUI)) && (!currentFileItem || !currentFileItem->isFolder);
+		return (isUIOpen(&saveSongUI)) && ((currentFileItem == nullptr) || !currentFileItem->isFolder);
 
 	case 1: // Create folder
-		return (!QwertyUI::enteredText.isEmpty() && !currentFileItem);
+		return (!QwertyUI::enteredText.isEmpty() && (currentFileItem == nullptr));
 
 	case 2: // Delete file
-		return (currentFileItem && !currentFileItem->isFolder);
+		return ((currentFileItem != nullptr) && !currentFileItem->isFolder);
 
 	default:
 		__builtin_unreachable();

--- a/src/deluge/gui/menu_item/active_scales.cpp
+++ b/src/deluge/gui/menu_item/active_scales.cpp
@@ -122,7 +122,7 @@ bool ActiveScaleMenu::isDisabled(uint8_t scaleIndex) {
 	if (kind == DEFAULT) {
 		return FlashStorage::defaultDisabledPresetScales[scaleIndex];
 	}
-	else if (currentSong) {
+	else if (currentSong != nullptr) {
 		return currentSong->disabledPresetScales[scaleIndex];
 	}
 	else {
@@ -134,7 +134,7 @@ void ActiveScaleMenu::setDisabled(uint8_t scaleIndex, bool value) {
 	if (kind == DEFAULT) {
 		FlashStorage::defaultDisabledPresetScales[scaleIndex] = value;
 	}
-	else if (currentSong) {
+	else if (currentSong != nullptr) {
 		currentSong->disabledPresetScales[scaleIndex] = value;
 	}
 }

--- a/src/deluge/gui/menu_item/audio_clip/reverse.h
+++ b/src/deluge/gui/menu_item/audio_clip/reverse.h
@@ -32,7 +32,7 @@ public:
 	void readCurrentValue() override { this->setValue(getCurrentAudioClip()->sampleControls.reversed); }
 	void writeCurrentValue() override {
 		auto* clip = getCurrentAudioClip();
-		bool active = (playbackHandler.isEitherClockActive() && currentSong->isClipActive(clip) && clip->voiceSample);
+		bool active = (playbackHandler.isEitherClockActive() && currentSong->isClipActive(clip) && (clip->voiceSample != nullptr));
 
 		clip->unassignVoiceSample(false);
 

--- a/src/deluge/gui/menu_item/audio_clip/reverse.h
+++ b/src/deluge/gui/menu_item/audio_clip/reverse.h
@@ -32,7 +32,8 @@ public:
 	void readCurrentValue() override { this->setValue(getCurrentAudioClip()->sampleControls.reversed); }
 	void writeCurrentValue() override {
 		auto* clip = getCurrentAudioClip();
-		bool active = (playbackHandler.isEitherClockActive() && currentSong->isClipActive(clip) && (clip->voiceSample != nullptr));
+		bool active = (playbackHandler.isEitherClockActive() && currentSong->isClipActive(clip)
+		               && (clip->voiceSample != nullptr));
 
 		clip->unassignVoiceSample(false);
 

--- a/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
+++ b/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
@@ -29,7 +29,7 @@ public:
 
 	void beginSession(MenuItem* navigatedBackwardFrom) override {
 		audioOutputBeingEdited = (AudioOutput*)getCurrentOutput();
-		if (audioOutputBeingEdited->getOutputRecordingFrom()) {
+		if (audioOutputBeingEdited->getOutputRecordingFrom() != nullptr) {
 			outputIndex = currentSong->getOutputIndex(audioOutputBeingEdited->getOutputRecordingFrom());
 		}
 		else {

--- a/src/deluge/gui/menu_item/automation/automation.cpp
+++ b/src/deluge/gui/menu_item/automation/automation.cpp
@@ -39,7 +39,7 @@ MenuItem* Automation::selectButtonPress() {
 	if (Buttons::isShiftButtonPressed()) {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithAutoParam* modelStack = getModelStackWithParam(modelStackMemory);
-		if (modelStack && modelStack->autoParam) {
+		if ((modelStack != nullptr) && (modelStack->autoParam != nullptr)) {
 			Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE, ActionAddition::NOT_ALLOWED);
 
 			modelStack->autoParam->deleteAutomation(action, modelStack);
@@ -136,7 +136,7 @@ ActionResult Automation::buttonAction(deluge::hid::Button b, bool on, bool inCar
 void Automation::selectAutomationViewParameter(bool clipMinder) {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithAutoParam* modelStack = getModelStackWithParam(modelStackMemory);
-	if (modelStack) {
+	if (modelStack != nullptr) {
 		int32_t knobPos = automationView.getAutomationParameterKnobPos(modelStack, view.modPos) + kKnobPosOffset;
 		automationView.setAutomationKnobIndicatorLevels(modelStack, knobPos, knobPos);
 

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -143,12 +143,12 @@ void Decimal::drawPixelsForOled() {
 
 	int32_t digitWidth = kTextHugeSpacingX;
 	int32_t periodWidth = digitWidth / 2;
-	int32_t stringWidth = digitWidth * length + (numDecimalPlaces ? periodWidth : 0);
+	int32_t stringWidth = digitWidth * length + ((numDecimalPlaces != 0) ? periodWidth : 0);
 	int32_t stringStartX = (OLED_MAIN_WIDTH_PIXELS - stringWidth) >> 1;
 	int32_t ourDigitStartX = stringStartX + editingChar * digitWidth;
 
 	// for values with decimal digits showing
-	if (numDecimalPlaces) {
+	if (numDecimalPlaces != 0) {
 		int32_t numCharsBeforeDecimalPoint = length - numDecimalPlaces;
 		// draw digits before period
 		hid::display::OLED::main.drawString(std::string_view(buffer, numCharsBeforeDecimalPoint), stringStartX, 20,
@@ -182,7 +182,7 @@ void Decimal::drawActualValue(bool justDidHorizontalScroll) {
 	}
 
 	int32_t dotPos;
-	if (getNumDecimalPlaces())
+	if (getNumDecimalPlaces() != 0)
 		dotPos = soundEditor.numberScrollAmount + 3 - getNumDecimalPlaces();
 	else
 		dotPos = 255;
@@ -235,7 +235,7 @@ void DecimalWithoutScrolling::drawActualValue(bool justDidHorizontalScroll) {
 	int32_t numDecimalPlaces = displayValue > 100 ? 1 : 2;
 	char buffer[12];
 	floatToString(displayValue, buffer, numDecimalPlaces, numDecimalPlaces);
-	if (numDecimalPlaces) {
+	if (numDecimalPlaces != 0) {
 		dotPos = 3 - numDecimalPlaces;
 	}
 	else {

--- a/src/deluge/gui/menu_item/dx/cartridge.cpp
+++ b/src/deluge/gui/menu_item/dx/cartridge.cpp
@@ -52,7 +52,7 @@ static bool openFile(const char* path, DX7Cartridge* data) {
 	UINT numBytesRead;
 	int readsize = std::min((int)fileSize, 8192);
 	auto buffer = (uint8_t*)GeneralMemoryAllocator::get().allocLowSpeed(readsize);
-	if (!buffer) {
+	if (buffer == nullptr) {
 		display->displayPopup(get(String::STRING_FOR_DX_ERROR_READ_ERROR));
 		goto close;
 	}

--- a/src/deluge/gui/menu_item/dx/param.cpp
+++ b/src/deluge/gui/menu_item/dx/param.cpp
@@ -176,7 +176,7 @@ void DxParam::selectEncoderAction(int32_t offset) {
 
 void DxParam::horizontalEncoderAction(int32_t offset) {
 	if (Buttons::isShiftButtonPressed()) {
-		if (param < 0 || param > 6 * 21 || !patch)
+		if (param < 0 || param > 6 * 21 || (patch == nullptr))
 			return; // TODO: remember last OP param?
 		int cur_op = param / 21;
 		int next_op = cur_op;
@@ -439,7 +439,7 @@ static void renderSensParams(uint8_t* params, int op, int idx) {
 
 static void renderTuning(uint8_t* params, int op, int param) {
 	int mode = params[op * 21 + 17];
-	const char* text = mode ? "fixed" : "ratio";
+	const char* text = (mode != 0) ? "fixed" : "ratio";
 	show(text, 0, 1, (17 == param));
 
 	for (int i = 0; i < 3; i++) {
@@ -475,7 +475,7 @@ static void renderLFO(uint8_t* params, int param) {
 		show(val, 1, 1 + i * 9 + 6, (i + 139 == param));
 	}
 
-	const char* sync = (params[141] ? "sync" : "    ");
+	const char* sync = ((params[141] != 0u) ? "sync" : "    ");
 	show(sync, 0, 7, (141 == param));
 	int shap = std::min((int)params[142], 5);
 	show(shapes_long[shap], 0, 12, (142 == param));
@@ -503,9 +503,9 @@ static void renderAlgorithm(uint8_t* params) {
 		buffer[1] = ':';
 		buffer[2] = ' ';
 		buffer[3] = ib[inbus];
-		buffer[4] = (f & OUT_BUS_ADD) ? '+' : '>';
+		buffer[4] = ((f & OUT_BUS_ADD) != 0) ? '+' : '>';
 		buffer[5] = ob[outbus];
-		buffer[6] = (f & (FB_IN | FB_OUT)) ? 'f' : ' ';
+		buffer[6] = ((f & (FB_IN | FB_OUT)) != 0) ? 'f' : ' ';
 		buffer[7] = 0;
 
 		int r = i / 3, c = i % 3;
@@ -556,7 +556,7 @@ void DxParam::drawValue() {
 		int val = getValue();
 		const char* text = NULL;
 		if (param < 6 * 21 && (idx == 17)) {
-			text = val ? "fixd" : "rati";
+			text = (val != 0) ? "fixd" : "rati";
 		}
 		else if (param < 6 * 21 && (idx == 11 || idx == 12)) {
 			text = curves[std::min(val, 4)];
@@ -571,7 +571,7 @@ void DxParam::drawValue() {
 		else if (param < 6 * 21 && (idx == 20)) {
 			val -= 7; // detuning -7 - 7
 		}
-		if (text) {
+		if (text != nullptr) {
 			display->setText(text);
 		}
 		else {

--- a/src/deluge/gui/menu_item/integer_range.cpp
+++ b/src/deluge/gui/menu_item/integer_range.cpp
@@ -74,12 +74,12 @@ void IntegerRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRig
 	intToString(lower, buffer);
 
 	int32_t leftLength = strlen(buffer);
-	if (getLeftLength) {
+	if (getLeftLength != nullptr) {
 		*getLeftLength = leftLength;
 	}
 
 	if (mayShowJustOne && lower == upper) {
-		if (getRightLength) {
+		if (getRightLength != nullptr) {
 			*getRightLength = 0;
 		}
 		return;
@@ -91,7 +91,7 @@ void IntegerRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRig
 
 	intToString(upper, bufferPos);
 
-	if (getRightLength) {
+	if (getRightLength != nullptr) {
 		*getRightLength = strlen(bufferPos);
 	}
 }

--- a/src/deluge/gui/menu_item/key_range.cpp
+++ b/src/deluge/gui/menu_item/key_range.cpp
@@ -67,13 +67,13 @@ void KeyRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRightLe
 		}
 	}
 
-	if (getLeftLength) {
+	if (getLeftLength != nullptr) {
 		*getLeftLength = leftLength;
 	}
 
 	if (mayShowJustOne && lower == upper) {
 		*buffer = 0;
-		if (getRightLength) {
+		if (getRightLength != nullptr) {
 			*getRightLength = 0;
 		}
 		return;
@@ -92,7 +92,7 @@ void KeyRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRightLe
 
 	*buffer = 0;
 
-	if (getRightLength) {
+	if (getRightLength != nullptr) {
 		*getRightLength = rightLength;
 	}
 }

--- a/src/deluge/gui/menu_item/midi/command.cpp
+++ b/src/deluge/gui/menu_item/midi/command.cpp
@@ -43,7 +43,7 @@ void Command::drawPixelsForOled() {
 	}
 	else {
 		char const* deviceString = l10n::get(l10n::String::STRING_FOR_ANY_MIDI_DEVICE);
-		if (command->cable) {
+		if (command->cable != nullptr) {
 			deviceString = command->cable->getDisplayName();
 		}
 		image.drawString(deviceString, 0, yPixel, kTextSpacingX, kTextSizeYUpdated);

--- a/src/deluge/gui/menu_item/midi/device_definition/linked.h
+++ b/src/deluge/gui/menu_item/midi/device_definition/linked.h
@@ -33,7 +33,7 @@ public:
 
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
 		Output* output = getCurrentOutput();
-		return (output && output->type == OutputType::MIDI_OUT);
+		return ((output != nullptr) && output->type == OutputType::MIDI_OUT);
 	}
 
 	void renderSubmenuItemTypeForOled(int32_t yPixel) final {

--- a/src/deluge/gui/menu_item/midi/device_definition/submenu.h
+++ b/src/deluge/gui/menu_item/midi/device_definition/submenu.h
@@ -12,7 +12,7 @@ public:
 
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		Output* output = getCurrentOutput();
-		return (output && output->type == OutputType::MIDI_OUT);
+		return ((output != nullptr) && output->type == OutputType::MIDI_OUT);
 	}
 };
 

--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -82,7 +82,7 @@ void Devices::selectEncoderAction(int32_t offset) {
 
 		soundEditor.currentMIDICable = getCable(this->getValue());
 
-	} while (!soundEditor.currentMIDICable->connectionFlags);
+	} while (soundEditor.currentMIDICable->connectionFlags == 0u);
 	// Don't show devices which aren't connected. Sometimes we won't even have a name to display for them.
 
 	if (display->haveOLED()) {
@@ -158,7 +158,7 @@ void Devices::drawPixelsForOled() {
 	size_t row = 0;
 	while (row < kOLEDMenuNumOptionsVisible && device_idx < MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
 		MIDICable* cable = getCable(device_idx);
-		if (cable && cable->connectionFlags != 0u) {
+		if ((cable != nullptr) && cable->connectionFlags != 0u) {
 			itemNames.push_back(cable->getDisplayName());
 			if (device_idx == this->getValue()) {
 				selectedRow = static_cast<int32_t>(row);

--- a/src/deluge/gui/menu_item/midi/follow/follow_channel.h
+++ b/src/deluge/gui/menu_item/midi/follow/follow_channel.h
@@ -53,7 +53,7 @@ public:
 		yPixel += kTextSpacingY;
 
 		char const* deviceString = l10n::get(l10n::String::STRING_FOR_FOLLOW_DEVICE_UNASSIGNED);
-		if (midiInput.cable) {
+		if (midiInput.cable != nullptr) {
 			deviceString = midiInput.cable->getDisplayName();
 		}
 		canvas.drawString(deviceString, 0, yPixel, kTextSpacingX, kTextSizeYUpdated);
@@ -75,7 +75,7 @@ public:
 		else {
 			channelText = l10n::get(l10n::String::STRING_FOR_CHANNEL);
 			char buffer[12];
-			int32_t channelmod = (midiInput.channelOrZone >= IS_A_CC) * IS_A_CC;
+			int32_t channelmod = static_cast<int>(midiInput.channelOrZone >= IS_A_CC) * IS_A_CC;
 			intToString(midiInput.channelOrZone + 1 - channelmod, buffer, 1);
 			canvas.drawString(buffer, kTextSpacingX * 8, yPixel, kTextSpacingX, kTextSizeYUpdated);
 		}

--- a/src/deluge/gui/menu_item/mpe/direction_selector.h
+++ b/src/deluge/gui/menu_item/mpe/direction_selector.h
@@ -39,7 +39,7 @@ public:
 	uint8_t whichDirection;
 	[[nodiscard]] std::string_view getTitle() const override {
 		return ((whichDirection != 0u) != 0u) ? l10n::getView(l10n::String::STRING_FOR_MPE_OUTPUT)
-		                      : l10n::getView(l10n::String::STRING_FOR_MPE_INPUT);
+		                                      : l10n::getView(l10n::String::STRING_FOR_MPE_INPUT);
 	}
 };
 

--- a/src/deluge/gui/menu_item/mpe/direction_selector.h
+++ b/src/deluge/gui/menu_item/mpe/direction_selector.h
@@ -38,8 +38,8 @@ public:
 	MenuItem* selectButtonPress() override;
 	uint8_t whichDirection;
 	[[nodiscard]] std::string_view getTitle() const override {
-		return ((whichDirection != 0u) != 0u) ? l10n::getView(l10n::String::STRING_FOR_MPE_OUTPUT)
-		                                      : l10n::getView(l10n::String::STRING_FOR_MPE_INPUT);
+		return (whichDirection != 0u) ? l10n::getView(l10n::String::STRING_FOR_MPE_OUTPUT)
+		                              : l10n::getView(l10n::String::STRING_FOR_MPE_INPUT);
 	}
 };
 

--- a/src/deluge/gui/menu_item/mpe/direction_selector.h
+++ b/src/deluge/gui/menu_item/mpe/direction_selector.h
@@ -38,7 +38,7 @@ public:
 	MenuItem* selectButtonPress() override;
 	uint8_t whichDirection;
 	[[nodiscard]] std::string_view getTitle() const override {
-		return whichDirection ? l10n::getView(l10n::String::STRING_FOR_MPE_OUTPUT)
+		return ((whichDirection != 0u) != 0u) ? l10n::getView(l10n::String::STRING_FOR_MPE_OUTPUT)
 		                      : l10n::getView(l10n::String::STRING_FOR_MPE_INPUT);
 	}
 };

--- a/src/deluge/gui/menu_item/mpe/zone_selector.cpp
+++ b/src/deluge/gui/menu_item/mpe/zone_selector.cpp
@@ -23,7 +23,7 @@ namespace deluge::gui::menu_item::mpe {
 ZoneSelector zoneSelectorMenu{};
 
 void ZoneSelector::beginSession(MenuItem* navigatedBackwardFrom) {
-	if (!navigatedBackwardFrom) {
+	if (navigatedBackwardFrom == nullptr) {
 		whichZone = 0;
 	}
 	Selection::beginSession(navigatedBackwardFrom);

--- a/src/deluge/gui/menu_item/multi_range.cpp
+++ b/src/deluge/gui/menu_item/multi_range.cpp
@@ -204,7 +204,7 @@ void MultiRange::selectEncoderAction(int32_t offset) {
 			AudioEngine::audioRoutineLocked = true;
 			::MultiRange* newRange = soundEditor.currentSource->ranges.insertMultiRange(newI);
 			AudioEngine::audioRoutineLocked = false;
-			if (!newRange) {
+			if (newRange == nullptr) {
 				display->displayError(Error::INSUFFICIENT_RAM);
 				return;
 			}
@@ -343,7 +343,7 @@ void MultiRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRight
 	// Lower end
 	if (this->getValue() == 0) {
 		strcpy(buffer, l10n::get(l10n::String::STRING_FOR_BOTTOM));
-		if (getLeftLength) {
+		if (getLeftLength != nullptr) {
 			*getLeftLength = display->haveOLED() ? 6 : 3;
 		}
 	}
@@ -371,7 +371,7 @@ void MultiRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRight
 		*(bufferPos++) = 'o';
 		*(bufferPos++) = 'p';
 		*(bufferPos++) = 0;
-		if (getRightLength) {
+		if (getRightLength != nullptr) {
 			*getRightLength = 3;
 		}
 	}

--- a/src/deluge/gui/menu_item/note/fill.h
+++ b/src/deluge/gui/menu_item/note/fill.h
@@ -43,7 +43,7 @@ public:
 	void readCurrentValue() final override {
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
 
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			this->setValue(leftMostNote->getFill());
 		}
 	}

--- a/src/deluge/gui/menu_item/note/iterance_divisor.h
+++ b/src/deluge/gui/menu_item/note/iterance_divisor.h
@@ -39,7 +39,7 @@ public:
 	void readCurrentValue() override {
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
 
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			Iterance iterance = leftMostNote->getIterance();
 			if (iterance == kDefaultIteranceValue) {
 				// if we end up here in this menu, convert OFF to the default CUSTOM value 1of1
@@ -53,7 +53,7 @@ public:
 	void writeCurrentValue() override {
 		int32_t val = this->getValue();
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			Iterance iterance = leftMostNote->getIterance();
 			if (iterance == kDefaultIteranceValue) {
 				// if we end up here in this menu, convert OFF to the default CUSTOM value 1of1

--- a/src/deluge/gui/menu_item/note/iterance_preset.h
+++ b/src/deluge/gui/menu_item/note/iterance_preset.h
@@ -42,7 +42,7 @@ public:
 	void readCurrentValue() override {
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
 
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			// Convert value to preset to choose from, if preset not found, then maybe it is CUSTOM
 			int32_t preset = leftMostNote->getIterance().toPresetIndex();
 			this->setValue(preset);

--- a/src/deluge/gui/menu_item/note/iterance_step_toggle.h
+++ b/src/deluge/gui/menu_item/note/iterance_step_toggle.h
@@ -33,7 +33,7 @@ public:
 	void readCurrentValue() override {
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
 
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			Iterance iterance = leftMostNote->getIterance();
 			if (iterance == kDefaultIteranceValue) {
 				// if we end up here in this menu, convert OFF to the default CUSTOM value 1of1
@@ -47,7 +47,7 @@ public:
 		bool value = this->getValue();
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
 
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			Iterance iterance = leftMostNote->getIterance();
 			if (iterance == kDefaultIteranceValue) {
 				// if we end up here in this menu, convert OFF to the default CUSTOM value 1of1
@@ -70,7 +70,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
 
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			Iterance iterance = leftMostNote->getIterance();
 			// Only show this iteration step if its index is smaller than current divisor value
 			return (iterance == kDefaultIteranceValue && index == 0) || iterance.divisor > index;

--- a/src/deluge/gui/menu_item/note/probability.h
+++ b/src/deluge/gui/menu_item/note/probability.h
@@ -43,7 +43,7 @@ public:
 	void readCurrentValue() override {
 		Note* leftMostNote = instrumentClipView.getLeftMostNotePressed();
 
-		if (leftMostNote) {
+		if (leftMostNote != nullptr) {
 			this->setValue(leftMostNote->getProbability());
 		}
 	}

--- a/src/deluge/gui/menu_item/note_row/iterance_step_toggle.h
+++ b/src/deluge/gui/menu_item/note_row/iterance_step_toggle.h
@@ -39,7 +39,7 @@ public:
 		bool isKit = clip->output->type == OutputType::KIT;
 
 		if (!isKit) {
-			if (!modelStackWithNoteRow->getNoteRowAllowNull()) { // if note row doesn't exist yet, create it
+			if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) { // if note row doesn't exist yet, create it
 				modelStackWithNoteRow =
 				    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
 			}

--- a/src/deluge/gui/menu_item/note_row/selected_note_row.h
+++ b/src/deluge/gui/menu_item/note_row/selected_note_row.h
@@ -47,7 +47,7 @@ public:
 		bool isKit = clip->output->type == OutputType::KIT;
 
 		if (!isKit) {
-			if (!modelStackWithNoteRow->getNoteRowAllowNull()) { // if note row doesn't exist yet, create it
+			if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) { // if note row doesn't exist yet, create it
 				modelStackWithNoteRow =
 				    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
 			}

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -114,7 +114,8 @@ void PatchCableStrength::renderOLED() {
 		int32_t rounded = this->getValue() / 100;
 		intToString(rounded, buffer, 1);
 		OLED::main.drawStringAlignRight(
-		    buffer, extraY + OLED_MAIN_TOPMOST_PIXEL + 4 + static_cast<int>(destinationDescriptor.isJustAParam()), 18, 20);
+		    buffer, extraY + OLED_MAIN_TOPMOST_PIXEL + 4 + static_cast<int>(destinationDescriptor.isJustAParam()), 18,
+		    20);
 
 		int32_t marginL = destinationDescriptor.isJustAParam() ? 0 : 80;
 		int32_t yBar = destinationDescriptor.isJustAParam() ? 36 : 37;
@@ -124,7 +125,8 @@ void PatchCableStrength::renderOLED() {
 		const int32_t digitWidth = kTextBigSpacingX;
 		const int32_t digitHeight = kTextBigSizeY;
 		intToString(this->getValue(), buffer, 3);
-		int32_t textPixelY = extraY + OLED_MAIN_TOPMOST_PIXEL + 10 + static_cast<int>(destinationDescriptor.isJustAParam());
+		int32_t textPixelY =
+		    extraY + OLED_MAIN_TOPMOST_PIXEL + 10 + static_cast<int>(destinationDescriptor.isJustAParam());
 		OLED::main.drawStringAlignRight(buffer, textPixelY, digitWidth, digitHeight);
 
 		int32_t ourDigitStartX = OLED_MAIN_WIDTH_PIXELS - (soundEditor.numberEditPos + 1) * digitWidth;

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -114,7 +114,7 @@ void PatchCableStrength::renderOLED() {
 		int32_t rounded = this->getValue() / 100;
 		intToString(rounded, buffer, 1);
 		OLED::main.drawStringAlignRight(
-		    buffer, extraY + OLED_MAIN_TOPMOST_PIXEL + 4 + destinationDescriptor.isJustAParam(), 18, 20);
+		    buffer, extraY + OLED_MAIN_TOPMOST_PIXEL + 4 + static_cast<int>(destinationDescriptor.isJustAParam()), 18, 20);
 
 		int32_t marginL = destinationDescriptor.isJustAParam() ? 0 : 80;
 		int32_t yBar = destinationDescriptor.isJustAParam() ? 36 : 37;
@@ -124,7 +124,7 @@ void PatchCableStrength::renderOLED() {
 		const int32_t digitWidth = kTextBigSpacingX;
 		const int32_t digitHeight = kTextBigSizeY;
 		intToString(this->getValue(), buffer, 3);
-		int32_t textPixelY = extraY + OLED_MAIN_TOPMOST_PIXEL + 10 + destinationDescriptor.isJustAParam();
+		int32_t textPixelY = extraY + OLED_MAIN_TOPMOST_PIXEL + 10 + static_cast<int>(destinationDescriptor.isJustAParam());
 		OLED::main.drawStringAlignRight(buffer, textPixelY, digitWidth, digitHeight);
 
 		int32_t ourDigitStartX = OLED_MAIN_WIDTH_PIXELS - (soundEditor.numberEditPos + 1) * digitWidth;
@@ -169,7 +169,7 @@ ModelStackWithAutoParam* PatchCableStrength::getModelStack(void* memory, bool al
 void PatchCableStrength::writeCurrentValue() {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithAutoParam* modelStackWithParam = getModelStack(modelStackMemory, true);
-	if (!modelStackWithParam->autoParam) {
+	if (modelStackWithParam->autoParam == nullptr) {
 		return;
 	}
 

--- a/src/deluge/gui/menu_item/range.cpp
+++ b/src/deluge/gui/menu_item/range.cpp
@@ -177,7 +177,7 @@ void Range::drawPixelsForOled() {
 
 	getText(buffer, &leftLength, &rightLength, soundEditor.editingRangeEdge == RangeEdit::OFF);
 
-	int32_t textLength = leftLength + rightLength + (bool)rightLength;
+	int32_t textLength = leftLength + rightLength + static_cast<int>((bool)rightLength);
 
 	int32_t baseY = 18;
 	int32_t digitWidth = kTextHugeSpacingX;

--- a/src/deluge/gui/menu_item/record/threshold_mode.h
+++ b/src/deluge/gui/menu_item/record/threshold_mode.h
@@ -33,7 +33,7 @@ public:
 		if (kind == DEFAULT) {
 			this->setValue(FlashStorage::defaultThresholdRecordingMode);
 		}
-		else if (currentSong) {
+		else if (currentSong != nullptr) {
 			this->setValue(currentSong->thresholdRecordingMode);
 		}
 	}
@@ -42,7 +42,7 @@ public:
 		if (kind == DEFAULT) {
 			FlashStorage::defaultThresholdRecordingMode = this->getValue<ThresholdRecordingMode>();
 		}
-		if (currentSong) {
+		if (currentSong != nullptr) {
 			currentSong->thresholdRecordingMode = this->getValue<ThresholdRecordingMode>();
 		}
 	}

--- a/src/deluge/gui/menu_item/sample/interpolation.h
+++ b/src/deluge/gui/menu_item/sample/interpolation.h
@@ -30,7 +30,7 @@ public:
 	[[nodiscard]] std::string_view getTitle() const override { return FormattedTitle::title(); }
 
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
-		if (getCurrentAudioClip()) {
+		if (getCurrentAudioClip() != nullptr) {
 			return true;
 		}
 		Sound* sound = static_cast<Sound*>(modControllable);

--- a/src/deluge/gui/menu_item/sample/loop_point.cpp
+++ b/src/deluge/gui/menu_item/sample/loop_point.cpp
@@ -46,7 +46,7 @@ MenuPermission LoopPoint::checkPermissionToBeginSession(ModControllableAudio* mo
 
 	// Before going ahead, make sure a Sample is loaded
 	if (permission == MenuPermission::YES) {
-		if (!(*currentRange)->getAudioFileHolder()->audioFile) {
+		if ((*currentRange)->getAudioFileHolder()->audioFile == nullptr) {
 			permission = MenuPermission::NO;
 		}
 	}

--- a/src/deluge/gui/menu_item/sample/pitch_speed.h
+++ b/src/deluge/gui/menu_item/sample/pitch_speed.h
@@ -31,7 +31,7 @@ public:
 	bool usesAffectEntire() override { return true; }
 
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) final {
-		return getCurrentAudioClip() || isSampleModeSample(modControllable, whichThing);
+		return (getCurrentAudioClip() != nullptr) || isSampleModeSample(modControllable, whichThing);
 	}
 
 	void readCurrentValue() override { this->setValue(soundEditor.currentSampleControls->pitchAndSpeedAreIndependent); }

--- a/src/deluge/gui/menu_item/sequence/direction.h
+++ b/src/deluge/gui/menu_item/sequence/direction.h
@@ -51,7 +51,7 @@ public:
 				// get model stack with note row but don't create note row if it doesn't exist
 				ModelStackWithNoteRow* modelStackWithNoteRow =
 				    clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay, modelStack);
-				if (!modelStackWithNoteRow->getNoteRowAllowNull()) { // if note row doesn't exist yet, create it
+				if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) { // if note row doesn't exist yet, create it
 					modelStackWithNoteRow = instrumentClipView.createNoteRowForYDisplay(
 					    modelStack, instrumentClipView.lastAuditionedYDisplay);
 				}

--- a/src/deluge/gui/menu_item/sequence/direction.h
+++ b/src/deluge/gui/menu_item/sequence/direction.h
@@ -51,7 +51,8 @@ public:
 				// get model stack with note row but don't create note row if it doesn't exist
 				ModelStackWithNoteRow* modelStackWithNoteRow =
 				    clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay, modelStack);
-				if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) { // if note row doesn't exist yet, create it
+				if (modelStackWithNoteRow->getNoteRowAllowNull()
+				    == nullptr) { // if note row doesn't exist yet, create it
 					modelStackWithNoteRow = instrumentClipView.createNoteRowForYDisplay(
 					    modelStack, instrumentClipView.lastAuditionedYDisplay);
 				}

--- a/src/deluge/gui/menu_item/source_selection.cpp
+++ b/src/deluge/gui/menu_item/source_selection.cpp
@@ -133,7 +133,7 @@ void SourceSelection::drawValue() {
 void SourceSelection::beginSession(MenuItem* navigatedBackwardFrom) {
 	this->setValue(0);
 
-	if (navigatedBackwardFrom) {
+	if (navigatedBackwardFrom != nullptr) {
 		while (sourceMenuContents[this->getValue()] != s) {
 			this->setValue(this->getValue() + 1);
 		}

--- a/src/deluge/gui/menu_item/toggle.cpp
+++ b/src/deluge/gui/menu_item/toggle.cpp
@@ -12,7 +12,7 @@ void Toggle::beginSession(MenuItem* navigatedBackwardFrom) {
 }
 
 void Toggle::selectEncoderAction(int32_t offset) {
-	const bool flip = offset & 0b1;
+	const bool flip = (offset & 0b1) != 0;
 	if (flip) {
 		this->setValue(!this->getValue());
 	}

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -139,7 +139,7 @@ bool AudioRecorder::setupRecordingToFile(AudioInputChannel newMode, int32_t newN
 
 	recorder = AudioEngine::getNewRecorder(newNumChannels, folderID, newMode, false, writeLoopPoints,
 	                                       kInternalButtonPressLatency, false, nullptr);
-	if (!recorder) {
+	if (recorder == nullptr) {
 		display->displayError(Error::INSUFFICIENT_RAM);
 		return false;
 	}
@@ -171,7 +171,7 @@ bool AudioRecorder::beginOutputRecording(AudioRecordingFolder folder, AudioInput
 void AudioRecorder::endRecordingSoon(int32_t buttonLatency) {
 
 	// Make sure we don't call the same thing multiple times - I think there's a few scenarios where this could happen
-	if (recorder && recorder->status == RecorderStatus::CAPTURING_DATA) {
+	if ((recorder != nullptr) && recorder->status == RecorderStatus::CAPTURING_DATA) {
 		display->displayLoadingAnimationText("Working");
 		recorder->endSyncedRecording(buttonLatency);
 	}
@@ -230,7 +230,7 @@ void AudioRecorder::process() {
 					display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CLIPPING_OCCURRED));
 				}
 			}
-			else if (!updatedRecordingStatus && recorder->numSamplesCaptured) {
+			else if (!updatedRecordingStatus && (recorder->numSamplesCaptured != 0u)) {
 				if (display->have7SEG()) {
 					display->setText("REC", false, 255, true);
 				}
@@ -285,6 +285,6 @@ ActionResult AudioRecorder::buttonAction(deluge::hid::Button b, bool on, bool in
 }
 
 bool AudioRecorder::isCurrentlyResampling() {
-	return (recordingSource >= AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION && recorder
+	return (recordingSource >= AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION && (recorder != nullptr)
 	        && recorder->status == RecorderStatus::CAPTURING_DATA);
 }

--- a/src/deluge/gui/ui/browser/dx_browser.cpp
+++ b/src/deluge/gui/ui/browser/dx_browser.cpp
@@ -68,7 +68,7 @@ Error DxSyxBrowser::getCurrentFilePath(String* path) {
 
 	path->set(&currentDir);
 	int oldLength = path->getLength();
-	if (oldLength) {
+	if (oldLength != 0) {
 		error = path->concatenateAtPos("/", oldLength);
 		if (error != Error::NONE) {
 gotError:
@@ -88,7 +88,7 @@ gotError:
 
 void DxSyxBrowser::enterKeyPress() {
 	FileItem* currentFileItem = getCurrentFileItem();
-	if (!currentFileItem) {
+	if (currentFileItem == nullptr) {
 		return;
 	}
 

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -952,7 +952,8 @@ doLoadAsSample:
 
 					// If this led to an actual loop end pos, with more waveform after it, and the sample's not too
 					// long, we can do a ONCE.
-					if ((((MultisampleRange*)soundEditor.currentMultiRange)->sampleHolder.loopEndPos != 0u) && mSec < 2002) {
+					if ((((MultisampleRange*)soundEditor.currentMultiRange)->sampleHolder.loopEndPos != 0u)
+					    && mSec < 2002) {
 						soundEditor.currentSource->repeatMode = SampleRepeatMode::ONCE;
 					}
 					else {

--- a/src/deluge/gui/ui/browser/slot_browser.cpp
+++ b/src/deluge/gui/ui/browser/slot_browser.cpp
@@ -72,7 +72,7 @@ ActionResult SlotBrowser::horizontalEncoderAction(int32_t offset) {
 	}
 	if (display->have7SEG()) {
 		FileItem* currentFileItem = getCurrentFileItem();
-		if (currentFileItem) {
+		if (currentFileItem != nullptr) {
 			// See if it's numeric. Here, filename has already had prefix removed if it's numeric.
 
 			Slot thisSlot = getSlot(enteredText.get());
@@ -129,7 +129,7 @@ void SlotBrowser::convertToPrefixFormatIfPossible() {
 
 	FileItem* currentFileItem = getCurrentFileItem();
 
-	if (currentFileItem && currentFileHasSuffixFormatNameImplied && !enteredText.isEmpty()
+	if ((currentFileItem != nullptr) && currentFileHasSuffixFormatNameImplied && !enteredText.isEmpty()
 	    && !currentFileItem->isFolder) {
 
 		int32_t enteredTextLength = enteredText.getLength();

--- a/src/deluge/gui/ui/keyboard/column_controls/chord_mem.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/chord_mem.cpp
@@ -56,7 +56,7 @@ void ChordMemColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTime
 	}
 	else {
 		activeChordMem = 0xFF;
-		if ((!chordMemNoteCount[pad.y] || Buttons::isShiftButtonPressed()) && currentNotesState.count) {
+		if (((chordMemNoteCount[pad.y] == 0u) || Buttons::isShiftButtonPressed()) && (currentNotesState.count != 0u)) {
 			auto noteCount = currentNotesState.count;
 			for (int i = 0; i < noteCount && i < kMaxNotesChordMem; i++) {
 				chordMem[pad.y][i] = currentNotesState.notes[i].note;
@@ -99,7 +99,7 @@ void ChordMemColumn::readFromFile(Deserializer& reader) {
 	reader.match('[');
 	int slot_index = 0;
 	const char* tagName;
-	while (reader.match('{') && *(tagName = reader.readNextTagOrAttributeName())) {
+	while (reader.match('{') && (*(tagName = reader.readNextTagOrAttributeName()) != 0)) {
 		if (!strcmp(tagName, "chordSlot")) {
 			int y = slot_index++;
 			if (y >= kDisplayHeight) {
@@ -108,10 +108,10 @@ void ChordMemColumn::readFromFile(Deserializer& reader) {
 			}
 			int i = 0;
 			reader.match('[');
-			while (reader.match('{') && *(tagName = reader.readNextTagOrAttributeName())) {
+			while (reader.match('{') && (*(tagName = reader.readNextTagOrAttributeName()) != 0)) {
 				if (!strcmp(tagName, "note")) {
 					reader.match('{');
-					while (*(tagName = reader.readNextTagOrAttributeName())) {
+					while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 						if (!strcmp(tagName, "code")) {
 							if (i < kMaxNotesChordMem) {
 								chordMem[y][i] = reader.readTagOrAttributeValueInt();

--- a/src/deluge/gui/ui/keyboard/column_controls/dx.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/dx.cpp
@@ -41,7 +41,7 @@ DxPatch* getCurrentDxPatch() {
 void DXColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t column, KeyboardLayout* layout) {
 	using menu_item::dxParam;
 	DxPatch* patch = getCurrentDxPatch();
-	if (!patch) {
+	if (patch == nullptr) {
 		return;
 	}
 	int algid = patch->params[134];
@@ -55,7 +55,7 @@ void DXColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int32_t 
 			if (!patch->opSwitch(op)) {
 				image[y][column] = {255, 0, 0};
 			}
-			else if (a.ops[op] & (OUT_BUS_ONE | OUT_BUS_TWO)) {
+			else if ((a.ops[op] & (OUT_BUS_ONE | OUT_BUS_TWO)) != 0) {
 				image[y][column] = {0, 128, 255};
 			}
 			else {
@@ -82,7 +82,7 @@ void DXColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelStackWith
 void DXColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
                          KeyboardLayout* layout) {
 	DxPatch* patch = getCurrentDxPatch();
-	if (!patch) {
+	if (patch == nullptr) {
 		return;
 	}
 

--- a/src/deluge/gui/ui/keyboard/column_controls/song_chord_mem.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/song_chord_mem.cpp
@@ -55,7 +55,7 @@ void SongChordMemColumn::handlePad(ModelStackWithTimelineCounter* modelStackWith
 	}
 	else {
 		activeChordMem = 0xFF;
-		if ((!currentSong->chordMemNoteCount[pad.y] || Buttons::isShiftButtonPressed()) && currentNotesState.count) {
+		if (((currentSong->chordMemNoteCount[pad.y] == 0u) || Buttons::isShiftButtonPressed()) && (currentNotesState.count != 0u)) {
 			auto noteCount = currentNotesState.count;
 			for (int i = 0; i < noteCount && i < MAX_NOTES_CHORD_MEM; i++) {
 				currentSong->chordMem[pad.y][i] = currentNotesState.notes[i].note;

--- a/src/deluge/gui/ui/keyboard/column_controls/song_chord_mem.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/song_chord_mem.cpp
@@ -55,7 +55,8 @@ void SongChordMemColumn::handlePad(ModelStackWithTimelineCounter* modelStackWith
 	}
 	else {
 		activeChordMem = 0xFF;
-		if (((currentSong->chordMemNoteCount[pad.y] == 0u) || Buttons::isShiftButtonPressed()) && (currentNotesState.count != 0u)) {
+		if (((currentSong->chordMemNoteCount[pad.y] == 0u) || Buttons::isShiftButtonPressed())
+		    && (currentNotesState.count != 0u)) {
 			auto noteCount = currentNotesState.count;
 			for (int i = 0; i < noteCount && i < MAX_NOTES_CHORD_MEM; i++) {
 				currentSong->chordMem[pad.y][i] = currentNotesState.notes[i].note;

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -101,7 +101,7 @@ ActionResult KeyboardScreen::padAction(int32_t x, int32_t y, int32_t velocity) {
 	}
 
 	// Handle overruling shortcut presses
-	ActionResult soundEditorResult = soundEditor.potentialShortcutPadAction(x, y, velocity);
+	ActionResult soundEditorResult = soundEditor.potentialShortcutPadAction(x, y, velocity != 0);
 	if (soundEditorResult != ActionResult::NOT_DEALT_WITH) {
 		return soundEditorResult;
 	}
@@ -109,7 +109,7 @@ ActionResult KeyboardScreen::padAction(int32_t x, int32_t y, int32_t velocity) {
 	int32_t markDead = -1;
 
 	// Pad pressed down, add to list if not full
-	if (velocity) {
+	if (velocity != 0) {
 		// TODO: Logic should be inverted as part of a bigger rewrite
 		if (currentUIMode == UI_MODE_IMPLODE_ANIMATION || currentUIMode == UI_MODE_ANIMATION_FADE
 		    || currentUIMode == UI_MODE_INSTRUMENT_CLIP_COLLAPSING) {

--- a/src/deluge/gui/ui/keyboard/layout.h
+++ b/src/deluge/gui/ui/keyboard/layout.h
@@ -108,7 +108,7 @@ protected:
 		if (getCurrentOutputType() == OutputType::KIT) {
 			if (note >= 0 && note < getCurrentInstrumentClip()->noteRows.getNumElements()) {
 				NoteRow* noteRow = getCurrentInstrumentClip()->noteRows.getElement(note);
-				if (noteRow) {
+				if (noteRow != nullptr) {
 					colourOffset = noteRow->getColourOffset(getCurrentInstrumentClip());
 				}
 			}

--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -264,7 +264,7 @@ void KeyboardLayoutChord::drawChordName(int16_t noteCode, const char* chordName,
 
 	char fullChordName[300];
 
-	if (voicingName && *voicingName) {
+	if ((voicingName != nullptr) && (*voicingName != 0)) {
 		sprintf(fullChordName, "%s%s - %s", noteName, chordName, voicingName);
 	}
 	else {
@@ -275,7 +275,7 @@ void KeyboardLayoutChord::drawChordName(int16_t noteCode, const char* chordName,
 		D_PRINTLN("Popup text: %s", fullChordName);
 	}
 	else {
-		int8_t drawDot = !isNatural ? 0 : 255;
+		int8_t drawDot = (isNatural == 0) ? 0 : 255;
 		display->setScrollingText(fullChordName, 0);
 	}
 }

--- a/src/deluge/gui/ui/keyboard/layout/chord_library.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_library.cpp
@@ -170,7 +170,7 @@ void KeyboardLayoutChordLibrary::drawChordName(int16_t noteCode, const char* cho
 
 	char fullChordName[300];
 
-	if (voicingName && *voicingName) {
+	if ((voicingName != nullptr) && (*voicingName != 0)) {
 		sprintf(fullChordName, "%s%s - %s", noteName, chordName, voicingName);
 	}
 	else {
@@ -181,7 +181,7 @@ void KeyboardLayoutChordLibrary::drawChordName(int16_t noteCode, const char* cho
 		display->popupTextTemporary(fullChordName);
 	}
 	else {
-		int8_t drawDot = !isNatural ? 0 : 255;
+		int8_t drawDot = (isNatural == 0) ? 0 : 255;
 		display->setScrollingText(fullChordName, 0);
 	}
 }

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -283,11 +283,11 @@ void ColumnControlState::writeToFile(Serializer& writer) {
 void ColumnControlState::readFromFile(Deserializer& reader) {
 	char const* tagName;
 	reader.match('{');
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		bool isLeft = !strcmp(tagName, "leftCol");
 		if (isLeft || !strcmp(tagName, "rightCol")) {
 			reader.match('{');
-			while (*(tagName = reader.readNextTagOrAttributeName())) {
+			while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 				if (!strcmp(tagName, "type")) {
 					auto value = stringToColumnFunction(reader.readTagOrAttributeValue());
 					(isLeft ? leftColFunc : rightColFunc) = value;
@@ -314,7 +314,7 @@ bool ColumnControlsKeyboard::horizontalEncoderHandledByColumns(int32_t offset, b
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(getCurrentClip());
 
 	ColumnControlState& state = getState().columnControl;
-	if (leftColHeld == 7 && offset) {
+	if (leftColHeld == 7 && (offset != 0)) {
 		state.leftCol->handleLeavingColumn(modelStackWithTimelineCounter, this);
 		state.leftColFunc = (offset > 0) ? nextControlFunction(state.leftColFunc, state.rightColFunc)
 		                                 : prevControlFunction(state.leftColFunc, state.rightColFunc);
@@ -323,7 +323,7 @@ bool ColumnControlsKeyboard::horizontalEncoderHandledByColumns(int32_t offset, b
 		keyboardScreen.killColumnSwitchKey(LEFT_COL);
 		return true;
 	}
-	else if (rightColHeld == 7 && offset) {
+	else if (rightColHeld == 7 && (offset != 0)) {
 		state.rightCol->handleLeavingColumn(modelStackWithTimelineCounter, this);
 		state.rightColFunc = (offset > 0) ? nextControlFunction(state.rightColFunc, state.leftColFunc)
 		                                  : prevControlFunction(state.rightColFunc, state.leftColFunc);

--- a/src/deluge/gui/ui/keyboard/layout/in_key.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/in_key.cpp
@@ -95,7 +95,7 @@ void KeyboardLayoutInKey::precalculate() {
 
 void KeyboardLayoutInKey::renderPads(RGB image[][kDisplayWidth + kSideBarWidth]) {
 	// Precreate list of all active notes per octave
-	bool scaleActiveNotes[kOctaveSize] = {0};
+	bool scaleActiveNotes[kOctaveSize] = {false};
 	for (uint8_t idx = 0; idx < currentNotesState.count; ++idx) {
 		scaleActiveNotes[((currentNotesState.notes[idx].note + kOctaveSize) - getRootNote()) % kOctaveSize] = true;
 	}

--- a/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/isomorphic.cpp
@@ -98,7 +98,7 @@ void KeyboardLayoutIsomorphic::precalculate() {
 
 void KeyboardLayoutIsomorphic::renderPads(RGB image[][kDisplayWidth + kSideBarWidth]) {
 	// Precreate list of all active notes per octave
-	bool octaveActiveNotes[kOctaveSize] = {0};
+	bool octaveActiveNotes[kOctaveSize] = {false};
 	for (uint8_t idx = 0; idx < currentNotesState.count; ++idx) {
 		octaveActiveNotes[((currentNotesState.notes[idx].note + kOctaveSize) - getRootNote()) % kOctaveSize] = true;
 	}

--- a/src/deluge/gui/ui/keyboard/layout/piano.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/piano.cpp
@@ -77,7 +77,7 @@ void KeyboardLayoutPiano::precalculate() {
 // Render RGB pads
 void KeyboardLayoutPiano::renderPads(RGB image[][kDisplayWidth + kSideBarWidth]) {
 	// Precreate list of all active notes per octave
-	bool octaveActiveNotes[kOctaveSize] = {0};
+	bool octaveActiveNotes[kOctaveSize] = {false};
 	for (uint8_t idx = 0; idx < currentNotesState.count; ++idx) {
 		octaveActiveNotes[((currentNotesState.notes[idx].note + kOctaveSize) - getRootNote()) % kOctaveSize] = true;
 	}

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -68,7 +68,7 @@ bool LoadInstrumentPresetUI::opened() {
 	if (getRootUI() == &keyboardScreen) {
 		PadLEDs::skipGreyoutFade();
 	}
-	if (instrumentToReplace) {
+	if (instrumentToReplace != nullptr) {
 		initialOutputType = instrumentToReplace->type;
 		initialName.set(&instrumentToReplace->name);
 		initialDirPath.set(&instrumentToReplace->dirPath);
@@ -76,7 +76,7 @@ bool LoadInstrumentPresetUI::opened() {
 
 	if (loadingSynthToKitRow) {
 		initialOutputType = outputTypeToLoad = OutputType::SYNTH;
-		if (soundDrumToReplace) {
+		if (soundDrumToReplace != nullptr) {
 			initialName.set(&soundDrumToReplace->name);
 		}
 		else {
@@ -99,7 +99,7 @@ bool LoadInstrumentPresetUI::opened() {
 	changedInstrumentForClip = false;
 	replacedWholeInstrument = false;
 
-	if (instrumentClipToLoadFor) {
+	if (instrumentClipToLoadFor != nullptr) {
 		instrumentClipToLoadFor
 		    ->backupPresetSlot(); // Store this now cos we won't be storing it between each navigation we do
 	}
@@ -186,7 +186,7 @@ Error LoadInstrumentPresetUI::setupForOutputType() {
 	// existing preset, or call confirmPresetOrNextUnlaunchedOne() to skip any which aren't "available".
 
 	// If same Instrument type as we already had...
-	if (instrumentToReplace && instrumentToReplace->type == outputTypeToLoad) {
+	if ((instrumentToReplace != nullptr) && instrumentToReplace->type == outputTypeToLoad) {
 
 		// Then we can start by just looking at the existing Instrument, cos they're the same type...
 		currentDir.set(&instrumentToReplace->dirPath);
@@ -199,15 +199,15 @@ Error LoadInstrumentPresetUI::setupForOutputType() {
 
 	// Or if the Instruments are different types...
 	else {
-		if (loadingSynthToKitRow && soundDrumToReplace) {
+		if (loadingSynthToKitRow && (soundDrumToReplace != nullptr)) {
 
-			if (&soundDrumToReplace->name) {
+			if ((&soundDrumToReplace->name) != nullptr) {
 				String* name = &soundDrumToReplace->name;
 				enteredText.set(name);
 				searchFilename.set(name);
 			}
 
-			if (&soundDrumToReplace->path) {
+			if ((&soundDrumToReplace->path) != nullptr) {
 				currentDir.set(&soundDrumToReplace->path);
 				if (currentDir.isEmpty()) {
 					goto useDefaultFolder;
@@ -219,7 +219,7 @@ Error LoadInstrumentPresetUI::setupForOutputType() {
 			}
 		}
 		// If we've got a Clip, we can see if it used to use another Instrument of this new type...
-		else if (instrumentClipToLoadFor && outputTypeToLoad != OutputType::MIDI_OUT) {
+		else if ((instrumentClipToLoadFor != nullptr) && outputTypeToLoad != OutputType::MIDI_OUT) {
 			const size_t outputTypeToLoadAsIdx = static_cast<size_t>(outputTypeToLoad);
 			String* backedUpName = &instrumentClipToLoadFor->backedUpInstrumentName[outputTypeToLoadAsIdx];
 			enteredText.set(backedUpName);
@@ -293,7 +293,7 @@ void LoadInstrumentPresetUI::currentFileChanged(int32_t movementDirection) {
 void LoadInstrumentPresetUI::enterKeyPress() {
 
 	FileItem* currentFileItem = getCurrentFileItem();
-	if (!currentFileItem) {
+	if (currentFileItem == nullptr) {
 		return;
 	}
 
@@ -325,7 +325,7 @@ void LoadInstrumentPresetUI::enterKeyPress() {
 		}
 
 		if (currentFileItem
-		        ->instrument) { // When would this not have something? Well ok, maybe now that we have folders.
+		        ->instrument != nullptr) { // When would this not have something? Well ok, maybe now that we have folders.
 			convertToPrefixFormatIfPossible();
 		}
 
@@ -398,7 +398,7 @@ ActionResult LoadInstrumentPresetUI::timerCallback() {
 		FileItem* currentFileItem = getCurrentFileItem();
 
 		// Folders don't have a context menu
-		if (!currentFileItem || currentFileItem->isFolder) {
+		if ((currentFileItem == nullptr) || currentFileItem->isFolder) {
 			return ActionResult::DEALT_WITH;
 		}
 
@@ -454,7 +454,7 @@ void LoadInstrumentPresetUI::changeOutputType(OutputType newOutputType) {
 
 		Instrument* newInstrument;
 		// In arranger...
-		if (!instrumentClipToLoadFor) {
+		if (instrumentClipToLoadFor == nullptr) {
 			newInstrument = currentSong->changeOutputType(instrumentToReplace, newOutputType);
 		}
 
@@ -469,11 +469,11 @@ void LoadInstrumentPresetUI::changeOutputType(OutputType newOutputType) {
 		}
 
 		// If that succeeded, get out
-		if (newInstrument) {
+		if (newInstrument != nullptr) {
 
 			// If going back to a view where the new selection won't immediately be displayed, gotta give some
 			// confirmation
-			if (!getRootUI()->toClipMinder()) {
+			if (getRootUI()->toClipMinder() == nullptr) {
 				char const* message;
 				if (display->haveOLED()) {
 					message = "Instrument switched to CV channel";
@@ -519,7 +519,7 @@ void LoadInstrumentPresetUI::revertToInitialPreset() {
 
 	Availability availabilityRequirement;
 	bool oldInstrumentShouldBeReplaced;
-	if (instrumentClipToLoadFor) {
+	if (instrumentClipToLoadFor != nullptr) {
 		oldInstrumentShouldBeReplaced =
 		    currentSong->shouldOldOutputBeReplaced(instrumentClipToLoadFor, &availabilityRequirement);
 	}
@@ -543,7 +543,7 @@ void LoadInstrumentPresetUI::revertToInitialPreset() {
 	    initialOutputType, initialChannel, initialChannelSuffix, initialName.get(), initialDirPath.get(), false, true);
 
 	// If we found it already as a non-hibernating one...
-	if (initialInstrument) {
+	if (initialInstrument != nullptr) {
 
 		// ... check that our availabilityRequirement allows this
 		if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {
@@ -568,7 +568,7 @@ void LoadInstrumentPresetUI::revertToInitialPreset() {
 			// One MIDIInstrument may be hibernating...
 			if (initialOutputType == OutputType::MIDI_OUT) {
 				initialInstrument = currentSong->grabHibernatingMIDIInstrument(initialChannel, initialChannelSuffix);
-				if (initialInstrument) {
+				if (initialInstrument != nullptr) {
 					goto gotAnInstrument;
 				}
 			}
@@ -576,7 +576,7 @@ void LoadInstrumentPresetUI::revertToInitialPreset() {
 			// Otherwise, create a new one
 			initialInstrument =
 			    StorageManager::createNewNonAudioInstrument(initialOutputType, initialChannel, initialChannelSuffix);
-			if (!initialInstrument) {
+			if (initialInstrument == nullptr) {
 				return;
 			}
 		}
@@ -589,7 +589,7 @@ void LoadInstrumentPresetUI::revertToInitialPreset() {
 			                                                             initialDirPath.get(), true, false);
 
 			// If found hibernating synth or kit...
-			if (initialInstrument) {
+			if (initialInstrument != nullptr) {
 				// Must remove it from hibernation list
 				currentSong->removeInstrumentFromHibernationList(initialInstrument);
 			}
@@ -665,7 +665,7 @@ gotAnInstrument:
 }
 
 bool LoadInstrumentPresetUI::isInstrumentInList(Instrument* searchInstrument, Output* list) {
-	while (list) {
+	while (list != nullptr) {
 		if (list == searchInstrument) {
 			return true;
 		}
@@ -716,7 +716,7 @@ doSlotNumber:
 
 				FileItem* fileItem = (FileItem*)fileItems.getElementAddress(i);
 				char const* fileItemNameChars = fileItem->filename.get();
-				if (!memcasecmp(buffer, fileItemNameChars, 4)) {
+				if (memcasecmp(buffer, fileItemNameChars, 4) == 0) {
 					if (fileItemNameChars[4] == 0) {
 						continue;
 					}
@@ -744,7 +744,7 @@ tryWholeNewSlotNumbers:
 
 					FileItem* fileItem = (FileItem*)fileItems.getElementAddress(i);
 					char const* fileItemNameChars = fileItem->filename.get();
-					if (!memcasecmp(buffer, fileItemNameChars, 4)) {
+					if (memcasecmp(buffer, fileItemNameChars, 4) == 0) {
 						if (fileItemNameChars[4] == 0) {
 							continue;
 						}
@@ -787,7 +787,7 @@ nonNumeric:
 		int32_t numberStartPos;
 
 		char const* underscoreAddress = strrchr(oldNameChars, ' ');
-		if (underscoreAddress) {
+		if (underscoreAddress != nullptr) {
 lookAtSuffixNumber:
 			int32_t underscorePos = (uint32_t)underscoreAddress - (uint32_t)oldNameChars;
 			numberStartPos = underscorePos + 1;
@@ -803,7 +803,7 @@ lookAtSuffixNumber:
 		}
 		else {
 			underscoreAddress = strrchr(oldNameChars, '_');
-			if (underscoreAddress) {
+			if (underscoreAddress != nullptr) {
 				goto lookAtSuffixNumber;
 			}
 		}
@@ -825,7 +825,7 @@ addNumber:
 			FileItem* fileItem = (FileItem*)fileItems.getElementAddress(i);
 			char const* fileItemNameChars = fileItem->filename.get();
 			int32_t newNameLength = strlen(newNameChars);
-			if (!memcasecmp(newNameChars, fileItemNameChars, newNameLength)) {
+			if (memcasecmp(newNameChars, fileItemNameChars, newNameLength) == 0) {
 				if (fileItemNameChars[newNameLength] == 0) {
 					continue;
 				}
@@ -863,7 +863,7 @@ Error LoadInstrumentPresetUI::performLoad(bool doClone) {
 	// Work out availabilityRequirement. This can't change as presets are navigated through... I don't think?
 	Availability availabilityRequirement;
 	bool oldInstrumentShouldBeReplaced;
-	if (instrumentClipToLoadFor) {
+	if (instrumentClipToLoadFor != nullptr) {
 		oldInstrumentShouldBeReplaced =
 		    currentSong->shouldOldOutputBeReplaced(instrumentClipToLoadFor, &availabilityRequirement);
 	}
@@ -882,7 +882,7 @@ Error LoadInstrumentPresetUI::performLoad(bool doClone) {
 	bool newInstrumentWasHibernating = false;
 
 	// If we found an already existing Instrument object...
-	if (!doClone && newInstrument) {
+	if (!doClone && (newInstrument != nullptr)) {
 
 		newInstrumentWasHibernating = isInstrumentInList(newInstrument, currentSong->firstHibernatingInstrument);
 
@@ -1005,7 +1005,7 @@ giveUsedError:
 	currentFileItem->instrument = newInstrument;
 	currentInstrument = newInstrument;
 
-	if (instrumentClipToLoadFor) {
+	if (instrumentClipToLoadFor != nullptr) {
 		view.instrumentChanged(modelStack,
 		                       newInstrument); // modelStack's TimelineCounter is set to instrumentClipToLoadFor, FYI
 
@@ -1040,7 +1040,7 @@ giveUsedError:
 Error LoadInstrumentPresetUI::performLoadSynthToKit() {
 	FileItem* currentFileItem = getCurrentFileItem();
 	Kit* kitToLoadFor = static_cast<Kit*>(instrumentToReplace);
-	if (!currentFileItem) {
+	if (currentFileItem == nullptr) {
 		// Make it say "NONE" on numeric Deluge, for consistency with old times.
 		return display->haveOLED() ? Error::FILE_NOT_FOUND : Error::NO_FURTHER_FILES_THIS_DIRECTION;
 	}
@@ -1072,7 +1072,7 @@ Error LoadInstrumentPresetUI::performLoadSynthToKit() {
 	soundDrumToReplace->path.set(&currentDir);
 	ParamManager* paramManager =
 	    currentSong->getBackedUpParamManagerPreferablyWithClip(soundDrumToReplace, instrumentClipToLoadFor);
-	if (paramManager) {
+	if (paramManager != nullptr) {
 		kitToLoadFor->addDrum(soundDrumToReplace);
 		// don't back up the param manager since we can't use the backup anyway
 		noteRow->setDrum(soundDrumToReplace, kitToLoadFor, modelStackWithNoteRow, instrumentClipToLoadFor, paramManager,
@@ -1102,7 +1102,7 @@ ActionResult LoadInstrumentPresetUI::padAction(int32_t x, int32_t y, int32_t on)
 			goto potentiallyExit;
 		}
 		if (currentInstrumentLoadError != Error::NONE) {
-			if (on) {
+			if (on != 0) {
 				display->displayError(currentInstrumentLoadError);
 			}
 		}
@@ -1114,7 +1114,7 @@ ActionResult LoadInstrumentPresetUI::padAction(int32_t x, int32_t y, int32_t on)
 	// Mute pad
 	else if (x == kDisplayWidth) {
 potentiallyExit:
-		if (on && !currentUIMode) {
+		if ((on != 0) && (currentUIMode == 0u)) {
 			if (sdRoutineLock) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -1160,7 +1160,7 @@ bool LoadInstrumentPresetUI::renderSidebar(uint32_t whichRows, RGB image[][kDisp
 }
 
 bool LoadInstrumentPresetUI::showingAuditionPads() {
-	return getRootUI()->toClipMinder();
+	return getRootUI()->toClipMinder() != nullptr;
 }
 
 void LoadInstrumentPresetUI::instrumentEdited(Instrument* instrument) {
@@ -1200,7 +1200,7 @@ goAgain:
 	sortFileItems();
 
 	// If that folder-read gave us no files, that's gotta mean we got to the end of the folder.
-	if (!fileItems.getNumElements()) {
+	if (fileItems.getNumElements() == 0) {
 
 		// If we weren't yet looking at subfolders, do that now, going back to the start of this folder's contents.
 		if (!doingSubfolders) {
@@ -1239,14 +1239,14 @@ startDoingFolders:
 
 		// Ok, we found none. Should we do some more reading of the folder contents, to get more files, or are there no
 		// more?
-		if (numFileItemsDeletedAtEnd) {
+		if (numFileItemsDeletedAtEnd != 0) {
 			searchNameLocalCopy.set(&lastFileItemDisplayNameBeforeFiltering); // Can't fail.
 			goto goAgain;
 		}
 
 		// Ok, we've looked at every file, and none were presets we could use. So now we want to look in subfolders. Do
 		// we still have the "start" of our folder's contents in memory?
-		if (numFileItemsDeletedAtStart) {
+		if (numFileItemsDeletedAtStart != 0) {
 			goto startDoingFolders;
 		}
 
@@ -1262,7 +1262,7 @@ startDoingFolders:
 			goto doThisFolder;
 		}
 	}
-	if (numFileItemsDeletedAtEnd) {
+	if (numFileItemsDeletedAtEnd != 0) {
 		searchNameLocalCopy.set(&lastFileItemDisplayNameBeforeFiltering);
 		goto goAgain;
 	}
@@ -1272,7 +1272,7 @@ startDoingFolders:
 
 	if (false) {
 doThisFolder:
-		bool anyMoreForLater = numFileItemsDeletedAtEnd || (i < (fileItems.getNumElements() - 1));
+		bool anyMoreForLater = (numFileItemsDeletedAtEnd != 0) || (i < (fileItems.getNumElements() - 1));
 		searchNameLocalCopy.set(fileItem->displayName);
 
 		Error error = currentDir.concatenate("/");
@@ -1334,12 +1334,12 @@ doReadFiles:
 	}
 
 	sortFileItems();
-	if (!fileItems.getNumElements()) {
+	if (fileItems.getNumElements() == 0) {
 		if (shouldJustGrabLeftmost) {
 			return justGetAnyPreset();
 		}
 
-		if (numFileItemsDeletedAtStart) {
+		if (numFileItemsDeletedAtStart != 0) {
 needToGrabLeftmostButHaveToReadFirst:
 			searchNameLocalCopy.clear();
 			shouldJustGrabLeftmost = true;
@@ -1362,8 +1362,8 @@ needToGrabLeftmostButHaveToReadFirst:
 
 	// If we've shot off the end of the list, that means our searched-for preset didn't exist or wasn't available, and
 	// any subsequent ones which at first made it onto the (possibly truncated) list also weren't available.
-	if (!fileItems.getNumElements()) {
-		if (numFileItemsDeletedAtEnd) { // Probably couldn'g happen anymore...
+	if (fileItems.getNumElements() == 0) {
+		if (numFileItemsDeletedAtEnd != 0) { // Probably couldn'g happen anymore...
 			// We have to read more FileItems, further to the right.
 			searchNameLocalCopy.set(&lastFileItemDisplayNameBeforeFiltering); // Can't fail.
 			goto doReadFiles;
@@ -1376,14 +1376,14 @@ needToGrabLeftmostButHaveToReadFirst:
 
 			// Otherwise, let's do that now:
 			// We might have to go back and read FileItems again from the start...
-			else if (numFileItemsDeletedAtStart) {
+			else if (numFileItemsDeletedAtStart != 0) {
 				goto needToGrabLeftmostButHaveToReadFirst;
 			}
 
 			// Or, if we've actually managed to fit the whole folder contents into our fileItems...
 			else {
 				// Well, if there's still nothing in that, then we really need to give up.
-				if (!fileItems.getNumElements()) {
+				if (fileItems.getNumElements() == 0) {
 					return justGetAnyPreset();
 				}
 				// Otherwise, everything's fine and we can just take the first element.
@@ -1442,7 +1442,7 @@ emptyFileItemsAndReturn:
 	AudioEngine::logAction("doPresetNavigation5");
 
 	// Now that we've deleted duplicates etc...
-	if (!fileItems.getNumElements()) {
+	if (fileItems.getNumElements() == 0) {
 reachedEnd:
 		// If we've reached one end, try going again from the far other end.
 		if (!oldNameString.isEmpty()) {
@@ -1496,12 +1496,12 @@ moveAgain:
 
 	// If moved left off the start of the list...
 	if (i < 0) {
-		if (numFileItemsDeletedAtStart) {
+		if (numFileItemsDeletedAtStart != 0) {
 			goto readAgain;
 		}
 		else { // Wrap to end
 			wrapped += 1;
-			if (numFileItemsDeletedAtEnd) {
+			if (numFileItemsDeletedAtEnd != 0) {
 searchFromOneEnd:
 				oldNameString.clear();
 				D_PRINTLN("reloading and wrap");
@@ -1515,12 +1515,12 @@ searchFromOneEnd:
 
 	// Or if moved right off the end of the list...
 	else if (i >= fileItems.getNumElements()) {
-		if (numFileItemsDeletedAtEnd) {
+		if (numFileItemsDeletedAtEnd != 0) {
 			goto readAgain;
 		}
 		else { // Wrap to start
 			wrapped += 1;
-			if (numFileItemsDeletedAtStart) {
+			if (numFileItemsDeletedAtStart != 0) {
 				goto searchFromOneEnd;
 			}
 			else {
@@ -1532,16 +1532,16 @@ searchFromOneEnd:
 doneMoving:
 	toReturn.fileItem = (FileItem*)fileItems.getElementAddress(i);
 
-	bool isAlreadyInSong = toReturn.fileItem->instrument && toReturn.fileItem->instrumentAlreadyInSong;
+	bool isAlreadyInSong = (toReturn.fileItem->instrument != nullptr) && toReturn.fileItem->instrumentAlreadyInSong;
 	// wrapped is here to prevent an infinite loop
 	if (availabilityRequirement == Availability::INSTRUMENT_UNUSED && isAlreadyInSong && wrapped < 2) {
 		goto moveAgain;
 	}
 
 	toReturn.loadedFromFile = false;
-	bool isHibernating = toReturn.fileItem->instrument && !toReturn.fileItem->instrumentAlreadyInSong;
+	bool isHibernating = (toReturn.fileItem->instrument != nullptr) && !toReturn.fileItem->instrumentAlreadyInSong;
 
-	if (toReturn.fileItem->instrument) {
+	if (toReturn.fileItem->instrument != nullptr) {
 		view.displayOutputName(toReturn.fileItem->instrument, doBlink);
 	}
 	else {
@@ -1562,7 +1562,7 @@ doneMoving:
 		deluge::hid::display::OLED::sendMainImage(); // Sorta cheating - bypassing the UI layered renderer.
 	}
 
-	if (encoders::getEncoder(EncoderName::SELECT).detentPos) {
+	if (encoders::getEncoder(EncoderName::SELECT).detentPos != 0) {
 		D_PRINTLN("go again 1 --------------------------");
 
 doPendingPresetNavigation:
@@ -1579,7 +1579,7 @@ doPendingPresetNavigation:
 	// that we were looking for "unused" ones only
 	// TODO: This isn't true, it's an argument so that must have changed at some point. This logic will create a clone
 	// if anything other than unused is passed in
-	if (!toReturn.fileItem->instrument) {
+	if (toReturn.fileItem->instrument == nullptr) {
 		toReturn.error = StorageManager::loadInstrumentFromFile(
 		    currentSong, nullptr, outputType, false, &toReturn.fileItem->instrument, &toReturn.fileItem->filePointer,
 		    &newName, &Browser::currentDir);
@@ -1590,7 +1590,7 @@ doPendingPresetNavigation:
 
 		toReturn.loadedFromFile = true;
 
-		if (encoders::getEncoder(EncoderName::SELECT).detentPos) {
+		if (encoders::getEncoder(EncoderName::SELECT).detentPos != 0) {
 			D_PRINTLN("go again 2 --------------------------");
 			goto doPendingPresetNavigation;
 		}
@@ -1605,7 +1605,7 @@ doPendingPresetNavigation:
 	currentUIMode = oldUIMode;
 
 	// If user wants to move on...
-	if (encoders::getEncoder(EncoderName::SELECT).detentPos) {
+	if (encoders::getEncoder(EncoderName::SELECT).detentPos != 0) {
 		D_PRINTLN("go again 3 --------------------------");
 		goto doPendingPresetNavigation;
 	}

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -324,8 +324,8 @@ void LoadInstrumentPresetUI::enterKeyPress() {
 			}
 		}
 
-		if (currentFileItem
-		        ->instrument != nullptr) { // When would this not have something? Well ok, maybe now that we have folders.
+		if (currentFileItem->instrument
+		    != nullptr) { // When would this not have something? Well ok, maybe now that we have folders.
 			convertToPrefixFormatIfPossible();
 		}
 

--- a/src/deluge/gui/ui/load/load_midi_device_definition_ui.cpp
+++ b/src/deluge/gui/ui/load/load_midi_device_definition_ui.cpp
@@ -46,7 +46,7 @@ bool LoadMidiDeviceDefinitionUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t*
 }
 
 bool LoadMidiDeviceDefinitionUI::opened() {
-	if (!getRootUI()->toClipMinder() || getCurrentOutputType() != OutputType::MIDI_OUT) {
+	if ((getRootUI()->toClipMinder() == nullptr) || getCurrentOutputType() != OutputType::MIDI_OUT) {
 		return false;
 	}
 
@@ -145,7 +145,7 @@ void LoadMidiDeviceDefinitionUI::folderContentsReady(int32_t entryDirection) {
 void LoadMidiDeviceDefinitionUI::enterKeyPress() {
 
 	FileItem* currentFileItem = getCurrentFileItem();
-	if (!currentFileItem) {
+	if (currentFileItem == nullptr) {
 		return;
 	}
 

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -150,7 +150,7 @@ void LoadSongUI::enterKeyPress() {
 	FileItem* currentFileItem = getCurrentFileItem();
 
 	// If it's a directory...
-	if (currentFileItem && currentFileItem->isFolder) {
+	if ((currentFileItem != nullptr) && currentFileItem->isFolder) {
 
 		Error error = goIntoFolder(currentFileItem->filename.get());
 
@@ -194,7 +194,7 @@ ActionResult LoadSongUI::buttonAction(deluge::hid::Button b, bool on, bool inCar
 	// want to "launch" the new song.
 	if ((b == LOAD) || (b == SELECT_ENC)) {
 		if (on) {
-			if (!currentUIMode) {
+			if (currentUIMode == 0u) {
 				if (inCardRoutine) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 				}
@@ -302,7 +302,7 @@ void LoadSongUI::performLoad() {
 	performingLoad = true;
 	FileItem* currentFileItem = getCurrentFileItem();
 
-	if (!currentFileItem) {
+	if (currentFileItem == nullptr) {
 		display->displayError(display->haveOLED()
 		                          ? Error::FILE_NOT_FOUND
 		                          : Error::NO_FURTHER_FILES_THIS_DIRECTION); // Make it say "NONE" on numeric Deluge,
@@ -346,7 +346,7 @@ void LoadSongUI::performLoad() {
 	}
 
 	void* songMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(Song));
-	if (!songMemory) {
+	if (songMemory == nullptr) {
 ramError:
 		error = Error::INSUFFICIENT_RAM;
 
@@ -355,7 +355,7 @@ someError:
 		activeDeserializer->closeWriter();
 fail:
 		// If we already deleted the old song, make a new blank one. This will take us back to InstrumentClipView.
-		if (!currentSong) {
+		if (currentSong == nullptr) {
 			// If we're here, it's most likely because of a file error. On paper, a RAM error could be possible too.
 			setupBlankSong();
 			audioFileManager.deleteAnyTempRecordedSamplesFromMemory();
@@ -572,7 +572,7 @@ swapDone:
 
 	// Delete the old song
 	AudioEngine::logAction("deleting old song");
-	if (toDelete) {
+	if (toDelete != nullptr) {
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Song();
 		delugeDealloc(toDealloc);
@@ -594,8 +594,8 @@ swapDone:
 	display->removeWorkingAnimation();
 
 	// for the song we just loaded, let's check if there's any midi labels we should load
-	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
-		if (thisOutput && thisOutput->type == OutputType::MIDI_OUT) {
+	for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
+		if ((thisOutput != nullptr) && thisOutput->type == OutputType::MIDI_OUT) {
 			MIDIInstrument* midiInstrument = (MIDIInstrument*)thisOutput;
 			if (midiInstrument->loadDeviceDefinitionFile) {
 				FilePointer tempfp;
@@ -736,7 +736,7 @@ ignoring the file extension.
 
 void LoadSongUI::currentFileChanged(int32_t movementDirection) {
 
-	if (movementDirection) {
+	if (movementDirection != 0) {
 		qwertyVisible = false;
 
 		// Start horizontal scrolling
@@ -829,7 +829,7 @@ goAgain:
 }
 
 ActionResult LoadSongUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	if (!currentUIMode && !Buttons::isButtonPressed(deluge::hid::button::Y_ENC) && !Buttons::isShiftButtonPressed()
+	if ((currentUIMode == 0u) && !Buttons::isButtonPressed(deluge::hid::button::Y_ENC) && !Buttons::isShiftButtonPressed()
 	    && offset < 0) {
 		if (inCardRoutine) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -870,7 +870,7 @@ void LoadSongUI::drawSongPreview(bool toStore) {
 
 	FileItem* currentFileItem = getCurrentFileItem();
 
-	if (!currentFileItem || currentFileItem->isFolder) {
+	if ((currentFileItem == nullptr) || currentFileItem->isFolder) {
 		return;
 	}
 
@@ -890,13 +890,13 @@ void LoadSongUI::drawSongPreview(bool toStore) {
 	}
 
 	int32_t previewNumPads = 40;
-	while (*(tagName = reader->readNextTagOrAttributeName())) {
+	while (*(tagName = reader->readNextTagOrAttributeName()) != 0) {
 
-		if (!strcmp(tagName, "previewNumPads")) {
+		if (strcmp(tagName, "previewNumPads") == 0) {
 			previewNumPads = reader->readTagOrAttributeValueInt();
 			reader->exitTag("previewNumPads");
 		}
-		else if (!strcmp(tagName, "preview")) {
+		else if (strcmp(tagName, "preview") == 0) {
 			int32_t skipNumCharsAfterRow = 0;
 
 			int32_t startX = 0;
@@ -913,7 +913,7 @@ void LoadSongUI::drawSongPreview(bool toStore) {
 
 			for (int32_t y = startY; y < endY; y++) {
 				char const* hexChars = reader->readNextCharsOfTagOrAttributeValue(numCharsToRead);
-				if (!hexChars) {
+				if (hexChars == nullptr) {
 					goto stopLoadingPreview;
 				}
 
@@ -951,7 +951,7 @@ void LoadSongUI::displayText(bool blinkImmediately) {
 ActionResult LoadSongUI::padAction(int32_t x, int32_t y, int32_t on) {
 	// If QWERTY not visible yet, make it visible now
 	if (!qwertyVisible) {
-		if (on && !currentUIMode) {
+		if ((on != 0) && (currentUIMode == 0u)) {
 			if (sdRoutineLock) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -829,8 +829,8 @@ goAgain:
 }
 
 ActionResult LoadSongUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	if ((currentUIMode == 0u) && !Buttons::isButtonPressed(deluge::hid::button::Y_ENC) && !Buttons::isShiftButtonPressed()
-	    && offset < 0) {
+	if ((currentUIMode == 0u) && !Buttons::isButtonPressed(deluge::hid::button::Y_ENC)
+	    && !Buttons::isShiftButtonPressed() && offset < 0) {
 		if (inCardRoutine) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/ui/rename/rename_clip_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.cpp
@@ -57,7 +57,7 @@ ActionResult RenameClipUI::buttonAction(deluge::hid::Button b, bool on, bool inC
 
 	// Back button
 	if (b == BACK) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -67,7 +67,7 @@ ActionResult RenameClipUI::buttonAction(deluge::hid::Button b, bool on, bool inC
 
 	// Select encoder button
 	else if (b == SELECT_ENC) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -86,7 +86,7 @@ void RenameClipUI::enterKeyPress() {
 
 	// Don't allow duplicate names on clips of a single output.
 	if (!clip->name.equalsCaseIrrespective(&enteredText)) {
-		if (clip->output->getClipFromName(&enteredText)) {
+		if (clip->output->getClipFromName(&enteredText) != nullptr) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
 		}
@@ -109,7 +109,7 @@ ActionResult RenameClipUI::padAction(int32_t x, int32_t y, int32_t on) {
 	}
 
 	// Otherwise, exit
-	if (on && !currentUIMode) {
+	if ((on != 0) && (currentUIMode == 0u)) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -63,7 +63,7 @@ ActionResult RenameDrumUI::buttonAction(deluge::hid::Button b, bool on, bool inC
 
 	// Back button
 	if (b == BACK) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -73,7 +73,7 @@ ActionResult RenameDrumUI::buttonAction(deluge::hid::Button b, bool on, bool inC
 
 	// Select encoder button
 	else if (b == SELECT_ENC) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -97,7 +97,7 @@ void RenameDrumUI::enterKeyPress() {
 	// If actually changing it...
 	if (!getDrum()->name.equalsCaseIrrespective(&enteredText)) {
 		// don't let user set a name that is a duplicate of another name that has been set for another drum
-		if (getCurrentKit()->getDrumFromName(enteredText.get())) {
+		if (getCurrentKit()->getDrumFromName(enteredText.get()) != nullptr) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
 		}
@@ -121,7 +121,7 @@ ActionResult RenameDrumUI::padAction(int32_t x, int32_t y, int32_t on) {
 	}
 
 	// Otherwise, exit
-	if (on && !currentUIMode) {
+	if ((on != 0) && (currentUIMode == 0u)) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
@@ -77,7 +77,7 @@ ActionResult RenameMidiCCUI::buttonAction(deluge::hid::Button b, bool on, bool i
 
 	// Back button
 	if (b == BACK) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -87,7 +87,7 @@ ActionResult RenameMidiCCUI::buttonAction(deluge::hid::Button b, bool on, bool i
 
 	// Select encoder button
 	else if (b == SELECT_ENC) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -128,7 +128,7 @@ ActionResult RenameMidiCCUI::padAction(int32_t x, int32_t y, int32_t on) {
 	}
 
 	// Otherwise, exit
-	if (on && !currentUIMode) {
+	if ((on != 0) && (currentUIMode == 0u)) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/ui/rename/rename_output_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_output_ui.cpp
@@ -57,7 +57,7 @@ ActionResult RenameOutputUI::buttonAction(deluge::hid::Button b, bool on, bool i
 
 	// Back button
 	if (b == BACK) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -67,7 +67,7 @@ ActionResult RenameOutputUI::buttonAction(deluge::hid::Button b, bool on, bool i
 
 	// Select encoder button
 	else if (b == SELECT_ENC) {
-		if (on && !currentUIMode) {
+		if (on && (currentUIMode == 0u)) {
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
@@ -93,7 +93,7 @@ void RenameOutputUI::enterKeyPress() {
 		// if this is an audio output
 		// don't let user set a name that is a duplicate of another name that has been set for another audio output
 		// Sean: do we only want to do this for audio output's?
-		if (currentSong->getAudioOutputFromName(&enteredText)) {
+		if (currentSong->getAudioOutputFromName(&enteredText) != nullptr) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 			return;
 		}
@@ -117,7 +117,7 @@ ActionResult RenameOutputUI::padAction(int32_t x, int32_t y, int32_t on) {
 	}
 
 	// Otherwise, exit
-	if (on && !currentUIMode) {
+	if ((on != 0) && (currentUIMode == 0u)) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
@@ -133,7 +133,7 @@ bool SaveInstrumentPresetUI::performSave(bool mayOverwrite) {
 
 		// We can't save into this slot if another Instrument in this Song already uses it
 		if (currentSong->getInstrumentFromPresetSlot(outputTypeToLoad, 0, 0, enteredText.get(), currentDir.get(),
-		                                             false)) {
+		                                             false) != nullptr) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_SAME_NAME));
 			display->removeWorkingAnimation();
 			return false;

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
@@ -132,8 +132,8 @@ bool SaveInstrumentPresetUI::performSave(bool mayOverwrite) {
 	if (isDifferentSlot) {
 
 		// We can't save into this slot if another Instrument in this Song already uses it
-		if (currentSong->getInstrumentFromPresetSlot(outputTypeToLoad, 0, 0, enteredText.get(), currentDir.get(),
-		                                             false) != nullptr) {
+		if (currentSong->getInstrumentFromPresetSlot(outputTypeToLoad, 0, 0, enteredText.get(), currentDir.get(), false)
+		    != nullptr) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_SAME_NAME));
 			display->removeWorkingAnimation();
 			return false;

--- a/src/deluge/gui/ui/save/save_kit_row_ui.cpp
+++ b/src/deluge/gui/ui/save/save_kit_row_ui.cpp
@@ -96,7 +96,7 @@ bool SaveKitRowUI::performSave(bool mayOverwrite) {
 	}
 
 	// We can't save into this slot if another Instrument in this Song already uses it
-	if (currentSong->getInstrumentFromPresetSlot(outputTypeToLoad, 0, 0, enteredText.get(), currentDir.get(), false)) {
+	if (currentSong->getInstrumentFromPresetSlot(outputTypeToLoad, 0, 0, enteredText.get(), currentDir.get(), false) != nullptr) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_SAME_NAME));
 		display->removeWorkingAnimation();
 		return false;

--- a/src/deluge/gui/ui/save/save_kit_row_ui.cpp
+++ b/src/deluge/gui/ui/save/save_kit_row_ui.cpp
@@ -96,7 +96,8 @@ bool SaveKitRowUI::performSave(bool mayOverwrite) {
 	}
 
 	// We can't save into this slot if another Instrument in this Song already uses it
-	if (currentSong->getInstrumentFromPresetSlot(outputTypeToLoad, 0, 0, enteredText.get(), currentDir.get(), false) != nullptr) {
+	if (currentSong->getInstrumentFromPresetSlot(outputTypeToLoad, 0, 0, enteredText.get(), currentDir.get(), false)
+	    != nullptr) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_SAME_NAME));
 		display->removeWorkingAnimation();
 		return false;

--- a/src/deluge/gui/ui/save/save_midi_device_definition_ui.cpp
+++ b/src/deluge/gui/ui/save/save_midi_device_definition_ui.cpp
@@ -40,7 +40,7 @@ SaveMidiDeviceDefinitionUI::SaveMidiDeviceDefinitionUI() {
 }
 
 bool SaveMidiDeviceDefinitionUI::opened() {
-	if (!getRootUI()->toClipMinder() || getCurrentOutputType() != OutputType::MIDI_OUT) {
+	if ((getRootUI()->toClipMinder() == nullptr) || getCurrentOutputType() != OutputType::MIDI_OUT) {
 		return false;
 	}
 

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -116,7 +116,7 @@ void SaveSongUI::focusRegained() {
 
 bool SaveSongUI::performSave(bool mayOverwrite) {
 
-	if (ALPHA_OR_BETA_VERSION && currentlyAccessingCard) {
+	if (ALPHA_OR_BETA_VERSION && (currentlyAccessingCard != 0u)) {
 		FREEZE_WITH_ERROR("E316");
 	}
 

--- a/src/deluge/gui/ui/save/save_ui.cpp
+++ b/src/deluge/gui/ui/save/save_ui.cpp
@@ -71,7 +71,7 @@ void SaveUI::enterKeyPress() {
 	FileItem* currentFileItem = getCurrentFileItem();
 
 	// If it's a directory...
-	if (currentFileItem && currentFileItem->isFolder) {
+	if ((currentFileItem != nullptr) && currentFileItem->isFolder) {
 
 		Error error = goIntoFolder(currentFileItem->filename.get());
 

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -579,7 +579,7 @@ ActionResult Slicer::padAction(int32_t x, int32_t y, int32_t on) {
 		uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 	}
 	else if ((on == 0) && x < kDisplayWidth && y < kDisplayHeight / 2 && slicerMode == SLICER_MODE_MANUAL) { // pad off
-		preview(0, 0, 0, 0);                                                                           // off
+		preview(0, 0, 0, 0);                                                                                 // off
 	}
 
 	if (slicerMode == SLICER_MODE_MANUAL) {

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -184,14 +184,14 @@ void Slicer::graphicsRoutine() {
 					continue;
 				}
 
-				if (!assignedVoice || thisVoice->orderSounded > assignedVoice->orderSounded) {
+				if ((assignedVoice == nullptr) || thisVoice->orderSounded > assignedVoice->orderSounded) {
 					assignedVoice = thisVoice;
 				}
 			}
 
-			if (assignedVoice) {
+			if (assignedVoice != nullptr) {
 				VoiceUnisonPartSource* part = &assignedVoice->unisonParts[drum->numUnison >> 1].sources[0];
-				if (part && part->active) {
+				if ((part != nullptr) && part->active) {
 					voiceSample = part->voiceSample;
 					guide = &assignedVoice->guides[soundEditor.currentSourceIndex];
 				}
@@ -199,7 +199,7 @@ void Slicer::graphicsRoutine() {
 		}
 	}
 
-	if (voiceSample) {
+	if (voiceSample != nullptr) {
 		int32_t samplePos = voiceSample->getPlaySample((Sample*)range->sampleHolder.audioFile, guide);
 		if (samplePos >= waveformBasicNavigator.xScroll) {
 			newTickSquare = (samplePos - waveformBasicNavigator.xScroll) / waveformBasicNavigator.xZoom;
@@ -447,13 +447,13 @@ void Slicer::stopAnyPreviewing() {
 	Kit* kit = getCurrentKit();
 	SoundDrum* drum = (SoundDrum*)kit->firstDrum;
 	drum->unassignAllVoices();
-	if (drum->sources[0].ranges.getNumElements()) {
+	if (drum->sources[0].ranges.getNumElements() != 0) {
 		MultisampleRange* range = (MultisampleRange*)drum->sources[0].ranges.getElement(0);
 		range->sampleHolder.setAudioFile(nullptr);
 	}
 }
 void Slicer::preview(int64_t startPoint, int64_t endPoint, int32_t transpose, int32_t on) {
-	if (on) {
+	if (on != 0) {
 		Kit* kit = getCurrentKit();
 		SoundDrum* drum = (SoundDrum*)kit->firstDrum;
 
@@ -487,12 +487,12 @@ void Slicer::preview(int64_t startPoint, int64_t endPoint, int32_t transpose, in
 		modelStackWithAutoParam->autoParam->setCurrentValueWithNoReversionOrRecording(
 		    modelStackWithAutoParam, getParamFromUserValue(params::LOCAL_ENV_0_ATTACK, 1));
 	}
-	instrumentClipView.sendAuditionNote(on, 0, 64, 0);
+	instrumentClipView.sendAuditionNote(on != 0, 0, 64, 0);
 }
 
 ActionResult Slicer::padAction(int32_t x, int32_t y, int32_t on) {
 
-	if (on && x < kDisplayWidth && y < kDisplayHeight / 2 && slicerMode == SLICER_MODE_MANUAL) { // pad on
+	if ((on != 0) && x < kDisplayWidth && y < kDisplayHeight / 2 && slicerMode == SLICER_MODE_MANUAL) { // pad on
 
 		int32_t slicePadIndex = (x % 4 + (x / 4) * 16) + ((y % 4) * 4); //
 
@@ -534,20 +534,20 @@ ActionResult Slicer::padAction(int32_t x, int32_t y, int32_t on) {
 						if (thisVoice->guides[0].audioFileHolder != range->getAudioFileHolder()) {
 							continue;
 						}
-						if (!assignedVoice || thisVoice->orderSounded > assignedVoice->orderSounded) {
+						if ((assignedVoice == nullptr) || thisVoice->orderSounded > assignedVoice->orderSounded) {
 							assignedVoice = thisVoice;
 						}
 					}
-					if (assignedVoice) {
+					if (assignedVoice != nullptr) {
 						VoiceUnisonPartSource* part = &assignedVoice->unisonParts[drum->numUnison >> 1].sources[0];
-						if (part && part->active) {
+						if ((part != nullptr) && part->active) {
 							voiceSample = part->voiceSample;
 							guide = &assignedVoice->guides[soundEditor.currentSourceIndex];
 						}
 					}
 				}
 			}
-			if (voiceSample) {
+			if (voiceSample != nullptr) {
 				int32_t samplePos = voiceSample->getPlaySample((Sample*)range->sampleHolder.audioFile, guide);
 				if (samplePos < waveformBasicNavigator.sample->lengthInSamples && numManualSlice < MAX_MANUAL_SLICES) {
 					manualSlicePoints[numManualSlice].startPos = samplePos;
@@ -578,7 +578,7 @@ ActionResult Slicer::padAction(int32_t x, int32_t y, int32_t on) {
 		}
 		uiNeedsRendering(this, 0xFFFFFFFF, 0xFFFFFFFF);
 	}
-	else if (!on && x < kDisplayWidth && y < kDisplayHeight / 2 && slicerMode == SLICER_MODE_MANUAL) { // pad off
+	else if ((on == 0) && x < kDisplayWidth && y < kDisplayHeight / 2 && slicerMode == SLICER_MODE_MANUAL) { // pad off
 		preview(0, 0, 0, 0);                                                                           // off
 	}
 
@@ -655,7 +655,7 @@ getOut:
 		firstDrum->sources[0].sampleControls.reversed = false;
 
 #if 1 || ALPHA_OR_BETA_VERSION
-		if (!firstRange->sampleHolder.audioFile) {
+		if (firstRange->sampleHolder.audioFile == nullptr) {
 			FREEZE_WITH_ERROR("i032"); // Trying to narrow down E368 that Kevin F got
 		}
 #endif
@@ -682,7 +682,7 @@ getOut:
 			}
 
 			void* drumMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(SoundDrum));
-			if (!drumMemory) {
+			if (drumMemory == nullptr) {
 ramError:
 				error = Error::INSUFFICIENT_RAM;
 				goto getOut;
@@ -691,7 +691,7 @@ ramError:
 			SoundDrum* newDrum = new (drumMemory) SoundDrum();
 
 			MultisampleRange* range = (MultisampleRange*)newDrum->sources[0].getOrCreateFirstRange();
-			if (!range) {
+			if (range == nullptr) {
 ramError2:
 				newDrum->~SoundDrum();
 				delugeDealloc(drumMemory);
@@ -735,7 +735,7 @@ ramError2:
 
 		// Make NoteRows for all these new Drums
 		getCurrentKit()->resetDrumTempValues();
-		firstDrum->noteRowAssignedTemp = 1;
+		firstDrum->noteRowAssignedTemp = true;
 	}
 	ModelStackWithTimelineCounter* modelStack = (ModelStackWithTimelineCounter*)modelStackMemory;
 	getCurrentInstrumentClip()->assignDrumsToNoteRows(modelStack);

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -42,7 +42,7 @@ void UI::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 }
 
 void UI::graphicsRoutine() {
-	if (getRootUI() && canSeeViewUnderneath()) {
+	if ((getRootUI() != nullptr) && canSeeViewUnderneath()) {
 		getRootUI()->graphicsRoutine();
 	}
 }
@@ -145,12 +145,12 @@ RootUI* getRootUI() {
 
 bool currentUIIsClipMinderScreen() {
 	UI* currentUI = getCurrentUI();
-	return (currentUI && currentUI->toClipMinder());
+	return ((currentUI != nullptr) && (currentUI->toClipMinder() != nullptr));
 }
 
 bool rootUIIsClipMinderScreen() {
 	UI* rootUI = getRootUI();
-	return (rootUI && rootUI->toClipMinder());
+	return ((rootUI != nullptr) && (rootUI->toClipMinder() != nullptr));
 }
 
 void swapOutRootUILowLevel(UI* newUI) {
@@ -285,14 +285,14 @@ void uiNeedsRendering(UI* ui, uint32_t whichMainRows, uint32_t whichSideRows) {
 			break;
 		}
 
-		if (whichMainRows && thisUI->renderMainPads()) {
+		if ((whichMainRows != 0u) && thisUI->renderMainPads()) {
 			whichMainRows = 0;
 		}
-		if (whichSideRows && thisUI->renderSidebar()) {
+		if ((whichSideRows != 0u) && thisUI->renderSidebar()) {
 			whichSideRows = 0;
 		}
 
-		if (!whichMainRows && !whichSideRows) {
+		if ((whichMainRows == 0u) && (whichSideRows == 0u)) {
 			break;
 		}
 	}
@@ -300,7 +300,7 @@ void uiNeedsRendering(UI* ui, uint32_t whichMainRows, uint32_t whichSideRows) {
 
 void doAnyPendingGridRendering() {
 
-	if (!whichMainRowsNeedRendering && !whichSideRowsNeedRendering) {
+	if ((whichMainRowsNeedRendering == 0u) && (whichSideRowsNeedRendering == 0u)) {
 		return;
 	}
 
@@ -316,26 +316,26 @@ void doAnyPendingGridRendering() {
 
 	for (int32_t u = numUIsOpen - 1; u >= 0; u--) {
 
-		if (!mainRowsNow && !sideRowsNow) {
+		if ((mainRowsNow == 0u) && (sideRowsNow == 0u)) {
 			break;
 		}
 
 		UI* thisUI = uiNavigationHierarchy[u];
 
-		if (mainRowsNow) {
+		if (mainRowsNow != 0u) {
 			bool usedUp = thisUI->renderMainPads(mainRowsNow, PadLEDs::image, PadLEDs::occupancyMask);
 			if (usedUp) {
-				if (!whichMainRowsNeedRendering) {
+				if (whichMainRowsNeedRendering == 0u) {
 					PadLEDs::sendOutMainPadColours();
 				}
 				mainRowsNow = 0;
 			}
 		}
 
-		if (sideRowsNow) {
+		if (sideRowsNow != 0u) {
 			bool usedUp = thisUI->renderSidebar(sideRowsNow, PadLEDs::image, PadLEDs::occupancyMask);
 			if (usedUp) {
-				if (!whichSideRowsNeedRendering) {
+				if (whichSideRowsNeedRendering == 0u) {
 					PadLEDs::sendOutSidebarColours();
 				}
 				sideRowsNow = 0;
@@ -389,7 +389,7 @@ uint32_t currentUIMode = 0;
 
 bool isUIModeActive(uint32_t uiMode) {
 	if (uiMode > EXCLUSIVE_UI_MODES_MASK) {
-		return (currentUIMode & uiMode);
+		return (currentUIMode & uiMode) != 0u;
 	}
 	else {
 		uint32_t exclusivesOnly = currentUIMode & EXCLUSIVE_UI_MODES_MASK;
@@ -407,7 +407,7 @@ bool isUIModeActiveExclusively(uint32_t uiMode) {
 bool isUIModeWithinRange(const uint32_t* modes) {
 	uint32_t exclusivesOnly = currentUIMode & EXCLUSIVE_UI_MODES_MASK;
 	uint32_t nonExclusivesOnly = currentUIMode & ~EXCLUSIVE_UI_MODES_MASK;
-	while (*modes) {
+	while (*modes != 0u) {
 		// If looking at an exclusive mode...
 		if (*modes <= EXCLUSIVE_UI_MODES_MASK) {
 			if (*modes == exclusivesOnly) {
@@ -422,11 +422,11 @@ bool isUIModeWithinRange(const uint32_t* modes) {
 		modes++;
 	}
 
-	return (!exclusivesOnly && !nonExclusivesOnly);
+	return ((exclusivesOnly == 0u) && (nonExclusivesOnly == 0u));
 }
 
 bool isNoUIModeActive() {
-	return !currentUIMode;
+	return currentUIMode == 0u;
 }
 
 // You can safely call this even if you don't know whether said UI mode is active.

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -743,7 +743,8 @@ void ArrangerView::beginAudition(Output* output) {
 
 			if (noteRow != nullptr) {
 				drum = noteRow->drum;
-				if ((drum != nullptr) && drum->type == DrumType::SOUND && !noteRow->paramManager.containsAnyMainParamCollections()) {
+				if ((drum != nullptr) && drum->type == DrumType::SOUND
+				    && !noteRow->paramManager.containsAnyMainParamCollections()) {
 					FREEZE_WITH_ERROR("E324"); // Vinz got this! I may have since fixed.
 				}
 			}
@@ -1037,7 +1038,8 @@ ActionResult ArrangerView::handleStatusPadAction(int32_t y, int32_t velocity, UI
 				// If we're the first Instrument to be soloing, need to tell others they've been inadvertedly
 				// deactivated
 				if (!currentSong->getAnyOutputsSoloingInArrangement()) {
-					for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
+					for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr;
+					     thisOutput = thisOutput->next) {
 						if (thisOutput != output && !thisOutput->mutedInArrangementMode) {
 							outputDeactivated(thisOutput);
 						}
@@ -1073,7 +1075,8 @@ doUnsolo:
 
 					// If no other Instruments still soloing, re-activate all the other ones
 					if (!currentSong->getAnyOutputsSoloingInArrangement()) {
-						for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
+						for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr;
+						     thisOutput = thisOutput->next) {
 							if (thisOutput != output && !thisOutput->mutedInArrangementMode) {
 								outputActivated(thisOutput);
 							}
@@ -2797,7 +2800,8 @@ ActionResult ArrangerView::horizontalEncoderAction(int32_t offset) {
 					}
 				}
 
-				for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
+				for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr;
+				     thisOutput = thisOutput->next) {
 					int32_t i = thisOutput->clipInstances.search(currentSong->xScroll[NAVIGATION_ARRANGEMENT],
 					                                             GREATER_OR_EQUAL);
 
@@ -3155,12 +3159,13 @@ void ArrangerView::graphicsRoutine() {
 
 			for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 				Output* output = outputsOnScreen[yDisplay];
-				tickSquares[yDisplay] =
-				    (currentSong->getAnyOutputsSoloingInArrangement() && ((output == nullptr) || !output->soloingInArrangementMode))
-				        ? 255
-				        : newTickSquare;
-				colours[yDisplay] =
-				    ((output != nullptr) && output->recordingInArrangement) ? 2 : ((output != nullptr) && output->mutedInArrangementMode ? 1 : 0);
+				tickSquares[yDisplay] = (currentSong->getAnyOutputsSoloingInArrangement()
+				                         && ((output == nullptr) || !output->soloingInArrangementMode))
+				                            ? 255
+				                            : newTickSquare;
+				colours[yDisplay] = ((output != nullptr) && output->recordingInArrangement)
+				                        ? 2
+				                        : ((output != nullptr) && output->mutedInArrangementMode ? 1 : 0);
 
 				if (arrangement.hasPlaybackActive() && currentUIMode != UI_MODE_EXPLODE_ANIMATION
 				    && currentUIMode != UI_MODE_IMPLODE_ANIMATION) {
@@ -3298,7 +3303,8 @@ uint32_t ArrangerView::getMaxZoom() {
 void ArrangerView::tellMatrixDriverWhichRowsContainSomethingZoomable() {
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 		PadLEDs::transitionTakingPlaceOnRow[yDisplay] =
-		    ((outputsOnScreen[yDisplay] != nullptr) && (outputsOnScreen[yDisplay]->clipInstances.getNumElements() != 0));
+		    ((outputsOnScreen[yDisplay] != nullptr)
+		     && (outputsOnScreen[yDisplay]->clipInstances.getNumElements() != 0));
 	}
 }
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -121,7 +121,7 @@ void ArrangerView::moveClipToSession() {
 	Clip* clip = clipInstance->clip;
 
 	// Empty ClipInstance - can't do
-	if (!clip) {
+	if (clip == nullptr) {
 		display->displayPopup(
 		    deluge::l10n::get(deluge::l10n::String::STRING_FOR_EMPTY_CLIP_INSTANCES_CANT_BE_MOVED_TO_THE_SESSION));
 	}
@@ -358,7 +358,7 @@ doChangeOutputType:
 						goto doActualSimpleChange;
 					}
 
-					if (!output) {
+					if (output == nullptr) {
 						return ActionResult::DEALT_WITH;
 					}
 
@@ -433,7 +433,7 @@ doActualSimpleChange:
 void ArrangerView::deleteOutput() {
 
 	Output* output = outputsOnScreen[yPressedEffective];
-	if (!output) {
+	if (output == nullptr) {
 		return;
 	}
 
@@ -445,13 +445,13 @@ void ArrangerView::deleteOutput() {
 	}
 
 	for (int32_t i = 0; i < output->clipInstances.getNumElements(); i++) {
-		if (output->clipInstances.getElement(i)->clip) {
+		if (output->clipInstances.getElement(i)->clip != nullptr) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DELETE_ALL_TRACKS_CLIPS_FIRST));
 			return;
 		}
 	}
 
-	if (currentSong->getSessionClipWithOutput(output)) {
+	if (currentSong->getSessionClipWithOutput(output) != nullptr) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_TRACK_STILL_HAS_CLIPS_IN_SESSION));
 		return;
 	}
@@ -487,7 +487,7 @@ void ArrangerView::clearArrangement() {
 	// improve on because the deletion of the Clips themselves, where there are arrangement-only ones, causes the
 	// calling of output->pickAnActiveClipIfPossible. So we have to ensure that extra ClipInstances don't exist at any
 	// instant in time, or else it'll look at those to pick the new activeClip, which might not exist anymore.
-	for (Output* output = currentSong->firstOutput; output; output = output->next) {
+	for (Output* output = currentSong->firstOutput; output != nullptr; output = output->next) {
 		for (int32_t i = output->clipInstances.getNumElements() - 1; i >= 0; i--) {
 			deleteClipInstance(output, i, output->clipInstances.getElement(i), action, false);
 		}
@@ -558,7 +558,7 @@ void ArrangerView::repopulateOutputsOnScreen(bool doRender) {
 
 	Output* output = currentSong->firstOutput;
 	int32_t row = 0 - currentSong->arrangementYScroll;
-	while (output) {
+	while (output != nullptr) {
 		if (row >= kDisplayHeight) {
 			break;
 		}
@@ -579,7 +579,7 @@ void ArrangerView::repopulateOutputsOnScreen(bool doRender) {
 
 bool ArrangerView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                  uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
-	if (!image) {
+	if (image == nullptr) {
 		return true;
 	}
 
@@ -588,7 +588,7 @@ bool ArrangerView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth +
 	}
 
 	for (int32_t i = 0; i < kDisplayHeight; i++) {
-		if (whichRows & (1 << i)) {
+		if ((whichRows & (1 << i)) != 0u) {
 			drawMuteSquare(i, image[i]);
 			drawAuditionSquare(i, image[i]);
 		}
@@ -600,7 +600,7 @@ void ArrangerView::drawMuteSquare(int32_t yDisplay, RGB thisImage[]) {
 	RGB& thisColour = thisImage[kDisplayWidth];
 
 	// If no Instrument, black
-	if (!outputsOnScreen[yDisplay]) {
+	if (outputsOnScreen[yDisplay] == nullptr) {
 		thisColour = colours::black;
 	}
 
@@ -648,7 +648,7 @@ void ArrangerView::drawAuditionSquare(int32_t yDisplay, RGB thisImage[]) {
 	if (view.midiLearnFlashOn) {
 		Output* output = outputsOnScreen[yDisplay];
 
-		if (!output || output->type == OutputType::AUDIO) {
+		if ((output == nullptr) || output->type == OutputType::AUDIO) {
 			goto drawNormally;
 		}
 
@@ -690,12 +690,12 @@ ModelStackWithNoteRow* ArrangerView::getNoteRowForAudition(ModelStack* modelStac
 
 		InstrumentClip* instrumentClip = (InstrumentClip*)kit->getActiveClip();
 		modelStackWithNoteRow = instrumentClip->getNoteRowForDrumName(modelStackWithTimelineCounter, "SNAR");
-		if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
-			if (kit->selectedDrum) {
+		if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
+			if (kit->selectedDrum != nullptr) {
 				modelStackWithNoteRow =
 				    instrumentClip->getNoteRowForDrum(modelStackWithTimelineCounter, kit->selectedDrum);
 			}
-			if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+			if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 				modelStackWithNoteRow =
 				    modelStackWithTimelineCounter->addNoteRow(0, instrumentClip->noteRows.getElement(0));
 			}
@@ -710,9 +710,9 @@ ModelStackWithNoteRow* ArrangerView::getNoteRowForAudition(ModelStack* modelStac
 
 Drum* ArrangerView::getDrumForAudition(Kit* kit) {
 	Drum* drum = kit->getDrumFromName("SNAR");
-	if (!drum) {
+	if (drum == nullptr) {
 		drum = kit->selectedDrum;
-		if (!drum) {
+		if (drum == nullptr) {
 			drum = kit->firstDrum;
 		}
 	}
@@ -728,7 +728,7 @@ void ArrangerView::beginAudition(Output* output) {
 
 	Instrument* instrument = (Instrument*)output;
 
-	if (!playbackHandler.playbackState && !Buttons::isShiftButtonPressed()) {
+	if ((playbackHandler.playbackState == 0u) && !Buttons::isShiftButtonPressed()) {
 
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
@@ -741,9 +741,9 @@ void ArrangerView::beginAudition(Output* output) {
 			Drum* drum;
 			NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
 
-			if (noteRow) {
+			if (noteRow != nullptr) {
 				drum = noteRow->drum;
-				if (drum && drum->type == DrumType::SOUND && !noteRow->paramManager.containsAnyMainParamCollections()) {
+				if ((drum != nullptr) && drum->type == DrumType::SOUND && !noteRow->paramManager.containsAnyMainParamCollections()) {
 					FREEZE_WITH_ERROR("E324"); // Vinz got this! I may have since fixed.
 				}
 			}
@@ -751,7 +751,7 @@ void ArrangerView::beginAudition(Output* output) {
 				drum = getDrumForAudition(kit);
 			}
 
-			if (drum) {
+			if (drum != nullptr) {
 				kit->beginAuditioningforDrum(modelStackWithNoteRow, drum, kit->defaultVelocity, zeroMPEValues);
 			}
 		}
@@ -772,7 +772,7 @@ void ArrangerView::endAudition(Output* output, bool evenIfPlaying) {
 
 	Instrument* instrument = (Instrument*)output;
 
-	if (!playbackHandler.playbackState || evenIfPlaying) {
+	if ((playbackHandler.playbackState == 0u) || evenIfPlaying) {
 
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
@@ -785,14 +785,14 @@ void ArrangerView::endAudition(Output* output, bool evenIfPlaying) {
 			Drum* drum;
 			NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
 
-			if (noteRow) {
+			if (noteRow != nullptr) {
 				drum = noteRow->drum;
 			}
 			else {
 				drum = getDrumForAudition(kit);
 			}
 
-			if (drum) {
+			if (drum != nullptr) {
 				kit->endAuditioningForDrum(modelStackWithNoteRow, drum);
 			}
 		}
@@ -820,10 +820,10 @@ Instrument* ArrangerView::createNewInstrument(OutputType newOutputType, bool* in
 	                                 });
 
 	Instrument* newInstrument = fileItem->instrument;
-	bool isHibernating = newInstrument && !fileItem->instrumentAlreadyInSong;
-	*instrumentAlreadyInSong = newInstrument && fileItem->instrumentAlreadyInSong;
+	bool isHibernating = (newInstrument != nullptr) && !fileItem->instrumentAlreadyInSong;
+	*instrumentAlreadyInSong = (newInstrument != nullptr) && fileItem->instrumentAlreadyInSong;
 
-	if (!newInstrument) {
+	if (newInstrument == nullptr) {
 		String newPresetName;
 		fileItem->getDisplayNameWithoutExtension(&newPresetName);
 		error = StorageManager::loadInstrumentFromFile(currentSong, nullptr, newOutputType, false, &newInstrument,
@@ -880,7 +880,7 @@ doNewPress:
 			yPressedActual = y;
 
 			// If nothing on this row yet, we'll add a brand new Instrument
-			if (!output) {
+			if (output == nullptr) {
 
 				int32_t minY = -currentSong->arrangementYScroll - 1;
 				int32_t maxY = -currentSong->arrangementYScroll + currentSong->getNumOutputs();
@@ -891,7 +891,7 @@ doNewPress:
 				bool instrumentAlreadyInSong; // Will always end up false
 
 				output = createNewInstrument(OutputType::SYNTH, &instrumentAlreadyInSong);
-				if (!output) {
+				if (output == nullptr) {
 					return;
 				}
 
@@ -910,7 +910,7 @@ doNewPress:
 
 			beginAudition(output);
 
-			if (output->getActiveClip()) {
+			if (output->getActiveClip() != nullptr) {
 				view.setActiveModControllableTimelineCounter(output->getActiveClip());
 			}
 			else {
@@ -980,11 +980,11 @@ ActionResult ArrangerView::handleEditPadAction(int32_t x, int32_t y, int32_t vel
 	Output* output = outputsOnScreen[y];
 
 	if (currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION) {
-		if (velocity) {
+		if (velocity != 0) {
 			// NAME shortcut
 			if (x == 11 && y == 5) {
 				Output* output = outputsOnScreen[yPressedEffective];
-				if (output && output->type != OutputType::CV) {
+				if ((output != nullptr) && output->type != OutputType::CV) {
 					endAudition(output);
 					currentUIMode = UI_MODE_NONE;
 					renameOutputUI.output = output;
@@ -995,8 +995,8 @@ ActionResult ArrangerView::handleEditPadAction(int32_t x, int32_t y, int32_t vel
 		}
 	}
 	else {
-		if (output) {
-			editPadAction(x, y, velocity);
+		if (output != nullptr) {
+			editPadAction(x, y, velocity != 0);
 		}
 	}
 	return ActionResult::DEALT_WITH;
@@ -1005,11 +1005,11 @@ ActionResult ArrangerView::handleEditPadAction(int32_t x, int32_t y, int32_t vel
 ActionResult ArrangerView::handleStatusPadAction(int32_t y, int32_t velocity, UI* ui) {
 	Output* output = outputsOnScreen[y];
 
-	if (!output) {
+	if (output == nullptr) {
 		return ActionResult::DEALT_WITH;
 	}
 
-	if (velocity) {
+	if (velocity != 0) {
 		uint32_t rowsToRedraw = 1 << y;
 
 		switch (currentUIMode) {
@@ -1037,7 +1037,7 @@ ActionResult ArrangerView::handleStatusPadAction(int32_t y, int32_t velocity, UI
 				// If we're the first Instrument to be soloing, need to tell others they've been inadvertedly
 				// deactivated
 				if (!currentSong->getAnyOutputsSoloingInArrangement()) {
-					for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
+					for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
 						if (thisOutput != output && !thisOutput->mutedInArrangementMode) {
 							outputDeactivated(thisOutput);
 						}
@@ -1073,7 +1073,7 @@ doUnsolo:
 
 					// If no other Instruments still soloing, re-activate all the other ones
 					if (!currentSong->getAnyOutputsSoloingInArrangement()) {
-						for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
+						for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
 							if (thisOutput != output && !thisOutput->mutedInArrangementMode) {
 								outputActivated(thisOutput);
 							}
@@ -1094,7 +1094,7 @@ doUnsolo:
 		case UI_MODE_NONE:
 			// If the user was just quick and is actually holding the record button but the submode just hasn't changed
 			// yet...
-			if (velocity && Buttons::isButtonPressed(deluge::hid::button::RECORD)) {
+			if ((velocity != 0) && Buttons::isButtonPressed(deluge::hid::button::RECORD)) {
 				output->armedForRecording = !output->armedForRecording;
 				timerCallback();                 // Get into UI_MODE_VIEWING_RECORD_ARMING
 				return ActionResult::DEALT_WITH; // No need to draw anything
@@ -1139,9 +1139,9 @@ ActionResult ArrangerView::handleAuditionPadAction(int32_t y, int32_t velocity, 
 
 	switch (currentUIMode) {
 	case UI_MODE_MIDI_LEARN:
-		if (output) {
+		if (output != nullptr) {
 			if (output->type == OutputType::AUDIO) {
-				if (velocity) {
+				if (velocity != 0) {
 					view.endMIDILearn();
 					context_menu::audioInputSelector.audioOutput = (AudioOutput*)output;
 					context_menu::audioInputSelector.setupAndCheckAvailability();
@@ -1155,7 +1155,7 @@ ActionResult ArrangerView::handleAuditionPadAction(int32_t y, int32_t velocity, 
 		break;
 
 	default:
-		auditionPadAction(velocity, y, ui);
+		auditionPadAction(velocity != 0, y, ui);
 		break;
 	}
 	return ActionResult::DEALT_WITH;
@@ -1171,7 +1171,7 @@ void ArrangerView::outputActivated(Output* output) {
 
 	int32_t i = output->clipInstances.search(actualPos + 1, LESS);
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
-	if (clipInstance && clipInstance->pos + clipInstance->length > actualPos) {
+	if ((clipInstance != nullptr) && clipInstance->pos + clipInstance->length > actualPos) {
 		arrangement.resumeClipInstancePlayback(clipInstance);
 	}
 
@@ -1186,7 +1186,7 @@ void ArrangerView::outputDeactivated(Output* output) {
 	output->stopAnyAuditioning(modelStack);
 
 	if (arrangement.hasPlaybackActive()) {
-		if (output->getActiveClip() && !output->recordingInArrangement) {
+		if ((output->getActiveClip() != nullptr) && !output->recordingInArrangement) {
 			output->getActiveClip()->expectNoFurtherTicks(currentSong);
 			output->getActiveClip()->activeIfNoSolo = false;
 		}
@@ -1197,7 +1197,7 @@ void ArrangerView::outputDeactivated(Output* output) {
 void ArrangerView::deleteClipInstance(Output* output, int32_t clipInstanceIndex, ClipInstance* clipInstance,
                                       Action* action, bool clearingWholeArrangement) {
 
-	if (action) {
+	if (action != nullptr) {
 		action->recordClipInstanceExistenceChange(output, clipInstance, ExistenceChangeType::DELETE);
 	}
 	Clip* clip = clipInstance->clip;
@@ -1213,7 +1213,7 @@ void ArrangerView::deleteClipInstance(Output* output, int32_t clipInstanceIndex,
 void ArrangerView::interactWithClipInstance(Output* output, int32_t yDisplay, ClipInstance* clipInstance) {
 	Clip* clip = clipInstance->clip;
 
-	if (clip) {
+	if (clip != nullptr) {
 		// it looks like this variable isn't used anywhere
 		originallyPressedClipActualLength = clipInstance->clip->loopLength;
 
@@ -1237,7 +1237,7 @@ void ArrangerView::interactWithClipInstance(Output* output, int32_t yDisplay, Cl
 void ArrangerView::rememberInteractionWithClipInstance(int32_t yDisplay, ClipInstance* clipInstance) {
 	lastInteractedOutputIndex = yDisplay + currentSong->arrangementYScroll;
 	lastInteractedPos = clipInstance->pos;
-	lastInteractedSection = clipInstance->clip ? clipInstance->clip->section : 255;
+	lastInteractedSection = (clipInstance->clip != nullptr) ? clipInstance->clip->section : 255;
 	lastInteractedClipInstance = clipInstance;
 }
 
@@ -1292,7 +1292,7 @@ void ArrangerView::editPadAction(int32_t x, int32_t y, bool on) {
 				if (x == xPressed && y == yPressedEffective) {
 					// if a section clip instance was changed to an arrangement only clip instance,
 					// the clip itself is created on pad release
-					if (lastInteractedSection == 255 && !lastInteractedClipInstance->clip) {
+					if (lastInteractedSection == 255 && (lastInteractedClipInstance->clip == nullptr)) {
 						createNewClipForClipInstance(output, lastInteractedClipInstance);
 					}
 
@@ -1318,11 +1318,11 @@ void ArrangerView::editPadAction(int32_t x, int32_t y, bool on) {
 
 							// If Clip wasn't created yet, create it first. This does both AudioClips and
 							// InstrumentClips
-							if (!clipInstance->clip) {
+							if (clipInstance->clip == nullptr) {
 								createNewClipForClipInstance(output, clipInstance);
 							}
 
-							if (clipInstance->clip) {
+							if (clipInstance->clip != nullptr) {
 								transitionToClipView(clipInstance);
 							}
 						}
@@ -1341,10 +1341,10 @@ void ArrangerView::cloneClipInstanceToWhite(Output* output, int32_t x, int32_t y
 
 	int32_t i = output->clipInstances.search(squareEnd, LESS);
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
-	if (clipInstance && clipInstance->pos + clipInstance->length >= squareStart) {
+	if ((clipInstance != nullptr) && clipInstance->pos + clipInstance->length >= squareStart) {
 		Clip* oldClip = clipInstance->clip;
 
-		if (oldClip && !oldClip->isArrangementOnlyClip() && !oldClip->getCurrentlyRecordingLinearly()) {
+		if ((oldClip != nullptr) && !oldClip->isArrangementOnlyClip() && !oldClip->getCurrentlyRecordingLinearly()) {
 			actionLogger.deleteAllLogs();
 
 			Error error = arrangement.doUniqueCloneOnClipInstance(clipInstance, clipInstance->length, true);
@@ -1370,12 +1370,12 @@ void ArrangerView::createNewClipInstance(Output* output, int32_t x, int32_t y, i
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
 
 	// If we did find a clip instance
-	if (clipInstance) {
+	if (clipInstance != nullptr) {
 		Clip* clip = clipInstance->clip;
 
-		if (clip) {
+		if (clip != nullptr) {
 			// If it's being recorded to, some special instructions
-			if (playbackHandler.playbackState && output->recordingInArrangement
+			if ((playbackHandler.playbackState != 0u) && output->recordingInArrangement
 			    && clip->getCurrentlyRecordingLinearly()) {
 				// Can't press here to the left of the play/record cursor!
 				if (squareStart < arrangement.getLivePos()) {
@@ -1427,7 +1427,7 @@ ClipInstance* ArrangerView::createClipInstance(Output* output, int32_t y, int32_
 	{
 		int32_t j = output->clipInstances.search(squareStart, GREATER_OR_EQUAL);
 		ClipInstance* nextClipInstance = output->clipInstances.getElement(j);
-		if (nextClipInstance && nextClipInstance->pos == squareStart) {
+		if ((nextClipInstance != nullptr) && nextClipInstance->pos == squareStart) {
 			FREEZE_WITH_ERROR("E233"); // Yes, this happened to someone. Including me!!
 		}
 	}
@@ -1441,7 +1441,7 @@ ClipInstance* ArrangerView::createClipInstance(Output* output, int32_t y, int32_
 	// Test thing
 	{
 		ClipInstance* nextInstance = output->clipInstances.getElement(pressedClipInstanceIndex + 1);
-		if (nextInstance) {
+		if (nextInstance != nullptr) {
 			if (nextInstance->pos == squareStart) {
 				FREEZE_WITH_ERROR("E232");
 			}
@@ -1449,14 +1449,14 @@ ClipInstance* ArrangerView::createClipInstance(Output* output, int32_t y, int32_
 	}
 
 	clipInstance = output->clipInstances.getElement(pressedClipInstanceIndex);
-	if (!clipInstance) {
+	if (clipInstance == nullptr) {
 		display->displayError(Error::INSUFFICIENT_RAM);
 		return nullptr;
 	}
 
 	clipInstance->clip = newClip;
 
-	if (clipInstance->clip) {
+	if (clipInstance->clip != nullptr) {
 		clipInstance->length = clipInstance->clip->loopLength;
 	}
 	else {
@@ -1468,7 +1468,7 @@ ClipInstance* ArrangerView::createClipInstance(Output* output, int32_t y, int32_
 	}
 
 	ClipInstance* nextInstance = output->clipInstances.getElement(pressedClipInstanceIndex + 1);
-	if (nextInstance) {
+	if (nextInstance != nullptr) {
 
 		if (nextInstance->pos == squareStart) {
 			FREEZE_WITH_ERROR("E209");
@@ -1491,7 +1491,7 @@ ClipInstance* ArrangerView::createClipInstance(Output* output, int32_t y, int32_
 	}
 
 	Action* action = actionLogger.getNewAction(ActionType::CLIP_INSTANCE_EDIT, ActionAddition::NOT_ALLOWED);
-	if (action) {
+	if (action != nullptr) {
 		action->recordClipInstanceExistenceChange(output, clipInstance, ExistenceChangeType::CREATE);
 	}
 
@@ -1511,11 +1511,11 @@ ClipInstance* ArrangerView::createClipInstance(Output* output, int32_t y, int32_
 Clip* ArrangerView::getClipForNewClipInstance(Output* output, Output* lastOutputInteractedWith,
                                               ClipInstance* lastClipInstance) {
 	Clip* newClip = nullptr;
-	if (lastClipInstance && lastClipInstance->pos == lastInteractedPos) {
+	if ((lastClipInstance != nullptr) && lastClipInstance->pos == lastInteractedPos) {
 
 		// If same Output...
 		if (lastOutputInteractedWith == output) {
-			if (lastClipInstance->clip && !lastClipInstance->clip->isArrangementOnlyClip()) {
+			if ((lastClipInstance->clip != nullptr) && !lastClipInstance->clip->isArrangementOnlyClip()) {
 				newClip = lastClipInstance->clip;
 			}
 		}
@@ -1523,7 +1523,7 @@ Clip* ArrangerView::getClipForNewClipInstance(Output* output, Output* lastOutput
 		// Or if different Output...
 		else {
 			// If yes Clip, look for another one with that section
-			if (lastClipInstance->clip) {
+			if (lastClipInstance->clip != nullptr) {
 				lastInteractedSection = lastClipInstance->clip->section;
 				newClip = getClipFromSection(output);
 			}
@@ -1544,7 +1544,7 @@ Clip* ArrangerView::getClipFromSection(Output* output) {
 		newClip = currentSong->getSessionClipWithOutput(output, lastInteractedSection);
 
 		// If that section had none, just get any old one (still might return NULL - that's fine)
-		if (!newClip) {
+		if (newClip == nullptr) {
 			newClip = currentSong->getSessionClipWithOutput(output);
 		}
 	}
@@ -1574,7 +1574,7 @@ void ArrangerView::adjustClipInstanceLength(Output* output, int32_t x, int32_t y
 	// Shorten
 	if (clipInstance->length > lengthTilNewSquareStart) {
 		Action* action = actionLogger.getNewAction(ActionType::CLIP_INSTANCE_EDIT, ActionAddition::ALLOWED);
-		if (clipInstance->clip) {
+		if (clipInstance->clip != nullptr) {
 			arrangement.rowEdited(output, clipInstance->pos + lengthTilNewSquareStart,
 			                      clipInstance->pos + clipInstance->length, clipInstance->clip, nullptr);
 		}
@@ -1590,7 +1590,7 @@ void ArrangerView::adjustClipInstanceLength(Output* output, int32_t x, int32_t y
 
 		// Make sure it doesn't collide with next ClipInstance
 		ClipInstance* nextClipInstance = output->clipInstances.getElement(pressedClipInstanceIndex + 1);
-		if (nextClipInstance) {
+		if (nextClipInstance != nullptr) {
 			int32_t maxLength = nextClipInstance->pos - clipInstance->pos;
 			if (newLength > maxLength) {
 				newLength = maxLength;
@@ -1645,7 +1645,7 @@ void ArrangerView::createNewClipForClipInstance(Output* output, ClipInstance* cl
 	int32_t size = (output->type == OutputType::AUDIO) ? sizeof(AudioClip) : sizeof(InstrumentClip);
 
 	void* memory = GeneralMemoryAllocator::get().allocMaxSpeed(size);
-	if (!memory) {
+	if (memory == nullptr) {
 		display->displayError(Error::INSUFFICIENT_RAM);
 		return exitSubModeWithoutAction();
 	}
@@ -1690,14 +1690,14 @@ void ArrangerView::createNewClipForClipInstance(Output* output, ClipInstance* cl
 	// Crucial that we do this not long after calling setInstrument, in case this is the
 	// first Clip with the Instrument and we just grabbed the backedUpParamManager for it,
 	// which it might go and look for again if the audio routine was called in the interim
-	if (!output->getActiveClip()) {
+	if (output->getActiveClip() == nullptr) {
 		output->setActiveClip(modelStack);
 	}
 
 	currentSong->arrangementOnlyClips.insertClipAtIndex(newClip, 0);
 
 	Action* action = actionLogger.getNewAction(ActionType::CLIP_INSTANCE_EDIT, ActionAddition::NOT_ALLOWED);
-	if (action) {
+	if (action != nullptr) {
 		action->recordClipExistenceChange(currentSong, &currentSong->arrangementOnlyClips, newClip,
 		                                  ExistenceChangeType::CREATE);
 	}
@@ -1742,7 +1742,7 @@ void ArrangerView::exitSubModeWithoutAction(UI* ui) {
 
 	if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION)) {
 		Output* output = outputsOnScreen[yPressedEffective];
-		if (output) {
+		if (output != nullptr) {
 			endAudition(output);
 			auditionEnded();
 			uiNeedsRendering(ui, 0, 1 << yPressedEffective);
@@ -1833,7 +1833,7 @@ void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 	}
 	else if (clip->type == ClipType::AUDIO) {
 		// If no sample, just skip directly there
-		if (!((AudioClip*)clip)->sampleHolder.audioFile) {
+		if (((AudioClip*)clip)->sampleHolder.audioFile == nullptr) {
 			currentUIMode = UI_MODE_NONE;
 			changeRootUI(&audioClipView);
 
@@ -1881,7 +1881,7 @@ void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 
 	int64_t clipLengthBig = ((uint64_t)clip->loopLength << 16) / currentSong->xZoom[NAVIGATION_ARRANGEMENT];
 
-	if (clipLengthBig) {
+	if (clipLengthBig != 0) {
 		while (true) {
 			int64_t nextPotentialStart = xStartBig + clipLengthBig;
 			if ((nextPotentialStart >> 16) > xPressed) {
@@ -1916,7 +1916,7 @@ bool ArrangerView::transitionToArrangementEditor() {
 	if (getCurrentClip()->type == ClipType::AUDIO && getCurrentUI() != &automationView) {
 
 		// If no sample, just skip directly there
-		if (!getCurrentAudioClip()->sampleHolder.audioFile) {
+		if (getCurrentAudioClip()->sampleHolder.audioFile == nullptr) {
 			changeRootUI(&arrangerView);
 			return true;
 		}
@@ -1925,7 +1925,7 @@ bool ArrangerView::transitionToArrangementEditor() {
 	Output* output = getCurrentOutput();
 	int32_t i = output->clipInstances.search(currentSong->lastClipInstanceEnteredStartPos, GREATER_OR_EQUAL);
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
-	if (!clipInstance || clipInstance->clip != getCurrentClip()) {
+	if ((clipInstance == nullptr) || clipInstance->clip != getCurrentClip()) {
 		return false;
 	}
 
@@ -2028,7 +2028,7 @@ bool ArrangerView::putDraggedClipInstanceInNewPosition(Output* newOutputToDragIn
 	if (newOutputToDragInto == pressedClipInstanceOutput) {
 
 		// If back to original (well, last valid) scroll pos too, nothing to do
-		if (!xMovement) {
+		if (xMovement == 0) {
 			pressedClipInstanceIsInValidPosition = true;
 			return true;
 		}
@@ -2036,7 +2036,7 @@ bool ArrangerView::putDraggedClipInstanceInNewPosition(Output* newOutputToDragIn
 
 	// Or if Output not the same
 	else {
-		if (clip) {
+		if (clip != nullptr) {
 			if (newOutputToDragInto->type != OutputType::AUDIO
 			    || pressedClipInstanceOutput->type != OutputType::AUDIO) {
 itsInvalid:
@@ -2068,7 +2068,7 @@ itsInvalid:
 	int32_t iPrev = newOutputToDragInto->clipInstances.search(newStartPos, LESS);
 	ClipInstance* prevClipInstance = newOutputToDragInto->clipInstances.getElement(iPrev);
 	if (prevClipInstance != clipInstance) {
-		if (prevClipInstance) {
+		if (prevClipInstance != nullptr) {
 			if (newOutputToDragInto->recordingInArrangement) {
 				if (newStartPos <= arrangement.getLivePos()) {
 					goto itsInvalid;
@@ -2086,7 +2086,7 @@ itsInvalid:
 	int32_t iNext = iPrev + 1;
 	ClipInstance* nextClipInstance = newOutputToDragInto->clipInstances.getElement(iNext);
 	if (nextClipInstance != clipInstance) {
-		if (nextClipInstance && nextClipInstance->pos < newStartPos + clipInstance->length) {
+		if ((nextClipInstance != nullptr) && nextClipInstance->pos < newStartPos + clipInstance->length) {
 			goto itsInvalid;
 		}
 	}
@@ -2095,7 +2095,7 @@ itsInvalid:
 
 	int32_t length = clipInstance->length;
 
-	if (clip) {
+	if (clip != nullptr) {
 		arrangement.rowEdited(pressedClipInstanceOutput, clipInstance->pos, clipInstance->pos + length, clip, nullptr);
 	}
 
@@ -2109,7 +2109,7 @@ itsInvalid:
 
 	// Or if it has...
 	else {
-		if (action) {
+		if (action != nullptr) {
 			action->recordClipInstanceExistenceChange(pressedClipInstanceOutput, clipInstance,
 			                                          ExistenceChangeType::DELETE);
 		}
@@ -2120,12 +2120,12 @@ itsInvalid:
 		clipInstance = newOutputToDragInto->clipInstances.getElement(pressedClipInstanceIndex);
 		clipInstance->clip = clip;
 		clipInstance->length = length;
-		if (action) {
+		if (action != nullptr) {
 			action->recordClipInstanceExistenceChange(newOutputToDragInto, clipInstance, ExistenceChangeType::CREATE);
 		}
 
 		// And if changing output...
-		if (newOutputToDragInto != pressedClipInstanceOutput && clip) {
+		if (newOutputToDragInto != pressedClipInstanceOutput && (clip != nullptr)) {
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
 
@@ -2139,7 +2139,7 @@ itsInvalid:
 		pressedClipInstanceOutput = newOutputToDragInto;
 	}
 
-	if (clip) {
+	if (clip != nullptr) {
 		arrangement.rowEdited(newOutputToDragInto, clipInstance->pos, clipInstance->pos + length, nullptr,
 		                      clipInstance);
 	}
@@ -2162,9 +2162,9 @@ uint32_t ArrangerView::doActualRender(int32_t xScroll, uint32_t xZoom, uint32_t 
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);
 
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-		if (whichRows & (1 << yDisplay)) {
+		if ((whichRows & (1 << yDisplay)) != 0u) {
 			uint8_t* occupancyMaskThisRow = nullptr;
-			if (occupancyMask) {
+			if (occupancyMask != nullptr) {
 				occupancyMaskThisRow = occupancyMask[yDisplay];
 			}
 
@@ -2182,7 +2182,7 @@ uint32_t ArrangerView::doActualRender(int32_t xScroll, uint32_t xZoom, uint32_t 
 
 bool ArrangerView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
-	if (!image) {
+	if (image == nullptr) {
 		return true;
 	}
 
@@ -2194,7 +2194,7 @@ bool ArrangerView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth 
 
 	PadLEDs::renderingLock = false;
 
-	if (whichRowsCouldntBeRendered && image == PadLEDs::image) {
+	if ((whichRowsCouldntBeRendered != 0u) && image == PadLEDs::image) {
 		uiNeedsRendering(this, whichRowsCouldntBeRendered, 0);
 	}
 
@@ -2208,7 +2208,7 @@ bool ArrangerView::renderRow(ModelStack* modelStack, int32_t yDisplay, int32_t x
 
 	Output* output = outputsOnScreen[yDisplay];
 
-	if (!output) {
+	if (output == nullptr) {
 
 		const RGB* imageEnd = imageThisRow + renderWidth;
 
@@ -2289,7 +2289,7 @@ bool ArrangerView::renderRowForOutput(ModelStack* modelStack, Output* output, in
 	// this is constant and zero - so does nothing?
 	int32_t firstXDisplayNotLeftOf0 = 0;
 
-	if (!output->clipInstances.getNumElements()) {
+	if (output->clipInstances.getNumElements() == 0) {
 		while (imageNow < imageEnd) {
 			*(imageNow++) = colours::black;
 		}
@@ -2327,7 +2327,7 @@ squareStartPosSet:
 		}
 		ClipInstance* clipInstance = output->clipInstances.getElement(i);
 
-		if (clipInstance) {
+		if (clipInstance != nullptr) {
 			RGB colour = clipInstance->getColour();
 
 			// If Instance starts exactly on square or somewhere within square, draw "head".
@@ -2343,7 +2343,7 @@ squareStartPosSet:
 				// get the end of the clip instance
 				int32_t instanceEnd = clipInstance->pos + clipInstance->length;
 				// for currently recording clips, get the playhead
-				if (output->recordingInArrangement && clipInstance->clip
+				if (output->recordingInArrangement && (clipInstance->clip != nullptr)
 				    && clipInstance->clip->getCurrentlyRecordingLinearly()) {
 					instanceEnd = arrangement.getLivePos();
 				}
@@ -2362,7 +2362,7 @@ squareStartPosSet:
 					// Draw either the blank, non-existent Clip if this Instance doesn't have one...
 					// Or the real Clip - for all squares in the Instance
 					for (auto* it = &image[xDisplay]; it != &image[xDisplay] + (squareEnd - xDisplay); it++) {
-						if (!clipInstance->clip) {
+						if (clipInstance->clip == nullptr) {
 							// Arranger only clip instances created from a section clip (hold clip + turn Select) don't
 							// have a clip until the pad is released. Their "clip preview" gets drawn here
 							image[xDisplay] = colour.dim(4);
@@ -2466,7 +2466,7 @@ void ArrangerView::selectEncoderAction(int8_t offset) {
 		ClipInstance* clipInstance = output->clipInstances.getElement(pressedClipInstanceIndex);
 
 		// If an arrangement-only Clip, can't do anything
-		if (clipInstance->clip && clipInstance->clip->section == 255) {
+		if ((clipInstance->clip != nullptr) && clipInstance->clip->section == 255) {
 			return;
 		}
 
@@ -2481,7 +2481,7 @@ void ArrangerView::selectEncoderAction(int8_t offset) {
 		}
 
 		// Notify the arrangement that the existing clip will be removed
-		if (clipInstance->clip) {
+		if (clipInstance->clip != nullptr) {
 			arrangement.rowEdited(output, clipInstance->pos, clipInstance->pos + clipInstance->length,
 			                      clipInstance->clip, nullptr);
 		}
@@ -2489,7 +2489,7 @@ void ArrangerView::selectEncoderAction(int8_t offset) {
 		int32_t newLength;
 
 		// No newClip means this will become a white clip
-		if (!newClip) {
+		if (newClip == nullptr) {
 			// which will have the same length as the original clip instance
 			newLength = desiredLength;
 		}
@@ -2501,7 +2501,7 @@ void ArrangerView::selectEncoderAction(int8_t offset) {
 
 		// Make sure it's not too long
 		ClipInstance* nextClipInstance = output->clipInstances.getElement(pressedClipInstanceIndex + 1);
-		if (nextClipInstance) {
+		if (nextClipInstance != nullptr) {
 			int32_t maxLength = nextClipInstance->pos - clipInstance->pos;
 
 			if (newLength > maxLength) {
@@ -2529,9 +2529,9 @@ void ArrangerView::selectEncoderAction(int8_t offset) {
 
 	else if (currentUIMode == UI_MODE_NONE) {
 
-		if (playbackHandler.playbackState) {
+		if (playbackHandler.playbackState != 0u) {
 			if (currentPlaybackMode == &session) {
-				if (session.launchEventAtSwungTickCount && session.switchToArrangementAtLaunchEvent) {
+				if ((session.launchEventAtSwungTickCount != 0) && session.switchToArrangementAtLaunchEvent) {
 					sessionView.editNumRepeatsTilLaunch(offset);
 				}
 			}
@@ -2586,7 +2586,7 @@ void ArrangerView::changeOutputType(OutputType newOutputType) {
 	endAudition(oldInstrument);
 
 	Instrument* newInstrument = currentSong->changeOutputType(oldInstrument, newOutputType);
-	if (!newInstrument) {
+	if (newInstrument == nullptr) {
 		return;
 	}
 
@@ -2609,7 +2609,7 @@ void ArrangerView::changeOutputToAudio() {
 		return;
 	}
 
-	if (oldOutput->clipInstances.getNumElements()) {
+	if (oldOutput->clipInstances.getNumElements() != 0) {
 cant:
 		display->displayPopup(deluge::l10n::get(
 		    deluge::l10n::String::STRING_FOR_INSTRUMENTS_WITH_CLIPS_CANT_BE_TURNED_INTO_AUDIO_TRACKS));
@@ -2618,11 +2618,11 @@ cant:
 
 	InstrumentClip* instrumentClip = (InstrumentClip*)currentSong->getClipWithOutput(oldOutput);
 
-	if (instrumentClip) {
+	if (instrumentClip != nullptr) {
 		if (instrumentClip->containsAnyNotes()) {
 			goto cant;
 		}
-		if (currentSong->getClipWithOutput(oldOutput, false, instrumentClip)) {
+		if (currentSong->getClipWithOutput(oldOutput, false, instrumentClip) != nullptr) {
 			goto cant; // Make sure not more than 1 Clip
 		}
 
@@ -2638,14 +2638,14 @@ cant:
 	Clip* newClip = nullptr;
 
 	// If the old Output had a Clip that we're going to replace too...
-	if (instrumentClip) {
+	if (instrumentClip != nullptr) {
 		int32_t clipIndex = currentSong->sessionClips.getIndexForClip(instrumentClip);
 		if (ALPHA_OR_BETA_VERSION && clipIndex == -1) {
 			FREEZE_WITH_ERROR("E266");
 		}
 		newClip = currentSong->replaceInstrumentClipWithAudioClip(instrumentClip, clipIndex);
 
-		if (!newClip) {
+		if (newClip == nullptr) {
 			display->displayError(Error::INSUFFICIENT_RAM);
 			return;
 		}
@@ -2659,7 +2659,7 @@ cant:
 
 		// Suss output
 		newOutput = currentSong->createNewAudioOutput(oldOutput);
-		if (!newOutput) {
+		if (newOutput == nullptr) {
 			display->displayError(Error::INSUFFICIENT_RAM);
 			return;
 		}
@@ -2759,7 +2759,7 @@ ActionResult ArrangerView::horizontalEncoderAction(int32_t offset) {
 
 				Action* action = actionLogger.getNewAction(actionType, ActionAddition::ALLOWED);
 
-				if (action
+				if ((action != nullptr)
 				    && (action->xScrollArranger[BEFORE] != currentSong->xScroll[NAVIGATION_ARRANGEMENT]
 				        || action->xZoomArranger[BEFORE] != currentSong->xZoom[NAVIGATION_ARRANGEMENT])) {
 					action = actionLogger.getNewAction(actionType, ActionAddition::NOT_ALLOWED);
@@ -2779,7 +2779,7 @@ ActionResult ArrangerView::horizontalEncoderAction(int32_t offset) {
 					if (offset >= 0) {
 						void* consMemory =
 						    GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceArrangerParamsTimeInserted));
-						if (consMemory) {
+						if (consMemory != nullptr) {
 							ConsequenceArrangerParamsTimeInserted* consequence = new (consMemory)
 							    ConsequenceArrangerParamsTimeInserted(currentSong->xScroll[NAVIGATION_ARRANGEMENT],
 							                                          scrollAmount);
@@ -2789,7 +2789,7 @@ ActionResult ArrangerView::horizontalEncoderAction(int32_t offset) {
 						                            currentSong->xScroll[NAVIGATION_ARRANGEMENT], scrollAmount);
 					}
 					else {
-						if (action) {
+						if (action != nullptr) {
 							unpatchedParams->backUpAllAutomatedParamsToAction(action, modelStackWithUnpatchedParams);
 						}
 						unpatchedParams->deleteTime(modelStackWithUnpatchedParams,
@@ -2797,7 +2797,7 @@ ActionResult ArrangerView::horizontalEncoderAction(int32_t offset) {
 					}
 				}
 
-				for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
+				for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
 					int32_t i = thisOutput->clipInstances.search(currentSong->xScroll[NAVIGATION_ARRANGEMENT],
 					                                             GREATER_OR_EQUAL);
 
@@ -3073,9 +3073,9 @@ void ArrangerView::graphicsRoutine() {
 	if (currentUIMode == UI_MODE_NONE) {
 		int32_t modKnobMode = -1;
 		bool editingComp = false;
-		if (view.activeModControllableModelStack.modControllable) {
+		if (view.activeModControllableModelStack.modControllable != nullptr) {
 			uint8_t* modKnobModePointer = view.activeModControllableModelStack.modControllable->getModKnobMode();
-			if (modKnobModePointer) {
+			if (modKnobModePointer != nullptr) {
 				modKnobMode = *modKnobModePointer;
 				editingComp = view.activeModControllableModelStack.modControllable->isEditingComp();
 			}
@@ -3104,7 +3104,7 @@ void ArrangerView::graphicsRoutine() {
 		int32_t newTickSquare;
 
 		if (!arrangement.hasPlaybackActive() || currentUIMode == UI_MODE_EXPLODE_ANIMATION
-		    || currentUIMode == UI_MODE_IMPLODE_ANIMATION || playbackHandler.ticksLeftInCountIn) {
+		    || currentUIMode == UI_MODE_IMPLODE_ANIMATION || (playbackHandler.ticksLeftInCountIn != 0)) {
 			newTickSquare = 255;
 		}
 		else {
@@ -3156,11 +3156,11 @@ void ArrangerView::graphicsRoutine() {
 			for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 				Output* output = outputsOnScreen[yDisplay];
 				tickSquares[yDisplay] =
-				    (currentSong->getAnyOutputsSoloingInArrangement() && (!output || !output->soloingInArrangementMode))
+				    (currentSong->getAnyOutputsSoloingInArrangement() && ((output == nullptr) || !output->soloingInArrangementMode))
 				        ? 255
 				        : newTickSquare;
 				colours[yDisplay] =
-				    (output && output->recordingInArrangement) ? 2 : (output && output->mutedInArrangementMode ? 1 : 0);
+				    ((output != nullptr) && output->recordingInArrangement) ? 2 : ((output != nullptr) && output->mutedInArrangementMode ? 1 : 0);
 
 				if (arrangement.hasPlaybackActive() && currentUIMode != UI_MODE_EXPLODE_ANIMATION
 				    && currentUIMode != UI_MODE_IMPLODE_ANIMATION) {
@@ -3216,7 +3216,7 @@ void ArrangerView::autoScrollOnPlaybackEnd() {
 
 		int32_t scrollDifference = newScrollPos - currentSong->xScroll[NAVIGATION_ARRANGEMENT];
 
-		if (scrollDifference) {
+		if (scrollDifference != 0) {
 
 			// If allowed to do a nice scrolling animation...
 			if (currentUIMode == UI_MODE_NONE && getCurrentUI() == this && !PadLEDs::renderingLock) {
@@ -3257,14 +3257,14 @@ bool ArrangerView::initiateXScroll(int32_t newScrollPos) {
 uint32_t ArrangerView::getMaxLength() {
 
 	uint32_t maxEndPos = 0;
-	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
+	for (Output* thisOutput = currentSong->firstOutput; thisOutput != nullptr; thisOutput = thisOutput->next) {
 
 		if (thisOutput->recordingInArrangement) {
 			maxEndPos = std::max<int32_t>(maxEndPos, arrangement.getLivePos());
 		}
 
 		int32_t numElements = thisOutput->clipInstances.getNumElements();
-		if (numElements) {
+		if (numElements != 0) {
 			ClipInstance* lastInstance = thisOutput->clipInstances.getElement(numElements - 1);
 			uint32_t endPos = lastInstance->pos + lastInstance->length;
 			maxEndPos = std::max(maxEndPos, endPos);
@@ -3298,7 +3298,7 @@ uint32_t ArrangerView::getMaxZoom() {
 void ArrangerView::tellMatrixDriverWhichRowsContainSomethingZoomable() {
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 		PadLEDs::transitionTakingPlaceOnRow[yDisplay] =
-		    (outputsOnScreen[yDisplay] && outputsOnScreen[yDisplay]->clipInstances.getNumElements());
+		    ((outputsOnScreen[yDisplay] != nullptr) && (outputsOnScreen[yDisplay]->clipInstances.getNumElements() != 0));
 	}
 }
 
@@ -3319,7 +3319,7 @@ bool ArrangerView::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 		*cols = 0xFFFFFFFD;
 		*rows = 0;
 		for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-			if (outputsOnScreen[yDisplay] && !outputsOnScreen[yDisplay]->armedForRecording) {
+			if ((outputsOnScreen[yDisplay] != nullptr) && !outputsOnScreen[yDisplay]->armedForRecording) {
 				*rows |= (1 << yDisplay);
 			}
 		}
@@ -3366,7 +3366,7 @@ void ArrangerView::clipNeedsReRendering(Clip* clip) {
 Clip* ArrangerView::getClipForSelection() {
 	Clip* clip = nullptr;
 	// if you're in arranger view, check if you're pressing a clip or holding audition pad to control that clip
-	if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW) && lastInteractedClipInstance) {
+	if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW) && (lastInteractedClipInstance != nullptr)) {
 		clip = lastInteractedClipInstance->clip;
 	}
 	else if (isUIModeActive(UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION)) {

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -779,7 +779,8 @@ ActionResult AudioClipView::editClipLengthWithoutTimestretching(int32_t offset) 
 }
 
 ActionResult AudioClipView::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	if ((currentUIMode == 0u) && Buttons::isShiftButtonPressed() && !Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
+	if ((currentUIMode == 0u) && Buttons::isShiftButtonPressed()
+	    && !Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
 		if (inCardRoutine && !allowSomeUserActionsEvenWhenInCardRoutine) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE; // Allow sometimes.
 		}

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -739,7 +739,8 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 		// you're not in a kit where you haven't selected a drum and you haven't selected affect entire either
 		// you're not in a kit where no sound drum has been selected and you're not editing velocity
 		// you're in a kit where midi or CV sound drum has been selected and you're editing velocity
-		if (onArrangerView || !(outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
+		if (onArrangerView
+		    || !(outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
 			bool isMIDICVDrum = false;
 			if (outputType == OutputType::KIT && !getAffectEntire()) {
 				isMIDICVDrum = ((((Kit*)output)->selectedDrum != nullptr)
@@ -1268,7 +1269,8 @@ void AutomationView::renderAutomationOverviewDisplayOLED(deluge::hid::display::o
 
 	// display Automation Overview
 	char const* overviewText;
-	if (!onArrangerView && (outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
+	if (!onArrangerView
+	    && (outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
 		overviewText = l10n::get(l10n::String::STRING_FOR_SELECT_A_ROW_OR_AFFECT_ENTIRE);
 		deluge::hid::display::OLED::drawPermanentPopupLookingText(overviewText);
 	}
@@ -1456,7 +1458,8 @@ void AutomationView::renderDisplay7SEG(Clip* clip, Output* output, OutputType ou
 
 void AutomationView::renderAutomationOverviewDisplay7SEG(Output* output, OutputType outputType) {
 	char const* overviewText;
-	if (!onArrangerView && (outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
+	if (!onArrangerView
+	    && (outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
 		overviewText = l10n::get(l10n::String::STRING_FOR_SELECT_A_ROW_OR_AFFECT_ENTIRE);
 	}
 	else {
@@ -1509,8 +1512,8 @@ void AutomationView::renderAutomationEditorDisplay7SEG(Clip* clip, OutputType ou
 		}
 	}
 
-	bool isAutomated =
-	    (modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr) && modelStackWithParam->autoParam->isAutomated();
+	bool isAutomated = (modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)
+	                   && modelStackWithParam->autoParam->isAutomated();
 	bool playbackStarted = playbackHandler.isEitherClockActive();
 
 	// display parameter value if knobPos is provided
@@ -2457,7 +2460,8 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 				// make sure the context is valid for selecting a parameter
 				// can't select a parameter in a kit if you haven't selected a drum
 				if (onArrangerView
-				    || !(outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))
+				    || !(outputType == OutputType::KIT && !getAffectEntire()
+				         && (((Kit*)output)->selectedDrum == nullptr))
 				    || (outputType == OutputType::KIT && getAffectEntire())) {
 
 					handleParameterSelection(clip, output, outputType, x, y);

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -441,7 +441,7 @@ void AutomationView::initializeView() {
 
 	if (!onArrangerView) {
 		// only applies to instrument clips (not audio)
-		if (clip) {
+		if (clip != nullptr) {
 			// check if we for some reason, left the automation view, then switched clip types, then came back in
 			// if you did that...reset the parameter selection and save the current parameter type selection
 			// so we can check this again next time it happens
@@ -505,10 +505,10 @@ void AutomationView::focusRegained() {
 			if (clip->lastSelectedParamKind == params::Kind::PATCH_CABLE) {
 				bool patchCableExists = false;
 				ParamManagerForTimeline* paramManager = clip->getCurrentParamManager();
-				if (paramManager) {
+				if (paramManager != nullptr) {
 					PatchCableSet* set = paramManager->getPatchCableSetAllowJibberish();
 					// make sure it's not jiberish
-					if (set) {
+					if (set != nullptr) {
 						PatchSource s;
 						ParamDescriptor destinationParamDescriptor;
 						set->dissectParamId(clip->lastSelectedParamID, &destinationParamDescriptor, &s);
@@ -625,7 +625,7 @@ AutomationSubType AutomationView::getAutomationSubType() {
 // rendering
 bool AutomationView::possiblyRefreshAutomationEditorGrid(Clip* clip, params::Kind paramKind, int32_t paramID) {
 	bool doRefreshGrid = false;
-	if (clip && !automationView.onArrangerView) {
+	if ((clip != nullptr) && !automationView.onArrangerView) {
 		if ((clip->lastSelectedParamID == paramID) && (clip->lastSelectedParamKind == paramKind)) {
 			doRefreshGrid = true;
 		}
@@ -648,11 +648,11 @@ bool AutomationView::possiblyRefreshAutomationEditorGrid(Clip* clip, params::Kin
 bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                     uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
 
-	if (!image) {
+	if (image == nullptr) {
 		return true;
 	}
 
-	if (!occupancyMask) {
+	if (occupancyMask == nullptr) {
 		return true;
 	}
 
@@ -709,7 +709,7 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 			                            ->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
 			                                                 modelStackWithTimelineCounter); // don't create
 			effectiveLength = modelStackWithNoteRow->getLoopLength();
-			if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+			if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 				NoteRow* noteRow = modelStackWithNoteRow->getNoteRow();
 				noteRow->getRowSquareInfo(effectiveLength, rowSquareInfo);
 			}
@@ -727,7 +727,7 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 	// get the param Kind and param bipolar status
 	// so that it can be passed through the automation editor rendering
 	// calls below
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		kind = modelStackWithParam->paramCollection->getParamKind();
 		isBipolar = isParamBipolar(kind, modelStackWithParam->paramId);
 	}
@@ -739,10 +739,10 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 		// you're not in a kit where you haven't selected a drum and you haven't selected affect entire either
 		// you're not in a kit where no sound drum has been selected and you're not editing velocity
 		// you're in a kit where midi or CV sound drum has been selected and you're editing velocity
-		if (onArrangerView || !(outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum)) {
+		if (onArrangerView || !(outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
 			bool isMIDICVDrum = false;
 			if (outputType == OutputType::KIT && !getAffectEntire()) {
-				isMIDICVDrum = (((Kit*)output)->selectedDrum
+				isMIDICVDrum = ((((Kit*)output)->selectedDrum != nullptr)
 				                && ((((Kit*)output)->selectedDrum->type == DrumType::MIDI)
 				                    || (((Kit*)output)->selectedDrum->type == DrumType::GATE)));
 			}
@@ -858,7 +858,7 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 				}
 			}
 
-			if (modelStackWithParam && modelStackWithParam->autoParam) {
+			if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 				// highlight pad white if the parameter it represents is currently automated
 				if (modelStackWithParam->autoParam->isAutomated()) {
 					pixel = {
@@ -900,7 +900,7 @@ void AutomationView::renderAutomationEditor(ModelStackWithAutoParam* modelStackW
                                             uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
                                             int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
                                             bool drawUndefinedArea, params::Kind kind, bool isBipolar) {
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		renderAutomationColumn(modelStackWithParam, image, occupancyMask, effectiveLength, xDisplay,
 		                       modelStackWithParam->autoParam->isAutomated(), xScroll, xZoom, kind, isBipolar);
 	}
@@ -1027,7 +1027,7 @@ void AutomationView::renderAutomationUnipolarSquare(RGB image[][kDisplayWidth + 
 
 	// determine whether or not you should render a row based on current value
 	bool doRender = false;
-	if (knobPos) {
+	if (knobPos != 0) {
 		doRender = (knobPos >= nonPatchCableMinPadDisplayValues[yDisplay]);
 	}
 
@@ -1064,7 +1064,7 @@ void AutomationView::renderNoteEditor(ModelStackWithNoteRow* modelStackWithNoteR
                                       uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
                                       int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
                                       bool drawUndefinedArea, SquareInfo& squareInfo) {
-	if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+	if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 		renderNoteColumn(modelStackWithNoteRow, clip, image, occupancyMask, xDisplay, xScroll, xZoom, squareInfo);
 	}
 	if (drawUndefinedArea) {
@@ -1156,7 +1156,7 @@ void AutomationView::renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_
 			if (!timelineView->isSquareDefined(xDisplay, xScroll, xZoom)) {
 				image[yDisplay][xDisplay] = colours::grey;
 
-				if (occupancyMask) {
+				if (occupancyMask != nullptr) {
 					occupancyMask[yDisplay][xDisplay] = 64;
 				}
 			}
@@ -1268,7 +1268,7 @@ void AutomationView::renderAutomationOverviewDisplayOLED(deluge::hid::display::o
 
 	// display Automation Overview
 	char const* overviewText;
-	if (!onArrangerView && (outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum)) {
+	if (!onArrangerView && (outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
 		overviewText = l10n::get(l10n::String::STRING_FOR_SELECT_A_ROW_OR_AFFECT_ENTIRE);
 		deluge::hid::display::OLED::drawPermanentPopupLookingText(overviewText);
 	}
@@ -1314,7 +1314,7 @@ void AutomationView::renderAutomationEditorDisplayOLED(deluge::hid::display::ole
 
 	// check if Parameter is currently automated so that the automation status can be drawn on
 	// the screen with the Parameter Name
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		if (modelStackWithParam->autoParam->isAutomated()) {
 			isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_ON);
 		}
@@ -1375,7 +1375,7 @@ void AutomationView::renderNoteEditorDisplayOLED(deluge::hid::display::oled_canv
 
 	ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
 	                                                                        modelStack); // don't create
-	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+	if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 		if (!isKit) {
 			modelStackWithNoteRow =
 			    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
@@ -1384,7 +1384,7 @@ void AutomationView::renderNoteEditorDisplayOLED(deluge::hid::display::oled_canv
 
 	char noteRowName[50];
 
-	if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+	if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 		if (isKit) {
 			DEF_STACK_STRING_BUF(drumName, 50);
 			instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
@@ -1456,7 +1456,7 @@ void AutomationView::renderDisplay7SEG(Clip* clip, Output* output, OutputType ou
 
 void AutomationView::renderAutomationOverviewDisplay7SEG(Output* output, OutputType outputType) {
 	char const* overviewText;
-	if (!onArrangerView && (outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum)) {
+	if (!onArrangerView && (outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))) {
 		overviewText = l10n::get(l10n::String::STRING_FOR_SELECT_A_ROW_OR_AFFECT_ENTIRE);
 	}
 	else {
@@ -1510,7 +1510,7 @@ void AutomationView::renderAutomationEditorDisplay7SEG(Clip* clip, OutputType ou
 	}
 
 	bool isAutomated =
-	    modelStackWithParam && modelStackWithParam->autoParam && modelStackWithParam->autoParam->isAutomated();
+	    (modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr) && modelStackWithParam->autoParam->isAutomated();
 	bool playbackStarted = playbackHandler.isEitherClockActive();
 
 	// display parameter value if knobPos is provided
@@ -1549,7 +1549,7 @@ void AutomationView::renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputTyp
 
 	ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
 	                                                                        modelStack); // don't create
-	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+	if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 		if (!isKit) {
 			modelStackWithNoteRow =
 			    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
@@ -1564,7 +1564,7 @@ void AutomationView::renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputTyp
 	else {
 		// display note / drum name
 		char noteRowName[50];
-		if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+		if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 			if (isKit) {
 				DEF_STACK_STRING_BUF(drumName, 50);
 				instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
@@ -1703,7 +1703,7 @@ void AutomationView::displayAutomation(bool padSelected, bool updateDisplay) {
 			modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
 		}
 
-		if (modelStackWithParam && modelStackWithParam->autoParam) {
+		if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 
 			if (modelStackWithParam->getTimelineCounter()
 			    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
@@ -1978,7 +1978,7 @@ void AutomationView::handleCrossScreenButtonAction(bool on) {
 			}
 			else {
 				InstrumentClip* clip = getCurrentInstrumentClip();
-				if (clip) {
+				if (clip != nullptr) {
 					if (clip->wrapEditing) {
 						clip->wrapEditing = false;
 					}
@@ -2203,7 +2203,7 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 			modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
 		}
 
-		if (modelStackWithParam && modelStackWithParam->autoParam) {
+		if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 			Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE);
 			modelStackWithParam->autoParam->deleteAutomation(action, modelStackWithParam);
 
@@ -2223,7 +2223,7 @@ bool AutomationView::handleBackAndHorizontalEncoderButtonComboAction(Clip* clip,
 		ModelStackWithNoteRow* modelStackWithNoteRow =
 		    ((InstrumentClip*)clip)->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay, modelStack);
 
-		if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+		if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 			NoteRow* noteRow = modelStackWithNoteRow->getNoteRow();
 			// don't clear automation, do clear notes and mpe
 			noteRow->clear(action, modelStackWithNoteRow, false, true);
@@ -2338,7 +2338,7 @@ ActionResult AutomationView::padAction(int32_t x, int32_t y, int32_t velocity) {
 			                            ->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
 			                                                 modelStackWithTimelineCounter); // don't create
 			// does note row exist?
-			if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+			if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 				// if you're in note editor and note row doesn't exist, create it
 				// don't create note rows that don't exist in kits because those are empty kit rows
 				if (outputType != OutputType::KIT) {
@@ -2347,7 +2347,7 @@ ActionResult AutomationView::padAction(int32_t x, int32_t y, int32_t velocity) {
 				}
 			}
 
-			if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+			if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 				effectiveLength = modelStackWithNoteRow->getLoopLength();
 				noteRow = modelStackWithNoteRow->getNoteRow();
 				noteRow->getSquareInfo(x, effectiveLength, squareInfo);
@@ -2408,7 +2408,7 @@ ActionResult AutomationView::handleEditPadAction(ModelStackWithAutoParam* modelS
 			automationEditPadAction(modelStackWithParam, clip, x, y, velocity, effectiveLength, xScroll, xZoom);
 		}
 		else if (inNoteEditor()) {
-			if (noteRow) {
+			if (noteRow != nullptr) {
 				noteEditPadAction(modelStackWithNoteRow, noteRow, (InstrumentClip*)clip, x, y, velocity,
 				                  effectiveLength, squareInfo);
 			}
@@ -2425,7 +2425,7 @@ ActionResult AutomationView::handleEditPadAction(ModelStackWithAutoParam* modelS
 bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, Output* output,
                                        OutputType outputType, int32_t effectiveLength, int32_t x, int32_t y,
                                        int32_t velocity, int32_t xScroll, int32_t xZoom, SquareInfo& squareInfo) {
-	if (velocity) {
+	if (velocity != 0) {
 		bool shortcutPress = false;
 		if (Buttons::isShiftButtonPressed()
 		    || (isUIModeActive(UI_MODE_AUDITIONING) && !FlashStorage::automationDisableAuditionPadShortcuts)) {
@@ -2457,7 +2457,7 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 				// make sure the context is valid for selecting a parameter
 				// can't select a parameter in a kit if you haven't selected a drum
 				if (onArrangerView
-				    || !(outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum)
+				    || !(outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum == nullptr))
 				    || (outputType == OutputType::KIT && getAffectEntire())) {
 
 					handleParameterSelection(clip, output, outputType, x, y);
@@ -2589,7 +2589,7 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	// potentially select a regular automatable parameter
 	else if (!onArrangerView
 	         && (outputType == OutputType::SYNTH
-	             || (outputType == OutputType::KIT && !getAffectEntire() && ((Kit*)output)->selectedDrum
+	             || (outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum != nullptr)
 	                 && ((Kit*)output)->selectedDrum->type == DrumType::SOUND))
 	         && ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
 	             || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
@@ -2658,7 +2658,7 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	// expression params, so sounds or midi/cv, or a single drum
 	else if ((util::one_of(outputType, {OutputType::MIDI_OUT, OutputType::CV, OutputType::SYNTH})
 	          // selected a single sound drum
-	          || ((outputType == OutputType::KIT && !getAffectEntire() && ((Kit*)output)->selectedDrum
+	          || ((outputType == OutputType::KIT && !getAffectEntire() && (((Kit*)output)->selectedDrum != nullptr)
 	               && ((Kit*)output)->selectedDrum->type == DrumType::SOUND)))
 	         && params::expressionParamFromShortcut(xDisplay, yDisplay) != kNoParamID) {
 		clip->lastSelectedParamID = params::expressionParamFromShortcut(xDisplay, yDisplay);
@@ -2695,7 +2695,7 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	view.setModLedStates();
 	uiNeedsRendering(this);
 	// turn off cross screen LED in automation editor
-	if (clip && clip->type == ClipType::INSTRUMENT && ((InstrumentClip*)clip)->wrapEditing) {
+	if ((clip != nullptr) && clip->type == ClipType::INSTRUMENT && ((InstrumentClip*)clip)->wrapEditing) {
 		indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
 	}
 }
@@ -2720,7 +2720,7 @@ void AutomationView::noteEditPadAction(ModelStackWithNoteRow* modelStackWithNote
 void AutomationView::velocityPadSelectionAction(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
                                                 int32_t x, int32_t y, int32_t velocity, SquareInfo& squareInfo) {
 
-	if (velocity) {
+	if (velocity != 0) {
 		// if selection has changed and note was previously selected, release previous press
 		// if we recorded the previous pad that was pressed
 		if (leftPadSelectedX != kNoSelection && isUIModeActive(UI_MODE_NOTES_PRESSED)) {
@@ -2778,7 +2778,7 @@ void AutomationView::velocityEditPadAction(ModelStackWithNoteRow* modelStackWith
 	bool showNewVelocity = true;
 
 	// check for middle or multi pad press
-	if (velocity && squareInfo.numNotes != 0 && instrumentClipView.numEditPadPresses == 1) {
+	if ((velocity != 0) && squareInfo.numNotes != 0 && instrumentClipView.numEditPadPresses == 1) {
 		// Find that original press
 		for (int32_t i = 0; i < kEditPadPressBufferSize; i++) {
 			if (instrumentClipView.editPadPresses[i].isActive) {
@@ -2925,7 +2925,7 @@ void AutomationView::velocityEditPadAction(ModelStackWithNoteRow* modelStackWith
 			}
 		}
 		else {
-			if (velocity) {
+			if (velocity != 0) {
 				renderDisplay(showNewVelocity ? newVelocity : squareInfo.averageVelocity);
 			}
 			else {
@@ -2953,7 +2953,7 @@ int32_t AutomationView::getYFromVelocity(int32_t velocity) {
 
 // add note and set velocity
 void AutomationView::addNoteWithNewVelocity(int32_t x, int32_t velocity, int32_t newVelocity) {
-	if (velocity) {
+	if (velocity != 0) {
 		// we change the instrument default velocity because it is used for new notes
 		getCurrentInstrument()->defaultVelocity = newVelocity;
 	}
@@ -2966,7 +2966,7 @@ void AutomationView::addNoteWithNewVelocity(int32_t x, int32_t velocity, int32_t
 // adjust velocity of existing notes
 void AutomationView::adjustNoteVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x,
                                         int32_t velocity, int32_t newVelocity, uint8_t squareType) {
-	if (velocity) {
+	if (velocity != 0) {
 		// record pad press
 		recordNoteEditPadAction(x, velocity);
 
@@ -2983,7 +2983,7 @@ void AutomationView::adjustNoteVelocity(ModelStackWithNoteRow* modelStackWithNot
 void AutomationView::setVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x,
                                  int32_t newVelocity) {
 	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
-	if (!action) {
+	if (action == nullptr) {
 		return;
 	}
 
@@ -3060,7 +3060,7 @@ void AutomationView::setVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, N
 void AutomationView::setVelocityRamp(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
                                      SquareInfo rowSquareInfo[kDisplayWidth], int32_t velocityIncrement) {
 	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
-	if (!action) {
+	if (action == nullptr) {
 		return;
 	}
 
@@ -3080,7 +3080,7 @@ void AutomationView::setVelocityRamp(ModelStackWithNoteRow* modelStackWithNoteRo
 
 				Note* note = noteRow->notes.getElement(noteI);
 
-				while (note && note->pos - intendedPos < intendedLength) {
+				while ((note != nullptr) && note->pos - intendedPos < intendedLength) {
 					int32_t intendedVelocity =
 					    std::clamp<int32_t>(startVelocity + (velocityIncrement * squaresProcessed), 1, 127);
 
@@ -3111,7 +3111,7 @@ void AutomationView::setVelocityRamp(ModelStackWithNoteRow* modelStackWithNoteRo
 
 // call instrument clip view edit pad action function to process velocity pad press actions
 void AutomationView::recordNoteEditPadAction(int32_t x, int32_t velocity) {
-	instrumentClipView.editPadAction(velocity, instrumentClipView.lastAuditionedYDisplay, x,
+	instrumentClipView.editPadAction(velocity != 0, instrumentClipView.lastAuditionedYDisplay, x,
 	                                 currentSong->xZoom[NAVIGATION_CLIP]);
 }
 
@@ -3125,7 +3125,7 @@ void AutomationView::automationEditPadAction(ModelStackWithAutoParam* modelStack
 		selectedPadPressed = velocity;
 	}
 	// If button down
-	if (velocity) {
+	if (velocity != 0) {
 		// If this is a automation-length-edit press...
 		// needed for Automation
 		if (instrumentClipView.numEditPadPresses == 1) {
@@ -3290,12 +3290,12 @@ ActionResult AutomationView::handleMutePadAction(ModelStackWithTimelineCounter* 
 				return ActionResult::DEALT_WITH;
 			}
 			NoteRow* noteRow = instrumentClip->getNoteRowOnScreen(y, currentSong);
-			if (!noteRow || !noteRow->drum) {
+			if ((noteRow == nullptr) || (noteRow->drum == nullptr)) {
 				return ActionResult::DEALT_WITH;
 			}
-			view.noteRowMuteMidiLearnPadPressed(velocity, noteRow);
+			view.noteRowMuteMidiLearnPadPressed(velocity != 0, noteRow);
 		}
-		else if (isUIModeWithinRange(mutePadActionUIModes) && velocity) {
+		else if (isUIModeWithinRange(mutePadActionUIModes) && (velocity != 0)) {
 			if (inAutomationEditor()) {
 				ModelStackWithNoteRow* modelStackWithNoteRow =
 				    instrumentClip->getNoteRowOnScreen(y, modelStackWithTimelineCounter);
@@ -3304,7 +3304,7 @@ ActionResult AutomationView::handleMutePadAction(ModelStackWithTimelineCounter* 
 				// check if it's a mute pad corresponding to the current selected drum
 				// if not, change the drum selection, refresh parameter selection and go back to automation overview
 				if (outputType == OutputType::KIT) {
-					if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+					if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 						Drum* drum = modelStackWithNoteRow->getNoteRow()->drum;
 						if (((Kit*)output)->selectedDrum != drum) {
 							if (!getAffectEntire()) {
@@ -3335,10 +3335,10 @@ ActionResult AutomationView::handleAuditionPadAction(InstrumentClip* instrumentC
 			if (getCurrentUI() == this) {
 				if (outputType == OutputType::KIT) {
 					NoteRow* thisNoteRow = instrumentClip->getNoteRowOnScreen(y, currentSong);
-					if (!thisNoteRow || !thisNoteRow->drum) {
+					if ((thisNoteRow == nullptr) || (thisNoteRow->drum == nullptr)) {
 						return ActionResult::DEALT_WITH;
 					}
-					view.drumMidiLearnPadPressed(velocity, thisNoteRow->drum, (Kit*)output);
+					view.drumMidiLearnPadPressed(velocity != 0, thisNoteRow->drum, (Kit*)output);
 				}
 				else {
 					view.instrumentMidiLearnPadPressed(velocity, (MelodicInstrument*)output);
@@ -3347,7 +3347,7 @@ ActionResult AutomationView::handleAuditionPadAction(InstrumentClip* instrumentC
 		}
 
 		// Actual basic audition pad press:
-		else if (!velocity || isUIModeWithinRange(auditionPadActionUIModes)) {
+		else if ((velocity == 0) || isUIModeWithinRange(auditionPadActionUIModes)) {
 			/* 	special handling of audition pad action for note editing mode:
 
 			    when we're in note editor mode, pressing audition pad changes note row selection
@@ -3391,7 +3391,7 @@ ActionResult AutomationView::handleAuditionPadAction(InstrumentClip* instrumentC
 // audition pad action
 // not used with Audio Clip Automation View or Arranger Automation View
 void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool shiftButtonDown) {
-	if (instrumentClipView.editedAnyPerNoteRowStuffSinceAuditioningBegan && !velocity) {
+	if (instrumentClipView.editedAnyPerNoteRowStuffSinceAuditioningBegan && (velocity == 0)) {
 		// in case we were editing quantize/humanize
 		actionLogger.closeAction(ActionType::NOTE_NUDGE);
 	}
@@ -3426,7 +3426,7 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 		// also check that you're not in affect entire mode
 		// if not, change the drum selection, refresh parameter selection and go back to automation
 		// overview
-		if (modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull()) {
+		if (modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull() != nullptr) {
 			drum = modelStackWithNoteRowOnCurrentClip->getNoteRow()->drum;
 			Drum* selectedDrum = ((Kit*)output)->selectedDrum;
 			if (selectedDrum != drum) {
@@ -3442,7 +3442,7 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 
 	// Or if synth
 	else if (outputType == OutputType::SYNTH) {
-		if (velocity) {
+		if (velocity != 0) {
 			if (getCurrentUI() == &soundEditor && soundEditor.getCurrentMenuItem() == &menu_item::multiRangeMenu) {
 				menu_item::multiRangeMenu.noteOnToChangeRange(clip->getYNoteFromYDisplay(yDisplay, currentSong)
 				                                              + ((SoundInstrument*)output)->transpose);
@@ -3454,14 +3454,14 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 	if (clipIsActiveOnInstrument && playbackHandler.shouldRecordNotesNow() && currentSong->isClipActive(clip)) {
 
 		// Note-on
-		if (velocity) {
+		if (velocity != 0) {
 
 			// If count-in is on, we only got here if it's very nearly finished, so pre-empt that note.
 			// This is basic. For MIDI input, we do this in a couple more cases - see
 			// noteMessageReceived() in MelodicInstrument and Kit
 			if (isUIModeActive(UI_MODE_RECORD_COUNT_IN)) {
 				if (isKit) {
-					if (drum) {
+					if (drum != nullptr) {
 						drum->recordNoteOnEarly(
 						    (velocity == USE_DEFAULT_VELOCITY) ? ((Instrument*)output)->defaultVelocity : velocity,
 						    clip->allowNoteTails(modelStackWithNoteRowOnCurrentClip));
@@ -3481,13 +3481,13 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 			else {
 
 				// May need to create NoteRow if there wasn't one previously
-				if (!modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull()) {
+				if (modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull() == nullptr) {
 
 					modelStackWithNoteRowOnCurrentClip =
 					    instrumentClipView.createNoteRowForYDisplay(modelStackWithTimelineCounter, yDisplay);
 				}
 
-				if (modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull()) {
+				if (modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull() != nullptr) {
 					clip->recordNoteOn(modelStackWithNoteRowOnCurrentClip, (velocity == USE_DEFAULT_VELOCITY)
 					                                                           ? ((Instrument*)output)->defaultVelocity
 					                                                           : velocity);
@@ -3498,7 +3498,7 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 		// Note-off
 		else {
 
-			if (modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull()) {
+			if (modelStackWithNoteRowOnCurrentClip->getNoteRowAllowNull() != nullptr) {
 				clip->recordNoteOff(modelStackWithNoteRowOnCurrentClip);
 			}
 		}
@@ -3525,7 +3525,7 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 		}
 
 		// If note on...
-		if (velocity) {
+		if (velocity != 0) {
 			int32_t velocityToSound = velocity;
 			if (velocityToSound == USE_DEFAULT_VELOCITY) {
 				velocityToSound = ((Instrument*)output)->defaultVelocity;
@@ -3534,7 +3534,7 @@ void AutomationView::auditionPadAction(int32_t velocity, int32_t yDisplay, bool 
 			// Yup, need to do this even if we're going to do a "silent" audition, so pad lights up etc.
 			instrumentClipView.auditionPadIsPressed[yDisplay] = velocityToSound;
 
-			if (noteRowOnActiveClip) {
+			if (noteRowOnActiveClip != nullptr) {
 				// Ensure our auditioning doesn't override a note playing in the sequence
 				if (playbackHandler.isEitherClockActive()
 				    && noteRowOnActiveClip->soundingStatus == STATUS_SEQUENCED_NOTE) {
@@ -3597,13 +3597,13 @@ doSilentAudition:
 
 		// Or if auditioning this NoteRow just finished...
 		else {
-			if (instrumentClipView.auditionPadIsPressed[yDisplay]) {
+			if (instrumentClipView.auditionPadIsPressed[yDisplay] != 0u) {
 				instrumentClipView.auditionPadIsPressed[yDisplay] = 0;
 				instrumentClipView.lastAuditionedVelocityOnScreen[yDisplay] = 255;
 
 				// Stop the note sounding - but only if a sequenced note isn't in fact being played here.
 				// Or if it's drone note, end auditioning to transfer the note's sustain to the sequencer
-				if (!noteRowOnActiveClip || noteRowOnActiveClip->soundingStatus == STATUS_OFF
+				if ((noteRowOnActiveClip == nullptr) || noteRowOnActiveClip->soundingStatus == STATUS_OFF
 				    || noteRowOnActiveClip->isDroning(modelStackWithNoteRowOnCurrentClip->getLoopLength())) {
 					instrumentClipView.sendAuditionNote(false, yDisplay, 64, 0);
 				}
@@ -3647,7 +3647,7 @@ getOut:
 	}
 
 	// This has to happen after instrumentClipView.setSelectedDrum is called, cos that resets LEDs
-	if (!clipIsActiveOnInstrument && velocity) {
+	if (!clipIsActiveOnInstrument && (velocity != 0)) {
 		indicator_leds::indicateAlertOnLed(IndicatorLED::SESSION_VIEW);
 	}
 }
@@ -3783,7 +3783,7 @@ ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 // feature i disabled automation shifting in the regular instrument clip view
 void AutomationView::shiftAutomationHorizontally(ModelStackWithAutoParam* modelStackWithParam, int32_t offset,
                                                  int32_t effectiveLength) {
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		modelStackWithParam->autoParam->shiftHorizontally(offset, effectiveLength);
 	}
 
@@ -3832,7 +3832,7 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 				ModelStackWithNoteRow* modelStackWithNoteRow =
 				    clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
 				                             modelStack); // don't create
-				if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+				if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 					if (clip->output->type != OutputType::KIT) {
 						modelStackWithNoteRow = instrumentClipView.createNoteRowForYDisplay(
 						    modelStack, instrumentClipView.lastAuditionedYDisplay);
@@ -3846,7 +3846,7 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 			}
 		}
 		// If user not wanting to move a noteCode, they want to transpose the key
-		else if (!currentUIMode && outputType != OutputType::KIT) {
+		else if ((currentUIMode == 0u) && outputType != OutputType::KIT) {
 			actionLogger.deleteAllLogs();
 
 			auto nudgeType = Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE;
@@ -3873,12 +3873,12 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 				}
 
 				for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-					if (instrumentClipView.auditionPadIsPressed[yDisplay]) {
+					if (instrumentClipView.auditionPadIsPressed[yDisplay] != 0u) {
 						ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(yDisplay, modelStack);
 						NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
 						// This is fine. If we were in Kit mode, we could only be auditioning if there
 						// was a NoteRow already
-						if (noteRow) {
+						if (noteRow != nullptr) {
 							noteRow->colourOffset += offset;
 							if (noteRow->colourOffset >= 72) {
 								noteRow->colourOffset -= 72;
@@ -3902,7 +3902,7 @@ shiftAllColour:
 			whichRowsToRender = 0xFFFFFFFF;
 		}
 
-		if (whichRowsToRender) {
+		if (whichRowsToRender != 0u) {
 			uiNeedsRendering(this, whichRowsToRender, whichRowsToRender);
 		}
 	}
@@ -3932,7 +3932,7 @@ shiftAllColour:
 						    ((InstrumentClip*)clip)
 						        ->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
 						                             modelStack); // don't create
-						if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+						if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 							NoteRow* noteRow = modelStackWithNoteRow->getNoteRow();
 							int32_t effectiveLength = modelStackWithNoteRow->getLoopLength();
 							SquareInfo squareInfo;
@@ -3961,9 +3961,9 @@ shiftAllColour:
 void AutomationView::potentiallyVerticalScrollToSelectedDrum(InstrumentClip* clip, Output* output) {
 	int32_t noteRowIndex;
 	Drum* selectedDrum = ((Kit*)output)->selectedDrum;
-	if (selectedDrum) {
+	if (selectedDrum != nullptr) {
 		NoteRow* noteRow = clip->getNoteRowForDrum(selectedDrum, &noteRowIndex);
-		if (noteRow) {
+		if (noteRow != nullptr) {
 			int32_t lastAuditionedYDisplayScrolled = instrumentClipView.lastAuditionedYDisplay + clip->yScroll;
 			if (noteRowIndex != lastAuditionedYDisplayScrolled) {
 				int32_t yScrollAdjustment = noteRowIndex - lastAuditionedYDisplayScrolled;
@@ -4006,13 +4006,13 @@ ActionResult AutomationView::scrollVertical(int32_t scrollAmount) {
 			ModelStackWithNoteRow* modelStackWithNoteRow =
 			    clip->getNoteRowOnScreen(lastAuditionedYDisplayScrolled, modelStack);
 			// over-scrolled, no valid note row, so return and don't do the actual scrolling
-			if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+			if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 				return ActionResult::DEALT_WITH;
 			}
 			// we have a valid note row, so let's set selected drum equal to previous auditioned y display
 			else {
 				NoteRow* noteRow = clip->getNoteRowOnScreen(lastAuditionedYDisplayScrolled, currentSong);
-				if (noteRow) {
+				if (noteRow != nullptr) {
 					instrumentClipView.setSelectedDrum(noteRow->drum, true);
 				}
 			}
@@ -4043,7 +4043,7 @@ ActionResult AutomationView::scrollVertical(int32_t scrollAmount) {
 		ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(yDisplay, modelStack);
 		NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
 
-		if (noteRow) {
+		if (noteRow != nullptr) {
 			// If recording, record a note-off for this NoteRow, if one exists
 			if (playbackHandler.shouldRecordNotesNow() && currentClipIsActive) {
 				clip->recordNoteOff(modelStackWithNoteRow);
@@ -4067,9 +4067,9 @@ ActionResult AutomationView::scrollVertical(int32_t scrollAmount) {
 			//  Check NoteRow exists, incase we've got a Kit
 			ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(yDisplay, modelStack);
 
-			if (!isKit || modelStackWithNoteRow->getNoteRowAllowNull()) {
+			if (!isKit || (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr)) {
 
-				if (modelStackWithNoteRow->getNoteRowAllowNull()
+				if ((modelStackWithNoteRow->getNoteRowAllowNull() != nullptr)
 				    && modelStackWithNoteRow->getNoteRow()->soundingStatus == STATUS_SEQUENCED_NOTE) {}
 				else {
 
@@ -4077,11 +4077,11 @@ ActionResult AutomationView::scrollVertical(int32_t scrollAmount) {
 					if (playbackHandler.shouldRecordNotesNow() && currentClipIsActive) {
 
 						// If no NoteRow existed before, try creating one
-						if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+						if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 							modelStackWithNoteRow = instrumentClipView.createNoteRowForYDisplay(modelStack, yDisplay);
 						}
 
-						if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+						if (modelStackWithNoteRow->getNoteRowAllowNull() != nullptr) {
 							clip->recordNoteOn(modelStackWithNoteRow, ((Instrument*)output)->defaultVelocity);
 						}
 					}
@@ -4092,12 +4092,12 @@ ActionResult AutomationView::scrollVertical(int32_t scrollAmount) {
 				}
 			}
 			else {
-				instrumentClipView.auditionPadIsPressed[yDisplay] = false;
+				instrumentClipView.auditionPadIsPressed[yDisplay] = 0u;
 				instrumentClipView.lastAuditionedVelocityOnScreen[yDisplay] = 255;
 				forceStoppedAnyAuditioning = true;
 			}
 			// If we're shiftingNoteRow, no need to re-draw the noteCode, because it'll be the same
-			if (!drawnNoteCodeYet && instrumentClipView.auditionPadIsPressed[yDisplay]) {
+			if (!drawnNoteCodeYet && (instrumentClipView.auditionPadIsPressed[yDisplay] != 0u)) {
 				/* if you're in the note editor:
 				    - don't draw note code because the note code is already on the display
 				    - don't update selected drum as this was done above
@@ -4108,7 +4108,7 @@ ActionResult AutomationView::scrollVertical(int32_t scrollAmount) {
 					if (isKit) {
 						Drum* newSelectedDrum = nullptr;
 						NoteRow* noteRow = clip->getNoteRowOnScreen(yDisplay, currentSong);
-						if (noteRow) {
+						if (noteRow != nullptr) {
 							newSelectedDrum = noteRow->drum;
 						}
 						instrumentClipView.setSelectedDrum(newSelectedDrum, true);
@@ -4200,7 +4200,7 @@ bool AutomationView::automationModEncoderActionForSelectedPad(ModelStackWithAuto
                                                               int32_t effectiveLength) {
 	Clip* clip = getCurrentClip();
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 
 		int32_t xDisplay = 0;
 
@@ -4290,7 +4290,7 @@ void AutomationView::automationModEncoderActionForUnselectedPad(ModelStackWithAu
                                                                 int32_t effectiveLength) {
 	Clip* clip = getCurrentClip();
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 
 		if (modelStackWithParam->getTimelineCounter()
 		    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
@@ -4388,7 +4388,7 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 
 	// delete automation of current parameter selected
 	else if (Buttons::isShiftButtonPressed() && inAutomationEditor()) {
-		if (modelStackWithParam && modelStackWithParam->autoParam) {
+		if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 			Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE);
 			modelStackWithParam->autoParam->deleteAutomation(action, modelStackWithParam);
 
@@ -4416,7 +4416,7 @@ followOnAction: // it will come here when you are on the automation overview / i
 
 void AutomationView::copyAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xScroll,
                                     int32_t xZoom) {
-	if (copiedParamAutomation.nodes) {
+	if (copiedParamAutomation.nodes != nullptr) {
 		delugeDealloc(copiedParamAutomation.nodes);
 		copiedParamAutomation.nodes = nullptr;
 		copiedParamAutomation.numNodes = 0;
@@ -4428,7 +4428,7 @@ void AutomationView::copyAutomation(ModelStackWithAutoParam* modelStackWithParam
 		return;
 	}
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 
 		bool isPatchCable = (modelStackWithParam->paramCollection
 		                     == modelStackWithParam->paramManager->getPatchCableSetAllowJibberish());
@@ -4439,7 +4439,7 @@ void AutomationView::copyAutomation(ModelStackWithAutoParam* modelStackWithParam
 		modelStackWithParam->autoParam->copy(startPos, endPos, &copiedParamAutomation, isPatchCable,
 		                                     modelStackWithParam);
 
-		if (copiedParamAutomation.nodes) {
+		if (copiedParamAutomation.nodes != nullptr) {
 			display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_COPIED));
 			return;
 		}
@@ -4450,7 +4450,7 @@ void AutomationView::copyAutomation(ModelStackWithAutoParam* modelStackWithParam
 
 void AutomationView::pasteAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t effectiveLength,
                                      int32_t xScroll, int32_t xZoom) {
-	if (!copiedParamAutomation.nodes) {
+	if (copiedParamAutomation.nodes == nullptr) {
 		display->displayPopup(l10n::get(l10n::String::STRING_FOR_NO_AUTOMATION_TO_PASTE));
 		return;
 	}
@@ -4465,10 +4465,10 @@ void AutomationView::pasteAutomation(ModelStackWithAutoParam* modelStackWithPara
 
 	float scaleFactor = (float)pastedAutomationWidth / copiedParamAutomation.width;
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_PASTE);
 
-		if (action) {
+		if (action != nullptr) {
 			action->recordParamChangeIfNotAlreadySnapshotted(modelStackWithParam, false);
 		}
 
@@ -4566,7 +4566,7 @@ void AutomationView::selectEncoderAction(int8_t offset) {
 		}
 		// if you're a synth or a kit (with affect entire off and a sound drum selected)
 		else if (outputType == OutputType::SYNTH
-		         || (outputType == OutputType::KIT && ((Kit*)output)->selectedDrum
+		         || (outputType == OutputType::KIT && (((Kit*)output)->selectedDrum != nullptr)
 		             && ((Kit*)output)->selectedDrum->type == DrumType::SOUND)) {
 			selectNonGlobalParam(offset, clip);
 		}
@@ -4717,10 +4717,10 @@ void AutomationView::selectNonGlobalParam(int32_t offset, Clip* clip) {
 // actual selecting of the patch cable is done in the selectPatchCableAtIndex function
 bool AutomationView::selectPatchCable(int32_t offset, Clip* clip) {
 	ParamManagerForTimeline* paramManager = clip->getCurrentParamManager();
-	if (paramManager) {
+	if (paramManager != nullptr) {
 		PatchCableSet* set = paramManager->getPatchCableSetAllowJibberish();
 		// make sure it's not jiberish
-		if (set) {
+		if (set != nullptr) {
 			// do we have any patch cables?
 			if (set->numPatchCables > 0) {
 				bool foundCurrentPatchCable = false;
@@ -4896,7 +4896,7 @@ void AutomationView::getLastSelectedParamArrayPosition(Clip* clip) {
 		}
 		// if you're a synth or a kit (with affect entire off and a drum selected)
 		else if (outputType == OutputType::SYNTH
-		         || (outputType == OutputType::KIT && ((Kit*)output)->selectedDrum
+		         || (outputType == OutputType::KIT && (((Kit*)output)->selectedDrum != nullptr)
 		             && ((Kit*)output)->selectedDrum->type == DrumType::SOUND)) {
 			getLastSelectedNonGlobalParamArrayPosition(clip);
 		}
@@ -5126,7 +5126,7 @@ int32_t AutomationView::getAutomationParameterKnobPos(ModelStackWithAutoParam* m
 // right node, relative to the current pos we are looking at
 bool AutomationView::getAutomationNodeInterpolation(ModelStackWithAutoParam* modelStack, int32_t pos, bool reversed) {
 
-	if (!modelStack->autoParam->nodes.getNumElements()) {
+	if (modelStack->autoParam->nodes.getNumElements() == 0) {
 		return false;
 	}
 
@@ -5248,7 +5248,7 @@ void AutomationView::updateAutomationModPosition(ModelStackWithAutoParam* modelS
                                                  bool updateDisplay, bool updateIndicatorLevels) {
 
 	if (!playbackHandler.isEitherClockActive() || padSelectionOn) {
-		if (modelStack && modelStack->autoParam) {
+		if ((modelStack != nullptr) && (modelStack->autoParam != nullptr)) {
 			if (modelStack->getTimelineCounter()
 			    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 
@@ -5318,7 +5318,7 @@ void AutomationView::handleAutomationParameterChange(ModelStackWithAutoParam* mo
 		}
 	}
 
-	else if (modelStackWithParam && modelStackWithParam->autoParam) {
+	else if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 
 		uint32_t squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
 
@@ -5411,7 +5411,7 @@ void AutomationView::handleAutomationMultiPadPress(ModelStackWithAutoParam* mode
 		return;
 	}
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		int32_t firstPadLeftEdge = getPosFromSquare(firstPadX, xScroll, xZoom);
 		int32_t secondPadRightEdge = getPosFromSquare(secondPadX + 1, xScroll, xZoom);
 
@@ -5537,7 +5537,7 @@ void AutomationView::renderAutomationDisplayForMultiPadPress(ModelStackWithAutoP
 		return;
 	}
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		int32_t firstPadLeftEdge = getPosFromSquare(leftPadSelectedX, xScroll, xZoom);
 		int32_t secondPadRightEdge = getPosFromSquare(rightPadSelectedX + 1, xScroll, xZoom);
 

--- a/src/deluge/gui/views/clip_navigation_timeline_view.cpp
+++ b/src/deluge/gui/views/clip_navigation_timeline_view.cpp
@@ -36,7 +36,7 @@ ActionResult ClipNavigationTimelineView::horizontalEncoderAction(int32_t offset)
 void ClipNavigationTimelineView::horizontalScrollForLinearRecording(int32_t newXScroll) {
 	// Make sure we don't scroll too far right
 	if (newXScroll < getMaxLength()) {
-		if (!PadLEDs::renderingLock && (!currentUIMode || currentUIMode == UI_MODE_AUDITIONING)
+		if (!PadLEDs::renderingLock && ((currentUIMode == 0u) || currentUIMode == UI_MODE_AUDITIONING)
 		    && getCurrentUI() == this) {
 			initiateXScroll(newXScroll);
 		}

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -80,7 +80,7 @@ Action* ClipView::lengthenClip(int32_t newLength) {
 	Action* action = nullptr;
 
 	// If the last action was a shorten, undo it
-	bool undoing = (actionLogger.firstAction[BEFORE] && actionLogger.firstAction[BEFORE]->openForAdditions
+	bool undoing = ((actionLogger.firstAction[BEFORE] != nullptr) && actionLogger.firstAction[BEFORE]->openForAdditions
 	                && actionLogger.firstAction[BEFORE]->type == ActionType::CLIP_LENGTH_DECREASE
 	                && actionLogger.firstAction[BEFORE]->currentClip == getCurrentClip());
 
@@ -98,7 +98,7 @@ Action* ClipView::lengthenClip(int32_t newLength) {
 		                                                                   : ActionType::CLIP_LENGTH_INCREASE;
 
 		action = actionLogger.getNewAction(actionType, ActionAddition::ALLOWED);
-		if (action && action->currentClip != getCurrentClip()) {
+		if ((action != nullptr) && action->currentClip != getCurrentClip()) {
 			action = actionLogger.getNewAction(actionType, ActionAddition::NOT_ALLOWED);
 		}
 
@@ -124,7 +124,7 @@ Action* ClipView::shortenClip(int32_t newLength) {
 	Action* action = nullptr;
 
 	action = actionLogger.getNewAction(ActionType::CLIP_LENGTH_DECREASE, ActionAddition::ALLOWED);
-	if (action && action->currentClip != getCurrentClip()) {
+	if ((action != nullptr) && action->currentClip != getCurrentClip()) {
 		action = actionLogger.getNewAction(ActionType::CLIP_LENGTH_DECREASE, ActionAddition::NOT_ALLOWED);
 	}
 
@@ -166,7 +166,7 @@ ActionResult ClipView::horizontalEncoderAction(int32_t offset) {
 
 		displayNumberOfBarsAndBeats(newLength, currentSong->xZoom[NAVIGATION_CLIP], false, "LONG");
 
-		if (action) {
+		if (action != nullptr) {
 			action->xScrollClip[AFTER] = currentSong->xScroll[NAVIGATION_CLIP];
 		}
 		return ActionResult::DEALT_WITH;
@@ -207,13 +207,13 @@ ActionResult ClipView::horizontalEncoderAction(int32_t offset) {
 
 		// If possible, just modify a previous Action to add this new shift amount to it.
 		Action* action = actionLogger.firstAction[BEFORE];
-		if (action && action->type == ActionType::CLIP_HORIZONTAL_SHIFT && action->openForAdditions
+		if ((action != nullptr) && action->type == ActionType::CLIP_HORIZONTAL_SHIFT && action->openForAdditions
 		    && action->currentClip == clip) {
 
 			// If there's no Consequence in the Action, that's probably because we deleted it a previous time with the
 			// code just below. Or possibly because the Action was created but there wasn't enough RAM to create the
 			// Consequence. Anyway, just go add a consequence now.
-			if (!action->firstConsequence)
+			if (action->firstConsequence == nullptr)
 				goto addConsequenceToAction;
 
 			ConsequenceClipHorizontalShift* consequence = (ConsequenceClipHorizontalShift*)action->firstConsequence;
@@ -227,11 +227,11 @@ ActionResult ClipView::horizontalEncoderAction(int32_t offset) {
 		else {
 
 			action = actionLogger.getNewAction(ActionType::CLIP_HORIZONTAL_SHIFT, ActionAddition::NOT_ALLOWED);
-			if (action) {
+			if (action != nullptr) {
 addConsequenceToAction:
 				void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceClipHorizontalShift));
 
-				if (consMemory) {
+				if (consMemory != nullptr) {
 					ConsequenceClipHorizontalShift* newConsequence = new (consMemory)
 					    ConsequenceClipHorizontalShift(shiftAmount, shiftAutomation, shiftSequenceAndMPE);
 					action->addConsequence(newConsequence);
@@ -350,7 +350,7 @@ int32_t ClipView::getTickSquare() {
 	// See if we maybe want to do an auto-scroll
 	if (getCurrentClip()->getCurrentlyRecordingLinearly()) {
 
-		if (newTickSquare == kDisplayWidth && (!currentUIMode || currentUIMode == UI_MODE_AUDITIONING)
+		if (newTickSquare == kDisplayWidth && ((currentUIMode == 0u) || currentUIMode == UI_MODE_AUDITIONING)
 		    && getCurrentUI() == this && // currentPlaybackMode == &session &&
 		    (getCurrentClip()->armState == ArmState::OFF || xScrollBeforeFollowingAutoExtendingLinearRecording != -1)) {
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1630,7 +1630,8 @@ ActionResult InstrumentClipView::padAction(int32_t x, int32_t y, int32_t velocit
 		// too - but this gets deactivated if they've done any "euclidean" or per-NoteRow editing already by holding
 		// down that audition pad, because if they've done that, they're probably not intending to deliberately go into
 		// the SoundEditor, but might be trying to edit notes. Which they currently can't do...
-		if ((velocity != 0) && (!isUIModeActive(UI_MODE_AUDITIONING) || !editedAnyPerNoteRowStuffSinceAuditioningBegan)) {
+		if ((velocity != 0)
+		    && (!isUIModeActive(UI_MODE_AUDITIONING) || !editedAnyPerNoteRowStuffSinceAuditioningBegan)) {
 			// are we trying to enter the automation view velocity note editor
 			// by pressing audition pad + velocity shortcut?
 			if (isUIModeActive(UI_MODE_AUDITIONING) && (x == kVelocityShortcutX && y == kVelocityShortcutY)) {
@@ -1753,8 +1754,9 @@ possiblyAuditionPad:
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 				}
 
-				if ((velocity != 0) && getCurrentOutputType() != OutputType::KIT) { // We probably couldn't have got this far
-					                                                         // if it was a Kit, but let's just check
+				if ((velocity != 0)
+				    && getCurrentOutputType() != OutputType::KIT) { // We probably couldn't have got this far
+					                                                // if it was a Kit, but let's just check
 					toggleScaleModeOnButtonRelease = false;
 					currentUIMode = UI_MODE_NONE;
 					if (getCurrentInstrumentClip()->inScaleMode) {
@@ -3068,7 +3070,8 @@ bool InstrumentClipView::enterNoteEditor() {
 void InstrumentClipView::exitNoteEditor() {
 	if (lastSelectedNoteXDisplay != kNoSelection && lastSelectedNoteYDisplay != kNoSelection) {
 		if (isUIModeActive(UI_MODE_NOTES_PRESSED)) {
-			editPadAction(false, lastSelectedNoteYDisplay, lastSelectedNoteXDisplay, currentSong->xZoom[NAVIGATION_CLIP]);
+			editPadAction(false, lastSelectedNoteYDisplay, lastSelectedNoteXDisplay,
+			              currentSong->xZoom[NAVIGATION_CLIP]);
 		}
 		gridSquareInfo[lastSelectedNoteXDisplay][lastSelectedNoteYDisplay].isValid = false;
 		lastSelectedNoteXDisplay = kNoSelection;
@@ -3988,8 +3991,9 @@ ActionResult InstrumentClipView::scrollVertical(int32_t scrollAmount, bool inCar
 				}
 			}
 			if (!draggingNoteRow && !drawnNoteCodeYet
-			    && (auditionPadIsPressed[yDisplay] != 0u)) { // If we're shiftingNoteRow, no need to re-draw the noteCode,
-				                                     // because it'll be the same
+			    && (auditionPadIsPressed[yDisplay]
+			        != 0u)) { // If we're shiftingNoteRow, no need to re-draw the noteCode,
+				              // because it'll be the same
 				drawNoteCode(yDisplay);
 				if (isKit) {
 					Drum* newSelectedDrum = nullptr;
@@ -5448,7 +5452,8 @@ void InstrumentClipView::drawAuditionSquare(uint8_t yDisplay, RGB thisImage[]) {
 
 		bool midiCommandAssigned;
 		if (getCurrentOutputType() == OutputType::KIT) {
-			midiCommandAssigned = ((noteRow != nullptr) && (noteRow->drum != nullptr) && noteRow->drum->midiInput.containsSomething());
+			midiCommandAssigned =
+			    ((noteRow != nullptr) && (noteRow->drum != nullptr) && noteRow->drum->midiInput.containsSomething());
 		}
 		else {
 			midiCommandAssigned = (((MelodicInstrument*)getCurrentOutput())->midiInput.containsSomething());
@@ -5682,8 +5687,9 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 						ModelStackWithNoteRow* modelStackWithNoteRow =
 						    getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, modelStack);
 						NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
-						if (noteRow != nullptr) { // This is fine. If we were in Kit mode, we could only be auditioning if
-							           // there was a NoteRow already
+						if (noteRow
+						    != nullptr) { // This is fine. If we were in Kit mode, we could only be auditioning if
+							              // there was a NoteRow already
 							noteRow->colourOffset += offset;
 							if (noteRow->colourOffset >= 72) {
 								noteRow->colourOffset -= 72;
@@ -6049,8 +6055,8 @@ void InstrumentClipView::editNoteRepeat(int32_t offset) {
 
 		// See if we can do a "secret UNDO".
 		Action* lastAction = actionLogger.firstAction[BEFORE];
-		if ((offset != 0) && (lastAction != nullptr) && lastAction->type == ActionType::NOTE_REPEAT_EDIT && lastAction->openForAdditions
-		    && lastAction->offset == -offset) {
+		if ((offset != 0) && (lastAction != nullptr) && lastAction->type == ActionType::NOTE_REPEAT_EDIT
+		    && lastAction->openForAdditions && lastAction->offset == -offset) {
 			actionLogger.undoJustOneConsequencePerNoteRow(
 			    modelStack->toWithSong()); // Only ok because we're not going to use the
 			                               // ModelStackWithTimelineCounter or with any more stuff again here.
@@ -6407,9 +6413,10 @@ void InstrumentClipView::graphicsRoutine() {
 
 	int32_t newTickSquare;
 
-	bool reallyNoTickSquare = (!playbackHandler.isEitherClockActive() || !currentSong->isClipActive(clip)
-	                           || currentUIMode == UI_MODE_EXPLODE_ANIMATION
-	                           || currentUIMode == UI_MODE_IMPLODE_ANIMATION || (playbackHandler.ticksLeftInCountIn != 0));
+	bool reallyNoTickSquare =
+	    (!playbackHandler.isEitherClockActive() || !currentSong->isClipActive(clip)
+	     || currentUIMode == UI_MODE_EXPLODE_ANIMATION || currentUIMode == UI_MODE_IMPLODE_ANIMATION
+	     || (playbackHandler.ticksLeftInCountIn != 0));
 
 	if (reallyNoTickSquare) {
 		newTickSquare = 255;
@@ -6751,8 +6758,8 @@ justDisplayOldNumNotes:
 			Action* lastAction = actionLogger.firstAction[BEFORE];
 			// No need to check that lastAction was for the same Clip or anything - the Action gets "closed"
 			// manually when we stop auditioning.
-			if ((lastAction != nullptr) && lastAction->type == ActionType::EUCLIDEAN_NUM_EVENTS_EDIT && lastAction->openForAdditions
-			    && lastAction->offset == -offset) {
+			if ((lastAction != nullptr) && lastAction->type == ActionType::EUCLIDEAN_NUM_EVENTS_EDIT
+			    && lastAction->openForAdditions && lastAction->offset == -offset) {
 
 				char modelStackMemory2[MODEL_STACK_MAX_SIZE];
 				ModelStack* modelStackWithJustSong = setupModelStackWithSong(modelStackMemory2, modelStack->song);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3991,9 +3991,8 @@ ActionResult InstrumentClipView::scrollVertical(int32_t scrollAmount, bool inCar
 				}
 			}
 			if (!draggingNoteRow && !drawnNoteCodeYet
-			    && (auditionPadIsPressed[yDisplay]
-			        != 0u)) { // If we're shiftingNoteRow, no need to re-draw the noteCode,
-				              // because it'll be the same
+			    && (auditionPadIsPressed[yDisplay] != 0u)) { // If we're shiftingNoteRow, no need to re-draw the
+				                                             // noteCode, because it'll be the same
 				drawNoteCode(yDisplay);
 				if (isKit) {
 					Drum* newSelectedDrum = nullptr;
@@ -5687,9 +5686,8 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 						ModelStackWithNoteRow* modelStackWithNoteRow =
 						    getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, modelStack);
 						NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
-						if (noteRow
-						    != nullptr) { // This is fine. If we were in Kit mode, we could only be auditioning if
-							              // there was a NoteRow already
+						if (noteRow != nullptr) { // This is fine. If we were in Kit mode, we could only be auditioning
+							                      // if there was a NoteRow already
 							noteRow->colourOffset += offset;
 							if (noteRow->colourOffset >= 72) {
 								noteRow->colourOffset -= 72;

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -266,7 +266,7 @@ bool PerformanceView::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 }
 
 bool PerformanceView::opened() {
-	if (playbackHandler.playbackState && currentPlaybackMode == &arrangement) {
+	if ((playbackHandler.playbackState != 0u) && currentPlaybackMode == &arrangement) {
 		PadLEDs::skipGreyoutFade();
 	}
 
@@ -303,9 +303,9 @@ void PerformanceView::graphicsRoutine() {
 	if (currentUIMode == UI_MODE_NONE) {
 		int32_t modKnobMode = -1;
 		bool editingComp = false;
-		if (view.activeModControllableModelStack.modControllable) {
+		if (view.activeModControllableModelStack.modControllable != nullptr) {
 			uint8_t* modKnobModePointer = view.activeModControllableModelStack.modControllable->getModKnobMode();
-			if (modKnobModePointer) {
+			if (modKnobModePointer != nullptr) {
 				modKnobMode = *modKnobModePointer;
 				editingComp = view.activeModControllableModelStack.modControllable->isEditingComp();
 			}
@@ -321,7 +321,7 @@ void PerformanceView::graphicsRoutine() {
 	}
 
 	// if we're not currently selecting a clip
-	if (!((currentSong->lastClipInstanceEnteredStartPos != -1) && arrangerView.getClipForSelection())) {
+	if (!((currentSong->lastClipInstanceEnteredStartPos != -1) && (arrangerView.getClipForSelection() != nullptr))) {
 		if (view.potentiallyRenderVUMeter(PadLEDs::image)) {
 			PadLEDs::sendOutSidebarColours();
 		}
@@ -330,7 +330,7 @@ void PerformanceView::graphicsRoutine() {
 	bool reallyNoTickSquare =
 	    (!playbackHandler.isEitherClockActive() || currentUIMode == UI_MODE_EXPLODE_ANIMATION
 	     || currentUIMode == UI_MODE_IMPLODE_ANIMATION || currentSong->lastClipInstanceEnteredStartPos != -1
-	     || !session.launchEventAtSwungTickCount);
+	     || (session.launchEventAtSwungTickCount == 0));
 
 	int32_t sixteenthNotesRemaining = 0;
 
@@ -355,11 +355,11 @@ ActionResult PerformanceView::timerCallback() {
 
 bool PerformanceView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea) {
-	if (!image) {
+	if (image == nullptr) {
 		return true;
 	}
 
-	if (!occupancyMask) {
+	if (occupancyMask == nullptr) {
 		return true;
 	}
 
@@ -452,11 +452,11 @@ bool PerformanceView::isParamAssignedToFXColumn(params::Kind paramKind, int32_t 
 /// if entered performance view using pink grid mode pad, render the pink pad
 bool PerformanceView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
                                     uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) {
-	if (!image) {
+	if (image == nullptr) {
 		return true;
 	}
 
-	if (!occupancyMask) {
+	if (occupancyMask == nullptr) {
 		return true;
 	}
 
@@ -766,12 +766,12 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 				Buttons::recordButtonPressUsedUp = true;
 
 				// Make sure we weren't already playing...
-				if (!playbackHandler.playbackState) {
+				if (playbackHandler.playbackState == 0u) {
 
 					Action* action = actionLogger.getNewAction(ActionType::ARRANGEMENT_RECORD);
 
 					arrangerView.xScrollWhenPlaybackStarted = currentSong->xScroll[NAVIGATION_ARRANGEMENT];
-					if (action) {
+					if (action != nullptr) {
 						action->posToClearArrangementFrom = arrangerView.xScrollWhenPlaybackStarted;
 					}
 
@@ -988,7 +988,7 @@ ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int3
 
 		// if pad was pressed in main deluge grid (not sidebar)
 		if (xDisplay < kDisplayWidth) {
-			if (on) {
+			if (on != 0) {
 				// if it's a shortcut press, enter soundEditor menu for that parameter
 				// but not if you're in default editing mode
 				if (Buttons::isShiftButtonPressed()) {
@@ -996,7 +996,7 @@ ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int3
 						return ActionResult::DEALT_WITH;
 					}
 					else {
-						return soundEditor.potentialShortcutPadAction(xDisplay, yDisplay, on);
+						return soundEditor.potentialShortcutPadAction(xDisplay, yDisplay, on != 0);
 					}
 				}
 			}
@@ -1032,7 +1032,7 @@ ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int3
 				else {
 					arrangerView.handleAuditionPadAction(yDisplay, on, this);
 					// when you let go of audition pad action, you need to reset led states
-					if (!on) {
+					if (on == 0) {
 						setCentralLEDStates();
 					}
 				}
@@ -1059,7 +1059,7 @@ ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int3
 			}
 		}
 	}
-	else if (!on) {
+	else if (on == 0) {
 		justExitedSoundEditor = false;
 	}
 	return ActionResult::DEALT_WITH;
@@ -1073,7 +1073,7 @@ void PerformanceView::normalPadAction(ModelStackWithThreeMainThings* modelStack,
 	int32_t lastSelectedParamID = layoutForPerformance[xDisplay].paramID;
 
 	// pressing a pad
-	if (on) {
+	if (on != 0) {
 		// no need to pad press action if you've already processed it previously and pad was held
 		if (fxPress[xDisplay].yDisplay != yDisplay) {
 			backupPerformanceLayout();
@@ -1201,7 +1201,7 @@ void PerformanceView::padReleaseAction(ModelStackWithThreeMainThings* modelStack
 void PerformanceView::paramEditorPadAction(ModelStackWithThreeMainThings* modelStack, int32_t xDisplay,
                                            int32_t yDisplay, int32_t on) {
 	// pressing a pad
-	if (on) {
+	if (on != 0) {
 		// if you haven't yet pressed and are holding a param shortcut pad on the param overview
 		if (!firstPadPress.isActive) {
 			if (isPadShortcut(xDisplay, yDisplay)) {
@@ -1210,7 +1210,7 @@ void PerformanceView::paramEditorPadAction(ModelStackWithThreeMainThings* modelS
 				firstPadPress.paramID = paramIDShortcutsForPerformanceView[xDisplay][yDisplay];
 				firstPadPress.xDisplay = xDisplay;
 				firstPadPress.yDisplay = yDisplay;
-				renderFXDisplay(firstPadPress.paramKind, firstPadPress.paramID, false);
+				renderFXDisplay(firstPadPress.paramKind, firstPadPress.paramID, 0);
 			}
 		}
 		// if you are holding a param shortcut pad and are now pressing a pad in an FX column
@@ -1396,7 +1396,7 @@ bool PerformanceView::setParameterValue(ModelStackWithThreeMainThings* modelStac
                                         int32_t paramID, int32_t xDisplay, int32_t knobPos, bool renderDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = currentSong->getModelStackWithParam(modelStack, paramID);
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 
 		if (modelStackWithParam->getTimelineCounter()
 		    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
@@ -1451,7 +1451,7 @@ void PerformanceView::getParameterValue(ModelStackWithThreeMainThings* modelStac
                                         int32_t paramID, int32_t xDisplay, bool renderDisplay) {
 	ModelStackWithAutoParam* modelStackWithParam = currentSong->getModelStackWithParam(modelStack, paramID);
 
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 
 		if (modelStackWithParam->getTimelineCounter()
 		    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
@@ -1603,9 +1603,9 @@ void PerformanceView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 	// release stutter if it's already active before beginning stutter again
 	if (on) {
 		int32_t modKnobMode = -1;
-		if (view.activeModControllableModelStack.modControllable) {
+		if (view.activeModControllableModelStack.modControllable != nullptr) {
 			uint8_t* modKnobModePointer = view.activeModControllableModelStack.modControllable->getModKnobMode();
-			if (modKnobModePointer) {
+			if (modKnobModePointer != nullptr) {
 				modKnobMode = *modKnobModePointer;
 
 				// Stutter section
@@ -1876,8 +1876,8 @@ void PerformanceView::readDefaultsFromFile() {
 	Deserializer& reader = smDeserializer;
 	char const* tagName;
 	// step into the <defaultFXValues> tag
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
-		if (!strcmp(tagName, PERFORM_DEFAULTS_FXVALUES_TAG)) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+		if (strcmp(tagName, PERFORM_DEFAULTS_FXVALUES_TAG) == 0) {
 			readDefaultFXValuesFromFile();
 		}
 		reader.exitTag();
@@ -1913,12 +1913,12 @@ void PerformanceView::readDefaultFXValuesFromFile() {
 	Deserializer& reader = smDeserializer;
 	// loop through all FX number tags
 	//<FX#>
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		// find the FX number that the tag corresponds to
 		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
 			intToString(xDisplay + 1, &tagNameFX[2]);
 
-			if (!strcmp(tagName, tagNameFX)) {
+			if (strcmp(tagName, tagNameFX) == 0) {
 				readDefaultFXParamAndRowValuesFromFile(xDisplay);
 				break;
 			}
@@ -1930,17 +1930,17 @@ void PerformanceView::readDefaultFXValuesFromFile() {
 void PerformanceView::readDefaultFXParamAndRowValuesFromFile(int32_t xDisplay) {
 	char const* tagName;
 	Deserializer& reader = smDeserializer;
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		//<param>
-		if (!strcmp(tagName, PERFORM_DEFAULTS_PARAM_TAG)) {
+		if (strcmp(tagName, PERFORM_DEFAULTS_PARAM_TAG) == 0) {
 			readDefaultFXParamFromFile(xDisplay);
 		}
 		//<row>
-		else if (!strcmp(tagName, PERFORM_DEFAULTS_ROW_TAG)) {
+		else if (strcmp(tagName, PERFORM_DEFAULTS_ROW_TAG) == 0) {
 			readDefaultFXRowNumberValuesFromFile(xDisplay);
 		}
 		//<hold>
-		else if (!strcmp(tagName, PERFORM_DEFAULTS_HOLD_TAG)) {
+		else if (strcmp(tagName, PERFORM_DEFAULTS_HOLD_TAG) == 0) {
 			readDefaultFXHoldStatusFromFile(xDisplay);
 		}
 		reader.exitTag();
@@ -1958,7 +1958,7 @@ void PerformanceView::readDefaultFXParamFromFile(int32_t xDisplay) {
 	for (int32_t i = 0; i < kNumParamsForPerformance; i++) {
 		paramName = params::paramNameForFile(songParamsForPerformance[i].paramKind,
 		                                     params::UNPATCHED_START + songParamsForPerformance[i].paramID);
-		if (!strcmp(tagName, paramName)) {
+		if (strcmp(tagName, paramName) == 0) {
 			memcpy(&layoutForPerformance[xDisplay], &songParamsForPerformance[i], sizeof(ParamsForPerformance));
 
 			memcpy(&backupXMLDefaultLayoutForPerformance[xDisplay], &layoutForPerformance[xDisplay],
@@ -1973,12 +1973,12 @@ void PerformanceView::readDefaultFXRowNumberValuesFromFile(int32_t xDisplay) {
 	char rowNumber[5];
 	Deserializer& reader = smDeserializer;
 	// loop through all row <#> number tags
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		// find the row number that the tag corresponds to
 		// reads from row 8 down to row 1
 		for (int32_t yDisplay = kDisplayHeight - 1; yDisplay >= 0; yDisplay--) {
 			intToString(yDisplay + 1, rowNumber);
-			if (!strcmp(tagName, rowNumber)) {
+			if (strcmp(tagName, rowNumber) == 0) {
 				defaultFXValues[xDisplay][yDisplay] = reader.readTagOrAttributeValueInt() - kKnobPosOffset;
 
 				// check if a value greater than 64 was entered as a default value in xml file
@@ -2004,11 +2004,11 @@ void PerformanceView::readDefaultFXHoldStatusFromFile(int32_t xDisplay) {
 	char const* tagName;
 	// loop through the hold tags
 	Deserializer& reader = smDeserializer;
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		//<status>
-		if (!strcmp(tagName, PERFORM_DEFAULTS_HOLD_STATUS_TAG)) {
+		if (strcmp(tagName, PERFORM_DEFAULTS_HOLD_STATUS_TAG) == 0) {
 			char const* holdStatus = reader.readTagOrAttributeValue();
-			if (!strcmp(holdStatus, PERFORM_DEFAULTS_ON)) {
+			if (strcmp(holdStatus, PERFORM_DEFAULTS_ON) == 0) {
 				if (!params::isParamStutter(layoutForPerformance[xDisplay].paramKind,
 				                            layoutForPerformance[xDisplay].paramID)) {
 					fxPress[xDisplay].padPressHeld = true;
@@ -2020,7 +2020,7 @@ void PerformanceView::readDefaultFXHoldStatusFromFile(int32_t xDisplay) {
 			}
 		}
 		//<row>
-		else if (!strcmp(tagName, PERFORM_DEFAULTS_ROW_TAG)) {
+		else if (strcmp(tagName, PERFORM_DEFAULTS_ROW_TAG) == 0) {
 			int32_t yDisplay = reader.readTagOrAttributeValueInt();
 			if ((yDisplay >= 1) && (yDisplay <= 8)) {
 				fxPress[xDisplay].yDisplay = yDisplay - 1;
@@ -2031,7 +2031,7 @@ void PerformanceView::readDefaultFXHoldStatusFromFile(int32_t xDisplay) {
 			}
 		}
 		//<resetValue>
-		else if (!strcmp(tagName, PERFORM_DEFAULTS_HOLD_RESETVALUE_TAG)) {
+		else if (strcmp(tagName, PERFORM_DEFAULTS_HOLD_RESETVALUE_TAG) == 0) {
 			fxPress[xDisplay].previousKnobPosition = reader.readTagOrAttributeValueInt() - kKnobPosOffset;
 			// check if a value greater than 64 was entered as a default value in xml file
 			if (fxPress[xDisplay].previousKnobPosition > kKnobPosOffset) {

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2190,8 +2190,9 @@ void SessionView::graphicsRoutine() {
 		displayPotentialTempoChange(this);
 	}
 
-	bool reallyNoTickSquare = (!playbackHandler.isEitherClockActive() || currentUIMode == UI_MODE_EXPLODE_ANIMATION
-	                           || currentUIMode == UI_MODE_IMPLODE_ANIMATION || (session.launchEventAtSwungTickCount == 0));
+	bool reallyNoTickSquare =
+	    (!playbackHandler.isEitherClockActive() || currentUIMode == UI_MODE_EXPLODE_ANIMATION
+	     || currentUIMode == UI_MODE_IMPLODE_ANIMATION || (session.launchEventAtSwungTickCount == 0));
 
 	int32_t sixteenthNotesRemaining = 0;
 
@@ -3154,7 +3155,8 @@ bool SessionView::gridRenderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 
 				else {
 					// If user assigning MIDI controls and has this section selected, flash to half brightness
-					if ((currentSong != nullptr) && view.learnedThing == &currentSong->sections[section].launchMIDICommand) {
+					if ((currentSong != nullptr)
+					    && view.learnedThing == &currentSong->sections[section].launchMIDICommand) {
 						ptrSectionColour = ptrSectionColour.dim();
 					}
 				}
@@ -3547,7 +3549,8 @@ void SessionView::setupNewClip(Clip* newClip) {
 				Clip* clip = currentSong->sessionClips.getClipAtIndex(c);
 
 				if (clip->type == ClipType::AUDIO && clip->armedForRecording) {
-					currentSong->defaultAudioClipOverdubOutputCloning = static_cast<int8_t>(((AudioClip*)clip)->overdubsShouldCloneOutput);
+					currentSong->defaultAudioClipOverdubOutputCloning =
+					    static_cast<int8_t>(((AudioClip*)clip)->overdubsShouldCloneOutput);
 					break;
 				}
 			}
@@ -3680,7 +3683,8 @@ Clip* SessionView::gridCreateClip(uint32_t targetSection, Output* targetOutput, 
 				}
 			}
 
-			if ((targetOutput != nullptr) && targetOutput != sourceClip->output && targetOutput->type == OutputType::AUDIO) {
+			if ((targetOutput != nullptr) && targetOutput != sourceClip->output
+			    && targetOutput->type == OutputType::AUDIO) {
 				((AudioOutput*)targetOutput)->cloneFrom((AudioOutput*)(sourceClip->output));
 				newAudioClip->setOutput(modelStack, targetOutput);
 			}

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -456,7 +456,7 @@ int32_t TimelineView::getSquareFromPos(int32_t pos, bool* rightOnSquare, int32_t
 			int32_t blockStartRelativeToScroll = blockStartPos - xScroll; // Will be negative or 0
 			int32_t posRelativeToBlockStart = pos - blockStartPos;
 
-			if (rightOnSquare) {
+			if (rightOnSquare != nullptr) {
 				*rightOnSquare =
 				    (posRelativeToBlockStart % (xZoom * 4 / 3) == 0); // Will the % be ok if it's negative? No! :O
 			}
@@ -473,7 +473,7 @@ int32_t TimelineView::getSquareFromPos(int32_t pos, bool* rightOnSquare, int32_t
 		else if (xZoom < currentSong->tripletsLevel * 2) {
 			int32_t posRelativeToTripletsStart =
 			    posRelativeToScroll % (currentSong->tripletsLevel * 3); // Will the % be ok if it's negative? No! :O
-			if (rightOnSquare) {
+			if (rightOnSquare != nullptr) {
 				*rightOnSquare =
 				    (posRelativeToTripletsStart == 0 || posRelativeToTripletsStart == currentSong->tripletsLevel * 2);
 			}
@@ -485,7 +485,7 @@ int32_t TimelineView::getSquareFromPos(int32_t pos, bool* rightOnSquare, int32_t
 		}
 	}
 
-	if (rightOnSquare) {
+	if (rightOnSquare != nullptr) {
 		*rightOnSquare = (posRelativeToScroll >= 0
 		                  && (posRelativeToScroll % xZoom) == 0); // Will the % be ok if it's negative? No! :O
 	}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1832,8 +1832,8 @@ void View::setModRegion(uint32_t pos, uint32_t length, int32_t noteRowId) {
 
 	// If holding down a note and not playing, permanently grab values from pos
 	if ((length != 0u) && activeModControllableModelStack.timelineCounterIsSet()
-	    && (activeModControllableModelStack.modControllable != nullptr) && (activeModControllableModelStack.paramManager != nullptr)
-	    && !playbackHandler.isEitherClockActive()
+	    && (activeModControllableModelStack.modControllable != nullptr)
+	    && (activeModControllableModelStack.paramManager != nullptr) && !playbackHandler.isEitherClockActive()
 	    && activeModControllableModelStack.paramManager->containsAnyMainParamCollections()) {
 
 		activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
@@ -2218,7 +2218,8 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 				}
 				else if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {
 					if (modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, -1, nullptr, nullptr,
-					                                                   false) == nullptr) {
+					                                                  false)
+					    == nullptr) {
 						break;
 					}
 				}
@@ -2284,8 +2285,9 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 					}
 				}
 				else if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {
-					if (modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix,
-					                                                   nullptr, nullptr, false) == nullptr) {
+					if (modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix, nullptr,
+					                                                  nullptr, false)
+					    == nullptr) {
 						break;
 					}
 				}
@@ -2408,10 +2410,10 @@ getOut:
 			for (Drum* thisDrum = kit->firstDrum; thisDrum != nullptr; thisDrum = thisDrum->next) {
 				if (thisDrum->type == DrumType::SOUND) {
 					SoundDrum* soundDrum = (SoundDrum*)thisDrum;
-					if (modelStack->song->getBackedUpParamManagerPreferablyWithClip(
-					        soundDrum, NULL) == nullptr) { // If no backedUpParamManager...
-						if (modelStack->song->findParamManagerForDrum(
-						        kit, soundDrum) == nullptr) { // If no ParamManager with a NoteRow somewhere...
+					if (modelStack->song->getBackedUpParamManagerPreferablyWithClip(soundDrum, NULL)
+					    == nullptr) { // If no backedUpParamManager...
+						if (modelStack->song->findParamManagerForDrum(kit, soundDrum)
+						    == nullptr) { // If no ParamManager with a NoteRow somewhere...
 
 							if (results.loadedFromFile) {
 								FREEZE_WITH_ERROR("E103");

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -345,8 +345,8 @@ cant:
 			}
 
 			// If no scaling currently, start it, if we're on a Clip-minder screen
-			if (!currentSong->getSyncScalingClip()) {
-				if (!getCurrentUI()->toClipMinder()) {
+			if (currentSong->getSyncScalingClip() == nullptr) {
+				if (getCurrentUI()->toClipMinder() == nullptr) {
 					indicator_leds::indicateAlertOnLed(IndicatorLED::CLIP_VIEW);
 					return ActionResult::DEALT_WITH;
 				}
@@ -464,7 +464,7 @@ void View::endMIDILearn() {
 	}
 	uiTimerManager.unsetTimer(TimerName::MIDI_LEARN_FLASH);
 	midiLearnFlashOn = false;
-	if (getRootUI()) {
+	if (getRootUI() != nullptr) {
 		getRootUI()->midiLearnFlash();
 	}
 
@@ -478,7 +478,7 @@ void View::endMIDILearn() {
 
 void View::setTimeBaseScaleLedState() {
 	// If this Clip is the inputTickScaleClip, flash the LED
-	if (getCurrentUI()->toClipMinder() && getCurrentClip() == currentSong->getSyncScalingClip()) {
+	if ((getCurrentUI()->toClipMinder() != nullptr) && getCurrentClip() == currentSong->getSyncScalingClip()) {
 		indicator_leds::blinkLed(IndicatorLED::SYNC_SCALING);
 	}
 
@@ -610,11 +610,11 @@ void View::noteOnReceivedForMidiLearn(MIDICable& cable, int32_t channelOrZone, i
 				newBendRange = cable.inputChannels[channelOrZone].bendRange;
 			}
 
-			if (newBendRange) {
+			if (newBendRange != 0) {
 				NoteRow* noteRow = getCurrentInstrumentClip()->getNoteRowForDrum(drumPressedForMIDILearn);
-				if (noteRow) {
+				if (noteRow != nullptr) {
 					ExpressionParamSet* expressionParams = noteRow->paramManager.getOrCreateExpressionParamSet(true);
-					if (expressionParams) {
+					if (expressionParams != nullptr) {
 						if (!expressionParams->params[0].isAutomated()) {
 							expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL] = newBendRange;
 						}
@@ -661,12 +661,12 @@ isMPEZone:
 				newBendRanges[BEND_RANGE_MAIN] = cable.mpeZoneBendRanges[zone][BEND_RANGE_MAIN];
 				newBendRanges[BEND_RANGE_FINGER_LEVEL] = cable.mpeZoneBendRanges[zone][BEND_RANGE_FINGER_LEVEL];
 
-				if (newBendRanges[BEND_RANGE_FINGER_LEVEL]) {
+				if (newBendRanges[BEND_RANGE_FINGER_LEVEL] != 0u) {
 					InstrumentClip* clip = (InstrumentClip*)instrumentPressedForMIDILearn->getActiveClip();
-					if (!clip || !clip->hasAnyPitchExpressionAutomationOnNoteRows()) {
-						if (paramManager) { // Could be NULL, e.g. for CVInstruments with no Clips
+					if ((clip == nullptr) || !clip->hasAnyPitchExpressionAutomationOnNoteRows()) {
+						if (paramManager != nullptr) { // Could be NULL, e.g. for CVInstruments with no Clips
 							ExpressionParamSet* expressionParams = paramManager->getOrCreateExpressionParamSet();
-							if (expressionParams) {
+							if (expressionParams != nullptr) {
 								expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL] =
 								    newBendRanges[BEND_RANGE_FINGER_LEVEL];
 							}
@@ -682,10 +682,10 @@ isMPEZone:
 				newBendRanges[BEND_RANGE_MAIN] = cable.inputChannels[channelOrZone].bendRange;
 			}
 
-			if (newBendRanges[BEND_RANGE_MAIN]) {
-				if (paramManager) { // Could be NULL, e.g. for CVInstruments with no Clips
+			if (newBendRanges[BEND_RANGE_MAIN] != 0u) {
+				if (paramManager != nullptr) { // Could be NULL, e.g. for CVInstruments with no Clips
 					ExpressionParamSet* expressionParams = paramManager->getOrCreateExpressionParamSet();
-					if (expressionParams && !expressionParams->params[0].isAutomated()) {
+					if ((expressionParams != nullptr) && !expressionParams->params[0].isAutomated()) {
 						expressionParams->bendRanges[BEND_RANGE_MAIN] = newBendRanges[BEND_RANGE_MAIN];
 					}
 				}
@@ -717,10 +717,10 @@ void View::clearMelodicInstrumentMonoExpressionIfPossible() {
 	ParamManager* paramManager = instrumentPressedForMIDILearn->getParamManager(
 	    currentSong); // Could be NULL, e.g. for CVInstruments with no Clips
 
-	if (paramManager) {
+	if (paramManager != nullptr) {
 		ParamCollectionSummary* expressionParamsSummary = paramManager->getExpressionParamSetSummary();
 		ExpressionParamSet* expressionParams = (ExpressionParamSet*)expressionParamsSummary->paramCollection;
-		if (expressionParams) {
+		if (expressionParams != nullptr) {
 
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithParamCollection* modelStack =
@@ -756,7 +756,7 @@ void View::ccReceivedForMIDILearn(MIDICable& cable, int32_t channel, int32_t cc,
 		// Or, for all other types of things the user might be holding down...
 		else {
 			// So long as the value wasn't 0, pretend it was a note-on for command-learn purposes
-			if (value) {
+			if (value != 0) {
 				noteOnReceivedForMidiLearn(cable, channel + IS_A_CC, cc, 127);
 			}
 		}
@@ -767,7 +767,7 @@ void View::midiLearnFlash() {
 	midiLearnFlashOn = !midiLearnFlashOn;
 	uiTimerManager.setTimer(TimerName::MIDI_LEARN_FLASH, kFastFlashTime);
 
-	if (getRootUI()) {
+	if (getRootUI() != nullptr) {
 		getRootUI()->midiLearnFlash();
 	}
 
@@ -791,13 +791,13 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 	//  	return;
 	//  }
 
-	if (activeModControllableModelStack.modControllable) {
+	if (activeModControllableModelStack.modControllable != nullptr) {
 
 		bool noteTailsAllowedBefore;
 		ModelStackWithAutoParam* modelStackWithParam = getModelStackWithParam(whichModEncoder, noteTailsAllowedBefore);
 
 		// If non-existent param, still let the ModControllable know
-		if (!modelStackWithParam || !modelStackWithParam->autoParam) {
+		if ((modelStackWithParam == nullptr) || (modelStackWithParam->autoParam == nullptr)) {
 			ActionResult result = activeModControllableModelStack.modControllable->modEncoderActionForNonExistentParam(
 			    offset, whichModEncoder, modelStackWithParam);
 
@@ -901,7 +901,7 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				    modelStackWithParam->modControllable->allowNoteTails(tempModelStack->addSoundFlags());
 
 				if (noteTailsAllowedBefore != noteTailsAllowedAfter) {
-					if (getRootUI() && getRootUI()->toTimelineView() != nullptr) {
+					if ((getRootUI() != nullptr) && getRootUI()->toTimelineView() != nullptr) {
 						uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0);
 					}
 				}
@@ -930,7 +930,7 @@ void View::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 ModelStackWithAutoParam* View::getModelStackWithParam(int32_t whichModEncoder, bool& noteTailsAllowedBefore) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
-	if (activeModControllableModelStack.modControllable) {
+	if (activeModControllableModelStack.modControllable != nullptr) {
 
 		/*
 		char newModelStackMemory[MODEL_STACK_MAX_SIZE];
@@ -971,7 +971,7 @@ ModelStackWithAutoParam* View::getModelStackWithParam(int32_t whichModEncoder, b
 void View::getParameterNameFromModEncoder(int32_t whichModEncoder, char* parameterName) {
 	bool noteTailsAllowedBefore;
 	ModelStackWithAutoParam* modelStackWithParam = getModelStackWithParam(whichModEncoder, noteTailsAllowedBefore);
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
+	if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 		params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
 
 		if (kind == params::Kind::PATCH_CABLE) {
@@ -1191,7 +1191,7 @@ void View::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 		return;
 	}
 
-	if (activeModControllableModelStack.modControllable) {
+	if (activeModControllableModelStack.modControllable != nullptr) {
 
 		if (Buttons::isShiftButtonPressed() && on) {
 
@@ -1199,7 +1199,7 @@ void View::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 			    activeModControllableModelStack.modControllable->getParamFromModEncoder(
 			        whichModEncoder, &activeModControllableModelStack);
 
-			if (modelStackWithParam && modelStackWithParam->autoParam) {
+			if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 				Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE, ActionAddition::NOT_ALLOWED);
 				modelStackWithParam->autoParam->deleteAutomation(action, modelStackWithParam);
 				display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_AUTOMATION_DELETED));
@@ -1225,7 +1225,7 @@ void View::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 }
 
 void View::setKnobIndicatorLevels() {
-	if (!getRootUI()) {
+	if (getRootUI() == nullptr) {
 		return; // What's this?
 	}
 
@@ -1235,7 +1235,7 @@ void View::setKnobIndicatorLevels() {
 		return;
 	}
 
-	if (activeModControllableModelStack.modControllable) {
+	if (activeModControllableModelStack.modControllable != nullptr) {
 		for (int32_t whichModEncoder = 0; whichModEncoder < NUM_LEVEL_INDICATORS; whichModEncoder++) {
 			if (!indicator_leds::isKnobIndicatorBlinking(whichModEncoder)) {
 				setKnobIndicatorLevel(whichModEncoder);
@@ -1258,7 +1258,7 @@ void View::setKnobIndicatorLevel(uint8_t whichModEncoder) {
 	int32_t knobPos;
 	bool isBipolar = false;
 
-	if (modelStackWithParam->autoParam) {
+	if (modelStackWithParam->autoParam != nullptr) {
 		int32_t value = modelStackWithParam->autoParam->getValuePossiblyAtPos(modPos, modelStackWithParam);
 		ParamCollection* paramCollection = modelStackWithParam->paramCollection;
 		params::Kind kind = paramCollection->getParamKind();
@@ -1354,7 +1354,7 @@ void View::modButtonAction(uint8_t whichButton, bool on) {
 
 	pretendModKnobsUntouchedForAWhile();
 
-	if (activeModControllableModelStack.modControllable) {
+	if (activeModControllableModelStack.modControllable != nullptr) {
 		if (on) {
 			if (isUIModeWithinRange(modButtonUIModes) || (rootUI == &performanceView)) {
 				// only displaying VU meter in session view, arranger view, performance view and arranger automation
@@ -1396,7 +1396,7 @@ void View::setModLedStates() {
 
 	RootUI* rootUI = getRootUI();
 	UIType uiType = UIType::NONE;
-	if (rootUI) {
+	if (rootUI != nullptr) {
 		uiType = rootUI->getUIType();
 	}
 	AutomationSubType automationSubType = AutomationSubType::NONE;
@@ -1436,7 +1436,7 @@ void View::setModLedStates() {
 
 	// here we will set a boolean flag to let the function know if affect entire is enabled
 	// so that it can correctly illuminate the affect entire LED indicator
-	bool affectEntire = rootUI && rootUI->getAffectEntire();
+	bool affectEntire = (rootUI != nullptr) && rootUI->getAffectEntire();
 
 	// if you are not in a song
 	// affect entire is always true if you are in an audio clip, or automation view for an audio clip
@@ -1483,7 +1483,7 @@ void View::setModLedStates() {
 		case UIType::SESSION: {
 			Clip* clip = sessionView.getClipForLayout();
 
-			if (clip) {
+			if (clip != nullptr) {
 				if (clip->onAutomationClipView) {
 					onAutomationClipView = true;
 				}
@@ -1493,7 +1493,7 @@ void View::setModLedStates() {
 		case UIType::ARRANGER: {
 			Output* output = arrangerView.outputsOnScreen[arrangerView.yPressedEffective];
 
-			if (output) {
+			if (output != nullptr) {
 				if (currentSong->getClipWithOutput(output)->onAutomationClipView) {
 					onAutomationClipView = true;
 				}
@@ -1576,9 +1576,9 @@ void View::setModLedStates() {
 
 int32_t View::getModKnobMode() {
 	int32_t modKnobMode = -1;
-	if (activeModControllableModelStack.modControllable) {
+	if (activeModControllableModelStack.modControllable != nullptr) {
 		uint8_t* modKnobModePointer = activeModControllableModelStack.modControllable->getModKnobMode();
-		if (modKnobModePointer) {
+		if (modKnobModePointer != nullptr) {
 			modKnobMode = *modKnobModePointer;
 		}
 	}
@@ -1615,7 +1615,7 @@ void View::sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam, 
 		if (channel != MIDI_CHANNEL_NONE) {
 			// check if we're dealing with a clip context param (don't send feedback for song params)
 			if (isClipContext()) {
-				if (modelStackWithParam && modelStackWithParam->autoParam) {
+				if ((modelStackWithParam != nullptr) && (modelStackWithParam->autoParam != nullptr)) {
 					params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
 					int32_t ccNumber = midiFollow.getCCFromParam(kind, modelStackWithParam->paramId);
 					if (ccNumber != MIDI_CC_NONE) {
@@ -1633,7 +1633,7 @@ void View::sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam, 
 // sets flag to let caller know if we are dealing with clip context
 bool View::isClipContext() {
 	bool itsAClip = false;
-	if (activeModControllableModelStack.modControllable) {
+	if (activeModControllableModelStack.modControllable != nullptr) {
 		itsAClip = (activeModControllableModelStack.timelineCounterIsSet()
 		            && activeModControllableModelStack.getTimelineCounter() != currentSong);
 	}
@@ -1659,7 +1659,7 @@ bool View::potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]) 
 	// 2) we've pressed a clip while vu meter was active
 	// then let's continue to render VU meter
 	if (displayVUMeter
-	    && ((activeModControllableModelStack.modControllable
+	    && (((activeModControllableModelStack.modControllable != nullptr)
 	         && *activeModControllableModelStack.modControllable->getModKnobMode() == 0)
 	        || (isClipContext() && renderedVUMeter))) {
 		PadLEDs::renderingLock = true;
@@ -1767,7 +1767,7 @@ void View::renderVUMeter(int32_t maxYDisplay, int32_t xDisplay, RGB thisImage[][
 }
 
 void View::setActiveModControllableTimelineCounter(TimelineCounter* timelineCounter, bool shouldSendMidiFeedback) {
-	if (timelineCounter) {
+	if (timelineCounter != nullptr) {
 		timelineCounter = timelineCounter->getTimelineCounterToRecordTo();
 	}
 	pretendModKnobsUntouchedForAWhile();
@@ -1775,7 +1775,7 @@ void View::setActiveModControllableTimelineCounter(TimelineCounter* timelineCoun
 	ModelStackWithTimelineCounter* modelStack =
 	    setupModelStackWithSong(&activeModControllableModelStack, currentSong)->addTimelineCounter(timelineCounter);
 
-	if (timelineCounter) {
+	if (timelineCounter != nullptr) {
 		timelineCounter->getActiveModControllable(modelStack);
 	}
 
@@ -1831,8 +1831,8 @@ void View::setModRegion(uint32_t pos, uint32_t length, int32_t noteRowId) {
 	pretendModKnobsUntouchedForAWhile();
 
 	// If holding down a note and not playing, permanently grab values from pos
-	if (length && activeModControllableModelStack.timelineCounterIsSet()
-	    && activeModControllableModelStack.modControllable && activeModControllableModelStack.paramManager
+	if ((length != 0u) && activeModControllableModelStack.timelineCounterIsSet()
+	    && (activeModControllableModelStack.modControllable != nullptr) && (activeModControllableModelStack.paramManager != nullptr)
 	    && !playbackHandler.isEitherClockActive()
 	    && activeModControllableModelStack.paramManager->containsAnyMainParamCollections()) {
 
@@ -1958,13 +1958,13 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 		}
 
 		InstrumentClip* clip = nullptr;
-		if (clip && clip->type == ClipType::INSTRUMENT) {
+		if ((clip != nullptr) && clip->type == ClipType::INSTRUMENT) {
 			clip = (InstrumentClip*)clip;
 		}
 
-		setLedState(LED::KEYBOARD, (clip && clip->onKeyboardScreen));
-		setLedState(LED::SCALE_MODE, (clip && clip->inScaleMode && clip->output->type != OutputType::KIT));
-		setLedState(LED::CROSS_SCREEN_EDIT, (clip && clip->wrapEditing));
+		setLedState(LED::KEYBOARD, ((clip != nullptr) && clip->onKeyboardScreen));
+		setLedState(LED::SCALE_MODE, ((clip != nullptr) && clip->inScaleMode && clip->output->type != OutputType::KIT));
+		setLedState(LED::CROSS_SCREEN_EDIT, ((clip != nullptr) && clip->wrapEditing));
 	}
 
 	// hook to render display for OLED and 7SEG when in Automation View
@@ -2018,7 +2018,7 @@ oledDrawString:
 				                                              kTextTitleSizeY, false);
 			}
 
-			if (clip) {
+			if (clip != nullptr) {
 				if (!clip->name.isEmpty()) {
 					yPos = yPos + 14;
 					canvas.drawStringCentred(clip->name.get(), yPos, kTextSpacingX, kTextSpacingY);
@@ -2217,8 +2217,8 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 					}
 				}
 				else if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {
-					if (!modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, -1, nullptr, nullptr,
-					                                                   false)) {
+					if (modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, -1, nullptr, nullptr,
+					                                                   false) == nullptr) {
 						break;
 					}
 				}
@@ -2284,8 +2284,8 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 					}
 				}
 				else if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {
-					if (!modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix,
-					                                                   nullptr, nullptr, false)) {
+					if (modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix,
+					                                                   nullptr, nullptr, false) == nullptr) {
 						break;
 					}
 				}
@@ -2297,7 +2297,7 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 		newInstrument = modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix, nullptr,
 		                                                              nullptr, false);
 
-		shouldReplaceWholeInstrument = (oldInstrumentCanBeReplaced && !newInstrument);
+		shouldReplaceWholeInstrument = (oldInstrumentCanBeReplaced && (newInstrument == nullptr));
 
 		// If we want to "replace" the old Instrument, we can instead sneakily just modify its channel
 		if (shouldReplaceWholeInstrument) {
@@ -2326,15 +2326,15 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 			bool instrumentAlreadyInSong = (newInstrument != nullptr);
 
 			// If an Instrument doesn't yet exist for the new channel we're gonna use...
-			if (!newInstrument) {
+			if (newInstrument == nullptr) {
 				if (outputType == OutputType::MIDI_OUT) {
 					newInstrument = modelStack->song->grabHibernatingMIDIInstrument(newChannel, newChannelSuffix);
-					if (newInstrument) {
+					if (newInstrument != nullptr) {
 						goto gotAnInstrument;
 					}
 				}
 				newInstrument = StorageManager::createNewNonAudioInstrument(outputType, newChannel, newChannelSuffix);
-				if (!newInstrument) {
+				if (newInstrument == nullptr) {
 					display->displayError(Error::INSUFFICIENT_RAM);
 					return;
 				}
@@ -2405,13 +2405,13 @@ getOut:
 #if ALPHA_OR_BETA_VERSION
 		if (newInstrument->type == OutputType::KIT) {
 			Kit* kit = (Kit*)newInstrument;
-			for (Drum* thisDrum = kit->firstDrum; thisDrum; thisDrum = thisDrum->next) {
+			for (Drum* thisDrum = kit->firstDrum; thisDrum != nullptr; thisDrum = thisDrum->next) {
 				if (thisDrum->type == DrumType::SOUND) {
 					SoundDrum* soundDrum = (SoundDrum*)thisDrum;
-					if (!modelStack->song->getBackedUpParamManagerPreferablyWithClip(
-					        soundDrum, NULL)) { // If no backedUpParamManager...
-						if (!modelStack->song->findParamManagerForDrum(
-						        kit, soundDrum)) { // If no ParamManager with a NoteRow somewhere...
+					if (modelStack->song->getBackedUpParamManagerPreferablyWithClip(
+					        soundDrum, NULL) == nullptr) { // If no backedUpParamManager...
+						if (modelStack->song->findParamManagerForDrum(
+						        kit, soundDrum) == nullptr) { // If no ParamManager with a NoteRow somewhere...
 
 							if (results.loadedFromFile) {
 								FREEZE_WITH_ERROR("E103");
@@ -2506,7 +2506,7 @@ bool View::changeOutputType(OutputType newOutputType, ModelStackWithTimelineCoun
 	}
 
 	Instrument* newInstrument = clip->changeOutputType(modelStack, newOutputType);
-	if (!newInstrument) {
+	if (newInstrument == nullptr) {
 		return false;
 	}
 
@@ -2530,7 +2530,7 @@ void View::instrumentChanged(ModelStackWithTimelineCounter* modelStack, Instrume
 
 RGB View::getClipMuteSquareColour(Clip* clip, RGB thisColour, bool allowMIDIFlash) {
 
-	if (currentUIMode == UI_MODE_VIEWING_RECORD_ARMING && clip && clip->armedForRecording) {
+	if (currentUIMode == UI_MODE_VIEWING_RECORD_ARMING && (clip != nullptr) && clip->armedForRecording) {
 		if (blinkOn) {
 			bool shouldGoPurple = clip->type == ClipType::AUDIO && ((AudioClip*)clip)->overdubsShouldCloneOutput;
 
@@ -2755,8 +2755,8 @@ bool View::renderMacros(int32_t column, uint32_t y, int32_t selectedMacro, RGB i
 		break;
 	}
 
-	if (occupancyMask) {
-		occupancyMask[y][column] = true;
+	if (occupancyMask != nullptr) {
+		occupancyMask[y][column] = 1u;
 	}
 
 	return armed;
@@ -2782,7 +2782,7 @@ void View::activateMacro(uint32_t y) {
 
 	case OUTPUT_CYCLE: {
 		Clip* nextClip = findNextClipForOutput(m.output);
-		if (nextClip) {
+		if (nextClip != nullptr) {
 			session.toggleClipStatus(nextClip, nullptr, Buttons::isShiftButtonPressed(), kInternalButtonPressLatency);
 		}
 		break;

--- a/src/deluge/gui/waveform/waveform_basic_navigator.cpp
+++ b/src/deluge/gui/waveform/waveform_basic_navigator.cpp
@@ -35,7 +35,7 @@ void WaveformBasicNavigator::opened(SampleHolder* holder) {
 	renderData.xScroll = -1;
 
 	// If want to use saved pos and sample already has peak info stored...
-	if (holder && holder->waveformViewZoom) {
+	if ((holder != nullptr) && (holder->waveformViewZoom != 0)) {
 		xScroll = holder->waveformViewScroll;
 		xZoom = holder->waveformViewZoom;
 
@@ -213,7 +213,7 @@ bool WaveformBasicNavigator::scroll(int32_t offset, bool shouldAllowExtraScrollR
 		}
 		else {
 			if (xScroll + xZoom * kDisplayWidth >= sample->lengthInSamples
-			    && (!cols || cols[util::to_underlying(MarkerType::END)].colOnScreen < kDisplayWidth)) {
+			    && ((cols == nullptr) || cols[util::to_underlying(MarkerType::END)].colOnScreen < kDisplayWidth)) {
 				return false;
 			}
 			xScroll += xZoom;

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -236,7 +236,7 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 
 	uint64_t numValidSamples;
 	int32_t endClusters;
-	if (recorder) {
+	if (recorder != nullptr) {
 		numValidSamples = recorder->numSamplesCaptured;
 		endClusters = sample->clusters.getNumElements();
 	}
@@ -273,7 +273,7 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 
 			// If we're still recording, we'll just want to come back and render this one when the waveform has grown to
 			// cover this whole column
-			if (recorder) {
+			if (recorder != nullptr) {
 				data->colStatus[col] = 0;
 				continue;
 			}
@@ -381,7 +381,7 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 
 		SampleCluster* sampleCluster = sample->clusters.getElement(clusterIndexToDo);
 
-		if (sampleCluster->cluster && sampleCluster->cluster->numReasonsToBeLoaded < 0) {
+		if ((sampleCluster->cluster != nullptr) && sampleCluster->cluster->numReasonsToBeLoaded < 0) {
 			FREEZE_WITH_ERROR("E449"); // Trying to catch errer before i028, which users have gotten.
 		}
 
@@ -395,7 +395,7 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 		// Otherwise, do our normal investigation
 		else {
 			char const* errorCode;
-			if (sampleCluster->cluster) {
+			if (sampleCluster->cluster != nullptr) {
 				if (sampleCluster->cluster->loaded) {
 					errorCode = "E343";
 				}
@@ -409,7 +409,7 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 			}
 
 			Cluster* cluster = sampleCluster->getCluster(sample, clusterIndexToDo, CLUSTER_LOAD_IMMEDIATELY);
-			if (!cluster) {
+			if (cluster == nullptr) {
 cantReadData:
 				D_PRINTLN("cant read");
 				data->colStatus[col] = 0;
@@ -462,7 +462,7 @@ cantReadData:
 
 				// If stereo sample, force an odd number here so we alternate between reading both channels
 				if (sample->numChannels == 2) {
-					if (!(timesTooManySamples & 1)) {
+					if ((timesTooManySamples & 1) == 0) {
 						timesTooManySamples++;
 					}
 				}

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -170,7 +170,7 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 				playbackHandler.playButtonPressed(kInternalButtonPressLatency);
 
 				// Begin output-recording simultaneously with playback
-				if (isButtonPressed(RECORD) && playbackHandler.playbackState && !recordButtonPressUsedUp) {
+				if (isButtonPressed(RECORD) && (playbackHandler.playbackState != 0u) && !recordButtonPressUsedUp) {
 					audioRecorder.beginOutputRecording();
 				}
 			}

--- a/src/deluge/hid/display/display.cpp
+++ b/src/deluge/hid/display/display.cpp
@@ -93,7 +93,7 @@ void swapDisplayType() {
 		display = new deluge::hid::display::OLED;
 	}
 	UI* ui = getCurrentUI();
-	if (ui) {
+	if (ui != nullptr) {
 		ui->displayOrLanguageChanged();
 	}
 }

--- a/src/deluge/hid/display/numeric_layer/numeric_layer_basic_text.cpp
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer_basic_text.cpp
@@ -29,7 +29,7 @@ NumericLayerBasicText::~NumericLayerBasicText() {
 }
 
 void NumericLayerBasicText::isNowOnTop() {
-	if (blinkSpeed) {
+	if (blinkSpeed != 0) {
 
 		if (blinkSpeed == 1 && uiTimerManager.isTimerSet(TimerName::LED_BLINK)) {
 			uiTimerManager.setTimerByOtherTimer(TimerName::DISPLAY, TimerName::LED_BLINK);

--- a/src/deluge/hid/display/numeric_layer/numeric_layer_loading_animation.cpp
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer_loading_animation.cpp
@@ -44,7 +44,7 @@ bool NumericLayerLoadingAnimation::callBack() {
 }
 
 void NumericLayerLoadingAnimation::render(uint8_t* returnSegments) {
-	if (animationIsTransparent && next) {
+	if (animationIsTransparent && (next != nullptr)) {
 		next->render(returnSegments);
 	}
 	else {

--- a/src/deluge/hid/display/numeric_layer/numeric_layer_scroll_transition.cpp
+++ b/src/deluge/hid/display/numeric_layer/numeric_layer_scroll_transition.cpp
@@ -59,7 +59,7 @@ bool NumericLayerScrollTransition::callBack() {
 	int8_t progressFlipped = (transitionProgress + transitionDirection) * transitionDirection;
 
 	// Fill character at the end with either a new one, or blank space
-	if (progressFlipped > 0 && next) {
+	if (progressFlipped > 0 && (next != nullptr)) {
 		int32_t readingFrom =
 		    (transitionDirection == 1) ? transitionProgress : (kNumericDisplayLength + transitionProgress - 1);
 

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -233,7 +233,7 @@ void moveAreaUpCrude(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, int
 
 	// First move any entire rows
 	int32_t deltaRows = delta >> 3;
-	if (deltaRows) {
+	if (deltaRows != 0) {
 		delta &= 7;
 		minY += delta; // There's a bit we can ignore here, potentially
 		int32_t firstRowHere = minY >> 3;
@@ -244,7 +244,7 @@ void moveAreaUpCrude(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, int
 	}
 
 	// Move final sub-row amount
-	if (delta) {
+	if (delta != 0) {
 		for (int32_t x = minX; x <= maxX; x++) {
 			uint8_t carry;
 
@@ -340,7 +340,7 @@ int32_t OLED::setupConsole(int32_t height) {
 	bool shouldRedrawTopLine = false;
 
 	// If already some console items...
-	if (numConsoleItems) {
+	if (numConsoleItems != 0) {
 
 		// If hit max num console items...
 		if (numConsoleItems == MAX_NUM_CONSOLE_ITEMS) {
@@ -419,10 +419,10 @@ void OLED::removePopup() {
 }
 
 bool OLED::isPopupPresent() {
-	return oledPopupWidth;
+	return oledPopupWidth != 0;
 }
 bool OLED::isPopupPresentOfType(PopupType type) {
-	return oledPopupWidth && popupType == type;
+	return (oledPopupWidth != 0) && popupType == type;
 }
 
 bool OLED::isPermanentPopupPresent() {
@@ -456,13 +456,13 @@ void copyBackgroundAroundForeground(ImageStore backgroundImage, ImageStore foreg
 	// Copy everything above
 	int32_t firstRow = minY >> 3;
 	int32_t lastRow = maxY >> 3;
-	if (firstRow) {
+	if (firstRow != 0) {
 		memcpy(foregroundImage, backgroundImage, OLED_MAIN_WIDTH_PIXELS * firstRow);
 	}
 
 	// Partial row above
 	int32_t partialRowPixelsAbove = minY & 7;
-	if (partialRowPixelsAbove) {
+	if (partialRowPixelsAbove != 0) {
 		uint8_t destMask = 255 << partialRowPixelsAbove;
 		copyRowWithMask(destMask, backgroundImage[firstRow], foregroundImage[firstRow], minX, maxX);
 	}
@@ -475,7 +475,7 @@ void copyBackgroundAroundForeground(ImageStore backgroundImage, ImageStore foreg
 
 	// Partial row below
 	int32_t partialRowPixelsBelow = 7 - (maxY & 7);
-	if (partialRowPixelsBelow) {
+	if (partialRowPixelsBelow != 0) {
 		uint8_t destMask = 255 >> partialRowPixelsBelow;
 		copyRowWithMask(destMask, backgroundImage[lastRow], foregroundImage[lastRow], minX, maxX);
 	}
@@ -494,13 +494,13 @@ void OLED::sendMainImage() {
 
 	oledCurrentImage = &main.hackGetImageStore()[0];
 
-	if (numConsoleItems) {
+	if (numConsoleItems != 0) {
 		copyBackgroundAroundForeground(main.hackGetImageStore(), console.hackGetImageStore(), consoleMinX,
 		                               consoleItems[numConsoleItems - 1].minY - 1, consoleMaxX,
 		                               OLED_MAIN_HEIGHT_PIXELS - 1);
 		oledCurrentImage = &console.hackGetImageStore()[0];
 	}
-	if (oledPopupWidth) {
+	if (oledPopupWidth != 0) {
 		copyBackgroundAroundForeground(oledCurrentImage, popup.hackGetImageStore(), popupMinX, popupMinY, popupMaxX,
 		                               popupMaxY);
 		oledCurrentImage = &popup.hackGetImageStore()[0];
@@ -655,7 +655,7 @@ findNextStringSplitPoint:
 			addLine(textLineBreakdown, lineStart, lineWidth, lineLength);
 			// did we reach the end of the original string? or the max number of lines?
 			// then return, we're done
-			if (!*space || textLineBreakdown->numLines == TEXT_MAX_NUM_LINES) {
+			if ((*space == 0) || textLineBreakdown->numLines == TEXT_MAX_NUM_LINES) {
 				return;
 			}
 			// set character to start drawing from on the next line
@@ -805,7 +805,7 @@ void OLED::removeWorkingAnimation() {
 	if (hasPopupOfType(PopupType::LOADING)) {
 		removePopup();
 	}
-	else if (workingAnimationText) {
+	else if (workingAnimationText != nullptr) {
 		workingAnimationText = nullptr;
 	}
 }
@@ -904,7 +904,7 @@ void OLED::setupBlink(int32_t minX, int32_t width, int32_t minY, int32_t maxY, b
 }
 
 void OLED::stopBlink() {
-	if (blinkArea.u32) {
+	if (blinkArea.u32 != 0u) {
 		blinkArea.u32 = 0;
 		uiTimerManager.unsetTimer(TimerName::OLED_SCROLLING_AND_BLINKING);
 	}
@@ -967,7 +967,7 @@ void OLED::setupSideScroller(int32_t index, std::string_view text, int32_t start
 }
 
 void OLED::stopScrollingAnimation() {
-	if (sideScrollerDirection) {
+	if (sideScrollerDirection != 0) {
 		sideScrollerDirection = 0;
 		for (int32_t s = 0; s < NUM_SIDE_SCROLLERS; s++) {
 			SideScroller* scroller = &sideScrollers[s];
@@ -979,7 +979,7 @@ void OLED::stopScrollingAnimation() {
 
 void OLED::timerRoutine() {
 
-	if (workingAnimationText) {
+	if (workingAnimationText != nullptr) {
 		workingAnimationCount = (workingAnimationCount + 1) & 3;
 		updateWorkingAnimation();
 	}
@@ -991,12 +991,12 @@ void OLED::timerRoutine() {
 
 void OLED::scrollingAndBlinkingTimerEvent() {
 
-	if (blinkArea.u32) {
+	if (blinkArea.u32 != 0u) {
 		performBlink();
 		return;
 	}
 
-	if (!sideScrollerDirection) {
+	if (sideScrollerDirection == 0) {
 		return; // Probably isn't necessary...
 	}
 
@@ -1006,7 +1006,7 @@ void OLED::scrollingAndBlinkingTimerEvent() {
 	for (int32_t s = 0; s < NUM_SIDE_SCROLLERS; s++) {
 		bool doRender = true;
 		SideScroller* scroller = &sideScrollers[s];
-		if (scroller->text) {
+		if (scroller->text != nullptr) {
 			if (doScroll) {
 				if (scroller->finished) {
 					continue;
@@ -1079,7 +1079,7 @@ void OLED::scrollingAndBlinkingTimerEvent() {
 
 void OLED::consoleTimerEvent() {
 	// If console active
-	if (!numConsoleItems) {
+	if (numConsoleItems == 0) {
 		return;
 	}
 
@@ -1170,12 +1170,12 @@ checkTimeTilTimeout:
 		bool shouldCheckAgain = false;
 		if (consoleItems[numConsoleItems - 1].minY > consoleItems[numConsoleItems - 1].maxY) {
 			numConsoleItems--;
-			shouldCheckAgain = numConsoleItems;
+			shouldCheckAgain = (numConsoleItems != 0);
 		}
 		else {
 			timeTilNext = CONSOLE_ANIMATION_FRAME_TIME_SAMPLES;
 		}
-		if (numConsoleItems) {
+		if (numConsoleItems != 0) {
 			drawConsoleTopLine();
 		}
 		if (shouldCheckAgain) {
@@ -1185,11 +1185,11 @@ checkTimeTilTimeout:
 
 	// Or if it hasn't timed out, then provided we didn't already want a real-soon callback, come back when it does time
 	// out
-	else if (!timeTilNext) {
+	else if (timeTilNext == 0) {
 		timeTilNext = timeLeft;
 	}
 
-	if (timeTilNext) {
+	if (timeTilNext != 0) {
 		uiTimerManager.setTimerSamples(TimerName::OLED_CONSOLE, timeTilNext);
 	}
 
@@ -1213,7 +1213,7 @@ void OLED::freezeWithError(char const* text) {
 
 	// Wait for existing DMA transfer to finish
 	uint16_t startTime = *TCNT[TIMER_SYSTEM_SLOW];
-	while (!(DMACn(OLED_SPI_DMA_CHANNEL).CHSTAT_n & DMAC0_CHSTAT_n_TC)
+	while (((DMACn(OLED_SPI_DMA_CHANNEL).CHSTAT_n & DMAC0_CHSTAT_n_TC) == 0u)
 	       && (uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(50)) {}
 
 	// Wait for PIC to de-select OLED, if it's been doing that.
@@ -1221,7 +1221,7 @@ void OLED::freezeWithError(char const* text) {
 		startTime = *TCNT[TIMER_SYSTEM_SLOW];
 		while ((uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(50)) {
 			uint8_t value;
-			bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
+			bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value) != 0u;
 			if (anything && value == oledWaitingForMessage) {
 				break;
 			}
@@ -1239,7 +1239,7 @@ void OLED::freezeWithError(char const* text) {
 	startTime = *TCNT[TIMER_SYSTEM_SLOW];
 	while ((uint16_t)(*TCNT[TIMER_SYSTEM_SLOW] - startTime) < msToSlowTimerCount(50)) {
 		uint8_t value;
-		bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
+		bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value) != 0u;
 		if (anything && value == 248) {
 			break;
 		}
@@ -1261,12 +1261,12 @@ void OLED::freezeWithError(char const* text) {
 	DMACn(OLED_SPI_DMA_CHANNEL).CHCTRL_n |=
 	    DMAC_CHCTRL_0S_CLRTC | DMAC_CHCTRL_0S_SETEN; // ---- Enable DMA Transfer and clear TC bit ----
 
-	while (1) {
+	while (true) {
 		PIC::flush();
 		uartFlushIfNotSending(UART_ITEM_MIDI);
 
 		uint8_t value;
-		bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
+		bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value) != 0u;
 		if (anything) {
 			if (value == 175) {
 				break;

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -116,7 +116,7 @@ public:
 
 	void displayPopup(char const* newText, int8_t numFlashes = 3, bool = false, uint8_t = 255, int32_t = 1,
 	                  PopupType type = PopupType::GENERAL) override {
-		popupText(newText, !numFlashes, type);
+		popupText(newText, numFlashes == 0, type);
 	}
 
 	void popupText(char const* text, PopupType type = PopupType::GENERAL) override { popupText(text, true, type); }

--- a/src/deluge/hid/display/oled_canvas/canvas.cpp
+++ b/src/deluge/hid/display/oled_canvas/canvas.cpp
@@ -35,7 +35,7 @@ void Canvas::clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t ma
 
 	// First row
 	int32_t firstRowPixelWithin = minY & 7;
-	if (firstRowPixelWithin) {
+	if (firstRowPixelWithin != 0) {
 		firstCompleteRow++;
 		uint8_t firstRowMask = ~(255 << firstRowPixelWithin);
 		if (willDoLastRow && firstRow == lastRow) {
@@ -130,7 +130,7 @@ void Canvas::drawString(std::string_view string, int32_t pixelX, int32_t pixelY,
 	// to do iterate through each character in the string, based on its size in pixels
 	// and compare that to the scroll position (which is also in pixels)
 	// any characters before the scroll position are chopped off;
-	if (scrollPos) {
+	if (scrollPos != 0) {
 		int32_t numCharsToChopOff = 0;
 		int32_t widthOfCharsToChopOff = 0;
 		int32_t charStartX = 0;

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -118,7 +118,7 @@ void SevenSegment::setTopLayer(NumericLayer* newTopLayer) {
 }
 
 void SevenSegment::deleteAllLayers() {
-	while (topLayer) {
+	while (topLayer != nullptr) {
 		NumericLayer* toDelete = topLayer;
 		topLayer = topLayer->next;
 		toDelete->~NumericLayer();
@@ -127,7 +127,7 @@ void SevenSegment::deleteAllLayers() {
 }
 
 void SevenSegment::removeTopLayer() {
-	if (!topLayer || !topLayer->next) {
+	if ((topLayer == nullptr) || (topLayer->next == nullptr)) {
 		return;
 	}
 
@@ -149,14 +149,14 @@ void SevenSegment::setText(std::string_view newText, bool alignRight, uint8_t dr
                            uint8_t* encodedAddition, bool justReplaceBottomLayer) {
 	// Paul: Render time could be lower putting this into internal
 	void* layerSpace = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(NumericLayerBasicText));
-	if (!layerSpace) {
+	if (layerSpace == nullptr) {
 		return;
 	}
 	NumericLayerBasicText* newLayer = new (layerSpace) NumericLayerBasicText();
 
 	encodeText(newText, newLayer->segments, alignRight, drawDot, true, scrollPos);
 
-	if (encodedAddition) {
+	if (encodedAddition != nullptr) {
 		for (int32_t i = 0; i < kNumericDisplayLength; i++) {
 			newLayer->segments[i] |= encodedAddition[i];
 		}
@@ -169,7 +169,7 @@ void SevenSegment::setText(std::string_view newText, bool alignRight, uint8_t dr
 		newLayer->blinkSpeed = 0;
 	}
 	else {
-		if (newBlinkMask) {
+		if (newBlinkMask != nullptr) {
 			for (int32_t i = 0; i < kNumericDisplayLength; i++) {
 				newLayer->blinkedSegments[i] = newLayer->segments[i] & newBlinkMask[i];
 			}
@@ -198,7 +198,7 @@ NumericLayerScrollingText* SevenSegment::setScrollingText(char const* newText, i
                                                           int32_t initialDelay, int count, uint8_t fixedDot) {
 	// Paul: Render time could be lower putting this into internal
 	void* layerSpace = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(NumericLayerScrollingText));
-	if (!layerSpace) {
+	if (layerSpace == nullptr) {
 		return nullptr;
 	}
 	NumericLayerScrollingText* newLayer = new (layerSpace) NumericLayerScrollingText(fixedDot);
@@ -227,7 +227,7 @@ NumericLayerScrollingText* SevenSegment::setScrollingText(char const* newText, i
 
 void SevenSegment::replaceBottomLayer(NumericLayer* newLayer) {
 	NumericLayer** prevPointer = &topLayer;
-	while ((*prevPointer)->next) {
+	while ((*prevPointer)->next != nullptr) {
 		prevPointer = &(*prevPointer)->next;
 	}
 
@@ -254,7 +254,7 @@ void SevenSegment::transitionToNewLayer(NumericLayer* newLayer) {
 		// Paul: Render time could be lower putting this into internal
 		void* layerSpace = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(NumericLayerScrollTransition));
 
-		if (layerSpace) {
+		if (layerSpace != nullptr) {
 			scrollTransition = new (layerSpace) NumericLayerScrollTransition();
 			scrollTransition->transitionDirection = nextTransitionDirection;
 
@@ -268,7 +268,7 @@ void SevenSegment::transitionToNewLayer(NumericLayer* newLayer) {
 	deleteAllLayers();
 
 	// And if doing a transition, put that on top
-	if (scrollTransition) {
+	if (scrollTransition != nullptr) {
 		topLayer = newLayer;
 		setTopLayer(scrollTransition);
 	}
@@ -288,7 +288,7 @@ int32_t SevenSegment::getEncodedPosFromLeft(int32_t textPos, char const* text, b
 
 	for (int32_t i = 0; true; i++) {
 		char thisChar = *text;
-		if (!thisChar) {
+		if (thisChar == 0) {
 			break; // Stop at end of string
 		}
 		bool isDot = (thisChar == '.' || thisChar == '#' || thisChar == ',');
@@ -321,7 +321,7 @@ void putDot(uint8_t* destination, uint8_t drawDot) {
 	}
 	else if ((drawDot & 0b11110000) == 0b10000000) {
 		for (int32_t i = 0; i < kNumericDisplayLength; i++) {
-			if ((drawDot >> (kNumericDisplayLength - 1 - i)) & 1) {
+			if (((drawDot >> (kNumericDisplayLength - 1 - i)) & 1) != 0) {
 				destination[i] |= 128;
 			}
 		}
@@ -334,7 +334,7 @@ void clearDot(uint8_t* destination, uint8_t drawDot) {
 	}
 	else if ((drawDot & 0b11110000) == 0b10000000) {
 		for (int32_t i = 0; i < kNumericDisplayLength; i++) {
-			if ((drawDot >> (kNumericDisplayLength - 1 - i)) & 1) {
+			if (((drawDot >> (kNumericDisplayLength - 1 - i)) & 1) != 0) {
 				destination[i] &= ~128;
 			}
 		}

--- a/src/deluge/hid/encoder.cpp
+++ b/src/deluge/hid/encoder.cpp
@@ -28,10 +28,10 @@ Encoder::Encoder() {
 	encPos = 0;
 	detentPos = 0;
 	encLastChange = 0;
-	pinALastSwitch = 1;
-	pinBLastSwitch = 1;
-	pinALastRead = 1;
-	pinBLastRead = 1;
+	pinALastSwitch = true;
+	pinBLastSwitch = true;
+	pinALastRead = true;
+	pinBLastRead = true;
 	doDetents = true;
 	valuesNow[0] = true;
 	valuesNow[1] = true;

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -105,7 +105,7 @@ bool interpretEncoders(bool skipActioning) {
 			}
 		}
 
-		if (encodersWaitingForCardRoutineEnd & (1 << e)) {
+		if ((encodersWaitingForCardRoutineEnd & (1 << e)) != 0u) {
 			continue;
 		}
 
@@ -169,7 +169,7 @@ checkResult:
 					PadLEDs::changeRefreshTime(limitedDetentPos);
 				}
 				else if (Buttons::isButtonPressed(deluge::hid::button::RECORD)) {
-					if (currentSong) {
+					if (currentSong != nullptr) {
 						currentSong->changeThresholdRecordingMode(limitedDetentPos);
 					}
 				}

--- a/src/deluge/hid/led/indicator_leds.cpp
+++ b/src/deluge/hid/led/indicator_leds.cpp
@@ -88,7 +88,7 @@ void blinkLed(LED led, uint8_t numBlinks, uint8_t blinkingType, bool initialStat
 	updateBlinkingLedStates(blinkingType);
 
 	int32_t thisInitialFlashTime;
-	if (blinkingType) {
+	if (blinkingType != 0u) {
 		thisInitialFlashTime = kFastFlashTime;
 	}
 	else {
@@ -114,7 +114,7 @@ void ledBlinkTimeout(uint8_t blinkingType, bool forceReset, bool resetToState) {
 
 	bool anyActive = updateBlinkingLedStates(blinkingType);
 
-	int32_t thisFlashTime = (blinkingType ? kFastFlashTime : kFlashTime);
+	int32_t thisFlashTime = ((blinkingType != 0u) ? kFastFlashTime : kFlashTime);
 	if (anyActive) {
 		uiTimerManager.setTimer(static_cast<TimerName>(util::to_underlying(TimerName::LED_BLINK) + blinkingType),
 		                        thisFlashTime);
@@ -315,13 +315,13 @@ void blinkKnobIndicatorLevelTimeout() {
 	                      levelIndicatorBlinkOn ? levelIndicatorBipolar : false);
 
 	levelIndicatorBlinkOn = !levelIndicatorBlinkOn;
-	if (--levelIndicatorBlinksLeft) {
+	if (--levelIndicatorBlinksLeft != 0u) {
 		uiTimerManager.setTimer(TimerName::LEVEL_INDICATOR_BLINK, 20);
 	}
 }
 
 bool isKnobIndicatorBlinking(int32_t whichKnob) {
-	return (levelIndicatorBlinksLeft && whichLevelIndicatorBlinking == whichKnob);
+	return ((levelIndicatorBlinksLeft != 0u) && whichLevelIndicatorBlinking == whichKnob);
 }
 
 void clearKnobIndicatorLevels() {

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -142,9 +142,9 @@ void clearTickSquares(bool shouldSend) {
 	memset(slowFlashSquares, 255, sizeof(slowFlashSquares));
 
 	if (shouldSend && flashCursor == FLASH_CURSOR_SLOW && !shouldNotRenderDuringTimerRoutine()) {
-		if (colsToSend) {
+		if (colsToSend != 0u) {
 			for (int32_t x = 0; x < 8; x++) {
-				if (colsToSend & (1 << x)) {
+				if ((colsToSend & (1 << x)) != 0u) {
 					if (uartGetTxBufferSpace(UART_ITEM_PIC_PADS) <= kNumBytesInColUpdateMessage) {
 						break;
 					}
@@ -210,9 +210,9 @@ void setTickSquares(const uint8_t* squares, const uint8_t* colours) {
 
 	if (flashCursor == FLASH_CURSOR_SLOW && !shouldNotRenderDuringTimerRoutine()) {
 		// Actually send everything, if there was a change
-		if (colsToSend) {
+		if (colsToSend != 0u) {
 			for (int32_t x = 0; x < 8; x++) {
-				if (colsToSend & (1 << x)) {
+				if ((colsToSend & (1 << x)) != 0u) {
 					if (uartGetTxBufferSpace(UART_ITEM_PIC_PADS) <= kNumBytesInColUpdateMessage) {
 						break;
 					}
@@ -284,8 +284,8 @@ RGB prepareColour(int32_t x, int32_t y, RGB colourSource) {
 		}
 	}
 
-	if ((greyoutRows || greyoutCols)
-	    && ((greyoutRows & (1 << y)) || (greyoutCols & (1 << (kDisplayWidth + kSideBarWidth - 1 - x))))) {
+	if (((greyoutRows != 0u) || (greyoutCols != 0u))
+	    && (((greyoutRows & (1 << y)) != 0u) || ((greyoutCols & (1 << (kDisplayWidth + kSideBarWidth - 1 - x))) != 0u))) {
 		return colourSource.greyOut(greyProportion);
 	}
 	return colourSource;
@@ -383,7 +383,7 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 		}
 
 		for (int32_t i = 0; i < numAnimatedRows; i++) {
-			if (!occupancyMaskStore[i][col]) {
+			if (occupancyMaskStore[i][col] == 0u) {
 				continue; // Nothing to do if there was nothing in this square
 			}
 
@@ -433,7 +433,7 @@ void setupAudioClipCollapseOrExplodeAnimation(AudioClip* clip) {
 
 	Sample* sample = (Sample*)clip->sampleHolder.audioFile;
 
-	if (ALPHA_OR_BETA_VERSION && !sample) {
+	if (ALPHA_OR_BETA_VERSION && (sample == nullptr)) {
 		FREEZE_WITH_ERROR("E311");
 	}
 
@@ -519,7 +519,7 @@ void renderAudioClipExplodeAnimation(int32_t explodedness, bool shouldSendOut) {
 		xSourceRightEdge = xSourceBig >> 16;
 
 		// For first iteration, we just wanted that value, to use next time - and we should get out now
-		if (!xDestSquareRightEdge) {
+		if (xDestSquareRightEdge == 0) {
 			continue;
 		}
 
@@ -600,7 +600,7 @@ void renderExplodeAnimation(int32_t explodedness, bool shouldSendOut) {
 
 		for (int32_t xSource = xStart; xSource < xEnd; xSource++) {
 
-			if (occupancyMaskStore[ySource + 1][xSource]) { // If there's actually anything in this source square...
+			if (occupancyMaskStore[ySource + 1][xSource] != 0u) { // If there's actually anything in this source square...
 
 				for (int32_t xOffset = 0; xOffset < 2; xOffset++) {
 					int32_t xNow = xDestArray[xSource] + xOffset;
@@ -645,7 +645,7 @@ void reassessGreyout(bool doInstantly) {
 		return;
 	}
 
-	bool anythingBefore = (greyoutCols || greyoutRows);
+	bool anythingBefore = ((greyoutCols != 0u) || (greyoutRows != 0u));
 	bool anythingNow = (newCols || newRows);
 
 	bool anythingBoth = (anythingBefore && anythingNow);
@@ -932,7 +932,7 @@ void sendOutMainPadColours() {
 	}
 
 	for (int32_t col = 0; col < kDisplayWidth; col++) {
-		if (col & 1) {
+		if ((col & 1) != 0) {
 			sortLedsForCol(col - 1);
 		}
 	}
@@ -1213,7 +1213,7 @@ void renderZoomWithProgress(int32_t inImageTimesBiggerThanNative, uint32_t inIma
 
 				bool drawingAnything = false;
 
-				if (inImageFadePerCol[xDisplay]) {
+				if (inImageFadePerCol[xDisplay] != 0u) {
 
 					renderZoomedSquare(outputSquareStartOnInImage[xDisplay], outputSquareEndOnInImage[xDisplay],
 					                   inImageTimesBiggerThanNative, inImageFadePerCol[xDisplay], outValue, innerImage,
@@ -1262,7 +1262,7 @@ void renderZoomedSquare(int32_t outputSquareStartOnSourceImage, int32_t outputSq
 		}
 
 		// If nothing (i.e. black) at this input pixel, continue
-		if (!((*(uint32_t*)&inputImageRow[xSource * 3]) & (uint32_t)16777215)) {
+		if (((*(uint32_t*)&inputImageRow[xSource * 3]) & (uint32_t)16777215) == 0u) {
 			continue;
 		}
 

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -285,7 +285,8 @@ RGB prepareColour(int32_t x, int32_t y, RGB colourSource) {
 	}
 
 	if (((greyoutRows != 0u) || (greyoutCols != 0u))
-	    && (((greyoutRows & (1 << y)) != 0u) || ((greyoutCols & (1 << (kDisplayWidth + kSideBarWidth - 1 - x))) != 0u))) {
+	    && (((greyoutRows & (1 << y)) != 0u)
+	        || ((greyoutCols & (1 << (kDisplayWidth + kSideBarWidth - 1 - x))) != 0u))) {
 		return colourSource.greyOut(greyProportion);
 	}
 	return colourSource;
@@ -600,7 +601,8 @@ void renderExplodeAnimation(int32_t explodedness, bool shouldSendOut) {
 
 		for (int32_t xSource = xStart; xSource < xEnd; xSource++) {
 
-			if (occupancyMaskStore[ySource + 1][xSource] != 0u) { // If there's actually anything in this source square...
+			if (occupancyMaskStore[ySource + 1][xSource]
+			    != 0u) { // If there's actually anything in this source square...
 
 				for (int32_t xOffset = 0; xOffset < 2; xOffset++) {
 					int32_t xNow = xDestArray[xSource] + xOffset;

--- a/src/deluge/hid/matrix/matrix_driver.cpp
+++ b/src/deluge/hid/matrix/matrix_driver.cpp
@@ -60,7 +60,7 @@ void MatrixDriver::noPressesHappening(bool inCardRoutine) {
 	for (int32_t x = 0; x < kDisplayWidth + kSideBarWidth; x++) {
 		for (int32_t y = 0; y < kDisplayHeight; y++) {
 			if (padStates[x][y]) {
-				padAction(x, y, false);
+				padAction(x, y, 0);
 			}
 		}
 	}
@@ -72,7 +72,7 @@ ActionResult MatrixDriver::padAction(int32_t x, int32_t y, int32_t velocity) {
 		return ActionResult::DEALT_WITH;
 	}
 
-	padStates[x][y] = velocity;
+	padStates[x][y] = (velocity != 0);
 #if ENABLE_MATRIX_DEBUG
 	D_PRINT("UI=%s,PAD_X=%d,PAD_Y=%d,VEL=%d", getCurrentUI()->getName(), x, y, velocity);
 #endif

--- a/src/deluge/io/debug/print.cpp
+++ b/src/deluge/io/debug/print.cpp
@@ -124,7 +124,7 @@ void prependTimeStamp(bool isNewLine) {
 void println(char const* output) {
 #if ENABLE_TEXT_OUTPUT
 	prependTimeStamp(true);
-	if (midiDebugCable) {
+	if (midiDebugCable != nullptr) {
 		sysexDebugPrint(*midiDebugCable, output, true);
 	}
 	else {
@@ -144,7 +144,7 @@ void println(int32_t number) {
 void print(char const* output) {
 #if ENABLE_TEXT_OUTPUT
 	prependTimeStamp(false);
-	if (midiDebugCable) {
+	if (midiDebugCable != nullptr) {
 		sysexDebugPrint(*midiDebugCable, output, false);
 	}
 	else {
@@ -208,7 +208,7 @@ void RTimer::stop() {
 	lutHexString(deltaT, buffer + 9);
 	buffer[17] = ' ';
 	strcpy(buffer + 18, m_label);
-	if (midiDebugCable) {
+	if (midiDebugCable != nullptr) {
 		sysexDebugPrint(*midiDebugCable, buffer, true);
 	}
 	else {
@@ -233,7 +233,7 @@ void RTimer::stop(const char* stopLabel) {
 	strcpy(buffer + 18, m_label);
 	char* stopplace = buffer + 18 + strlen(m_label);
 	strcpy(stopplace, stopLabel);
-	if (midiDebugCable) {
+	if (midiDebugCable != nullptr) {
 		sysexDebugPrint(*midiDebugCable, buffer, true);
 	}
 	else {
@@ -260,7 +260,7 @@ void RTimer::stop(int number) {
 	ibuffer[0] = ' ';
 	intToString(number, ibuffer + 1);
 	strcpy(stopplace, ibuffer);
-	if (midiDebugCable) {
+	if (midiDebugCable != nullptr) {
 		sysexDebugPrint(*midiDebugCable, buffer, true);
 	}
 	else {

--- a/src/deluge/io/midi/cable_types/usb_common.cpp
+++ b/src/deluge/io/midi/cable_types/usb_common.cpp
@@ -24,16 +24,16 @@ void MIDICableUSB::connectedNow(int32_t midiDeviceNum) {
 }
 
 void MIDICableUSB::sendMCMsNowIfNeeded() {
-	if (needsToSendMCMs) {
+	if (needsToSendMCMs != 0u) {
 		needsToSendMCMs--;
-		if (!needsToSendMCMs) {
+		if (needsToSendMCMs == 0u) {
 			sendAllMCMs();
 		}
 	}
 }
 
 void MIDICableUSB::sendMessage(MIDIMessage message) {
-	if (!connectionFlags) {
+	if (connectionFlags == 0u) {
 		return;
 	}
 
@@ -42,7 +42,7 @@ void MIDICableUSB::sendMessage(MIDIMessage message) {
 	uint32_t fullMessage = setupUSBMessage(message);
 
 	for (int32_t d = 0; d < MAX_NUM_USB_MIDI_DEVICES; d++) {
-		if (connectionFlags & (1 << d)) {
+		if ((connectionFlags & (1 << d)) != 0) {
 			ConnectedUSBMIDIDevice* connectedDevice = &connectedUSBMIDIDevices[ip][d];
 			connectedDevice->bufferMessage(fullMessage);
 		}
@@ -56,13 +56,13 @@ size_t MIDICableUSB::sendBufferSpace() {
 	// find the connected device for this specific device. Note that virtual
 	// port number is specified as part of the message, implemented below.
 	for (int32_t d = 0; d < MAX_NUM_USB_MIDI_DEVICES; d++) {
-		if (connectionFlags & (1 << d)) {
+		if ((connectionFlags & (1 << d)) != 0) {
 			connectedDevice = &connectedUSBMIDIDevices[ip][d];
 			break;
 		}
 	}
 
-	if (!connectedDevice) {
+	if (connectedDevice == nullptr) {
 		return 0;
 	}
 
@@ -82,13 +82,13 @@ void MIDICableUSB::sendSysex(const uint8_t* data, int32_t len) {
 	// find the connected device for this specific device. Note that virtual
 	// port number is specified as part of the message, implemented below.
 	for (int32_t d = 0; d < MAX_NUM_USB_MIDI_DEVICES; d++) {
-		if (connectionFlags & (1 << d)) {
+		if ((connectionFlags & (1 << d)) != 0) {
 			connectedDevice = &connectedUSBMIDIDevices[ip][d];
 			break;
 		}
 	}
 
-	if (!connectedDevice) {
+	if (connectedDevice == nullptr) {
 		return;
 	}
 

--- a/src/deluge/io/midi/cable_types/usb_device_cable.cpp
+++ b/src/deluge/io/midi/cable_types/usb_device_cable.cpp
@@ -22,12 +22,12 @@
 
 void MIDIDeviceUSBUpstream::writeReferenceAttributesToFile(Serializer& writer) {
 	// Same line. Usually the user wouldn't have default velocity sensitivity set for their computer.
-	writer.writeAttribute("port", portNumber ? "upstreamUSB2" : "upstreamUSB", false);
+	writer.writeAttribute("port", (portNumber != 0u) ? "upstreamUSB2" : "upstreamUSB", false);
 }
 
 void MIDIDeviceUSBUpstream::writeToFlash(uint8_t* memory) {
 	D_PRINTLN("writing to flash port  %d  into ", portNumber);
-	*(uint16_t*)memory = portNumber ? VENDOR_ID_UPSTREAM_USB2 : VENDOR_ID_UPSTREAM_USB;
+	*(uint16_t*)memory = (portNumber != 0u) ? VENDOR_ID_UPSTREAM_USB2 : VENDOR_ID_UPSTREAM_USB;
 }
 
 char const* MIDIDeviceUSBUpstream::getDisplayName() {

--- a/src/deluge/io/midi/device_specific/midi_device_lumi_keys.cpp
+++ b/src/deluge/io/midi/device_specific/midi_device_lumi_keys.cpp
@@ -114,10 +114,10 @@ void MIDIDeviceLumiKeys::hookOnRecalculateColour() {
 
 	bool learnedToCurrentClip = false;
 
-	if (clip) {
+	if (clip != nullptr) {
 		// Determine if learned device on the current clip is the same as this one
 		LearnedMIDI* midiInput = &(((MelodicInstrument*)clip->output)->midiInput);
-		if (midiInput->containsSomething() && midiInput->cable) {
+		if (midiInput->containsSomething() && (midiInput->cable != nullptr)) {
 			if (midiInput->cable->getDisplayName() == getDisplayName()
 			    && midiInput->cable->connectionFlags == connectionFlags) {
 				learnedToCurrentClip = true;
@@ -132,7 +132,7 @@ void MIDIDeviceLumiKeys::hookOnRecalculateColour() {
 			uint32_t offset = 0;
 			NoteRow* noteRow = clip->getNoteRowOnScreen(yPos, currentSong);
 
-			if (noteRow) {
+			if (noteRow != nullptr) {
 				offset = noteRow->getColourOffset(clip);
 			}
 

--- a/src/deluge/io/midi/device_specific/specific_midi_device.cpp
+++ b/src/deluge/io/midi/device_specific/specific_midi_device.cpp
@@ -52,7 +52,7 @@ MIDIDeviceUSBHosted* getSpecificDeviceFromMIDICable(MIDICable& cable) {
 	// This depends on the MIDIDevice having been originally cast as something with a name
 	const char* sourceName = cable.getDisplayName();
 
-	if (cable.connectionFlags && sourceName) {
+	if ((cable.connectionFlags != 0u) && (sourceName != nullptr)) {
 		for (int32_t i = 0; i < hostedMIDIDevices.getNumElements(); i++) {
 			MIDIDeviceUSBHosted* candidate = recastSpecificMidiDevice(hostedMIDIDevices.getElement(i));
 

--- a/src/deluge/io/midi/learned_midi.cpp
+++ b/src/deluge/io/midi/learned_midi.cpp
@@ -90,7 +90,7 @@ void LearnedMIDI::writeToFile(Serializer& writer, char const* commandName, int32
 	writer.writeOpeningTagBeginning(commandName);
 	writeAttributesToFile(writer, midiMessageType);
 
-	if (cable) {
+	if (cable != nullptr) {
 		writer.writeOpeningTagEnd();
 		cable->writeReferenceToFile(writer);
 		writer.writeClosingTag(commandName);
@@ -103,18 +103,18 @@ void LearnedMIDI::writeToFile(Serializer& writer, char const* commandName, int32
 void LearnedMIDI::readFromFile(Deserializer& reader, int32_t midiMessageType) {
 
 	char const* tagName;
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
-		if (!strcmp(tagName, "channel")) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+		if (strcmp(tagName, "channel") == 0) {
 			channelOrZone = reader.readTagOrAttributeValueInt();
 		}
-		else if (!strcmp(tagName, "mpeZone")) {
+		else if (strcmp(tagName, "mpeZone") == 0) {
 			readMPEZone(reader);
 		}
-		else if (!strcmp(tagName, "device")) {
+		else if (strcmp(tagName, "device") == 0) {
 			cable = MIDIDeviceManager::readDeviceReferenceFromFile(reader);
 		}
 		else if (midiMessageType != MIDI_MESSAGE_NONE
-		         && !strcmp(tagName, getTagNameFromMIDIMessageType(midiMessageType))) {
+		         && (strcmp(tagName, getTagNameFromMIDIMessageType(midiMessageType)) == 0)) {
 			noteOrCC = reader.readTagOrAttributeValueInt();
 			noteOrCC = std::min<int32_t>(noteOrCC, 127);
 		}
@@ -124,10 +124,10 @@ void LearnedMIDI::readFromFile(Deserializer& reader, int32_t midiMessageType) {
 
 void LearnedMIDI::readMPEZone(Deserializer& reader) {
 	char const* text = reader.readTagOrAttributeValue();
-	if (!strcmp(text, "lower")) {
+	if (strcmp(text, "lower") == 0) {
 		channelOrZone = MIDI_CHANNEL_MPE_LOWER_ZONE;
 	}
-	else if (!strcmp(text, "upper")) {
+	else if (strcmp(text, "upper") == 0) {
 		channelOrZone = MIDI_CHANNEL_MPE_UPPER_ZONE;
 	}
 }
@@ -139,7 +139,7 @@ bool LearnedMIDI::equalsChannelAllowMPE(MIDICable* newCable, int32_t newChannel)
 	if (!equalsCable(newCable)) {
 		return false;
 	}
-	if (!cable) {
+	if (cable == nullptr) {
 		return false; // Could we actually be set to MPE but have no device? Maybe if loaded from weird song file?
 	}
 	int32_t newCorZ = newCable->ports[MIDI_DIRECTION_INPUT_TO_DELUGE].channelToZone(newChannel);

--- a/src/deluge/io/midi/learned_midi.h
+++ b/src/deluge/io/midi/learned_midi.h
@@ -33,7 +33,7 @@ public:
 	void clear();
 
 	inline bool equalsCable(MIDICable* newCable) {
-		return (!MIDIDeviceManager::differentiatingInputsByDevice || !cable || newCable == cable);
+		return (!MIDIDeviceManager::differentiatingInputsByDevice || (cable == nullptr) || newCable == cable);
 	}
 
 	inline bool equalsChannelOrZone(MIDICable* newCable, int32_t newChannelOrZone) {

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -298,8 +298,9 @@ void MIDIPort::readFromFile(Deserializer& reader, MIDICable* deviceToSendMCMsOn)
 			while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 				if (strcmp(tagName, "numMemberChannels") == 0) {
 
-					if (mpeLowerZoneLastMemberChannel == 0u) { // If value was already set, then leave it - the user or an
-						                                  // MCM might have changed it since the file was last read.
+					if (mpeLowerZoneLastMemberChannel
+					    == 0u) { // If value was already set, then leave it - the user or an
+						         // MCM might have changed it since the file was last read.
 						int32_t newMPELowerZoneLastMemberChannel = reader.readTagOrAttributeValueInt();
 						if (newMPELowerZoneLastMemberChannel >= 0 && newMPELowerZoneLastMemberChannel < 16) {
 							mpeLowerZoneLastMemberChannel = newMPELowerZoneLastMemberChannel;

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -135,7 +135,7 @@ public:
 	void sendRPN(int32_t channel, int32_t rpnMSB, int32_t rpnLSB, int32_t valueMSB);
 	// @}
 
-	inline bool hasDefaultVelocityToLevelSet() { return defaultVelocityToLevel; }
+	inline bool hasDefaultVelocityToLevelSet() { return defaultVelocityToLevel != 0; }
 
 	// Only 2 ports per device, but this is functionally set in stone due to existing code
 	// Originally done to ease integration to the midi device setting menu

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -245,7 +245,8 @@ extern "C" void hostedDeviceConfigured(int32_t ip, int32_t midiDeviceNum) {
 	}
 
 	connectedDevice->sq = 0;
-	connectedDevice->canHaveMIDISent = static_cast<uint8_t>((bool)strcmp(device->name.get(), "Synthstrom MIDI Foot Controller"));
+	connectedDevice->canHaveMIDISent =
+	    static_cast<uint8_t>((bool)strcmp(device->name.get(), "Synthstrom MIDI Foot Controller"));
 	connectedDevice->canHaveMIDISent = static_cast<uint8_t>((bool)strcmp(device->name.get(), "LUMI Keys BLOCK"));
 
 	device->connectedNow(midiDeviceNum);

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -863,7 +863,8 @@ void MidiEngine::checkIncomingUsbMidi() {
 		int32_t numDevicesNow = aPeripheral ? 1 : MAX_NUM_USB_MIDI_DEVICES;
 
 		for (int32_t d = 0; d < numDevicesNow; d++) {
-			if ((connectedUSBMIDIDevices[ip][d].cable[0] != nullptr) && (connectedUSBMIDIDevices[ip][d].currentlyWaitingToReceive == 0u)) {
+			if ((connectedUSBMIDIDevices[ip][d].cable[0] != nullptr)
+			    && (connectedUSBMIDIDevices[ip][d].currentlyWaitingToReceive == 0u)) {
 
 				int32_t bytesReceivedHere = connectedUSBMIDIDevices[ip][d].numBytesReceived;
 				if (bytesReceivedHere != 0) {
@@ -991,7 +992,8 @@ void MidiEngine::midiMessageReceived(MIDICable& cable, uint8_t statusType, uint8
 				// No break
 
 			case 0x08: // Note off, and note on continues here too
-				playbackHandler.noteMessageReceived(cable, (statusType & 1) != 0, channel, data1, data2, &shouldDoMidiThruNow);
+				playbackHandler.noteMessageReceived(cable, (statusType & 1) != 0, channel, data1, data2,
+				                                    &shouldDoMidiThruNow);
 #if MISSING_MESSAGE_CHECK
 				if (lastWasNoteOn == (bool)(statusType & 1))
 					FREEZE_WITH_ERROR("MISSED!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -540,7 +540,8 @@ void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithT
 
 		// Only if this exact TimelineCounter is having automation step-edited, we can set the value for just a
 		// region.
-		if ((view.modLength != 0u) && timelineCounter == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+		if ((view.modLength != 0u)
+		    && timelineCounter == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
 			modPos = view.modPos;
 			modLength = view.modLength;
 			isStepEditing = true;
@@ -929,17 +930,20 @@ void MidiFollow::readDefaultMappingsFromFile(Deserializer& reader) {
 				// if we have a valid param shortcut, let's confirm the tag name corresponds to that shortcut
 				if (((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
 				     && (strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED,
-				                                                  patchedParamShortcuts[xDisplay][yDisplay])) == 0))
+				                                                  patchedParamShortcuts[xDisplay][yDisplay]))
+				         == 0))
 				    || ((unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
 				        && (strcmp(tagName,
-				                   params::paramNameForFile(
-				                       params::Kind::UNPATCHED_SOUND,
-				                       params::UNPATCHED_START + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay])) == 0))
+				                   params::paramNameForFile(params::Kind::UNPATCHED_SOUND,
+				                                            params::UNPATCHED_START
+				                                                + unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay]))
+				            == 0))
 				    || ((unpatchedGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
 				        && (strcmp(tagName,
-				                   params::paramNameForFile(
-				                       params::Kind::UNPATCHED_GLOBAL,
-				                       params::UNPATCHED_START + unpatchedGlobalParamShortcuts[xDisplay][yDisplay])) == 0))) {
+				                   params::paramNameForFile(params::Kind::UNPATCHED_GLOBAL,
+				                                            params::UNPATCHED_START
+				                                                + unpatchedGlobalParamShortcuts[xDisplay][yDisplay]))
+				            == 0))) {
 					// tag name matches the param shortcut, so we can load the cc mapping for that param
 					// into the paramToCC grid shortcut array which holds the cc value for each param
 					paramToCC[xDisplay][yDisplay] = reader.readTagOrAttributeValueInt();

--- a/src/deluge/io/midi/sysex.cpp
+++ b/src/deluge/io/midi/sysex.cpp
@@ -59,7 +59,7 @@ void Debug::sysexReceived(MIDICable& cable, uint8_t* data, int32_t len) {
 }
 
 void Debug::sysexDebugPrint(MIDICable& cable, const char* msg, bool nl) {
-	if (!msg) {
+	if (msg == nullptr) {
 		return; // Do not do that
 	}
 	// data[4]: reserved, could serve as a message identifier to filter messages

--- a/src/deluge/memory/cache_manager.cpp
+++ b/src/deluge/memory/cache_manager.cpp
@@ -140,7 +140,7 @@ uint32_t CacheManager::ReclaimMemory(MemoryRegion& region, int32_t totalSizeNeed
 
 			// If that couldn't be done (in which case the original, central Stealable won't have been stolen either),
 			// move on to next Stealable to assess
-			if (!result.address) {
+			if (result.address == 0u) {
 				if (result.longestRunFound > longestRunSeenInThisQueue) {
 					longestRunSeenInThisQueue = result.longestRunFound;
 				}

--- a/src/deluge/memory/general_memory_allocator.cpp
+++ b/src/deluge/memory/general_memory_allocator.cpp
@@ -93,7 +93,7 @@ void* GeneralMemoryAllocator::allocExternal(uint32_t requiredSize) {
 	lock = true;
 	void* address = regions[MEMORY_REGION_EXTERNAL].alloc(requiredSize, false, NULL);
 	lock = false;
-	if (!address) {
+	if (address == nullptr) {
 		// FREEZE_WITH_ERROR("M998");
 		return nullptr;
 	}
@@ -124,7 +124,7 @@ void* GeneralMemoryAllocator::alloc(uint32_t requiredSize, bool mayUseOnChipRam,
 			address = regions[MEMORY_REGION_INTERNAL].alloc(requiredSize, makeStealable, thingNotToStealFrom);
 			lock = false;
 
-			if (address) {
+			if (address != nullptr) {
 				return address;
 			}
 
@@ -136,7 +136,7 @@ void* GeneralMemoryAllocator::alloc(uint32_t requiredSize, bool mayUseOnChipRam,
 		address = regions[MEMORY_REGION_EXTERNAL].alloc(requiredSize, makeStealable, thingNotToStealFrom);
 		lock = false;
 
-		if (address) {
+		if (address != nullptr) {
 			return address;
 		}
 

--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -607,8 +607,8 @@ tryNotStealingFirst:
 
 				uint32_t emptySpaceHereSizeWithoutHeaders = *lookLeftOrRight & SPACE_SIZE_MASK;
 
-				uint32_t spaceHereAddress =
-				    (lookingLeft != 0) ? (uint32_t)lookLeft - emptySpaceHereSizeWithoutHeaders : (uint32_t)(lookRight + 1);
+				uint32_t spaceHereAddress = (lookingLeft != 0) ? (uint32_t)lookLeft - emptySpaceHereSizeWithoutHeaders
+				                                               : (uint32_t)(lookRight + 1);
 
 				Stealable* stealable;
 

--- a/src/deluge/model/action/action.cpp
+++ b/src/deluge/model/action/action.cpp
@@ -58,14 +58,14 @@ void Action::prepareForDestruction(int32_t whichQueueActionIn, Song* song) {
 
 	deleteAllConsequences(whichQueueActionIn, song, true);
 
-	if (clipStates) {
+	if (clipStates != nullptr) {
 		delugeDealloc(clipStates);
 	}
 }
 
 void Action::deleteAllConsequences(int32_t whichQueueActionIn, Song* song, bool destructing) {
 	Consequence* currentConsequence = firstConsequence;
-	while (currentConsequence) {
+	while (currentConsequence != nullptr) {
 		AudioEngine::routineWithClusterLoading(); // -----------------------------------
 		Consequence* toDelete = currentConsequence;
 		currentConsequence = currentConsequence->next;
@@ -102,7 +102,7 @@ Error Action::revert(TimeType time, ModelStack* modelStack) {
 
 	Error error = Error::NONE;
 
-	while (thisConsequence) {
+	while (thisConsequence != nullptr) {
 		if (error == Error::NONE) {
 
 			// Can't quite remember why, but we don't wanna revert param changes for arrangement-record actions
@@ -147,7 +147,7 @@ Error Action::revert(TimeType time, ModelStack* modelStack) {
 
 bool Action::containsConsequenceParamChange(ParamCollection* paramCollection, int32_t paramId) {
 	// See if this param has already had its state snapshotted. If so, get out
-	for (Consequence* thisCons = firstConsequence; thisCons; thisCons = thisCons->next) {
+	for (Consequence* thisCons = firstConsequence; thisCons != nullptr; thisCons = thisCons->next) {
 		if (thisCons->type == Consequence::PARAM_CHANGE) {
 			ConsequenceParamChange* thisConsParamChange = (ConsequenceParamChange*)thisCons;
 			if (thisConsParamChange->modelStack.paramCollection == paramCollection
@@ -180,7 +180,7 @@ void Action::recordParamChangeDefinitely(ModelStackWithAutoParam const* modelSta
 
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceParamChange));
 
-	if (consMemory) {
+	if (consMemory != nullptr) {
 		ConsequenceParamChange* newCons = new (consMemory) ConsequenceParamChange(modelStack, stealData);
 		addConsequence(newCons);
 	}
@@ -188,7 +188,7 @@ void Action::recordParamChangeDefinitely(ModelStackWithAutoParam const* modelSta
 
 bool Action::containsConsequenceNoteArrayChange(InstrumentClip* clip, int32_t noteRowId, bool moveToFrontIfFound) {
 
-	for (Consequence** prevPointer = &firstConsequence; *prevPointer; prevPointer = &(*prevPointer)->next) {
+	for (Consequence** prevPointer = &firstConsequence; *prevPointer != nullptr; prevPointer = &(*prevPointer)->next) {
 		Consequence* thisCons = *prevPointer;
 		if (thisCons->type == Consequence::NOTE_ARRAY_CHANGE) {
 			ConsequenceNoteArrayChange* thisNoteArrayChange = (ConsequenceNoteArrayChange*)thisCons;
@@ -221,7 +221,7 @@ Error Action::recordNoteArrayChangeDefinitely(InstrumentClip* clip, int32_t note
                                               bool stealData) {
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceNoteArrayChange));
 
-	if (!consMemory) {
+	if (consMemory == nullptr) {
 		return Error::INSUFFICIENT_RAM;
 	}
 
@@ -241,7 +241,7 @@ void Action::recordNoteExistenceChange(InstrumentClip* clip, int32_t noteRowId, 
 
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceNoteExistence));
 
-	if (consMemory) {
+	if (consMemory != nullptr) {
 		ConsequenceNoteExistence* newConsequence =
 		    new (consMemory) ConsequenceNoteExistence(clip, noteRowId, note, type);
 		addConsequence(newConsequence);
@@ -252,7 +252,7 @@ void Action::recordClipInstanceExistenceChange(Output* output, ClipInstance* cli
 
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceClipInstanceExistence));
 
-	if (consMemory) {
+	if (consMemory != nullptr) {
 		ConsequenceClipInstanceExistence* newConsequence =
 		    new (consMemory) ConsequenceClipInstanceExistence(output, clipInstance, type);
 		addConsequence(newConsequence);
@@ -262,7 +262,7 @@ void Action::recordClipInstanceExistenceChange(Output* output, ClipInstance* cli
 void Action::recordClipLengthChange(Clip* clip, int32_t oldLength) {
 
 	// Check we don't already have a Consequence for this Clip's length
-	for (Consequence* cons = firstConsequence; cons; cons = cons->next) {
+	for (Consequence* cons = firstConsequence; cons != nullptr; cons = cons->next) {
 		if (cons->type == Consequence::CLIP_LENGTH) {
 			ConsequenceClipLength* consequenceClipLength = (ConsequenceClipLength*)cons;
 			if (consequenceClipLength->clip == clip) {
@@ -273,7 +273,7 @@ void Action::recordClipLengthChange(Clip* clip, int32_t oldLength) {
 
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceClipLength));
 
-	if (consMemory) {
+	if (consMemory != nullptr) {
 		ConsequenceClipLength* consequenceClipLength = new (consMemory) ConsequenceClipLength(clip, oldLength);
 		addConsequence(consequenceClipLength);
 	}
@@ -281,7 +281,7 @@ void Action::recordClipLengthChange(Clip* clip, int32_t oldLength) {
 
 bool Action::recordClipExistenceChange(Song* song, ClipArray* clipArray, Clip* clip, ExistenceChangeType type) {
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceClipExistence));
-	if (!consMemory) {
+	if (consMemory == nullptr) {
 		return false;
 	}
 
@@ -304,14 +304,14 @@ bool Action::recordClipExistenceChange(Song* song, ClipArray* clipArray, Clip* c
 // Call this *before* you change the Sample or its filePath
 void Action::recordAudioClipSampleChange(AudioClip* clip) {
 	void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceAudioClipSetSample));
-	if (consMemory) {
+	if (consMemory != nullptr) {
 		ConsequenceAudioClipSetSample* cons = new (consMemory) ConsequenceAudioClipSetSample(clip);
 		addConsequence(cons);
 	}
 }
 
 void Action::updateYScrollClipViewAfter(InstrumentClip* clip) {
-	if (!numClipStates) {
+	if (numClipStates == 0) {
 		return;
 	}
 

--- a/src/deluge/model/action/action_clip_state.cpp
+++ b/src/deluge/model/action/action_clip_state.cpp
@@ -41,7 +41,7 @@ void ActionClipState::grabFromClip(Clip* thisClip) {
 		}
 		else {
 			Kit* kit = (Kit*)thisClip->output;
-			if (!kit->selectedDrum) {
+			if (kit->selectedDrum == nullptr) {
 				selectedDrumIndex = -1;
 			}
 			else {

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -571,9 +571,8 @@ otherOption:
 
 		// Swap currentClip over. Can only do this after calling transitionToSessionView(). Previously, we did this much
 		// earlier, causing a crash. Hopefully moving it later here is ok...
-		if (action->currentClip
-		    != nullptr) { // If song just loaded and we hadn't been into ClipMinder yet, this would be NULL,
-			              // and we don't want to set currentSong->currentClip back to this
+		if (action->currentClip != nullptr) { // If song just loaded and we hadn't been into ClipMinder yet, this would
+			                                  // be NULL, and we don't want to set currentSong->currentClip back to this
 			currentSong->setCurrentClip(action->currentClip);
 		}
 	}

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -571,8 +571,9 @@ otherOption:
 
 		// Swap currentClip over. Can only do this after calling transitionToSessionView(). Previously, we did this much
 		// earlier, causing a crash. Hopefully moving it later here is ok...
-		if (action->currentClip != nullptr) { // If song just loaded and we hadn't been into ClipMinder yet, this would be NULL,
-			                       // and we don't want to set currentSong->currentClip back to this
+		if (action->currentClip
+		    != nullptr) { // If song just loaded and we hadn't been into ClipMinder yet, this would be NULL,
+			              // and we don't want to set currentSong->currentClip back to this
 			currentSong->setCurrentClip(action->currentClip);
 		}
 	}

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -137,7 +137,8 @@ void AudioClip::abortRecording() {
 }
 
 bool AudioClip::wantsToBeginLinearRecording(Song* song) {
-	return (Clip::wantsToBeginLinearRecording(song) && ((sampleHolder.audioFile == nullptr) || !shouldCloneForOverdubs())
+	return (Clip::wantsToBeginLinearRecording(song)
+	        && ((sampleHolder.audioFile == nullptr) || !shouldCloneForOverdubs())
 	        && ((AudioOutput*)output)->inputChannel > AudioInputChannel::NONE);
 }
 
@@ -190,7 +191,8 @@ void AudioClip::finishLinearRecording(ModelStackWithTimelineCounter* modelStack,
 
 	// Got to check reachedMaxFileSize here, cos that'll go true a bit before cardRoutine() sets status to ERROR
 	// also check if we haven't captured any samples (which can happen with threshold recording)
-	if (recorder->status == RecorderStatus::ABORTED || recorder->reachedMaxFileSize || (recorder->numSamplesCaptured == 0u)) {
+	if (recorder->status == RecorderStatus::ABORTED || recorder->reachedMaxFileSize
+	    || (recorder->numSamplesCaptured == 0u)) {
 		abortRecording();
 		return;
 	}
@@ -482,7 +484,8 @@ void AudioClip::resumePlayback(ModelStackWithTimelineCounter* modelStack, bool m
 	// If already time stretching, no need to do anything - that'll take care of the new play-position.
 	// Also can only do this if envelope not releasing, which (possibly not anymore since I fixed other bug) it can
 	// still be if this is our second quick successive <>+play starting playback partway through Clip
-	if ((voiceSample != nullptr) && (voiceSample->timeStretcher != nullptr) && ((AudioOutput*)output)->envelope.state < EnvelopeStage::RELEASE) {
+	if ((voiceSample != nullptr) && (voiceSample->timeStretcher != nullptr)
+	    && ((AudioOutput*)output)->envelope.state < EnvelopeStage::RELEASE) {
 		return;
 	}
 
@@ -652,7 +655,8 @@ justDontTimeStretch:
 
 	int32_t priorityRating = 1;
 
-	bool clipWillLoopAtEnd = (playbackHandler.playbackState != 0u) && currentPlaybackMode->willClipLoopAtSomePoint(modelStack);
+	bool clipWillLoopAtEnd =
+	    (playbackHandler.playbackState != 0u) && currentPlaybackMode->willClipLoopAtSomePoint(modelStack);
 	// I don't love that this is being called for every AudioClip at every render. This is to determine the "looping"
 	// parameter for the call to VoiceSample::render() below. It'd be better to maybe have that just query the
 	// currentPlaybackMode when it needs to actually use this info, cos it only occasionally needs it
@@ -933,7 +937,8 @@ doNormal:
 	else {
 
 		// If our ParamManager was the only one that the old Output had, we have to clone it
-		if ((song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)output->toModControllable(), this) == nullptr)
+		if ((song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)output->toModControllable(), this)
+		     == nullptr)
 		    && (song->getClipWithOutput(output, false, this) == nullptr)) {
 
 			ParamManagerForTimeline newParamManager;
@@ -991,7 +996,8 @@ void AudioClip::getScrollAndZoomInSamples(int32_t xScroll, int32_t xZoom, int64_
 			    sampleHolder.getEndPos(true) - xScrollSamplesWithinZone - (*xZoomSamples << kDisplayWidthMagnitude);
 		}
 		else {
-			int64_t sampleStartPos = (recorder != nullptr) ? recorder->sample->fileLoopStartSamples : sampleHolder.startPos;
+			int64_t sampleStartPos =
+			    (recorder != nullptr) ? recorder->sample->fileLoopStartSamples : sampleHolder.startPos;
 			*xScrollSamples = xScrollSamplesWithinZone + sampleStartPos;
 		}
 	}
@@ -1049,7 +1055,7 @@ void AudioClip::writeDataToFile(Serializer& writer, Song* song) {
 	writer.writeAttribute("trackName", output->name.get());
 
 	writer.writeAttribute("filePath", (sampleHolder.audioFile != nullptr) ? sampleHolder.audioFile->filePath.get()
-	                                                         : sampleHolder.filePath.get());
+	                                                                      : sampleHolder.filePath.get());
 	writer.writeAttribute("startSamplePos", sampleHolder.startPos);
 	writer.writeAttribute("endSamplePos", sampleHolder.endPos);
 	writer.writeAttribute("pitchSpeedIndependent", static_cast<int32_t>(sampleControls.pitchAndSpeedAreIndependent));
@@ -1373,7 +1379,8 @@ bool AudioClip::shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int
 		uint64_t length = sampleHolder.endPos - sampleHolder.startPos;
 
 		// Stop the clip if it is playing
-		bool active = (playbackHandler.isEitherClockActive() && modelStack->song->isClipActive(this) && (voiceSample != nullptr));
+		bool active =
+		    (playbackHandler.isEitherClockActive() && modelStack->song->isClipActive(this) && (voiceSample != nullptr));
 		unassignVoiceSample(false);
 
 		sampleHolder.startPos = newStartPos;

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -570,7 +570,8 @@ Error Clip::undoDetachmentFromOutput(ModelStackWithTimelineCounter* modelStack) 
 	ModControllable* modControllable = output->toModControllable();
 
 	bool success = modelStack->song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)modControllable,
-	                                                                           this, &paramManager) != nullptr;
+	                                                                           this, &paramManager)
+	               != nullptr;
 
 	if (!success) {
 		if (ALPHA_OR_BETA_VERSION) {
@@ -792,8 +793,9 @@ void Clip::prepareForDestruction(ModelStackWithTimelineCounter* modelStack,
 		detachFromOutput(modelStack, false);
 	}
 
-	if (oldOutput != nullptr) { // One case where there won't be an Output is if the song is being deleted because it wasn't able
-		             // to be completely loaded
+	if (oldOutput
+	    != nullptr) { // One case where there won't be an Output is if the song is being deleted because it wasn't able
+		              // to be completely loaded
 
 		if (instrumentRemovalInstruction == InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED) {
 			modelStack->song->deleteOrHibernateOutputIfNoClips(oldOutput);
@@ -931,8 +933,8 @@ Error Clip::solicitParamManager(Song* song, ParamManager* newParamManager, Clip*
 
 			// Let's first just see if there already was a *perfect* backed-up one for this *exact* Clip, that we could
 			// just have. If so, great, we're done.
-			if (song->getBackedUpParamManagerForExactClip((ModControllableAudio*)modControllable, this,
-			                                              &paramManager) != nullptr) {
+			if (song->getBackedUpParamManagerForExactClip((ModControllableAudio*)modControllable, this, &paramManager)
+			    != nullptr) {
 trimFoundParamManager:
 				char modelStackMemory[MODEL_STACK_MAX_SIZE];
 				ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
@@ -953,7 +955,8 @@ trimFoundParamManager:
 		if (!paramManager.containsAnyMainParamCollections()) {
 
 			bool success = song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)modControllable, this,
-			                                                               &paramManager) != nullptr;
+			                                                               &paramManager)
+			               != nullptr;
 
 			if (success) {
 				goto trimFoundParamManager;

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -793,9 +793,8 @@ void Clip::prepareForDestruction(ModelStackWithTimelineCounter* modelStack,
 		detachFromOutput(modelStack, false);
 	}
 
-	if (oldOutput
-	    != nullptr) { // One case where there won't be an Output is if the song is being deleted because it wasn't able
-		              // to be completely loaded
+	if (oldOutput != nullptr) { // One case where there won't be an Output is if the song is being deleted because it
+		                        // wasn't able to be completely loaded
 
 		if (instrumentRemovalInstruction == InstrumentRemoval::DELETE_OR_HIBERNATE_IF_UNUSED) {
 			modelStack->song->deleteOrHibernateOutputIfNoClips(oldOutput);

--- a/src/deluge/model/clip/clip_instance.cpp
+++ b/src/deluge/model/clip/clip_instance.cpp
@@ -29,7 +29,7 @@ ClipInstance::ClipInstance() {
 }
 
 RGB ClipInstance::getColour() {
-	if (!clip || clip->isArrangementOnlyClip()) {
+	if ((clip == nullptr) || clip->isArrangementOnlyClip()) {
 		return RGB::monochrome(128);
 	}
 
@@ -37,10 +37,10 @@ RGB ClipInstance::getColour() {
 }
 
 void ClipInstance::change(Action* action, Output* output, int32_t newPos, int32_t newLength, Clip* newClip) {
-	if (action) {
+	if (action != nullptr) {
 		void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceClipInstanceChange));
 
-		if (consMemory) {
+		if (consMemory != nullptr) {
 			ConsequenceClipInstanceChange* newConsequence =
 			    new (consMemory) ConsequenceClipInstanceChange(output, this, newPos, newLength, newClip);
 			action->addConsequence(newConsequence);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1182,7 +1182,8 @@ void InstrumentClip::expectNoFurtherTicks(Song* song, bool actuallySoundChange) 
 	if (output->type == OutputType::KIT) {
 		for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
 			NoteRow* thisNoteRow = noteRows.getElement(i);
-			if ((thisNoteRow->drum != nullptr) && thisNoteRow->paramManager.containsAnyParamCollectionsIncludingExpression()) {
+			if ((thisNoteRow->drum != nullptr)
+			    && thisNoteRow->paramManager.containsAnyParamCollectionsIncludingExpression()) {
 				ModelStackWithThreeMainThings* modelStackWithThreeMainThingsForNoteRow =
 				    modelStack->addNoteRow(i, thisNoteRow)
 				        ->addOtherTwoThings(thisNoteRow->drum->toModControllable(), &thisNoteRow->paramManager);
@@ -1781,7 +1782,8 @@ Error InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelStack
 			NoteRow* thisNoteRow = noteRows.getElement(i);
 
 			// Cycle through the backed up drum names for this NoteRow
-			for (DrumName* oldDrumName = thisNoteRow->firstOldDrumName; oldDrumName != nullptr; oldDrumName = oldDrumName->next) {
+			for (DrumName* oldDrumName = thisNoteRow->firstOldDrumName; oldDrumName != nullptr;
+			     oldDrumName = oldDrumName->next) {
 
 				// See if a Drum (which hasn't been assigned yet) has this name
 				SoundDrum* thisDrum = kit->getDrumFromName(oldDrumName->name.get(), true);
@@ -2026,7 +2028,8 @@ void InstrumentClip::assignDrumsToNoteRows(ModelStackWithTimelineCounter* modelS
 insertSomeAtBottom:
 		int32_t numNoteRowsInsertedAtBottom = 0;
 
-		while ((nextPotentiallyUnassignedDrum != nullptr) && numNoteRowsInsertedAtBottom < maxNumNoteRowsToInsertAtBottom) {
+		while ((nextPotentiallyUnassignedDrum != nullptr)
+		       && numNoteRowsInsertedAtBottom < maxNumNoteRowsToInsertAtBottom) {
 
 			Drum* thisDrum = nextPotentiallyUnassignedDrum;
 			nextPotentiallyUnassignedDrum = nextPotentiallyUnassignedDrum->next;
@@ -2101,7 +2104,8 @@ noUnassignedDrumsLeft:
 	// NoteRow, and make them one
 	else {
 
-		for (; nextPotentiallyUnassignedDrum != nullptr; nextPotentiallyUnassignedDrum = nextPotentiallyUnassignedDrum->next) {
+		for (; nextPotentiallyUnassignedDrum != nullptr;
+		     nextPotentiallyUnassignedDrum = nextPotentiallyUnassignedDrum->next) {
 
 			// If this Drum is already assigned to a NoteRow...
 			if (nextPotentiallyUnassignedDrum->noteRowAssignedTemp) {
@@ -2166,7 +2170,8 @@ Error InstrumentClip::undoUnassignmentOfAllNoteRowsFromDrums(ModelStackWithTimel
 		if ((noteRow->drum != nullptr) && noteRow->drum->type == DrumType::SOUND) {
 
 			bool success = modelStack->song->getBackedUpParamManagerPreferablyWithClip((SoundDrum*)noteRow->drum, this,
-			                                                                           &noteRow->paramManager) != nullptr;
+			                                                                           &noteRow->paramManager)
+			               != nullptr;
 
 			if (!success) {
 				if (ALPHA_OR_BETA_VERSION) {
@@ -3135,7 +3140,8 @@ doReadBendRange:
 				// Try grabbing the Instrument's "backed up" one
 				ModControllable* modControllable = output->toModControllable();
 				bool success = song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)modControllable,
-				                                                               this, &paramManager) != nullptr;
+				                                                               this, &paramManager)
+				               != nullptr;
 				if (success) {
 					char modelStackMemory[MODEL_STACK_MAX_SIZE];
 					ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
@@ -4054,7 +4060,8 @@ void InstrumentClip::getSuggestedParamManager(Clip* newClip, ParamManagerForTime
 		InstrumentClip* newInstrumentClip = (InstrumentClip*)newClip;
 		for (int32_t i = 0; i < newInstrumentClip->noteRows.getNumElements(); i++) {
 			NoteRow* noteRow = newInstrumentClip->noteRows.getElement(i);
-			if ((noteRow->drum != nullptr) && noteRow->drum->type == DrumType::SOUND && (SoundDrum*)noteRow->drum == sound) {
+			if ((noteRow->drum != nullptr) && noteRow->drum->type == DrumType::SOUND
+			    && (SoundDrum*)noteRow->drum == sound) {
 				*suggestedParamManager = &noteRow->paramManager;
 				break;
 			}
@@ -4087,8 +4094,9 @@ ParamManagerForTimeline* InstrumentClip::getCurrentParamManager() {
 
 Error InstrumentClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 
-	if (output == nullptr) { // Would only have an output already if file from before V2.0.0 I think? So, this block normally does
-		           // apply.
+	if (output == nullptr) { // Would only have an output already if file from before V2.0.0 I think? So, this block
+		                     // normally does
+		                     // apply.
 		const OutputType outputType = outputTypeWhileLoading;
 		const size_t outputTypeAsIdx = static_cast<size_t>(outputType);
 
@@ -4190,7 +4198,8 @@ Error InstrumentClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 
 					// Try grabbing the Drum's "backed up" one
 					success = (modelStackWithNoteRow->song->getBackedUpParamManagerPreferablyWithClip(
-					    (SoundDrum*)thisNoteRow->drum, this, &thisNoteRow->paramManager) != nullptr);
+					               (SoundDrum*)thisNoteRow->drum, this, &thisNoteRow->paramManager)
+					           != nullptr);
 					if (success) {
 						thisNoteRow->trimParamManager(modelStackWithNoteRow);
 					}
@@ -4368,8 +4377,8 @@ void InstrumentClip::finishLinearRecording(ModelStackWithTimelineCounter* modelS
 
 		bool mayStillLengthen = true;
 
-		while (
-		    thisNoteRow->notes.getNumElements() != 0) { // There's most likely only one offender, but you never really know
+		while (thisNoteRow->notes.getNumElements()
+		       != 0) { // There's most likely only one offender, but you never really know
 			Note* lastNote = thisNoteRow->notes.getLast();
 
 			// If Note is past new end-point that we're setting now, then delete / move the Note

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -104,7 +104,7 @@ void InstrumentClipMinder::selectEncoderAction(int32_t offset) {
 
 void InstrumentClipMinder::redrawNumericDisplay() {
 	if (display->have7SEG()) {
-		if (getCurrentUI()->toClipMinder()) { // Seems a redundant check now? Maybe? Or not?
+		if (getCurrentUI()->toClipMinder() != nullptr) { // Seems a redundant check now? Maybe? Or not?
 			view.displayOutputName(getCurrentOutput(), false);
 		}
 	}
@@ -222,7 +222,7 @@ gotError:
 
 	ParamManagerForTimeline newParamManager;
 	Instrument* newInstrument = StorageManager::createNewInstrument(newOutputType, &newParamManager);
-	if (!newInstrument) {
+	if (newInstrument == nullptr) {
 		error = Error::INSUFFICIENT_RAM;
 		goto gotError;
 	}
@@ -566,7 +566,7 @@ void InstrumentClipMinder::drawActualNoteCode(int16_t noteCode) {
 		display->popupTextTemporary(noteName);
 	}
 	else {
-		uint8_t drawDot = !isNatural ? 0 : 255;
+		uint8_t drawDot = (isNatural == 0) ? 0 : 255;
 		display->setText(noteName, false, drawDot, true);
 	}
 }

--- a/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
+++ b/src/deluge/model/consequence/consequence_audio_clip_set_sample.cpp
@@ -46,7 +46,7 @@ Error ConsequenceAudioClipSetSample::revert(TimeType time, ModelStack* modelStac
 		clip->sampleHolder.setAudioFile(nullptr);
 
 		// Deactivate Clip if it'd otherwise suddenly start recording again
-		if (playbackHandler.playbackState && playbackHandler.recording == RecordingMode::NORMAL) {
+		if ((playbackHandler.playbackState != 0u) && playbackHandler.recording == RecordingMode::NORMAL) {
 			clip->activeIfNoSolo = false;
 		}
 	}

--- a/src/deluge/model/consequence/consequence_begin_playback.cpp
+++ b/src/deluge/model/consequence/consequence_begin_playback.cpp
@@ -30,7 +30,7 @@ Error ConsequenceBeginPlayback::revert(TimeType time, ModelStack* modelStack) {
 	}
 
 	else {
-		if (!playbackHandler.playbackState) {
+		if (playbackHandler.playbackState == 0u) {
 			playbackHandler.setupPlaybackUsingInternalClock(0);
 		}
 	}

--- a/src/deluge/model/consequence/consequence_clip_begin_linear_record.cpp
+++ b/src/deluge/model/consequence/consequence_clip_begin_linear_record.cpp
@@ -53,7 +53,7 @@ Error ConsequenceClipBeginLinearRecord::revert(TimeType time, ModelStack* modelS
 
 			// Or if we're viewing the Clip, don't deactivate it, cos it's a massive hassle, and confusing, for user to
 			// go out and reactivate it
-			if (modelStack->song->getCurrentClip() == clip && getCurrentUI()->toClipMinder()) {
+			if (modelStack->song->getCurrentClip() == clip && (getCurrentUI()->toClipMinder() != nullptr)) {
 				return Error::NONE;
 			}
 

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -45,7 +45,7 @@ void ConsequenceClipExistence::prepareForDestruction(int32_t whichQueueActionIn,
 
 #if ALPHA_OR_BETA_VERSION
 		if (clip->type == ClipType::AUDIO) {
-			if (((AudioClip*)clip)->recorder) {
+			if (((AudioClip*)clip)->recorder != nullptr) {
 				FREEZE_WITH_ERROR("i002"); // Trying to diversify Qui's E278
 			}
 		}
@@ -74,7 +74,7 @@ Error ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) {
 		}
 
 #if ALPHA_OR_BETA_VERSION
-		if (clip->type == ClipType::AUDIO && !clip->paramManager.summaries[0].paramCollection) {
+		if (clip->type == ClipType::AUDIO && (clip->paramManager.summaries[0].paramCollection == nullptr)) {
 			FREEZE_WITH_ERROR("E419"); // Trying to diversify Leo's E410
 		}
 #endif
@@ -84,14 +84,14 @@ Error ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) {
 		clip->activeIfNoSolo = false;   // So we can toggle it back on, below
 		clip->armState = ArmState::OFF; // In case was left on before
 
-		if (shouldBeActiveWhileExistent && !(playbackHandler.playbackState && currentPlaybackMode == &arrangement)) {
+		if (shouldBeActiveWhileExistent && !((playbackHandler.playbackState != 0u) && currentPlaybackMode == &arrangement)) {
 			session.toggleClipStatus(clip, &clipIndex, true, 0);
 			if (!clip->activeIfNoSolo) {
 				D_PRINTLN("still not active!");
 			}
 		}
 
-		if (!clip->output->getActiveClip()) {
+		if (clip->output->getActiveClip() == nullptr) {
 			clip->output->setActiveClip(
 			    modelStackWithTimelineCounter); // Must do this to avoid E170 error. If Instrument has no
 			                                    // backedUpParamManager, it must have an activeClip
@@ -145,14 +145,14 @@ Error ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) {
 
 #if ALPHA_OR_BETA_VERSION
 		if (clip->type == ClipType::AUDIO) {
-			if (((AudioClip*)clip)->recorder) {
+			if (((AudioClip*)clip)->recorder != nullptr) {
 				FREEZE_WITH_ERROR("i003"); // Trying to diversify Qui's E278
 			}
 		}
 #endif
 
 #if ALPHA_OR_BETA_VERSION
-		if (clip->type == ClipType::AUDIO && !clip->paramManager.summaries[0].paramCollection) {
+		if (clip->type == ClipType::AUDIO && (clip->paramManager.summaries[0].paramCollection == nullptr)) {
 			FREEZE_WITH_ERROR("E420"); // Trying to diversify Leo's E410
 		}
 #endif

--- a/src/deluge/model/consequence/consequence_clip_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_existence.cpp
@@ -84,7 +84,8 @@ Error ConsequenceClipExistence::revert(TimeType time, ModelStack* modelStack) {
 		clip->activeIfNoSolo = false;   // So we can toggle it back on, below
 		clip->armState = ArmState::OFF; // In case was left on before
 
-		if (shouldBeActiveWhileExistent && !((playbackHandler.playbackState != 0u) && currentPlaybackMode == &arrangement)) {
+		if (shouldBeActiveWhileExistent
+		    && !((playbackHandler.playbackState != 0u) && currentPlaybackMode == &arrangement)) {
 			session.toggleClipStatus(clip, &clipIndex, true, 0);
 			if (!clip->activeIfNoSolo) {
 				D_PRINTLN("still not active!");

--- a/src/deluge/model/consequence/consequence_clip_instance_change.cpp
+++ b/src/deluge/model/consequence/consequence_clip_instance_change.cpp
@@ -34,7 +34,7 @@ ConsequenceClipInstanceChange::ConsequenceClipInstanceChange(Output* newOutput, 
 Error ConsequenceClipInstanceChange::revert(TimeType time, ModelStack* modelStack) {
 	int32_t i = output->clipInstances.search(pos[1 - time], GREATER_OR_EQUAL);
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
-	if (!clipInstance) {
+	if (clipInstance == nullptr) {
 		return Error::BUG;
 	}
 	clipInstance->pos = pos[time];

--- a/src/deluge/model/consequence/consequence_clip_instance_existence.cpp
+++ b/src/deluge/model/consequence/consequence_clip_instance_existence.cpp
@@ -44,7 +44,7 @@ Error ConsequenceClipInstanceExistence::revert(TimeType time, ModelStack* modelS
 	else { // (Re-)create
 		int32_t i = output->clipInstances.insertAtKey(pos);
 		ClipInstance* clipInstance = output->clipInstances.getElement(i);
-		if (!clipInstance) {
+		if (clipInstance == nullptr) {
 			return Error::INSUFFICIENT_RAM;
 		}
 		clipInstance->length = length;

--- a/src/deluge/model/consequence/consequence_clip_length.cpp
+++ b/src/deluge/model/consequence/consequence_clip_length.cpp
@@ -31,7 +31,7 @@ ConsequenceClipLength::ConsequenceClipLength(Clip* newClip, int32_t oldLength) {
 Error ConsequenceClipLength::revert(TimeType time, ModelStack* modelStack) {
 
 	uint64_t markerValueBeforeRevert;
-	if (pointerToMarkerValue) {
+	if (pointerToMarkerValue != nullptr) {
 		markerValueBeforeRevert = *pointerToMarkerValue;
 		*pointerToMarkerValue = markerValueToRevertTo;
 		markerValueToRevertTo = markerValueBeforeRevert;

--- a/src/deluge/model/consequence/consequence_note_array_change.cpp
+++ b/src/deluge/model/consequence/consequence_note_array_change.cpp
@@ -40,7 +40,7 @@ ConsequenceNoteArrayChange::ConsequenceNoteArrayChange(InstrumentClip* newClip, 
 Error ConsequenceNoteArrayChange::revert(TimeType time, ModelStack* modelStack) {
 
 	NoteRow* noteRow = clip->getNoteRowFromId(noteRowId);
-	if (!noteRow) {
+	if (noteRow == nullptr) {
 		return Error::BUG;
 	}
 

--- a/src/deluge/model/consequence/consequence_note_existence.cpp
+++ b/src/deluge/model/consequence/consequence_note_existence.cpp
@@ -40,7 +40,7 @@ ConsequenceNoteExistence::ConsequenceNoteExistence(InstrumentClip* newClip, int3
 
 Error ConsequenceNoteExistence::revert(TimeType time, ModelStack* modelStack) {
 	NoteRow* noteRow = clip->getNoteRowFromId(noteRowId);
-	if (!noteRow) {
+	if (noteRow == nullptr) {
 		return Error::BUG;
 	}
 
@@ -57,7 +57,7 @@ Error ConsequenceNoteExistence::revert(TimeType time, ModelStack* modelStack) {
 		// Create a note now
 		int32_t i = noteRow->notes.insertAtKey(pos);
 		Note* note = noteRow->notes.getElement(i);
-		if (!note) {
+		if (note == nullptr) {
 			return Error::INSUFFICIENT_RAM;
 		}
 		note->setLength(length);

--- a/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_horizontal_shift.cpp
@@ -44,7 +44,7 @@ Error ConsequenceNoteRowHorizontalShift::revert(TimeType time, ModelStack* model
 	                                                   ->addNoteRowId(noteRowId)
 	                                                   ->automaticallyAddNoteRowFromId();
 
-	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+	if (modelStackWithNoteRow->getNoteRowAllowNull() == nullptr) {
 #if ALPHA_OR_BETA_VERSION
 		FREEZE_WITH_ERROR("E377");
 #endif

--- a/src/deluge/model/consequence/consequence_note_row_mute.cpp
+++ b/src/deluge/model/consequence/consequence_note_row_mute.cpp
@@ -29,7 +29,7 @@ ConsequenceNoteRowMute::ConsequenceNoteRowMute(InstrumentClip* newClip, int32_t 
 
 Error ConsequenceNoteRowMute::revert(TimeType time, ModelStack* modelStack) {
 	NoteRow* noteRow = clip->getNoteRowFromId(noteRowId);
-	if (!noteRow) {
+	if (noteRow == nullptr) {
 		return Error::BUG;
 	}
 

--- a/src/deluge/model/drum/drum.cpp
+++ b/src/deluge/model/drum/drum.cpp
@@ -49,12 +49,12 @@ void Drum::writeMIDICommandsToFile(Serializer& writer) {
 
 bool Drum::readDrumTagFromFile(Deserializer& reader, char const* tagName) {
 
-	if (!strcmp(tagName, "midiMuteCommand")) {
+	if (strcmp(tagName, "midiMuteCommand") == 0) {
 		muteMIDICommand.readNoteFromFile(reader);
 		reader.exitTag();
 	}
 
-	else if (!strcmp(tagName, "midiInput")) {
+	else if (strcmp(tagName, "midiInput") == 0) {
 		midiInput.readNoteFromFile(reader);
 		reader.exitTag();
 	}
@@ -94,7 +94,7 @@ void Drum::expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelS
 	// stuff.
 	lastExpressionInputsReceived[level][expressionDimension] = newValue >> 8; // Store value
 	int32_t combinedValue =
-	    (int32_t)newValue + ((int32_t)lastExpressionInputsReceived[!level][expressionDimension] << 8);
+	    (int32_t)newValue + ((int32_t)lastExpressionInputsReceived[level == 0][expressionDimension] << 8);
 	combinedValue = lshiftAndSaturate<16>(combinedValue);
 
 	expressionValueChangesMustBeDoneSmoothly = true;
@@ -107,7 +107,7 @@ void Drum::expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelS
 		ModelStackWithNoteRow* modelStackWithNoteRow =
 		    ((InstrumentClip*)modelStack->getTimelineCounter())->getNoteRowForDrum(modelStack, this);
 		NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
-		if (!noteRow) {
+		if (noteRow == nullptr) {
 			goto justSend;
 		}
 

--- a/src/deluge/model/drum/gate_drum.cpp
+++ b/src/deluge/model/drum/gate_drum.cpp
@@ -53,7 +53,7 @@ void GateDrum::writeToFile(Serializer& writer, bool savingSong, ParamManager* pa
 Error GateDrum::readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 	char const* tagName;
 
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		if (NonAudioDrum::readDrumTagFromFile(reader, tagName)) {}
 		else {
 			reader.exitTag(tagName);

--- a/src/deluge/model/drum/midi_drum.cpp
+++ b/src/deluge/model/drum/midi_drum.cpp
@@ -64,8 +64,8 @@ void MIDIDrum::writeToFile(Serializer& writer, bool savingSong, ParamManager* pa
 Error MIDIDrum::readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos) {
 	char const* tagName;
 
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
-		if (!strcmp(tagName, "note")) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+		if (strcmp(tagName, "note") == 0) {
 			note = reader.readTagOrAttributeValueInt();
 			reader.exitTag("note");
 		}

--- a/src/deluge/model/fx/stutterer.cpp
+++ b/src/deluge/model/fx/stutterer.cpp
@@ -203,7 +203,7 @@ void Stutterer::endStutter(ParamManagerForTimeline* paramManager) {
 
 	bool automationOccurred = false;
 
-	if (paramManager) {
+	if (paramManager != nullptr) {
 
 		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -784,7 +784,7 @@ void GlobalEffectable::writeAttributesToFile(Serializer& writer, bool writeAutom
 }
 
 void GlobalEffectable::writeTagsToFile(Serializer& writer, ParamManager* paramManager, bool writeAutomation) {
-	if (paramManager) {
+	if (paramManager != nullptr) {
 		writer.writeOpeningTagBeginning("defaultParams");
 		GlobalEffectable::writeParamAttributesToFile(writer, paramManager, writeAutomation);
 		writer.writeOpeningTagEnd();
@@ -869,7 +869,7 @@ void GlobalEffectable::readParamsFromFile(Deserializer& reader, ParamManagerForT
                                           int32_t readAutomationUpToPos) {
 	char const* tagName;
 
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		if (readParamTagFromFile(reader, tagName, paramManager, readAutomationUpToPos)) {}
 		else {
 			reader.exitTag(tagName);
@@ -883,15 +883,15 @@ bool GlobalEffectable::readParamTagFromFile(Deserializer& reader, char const* ta
 	ParamCollectionSummary* unpatchedParamsSummary = paramManager->getUnpatchedParamSetSummary();
 	UnpatchedParamSet* unpatchedParams = (UnpatchedParamSet*)unpatchedParamsSummary->paramCollection;
 
-	if (!strcmp(tagName, "delay")) {
+	if (strcmp(tagName, "delay") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "rate")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "rate") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_DELAY_RATE,
 				                           readAutomationUpToPos);
 				reader.exitTag("rate");
 			}
-			else if (!strcmp(tagName, "feedback")) {
+			else if (strcmp(tagName, "feedback") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_DELAY_AMOUNT,
 				                           readAutomationUpToPos);
 				reader.exitTag("feedback");
@@ -900,21 +900,21 @@ bool GlobalEffectable::readParamTagFromFile(Deserializer& reader, char const* ta
 		reader.exitTag("delay", true);
 	}
 
-	else if (!strcmp(tagName, "lpf")) {
+	else if (strcmp(tagName, "lpf") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "frequency")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "frequency") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_LPF_FREQ,
 				                           readAutomationUpToPos);
 				reader.exitTag("frequency");
 			}
-			else if (!strcmp(tagName, "resonance")) {
+			else if (strcmp(tagName, "resonance") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_LPF_RES,
 				                           readAutomationUpToPos);
 				reader.exitTag("resonance");
 			}
 
-			else if (!strcmp(tagName, "morph")) {
+			else if (strcmp(tagName, "morph") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_LPF_MORPH,
 				                           readAutomationUpToPos);
 				reader.exitTag("morph");
@@ -923,21 +923,21 @@ bool GlobalEffectable::readParamTagFromFile(Deserializer& reader, char const* ta
 		reader.exitTag("lpf", true);
 	}
 
-	else if (!strcmp(tagName, "hpf")) {
+	else if (strcmp(tagName, "hpf") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "frequency")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "frequency") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_HPF_FREQ,
 				                           readAutomationUpToPos);
 				reader.exitTag("frequency");
 			}
-			else if (!strcmp(tagName, "resonance")) {
+			else if (strcmp(tagName, "resonance") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_HPF_RES,
 				                           readAutomationUpToPos);
 				reader.exitTag("resonance");
 			}
 
-			else if (!strcmp(tagName, "morph")) {
+			else if (strcmp(tagName, "morph") == 0) {
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_HPF_MORPH,
 				                           readAutomationUpToPos);
 				reader.exitTag("morph");
@@ -946,61 +946,61 @@ bool GlobalEffectable::readParamTagFromFile(Deserializer& reader, char const* ta
 		reader.exitTag("hpf", true);
 	}
 
-	else if (!strcmp(tagName, "reverbAmount")) {
+	else if (strcmp(tagName, "reverbAmount") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_REVERB_SEND_AMOUNT,
 		                           readAutomationUpToPos);
 		reader.exitTag("reverbAmount");
 	}
 
-	else if (!strcmp(tagName, "lpfMorph")) {
+	else if (strcmp(tagName, "lpfMorph") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_LPF_MORPH, readAutomationUpToPos);
 		reader.exitTag("lpfMorph");
 	}
 
-	else if (!strcmp(tagName, "hpfMorph")) {
+	else if (strcmp(tagName, "hpfMorph") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_HPF_MORPH, readAutomationUpToPos);
 		reader.exitTag("hpfMorph");
 	}
-	else if (!strcmp(tagName, "tempo")) {
+	else if (strcmp(tagName, "tempo") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_TEMPO, readAutomationUpToPos);
 		reader.exitTag("tempo");
 	}
 
-	else if (!strcmp(tagName, "volume")) {
+	else if (strcmp(tagName, "volume") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_VOLUME, readAutomationUpToPos);
 		reader.exitTag("volume");
 	}
 
-	else if (!strcmp(tagName, "sidechainCompressorVolume")) {
+	else if (strcmp(tagName, "sidechainCompressorVolume") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SIDECHAIN_VOLUME,
 		                           readAutomationUpToPos);
 		reader.exitTag("sidechainCompressorVolume");
 	}
 
-	else if (!strcmp(tagName, "sidechainCompressorShape")) {
+	else if (strcmp(tagName, "sidechainCompressorShape") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SIDECHAIN_SHAPE,
 		                           readAutomationUpToPos);
 		reader.exitTag("sidechainCompressorShape");
 	}
 
-	else if (!strcmp(tagName, "pan")) {
+	else if (strcmp(tagName, "pan") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_PAN, readAutomationUpToPos);
 		reader.exitTag("pan");
 	}
 
-	else if (!strcmp(tagName, "pitchAdjust")) {
+	else if (strcmp(tagName, "pitchAdjust") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_PITCH_ADJUST,
 		                           readAutomationUpToPos);
 		reader.exitTag("pitchAdjust");
 	}
 
-	else if (!strcmp(tagName, "modFXDepth")) {
+	else if (strcmp(tagName, "modFXDepth") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MOD_FX_DEPTH,
 		                           readAutomationUpToPos);
 		reader.exitTag("modFXDepth");
 	}
 
-	else if (!strcmp(tagName, "modFXRate")) {
+	else if (strcmp(tagName, "modFXRate") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_MOD_FX_RATE,
 		                           readAutomationUpToPos);
 		reader.exitTag("modFXRate");
@@ -1025,7 +1025,7 @@ Error GlobalEffectable::readTagFromFile(Deserializer& reader, char const* tagNam
 	// readAutomation)) {}
 
 	// else
-	if (paramManager && !strcmp(tagName, "defaultParams")) {
+	if ((paramManager != nullptr) && (strcmp(tagName, "defaultParams") == 0)) {
 
 		if (!paramManager->containsAnyMainParamCollections()) {
 			Error error = paramManager->setupUnpatched();
@@ -1039,17 +1039,17 @@ Error GlobalEffectable::readTagFromFile(Deserializer& reader, char const* tagNam
 		reader.exitTag("defaultParams");
 	}
 
-	else if (!strcmp(tagName, "modFXType")) {
+	else if (strcmp(tagName, "modFXType") == 0) {
 		modFXType_ = stringToFXType(reader.readTagOrAttributeValue());
 		reader.exitTag("modFXType");
 	}
 
-	else if (!strcmp(tagName, "modFXCurrentParam")) {
+	else if (strcmp(tagName, "modFXCurrentParam") == 0) {
 		currentModFXParam = stringToModFXParam(reader.readTagOrAttributeValue());
 		reader.exitTag("modFXCurrentParam");
 	}
 
-	else if (!strcmp(tagName, "currentFilterType")) {
+	else if (strcmp(tagName, "currentFilterType") == 0) {
 		currentFilterType = stringToFilterType(reader.readTagOrAttributeValue());
 		reader.exitTag("currentFilterType");
 	}
@@ -1150,7 +1150,7 @@ void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, i
 		disableGrain();
 	}
 	else if (modFXTypeNow == ModFXType::GRAIN) {
-		if (anySoundComingIn && !grainFX) {
+		if (anySoundComingIn && (grainFX == nullptr)) {
 			enableGrain();
 		}
 	}

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -160,9 +160,11 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	if (playbackHandler.isEitherClockActive() && (playbackHandler.ticksLeftInCountIn == 0) && isClipActive) {
 		const bool result =
 		    (params::kMaxNumUnpatchedParams > 32
-		        ? (static_cast<uint32_t>(paramManagerForClip->getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0] != 0u)
-		              || (paramManagerForClip->getUnpatchedParamSetSummary()->whichParamsAreInterpolating[1] != 0u))
-		        : paramManagerForClip->getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0]) != 0u;
+		         ? (static_cast<uint32_t>(
+		                paramManagerForClip->getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0] != 0u)
+		            || (paramManagerForClip->getUnpatchedParamSetSummary()->whichParamsAreInterpolating[1] != 0u))
+		         : paramManagerForClip->getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0])
+		    != 0u;
 		if (result) {
 			ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 			    modelStack->addOtherTwoThingsButNoNoteRow(this, paramManagerForClip);

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -44,7 +44,7 @@ public:
 
 	inline void saturate(int32_t* data, uint32_t* workingValue) {
 		// Clipping
-		if (clippingAmount) {
+		if (clippingAmount != 0u) {
 			int32_t shiftAmount = (clippingAmount >= 3) ? (clippingAmount - 3) : 0;
 			//*data = getTanHUnknown(*data, 5 + clippingAmount) << (shiftAmount);
 			*data = getTanHAntialiased(*data, workingValue, 3 + clippingAmount) << (shiftAmount);

--- a/src/deluge/model/instrument/cv_instrument.cpp
+++ b/src/deluge/model/instrument/cv_instrument.cpp
@@ -47,7 +47,7 @@ void CVInstrument::noteOffPostArp(int32_t noteCodePostArp, int32_t oldMIDIChanne
 void CVInstrument::polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,
                                                             int32_t expressionDimension, ArpNote* arpNote) {
 	if (cvEngine.isNoteOn(getPitchChannel(), noteCodeAfterArpeggiation)) {
-		if (!expressionDimension) { // Pitch bend only, handles different polyphonic vs mpe pitch scales
+		if (expressionDimension == 0) { // Pitch bend only, handles different polyphonic vs mpe pitch scales
 			polyPitchBendValue = newValue;
 			updatePitchBendOutput();
 		}
@@ -60,7 +60,7 @@ void CVInstrument::polyphonicExpressionEventPostArpeggiator(int32_t newValue, in
 }
 
 void CVInstrument::monophonicExpressionEvent(int32_t newValue, int32_t expressionDimension) {
-	if (!expressionDimension) { // Pitch bend only
+	if (expressionDimension == 0) { // Pitch bend only
 		monophonicPitchBendValue = newValue;
 		updatePitchBendOutput();
 	}
@@ -73,9 +73,9 @@ void CVInstrument::monophonicExpressionEvent(int32_t newValue, int32_t expressio
 void CVInstrument::updatePitchBendOutput(bool outputToo) {
 
 	ParamManager* paramManager = getParamManager(nullptr);
-	if (paramManager) {
+	if (paramManager != nullptr) {
 		ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
-		if (expressionParams) {
+		if (expressionParams != nullptr) {
 			cachedBendRanges[BEND_RANGE_MAIN] = expressionParams->bendRanges[BEND_RANGE_MAIN];
 			cachedBendRanges[BEND_RANGE_FINGER_LEVEL] = expressionParams->bendRanges[BEND_RANGE_FINGER_LEVEL];
 		}
@@ -98,7 +98,7 @@ bool CVInstrument::writeDataToFile(Serializer& writer, Clip* clipForSavingOutput
 	// call
 	writeMelodicInstrumentAttributesToFile(writer, clipForSavingOutputOnly, song);
 	writer.writeAttribute("cv2Source", static_cast<int32_t>(cvmode[1]));
-	if (clipForSavingOutputOnly || !midiInput.containsSomething()) {
+	if ((clipForSavingOutputOnly != nullptr) || !midiInput.containsSomething()) {
 		return false; // If we don't need to write a "device" tag, opt not to end the opening tag
 	}
 
@@ -126,11 +126,11 @@ bool CVInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmC
 	bool clipChanged = NonAudioInstrument::setActiveClip(modelStack, maySendMIDIPGMs);
 
 	if (clipChanged) {
-		if (modelStack) {
+		if (modelStack != nullptr) {
 
 			ParamManager* paramManager = &modelStack->getTimelineCounter()->paramManager;
 			ExpressionParamSet* expressionParams = paramManager->getExpressionParamSet();
-			if (expressionParams) {
+			if (expressionParams != nullptr) {
 				monophonicPitchBendValue = expressionParams->params[0].getCurrentValue();
 
 				cachedBendRanges[BEND_RANGE_MAIN] = expressionParams->bendRanges[BEND_RANGE_MAIN];

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -83,12 +83,12 @@ bool Instrument::writeDataToFile(Serializer& writer, Clip* clipForSavingOutputOn
 			writer.writeAttribute(slotXMLTag, ((NonAudioInstrument*)this)->getChannel());
 		}
 		char const* subSlotTag = getSubSlotXMLTag();
-		if (subSlotTag) {
+		if (subSlotTag != nullptr) {
 			writer.writeAttribute(subSlotTag, ((MIDIInstrument*)this)->channelSuffix);
 		}
 	}
 	// saving song
-	if (!clipForSavingOutputOnly) {
+	if (clipForSavingOutputOnly == nullptr) {
 		if (!name.isEmpty()) {
 			writer.writeAttribute("presetName", name.get());
 		}
@@ -152,7 +152,7 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 
 	// Allocate memory for Clip
 	void* clipMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(InstrumentClip));
-	if (!clipMemory) {
+	if (clipMemory == nullptr) {
 		return nullptr;
 	}
 
@@ -171,7 +171,7 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 		}
 	}
 	else if (type == OutputType::CV) {
-		if (getActiveClip()) {
+		if (getActiveClip() != nullptr) {
 			newParamManager.cloneParamCollectionsFrom(&getActiveClip()->paramManager, false,
 			                                          true); // Because we want the bend ranges
 		}

--- a/src/deluge/model/instrument/instrument.h
+++ b/src/deluge/model/instrument/instrument.h
@@ -58,7 +58,7 @@ public:
 		if (type == otherType) {
 
 			if (otherType == OutputType::SYNTH || otherType == OutputType::KIT) {
-				match = !strcasecmp(otherName, name.get()) && !strcasecmp(otherPath, dirPath.get());
+				match = (strcasecmp(otherName, name.get()) == 0) && (strcasecmp(otherPath, dirPath.get()) == 0);
 			}
 		}
 		return match;

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -265,7 +265,8 @@ Error Kit::readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t re
 			while (reader.match('{') && (*(tagName = reader.readNextTagOrAttributeName()) != 0)) {
 				DrumType drumType;
 
-				if ((strcmp(tagName, "sample") == 0) || (strcmp(tagName, "synth") == 0) || (strcmp(tagName, "sound") == 0)) {
+				if ((strcmp(tagName, "sample") == 0) || (strcmp(tagName, "synth") == 0)
+				    || (strcmp(tagName, "sound") == 0)) {
 					drumType = DrumType::SOUND;
 doReadDrum:
 					reader.match('{');
@@ -868,8 +869,9 @@ bool Kit::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend
 			for (int32_t i = 0; i < noteRows->getNumElements(); i++) {
 				NoteRow* thisNoteRow = noteRows->getElement(i);
 
-				if (thisNoteRow->drum != nullptr) { // In a perfect world we'd do this for every Drum, even any without NoteRows in
-					                     // new Clip, but meh this'll be fine
+				if (thisNoteRow->drum
+				    != nullptr) { // In a perfect world we'd do this for every Drum, even any without NoteRows in
+					              // new Clip, but meh this'll be fine
 
 					thisNoteRow->drum->noteRowAssignedTemp = true;
 					thisNoteRow->drum->earlyNoteVelocity = 0;
@@ -1047,7 +1049,8 @@ void Kit::receivedNoteForDrum(ModelStackWithTimelineCounter* modelStack, MIDICab
 
 	bool recordingNoteOnEarly = false;
 
-	bool shouldRecordNoteOn = shouldRecordNotes && (instrumentClip != nullptr) && currentSong->isClipActive(instrumentClip)
+	bool shouldRecordNoteOn = shouldRecordNotes && (instrumentClip != nullptr)
+	                          && currentSong->isClipActive(instrumentClip)
 	                          && instrumentClip->armedForRecording; // Even if this comes out as false here,
 	                                                                // there are some special cases below where
 	                                                                // we might insist on making it true
@@ -1523,8 +1526,9 @@ void Kit::stopAnyAuditioning(ModelStack* modelStack) {
 	for (Drum* thisDrum = firstDrum; thisDrum != nullptr; thisDrum = thisDrum->next) {
 		if (thisDrum->auditioned) {
 			ModelStackWithNoteRow* modelStackWithNoteRow =
-			    (activeClip != nullptr) ? ((InstrumentClip*)activeClip)->getNoteRowForDrum(modelStackWithTimelineCounter, thisDrum)
-			               : modelStackWithTimelineCounter->addNoteRow(0, nullptr);
+			    (activeClip != nullptr)
+			        ? ((InstrumentClip*)activeClip)->getNoteRowForDrum(modelStackWithTimelineCounter, thisDrum)
+			        : modelStackWithTimelineCounter->addNoteRow(0, nullptr);
 
 			endAuditioningForDrum(modelStackWithNoteRow, thisDrum);
 		}
@@ -1673,7 +1677,8 @@ ModelStackWithAutoParam* Kit::getModelStackWithParamForKitRow(ModelStackWithTime
                                                               bool useMenuStack) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
 
-	if ((selectedDrum != nullptr) && selectedDrum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
+	if ((selectedDrum != nullptr)
+	    && selectedDrum->type == DrumType::SOUND) { // no automation for MIDI or CV kit drum types
 
 		ModelStackWithNoteRow* modelStackWithNoteRow = ((InstrumentClip*)clip)->getNoteRowForSelectedDrum(modelStack);
 

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -869,9 +869,8 @@ bool Kit::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend
 			for (int32_t i = 0; i < noteRows->getNumElements(); i++) {
 				NoteRow* thisNoteRow = noteRows->getElement(i);
 
-				if (thisNoteRow->drum
-				    != nullptr) { // In a perfect world we'd do this for every Drum, even any without NoteRows in
-					              // new Clip, but meh this'll be fine
+				if (thisNoteRow->drum != nullptr) { // In a perfect world we'd do this for every Drum, even any without
+					                                // NoteRows in new Clip, but meh this'll be fine
 
 					thisNoteRow->drum->noteRowAssignedTemp = true;
 					thisNoteRow->drum->earlyNoteVelocity = 0;

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -108,8 +108,9 @@ void MelodicInstrument::receivedNote(ModelStackWithTimelineCounter* modelStack, 
 		// -1 means no change
 		auto* instrumentClip = (InstrumentClip*)activeClip;
 
-		ModelStackWithNoteRow* modelStackWithNoteRow =
-		    (instrumentClip != nullptr) ? instrumentClip->getNoteRowForYNote(note, modelStack) : modelStack->addNoteRow(0, nullptr);
+		ModelStackWithNoteRow* modelStackWithNoteRow = (instrumentClip != nullptr)
+		                                                   ? instrumentClip->getNoteRowForYNote(note, modelStack)
+		                                                   : modelStack->addNoteRow(0, nullptr);
 
 		NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
 

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -112,9 +112,8 @@ ModelStackWithAutoParam* MIDIInstrument::getParamFromModEncoder(int32_t whichMod
                                                                 ModelStackWithThreeMainThings* modelStack,
                                                                 bool allowCreation) {
 
-	if (modelStack->paramManager
-	    == nullptr) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
-		              // have no Clips
+	if (modelStack->paramManager == nullptr) { // Could be NULL - if the user is holding down an audition pad in
+		                                       // Arranger, and we have no Clips
 noParam:
 		return modelStack->addParamCollectionAndId(nullptr, nullptr, 0)->addAutoParam(nullptr); // "No param"
 	}
@@ -138,9 +137,8 @@ int32_t MIDIInstrument::getKnobPosForNonExistentParam(int32_t whichModEncoder, M
 ModelStackWithAutoParam*
 MIDIInstrument::getParamToControlFromInputMIDIChannel(int32_t cc, ModelStackWithThreeMainThings* modelStack) {
 
-	if (modelStack->paramManager
-	    == nullptr) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
-		              // have no Clips
+	if (modelStack->paramManager == nullptr) { // Could be NULL - if the user is holding down an audition pad in
+		                                       // Arranger, and we have no Clips
 noParam:
 		return modelStack->addParamCollectionAndId(nullptr, nullptr, 0)->addAutoParam(nullptr); // "No param"
 	}

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -112,8 +112,9 @@ ModelStackWithAutoParam* MIDIInstrument::getParamFromModEncoder(int32_t whichMod
                                                                 ModelStackWithThreeMainThings* modelStack,
                                                                 bool allowCreation) {
 
-	if (modelStack->paramManager == nullptr) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
-		                             // have no Clips
+	if (modelStack->paramManager
+	    == nullptr) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
+		              // have no Clips
 noParam:
 		return modelStack->addParamCollectionAndId(nullptr, nullptr, 0)->addAutoParam(nullptr); // "No param"
 	}
@@ -137,8 +138,9 @@ int32_t MIDIInstrument::getKnobPosForNonExistentParam(int32_t whichModEncoder, M
 ModelStackWithAutoParam*
 MIDIInstrument::getParamToControlFromInputMIDIChannel(int32_t cc, ModelStackWithThreeMainThings* modelStack) {
 
-	if (modelStack->paramManager == nullptr) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
-		                             // have no Clips
+	if (modelStack->paramManager
+	    == nullptr) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
+		              // have no Clips
 noParam:
 		return modelStack->addParamCollectionAndId(nullptr, nullptr, 0)->addAutoParam(nullptr); // "No param"
 	}
@@ -252,10 +254,11 @@ bool MIDIInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, Pg
 		InstrumentClip* newInstrumentClip = (InstrumentClip*)modelStack->getTimelineCounter();
 		InstrumentClip* oldInstrumentClip = (InstrumentClip*)activeClip;
 
-		shouldSendPGMs = (maySendMIDIPGMs != PgmChangeSend::NEVER && (activeClip != nullptr) && activeClip != newInstrumentClip
-		                  && (newInstrumentClip->midiPGM != oldInstrumentClip->midiPGM
-		                      || newInstrumentClip->midiSub != oldInstrumentClip->midiSub
-		                      || newInstrumentClip->midiBank != oldInstrumentClip->midiBank));
+		shouldSendPGMs =
+		    (maySendMIDIPGMs != PgmChangeSend::NEVER && (activeClip != nullptr) && activeClip != newInstrumentClip
+		     && (newInstrumentClip->midiPGM != oldInstrumentClip->midiPGM
+		         || newInstrumentClip->midiSub != oldInstrumentClip->midiSub
+		         || newInstrumentClip->midiBank != oldInstrumentClip->midiBank));
 	}
 	else {
 		shouldSendPGMs = false;

--- a/src/deluge/model/instrument/non_audio_instrument.cpp
+++ b/src/deluge/model/instrument/non_audio_instrument.cpp
@@ -31,7 +31,7 @@ void NonAudioInstrument::renderOutput(ModelStack* modelStack, StereoSample* star
                                       int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive) {
 
 	// MIDI / CV arpeggiator
-	if (activeClip) {
+	if (activeClip != nullptr) {
 		InstrumentClip* activeInstrumentClip = (InstrumentClip*)activeClip;
 
 		if (activeInstrumentClip->arpSettings.mode != ArpMode::OFF) {
@@ -73,7 +73,7 @@ void NonAudioInstrument::sendNote(ModelStackWithThreeMainThings* modelStack, boo
                                   uint32_t sampleSyncLength, int32_t ticksLate, uint32_t samplesLate) {
 
 	ArpeggiatorSettings* arpSettings = nullptr;
-	if (activeClip) {
+	if (activeClip != nullptr) {
 		arpSettings = &((InstrumentClip*)activeClip)->arpSettings;
 	}
 
@@ -195,7 +195,7 @@ lookAtArpNote:
 
 // Returns num ticks til next arp event
 int32_t NonAudioInstrument::doTickForwardForArp(ModelStack* modelStack, int32_t currentPos) {
-	if (!activeClip) {
+	if (activeClip == nullptr) {
 		return 2147483647;
 	}
 
@@ -234,7 +234,7 @@ int32_t NonAudioInstrument::doTickForwardForArp(ModelStack* modelStack, int32_t 
 // Unlike other Outputs, these don't have ParamManagers backed up at the Song level
 ParamManager* NonAudioInstrument::getParamManager(Song* song) {
 
-	if (activeClip) {
+	if (activeClip != nullptr) {
 		return &activeClip->paramManager;
 	}
 	else {

--- a/src/deluge/model/mod_controllable/ModFXProcessor.cpp
+++ b/src/deluge/model/mod_controllable/ModFXProcessor.cpp
@@ -274,7 +274,7 @@ void ModFXProcessor::processOnePhaserSample(int32_t modFXDepth, int32_t feedback
 }
 
 void ModFXProcessor::resetMemory() {
-	if (modFXBuffer) {
+	if (modFXBuffer != nullptr) {
 		memset(modFXBuffer, 0, kModFXBufferSize * sizeof(StereoSample));
 	}
 
@@ -285,15 +285,15 @@ void ModFXProcessor::resetMemory() {
 }
 
 void ModFXProcessor::setupBuffer() {
-	if (!modFXBuffer) {
+	if (modFXBuffer == nullptr) {
 		modFXBuffer = (StereoSample*)delugeAlloc(kModFXBufferSize * sizeof(StereoSample));
-		if (modFXBuffer) {
+		if (modFXBuffer != nullptr) {
 			memset(modFXBuffer, 0, kModFXBufferSize * sizeof(StereoSample));
 		}
 	}
 }
 void ModFXProcessor::disableBuffer() {
-	if (modFXBuffer) {
+	if (modFXBuffer != nullptr) {
 		delugeDealloc(modFXBuffer);
 		modFXBuffer = nullptr;
 	}

--- a/src/deluge/model/mod_controllable/ModFXProcessor.h
+++ b/src/deluge/model/mod_controllable/ModFXProcessor.h
@@ -52,7 +52,7 @@ public:
 	}
 	~ModFXProcessor() {
 		// Free the mod fx memory
-		if (modFXBuffer) {
+		if (modFXBuffer != nullptr) {
 			delugeDealloc(modFXBuffer);
 		}
 	}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -708,7 +708,8 @@ doReadPatchedParam:
 		reader.exitTag("AudioCompressor", true);
 	}
 	// this is actually the sidechain but pre c1.1 songs save it as compressor
-	else if ((strcmp(tagName, "compressor") == 0) || (strcmp(tagName, "sidechain") == 0)) { // Remember, Song doesn't use this
+	else if ((strcmp(tagName, "compressor") == 0)
+	         || (strcmp(tagName, "sidechain") == 0)) { // Remember, Song doesn't use this
 		// Set default values in case they are not configured
 		const char* name = tagName;
 		sidechain.syncType = SYNC_TYPE_EVEN;

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -180,9 +180,10 @@ ModelStackWithThreeMainThings* ModelStackWithNoteRow::addOtherTwoThingsAutomatic
 	ModelStackWithThreeMainThings* toReturn = (ModelStackWithThreeMainThings*)this;
 	NoteRow* noteRowHere = getNoteRow();
 	InstrumentClip* clip = (InstrumentClip*)getTimelineCounter();
-	toReturn->modControllable = (clip->output->type == OutputType::KIT && (noteRowHere->drum != nullptr)) // What if there's no Drum?
-	                                ? noteRowHere->drum->toModControllable()
-	                                : clip->output->toModControllable();
+	toReturn->modControllable =
+	    (clip->output->type == OutputType::KIT && (noteRowHere->drum != nullptr)) // What if there's no Drum?
+	        ? noteRowHere->drum->toModControllable()
+	        : clip->output->toModControllable();
 	toReturn->paramManager = &noteRowHere->paramManager;
 	return toReturn;
 }
@@ -194,8 +195,9 @@ bool ModelStackWithParamId::isParam(Kind kind, ParamType id) {
 bool ModelStackWithSoundFlags::checkSourceEverActiveDisregardingMissingSample(int32_t s) {
 	int32_t flagValue = soundFlags[SOUND_FLAG_SOURCE_0_ACTIVE_DISREGARDING_MISSING_SAMPLE + s];
 	if (flagValue == FLAG_TBD) {
-		flagValue = static_cast<int32_t>(((Sound*)modControllable)
-		                ->isSourceActiveEverDisregardingMissingSample(s, (ParamManagerForTimeline*)paramManager));
+		flagValue = static_cast<int32_t>(
+		    ((Sound*)modControllable)
+		        ->isSourceActiveEverDisregardingMissingSample(s, (ParamManagerForTimeline*)paramManager));
 		soundFlags[SOUND_FLAG_SOURCE_0_ACTIVE_DISREGARDING_MISSING_SAMPLE + s] = flagValue;
 	}
 	return flagValue != 0;
@@ -207,8 +209,8 @@ bool ModelStackWithSoundFlags::checkSourceEverActive(int32_t s) {
 		flagValue = static_cast<int32_t>(checkSourceEverActiveDisregardingMissingSample(s));
 		if (flagValue != 0) { // Does an &&
 			Sound* sound = (Sound*)modControllable;
-			flagValue =
-			    static_cast<int32_t>(sound->synthMode == SynthMode::FM
+			flagValue = static_cast<int32_t>(
+			    sound->synthMode == SynthMode::FM
 			    || (sound->sources[s].oscType != OscType::SAMPLE && sound->sources[s].oscType != OscType::WAVETABLE)
 			    || sound->sources[s].hasAtLeastOneAudioFileLoaded());
 		}

--- a/src/deluge/model/model_stack.h
+++ b/src/deluge/model/model_stack.h
@@ -143,11 +143,11 @@ public:
 		return (ModelStack*)this;
 	}
 
-	inline bool timelineCounterIsSet() const { return timelineCounter; }
+	inline bool timelineCounterIsSet() const { return timelineCounter != nullptr; }
 
 	inline TimelineCounter* getTimelineCounter() const {
 #if ALPHA_OR_BETA_VERSION
-		if (!timelineCounter) {
+		if (timelineCounter == nullptr) {
 			FREEZE_WITH_ERROR("E369");
 		}
 #endif
@@ -196,7 +196,7 @@ public:
 
 	inline NoteRow* getNoteRow() const {
 #if ALPHA_OR_BETA_VERSION
-		if (!noteRow) {
+		if (noteRow == nullptr) {
 			FREEZE_WITH_ERROR("E379");
 		}
 #endif

--- a/src/deluge/model/note/copied_note_row.cpp
+++ b/src/deluge/model/note/copied_note_row.cpp
@@ -24,7 +24,7 @@ CopiedNoteRow::CopiedNoteRow() {
 }
 
 CopiedNoteRow::~CopiedNoteRow() {
-	if (notes) {
+	if (notes != nullptr) {
 		delugeDealloc(notes);
 	}
 }

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -318,7 +318,8 @@ void NoteRow::addNotesToSquareInfo(int32_t effectiveLength, SquareInfo& squareIn
 	// does the note fall within the square we're looking at
 	if ((*note != nullptr) && ((*note)->pos >= squareInfo.squareStartPos) && ((*note)->pos < squareInfo.squareEndPos)) {
 		while ((noteIndex >= 0)
-		       && ((*note != nullptr) && ((*note)->pos >= squareInfo.squareStartPos) && ((*note)->pos < squareInfo.squareEndPos))) {
+		       && ((*note != nullptr) && ((*note)->pos >= squareInfo.squareStartPos)
+		           && ((*note)->pos < squareInfo.squareEndPos))) {
 			squareInfo.numNotes += 1;
 
 			if (squareInfo.numNotes == 1 && (*note)->pos == squareInfo.squareStartPos) {
@@ -879,7 +880,8 @@ Error NoteRow::clearArea(int32_t areaStart, int32_t areaWidth, ModelStackWithNot
 	// area
 	int32_t areaStartThisScreen =
 	    areaStart
-	    + static_cast<int>(actuallyExtendNoteAtStartOfArea); // If actuallyExtendNoteAtStartOfArea, then only clear from 1 tick later
+	    + static_cast<int>(
+	        actuallyExtendNoteAtStartOfArea); // If actuallyExtendNoteAtStartOfArea, then only clear from 1 tick later
 	int32_t areaEndThisScreen = areaStart + areaWidth;
 
 	for (int32_t i = 0; i < (numScreens << 1); i++) {
@@ -1036,14 +1038,16 @@ void NoteRow::recordNoteOff(uint32_t noteOffPos, ModelStackWithNoteRow* modelSta
 	int32_t newLength;
 	int32_t newNoteLeftPos;
 
-	int32_t i = notes.search(noteOffPos + static_cast<uint32_t>(!reversed), GREATER_OR_EQUAL) - static_cast<int>(!reversed);
+	int32_t i =
+	    notes.search(noteOffPos + static_cast<uint32_t>(!reversed), GREATER_OR_EQUAL) - static_cast<int>(!reversed);
 	bool wrapping = (i == -1 || i == notes.getNumElements());
 	if (wrapping) {
 
 		// If pingponging, do something quite unique
 		if (getEffectiveSequenceDirectionMode(modelStack) == SequenceDirection::PINGPONG) {
-			note = notes.getElement((notes.getNumElements() - 1) * static_cast<int>(reversed)); // Will be 0 if playing forwards
-			newNoteLeftPos = note->pos * static_cast<int>(reversed);                            // Will be 0 if playing forwards
+			note = notes.getElement((notes.getNumElements() - 1)
+			                        * static_cast<int>(reversed));   // Will be 0 if playing forwards
+			newNoteLeftPos = note->pos * static_cast<int>(reversed); // Will be 0 if playing forwards
 			newLength = reversed ? (effectiveLength - note->pos) : (note->pos + note->length);
 			wrapping = false; // Ensure we don't execute that if-block below
 			goto modifyNote;
@@ -2033,7 +2037,7 @@ int32_t NoteRow::processCurrentPos(ModelStackWithNoteRow* modelStack, int32_t ti
 
 		// Deal with recording from session to arrangement.
 		if ((loopLengthIfIndependent != 0) // Only if independent *length* - which isn't always the case when we have
-		                            // independent play pos.
+		                                   // independent play pos.
 		    && playbackHandler.recording == RecordingMode::ARRANGEMENT
 		    && lastProcessedPosIfIndependent
 		           == (playingReversedNow ? 0 : effectiveLength) // If reached end (or start) of row length.
@@ -2115,7 +2119,8 @@ int32_t NoteRow::processCurrentPos(ModelStackWithNoteRow* modelStack, int32_t ti
 			paramManager.notifyPingpongOccurred(modelStackWithThreeMainThings);
 		}
 
-		bool mayInterpolate = (drum != nullptr) ? drum->type == DrumType::SOUND : (clip->output->type == OutputType::SYNTH);
+		bool mayInterpolate =
+		    (drum != nullptr) ? drum->type == DrumType::SOUND : (clip->output->type == OutputType::SYNTH);
 		// We'll not interpolate for CV, just for efficiency. Since our CV output steps are limited anyway, this
 		// is probably reasonably reasonable.
 
@@ -2246,7 +2251,8 @@ stopNote:
 								goto stopNote;
 							}
 						}
-						else if (clip->output->type == OutputType::KIT && (drum != nullptr) && drum->type == DrumType::SOUND
+						else if (clip->output->type == OutputType::KIT && (drum != nullptr)
+						         && drum->type == DrumType::SOUND
 						         && clip->arpSettings.mode == ArpMode::OFF) { // For Kits
 							if (((SoundDrum*)drum)->hasCutModeSamples(&paramManager)) {
 								goto stopNote;
@@ -2295,7 +2301,8 @@ currentlyOff:
 					// Special case for currentPos 0...
 					if (searchPos == 0) {
 						if (!allowingNoteTailsNow) {
-							if (!alreadySearchedBackwards && (notes.getNumElements() != 0) && (notes.getElement(0)->pos == 0)) {
+							if (!alreadySearchedBackwards && (notes.getNumElements() != 0)
+							    && (notes.getElement(0)->pos == 0)) {
 								nextNoteI = 0;
 								goto gotValidNoteIndex;
 							}
@@ -2807,7 +2814,8 @@ bool NoteRow::generateRepeats(ModelStackWithNoteRow* modelStack, uint32_t oldLoo
 		}
 
 		if ((sound == nullptr)
-		    || (!sound->hasCutModeSamples(paramManagerNow) && (sound->hasAnyTimeStretchSyncing(paramManagerNow) == 0))) {
+		    || (!sound->hasCutModeSamples(paramManagerNow)
+		        && (sound->hasAnyTimeStretchSyncing(paramManagerNow) == 0))) {
 
 			notes.getElement(0)->length = newLoopLength;
 			return true;
@@ -2983,7 +2991,8 @@ bool NoteRow::generateRepeats(ModelStackWithNoteRow* modelStack, uint32_t oldLoo
 		if (iterance != kDefaultIteranceValue) {
 			int32_t divisor = iterance.divisor;
 
-			int32_t newNumFullLoops = (numRepeatsRounded != 0) ? newLoopLength / (uint32_t)(oldLoopLength * divisor) : 1;
+			int32_t newNumFullLoops =
+			    (numRepeatsRounded != 0) ? newLoopLength / (uint32_t)(oldLoopLength * divisor) : 1;
 
 			int32_t whichFullLoop = 0; // If newNumFullLoops is 0, this will never get above 0
 			int32_t whichRepeatWithinLoop = 0;
@@ -3687,7 +3696,8 @@ void NoteRow::setDrum(Drum* newDrum, Kit* kit, ModelStackWithNoteRow* modelStack
 				drum = soundDrum; // Better set this temporarily for this call. See comment above for why we
 				                  // can't set it permanently yet
 				bool success = modelStack->song->getBackedUpParamManagerPreferablyWithClip(
-				    soundDrum, (Clip*)modelStack->getTimelineCounter(), &paramManager) != nullptr;
+				                   soundDrum, (Clip*)modelStack->getTimelineCounter(), &paramManager)
+				               != nullptr;
 				if (success) {
 					trimParamManager(modelStack);
 				}
@@ -4114,7 +4124,8 @@ Error NoteRow::appendNoteRow(ModelStackWithNoteRow* thisModelStack, ModelStackWi
 		}
 
 		if ((sound == nullptr)
-		    || (!sound->hasCutModeSamples(paramManagerNow) && (sound->hasAnyTimeStretchSyncing(paramManagerNow) == 0))) {
+		    || (!sound->hasCutModeSamples(paramManagerNow)
+		        && (sound->hasAnyTimeStretchSyncing(paramManagerNow) == 0))) {
 
 			int32_t numNotesHere = notes.getNumElements();
 			if (numNotesHere != 0) {
@@ -4261,8 +4272,8 @@ void NoteRow::resumeOriginalNoteRowFromThisClone(ModelStackWithNoteRow* modelSta
 		originalNoteRow->silentlyResumePlayback(modelStackOriginal);
 	}
 
-	bool stillSounding =
-	    ((originalNoteRow != nullptr) && !originalNoteRow->muted && originalNoteRow->soundingStatus == STATUS_SEQUENCED_NOTE);
+	bool stillSounding = ((originalNoteRow != nullptr) && !originalNoteRow->muted
+	                      && originalNoteRow->soundingStatus == STATUS_SEQUENCED_NOTE);
 
 	bool shouldSoundNoteOffNow = (wasSounding && !stillSounding);
 

--- a/src/deluge/model/note/note_row_vector.cpp
+++ b/src/deluge/model/note/note_row_vector.cpp
@@ -51,8 +51,8 @@ void NoteRowVector::deleteNoteRowAtIndex(int32_t startIndex, int32_t numToDelete
 NoteRow* NoteRowVector::insertNoteRowAtY(int32_t y, int32_t* getIndex) {
 	int32_t i = search(y, GREATER_OR_EQUAL);
 	NoteRow* noteRow = insertNoteRowAtIndex(i);
-	if (noteRow) {
-		if (getIndex) {
+	if (noteRow != nullptr) {
+		if (getIndex != nullptr) {
 			*getIndex = i;
 		}
 		noteRow->y = y;

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -197,7 +197,7 @@ public:
 	                                                        int32_t paramID, deluge::modulation::params::Kind paramKind,
 	                                                        bool affectEntire, bool useMenuStack) = 0;
 	virtual bool needsEarlyPlayback() const { return false; }
-	bool hasRecorder() { return recorder; }
+	bool hasRecorder() { return recorder != nullptr; }
 	bool shouldRenderInSong() { return !(recorderIsEchoing); }
 
 	/// disable rendering to the song buffer if this clip is the input to an audio output that's monitoring
@@ -206,7 +206,7 @@ public:
 		outputRecordingThisOutput = output;
 	}
 	bool addRecorder(SampleRecorder* newRecorder) {
-		if (recorder) {
+		if (recorder != nullptr) {
 			return false;
 		}
 		recorder = newRecorder;
@@ -214,7 +214,7 @@ public:
 	}
 	// returns whether a recorder was removed
 	bool removeRecorder() {
-		if (recorder) {
+		if (recorder != nullptr) {
 			recorder->removeFromOutput();
 			recorder = nullptr;
 			return true;

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -564,7 +564,7 @@ doLoading:
 			// Bytes and samples are the same for the dest Cluster
 			int32_t samplesLeftThisDestCluster =
 			    (reversed != 0) ? (posWithinPercClusterBig + 1)
-			             : ((Cluster::size << kPercBufferReductionMagnitude) - posWithinPercClusterBig);
+			                    : ((Cluster::size << kPercBufferReductionMagnitude) - posWithinPercClusterBig);
 			numSamplesThisClusterReadWrite = std::min(numSamplesThisClusterReadWrite, samplesLeftThisDestCluster);
 		}
 
@@ -582,8 +582,9 @@ doLoading:
 		int32_t bytePosWithinCluster = sourceBytePos & (Cluster::size - 1);
 
 		// Ok, how many samples can we load right now?
-		int32_t bytesLeftThisSourceCluster = (reversed != 0) ? (bytePosWithinCluster + bytesPerSample)
-		                                              : (Cluster::size - bytePosWithinCluster + bytesPerSample - 1);
+		int32_t bytesLeftThisSourceCluster = (reversed != 0)
+		                                         ? (bytePosWithinCluster + bytesPerSample)
+		                                         : (Cluster::size - bytePosWithinCluster + bytesPerSample - 1);
 		int32_t bytesWeWantToRead = numSamplesThisClusterReadWrite * bytesPerSample;
 		if (bytesWeWantToRead > bytesLeftThisSourceCluster + bytesPerSample) {
 			numSamplesThisClusterReadWrite = bytesLeftThisSourceCluster / bytesPerSample;
@@ -602,9 +603,10 @@ doLoading:
 			int32_t numSamplesThisPercPixelSegment = numSamplesThisClusterReadWrite;
 
 			int32_t numSamplesLeftThisPercPixelSegment =
-			    (reversed != 0) ? (startPosSamples + 1 + (kPercBufferReductionSize >> 1)) & (kPercBufferReductionSize - 1)
-			             : kPercBufferReductionSize
-			                   - ((startPosSamples + (kPercBufferReductionSize >> 1)) & (kPercBufferReductionSize - 1));
+			    (reversed != 0)
+			        ? (startPosSamples + 1 + (kPercBufferReductionSize >> 1)) & (kPercBufferReductionSize - 1)
+			        : kPercBufferReductionSize
+			              - ((startPosSamples + (kPercBufferReductionSize >> 1)) & (kPercBufferReductionSize - 1));
 
 			if (numSamplesLeftThisPercPixelSegment == 0) {
 				numSamplesLeftThisPercPixelSegment = kPercBufferReductionSize;

--- a/src/deluge/model/sample/sample_cache.cpp
+++ b/src/deluge/model/sample/sample_cache.cpp
@@ -92,7 +92,7 @@ void SampleCache::unlinkClusters(int32_t startAtIndex, bool beingDestructed) {
 	// And there's now no point in having any further Clusters
 	int32_t numExistentClusters = getNumExistentClusters(writeBytePos);
 	for (int32_t i = startAtIndex; i < numExistentClusters; i++) {
-		if (ALPHA_OR_BETA_VERSION && !clusters[i]) {
+		if (ALPHA_OR_BETA_VERSION && (clusters[i] == nullptr)) {
 			FREEZE_WITH_ERROR("E167");
 		}
 
@@ -150,7 +150,7 @@ bool SampleCache::setupNewCluster(int32_t clusterIndex) {
 
 	// Do not add reasons, and don't steal from this SampleCache
 	clusters[clusterIndex] = Cluster::create(Cluster::Type::SAMPLE_CACHE, false, this);
-	if (!clusters[clusterIndex]) { // If that allocation failed...
+	if (clusters[clusterIndex] == nullptr) { // If that allocation failed...
 		D_PRINTLN("allocation fail");
 		return false;
 	}

--- a/src/deluge/model/sample/sample_cluster.cpp
+++ b/src/deluge/model/sample/sample_cluster.cpp
@@ -25,7 +25,7 @@
 #include <cstddef>
 
 SampleCluster::~SampleCluster() {
-	if (cluster) {
+	if (cluster != nullptr) {
 
 #if ALPHA_OR_BETA_VERSION
 		int32_t numReasonsToBeLoaded = cluster->numReasonsToBeLoaded;
@@ -33,7 +33,7 @@ SampleCluster::~SampleCluster() {
 			numReasonsToBeLoaded--;
 		}
 
-		if (numReasonsToBeLoaded) {
+		if (numReasonsToBeLoaded != 0) {
 			D_PRINTLN("uh oh, some reasons left...  %d", numReasonsToBeLoaded);
 
 			// Bay_Mud got this, and thinks a FlashAir card might have been a catalyst. It still "shouldn't" be able to
@@ -46,8 +46,8 @@ SampleCluster::~SampleCluster() {
 }
 
 void SampleCluster::ensureNoReason(Sample* sample) {
-	if (cluster) {
-		if (cluster->numReasonsToBeLoaded) {
+	if (cluster != nullptr) {
+		if (cluster->numReasonsToBeLoaded != 0) {
 			D_PRINTLN("Cluster has reason!  %d %d", cluster->numReasonsToBeLoaded, sample->filePath.get());
 
 			if (cluster->numReasonsToBeLoaded >= 0) {
@@ -71,7 +71,7 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 	}
 
 	// If the Cluster hasn't been created yet
-	if (!cluster) {
+	if (cluster == nullptr) {
 
 		// If the file can no longer be found on the card, we're in trouble
 		if (sample->unloadable) {
@@ -85,7 +85,7 @@ Cluster* SampleCluster::getCluster(Sample* sample, uint32_t clusterIndex, int32_
 		// D_PRINTLN("loading");
 		cluster = Cluster::create(); // Adds 1 reason
 
-		if (!cluster) {
+		if (cluster == nullptr) {
 			D_PRINTLN("couldn't allocate");
 			if (error != nullptr) {
 				*error = Error::INSUFFICIENT_RAM;
@@ -123,7 +123,7 @@ justEnqueue:
 			audioFileManager.loadingQueue.push(*cluster, priorityRating);
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
-			if (cluster && cluster->numReasonsToBeLoaded <= 0) {
+			if ((cluster != nullptr) && cluster->numReasonsToBeLoaded <= 0) {
 				FREEZE_WITH_ERROR("i027"); // Diversifying Ron R's i004, which was diversifying Qui's E341
 			}
 #endif
@@ -161,7 +161,7 @@ justEnqueue:
 				cluster = nullptr;
 			}
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on on V4.0.x have been getting E341.
-			if (cluster && cluster->numReasonsToBeLoaded <= 0) {
+			if ((cluster != nullptr) && cluster->numReasonsToBeLoaded <= 0) {
 				FREEZE_WITH_ERROR("i026"); // Michael B got - insane.
 			}
 #endif
@@ -172,7 +172,7 @@ justEnqueue:
 	else {
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on V4.1.3 have been getting E341.
-		if (cluster && cluster->numReasonsToBeLoaded < 0) {
+		if ((cluster != nullptr) && cluster->numReasonsToBeLoaded < 0) {
 			FREEZE_WITH_ERROR("i028"); // bnhrsch got this!!
 		}
 #endif
@@ -195,14 +195,14 @@ justEnqueue:
 		cluster->addReason();
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on V4.0.x have been getting E341.
-		if (cluster && cluster->numReasonsToBeLoaded <= 0) {
+		if ((cluster != nullptr) && cluster->numReasonsToBeLoaded <= 0) {
 			FREEZE_WITH_ERROR("i025"); // Diversifying Ron R's i004, which was diversifying Qui's E341
 		}
 #endif
 	}
 
 #if 1 || ALPHA_OR_BETA_VERSION // Switching permanently on for now, as users on V4.0.x have been getting E341.
-	if (cluster && cluster->numReasonsToBeLoaded <= 0) {
+	if ((cluster != nullptr) && cluster->numReasonsToBeLoaded <= 0) {
 		FREEZE_WITH_ERROR("i004"); // Ron R got this! Diversifying Qui's E341
 	}
 #endif

--- a/src/deluge/model/sample/sample_controls.cpp
+++ b/src/deluge/model/sample/sample_controls.cpp
@@ -33,7 +33,7 @@ useLinearInterpolation:
 	else {
 
 		// If CPU dire...
-		if (AudioEngine::cpuDireness) {
+		if (AudioEngine::cpuDireness != 0) {
 			int32_t octave =
 			    getMagnitudeOld(phaseIncrement); // Unstretched, and the first octave going up from that, would be '25'
 			if (octave >= 26

--- a/src/deluge/model/sample/sample_holder.cpp
+++ b/src/deluge/model/sample/sample_holder.cpp
@@ -41,7 +41,7 @@ SampleHolder::~SampleHolder() {
 
 	// Don't call setSample() - that does writing to variables which isn't necessary
 
-	if ((Sample*)audioFile) {
+	if (((Sample*)audioFile) != nullptr) {
 		unassignAllClusterReasons(true);
 #if ALPHA_OR_BETA_VERSION
 		if (audioFile->numReasonsToBeLoaded <= 0) {
@@ -54,7 +54,7 @@ SampleHolder::~SampleHolder() {
 
 void SampleHolder::beenClonedFrom(SampleHolder const* other, bool reversed) {
 	filePath.set(&other->filePath);
-	if (other->audioFile) {
+	if (other->audioFile != nullptr) {
 		setAudioFile(other->audioFile, reversed);
 	}
 
@@ -100,7 +100,7 @@ int32_t SampleHolder::getLengthInSamplesAtSystemSampleRate(bool forTimeStretchin
 
 // returns loop length in ticks from the sample waveform start and end positions selected
 int32_t SampleHolder::getLoopLengthAtSystemSampleRate(bool forTimeStretching) {
-	if (audioFile) {
+	if (audioFile != nullptr) {
 		double loopLength = (double)getLengthInSamplesAtSystemSampleRate(forTimeStretching)
 		                    / playbackHandler.getTimePerInternalTickFloat();
 
@@ -114,7 +114,7 @@ void SampleHolder::setAudioFile(AudioFile* newSample, bool reversed, bool manual
 
 	AudioFileHolder::setAudioFile(newSample, reversed, manuallySelected, clusterLoadInstruction);
 
-	if (audioFile) {
+	if (audioFile != nullptr) {
 
 		if (manuallySelected && ((Sample*)audioFile)->tempFilePathForRecording.isEmpty()) {
 			sampleBrowser.lastFilePathLoaded.set(&filePath);
@@ -142,7 +142,7 @@ void SampleHolder::setAudioFile(AudioFile* newSample, bool reversed, bool manual
 		sampleBeenSet(reversed, manuallySelected);
 
 #if 1 || ALPHA_OR_BETA_VERSION
-		if (!audioFile) {
+		if (audioFile == nullptr) {
 			FREEZE_WITH_ERROR("i031"); // Trying to narrow down E368 that Kevin F got
 		}
 #endif
@@ -157,7 +157,7 @@ constexpr int32_t kMarkerSamplesBeforeToClaim = 150;
 // Ensure there is a sample before you call this.
 void SampleHolder::claimClusterReasons(bool reversed, int32_t clusterLoadInstruction) {
 
-	if (ALPHA_OR_BETA_VERSION && !audioFile) {
+	if (ALPHA_OR_BETA_VERSION && (audioFile == nullptr)) {
 		FREEZE_WITH_ERROR("E368");
 	}
 
@@ -219,7 +219,7 @@ void SampleHolder::claimClusterReasonsForMarker(Cluster** clusters, uint32_t sta
 
 		newClusters[l] = sampleCluster->getCluster(((Sample*)audioFile), clusterIndex, clusterLoadInstruction);
 
-		if (!newClusters[l]) {
+		if (newClusters[l] == nullptr) {
 			D_PRINTLN("NULL!!");
 		}
 		else if (clusterLoadInstruction == CLUSTER_LOAD_IMMEDIATELY_OR_ENQUEUE && !newClusters[l]->loaded) {

--- a/src/deluge/model/sample/sample_holder_for_clip.cpp
+++ b/src/deluge/model/sample/sample_holder_for_clip.cpp
@@ -37,7 +37,7 @@ void SampleHolderForClip::setAudioFile(AudioFile* newAudioFile, bool reversed, b
 
 void SampleHolderForClip::recalculateNeutralPhaseIncrement() {
 
-	if (audioFile) {
+	if (audioFile != nullptr) {
 
 		int32_t noteWithinOctave = (uint16_t)(transpose + 240) % 12;
 		int32_t octave = ((uint16_t)(transpose + 120) / 12) - 10;
@@ -48,7 +48,7 @@ void SampleHolderForClip::recalculateNeutralPhaseIncrement() {
 			neutralPhaseIncrement = (uint64_t)neutralPhaseIncrement * ((Sample*)audioFile)->sampleRate / kSampleRate;
 		}
 
-		if (cents) {
+		if (cents != 0) {
 			int32_t multiplier = interpolateTable(2147483648u + (int32_t)cents * 42949672, 32, centAdjustTableSmall);
 			neutralPhaseIncrement = multiply_32x32_rshift32(neutralPhaseIncrement, multiplier) << 2;
 		}
@@ -63,14 +63,14 @@ void SampleHolderForClip::beenClonedFrom(SampleHolderForClip const* other, bool 
 
 void SampleHolderForClip::sampleBeenSet(bool reversed, bool manuallySelected) {
 
-	if (manuallySelected && ((Sample*)audioFile)->fileLoopEndSamples
+	if (manuallySelected && (((Sample*)audioFile)->fileLoopEndSamples != 0u)
 	    && ((Sample*)audioFile)->fileLoopEndSamples <= ((Sample*)audioFile)->lengthInSamples) {
 
 		endPos = ((Sample*)audioFile)->fileLoopEndSamples;
 
 		// Grab loop start from file too, if it's not erroneously late
 		if (((Sample*)audioFile)->fileLoopStartSamples < ((Sample*)audioFile)->lengthInSamples
-		    && (!((Sample*)audioFile)->fileLoopEndSamples
+		    && ((((Sample*)audioFile)->fileLoopEndSamples == 0u)
 		        || ((Sample*)audioFile)->fileLoopStartSamples < ((Sample*)audioFile)->fileLoopEndSamples)) {
 			startPos =
 			    ((Sample*)audioFile)->fileLoopStartSamples; // If it's 0, that'll translate to meaning no loop start

--- a/src/deluge/model/sample/sample_holder_for_voice.cpp
+++ b/src/deluge/model/sample/sample_holder_for_voice.cpp
@@ -178,7 +178,8 @@ void SampleHolderForVoice::sampleBeenSet(bool reversed, bool manuallySelected) {
 		loopStartPos = 0;
 		loopEndPos = 0;
 
-		if ((((Sample*)audioFile)->fileLoopEndSamples != 0u) && ((Sample*)audioFile)->fileLoopEndSamples <= lengthInSamples) {
+		if ((((Sample*)audioFile)->fileLoopEndSamples != 0u)
+		    && ((Sample*)audioFile)->fileLoopEndSamples <= lengthInSamples) {
 
 			int32_t loopLength = ((Sample*)audioFile)->fileLoopEndSamples - ((Sample*)audioFile)->fileLoopStartSamples;
 

--- a/src/deluge/model/sample/sample_holder_for_voice.h
+++ b/src/deluge/model/sample/sample_holder_for_voice.h
@@ -31,7 +31,7 @@ public:
 	void recalculateFineTuner();
 	void claimClusterReasons(bool reversed, int32_t clusterLoadInstruction = CLUSTER_ENQUEUE) override;
 	void setTransposeAccordingToSamplePitch(bool minimizeOctaves = false, bool doingSingleCycle = false,
-	                                        bool rangeCoversJustOneNote = false, bool thatOneNote = 0);
+	                                        bool rangeCoversJustOneNote = false, bool thatOneNote = false);
 	uint32_t getMSecLimit(Source* source);
 
 	/// In samples. 0 means not set.

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -183,7 +183,8 @@ void SampleLowLevelReader::setupReassessmentLocation(SamplePlaybackGuide* guide,
 
 #if ALPHA_OR_BETA_VERSION
 			if (((endPosWithinCurrentCluster + currentClusterIndex * Cluster::size - sample->audioDataStartPosBytes)
-			    % bytesPerSample) != 0u) {
+			     % bytesPerSample)
+			    != 0u) {
 				FREEZE_WITH_ERROR("E163");
 			}
 #endif

--- a/src/deluge/model/sample/sample_playback_guide.cpp
+++ b/src/deluge/model/sample/sample_playback_guide.cpp
@@ -43,7 +43,7 @@ int32_t SamplePlaybackGuide::getFinalClusterIndex(Sample* sample, bool obeyMarke
 		endPlaybackAtByteNow = getBytePosToEndOrLoopPlayback();
 	}
 
-	if (getEndPlaybackAtByte) {
+	if (getEndPlaybackAtByte != nullptr) {
 		*getEndPlaybackAtByte = endPlaybackAtByteNow;
 	}
 

--- a/src/deluge/model/sample/sample_reader.cpp
+++ b/src/deluge/model/sample/sample_reader.cpp
@@ -24,7 +24,7 @@
 
 Error SampleReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t num) {
 
-	while (num--) {
+	while ((num--) != 0) {
 		Error error = advanceClustersIfNecessary();
 		if (error != Error::NONE) {
 			return error;

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -34,7 +34,7 @@ public:
 	void remove(int8_t note) { bits = 0xfff & (bits & ~(1 << note)); }
 	/** Returns true if note is part of the NoteSet.
 	 */
-	bool has(int8_t note) const { return (bits >> note) & 1; }
+	bool has(int8_t note) const { return ((bits >> note) & 1) != 0; }
 	/** Like add(), but ensures note is in range and higher than previous notes.
 	 */
 	void addUntrusted(uint8_t note);

--- a/src/deluge/model/settings/runtime_feature_settings.cpp
+++ b/src/deluge/model/settings/runtime_feature_settings.cpp
@@ -230,7 +230,7 @@ void RuntimeFeatureSettings::readSettingsFromFile() {
 	int32_t currentValue = 0;
 	char const* currentTag = nullptr;
 
-	while (*(currentTag = reader.readNextTagOrAttributeName())) {
+	while (*(currentTag = reader.readNextTagOrAttributeName()) != 0) {
 
 		if (strcmp(currentTag, "startupSong") == 0) {
 			reader.readTagOrAttributeValueString(&startupSong);

--- a/src/deluge/model/song/clip_iterators.cpp
+++ b/src/deluge/model/song/clip_iterators.cpp
@@ -34,7 +34,7 @@ void ClipIteratorBase::deleteClip(InstrumentRemoval instrumentRemoval) {
 void ClipIteratorBase::next() {
 	for (;;) {
 		index++;
-		if (index >= array->getNumElements() && nextArray) {
+		if (index >= array->getNumElements() && (nextArray != nullptr)) {
 			array = nextArray;
 			nextArray = nullptr;
 			index = 0;
@@ -67,8 +67,8 @@ ClipIterator<Clip> AllClips::begin() {
 }
 
 ClipIterator<Clip> AllClips::end() {
-	ClipArray* last = second ? second : first;
-	int32_t n = last ? last->getNumElements() : 0;
+	ClipArray* last = (second != nullptr) ? second : first;
+	int32_t n = (last != nullptr) ? last->getNumElements() : 0;
 	return ClipIterator<Clip>(last, n, nullptr, {});
 }
 
@@ -81,7 +81,7 @@ ClipIterator<InstrumentClip> InstrumentClips::begin() {
 }
 
 ClipIterator<InstrumentClip> InstrumentClips::end() {
-	ClipArray* last = second ? second : first;
+	ClipArray* last = (second != nullptr) ? second : first;
 	return ClipIterator<InstrumentClip>(last, last->getNumElements(), nullptr, ClipType::INSTRUMENT);
 }
 
@@ -94,6 +94,6 @@ ClipIterator<AudioClip> AudioClips::begin() {
 }
 
 ClipIterator<AudioClip> AudioClips::end() {
-	ClipArray* last = second ? second : first;
+	ClipArray* last = (second != nullptr) ? second : first;
 	return ClipIterator<AudioClip>(last, last->getNumElements(), nullptr, ClipType::AUDIO);
 }

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -208,7 +208,7 @@ Song::~Song() {
 
 	// Delete existing Clips, if any
 	for (int32_t c = 0; c < sessionClips.getNumElements(); c++) {
-		if ((c & 31) == 0) {                              // Exact number here not fine-tuned
+		if ((c & 31) == 0) {                          // Exact number here not fine-tuned
 			AudioEngine::routineWithClusterLoading(); // -----------------------------------
 		}
 
@@ -217,7 +217,7 @@ Song::~Song() {
 	}
 
 	for (int32_t c = 0; c < arrangementOnlyClips.getNumElements(); c++) {
-		if ((c & 31) == 0) {                              // Exact number here not fine-tuned
+		if ((c & 31) == 0) {                          // Exact number here not fine-tuned
 			AudioEngine::routineWithClusterLoading(); // -----------------------------------
 		}
 
@@ -1562,8 +1562,9 @@ unknownTag:
 			}
 
 			else if (strcmp(tagName,
-			                 "inArrangementView") == 0) { // For V2.0 pre-beta songs. There'd be another way to detect
-				                                     // this...
+			                "inArrangementView")
+			         == 0) { // For V2.0 pre-beta songs. There'd be another way to detect
+				             // this...
 				lastClipInstanceEnteredStartPos = 0;
 				reader.exitTag("inArrangementView");
 			}
@@ -1996,7 +1997,8 @@ loadOutput:
 				reader.exitTag();
 			}
 
-			else if ((strcmp(tagName, "arrangementOnlyTracks") == 0) || (strcmp(tagName, "arrangementOnlyClips") == 0)) {
+			else if ((strcmp(tagName, "arrangementOnlyTracks") == 0)
+			         || (strcmp(tagName, "arrangementOnlyClips") == 0)) {
 				Error error = readClipsFromFile(reader, &arrangementOnlyClips);
 				if (error != Error::NONE) {
 					return error;
@@ -2239,7 +2241,8 @@ skipInstance:
 
 	AudioEngine::routineWithClusterLoading(); // -----------------------------------
 
-	int32_t playbackWillStartInArrangerAtPos = (playbackHandler.playbackState != 0u) ? lastClipInstanceEnteredStartPos : -1;
+	int32_t playbackWillStartInArrangerAtPos =
+	    (playbackHandler.playbackState != 0u) ? lastClipInstanceEnteredStartPos : -1;
 
 	AudioEngine::logAction("aaa5.1");
 	sortOutWhichClipsAreActiveWithoutSendingPGMs(modelStack, playbackWillStartInArrangerAtPos);
@@ -2459,10 +2462,13 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 
 	if (playbackHandler.isEitherClockActive() && (playbackHandler.ticksLeftInCountIn == 0)
 	    && currentPlaybackMode == &arrangement) {
-		const bool result = (params::kMaxNumUnpatchedParams > 32
-		                        ? (static_cast<uint32_t>(paramManager.getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0] != 0u)
-		                              || (paramManager.getUnpatchedParamSetSummary()->whichParamsAreInterpolating[1] != 0u))
-		                        : paramManager.getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0]) != 0u;
+		const bool result =
+		    (params::kMaxNumUnpatchedParams > 32
+		         ? (static_cast<uint32_t>(paramManager.getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0]
+		                                  != 0u)
+		            || (paramManager.getUnpatchedParamSetSummary()->whichParamsAreInterpolating[1] != 0u))
+		         : paramManager.getUnpatchedParamSetSummary()->whichParamsAreInterpolating[0])
+		    != 0u;
 		if (result) {
 			ModelStackWithThreeMainThings* modelStackWithThreeMainThings = addToModelStack(modelStack);
 			paramManager.tickSamples(numSamples, modelStackWithThreeMainThings);
@@ -4210,7 +4216,8 @@ void Song::sortOutWhichClipsAreActiveWithoutSendingPGMs(ModelStack* modelStack,
 		else {
 			if (output->type == OutputType::SYNTH || output->type == OutputType::KIT) {
 				if (getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)output->toModControllable(),
-				                                               nullptr) == nullptr) {
+				                                              nullptr)
+				    == nullptr) {
 #if ALPHA_OR_BETA_VERSION
 					display->displayPopup("E044");
 #endif
@@ -4232,9 +4239,11 @@ void Song::sortOutWhichClipsAreActiveWithoutSendingPGMs(ModelStack* modelStack,
 				if (thisDrum->type == DrumType::SOUND) {
 					SoundDrum* soundDrum = (SoundDrum*)thisDrum;
 					if (getBackedUpParamManagerPreferablyWithClip(soundDrum,
-					                                               NULL) == nullptr) { // If no backedUpParamManager...
+					                                              NULL)
+					    == nullptr) { // If no backedUpParamManager...
 						if (findParamManagerForDrum(kit,
-						                             soundDrum) == nullptr) { // If no ParamManager with a NoteRow somewhere...
+						                            soundDrum)
+						    == nullptr) { // If no ParamManager with a NoteRow somewhere...
 							FREEZE_WITH_ERROR("E102");
 						}
 					}
@@ -4388,7 +4397,8 @@ void Song::ensureAllInstrumentsHaveAClipOrBackedUpParamManager(char const* error
 
 		else {
 			if (getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)thisOutput->toModControllable(),
-			                                               nullptr) == nullptr) {
+			                                              nullptr)
+			    == nullptr) {
 				FREEZE_WITH_ERROR(errorMessageNormal);
 			}
 		}
@@ -4412,7 +4422,8 @@ void Song::ensureAllInstrumentsHaveAClipOrBackedUpParamManager(char const* error
 
 		else {
 			if (getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)thisInstrument->toModControllable(),
-			                                               nullptr) == nullptr) {
+			                                              nullptr)
+			    == nullptr) {
 				FREEZE_WITH_ERROR(errorMessageHibernating);
 			}
 		}
@@ -4691,7 +4702,8 @@ cantDoIt:
 					return output;
 				}
 
-			} while (currentSong->getInstrumentFromPresetSlot(outputType, newChannel, -1, nullptr, nullptr, false) != nullptr);
+			} while (currentSong->getInstrumentFromPresetSlot(outputType, newChannel, -1, nullptr, nullptr, false)
+			         != nullptr);
 		}
 
 		// Or MIDI
@@ -4724,7 +4736,8 @@ cantDoIt:
 				}
 
 			} while (currentSong->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix, nullptr,
-			                                                  nullptr, false) != nullptr);
+			                                                  nullptr, false)
+			         != nullptr);
 
 			oldNonAudioInstrument->setChannel(oldChannel); // Put it back, before switching notes off etc
 		}
@@ -5520,7 +5533,8 @@ Clip* Song::replaceInstrumentClipWithAudioClip(Clip* oldClip, int32_t clipIndex)
 			Clip* clip = sessionClips.getClipAtIndex(c);
 
 			if (clip->type == ClipType::AUDIO && clip->armedForRecording) {
-				defaultAudioClipOverdubOutputCloning = static_cast<int8_t>(((AudioClip*)clip)->overdubsShouldCloneOutput);
+				defaultAudioClipOverdubOutputCloning =
+				    static_cast<int8_t>(((AudioClip*)clip)->overdubsShouldCloneOutput);
 				break;
 			}
 		}
@@ -5660,7 +5674,8 @@ void Song::setDefaultVelocityForAllInstruments(uint8_t newDefaultVelocity) {
 		}
 	}
 
-	for (Instrument* instrument = firstHibernatingInstrument; instrument != nullptr; instrument = (Instrument*)instrument->next) {
+	for (Instrument* instrument = firstHibernatingInstrument; instrument != nullptr;
+	     instrument = (Instrument*)instrument->next) {
 		instrument->defaultVelocity = newDefaultVelocity;
 	}
 }

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -424,7 +424,7 @@ public:
 	void displayMasterTransposeInterval();
 
 	// MIDI controlled song transpose
-	bool hasBeenTransposed = 0;
+	bool hasBeenTransposed = false;
 	int16_t transposeOffset = 0;
 
 	int32_t countAudioClips() const;

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -233,8 +233,9 @@ bool Voice::noteOn(ModelStackWithVoice* modelStack, int32_t newNoteCodeBeforeArp
 
 				// Set up MultiRange
 				MultiRange* range = sound.sources[s].getRange(noteCodeAfterArpeggiation + sound.transpose);
-				if (range == nullptr) { // There could be no Range for a SAMPLE or WAVETABLE Source that just hasn't had a file
-					          // loaded, like how OSC2 very often would be sitting
+				if (range == nullptr) { // There could be no Range for a SAMPLE or WAVETABLE Source that just hasn't had
+					                    // a file
+					                    // loaded, like how OSC2 very often would be sitting
 					goto gotInactive;
 				}
 
@@ -435,7 +436,8 @@ makeInactive: // Frequency too high to render! (Higher than 22.05kHz)
 		Source* source = &sound.sources[s];
 
 		int32_t oscillatorTranspose;
-		if (source->oscType == OscType::SAMPLE && (guides[s].audioFileHolder != nullptr)) { // Do not do this for WaveTables
+		if (source->oscType == OscType::SAMPLE
+		    && (guides[s].audioFileHolder != nullptr)) { // Do not do this for WaveTables
 			oscillatorTranspose = ((SampleHolderForVoice*)guides[s].audioFileHolder)->transpose;
 		}
 		else {
@@ -862,7 +864,8 @@ uint32_t Voice::getLocalLFOPhaseIncrement() {
 			    || source->repeatMode
 			           != SampleRepeatMode::ONCE // Don't do it for anything else. STRETCH is too hard to calculate
 			    || (guides[s].audioFileHolder == nullptr)
-			    || ((((SampleHolderForVoice*)guides[s].audioFileHolder)->loopEndPos != 0u) && !guides[s].noteOffReceived)) {
+			    || ((((SampleHolderForVoice*)guides[s].audioFileHolder)->loopEndPos != 0u)
+			        && !guides[s].noteOffReceived)) {
 				goto skipAutoRelease;
 			}
 

--- a/src/deluge/model/voice/voice_sample.cpp
+++ b/src/deluge/model/voice/voice_sample.cpp
@@ -565,7 +565,8 @@ bool VoiceSample::render(SamplePlaybackGuide* guide, int32_t* __restrict__ outpu
 #endif
 				{
 					canExit = (currentPlayPos == timeStretcher->olderPartReader.currentPlayPos
-					           && ((guide->sequenceSyncLengthTicks == 0u) || (guide->getNumSamplesLaggingBehindSync(this) == 0)));
+					           && ((guide->sequenceSyncLengthTicks == 0u)
+					               || (guide->getNumSamplesLaggingBehindSync(this) == 0)));
 				}
 				if (canExit) {
 					D_PRINTLN("time stretcher no longer needed");
@@ -1430,7 +1431,8 @@ headsFinishedReading:
 			}
 #endif
 
-			if ((cache == nullptr) && loopingType == LoopType::NONE && !timeStretcher->playHeadStillActive[PLAY_HEAD_OLDER]
+			if ((cache == nullptr) && loopingType == LoopType::NONE
+			    && !timeStretcher->playHeadStillActive[PLAY_HEAD_OLDER]
 			    && !timeStretcher->playHeadStillActive[PLAY_HEAD_NEWER]) {
 				return false;
 			}
@@ -1532,8 +1534,9 @@ headsFinishedReading:
 					existingValueL = *outputBufferWritePos;
 				}
 
-				if (cache != nullptr) { // Might not be true anymore if we had to abandon the cache just above cos it got Clusters
-					         // stolen.
+				if (cache != nullptr) { // Might not be true anymore if we had to abandon the cache just above cos it
+					                    // got Clusters
+					                    // stolen.
 					cacheWritePos =
 					    cacheWritePosNow; // Not necessary I don't think - cacheWritePos doesn't get used again does it?
 

--- a/src/deluge/model/voice/voice_sample.h
+++ b/src/deluge/model/voice/voice_sample.h
@@ -53,7 +53,7 @@ public:
 	// AudioClips don't obey markers because they "fudge" instead.
 	// Or if fudging can't happen cos no pre-margin, then
 	// AudioClip::doTickForward() manually forces restart.
-	bool shouldObeyMarkers() override { return (!cache && !timeStretcher && !forAudioClip); }
+	bool shouldObeyMarkers() override { return (cache == nullptr) && (timeStretcher == nullptr) && !forAudioClip; }
 
 	void readSamplesResampledPossiblyCaching(int32_t** oscBufferPos, int32_t** oscBufferRPos, int32_t numSamples,
 	                                         Sample* sample, int32_t jumpAmount, int32_t numChannels,

--- a/src/deluge/model/voice/voice_sample_playback_guide.cpp
+++ b/src/deluge/model/voice/voice_sample_playback_guide.cpp
@@ -33,7 +33,7 @@ void VoiceSamplePlaybackGuide::setupPlaybackBounds(bool reversed) {
 	int32_t loopEndPlaybackAtSample = 0;
 
 	// Loop points are only obeyed if not in STRETCH mode
-	if (!sequenceSyncLengthTicks) {
+	if (sequenceSyncLengthTicks == 0u) {
 
 		loopStartPlaybackAtSample = reversed ? ((SampleHolderForVoice*)audioFileHolder)->loopEndPos
 		                                     : ((SampleHolderForVoice*)audioFileHolder)->loopStartPos;
@@ -41,10 +41,10 @@ void VoiceSamplePlaybackGuide::setupPlaybackBounds(bool reversed) {
 		                                   : ((SampleHolderForVoice*)audioFileHolder)->loopEndPos;
 
 		if (reversed) { // Don't mix this with the above - we want to keep 0s as 0
-			if (loopStartPlaybackAtSample) {
+			if (loopStartPlaybackAtSample != 0) {
 				loopStartPlaybackAtSample--;
 			}
-			if (loopEndPlaybackAtSample) {
+			if (loopEndPlaybackAtSample != 0) {
 				loopEndPlaybackAtSample--;
 			}
 		}
@@ -56,14 +56,14 @@ void VoiceSamplePlaybackGuide::setupPlaybackBounds(bool reversed) {
 	Sample* sample = (Sample*)audioFileHolder->audioFile;
 	int32_t bytesPerSample = sample->numChannels * sample->byteDepth;
 
-	if (loopStartPlaybackAtSample) {
+	if (loopStartPlaybackAtSample != 0) {
 		loopStartPlaybackAtByte = sample->audioDataStartPosBytes + loopStartPlaybackAtSample * bytesPerSample;
 	}
 	else {
 		loopStartPlaybackAtByte = startPlaybackAtByte;
 	}
 
-	if (loopEndPlaybackAtSample) {
+	if (loopEndPlaybackAtSample != 0) {
 		loopEndPlaybackAtByte = sample->audioDataStartPosBytes + loopEndPlaybackAtSample * bytesPerSample;
 	}
 }
@@ -71,7 +71,7 @@ void VoiceSamplePlaybackGuide::setupPlaybackBounds(bool reversed) {
 // This is, whether to obey the loop-end point as opposed to the actual end-of-sample point (which sometimes might cause
 // looping too)
 bool VoiceSamplePlaybackGuide::shouldObeyLoopEndPointNow() {
-	return (loopEndPlaybackAtByte && !noteOffReceived);
+	return ((loopEndPlaybackAtByte != 0u) && !noteOffReceived);
 }
 
 int32_t VoiceSamplePlaybackGuide::getBytePosToStartPlayback(bool justLooped) {
@@ -94,7 +94,7 @@ int32_t VoiceSamplePlaybackGuide::getBytePosToEndOrLoopPlayback() {
 }
 
 LoopType VoiceSamplePlaybackGuide::getLoopingType(const Source& source) const {
-	if (loopEndPlaybackAtByte) {
+	if (loopEndPlaybackAtByte != 0u) {
 		return noteOffReceived ? LoopType::NONE : LoopType::LOW_LEVEL;
 	}
 	return (source.repeatMode == SampleRepeatMode::LOOP) ? LoopType::LOW_LEVEL : LoopType::NONE;

--- a/src/deluge/model/voice/voice_sample_playback_guide.h
+++ b/src/deluge/model/voice/voice_sample_playback_guide.h
@@ -36,7 +36,7 @@ public:
 
 	uint32_t getLoopStartPlaybackAtByte() const { return loopStartPlaybackAtByte; }
 	uint32_t getLoopEndPlaybackAtByte() const {
-		return loopEndPlaybackAtByte ? loopEndPlaybackAtByte : endPlaybackAtByte;
+		return (loopEndPlaybackAtByte != 0u) ? loopEndPlaybackAtByte : endPlaybackAtByte;
 	}
 
 	uint32_t loopStartPlaybackAtByte; // If no loop-start point defined, this will be the same as startPlaybackAtByte,

--- a/src/deluge/model/voice/voice_unison_part_source.cpp
+++ b/src/deluge/model/voice/voice_unison_part_source.cpp
@@ -114,7 +114,7 @@ bool VoiceUnisonPartSource::getPitchAndSpeedParams(Source* source, VoiceSamplePl
 	int32_t pitchAdjustNeutralValue = ((SampleHolder*)guide->audioFileHolder)->neutralPhaseIncrement;
 
 	// If syncing...
-	if (guide->sequenceSyncLengthTicks) {
+	if (guide->sequenceSyncLengthTicks != 0u) {
 
 		*timeStretchRatio = kMaxSampleValue;
 

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -34,10 +34,10 @@ ArpeggiatorSettings::ArpeggiatorSettings() {
 	// sound if no SD card inserted, but also some synth presets, possibly just older ones, are saved without this so it
 	// can be set to the default at the time of loading.
 	Song* song = preLoadedSong;
-	if (!song) {
+	if (song == nullptr) {
 		song = currentSong;
 	}
-	if (song) {
+	if (song != nullptr) {
 		syncLevel = (SyncLevel)(8 - (song->insideWorldTickMagnitude + song->insideWorldTickMagnitudeOffsetFromBPM));
 	}
 	else {
@@ -87,7 +87,7 @@ void ArpeggiatorForDrum::noteOn(ArpeggiatorSettings* settings, int32_t noteCode,
                                 ArpReturnInstruction* instruction, int32_t fromMIDIChannel, int16_t const* mpeValues) {
 	lastVelocity = velocity;
 
-	bool wasActiveBefore = arpNote.velocity;
+	bool wasActiveBefore = arpNote.velocity != 0u;
 
 	arpNote.inputCharacteristics[util::to_underlying(MIDICharacteristic::NOTE)] = noteCode;
 	arpNote.inputCharacteristics[util::to_underlying(MIDICharacteristic::CHANNEL)] = fromMIDIChannel;
@@ -109,7 +109,7 @@ void ArpeggiatorForDrum::noteOn(ArpeggiatorSettings* settings, int32_t noteCode,
 			playedFirstArpeggiatedNoteYet = false;
 			gateCurrentlyActive = false;
 
-			if (!(playbackHandler.isEitherClockActive()) || !settings->syncLevel) {
+			if (!(playbackHandler.isEitherClockActive()) || (settings->syncLevel == 0u)) {
 				switchNoteOn(settings, instruction, false);
 			}
 		}
@@ -243,7 +243,7 @@ noteInserted:
 			playedFirstArpeggiatedNoteYet = false;
 			gateCurrentlyActive = false;
 
-			if (!(playbackHandler.isEitherClockActive()) || !settings->syncLevel) {
+			if (!(playbackHandler.isEitherClockActive()) || (settings->syncLevel == 0u)) {
 				switchNoteOn(settings, instruction, false);
 			}
 		}
@@ -945,11 +945,11 @@ void Arpeggiator::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstructi
 }
 
 bool Arpeggiator::hasAnyInputNotesActive() {
-	return notes.getNumElements();
+	return notes.getNumElements() != 0;
 }
 
 bool ArpeggiatorForDrum::hasAnyInputNotesActive() {
-	return arpNote.velocity;
+	return arpNote.velocity != 0u;
 }
 
 void ArpeggiatorBase::updateParams(uint32_t sequenceLength, uint32_t rhythmValue, uint32_t noteProb,
@@ -1039,7 +1039,7 @@ void ArpeggiatorBase::render(ArpeggiatorSettings* settings, int32_t numSamples, 
 
 	uint32_t maxGateForRatchet = maxGate >> ratchetNotesMultiplier;
 
-	bool syncedNow = (settings->syncLevel && (playbackHandler.isEitherClockActive()));
+	bool syncedNow = ((settings->syncLevel != 0u) && (playbackHandler.isEitherClockActive()));
 
 	// If gatePos is far enough along that we at least want to switch off any note...
 	if (gatePos >= ratchetNotesIndex * maxGateForRatchet + gateThresholdSmall) {
@@ -1083,7 +1083,7 @@ int32_t ArpeggiatorBase::doTickForward(ArpeggiatorSettings* settings, ArpReturnI
 
 	int32_t howFarIntoPeriod = clipCurrentPos % ticksPerPeriod;
 
-	if (!howFarIntoPeriod) {
+	if (howFarIntoPeriod == 0) {
 		if (hasAnyInputNotesActive()) {
 			switchAnyNoteOff(instruction);
 			switchNoteOn(settings, instruction, false);

--- a/src/deluge/modulation/arpeggiator_rhythms.h
+++ b/src/deluge/modulation/arpeggiator_rhythms.h
@@ -80,57 +80,57 @@ const int32_t kMaxPresetArpRhythm = kMaxMenuValue;
 // 	4, // <-
 // };
 const ArpRhythm arpRhythmPatterns[kMaxPresetArpRhythm + 1] = {
-    {1, {true, true, true, true, true, true}}, // <- 1 step
-    {3, {true, false, false, true, true, true}}, // <- 3 steps
-    {3, {true, true, false, true, true, true}}, // <-
-    {3, {true, false, true, true, true, true}}, // <-
-    {4, {true, false, true, true, true, true}}, // <- 4 steps
-    {4, {true, true, false, false, true, true}}, // <-
-    {4, {true, true, true, false, true, true}}, // <-
-    {4, {true, false, false, true, true, true}}, // <-
-    {4, {true, true, false, true, true, true}}, // <-
-    {5, {true, false, false, false, false, true}}, // <- 5 steps
-    {5, {true, false, true, true, true, true}}, // <-
-    {5, {true, true, false, false, false, true}}, // <-
-    {5, {true, true, true, true, false, true}}, // <-
-    {5, {true, false, false, false, true, true}}, // <-
-    {5, {true, true, false, true, true, true}}, // <-
-    {5, {true, false, true, false, false, true}}, // <-
-    {5, {true, true, true, false, true, true}}, // <-
-    {5, {true, false, false, true, false, true}}, // <-
-    {5, {true, false, false, true, true, true}}, // <-
-    {5, {true, true, true, false, false, true}}, // <-
-    {5, {true, true, false, false, true, true}}, // <-
-    {5, {true, false, true, true, false, true}}, // <-
-    {5, {true, true, false, true, false, true}}, // <-
-    {5, {true, false, true, false, true, true}}, // <-
+    {1, {true, true, true, true, true, true}},      // <- 1 step
+    {3, {true, false, false, true, true, true}},    // <- 3 steps
+    {3, {true, true, false, true, true, true}},     // <-
+    {3, {true, false, true, true, true, true}},     // <-
+    {4, {true, false, true, true, true, true}},     // <- 4 steps
+    {4, {true, true, false, false, true, true}},    // <-
+    {4, {true, true, true, false, true, true}},     // <-
+    {4, {true, false, false, true, true, true}},    // <-
+    {4, {true, true, false, true, true, true}},     // <-
+    {5, {true, false, false, false, false, true}},  // <- 5 steps
+    {5, {true, false, true, true, true, true}},     // <-
+    {5, {true, true, false, false, false, true}},   // <-
+    {5, {true, true, true, true, false, true}},     // <-
+    {5, {true, false, false, false, true, true}},   // <-
+    {5, {true, true, false, true, true, true}},     // <-
+    {5, {true, false, true, false, false, true}},   // <-
+    {5, {true, true, true, false, true, true}},     // <-
+    {5, {true, false, false, true, false, true}},   // <-
+    {5, {true, false, false, true, true, true}},    // <-
+    {5, {true, true, true, false, false, true}},    // <-
+    {5, {true, true, false, false, true, true}},    // <-
+    {5, {true, false, true, true, false, true}},    // <-
+    {5, {true, true, false, true, false, true}},    // <-
+    {5, {true, false, true, false, true, true}},    // <-
     {6, {true, false, false, false, false, false}}, // <- 6 steps
-    {6, {true, false, true, true, true, true}}, // <-
-    {6, {true, true, false, false, false, false}}, // <-
-    {6, {true, true, true, true, true, false}}, // <-
-    {6, {true, false, false, false, false, true}}, // <-
-    {6, {true, true, false, true, true, true}}, // <-
-    {6, {true, false, true, false, false, false}}, // <-
-    {6, {true, true, true, true, false, true}}, // <-
-    {6, {true, false, false, false, true, false}}, // <-
-    {6, {true, true, true, false, true, true}}, // <-
-    {6, {true, false, false, true, true, true}}, // <-
-    {6, {true, true, true, false, false, false}}, // <-
-    {6, {true, true, true, true, false, false}}, // <-
-    {6, {true, false, false, false, true, true}}, // <-
-    {6, {true, true, false, false, true, true}}, // <-
-    {6, {true, false, true, true, false, false}}, // <-
-    {6, {true, true, true, false, false, true}}, // <-
-    {6, {true, false, false, true, true, false}}, // <-
-    {6, {true, false, true, false, true, true}}, // <-
-    {6, {true, true, false, true, false, false}}, // <-
-    {6, {true, true, true, false, true, false}}, // <-
-    {6, {true, false, false, true, false, true}}, // <-
-    {6, {true, false, true, true, true, false}}, // <-
-    {6, {true, true, false, false, false, true}}, // <-
-    {6, {true, true, false, false, true, false}}, // <-
-    {6, {true, false, true, false, false, true}}, // <-
-    {6, {true, true, false, true, false, true}}, // <-
+    {6, {true, false, true, true, true, true}},     // <-
+    {6, {true, true, false, false, false, false}},  // <-
+    {6, {true, true, true, true, true, false}},     // <-
+    {6, {true, false, false, false, false, true}},  // <-
+    {6, {true, true, false, true, true, true}},     // <-
+    {6, {true, false, true, false, false, false}},  // <-
+    {6, {true, true, true, true, false, true}},     // <-
+    {6, {true, false, false, false, true, false}},  // <-
+    {6, {true, true, true, false, true, true}},     // <-
+    {6, {true, false, false, true, true, true}},    // <-
+    {6, {true, true, true, false, false, false}},   // <-
+    {6, {true, true, true, true, false, false}},    // <-
+    {6, {true, false, false, false, true, true}},   // <-
+    {6, {true, true, false, false, true, true}},    // <-
+    {6, {true, false, true, true, false, false}},   // <-
+    {6, {true, true, true, false, false, true}},    // <-
+    {6, {true, false, false, true, true, false}},   // <-
+    {6, {true, false, true, false, true, true}},    // <-
+    {6, {true, true, false, true, false, false}},   // <-
+    {6, {true, true, true, false, true, false}},    // <-
+    {6, {true, false, false, true, false, true}},   // <-
+    {6, {true, false, true, true, true, false}},    // <-
+    {6, {true, true, false, false, false, true}},   // <-
+    {6, {true, true, false, false, true, false}},   // <-
+    {6, {true, false, true, false, false, true}},   // <-
+    {6, {true, true, false, true, false, true}},    // <-
 };
 
 const std::array<char const*, kMaxPresetArpRhythm + 1> arpRhythmPatternNames = {

--- a/src/deluge/modulation/arpeggiator_rhythms.h
+++ b/src/deluge/modulation/arpeggiator_rhythms.h
@@ -80,57 +80,57 @@ const int32_t kMaxPresetArpRhythm = kMaxMenuValue;
 // 	4, // <-
 // };
 const ArpRhythm arpRhythmPatterns[kMaxPresetArpRhythm + 1] = {
-    {1, {1, 1, 1, 1, 1, 1}}, // <- 1 step
-    {3, {1, 0, 0, 1, 1, 1}}, // <- 3 steps
-    {3, {1, 1, 0, 1, 1, 1}}, // <-
-    {3, {1, 0, 1, 1, 1, 1}}, // <-
-    {4, {1, 0, 1, 1, 1, 1}}, // <- 4 steps
-    {4, {1, 1, 0, 0, 1, 1}}, // <-
-    {4, {1, 1, 1, 0, 1, 1}}, // <-
-    {4, {1, 0, 0, 1, 1, 1}}, // <-
-    {4, {1, 1, 0, 1, 1, 1}}, // <-
-    {5, {1, 0, 0, 0, 0, 1}}, // <- 5 steps
-    {5, {1, 0, 1, 1, 1, 1}}, // <-
-    {5, {1, 1, 0, 0, 0, 1}}, // <-
-    {5, {1, 1, 1, 1, 0, 1}}, // <-
-    {5, {1, 0, 0, 0, 1, 1}}, // <-
-    {5, {1, 1, 0, 1, 1, 1}}, // <-
-    {5, {1, 0, 1, 0, 0, 1}}, // <-
-    {5, {1, 1, 1, 0, 1, 1}}, // <-
-    {5, {1, 0, 0, 1, 0, 1}}, // <-
-    {5, {1, 0, 0, 1, 1, 1}}, // <-
-    {5, {1, 1, 1, 0, 0, 1}}, // <-
-    {5, {1, 1, 0, 0, 1, 1}}, // <-
-    {5, {1, 0, 1, 1, 0, 1}}, // <-
-    {5, {1, 1, 0, 1, 0, 1}}, // <-
-    {5, {1, 0, 1, 0, 1, 1}}, // <-
-    {6, {1, 0, 0, 0, 0, 0}}, // <- 6 steps
-    {6, {1, 0, 1, 1, 1, 1}}, // <-
-    {6, {1, 1, 0, 0, 0, 0}}, // <-
-    {6, {1, 1, 1, 1, 1, 0}}, // <-
-    {6, {1, 0, 0, 0, 0, 1}}, // <-
-    {6, {1, 1, 0, 1, 1, 1}}, // <-
-    {6, {1, 0, 1, 0, 0, 0}}, // <-
-    {6, {1, 1, 1, 1, 0, 1}}, // <-
-    {6, {1, 0, 0, 0, 1, 0}}, // <-
-    {6, {1, 1, 1, 0, 1, 1}}, // <-
-    {6, {1, 0, 0, 1, 1, 1}}, // <-
-    {6, {1, 1, 1, 0, 0, 0}}, // <-
-    {6, {1, 1, 1, 1, 0, 0}}, // <-
-    {6, {1, 0, 0, 0, 1, 1}}, // <-
-    {6, {1, 1, 0, 0, 1, 1}}, // <-
-    {6, {1, 0, 1, 1, 0, 0}}, // <-
-    {6, {1, 1, 1, 0, 0, 1}}, // <-
-    {6, {1, 0, 0, 1, 1, 0}}, // <-
-    {6, {1, 0, 1, 0, 1, 1}}, // <-
-    {6, {1, 1, 0, 1, 0, 0}}, // <-
-    {6, {1, 1, 1, 0, 1, 0}}, // <-
-    {6, {1, 0, 0, 1, 0, 1}}, // <-
-    {6, {1, 0, 1, 1, 1, 0}}, // <-
-    {6, {1, 1, 0, 0, 0, 1}}, // <-
-    {6, {1, 1, 0, 0, 1, 0}}, // <-
-    {6, {1, 0, 1, 0, 0, 1}}, // <-
-    {6, {1, 1, 0, 1, 0, 1}}, // <-
+    {1, {true, true, true, true, true, true}}, // <- 1 step
+    {3, {true, false, false, true, true, true}}, // <- 3 steps
+    {3, {true, true, false, true, true, true}}, // <-
+    {3, {true, false, true, true, true, true}}, // <-
+    {4, {true, false, true, true, true, true}}, // <- 4 steps
+    {4, {true, true, false, false, true, true}}, // <-
+    {4, {true, true, true, false, true, true}}, // <-
+    {4, {true, false, false, true, true, true}}, // <-
+    {4, {true, true, false, true, true, true}}, // <-
+    {5, {true, false, false, false, false, true}}, // <- 5 steps
+    {5, {true, false, true, true, true, true}}, // <-
+    {5, {true, true, false, false, false, true}}, // <-
+    {5, {true, true, true, true, false, true}}, // <-
+    {5, {true, false, false, false, true, true}}, // <-
+    {5, {true, true, false, true, true, true}}, // <-
+    {5, {true, false, true, false, false, true}}, // <-
+    {5, {true, true, true, false, true, true}}, // <-
+    {5, {true, false, false, true, false, true}}, // <-
+    {5, {true, false, false, true, true, true}}, // <-
+    {5, {true, true, true, false, false, true}}, // <-
+    {5, {true, true, false, false, true, true}}, // <-
+    {5, {true, false, true, true, false, true}}, // <-
+    {5, {true, true, false, true, false, true}}, // <-
+    {5, {true, false, true, false, true, true}}, // <-
+    {6, {true, false, false, false, false, false}}, // <- 6 steps
+    {6, {true, false, true, true, true, true}}, // <-
+    {6, {true, true, false, false, false, false}}, // <-
+    {6, {true, true, true, true, true, false}}, // <-
+    {6, {true, false, false, false, false, true}}, // <-
+    {6, {true, true, false, true, true, true}}, // <-
+    {6, {true, false, true, false, false, false}}, // <-
+    {6, {true, true, true, true, false, true}}, // <-
+    {6, {true, false, false, false, true, false}}, // <-
+    {6, {true, true, true, false, true, true}}, // <-
+    {6, {true, false, false, true, true, true}}, // <-
+    {6, {true, true, true, false, false, false}}, // <-
+    {6, {true, true, true, true, false, false}}, // <-
+    {6, {true, false, false, false, true, true}}, // <-
+    {6, {true, true, false, false, true, true}}, // <-
+    {6, {true, false, true, true, false, false}}, // <-
+    {6, {true, true, true, false, false, true}}, // <-
+    {6, {true, false, false, true, true, false}}, // <-
+    {6, {true, false, true, false, true, true}}, // <-
+    {6, {true, true, false, true, false, false}}, // <-
+    {6, {true, true, true, false, true, false}}, // <-
+    {6, {true, false, false, true, false, true}}, // <-
+    {6, {true, false, true, true, true, false}}, // <-
+    {6, {true, true, false, false, false, true}}, // <-
+    {6, {true, true, false, false, true, false}}, // <-
+    {6, {true, false, true, false, false, true}}, // <-
+    {6, {true, true, false, true, false, true}}, // <-
 };
 
 const std::array<char const*, kMaxPresetArpRhythm + 1> arpRhythmPatternNames = {

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -162,7 +162,7 @@ void AutoParam::setCurrentValueInResponseToUserInput(int32_t value, ModelStackWi
 
 			if (!reversed
 			    && (nodes.getNumElements() != 0)) { // Yeah turns out we just don't need the result from this if we're
-				                             // reversed. RIP the work I put into making this code reverse-compatible.
+				// reversed. RIP the work I put into making this code reverse-compatible.
 				int32_t prevNodeI = nodes.search(livePos + (int32_t)reversed, reversed ? GREATER_OR_EQUAL : LESS);
 				if (prevNodeI >= 0 && prevNodeI < nodes.getNumElements()) { // If there was a Node before livePos...
 investigatePrevNode:
@@ -1017,7 +1017,8 @@ void AutoParam::setValueForRegion(uint32_t pos, uint32_t length, int32_t value,
 		}
 
 		// If we're in the region right now...
-		mostRecentI = nodes.search(modelStack->getLivePos() + static_cast<int>(!modelStack->isCurrentlyPlayingReversed()), LESS);
+		mostRecentI =
+		    nodes.search(modelStack->getLivePos() + static_cast<int>(!modelStack->isCurrentlyPlayingReversed()), LESS);
 		if (mostRecentI == -1) {
 			mostRecentI = nodes.getNumElements() - 1;
 		}
@@ -1764,7 +1765,7 @@ void AutoParam::trimToLength(uint32_t newLength, Action* action, ModelStackWithA
 	// To ensure that the effective value at pos 0 remains the same even after earlier nodes deleted, we might need to
 	// add a new, non-interpolating node there.
 	bool needNewNodeAt0 = nodes.getFirst()->pos != 0; // Deactivated for now, but I'm going to enable in the ModelStacks
-	                                             // branch, where we have a TimelineCounter here.
+	                                                  // branch, where we have a TimelineCounter here.
 	int32_t oldValueAt0;
 	if (needNewNodeAt0) {
 		oldValueAt0 = getValueAtPos(0, modelStack);

--- a/src/deluge/modulation/automation/auto_param.h
+++ b/src/deluge/modulation/automation/auto_param.h
@@ -115,7 +115,7 @@ public:
 
 	inline void setCurrentValueBasicForSetup(int32_t value) { currentValue = value; }
 
-	inline bool isAutomated() { return (nodes.getNumElements()); }
+	inline bool isAutomated() { return (nodes.getNumElements()) != 0; }
 
 	inline void cancelOverriding() { // Will also cancel "latching".
 		renewedOverridingAtTime = 0;

--- a/src/deluge/modulation/params/param_collection.cpp
+++ b/src/deluge/modulation/params/param_collection.cpp
@@ -39,8 +39,8 @@ void ParamCollection::notifyParamModifiedInSomeWay(ModelStackWithAutoParam const
 
 	bool currentValueChanged = (oldValue != modelStack->autoParam->getCurrentValue());
 	if (currentValueChanged || automationChanged) {
-		modelStack->paramManager->notifyParamModifiedInSomeWay(modelStack, static_cast<int32_t>(currentValueChanged), automationChanged,
-		                                                       automatedNow);
+		modelStack->paramManager->notifyParamModifiedInSomeWay(modelStack, static_cast<int32_t>(currentValueChanged),
+		                                                       automationChanged, automatedNow);
 	}
 
 	if (automationChanged && automatedNow) {

--- a/src/deluge/modulation/params/param_collection.cpp
+++ b/src/deluge/modulation/params/param_collection.cpp
@@ -39,7 +39,7 @@ void ParamCollection::notifyParamModifiedInSomeWay(ModelStackWithAutoParam const
 
 	bool currentValueChanged = (oldValue != modelStack->autoParam->getCurrentValue());
 	if (currentValueChanged || automationChanged) {
-		modelStack->paramManager->notifyParamModifiedInSomeWay(modelStack, currentValueChanged, automationChanged,
+		modelStack->paramManager->notifyParamModifiedInSomeWay(modelStack, static_cast<int32_t>(currentValueChanged), automationChanged,
 		                                                       automatedNow);
 	}
 

--- a/src/deluge/modulation/params/param_collection_summary.h
+++ b/src/deluge/modulation/params/param_collection_summary.h
@@ -25,10 +25,10 @@ class ParamCollectionSummary {
 public:
 	inline bool containsAutomation() {
 		if constexpr (kMaxNumUnsignedIntegerstoRepAllParams > 2) {
-			return (whichParamsAreAutomated[0] | whichParamsAreAutomated[1] | whichParamsAreAutomated[2]);
+			return (whichParamsAreAutomated[0] | whichParamsAreAutomated[1] | whichParamsAreAutomated[2]) != 0u != 0u;
 		}
 		else {
-			return (whichParamsAreAutomated[0] | whichParamsAreAutomated[1]);
+			return (whichParamsAreAutomated[0] | whichParamsAreAutomated[1]) != 0u != 0u;
 		}
 	}
 

--- a/src/deluge/modulation/params/param_manager.cpp
+++ b/src/deluge/modulation/params/param_manager.cpp
@@ -232,7 +232,8 @@ Error ParamManager::cloneParamCollectionsFrom(ParamManager const* other, bool co
 	}
 	else {
 		*newSummary = mpeParamsOrNullHere;
-		if (mpeParamsOrNullHere.paramCollection != nullptr) { // Check first, otherwise we'll overflow the array, I think...
+		if (mpeParamsOrNullHere.paramCollection
+		    != nullptr) { // Check first, otherwise we'll overflow the array, I think...
 			newSummary++;
 			*newSummary = {0}; // Mark end of list
 		}
@@ -390,7 +391,8 @@ void ParamManagerForTimeline::processCurrentPos(ModelStackWithThreeMainThings* m
 
 void ParamManagerForTimeline::expectEvent(ModelStackWithThreeMainThings const* modelStack) {
 	TimelineCounter* timelineCounter = modelStack->getTimelineCounterAllowNull();
-	if (playbackHandler.isEitherClockActive() && ((timelineCounter == nullptr) || timelineCounter->isPlayingAutomationNow())) {
+	if (playbackHandler.isEitherClockActive()
+	    && ((timelineCounter == nullptr) || timelineCounter->isPlayingAutomationNow())) {
 		ticksTilNextEvent = 0;
 		if (timelineCounter != nullptr) {
 			timelineCounter->expectEvent();

--- a/src/deluge/modulation/params/param_manager.h
+++ b/src/deluge/modulation/params/param_manager.h
@@ -48,9 +48,9 @@ public:
 	~ParamManager();
 
 	// Not including MPE params
-	inline bool containsAnyMainParamCollections() { return expressionParamSetOffset; }
+	inline bool containsAnyMainParamCollections() { return expressionParamSetOffset != 0u != 0u; }
 
-	inline bool containsAnyParamCollectionsIncludingExpression() { return summaries[0].paramCollection; }
+	inline bool containsAnyParamCollectionsIncludingExpression() { return summaries[0].paramCollection != nullptr; }
 
 	Error setupWithPatching();
 	Error setupUnpatched();
@@ -78,7 +78,7 @@ public:
 
 	inline MIDIParamCollection* getMIDIParamCollection() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[0].paramCollection) {
+		if (summaries[0].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E409");
 		}
 #endif
@@ -87,7 +87,7 @@ public:
 
 	inline ParamCollectionSummary* getMIDIParamCollectionSummary() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[0].paramCollection) {
+		if (summaries[0].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E409");
 		}
 #endif
@@ -96,7 +96,7 @@ public:
 
 	inline UnpatchedParamSet* getUnpatchedParamSet() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[0].paramCollection) {
+		if (summaries[0].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E410");
 		}
 #endif
@@ -105,7 +105,7 @@ public:
 
 	inline ParamCollectionSummary* getUnpatchedParamSetSummary() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[0].paramCollection) {
+		if (summaries[0].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E410");
 		}
 #endif
@@ -114,7 +114,7 @@ public:
 
 	inline PatchedParamSet* getPatchedParamSet() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[1].paramCollection) {
+		if (summaries[1].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E411");
 		}
 #endif
@@ -123,7 +123,7 @@ public:
 
 	inline ParamCollectionSummary* getPatchedParamSetSummary() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[1].paramCollection) {
+		if (summaries[1].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E411");
 		}
 #endif
@@ -132,7 +132,7 @@ public:
 
 	inline ParamCollectionSummary* getPatchCableSetSummary() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[2].paramCollection) {
+		if (summaries[2].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E412");
 		}
 #endif
@@ -141,7 +141,7 @@ public:
 
 	inline PatchCableSet* getPatchCableSet() {
 #if ALPHA_OR_BETA_VERSION
-		if (!summaries[2].paramCollection) {
+		if (summaries[2].paramCollection == nullptr) {
 			FREEZE_WITH_ERROR("E412");
 		}
 #endif

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -102,7 +102,7 @@ void ParamSet::paramHasNoAutomationNow(ModelStackWithParamCollection const* mode
 	}
 
 inline void ParamSet::checkWhetherParamHasInterpolationNow(ModelStackWithParamCollection const* modelStack, int32_t p) {
-	if (params[p].valueIncrementPerHalfTick) {
+	if (params[p].valueIncrementPerHalfTick != 0) {
 		modelStack->summary->whichParamsAreInterpolating[p >> 5] |= ((uint32_t)1 << (p & 31));
 	}
 }
@@ -171,7 +171,7 @@ void ParamSet::writeParamAsAttribute(Serializer& writer, char const* name, int32
 		return;
 	}
 
-	int32_t* valueForOverride = valuesForOverride ? &valuesForOverride[p] : nullptr;
+	int32_t* valueForOverride = (valuesForOverride != nullptr) ? &valuesForOverride[p] : nullptr;
 	writer.insertCommaIfNeeded();
 	writer.write("\n");
 	writer.printIndents();
@@ -401,7 +401,7 @@ bool UnpatchedParamSet::shouldParamIndicateMiddleValue(ModelStackWithParamId con
 	return false;
 }
 int32_t UnpatchedParamSet::paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack) {
-	if (modelStack && (modelStack->paramId == params::UNPATCHED_COMPRESSOR_THRESHOLD)) {
+	if ((modelStack != nullptr) && (modelStack->paramId == params::UNPATCHED_COMPRESSOR_THRESHOLD)) {
 		return (paramValue >> 24) - 64;
 	}
 	else {
@@ -410,7 +410,7 @@ int32_t UnpatchedParamSet::paramValueToKnobPos(int32_t paramValue, ModelStackWit
 }
 
 int32_t UnpatchedParamSet::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
-	if (modelStack && (modelStack->paramId == params::UNPATCHED_COMPRESSOR_THRESHOLD)) {
+	if ((modelStack != nullptr) && (modelStack->paramId == params::UNPATCHED_COMPRESSOR_THRESHOLD)) {
 		int32_t paramValue = 2147483647;
 		if (knobPos < 64) {
 			paramValue = (knobPos + 64) << 24;
@@ -495,7 +495,7 @@ void PatchedParamSet::notifyParamModifiedInSomeWay(ModelStackWithAutoParam const
 }
 
 int32_t PatchedParamSet::paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack) {
-	if (modelStack
+	if ((modelStack != nullptr)
 	    && (modelStack->paramId == params::LOCAL_OSC_A_PHASE_WIDTH
 	        || modelStack->paramId == params::LOCAL_OSC_B_PHASE_WIDTH)) {
 		return (paramValue >> 24) - 64;
@@ -506,7 +506,7 @@ int32_t PatchedParamSet::paramValueToKnobPos(int32_t paramValue, ModelStackWithA
 }
 
 int32_t PatchedParamSet::knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) {
-	if (modelStack
+	if ((modelStack != nullptr)
 	    && (modelStack->paramId == params::LOCAL_OSC_A_PHASE_WIDTH
 	        || modelStack->paramId == params::LOCAL_OSC_B_PHASE_WIDTH)) {
 		int32_t paramValue = 2147483647;
@@ -570,7 +570,7 @@ void ExpressionParamSet::notifyParamModifiedInSomeWay(ModelStackWithAutoParam co
 
 			NoteRow* noteRow = modelStack->getNoteRowAllowNull();
 
-			if (noteRow) {
+			if (noteRow != nullptr) {
 				modelStack->modControllable->polyphonicExpressionEventOnChannelOrNote(
 				    currentValue, modelStack->paramId, modelStack->getNoteRow()->y, MIDICharacteristic::NOTE);
 			}
@@ -640,18 +640,18 @@ void ExpressionParamSet::readFromFile(Deserializer& reader, ParamCollectionSumma
 
 	char const* tagName;
 
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		int32_t p;
 		for (p = 0; p < kNumExpressionDimensions; p++) {
-			if (!strcmp(tagName, expressionParamNames[p])) {
+			if (strcmp(tagName, expressionParamNames[p]) == 0) {
 doReadParam:
 				readParam(reader, summary, p, readAutomationUpToPos);
 				goto finishedTag;
 			}
 		}
 
-		if (!strcmp(tagName,
-		            "channelPressure")) { // Alpha testers had 2 weeks or so to create files like this - not sure if
+		if (strcmp(tagName,
+		            "channelPressure") == 0) { // Alpha testers had 2 weeks or so to create files like this - not sure if
 			                              // anyone even did.
 			p = 2;
 			goto doReadParam;

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -651,8 +651,9 @@ doReadParam:
 		}
 
 		if (strcmp(tagName,
-		            "channelPressure") == 0) { // Alpha testers had 2 weeks or so to create files like this - not sure if
-			                              // anyone even did.
+		           "channelPressure")
+		    == 0) { // Alpha testers had 2 weeks or so to create files like this - not sure if
+			        // anyone even did.
 			p = 2;
 			goto doReadParam;
 		}

--- a/src/deluge/modulation/patch/patcher.cpp
+++ b/src/deluge/modulation/patch/patcher.cpp
@@ -75,19 +75,19 @@ void Patcher::performPatching(uint32_t sourcesChanged, Sound* sound, ParamManage
 	PatchCableSet* patchCableSet = paramManager->getPatchCableSet();
 	int32_t globality = patchableInfo->globality;
 	Destination* destination = patchCableSet->destinations[globality];
-	if (!destination) {
+	if (destination == nullptr) {
 		return;
 	}
 
 	sourcesChanged &= patchCableSet->sourcesPatchedToAnything[globality];
-	if (!sourcesChanged) {
+	if (sourcesChanged == 0u) {
 		return;
 	}
 
 	// First, "range" Destinations
 	int32_t i = 0;
 	for (; destination->destinationParamDescriptor.data < (uint32_t)0xFFFFFF00; destination++) {
-		if (!(destination->sources & sourcesChanged)) {
+		if ((destination->sources & sourcesChanged) == 0u) {
 			continue; // And don't increment i.
 		}
 
@@ -109,7 +109,7 @@ void Patcher::performPatching(uint32_t sourcesChanged, Sound* sound, ParamManage
 		// Now normal, actual params/destinations
 		uint32_t firstHybridParam = patchableInfo->firstHybridParam | 0xFFFFFF00;
 		for (; destination->destinationParamDescriptor.data < firstHybridParam; destination++) {
-			if (!(destination->sources & sourcesChanged)) {
+			if ((destination->sources & sourcesChanged) == 0u) {
 				continue;
 			}
 
@@ -119,8 +119,8 @@ void Patcher::performPatching(uint32_t sourcesChanged, Sound* sound, ParamManage
 			numParamsPatched++;
 		}
 
-		for (; destination->sources; destination++) {
-			if (!(destination->sources & sourcesChanged)) {
+		for (; destination->sources != 0u; destination++) {
+			if ((destination->sources & sourcesChanged) == 0u) {
 				continue;
 			}
 
@@ -250,7 +250,7 @@ inline int32_t Patcher::combineCablesLinear(Destination const* destination, uint
 	cableToLinearParamWithoutRangeAdjustment(sound->getSmoothedPatchedParamValue(p, paramManager), paramRanges[p],
 	                                         &runningTotalCombination);
 
-	if (destination) {
+	if (destination != nullptr) {
 		// For each patch cable affecting this parameter
 		for (int32_t c = destination->firstCable; c < destination->endCable; c++) {
 			PatchCable* patchCable = &patchCableSet->patchCables[c];
@@ -278,7 +278,7 @@ inline int32_t Patcher::combineCablesExp(Destination const* destination, uint32_
 
 	PatchCableSet* patchCableSet = paramManager->getPatchCableSet();
 
-	if (destination) {
+	if (destination != nullptr) {
 		// For each patch cable affecting this parameter
 		for (int32_t c = destination->firstCable; c < destination->endCable; c++) {
 			PatchCable* patchCable = &patchCableSet->patchCables[c];
@@ -338,7 +338,7 @@ void Patcher::performInitialPatching(Sound* sound, ParamManager* paramManager) {
 		}
 
 		Destination* destination = paramManager->getPatchCableSet()->destinations[patchableInfo->globality];
-		if (destination) {
+		if (destination != nullptr) {
 
 			// First, "range" Destinations
 			int32_t i = 0;
@@ -355,7 +355,7 @@ void Patcher::performInitialPatching(Sound* sound, ParamManager* paramManager) {
 				int32_t p = destination->destinationParamDescriptor.getJustTheParam();
 				paramFinalValues[p] = combineCablesLinear(destination, p, sound, paramManager);
 			}
-			for (; destination->sources; destination++) {
+			for (; destination->sources != 0u; destination++) {
 				int32_t p = destination->destinationParamDescriptor.getJustTheParam();
 				paramFinalValues[p] = combineCablesExp(destination, p, sound, paramManager);
 			}

--- a/src/deluge/modulation/sidechain/sidechain.cpp
+++ b/src/deluge/modulation/sidechain/sidechain.cpp
@@ -35,10 +35,10 @@ SideChain::SideChain() {
 	// sound if no SD card inserted, but also some synth presets, possibly just older ones, are saved without this so it
 	// can be set to the default at the time of loading.
 	Song* song = preLoadedSong;
-	if (!song) {
+	if (song == nullptr) {
 		song = currentSong;
 	}
-	if (song) {
+	if (song != nullptr) {
 		syncLevel = (SyncLevel)(7 - (song->insideWorldTickMagnitude + song->insideWorldTickMagnitudeOffsetFromBPM));
 	}
 	else {

--- a/src/deluge/playback/mode/arrangement.cpp
+++ b/src/deluge/playback/mode/arrangement.cpp
@@ -206,7 +206,8 @@ notRecording:
 							// If it's ended right now...
 							if (endPos == lastProcessedPos) {
 
-								if (posIncrement != 0) { // Don't deactivate any Clips on the first, 0-length tick, or else!
+								if (posIncrement
+								    != 0) { // Don't deactivate any Clips on the first, 0-length tick, or else!
 									thisClip->expectNoFurtherTicks(currentSong);
 									thisClip->activeIfNoSolo = false;
 
@@ -260,8 +261,9 @@ notRecording:
 						ModelStackWithTimelineCounter* modelStackWithTimelineCounter =
 						    modelStack->addTimelineCounter(thisClip);
 
-						if (posIncrement != 0) { // If posIncrement is 0, it means this is the very first tick of playback,
-							                // in which case this has just been set up already. But otherwise...
+						if (posIncrement
+						    != 0) { // If posIncrement is 0, it means this is the very first tick of playback,
+							        // in which case this has just been set up already. But otherwise...
 							thisClip->activeIfNoSolo = true;
 							thisClip->setPos(modelStackWithTimelineCounter, 0);
 							// Rohan: used to call assertActiveness(), but that's actually
@@ -438,7 +440,8 @@ void Arrangement::reSyncClip(ModelStackWithTimelineCounter* modelStack, bool mus
 
 	int32_t i = output->clipInstances.search(actualPos + 1, LESS);
 	ClipInstance* clipInstance = output->clipInstances.getElement(i);
-	if ((clipInstance != nullptr) && clipInstance->clip == clip && clipInstance->pos + clipInstance->length > actualPos + 1) {
+	if ((clipInstance != nullptr) && clipInstance->clip == clip
+	    && clipInstance->pos + clipInstance->length > actualPos + 1) {
 		resumeClipInstancePlayback(clipInstance, true, mayResumeClip);
 	}
 }

--- a/src/deluge/playback/mode/playback_mode.cpp
+++ b/src/deluge/playback/mode/playback_mode.cpp
@@ -29,5 +29,5 @@ PlaybackMode::~PlaybackMode() {
 }
 
 bool PlaybackMode::hasPlaybackActive() {
-	return (currentPlaybackMode == this && playbackHandler.playbackState);
+	return (currentPlaybackMode == this && (playbackHandler.playbackState != 0u));
 }

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -2217,7 +2217,8 @@ traverseClips:
 		Clip* clip = clipArray->getClipAtIndex(c);
 
 		if (clip->fillEventAtTickCount > 0) {
-			if ((nextClipWithFillEvent == nullptr) || nextClipWithFillEvent->fillEventAtTickCount > clip->fillEventAtTickCount) {
+			if ((nextClipWithFillEvent == nullptr)
+			    || nextClipWithFillEvent->fillEventAtTickCount > clip->fillEventAtTickCount) {
 				nextClipWithFillEvent = clip;
 			}
 		}
@@ -2225,7 +2226,8 @@ traverseClips:
 			continue;
 		}
 
-		if ((clip->output->getActiveClip() != nullptr) && clip->output->getActiveClip()->beingRecordedFromClip == clip) {
+		if ((clip->output->getActiveClip() != nullptr)
+		    && clip->output->getActiveClip()->beingRecordedFromClip == clip) {
 			clip = clip->output->getActiveClip();
 		}
 
@@ -2240,7 +2242,8 @@ traverseClips:
 
 	bool enforceSettingUpArming = false;
 
-	if ((nextClipWithFillEvent != nullptr) && playbackHandler.lastSwungTickActioned >= nextClipWithFillEvent->fillEventAtTickCount) {
+	if ((nextClipWithFillEvent != nullptr)
+	    && playbackHandler.lastSwungTickActioned >= nextClipWithFillEvent->fillEventAtTickCount) {
 		doLaunch(true);
 		armingChanged();
 		nextClipWithFillEvent->fillEventAtTickCount = 0;
@@ -2398,7 +2401,8 @@ void Session::doTickForward(int32_t posIncrement) {
 				continue;
 			}
 
-			if ((clip->output->getActiveClip() != nullptr) && clip->output->getActiveClip()->beingRecordedFromClip == clip) {
+			if ((clip->output->getActiveClip() != nullptr)
+			    && clip->output->getActiveClip()->beingRecordedFromClip == clip) {
 				clip = clip->output->getActiveClip();
 			}
 
@@ -2648,7 +2652,7 @@ bool Session::willClipContinuePlayingAtEnd(ModelStackWithTimelineCounter const* 
 	// Note: this isn't quite perfect - it doesn’t know if Clip will cut out due to another one launching. But the ill
 	// effects of this are pretty minor.
 	bool willLoop =
-	    (launchEventAtSwungTickCount == 0)             // If no launch event scheduled, obviously it'll loop
+	    (launchEventAtSwungTickCount == 0)       // If no launch event scheduled, obviously it'll loop
 	    || numRepeatsTilLaunch > 1               // If the launch event is gonna just trigger another repeat, it'll loop
 	    || clip->armState != ArmState::ON_NORMAL // If not armed, or armed to solo, it'll loop (except see above)
 	    || (clip->soloingInSessionMode
@@ -2681,7 +2685,8 @@ bool Session::deletingClipWhichCouldBeAbandonedOverdub(Clip* clip) {
 	    clip->activeIfNoSolo; // Yep, this works better (in some complex scenarios I tested) than calling
 	                          // isClipActive(), which would take soloing into account
 
-	if (shouldBeActiveWhileExistent && !((playbackHandler.playbackState != 0u) && currentPlaybackMode == &arrangement)) {
+	if (shouldBeActiveWhileExistent
+	    && !((playbackHandler.playbackState != 0u) && currentPlaybackMode == &arrangement)) {
 		int32_t newClipIndex;
 		Clip* newClip = currentSong->getSessionClipWithOutput(clip->output, -1, clip, &newClipIndex, true);
 		if (newClip != nullptr) {

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -400,7 +400,8 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 
 	// See if we want a count-in
 	if (allowCountIn && !doingTempolessRecord && recording == RecordingMode::NORMAL && (countInBars != 0u)
-	    && ((currentUIMode == 0u) || currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) && getCurrentUI() == rootUI) {
+	    && ((currentUIMode == 0u) || currentUIMode == UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON)
+	    && getCurrentUI() == rootUI) {
 
 		ticksLeftInCountIn = currentSong->getBarLength() * countInBars;
 		currentVisualCountForCountIn = 0; // Reset it. In a moment it'll display as 4 - 12.
@@ -472,7 +473,8 @@ void PlaybackHandler::tapTempoAutoSwitchOff() {
 void PlaybackHandler::decideOnCurrentPlaybackMode() {
 	// If in arranger...
 	if (getRootUI() == &arrangerView
-	    || ((getRootUI() == nullptr) && (currentSong != nullptr) && currentSong->lastClipInstanceEnteredStartPos != -1)) {
+	    || ((getRootUI() == nullptr) && (currentSong != nullptr)
+	        && currentSong->lastClipInstanceEnteredStartPos != -1)) {
 		goto useArranger;
 	}
 
@@ -1133,9 +1135,9 @@ int64_t PlaybackHandler::getActualSwungTickCount(uint32_t* timeRemainder) {
 
 	else {
 		int64_t nextSwungTickToAction = lastSwungTickActioned + swungTicksTilNextEvent;
-		if ((nextSwungTickToAction != 0) // Checking for special case when nextSwungTickToAction == 0, when playback first
-		                          // starts. Unchecked, that would sometimes lead to us returning -1 when following
-		                          // external clock.
+		if ((nextSwungTickToAction != 0) // Checking for special case when nextSwungTickToAction == 0, when playback
+		                                 // first starts. Unchecked, that would sometimes lead to us returning -1 when
+		                                 // following external clock.
 		    && actualSwungTick >= nextSwungTickToAction) {
 			actualSwungTick = nextSwungTickToAction - 1;
 			if (timeRemainder != nullptr) {

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -209,9 +209,9 @@ public:
 	void scheduleSwungTickFromInternalClock();
 	bool currentlySendingMIDIOutputClocks();
 
-	inline bool isExternalClockActive() { return (playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE); }
-	inline bool isInternalClockActive() { return (playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE); }
-	inline bool isEitherClockActive() { return (playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE); }
+	inline bool isExternalClockActive() { return (playbackState & PLAYBACK_CLOCK_EXTERNAL_ACTIVE) != 0; }
+	inline bool isInternalClockActive() { return (playbackState & PLAYBACK_CLOCK_INTERNAL_ACTIVE) != 0; }
+	inline bool isEitherClockActive() { return (playbackState & PLAYBACK_CLOCK_EITHER_ACTIVE) != 0; }
 
 	// TEMPO encoder commands
 	void commandDisplaySwingAmount();

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -250,7 +250,8 @@ renderEnvelope:
 	if (mode != AudioOutputMode::player && modelStack->song->isOutputActiveInArrangement(this)
 	    && inputChannel != AudioInputChannel::SPECIFIC_OUTPUT) {
 		rendered = true;
-		StereoSample* __restrict__ outputPos = (bufferToTransferTo != nullptr) ? (StereoSample*)bufferToTransferTo : renderBuffer;
+		StereoSample* __restrict__ outputPos =
+		    (bufferToTransferTo != nullptr) ? (StereoSample*)bufferToTransferTo : renderBuffer;
 		StereoSample const* const outputPosEnd = outputPos + numSamples;
 
 		int32_t const* __restrict__ inputReadPos = (int32_t const*)AudioEngine::i2sRXBufferPos;
@@ -315,7 +316,8 @@ renderEnvelope:
 	else if (mode != AudioOutputMode::player && modelStack->song->isOutputActiveInArrangement(this)
 	         && inputChannel == AudioInputChannel::SPECIFIC_OUTPUT && (outputRecordingFrom != nullptr)) {
 		rendered = true;
-		StereoSample* __restrict__ outputBuffer = (bufferToTransferTo != nullptr) ? (StereoSample*)bufferToTransferTo : renderBuffer;
+		StereoSample* __restrict__ outputBuffer =
+		    (bufferToTransferTo != nullptr) ? (StereoSample*)bufferToTransferTo : renderBuffer;
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* songModelStack = setupModelStackWithSong(modelStackMemory, currentSong);
 		outputRecordingFrom->renderOutput(songModelStack, outputBuffer, outputBuffer + numSamples, numSamples,
@@ -467,7 +469,8 @@ bool AudioOutput::setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmCh
 }
 
 bool AudioOutput::isSkippingRendering() {
-	return mode == AudioOutputMode::player && ((activeClip == nullptr) || (((AudioClip*)activeClip)->voiceSample == nullptr));
+	return mode == AudioOutputMode::player
+	       && ((activeClip == nullptr) || (((AudioClip*)activeClip)->voiceSample == nullptr));
 }
 
 void AudioOutput::getThingWithMostReverb(Sound** soundWithMostReverb, ParamManager** paramManagerWithMostReverb,

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -109,11 +109,11 @@ public:
 			// can happen from bad save files
 			return;
 		}
-		if (outputRecordingFrom) {
+		if (outputRecordingFrom != nullptr) {
 			outputRecordingFrom->setRenderingToAudioOutput(false, nullptr);
 		}
 		outputRecordingFrom = toRecordfrom;
-		if (outputRecordingFrom) {
+		if (outputRecordingFrom != nullptr) {
 			// If we are a SAMPLER or a LOOPER then we're monitoring the audio, so tell the other output that we're in
 			// charge of rendering
 			outputRecordingFrom->setRenderingToAudioOutput(mode != AudioOutputMode::player, this);
@@ -128,7 +128,7 @@ public:
 		modeInt = (modeInt + offset) % kNumAudioOutputModes;
 
 		mode = static_cast<AudioOutputMode>(std::clamp<int>(modeInt, 0, kNumAudioOutputModes - 1));
-		if (outputRecordingFrom) {
+		if (outputRecordingFrom != nullptr) {
 			// update the output we're recording from on whether we're monitoring
 			outputRecordingFrom->setRenderingToAudioOutput(mode != AudioOutputMode::player, this);
 		}

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -975,7 +975,7 @@ void setMonitoringMode() { // Monitoring setup
 
 	monitoringAction = MonitoringAction::NONE;
 	if (doMonitoring && (audioRecorder.recorder != nullptr)) { // Double-check
-		if (lineInPluggedIn) {                    // Line input
+		if (lineInPluggedIn) {                                 // Line input
 			if (audioRecorder.recorder->inputLooksDifferential()) {
 				monitoringAction = MonitoringAction::SUBTRACT_RIGHT_CHANNEL;
 			}
@@ -1120,14 +1120,16 @@ bool doSomeOutputting() {
 
 		// If we've reached the end of the known space in the output buffer...
 		if ((((uint32_t)((uint32_t)i2sTXBufferPosNow - saddr) >> (2 + NUM_MONO_OUTPUT_CHANNELS_MAGNITUDE))
-		      & (SSI_TX_BUFFER_NUM_SAMPLES - 1)) == 0u) {
+		     & (SSI_TX_BUFFER_NUM_SAMPLES - 1))
+		    == 0u) {
 
 			// See if there's now some more space.
 			saddr = (uint32_t)getTxBufferCurrentPlace();
 
 			// If there wasn't, stop for now
 			if ((((uint32_t)((uint32_t)i2sTXBufferPosNow - saddr) >> (2 + NUM_MONO_OUTPUT_CHANNELS_MAGNITUDE))
-			      & (SSI_TX_BUFFER_NUM_SAMPLES - 1)) == 0u) {
+			     & (SSI_TX_BUFFER_NUM_SAMPLES - 1))
+			    == 0u) {
 				break;
 			}
 		}

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -123,7 +123,7 @@ void CVEngine::switchGateOff(int32_t channel) {
 void CVEngine::switchGateOn(int32_t channel, int32_t doInstantlyIfPossible) {
 	gateChannels[channel].on = true;
 
-	if (doInstantlyIfPossible) {
+	if (doInstantlyIfPossible != 0) {
 		uint32_t timeSinceLastSwitchedOff = AudioEngine::audioSampleTimer - gateChannels[channel].timeLastSwitchedOff;
 		if (timeSinceLastSwitchedOff >= minGateOffTime * 441) {
 			physicallySwitchGate(channel);
@@ -131,7 +131,7 @@ void CVEngine::switchGateOn(int32_t channel, int32_t doInstantlyIfPossible) {
 		}
 	}
 
-	if (doInstantlyIfPossible) {
+	if (doInstantlyIfPossible != 0) {
 		asapGateOutputPending = true;
 	}
 	else {
@@ -208,7 +208,7 @@ void CVEngine::sendVoltageOut(uint8_t channel, uint16_t voltage) {
 
 void CVEngine::physicallySwitchGate(int32_t channel) {
 	// setOutputState is inverted - sending true turns the gate off
-	int32_t on = gateChannels[channel].on == (gateChannels[channel].mode == GateType::S_TRIG);
+	int32_t on = static_cast<int32_t>(gateChannels[channel].on == (gateChannels[channel].mode == GateType::S_TRIG));
 	setOutputState(gatePort[channel], gatePin[channel], on);
 }
 
@@ -335,11 +335,11 @@ void CVEngine::updateRunOutput() {
 		return;
 	}
 
-	bool runState = (playbackHandler.isEitherClockActive() && !playbackHandler.ticksLeftInCountIn);
+	bool runState = (playbackHandler.isEitherClockActive() && (playbackHandler.ticksLeftInCountIn == 0));
 
 	if (runState) {
 		switchGateOn(WHICH_GATE_OUTPUT_IS_RUN,
-		             true); // Try to do instantly, because it's actually good if RUN can switch on before the first
+		             1); // Try to do instantly, because it's actually good if RUN can switch on before the first
 		                    // clock is sent
 	}
 	else {

--- a/src/deluge/processing/engines/cv_engine.cpp
+++ b/src/deluge/processing/engines/cv_engine.cpp
@@ -340,7 +340,7 @@ void CVEngine::updateRunOutput() {
 	if (runState) {
 		switchGateOn(WHICH_GATE_OUTPUT_IS_RUN,
 		             1); // Try to do instantly, because it's actually good if RUN can switch on before the first
-		                    // clock is sent
+		                 // clock is sent
 	}
 	else {
 		switchGateOff(WHICH_GATE_OUTPUT_IS_RUN);

--- a/src/deluge/processing/engines/cv_engine.h
+++ b/src/deluge/processing/engines/cv_engine.h
@@ -103,7 +103,7 @@ public:
 private:
 	void recalculateCVChannelVoltage(uint8_t channel);
 	void switchGateOff(int32_t channel);
-	void switchGateOn(int32_t channel, int32_t doInstantlyIfPossible = false);
+	void switchGateOn(int32_t channel, int32_t doInstantlyIfPossible = 0);
 	/// signifies there's a gate that can't go until the cv is output
 	bool cvOutPending{false};
 	/// gate 1-4 as synths or drums

--- a/src/deluge/processing/live/live_pitch_shifter.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter.cpp
@@ -613,7 +613,9 @@ stopPercSearch:
 		}
 
 		if (((uint32_t)(numRawSamplesProcessedLatest - averagesStartPosNewHead)
-		    & static_cast<uint32_t>((kInputRawBufferSize - 1) < lengthPerMovingAverage * TimeStretch::Crossfade::kNumMovingAverages)) != 0u) {
+		     & static_cast<uint32_t>((kInputRawBufferSize - 1)
+		                             < lengthPerMovingAverage * TimeStretch::Crossfade::kNumMovingAverages))
+		    != 0u) {
 			goto stopSearch;
 		}
 

--- a/src/deluge/processing/metronome/metronome.cpp
+++ b/src/deluge/processing/metronome/metronome.cpp
@@ -39,7 +39,7 @@ void Metronome::render(StereoSample* buffer, uint16_t numSamples) {
 		return;
 	}
 	int32_t volumePostFX;
-	if (currentSong) {
+	if (currentSong != nullptr) {
 		volumePostFX =
 		    getFinalParameterValueVolume(
 		        134217728, cableToLinearParamShortcut(currentSong->paramManager.getUnpatchedParamSet()->getValue(

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -624,8 +624,9 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 
 			if (strcmp(tagName,
-			            "rate") == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs with
-				                   // firmware in September 2016
+			           "rate")
+			    == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs with
+				        // firmware in September 2016
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_ARP_RATE, readAutomationUpToPos);
 				reader.exitTag("rate");
@@ -773,8 +774,9 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 					reader.exitTag("mode");
 			}
 			else if (strcmp(tagName,
-			                 "gate") == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs
-				                        // with firmware in September 2016
+			                "gate")
+			         == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs
+				             // with firmware in September 2016
 				ENSURE_PARAM_MANAGER_EXISTS
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_GATE,
 				                           readAutomationUpToPos);
@@ -855,8 +857,9 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 	}
 
 	else if (strcmp(tagName,
-	                 "portamento") == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs
-		                              // with firmware in September 2016
+	                "portamento")
+	         == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs
+		             // with firmware in September 2016
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_PORTAMENTO, readAutomationUpToPos);
 		reader.exitTag("portamento");
@@ -3132,7 +3135,8 @@ void Sound::setNumUnison(int32_t newNum, ModelStackWithSoundFlags* modelStack) {
 					bool sourceEverActive = modelStack->checkSourceEverActive(s);
 
 					if (sourceEverActive && synthMode != SynthMode::FM && sources[s].oscType == OscType::SAMPLE
-					    && (thisVoice->guides[s].audioFileHolder != nullptr) && (thisVoice->guides[s].audioFileHolder->audioFile != nullptr)) {
+					    && (thisVoice->guides[s].audioFileHolder != nullptr)
+					    && (thisVoice->guides[s].audioFileHolder->audioFile != nullptr)) {
 
 						// For samples, set the current play pos for the new unison part, if num unison went up
 						if (newNum > oldNum) {
@@ -3622,7 +3626,8 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 	    && synthMode != SynthMode::FM) { // Don't combine this with the above "if" - there's an "else" below
 		writer.writeAttribute("loopMode", util::to_underlying(source->repeatMode));
 		writer.writeAttribute("reversed", static_cast<int32_t>(source->sampleControls.reversed));
-		writer.writeAttribute("timeStretchEnable", static_cast<int32_t>(source->sampleControls.pitchAndSpeedAreIndependent));
+		writer.writeAttribute("timeStretchEnable",
+		                      static_cast<int32_t>(source->sampleControls.pitchAndSpeedAreIndependent));
 		writer.writeAttribute("timeStretchAmount", source->timeStretchAmount);
 		if (source->sampleControls.interpolationMode == InterpolationMode::LINEAR) {
 			writer.writeAttribute("linearInterpolation", 1);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -408,7 +408,7 @@ void Sound::patchedParamPresetValueChanged(uint8_t p, ModelStackWithSoundFlags* 
 void Sound::recalculatePatchingToParam(uint8_t p, ParamManagerForTimeline* paramManager) {
 
 	Destination* destination = paramManager->getPatchCableSet()->getDestinationForParam(p);
-	if (destination) {
+	if (destination != nullptr) {
 		sourcesChanged |= destination->sources; // Pretend those sources have changed, and the param will update - for
 		                                        // each Voice too if local.
 	}
@@ -423,7 +423,7 @@ void Sound::recalculatePatchingToParam(uint8_t p, ParamManagerForTimeline* param
 
 		// Or local (do to each voice)...
 		else {
-			if (numVoicesAssigned) {
+			if (numVoicesAssigned != 0) {
 				int32_t ends[2];
 				AudioEngine::activeVoices.getRangeForSound(this, ends);
 				for (int32_t v = ends[0]; v < ends[1]; v++) {
@@ -452,7 +452,7 @@ void Sound::recalculatePatchingToParam(uint8_t p, ParamManagerForTimeline* param
 Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamManagerForTimeline* paramManager,
                              int32_t readAutomationUpToPos, ArpeggiatorSettings* arpSettings, Song* song) {
 
-	if (!strcmp(tagName, "osc1")) {
+	if (strcmp(tagName, "osc1") == 0) {
 		reader.match('{');
 		Error error = readSourceFromFile(reader, 0, paramManager, readAutomationUpToPos);
 		if (error != Error::NONE) {
@@ -461,7 +461,7 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("osc1", true);
 	}
 
-	else if (!strcmp(tagName, "osc2")) {
+	else if (strcmp(tagName, "osc2") == 0) {
 		reader.match('{');
 		Error error = readSourceFromFile(reader, 1, paramManager, readAutomationUpToPos);
 		if (error != Error::NONE) {
@@ -470,7 +470,7 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("osc2", true);
 	}
 
-	else if (!strcmp(tagName, "mode")) {
+	else if (strcmp(tagName, "mode") == 0) {
 		char const* contents = reader.readTagOrAttributeValue();
 		if (synthMode != SynthMode::RINGMOD) { // Compatibility with old XML files
 			synthMode = stringToSynthMode(contents);
@@ -481,27 +481,27 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 	}
 
 	// Backwards-compatible reading of old-style oscs, from pre-mid-2016 files
-	else if (!strcmp(tagName, "oscillatorA")) {
+	else if (strcmp(tagName, "oscillatorA") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 
-			if (!strcmp(tagName, "type")) {
+			if (strcmp(tagName, "type") == 0) {
 				sources[0].oscType = stringToOscType(reader.readTagOrAttributeValue());
 				reader.exitTag("type");
 			}
-			else if (!strcmp(tagName, "volume")) {
+			else if (strcmp(tagName, "volume") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_VOLUME,
 				                         readAutomationUpToPos);
 				reader.exitTag("volume");
 			}
-			else if (!strcmp(tagName, "phaseWidth")) {
+			else if (strcmp(tagName, "phaseWidth") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_PHASE_WIDTH,
 				                         readAutomationUpToPos);
 				reader.exitTag("phaseWidth");
 			}
-			else if (!strcmp(tagName, "note")) {
+			else if (strcmp(tagName, "note") == 0) {
 				int32_t presetNote = std::clamp<int32_t>(reader.readTagOrAttributeValueInt(), 1, 127);
 
 				sources[0].transpose += presetNote - 60;
@@ -517,20 +517,20 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("oscillatorA", true);
 	}
 
-	else if (!strcmp(tagName, "oscillatorB")) {
+	else if (strcmp(tagName, "oscillatorB") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "type")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "type") == 0) {
 				sources[1].oscType = stringToOscType(reader.readTagOrAttributeValue());
 				reader.exitTag("type");
 			}
-			else if (!strcmp(tagName, "volume")) {
+			else if (strcmp(tagName, "volume") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_B_VOLUME,
 				                         readAutomationUpToPos);
 				reader.exitTag("volume");
 			}
-			else if (!strcmp(tagName, "phaseWidth")) {
+			else if (strcmp(tagName, "phaseWidth") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_B_PHASE_WIDTH,
 				                         readAutomationUpToPos);
@@ -538,11 +538,11 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				// 1); // Special case - pw values are stored at half size in file
 				reader.exitTag("phaseWidth");
 			}
-			else if (!strcmp(tagName, "transpose")) {
+			else if (strcmp(tagName, "transpose") == 0) {
 				sources[1].transpose += reader.readTagOrAttributeValueInt();
 				reader.exitTag("transpose");
 			}
-			else if (!strcmp(tagName, "cents")) {
+			else if (strcmp(tagName, "cents") == 0) {
 				sources[1].cents = reader.readTagOrAttributeValueInt();
 				reader.exitTag("cents");
 			}
@@ -553,24 +553,24 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("oscillatorB", true);
 	}
 
-	else if (!strcmp(tagName, "modulator1")) {
+	else if (strcmp(tagName, "modulator1") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "volume")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "volume") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_0_VOLUME,
 				                         readAutomationUpToPos);
 				reader.exitTag("volume");
 			}
-			else if (!strcmp(tagName, "transpose")) {
+			else if (strcmp(tagName, "transpose") == 0) {
 				modulatorTranspose[0] += reader.readTagOrAttributeValueInt();
 				reader.exitTag("transpose");
 			}
-			else if (!strcmp(tagName, "cents")) {
+			else if (strcmp(tagName, "cents") == 0) {
 				modulatorCents[0] = reader.readTagOrAttributeValueInt();
 				reader.exitTag("cents");
 			}
-			else if (!strcmp(tagName, "retrigPhase")) {
+			else if (strcmp(tagName, "retrigPhase") == 0) {
 				modulatorRetriggerPhase[0] = reader.readTagOrAttributeValueInt();
 				reader.exitTag("retrigPhase");
 			}
@@ -581,31 +581,31 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("modulator1", true);
 	}
 
-	else if (!strcmp(tagName, "modulator2")) {
+	else if (strcmp(tagName, "modulator2") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "volume")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "volume") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_1_VOLUME,
 				                         readAutomationUpToPos);
 				reader.exitTag("volume");
 			}
-			else if (!strcmp(tagName, "transpose")) {
+			else if (strcmp(tagName, "transpose") == 0) {
 				modulatorTranspose[1] += reader.readTagOrAttributeValueInt();
 				reader.exitTag("transpose");
 			}
-			else if (!strcmp(tagName, "cents")) {
+			else if (strcmp(tagName, "cents") == 0) {
 				modulatorCents[1] = reader.readTagOrAttributeValueInt();
 				reader.exitTag("cents");
 			}
-			else if (!strcmp(tagName, "retrigPhase")) {
+			else if (strcmp(tagName, "retrigPhase") == 0) {
 				modulatorRetriggerPhase[1] = reader.readTagOrAttributeValueInt();
 				reader.exitTag("retrigPhase");
 			}
-			else if (!strcmp(tagName, "toModulator1")) {
-				modulator1ToModulator0 = reader.readTagOrAttributeValueInt();
-				if (modulator1ToModulator0 != 0) {
-					modulator1ToModulator0 = 1;
+			else if (strcmp(tagName, "toModulator1") == 0) {
+				modulator1ToModulator0 = (reader.readTagOrAttributeValueInt() != 0);
+				if (static_cast<int>(modulator1ToModulator0) != 0) {
+					modulator1ToModulator0 = true;
 				}
 				reader.exitTag("toModulator1");
 			}
@@ -616,56 +616,56 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("modulator2", true);
 	}
 
-	else if (!strcmp(tagName, "arpeggiator")) {
+	else if (strcmp(tagName, "arpeggiator") == 0) {
 		// Set default values in case they are not configured
 		arpSettings->syncType = SYNC_TYPE_EVEN;
 		arpSettings->syncLevel = SYNC_LEVEL_NONE;
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 
-			if (!strcmp(tagName,
-			            "rate")) { // This is here for compatibility only for people (Lou and Ian) who saved songs with
+			if (strcmp(tagName,
+			            "rate") == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs with
 				                   // firmware in September 2016
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_ARP_RATE, readAutomationUpToPos);
 				reader.exitTag("rate");
 			}
-			else if (!strcmp(tagName, "numOctaves")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "numOctaves") == 0) {
+				if (arpSettings != nullptr) {
 					arpSettings->numOctaves = reader.readTagOrAttributeValueInt();
 				}
 				reader.exitTag("numOctaves");
 			}
-			else if (!strcmp(tagName, "syncType")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "syncType") == 0) {
+				if (arpSettings != nullptr) {
 					arpSettings->syncType = (SyncType)reader.readTagOrAttributeValueInt();
 					;
 				}
 				reader.exitTag("syncType");
 			}
-			else if (!strcmp(tagName, "syncLevel")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "syncLevel") == 0) {
+				if (arpSettings != nullptr) {
 					arpSettings->syncLevel = (SyncLevel)song->convertSyncLevelFromFileValueToInternalValue(
 					    reader.readTagOrAttributeValueInt());
 				}
 				reader.exitTag("syncLevel");
 			}
-			else if (!strcmp(tagName, "octaveMode")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "octaveMode") == 0) {
+				if (arpSettings != nullptr) {
 					arpSettings->octaveMode = stringToArpOctaveMode(reader.readTagOrAttributeValue());
 					arpSettings->updatePresetFromCurrentSettings();
 				}
 				reader.exitTag("octaveMode");
 			}
-			else if (!strcmp(tagName, "noteMode")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "noteMode") == 0) {
+				if (arpSettings != nullptr) {
 					arpSettings->noteMode = stringToArpNoteMode(reader.readTagOrAttributeValue());
 					arpSettings->updatePresetFromCurrentSettings();
 				}
 				reader.exitTag("noteMode");
 			}
-			else if (!strcmp(tagName, "chordType")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "chordType") == 0) {
+				if (arpSettings != nullptr) {
 					uint8_t chordTypeIndex = (uint8_t)reader.readTagOrAttributeValueInt();
 					char buffer[12];
 					intToString(chordTypeIndex, buffer + strlen(buffer));
@@ -676,33 +676,33 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				}
 				reader.exitTag("chordType");
 			}
-			else if (!strcmp(tagName, "mpeVelocity")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "mpeVelocity") == 0) {
+				if (arpSettings != nullptr) {
 					arpSettings->mpeVelocity = stringToArpMpeModSource(reader.readTagOrAttributeValue());
 				}
 				reader.exitTag("mpeVelocity");
 			}
-			else if (!strcmp(tagName, "arpMode")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "arpMode") == 0) {
+				if (arpSettings != nullptr) {
 					arpSettings->mode = stringToArpMode(reader.readTagOrAttributeValue());
 					arpSettings->updatePresetFromCurrentSettings();
 				}
 				reader.exitTag("arpMode");
 			}
-			else if (!strcmp(tagName, "spreadLock")) {
-				if (arpSettings) {
-					arpSettings->spreadLock = reader.readTagOrAttributeValueInt();
+			else if (strcmp(tagName, "spreadLock") == 0) {
+				if (arpSettings != nullptr) {
+					arpSettings->spreadLock = (reader.readTagOrAttributeValueInt() != 0);
 				}
 				reader.exitTag("spreadLock");
 			}
-			else if (!strcmp(tagName, "lockedSpreadVelocity")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "lockedSpreadVelocity") == 0) {
+				if (arpSettings != nullptr) {
 					if (reader.prepareToReadTagOrAttributeValueOneCharAtATime()) {
 						char const* firstChars = reader.readNextCharsOfTagOrAttributeValue(2);
-						if (firstChars && *(uint16_t*)firstChars == charsToIntegerConstant('0', 'x')) {
+						if ((firstChars != nullptr) && *(uint16_t*)firstChars == charsToIntegerConstant('0', 'x')) {
 							char const* hexChars =
 							    reader.readNextCharsOfTagOrAttributeValue(8 + 2 * SPREAD_LOCK_MAX_SAVED_VALUES);
-							if (hexChars) {
+							if (hexChars != nullptr) {
 								arpSettings->lastLockedSpreadVelocityParameterValue = hexToIntFixedLength(hexChars, 8);
 								for (int i = 0; i < SPREAD_LOCK_MAX_SAVED_VALUES; i++) {
 									arpSettings->lockedSpreadVelocityValues[i] =
@@ -714,14 +714,14 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				}
 				reader.exitTag("lockedSpreadVelocity");
 			}
-			else if (!strcmp(tagName, "lockedSpreadGate")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "lockedSpreadGate") == 0) {
+				if (arpSettings != nullptr) {
 					if (reader.prepareToReadTagOrAttributeValueOneCharAtATime()) {
 						char const* firstChars = reader.readNextCharsOfTagOrAttributeValue(2);
-						if (firstChars && *(uint16_t*)firstChars == charsToIntegerConstant('0', 'x')) {
+						if ((firstChars != nullptr) && *(uint16_t*)firstChars == charsToIntegerConstant('0', 'x')) {
 							char const* hexChars =
 							    reader.readNextCharsOfTagOrAttributeValue(8 + 2 * SPREAD_LOCK_MAX_SAVED_VALUES);
-							if (hexChars) {
+							if (hexChars != nullptr) {
 								arpSettings->lastLockedSpreadGateParameterValue = hexToIntFixedLength(hexChars, 8);
 								for (int i = 0; i < SPREAD_LOCK_MAX_SAVED_VALUES; i++) {
 									arpSettings->lockedSpreadGateValues[i] =
@@ -733,14 +733,14 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				}
 				reader.exitTag("lockedSpreadGate");
 			}
-			else if (!strcmp(tagName, "lockedSpreadOctave")) {
-				if (arpSettings) {
+			else if (strcmp(tagName, "lockedSpreadOctave") == 0) {
+				if (arpSettings != nullptr) {
 					if (reader.prepareToReadTagOrAttributeValueOneCharAtATime()) {
 						char const* firstChars = reader.readNextCharsOfTagOrAttributeValue(2);
-						if (firstChars && *(uint16_t*)firstChars == charsToIntegerConstant('0', 'x')) {
+						if ((firstChars != nullptr) && *(uint16_t*)firstChars == charsToIntegerConstant('0', 'x')) {
 							char const* hexChars =
 							    reader.readNextCharsOfTagOrAttributeValue(8 + 2 * SPREAD_LOCK_MAX_SAVED_VALUES);
-							if (hexChars) {
+							if (hexChars != nullptr) {
 								arpSettings->lastLockedSpreadOctaveParameterValue = hexToIntFixedLength(hexChars, 8);
 								for (int i = 0; i < SPREAD_LOCK_MAX_SAVED_VALUES; i++) {
 									arpSettings->lockedSpreadOctaveValues[i] =
@@ -752,12 +752,12 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				}
 				reader.exitTag("lockedSpreadOctave");
 			}
-			else if (!strcmp(tagName, "mode")) {
+			else if (strcmp(tagName, "mode") == 0) {
 				if (song_firmware_version < FirmwareVersion::community({1, 2, 0})) {
 					// Import the old "mode" into the new splitted params "arpMode", "noteMode", and "octaveMode
 					// but only if the new params are not already read and set,
 					// that is, if we detect they have a value other than default
-					if (arpSettings) {
+					if (arpSettings != nullptr) {
 						OldArpMode oldMode = stringToOldArpMode(reader.readTagOrAttributeValue());
 						if (arpSettings->mode == ArpMode::OFF && arpSettings->noteMode == ArpNoteMode::UP
 						    && arpSettings->octaveMode == ArpOctaveMode::UP) {
@@ -772,8 +772,8 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				else
 					reader.exitTag("mode");
 			}
-			else if (!strcmp(tagName,
-			                 "gate")) { // This is here for compatibility only for people (Lou and Ian) who saved songs
+			else if (strcmp(tagName,
+			                 "gate") == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs
 				                        // with firmware in September 2016
 				ENSURE_PARAM_MANAGER_EXISTS
 				unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_GATE,
@@ -788,74 +788,74 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("arpeggiator", true);
 	}
 
-	else if (!strcmp(tagName, "transpose")) {
+	else if (strcmp(tagName, "transpose") == 0) {
 		transpose = reader.readTagOrAttributeValueInt();
 		reader.exitTag("transpose");
 	}
 
-	else if (!strcmp(tagName, "noiseVolume")) {
+	else if (strcmp(tagName, "noiseVolume") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_NOISE_VOLUME, readAutomationUpToPos);
 		reader.exitTag("noiseVolume");
 	}
 
-	else if (!strcmp(tagName, "ratchetAmount")) {
+	else if (strcmp(tagName, "ratchetAmount") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_RATCHET_AMOUNT,
 		                           readAutomationUpToPos);
 		reader.exitTag("ratchetAmount");
 	}
 
-	else if (!strcmp(tagName, "ratchetProbability")) {
+	else if (strcmp(tagName, "ratchetProbability") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_RATCHET_PROBABILITY,
 		                           readAutomationUpToPos);
 		reader.exitTag("ratchetProbability");
 	}
 
-	else if (!strcmp(tagName, "noteProbability")) {
+	else if (strcmp(tagName, "noteProbability") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_NOTE_PROBABILITY,
 		                           readAutomationUpToPos);
 		reader.exitTag("noteProbability");
 	}
 
-	else if (!strcmp(tagName, "sequenceLength")) {
+	else if (strcmp(tagName, "sequenceLength") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SEQUENCE_LENGTH,
 		                           readAutomationUpToPos);
 		reader.exitTag("sequenceLength");
 	}
 
-	else if (!strcmp(tagName, "rhythm")) {
+	else if (strcmp(tagName, "rhythm") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_RHYTHM, readAutomationUpToPos);
 		reader.exitTag("rhythm");
 	}
 
-	else if (!strcmp(tagName, "spreadVelocity")) {
+	else if (strcmp(tagName, "spreadVelocity") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SPREAD_VELOCITY,
 		                           readAutomationUpToPos);
 		reader.exitTag("spreadVelocity");
 	}
 
-	else if (!strcmp(tagName, "spreadGate")) {
+	else if (strcmp(tagName, "spreadGate") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SPREAD_GATE,
 		                           readAutomationUpToPos);
 		reader.exitTag("spreadGate");
 	}
 
-	else if (!strcmp(tagName, "spreadOctave")) {
+	else if (strcmp(tagName, "spreadOctave") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SPREAD_OCTAVE,
 		                           readAutomationUpToPos);
 		reader.exitTag("spreadOctave");
 	}
 
-	else if (!strcmp(tagName,
-	                 "portamento")) { // This is here for compatibility only for people (Lou and Ian) who saved songs
+	else if (strcmp(tagName,
+	                 "portamento") == 0) { // This is here for compatibility only for people (Lou and Ian) who saved songs
 		                              // with firmware in September 2016
 		ENSURE_PARAM_MANAGER_EXISTS
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_PORTAMENTO, readAutomationUpToPos);
@@ -863,9 +863,9 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 	}
 
 	// For backwards compatibility. If off, switch off for all operators
-	else if (!strcmp(tagName, "oscillatorReset")) {
+	else if (strcmp(tagName, "oscillatorReset") == 0) {
 		int32_t value = reader.readTagOrAttributeValueInt();
-		if (!value) {
+		if (value == 0) {
 			for (int32_t s = 0; s < kNumSources; s++) {
 				oscRetriggerPhase[s] = 0xFFFFFFFF;
 			}
@@ -876,20 +876,20 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("oscillatorReset");
 	}
 
-	else if (!strcmp(tagName, "unison")) {
+	else if (strcmp(tagName, "unison") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "num")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "num") == 0) {
 				int32_t contents = reader.readTagOrAttributeValueInt();
 				numUnison = std::max((int32_t)0, std::min((int32_t)kMaxNumVoicesUnison, contents));
 				reader.exitTag("num");
 			}
-			else if (!strcmp(tagName, "detune")) {
+			else if (strcmp(tagName, "detune") == 0) {
 				int32_t contents = reader.readTagOrAttributeValueInt();
 				unisonDetune = std::clamp(contents, 0_i32, kMaxUnisonDetune);
 				reader.exitTag("detune");
 			}
-			else if (!strcmp(tagName, "spread")) {
+			else if (strcmp(tagName, "spread") == 0) {
 				int32_t contents = reader.readTagOrAttributeValueInt();
 				unisonStereoSpread = std::clamp(contents, 0_i32, kMaxUnisonStereoSpread);
 				reader.exitTag("spread");
@@ -901,26 +901,26 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("unison", true);
 	}
 
-	else if (!strcmp(tagName, "oscAPitchAdjust")) {
+	else if (strcmp(tagName, "oscAPitchAdjust") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_PITCH_ADJUST, readAutomationUpToPos);
 		reader.exitTag("oscAPitchAdjust");
 	}
 
-	else if (!strcmp(tagName, "oscBPitchAdjust")) {
+	else if (strcmp(tagName, "oscBPitchAdjust") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_B_PITCH_ADJUST, readAutomationUpToPos);
 		reader.exitTag("oscBPitchAdjust");
 	}
 
-	else if (!strcmp(tagName, "mod1PitchAdjust")) {
+	else if (strcmp(tagName, "mod1PitchAdjust") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_0_PITCH_ADJUST,
 		                         readAutomationUpToPos);
 		reader.exitTag("mod1PitchAdjust");
 	}
 
-	else if (!strcmp(tagName, "mod2PitchAdjust")) {
+	else if (strcmp(tagName, "mod2PitchAdjust") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_1_PITCH_ADJUST,
 		                         readAutomationUpToPos);
@@ -928,11 +928,11 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 	}
 
 	// Stuff from the early-2016 format, for compatibility
-	else if (!strcmp(tagName, "fileName")) {
+	else if (strcmp(tagName, "fileName") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 
 		MultisampleRange* range = (MultisampleRange*)sources[0].getOrCreateFirstRange();
-		if (!range) {
+		if (range == nullptr) {
 			return Error::INSUFFICIENT_RAM;
 		}
 
@@ -954,26 +954,26 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("fileName");
 	}
 
-	else if (!strcmp(tagName, "cents")) {
+	else if (strcmp(tagName, "cents") == 0) {
 		int8_t newCents = reader.readTagOrAttributeValueInt();
 		// We don't need to call the setTranspose method here, because this will get called soon anyway, once the sample
 		// rate is known
 		sources[0].cents = (std::max((int8_t)-50, std::min((int8_t)50, newCents)));
 		reader.exitTag("cents");
 	}
-	else if (!strcmp(tagName, "continuous")) {
+	else if (strcmp(tagName, "continuous") == 0) {
 		sources[0].repeatMode = static_cast<SampleRepeatMode>(reader.readTagOrAttributeValueInt());
 		sources[0].repeatMode = std::min(sources[0].repeatMode, static_cast<SampleRepeatMode>(kNumRepeatModes - 1));
 		reader.exitTag("continuous");
 	}
-	else if (!strcmp(tagName, "reversed")) {
-		sources[0].sampleControls.reversed = reader.readTagOrAttributeValueInt();
+	else if (strcmp(tagName, "reversed") == 0) {
+		sources[0].sampleControls.reversed = (reader.readTagOrAttributeValueInt() != 0);
 		reader.exitTag("reversed");
 	}
-	else if (!strcmp(tagName, "zone")) {
+	else if (strcmp(tagName, "zone") == 0) {
 		reader.match('{');
 		MultisampleRange* range = (MultisampleRange*)sources[0].getOrCreateFirstRange();
-		if (!range) {
+		if (range == nullptr) {
 			return Error::INSUFFICIENT_RAM;
 		}
 
@@ -981,22 +981,22 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		range->sampleHolder.endMSec = 0;
 		range->sampleHolder.startPos = 0;
 		range->sampleHolder.endPos = 0;
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 			// Because this is for old, early-2016 format, there'll only be seconds and milliseconds in here, not
 			// samples
-			if (!strcmp(tagName, "startSeconds")) {
+			if (strcmp(tagName, "startSeconds") == 0) {
 				range->sampleHolder.startMSec += reader.readTagOrAttributeValueInt() * 1000;
 				reader.exitTag("startSeconds");
 			}
-			else if (!strcmp(tagName, "startMilliseconds")) {
+			else if (strcmp(tagName, "startMilliseconds") == 0) {
 				range->sampleHolder.startMSec += reader.readTagOrAttributeValueInt();
 				reader.exitTag("startMilliseconds");
 			}
-			else if (!strcmp(tagName, "endSeconds")) {
+			else if (strcmp(tagName, "endSeconds") == 0) {
 				range->sampleHolder.endMSec += reader.readTagOrAttributeValueInt() * 1000;
 				reader.exitTag("endSeconds");
 			}
-			else if (!strcmp(tagName, "endMilliseconds")) {
+			else if (strcmp(tagName, "endMilliseconds") == 0) {
 				range->sampleHolder.endMSec += reader.readTagOrAttributeValueInt();
 				reader.exitTag("endMilliseconds");
 			}
@@ -1004,7 +1004,7 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("zone", true);
 	}
 
-	else if (!strcmp(tagName, "ringMod")) {
+	else if (strcmp(tagName, "ringMod") == 0) {
 		int32_t contents = reader.readTagOrAttributeValueInt();
 		if (contents == 1) {
 			synthMode = SynthMode::RINGMOD;
@@ -1012,27 +1012,27 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("ringMod");
 	}
 
-	else if (!strcmp(tagName, "modKnobs")) {
+	else if (strcmp(tagName, "modKnobs") == 0) {
 
 		int32_t k = 0;
 		int32_t w = 0;
 		reader.match('[');
-		while (reader.match('{') && *(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "modKnob")) {
+		while (reader.match('{') && (*(tagName = reader.readNextTagOrAttributeName()) != 0)) {
+			if (strcmp(tagName, "modKnob") == 0) {
 				reader.match('{');
 				uint8_t p = params::GLOBAL_NONE;
 				PatchSource s = PatchSource::NOT_AVAILABLE;
 				PatchSource s2 = PatchSource::NOT_AVAILABLE;
 
-				while (*(tagName = reader.readNextTagOrAttributeName())) {
-					if (!strcmp(tagName, "controlsParam")) {
+				while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+					if (strcmp(tagName, "controlsParam") == 0) {
 						p = params::fileStringToParam(params::Kind::UNPATCHED_SOUND, reader.readTagOrAttributeValue(),
 						                              true);
 					}
-					else if (!strcmp(tagName, "patchAmountFromSource")) {
+					else if (strcmp(tagName, "patchAmountFromSource") == 0) {
 						s = stringToSource(reader.readTagOrAttributeValue());
 					}
-					else if (!strcmp(tagName, "patchAmountFromSecondSource")) {
+					else if (strcmp(tagName, "patchAmountFromSecondSource") == 0) {
 						s2 = stringToSource(reader.readTagOrAttributeValue());
 					}
 					reader.exitTag(tagName);
@@ -1071,31 +1071,31 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.match(']');
 	}
 
-	else if (!strcmp(tagName, "patchCables")) {
+	else if (strcmp(tagName, "patchCables") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		paramManager->getPatchCableSet()->readPatchCablesFromFile(reader, readAutomationUpToPos);
 		reader.exitTag("patchCables");
 	}
 
-	else if (!strcmp(tagName, "volume")) {
+	else if (strcmp(tagName, "volume") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_VOLUME_POST_FX, readAutomationUpToPos);
 		reader.exitTag("volume");
 	}
 
-	else if (!strcmp(tagName, "pan")) {
+	else if (strcmp(tagName, "pan") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_PAN, readAutomationUpToPos);
 		reader.exitTag("pan");
 	}
 
-	else if (!strcmp(tagName, "pitchAdjust")) {
+	else if (strcmp(tagName, "pitchAdjust") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_PITCH_ADJUST, readAutomationUpToPos);
 		reader.exitTag("pitchAdjust");
 	}
 
-	else if (!strcmp(tagName, "modFXType")) {
+	else if (strcmp(tagName, "modFXType") == 0) {
 		bool result =
 		    setModFXType(stringToFXType(reader.readTagOrAttributeValue())); // This might not work if not enough RAM
 		if (!result) {
@@ -1104,10 +1104,10 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("modFXType");
 	}
 
-	else if (!strcmp(tagName, "fx")) {
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
+	else if (strcmp(tagName, "fx") == 0) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 
-			if (!strcmp(tagName, "type")) {
+			if (strcmp(tagName, "type") == 0) {
 				bool result = setModFXType(
 				    stringToFXType(reader.readTagOrAttributeValue())); // This might not work if not enough RAM
 				if (!result) {
@@ -1115,13 +1115,13 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				}
 				reader.exitTag("type");
 			}
-			else if (!strcmp(tagName, "rate")) {
+			else if (strcmp(tagName, "rate") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_MOD_FX_RATE,
 				                         readAutomationUpToPos);
 				reader.exitTag("rate");
 			}
-			else if (!strcmp(tagName, "feedback")) {
+			else if (strcmp(tagName, "feedback") == 0) {
 				// This is for compatibility with old files. Some reverse calculation needs to be done.
 				int32_t finalValue = reader.readTagOrAttributeValueInt();
 				int32_t i =
@@ -1132,7 +1132,7 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				    .setCurrentValueBasicForSetup(i);
 				reader.exitTag("feedback");
 			}
-			else if (!strcmp(tagName, "offset")) {
+			else if (strcmp(tagName, "offset") == 0) {
 				// This is for compatibility with old files. Some reverse calculation needs to be done.
 				int32_t contents = reader.readTagOrAttributeValueInt();
 				int32_t value = ((int64_t)contents << 8) - 2147483648;
@@ -1142,7 +1142,7 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 				    .setCurrentValueBasicForSetup(value);
 				reader.exitTag("offset");
 			}
-			else if (!strcmp(tagName, "depth")) {
+			else if (strcmp(tagName, "depth") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_MOD_FX_DEPTH,
 				                         readAutomationUpToPos);
@@ -1155,26 +1155,26 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("fx");
 	}
 
-	else if (!strcmp(tagName, "lfo1")) {
+	else if (strcmp(tagName, "lfo1") == 0) {
 		// Set default values in case they are not configured.
 		lfoConfig[LFO1_ID].syncLevel = SYNC_LEVEL_NONE;
 		lfoConfig[LFO1_ID].syncType = SYNC_TYPE_EVEN;
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "type")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "type") == 0) {
 				lfoConfig[LFO1_ID].waveType = stringToLFOType(reader.readTagOrAttributeValue());
 				reader.exitTag("type");
 			}
-			else if (!strcmp(tagName, "rate")) {
+			else if (strcmp(tagName, "rate") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_LFO_FREQ, readAutomationUpToPos);
 				reader.exitTag("rate");
 			}
-			else if (!strcmp(tagName, "syncType")) {
+			else if (strcmp(tagName, "syncType") == 0) {
 				lfoConfig[LFO1_ID].syncType = (SyncType)reader.readTagOrAttributeValueInt();
 				reader.exitTag("syncType");
 			}
-			else if (!strcmp(tagName, "syncLevel")) {
+			else if (strcmp(tagName, "syncLevel") == 0) {
 				lfoConfig[LFO1_ID].syncLevel =
 				    (SyncLevel)song->convertSyncLevelFromFileValueToInternalValue(reader.readTagOrAttributeValueInt());
 				reader.exitTag("syncLevel");
@@ -1187,27 +1187,27 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		resyncGlobalLFO();
 	}
 
-	else if (!strcmp(tagName, "lfo2")) {
+	else if (strcmp(tagName, "lfo2") == 0) {
 		// Set default values in case they are not configured.
 		lfoConfig[LFO2_ID].syncLevel = SYNC_LEVEL_NONE;
 		lfoConfig[LFO2_ID].syncType = SYNC_TYPE_EVEN;
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "type")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "type") == 0) {
 				lfoConfig[LFO2_ID].waveType = stringToLFOType(reader.readTagOrAttributeValue());
 				reader.exitTag("type");
 			}
-			else if (!strcmp(tagName, "rate")) {
+			else if (strcmp(tagName, "rate") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LFO_LOCAL_FREQ,
 				                         readAutomationUpToPos);
 				reader.exitTag("rate");
 			}
-			else if (!strcmp(tagName, "syncType")) {
+			else if (strcmp(tagName, "syncType") == 0) {
 				lfoConfig[LFO2_ID].syncType = (SyncType)reader.readTagOrAttributeValueInt();
 				reader.exitTag("syncType");
 			}
-			else if (!strcmp(tagName, "syncLevel")) {
+			else if (strcmp(tagName, "syncLevel") == 0) {
 				lfoConfig[LFO2_ID].syncLevel =
 				    (SyncLevel)song->convertSyncLevelFromFileValueToInternalValue(reader.readTagOrAttributeValueInt());
 				reader.exitTag("syncLevel");
@@ -1220,37 +1220,37 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		// No resync for LFO2
 	}
 
-	else if (!strcmp(tagName, "sideChainSend")) {
+	else if (strcmp(tagName, "sideChainSend") == 0) {
 		sideChainSendLevel = reader.readTagOrAttributeValueInt();
 		reader.exitTag("sideChainSend");
 	}
 
-	else if (!strcmp(tagName, "lpf")) {
+	else if (strcmp(tagName, "lpf") == 0) {
 		bool switchedOn = true; // For backwards compatibility with pre November 2015 files
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "status")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "status") == 0) {
 				int32_t contents = reader.readTagOrAttributeValueInt();
 				switchedOn = std::max((int32_t)0, std::min((int32_t)1, contents));
 				reader.exitTag("status");
 			}
-			else if (!strcmp(tagName, "frequency")) {
+			else if (strcmp(tagName, "frequency") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LPF_FREQ, readAutomationUpToPos);
 				reader.exitTag("frequency");
 			}
-			else if (!strcmp(tagName, "morph")) {
+			else if (strcmp(tagName, "morph") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LPF_MORPH, readAutomationUpToPos);
 				reader.exitTag("morph");
 			}
-			else if (!strcmp(tagName, "resonance")) {
+			else if (strcmp(tagName, "resonance") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LPF_RESONANCE,
 				                         readAutomationUpToPos);
 				reader.exitTag("resonance");
 			}
-			else if (!strcmp(tagName, "mode")) { // For old, pre- October 2016 files
+			else if (strcmp(tagName, "mode") == 0) { // For old, pre- October 2016 files
 				lpfMode = stringToLPFType(reader.readTagOrAttributeValue());
 				reader.exitTag("mode");
 			}
@@ -1267,27 +1267,27 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("lpf", true);
 	}
 
-	else if (!strcmp(tagName, "hpf")) {
+	else if (strcmp(tagName, "hpf") == 0) {
 		bool switchedOn = true; // For backwards compatibility with pre November 2015 files
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "status")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "status") == 0) {
 				int32_t contents = reader.readTagOrAttributeValueInt();
 				switchedOn = std::max((int32_t)0, std::min((int32_t)1, contents));
 				reader.exitTag("status");
 			}
-			else if (!strcmp(tagName, "frequency")) {
+			else if (strcmp(tagName, "frequency") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_HPF_FREQ, readAutomationUpToPos);
 				reader.exitTag("frequency");
 			}
-			else if (!strcmp(tagName, "resonance")) {
+			else if (strcmp(tagName, "resonance") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_HPF_RESONANCE,
 				                         readAutomationUpToPos);
 				reader.exitTag("resonance");
 			}
-			else if (!strcmp(tagName, "morph")) {
+			else if (strcmp(tagName, "morph") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_HPF_MORPH, readAutomationUpToPos);
 				reader.exitTag("morph");
@@ -1305,28 +1305,28 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("hpf", true);
 	}
 
-	else if (!strcmp(tagName, "envelope1")) {
+	else if (strcmp(tagName, "envelope1") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "attack")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "attack") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_ATTACK,
 				                         readAutomationUpToPos);
 				reader.exitTag("attack");
 			}
-			else if (!strcmp(tagName, "decay")) {
+			else if (strcmp(tagName, "decay") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_DECAY,
 				                         readAutomationUpToPos);
 				reader.exitTag("decay");
 			}
-			else if (!strcmp(tagName, "sustain")) {
+			else if (strcmp(tagName, "sustain") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_SUSTAIN,
 				                         readAutomationUpToPos);
 				reader.exitTag("sustain");
 			}
-			else if (!strcmp(tagName, "release")) {
+			else if (strcmp(tagName, "release") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_RELEASE,
 				                         readAutomationUpToPos);
@@ -1340,28 +1340,28 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("envelope1", true);
 	}
 
-	else if (!strcmp(tagName, "envelope2")) {
+	else if (strcmp(tagName, "envelope2") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "attack")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "attack") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_ATTACK,
 				                         readAutomationUpToPos);
 				reader.exitTag("attack");
 			}
-			else if (!strcmp(tagName, "decay")) {
+			else if (strcmp(tagName, "decay") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_DECAY,
 				                         readAutomationUpToPos);
 				reader.exitTag("decay");
 			}
-			else if (!strcmp(tagName, "sustain")) {
+			else if (strcmp(tagName, "sustain") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_SUSTAIN,
 				                         readAutomationUpToPos);
 				reader.exitTag("sustain");
 			}
-			else if (!strcmp(tagName, "release")) {
+			else if (strcmp(tagName, "release") == 0) {
 				ENSURE_PARAM_MANAGER_EXISTS
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_RELEASE,
 				                         readAutomationUpToPos);
@@ -1375,33 +1375,33 @@ Error Sound::readTagFromFile(Deserializer& reader, char const* tagName, ParamMan
 		reader.exitTag("envelope2", true);
 	}
 
-	else if (!strcmp(tagName, "polyphonic")) {
+	else if (strcmp(tagName, "polyphonic") == 0) {
 		polyphonic = stringToPolyphonyMode(reader.readTagOrAttributeValue());
 		reader.exitTag("polyphonic");
 	}
 
-	else if (!strcmp(tagName, "maxVoices")) {
+	else if (strcmp(tagName, "maxVoices") == 0) {
 		maxVoiceCount = reader.readTagOrAttributeValueInt();
 		reader.exitTag("maxVoices");
 	}
 
-	else if (!strcmp(tagName, "voicePriority")) {
+	else if (strcmp(tagName, "voicePriority") == 0) {
 		voicePriority = static_cast<VoicePriority>(reader.readTagOrAttributeValueInt());
 		reader.exitTag("voicePriority");
 	}
 
-	else if (!strcmp(tagName, "reverbAmount")) {
+	else if (strcmp(tagName, "reverbAmount") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_REVERB_AMOUNT, readAutomationUpToPos);
 		reader.exitTag("reverbAmount");
 	}
 
-	else if (!strcmp(tagName, "defaultParams")) {
+	else if (strcmp(tagName, "defaultParams") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		Sound::readParamsFromFile(reader, paramManager, readAutomationUpToPos);
 		reader.exitTag("defaultParams");
 	}
-	else if (!strcmp(tagName, "waveFold")) {
+	else if (strcmp(tagName, "waveFold") == 0) {
 		ENSURE_PARAM_MANAGER_EXISTS
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_FOLD, readAutomationUpToPos);
 		reader.exitTag("waveFold");
@@ -1662,7 +1662,7 @@ void Sound::noteOnPostArpeggiator(ModelStackWithSoundFlags* modelStack, int32_t 
 	ParamManagerForTimeline* paramManager = (ParamManagerForTimeline*)modelStack->paramManager;
 
 	// If not polyphonic, stop any notes which are releasing, now
-	if (numVoicesAssigned && polyphonic != PolyphonyMode::POLY) [[unlikely]] {
+	if ((numVoicesAssigned != 0) && polyphonic != PolyphonyMode::POLY) [[unlikely]] {
 
 		int32_t ends[2];
 		AudioEngine::activeVoices.getRangeForSound(this, ends);
@@ -1680,7 +1680,7 @@ void Sound::noteOnPostArpeggiator(ModelStackWithSoundFlags* modelStack, int32_t 
 				if (synthMode == SynthMode::FM) {
 justUnassign:
 					// Ideally, we want to save this voice to reuse. But we can only do that for the first such one
-					if (!voiceToReuse) {
+					if (voiceToReuse == nullptr) {
 						voiceToReuse = thisVoice;
 						thisVoice->unassignStuff(false);
 					}
@@ -1720,7 +1720,7 @@ justUnassign:
 		}
 	}
 
-	if (polyphonic == PolyphonyMode::LEGATO && voiceForLegato) [[unlikely]] {
+	if (polyphonic == PolyphonyMode::LEGATO && (voiceForLegato != nullptr)) [[unlikely]] {
 		ModelStackWithVoice* modelStackWithVoice = modelStack->addVoice(voiceForLegato);
 		voiceForLegato->changeNoteCode(modelStackWithVoice, noteCodePreArp, noteCodePostArp, fromMIDIChannel,
 		                               mpeValues);
@@ -1730,7 +1730,7 @@ justUnassign:
 		Voice* newVoice;
 		int32_t envelopePositions[kNumEnvelopes];
 
-		if (voiceToReuse) [[unlikely]] {
+		if (voiceToReuse != nullptr) [[unlikely]] {
 			newVoice = voiceToReuse;
 
 			// The osc phases and stuff will remain
@@ -1742,7 +1742,7 @@ justUnassign:
 
 		else {
 			newVoice = AudioEngine::solicitVoice(this);
-			if (!newVoice) {
+			if (newVoice == nullptr) {
 				return; // Should basically never happen
 			}
 			numVoicesAssigned++;
@@ -1762,7 +1762,7 @@ justUnassign:
 		    newVoice->noteOn(modelStackWithVoice, noteCodePreArp, noteCodePostArp, velocity, sampleSyncLength,
 		                     ticksLate, samplesLate, voiceToReuse == nullptr, fromMIDIChannel, mpeValues);
 		if (success) {
-			if (voiceToReuse) {
+			if (voiceToReuse != nullptr) {
 				for (int32_t e = 0; e < kNumEnvelopes; e++) {
 					newVoice->envelopes[e].resumeAttack(envelopePositions[e]);
 				}
@@ -1783,7 +1783,7 @@ void Sound::allNotesOff(ModelStackWithThreeMainThings* modelStack, ArpeggiatorBa
 	arpeggiator->reset();
 
 #if ALPHA_OR_BETA_VERSION
-	if (!modelStack->paramManager) {
+	if (modelStack->paramManager == nullptr) {
 		// Previously we were allowed to receive a NULL paramManager, then would just crudely do an unassignAllVoices().
 		// But I'm pretty sure this doesn't exist anymore?
 		FREEZE_WITH_ERROR("E403");
@@ -1797,7 +1797,7 @@ void Sound::allNotesOff(ModelStackWithThreeMainThings* modelStack, ArpeggiatorBa
 
 // noteCode = -32768 (default) means stop *any* voice, regardless of noteCode
 void Sound::noteOffPostArpeggiator(ModelStackWithSoundFlags* modelStack, int32_t noteCode) {
-	if (!numVoicesAssigned) {
+	if (numVoicesAssigned == 0) {
 		return;
 	}
 
@@ -1908,7 +1908,7 @@ int32_t Sound::hasAnyTimeStretchSyncing(ParamManagerForTimeline* paramManager, b
 
 	for (int32_t s = 0; s < kNumSources; s++) {
 
-		bool sourceEverActive = s ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
+		bool sourceEverActive = (s != 0) ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
 
 		if (sourceEverActive && sources[s].oscType == OscType::SAMPLE
 		    && sources[s].repeatMode == SampleRepeatMode::STRETCH) {
@@ -1934,12 +1934,12 @@ int32_t Sound::hasCutOrLoopModeSamples(ParamManagerForTimeline* paramManager, in
 	}
 
 	int32_t maxLength = 0;
-	if (anyLooping) {
+	if (anyLooping != nullptr) {
 		*anyLooping = false;
 	}
 
 	for (int32_t s = 0; s < kNumSources; s++) {
-		bool sourceEverActive = s ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
+		bool sourceEverActive = (s != 0) ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
 		if (!sourceEverActive) {
 			continue;
 		}
@@ -1949,7 +1949,7 @@ int32_t Sound::hasCutOrLoopModeSamples(ParamManagerForTimeline* paramManager, in
 		}
 		else if (sources[s].repeatMode == SampleRepeatMode::CUT || sources[s].repeatMode == SampleRepeatMode::LOOP) {
 
-			if (anyLooping && sources[s].repeatMode == SampleRepeatMode::LOOP) {
+			if ((anyLooping != nullptr) && sources[s].repeatMode == SampleRepeatMode::LOOP) {
 				*anyLooping = true;
 			}
 			int32_t length = sources[s].getLengthInSamplesAtSystemSampleRate(note);
@@ -1975,7 +1975,7 @@ bool Sound::hasCutModeSamples(ParamManagerForTimeline* paramManager) {
 	}
 
 	for (int32_t s = 0; s < kNumSources; s++) {
-		bool sourceEverActive = s ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
+		bool sourceEverActive = (s != 0) ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
 		if (!sourceEverActive) {
 			continue;
 		}
@@ -2004,7 +2004,7 @@ bool Sound::allowsVeryLateNoteStart(InstrumentClip* clip, ParamManagerForTimelin
 	// Basically, if any wave-based oscillators active, or one-shot samples, that means no not allowed
 	for (int32_t s = 0; s < kNumSources; s++) {
 
-		bool sourceEverActive = s ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
+		bool sourceEverActive = (s != 0) ? isSourceActiveEver(1, paramManager) : isSourceActiveEver(0, paramManager);
 		if (!sourceEverActive) {
 			continue;
 		}
@@ -2081,7 +2081,7 @@ bool Sound::renderingOscillatorSyncEver(ParamManager* paramManager) {
 }
 
 void Sound::sampleZoneChanged(MarkerType markerType, int32_t s, ModelStackWithSoundFlags* modelStack) {
-	if (!numVoicesAssigned) {
+	if (numVoicesAssigned == 0) {
 		return;
 	}
 
@@ -2124,7 +2124,7 @@ void Sound::reassessRenderSkippingStatus(ModelStackWithSoundFlags* modelStack, b
 			if ((modFXType_ != ModFXType::NONE) || compressor.getThreshold() > 0) {
 
 				// If we didn't start the wait-time yet, start it now
-				if (!startSkippingRenderingAtTime) {
+				if (startSkippingRenderingAtTime == 0u) {
 
 					// But wait, first, maybe we actually have just been instructed to cut the MODFX tail
 					if (shouldJustCutModFX) {
@@ -2281,7 +2281,7 @@ void Sound::stopParamLPF(ModelStackWithSoundFlags* modelStack) {
 		int32_t p = paramLPF.p;
 		paramLPF.p = PARAM_LPF_OFF; // Must do this first, because the below call will involve the Sound calling us back
 		                            // for the current value
-		if (modelStack) {
+		if (modelStack != nullptr) {
 			patchedParamPresetValueChanged(p, modelStack, paramLPF.currentValue,
 			                               modelStack->paramManager->getPatchedParamSet()->getValue(p));
 		}
@@ -2315,14 +2315,14 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	}
 
 	for (int s = 0; s < kNumSources; s++) {
-		if (sources[s].oscType == OscType::DX7 and sources[s].dxPatch) {
+		if (sources[s].oscType == OscType::DX7 and (sources[s].dxPatch != nullptr)) {
 			sources[s].dxPatch->computeLfo(numSamples);
 		}
 	}
 
 	// Do sidechain
 	if (paramManager->getPatchCableSet()->isSourcePatchedToSomething(PatchSource::SIDECHAIN)) {
-		if (sideChainHitPending) {
+		if (sideChainHitPending != 0) {
 			sidechain.registerHit(sideChainHitPending);
 		}
 
@@ -2336,7 +2336,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	}
 
 	// Perform the actual patching
-	if (sourcesChanged) {
+	if (sourcesChanged != 0u) {
 		patcher.performPatching(sourcesChanged, this, paramManager);
 	}
 
@@ -2350,7 +2350,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 
 	// Arpeggiator
 	ArpeggiatorSettings* arpSettings = getArpSettings();
-	if (arpSettings && arpSettings->mode != ArpMode::OFF) {
+	if ((arpSettings != nullptr) && arpSettings->mode != ArpMode::OFF) {
 
 		UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 		uint32_t gateThreshold = (uint32_t)unpatchedParams->getValue(params::UNPATCHED_ARP_GATE) + 2147483648;
@@ -2404,9 +2404,9 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	// Render each voice into a local buffer here
 	bool renderingInStereo = renderingVoicesInStereo(modelStackWithSoundFlags);
 	static int32_t soundBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2];
-	memset(soundBuffer, 0, (numSamples * sizeof(int32_t)) << renderingInStereo);
+	memset(soundBuffer, 0, (numSamples * sizeof(int32_t)) << static_cast<int>(renderingInStereo));
 
-	if (numVoicesAssigned) {
+	if (numVoicesAssigned != 0) {
 
 		// Very often, we'll just apply panning here at the Sound level rather than the Voice level
 		bool applyingPanAtVoiceLevel =
@@ -2546,7 +2546,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 		compressor.reset();
 	}
 
-	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
+	if ((recorder != nullptr) && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
 		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
 		recorder->feedAudio(soundBuffer, numSamples, true, 2);
 	}
@@ -2596,7 +2596,7 @@ void Sound::stopSkippingRendering(ArpeggiatorSettings* arpSettings) {
 		                                                            // actually was skipping at all
 
 		// If rendering was actually stopped for any length of time...
-		if (modFXTimeOff) {
+		if (modFXTimeOff != 0) {
 
 			// Do LFO
 			globalLFO.tick(AudioEngine::audioSampleTimer - timeStartedSkippingRenderingLFO,
@@ -2610,7 +2610,7 @@ void Sound::stopSkippingRendering(ArpeggiatorSettings* arpSettings) {
 
 			// Do sidechain
 			// if (paramManager->getPatchCableSet()->isSourcePatchedToSomething(PatchSource::SIDECHAIN)) {
-			if (AudioEngine::sizeLastSideChainHit) {
+			if (AudioEngine::sizeLastSideChainHit != 0) {
 				sidechain.registerHitRetrospectively(AudioEngine::sizeLastSideChainHit,
 				                                     AudioEngine::audioSampleTimer - AudioEngine::timeLastSideChainHit);
 				//}
@@ -2628,7 +2628,7 @@ void Sound::stopSkippingRendering(ArpeggiatorSettings* arpSettings) {
 void Sound::getArpBackInTimeAfterSkippingRendering(ArpeggiatorSettings* arpSettings) {
 
 	if (skippingRendering) {
-		if (arpSettings && arpSettings->mode != ArpMode::OFF) {
+		if ((arpSettings != nullptr) && arpSettings->mode != ArpMode::OFF) {
 			uint32_t phaseIncrement =
 			    arpSettings->getPhaseIncrement(paramFinalValues[params::GLOBAL_ARP_RATE - params::FIRST_GLOBAL]);
 			getArp()->gatePos +=
@@ -2640,7 +2640,7 @@ void Sound::getArpBackInTimeAfterSkippingRendering(ArpeggiatorSettings* arpSetti
 }
 
 void Sound::unassignAllVoices() {
-	if (!numVoicesAssigned) {
+	if (numVoicesAssigned == 0) {
 		return;
 	}
 
@@ -2655,7 +2655,7 @@ void Sound::unassignAllVoices() {
 	}
 
 	int32_t numToDelete = ends[1] - ends[0];
-	if (numToDelete) {
+	if (numToDelete != 0) {
 		AudioEngine::activeVoices.deleteAtIndex(ends[0], numToDelete);
 	}
 
@@ -2781,7 +2781,7 @@ void Sound::resyncGlobalLFO() {
 		int64_t lastInternalTickDone = playbackHandler.getCurrentInternalTickCount(&timeSinceLastTick);
 
 		// If we're right at the first tick, no need to do anything else!
-		if (!lastInternalTickDone && !timeSinceLastTick) {
+		if ((lastInternalTickDone == 0) && (timeSinceLastTick == 0u)) {
 			return;
 		}
 
@@ -2800,7 +2800,7 @@ void Sound::resyncGlobalLFO() {
 		uint32_t offsetTicks = (uint64_t)lastInternalTickDone % (uint16_t)numInternalTicksPerPeriod;
 
 		// If we're right at a bar (or something), no need to do anyting else
-		if (!timeSinceLastTick && !offsetTicks) {
+		if ((timeSinceLastTick == 0u) && (offsetTicks == 0u)) {
 			return;
 		}
 
@@ -2858,7 +2858,7 @@ void Sound::ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(Song* song) {
 			break;
 		}
 
-		if (backedUp->clip) {
+		if (backedUp->clip != nullptr) {
 			char modelStackMemory[MODEL_STACK_MAX_SIZE];
 			ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 			    setupModelStackWithThreeMainThingsButNoNoteRow(modelStackMemory, song, this, backedUp->clip,
@@ -2897,7 +2897,7 @@ void Sound::ensureInaccessibleParamPresetValuesWithoutKnobsAreZero(ModelStackWit
 		    modelStackWithParamCollection->addParamId(patchedParamsWhichShouldBeZeroIfNoKnobAssigned[i]);
 		ModelStackWithAutoParam* modelStackWithAutoParam = modelStackWithParamId->paramCollection->getAutoParamFromId(
 		    modelStackWithParamId, false); // Don't allow creation
-		if (modelStackWithAutoParam->autoParam) {
+		if (modelStackWithAutoParam->autoParam != nullptr) {
 			ensureParamPresetValueWithoutKnobIsZero(modelStackWithAutoParam);
 		}
 	}
@@ -2995,7 +2995,7 @@ void Sound::setupUnisonDetuners(ModelStackWithSoundFlags* modelStack) {
 		for (int32_t u = 0; u < numUnison; u++) {
 
 			// Middle unison part gets no detune
-			if ((numUnison & 1) && u == ((numUnison - 1) >> 1)) {
+			if (((numUnison & 1) != 0) && u == ((numUnison - 1) >> 1)) {
 				unisonDetuners[u].setNoDetune();
 			}
 			else {
@@ -3096,7 +3096,7 @@ void Sound::recalculateModulatorTransposer(uint8_t m, ModelStackWithSoundFlags* 
 // Can handle NULL modelStack, which you'd only want to do if no Voices active
 void Sound::recalculateAllVoicePhaseIncrements(ModelStackWithSoundFlags* modelStack) {
 
-	if (!numVoicesAssigned || !modelStack) {
+	if ((numVoicesAssigned == 0) || (modelStack == nullptr)) {
 		return; // These two "should" always be false in tandem...
 	}
 
@@ -3118,7 +3118,7 @@ void Sound::setNumUnison(int32_t newNum, ModelStackWithSoundFlags* modelStack) {
 	calculateEffectiveVolume();
 
 	// Effective volume has changed. Need to pass that change onto Voices
-	if (numVoicesAssigned) {
+	if (numVoicesAssigned != 0) {
 
 		int32_t ends[2];
 		AudioEngine::activeVoices.getRangeForSound(this, ends);
@@ -3132,7 +3132,7 @@ void Sound::setNumUnison(int32_t newNum, ModelStackWithSoundFlags* modelStack) {
 					bool sourceEverActive = modelStack->checkSourceEverActive(s);
 
 					if (sourceEverActive && synthMode != SynthMode::FM && sources[s].oscType == OscType::SAMPLE
-					    && thisVoice->guides[s].audioFileHolder && thisVoice->guides[s].audioFileHolder->audioFile) {
+					    && (thisVoice->guides[s].audioFileHolder != nullptr) && (thisVoice->guides[s].audioFileHolder->audioFile != nullptr)) {
 
 						// For samples, set the current play pos for the new unison part, if num unison went up
 						if (newNum > oldNum) {
@@ -3148,7 +3148,7 @@ void Sound::setNumUnison(int32_t newNum, ModelStackWithSoundFlags* modelStack) {
 								newPart->carrierFeedback = oldPart->carrierFeedback;
 
 								newPart->voiceSample = AudioEngine::solicitVoiceSample();
-								if (!newPart->voiceSample) {
+								if (newPart->voiceSample == nullptr) {
 									newPart->active = false;
 								}
 
@@ -3198,11 +3198,11 @@ bool Sound::anyNoteIsOn() {
 
 	ArpeggiatorSettings* arpSettings = getArpSettings();
 
-	if (arpSettings && arpSettings->mode != ArpMode::OFF) {
+	if ((arpSettings != nullptr) && arpSettings->mode != ArpMode::OFF) {
 		return (getArp()->hasAnyInputNotesActive());
 	}
 
-	return numVoicesAssigned;
+	return numVoicesAssigned != 0;
 }
 
 bool Sound::hasFilters() {
@@ -3213,7 +3213,7 @@ void Sound::readParamsFromFile(Deserializer& reader, ParamManagerForTimeline* pa
                                int32_t readAutomationUpToPos) {
 	char const* tagName;
 	reader.match('{');
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		if (readParamTagFromFile(reader, tagName, paramManager, readAutomationUpToPos)) {}
 		else {
 			reader.exitTag(tagName);
@@ -3236,7 +3236,7 @@ Error Sound::readFromFile(Deserializer& reader, ModelStackWithModControllable* m
 
 	ParamManagerForTimeline paramManager;
 
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 		Error result =
 		    readTagFromFile(reader, tagName, &paramManager, readAutomationUpToPos, arpSettings, modelStack->song);
 		if (result == Error::NONE) {}
@@ -3347,56 +3347,56 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 	Source* source = &sources[s];
 
 	char const* tagName;
-	while (*(tagName = reader.readNextTagOrAttributeName())) {
-		if (!strcmp(tagName, "type")) {
+	while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+		if (strcmp(tagName, "type") == 0) {
 			source->setOscType(stringToOscType(reader.readTagOrAttributeValue()));
 			reader.exitTag("type");
 		}
-		else if (!strcmp(tagName, "phaseWidth")) {
+		else if (strcmp(tagName, "phaseWidth") == 0) {
 			ENSURE_PARAM_MANAGER_EXISTS
 			patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_PHASE_WIDTH + s,
 			                         readAutomationUpToPos);
 			reader.exitTag("phaseWidth");
 		}
-		else if (!strcmp(tagName, "volume")) {
+		else if (strcmp(tagName, "volume") == 0) {
 			ENSURE_PARAM_MANAGER_EXISTS
 			patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_VOLUME + s,
 			                         readAutomationUpToPos);
 			reader.exitTag("volume");
 		}
-		else if (!strcmp(tagName, "transpose")) {
+		else if (strcmp(tagName, "transpose") == 0) {
 			source->transpose = reader.readTagOrAttributeValueInt();
 			reader.exitTag("transpose");
 		}
-		else if (!strcmp(tagName, "cents")) {
+		else if (strcmp(tagName, "cents") == 0) {
 			source->cents = reader.readTagOrAttributeValueInt();
 			reader.exitTag("cents");
 		}
-		else if (!strcmp(tagName, "loopMode")) {
+		else if (strcmp(tagName, "loopMode") == 0) {
 			source->repeatMode = static_cast<SampleRepeatMode>(reader.readTagOrAttributeValueInt());
 			source->repeatMode = std::min(source->repeatMode, static_cast<SampleRepeatMode>(kNumRepeatModes - 1));
 			reader.exitTag("loopMode");
 		}
-		else if (!strcmp(tagName, "oscillatorSync")) {
+		else if (strcmp(tagName, "oscillatorSync") == 0) {
 			int32_t value = reader.readTagOrAttributeValueInt();
 			oscillatorSync = (value != 0);
 			reader.exitTag("oscillatorSync");
 		}
-		else if (!strcmp(tagName, "reversed")) {
-			source->sampleControls.reversed = reader.readTagOrAttributeValueInt();
+		else if (strcmp(tagName, "reversed") == 0) {
+			source->sampleControls.reversed = (reader.readTagOrAttributeValueInt() != 0);
 			reader.exitTag("reversed");
 		}
-		else if (!strcmp(tagName, "dx7patch")) {
+		else if (strcmp(tagName, "dx7patch") == 0) {
 			DxPatch* patch = source->ensureDxPatch();
 			int len = reader.readTagOrAttributeValueHexBytes(patch->params, 156);
 			reader.exitTag("dx7patch");
 		}
-		else if (!strcmp(tagName, "dx7randomdetune")) {
+		else if (strcmp(tagName, "dx7randomdetune") == 0) {
 			DxPatch* patch = source->ensureDxPatch();
 			patch->random_detune = reader.readTagOrAttributeValueInt();
 			reader.exitTag("dx7randomdetune");
 		}
-		else if (!strcmp(tagName, "dx7enginemode")) {
+		else if (strcmp(tagName, "dx7enginemode") == 0) {
 			DxPatch* patch = source->ensureDxPatch();
 			patch->setEngineMode(reader.readTagOrAttributeValueInt());
 			reader.exitTag("dx7enginemode");
@@ -3407,28 +3407,28 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 		    reader.exitTag("sampleSync");
 		}
 		*/
-		else if (!strcmp(tagName, "timeStretchEnable")) {
-			source->sampleControls.pitchAndSpeedAreIndependent = reader.readTagOrAttributeValueInt();
+		else if (strcmp(tagName, "timeStretchEnable") == 0) {
+			source->sampleControls.pitchAndSpeedAreIndependent = (reader.readTagOrAttributeValueInt() != 0);
 			reader.exitTag("timeStretchEnable");
 		}
-		else if (!strcmp(tagName, "timeStretchAmount")) {
+		else if (strcmp(tagName, "timeStretchAmount") == 0) {
 			source->timeStretchAmount = reader.readTagOrAttributeValueInt();
 			reader.exitTag("timeStretchAmount");
 		}
-		else if (!strcmp(tagName, "linearInterpolation")) {
-			if (reader.readTagOrAttributeValueInt()) {
+		else if (strcmp(tagName, "linearInterpolation") == 0) {
+			if (reader.readTagOrAttributeValueInt() != 0) {
 				source->sampleControls.interpolationMode = InterpolationMode::LINEAR;
 			}
 			reader.exitTag("linearInterpolation");
 		}
-		else if (!strcmp(tagName, "retrigPhase")) {
+		else if (strcmp(tagName, "retrigPhase") == 0) {
 			oscRetriggerPhase[s] = reader.readTagOrAttributeValueInt();
 			reader.exitTag("retrigPhase");
 		}
-		else if (!strcmp(tagName, "fileName")) {
+		else if (strcmp(tagName, "fileName") == 0) {
 
 			MultiRange* range = source->getOrCreateFirstRange();
-			if (!range) {
+			if (range == nullptr) {
 				return Error::INSUFFICIENT_RAM;
 			}
 
@@ -3436,10 +3436,10 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 
 			reader.exitTag("fileName");
 		}
-		else if (!strcmp(tagName, "zone")) {
+		else if (strcmp(tagName, "zone") == 0) {
 
 			MultisampleRange* range = (MultisampleRange*)source->getOrCreateFirstRange();
-			if (!range) {
+			if (range == nullptr) {
 				return Error::INSUFFICIENT_RAM;
 			}
 
@@ -3449,38 +3449,38 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 			range->sampleHolder.endPos = 0;
 			reader.match('{');
 
-			while (*(tagName = reader.readNextTagOrAttributeName())) {
-				if (!strcmp(tagName, "startSeconds")) {
+			while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+				if (strcmp(tagName, "startSeconds") == 0) {
 					range->sampleHolder.startMSec += reader.readTagOrAttributeValueInt() * 1000;
 					reader.exitTag("startSeconds");
 				}
-				else if (!strcmp(tagName, "startMilliseconds")) {
+				else if (strcmp(tagName, "startMilliseconds") == 0) {
 					range->sampleHolder.startMSec += reader.readTagOrAttributeValueInt();
 					reader.exitTag("startMilliseconds");
 				}
-				else if (!strcmp(tagName, "endSeconds")) {
+				else if (strcmp(tagName, "endSeconds") == 0) {
 					range->sampleHolder.endMSec += reader.readTagOrAttributeValueInt() * 1000;
 					reader.exitTag("endSeconds");
 				}
-				else if (!strcmp(tagName, "endMilliseconds")) {
+				else if (strcmp(tagName, "endMilliseconds") == 0) {
 					range->sampleHolder.endMSec += reader.readTagOrAttributeValueInt();
 					reader.exitTag("endMilliseconds");
 				}
 
-				else if (!strcmp(tagName, "startSamplePos")) {
+				else if (strcmp(tagName, "startSamplePos") == 0) {
 					range->sampleHolder.startPos = reader.readTagOrAttributeValueInt();
 					reader.exitTag("startSamplePos");
 				}
-				else if (!strcmp(tagName, "endSamplePos")) {
+				else if (strcmp(tagName, "endSamplePos") == 0) {
 					range->sampleHolder.endPos = reader.readTagOrAttributeValueInt();
 					reader.exitTag("endSamplePos");
 				}
 
-				else if (!strcmp(tagName, "startLoopPos")) {
+				else if (strcmp(tagName, "startLoopPos") == 0) {
 					range->sampleHolder.loopStartPos = reader.readTagOrAttributeValueInt();
 					reader.exitTag("startLoopPos");
 				}
-				else if (!strcmp(tagName, "endLoopPos")) {
+				else if (strcmp(tagName, "endLoopPos") == 0) {
 					range->sampleHolder.loopEndPos = reader.readTagOrAttributeValueInt();
 					reader.exitTag("endLoopPos");
 				}
@@ -3491,11 +3491,11 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 			}
 			reader.exitTag("zone", true);
 		}
-		else if (!strcmp(tagName, "sampleRanges") || !strcmp(tagName, "wavetableRanges")) {
+		else if ((strcmp(tagName, "sampleRanges") == 0) || (strcmp(tagName, "wavetableRanges") == 0)) {
 			reader.match('[');
-			while (reader.match('{') && *(tagName = reader.readNextTagOrAttributeName())) {
+			while (reader.match('{') && (*(tagName = reader.readNextTagOrAttributeName()) != 0)) {
 
-				if (!strcmp(tagName, "sampleRange") || !strcmp(tagName, "wavetableRange")) {
+				if ((strcmp(tagName, "sampleRange") == 0) || (strcmp(tagName, "wavetableRange") == 0)) {
 
 					char tempMemory[source->ranges.elementSize];
 
@@ -3509,35 +3509,35 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 
 					AudioFileHolder* holder = tempRange->getAudioFileHolder();
 					reader.match('{');
-					while (*(tagName = reader.readNextTagOrAttributeName())) {
+					while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
 
-						if (!strcmp(tagName, "fileName")) {
+						if (strcmp(tagName, "fileName") == 0) {
 							reader.readTagOrAttributeValueString(&holder->filePath);
 							reader.exitTag("fileName");
 						}
-						else if (!strcmp(tagName, "rangeTopNote")) {
+						else if (strcmp(tagName, "rangeTopNote") == 0) {
 							tempRange->topNote = reader.readTagOrAttributeValueInt();
 							reader.exitTag("rangeTopNote");
 						}
 						else if (source->oscType != OscType::WAVETABLE) {
-							if (!strcmp(tagName, "zone")) {
+							if (strcmp(tagName, "zone") == 0) {
 								reader.match('{');
-								while (*(tagName = reader.readNextTagOrAttributeName())) {
-									if (!strcmp(tagName, "startSamplePos")) {
+								while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+									if (strcmp(tagName, "startSamplePos") == 0) {
 										((SampleHolder*)holder)->startPos = reader.readTagOrAttributeValueInt();
 										reader.exitTag("startSamplePos");
 									}
-									else if (!strcmp(tagName, "endSamplePos")) {
+									else if (strcmp(tagName, "endSamplePos") == 0) {
 										((SampleHolder*)holder)->endPos = reader.readTagOrAttributeValueInt();
 										reader.exitTag("endSamplePos");
 									}
 
-									else if (!strcmp(tagName, "startLoopPos")) {
+									else if (strcmp(tagName, "startLoopPos") == 0) {
 										((SampleHolderForVoice*)holder)->loopStartPos =
 										    reader.readTagOrAttributeValueInt();
 										reader.exitTag("startLoopPos");
 									}
-									else if (!strcmp(tagName, "endLoopPos")) {
+									else if (strcmp(tagName, "endLoopPos") == 0) {
 										((SampleHolderForVoice*)holder)->loopEndPos =
 										    reader.readTagOrAttributeValueInt();
 										reader.exitTag("endLoopPos");
@@ -3548,11 +3548,11 @@ Error Sound::readSourceFromFile(Deserializer& reader, int32_t s, ParamManagerFor
 								}
 								reader.exitTag("zone", true);
 							}
-							else if (!strcmp(tagName, "transpose")) {
+							else if (strcmp(tagName, "transpose") == 0) {
 								((SampleHolderForVoice*)holder)->transpose = reader.readTagOrAttributeValueInt();
 								reader.exitTag("transpose");
 							}
-							else if (!strcmp(tagName, "cents")) {
+							else if (strcmp(tagName, "cents") == 0) {
 								((SampleHolderForVoice*)holder)->cents = reader.readTagOrAttributeValueInt();
 								reader.exitTag("cents");
 							}
@@ -3621,8 +3621,8 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 	if (source->oscType == OscType::SAMPLE
 	    && synthMode != SynthMode::FM) { // Don't combine this with the above "if" - there's an "else" below
 		writer.writeAttribute("loopMode", util::to_underlying(source->repeatMode));
-		writer.writeAttribute("reversed", source->sampleControls.reversed);
-		writer.writeAttribute("timeStretchEnable", source->sampleControls.pitchAndSpeedAreIndependent);
+		writer.writeAttribute("reversed", static_cast<int32_t>(source->sampleControls.reversed));
+		writer.writeAttribute("timeStretchEnable", static_cast<int32_t>(source->sampleControls.pitchAndSpeedAreIndependent));
 		writer.writeAttribute("timeStretchAmount", source->timeStretchAmount);
 		if (source->sampleControls.interpolationMode == InterpolationMode::LINEAR) {
 			writer.writeAttribute("linearInterpolation", 1);
@@ -3646,13 +3646,13 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 				}
 			}
 
-			writer.writeAttribute("fileName", range->sampleHolder.audioFile
+			writer.writeAttribute("fileName", (range->sampleHolder.audioFile != nullptr)
 			                                      ? range->sampleHolder.audioFile->filePath.get()
 			                                      : range->sampleHolder.filePath.get());
-			if (range->sampleHolder.transpose) {
+			if (range->sampleHolder.transpose != 0) {
 				writer.writeAttribute("transpose", range->sampleHolder.transpose);
 			}
-			if (range->sampleHolder.cents) {
+			if (range->sampleHolder.cents != 0) {
 				writer.writeAttribute("cents", range->sampleHolder.cents);
 			}
 
@@ -3661,10 +3661,10 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 			writer.writeOpeningTagBeginning("zone");
 			writer.writeAttribute("startSamplePos", range->sampleHolder.startPos);
 			writer.writeAttribute("endSamplePos", range->sampleHolder.endPos);
-			if (range->sampleHolder.loopStartPos) {
+			if (range->sampleHolder.loopStartPos != 0u) {
 				writer.writeAttribute("startLoopPos", range->sampleHolder.loopStartPos);
 			}
-			if (range->sampleHolder.loopEndPos) {
+			if (range->sampleHolder.loopEndPos != 0u) {
 				writer.writeAttribute("endLoopPos", range->sampleHolder.loopEndPos);
 			}
 			writer.closeTag();
@@ -3689,7 +3689,7 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 		writer.writeAttribute("transpose", source->transpose);
 		writer.writeAttribute("cents", source->cents);
 		if (s == 1 && oscillatorSync) {
-			writer.writeAttribute("oscillatorSync", oscillatorSync);
+			writer.writeAttribute("oscillatorSync", static_cast<int32_t>(oscillatorSync));
 		}
 		writer.writeAttribute("retrigPhase", oscRetriggerPhase[s]);
 
@@ -3714,7 +3714,7 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 					}
 				}
 
-				writer.writeAttribute("fileName", range->sampleHolder.audioFile
+				writer.writeAttribute("fileName", (range->sampleHolder.audioFile != nullptr)
 				                                      ? range->sampleHolder.audioFile->filePath.get()
 				                                      : range->sampleHolder.filePath.get());
 
@@ -3733,7 +3733,7 @@ void Sound::writeSourceToFile(Serializer& writer, int32_t s, char const* tagName
 		}
 		else if (source->oscType == OscType::DX7
 		         && synthMode != SynthMode::FM) { // Don't combine this with the above "if" - there's an "else" below
-			if (source->dxPatch) {
+			if (source->dxPatch != nullptr) {
 				DxPatch* patch = source->dxPatch;
 				writer.writeAttributeHexBytes("dx7patch", patch->params, 156);
 
@@ -3763,143 +3763,143 @@ bool Sound::readParamTagFromFile(Deserializer& reader, char const* tagName, Para
 	ParamCollectionSummary* patchedParamsSummary = paramManager->getPatchedParamSetSummary();
 	PatchedParamSet* patchedParams = (PatchedParamSet*)patchedParamsSummary->paramCollection;
 
-	if (!strcmp(tagName, "arpeggiatorGate")) {
+	if (strcmp(tagName, "arpeggiatorGate") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_GATE, readAutomationUpToPos);
 		reader.exitTag("arpeggiatorGate");
 	}
-	else if (!strcmp(tagName, "noteProbability")) {
+	else if (strcmp(tagName, "noteProbability") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_NOTE_PROBABILITY,
 		                           readAutomationUpToPos);
 		reader.exitTag("noteProbability");
 	}
-	else if (!strcmp(tagName, "ratchetProbability")) {
+	else if (strcmp(tagName, "ratchetProbability") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_RATCHET_PROBABILITY,
 		                           readAutomationUpToPos);
 		reader.exitTag("ratchetProbability");
 	}
-	else if (!strcmp(tagName, "ratchetAmount")) {
+	else if (strcmp(tagName, "ratchetAmount") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_RATCHET_AMOUNT,
 		                           readAutomationUpToPos);
 		reader.exitTag("ratchetAmount");
 	}
-	else if (!strcmp(tagName, "sequenceLength")) {
+	else if (strcmp(tagName, "sequenceLength") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SEQUENCE_LENGTH,
 		                           readAutomationUpToPos);
 		reader.exitTag("sequenceLength");
 	}
-	else if (!strcmp(tagName, "rhythm")) {
+	else if (strcmp(tagName, "rhythm") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_RHYTHM, readAutomationUpToPos);
 		reader.exitTag("rhythm");
 	}
-	else if (!strcmp(tagName, "spreadVelocity")) {
+	else if (strcmp(tagName, "spreadVelocity") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SPREAD_VELOCITY,
 		                           readAutomationUpToPos);
 		reader.exitTag("spreadVelocity");
 	}
-	else if (!strcmp(tagName, "spreadGate")) {
+	else if (strcmp(tagName, "spreadGate") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SPREAD_GATE,
 		                           readAutomationUpToPos);
 		reader.exitTag("spreadGate");
 	}
-	else if (!strcmp(tagName, "spreadOctave")) {
+	else if (strcmp(tagName, "spreadOctave") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_ARP_SPREAD_OCTAVE,
 		                           readAutomationUpToPos);
 		reader.exitTag("spreadOctave");
 	}
-	else if (!strcmp(tagName, "portamento")) {
+	else if (strcmp(tagName, "portamento") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_PORTAMENTO, readAutomationUpToPos);
 		reader.exitTag("portamento");
 	}
-	else if (!strcmp(tagName, "compressorShape")) {
+	else if (strcmp(tagName, "compressorShape") == 0) {
 		unpatchedParams->readParam(reader, unpatchedParamsSummary, params::UNPATCHED_SIDECHAIN_SHAPE,
 		                           readAutomationUpToPos);
 		reader.exitTag("compressorShape");
 	}
 
-	else if (!strcmp(tagName, "noiseVolume")) {
+	else if (strcmp(tagName, "noiseVolume") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_NOISE_VOLUME, readAutomationUpToPos);
 		reader.exitTag("noiseVolume");
 	}
-	else if (!strcmp(tagName, "oscAVolume")) {
+	else if (strcmp(tagName, "oscAVolume") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_VOLUME, readAutomationUpToPos);
 		reader.exitTag("oscAVolume");
 	}
-	else if (!strcmp(tagName, "oscBVolume")) {
+	else if (strcmp(tagName, "oscBVolume") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_B_VOLUME, readAutomationUpToPos);
 		reader.exitTag("oscBVolume");
 	}
-	else if (!strcmp(tagName, "oscAPulseWidth")) {
+	else if (strcmp(tagName, "oscAPulseWidth") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_PHASE_WIDTH, readAutomationUpToPos);
 		reader.exitTag("oscAPulseWidth");
 	}
-	else if (!strcmp(tagName, "oscBPulseWidth")) {
+	else if (strcmp(tagName, "oscBPulseWidth") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_B_PHASE_WIDTH, readAutomationUpToPos);
 		reader.exitTag("oscBPulseWidth");
 	}
-	else if (!strcmp(tagName, "oscAWavetablePosition")) {
+	else if (strcmp(tagName, "oscAWavetablePosition") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_WAVE_INDEX, readAutomationUpToPos);
 		reader.exitTag();
 	}
-	else if (!strcmp(tagName, "oscBWavetablePosition")) {
+	else if (strcmp(tagName, "oscBWavetablePosition") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_B_WAVE_INDEX, readAutomationUpToPos);
 		reader.exitTag();
 	}
-	else if (!strcmp(tagName, "volume")) {
+	else if (strcmp(tagName, "volume") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_VOLUME_POST_FX, readAutomationUpToPos);
 		reader.exitTag("volume");
 	}
-	else if (!strcmp(tagName, "pan")) {
+	else if (strcmp(tagName, "pan") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_PAN, readAutomationUpToPos);
 		reader.exitTag("pan");
 	}
-	else if (!strcmp(tagName, "lpfFrequency")) {
+	else if (strcmp(tagName, "lpfFrequency") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LPF_FREQ, readAutomationUpToPos);
 		reader.exitTag("lpfFrequency");
 	}
-	else if (!strcmp(tagName, "lpfResonance")) {
+	else if (strcmp(tagName, "lpfResonance") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LPF_RESONANCE, readAutomationUpToPos);
 		reader.exitTag("lpfResonance");
 	}
-	else if (!strcmp(tagName, "lpfMorph")) {
+	else if (strcmp(tagName, "lpfMorph") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LPF_MORPH, readAutomationUpToPos);
 		reader.exitTag("lpfMorph");
 	}
-	else if (!strcmp(tagName, "hpfFrequency")) {
+	else if (strcmp(tagName, "hpfFrequency") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_HPF_FREQ, readAutomationUpToPos);
 		reader.exitTag("hpfFrequency");
 	}
-	else if (!strcmp(tagName, "hpfResonance")) {
+	else if (strcmp(tagName, "hpfResonance") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_HPF_RESONANCE, readAutomationUpToPos);
 		reader.exitTag("hpfResonance");
 	}
-	else if (!strcmp(tagName, "hpfMorph")) {
+	else if (strcmp(tagName, "hpfMorph") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_HPF_MORPH, readAutomationUpToPos);
 		reader.exitTag("hpfMorph");
 	}
-	else if (!strcmp(tagName, "waveFold")) {
+	else if (strcmp(tagName, "waveFold") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_FOLD, readAutomationUpToPos);
 		reader.exitTag("waveFold");
 	}
 
-	else if (!strcmp(tagName, "envelope1")) {
+	else if (strcmp(tagName, "envelope1") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "attack")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "attack") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_ATTACK,
 				                         readAutomationUpToPos);
 				reader.exitTag("attack");
 			}
-			else if (!strcmp(tagName, "decay")) {
+			else if (strcmp(tagName, "decay") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_DECAY,
 				                         readAutomationUpToPos);
 				reader.exitTag("decay");
 			}
-			else if (!strcmp(tagName, "sustain")) {
+			else if (strcmp(tagName, "sustain") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_SUSTAIN,
 				                         readAutomationUpToPos);
 				reader.exitTag("sustain");
 			}
-			else if (!strcmp(tagName, "release")) {
+			else if (strcmp(tagName, "release") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_0_RELEASE,
 				                         readAutomationUpToPos);
 				reader.exitTag("release");
@@ -3907,25 +3907,25 @@ bool Sound::readParamTagFromFile(Deserializer& reader, char const* tagName, Para
 		}
 		reader.exitTag("envelope1", true);
 	}
-	else if (!strcmp(tagName, "envelope2")) {
+	else if (strcmp(tagName, "envelope2") == 0) {
 		reader.match('{');
-		while (*(tagName = reader.readNextTagOrAttributeName())) {
-			if (!strcmp(tagName, "attack")) {
+		while (*(tagName = reader.readNextTagOrAttributeName()) != 0) {
+			if (strcmp(tagName, "attack") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_ATTACK,
 				                         readAutomationUpToPos);
 				reader.exitTag("attack");
 			}
-			else if (!strcmp(tagName, "decay")) {
+			else if (strcmp(tagName, "decay") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_DECAY,
 				                         readAutomationUpToPos);
 				reader.exitTag("decay");
 			}
-			else if (!strcmp(tagName, "sustain")) {
+			else if (strcmp(tagName, "sustain") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_SUSTAIN,
 				                         readAutomationUpToPos);
 				reader.exitTag("sustain");
 			}
-			else if (!strcmp(tagName, "release")) {
+			else if (strcmp(tagName, "release") == 0) {
 				patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_ENV_1_RELEASE,
 				                         readAutomationUpToPos);
 				reader.exitTag("release");
@@ -3933,87 +3933,87 @@ bool Sound::readParamTagFromFile(Deserializer& reader, char const* tagName, Para
 		}
 		reader.exitTag("envelope2", true);
 	}
-	else if (!strcmp(tagName, "lfo1Rate")) {
+	else if (strcmp(tagName, "lfo1Rate") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_LFO_FREQ, readAutomationUpToPos);
 		reader.exitTag("lfo1Rate");
 	}
-	else if (!strcmp(tagName, "lfo2Rate")) {
+	else if (strcmp(tagName, "lfo2Rate") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_LFO_LOCAL_FREQ, readAutomationUpToPos);
 		reader.exitTag("lfo2Rate");
 	}
-	else if (!strcmp(tagName, "modulator1Amount")) {
+	else if (strcmp(tagName, "modulator1Amount") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_0_VOLUME, readAutomationUpToPos);
 		reader.exitTag("modulator1Amount");
 	}
-	else if (!strcmp(tagName, "modulator2Amount")) {
+	else if (strcmp(tagName, "modulator2Amount") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_1_VOLUME, readAutomationUpToPos);
 		reader.exitTag("modulator2Amount");
 	}
-	else if (!strcmp(tagName, "modulator1Feedback")) {
+	else if (strcmp(tagName, "modulator1Feedback") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_0_FEEDBACK,
 		                         readAutomationUpToPos);
 		reader.exitTag("modulator1Feedback");
 	}
-	else if (!strcmp(tagName, "modulator2Feedback")) {
+	else if (strcmp(tagName, "modulator2Feedback") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_1_FEEDBACK,
 		                         readAutomationUpToPos);
 		reader.exitTag("modulator2Feedback");
 	}
-	else if (!strcmp(tagName, "carrier1Feedback")) {
+	else if (strcmp(tagName, "carrier1Feedback") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_CARRIER_0_FEEDBACK, readAutomationUpToPos);
 		reader.exitTag("carrier1Feedback");
 	}
-	else if (!strcmp(tagName, "carrier2Feedback")) {
+	else if (strcmp(tagName, "carrier2Feedback") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_CARRIER_1_FEEDBACK, readAutomationUpToPos);
 		reader.exitTag("carrier2Feedback");
 	}
-	else if (!strcmp(tagName, "pitchAdjust")) {
+	else if (strcmp(tagName, "pitchAdjust") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_PITCH_ADJUST, readAutomationUpToPos);
 		reader.exitTag("pitchAdjust");
 	}
-	else if (!strcmp(tagName, "oscAPitchAdjust")) {
+	else if (strcmp(tagName, "oscAPitchAdjust") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_A_PITCH_ADJUST, readAutomationUpToPos);
 		reader.exitTag("oscAPitchAdjust");
 	}
-	else if (!strcmp(tagName, "oscBPitchAdjust")) {
+	else if (strcmp(tagName, "oscBPitchAdjust") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_OSC_B_PITCH_ADJUST, readAutomationUpToPos);
 		reader.exitTag("oscBPitchAdjust");
 	}
-	else if (!strcmp(tagName, "mod1PitchAdjust")) {
+	else if (strcmp(tagName, "mod1PitchAdjust") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_0_PITCH_ADJUST,
 		                         readAutomationUpToPos);
 		reader.exitTag("mod1PitchAdjust");
 	}
-	else if (!strcmp(tagName, "mod2PitchAdjust")) {
+	else if (strcmp(tagName, "mod2PitchAdjust") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::LOCAL_MODULATOR_1_PITCH_ADJUST,
 		                         readAutomationUpToPos);
 		reader.exitTag("mod2PitchAdjust");
 	}
-	else if (!strcmp(tagName, "modFXRate")) {
+	else if (strcmp(tagName, "modFXRate") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_MOD_FX_RATE, readAutomationUpToPos);
 		reader.exitTag("modFXRate");
 	}
-	else if (!strcmp(tagName, "modFXDepth")) {
+	else if (strcmp(tagName, "modFXDepth") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_MOD_FX_DEPTH, readAutomationUpToPos);
 		reader.exitTag("modFXDepth");
 	}
-	else if (!strcmp(tagName, "delayRate")) {
+	else if (strcmp(tagName, "delayRate") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_DELAY_RATE, readAutomationUpToPos);
 		reader.exitTag("delayRate");
 	}
-	else if (!strcmp(tagName, "delayFeedback")) {
+	else if (strcmp(tagName, "delayFeedback") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_DELAY_FEEDBACK, readAutomationUpToPos);
 		reader.exitTag("delayFeedback");
 	}
-	else if (!strcmp(tagName, "reverbAmount")) {
+	else if (strcmp(tagName, "reverbAmount") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_REVERB_AMOUNT, readAutomationUpToPos);
 		reader.exitTag("reverbAmount");
 	}
-	else if (!strcmp(tagName, "arpeggiatorRate")) {
+	else if (strcmp(tagName, "arpeggiatorRate") == 0) {
 		patchedParams->readParam(reader, patchedParamsSummary, params::GLOBAL_ARP_RATE, readAutomationUpToPos);
 		reader.exitTag("arpeggiatorRate");
 	}
-	else if (!strcmp(tagName, "patchCables")) {
+	else if (strcmp(tagName, "patchCables") == 0) {
 		paramManager->getPatchCableSet()->readPatchCablesFromFile(reader, readAutomationUpToPos);
 		reader.exitTag("patchCables");
 	}
@@ -4154,7 +4154,7 @@ void Sound::writeToFile(Serializer& writer, bool savingSong, ParamManager* param
 	ModControllableAudio::writeAttributesToFile(writer);
 
 	// Community Firmware parameters (always write them after the official ones)
-	if (pathAttribute) {
+	if (pathAttribute != nullptr) {
 		writer.writeAttribute("path", pathAttribute);
 	}
 	writer.writeAttribute("maxVoices", maxVoiceCount);
@@ -4191,7 +4191,7 @@ void Sound::writeToFile(Serializer& writer, bool savingSong, ParamManager* param
 		writer.writeAttribute("transpose", modulatorTranspose[1]);
 		writer.writeAttribute("cents", modulatorCents[1]);
 		writer.writeAttribute("retrigPhase", modulatorRetriggerPhase[1]);
-		writer.writeAttribute("toModulator1", modulator1ToModulator0);
+		writer.writeAttribute("toModulator1", static_cast<int32_t>(modulator1ToModulator0));
 		writer.closeTag();
 	}
 
@@ -4202,17 +4202,17 @@ void Sound::writeToFile(Serializer& writer, bool savingSong, ParamManager* param
 	writer.writeAttribute("spread", unisonStereoSpread, false);
 	writer.closeTag();
 
-	if (paramManager) {
+	if (paramManager != nullptr) {
 		writer.writeOpeningTagBeginning("defaultParams", true);
 		Sound::writeParamsToFile(writer, paramManager, false);
 		writer.writeClosingTag("defaultParams", true, true);
 	}
 
-	if (arpSettings) {
+	if (arpSettings != nullptr) {
 		writer.writeOpeningTagBeginning("arpeggiator");
 		writer.writeAttribute("mode", arpPresetToOldArpMode(arpSettings->preset)); // For backwards compatibility
 		writer.writeAttribute("numOctaves", arpSettings->numOctaves);
-		writer.writeAttribute("spreadLock", arpSettings->spreadLock);
+		writer.writeAttribute("spreadLock", static_cast<int32_t>(arpSettings->spreadLock));
 
 		// Write locked spread params
 		char buffer[9];
@@ -4313,7 +4313,7 @@ int16_t Sound::getMaxOscTranspose(InstrumentClip* clip) {
 
 	ArpeggiatorSettings* arpSettings = getArpSettings(clip);
 
-	if (arpSettings && arpSettings->mode != ArpMode::OFF) {
+	if ((arpSettings != nullptr) && arpSettings->mode != ArpMode::OFF) {
 		maxRawOscTranspose += (arpSettings->numOctaves - 1) * 12;
 	}
 
@@ -4629,7 +4629,7 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 	         && ourModKnob->paramDescriptor.getTopLevelSource() == PatchSource::SIDECHAIN) {
 		if (on) {
 			int32_t insideWorldTickMagnitude;
-			if (currentSong) { // Bit of a hack just referring to currentSong in here...
+			if (currentSong != nullptr) { // Bit of a hack just referring to currentSong in here...
 				insideWorldTickMagnitude =
 				    (currentSong->insideWorldTickMagnitude + currentSong->insideWorldTickMagnitudeOffsetFromBPM);
 			}
@@ -4734,7 +4734,7 @@ bool Sound::modEncoderButtonAction(uint8_t whichModEncoder, bool on, ModelStackW
 
 // modelStack may be NULL
 void Sound::fastReleaseAllVoices(ModelStackWithSoundFlags* modelStack) {
-	if (!numVoicesAssigned) {
+	if (numVoicesAssigned == 0) {
 		return;
 	}
 
@@ -4801,7 +4801,7 @@ bool Sound::renderingVoicesInStereo(ModelStackWithSoundFlags* modelStack) {
 		return false;
 	}
 
-	if (!numVoicesAssigned) {
+	if (numVoicesAssigned == 0) {
 		return false;
 	}
 
@@ -4815,7 +4815,7 @@ bool Sound::renderingVoicesInStereo(ModelStackWithSoundFlags* modelStack) {
 		return true;
 	}
 
-	if (unisonStereoSpread && numUnison > 1) {
+	if ((unisonStereoSpread != 0u) && numUnison > 1) {
 		return true;
 	}
 
@@ -4843,7 +4843,7 @@ bool Sound::renderingVoicesInStereo(ModelStackWithSoundFlags* modelStack) {
 				MultiRange* range = source->ranges.getElement(0);
 				AudioFileHolder* holder = range->getAudioFileHolder();
 
-				if (holder->audioFile && holder->audioFile->numChannels == 2) {
+				if ((holder->audioFile != nullptr) && holder->audioFile->numChannels == 2) {
 					return true;
 				}
 			}
@@ -4852,7 +4852,7 @@ bool Sound::renderingVoicesInStereo(ModelStackWithSoundFlags* modelStack) {
 
 	// Ok, if that determined that either source has multiple samples (multisample ranges), we now have to
 	// investigate each Voice
-	if (mustExamineSourceInEachVoice) {
+	if (mustExamineSourceInEachVoice != 0u) {
 
 		int32_t ends[2];
 		AudioEngine::activeVoices.getRangeForSound(this, ends);
@@ -4860,9 +4860,9 @@ bool Sound::renderingVoicesInStereo(ModelStackWithSoundFlags* modelStack) {
 			Voice* thisVoice = AudioEngine::activeVoices.getVoice(v);
 
 			for (int32_t s = 0; s < kNumSources; s++) {
-				if (mustExamineSourceInEachVoice & (1 << s)) {
+				if ((mustExamineSourceInEachVoice & (1 << s)) != 0u) {
 					AudioFileHolder* holder = thisVoice->guides[s].audioFileHolder;
-					if (holder && holder->audioFile && holder->audioFile->numChannels == 2) {
+					if ((holder != nullptr) && (holder->audioFile != nullptr) && holder->audioFile->numChannels == 2) {
 						return true;
 					}
 				}

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -280,7 +280,7 @@ public:
 
 	inline void saturate(int32_t* data, uint32_t* workingValue) {
 		// Clipping
-		if (clippingAmount) {
+		if (clippingAmount != 0u) {
 			int32_t shiftAmount = (clippingAmount >= 2) ? (clippingAmount - 2) : 0;
 			//*data = getTanHUnknown(*data, 5 + clippingAmount) << (shiftAmount);
 			*data = getTanHAntialiased(*data, workingValue, 5 + clippingAmount) << (shiftAmount);

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -50,11 +50,11 @@ Drum* SoundDrum::clone() {
 */
 
 bool SoundDrum::readTagFromFile(Deserializer& reader, char const* tagName) {
-	if (!strcmp(tagName, "name")) {
+	if (strcmp(tagName, "name") == 0) {
 		reader.readTagOrAttributeValueString(&name);
 		reader.exitTag("name");
 	}
-	else if (!strcmp(tagName, "path")) {
+	else if (strcmp(tagName, "path") == 0) {
 		reader.readTagOrAttributeValueString(&path);
 		reader.exitTag("path");
 	}
@@ -206,7 +206,7 @@ void SoundDrum::choke(ModelStackWithSoundFlags* modelStack) {
 }
 
 void SoundDrum::setSkippingRendering(bool newSkipping) {
-	if (kit && newSkipping != skippingRendering) {
+	if ((kit != nullptr) && newSkipping != skippingRendering) {
 		if (newSkipping) {
 			kit->drumsWithRenderingActive.deleteAtKey((int32_t)(Drum*)this);
 		}

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -65,7 +65,8 @@ bool SoundInstrument::writeDataToFile(Serializer& writer, Clip* clipForSavingOut
 	}
 
 	Sound::writeToFile(writer, clipForSavingOutputOnly == nullptr, paramManager,
-	                   (clipForSavingOutputOnly != nullptr) ? &((InstrumentClip*)clipForSavingOutputOnly)->arpSettings : nullptr,
+	                   (clipForSavingOutputOnly != nullptr) ? &((InstrumentClip*)clipForSavingOutputOnly)->arpSettings
+	                                                        : nullptr,
 	                   NULL);
 
 	MelodicInstrument::writeMelodicInstrumentTagsToFile(writer, clipForSavingOutputOnly, song);

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -84,18 +84,18 @@ bool Source::renderInStereo(Sound* s, SampleHolder* sampleHolder) {
 		return false;
 	}
 
-	if (s->unisonStereoSpread && s->numUnison > 1) {
+	if ((s->unisonStereoSpread != 0u) && s->numUnison > 1) {
 		return true;
 	}
 
-	return (oscType == OscType::SAMPLE && sampleHolder && sampleHolder->audioFile
+	return (oscType == OscType::SAMPLE && (sampleHolder != nullptr) && (sampleHolder->audioFile != nullptr)
 	        && sampleHolder->audioFile->numChannels == 2)
 	       || (oscType == OscType::INPUT_STEREO && (AudioEngine::micPluggedIn || AudioEngine::lineInPluggedIn));
 }
 
 void Source::detachAllAudioFiles() {
 	for (int32_t e = 0; e < ranges.getNumElements(); e++) {
-		if (!(e & 7)) {
+		if ((e & 7) == 0) {
 			AudioEngine::routineWithClusterLoading(); // --------------------------------------- // 7 works, 15
 			                                          // occasionally drops voices - for multisampled synths
 		}
@@ -106,7 +106,7 @@ void Source::detachAllAudioFiles() {
 Error Source::loadAllSamples(bool mayActuallyReadFiles) {
 	for (int32_t e = 0; e < ranges.getNumElements(); e++) {
 		AudioEngine::logAction("Source::loadAllSamples");
-		if (!(e & 3)) {
+		if ((e & 3) == 0) {
 			AudioEngine::routineWithClusterLoading(); // -------------------------------------- // 3 works, 7
 			                                          // occasionally drops voices - for multisampled synths
 		}
@@ -127,7 +127,7 @@ void Source::setReversed(bool newReversed) {
 		MultiRange* range = (MultisampleRange*)ranges.getElement(e);
 		SampleHolder* holder = (SampleHolder*)range->getAudioFileHolder();
 		Sample* sample = (Sample*)holder->audioFile;
-		if (sample) {
+		if (sample != nullptr) {
 			if (sampleControls.reversed && holder->endPos > sample->lengthInSamples) {
 				holder->endPos = sample->lengthInSamples;
 			}
@@ -166,11 +166,11 @@ int32_t Source::getRangeIndex(int32_t note) {
 }
 
 MultiRange* Source::getOrCreateFirstRange() {
-	if (!ranges.getNumElements()) {
+	if (ranges.getNumElements() == 0) {
 		MultiRange* newRange = ranges.insertMultiRange(
 		    0); // Default option - allowed e.g. for a new Sound where the current process is the Ranges get set up
 		        // before oscType is switched over to SAMPLE - but this can't happen for WAVETABLE so that's ok
-		if (!newRange) {
+		if (newRange == nullptr) {
 			return nullptr;
 		}
 
@@ -185,7 +185,7 @@ MultiRange* Source::getOrCreateFirstRange() {
 
 bool Source::hasAtLeastOneAudioFileLoaded() {
 	for (int32_t e = 0; e < ranges.getNumElements(); e++) {
-		if (ranges.getElement(e)->getAudioFileHolder()->audioFile) {
+		if (ranges.getElement(e)->getAudioFileHolder()->audioFile != nullptr) {
 			return true;
 		}
 	}
@@ -232,7 +232,7 @@ void Source::doneReadingFromFile(Sound* sound) {
 bool Source::hasAnyLoopEndPoint() {
 	for (int32_t e = 0; e < ranges.getNumElements(); e++) {
 		MultisampleRange* range = (MultisampleRange*)ranges.getElement(e);
-		if (range->sampleHolder.loopEndPos) {
+		if (range->sampleHolder.loopEndPos != 0u) {
 			return true;
 		}
 	}

--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -260,11 +260,11 @@ int32_t StemExport::disarmAllInstrumentsForStemExport(StemExportType stemExportT
 	// so get the number and store it so we only need to ping getNumElements once
 	int32_t totalNumOutputs = currentSong->getNumOutputs();
 
-	if (totalNumOutputs) {
+	if (totalNumOutputs != 0) {
 		// iterate through all the instruments to disable all the recording relevant flags
 		for (int32_t idxOutput = 0; idxOutput < totalNumOutputs; ++idxOutput) {
 			Output* output = currentSong->getOutputFromIndex(idxOutput);
-			if (output) {
+			if (output != nullptr) {
 				/* export output stem if all these conditions are met:
 				    1) the output is not muted in arranger
 				    2) the output is not empty (it has clips with notes in them)
@@ -293,7 +293,7 @@ int32_t StemExport::disarmAllInstrumentsForStemExport(StemExportType stemExportT
 	}
 
 	// if exporting master arrangement, just exporting one stem
-	if ((stemExportType == StemExportType::MASTER_ARRANGEMENT) && totalNumStemsToExport) {
+	if ((stemExportType == StemExportType::MASTER_ARRANGEMENT) && (totalNumStemsToExport != 0)) {
 		totalNumStemsToExport = 1;
 	}
 	return totalNumOutputs;
@@ -301,11 +301,11 @@ int32_t StemExport::disarmAllInstrumentsForStemExport(StemExportType stemExportT
 
 /// set instrument mutes back to their previous state (before exporting stems)
 void StemExport::restoreAllInstrumentMutes(int32_t totalNumOutputs) {
-	if (totalNumOutputs) {
+	if (totalNumOutputs != 0) {
 		// iterate through all the instruments to restore previous mute states
 		for (int32_t idxOutput = 0; idxOutput < totalNumOutputs; ++idxOutput) {
 			Output* output = currentSong->getOutputFromIndex(idxOutput);
-			if (output) {
+			if (output != nullptr) {
 				output->mutedInArrangementMode = output->mutedInArrangementModeBeforeStemExport;
 			}
 		}
@@ -319,11 +319,11 @@ int32_t StemExport::exportInstrumentStems(StemExportType stemExportType) {
 	// prepare all the instruments for stem export
 	int32_t totalNumOutputs = disarmAllInstrumentsForStemExport(stemExportType);
 
-	if (totalNumOutputs && totalNumStemsToExport) {
+	if ((totalNumOutputs != 0) && (totalNumStemsToExport != 0)) {
 		// now we're going to iterate through all instruments to find the ones that should be exported
 		for (int32_t idxOutput = totalNumOutputs - 1; idxOutput >= 0; --idxOutput) {
 			Output* output = currentSong->getOutputFromIndex(idxOutput);
-			if (output) {
+			if (output != nullptr) {
 				bool started = startCurrentStemExport(stemExportType, output, output->mutedInArrangementMode, idxOutput,
 				                                      output->exportStem);
 
@@ -366,7 +366,7 @@ int32_t StemExport::exportMasterArrangementStem(StemExportType stemExportType) {
 	// prepare all the instruments for stem export
 	int32_t totalNumOutputs = disarmAllInstrumentsForStemExport(stemExportType);
 
-	if (totalNumOutputs && totalNumStemsToExport) {
+	if ((totalNumOutputs != 0) && (totalNumStemsToExport != 0)) {
 		// set wav file name for stem to be exported
 		setWavFileNameForStemExport(stemExportType, nullptr, 0);
 
@@ -405,11 +405,11 @@ int32_t StemExport::disarmAllClipsForStemExport() {
 	// so get the number and store it so we only need to ping getNumElements once
 	int32_t totalNumClips = currentSong->sessionClips.getNumElements();
 
-	if (totalNumClips) {
+	if (totalNumClips != 0) {
 		// iterate through all clips to disable all the recording relevant flags
 		for (int32_t idxClip = 0; idxClip < totalNumClips; ++idxClip) {
 			Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
-			if (clip) {
+			if (clip != nullptr) {
 				/* export clip stem if all these conditions are met:
 				    1) the clip is not empty (it has notes in it)
 				    2) the output type is not MIDI or CV
@@ -435,11 +435,11 @@ int32_t StemExport::disarmAllClipsForStemExport() {
 
 /// set clip mutes back to their previous state (before exporting stems)
 void StemExport::restoreAllClipMutes(int32_t totalNumClips) {
-	if (totalNumClips) {
+	if (totalNumClips != 0) {
 		// iterate through all clips to restore previous mute states
 		for (int32_t idxClip = 0; idxClip < totalNumClips; ++idxClip) {
 			Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
-			if (clip) {
+			if (clip != nullptr) {
 				clip->activeIfNoSolo = clip->activeIfNoSoloBeforeStemExport;
 			}
 		}
@@ -454,11 +454,11 @@ void StemExport::getLoopLengthOfLongestNotEmptyNoteRow(Clip* clip) {
 	if (clip->type == ClipType::INSTRUMENT) {
 		InstrumentClip* instrumentClip = (InstrumentClip*)clip;
 		int32_t totalNumNoteRows = instrumentClip->noteRows.getNumElements();
-		if (totalNumNoteRows) {
+		if (totalNumNoteRows != 0) {
 			// iterate through all the note rows to find the longest one
 			for (int32_t idxNoteRow = 0; idxNoteRow < totalNumNoteRows; ++idxNoteRow) {
 				NoteRow* thisNoteRow = instrumentClip->noteRows.getElement(idxNoteRow);
-				if (thisNoteRow && (thisNoteRow->loopLengthIfIndependent > loopLengthToStopStemExport)
+				if ((thisNoteRow != nullptr) && (thisNoteRow->loopLengthIfIndependent > loopLengthToStopStemExport)
 				    && !thisNoteRow->hasNoNotes()) {
 					loopLengthToStopStemExport = thisNoteRow->loopLengthIfIndependent;
 				}
@@ -488,11 +488,11 @@ int32_t StemExport::exportClipStems(StemExportType stemExportType) {
 	// prepare all the clips for stem export
 	int32_t totalNumClips = disarmAllClipsForStemExport();
 
-	if (totalNumClips && totalNumStemsToExport) {
+	if ((totalNumClips != 0) && (totalNumStemsToExport != 0)) {
 		// now we're going to iterate through all clips to find the ones that should be exported
 		for (int32_t idxClip = totalNumClips - 1; idxClip >= 0; --idxClip) {
 			Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
-			if (clip) {
+			if (clip != nullptr) {
 				getLoopLengthOfLongestNotEmptyNoteRow(clip);
 				getLoopEndPointInSamplesForAudioFile(clip->loopLength);
 
@@ -800,7 +800,7 @@ Error StemExport::getUnusedStemRecordingFolderPath(String* filePath, AudioRecord
 
 	// did we just export this same folder?
 	// if yes, no need to find folder number to append (we have it)
-	if (strcmp(folderNameToCompare.get(), lastFolderNameForStemExport.get())) {
+	if (strcmp(folderNameToCompare.get(), lastFolderNameForStemExport.get()) != 0) {
 		// if we're here we didn't just export this song
 		String tempPathForSearch;
 

--- a/src/deluge/storage/DX7Cartridge.cpp
+++ b/src/deluge/storage/DX7Cartridge.cpp
@@ -85,7 +85,7 @@ void DX7Cartridge::packProgram(uint8_t* src, int idx, char* name, char* opSwitch
 		char c = (char)name[i];
 		if (c == 0)
 			eos = 1;
-		if (eos) {
+		if (eos != 0) {
 			bulk[118 + i] = ' ';
 			continue;
 		}

--- a/src/deluge/storage/Deserializer.cpp
+++ b/src/deluge/storage/Deserializer.cpp
@@ -114,7 +114,7 @@ skipToNextTag:
 			goto getOut;
 
 		default:
-			if (!charPos) {
+			if (charPos == 0) {
 				tagDepthFile++;
 			}
 
@@ -218,7 +218,7 @@ reachedNameEnd:
 			readDone();
 			haveReachedNameEnd = true;
 			// If possible, just return a pointer to the chars within the existing buffer
-			if (!charPos && fileReadBufferCurrentPos < currentReadBufferEndPos) {
+			if ((charPos == 0) && fileReadBufferCurrentPos < currentReadBufferEndPos) {
 				fileClusterBuffer[fileReadBufferCurrentPos] = 0; // NULL end of the string we're returning
 				fileReadBufferCurrentPos++;                      // Gets us past the endChar
 				return &fileClusterBuffer[bufferPosAtStart];
@@ -271,7 +271,7 @@ char const* XMLDeserializer::readNextTagOrAttributeName() {
 	case IN_TAG_PAST_NAME:
 		toReturn = readNextAttributeName();
 		// If depth has changed, this means we met a /> and must get out
-		if (*toReturn || tagDepthFile != tagDepthStart) {
+		if ((*toReturn != 0) || tagDepthFile != tagDepthStart) {
 			break;
 		}
 		// No break
@@ -285,7 +285,7 @@ char const* XMLDeserializer::readNextTagOrAttributeName() {
 		toReturn = readTagName();
 	}
 
-	if (*toReturn) {
+	if (*toReturn != 0) {
 		/*
 		for (int32_t t = 0; t < tagDepthCaller; t++) {
 D_PRINTLN("\t");
@@ -421,7 +421,7 @@ Error XMLDeserializer::readStringUntilChar(String* string, char endChar) {
 
 		int32_t numCharsHere = bufferPosNow - fileReadBufferCurrentPos;
 
-		if (numCharsHere) {
+		if (numCharsHere != 0) {
 			Error error =
 			    string->concatenateAtPos(&fileClusterBuffer[fileReadBufferCurrentPos], newStringPos, numCharsHere);
 
@@ -453,7 +453,7 @@ char const* XMLDeserializer::readUntilChar(char endChar) {
 		}
 
 		// If possible, just return a pointer to the chars within the existing buffer
-		if (!charPos && fileReadBufferCurrentPos < currentReadBufferEndPos) {
+		if ((charPos == 0) && fileReadBufferCurrentPos < currentReadBufferEndPos) {
 			fileClusterBuffer[fileReadBufferCurrentPos] = 0;
 
 			fileReadBufferCurrentPos++; // Gets us past the endChar
@@ -845,9 +845,9 @@ Error XMLDeserializer::openXMLFile(FilePointer* filePointer, char const* firstTa
 
 	char const* tagName;
 
-	while (*(tagName = readNextTagOrAttributeName())) {
+	while (*(tagName = readNextTagOrAttributeName()) != 0) {
 
-		if (!strcmp(tagName, firstTagName) || !strcmp(tagName, altTagName)) {
+		if ((strcmp(tagName, firstTagName) == 0) || (strcmp(tagName, altTagName) == 0)) {
 			return Error::NONE;
 		}
 
@@ -864,13 +864,13 @@ Error XMLDeserializer::openXMLFile(FilePointer* filePointer, char const* firstTa
 
 Error XMLDeserializer::tryReadingFirmwareTagFromFile(char const* tagName, bool ignoreIncorrectFirmware) {
 
-	if (!strcmp(tagName, "firmwareVersion")) {
+	if (strcmp(tagName, "firmwareVersion") == 0) {
 		char const* firmware_version_string = readTagOrAttributeValue();
 		song_firmware_version = FirmwareVersion::parse(firmware_version_string);
 	}
 
 	// If this tag doesn't exist, it's from old firmware so is ok
-	else if (!strcmp(tagName, "earliestCompatibleFirmware")) {
+	else if (strcmp(tagName, "earliestCompatibleFirmware") == 0) {
 		char const* firmware_version_string = readTagOrAttributeValue();
 		auto earliestFirmware = FirmwareVersion::parse(firmware_version_string);
 		if (earliestFirmware > FirmwareVersion::current() && !ignoreIncorrectFirmware) {

--- a/src/deluge/storage/JSONSerializer.cpp
+++ b/src/deluge/storage/JSONSerializer.cpp
@@ -185,10 +185,10 @@ void JsonSerializer::writeOpeningTagBeginning(char const* tag, bool box, bool ne
 	if (newLineBefore) // prepend newLine almost always.
 		write("\n");
 	printIndents();
-	if (box || !tag) {
+	if (box || (tag == nullptr)) {
 		write("{");
 	}
-	if (tag) {
+	if (tag != nullptr) {
 		write("\"");
 		write(tag);
 		write("\": {");

--- a/src/deluge/storage/JsonDeserializer.cpp
+++ b/src/deluge/storage/JsonDeserializer.cpp
@@ -179,7 +179,7 @@ char const* JsonDeserializer::readNextTagOrAttributeName() {
 // the stream index is left directly addressing the leading character of the value.
 bool JsonDeserializer::getIntoAttributeValue() {
 	if (!skipWhiteSpace())
-		return 0;
+		return false;
 	// valid characters to start a value are a digit, minus sign,
 	// or a double quote. If it is double quote, skip past it.
 	char thisChar;
@@ -252,7 +252,7 @@ Error JsonDeserializer::readStringUntilChar(String* string, char endChar) {
 
 		int32_t numCharsHere = bufferPosNow - fileReadBufferCurrentPos;
 
-		if (numCharsHere) {
+		if (numCharsHere != 0) {
 			Error error =
 			    string->concatenateAtPos(&fileClusterBuffer[fileReadBufferCurrentPos], newStringPos, numCharsHere);
 
@@ -289,7 +289,7 @@ char const* JsonDeserializer::readUntilChar(char endChar) {
 		}
 		readState = JsonState::ValueRead;
 		// If possible, just return a pointer to the chars within the existing buffer
-		if (!charPos && fileReadBufferCurrentPos < currentReadBufferEndPos) {
+		if ((charPos == 0) && fileReadBufferCurrentPos < currentReadBufferEndPos) {
 			fileClusterBuffer[fileReadBufferCurrentPos] = 0;
 
 			fileReadBufferCurrentPos++; // Gets us past the endChar
@@ -582,9 +582,9 @@ Error JsonDeserializer::openJsonFile(FilePointer* filePointer, char const* first
 		return Error::FILE_CORRUPTED;
 	char const* tagName;
 
-	while (*(tagName = readNextTagOrAttributeName())) {
+	while (*(tagName = readNextTagOrAttributeName()) != 0) {
 
-		if (!strcmp(tagName, firstTagName) || !strcmp(tagName, altTagName)) {
+		if ((strcmp(tagName, firstTagName) == 0) || (strcmp(tagName, altTagName) == 0)) {
 			return Error::NONE;
 		}
 
@@ -601,13 +601,13 @@ Error JsonDeserializer::openJsonFile(FilePointer* filePointer, char const* first
 
 Error JsonDeserializer::tryReadingFirmwareTagFromFile(char const* tagName, bool ignoreIncorrectFirmware) {
 
-	if (!strcmp(tagName, "firmwareVersion")) {
+	if (strcmp(tagName, "firmwareVersion") == 0) {
 		char const* firmware_version_string = readTagOrAttributeValue();
 		song_firmware_version = FirmwareVersion::parse(firmware_version_string);
 	}
 
 	// If this tag doesn't exist, it's from old firmware so is ok
-	else if (!strcmp(tagName, "earliestCompatibleFirmware")) {
+	else if (strcmp(tagName, "earliestCompatibleFirmware") == 0) {
 		char const* firmware_version_string = readTagOrAttributeValue();
 		auto earliestFirmware = FirmwareVersion::parse(firmware_version_string);
 		if (earliestFirmware > FirmwareVersion::current() && !ignoreIncorrectFirmware) {

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -113,7 +113,7 @@ doSetupWaveTable:
 					// the user isn't insisting, then opt not to do it.
 					if (!fileExplicitlySpecifiesSelfAsWaveTable && !makeWaveTableWorkAtAllCosts) {
 						int32_t audioDataLengthSamples = audioDataLengthBytes / byteDepth;
-						if (audioDataLengthSamples & 2047) {
+						if ((audioDataLengthSamples & 2047) != 0) {
 							return Error::FILE_NOT_LOADABLE_AS_WAVETABLE;
 						}
 					}
@@ -199,7 +199,7 @@ doSetupWaveTable:
 					uint32_t midiPitchFraction = data[4];
 					uint32_t numLoops = data[7];
 
-					if ((midiNote || midiPitchFraction) && midiNote < 128) {
+					if (((midiNote != 0u) || (midiPitchFraction != 0u)) && midiNote < 128) {
 						((Sample*)this)->midiNoteFromFile = (float)midiPitchFraction / ((uint64_t)1 << 32) + midiNote;
 					}
 
@@ -413,7 +413,7 @@ doSetupWaveTable:
 
 					uint8_t midiNote = data[0];
 					int8_t fineTune = data[1];
-					if ((midiNote || fineTune) && midiNote < 128) {
+					if (((midiNote != 0u) || (fineTune != 0)) && midiNote < 128) {
 						((Sample*)this)->midiNoteFromFile = (float)midiNote - (float)fineTune * 0.01;
 						D_PRINTLN("unshifted note:  %s", ((Sample*)this)->midiNoteFromFile);
 					}
@@ -485,7 +485,7 @@ finishedWhileLoop:
 
 void AudioFile::addReason() {
 	// If it was zero before, it's no longer unused
-	if (!numReasonsToBeLoaded) {
+	if (numReasonsToBeLoaded == 0) {
 		remove();
 		numReasonsIncreasedFromZero();
 	}

--- a/src/deluge/storage/audio/audio_file_holder.cpp
+++ b/src/deluge/storage/audio/audio_file_holder.cpp
@@ -61,7 +61,7 @@ Error AudioFileHolder::loadFile(bool reversed, bool manuallySelected, bool mayAc
 // For if we've already got a pointer to the AudioFile in memory.
 void AudioFileHolder::setAudioFile(AudioFile* newAudioFile, bool reversed, bool manuallySelected,
                                    int32_t clusterLoadInstruction) {
-	if (audioFile) {
+	if (audioFile != nullptr) {
 		unassignAllClusterReasons();
 #if ALPHA_OR_BETA_VERSION
 		if (audioFile->numReasonsToBeLoaded <= 0) {
@@ -73,7 +73,7 @@ void AudioFileHolder::setAudioFile(AudioFile* newAudioFile, bool reversed, bool 
 
 	audioFile = newAudioFile;
 
-	if (audioFile) {
+	if (audioFile != nullptr) {
 		audioFile->addReason();
 	}
 }

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -245,8 +245,9 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String& filePath, String
 					return Error::SD_CARD;
 				}
 
-				if (__builtin_expect(static_cast<long>((*(uint32_t*)staticFNO.altname & 0x00FFFFFF) == 0x00434552), 1) != 0) { // "REC"
-					if (*(uint32_t*)&staticFNO.altname[8] == 0x5641572E) {                             // ".WAV"
+				if (__builtin_expect(static_cast<long>((*(uint32_t*)staticFNO.altname & 0x00FFFFFF) == 0x00434552), 1)
+				    != 0) {                                                // "REC"
+					if (*(uint32_t*)&staticFNO.altname[8] == 0x5641572E) { // ".WAV"
 
 						int32_t thisSlot = memToUIntOrError(&staticFNO.altname[3], &staticFNO.altname[8]);
 						if (thisSlot == -1) {
@@ -492,7 +493,8 @@ AudioFileManager::getAudioFileFromFilename(String& filePath, bool mayReadCard, F
 
 				// If this isn't actually a wavetable-specifying file or at least a wavetable-looking length, and
 				// the user isn't insisting, then opt not to do it.
-				if (!foundSample->fileExplicitlySpecifiesSelfAsWaveTable && ((foundSample->lengthInSamples & 2047) != 0u)) {
+				if (!foundSample->fileExplicitlySpecifiesSelfAsWaveTable
+				    && ((foundSample->lengthInSamples & 2047) != 0u)) {
 					return std::unexpected(Error::FILE_NOT_LOADABLE_AS_WAVETABLE);
 				}
 			}

--- a/src/deluge/storage/audio/audio_file_reader.cpp
+++ b/src/deluge/storage/audio/audio_file_reader.cpp
@@ -48,7 +48,7 @@ Error AudioFileReader::advanceClustersIfNecessary() {
 
 	int32_t numClustersToAdvance = byteIndexWithinCluster >> Cluster::size_magnitude;
 
-	if (!numClustersToAdvance) {
+	if (numClustersToAdvance == 0) {
 		return Error::NONE;
 	}
 

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -149,7 +149,7 @@ void Cluster::convertDataIfNecessary() {
 
 			for (; pos < endPos; pos++) {
 
-				if (!((uint32_t)pos & 0b1111111100)) {
+				if (((uint32_t)pos & 0b1111111100) == 0u) {
 					AudioEngine::logAction("from convert-data");
 					AudioEngine::routine(); // ----------------------------------------------------
 				}
@@ -165,19 +165,19 @@ StealableQueue Cluster::getAppropriateQueue() {
 
 	// If it's a perc cache...
 	if (type == Type::PERC_CACHE_FORWARDS || type == Type::PERC_CACHE_REVERSED) {
-		q = sample->numReasonsToBeLoaded ? StealableQueue::CURRENT_SONG_SAMPLE_DATA_PERC_CACHE
+		q = (sample->numReasonsToBeLoaded != 0) ? StealableQueue::CURRENT_SONG_SAMPLE_DATA_PERC_CACHE
 		                                 : StealableQueue::NO_SONG_SAMPLE_DATA_PERC_CACHE;
 	}
 
 	// If it's a regular repitched cache...
-	else if (sampleCache) {
-		q = (sampleCache->sample->numReasonsToBeLoaded) ? StealableQueue::CURRENT_SONG_SAMPLE_DATA_REPITCHED_CACHE
+	else if (sampleCache != nullptr) {
+		q = ((sampleCache->sample->numReasonsToBeLoaded) != 0) ? StealableQueue::CURRENT_SONG_SAMPLE_DATA_REPITCHED_CACHE
 		                                                : StealableQueue::NO_SONG_SAMPLE_DATA_REPITCHED_CACHE;
 	}
 
 	// Or, if it has a Sample...
-	else if (sample) {
-		q = sample->numReasonsToBeLoaded ? StealableQueue::CURRENT_SONG_SAMPLE_DATA
+	else if (sample != nullptr) {
+		q = (sample->numReasonsToBeLoaded != 0) ? StealableQueue::CURRENT_SONG_SAMPLE_DATA
 		                                 : StealableQueue::NO_SONG_SAMPLE_DATA;
 
 		if (sample->rawDataFormat != RawDataFormat::NATIVE) {
@@ -228,11 +228,11 @@ void Cluster::steal(char const* errorCode) {
 }
 
 bool Cluster::mayBeStolen(void* thingNotToStealFrom) {
-	if (numReasonsToBeLoaded) {
+	if (numReasonsToBeLoaded != 0) {
 		return false;
 	}
 
-	if (!thingNotToStealFrom) {
+	if (thingNotToStealFrom == nullptr) {
 		return true;
 	}
 

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -166,19 +166,20 @@ StealableQueue Cluster::getAppropriateQueue() {
 	// If it's a perc cache...
 	if (type == Type::PERC_CACHE_FORWARDS || type == Type::PERC_CACHE_REVERSED) {
 		q = (sample->numReasonsToBeLoaded != 0) ? StealableQueue::CURRENT_SONG_SAMPLE_DATA_PERC_CACHE
-		                                 : StealableQueue::NO_SONG_SAMPLE_DATA_PERC_CACHE;
+		                                        : StealableQueue::NO_SONG_SAMPLE_DATA_PERC_CACHE;
 	}
 
 	// If it's a regular repitched cache...
 	else if (sampleCache != nullptr) {
-		q = ((sampleCache->sample->numReasonsToBeLoaded) != 0) ? StealableQueue::CURRENT_SONG_SAMPLE_DATA_REPITCHED_CACHE
-		                                                : StealableQueue::NO_SONG_SAMPLE_DATA_REPITCHED_CACHE;
+		q = ((sampleCache->sample->numReasonsToBeLoaded) != 0)
+		        ? StealableQueue::CURRENT_SONG_SAMPLE_DATA_REPITCHED_CACHE
+		        : StealableQueue::NO_SONG_SAMPLE_DATA_REPITCHED_CACHE;
 	}
 
 	// Or, if it has a Sample...
 	else if (sample != nullptr) {
 		q = (sample->numReasonsToBeLoaded != 0) ? StealableQueue::CURRENT_SONG_SAMPLE_DATA
-		                                 : StealableQueue::NO_SONG_SAMPLE_DATA;
+		                                        : StealableQueue::NO_SONG_SAMPLE_DATA;
 
 		if (sample->rawDataFormat != RawDataFormat::NATIVE) {
 			q = static_cast<StealableQueue>(util::to_underlying(q) + 1); // next queue

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -68,7 +68,7 @@ Error FileItem::getFilenameWithoutExtension(String* filenameWithoutExtension) {
 	if (filenameIncludesExtension) {
 		char const* chars = filenameWithoutExtension->get();
 		char const* dotAddress = strrchr(chars, '.');
-		if (dotAddress) {
+		if (dotAddress != nullptr) {
 			int32_t newLength = (uint32_t)dotAddress - (uint32_t)chars;
 			Error error = filenameWithoutExtension->shorten(newLength);
 			if (error != Error::NONE) {
@@ -92,7 +92,7 @@ Error FileItem::getDisplayNameWithoutExtension(String* displayNameWithoutExtensi
 	if (filenameIncludesExtension) {
 		char const* chars = displayNameWithoutExtension->get();
 		char const* dotAddress = strrchr(chars, '.');
-		if (dotAddress) {
+		if (dotAddress != nullptr) {
 			int32_t newLength = (uint32_t)dotAddress - (uint32_t)chars;
 			error = displayNameWithoutExtension->shorten(newLength);
 			if (error != Error::NONE) {

--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -562,7 +562,7 @@ void readSettings() {
 	MIDIDeviceManager::differentiatingInputsByDevice = buffer[79];
 
 	defaultBendRange[BEND_RANGE_MAIN] = buffer[112];
-	if (!defaultBendRange[BEND_RANGE_MAIN]) {
+	if (defaultBendRange[BEND_RANGE_MAIN] == 0u) {
 		defaultBendRange[BEND_RANGE_MAIN] = 12;
 	}
 

--- a/src/deluge/storage/multi_range/multi_range_array.cpp
+++ b/src/deluge/storage/multi_range/multi_range_array.cpp
@@ -54,7 +54,7 @@ MultiRange* MultiRangeArray::insertMultiRange(int32_t i) {
 
 Error MultiRangeArray::changeType(int32_t newSize) {
 
-	if (!numElements) {
+	if (numElements == 0) {
 		elementSize = newSize;
 		return Error::NONE;
 	}

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -86,7 +86,8 @@ FatFS::Filesystem fileSystem;
 
 Error StorageManager::checkSpaceOnCard() {
 	D_PRINTLN("free clusters:  %d", fileSystem.free_clst);
-	return (fileSystem.free_clst != 0u) ? Error::NONE : Error::SD_CARD_FULL; // This doesn't seem to always be 100% accurate...
+	return (fileSystem.free_clst != 0u) ? Error::NONE
+	                                    : Error::SD_CARD_FULL; // This doesn't seem to always be 100% accurate...
 }
 
 // Creates folders and subfolders as needed!
@@ -367,7 +368,8 @@ deleteInstrumentAndGetOut:
 
 	// Check that a ParamManager was actually loaded for the Instrument, cos if not, that'd spell havoc
 	if (song->getBackedUpParamManagerPreferablyWithClip((ModControllableAudio*)newInstrument->toModControllable(),
-	                                                     nullptr) == nullptr) {
+	                                                    nullptr)
+	    == nullptr) {
 
 		// Prior to V2.0 (or was it only in V1.0 on the 40-pad?) Kits didn't have anything that would have caused the
 		// paramManager to be created when we read the Kit just now. So, just make one.

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -235,8 +235,9 @@ tryGettingFFTConfig:
 	// numBands is set such that the "smallest" band will have 8 samples per cycle. Not 4 - because NE10 can't do FFTs
 	// that small unless we enable its additional C code, which would take up program size for little advantage.
 	{
-		int32_t numBands =
-		    (fftCFGForInitialBand != nullptr) ? ((initialBandCycleMagnitude - 2) >> (NUM_OCTAVES_BETWEEN_WAVETABLE_BANDS - 1)) : 1;
+		int32_t numBands = (fftCFGForInitialBand != nullptr)
+		                       ? ((initialBandCycleMagnitude - 2) >> (NUM_OCTAVES_BETWEEN_WAVETABLE_BANDS - 1))
+		                       : 1;
 
 		// Don't refer to numBands after this! (Why? Because we might end up using less after all?)
 		error = bands.insertAtIndex(0, numBands);

--- a/src/deluge/storage/wave_table/wave_table_band_data.cpp
+++ b/src/deluge/storage/wave_table/wave_table_band_data.cpp
@@ -29,7 +29,7 @@ bool WaveTableBandData::mayBeStolen(void* thingNotToStealFrom) {
 
 void WaveTableBandData::steal(char const* errorCode) {
 #if ALPHA_OR_BETA_VERSION
-	if (!waveTable || waveTable->numReasonsToBeLoaded) {
+	if ((waveTable == nullptr) || (waveTable->numReasonsToBeLoaded != 0)) {
 		FREEZE_WITH_ERROR("E387");
 	}
 #endif

--- a/src/deluge/storage/wave_table/wave_table_reader.cpp
+++ b/src/deluge/storage/wave_table/wave_table_reader.cpp
@@ -22,7 +22,7 @@
 
 Error WaveTableReader::readBytesPassedErrorChecking(char* outputBuffer, int32_t num) {
 
-	while (num--) {
+	while ((num--) != 0) {
 		Error error = advanceClustersIfNecessary();
 		if (error != Error::NONE) {
 			return error;
@@ -40,7 +40,7 @@ Error WaveTableReader::readNewCluster() {
 
 	UINT bytesRead;
 	FRESULT result = f_read(&smDeserializer.readFIL, smDeserializer.fileClusterBuffer, Cluster::size, &bytesRead);
-	if (result) {
+	if (result != 0u) {
 		return Error::SD_CARD; // Failed to load cluster from card
 	}
 	return Error::NONE;

--- a/src/deluge/testing/hardware_testing.cpp
+++ b/src/deluge/testing/hardware_testing.cpp
@@ -49,7 +49,7 @@ void ramTestUart() {
 	uint32_t lastErrorAt = 0;
 	uint32_t* address;
 
-	while (1) {
+	while (true) {
 
 		// while (1) {
 		D_PRINTLN("writing to ram");
@@ -134,12 +134,12 @@ void sendColoursForHardwareTest(bool testButtonStates[9][16]) {
 bool anythingProbablyPressed = false;
 
 void readInputsForHardwareTest(bool testButtonStates[9][16]) {
-	bool outputPluggedInL = readInput(LINE_OUT_DETECT_L.port, LINE_OUT_DETECT_L.pin);
-	bool outputPluggedInR = readInput(LINE_OUT_DETECT_R.port, LINE_OUT_DETECT_R.pin);
-	bool headphoneNow = readInput(HEADPHONE_DETECT.port, HEADPHONE_DETECT.pin);
-	bool micNow = !readInput(MIC_DETECT.port, MIC_DETECT.pin);
-	bool lineInNow = readInput(LINE_IN_DETECT.port, LINE_IN_DETECT.pin);
-	bool gateInNow = readInput(ANALOG_CLOCK_IN.port, ANALOG_CLOCK_IN.pin);
+	bool outputPluggedInL = readInput(LINE_OUT_DETECT_L.port, LINE_OUT_DETECT_L.pin) != 0u;
+	bool outputPluggedInR = readInput(LINE_OUT_DETECT_R.port, LINE_OUT_DETECT_R.pin) != 0u;
+	bool headphoneNow = readInput(HEADPHONE_DETECT.port, HEADPHONE_DETECT.pin) != 0u;
+	bool micNow = readInput(MIC_DETECT.port, MIC_DETECT.pin) == 0u;
+	bool lineInNow = readInput(LINE_IN_DETECT.port, LINE_IN_DETECT.pin) != 0u;
+	bool gateInNow = readInput(ANALOG_CLOCK_IN.port, ANALOG_CLOCK_IN.pin) != 0u;
 
 	bool inputStateNow = (outputPluggedInL == outputPluggedInR == headphoneNow == micNow == lineInNow == gateInNow);
 
@@ -149,7 +149,7 @@ void readInputsForHardwareTest(bool testButtonStates[9][16]) {
 	}
 
 	uint8_t value;
-	bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
+	bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value) != 0u;
 	if (anything) {
 		if (value == 252) {
 			nextIsDepress = true;
@@ -311,14 +311,14 @@ void ramTestLED(bool stuffAlreadySetUp) {
 	uint32_t* address;
 	bool ledState = true;
 
-	while (1) {
+	while (true) {
 
 		sendColoursForHardwareTest(testButtonStates);
 
 		hardwareTestWhichColour = (hardwareTestWhichColour + 1) % 3;
 
 		// Write Synced LED
-		setOutputState(SYNCED_LED.port, SYNCED_LED.pin, true);
+		setOutputState(SYNCED_LED.port, SYNCED_LED.pin, 1u);
 
 		// Write gate outputs
 		for (int32_t i = 0; i < NUM_GATE_CHANNELS; i++) {
@@ -342,7 +342,7 @@ void ramTestLED(bool stuffAlreadySetUp) {
 			address++;
 		}
 
-		setOutputState(SYNCED_LED.port, SYNCED_LED.pin, false);
+		setOutputState(SYNCED_LED.port, SYNCED_LED.pin, 0u);
 
 		address = (uint32_t*)0x0C000000;
 		while (address != (uint32_t*)0x10000000) {
@@ -354,19 +354,19 @@ void ramTestLED(bool stuffAlreadySetUp) {
 			if (*address != (uint32_t)address) {
 
 				// Error!!!
-				while (1) {
+				while (true) {
 					readInputsForHardwareTest(testButtonStates);
 
-					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, true);
+					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, 1u);
 					delayMS(50);
 					delayMS(50);
-					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, false);
+					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, 0u);
 					delayMS(50);
 					delayMS(50);
-					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, true);
+					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, 1u);
 					delayMS(50);
 					delayMS(50);
-					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, false);
+					setOutputState(SYNCED_LED.port, SYNCED_LED.pin, 0u);
 					delayMS(50);
 					delayMS(50);
 					delayMS(50);

--- a/src/deluge/util/container/array/c_string_array.cpp
+++ b/src/deluge/util/container/array/c_string_array.cpp
@@ -102,8 +102,8 @@ int32_t CStringArray::search(char const* searchString, bool* foundExact) {
 		char const* stringHere = *(char const**)getElementAddress(proposedIndex);
 		int32_t result = strcmpspecial(stringHere, searchString);
 
-		if (!result) {
-			if (foundExact) {
+		if (result == 0) {
+			if (foundExact != nullptr) {
 				*foundExact = true;
 			}
 			return proposedIndex;
@@ -116,7 +116,7 @@ int32_t CStringArray::search(char const* searchString, bool* foundExact) {
 		}
 	}
 
-	if (foundExact) {
+	if (foundExact != nullptr) {
 		*foundExact = false;
 	}
 	return rangeBegin;

--- a/src/deluge/util/container/array/ordered_resizeable_array.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array.cpp
@@ -197,7 +197,7 @@ void OrderedResizeableArrayWith32bitKey::searchMultiple(int32_t* __restrict__ se
 }
 
 bool OrderedResizeableArrayWith32bitKey::generateRepeats(int32_t wrapPoint, int32_t endPos) {
-	if (!memory) {
+	if (memory == nullptr) {
 		return true;
 	}
 
@@ -534,7 +534,7 @@ OrderedResizeableArrayWith32bitKey::OrderedResizeableArrayWith32bitKey(int32_t n
 
 void OrderedResizeableArrayWith32bitKey::shiftHorizontal(int32_t shiftAmount, int32_t effectiveLength) {
 
-	if (!numElements) {
+	if (numElements == 0) {
 		return;
 	}
 
@@ -546,7 +546,7 @@ void OrderedResizeableArrayWith32bitKey::shiftHorizontal(int32_t shiftAmount, in
 		shiftAmount = -((uint32_t)(-shiftAmount) % (uint32_t)effectiveLength);
 	}
 
-	if (!shiftAmount) {
+	if (shiftAmount == 0) {
 		return;
 	}
 
@@ -582,11 +582,11 @@ updateKeys:
 	}
 
 	// If the leftmost element (in terms of key/position, *not* physical memory location!) has actually changed...
-	if (cutoffIndex && cutoffIndex < numElements) {
+	if ((cutoffIndex != 0) && cutoffIndex < numElements) {
 
 		// If ends aren't touching...
 		int32_t memoryTooBigBy = memorySize - numElements;
-		if (memoryTooBigBy) {
+		if (memoryTooBigBy != 0) {
 
 			// If wrap, then do the smallest amount of memory moving possible to make the ends touch
 			int32_t numElementsBeforeWrap = memorySize - memoryStart;

--- a/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
+++ b/src/deluge/util/container/array/ordered_resizeable_array_with_multi_word_key.cpp
@@ -80,7 +80,7 @@ int32_t OrderedResizeableArrayWithMultiWordKey::searchMultiWordExact(uint32_t* _
 	}
 
 notFound:
-	if (getIndexToInsertAt) {
+	if (getIndexToInsertAt != nullptr) {
 		*getIndexToInsertAt = i;
 	}
 	return -1;

--- a/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
+++ b/src/deluge/util/container/hashtable/open_addressing_hash_table.cpp
@@ -44,10 +44,10 @@ OpenAddressingHashTable::~OpenAddressingHashTable() {
 }
 
 void OpenAddressingHashTable::empty(bool destructing) {
-	if (memory) {
+	if (memory != nullptr) {
 		delugeDealloc(memory);
 	}
-	if (secondaryMemory) {
+	if (secondaryMemory != nullptr) {
 		delugeDealloc(secondaryMemory);
 	}
 
@@ -93,10 +93,10 @@ void* OpenAddressingHashTable::insert(uint32_t key, bool* onlyIfNotAlreadyPresen
 #endif
 
 	// If no memory, get some
-	if (!memory) {
+	if (memory == nullptr) {
 		int32_t newNumBuckets = initialNumBuckets;
 		memory = GeneralMemoryAllocator::get().allocMaxSpeed(newNumBuckets * elementSize);
-		if (!memory) {
+		if (memory == nullptr) {
 			return nullptr;
 		}
 
@@ -111,7 +111,7 @@ void* OpenAddressingHashTable::insert(uint32_t key, bool* onlyIfNotAlreadyPresen
 		int32_t newNumBuckets = numBuckets << 1;
 
 		secondaryMemory = GeneralMemoryAllocator::get().allocMaxSpeed(newNumBuckets * elementSize);
-		if (secondaryMemory) {
+		if (secondaryMemory != nullptr) {
 
 			// Initialize
 			secondaryMemoryNumBuckets = newNumBuckets;
@@ -174,7 +174,7 @@ void* OpenAddressingHashTable::insert(uint32_t key, bool* onlyIfNotAlreadyPresen
 	while (true) {
 		bucketAddress = getBucketAddress(b);
 		uint32_t destKey = getKeyFromAddress(bucketAddress);
-		if (onlyIfNotAlreadyPresent && destKey == key) {
+		if ((onlyIfNotAlreadyPresent != nullptr) && destKey == key) {
 			*onlyIfNotAlreadyPresent = true;
 			goto justReturnAddress;
 		}
@@ -201,7 +201,7 @@ void* OpenAddressingHashTable::lookup(uint32_t key) {
 	}
 #endif
 
-	if (!memory) {
+	if (memory == nullptr) {
 		return nullptr;
 	}
 
@@ -242,7 +242,7 @@ bool OpenAddressingHashTable::remove(uint32_t key) {
 	}
 #endif
 
-	if (!memory) {
+	if (memory == nullptr) {
 		return false;
 	}
 

--- a/src/deluge/util/container/list/bidirectional_linked_list.cpp
+++ b/src/deluge/util/container/list/bidirectional_linked_list.cpp
@@ -131,7 +131,7 @@ BidirectionalLinkedListNode::~BidirectionalLinkedListNode() {
 
 // It's intended that you may call this function even if you're not sure whether the node is in a list or not
 void BidirectionalLinkedListNode::remove() {
-	if (!list) {
+	if (list == nullptr) {
 		return;
 	}
 	*prevPointer = next;
@@ -151,7 +151,7 @@ void BidirectionalLinkedListNode::insertOtherNodeBefore(BidirectionalLinkedListN
 	if constexpr (ALPHA_OR_BETA_VERSION) {
 		// If we're not already in a list, that means we also don't have a valid prevPointer, so everything's about to
 		// break. This happened!
-		if (!list) {
+		if (list == nullptr) {
 			FREEZE_WITH_ERROR("E443");
 		}
 	}
@@ -167,7 +167,7 @@ void BidirectionalLinkedListNode::insertOtherNodeBefore(BidirectionalLinkedListN
 // Ok this is a little bit dangerous - you'd better make damn sure list is set before calling this!
 bool BidirectionalLinkedListNode::isLast() {
 	if constexpr (ALPHA_OR_BETA_VERSION) {
-		if (!list) {
+		if (list == nullptr) {
 			FREEZE_WITH_ERROR("E444");
 		}
 	}

--- a/src/deluge/util/container/vector/named_thing_vector.cpp
+++ b/src/deluge/util/container/vector/named_thing_vector.cpp
@@ -41,8 +41,8 @@ int32_t NamedThingVector::search(char const* searchString, int32_t comparison, b
 		NamedThingVectorElement* element = getMemory(proposedIndex);
 		int32_t result = strcasecmp(element->name.get(), searchString);
 
-		if (!result) {
-			if (foundExact) {
+		if (result == 0) {
+			if (foundExact != nullptr) {
 				*foundExact = true;
 			}
 			return proposedIndex + comparison;
@@ -55,7 +55,7 @@ int32_t NamedThingVector::search(char const* searchString, int32_t comparison, b
 		}
 	}
 
-	if (foundExact) {
+	if (foundExact != nullptr) {
 		*foundExact = false;
 	}
 	return rangeBegin + comparison;

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -37,7 +37,7 @@ void String::setNumReasons(int32_t newNum) {
 }
 
 void String::clear(bool destructing) {
-	if (stringMemory) {
+	if (stringMemory != nullptr) {
 		int32_t numReasons = getNumReasons();
 		if (numReasons > 1) {
 			setNumReasons(numReasons - 1);
@@ -58,7 +58,7 @@ Error String::set(char const* newChars, int32_t newLength) {
 		newLength = strlen(newChars);
 	}
 
-	if (!newLength) {
+	if (newLength == 0) {
 		clear();
 		return Error::NONE;
 	}
@@ -66,7 +66,7 @@ Error String::set(char const* newChars, int32_t newLength) {
 	// If we're here, new length is not 0
 
 	// If already got some memory...
-	if (stringMemory) {
+	if (stringMemory != nullptr) {
 
 		{
 			// If it's shared with another object, can't use it
@@ -108,7 +108,7 @@ clearAndAllocateNew:
 
 	{
 		void* newMemory = GeneralMemoryAllocator::get().allocExternal(newLength + 1 + 4);
-		if (!newMemory) {
+		if (newMemory == nullptr) {
 			return Error::INSUFFICIENT_RAM;
 		}
 		stringMemory = (char*)newMemory + 4;
@@ -132,7 +132,7 @@ void String::set(String const* otherString) {
 			return;
 		}
 		// or if it doesn't have an allocation
-		if (!GeneralMemoryAllocator::get().getAllocatedSize(sm)) {
+		if (GeneralMemoryAllocator::get().getAllocatedSize(sm) == 0u) {
 			FREEZE_WITH_ERROR("S002");
 			return;
 		}
@@ -158,7 +158,7 @@ size_t String::getLength() {
 }
 
 Error String::shorten(int32_t newLength) {
-	if (!newLength) {
+	if (newLength == 0) {
 		clear();
 	}
 	else {
@@ -168,7 +168,7 @@ Error String::shorten(int32_t newLength) {
 		// If reasons, we have to do a clone
 		if (oldNumReasons > 1) {
 			void* newMemory = GeneralMemoryAllocator::get().allocExternal(newLength + 1 + 4);
-			if (!newMemory) {
+			if (newMemory == nullptr) {
 				return Error::INSUFFICIENT_RAM;
 			}
 
@@ -188,7 +188,7 @@ Error String::shorten(int32_t newLength) {
 }
 
 Error String::concatenate(String* otherString) {
-	if (!stringMemory) {
+	if (stringMemory == nullptr) {
 		set(otherString);
 		return Error::NONE;
 	}
@@ -237,10 +237,10 @@ Error String::concatenateAtPos(char const* newChars, int32_t pos, int32_t newCha
 		                                     &amountExtendedRight);
 
 		// If that worked...
-		if (amountExtendedLeft || amountExtendedRight) {
+		if ((amountExtendedLeft != 0u) || (amountExtendedRight != 0u)) {
 
 			// If extended left, gotta move stuff
-			if (amountExtendedLeft) {
+			if (amountExtendedLeft != 0u) {
 				memmove(stringMemory - amountExtendedLeft - 4, stringMemory - 4,
 				        pos + 4); // Moves the stored num reasons, too
 				stringMemory -= amountExtendedLeft;
@@ -251,7 +251,7 @@ Error String::concatenateAtPos(char const* newChars, int32_t pos, int32_t newCha
 		else {
 allocateNewMemory:
 			void* newMemory = GeneralMemoryAllocator::get().allocExternal(requiredSize);
-			if (!newMemory) {
+			if (newMemory == nullptr) {
 				return Error::INSUFFICIENT_RAM;
 			}
 
@@ -295,7 +295,7 @@ Error String::setChar(char newChar, int32_t pos) {
 
 		int32_t requiredSize = length + 4 + 1;
 		void* newMemory = GeneralMemoryAllocator::get().allocExternal(requiredSize);
-		if (!newMemory) {
+		if (newMemory == nullptr) {
 			return Error::INSUFFICIENT_RAM;
 		}
 
@@ -352,7 +352,7 @@ void intToHex(uint32_t number, char* output, int32_t numChars) {
 
 uint32_t hexToInt(char const* string) {
 	int32_t output = 0;
-	while (*string) {
+	while (*string != 0) {
 		output <<= 4;
 		output |= hexCharToHalfByte(*string);
 		string++;

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -68,7 +68,7 @@ public:
 		if (stringMemory == otherString->stringMemory) {
 			return true; // Works if both lengths are 0, too
 		}
-		if (!stringMemory || !otherString->stringMemory) {
+		if ((stringMemory == nullptr) || (otherString->stringMemory == nullptr)) {
 			return false; // If just one is empty, then not equal
 		}
 		return equals(otherString->get());
@@ -78,20 +78,20 @@ public:
 		if (stringMemory == otherString->stringMemory) {
 			return true; // Works if both lengths are 0, too
 		}
-		if (!stringMemory || !otherString->stringMemory) {
+		if ((stringMemory == nullptr) || (otherString->stringMemory == nullptr)) {
 			return false; // If just one is empty, then not equal
 		}
 		return equalsCaseIrrespective(otherString->get());
 	}
 
 	inline char const* get() {
-		if (!stringMemory) {
+		if (stringMemory == nullptr) {
 			return &nothing;
 		}
 		return stringMemory;
 	}
 
-	inline bool isEmpty() { return !stringMemory; }
+	inline bool isEmpty() { return stringMemory == nullptr; }
 
 private:
 	int32_t getNumReasons();

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1342,7 +1342,8 @@ bool isAudioFilename(char const* filename) {
 		return false;
 	}
 	char* dotPos = strrchr(filename, '.');
-	return ((strcasecmp(dotPos, ".WAV") == 0) || (strcasecmp(dotPos, ".AIF") == 0) || (strcasecmp(dotPos, ".AIFF") == 0));
+	return ((strcasecmp(dotPos, ".WAV") == 0) || (strcasecmp(dotPos, ".AIF") == 0)
+	        || (strcasecmp(dotPos, ".AIFF") == 0));
 }
 
 bool isAiffFilename(char const* filename) {
@@ -2023,8 +2024,9 @@ int32_t getHowManyCharsAreTheSame(char const* a, char const* b) {
 }
 
 bool shouldAbortLoading() {
-	return (currentUIMode == UI_MODE_LOADING_BUT_ABORT_IF_SELECT_ENCODER_TURNED
-	        && ((encoders::getEncoder(encoders::EncoderName::SELECT).detentPos != 0) || QwertyUI::predictionInterrupted));
+	return (
+	    currentUIMode == UI_MODE_LOADING_BUT_ABORT_IF_SELECT_ENCODER_TURNED
+	    && ((encoders::getEncoder(encoders::EncoderName::SELECT).detentPos != 0) || QwertyUI::predictionInterrupted));
 }
 
 int32_t getNoteMagnitudeFfromNoteLength(uint32_t noteLength, int32_t tickMagnitude) {

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -352,7 +352,7 @@ char const* getSourceDisplayNameForOLED(PatchSource s) {
 PatchSource stringToSource(char const* string) {
 	for (int32_t s = 0; s < kNumPatchSources; s++) {
 		auto patchSource = static_cast<PatchSource>(s);
-		if (!strcmp(string, sourceToString(patchSource))) {
+		if (strcmp(string, sourceToString(patchSource)) == 0) {
 			return patchSource;
 		}
 	}
@@ -657,7 +657,7 @@ int32_t stringToInt(char const* __restrict__ string) {
 
 int32_t stringToUIntOrError(char const* __restrict__ mem) {
 	uint32_t number = 0;
-	while (*mem) {
+	while (*mem != 0) {
 		if (*mem < '0' || *mem > '9') {
 			return -1;
 		}
@@ -740,37 +740,37 @@ char const* oscTypeToString(OscType oscType) {
 
 OscType stringToOscType(char const* string) {
 
-	if (!strcmp(string, "square")) {
+	if (strcmp(string, "square") == 0) {
 		return OscType::SQUARE;
 	}
-	else if (!strcmp(string, "analogSquare")) {
+	else if (strcmp(string, "analogSquare") == 0) {
 		return OscType::ANALOG_SQUARE;
 	}
-	else if (!strcmp(string, "analogSaw")) {
+	else if (strcmp(string, "analogSaw") == 0) {
 		return OscType::ANALOG_SAW_2;
 	}
-	else if (!strcmp(string, "saw")) {
+	else if (strcmp(string, "saw") == 0) {
 		return OscType::SAW;
 	}
-	else if (!strcmp(string, "sine")) {
+	else if (strcmp(string, "sine") == 0) {
 		return OscType::SINE;
 	}
-	else if (!strcmp(string, "sample")) {
+	else if (strcmp(string, "sample") == 0) {
 		return OscType::SAMPLE;
 	}
-	else if (!strcmp(string, "wavetable")) {
+	else if (strcmp(string, "wavetable") == 0) {
 		return OscType::WAVETABLE;
 	}
-	else if (!strcmp(string, "inLeft")) {
+	else if (strcmp(string, "inLeft") == 0) {
 		return OscType::INPUT_L;
 	}
-	else if (!strcmp(string, "inRight")) {
+	else if (strcmp(string, "inRight") == 0) {
 		return OscType::INPUT_R;
 	}
-	else if (!strcmp(string, "inStereo")) {
+	else if (strcmp(string, "inStereo") == 0) {
 		return OscType::INPUT_STEREO;
 	}
-	else if (!strcmp(string, "dx7")) {
+	else if (strcmp(string, "dx7") == 0) {
 		return OscType::DX7;
 	}
 	else {
@@ -802,22 +802,22 @@ char const* lfoTypeToString(LFOType oscType) {
 }
 
 LFOType stringToLFOType(char const* string) {
-	if (!strcmp(string, "square")) {
+	if (strcmp(string, "square") == 0) {
 		return LFOType::SQUARE;
 	}
-	else if (!strcmp(string, "saw")) {
+	else if (strcmp(string, "saw") == 0) {
 		return LFOType::SAW;
 	}
-	else if (!strcmp(string, "sine")) {
+	else if (strcmp(string, "sine") == 0) {
 		return LFOType::SINE;
 	}
-	else if (!strcmp(string, "sah")) {
+	else if (strcmp(string, "sah") == 0) {
 		return LFOType::SAMPLE_AND_HOLD;
 	}
-	else if (!strcmp(string, "warbler")) {
+	else if (strcmp(string, "warbler") == 0) {
 		return LFOType::WARBLER;
 	}
-	else if (!strcmp(string, "rwalk")) {
+	else if (strcmp(string, "rwalk") == 0) {
 		return LFOType::RANDOM_WALK;
 	}
 	else {
@@ -839,10 +839,10 @@ char const* synthModeToString(SynthMode synthMode) {
 }
 
 SynthMode stringToSynthMode(char const* string) {
-	if (!strcmp(string, "fm")) {
+	if (strcmp(string, "fm") == 0) {
 		return SynthMode::FM;
 	}
-	else if (!strcmp(string, "ringmod")) {
+	else if (strcmp(string, "ringmod") == 0) {
 		return SynthMode::RINGMOD;
 	}
 	else {
@@ -870,22 +870,22 @@ char const* polyphonyModeToString(PolyphonyMode synthMode) {
 }
 
 PolyphonyMode stringToPolyphonyMode(char const* string) {
-	if (!strcmp(string, "mono")) {
+	if (strcmp(string, "mono") == 0) {
 		return PolyphonyMode::MONO;
 	}
-	else if (!strcmp(string, "auto")) {
+	else if (strcmp(string, "auto") == 0) {
 		return PolyphonyMode::AUTO;
 	}
-	else if (!strcmp(string, "0")) {
+	else if (strcmp(string, "0") == 0) {
 		return PolyphonyMode::AUTO; // Old firmware, pre June 2017
 	}
-	else if (!strcmp(string, "legato")) {
+	else if (strcmp(string, "legato") == 0) {
 		return PolyphonyMode::LEGATO;
 	}
-	else if (!strcmp(string, "choke")) {
+	else if (strcmp(string, "choke") == 0) {
 		return PolyphonyMode::CHOKE;
 	}
-	else if (!strcmp(string, "2")) {
+	else if (strcmp(string, "2") == 0) {
 		return PolyphonyMode::CHOKE; // Old firmware, pre June 2017
 	}
 	else {
@@ -917,22 +917,22 @@ char const* fxTypeToString(ModFXType fxType) {
 }
 
 ModFXType stringToFXType(char const* string) {
-	if (!strcmp(string, "flanger")) {
+	if (strcmp(string, "flanger") == 0) {
 		return ModFXType::FLANGER;
 	}
-	else if (!strcmp(string, "TapeWarble")) {
+	else if (strcmp(string, "TapeWarble") == 0) {
 		return ModFXType::WARBLE;
 	}
-	else if (!strcmp(string, "chorus")) {
+	else if (strcmp(string, "chorus") == 0) {
 		return ModFXType::CHORUS;
 	}
-	else if (!strcmp(string, "StereoChorus")) {
+	else if (strcmp(string, "StereoChorus") == 0) {
 		return ModFXType::CHORUS_STEREO;
 	}
-	else if (!strcmp(string, "grainFX")) {
+	else if (strcmp(string, "grainFX") == 0) {
 		return ModFXType::GRAIN;
 	}
-	else if (!strcmp(string, "phaser")) {
+	else if (strcmp(string, "phaser") == 0) {
 		return ModFXType::PHASER;
 	}
 	else {
@@ -954,10 +954,10 @@ char const* modFXParamToString(ModFXParam fxType) {
 }
 
 ModFXParam stringToModFXParam(char const* string) {
-	if (!strcmp(string, "depth")) {
+	if (strcmp(string, "depth") == 0) {
 		return ModFXParam::DEPTH;
 	}
-	else if (!strcmp(string, "feedback")) {
+	else if (strcmp(string, "feedback") == 0) {
 		return ModFXParam::FEEDBACK;
 	}
 	else {
@@ -979,10 +979,10 @@ char const* filterTypeToString(FilterType fxType) {
 }
 
 FilterType stringToFilterType(char const* string) {
-	if (!strcmp(string, "hpf")) {
+	if (strcmp(string, "hpf") == 0) {
 		return FilterType::HPF;
 	}
-	else if (!strcmp(string, "eq")) {
+	else if (strcmp(string, "eq") == 0) {
 		return FilterType::EQ;
 	}
 	else {
@@ -1067,16 +1067,16 @@ char const* arpPresetToOldArpMode(ArpPreset preset) {
 }
 
 OldArpMode stringToOldArpMode(char const* string) {
-	if (!strcmp(string, "up")) {
+	if (strcmp(string, "up") == 0) {
 		return OldArpMode::UP;
 	}
-	else if (!strcmp(string, "down")) {
+	else if (strcmp(string, "down") == 0) {
 		return OldArpMode::DOWN;
 	}
-	else if (!strcmp(string, "both")) {
+	else if (strcmp(string, "both") == 0) {
 		return OldArpMode::BOTH;
 	}
-	else if (!strcmp(string, "random")) {
+	else if (strcmp(string, "random") == 0) {
 		return OldArpMode::RANDOM;
 	}
 	else {
@@ -1095,7 +1095,7 @@ char const* arpModeToString(ArpMode mode) {
 }
 
 ArpMode stringToArpMode(char const* string) {
-	if (!strcmp(string, "arp")) {
+	if (strcmp(string, "arp") == 0) {
 		return ArpMode::ARP;
 	}
 	else {
@@ -1123,16 +1123,16 @@ char const* arpNoteModeToString(ArpNoteMode mode) {
 }
 
 ArpNoteMode stringToArpNoteMode(char const* string) {
-	if (!strcmp(string, "down")) {
+	if (strcmp(string, "down") == 0) {
 		return ArpNoteMode::DOWN;
 	}
-	else if (!strcmp(string, "upDown")) {
+	else if (strcmp(string, "upDown") == 0) {
 		return ArpNoteMode::UP_DOWN;
 	}
-	else if (!strcmp(string, "asPlayed")) {
+	else if (strcmp(string, "asPlayed") == 0) {
 		return ArpNoteMode::AS_PLAYED;
 	}
-	else if (!strcmp(string, "random")) {
+	else if (strcmp(string, "random") == 0) {
 		return ArpNoteMode::RANDOM;
 	}
 	else {
@@ -1160,16 +1160,16 @@ char const* arpOctaveModeToString(ArpOctaveMode mode) {
 }
 
 ArpOctaveMode stringToArpOctaveMode(char const* string) {
-	if (!strcmp(string, "down")) {
+	if (strcmp(string, "down") == 0) {
 		return ArpOctaveMode::DOWN;
 	}
-	else if (!strcmp(string, "upDown")) {
+	else if (strcmp(string, "upDown") == 0) {
 		return ArpOctaveMode::RANDOM;
 	}
-	else if (!strcmp(string, "alt")) {
+	else if (strcmp(string, "alt") == 0) {
 		return ArpOctaveMode::ALTERNATE;
 	}
-	else if (!strcmp(string, "random")) {
+	else if (strcmp(string, "random") == 0) {
 		return ArpOctaveMode::RANDOM;
 	}
 	else {
@@ -1191,10 +1191,10 @@ char const* arpMpeModSourceToString(ArpMpeModSource modSource) {
 }
 
 ArpMpeModSource stringToArpMpeModSource(char const* string) {
-	if (!strcmp(string, "y")) {
+	if (strcmp(string, "y") == 0) {
 		return ArpMpeModSource::MPE_Y;
 	}
-	else if (!strcmp(string, "z")) {
+	else if (strcmp(string, "z") == 0) {
 		return ArpMpeModSource::AFTERTOUCH;
 	}
 	else {
@@ -1231,25 +1231,25 @@ char const* inputChannelToString(AudioInputChannel inputChannel) {
 }
 
 AudioInputChannel stringToInputChannel(char const* string) {
-	if (!strcmp(string, "left")) {
+	if (strcmp(string, "left") == 0) {
 		return AudioInputChannel::LEFT;
 	}
-	else if (!strcmp(string, "right")) {
+	else if (strcmp(string, "right") == 0) {
 		return AudioInputChannel::RIGHT;
 	}
-	else if (!strcmp(string, "stereo")) {
+	else if (strcmp(string, "stereo") == 0) {
 		return AudioInputChannel::STEREO;
 	}
-	else if (!strcmp(string, "balanced")) {
+	else if (strcmp(string, "balanced") == 0) {
 		return AudioInputChannel::BALANCED;
 	}
-	else if (!strcmp(string, "mix")) {
+	else if (strcmp(string, "mix") == 0) {
 		return AudioInputChannel::MIX;
 	}
-	else if (!strcmp(string, "output")) {
+	else if (strcmp(string, "output") == 0) {
 		return AudioInputChannel::OUTPUT;
 	}
-	else if (!strcmp(string, "specificTrack")) {
+	else if (strcmp(string, "specificTrack") == 0) {
 		return AudioInputChannel::SPECIFIC_OUTPUT;
 	}
 
@@ -1279,13 +1279,13 @@ char const* sequenceDirectionModeToString(SequenceDirection sequenceDirectionMod
 }
 
 SequenceDirection stringToSequenceDirectionMode(char const* string) {
-	if (!strcmp(string, "reverse")) {
+	if (strcmp(string, "reverse") == 0) {
 		return SequenceDirection::REVERSE;
 	}
-	else if (!strcmp(string, "pingpong")) {
+	else if (strcmp(string, "pingpong") == 0) {
 		return SequenceDirection::PINGPONG;
 	}
-	else if (!strcmp(string, "obeyParent")) {
+	else if (strcmp(string, "obeyParent") == 0) {
 		return SequenceDirection::OBEY_PARENT;
 	}
 	else {
@@ -1311,10 +1311,10 @@ char const* launchStyleToString(LaunchStyle launchStyle) {
 }
 
 LaunchStyle stringToLaunchStyle(char const* string) {
-	if (!strcmp(string, "fill")) {
+	if (strcmp(string, "fill") == 0) {
 		return LaunchStyle::FILL;
 	}
-	else if (!strcmp(string, "once")) {
+	else if (strcmp(string, "once") == 0) {
 		return LaunchStyle::ONCE;
 	}
 	else {
@@ -1342,12 +1342,12 @@ bool isAudioFilename(char const* filename) {
 		return false;
 	}
 	char* dotPos = strrchr(filename, '.');
-	return (!strcasecmp(dotPos, ".WAV") || !strcasecmp(dotPos, ".AIF") || !strcasecmp(dotPos, ".AIFF"));
+	return ((strcasecmp(dotPos, ".WAV") == 0) || (strcasecmp(dotPos, ".AIF") == 0) || (strcasecmp(dotPos, ".AIFF") == 0));
 }
 
 bool isAiffFilename(char const* filename) {
 	char* dotPos = strrchr(filename, '.');
-	return (dotPos != NULL && (!strcasecmp(dotPos, ".AIF") || !strcasecmp(dotPos, ".AIFF")));
+	return (dotPos != NULL && ((strcasecmp(dotPos, ".AIF") == 0) || (strcasecmp(dotPos, ".AIFF") == 0)));
 }
 
 int32_t lookupReleaseRate(int32_t input) {
@@ -1698,7 +1698,7 @@ int32_t strcmpspecial(char const* first, char const* second) {
 		if (firstIsNumber && secondIsNumber) {
 
 			// If we haven't yet seen a differing number of leading zeros in a number, see if that exists here.
-			if (!resultIfGetToEndOfBothStrings) {
+			if (resultIfGetToEndOfBothStrings == 0) {
 				char const* firstHere = first;
 				char const* secondHere = second;
 				while (true) {
@@ -1743,7 +1743,7 @@ int32_t strcmpspecial(char const* first, char const* second) {
 			}
 
 			int32_t difference = firstNumber - secondNumber;
-			if (difference) {
+			if (difference != 0) {
 				return difference;
 			}
 		}
@@ -1779,7 +1779,7 @@ int32_t strcmpspecial(char const* first, char const* second) {
 				}
 
 				if (firstResult.noteNumber == secondResult.noteNumber) {
-					if (!firstResult.stringLength && !secondResult.stringLength) {
+					if ((firstResult.stringLength == 0) && (secondResult.stringLength == 0)) {
 						goto doNormal;
 					}
 					first += firstResult.stringLength;
@@ -1827,7 +1827,7 @@ char* replace_char(const char* str, char find, char replace) {
 
 	strcpy(copy, str);
 	char* current_pos = strchr(copy, find);
-	while (current_pos) {
+	while (current_pos != nullptr) {
 		*current_pos = replace;
 		current_pos = strchr(current_pos, find);
 	}
@@ -1892,7 +1892,7 @@ void noteCodeToString(int32_t noteCode, char* buffer, int32_t* getLengthWithoutD
 		intToString(octave, thisChar, 1);
 	}
 
-	if (getLengthWithoutDot) {
+	if (getLengthWithoutDot != nullptr) {
 		*getLengthWithoutDot = strlen(buffer);
 		if (noteCodeIsSharp[noteCodeWithinOctave]) {
 			(*getLengthWithoutDot)--;
@@ -1954,7 +1954,7 @@ double ConvertFromIeeeExtended(unsigned char* bytes /* LCN */) {
 		}
 	}
 
-	if (bytes[0] & 0x80) {
+	if ((bytes[0] & 0x80) != 0) {
 		return -f;
 	}
 	else {
@@ -1998,7 +1998,7 @@ int32_t getHowManyCharsAreTheSame(char const* a, char const* b) {
 	int32_t count = 0;
 	while (true) {
 		char charA = *a;
-		if (!charA) {
+		if (charA == 0) {
 			break;
 		}
 		char charB = *b;
@@ -2024,7 +2024,7 @@ int32_t getHowManyCharsAreTheSame(char const* a, char const* b) {
 
 bool shouldAbortLoading() {
 	return (currentUIMode == UI_MODE_LOADING_BUT_ABORT_IF_SELECT_ENCODER_TURNED
-	        && (encoders::getEncoder(encoders::EncoderName::SELECT).detentPos || QwertyUI::predictionInterrupted));
+	        && ((encoders::getEncoder(encoders::EncoderName::SELECT).detentPos != 0) || QwertyUI::predictionInterrupted));
 }
 
 int32_t getNoteMagnitudeFfromNoteLength(uint32_t noteLength, int32_t tickMagnitude) {
@@ -2108,17 +2108,17 @@ void getNoteLengthNameFromMagnitude(StringBuf& noteLengthBuf, int32_t magnitude,
 
 char const* getFileNameFromEndOfPath(char const* filePathChars) {
 	char const* slashPos = strrchr(filePathChars, '/');
-	return slashPos ? (slashPos + 1) : filePathChars;
+	return (slashPos != nullptr) ? (slashPos + 1) : filePathChars;
 }
 
 bool doesFilenameFitPrefixFormat(char const* fileName, char const* filePrefix, int32_t prefixLength) {
 
-	if (memcasecmp(fileName, filePrefix, prefixLength)) {
+	if (memcasecmp(fileName, filePrefix, prefixLength) != 0) {
 		return false;
 	}
 
 	char* dotAddress = strrchr(fileName, '.');
-	if (!dotAddress) {
+	if (dotAddress == nullptr) {
 		return false;
 	}
 

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -277,7 +277,7 @@ template <unsigned saturationAmount>
 [[gnu::always_inline]] inline int32_t getTanHUnknown(int32_t input, uint32_t saturationAmount) {
 	uint32_t workingValue;
 
-	if (saturationAmount)
+	if (saturationAmount != 0u != 0u)
 		workingValue = (uint32_t)lshiftAndSaturateUnknown(input, saturationAmount) + 2147483648u;
 	else
 		workingValue = (uint32_t)input + 2147483648u;

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -483,7 +483,7 @@ const int16_t lanczosKernelA16[1025] = {
 
 
 const uint8_t noteCodeToNoteLetter[12] = {67, 67, 68, 68, 69, 70, 70, 71, 71, 65, 65, 66};
-const bool noteCodeIsSharp[12] = {0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0};
+const bool noteCodeIsSharp[12] = {false, true, false, true, false, false, true, false, true, false, true, false};
 
 /**
  * @brief How iterance is encoded:


### PR DESCRIPTION
Use clang-tidy to convert implicit boolean conversions in places like `if` statements to actual boolean tests