### PR TITLE
replace UI::getName() virtual functions with a lookup table for names

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -194,29 +194,37 @@ constexpr int32_t kNumInstrumentSlots = 1000;
 // Don't ever make this less! The zoom rendering code uses this buffer for its stuff
 constexpr size_t kFilenameBufferSize = 256;
 
+// Macro that enumerates UI types, allowing single definition of them: used here for
+// the enum, and for names in ui.cpp
+#define DEF_UI_TYPES
+
 /// Static enum representing which view a generic UI pointer actually represents.
+/// If you update this, also update the string translations in ui.cpp!
 enum class UIType : uint8_t {
 	ARRANGER,
 	AUDIO_CLIP,
 	AUDIO_RECORDER,
 	AUTOMATION,
-	BROWSER,
 	CONTEXT_MENU,
+	DX_BROWSER,
 	INSTRUMENT_CLIP,
 	KEYBOARD_SCREEN,
 	LOAD_INSTRUMENT_PRESET,
+	LOAD_MIDI_DEVICE_DEFINITION,
 	LOAD_SONG,
 	PERFORMANCE,
-	RENAME_DRUM,
-	RENAME_OUTPUT,
+	RENAME,
+	SAMPLE_BROWSER,
 	SAMPLE_MARKER_EDITOR,
+	SAVE_INSTRUMENT_PRESET,
+	SAVE_KIT_ROW,
+	SAVE_MIDI_DEVICE_DEFINITION,
+	SAVE_SONG,
 	SESSION,
 	SLICER,
 	SOUND_EDITOR,
-	TIMELINE,
-	RENAME_CLIP,
-	RENAME_MIDI_CC,
-	LOAD_MIDI_DEVICE_DEFINITION,
+	// Keep these at the bottom!
+	UI_TYPE_COUNT,
 	NONE = 255,
 };
 

--- a/src/deluge/gui/context_menu/context_menu.h
+++ b/src/deluge/gui/context_menu/context_menu.h
@@ -51,7 +51,9 @@ public:
 	int32_t scrollPos = 0; // Don't make static. We'll have multiple nested ContextMenus open at the same time
 	virtual char const* getTitle() = 0;
 
-	// ui
+	// UI
+
+	// NB! Context menus all share a type!
 	UIType getUIType() override { return UIType::CONTEXT_MENU; }
 };
 

--- a/src/deluge/gui/ui/audio_recorder.h
+++ b/src/deluge/gui/ui/audio_recorder.h
@@ -53,7 +53,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::AUDIO_RECORDER; }
-	const char* getName() override { return "audio_recorder"; }
 
 private:
 	void finishRecording();

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -98,8 +98,6 @@ public:
 	static char const* filenameToStartSearchAt;
 
 	// ui
-	UIType getUIType() override { return UIType::BROWSER; }
-	const char* getName() override { return "browser"; }
 	bool exitUI() override {
 		Browser::close();
 		return true;

--- a/src/deluge/gui/ui/browser/dx_browser.h
+++ b/src/deluge/gui/ui/browser/dx_browser.h
@@ -27,7 +27,8 @@ public:
 	bool opened() override;
 	void enterKeyPress() override;
 	Error getCurrentFilePath(String* path) override;
-	const char* getName() override { return "dx_browser"; }
+	// ui
+	UIType getUIType() override { return UIType::DX_BROWSER; }
 };
 
 extern DxSyxBrowser dxBrowser;

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -58,8 +58,10 @@ public:
 	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true) override;
 	void exitAndNeverDeleteDrum();
 
-	const char* getName() override { return "sample_browser"; }
 	String lastFilePathLoaded;
+
+	// ui
+	UIType getUIType() override { return UIType::SAMPLE_BROWSER; }
 
 protected:
 	void enterKeyPress() override;

--- a/src/deluge/gui/ui/browser/slot_browser.h
+++ b/src/deluge/gui/ui/browser/slot_browser.h
@@ -30,7 +30,6 @@ public:
 	void focusRegained() override;
 	ActionResult horizontalEncoderAction(int32_t offset) override;
 
-	const char* getName() override { return "slot_browser"; }
 	Error getCurrentFilePath(String* path) override;
 
 protected:

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.h
@@ -61,7 +61,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::KEYBOARD_SCREEN; }
-	const char* getName() override { return "keyboard_screen"; }
 	void checkNewInstrument(Instrument* newInstrument);
 
 private:

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -50,9 +50,6 @@ using encoders::EncoderName;
 
 LoadInstrumentPresetUI loadInstrumentPresetUI{};
 
-LoadInstrumentPresetUI::LoadInstrumentPresetUI() {
-}
-
 bool LoadInstrumentPresetUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	if (showingAuditionPads()) {
 		*cols = 0b10;

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.h
@@ -30,7 +30,7 @@ class Output;
 
 class LoadInstrumentPresetUI final : public LoadUI {
 public:
-	LoadInstrumentPresetUI();
+	LoadInstrumentPresetUI() = default;
 	bool opened() override;
 	// void selectEncoderAction(int8_t offset);
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
@@ -74,9 +74,9 @@ public:
 		noteRowIndex = rowIndex; // (not set value for note rows)
 		noteRow = row;
 	}
+
 	// ui
 	UIType getUIType() override { return UIType::LOAD_INSTRUMENT_PRESET; }
-	const char* getName() override { return "load_instrument_preset"; }
 
 protected:
 	void enterKeyPress() override;

--- a/src/deluge/gui/ui/load/load_midi_device_definition_ui.cpp
+++ b/src/deluge/gui/ui/load/load_midi_device_definition_ui.cpp
@@ -37,9 +37,6 @@ using namespace deluge;
 
 LoadMidiDeviceDefinitionUI loadMidiDeviceDefinitionUI{};
 
-LoadMidiDeviceDefinitionUI::LoadMidiDeviceDefinitionUI() {
-}
-
 bool LoadMidiDeviceDefinitionUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 	*cols = 0xFFFFFFFF;
 	return true;

--- a/src/deluge/gui/ui/load/load_midi_device_definition_ui.h
+++ b/src/deluge/gui/ui/load/load_midi_device_definition_ui.h
@@ -23,7 +23,7 @@
 
 class LoadMidiDeviceDefinitionUI final : public LoadUI {
 public:
-	LoadMidiDeviceDefinitionUI();
+	LoadMidiDeviceDefinitionUI() = default;
 
 	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
 	bool opened() override;
@@ -45,7 +45,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::LOAD_MIDI_DEVICE_DEFINITION; }
-	const char* getName() override { return "load_midi_device_definition_ui"; }
 
 protected:
 	void folderContentsReady(int32_t entryDirection) override;

--- a/src/deluge/gui/ui/load/load_song_ui.h
+++ b/src/deluge/gui/ui/load/load_song_ui.h
@@ -40,7 +40,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::LOAD_SONG; }
-	const char* getName() override { return "load_song_ui"; }
 
 protected:
 	void displayText(bool blinkImmediately = false) override;

--- a/src/deluge/gui/ui/load/load_ui.cpp
+++ b/src/deluge/gui/ui/load/load_ui.cpp
@@ -18,9 +18,6 @@
 #include "gui/ui/load/load_ui.h"
 #include "hid/led/indicator_leds.h"
 
-LoadUI::LoadUI() {
-}
-
 void LoadUI::focusRegained() {
 	indicator_leds::blinkLed(IndicatorLED::LOAD);
 	indicator_leds::setLedState(IndicatorLED::SAVE,

--- a/src/deluge/gui/ui/load/load_ui.h
+++ b/src/deluge/gui/ui/load/load_ui.h
@@ -21,10 +21,9 @@
 
 class LoadUI : public SlotBrowser {
 public:
-	LoadUI();
+	LoadUI() = default;
 
 	void focusRegained() override;
-	const char* getName() override { return "load_ui"; }
 
 protected:
 	virtual void searchMemoryForBetterFile(int32_t offset, char* bestFilenameFound) {}

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -40,9 +40,6 @@ String QwertyUI::enteredText{};
 int16_t QwertyUI::enteredTextEditPos;
 int32_t QwertyUI::scrollPosHorizontal;
 
-QwertyUI::QwertyUI() {
-}
-
 bool QwertyUI::opened() {
 
 	indicator_leds::blinkLed(IndicatorLED::BACK);

--- a/src/deluge/gui/ui/qwerty_ui.h
+++ b/src/deluge/gui/ui/qwerty_ui.h
@@ -23,7 +23,7 @@
 
 class QwertyUI : public UI {
 public:
-	QwertyUI();
+	QwertyUI() = default;
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
 	ActionResult horizontalEncoderAction(int32_t offset) override;
 	ActionResult timerCallback() override;
@@ -33,7 +33,6 @@ public:
 		return true;
 	}
 
-	const char* getName() override { return "qwerty_ui"; }
 	static bool predictionInterrupted;
 	static String enteredText;
 

--- a/src/deluge/gui/ui/rename/rename_clip_ui.h
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.h
@@ -36,8 +36,6 @@ public:
 	Clip* clip;
 
 	// ui
-	UIType getUIType() override { return UIType::RENAME_CLIP; }
-	const char* getName() override { return "rename_clip_ui"; }
 	bool exitUI() override;
 
 protected:

--- a/src/deluge/gui/ui/rename/rename_drum_ui.h
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.h
@@ -32,8 +32,6 @@ public:
 	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
 
 	// ui
-	UIType getUIType() override { return UIType::RENAME_DRUM; }
-	const char* getName() override { return "rename_drum_ui"; }
 	bool exitUI() override;
 
 protected:

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
@@ -33,8 +33,6 @@ public:
 	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
 
 	// ui
-	UIType getUIType() override { return UIType::RENAME_MIDI_CC; }
-	const char* getName() override { return "rename_midi_cc_ui"; }
 	bool exitUI() override;
 
 protected:

--- a/src/deluge/gui/ui/rename/rename_output_ui.h
+++ b/src/deluge/gui/ui/rename/rename_output_ui.h
@@ -34,8 +34,6 @@ public:
 	Output* output;
 
 	// ui
-	UIType getUIType() override { return UIType::RENAME_OUTPUT; }
-	const char* getName() override { return "rename_output_ui"; }
 	bool exitUI() override;
 
 protected:

--- a/src/deluge/gui/ui/rename/rename_ui.h
+++ b/src/deluge/gui/ui/rename/rename_ui.h
@@ -25,5 +25,7 @@ public:
 
 	void displayText(bool blinkImmediately = false) override;
 	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
-	const char* getName() override { return "rename_ui"; }
+
+	// ui
+	UIType getUIType() override { return UIType::RENAME; }
 };

--- a/src/deluge/gui/ui/root_ui.cpp
+++ b/src/deluge/gui/ui/root_ui.cpp
@@ -18,10 +18,6 @@
 #include "gui/ui/root_ui.h"
 #include "model/song/song.h"
 
-RootUI::RootUI() {
-	// TODO Auto-generated constructor stub
-}
-
 bool RootUI::getAffectEntire() {
 	return currentSong->affectEntire;
 }

--- a/src/deluge/gui/ui/root_ui.h
+++ b/src/deluge/gui/ui/root_ui.h
@@ -26,7 +26,7 @@ class Sample;
 
 class RootUI : public UI {
 public:
-	RootUI();
+	RootUI() = default;
 	virtual bool getAffectEntire();
 	bool canSeeViewUnderneath() final { return true; }
 	[[nodiscard]] virtual bool supportsTriplets() const { return true; }
@@ -37,7 +37,4 @@ public:
 	virtual void clipNeedsReRendering(Clip* clip) {}
 	virtual void sampleNeedsReRendering(Sample* sample) {}
 	virtual void midiLearnFlash() {}
-	// ui
-	UIType getUIType() override { return UIType::NONE; }
-	const char* getName() override { return "root_ui"; }
 };

--- a/src/deluge/gui/ui/sample_marker_editor.h
+++ b/src/deluge/gui/ui/sample_marker_editor.h
@@ -68,7 +68,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::SAMPLE_MARKER_EDITOR; }
-	const char* getName() override { return "sampler_marker_editor"; }
 	bool exitUI() override;
 
 private:

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
@@ -41,9 +41,6 @@ using namespace deluge;
 
 SaveInstrumentPresetUI saveInstrumentPresetUI{};
 
-SaveInstrumentPresetUI::SaveInstrumentPresetUI() {
-}
-
 bool SaveInstrumentPresetUI::opened() {
 
 	Instrument* currentInstrument = getCurrentInstrument();

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.h
@@ -23,7 +23,7 @@ class Instrument;
 
 class SaveInstrumentPresetUI final : public SaveUI {
 public:
-	SaveInstrumentPresetUI();
+	SaveInstrumentPresetUI() = default;
 
 	bool opened() override;
 	// void selectEncoderAction(int8_t offset);
@@ -35,7 +35,9 @@ public:
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth] = nullptr) override {
 		return true;
 	}
-	const char* getName() override { return "save_instrument_preset_ui"; }
+
+	// ui
+	UIType getUIType() override { return UIType::SAVE_INSTRUMENT_PRESET; }
 
 protected:
 	// int32_t arrivedInNewFolder(int32_t direction);

--- a/src/deluge/gui/ui/save/save_kit_row_ui.h
+++ b/src/deluge/gui/ui/save/save_kit_row_ui.h
@@ -39,7 +39,9 @@ public:
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth] = nullptr) override {
 		return true;
 	}
-	const char* getName() override { return "save_kit_row_ui"; }
+
+	// ui
+	UIType getUIType() override { return UIType::SAVE_KIT_ROW; }
 
 protected:
 	SoundDrum* soundDrumToSave;

--- a/src/deluge/gui/ui/save/save_midi_device_definition_ui.cpp
+++ b/src/deluge/gui/ui/save/save_midi_device_definition_ui.cpp
@@ -36,9 +36,6 @@ using namespace deluge;
 
 SaveMidiDeviceDefinitionUI saveMidiDeviceDefinitionUI{};
 
-SaveMidiDeviceDefinitionUI::SaveMidiDeviceDefinitionUI() {
-}
-
 bool SaveMidiDeviceDefinitionUI::opened() {
 	if (!getRootUI()->toClipMinder() || getCurrentOutputType() != OutputType::MIDI_OUT) {
 		return false;

--- a/src/deluge/gui/ui/save/save_midi_device_definition_ui.h
+++ b/src/deluge/gui/ui/save/save_midi_device_definition_ui.h
@@ -22,7 +22,7 @@ class Song;
 
 class SaveMidiDeviceDefinitionUI final : public SaveUI {
 public:
-	SaveMidiDeviceDefinitionUI();
+	SaveMidiDeviceDefinitionUI() = default;
 
 	bool opened() override;
 	void verticalEncoderAction(int32_t offset, bool encoderButtonPressed, bool shiftButtonPressed){};
@@ -33,7 +33,9 @@ public:
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth] = nullptr) override {
 		return true;
 	}
-	const char* getName() override { return "save_midi_device_definition_ui"; }
+
+	// ui
+	UIType getUIType() override { return UIType::SAVE_MIDI_DEVICE_DEFINITION; }
 };
 
 extern SaveMidiDeviceDefinitionUI saveMidiDeviceDefinitionUI;

--- a/src/deluge/gui/ui/save/save_song_ui.h
+++ b/src/deluge/gui/ui/save/save_song_ui.h
@@ -28,8 +28,9 @@ public:
 	void focusRegained() override;
 	// void selectEncoderAction(int8_t offset);
 	bool performSave(bool mayOverwrite = false) override;
-	const char* getName() override { return "save_song_ui"; }
 	bool collectingSamples;
+	// ui
+	UIType getUIType() override { return UIType::SAVE_SONG; }
 
 protected:
 	// int32_t arrivedInNewFolder(int32_t direction);

--- a/src/deluge/gui/ui/save/save_ui.h
+++ b/src/deluge/gui/ui/save/save_ui.h
@@ -36,7 +36,6 @@ public:
 	bool canSeeViewUnderneath() final { return false; }
 	ActionResult timerCallback() override;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
-	const char* getName() override { return "save_ui"; }
 
 protected:
 	// void displayText(bool blinkImmediately) final;

--- a/src/deluge/gui/ui/slicer.h
+++ b/src/deluge/gui/ui/slicer.h
@@ -59,7 +59,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::SLICER; }
-	const char* getName() override { return "slicer"; }
 
 private:
 	// 7SEG Only

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -122,7 +122,7 @@ void SoundEditor::setShortcutsVersion(int32_t newVersion) {
 	}
 }
 
-SoundEditor soundEditor;
+SoundEditor soundEditor{};
 
 SoundEditor::SoundEditor() {
 	currentParamShorcutX = 255;

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -146,7 +146,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::SOUND_EDITOR; }
-	const char* getName() override { return "sound_editor"; }
 
 	bool selectedNoteRow;
 

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -21,6 +21,7 @@
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
 #include "hid/led/pad_leds.h"
+#include "util/misc.h"
 #include <utility>
 
 using deluge::hid::display::OLED;
@@ -449,3 +450,33 @@ void enterUIMode(uint32_t uiMode) {
 		currentUIMode = (currentUIMode & ~EXCLUSIVE_UI_MODES_MASK) | uiMode;
 	}
 }
+
+#if ENABLE_MATRIX_DEBUG
+EnumStringMap<UIType, util::to_underlying(UIType::UI_TYPE_COUNT)> uiTypeMap = {
+    {{{UIType::ARRANGER, "arranger"},
+      {UIType::AUDIO_CLIP, "audio_clip"},
+      {UIType::AUDIO_RECORDER, "audio_recorder"},
+      {UIType::AUTOMATION, "automation"},
+      {UIType::CONTEXT_MENU, "context_menu"},
+      {UIType::DX_BROWSER, "dx_browser"},
+      {UIType::INSTRUMENT_CLIP, "instrument_clip"},
+      {UIType::KEYBOARD_SCREEN, "keyboard_screen"},
+      {UIType::LOAD_INSTRUMENT_PRESET, "load_instrument_preset"},
+      {UIType::LOAD_MIDI_DEVICE_DEFINITION, "load_midi_device_definition"},
+      {UIType::LOAD_SONG, "load_song"},
+      {UIType::PERFORMANCE, "performance"},
+      {UIType::RENAME, "rename"},
+      {UIType::SAMPLE_BROWSER, "sample_browser"},
+      {UIType::SAMPLE_MARKER_EDITOR, "sample_marker_editor"},
+      {UIType::SAVE_INSTRUMENT_PRESET, "save_instrument_preset"},
+      {UIType::SAVE_KIT_ROW, "save_kit_row"},
+      {UIType::SAVE_MIDI_DEVICE_DEFINITION, "save_midi_device_definition"},
+      {UIType::SAVE_SONG, "save_song"},
+      {UIType::SESSION, "session"},
+      {UIType::SLICER, "slicer"},
+      {UIType::SOUND_EDITOR, "sound_editor"}}}};
+
+const char* UI::getUIName() {
+	return uiTypeMap(getUIType());
+}
+#endif

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -126,7 +126,6 @@ public:
 	virtual TimelineView* toTimelineView() { return nullptr; }
 
 	virtual void scrollFinished() {}
-	virtual const char* getName() { return "UI"; }
 	virtual bool pcReceivedForMidiLearn(MIDICable& fromCable, int32_t channel, int32_t program) { return false; }
 
 	virtual bool noteOnReceivedForMidiLearn(MIDICable& fromCable, int32_t channel, int32_t note, int32_t velocity) {
@@ -158,6 +157,12 @@ public:
 	bool oledShowsUIUnderneath;
 
 	virtual UIType getUIType() = 0;
+#if ENABLE_MATRIX_DEBUG
+	const char* getUIName();
+#endif
+
+protected:
+	UIType uiType;
 };
 
 // UIs

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -120,7 +120,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::ARRANGER; }
-	const char* getName() override { return "arranger_view"; }
 
 	Clip* getClipForSelection();
 

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -57,9 +57,6 @@ using namespace deluge::gui;
 
 AudioClipView audioClipView{};
 
-AudioClipView::AudioClipView() {
-}
-
 inline Sample* getSample() {
 	if (getCurrentAudioClip()->getCurrentlyRecordingLinearly()) {
 		return getCurrentAudioClip()->recorder->sample;

--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -26,7 +26,7 @@ class AudioClip;
 
 class AudioClipView final : public ClipView, public ClipMinder {
 public:
-	AudioClipView();
+	AudioClipView() = default;
 
 	bool opened() override;
 	void focusRegained() override;
@@ -61,7 +61,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::AUDIO_CLIP; }
-	const char* getName() override { return "audio_clip_view"; }
 
 private:
 	uint32_t timeSongButtonPressed;

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -61,7 +61,6 @@ public:
 	// ui
 	UIType getUIType() override { return UIType::AUTOMATION; }
 	AutomationSubType getAutomationSubType();
-	const char* getName() override { return "automation_view"; }
 
 	// rendering
 	bool possiblyRefreshAutomationEditorGrid(Clip* clip, deluge::modulation::params::Kind paramKind, int32_t paramID);

--- a/src/deluge/gui/views/clip_navigation_timeline_view.h
+++ b/src/deluge/gui/views/clip_navigation_timeline_view.h
@@ -25,7 +25,6 @@ public:
 	ClipNavigationTimelineView() = default;
 	void focusRegained() override;
 	ActionResult horizontalEncoderAction(int32_t offset) override;
-	const char* getName() override { return "clip_navigation_timeline_view"; }
 
 protected:
 	void horizontalScrollForLinearRecording(int32_t newXScroll);

--- a/src/deluge/gui/views/clip_view.cpp
+++ b/src/deluge/gui/views/clip_view.cpp
@@ -32,9 +32,6 @@
 #include "playback/mode/session.h"
 #include "playback/playback_handler.h"
 
-ClipView::ClipView() {
-}
-
 uint32_t ClipView::getMaxZoom() {
 	return getCurrentClip()->getMaxZoom();
 }

--- a/src/deluge/gui/views/clip_view.h
+++ b/src/deluge/gui/views/clip_view.h
@@ -24,9 +24,8 @@ class Action;
 
 class ClipView : public ClipNavigationTimelineView {
 public:
-	ClipView();
+	ClipView() = default;
 
-	const char* getName() override { return "clip_view"; }
 	uint32_t getMaxZoom() override;
 	uint32_t getMaxLength() override;
 	ActionResult horizontalEncoderAction(int32_t offset) override;

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -73,7 +73,6 @@ public:
 	bool opened() override;
 	void focusRegained() override;
 	void displayOrLanguageChanged() final;
-	const char* getName() override { return "instrument_clip_view"; }
 
 	// BUTTON ACTION button press / release handling
 

--- a/src/deluge/gui/views/performance_view.h
+++ b/src/deluge/gui/views/performance_view.h
@@ -67,7 +67,6 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::PERFORMANCE; }
-	const char* getName() override { return "performance_view"; }
 	[[nodiscard]] int32_t getNavSysId() const override;
 
 	// rendering

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -48,7 +48,6 @@ public:
 	bool opened() override;
 	void focusRegained() override;
 
-	const char* getName() override { return "session_view"; }
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	ActionResult clipCreationButtonPressed(hid::Button i, bool on, bool routine);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;

--- a/src/deluge/gui/views/timeline_view.h
+++ b/src/deluge/gui/views/timeline_view.h
@@ -26,13 +26,12 @@ class NoteRow;
 
 class TimelineView : public RootUI {
 public:
-	TimelineView() {}
+	TimelineView() = default;
 
 	void scrollFinished() override;
 
 	TimelineView* toTimelineView() final { return this; }
 
-	const char* getName() override { return "timeline_view"; }
 	virtual uint32_t getMaxZoom() = 0;
 	virtual bool calculateZoomPinSquares(uint32_t oldScroll, uint32_t newScroll, uint32_t newZoom,
 	                                     uint32_t oldZoom); // Returns false if no animation needed
@@ -70,9 +69,6 @@ public:
 	bool isSquareDefined(int32_t square, int32_t xScroll, uint32_t xZoom);
 
 	[[nodiscard]] bool inTripletsView() const;
-
-	// ui
-	UIType getUIType() override { return UIType::TIMELINE; }
 
 private:
 	/// Used when scrolling horizontally to briefly catch on clip's max zoom

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -56,7 +56,6 @@ public:
 	void setTimeBaseScaleLedState();
 	void setLedStates();
 
-	const char* getName() { return "view"; }
 	void clipStatusMidiLearnPadPressed(bool on, Clip* whichLoopable);
 	void noteRowMuteMidiLearnPadPressed(bool on, NoteRow* whichNoteRow);
 	void endMidiLearnPressSession(MidiLearn newThingPressed = MidiLearn::NONE);

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -146,7 +146,6 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 		}
 	}
 
-	D_PRINTLN("HID buttonAction() for %s", getCurrentUI()->getName());
 	result = getCurrentUI()->buttonAction(b, on, inCardRoutine);
 
 	if (result == ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE) {

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -90,7 +90,7 @@ ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 // This is a debug feature that allows us to output SYSEX debug logging button presses
 // See contributing.md for more information
 #if ENABLE_MATRIX_DEBUG
-	D_PRINT("UI=%s, Button=%s, On=%d", getCurrentUI()->getName(), getButtonName(b), on);
+	D_PRINT("UI=%s, Button=%s, On=%d", getCurrentUI()->getUIName(), getButtonName(b), on);
 #endif
 	if (on) {
 		// If the user presses a different button while holding shift, don't consider the shift press for the purposes

--- a/src/deluge/hid/matrix/matrix_driver.cpp
+++ b/src/deluge/hid/matrix/matrix_driver.cpp
@@ -74,7 +74,7 @@ ActionResult MatrixDriver::padAction(int32_t x, int32_t y, int32_t velocity) {
 
 	padStates[x][y] = velocity;
 #if ENABLE_MATRIX_DEBUG
-	D_PRINT("UI=%s,PAD_X=%d,PAD_Y=%d,VEL=%d", getCurrentUI()->getName(), x, y, velocity);
+	D_PRINT("UI=%s,PAD_X=%d,PAD_Y=%d,VEL=%d", getCurrentUI()->getUIName(), x, y, velocity);
 #endif
 	auto ui = getCurrentUI();
 	if (ui == nullptr) {


### PR DESCRIPTION
- conditionalize name storage on ENABLE_MATRIX_DEBUG, the only current user of the name

- make sure all concrete UIs actually have an UIType, and no abstract ones have one. minor exception with ContextMenus, which all same the same type.

- shrinks the binary by ~1.2kB. storing the info in members is marginally better, but leads to uglier code. (earlier 52kB claim was just bogus measurement, *blush*)
