### PR TITLE
add section number to clip names, copy clip names along with clips

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2145,6 +2145,7 @@ ramError:
 	Clip* newClip = (Clip*)modelStack->getTimelineCounter();
 
 	newClip->section = (uint8_t)(newClip->section + 1) % kMaxNumSections;
+	copyClipName(clipToClone, newClip, clipToClone->output);
 
 	int32_t newIndex = yDisplayTo + currentSong->songViewYScroll;
 
@@ -3566,6 +3567,34 @@ void SessionView::setupNewClip(Clip* newClip) {
 	}
 }
 
+void SessionView::copyClipName(Clip* source, Clip* target, Output* targetOutput) {
+	if (source->name.isEmpty()) {
+		return;
+	}
+	// Start from the original clip name. We have max 12 sections, so being able to append
+	// a two digit number is enough.
+	DEF_STACK_STRING_BUF(newName, source->name.getLength() + 2);
+	newName.append(source->name.get());
+	// If the name already exists on the target output, we'll append a number. We start from 2,
+	// because "BRIDGE" & "BRIDGE2" make more sense than "BRIDGE" & "BRIDGE1".
+	int32_t counter = 2;
+	// If the original ends in a number, grab it instead.
+	int32_t sourceEnd = newName.size();
+	int32_t end = sourceEnd;
+	while (end > 0 && isdigit(newName.data()[end - 1])) {
+		end--;
+	}
+	if (end < sourceEnd) {
+		counter = atoi(newName.data() + end);
+	}
+	// Keep trying until we have a name that's unique on the output.
+	while (targetOutput->getClipFromName(newName.data()) != nullptr) {
+		newName.truncate(end);
+		newName.appendInt(counter++);
+	}
+	target->name.set(newName.data());
+}
+
 Clip* SessionView::gridCreateClip(uint32_t targetSection, Output* targetOutput, Clip* sourceClip) {
 	actionLogger.deleteAllLogs();
 
@@ -3588,6 +3617,8 @@ Clip* SessionView::gridCreateClip(uint32_t targetSection, Output* targetOutput, 
 		if (newClip == nullptr) {
 			return nullptr;
 		}
+		// ...with a derived name
+		copyClipName(sourceClip, newClip, targetOutput);
 	}
 
 	// Create new clip in existing track

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -119,6 +119,8 @@ public:
 
 	Clip* getClipForLayout();
 
+	void copyClipName(Clip* source, Clip* target, Output* targetOutput);
+
 	// Members for grid layout
 	inline bool gridFirstPadActive() { return (gridFirstPressedX != -1 && gridFirstPressedY != -1); }
 	ActionResult gridHandlePads(int32_t x, int32_t y, int32_t on);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2045,13 +2045,22 @@ oledDrawString:
 			}
 
 			if (clip) {
-				if (!clip->name.isEmpty()) {
-					yPos = yPos + 14;
-					canvas.drawStringCentred(clip->name.get(), yPos, kTextSpacingX, kTextSpacingY);
-					deluge::hid::display::OLED::setupSideScroller(1, clip->name.get(), 0, OLED_MAIN_WIDTH_PIXELS, yPos,
-					                                              yPos + kTextSpacingY, kTextSpacingX, kTextSpacingY,
-					                                              false);
+				// "SECTION NN" is 10, "NN: " is 3 => 10 over current name is always enough.
+				DEF_STACK_STRING_BUF(info, clip->name.getLength() + 10);
+				if (clip->name.isEmpty()) {
+					info.append("Section ");
+					info.appendInt(clip->section + 1);
 				}
+				else {
+					info.appendInt(clip->section + 1);
+					info.append(": ");
+					info.append(clip->name.get());
+				}
+				yPos = yPos + 14;
+				canvas.drawStringCentred(info.data(), yPos, kTextSpacingX, kTextSpacingY);
+				deluge::hid::display::OLED::setupSideScroller(1, info.data(), 0, OLED_MAIN_WIDTH_PIXELS, yPos,
+				                                              yPos + kTextSpacingY, kTextSpacingX, kTextSpacingY,
+				                                              false);
 			}
 		}
 		else {

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -115,6 +115,11 @@ public:
 	void append(const char* str) { ::strncat(buf_, str, capacity_ - size() - 1); }
 	void append(char c) { ::strncat(buf_, &c, 1); }
 	void clear() { buf_[0] = 0; }
+	void truncate(std::size_t newSize) {
+		if (newSize < capacity_) {
+			buf_[newSize] = 0;
+		}
+	}
 
 	// TODO: Validate buffer size. These can overflow
 	void appendInt(int i, int minChars = 1) { intToString(i, buf_ + size(), minChars); }


### PR DESCRIPTION
- if clip has no name, display "SECTION NUM"
- if clip has a name, display "NUM: CLIP NAME"
- when copying clips, copy the clip name as well. append/increment tailing number to keep it unique on the target output
- Implements what https://github.com/SynthstromAudible/DelugeFirmware/discussions/3167 asks for, among other things.