### PR TITLE
Bugfix/only reallocate if were saving a reasonable amount of space

### DIFF
--- a/src/deluge/dsp/delay/delay.cpp
+++ b/src/deluge/dsp/delay/delay.cpp
@@ -254,7 +254,7 @@ void Delay::process(std::span<StereoSample> buffer, const State& delayWorkingSta
 
 			// If spinning below native rate, the quality's going to be suffering, so make a new buffer whose native
 			// rate is half our current rate (double the quality)
-			else if (delayWorkingState.userDelayRate < primaryBuffer.nativeRate()) {
+			else if (delayWorkingState.userDelayRate < primaryBuffer.nativeRate() >> 1) {
 				initializeSecondaryBuffer(delayWorkingState.userDelayRate >> 1, false);
 			}
 		}

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -230,8 +230,6 @@ doSetupWaveTable:
 							D_PRINTLN("play count:  %d", loopData[5]);
 						}
 					}
-
-					D_PRINTLN("");
 				}
 				break;
 			}


### PR DESCRIPTION
The delay reallocates every time it's rate reduces to "improve quality" which seems dicey, and if delay rate is patched or automated results  in continuously reallocating and filling ram. Instead lets only do that if we're off by a factor of 2