### PR TITLE
Bugfix - move record point to before volume

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -140,6 +140,11 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	processFXForGlobalEffectable(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip,
 	                             delayWorkingState, renderedLastTime, reverbSendAmount);
 	processStutter(globalEffectableBuffer, numSamples, paramManagerForClip);
+	// record before pan/compression/volume to keep volumes consistent
+	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
+		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
+		recorder->feedAudio((int32_t*)globalEffectableBuffer, numSamples, true, 2);
+	}
 
 	processReverbSendAndVolume(globalEffectableBuffer, numSamples, reverbBuffer, volumePostFX, postReverbVolume,
 	                           reverbSendAmount, pan, true);
@@ -149,10 +154,7 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	else {
 		compressor.reset();
 	}
-	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
-		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
-		recorder->feedAudio((int32_t*)globalEffectableBuffer, numSamples, true, 2);
-	}
+
 	addAudio(globalEffectableBuffer, outputBuffer, numSamples);
 
 	postReverbVolumeLastTime = postReverbVolume;


### PR DESCRIPTION
Record pre volume application to reduce the looper fade out effect