### PR TITLE
refactor rename-uis, allow naming CV clips as well

### DIFF
--- a/src/deluge/gui/menu_item/edit_name.h
+++ b/src/deluge/gui/menu_item/edit_name.h
@@ -18,13 +18,13 @@
 #pragma once
 
 #include "gui/menu_item/menu_item.h"
+#include "gui/ui/rename/rename_ui.h"
 
 namespace deluge::gui::menu_item {
 
-class DrumName final : public MenuItem {
+class EditName final : public MenuItem {
 public:
 	using MenuItem::MenuItem;
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
-	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override;
 };
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -55,11 +55,11 @@
 #include "gui/menu_item/delay/analog.h"
 #include "gui/menu_item/delay/ping_pong.h"
 #include "gui/menu_item/delay/sync.h"
-#include "gui/menu_item/drum_name.h"
 #include "gui/menu_item/dx/browse.h"
 #include "gui/menu_item/dx/engine_select.h"
 #include "gui/menu_item/dx/global_params.h"
 #include "gui/menu_item/dx/param.h"
+#include "gui/menu_item/edit_name.h"
 #include "gui/menu_item/envelope/segment.h"
 #include "gui/menu_item/file_selector.h"
 #include "gui/menu_item/filter/hpf_freq.h"
@@ -745,13 +745,15 @@ Submenu audioClipSampleMenu{
 
 audio_clip::Attack audioClipAttackMenu{STRING_FOR_ATTACK};
 
+menu_item::EditName nameEditMenu{STRING_FOR_NAME};
+
 const MenuItem* midiOrCVParamShortcuts[kDisplayHeight] = {
     &arpRateMenuMIDIOrCV,
     &arpSyncMenu,
     &arpGateMenuMIDIOrCV,
     &arpOctavesMenu,
     &arpPresetModeMenu,
-    nullptr,
+    &nameEditMenu,
     nullptr,
     nullptr,
 };
@@ -1190,9 +1192,6 @@ MasterTranspose masterTransposeMenu{STRING_FOR_MASTER_TRANSPOSE, STRING_FOR_MAST
 
 patch_cable_strength::Fixed vibratoMenu{STRING_FOR_VIBRATO, params::LOCAL_PITCH_ADJUST, PatchSource::LFO_GLOBAL};
 
-// Drum only
-menu_item::DrumName drumNameMenu{STRING_FOR_NAME};
-
 // Synth only
 menu_item::SynthMode synthModeMenu{STRING_FOR_SYNTH_MODE};
 bend_range::PerFinger drumBendRangeMenu{STRING_FOR_BEND_RANGE}; // The single option available for Drums
@@ -1209,7 +1208,7 @@ Submenu soundMasterMenu{
         &vibratoMenu,
         &panMenu,
         &synthModeMenu,
-        &drumNameMenu,
+        &nameEditMenu,
     },
 };
 
@@ -1503,7 +1502,7 @@ MenuItem* paramShortcutsForSounds[][kDisplayHeight] = {
     {&envReleaseMenu,         &envSustainMenu,         &envDecayMenu,                  &envAttackMenu,                 &lpfMorphMenu,        &lpfModeMenu,           &lpfResMenu,              &lpfFreqMenu                       },
     {&envReleaseMenu,         &envSustainMenu,         &envDecayMenu,                  &envAttackMenu,                 &hpfMorphMenu,        &hpfModeMenu,           &hpfResMenu,              &hpfFreqMenu                       },
     {&sidechainReleaseMenu,   &sidechainSyncMenu,      &sidechainVolumeShortcutMenu,   &sidechainAttackMenu,           &sidechainShapeMenu,  &sidechainSendMenu,     &bassMenu,                &bassFreqMenu                      },
-    {&arpRateMenu,            &arpSyncMenu,            &arpGateMenu,                   &arpOctavesMenu,                &arpPresetModeMenu,   &drumNameMenu,          &trebleMenu,              &trebleFreqMenu                    },
+    {&arpRateMenu,            &arpSyncMenu,            &arpGateMenu,                   &arpOctavesMenu,                &arpPresetModeMenu,   &nameEditMenu,          &trebleMenu,              &trebleFreqMenu                    },
     {&lfo1RateMenu,           &lfo1SyncMenu,           &lfo1TypeMenu,                  &modFXTypeMenu,                 &modFXOffsetMenu,     &modFXFeedbackMenu,     &modFXDepthMenu,          &modFXRateMenu                     },
     {&lfo2RateMenu,           &lfo2SyncMenu,           &lfo2TypeMenu,                  &reverbAmountMenu,              &reverbPanMenu,       &reverbWidthMenu,       &reverbDampingMenu,       &reverbRoomSizeMenu                },
     {&delayRateMenu,          &delaySyncMenu,          &delayAnalogMenu,               &delayFeedbackMenu,             &delayPingPongMenu,   nullptr,                nullptr,                  nullptr                            },
@@ -1537,7 +1536,7 @@ MenuItem* paramShortcutsForAudioClips[][kDisplayHeight] = {
     {nullptr,                 nullptr,                 nullptr,                        &audioClipAttackMenu,           &globalLPFMorphMenu,  &lpfModeMenu,           &globalLPFResMenu,        &globalLPFFreqMenu              	  },
     {nullptr,                 nullptr,                 nullptr,                        &audioClipAttackMenu,           &globalHPFMorphMenu,  &hpfModeMenu,           &globalHPFResMenu,        &globalHPFFreqMenu                 },
     {&sidechainReleaseMenu,   &sidechainSyncMenu,      &globalSidechainVolumeMenu,     &sidechainAttackMenu,           &sidechainShapeMenu,  nullptr,                &bassMenu,                &bassFreqMenu                      },
-    {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              nullptr,                &trebleMenu,              &trebleFreqMenu                    },
+    {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,              &nameEditMenu,          &trebleMenu,              &trebleFreqMenu                    },
     {nullptr,                 nullptr,                 nullptr,                        &modFXTypeMenu,           	   &modFXOffsetMenu,     &modFXFeedbackMenu,     &globalModFXDepthMenu,    &globalModFXRateMenu            	  },
     {nullptr,                 nullptr,                 nullptr,                        &globalReverbSendAmountMenu,    &reverbPanMenu,       &reverbWidthMenu,       &reverbDampingMenu,       &reverbRoomSizeMenu                },
     {&globalDelayRateMenu, 	  &delaySyncMenu,          &delayAnalogMenu,               &globalDelayFeedbackMenu,       &delayPingPongMenu,   nullptr,                nullptr,                  nullptr                            },
@@ -1573,7 +1572,7 @@ MenuItem* paramShortcutsForKitGlobalFX[][kDisplayHeight] = {
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        &globalLPFMorphMenu,  &lpfModeMenu,           &globalLPFResMenu,        &globalLPFFreqMenu                 },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        &globalHPFMorphMenu,  &hpfModeMenu,           &globalHPFResMenu,        &globalHPFFreqMenu                 },
     {&sidechainReleaseMenu,   &sidechainSyncMenu,      &globalSidechainVolumeMenu,     &sidechainAttackMenu,           &sidechainShapeMenu,  nullptr,                &bassMenu,                &bassFreqMenu                      },
-    {nullptr,                 nullptr,            	   nullptr,                        nullptr,                		   nullptr,         	 nullptr,                &trebleMenu,              &trebleFreqMenu                    },
+    {nullptr,                 nullptr,            	   nullptr,                        nullptr,                		   nullptr,         	 &nameEditMenu,          &trebleMenu,              &trebleFreqMenu                    },
     {nullptr,                 nullptr,                 nullptr,                        &modFXTypeMenu,                 &modFXOffsetMenu,     &modFXFeedbackMenu,     &globalModFXDepthMenu,    &globalModFXRateMenu               },
     {nullptr,                 nullptr,                 nullptr,                        &globalReverbSendAmountMenu,    &reverbPanMenu,       &reverbWidthMenu,       &reverbDampingMenu,       &reverbRoomSizeMenu                },
     {&globalDelayRateMenu,    &delaySyncMenu,          &delayAnalogMenu,               &globalDelayFeedbackMenu,       &delayPingPongMenu,   nullptr,                nullptr,                  nullptr                            },

--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -2,6 +2,7 @@
 #include "gui/menu_item/audio_clip/audio_source_selector.h"
 #include "gui/menu_item/audio_clip/sample_marker_editor.h"
 #include "gui/menu_item/defaults/swing_interval.h"
+#include "gui/menu_item/edit_name.h"
 #include "gui/menu_item/firmware/version.h"
 #include "gui/menu_item/note/fill.h"
 #include "gui/menu_item/note/iterance_divisor.h"
@@ -32,7 +33,7 @@ extern deluge::gui::menu_item::sample::Start sampleStartMenu;
 extern deluge::gui::menu_item::sample::End sampleEndMenu;
 extern deluge::gui::menu_item::audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuStart;
 extern deluge::gui::menu_item::audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuEnd;
-extern DrumName drumNameMenu;
+extern deluge::gui::menu_item::EditName nameEditMenu;
 extern deluge::gui::menu_item::Submenu dxMenu;
 extern deluge::gui::menu_item::Submenu stemExportMenu;
 extern deluge::gui::menu_item::stem_export::Start startStemExportMenu;

--- a/src/deluge/gui/ui/rename/rename_clip_ui.h
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.h
@@ -19,27 +19,16 @@
 
 #include "gui/ui/rename/rename_ui.h"
 #include "hid/button.h"
-
-class Output;
-class Clip;
+#include "model/clip/clip.h"
 
 class RenameClipUI final : public RenameUI {
 public:
-	RenameClipUI();
-	bool opened() override;
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
-	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
-	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
-
-	Output* output;
+	RenameClipUI(const char* title_) : RenameUI(title){};
 	Clip* clip;
 
-	// ui
-	bool exitUI() override;
-
 protected:
-	void enterKeyPress() override;
+	bool trySetName(const std::string_view&) override;
+	std::string_view getName() const override;
 };
 
 extern RenameClipUI renameClipUI;

--- a/src/deluge/gui/ui/rename/rename_clip_ui.h
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.h
@@ -23,7 +23,7 @@
 
 class RenameClipUI final : public RenameUI {
 public:
-	RenameClipUI(const char* title_) : RenameUI(title){};
+	RenameClipUI(const char* title_) : RenameUI(title_){};
 	Clip* clip;
 
 protected:

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -17,7 +17,6 @@
 
 #include "gui/ui/rename/rename_drum_ui.h"
 #include "definitions_cxx.hpp"
-#include "extern.h"
 #include "gui/l10n/l10n.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/instrument_clip_view.h"
@@ -28,109 +27,22 @@
 #include "model/song/song.h"
 #include "processing/sound/sound_drum.h"
 
-RenameDrumUI renameDrumUI{};
+RenameDrumUI renameDrumUI{"Drum Name"};
 
-RenameDrumUI::RenameDrumUI() {
-	title = "Drum Name";
+std::string_view RenameDrumUI::getName() const {
+	return getDrum()->name.get();
 }
 
-bool RenameDrumUI::opened() {
-	bool success = QwertyUI::opened();
-	if (!success) {
-		return false;
-	}
-
-	enteredText.set(&getDrum()->name);
-
-	displayText();
-
-	drawKeys();
-
-	return true;
-}
-
-bool RenameDrumUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
-	*cols = 0b11;
-	return true;
-}
-
-SoundDrum* RenameDrumUI::getDrum() {
+SoundDrum* RenameDrumUI::getDrum() const {
 	return (SoundDrum*)soundEditor.currentSound;
 }
 
-ActionResult RenameDrumUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
-	using namespace deluge::hid::button;
-
-	// Back button
-	if (b == BACK) {
-		if (on && !currentUIMode) {
-			if (inCardRoutine) {
-				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-			}
-			exitUI();
-		}
+bool RenameDrumUI::trySetName(const std::string_view& name) {
+	// don't let user set a name that is a duplicate of another name that has been set for another drum
+	if (!getDrum()->name.equalsCaseIrrespective(name) && getCurrentKit()->getDrumFromName(name.data())) {
+		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
+		return false;
 	}
-
-	// Select encoder button
-	else if (b == SELECT_ENC) {
-		if (on && !currentUIMode) {
-			if (inCardRoutine) {
-				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-			}
-			enterKeyPress();
-		}
-	}
-
-	else {
-		return ActionResult::NOT_DEALT_WITH;
-	}
-
-	return ActionResult::DEALT_WITH;
-}
-
-void RenameDrumUI::enterKeyPress() {
-
-	if (enteredText.isEmpty()) {
-		return;
-	}
-
-	// If actually changing it...
-	if (!getDrum()->name.equalsCaseIrrespective(&enteredText)) {
-		// don't let user set a name that is a duplicate of another name that has been set for another drum
-		if (getCurrentKit()->getDrumFromName(enteredText.get())) {
-			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
-			return;
-		}
-	}
-
-	getDrum()->name.set(&enteredText);
-	exitUI();
-}
-
-bool RenameDrumUI::exitUI() {
-	display->setNextTransitionDirection(-1);
-	close();
+	getDrum()->name.set(name.data(), name.size());
 	return true;
-}
-
-ActionResult RenameDrumUI::padAction(int32_t x, int32_t y, int32_t on) {
-
-	// Main pad
-	if (x < kDisplayWidth) {
-		return QwertyUI::padAction(x, y, on);
-	}
-
-	// Otherwise, exit
-	if (on && !currentUIMode) {
-		if (sdRoutineLock) {
-			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-		}
-		exitUI();
-	}
-
-	return ActionResult::DEALT_WITH;
-}
-
-ActionResult RenameDrumUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	return ActionResult::DEALT_WITH;
 }

--- a/src/deluge/gui/ui/rename/rename_drum_ui.h
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.h
@@ -24,21 +24,15 @@ class SoundDrum;
 
 class RenameDrumUI final : public RenameUI {
 public:
-	RenameDrumUI();
-	bool opened() override;
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
-	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
-	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
-
-	// ui
-	bool exitUI() override;
+	RenameDrumUI(const char* title_) : RenameUI(title){};
 
 protected:
-	void enterKeyPress() override;
+	bool trySetName(const std::string_view&) override;
+	std::string_view getName() const override;
+	bool allowEmpty() const override { return false; }
 
 private:
-	SoundDrum* getDrum();
+	SoundDrum* getDrum() const;
 };
 
 extern RenameDrumUI renameDrumUI;

--- a/src/deluge/gui/ui/rename/rename_drum_ui.h
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.h
@@ -24,7 +24,7 @@ class SoundDrum;
 
 class RenameDrumUI final : public RenameUI {
 public:
-	RenameDrumUI(const char* title_) : RenameUI(title){};
+	RenameDrumUI(const char* title_) : RenameUI(title_){};
 
 protected:
 	bool trySetName(const std::string_view&) override;

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
@@ -17,7 +17,6 @@
 
 #include "gui/ui/rename/rename_midi_cc_ui.h"
 #include "definitions_cxx.hpp"
-#include "extern.h"
 #include "gui/l10n/l10n.h"
 #include "gui/views/automation_view.h"
 #include "hid/buttons.h"
@@ -28,81 +27,29 @@
 #include "model/song/song.h"
 #include <string_view>
 
-RenameMidiCCUI renameMidiCCUI{};
+RenameMidiCCUI renameMidiCCUI{"CC Name"};
 
-RenameMidiCCUI::RenameMidiCCUI() {
-	title = "CC Name";
-}
-
-bool RenameMidiCCUI::opened() {
-	bool success = QwertyUI::opened();
-	if (!success) {
-		return false;
-	}
-
+bool RenameMidiCCUI::canRename() const {
 	Clip* clip = getCurrentClip();
-
 	int32_t cc = clip->lastSelectedParamID;
-
 	// if we're not dealing with a real cc number
 	// then don't allow user to edit the name
 	if (cc < 0 || cc == CC_EXTERNAL_MOD_WHEEL || cc >= kNumRealCCNumbers) {
 		return false;
 	}
+	else {
+		return true;
+	}
+}
 
+std::string_view RenameMidiCCUI::getName() const {
+	Clip* clip = getCurrentClip();
 	MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
-
-	std::string_view name = midiInstrument->getNameFromCC(cc);
-	if (!name.empty()) {
-		enteredText.set(name.data());
-	}
-	else {
-		enteredText.clear();
-	}
-
-	displayText();
-
-	drawKeys();
-
-	return true;
+	int32_t cc = clip->lastSelectedParamID;
+	return midiInstrument->getNameFromCC(cc);
 }
 
-bool RenameMidiCCUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
-	*cols = 0b11;
-	return true;
-}
-
-ActionResult RenameMidiCCUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
-	using namespace deluge::hid::button;
-
-	// Back button
-	if (b == BACK) {
-		if (on && !currentUIMode) {
-			if (inCardRoutine) {
-				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-			}
-			exitUI();
-		}
-	}
-
-	// Select encoder button
-	else if (b == SELECT_ENC) {
-		if (on && !currentUIMode) {
-			if (inCardRoutine) {
-				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-			}
-			enterKeyPress();
-		}
-	}
-
-	else {
-		return ActionResult::NOT_DEALT_WITH;
-	}
-
-	return ActionResult::DEALT_WITH;
-}
-
-void RenameMidiCCUI::enterKeyPress() {
+bool RenameMidiCCUI::trySetName(const std::string_view& name) {
 
 	Clip* clip = getCurrentClip();
 	MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
@@ -111,33 +58,5 @@ void RenameMidiCCUI::enterKeyPress() {
 	midiInstrument->setNameForCC(cc, enteredText.get());
 	midiInstrument->editedByUser = true; // need to set this to true so that the name gets saved with the song / preset
 
-	exitUI();
-}
-
-bool RenameMidiCCUI::exitUI() {
-	display->setNextTransitionDirection(-1);
-	close();
 	return true;
-}
-
-ActionResult RenameMidiCCUI::padAction(int32_t x, int32_t y, int32_t on) {
-
-	// Main pad
-	if (x < kDisplayWidth) {
-		return QwertyUI::padAction(x, y, on);
-	}
-
-	// Otherwise, exit
-	if (on && !currentUIMode) {
-		if (sdRoutineLock) {
-			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-		}
-		exitUI();
-	}
-
-	return ActionResult::DEALT_WITH;
-}
-
-ActionResult RenameMidiCCUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	return ActionResult::DEALT_WITH;
 }

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
@@ -25,18 +25,12 @@ class Clip;
 
 class RenameMidiCCUI final : public RenameUI {
 public:
-	RenameMidiCCUI();
-	bool opened() override;
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
-	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
-	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
-
-	// ui
-	bool exitUI() override;
+	RenameMidiCCUI(const char* title_) : RenameUI(title_) {}
 
 protected:
-	void enterKeyPress() override;
+	bool trySetName(const std::string_view&) override;
+	std::string_view getName() const override;
+	bool canRename() const override;
 };
 
 extern RenameMidiCCUI renameMidiCCUI;

--- a/src/deluge/gui/ui/rename/rename_output_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_output_ui.cpp
@@ -17,7 +17,6 @@
 
 #include "gui/ui/rename/rename_output_ui.h"
 #include "definitions_cxx.hpp"
-#include "extern.h"
 #include "gui/l10n/l10n.h"
 #include "gui/views/arranger_view.h"
 #include "hid/buttons.h"
@@ -26,107 +25,18 @@
 #include "model/output.h"
 #include "model/song/song.h"
 
-RenameOutputUI renameOutputUI{};
+RenameOutputUI renameOutputUI{"Track name"};
 
-RenameOutputUI::RenameOutputUI() {
-	title = "Track Name";
+std::string_view RenameOutputUI::getName() const {
+	return output->name.get();
 }
 
-bool RenameOutputUI::opened() {
-	bool success = QwertyUI::opened();
-	if (!success) {
+bool RenameOutputUI::trySetName(const std::string_view& name) {
+	// Duplicate names not allowed for audio outputs.
+	if (!output->name.equalsCaseIrrespective(name) && currentSong->getAudioOutputFromName(name)) {
+		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 		return false;
 	}
-
-	enteredText.set(&output->name);
-
-	displayText();
-
-	drawKeys();
-
+	output->name.set(name.data(), name.size());
 	return true;
-}
-
-bool RenameOutputUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
-	*cols = 0b11;
-	return true;
-}
-
-ActionResult RenameOutputUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
-	using namespace deluge::hid::button;
-
-	// Back button
-	if (b == BACK) {
-		if (on && !currentUIMode) {
-			if (inCardRoutine) {
-				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-			}
-			exitUI();
-		}
-	}
-
-	// Select encoder button
-	else if (b == SELECT_ENC) {
-		if (on && !currentUIMode) {
-			if (inCardRoutine) {
-				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-			}
-			enterKeyPress();
-		}
-	}
-
-	else {
-		return ActionResult::NOT_DEALT_WITH;
-	}
-
-	return ActionResult::DEALT_WITH;
-}
-
-void RenameOutputUI::enterKeyPress() {
-
-	if (enteredText.isEmpty()) {
-		return;
-	}
-
-	// If actually changing it...
-	if (!output->name.equalsCaseIrrespective(&enteredText)) {
-		// if this is an audio output
-		// don't let user set a name that is a duplicate of another name that has been set for another audio output
-		// Sean: do we only want to do this for audio output's?
-		if (currentSong->getAudioOutputFromName(&enteredText)) {
-			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
-			return;
-		}
-	}
-
-	output->name.set(&enteredText);
-	exitUI();
-}
-
-bool RenameOutputUI::exitUI() {
-	display->setNextTransitionDirection(-1);
-	close();
-	return true;
-}
-
-ActionResult RenameOutputUI::padAction(int32_t x, int32_t y, int32_t on) {
-
-	// Main pad
-	if (x < kDisplayWidth) {
-		return QwertyUI::padAction(x, y, on);
-	}
-
-	// Otherwise, exit
-	if (on && !currentUIMode) {
-		if (sdRoutineLock) {
-			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-		}
-		exitUI();
-	}
-
-	return ActionResult::DEALT_WITH;
-}
-
-ActionResult RenameOutputUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	return ActionResult::DEALT_WITH;
 }

--- a/src/deluge/gui/ui/rename/rename_output_ui.h
+++ b/src/deluge/gui/ui/rename/rename_output_ui.h
@@ -24,20 +24,13 @@ class Output;
 
 class RenameOutputUI final : public RenameUI {
 public:
-	RenameOutputUI();
-	bool opened() override;
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
-	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
-	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
-
+	RenameOutputUI(const char* title_) : RenameUI(title){};
+	// Assigned before openUI() is called -- not necessarily the current output!
 	Output* output;
 
-	// ui
-	bool exitUI() override;
-
 protected:
-	void enterKeyPress() override;
+	bool trySetName(const std::string_view& name) override;
+	std::string_view getName() const override;
 };
 
 extern RenameOutputUI renameOutputUI;

--- a/src/deluge/gui/ui/rename/rename_output_ui.h
+++ b/src/deluge/gui/ui/rename/rename_output_ui.h
@@ -24,7 +24,7 @@ class Output;
 
 class RenameOutputUI final : public RenameUI {
 public:
-	RenameOutputUI(const char* title_) : RenameUI(title){};
+	RenameOutputUI(const char* title_) : RenameUI(title_){};
 	// Assigned before openUI() is called -- not necessarily the current output!
 	Output* output;
 

--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -16,12 +16,41 @@
  */
 
 #include "gui/ui/rename/rename_ui.h"
+#include "extern.h"
 #include "gui/ui/qwerty_ui.h"
 #include "hid/display/oled.h"
 
-RenameUI::RenameUI() {
+RenameUI::RenameUI(const char* title_) {
+	title = title_;
 	scrollPosHorizontal = 0;
 	oledShowsUIUnderneath = true;
+}
+
+bool RenameUI::opened() {
+	if (!QwertyUI::opened()) {
+		return false;
+	}
+	if (!canRename()) {
+		return false;
+	}
+
+	std::string_view name = getName();
+	enteredText.clear();
+	enteredText.concatenate(name);
+
+	displayText();
+	drawKeys();
+
+	return true;
+}
+
+void RenameUI::enterKeyPress() {
+	if (enteredText.isEmpty() && !allowEmpty()) {
+		return;
+	}
+	if (trySetName(enteredText.get())) {
+		exitUI();
+	}
 }
 
 void RenameUI::displayText(bool blinkImmediately) {
@@ -31,6 +60,11 @@ void RenameUI::displayText(bool blinkImmediately) {
 	else {
 		QwertyUI::displayText(blinkImmediately);
 	}
+}
+
+bool RenameUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
+	*cols = 0b11;
+	return true;
 }
 
 void RenameUI::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
@@ -56,4 +90,62 @@ void RenameUI::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	canvas.drawRectangle(boxStartPixel, 24, OLED_MAIN_WIDTH_PIXELS - boxStartPixel, 38);
 
 	drawTextForOLEDEditing(charsStartPixel, OLED_MAIN_WIDTH_PIXELS - charsStartPixel + 1, 27, maxNumChars, canvas);
+}
+
+bool RenameUI::exitUI() {
+	display->setNextTransitionDirection(-1);
+	close();
+	return true;
+}
+
+ActionResult RenameUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
+	using namespace deluge::hid::button;
+
+	// Back button
+	if (b == BACK) {
+		if (on && !currentUIMode) {
+			if (inCardRoutine) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			}
+			exitUI();
+		}
+	}
+
+	// Select encoder button
+	else if (b == SELECT_ENC) {
+		if (on && !currentUIMode) {
+			if (inCardRoutine) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			}
+			enterKeyPress();
+		}
+	}
+
+	else {
+		return ActionResult::NOT_DEALT_WITH;
+	}
+
+	return ActionResult::DEALT_WITH;
+}
+
+ActionResult RenameUI::padAction(int32_t x, int32_t y, int32_t on) {
+
+	// Main pad
+	if (x < kDisplayWidth) {
+		return QwertyUI::padAction(x, y, on);
+	}
+
+	// Otherwise, exit
+	if (on && !currentUIMode) {
+		if (sdRoutineLock) {
+			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+		}
+		exitUI();
+	}
+
+	return ActionResult::DEALT_WITH;
+}
+
+ActionResult RenameUI::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
+	return ActionResult::DEALT_WITH;
 }

--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -20,7 +20,7 @@
 #include "gui/ui/qwerty_ui.h"
 #include "hid/display/oled.h"
 
-RenameUI::RenameUI(const char* title_) {
+RenameUI::RenameUI(const char* title_) : QwertyUI() {
 	title = title_;
 	scrollPosHorizontal = 0;
 	oledShowsUIUnderneath = true;

--- a/src/deluge/gui/ui/rename/rename_ui.h
+++ b/src/deluge/gui/ui/rename/rename_ui.h
@@ -21,11 +21,21 @@
 
 class RenameUI : public QwertyUI {
 public:
-	RenameUI();
-
+	RenameUI(const char* title_);
+	bool opened();
 	void displayText(bool blinkImmediately = false) override;
 	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
-
-	// ui
+	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
+	bool exitUI() override;
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
+	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
+	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
 	UIType getUIType() override { return UIType::RENAME; }
+
+protected:
+	void enterKeyPress() override;
+	virtual bool trySetName(const std::string_view&) = 0;
+	virtual std::string_view getName() const = 0;
+	virtual bool canRename() const { return true; }
+	virtual bool allowEmpty() const { return true; }
 };

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -11,9 +11,7 @@
 #include "gui/ui/audio_recorder.h"
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
-#include "gui/ui/rename/rename_clip_ui.h"
 #include "gui/ui/rename/rename_drum_ui.h"
-#include "gui/ui/rename/rename_output_ui.h"
 #include "gui/ui/sample_marker_editor.h"
 #include "gui/ui/save/save_instrument_preset_ui.h"
 #include "gui/ui/ui.h"
@@ -589,7 +587,7 @@ void SoundEditor::updatePadLightsFor(MenuItem* currentItem) {
 
 	if (!inSettingsMenu() && !inNoteEditor() && currentItem != &sampleStartMenu && currentItem != &sampleEndMenu
 	    && currentItem != &audioClipSampleMarkerEditorMenuStart && currentItem != &audioClipSampleMarkerEditorMenuEnd
-	    && currentItem != &fileSelectorMenu && currentItem != static_cast<void*>(&drumNameMenu)) {
+	    && currentItem != &fileSelectorMenu && currentItem != static_cast<void*>(&nameEditMenu)) {
 
 		memset(sourceShortcutBlinkFrequencies, 255, sizeof(sourceShortcutBlinkFrequencies));
 		memset(sourceShortcutBlinkColours, 0, sizeof(sourceShortcutBlinkColours));
@@ -693,6 +691,8 @@ bool SoundEditor::beginScreen(MenuItem* oldMenuItem) {
 	currentItem->beginSession(oldMenuItem);
 
 	// If that didn't succeed (file browser)
+	// XXX: Why do we need to check for renameDrumUI, but not other rename UIs? either way, this should probably
+	// be a virtual function getCurrentUI()->noSoundEditor() or something.
 	if (getCurrentUI() != &soundEditor && getCurrentUI() != &sampleBrowser && getCurrentUI() != &audioRecorder
 	    && getCurrentUI() != &sampleMarkerEditor && getCurrentUI() != &renameDrumUI) {
 		return false;
@@ -943,33 +943,11 @@ ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool 
 		// AudioClips - there are just a few shortcuts
 		else if (getCurrentClip()->type == ClipType::AUDIO) {
 
-			// NAME shortcut
-			if (x == 11 && y == 5) {
-				// Renames the output (track), not the clip
-				Output* output = getCurrentOutput();
-				if (output) {
-					renameOutputUI.output = output;
-					openUI(&renameOutputUI);
-					return ActionResult::DEALT_WITH;
-				}
-			}
-			else if (x <= 14) {
+			if (x <= 14) {
 				item = paramShortcutsForAudioClips[x][y];
 			}
 
 			goto doSetup;
-		}
-
-		else if (x == 11 && y == 5) {
-
-			if (handleClipName()) {
-				ActionResult::DEALT_WITH;
-			}
-			else {
-				item = paramShortcutsForSounds[x][y];
-				parent = parentsForSoundShortcuts[x][y];
-				goto doSetup;
-			}
 		}
 
 		else {
@@ -1758,7 +1736,7 @@ void SoundEditor::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) 
 
 	// Sorry - extremely ugly hack here.
 	MenuItem* currentMenuItem = getCurrentMenuItem();
-	if (currentMenuItem == static_cast<void*>(&drumNameMenu)) {
+	if (currentMenuItem == static_cast<void*>(&nameEditMenu)) {
 		if (!navigationDepth) {
 			return;
 		}
@@ -1768,32 +1746,6 @@ void SoundEditor::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) 
 	currentMenuItem->renderOLED();
 }
 
-bool SoundEditor::handleClipName() {
-
-	Clip* clip = getCurrentClip();
-	Output* output = getCurrentOutput();
-
-	switch (clip->type) {
-
-	case ClipType::INSTRUMENT:
-
-		if (output->type == OutputType::SYNTH || output->type == OutputType::MIDI_OUT
-		    || (output->type == OutputType::KIT && getRootUI()->getAffectEntire())) {
-			if (clip) {
-				renameClipUI.clip = clip;
-				openUI(&renameClipUI);
-				return true;
-			}
-		}
-		else {
-
-			return false;
-		}
-
-	default:
-		return false;
-	}
-}
 /*
 char modelStackMemory[MODEL_STACK_MAX_SIZE];
 ModelStackWithThreeMainThings* modelStack = soundEditor.getCurrentModelStack(modelStackMemory);

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1207,7 +1207,7 @@ someError:
 
 Error AudioClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 
-	output = modelStack->song->getAudioOutputFromName(&outputNameWhileLoading);
+	output = modelStack->song->getAudioOutputFromName(outputNameWhileLoading.get());
 
 	if (!output) {
 		return Error::FILE_CORRUPTED;

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -53,7 +53,7 @@ Output::~Output() {
 	}
 }
 
-Clip* Output::getClipFromName(String* name) {
+Clip* Output::getClipFromName(const std::string_view& name) {
 	for (Clip* clip : AllClips::everywhere(currentSong)) {
 		if (clip->output == this && clip->name.equalsCaseIrrespective(name)) {
 			return clip;

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -137,7 +137,7 @@ public:
 	                                    GlobalEffectableForClip** globalEffectableWithMostReverb,
 	                                    int32_t* highestReverbAmountFound) {}
 	/// If there's a clip matching the name on this output, returns it.
-	Clip* getClipFromName(String* name);
+	Clip* getClipFromName(const std::string_view& name);
 
 	/// Pitch bend is available in the mod matrix as X and shouldn't be learned to params anymore (post 4.0)
 	virtual bool offerReceivedPitchBendToLearnedParams(MIDICable& cable, uint8_t channel, uint8_t data1, uint8_t data2,

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3570,7 +3570,7 @@ void Song::markAllInstrumentsAsEdited() {
 
 // used with the renameOutputUI class to check if you're trying to rename an output to the same
 // name as another output
-AudioOutput* Song::getAudioOutputFromName(String* name) {
+AudioOutput* Song::getAudioOutputFromName(const std::string_view& name) {
 	for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
 		if (thisOutput->type == OutputType::AUDIO) {
 			if (thisOutput->name.equalsCaseIrrespective(name)) {

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -166,7 +166,7 @@ public:
 	Instrument* getInstrumentFromPresetSlot(OutputType outputType, int32_t presetNumber, int32_t presetSubSlotNumber,
 	                                        char const* name, char const* dirPath, bool searchHibernatingToo = true,
 	                                        bool searchNonHibernating = true);
-	AudioOutput* getAudioOutputFromName(String* name);
+	AudioOutput* getAudioOutputFromName(const std::string_view& name);
 	void setupPatchingForAllParamManagers();
 	void replaceInstrument(Instrument* oldInstrument, Instrument* newInstrument, bool keepNoteRowsWithMIDIInput = true);
 	void stopAllMIDIAndGateNotesPlaying();

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -200,6 +200,10 @@ Error String::concatenate(char const* newChars) {
 	return concatenateAtPos(newChars, getLength());
 }
 
+Error String::concatenate(const std::string_view& otherString) {
+	return concatenateAtPos(otherString.data(), getLength(), otherString.size());
+}
+
 Error String::concatenateAtPos(char const* newChars, int32_t pos, int32_t newCharsLength) {
 	if (pos == 0) {
 		return set(newChars, newCharsLength);
@@ -316,8 +320,11 @@ bool String::equals(char const* otherChars) {
 	return !strcmp(get(), otherChars);
 }
 
-bool String::equalsCaseIrrespective(char const* otherChars) {
-	return !strcasecmp(get(), otherChars);
+bool String::equalsCaseIrrespective(char const* otherChars, int32_t numChars) {
+	if (numChars < 0) {
+		numChars = strlen(otherChars);
+	}
+	return !strncasecmp(get(), otherChars, numChars);
 }
 
 /**********************************************************************************************************************\

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -60,8 +60,9 @@ public:
 	Error setChar(char newChar, int32_t pos);
 	Error concatenate(String* otherString);
 	Error concatenate(char const* newChars);
+	Error concatenate(const std::string_view& otherString);
 	bool equals(char const* otherChars);
-	bool equalsCaseIrrespective(char const* otherChars);
+	bool equalsCaseIrrespective(char const* otherChars, int32_t numChars = -1);
 
 	inline bool contains(const char* otherChars) { return strstr(stringMemory, otherChars) != NULL; }
 	inline bool equals(String* otherString) {
@@ -74,7 +75,11 @@ public:
 		return equals(otherString->get());
 	}
 
-	inline bool equalsCaseIrrespective(String* otherString) {
+	inline bool equalsCaseIrrespective(const std::string_view& otherString) {
+		return equalsCaseIrrespective(otherString.data(), otherString.size());
+	}
+
+	inline bool equalsCaseIrrespective(const String* otherString) {
 		if (stringMemory == otherString->stringMemory) {
 			return true; // Works if both lengths are 0, too
 		}
@@ -84,7 +89,7 @@ public:
 		return equalsCaseIrrespective(otherString->get());
 	}
 
-	inline char const* get() {
+	inline char const* get() const {
 		if (!stringMemory) {
 			return &nothing;
 		}


### PR DESCRIPTION
- allow deleting names (by replacing them with empty) for all but drums

- consolidate shared code in RenameUI class: subclasses implement only a couple of methods to specialize their behaviour

- ad-hoc dispatch in sound_editor.cpp replaced with normal shortcut machinery

- shrinks the binary by just a hair, but *shrinks*, not grows!