### PR TITLE
Bugfix/dont realloc active kit rows

### DIFF
--- a/src/deluge/dsp/delay/delay.cpp
+++ b/src/deluge/dsp/delay/delay.cpp
@@ -254,7 +254,7 @@ void Delay::process(std::span<StereoSample> buffer, const State& delayWorkingSta
 
 			// If spinning below native rate, the quality's going to be suffering, so make a new buffer whose native
 			// rate is half our current rate (double the quality)
-			else if (delayWorkingState.userDelayRate < primaryBuffer.nativeRate()) {
+			else if (delayWorkingState.userDelayRate < primaryBuffer.nativeRate() >> 1) {
 				initializeSecondaryBuffer(delayWorkingState.userDelayRate >> 1, false);
 			}
 		}

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -50,6 +50,7 @@ namespace params = deluge::modulation::params;
 Kit::Kit() : Instrument(OutputType::KIT), drumsWithRenderingActive(sizeof(Drum*)) {
 	firstDrum = nullptr;
 	selectedDrum = nullptr;
+	drumsWithRenderingActive.emptyingShouldFreeMemory = false;
 }
 
 Kit::~Kit() {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1062,7 +1062,9 @@ void routine() {
 	audioRoutineLocked = true;
 
 	numRoutines = 0;
-	voicesStartedThisRender = 0;
+	voicesStartedThisRender = std::max<int>(
+	    cpuDireness - 12,
+	    0); // if we're at high direness then we pretend a couple have already been started to limit note ons
 	if (!stemExport.processStarted || (stemExport.processStarted && !stemExport.renderOffline)) {
 		while (doSomeOutputting() && numRoutines < 2) {
 

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -230,8 +230,6 @@ doSetupWaveTable:
 							D_PRINTLN("play count:  %d", loopData[5]);
 						}
 					}
-
-					D_PRINTLN("");
 				}
 				break;
 			}


### PR DESCRIPTION
These would get freed every time there's no drum currently playing, then immediately allocated again 