### PR TITLE
enable some warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,12 +209,12 @@ list(APPEND DELUGE_COMMON_COMPILE_OPTIONS
 
     # Warnings
     -Warray-bounds=1
+    -Wnull-dereference
     -Wsequence-point
     $<$<BOOL:${MAINTAINER_MODE}>:-Wextra>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wall>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wabi>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wpedantic>
-    $<$<CONFIG:DEBUG>:-Wnull-dereference>
     $<$<CONFIG:DEBUG>:-Wno-psabi>
     $<$<CONFIG:DEBUG>:-Wno-unused-parameter>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ list(APPEND DELUGE_COMMON_COMPILE_OPTIONS
     -Wnull-dereference
     -Wparentheses
     -Wsequence-point
+    -Wswitch
     $<$<BOOL:${MAINTAINER_MODE}>:-Wextra>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wall>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wabi>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ list(APPEND DELUGE_COMMON_COMPILE_OPTIONS
     # Warnings
     -Warray-bounds=1
     -Wnull-dereference
+    -Wparentheses
     -Wsequence-point
     $<$<BOOL:${MAINTAINER_MODE}>:-Wextra>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wall>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ list(APPEND DELUGE_COMMON_COMPILE_OPTIONS
     $<$<AND:$<BOOL:${MAINTAINER_MODE}>,$<CXX_COMPILER_ID:GNU>>:-fanalyzer> # static analysis
 
     # Warnings
+    -Warray-bounds=1
     -Wsequence-point
     $<$<BOOL:${MAINTAINER_MODE}>:-Wextra>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wall>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ list(APPEND DELUGE_COMMON_COMPILE_OPTIONS
     $<$<AND:$<BOOL:${MAINTAINER_MODE}>,$<CXX_COMPILER_ID:GNU>>:-fanalyzer> # static analysis
 
     # Warnings
+    -Wsequence-point
     $<$<BOOL:${MAINTAINER_MODE}>:-Wextra>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wall>
     $<$<BOOL:${MAINTAINER_MODE}>:-Wabi>

--- a/src/deluge/dsp/envelope_follower/absolute_value.h
+++ b/src/deluge/dsp/envelope_follower/absolute_value.h
@@ -61,7 +61,7 @@ private:
 	float attackMS{1};
 	float releaseMS{10};
 	// parameters in use
-	float a_ = a_ = (-1000.0f / kSampleRate) / attackMS;
+	float a_ = (-1000.0f / kSampleRate) / attackMS;
 
 	float r_ = (-1000.0f / kSampleRate) / releaseMS;
 

--- a/src/deluge/gui/menu_item/dx/engine_select.cpp
+++ b/src/deluge/gui/menu_item/dx/engine_select.cpp
@@ -51,7 +51,7 @@ void DxEngineSelect::drawValue() {
 		renderUIsForOled();
 	}
 	else {
-		static const char*(items[]) = {"AUTO", "MODR", "VINT"};
+		static const char* items[] = {"AUTO", "MODR", "VINT"};
 		display->setScrollingText(items[currentValue]);
 	}
 }

--- a/src/deluge/gui/menu_item/source_selection.cpp
+++ b/src/deluge/gui/menu_item/source_selection.cpp
@@ -123,6 +123,11 @@ void SourceSelection::drawValue() {
 	case PatchSource::Y:
 		text = STRING_FOR_PATCH_SOURCE_Y;
 		break;
+
+	// explicit fallthrough cases
+	case PatchSource::NOT_AVAILABLE:
+	case PatchSource::SOON:
+	case PatchSource::NONE:;
 	}
 
 	uint8_t drawDot = shouldDrawDotOnValue();

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -212,6 +212,8 @@ ControlColumn* ColumnControlState::getColumnForFunc(ColumnControlFunction func) 
 		return &dxColumn;
 	case SESSION:
 		return &sessionColumn;
+	// explicit fallthrough cases
+	case COL_CTRL_FUNC_MAX:;
 	}
 	return nullptr;
 }
@@ -234,6 +236,9 @@ const char* columnFunctionToString(ColumnControlFunction func) {
 		return "dx";
 	case SESSION:
 		return "session";
+	// explicit fallthrough cases
+	case COL_CTRL_FUNC_MAX: // counter: should not appear here
+	    ;
 	}
 	return "";
 }

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -86,11 +86,17 @@ bool LoadInstrumentPresetUI::opened() {
 	switch (instrumentToReplace->type) {
 	case OutputType::MIDI_OUT:
 		initialChannelSuffix = ((MIDIInstrument*)instrumentToReplace)->channelSuffix;
-		// No break
+		// intentional fallthrough to share code with CV case
 
 	case OutputType::CV:
 		initialChannel = ((NonAudioInstrument*)instrumentToReplace)->getChannel();
 		break;
+
+	// explicit fallthrough cases
+	case OutputType::AUDIO:
+	case OutputType::SYNTH:
+	case OutputType::KIT:
+	case OutputType::NONE:;
 	}
 
 	changedInstrumentForClip = false;
@@ -166,6 +172,11 @@ Error LoadInstrumentPresetUI::setupForOutputType() {
 				fileIcon = deluge::hid::display::OLED::midiIcon;
 				fileIconPt2 = deluge::hid::display::OLED::midiIconPt2;
 				fileIconPt2Width = 1;
+				break;
+			// explicit fallthrough cases
+			case OutputType::AUDIO:
+			case OutputType::CV:
+			case OutputType::NONE:;
 			}
 		}
 	}

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
@@ -86,6 +86,11 @@ tryDefaultDir:
 			fileIcon = deluge::hid::display::OLED::midiIcon;
 			fileIconPt2 = deluge::hid::display::OLED::midiIconPt2;
 			fileIconPt2Width = 1;
+			break;
+		// explicit fallthrough cases
+		case OutputType::CV:
+		case OutputType::AUDIO:
+		case OutputType::NONE:;
 		}
 	}
 
@@ -187,6 +192,10 @@ fail:
 		break;
 	case OutputType::MIDI_OUT:
 		endString = "\n</midi>\n";
+	// explicit fallthrough cases
+	case OutputType::AUDIO:
+	case OutputType::CV:
+	case OutputType::NONE:;
 	}
 
 	error = GetSerializer().closeFileAfterWriting(filePath.get(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -900,7 +900,7 @@ ActionResult SoundEditor::potentialShortcutPadAction(int32_t x, int32_t y, bool 
 	}
 	else {
 		// allow automation view to handle interpolation and pad selection shortcut
-		if ((getRootUI() == &automationView) && (x == 0 && (y == 6) || (y == 7))) {
+		if ((getRootUI() == &automationView) && (x == 0) && ((y == 6) || (y == 7))) {
 			ignoreAction = true;
 		}
 	}
@@ -1778,7 +1778,7 @@ bool SoundEditor::handleClipName() {
 	case ClipType::INSTRUMENT:
 
 		if (output->type == OutputType::SYNTH || output->type == OutputType::MIDI_OUT
-		    || output->type == OutputType::KIT && getRootUI()->getAffectEntire()) {
+		    || (output->type == OutputType::KIT && getRootUI()->getAffectEntire())) {
 			if (clip) {
 				renameClipUI.clip = clip;
 				openUI(&renameClipUI);

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -226,6 +226,10 @@ void UITimerManager::routine() {
 				case TimerName::SYSEX_DISPLAY:
 					HIDSysex::sendDisplayIfChanged();
 					break;
+
+				// explicit fallthrough cases
+				case TimerName::METER_INDICATOR_BLINK: // really nothing for this?
+				case TimerName::NUM_TIMERS:;
 				}
 			}
 		}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -5922,7 +5922,7 @@ void InstrumentClipView::commandQuantizeNotes(int8_t offset, NudgeMode nudgeMode
 	}
 
 	// Get the action in to which we should back up the current state
-	Action* action = action = actionLogger.getNewAction(ActionType::NOTE_NUDGE, ActionAddition::ALLOWED);
+	Action* action = actionLogger.getNewAction(ActionType::NOTE_NUDGE, ActionAddition::ALLOWED);
 	if (action) {
 		// XXX(sapphire): the old QUANTIZE_ALL code used quantizeAmount here instead, but I don't think anything
 		// reads this so it's probably fine?

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -117,6 +117,8 @@ bool SessionView::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 			*rows = 0x0;
 			break;
 		}
+		// explicit fallthrough cases
+		case SessionLayoutType::SessionLayoutTypeMaxElement:;
 		}
 
 		return true;
@@ -616,6 +618,8 @@ doActualSimpleChange:
 							}
 							break;
 						}
+						// explicit fallthrough cases
+						case SessionLayoutType::SessionLayoutTypeMaxElement:;
 						}
 					}
 				}
@@ -1309,6 +1313,8 @@ void SessionView::commandChangeClipPreset(int8_t offset) {
 			}
 			break;
 		}
+		// explicit fallthrough cases
+		case SessionLayoutType::SessionLayoutTypeMaxElement:;
 		}
 	}
 	else {
@@ -2565,6 +2571,8 @@ void SessionView::flashPlayRoutine() {
 		}
 		break;
 	}
+	// explicit fallthrough cases
+	case SessionLayoutType::SessionLayoutTypeMaxElement:;
 	}
 }
 
@@ -3063,6 +3071,8 @@ void SessionView::selectLayout(int8_t offset) {
 			currentSong->sessionLayout = SessionLayoutType::SessionLayoutTypeRows;
 			break;
 		}
+		// explicit fallthrough cases
+		case SessionLayoutType::SessionLayoutTypeMaxElement:;
 		}
 		renderLayoutChange();
 	}
@@ -3824,6 +3834,8 @@ ActionResult SessionView::gridHandlePads(int32_t x, int32_t y, int32_t on) {
 			modeHandleResult = gridHandlePadsMacros(x, y, on, clip);
 			break;
 		}
+		// explicit fallthrough cases
+		case SessionGridModeMaxElement:;
 		}
 
 		if (modeHandleResult == ActionResult::DEALT_WITH) {

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -269,6 +269,9 @@ private:
 			gridModeSelected = SessionGridModeEdit;
 			break;
 		}
+		// explicit fallthrough cases
+		case GridDefaultActiveModeSelection: // handled outside
+		case GridDefaultActiveModeMaxElement:;
 		}
 	}
 	void setupTrackCreation() const;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -579,6 +579,13 @@ void View::endMidiLearnPressSession(MidiLearn newThingPressed) {
 	case MidiLearn::TAP_TEMPO_BUTTON:
 		playbackHandler.setLedStates();
 		break;
+	// explicit fallthrough cases
+	case MidiLearn::CLIP:
+	case MidiLearn::NONE:
+	case MidiLearn::NOTEROW_MUTE:
+	case MidiLearn::SECTION:
+	case MidiLearn::INSTRUMENT_INPUT:
+	case MidiLearn::DRUM_INPUT:;
 	}
 
 	learnedThing = nullptr;
@@ -1427,6 +1434,10 @@ void View::setModLedStates() {
 				itsTheSong = true;
 			}
 			break;
+
+		default:
+		    // fallthrough for everything else -- to many UIs to list explicitly
+		    ;
 		}
 	}
 
@@ -1465,6 +1476,9 @@ void View::setModLedStates() {
 		case UIType::AUDIO_CLIP:
 			affectEntire = true;
 			break;
+		default:
+		    // fallthrough for everything else -- to many UIs to list explicitly
+		    ;
 		}
 	}
 	indicator_leds::setLedState(IndicatorLED::AFFECT_ENTIRE, affectEntire);
@@ -1508,6 +1522,9 @@ void View::setModLedStates() {
 		case UIType::AUTOMATION:
 			onAutomationClipView = true;
 			break;
+		default:
+		    // fallthrough for everything else -- to many UIs to list explicitly
+		    ;
 		}
 
 		if (onAutomationClipView) {
@@ -1545,6 +1562,9 @@ void View::setModLedStates() {
 			case UIType::SESSION:
 				indicator_leds::setLedState(IndicatorLED::SESSION_VIEW, true);
 				break;
+			default:
+			    // fallthrough for everything else -- to many UIs to list explicitly
+			    ;
 			}
 		}
 	}
@@ -1905,6 +1925,12 @@ void View::displayOutputName(Output* output, bool doBlink, Clip* clip) {
 		case OutputType::CV:
 			channel = ((NonAudioInstrument*)instrument)->getChannel();
 			break;
+
+		// explicit fallthrough cases
+		case OutputType::SYNTH:
+		case OutputType::KIT:
+		case OutputType::AUDIO:
+		case OutputType::NONE:;
 		}
 	}
 	else {
@@ -2753,6 +2779,8 @@ bool View::renderMacros(int32_t column, uint32_t y, int32_t selectedMacro, RGB i
 	case NO_MACRO:
 		image[y][column] = {dark, dark, dark};
 		break;
+	// explicit fallthrough
+	case NUM_KINDS:;
 	}
 
 	if (occupancyMask) {

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -177,6 +177,11 @@ checkResult:
 					getCurrentUI()->selectEncoderAction(limitedDetentPos);
 				}
 				break;
+
+			// explicit fallthrough cases
+			case EncoderName::MOD_0: // nothing, really?
+			case EncoderName::MAX_ENCODER:
+			case EncoderName::MAX_FUNCTION_ENCODERS:;
 			}
 		}
 	}

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -233,6 +233,10 @@ MidiFollow::getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelSt
 		modelStackWithParam =
 		    getModelStackWithParamForAudioClip(modelStackWithTimelineCounter, clip, xDisplay, yDisplay);
 		break;
+	// explicit fallthrough cases
+	case OutputType::CV:
+	case OutputType::MIDI_OUT:
+	case OutputType::NONE:;
 	}
 
 	return modelStackWithParam;

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -378,9 +378,9 @@ ActionResult InstrumentClipMinder::buttonAction(deluge::hid::Button b, bool on, 
 		if (getCurrentOutputType() == OutputType::MIDI_OUT && (b == MOD_ENCODER_0 || b == MOD_ENCODER_1)) {
 			openUI(&saveMidiDeviceDefinitionUI);
 		}
-		else if (b == SYNTH && getCurrentOutputType() == OutputType::SYNTH
-		         || b == KIT && getCurrentOutputType() == OutputType::KIT
-		         || b == MIDI && getCurrentOutputType() == OutputType::MIDI_OUT) {
+		else if ((b == SYNTH && getCurrentOutputType() == OutputType::SYNTH)
+		         || (b == KIT && getCurrentOutputType() == OutputType::KIT)
+		         || (b == MIDI && getCurrentOutputType() == OutputType::MIDI_OUT)) {
 			openUI(&saveInstrumentPresetUI);
 		}
 	}

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -490,6 +490,9 @@ int32_t GlobalEffectable::getKnobPosForNonExistentParam(int32_t whichModEncoder,
 			case CompParam::BLEND:
 				current = compressor.getBlend() >> 24;
 				break;
+
+			// explicit fallthrough case
+			case CompParam::LAST:;
 			}
 		}
 	}
@@ -573,7 +576,7 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				unit = " HZ";
 				break;
 
-			case CompParam::BLEND:
+			case CompParam::BLEND: {
 				if (display->haveOLED()) {
 					popupMsg.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_BLEND));
 				}
@@ -585,6 +588,10 @@ ActionResult GlobalEffectable::modEncoderActionForNonExistentParam(int32_t offse
 				displayLevel = compressor.setBlend(level);
 				unit = " %";
 				break;
+			}
+
+			// explicit fallthrough case
+			case CompParam::LAST:;
 			}
 			indicator_leds::setKnobIndicatorLevel(0, ledLevel);
 		}

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -394,7 +394,7 @@ doReturnNoError:
 				if (!clusterHere) {
 
 					// That's actually allowed if we're right at the start of that cluster. But otherwise...
-					if (startPosSamples & ((1 << Cluster::size_magnitude + kPercBufferReductionMagnitude) - 1)) {
+					if (startPosSamples & ((1 << (Cluster::size_magnitude + kPercBufferReductionMagnitude)) - 1)) {
 						// If Cluster has been stolen, the zones should have been updated, so we shouldn't be here
 						D_PRINTLN("startPosSamples: %d", startPosSamples);
 						FREEZE_WITH_ERROR("E139");

--- a/src/deluge/model/sample/sample_holder_for_voice.cpp
+++ b/src/deluge/model/sample/sample_holder_for_voice.cpp
@@ -95,7 +95,7 @@ void SampleHolderForVoice::claimClusterReasons(bool reversed, int32_t clusterLoa
 
 	else if (((Sample*)audioFile)->clusters.getNumElements() <= 4) {
 		// claim the next few reasons for the sample instead since we can keep it all cached
-		int32_t nextClusterStartByte = ((Sample*)audioFile)->audioDataStartPosBytes + Cluster::size_magnitude << 1;
+		int32_t nextClusterStartByte = (((Sample*)audioFile)->audioDataStartPosBytes + Cluster::size_magnitude) << 1;
 
 		claimClusterReasonsForMarker(clustersForLoopStart, nextClusterStartByte, playDirection, clusterLoadInstruction);
 	}

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1315,6 +1315,8 @@ weAreInArrangementEditorOrInClipInstance:
 				break;
 			case NO_MACRO:
 				break;
+			// explicit fallthrough cases
+			case NUM_KINDS:;
 			}
 			writer.closeTag(true);
 		}

--- a/src/deluge/modulation/arpeggiator.cpp
+++ b/src/deluge/modulation/arpeggiator.cpp
@@ -531,6 +531,8 @@ void ArpeggiatorForDrum::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnIn
 				// velocity = ((arpNote.mpeValues[util::to_underlying(Expression::Y_SLIDE_TIMBRE)] >> 1) + (1 << 14)) >>
 				// 8;
 				break;
+			// explicit fallthrough case
+			case ArpMpeModSource::OFF:;
 			}
 			// Fix base velocity if it's outside of MPE-controlled bounds
 			if (velocity < MIN_MPE_MODULATED_VELOCITY) {
@@ -893,6 +895,8 @@ void Arpeggiator::switchNoteOn(ArpeggiatorSettings* settings, ArpReturnInstructi
 			case ArpMpeModSource::MPE_Y:
 				velocity = arpNote->mpeValues[util::to_underlying(Expression::Y_SLIDE_TIMBRE)] >> 8;
 				break;
+			// explicit fallthrough case
+			case ArpMpeModSource::OFF:;
 			}
 			// Fix base velocity if it's outside of MPE-controlled bounds
 			if (velocity < MIN_MPE_MODULATED_VELOCITY) {

--- a/src/deluge/modulation/params/param.cpp
+++ b/src/deluge/modulation/params/param.cpp
@@ -426,9 +426,10 @@ constexpr char const* paramNameForFileConst(Kind const kind, ParamType const par
 
 		case UNPATCHED_PITCH_ADJUST:
 			return "pitchAdjust";
-		case UNPATCHED_GLOBAL_MAX_NUM:
-		    // Intentional fallthrough, not handled
-		    ;
+
+		// explicit fallthrough cases
+		case UNPATCHED_TEMPO: // nothing, really?
+		case UNPATCHED_GLOBAL_MAX_NUM:;
 		}
 	}
 

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -163,6 +163,9 @@ void PlaybackHandler::slowRoutine() {
 			case GlobalMIDICommand::REDO:
 				actionLogger.redo();
 				break;
+
+			// we're explicitly only interedted in UNDO and REDO
+			default:;
 			}
 
 			if (ALPHA_OR_BETA_VERSION && pendingGlobalMIDICommandNumClustersWritten) {

--- a/src/deluge/processing/live/live_pitch_shifter.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter.cpp
@@ -612,8 +612,8 @@ stopPercSearch:
 			goto stopSearch;
 		}
 
-		if ((uint32_t)(numRawSamplesProcessedLatest - averagesStartPosNewHead)
-		    & (kInputRawBufferSize - 1) < lengthPerMovingAverage * TimeStretch::Crossfade::kNumMovingAverages) {
+		if (((uint32_t)(numRawSamplesProcessedLatest - averagesStartPosNewHead) & (kInputRawBufferSize - 1))
+		    < lengthPerMovingAverage * TimeStretch::Crossfade::kNumMovingAverages) {
 			goto stopSearch;
 		}
 

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -243,6 +243,12 @@ bool Cluster::mayBeStolen(void* thingNotToStealFrom) {
 	case Type::PERC_CACHE_FORWARDS:
 	case Type::PERC_CACHE_REVERSED:
 		return (sample != thingNotToStealFrom);
+
+	// explicit fallthrough cases
+	case Type::SAMPLE:
+	case Type::EMPTY:
+	case Type::GENERAL_MEMORY:
+	case Type::OTHER:;
 	}
 	return true;
 }

--- a/src/deluge/testing/hardware_testing.cpp
+++ b/src/deluge/testing/hardware_testing.cpp
@@ -141,7 +141,13 @@ void readInputsForHardwareTest(bool testButtonStates[9][16]) {
 	bool lineInNow = readInput(LINE_IN_DETECT.port, LINE_IN_DETECT.pin);
 	bool gateInNow = readInput(ANALOG_CLOCK_IN.port, ANALOG_CLOCK_IN.pin);
 
-	bool inputStateNow = (outputPluggedInL == outputPluggedInR == headphoneNow == micNow == lineInNow == gateInNow);
+	// FIXME: This used to be
+	//    bool inputStateNow = (outputPluggedInL == outputPluggedInR == headphoneNow == micNow == lineInNow ==
+	//    gateInNow);
+	// probably _intending_ to check that they're all the same. However, the actual meaning was the same as the
+	// re-written expression below, since == is binary and left-associative, not N-ary.
+	bool inputStateNow =
+	    (((((outputPluggedInL == outputPluggedInR) == headphoneNow) == micNow) == lineInNow) == gateInNow);
 
 	if (inputStateNow != inputStateLastTime) {
 		indicator_leds::setLedState(IndicatorLED::TAP_TEMPO, !inputStateNow);


### PR DESCRIPTION
adds:

    -Warray-bounds=1
    -Wnull-dereference
    -Wparentheses
    -Wsequence-point
    -Wswitch

Parentheses catches a few apparent buglets. Switch shows a couple of _possibly_ missing cases, but not obvious.