### PR TITLE
simplify SoundEditor::beginScreen() and updatePadLightsFor() logic

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -584,13 +584,19 @@ void SoundEditor::setupShortcutsBlinkFromTable(MenuItem const* const currentItem
 }
 
 void SoundEditor::updatePadLightsFor(MenuItem* currentItem) {
+	// First we clear everything.
+	memset(sourceShortcutBlinkFrequencies, 255, sizeof(sourceShortcutBlinkFrequencies));
+	memset(sourceShortcutBlinkColours, 0, sizeof(sourceShortcutBlinkColours));
+	uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 
-	if (!inSettingsMenu() && !inNoteEditor() && currentItem != &sampleStartMenu && currentItem != &sampleEndMenu
-	    && currentItem != &audioClipSampleMarkerEditorMenuStart && currentItem != &audioClipSampleMarkerEditorMenuEnd
-	    && currentItem != &fileSelectorMenu && currentItem != static_cast<void*>(&nameEditMenu)) {
+	// In these cases that's all we need to do.
+	if (inSettingsMenu() || inNoteEditor() || getCurrentUI() != &soundEditor) {
+		return;
+	}
 
-		memset(sourceShortcutBlinkFrequencies, 255, sizeof(sourceShortcutBlinkFrequencies));
-		memset(sourceShortcutBlinkColours, 0, sizeof(sourceShortcutBlinkColours));
+	// Extra braces to make the diff easier to read. Will submit a separate cleanup.
+	{
+
 		paramShortcutBlinkFrequency = 3;
 
 		// Find param shortcut
@@ -661,18 +667,11 @@ stopThat:
 			}
 		}
 
-		// If we found nothing...
-		if (currentParamShorcutX == 255) {
-			uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
-		}
-
-		// Or if we found something...
-		else {
+		// If we found something...
+		if (currentParamShorcutX != 255) {
 			blinkShortcut();
 		}
 	}
-
-shortcutsPicked:
 
 	if (currentItem->shouldBlinkLearnLed()) {
 		indicator_leds::blinkLed(IndicatorLED::LEARN);
@@ -680,23 +679,11 @@ shortcutsPicked:
 	else {
 		indicator_leds::setLedState(IndicatorLED::LEARN, false);
 	}
-
-	possibleChangeToCurrentRangeDisplay();
 }
 
 bool SoundEditor::beginScreen(MenuItem* oldMenuItem) {
-
 	MenuItem* currentItem = getCurrentMenuItem();
-
 	currentItem->beginSession(oldMenuItem);
-
-	// If that didn't succeed (file browser)
-	// XXX: Why do we need to check for renameDrumUI, but not other rename UIs? either way, this should probably
-	// be a virtual function getCurrentUI()->noSoundEditor() or something.
-	if (getCurrentUI() != &soundEditor && getCurrentUI() != &sampleBrowser && getCurrentUI() != &audioRecorder
-	    && getCurrentUI() != &sampleMarkerEditor && getCurrentUI() != &renameDrumUI) {
-		return false;
-	}
 
 	if (display->haveOLED()) {
 		renderUIsForOled();
@@ -704,7 +691,9 @@ bool SoundEditor::beginScreen(MenuItem* oldMenuItem) {
 
 	currentItem->updatePadLights();
 
-	return true;
+	possibleChangeToCurrentRangeDisplay();
+
+	return getCurrentUI() == &soundEditor;
 }
 
 void SoundEditor::possibleChangeToCurrentRangeDisplay() {

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -124,11 +124,16 @@ SoundEditor soundEditor{};
 
 SoundEditor::SoundEditor() {
 	currentParamShorcutX = 255;
-	memset(sourceShortcutBlinkFrequencies, 255, sizeof(sourceShortcutBlinkFrequencies));
 	timeLastAttemptedAutomatedParamEdit = 0;
 	shouldGoUpOneLevelOnBegin = false;
 	setupKitGlobalFXMenu = false;
 	selectedNoteRow = false;
+	resetSourceBlinks();
+}
+
+void SoundEditor::resetSourceBlinks() {
+	memset(sourceShortcutBlinkFrequencies, 255, sizeof(sourceShortcutBlinkFrequencies));
+	memset(sourceShortcutBlinkColours, 0, sizeof(sourceShortcutBlinkColours));
 }
 
 bool SoundEditor::editingKit() {
@@ -585,8 +590,7 @@ void SoundEditor::setupShortcutsBlinkFromTable(MenuItem const* const currentItem
 
 void SoundEditor::updatePadLightsFor(MenuItem* currentItem) {
 	// First we clear everything.
-	memset(sourceShortcutBlinkFrequencies, 255, sizeof(sourceShortcutBlinkFrequencies));
-	memset(sourceShortcutBlinkColours, 0, sizeof(sourceShortcutBlinkColours));
+	resetSourceBlinks();
 	uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 
 	// In these cases that's all we need to do.
@@ -711,7 +715,7 @@ void SoundEditor::setupShortcutBlink(int32_t x, int32_t y, int32_t frequency) {
 }
 
 void SoundEditor::setupExclusiveShortcutBlink(int32_t x, int32_t y) {
-	memset(sourceShortcutBlinkFrequencies, 255, sizeof(sourceShortcutBlinkFrequencies));
+	resetSourceBlinks();
 	setupShortcutBlink(x, y, 1);
 	blinkShortcut();
 }

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -83,14 +83,13 @@ public:
 	void setupShortcutBlink(int32_t x, int32_t y, int32_t frequency);
 	bool findPatchedParam(int32_t paramLookingFor, int32_t* xout, int32_t* yout);
 	void updateSourceBlinks(MenuItem* currentItem);
+	void resetSourceBlinks();
 
 	uint8_t navigationDepth;
 	uint8_t patchingParamSelected;
 	uint8_t currentParamShorcutX;
 	uint8_t currentParamShorcutY;
 	uint8_t paramShortcutBlinkFrequency;
-	uint8_t sourceShortcutBlinkFrequencies[2][kDisplayHeight];
-	uint8_t sourceShortcutBlinkColours[2][kDisplayHeight];
 	uint32_t shortcutBlinkCounter;
 
 	uint32_t timeLastAttemptedAutomatedParamEdit;
@@ -167,6 +166,9 @@ private:
 	void handlePotentialParamMenuChange(deluge::hid::Button b, bool on, bool inCardRoutine, MenuItem* previousItem,
 	                                    MenuItem* currentItem);
 	bool handleClipName();
+
+	uint8_t sourceShortcutBlinkFrequencies[2][kDisplayHeight];
+	uint8_t sourceShortcutBlinkColours[2][kDisplayHeight];
 };
 
 extern SoundEditor soundEditor;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -535,7 +535,7 @@ void AutomationView::focusRegained() {
 		padSelectionShortcutBlinking = false;
 		instrumentClipView.noteRowBlinking = false;
 		// remove patch cable blink frequencies
-		memset(soundEditor.sourceShortcutBlinkFrequencies, 255, sizeof(soundEditor.sourceShortcutBlinkFrequencies));
+		soundEditor.resetSourceBlinks();
 		// possibly restablish parameter shortcut blinking (if parameter is selected)
 		blinkShortcuts();
 	}
@@ -5731,7 +5731,7 @@ void AutomationView::blinkShortcuts() {
 }
 
 void AutomationView::resetShortcutBlinking() {
-	memset(soundEditor.sourceShortcutBlinkFrequencies, 255, sizeof(soundEditor.sourceShortcutBlinkFrequencies));
+	soundEditor.resetSourceBlinks();
 	resetParameterShortcutBlinking();
 	resetInterpolationShortcutBlinking();
 	resetPadSelectionShortcutBlinking();


### PR DESCRIPTION
- beginScreen() used to return false & skip part of the setup if the UI was one of a list of specific UIs. Do the full setup always, and return false if the UI isn't SoundEditor itself.

- updatePadLightsFor() had a similar list of exceptions, replace most of that list with a simple check of "is the current UI the SoundEditor"; unlike before clear the existing pad lights to start with anyhow.

- Fixes #3081
