### PR TITLE
Scale-Aware-Accidentals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,7 @@ also affect normal sequenced notes while arpeggiator is Off.
 - A white playhead is now rendered in Song Grid and Performance Views that let's you know when a clip or section launch event is scheduled to occur. The playhead only renders the last 16 notes before a launch event.
   - Note: this playhead can be turned off in the Community Features submenu titled: `Enable Launch Event Playhead (PLAY)`
 - The display now shows the number of Bars (or Quarter Notes for the last bar) remaining until a clip or section launch event in all Song views (Grid, Row, Performance).
+- A new option, 'Launch Exclusively', isolates a clip section from all other launch activity. This option is found to the left of option 'Launch non-exclusively' when selecting the section's number of repetitions. As a complement to non-exclusive sections that arm and turn off when another section is launched, exclusive sections remain independant.
 
 #### <ins>Audio Clips</ins>
 

--- a/src/deluge/gui/menu_item/key_range.cpp
+++ b/src/deluge/gui/menu_item/key_range.cpp
@@ -19,6 +19,7 @@
 #include "gui/menu_item/range.h"
 #include "gui/ui/sound_editor.h"
 #include "hid/display/display.h"
+#include "model/scale/preset_scales.h"
 #include "util/functions.h"
 
 namespace deluge::gui::menu_item {
@@ -57,10 +58,10 @@ void KeyRange::selectEncoderAction(int32_t offset) {
 
 void KeyRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRightLength, bool mayShowJustOne) {
 
-	*(buffer++) = noteCodeToNoteLetter[lower];
+	*(buffer++) = noteLetter[lower];
 	int32_t leftLength = 1;
 
-	if (noteCodeIsSharp[lower]) {
+	if (noteIsAltered[lower]) {
 		*(buffer++) = (display->haveOLED()) ? '#' : '.';
 		if (display->haveOLED()) {
 			leftLength++;
@@ -81,9 +82,9 @@ void KeyRange::getText(char* buffer, int32_t* getLeftLength, int32_t* getRightLe
 
 	*(buffer++) = '-';
 
-	*(buffer++) = noteCodeToNoteLetter[upper];
+	*(buffer++) = noteLetter[upper];
 	int32_t rightLength = 1;
-	if (noteCodeIsSharp[upper]) {
+	if (noteIsAltered[upper]) {
 		*(buffer++) = (display->haveOLED()) ? '#' : '.';
 		if (display->haveOLED()) {
 			rightLength++;

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -768,13 +768,13 @@ void KeyboardScreen::selectEncoderAction(int8_t offset) {
 		instrumentClipView.setupChangingOfRootNote(newRootNote);
 
 		char noteName[3] = {0};
-		noteName[0] = noteCodeToNoteLetter[newRootNote];
+		noteName[0] = noteLetter[newRootNote];
 		if (display->haveOLED()) {
-			if (noteCodeIsSharp[newRootNote]) {
+			if (noteIsAltered[newRootNote]) {
 				noteName[1] = '#';
 			}
 		}
-		display->displayPopup(noteName, 3, false, (noteCodeIsSharp[newRootNote] ? 0 : 255));
+		display->displayPopup(noteName, 3, false, (noteIsAltered[newRootNote] ? 0 : 255));
 		layoutList[getCurrentInstrumentClip()->keyboardState.currentLayout]->handleHorizontalEncoder(
 		    0, false, pressedPads, xEncoderActive);
 		layoutList[getCurrentInstrumentClip()->keyboardState.currentLayout]->precalculate();

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1226,7 +1226,10 @@ void SessionView::drawSectionRepeatNumber() {
 	char const* outputText;
 	if (display->haveOLED()) {
 		char buffer[21];
-		if (number == -1) {
+		if (number == -2) {
+			outputText = "Launch \nexclusively"; // Need line break to match format of next label.
+		}
+		else if (number == -1) {
 			outputText = "Launch non-\nexclusively"; // Need line break cos line splitter doesn't deal with hyphens.
 		}
 		else {
@@ -1273,8 +1276,8 @@ void SessionView::commandChangeSectionRepeats(int8_t offset) {
 		if (*numRepetitions > 9999) {
 			*numRepetitions = 9999;
 		}
-		else if (*numRepetitions < -1) {
-			*numRepetitions = -1;
+		else if (*numRepetitions < -2) {
+			*numRepetitions = -2;
 		}
 		drawSectionRepeatNumber();
 	}
@@ -3764,7 +3767,7 @@ void SessionView::gridClonePad(uint32_t sourceX, uint32_t sourceY, uint32_t targ
 
 void SessionView::gridStartSection(uint32_t section, bool instant) {
 	if (instant) {
-		currentSong->turnSoloingIntoJustPlaying(currentSong->sections[section].numRepetitions != -1);
+		currentSong->turnSoloingIntoJustPlaying(currentSong->sections[section].numRepetitions > -1);
 
 		for (int32_t idxClip = 0; idxClip < currentSong->sessionClips.getNumElements(); ++idxClip) {
 			Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -559,8 +559,10 @@ void InstrumentClipMinder::drawActualNoteCode(int16_t noteCode) {
 	}
 
 	char noteName[5];
-	int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
-	noteCodeToString(noteCode, noteName, &isNatural);
+	int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp or flat.
+	noteCodeToString(noteCode, noteName, &isNatural, true
+		, currentSong->key.rootNote, currentSong->getCurrentScale()
+	);
 
 	if (display->haveOLED()) {
 		display->popupTextTemporary(noteName);

--- a/src/deluge/model/scale/preset_scales.cpp
+++ b/src/deluge/model/scale/preset_scales.cpp
@@ -1,5 +1,6 @@
 #include "model/scale/preset_scales.h"
 #include "model/scale/note_set.h"
+#include "util/d_string.h"
 
 std::array<char const*, NUM_SCALELIKE> scalelikeNames = {
 #define DEF(id, name, notes) name,
@@ -24,6 +25,78 @@ const char* getScaleName(Scale scale) {
 	}
 	else {
 		return "ERR";
+	}
+}
+
+const uint8_t getAccidental(int32_t rootNoteCode, Scale scale) {
+	if (rootNoteCode >= 0 && scale < NUM_SCALELIKE) {
+		int8_t degree = 0;
+		switch(scale) {
+			case MAJOR_SCALE: degree=1; break;
+			case DORIAN_SCALE: degree=2; break;
+			case PHRYGIAN_SCALE: degree=3; break;
+			case LYDIAN_SCALE: degree=4; break;
+			case MIXOLYDIAN_SCALE: degree=5; break;
+			case MELODIC_MINOR_SCALE:
+			case HARMONIC_MINOR_SCALE:
+			case HUNGARIAN_MINOR_SCALE:
+			case BLUES_SCALE:
+			case PENTATONIC_MINOR_SCALE:
+			case HIRAJOSHI_SCALE:
+			case MINOR_SCALE: degree=6; break;
+			case LOCRIAN_SCALE: degree=7; break;
+			default: degree=1; break;
+		}
+		switch(degree) {
+			case 1: break;
+			case 2: rootNoteCode -= 2; break;
+			case 3: rootNoteCode -= 4; break;
+			case 4: rootNoteCode -= 5; break;
+			case 5: rootNoteCode -= 7; break;
+			case 6: rootNoteCode -= 9; break;
+			case 7: rootNoteCode -= 11; break;
+			default: break;
+		}
+		int32_t majorRoot = rootNoteCode % 12;
+		return majorAccidental[majorRoot];
+	}
+	else {
+		return '.';
+	}
+}
+
+void noteCodeToString(int32_t noteCode, char* buffer
+	, int32_t* getLengthWithoutDot
+	, bool appendOctaveNo // defaults to true
+	, int32_t rootNoteCode // defaults to -1
+	, Scale scale // defaults to NO_SCALE
+) {
+	char* thisChar = buffer;
+	int32_t octave = (noteCode) / 12 - 2;
+	int32_t n = (uint16_t)(noteCode + 120) % (uint8_t)12;
+
+	uint8_t accidental = getAccidental(rootNoteCode, scale);
+	if(noteIsAltered[n] ) {  // actually: if code is a black key on the piano?
+		if((accidental=='#')) {
+			*thisChar++ = noteLetter[n];
+			*thisChar = accidental;
+		} else {
+			*thisChar++ = noteLetter[n+1];
+			*thisChar = accidental;
+		}
+	} else {
+		*thisChar = noteLetter[n];
+	}
+	thisChar++;
+	if (appendOctaveNo) {
+		intToString(octave, thisChar, 1);
+	}
+
+	if (getLengthWithoutDot) {
+		*getLengthWithoutDot = strlen(buffer);
+		if (noteIsAltered[n]) {
+			(*getLengthWithoutDot)--;
+		}
 	}
 }
 

--- a/src/deluge/model/scale/preset_scales.h
+++ b/src/deluge/model/scale/preset_scales.h
@@ -98,6 +98,20 @@ extern std::array<char const*, NUM_SCALELIKE> scalelikeNames;
 
 const char* getScaleName(Scale scale);
 
+/* Calculate relative major key accidental preference */
+								//    C   Db  D   Eb  E   F   F#  G   Ab  A   Bb  B
+const uint8_t majorAccidental[12] = {'&','&','#','&','#','&','#','#','&','#','&','#'};
+const uint8_t noteLetter[13] = {'C','C','D','D','E','F','F','G','G','A','A','B','C'}; // 1 more for Cb
+const uint8_t noteIsAltered[12] = {0,1,0,1,0,0,1,0,1,0,1,0};
+
+const uint8_t getAccidental(int32_t rootNoteCode, Scale scale);
+void noteCodeToString(int32_t noteCode, char* buffer
+					, int32_t* getLengthWithoutDot = nullptr
+                    , bool appendOctaveNo = true
+					, int32_t rootNoteCode = -1
+					, Scale scale = Scale::NO_SCALE
+				);
+
 Scale getScale(NoteSet notes);
 
 bool isUserScale(NoteSet notes);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1854,7 +1854,7 @@ unknownTag:
 
 							else if (!strcmp(tagName, "numRepeats")) {
 								numRepeats = reader.readTagOrAttributeValueInt();
-								if (numRepeats < -1 || numRepeats > 9999) {
+								if (numRepeats < -2 || numRepeats > 9999) {
 									numRepeats = 0;
 								}
 							}

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -5782,8 +5782,10 @@ doHibernatingInstruments:
 
 void Song::getCurrentRootNoteAndScaleName(StringBuf& buffer) {
 	char noteName[5];
-	int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
-	noteCodeToString(currentSong->key.rootNote, noteName, &isNatural);
+	int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp or flat.
+	noteCodeToString(currentSong->key.rootNote, noteName, &isNatural, true
+		, currentSong->key.rootNote, currentSong->getCurrentScale()
+	);
 
 	buffer.append(noteName);
 	if (display->haveOLED()) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -147,7 +147,7 @@ void Session::armNextSection(int32_t oldSection, int32_t numRepetitions) {
 				Clip* clip = currentSong->sessionClips.getClipAtIndex(c);
 
 				// Launch non-exclusively section
-				if(currentSong->sections[clip->section].numRepetitions == -1) {
+				if (currentSong->sections[clip->section].numRepetitions == -1) {
 					continue;
 				}
 
@@ -286,12 +286,12 @@ void Session::doLaunch(bool isFillLaunch) {
 		Clip* clip = currentSong->sessionClips.getClipAtIndex(c);
 
 		// Launch non-exclusively section
-		if(currentSong->sections[clip->section].numRepetitions == -1) {
+		if (currentSong->sections[clip->section].numRepetitions == -1) {
 			continue;
 		}
 		else if (isFillLaunch
-		    && (clip->fillEventAtTickCount <= 0
-		        || playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
+		    	&& (clip->fillEventAtTickCount <= 0
+		        	|| playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
 			/* This clip needs no action, since it is not a fill clip,
 			   or it is but it's not time to start it, or it's not armed at all. */
 			continue;
@@ -352,7 +352,7 @@ void Session::doLaunch(bool isFillLaunch) {
 			}
 			else { // Not armed
 				// Launch non-exclusively section
-				if(currentSong->sections[clip->section].numRepetitions == -1) {
+				if (currentSong->sections[clip->section].numRepetitions == -1) {
 					continue;
 				}
 				else if (clip->soloingInSessionMode || clip->activeIfNoSolo) {
@@ -380,7 +380,7 @@ void Session::doLaunch(bool isFillLaunch) {
 		Clip* clip = currentSong->sessionClips.getClipAtIndex(c);
 
 		// Launch non-exclusively section
-		if(currentSong->sections[clip->section].numRepetitions == -1) {
+		if (currentSong->sections[clip->section].numRepetitions == -1) {
 			continue;
 		}
 
@@ -546,7 +546,7 @@ stopOnlyIfOutputTaken:
 		Clip* clip = currentSong->sessionClips.getClipAtIndex(c);
 
 		// Launch non-exclusively section
-		if(currentSong->sections[clip->section].numRepetitions == -1) {
+		if (currentSong->sections[clip->section].numRepetitions == -1) {
 			continue;
 		}
 		if (isFillLaunch
@@ -1359,7 +1359,7 @@ void Session::armClipsAlongWithExistingLaunching(ArmState armState, uint8_t sect
 		for (int l = 0; l < currentSong->sessionClips.getNumElements(); l++) {
 			Clip* thisClip = currentSong->sessionClips.getClipAtIndex(l);
 			// Skip Launch non-exclusively
-			if(currentSong->sections[thisClip->section].numRepetitions == -1) {
+			if (currentSong->sections[thisClip->section].numRepetitions == -1) {
 				continue;
 			}
 			if (thisClip->section == section) {
@@ -1652,7 +1652,7 @@ void Session::armClipsToStartOrSoloWithQuantization(uint32_t pos, uint32_t quant
 			Clip* thisClip = currentSong->sessionClips.getClipAtIndex(c);
 
 			// Launch non-exclusively section
-			if(currentSong->sections[thisClip->section].numRepetitions == -1) {
+			if (currentSong->sections[thisClip->section].numRepetitions == -1) {
 				continue;
 			}
 			if (thisClip->launchStyle == LaunchStyle::FILL) {
@@ -1720,7 +1720,7 @@ wantActive:
 
 weWantThisClipInactive:
 					// Clip is launched non-exclusively
-					if(currentSong->sections[thisClip->section].numRepetitions == -1) {
+					if (currentSong->sections[thisClip->section].numRepetitions == -1) {
 						thisClip->armState = ArmState::OFF;
 					}
 
@@ -1753,7 +1753,7 @@ weWantThisClipInactive:
 				Clip* thisClip = currentSong->sessionClips.getClipAtIndex(c);
 
 				// Launch non-exclusively section
-				if(currentSong->sections[thisClip->section].numRepetitions == -1) {
+				if (currentSong->sections[thisClip->section].numRepetitions == -1) {
 					continue;
 				}
 
@@ -2012,7 +2012,7 @@ int32_t Session::getCurrentSection() {
 		Clip* clip = currentSong->sessionClips.getClipAtIndex(l);
 
 		// Launch non-exclusively section
-		if(currentSong->sections[clip->section].numRepetitions == -1) {
+		if (currentSong->sections[clip->section].numRepetitions == -1) {
 			continue;
 		}
 

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -290,8 +290,8 @@ void Session::doLaunch(bool isFillLaunch) {
 			continue;
 		}
 		else if (isFillLaunch
-		    	&& (clip->fillEventAtTickCount <= 0
-		        	|| playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
+		    	 && (clip->fillEventAtTickCount <= 0
+		        	 || playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
 			/* This clip needs no action, since it is not a fill clip,
 			   or it is but it's not time to start it, or it's not armed at all. */
 			continue;

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -1665,7 +1665,7 @@ void Session::armClipsToStartOrSoloWithQuantization(uint32_t pos, uint32_t quant
 			Clip* thisClip = currentSong->sessionClips.getClipAtIndex(c);
 
 			// Launch exclusively section
-			if (currentSong->sections[thisClip->section].numRepetitions == -2){
+			if (currentSong->sections[thisClip->section].numRepetitions == -2) {
 				continue;
 			}
 			if (thisClip->launchStyle == LaunchStyle::FILL) {

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -291,7 +291,7 @@ void Session::doLaunch(bool isFillLaunch) {
 		}
 		else if (isFillLaunch
 		    	 && (clip->fillEventAtTickCount <= 0
-		        	 || playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
+		    		 || playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
 			/* This clip needs no action, since it is not a fill clip,
 			   or it is but it's not time to start it, or it's not armed at all. */
 			continue;

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -290,8 +290,8 @@ void Session::doLaunch(bool isFillLaunch) {
 			continue;
 		}
 		else if (isFillLaunch
-		    	 && (clip->fillEventAtTickCount <= 0
-		    		 || playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
+		         && (clip->fillEventAtTickCount <= 0
+		             || playbackHandler.lastSwungTickActioned < clip->fillEventAtTickCount)) {
 			/* This clip needs no action, since it is not a fill clip,
 			   or it is but it's not time to start it, or it's not armed at all. */
 			continue;

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1874,29 +1874,6 @@ int32_t howMuchMoreMagnitude(uint32_t to, uint32_t from) {
 	return getMagnitudeOld(to) - getMagnitudeOld(from);
 }
 
-void noteCodeToString(int32_t noteCode, char* buffer, int32_t* getLengthWithoutDot, bool appendOctaveNo) {
-	char* thisChar = buffer;
-	int32_t octave = (noteCode) / 12 - 2;
-	int32_t noteCodeWithinOctave = (uint16_t)(noteCode + 120) % (uint8_t)12;
-
-	*thisChar = noteCodeToNoteLetter[noteCodeWithinOctave];
-	thisChar++;
-	if (noteCodeIsSharp[noteCodeWithinOctave]) {
-		*thisChar = display->haveOLED() ? '#' : '.';
-		thisChar++;
-	}
-	if (appendOctaveNo) {
-		intToString(octave, thisChar, 1);
-	}
-
-	if (getLengthWithoutDot) {
-		*getLengthWithoutDot = strlen(buffer);
-		if (noteCodeIsSharp[noteCodeWithinOctave]) {
-			(*getLengthWithoutDot)--;
-		}
-	}
-}
-
 void concatenateLines(const char* lines[], size_t numLines, char* resultString) {
 	const size_t maxCharsPerLine = 19;
 	size_t resultIndex = 0;

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -375,8 +375,6 @@ inline RGB drawSquare(const RGB& squareColour, int32_t intensity, const RGB& squ
 }
 
 int32_t howMuchMoreMagnitude(uint32_t to, uint32_t from);
-void noteCodeToString(int32_t noteCode, char* buffer, int32_t* getLengthWithoutDot = nullptr,
-                      bool appendOctaveNo = true);
 void concatenateLines(const char* lines[], size_t numLines, char* resultString);
 double ConvertFromIeeeExtended(unsigned char* bytes /* LCN */);
 int32_t divide_round_negative(int32_t dividend, int32_t divisor);

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -482,9 +482,6 @@ const int16_t lanczosKernelA16[1025] = {
 
 
 
-const uint8_t noteCodeToNoteLetter[12] = {67, 67, 68, 68, 69, 70, 70, 71, 71, 65, 65, 66};
-const bool noteCodeIsSharp[12] = {0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0};
-
 /**
  * @brief How iterance is encoded:
  *

--- a/src/deluge/util/lookuptables/lookuptables.h
+++ b/src/deluge/util/lookuptables/lookuptables.h
@@ -130,9 +130,6 @@ const uint8_t presetReverbRoomSize[NUM_PRESET_REVERBS] = {16, 30, 44};
 const uint8_t presetReverbDamping[NUM_PRESET_REVERBS] = {29, 36, 45};
 extern deluge::l10n::String presetReverbNames[NUM_PRESET_REVERBS];
 
-extern const uint8_t noteCodeToNoteLetter[];
-extern const bool noteCodeIsSharp[];
-
 extern const std::array<Iterance, 35> iterancePresets;
 
 #define MAX_CHORD_TYPES 9


### PR DESCRIPTION
1. Move noteCodeToString() from functions.cpp to preset_scales.cpp because of new dependency on Scale.
2. Move codeIsSharp[] and noteCodetoLetter[] from lookuptables.cpp to preset_scales.cpp and renamed codeIsAltered[] and noteLetter[].  Public usage of
these tables in key_range and keyboard_screen still need review as they are still displaying sharps.
3. Add getAccidental() to preset_scales.cpp. This function determines if the relative major key of the current song is sharp or flat.
4. Modify song.cpp and instrument_clip_minder.cpp to send the key and scale from the current song to noteCodeToString() so it can determine which accidental to use.