### PR TITLE
Audio pipeline buffers to std::span

### DIFF
--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -21,6 +21,7 @@
 #include "dsp/filter/ladder_components.h"
 #include "dsp/stereo_sample.h"
 #include <cmath>
+#include <span>
 
 class [[gnu::hot]] RMSFeedbackCompressor {
 public:

--- a/src/deluge/dsp/compressor/rms_feedback.h
+++ b/src/deluge/dsp/compressor/rms_feedback.h
@@ -54,12 +54,12 @@ public:
 	/// @param volAdjustL Linear gain to apply to the left channel as a 4.27 signed fixed point number.
 	/// @param volAdjustL Linear gain to apply to the right channel as a 4.27 signed fixed point number.
 	/// @param finalVolume Linear peak-to-peak volume scale, as a 3.29 fixed-point integer.
-	void render(StereoSample* buffer, uint16_t numSamples, q31_t volAdjustL, q31_t volAdjustR, q31_t finalVolume);
+	void render(std::span<StereoSample> buffer, q31_t volAdjustL, q31_t volAdjustR, q31_t finalVolume);
 
 	/// Render the compressor with neutral left/right gain and with the finalVolume tweaked so the compressor applies
 	/// 0db gain change at theshold zero. Used by the per-clip compressors because the clip volume is applied without
 	/// the compressor being involved.
-	void renderVolNeutral(StereoSample* buffer, uint16_t numSamples, q31_t finalVolume);
+	void renderVolNeutral(std::span<StereoSample> buffer, q31_t finalVolume);
 
 	/// Compute an updated envelope value, using the attack time constant if desired > current and the release time
 	/// constant otherwise.
@@ -169,7 +169,7 @@ public:
 	void updateER(float numSamples, q31_t finalVolume);
 
 	/// Calculate the RMS amplitude, post internal HPF, of the samples.
-	float calcRMS(StereoSample* buffer, uint16_t numSamples);
+	float calcRMS(std::span<StereoSample> buffer);
 
 	/// Amount of gain reduction applied during the last render pass, in 6.2 fixed point decibels
 	uint8_t gainReduction = 0;

--- a/src/deluge/dsp/envelope_follower/absolute_value.h
+++ b/src/deluge/dsp/envelope_follower/absolute_value.h
@@ -19,6 +19,8 @@
 
 #include "dsp/stereo_sample.h"
 #include <cmath>
+#include <span>
+
 class AbsValueFollower {
 public:
 	AbsValueFollower() = default;

--- a/src/deluge/dsp/envelope_follower/absolute_value.h
+++ b/src/deluge/dsp/envelope_follower/absolute_value.h
@@ -53,7 +53,7 @@ public:
 		return releaseMS;
 	};
 
-	StereoFloatSample calcApproxRMS(StereoSample* buffer, uint16_t numSamples);
+	StereoFloatSample calcApproxRMS(std::span<StereoSample> buffer);
 
 private:
 	float runEnvelope(float current, float desired, float numSamples);

--- a/src/deluge/dsp/granular/GranularProcessor.h
+++ b/src/deluge/dsp/granular/GranularProcessor.h
@@ -24,6 +24,7 @@
 #include "dsp/stereo_sample.h"
 #include "memory/stealable.h"
 #include "modulation/lfo.h"
+#include <span>
 
 class UnpatchedParamSet;
 

--- a/src/deluge/dsp/granular/GranularProcessor.h
+++ b/src/deluge/dsp/granular/GranularProcessor.h
@@ -53,9 +53,9 @@ public:
 	void startSkippingRendering();
 
 	/// preset is currently converted from a param to a 0-4 preset inside the grain, which is probably not great
-	void processGrainFX(StereoSample* buffer, int32_t grainRate, int32_t grainMix, int32_t grainDensity,
-	                    int32_t pitchRandomness, int32_t* postFXVolume, const StereoSample* bufferEnd,
-	                    bool anySoundComingIn, float tempoBPM, q31_t reverbAmount);
+	void processGrainFX(std::span<StereoSample> buffer, int32_t grainRate, int32_t grainMix, int32_t grainDensity,
+	                    int32_t pitchRandomness, int32_t* postFXVolume, bool anySoundComingIn, float tempoBPM,
+	                    q31_t reverbAmount);
 
 	void clearGrainFXBuffer();
 	void grainBufferStolen() { grainBuffer = nullptr; }
@@ -63,7 +63,7 @@ public:
 private:
 	void setupGrainFX(int32_t grainRate, int32_t grainMix, int32_t grainDensity, int32_t pitchRandomness,
 	                  int32_t* postFXVolume, float timePerInternalTick);
-	StereoSample processOneGrainSample(StereoSample* currentSample);
+	StereoSample processOneGrainSample(StereoSample currentSample);
 	void getBuffer();
 	void setWrapsToShutdown();
 	void setupGrainsIfNeeded(int32_t writeIndex);

--- a/src/deluge/dsp/stereo_sample.h
+++ b/src/deluge/dsp/stereo_sample.h
@@ -23,6 +23,13 @@
 #include "util/functions.h"
 
 struct StereoSample {
+	[[gnu::always_inline]] static constexpr StereoSample fromMono(q31_t sampleValue) {
+		return StereoSample{
+		    .l = sampleValue,
+		    .r = sampleValue,
+		};
+	}
+
 	inline void addMono(q31_t sampleValue) {
 		l += sampleValue;
 		r += sampleValue;

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -39,7 +39,7 @@ public:
 	void processCurrentPos(ModelStackWithTimelineCounter* modelStack, uint32_t ticksSinceLast) override;
 	void expectNoFurtherTicks(Song* song, bool actuallySoundChange = true) override;
 	Error clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false) const override;
-	void render(ModelStackWithTimelineCounter* modelStack, int32_t* outputBuffer, int32_t numSamples, int32_t amplitude,
+	void render(ModelStackWithTimelineCounter* modelStack, std::span<q31_t> output, int32_t amplitude,
 	            int32_t amplitudeIncrement, int32_t pitchAdjust);
 	void detachFromOutput(ModelStackWithTimelineCounter* modelStack, bool shouldRememberDrumName,
 	                      bool shouldDeleteEmptyNoteRowsAtEndOfList = false, bool shouldRetainLinksToSounds = false,

--- a/src/deluge/model/fx/stutterer.h
+++ b/src/deluge/model/fx/stutterer.h
@@ -19,6 +19,7 @@
 
 #include "dsp/delay/delay_buffer.h"
 #include <cstdint>
+#include <span>
 
 class ParamManagerForTimeline;
 class ParamManager;

--- a/src/deluge/model/fx/stutterer.h
+++ b/src/deluge/model/fx/stutterer.h
@@ -33,7 +33,7 @@ public:
 	// on currentSong and playbackhandler...
 	[[nodiscard]] Error beginStutter(void* source, ParamManagerForTimeline* paramManager, bool quantize,
 	                                 int32_t magnitude, uint32_t timePerTickInverse);
-	void processStutter(StereoSample* buffer, int32_t numSamples, ParamManager* paramManager, int32_t magnitude,
+	void processStutter(std::span<StereoSample> buffer, ParamManager* paramManager, int32_t magnitude,
 	                    uint32_t timePerTickInverse, bool reverse);
 	void endStutter(ParamManagerForTimeline* paramManager = nullptr);
 

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -17,6 +17,7 @@
 
 #include "model/global_effectable/global_effectable.h"
 #include "definitions_cxx.hpp"
+#include "dsp/stereo_sample.h"
 #include "gui/l10n/l10n.h"
 #include "gui/views/performance_view.h"
 #include "gui/views/view.h"
@@ -778,8 +779,8 @@ void GlobalEffectable::setupFilterSetConfig(int32_t* postFXVolume, ParamManager*
 	                        hpfModeForRender, hpfMorph, *postFXVolume, filterRoute, false, NULL);
 }
 
-[[gnu::hot]] void GlobalEffectable::processFilters(StereoSample* buffer, int32_t numSamples) {
-	filterSet.renderLongStereo(&buffer->l, &(buffer + numSamples)->l);
+[[gnu::hot]] void GlobalEffectable::processFilters(std::span<StereoSample> buffer) {
+	filterSet.renderLongStereo(&buffer.data()->l, &(buffer.data() + buffer.size())->l);
 }
 
 void GlobalEffectable::writeAttributesToFile(Serializer& writer, bool writeAutomation) {
@@ -1128,13 +1129,9 @@ Delay::State GlobalEffectable::createDelayWorkingState(ParamManager& paramManage
 	return delayWorkingState;
 }
 
-void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, int32_t numSamples,
-                                                    int32_t* postFXVolume, ParamManager* paramManager,
-                                                    const Delay::State& delayWorkingState, bool anySoundComingIn,
-                                                    q31_t verbAmount) {
-
-	StereoSample* inputBufferEnd = inputBuffer + numSamples;
-
+void GlobalEffectable::processFXForGlobalEffectable(std::span<StereoSample> buffer, int32_t* postFXVolume,
+                                                    ParamManager* paramManager, const Delay::State& delayWorkingState,
+                                                    bool anySoundComingIn, q31_t verbAmount) {
 	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
 
 	int32_t modFXRate =
@@ -1166,8 +1163,8 @@ void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, i
 		disableGrain();
 	}
 
-	processFX({inputBuffer, numSamples}, modFXTypeNow, modFXRate, modFXDepth, delayWorkingState, postFXVolume,
-	          paramManager, anySoundComingIn, verbAmount);
+	processFX(buffer, modFXTypeNow, modFXRate, modFXDepth, delayWorkingState, postFXVolume, paramManager,
+	          anySoundComingIn, verbAmount);
 }
 
 namespace modfx {

--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -1166,7 +1166,7 @@ void GlobalEffectable::processFXForGlobalEffectable(StereoSample* inputBuffer, i
 		disableGrain();
 	}
 
-	processFX(inputBuffer, numSamples, modFXTypeNow, modFXRate, modFXDepth, delayWorkingState, postFXVolume,
+	processFX({inputBuffer, numSamples}, modFXTypeNow, modFXRate, modFXDepth, delayWorkingState, postFXVolume,
 	          paramManager, anySoundComingIn, verbAmount);
 }
 

--- a/src/deluge/model/global_effectable/global_effectable.h
+++ b/src/deluge/model/global_effectable/global_effectable.h
@@ -37,11 +37,10 @@ public:
 	ModelStackWithAutoParam* getParamFromModEncoder(int32_t whichModEncoder, ModelStackWithThreeMainThings* modelStack,
 	                                                bool allowCreation = true) override;
 	void setupFilterSetConfig(int32_t* postFXVolume, ParamManager* paramManager);
-	void processFilters(StereoSample* buffer, int32_t numSamples);
+	void processFilters(std::span<StereoSample> buffer);
 	void compensateVolumeForResonance(ParamManagerForTimeline* paramManager);
-	void processFXForGlobalEffectable(StereoSample* inputBuffer, int32_t numSamples, int32_t* postFXVolume,
-	                                  ParamManager* paramManager, const Delay::State& delayWorkingState,
-	                                  bool anySoundComingIn, q31_t verbAmount);
+	void processFXForGlobalEffectable(std::span<StereoSample> buffer, int32_t* postFXVolume, ParamManager* paramManager,
+	                                  const Delay::State& delayWorkingState, bool anySoundComingIn, q31_t verbAmount);
 
 	void writeAttributesToFile(Serializer& writer, bool writeToFile);
 	void writeTagsToFile(Serializer& writer, ParamManager* paramManager, bool writeToFile);

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -155,7 +155,10 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 		compressor.reset();
 	}
 
-	addAudio(globalEffectableBuffer, outputBuffer, numSamples);
+
+	for (size_t i = 0; i < numSamples; ++i) {
+		outputBuffer[i] += globalEffectableBuffer[i];
+	}
 
 	postReverbVolumeLastTime = postReverbVolume;
 

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -114,8 +114,8 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 
 	// Render actual Drums / AudioClip
 	renderedLastTime = renderGlobalEffectableForClip(
-	    modelStack, global_effectable_audio.data(), nullptr, output.size(), reverbBuffer, reverbAmountAdjustForDrums,
-	    sideChainHitPending, shouldLimitDelayFeedback, isClipActive, pitchAdjust, 134217728, 134217728);
+	    modelStack, global_effectable_audio, nullptr, reverbBuffer, reverbAmountAdjustForDrums, sideChainHitPending,
+	    shouldLimitDelayFeedback, isClipActive, pitchAdjust, 134217728, 134217728);
 
 	// Render saturation
 	if (clippingAmount != 0u) {

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -136,17 +136,17 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	processFilters(globalEffectableBuffer, numSamples);
 
 	// Render FX
-	processSRRAndBitcrushing(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip);
+	processSRRAndBitcrushing({globalEffectableBuffer, numSamples}, &volumePostFX, paramManagerForClip);
 	processFXForGlobalEffectable(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip,
 	                             delayWorkingState, renderedLastTime, reverbSendAmount);
-	processStutter(globalEffectableBuffer, numSamples, paramManagerForClip);
+	processStutter({globalEffectableBuffer, numSamples}, paramManagerForClip);
 	// record before pan/compression/volume to keep volumes consistent
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
 		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
 		recorder->feedAudio({globalEffectableBuffer, numSamples}, true, 2);
 	}
 
-	processReverbSendAndVolume(globalEffectableBuffer, numSamples, reverbBuffer, volumePostFX, postReverbVolume,
+	processReverbSendAndVolume({globalEffectableBuffer, numSamples}, reverbBuffer, volumePostFX, postReverbVolume,
 	                           reverbSendAmount, pan, true);
 	if (compThreshold > 0) {
 		compressor.renderVolNeutral({globalEffectableBuffer, numSamples}, volumePostFX);

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -149,7 +149,7 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	processReverbSendAndVolume(globalEffectableBuffer, numSamples, reverbBuffer, volumePostFX, postReverbVolume,
 	                           reverbSendAmount, pan, true);
 	if (compThreshold > 0) {
-		compressor.renderVolNeutral(globalEffectableBuffer, numSamples, volumePostFX);
+		compressor.renderVolNeutral({globalEffectableBuffer, numSamples}, volumePostFX);
 	}
 	else {
 		compressor.reset();

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -133,11 +133,11 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	}
 
 	// Render filters
-	processFilters(globalEffectableBuffer, numSamples);
+	processFilters({globalEffectableBuffer, numSamples});
 
 	// Render FX
 	processSRRAndBitcrushing({globalEffectableBuffer, numSamples}, &volumePostFX, paramManagerForClip);
-	processFXForGlobalEffectable(globalEffectableBuffer, numSamples, &volumePostFX, paramManagerForClip,
+	processFXForGlobalEffectable({globalEffectableBuffer, numSamples}, &volumePostFX, paramManagerForClip,
 	                             delayWorkingState, renderedLastTime, reverbSendAmount);
 	processStutter({globalEffectableBuffer, numSamples}, paramManagerForClip);
 	// record before pan/compression/volume to keep volumes consistent

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -143,7 +143,7 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 	// record before pan/compression/volume to keep volumes consistent
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
 		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
-		recorder->feedAudio((int32_t*)globalEffectableBuffer, numSamples, true, 2);
+		recorder->feedAudio({globalEffectableBuffer, numSamples}, true, 2);
 	}
 
 	processReverbSendAndVolume(globalEffectableBuffer, numSamples, reverbBuffer, volumePostFX, postReverbVolume,

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -43,16 +43,17 @@ public:
 	                            GlobalEffectableForClip** globalEffectableWithMostReverb,
 	                            int32_t* highestReverbAmountFound);
 
-	inline void saturate(int32_t* data, uint32_t* workingValue) {
+	[[gnu::always_inline]] q31_t saturate(q31_t data, uint32_t* workingValue) {
 		// Clipping
-		if (clippingAmount) {
+		if (clippingAmount != 0u) {
 			int32_t shiftAmount = (clippingAmount >= 3) ? (clippingAmount - 3) : 0;
 			//*data = getTanHUnknown(*data, 5 + clippingAmount) << (shiftAmount);
-			*data = getTanHAntialiased(*data, workingValue, 3 + clippingAmount) << (shiftAmount);
+			return getTanHAntialiased(data, workingValue, 3 + clippingAmount) << (shiftAmount);
 		}
+		return data;
 	}
 
-	uint32_t lastSaturationTanHWorkingValue[2];
+	std::array<uint32_t, 2> lastSaturationTanHWorkingValue = {2147483648u, 2147483648u};
 
 protected:
 	int32_t getParameterFromKnob(int32_t whichModEncoder) final;
@@ -71,5 +72,5 @@ protected:
 	virtual bool willRenderAsOneChannelOnlyWhichWillNeedCopying() { return false; }
 
 private:
-	bool renderedLastTime;
+	bool renderedLastTime = false;
 };

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -63,11 +63,11 @@ protected:
 	                  OutputType outputType, SampleRecorder* recorder);
 
 	virtual bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
-	                                           StereoSample* globalEffectableBuffer, int32_t* bufferToTransferTo,
-	                                           int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
-	                                           int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
-	                                           bool isClipActive, int32_t pitchAdjust, int32_t amplitudeAtStart,
-	                                           int32_t amplitudeAtEnd) = 0;
+	                                           std::span<StereoSample> globalEffectableBuffer,
+	                                           int32_t* bufferToTransferTo, int32_t* reverbBuffer,
+	                                           int32_t reverbAmountAdjust, int32_t sideChainHitPending,
+	                                           bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,
+	                                           int32_t amplitudeAtStart, int32_t amplitudeAtEnd) = 0;
 
 	virtual bool willRenderAsOneChannelOnlyWhichWillNeedCopying() { return false; }
 

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "dsp/stereo_sample.h"
 #include "model/global_effectable/global_effectable.h"
 #include "model/sample/sample_recorder.h"
 
@@ -56,7 +57,7 @@ public:
 protected:
 	int32_t getParameterFromKnob(int32_t whichModEncoder) final;
 	void renderOutput(ModelStackWithTimelineCounter* modelStack, ParamManager* paramManagerForClip,
-	                  StereoSample* outputBuffer, int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
+	                  std::span<StereoSample> output, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
 	                  int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive,
 	                  OutputType outputType, SampleRecorder* recorder);
 

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -519,9 +519,9 @@ void Kit::cutAllSound() {
 }
 
 // Beware - unlike usual, modelStack, a ModelStackWithThreeMainThings*,  might have a NULL timelineCounter
-bool Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
-                                        int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,
-                                        int32_t reverbAmountAdjust, int32_t sideChainHitPending,
+bool Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
+                                        std::span<StereoSample> globalEffectableBuffer, int32_t* bufferToTransferTo,
+                                        int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
                                         bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,
                                         int32_t amplitudeAtStart, int32_t amplitudeAtEnd) {
 	bool rendered = false;
@@ -563,8 +563,8 @@ bool Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStac
 		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 		    modelStack->addNoteRow(noteRowIndex, thisNoteRow)->addOtherTwoThings(soundDrum, drumParamManager);
 
-		soundDrum->render(modelStackWithThreeMainThings, {globalEffectableBuffer, numSamples}, reverbBuffer,
-		                  sideChainHitPending, reverbAmountAdjust, shouldLimitDelayFeedback, pitchAdjust,
+		soundDrum->render(modelStackWithThreeMainThings, globalEffectableBuffer, reverbBuffer, sideChainHitPending,
+		                  reverbAmountAdjust, shouldLimitDelayFeedback, pitchAdjust,
 		                  nullptr); // According to our volume, we tell Drums to send less reverb
 		rendered = true;
 	}
@@ -598,7 +598,7 @@ yesTickParamManager:
 					ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 					    modelStack->addNoteRow(i, thisNoteRow)
 					        ->addOtherTwoThings((SoundDrum*)thisNoteRow->drum, &thisNoteRow->paramManager);
-					thisNoteRow->paramManager.tickSamples(numSamples, modelStackWithThreeMainThings);
+					thisNoteRow->paramManager.tickSamples(globalEffectableBuffer.size(), modelStackWithThreeMainThings);
 					continue;
 				}
 

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -563,7 +563,7 @@ bool Kit::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStac
 		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
 		    modelStack->addNoteRow(noteRowIndex, thisNoteRow)->addOtherTwoThings(soundDrum, drumParamManager);
 
-		soundDrum->render(modelStackWithThreeMainThings, globalEffectableBuffer, numSamples, reverbBuffer,
+		soundDrum->render(modelStackWithThreeMainThings, {globalEffectableBuffer, numSamples}, reverbBuffer,
 		                  sideChainHitPending, reverbAmountAdjust, shouldLimitDelayFeedback, pitchAdjust,
 		                  nullptr); // According to our volume, we tell Drums to send less reverb
 		rendered = true;

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -662,9 +662,9 @@ void Kit::renderOutput(ModelStack* modelStack, std::span<StereoSample> output, i
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(activeClip);
 	// Beware - modelStackWithThreeMainThings might have a NULL timelineCounter
 
-	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, output.data(), output.size(),
-	                                      reverbBuffer, reverbAmountAdjust, sideChainHitPending,
-	                                      shouldLimitDelayFeedback, isClipActive, OutputType::KIT, recorder);
+	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, output, reverbBuffer,
+	                                      reverbAmountAdjust, sideChainHitPending, shouldLimitDelayFeedback,
+	                                      isClipActive, OutputType::KIT, recorder);
 
 	for (int32_t i = 0; i < ((InstrumentClip*)activeClip)->noteRows.getNumElements(); i++) {
 		NoteRow* thisNoteRow = ((InstrumentClip*)activeClip)->noteRows.getElement(i);

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "dsp/stereo_sample.h"
 #include "model/global_effectable/global_effectable_for_clip.h"
 #include "model/instrument/instrument.h"
 class InstrumentClip;
@@ -45,9 +46,9 @@ public:
 
 	Error loadAllAudioFiles(bool mayActuallyReadFiles) override;
 	void cutAllSound() override;
-	void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
-	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
-	                  bool shouldLimitDelayFeedback, bool isClipActive) override;
+	void renderOutput(ModelStack* modelStack, std::span<StereoSample> buffer, int32_t* reverbBuffer,
+	                  int32_t reverbAmountAdjust, int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
+	                  bool isClipActive) override;
 
 	void offerReceivedCC(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, MIDICable& cable,
 	                     uint8_t channel, uint8_t ccNumber, uint8_t value, bool* doingMidiThru) override;

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -130,9 +130,9 @@ public:
 	void offerBendRangeUpdate(ModelStack* modelStack, MIDICable& cable, int32_t channelOrZone, int32_t whichBendRange,
 	                          int32_t bendSemitones) override;
 
-	bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
-	                                   int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,
-	                                   int32_t reverbAmountAdjust, int32_t sideChainHitPending,
+	bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
+	                                   std::span<StereoSample> globalEffectableBuffer, int32_t* bufferToTransferTo,
+	                                   int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                                   bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,
 	                                   int32_t amplitudeAtStart, int32_t amplitudeAtEnd) override;
 

--- a/src/deluge/model/instrument/non_audio_instrument.cpp
+++ b/src/deluge/model/instrument/non_audio_instrument.cpp
@@ -17,6 +17,7 @@
 
 #include "model/instrument/non_audio_instrument.h"
 #include "definitions_cxx.hpp"
+#include "dsp/stereo_sample.h"
 #include "model/clip/instrument_clip.h"
 #include "model/model_stack.h"
 #include "modulation/arpeggiator.h"
@@ -26,9 +27,9 @@
 #include "util/functions.h"
 #include <cstring>
 
-void NonAudioInstrument::renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos,
-                                      int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
-                                      int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive) {
+void NonAudioInstrument::renderOutput(ModelStack* modelStack, std::span<StereoSample> output, int32_t* reverbBuffer,
+                                      int32_t reverbAmountAdjust, int32_t sideChainHitPending,
+                                      bool shouldLimitDelayFeedback, bool isClipActive) {
 
 	// MIDI / CV arpeggiator
 	if (activeClip) {
@@ -42,7 +43,7 @@ void NonAudioInstrument::renderOutput(ModelStack* modelStack, StereoSample* star
 
 			ArpReturnInstruction instruction;
 
-			arpeggiator.render(&activeInstrumentClip->arpSettings, &instruction, numSamples, gateThreshold,
+			arpeggiator.render(&activeInstrumentClip->arpSettings, &instruction, output.size(), gateThreshold,
 			                   phaseIncrement);
 
 			for (int32_t n = 0; n < ARP_MAX_INSTRUCTION_NOTES; n++) {

--- a/src/deluge/model/instrument/non_audio_instrument.h
+++ b/src/deluge/model/instrument/non_audio_instrument.h
@@ -31,9 +31,9 @@ public:
 		cachedBendRanges[BEND_RANGE_FINGER_LEVEL] = FlashStorage::defaultBendRange[BEND_RANGE_FINGER_LEVEL];
 	}
 
-	void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
-	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
-	                  bool shouldLimitDelayFeedback, bool isClipActive) override;
+	void renderOutput(ModelStack* modelStack, std::span<StereoSample> buffer, int32_t* reverbBuffer,
+	                  int32_t reverbAmountAdjust, int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
+	                  bool isClipActive) override;
 	void sendNote(ModelStackWithThreeMainThings* modelStack, bool isOn, int32_t noteCode, int16_t const* mpeValues,
 	              int32_t fromMIDIChannel = 16, uint8_t velocity = 64, uint32_t sampleSyncLength = 0,
 	              int32_t ticksLate = 0, uint32_t samplesLate = 0) override;

--- a/src/deluge/model/mod_controllable/ModFXProcessor.h
+++ b/src/deluge/model/mod_controllable/ModFXProcessor.h
@@ -14,15 +14,15 @@
  * You should have received a copy of the GNU General Public License along with this program.
  * If not, see <https://www.gnu.org/licenses/>.
  */
-
-#ifndef DELUGE_MODFXPROCESSOR_H
-#define DELUGE_MODFXPROCESSOR_H
+#pragma once
 
 #include "definitions_cxx.hpp"
 #include "dsp/stereo_sample.h"
 #include "modulation/lfo.h"
 #include "util/containers.h"
 #include <cstdint>
+#include <span>
+
 class ModFXProcessor {
 
 	void setupChorus(const ModFXType& modFXType, int32_t modFXDepth, int32_t* postFXVolume,
@@ -85,5 +85,3 @@ const char* getParamName(ModFXType type, ModFXParam param);
 
 const char* modFXToString(ModFXType type);
 } // namespace modfx
-
-#endif // DELUGE_MODFXPROCESSOR_H

--- a/src/deluge/model/mod_controllable/ModFXProcessor.h
+++ b/src/deluge/model/mod_controllable/ModFXProcessor.h
@@ -22,26 +22,30 @@
 #include "dsp/stereo_sample.h"
 #include "modulation/lfo.h"
 #include "util/containers.h"
+#include <cstdint>
 class ModFXProcessor {
 
 	void setupChorus(const ModFXType& modFXType, int32_t modFXDepth, int32_t* postFXVolume,
 	                 UnpatchedParamSet* unpatchedParams, LFOType& modFXLFOWaveType, int32_t& modFXDelayOffset,
 	                 int32_t& thisModFXDelayDepth) const;
+
 	/// flanger, phaser, warble - generally any modulated delay tap based effect with feedback
 	void setupModFXWFeedback(const ModFXType& modFXType, int32_t modFXDepth, int32_t* postFXVolume,
 	                         UnpatchedParamSet* unpatchedParams, LFOType& modFXLFOWaveType, int32_t& modFXDelayOffset,
 	                         int32_t& thisModFXDelayDepth, int32_t& feedback) const;
 	// not grain!
 	template <ModFXType modFXType>
-	void processModFXBuffer(StereoSample* buffer, int32_t modFXRate, int32_t modFXDepth, const StereoSample* bufferEnd,
+	void processModFXBuffer(std::span<StereoSample> buffer, int32_t modFXRate, int32_t modFXDepth,
 	                        LFOType& modFXLFOWaveType, int32_t modFXDelayOffset, int32_t thisModFXDelayDepth,
 	                        int32_t feedback, bool stereo);
+
 	template <ModFXType modFXType>
-	void processModLFOs(int32_t modFXRate, LFOType& modFXLFOWaveType, int32_t& lfoOutput, int32_t& lfo2Output);
+	std::pair<int32_t, int32_t> processModLFOs(int32_t modFXRate, LFOType modFXLFOWaveType);
+
 	template <ModFXType modFXType, bool stereo>
-	void processOneModFXSample(int32_t modFXDelayOffset, int32_t thisModFXDelayDepth, int32_t feedback,
-	                           StereoSample* currentSample, int32_t lfoOutput, int32_t lfo2Output);
-	void processOnePhaserSample(int32_t modFXDepth, int32_t feedback, StereoSample* currentSample, int32_t lfoOutput);
+	StereoSample processOneModFXSample(StereoSample sample, int32_t modFXDelayOffset, int32_t thisModFXDelayDepth,
+	                                   int32_t feedback, int32_t lfoOutput, int32_t lfo2Output);
+	StereoSample processOnePhaserSample(StereoSample sample, int32_t modFXDepth, int32_t feedback, int32_t lfoOutput);
 
 public:
 	ModFXProcessor() {
@@ -63,9 +67,8 @@ public:
 	uint16_t modFXBufferWriteIndex{0};
 	LFO modFXLFO;
 	LFO modFXLFOStereo;
-	void processModFX(StereoSample* buffer, const ModFXType& modFXType, int32_t modFXRate, int32_t modFXDepth,
-	                  int32_t* postFXVolume, UnpatchedParamSet* unpatchedParams, const StereoSample* bufferEnd,
-	                  bool anySoundComingIn);
+	void processModFX(std::span<StereoSample> buffer, const ModFXType& modFXType, int32_t modFXRate, int32_t modFXDepth,
+	                  int32_t* postFXVolume, UnpatchedParamSet* unpatchedParams, bool anySoundComingIn);
 	void resetMemory();
 	void setupBuffer();
 	void disableBuffer();

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1132,7 +1132,7 @@ void ModControllableAudio::beginStutter(ParamManagerForTimeline* paramManager) {
 
 void ModControllableAudio::processStutter(StereoSample* buffer, int32_t numSamples, ParamManager* paramManager) {
 	if (stutterer.isStuttering(this)) {
-		stutterer.processStutter(buffer, numSamples, paramManager, currentSong->getInputTickMagnitude(),
+		stutterer.processStutter({buffer, numSamples}, paramManager, currentSong->getInputTickMagnitude(),
 		                         playbackHandler.getTimePerInternalTickInverse(),
 		                         runtimeFeatureSettings.isOn(RuntimeFeatureSettingType::ReverseStutterRate));
 	}

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -188,9 +188,9 @@ void ModControllableAudio::processGrainFX(StereoSample* buffer, int32_t modFXRat
 
 	if (grainFX) {
 		int32_t reverbSendAmountAndPostFXVolume = multiply_32x32_rshift32(*postFXVolume, verbAmount) << 5;
-		grainFX->processGrainFX(buffer, modFXRate, modFXDepth,
+		grainFX->processGrainFX({buffer, bufferEnd - buffer}, modFXRate, modFXDepth,
 		                        unpatchedParams->getValue(params::UNPATCHED_MOD_FX_OFFSET),
-		                        unpatchedParams->getValue(params::UNPATCHED_MOD_FX_FEEDBACK), postFXVolume, bufferEnd,
+		                        unpatchedParams->getValue(params::UNPATCHED_MOD_FX_FEEDBACK), postFXVolume,
 		                        anySoundComingIn, currentSong->calculateBPM(), reverbSendAmountAndPostFXVolume);
 	}
 }

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -141,8 +141,7 @@ void ModControllableAudio::processFX(std::span<StereoSample> buffer, ModFXType m
 		               reverbSendAmount);
 	}
 	else {
-		modfx.processModFX(buffer.data(), modFXType, modFXRate, modFXDepth, postFXVolume, unpatchedParams,
-		                   buffer.data() + buffer.size(), anySoundComingIn);
+		modfx.processModFX(buffer, modFXType, modFXRate, modFXDepth, postFXVolume, unpatchedParams, anySoundComingIn);
 	}
 
 	// EQ -------------------------------------------------------------------------------------

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.h
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.h
@@ -49,16 +49,15 @@ public:
 	virtual ~ModControllableAudio();
 	virtual void cloneFrom(ModControllableAudio* other);
 
-	void processStutter(StereoSample* buffer, int32_t numSamples, ParamManager* paramManager);
-	void processReverbSendAndVolume(StereoSample* buffer, int32_t numSamples, int32_t* reverbBuffer,
-	                                int32_t postFXVolume, int32_t postReverbVolume, int32_t reverbSendAmount,
-	                                int32_t pan = 0, bool doAmplitudeIncrement = false);
+	void processStutter(std::span<StereoSample> buffer, ParamManager* paramManager);
+	void processReverbSendAndVolume(std::span<StereoSample> buffer, int32_t* reverbBuffer, int32_t postFXVolume,
+	                                int32_t postReverbVolume, int32_t reverbSendAmount, int32_t pan = 0,
+	                                bool doAmplitudeIncrement = false);
 	void writeAttributesToFile(Serializer& writer);
 	void writeTagsToFile(Serializer& writer);
 	virtual Error readTagFromFile(Deserializer& reader, char const* tagName, ParamManagerForTimeline* paramManager,
 	                              int32_t readAutomationUpToPos, Song* song);
-	void processSRRAndBitcrushing(StereoSample* buffer, int32_t numSamples, int32_t* postFXVolume,
-	                              ParamManager* paramManager);
+	void processSRRAndBitcrushing(std::span<StereoSample> buffer, int32_t* postFXVolume, ParamManager* paramManager);
 	static void writeParamAttributesToFile(Serializer& writer, ParamManager* paramManager, bool writeAutomation,
 	                                       int32_t* valuesForOverride = nullptr);
 	static void writeParamTagsToFile(Serializer& writer, ParamManager* paramManager, bool writeAutomation,
@@ -126,7 +125,7 @@ public:
 	int32_t postReverbVolumeLastTime{};
 
 protected:
-	void processFX(StereoSample* buffer, int32_t numSamples, ModFXType modFXType, int32_t modFXRate, int32_t modFXDepth,
+	void processFX(std::span<StereoSample> buffer, ModFXType modFXType, int32_t modFXRate, int32_t modFXDepth,
 	               const Delay::State& delayWorkingState, int32_t* postFXVolume, ParamManager* paramManager,
 	               bool anySoundComingIn, q31_t reverbSendAmount);
 	void switchDelayPingPong();
@@ -170,7 +169,6 @@ private:
 	void switchHPFModeWithOff();
 	void switchLPFModeWithOff();
 
-	void processGrainFX(StereoSample* buffer, int32_t modFXRate, int32_t modFXDepth, int32_t* postFXVolume,
-	                    UnpatchedParamSet* unpatchedParams, const StereoSample* bufferEnd, bool anySoundComingIn,
-	                    q31_t verbAmount);
+	void processGrainFX(std::span<StereoSample> buffer, int32_t modFXRate, int32_t modFXDepth, int32_t* postFXVolume,
+	                    UnpatchedParamSet* unpatchedParams, bool anySoundComingIn, q31_t verbAmount);
 };

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -112,9 +112,9 @@ public:
 
 	// reverbAmountAdjust has "1" as 67108864
 	// Only gets called if there's an activeClip
-	virtual void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
-	                          int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
-	                          bool shouldLimitDelayFeedback, bool isClipActive) = 0;
+	virtual void renderOutput(ModelStack* modelStack, std::span<StereoSample> outputBuffer, int32_t* reverbBuffer,
+	                          int32_t reverbAmountAdjust, int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
+	                          bool isClipActive) = 0;
 
 	virtual void setupWithoutActiveClip(ModelStack* modelStack);
 	virtual bool setActiveClip(

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -1105,7 +1105,7 @@ doFinishCapturing:
 			// check if there's any audio in this cycle
 			else {
 				StereoFloatSample approxRMSLevel =
-				    envelopeFollower.calcApproxRMS((StereoSample*)beginInputNow, numSamplesThisCycle);
+				    envelopeFollower.calcApproxRMS({(StereoSample*)beginInputNow, numSamplesThisCycle});
 				if (std::max(approxRMSLevel.l, approxRMSLevel.r) > startValueThreshold) {
 					writePos = writePosNow;
 					numSamplesCaptured += numSamplesThisCycle;

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -31,7 +31,9 @@
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 #include "util/exceptions.h"
+#include "util/fixedpoint.h"
 #include "util/functions.h"
+#include <algorithm>
 #include <new>
 
 extern "C" {
@@ -906,14 +908,10 @@ void SampleRecorder::finishCapturing() {
 
 // Only call this after checking that status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING
 // Watch out - this could be called during SD writing - including during cardRoutine() for this class!
-void SampleRecorder::feedAudio(int32_t* __restrict__ inputAddress, int32_t numSamples, bool applyGain,
-                               uint8_t gainToApply) {
-
+void SampleRecorder::feedAudio(std::span<StereoSample> input, bool applyGain, uint8_t gainToApply) {
+	int32_t numSamples = input.size();
 	do {
-		int32_t numSamplesThisCycle = numSamples;
-		if (ALPHA_OR_BETA_VERSION && numSamplesThisCycle <= 0) {
-			FREEZE_WITH_ERROR("cccc");
-		}
+		int32_t numSamplesThisCycle = input.size();
 
 		// If haven't actually started recording yet cos we're compensating for lag...
 		if (numSamplesBeenRunning < (uint32_t)numSamplesToRunBeforeBeginningCapturing) {
@@ -962,7 +960,8 @@ doFinishCapturing:
 
 			if (bytesTilClusterEnd <= bytesWeWantToWrite - bytesPerSample) {
 				int32_t samplesTilClusterEnd =
-				    (uint16_t)(bytesTilClusterEnd - 1) / (uint8_t)bytesPerSample + 1; // Rounds up
+				    (static_cast<uint16_t>(bytesTilClusterEnd - 1) / static_cast<uint8_t>(bytesPerSample))
+				    + 1; // Rounds up
 				numSamplesThisCycle = std::min(numSamplesThisCycle, samplesTilClusterEnd);
 			}
 
@@ -970,56 +969,32 @@ doFinishCapturing:
 				FREEZE_WITH_ERROR("aaaa");
 			}
 
-			int32_t* beginInputNow = inputAddress;
-			int32_t* endInputNow = inputAddress + (numSamplesThisCycle << NUM_MONO_INPUT_CHANNELS_MAGNITUDE);
-
-			char* __restrict__ writePosNow = writePos;
-
-			// Balanced input. For this, we skip a bunch of stat-grabbing, cos we knob this is just for AudioClips.
+			std::byte* __restrict__ writePosNow = reinterpret_cast<std::byte*>(writePos);
+			// Balanced input. For this, we skip a bunch of stat-grabbing, cos we know this is just for AudioClips.
 			// We also know that applyGain is false - that's just for the MIX option
 			if (mode == AudioInputChannel::BALANCED) {
+				for (StereoSample sample : input.first(numSamplesThisCycle)) {
+					q31_t rxBalanced = (sample.l / 2) - (sample.r / 2);
 
-				do {
-					int32_t rxL = *inputAddress;
-					int32_t rxR = *(inputAddress + 1);
-					int32_t rxBalanced = (rxL >> 1) - (rxR >> 1);
-
-					char* __restrict__ readPos = (char*)&rxBalanced + 1;
-					*(writePosNow++) = *(readPos++);
-					*(writePosNow++) = *(readPos++);
-					*(writePosNow++) = *(readPos++);
-
-					inputAddress += NUM_MONO_INPUT_CHANNELS;
-				} while (inputAddress < endInputNow);
+					// Copy the last 24 bits (lower 3 bytes) to writePosNow
+					writePosNow = std::copy_n(&reinterpret_cast<std::byte*>(&rxBalanced)[1], 3, writePosNow);
+				}
 			}
 
 			// Or, all other, non-balanced input types
 			else {
-				do {
-					int32_t rxL = *inputAddress;
+				for (auto [rxL, rxR] : input.first(numSamplesThisCycle)) {
 					if (applyGain) {
 						rxL = lshiftAndSaturateUnknown(rxL, gainToApply);
 					}
 
-					char* __restrict__ readPos = (char*)&rxL + 1;
-					*(writePosNow++) = *(readPos++);
-					*(writePosNow++) = *(readPos++);
-					*(writePosNow++) = *(readPos++);
+					// Copy the last 24 bits (lower 3 bytes) to writePosNow
+					writePosNow = std::copy_n(&reinterpret_cast<std::byte*>(&rxL)[1], 3, writePosNow);
 
-					if (rxL > recordMax) {
-						recordMax = rxL;
-					}
-					if (rxL < recordMin) {
-						recordMin = rxL;
-					}
+					recordMax = std::max(rxL, recordMax);
+					recordMin = std::min(rxL, recordMin);
 
-					int32_t absL;
-					if (rxL >= 0) {
-						absL = rxL;
-					}
-					else {
-						absL = -1 - rxL;
-					}
+					q31_t absL = (rxL >= 0) ? rxL : -1 - rxL;
 					recordSumL += absL;
 
 					if (rxL < recordPeakL) {
@@ -1028,51 +1003,29 @@ doFinishCapturing:
 					else if (-rxL < recordPeakL) {
 						recordPeakL = -rxL;
 					}
-					if (rxL == 2147483647 || rxL == -2147483648) {
+					if (rxL == std::numeric_limits<q31_t>::max() || rxL == std::numeric_limits<q31_t>::min()) {
 						recordingClippedRecently = true;
 					}
 
 					// recording stereo
 					if (recordingNumChannels == 2) {
-						int32_t rxR = *(inputAddress + 1);
 						if (applyGain) {
 							rxR = lshiftAndSaturateUnknown(rxR, gainToApply);
 						}
 
-						readPos = (char*)&rxR + 1;
-						*(writePosNow++) = *(readPos++);
-						*(writePosNow++) = *(readPos++);
-						*(writePosNow++) = *(readPos++);
+						// Copy the last 24 bits (lower 3 bytes) to writePosNow
+						writePosNow = std::copy_n(&reinterpret_cast<std::byte*>(&rxR)[1], 3, writePosNow);
 
-						if (rxR > recordMax) {
-							recordMax = rxR;
-						}
-						if (rxR < recordMin) {
-							recordMin = rxR;
-						}
+						recordMax = std::max(rxR, recordMax);
+						recordMin = std::min(rxR, recordMin);
 
-						if (rxR >= 0) {
-							recordSumR += rxR;
-						}
-						else {
-							recordSumR += -1 - rxR;
-						}
+						recordSumR += (rxR >= 0) ? rxR : -1 - rxR;
 
 						int32_t lPlusR = (rxL >> 1) + (rxR >> 1);
-						if (lPlusR >= 0) {
-							recordSumLPlusR += lPlusR;
-						}
-						else {
-							recordSumLPlusR += -1 - lPlusR;
-						}
+						recordSumLPlusR += (lPlusR >= 0) ? lPlusR : -1 - lPlusR;
 
 						int32_t lMinusR = (rxL >> 1) - (rxR >> 1);
-						if (lMinusR >= 0) {
-							recordSumLMinusR += lMinusR;
-						}
-						else {
-							recordSumLMinusR += -1 - lMinusR;
-						}
+						recordSumLMinusR += (lMinusR >= 0) ? lMinusR : -1 - lMinusR;
 
 						if (rxR < recordPeakR) {
 							recordPeakR = rxR;
@@ -1080,7 +1033,7 @@ doFinishCapturing:
 						else if (-rxR < recordPeakR) {
 							recordPeakR = -rxR;
 						}
-						if (rxR == 2147483647 || rxR == -2147483648) {
+						if (rxR == std::numeric_limits<q31_t>::max() || rxR == std::numeric_limits<q31_t>::min()) {
 							recordingClippedRecently = true;
 						}
 
@@ -1091,23 +1044,22 @@ doFinishCapturing:
 							recordPeakLMinusR = -lMinusR;
 						}
 					}
-
-					inputAddress += NUM_MONO_INPUT_CHANNELS;
-				} while (inputAddress < endInputNow);
+				}
 			}
+			// update our input view to exclude the chunk we just processed
+			input = input.subspan(numSamplesThisCycle);
 
 			// if we're not threshold recording or we're threshold recording and detected audio
 			if (!thresholdRecording || sample->audioStartDetected) {
-				writePos = writePosNow;
+				writePos = reinterpret_cast<char*>(writePosNow);
 				numSamplesCaptured += numSamplesThisCycle;
 			}
 			// if we're threshold recording and didn't detect audio in previous cycles
 			// check if there's any audio in this cycle
 			else {
-				StereoFloatSample approxRMSLevel =
-				    envelopeFollower.calcApproxRMS({(StereoSample*)beginInputNow, numSamplesThisCycle});
+				StereoFloatSample approxRMSLevel = envelopeFollower.calcApproxRMS(input);
 				if (std::max(approxRMSLevel.l, approxRMSLevel.r) > startValueThreshold) {
-					writePos = writePosNow;
+					writePos = reinterpret_cast<char*>(writePosNow);
 					numSamplesCaptured += numSamplesThisCycle;
 					sample->audioStartDetected = true;
 				}
@@ -1117,7 +1069,7 @@ doFinishCapturing:
 		numSamplesBeenRunning += numSamplesThisCycle;
 
 		numSamples -= numSamplesThisCycle;
-	} while (numSamples);
+	} while (numSamples > 0);
 }
 
 void SampleRecorder::endSyncedRecording(int32_t buttonLatencyForTempolessRecording) {

--- a/src/deluge/model/sample/sample_recorder.h
+++ b/src/deluge/model/sample/sample_recorder.h
@@ -53,7 +53,7 @@ public:
 	            bool shouldRecordExtraMargins, AudioRecordingFolder newFolderID, int32_t buttonPressLatency,
 	            Output* outputRecordingFrom);
 	void setRecordingThreshold();
-	void feedAudio(int32_t* inputAddress, int32_t numSamples, bool applyGain = false, uint8_t gainToApply = 5);
+	void feedAudio(std::span<StereoSample> input, bool applyGain = false, uint8_t gainToApply = 5);
 	Error cardRoutine();
 	void endSyncedRecording(int32_t buttonLatencyForTempolessRecording);
 	bool inputLooksDifferential();

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2439,7 +2439,7 @@ void Song::renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* 
 		}
 
 		if (recorder->mode == AudioInputChannel::MIX) {
-			recorder->feedAudio((int32_t*)outputBuffer, numSamples, true);
+			recorder->feedAudio({outputBuffer, numSamples}, true);
 		}
 	}
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2418,8 +2418,7 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 		    (output->getActiveClip() && isClipActive(output->getActiveClip()->getClipBeingRecordedFrom()));
 		DISABLE_ALL_INTERRUPTS();
 		if (output->shouldRenderInSong()) {
-			output->renderOutput(modelStack, outputBuffer.data(), outputBuffer.data() + outputBuffer.size(),
-			                     outputBuffer.size(), reverbBuffer, volumePostFX >> 1, sideChainHitPending,
+			output->renderOutput(modelStack, outputBuffer, reverbBuffer, volumePostFX >> 1, sideChainHitPending,
 			                     !isClipActiveNow, isClipActiveNow);
 		}
 		ENABLE_INTERRUPTS();

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2456,8 +2456,8 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 	globalEffectable.processFXForGlobalEffectable(outputBuffer.data(), outputBuffer.size(), &volumePostFX,
 	                                              &paramManager, delayWorkingState, true, reverbSendAmount >> 3);
 
-	globalEffectable.processReverbSendAndVolume(outputBuffer.data(), outputBuffer.size(), reverbBuffer, volumePostFX,
-	                                            postReverbVolume, reverbSendAmount >> 1);
+	globalEffectable.processReverbSendAndVolume(outputBuffer, reverbBuffer, volumePostFX, postReverbVolume,
+	                                            reverbSendAmount >> 1);
 
 	if (playbackHandler.isEitherClockActive() && !playbackHandler.ticksLeftInCountIn
 	    && currentPlaybackMode == &arrangement) {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2453,8 +2453,8 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 
 	// don't bother checking if sound is coming in - its just to save resources and if nothing is being rendered we
 	// don't need to
-	globalEffectable.processFXForGlobalEffectable(outputBuffer.data(), outputBuffer.size(), &volumePostFX,
-	                                              &paramManager, delayWorkingState, true, reverbSendAmount >> 3);
+	globalEffectable.processFXForGlobalEffectable(outputBuffer, &volumePostFX, &paramManager, delayWorkingState, true,
+	                                              reverbSendAmount >> 3);
 
 	globalEffectable.processReverbSendAndVolume(outputBuffer, reverbBuffer, volumePostFX, postReverbVolume,
 	                                            reverbSendAmount >> 1);

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -277,8 +277,7 @@ public:
 	Error readFromFile(Deserializer& reader);
 	void writeToFile();
 	void loadAllSamples(bool mayActuallyReadFiles = true);
-	void renderAudio(StereoSample* outputBuffer, int32_t numSamples, int32_t* reverbBuffer,
-	                 int32_t sideChainHitPending);
+	void renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuffer, int32_t sideChainHitPending);
 	bool isYNoteAllowed(int32_t yNote, bool inKeyMode);
 	Clip* syncScalingClip;
 	void setTimePerTimerTick(uint64_t newTimeBig, bool shouldLogAction = false);

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -90,15 +90,15 @@ void AudioOutput::cloneFrom(ModControllableAudio* other) {
 	}
 }
 
-void AudioOutput::renderOutput(ModelStack* modelStack, StereoSample* outputBuffer, StereoSample* outputBufferEnd,
-                               int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
-                               int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive) {
+void AudioOutput::renderOutput(ModelStack* modelStack, std::span<StereoSample> output, int32_t* reverbBuffer,
+                               int32_t reverbAmountAdjust, int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
+                               bool isClipActive) {
 
 	ParamManager* paramManager = getParamManager(modelStack->song);
 
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(activeClip);
 
-	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, outputBuffer, numSamples,
+	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, output.data(), output.size(),
 	                                      reverbBuffer, reverbAmountAdjust, sideChainHitPending,
 	                                      shouldLimitDelayFeedback, isClipActive, OutputType::AUDIO, recorder);
 }
@@ -318,9 +318,8 @@ renderEnvelope:
 		StereoSample* __restrict__ outputBuffer = bufferToTransferTo ? (StereoSample*)bufferToTransferTo : renderBuffer;
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* songModelStack = setupModelStackWithSong(modelStackMemory, currentSong);
-		outputRecordingFrom->renderOutput(songModelStack, outputBuffer, outputBuffer + numSamples, numSamples,
-		                                  reverbBuffer, reverbAmountAdjust, sideChainHitPending,
-		                                  shouldLimitDelayFeedback, isClipActive);
+		outputRecordingFrom->renderOutput(songModelStack, {outputBuffer, numSamples}, reverbBuffer, reverbAmountAdjust,
+		                                  sideChainHitPending, shouldLimitDelayFeedback, isClipActive);
 	}
 	return rendered;
 }

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -98,9 +98,9 @@ void AudioOutput::renderOutput(ModelStack* modelStack, std::span<StereoSample> o
 
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(activeClip);
 
-	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, output.data(), output.size(),
-	                                      reverbBuffer, reverbAmountAdjust, sideChainHitPending,
-	                                      shouldLimitDelayFeedback, isClipActive, OutputType::AUDIO, recorder);
+	GlobalEffectableForClip::renderOutput(modelStackWithTimelineCounter, paramManager, output, reverbBuffer,
+	                                      reverbAmountAdjust, sideChainHitPending, shouldLimitDelayFeedback,
+	                                      isClipActive, OutputType::AUDIO, recorder);
 }
 
 void AudioOutput::resetEnvelope() {

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "processing/audio_output.h"
+#include "definitions.h"
 #include "definitions_cxx.hpp"
+#include "dsp/stereo_sample.h"
 #include "gui/views/view.h"
 #include "memory/general_memory_allocator.h"
 #include "model/clip/audio_clip.h"
@@ -30,7 +32,9 @@
 #include "storage/audio/audio_file.h"
 #include "storage/storage_manager.h"
 #include "util/lookuptables/lookuptables.h"
+#include <algorithm>
 #include <new>
+#include <ranges>
 
 extern "C" {
 #include "drivers/ssi/ssi.h"
@@ -116,7 +120,7 @@ void AudioOutput::resetEnvelope() {
 
 // Beware - unlike usual, modelStack, a ModelStackWithThreeMainThings*,  might have a NULL timelineCounter
 bool AudioOutput::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
-                                                std::span<StereoSample> renderBuffer, int32_t* bufferToTransferTo,
+                                                std::span<StereoSample> render, int32_t* bufferToTransferTo,
                                                 int32_t* reverbBuffer, int32_t reverbAmountAdjust,
                                                 int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
                                                 bool isClipActive, int32_t pitchAdjust, int32_t amplitudeAtStart,
@@ -124,26 +128,25 @@ bool AudioOutput::renderGlobalEffectableForClip(ModelStackWithTimelineCounter* m
 	bool rendered = false;
 	// audio outputs can have an activeClip while being muted
 	if (isClipActive) {
-		AudioClip* activeAudioClip = (AudioClip*)activeClip;
-		if (activeAudioClip->voiceSample) {
+		auto& activeAudioClip = static_cast<AudioClip&>(*activeClip);
+		if (activeAudioClip.voiceSample) {
 
 			int32_t attackNeutralValue = paramNeutralValues[params::LOCAL_ENV_0_ATTACK];
-			int32_t attack = getExp(attackNeutralValue, -(activeAudioClip->attack >> 2));
+			int32_t attack = getExp(attackNeutralValue, -(activeAudioClip.attack / 4));
 
 renderEnvelope:
 			int32_t amplitudeLocal =
-			    (envelope.render(renderBuffer.size(), attack, 8388608, 2147483647, 0, decayTableSmall4) >> 1)
-			    + 1073741824;
+			    (envelope.render(render.size(), attack, 8388608, 2147483647, 0, decayTableSmall4) >> 1) + 1073741824;
 
 			if (envelope.state >= EnvelopeStage::OFF) {
-				if (activeAudioClip->doingLateStart) {
+				if (activeAudioClip.doingLateStart) {
 					resetEnvelope();
 					goto renderEnvelope;
 				}
 
 				else {
 					// I think we can only be here for one shot audio clips, so maybe we shouldn't keep it?
-					activeAudioClip->unassignVoiceSample(false);
+					activeAudioClip.unassignVoiceSample(false);
 				}
 			}
 
@@ -160,174 +163,96 @@ renderEnvelope:
 
 				int32_t amplitudeIncrementEffective =
 				    static_cast<int32_t>(static_cast<double>(amplitudeEffectiveEnd - amplitudeEffectiveStart)
-				                         / static_cast<double>(renderBuffer.size()));
+				                         / static_cast<double>(render.size()));
 
-				int32_t* intBuffer = (int32_t*)renderBuffer.data();
-				activeAudioClip->render(modelStack, intBuffer, renderBuffer.size(), amplitudeEffectiveStart,
-				                        amplitudeIncrementEffective, pitchAdjust);
+				std::span render_mono{reinterpret_cast<q31_t*>(render.data()), render.size()};
+				activeAudioClip.render(modelStack, render_mono.data(), render_mono.size(), amplitudeEffectiveStart,
+				                       amplitudeIncrementEffective, pitchAdjust);
 				rendered = true;
 				amplitudeLastTime = amplitudeLocal;
 
 				// If we need to duplicate mono to stereo...
 				if (AudioOutput::willRenderAsOneChannelOnlyWhichWillNeedCopying()) {
-
 					// If can write directly into Song buffer...
-					if (bufferToTransferTo) {
-						int32_t const* __restrict__ input = intBuffer;
-						int32_t const* const inputBufferEnd = input + renderBuffer.size();
-						int32_t* __restrict__ output = bufferToTransferTo;
-
-						int32_t const* const remainderEnd = input + (renderBuffer.size() & 1);
-
-						while (input != remainderEnd) {
-							*output += *input;
-							output++;
-							*output += *input;
-							output++;
-
-							input++;
-						}
-
-						while (input != inputBufferEnd) {
-							*output += *input;
-							output++;
-							*output += *input;
-							output++;
-							input++;
-
-							*output += *input;
-							output++;
-							*output += *input;
-							output++;
-							input++;
-						}
+					if (bufferToTransferTo != nullptr) {
+						std::ranges::transform(render_mono, reinterpret_cast<StereoSample*>(bufferToTransferTo),
+						                       StereoSample::fromMono);
 					}
 
 					// Or, if duplicating within same rendering buffer (cos there's FX to be applied)
 					else {
-						int32_t i = renderBuffer.size() - 1;
-
-						int32_t firstStopAt = renderBuffer.size() & ~3;
-
-						while (i >= firstStopAt) {
-							int32_t sampleValue = intBuffer[i];
-							intBuffer[(i << 1)] = sampleValue;
-							intBuffer[(i << 1) + 1] = sampleValue;
-							i--;
-						}
-
-						while (i >= 0) {
-							{
-								int32_t sampleValue = intBuffer[i];
-								intBuffer[(i << 1)] = sampleValue;
-								intBuffer[(i << 1) + 1] = sampleValue;
-								i--;
-							}
-
-							{
-								int32_t sampleValue = intBuffer[i];
-								intBuffer[(i << 1)] = sampleValue;
-								intBuffer[(i << 1) + 1] = sampleValue;
-								i--;
-							}
-
-							{
-								int32_t sampleValue = intBuffer[i];
-								intBuffer[(i << 1)] = sampleValue;
-								intBuffer[(i << 1) + 1] = sampleValue;
-								i--;
-							}
-
-							{
-								int32_t sampleValue = intBuffer[i];
-								intBuffer[(i << 1)] = sampleValue;
-								intBuffer[(i << 1) + 1] = sampleValue;
-								i--;
-							}
-						}
+						std::ranges::transform(render_mono.rbegin(), render_mono.rend(), render.rbegin(),
+						                       StereoSample::fromMono);
 					}
 				}
 			}
 		}
 	}
+
+	std::span<StereoSample> output = (bufferToTransferTo != nullptr)
+	                                     ? std::span{reinterpret_cast<StereoSample*>(bufferToTransferTo), render.size()}
+	                                     : render;
+
 	// add in the monitored audio if in sampler or looper mode
 	if (mode != AudioOutputMode::player && modelStack->song->isOutputActiveInArrangement(this)
 	    && inputChannel != AudioInputChannel::SPECIFIC_OUTPUT) {
 		rendered = true;
-		StereoSample* __restrict__ outputPos =
-		    bufferToTransferTo ? (StereoSample*)bufferToTransferTo : renderBuffer.data();
-		StereoSample const* const outputPosEnd = outputPos + renderBuffer.size();
+		int32_t const* __restrict__ input_ptr = (int32_t const*)AudioEngine::i2sRXBufferPos;
 
-		int32_t const* __restrict__ inputReadPos = (int32_t const*)AudioEngine::i2sRXBufferPos;
-
-		AudioInputChannel inputChannelNow = inputChannel;
-		if (inputChannelNow == AudioInputChannel::STEREO && !AudioEngine::renderInStereo) {
-			inputChannelNow = AudioInputChannel::NONE; // 0 means combine channels
+		AudioInputChannel input_channel = this->inputChannel;
+		if (input_channel == AudioInputChannel::STEREO && !AudioEngine::renderInStereo) {
+			input_channel = AudioInputChannel::NONE; // 0 means combine channels
 		}
 
-		int32_t amplitudeIncrement = static_cast<int32_t>((static_cast<double>(amplitudeAtEnd - amplitudeAtStart) //
-		                                                   / static_cast<double>(renderBuffer.size())));
-		int32_t amplitudeNow = amplitudeAtStart;
+		auto amplitude_increment = static_cast<int32_t>((static_cast<double>(amplitudeAtEnd - amplitudeAtStart) //
+		                                                 / static_cast<double>(render.size())));
+		int32_t amplitude = amplitudeAtStart;
 
-		do {
+		for (StereoSample& output_sample : output) {
+			amplitude += amplitude_increment;
 
-			amplitudeNow += amplitudeIncrement;
+			StereoSample input = {
+			    .l = multiply_32x32_rshift32(input_ptr[0], amplitude) << 2,
+			    .r = multiply_32x32_rshift32(input_ptr[1], amplitude) << 2,
+			};
 
-			int32_t inputL = multiply_32x32_rshift32(inputReadPos[0], amplitudeNow) << 2;
-			int32_t inputR = multiply_32x32_rshift32(inputReadPos[1], amplitudeNow) << 2;
-
-			switch (inputChannelNow) {
+			switch (input_channel) {
 			case AudioInputChannel::LEFT:
-				outputPos->l += inputL;
-				outputPos->r += inputL;
+				output_sample += StereoSample::fromMono(input.l);
 				break;
 
 			case AudioInputChannel::RIGHT:
-				outputPos->l += inputR;
-				outputPos->r += inputR;
+				output_sample += StereoSample::fromMono(input.r);
 				break;
 
-			case AudioInputChannel::BALANCED: {
-				int32_t difference = (inputL >> 1) - (inputR >> 1);
-				outputPos->l += difference;
-				outputPos->r += difference;
+			case AudioInputChannel::BALANCED:
+				output_sample += StereoSample::fromMono((input.l / 2) - (input.r / 2));
 				break;
-			}
 
 			case AudioInputChannel::NONE: // Means combine channels
-			{
-				int32_t sum = (inputL >> 1) + (inputR >> 1);
-				outputPos->l += sum;
-				outputPos->r += sum;
+				output_sample += StereoSample::fromMono((input.l / 2) + (input.r / 2));
 				break;
-			}
 
 			default: // STEREO
-				outputPos->l += inputL;
-				outputPos->r += inputR;
-
+				output_sample += input;
+				break;
 				// Remember, there is no case for echoing out the "output" channel - that function doesn't exist, cos
 				// you're obviously already hearing the output channel
 			}
 
-			outputPos++;
-
-			inputReadPos += NUM_MONO_INPUT_CHANNELS;
-			if (inputReadPos >= getRxBufferEnd()) {
-				inputReadPos -= SSI_RX_BUFFER_NUM_SAMPLES * NUM_MONO_INPUT_CHANNELS;
+			input_ptr += NUM_MONO_INPUT_CHANNELS;
+			if (input_ptr >= getRxBufferEnd()) {
+				input_ptr -= SSI_RX_BUFFER_NUM_SAMPLES * NUM_MONO_INPUT_CHANNELS;
 			}
-		} while (outputPos < outputPosEnd);
+		}
 	}
 	else if (mode != AudioOutputMode::player && modelStack->song->isOutputActiveInArrangement(this)
-	         && inputChannel == AudioInputChannel::SPECIFIC_OUTPUT && outputRecordingFrom) {
+	         && inputChannel == AudioInputChannel::SPECIFIC_OUTPUT && (outputRecordingFrom != nullptr)) {
 		rendered = true;
-		StereoSample* __restrict__ outputBuffer =
-		    bufferToTransferTo ? (StereoSample*)bufferToTransferTo : renderBuffer.data();
-		char modelStackMemory[MODEL_STACK_MAX_SIZE];
+		std::byte modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* songModelStack = setupModelStackWithSong(modelStackMemory, currentSong);
-		outputRecordingFrom->renderOutput(songModelStack, {outputBuffer, renderBuffer.size()}, reverbBuffer,
-		                                  reverbAmountAdjust, sideChainHitPending, shouldLimitDelayFeedback,
-		                                  isClipActive);
+		outputRecordingFrom->renderOutput(songModelStack, output, reverbBuffer, reverbAmountAdjust, sideChainHitPending,
+		                                  shouldLimitDelayFeedback, isClipActive);
 	}
 	return rendered;
 }

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -166,8 +166,8 @@ renderEnvelope:
 				                         / static_cast<double>(render.size()));
 
 				std::span render_mono{reinterpret_cast<q31_t*>(render.data()), render.size()};
-				activeAudioClip.render(modelStack, render_mono.data(), render_mono.size(), amplitudeEffectiveStart,
-				                       amplitudeIncrementEffective, pitchAdjust);
+				activeAudioClip.render(modelStack, render_mono, amplitudeEffectiveStart, amplitudeIncrementEffective,
+				                       pitchAdjust);
 				rendered = true;
 				amplitudeLastTime = amplitudeLocal;
 

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -40,9 +40,9 @@ public:
 	~AudioOutput() override;
 	void cloneFrom(ModControllableAudio* other) override;
 
-	void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
-	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
-	                  bool shouldLimitDelayFeedback, bool isClipActive) override;
+	void renderOutput(ModelStack* modelStack, std::span<StereoSample> buffer, int32_t* reverbBuffer,
+	                  int32_t reverbAmountAdjust, int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
+	                  bool isClipActive) override;
 
 	bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
 	                                   int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -44,9 +44,9 @@ public:
 	                  int32_t reverbAmountAdjust, int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
 	                  bool isClipActive) override;
 
-	bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack, StereoSample* globalEffectableBuffer,
-	                                   int32_t* bufferToTransferTo, int32_t numSamples, int32_t* reverbBuffer,
-	                                   int32_t reverbAmountAdjust, int32_t sideChainHitPending,
+	bool renderGlobalEffectableForClip(ModelStackWithTimelineCounter* modelStack,
+	                                   std::span<StereoSample> globalEffectableBuffer, int32_t* bufferToTransferTo,
+	                                   int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
 	                                   bool shouldLimitDelayFeedback, bool isClipActive, int32_t pitchAdjust,
 	                                   int32_t amplitudeAtStart, int32_t amplitudeAtEnd) override;
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -703,7 +703,7 @@ void renderAudio(size_t numSamples) {
 
 	metronome.render(renderingBuffer);
 
-	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), renderingBuffer.size());
+	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer);
 
 	setMonitoringMode();
 
@@ -746,7 +746,7 @@ void renderAudioForStemExport(size_t numSamples) {
 		}
 	}
 
-	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), renderingBuffer.size());
+	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer);
 
 	doMonitoring = false;
 	monitoringAction = MonitoringAction::NONE;

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -742,7 +742,7 @@ void renderAudioForStemExport(size_t numSamples) {
 	if (recorder && recorder->mode == AudioInputChannel::OFFLINE_OUTPUT) {
 		// continue feeding audio if we're not finished recording
 		if (recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
-			recorder->feedAudio(reinterpret_cast<q31_t*>(renderingBuffer.data()), numSamples, true);
+			recorder->feedAudio(renderingBuffer, true);
 		}
 	}
 
@@ -1245,7 +1245,7 @@ bool doSomeOutputting() {
 		}
 
 		// Go through each SampleRecorder, feeding them audio
-		for (SampleRecorder* recorder = firstRecorder; recorder; recorder = recorder->next) {
+		for (SampleRecorder* recorder = firstRecorder; recorder != nullptr; recorder = recorder->next) {
 
 			if (recorder->status >= RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
 				continue;
@@ -1253,7 +1253,7 @@ bool doSomeOutputting() {
 
 			// Recording final output
 			if (recorder->mode == AudioInputChannel::OUTPUT) {
-				recorder->feedAudio(reinterpret_cast<q31_t*>(outputBufferForResampling.data()), numSamplesOutputted);
+				recorder->feedAudio(outputBufferForResampling.first(numSamplesOutputted));
 			}
 
 			// Recording from an input source
@@ -1279,7 +1279,7 @@ bool doSomeOutputting() {
 				        ? std::span{reinterpret_cast<StereoSample*>(recorder->sourcePos + 1), numSamplesFeedingNow}
 				        : std::span{reinterpret_cast<StereoSample*>(recorder->sourcePos), numSamplesFeedingNow};
 
-				recorder->feedAudio(reinterpret_cast<q31_t*>(streamToRecord.data()), streamToRecord.size());
+				recorder->feedAudio(streamToRecord);
 
 				recorder->sourcePos += numSamplesFeedingNow << NUM_MONO_INPUT_CHANNELS_MAGNITUDE;
 				if (recorder->sourcePos >= getRxBufferEnd()) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -968,9 +968,8 @@ void renderSongFX(size_t numSamples) { // LPF and stutter for song (must happen 
 		    >> 1;
 		// there used to be a static subtraction of 2 nepers (natural log based dB), this is the multiplicative
 		// equivalent
-		currentSong->globalEffectable.compressor.render(renderingBuffer.data(), renderingBuffer.size(),
-		                                                masterVolumeAdjustmentL >> 1, masterVolumeAdjustmentR >> 1,
-		                                                songVolume >> 3);
+		currentSong->globalEffectable.compressor.render(renderingBuffer, masterVolumeAdjustmentL >> 1,
+		                                                masterVolumeAdjustmentR >> 1, songVolume >> 3);
 		masterVolumeAdjustmentL = ONE_Q31;
 		masterVolumeAdjustmentR = ONE_Q31;
 		logAction("mastercomp end");

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -933,7 +933,7 @@ void renderSongFX(size_t numSamples) { // LPF and stutter for song (must happen 
 
 	if (currentSong) {
 		currentSong->globalEffectable.setupFilterSetConfig(&masterVolumeAdjustmentL, &currentSong->paramManager);
-		currentSong->globalEffectable.processFilters(renderingBuffer.data(), renderingBuffer.size());
+		currentSong->globalEffectable.processFilters(renderingBuffer);
 		currentSong->globalEffectable.processSRRAndBitcrushing(renderingBuffer, &masterVolumeAdjustmentL,
 		                                                       &currentSong->paramManager);
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -934,13 +934,12 @@ void renderSongFX(size_t numSamples) { // LPF and stutter for song (must happen 
 	if (currentSong) {
 		currentSong->globalEffectable.setupFilterSetConfig(&masterVolumeAdjustmentL, &currentSong->paramManager);
 		currentSong->globalEffectable.processFilters(renderingBuffer.data(), renderingBuffer.size());
-		currentSong->globalEffectable.processSRRAndBitcrushing(renderingBuffer.data(), renderingBuffer.size(),
-		                                                       &masterVolumeAdjustmentL, &currentSong->paramManager);
+		currentSong->globalEffectable.processSRRAndBitcrushing(renderingBuffer, &masterVolumeAdjustmentL,
+		                                                       &currentSong->paramManager);
 
 		masterVolumeAdjustmentR = masterVolumeAdjustmentL; // This might have changed in the above function calls
 
-		currentSong->globalEffectable.processStutter(renderingBuffer.data(), renderingBuffer.size(),
-		                                             &currentSong->paramManager);
+		currentSong->globalEffectable.processStutter(renderingBuffer, &currentSong->paramManager);
 
 		// And we do panning for song here too - must be post reverb, and we had to do a volume adjustment below
 		// anyway

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -691,8 +691,7 @@ void renderAudio(size_t numSamples) {
 	// Render audio for song
 	if (currentSong) {
 
-		currentSong->renderAudio(renderingBuffer.data(), renderingBuffer.size(), reverbBuffer.data(),
-		                         sideChainHitPending);
+		currentSong->renderAudio(renderingBuffer, reverbBuffer.data(), sideChainHitPending);
 	}
 
 	renderReverb(numSamples);
@@ -727,8 +726,7 @@ void renderAudioForStemExport(size_t numSamples) {
 
 	// Render audio for song
 	if (currentSong != nullptr) {
-		currentSong->renderAudio(renderingBuffer.data(), renderingBuffer.size(), reverbBuffer.data(),
-		                         sideChainHitPending);
+		currentSong->renderAudio(renderingBuffer, reverbBuffer.data(), sideChainHitPending);
 	}
 
 	if (stemExport.includeSongFX) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "processing/engines/audio_engine.h"
+#include "definitions.h"
 #include "definitions_cxx.hpp"
 #include "dsp/reverb/reverb.hpp"
 #include "dsp/timestretch/time_stretcher.h"
@@ -185,11 +186,11 @@ LiveInputBuffer* liveInputBuffers[3];
 // For debugging
 uint16_t lastRoutineTime;
 
-std::array<StereoSample, SSI_TX_BUFFER_NUM_SAMPLES> renderingBuffer __attribute__((aligned(CACHE_LINE_SIZE)));
-std::array<int32_t, 2 * SSI_TX_BUFFER_NUM_SAMPLES> reverbBuffer __attribute__((aligned(CACHE_LINE_SIZE)));
+alignas(CACHE_LINE_SIZE) std::array<StereoSample, SSI_TX_BUFFER_NUM_SAMPLES> renderingMemory;
+alignas(CACHE_LINE_SIZE) std::array<int32_t, 2 * SSI_TX_BUFFER_NUM_SAMPLES> reverbMemory;
 
-StereoSample* renderingBufferOutputPos = renderingBuffer.begin();
-StereoSample* renderingBufferOutputEnd = renderingBuffer.begin();
+StereoSample* renderingBufferOutputPos = renderingMemory.begin();
+StereoSample* renderingBufferOutputEnd = renderingMemory.begin();
 
 int32_t masterVolumeAdjustmentL;
 int32_t masterVolumeAdjustmentR;
@@ -674,8 +675,11 @@ void renderAudioForStemExport(size_t numSamples);
 	bypassCulling = false;
 }
 void renderAudio(size_t numSamples) {
-	memset(&renderingBuffer, 0, numSamples * sizeof(StereoSample));
-	memset(&reverbBuffer, 0, numSamples * sizeof(StereoSample));
+	std::span renderingBuffer{renderingMemory.data(), numSamples};
+	std::span reverbBuffer{reverbMemory.data(), numSamples};
+
+	memset(&renderingMemory, 0, renderingBuffer.size_bytes());
+	memset(&reverbMemory, 0, reverbBuffer.size_bytes());
 
 	if (sideChainHitPending) {
 		timeLastSideChainHit = audioSampleTimer;
@@ -687,7 +691,8 @@ void renderAudio(size_t numSamples) {
 	// Render audio for song
 	if (currentSong) {
 
-		currentSong->renderAudio(renderingBuffer.data(), numSamples, reverbBuffer.data(), sideChainHitPending);
+		currentSong->renderAudio(renderingBuffer.data(), renderingBuffer.size(), reverbBuffer.data(),
+		                         sideChainHitPending);
 	}
 
 	renderReverb(numSamples);
@@ -696,19 +701,22 @@ void renderAudio(size_t numSamples) {
 
 	renderSongFX(numSamples);
 
-	metronome.render(renderingBuffer.data(), numSamples);
+	metronome.render(renderingBuffer.data(), renderingBuffer.size());
 
-	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), numSamples);
+	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), renderingBuffer.size());
 
 	setMonitoringMode();
 
-	renderingBufferOutputPos = renderingBuffer.begin();
-	renderingBufferOutputEnd = renderingBuffer.begin() + numSamples;
+	renderingBufferOutputPos = renderingMemory.begin();
+	renderingBufferOutputEnd = renderingMemory.begin() + numSamples;
 }
 
 void renderAudioForStemExport(size_t numSamples) {
-	memset(&renderingBuffer, 0, numSamples * sizeof(StereoSample));
-	memset(&reverbBuffer, 0, numSamples * sizeof(StereoSample));
+	std::span renderingBuffer{renderingMemory.data(), numSamples};
+	std::span reverbBuffer{reverbMemory.data(), numSamples};
+
+	memset(&renderingMemory, 0, renderingBuffer.size_bytes());
+	memset(&reverbMemory, 0, reverbBuffer.size_bytes());
 
 	if (sideChainHitPending) {
 		timeLastSideChainHit = audioSampleTimer;
@@ -718,9 +726,9 @@ void renderAudioForStemExport(size_t numSamples) {
 	numHopsEndedThisRoutineCall = 0;
 
 	// Render audio for song
-	if (currentSong) {
-
-		currentSong->renderAudio(renderingBuffer.data(), numSamples, reverbBuffer.data(), sideChainHitPending);
+	if (currentSong != nullptr) {
+		currentSong->renderAudio(renderingBuffer.data(), renderingBuffer.size(), reverbBuffer.data(),
+		                         sideChainHitPending);
 	}
 
 	if (stemExport.includeSongFX) {
@@ -734,17 +742,17 @@ void renderAudioForStemExport(size_t numSamples) {
 	if (recorder && recorder->mode == AudioInputChannel::OFFLINE_OUTPUT) {
 		// continue feeding audio if we're not finished recording
 		if (recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
-			recorder->feedAudio((int32_t*)renderingBuffer.data(), numSamples, true);
+			recorder->feedAudio(reinterpret_cast<q31_t*>(renderingBuffer.data()), numSamples, true);
 		}
 	}
 
-	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), numSamples);
+	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), renderingBuffer.size());
 
 	doMonitoring = false;
 	monitoringAction = MonitoringAction::NONE;
 
-	renderingBufferOutputPos = renderingBuffer.begin();
-	renderingBufferOutputEnd = renderingBuffer.begin() + numSamples;
+	renderingBufferOutputPos = renderingMemory.begin();
+	renderingBufferOutputEnd = renderingMemory.begin() + numSamples;
 }
 
 void flushMIDIGateBuffers() { // Flush everything out of the MIDI buffer now. At this stage, it would only really have
@@ -849,9 +857,12 @@ startAgain:
 }
 
 void feedReverbBackdoorForGrain(int index, q31_t value) {
-	reverbBuffer[index] += value;
+	reverbMemory[index] += value;
 }
 void renderReverb(size_t numSamples) {
+	std::span renderingBuffer{renderingMemory.data(), numSamples};
+	std::span reverbBuffer{reverbMemory.data(), numSamples};
+
 	if (currentSong && mustUpdateReverbParamsBeforeNextRender) {
 		updateReverbParams();
 		mustUpdateReverbParamsBeforeNextRender = false;
@@ -892,16 +903,16 @@ void renderReverb(size_t numSamples) {
 			reverbAmplitudeL = reverbAmplitudeR = reverbOutputVolume;
 		}
 
-		auto reverb_buffer_slice = std::span{reverbBuffer.data(), numSamples};
-		auto render_buffer_slice = std::span{renderingBuffer.data(), numSamples};
-
 		// Mix reverb into main render
 		reverb.setPanLevels(reverbAmplitudeL, reverbAmplitudeR);
-		reverb.process(reverb_buffer_slice, render_buffer_slice);
+		reverb.process(reverbBuffer, renderingBuffer);
 		logAction("Reverb complete");
 	}
 }
 void renderSamplePreview(size_t numSamples) { // Previewing sample
+	std::span renderingBuffer{renderingMemory.data(), numSamples};
+	std::span reverbBuffer{reverbMemory.data(), numSamples};
+
 	if (getCurrentUI() == &sampleBrowser || getCurrentUI() == &gui::context_menu::sample_browser::kit
 	    || getCurrentUI() == &gui::context_menu::sample_browser::synth || getCurrentUI() == &slicer) {
 
@@ -909,25 +920,29 @@ void renderSamplePreview(size_t numSamples) { // Previewing sample
 		ModelStackWithThreeMainThings* modelStack = setupModelStackWithThreeMainThingsButNoNoteRow(
 		    modelStackMemory, currentSong, sampleForPreview, NULL, paramManagerForSamplePreview);
 
-		sampleForPreview->render(modelStack, renderingBuffer.data(), numSamples, reverbBuffer.data(),
+		sampleForPreview->render(modelStack, renderingBuffer.data(), renderingBuffer.size(), reverbBuffer.data(),
 		                         sideChainHitPending);
 	}
 }
 void renderSongFX(size_t numSamples) { // LPF and stutter for song (must happen after reverb mixed in, which is why it's
 	                                   // happening all the way out here
+	std::span renderingBuffer{renderingMemory.data(), numSamples};
+	std::span reverbBuffer{reverbMemory.data(), numSamples};
+
 	masterVolumeAdjustmentL = 167763968; // getParamNeutralValue(params::GLOBAL_VOLUME_POST_FX);
 	masterVolumeAdjustmentR = 167763968; // getParamNeutralValue(params::GLOBAL_VOLUME_POST_FX);
 	// 167763968 is 134217728 made a bit bigger so that default filter resonance doesn't reduce volume overall
 
 	if (currentSong) {
 		currentSong->globalEffectable.setupFilterSetConfig(&masterVolumeAdjustmentL, &currentSong->paramManager);
-		currentSong->globalEffectable.processFilters(renderingBuffer.data(), numSamples);
-		currentSong->globalEffectable.processSRRAndBitcrushing(renderingBuffer.data(), numSamples,
+		currentSong->globalEffectable.processFilters(renderingBuffer.data(), renderingBuffer.size());
+		currentSong->globalEffectable.processSRRAndBitcrushing(renderingBuffer.data(), renderingBuffer.size(),
 		                                                       &masterVolumeAdjustmentL, &currentSong->paramManager);
 
 		masterVolumeAdjustmentR = masterVolumeAdjustmentL; // This might have changed in the above function calls
 
-		currentSong->globalEffectable.processStutter(renderingBuffer.data(), numSamples, &currentSong->paramManager);
+		currentSong->globalEffectable.processStutter(renderingBuffer.data(), renderingBuffer.size(),
+		                                             &currentSong->paramManager);
 
 		// And we do panning for song here too - must be post reverb, and we had to do a volume adjustment below
 		// anyway
@@ -953,7 +968,7 @@ void renderSongFX(size_t numSamples) { // LPF and stutter for song (must happen 
 		    >> 1;
 		// there used to be a static subtraction of 2 nepers (natural log based dB), this is the multiplicative
 		// equivalent
-		currentSong->globalEffectable.compressor.render(renderingBuffer.data(), numSamples,
+		currentSong->globalEffectable.compressor.render(renderingBuffer.data(), renderingBuffer.size(),
 		                                                masterVolumeAdjustmentL >> 1, masterVolumeAdjustmentR >> 1,
 		                                                songVolume >> 3);
 		masterVolumeAdjustmentL = ONE_Q31;
@@ -1114,7 +1129,7 @@ bool doSomeOutputting() {
 	// Copy to actual output buffer, and apply heaps of gain too, with clipping
 	int32_t numSamplesOutputted = 0;
 
-	StereoSample* __restrict__ outputBufferForResampling = (StereoSample*)spareRenderingBuffer;
+	std::span<StereoSample> outputBufferForResampling{reinterpret_cast<StereoSample*>(spareRenderingBuffer), 128 * 2};
 	StereoSample* __restrict__ renderingBufferOutputPosNow = renderingBufferOutputPos;
 	int32_t* __restrict__ i2sTXBufferPosNow = (int32_t*)i2sTXBufferPos;
 	int32_t* __restrict__ inputReadPos = (int32_t*)i2sRXBufferPos;
@@ -1239,7 +1254,7 @@ bool doSomeOutputting() {
 
 			// Recording final output
 			if (recorder->mode == AudioInputChannel::OUTPUT) {
-				recorder->feedAudio((int32_t*)outputBufferForResampling, numSamplesOutputted);
+				recorder->feedAudio(reinterpret_cast<q31_t*>(outputBufferForResampling.data()), numSamplesOutputted);
 			}
 
 			// Recording from an input source
@@ -1251,19 +1266,21 @@ bool doSomeOutputting() {
 				uint32_t stopPos =
 				    (i2sRXBufferPos < (uint32_t)recorder->sourcePos) ? (uint32_t)getRxBufferEnd() : i2sRXBufferPos;
 
-				int32_t* streamToRecord = recorder->sourcePos;
-				int32_t numSamplesFeedingNow =
+				size_t numSamplesFeedingNow =
 				    (stopPos - (uint32_t)recorder->sourcePos) >> (2 + NUM_MONO_INPUT_CHANNELS_MAGNITUDE);
 
 				// We also enforce a firm limit on how much to feed, to keep things sane. Any remaining will get
 				// done next time.
-				numSamplesFeedingNow = std::min(numSamplesFeedingNow, 256_i32);
+				numSamplesFeedingNow = std::min(numSamplesFeedingNow, 256u);
 
-				if (recorder->mode == AudioInputChannel::RIGHT) {
-					streamToRecord++;
-				}
+				// this is extremely janky, but essentially because feedAudio only works on an interleaved stream of
+				// stereo samples, we can offset it one sample to get it to operate on the right channel
+				std::span streamToRecord =
+				    (recorder->mode == AudioInputChannel::RIGHT)
+				        ? std::span{reinterpret_cast<StereoSample*>(recorder->sourcePos + 1), numSamplesFeedingNow}
+				        : std::span{reinterpret_cast<StereoSample*>(recorder->sourcePos), numSamplesFeedingNow};
 
-				recorder->feedAudio(streamToRecord, numSamplesFeedingNow);
+				recorder->feedAudio(reinterpret_cast<q31_t*>(streamToRecord.data()), streamToRecord.size());
 
 				recorder->sourcePos += numSamplesFeedingNow << NUM_MONO_INPUT_CHANNELS_MAGNITUDE;
 				if (recorder->sourcePos >= getRxBufferEnd()) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -918,8 +918,7 @@ void renderSamplePreview(size_t numSamples) { // Previewing sample
 		ModelStackWithThreeMainThings* modelStack = setupModelStackWithThreeMainThingsButNoNoteRow(
 		    modelStackMemory, currentSong, sampleForPreview, NULL, paramManagerForSamplePreview);
 
-		sampleForPreview->render(modelStack, renderingBuffer.data(), renderingBuffer.size(), reverbBuffer.data(),
-		                         sideChainHitPending);
+		sampleForPreview->render(modelStack, renderingBuffer, reverbBuffer.data(), sideChainHitPending);
 	}
 }
 void renderSongFX(size_t numSamples) { // LPF and stutter for song (must happen after reverb mixed in, which is why it's

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -701,7 +701,7 @@ void renderAudio(size_t numSamples) {
 
 	renderSongFX(numSamples);
 
-	metronome.render(renderingBuffer.data(), renderingBuffer.size());
+	metronome.render(renderingBuffer);
 
 	approxRMSLevel = envelopeFollower.calcApproxRMS(renderingBuffer.data(), renderingBuffer.size());
 

--- a/src/deluge/processing/metronome/metronome.h
+++ b/src/deluge/processing/metronome/metronome.h
@@ -19,6 +19,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <span>
 
 class StereoSample;
 
@@ -26,7 +27,7 @@ class Metronome {
 public:
 	Metronome();
 	void trigger(uint32_t newPhaseIncrement);
-	void render(StereoSample* buffer, uint16_t numSamples);
+	void render(std::span<StereoSample> buffer);
 	void setVolume(int32_t linearParam) { metronomeVolume = (exp(float(linearParam) / 200.0f) - 1.0) * float(1 << 27); }
 
 	uint32_t phase;

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2448,7 +2448,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
 		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
-		recorder->feedAudio(soundBuffer, numSamples, true, 2);
+		recorder->feedAudio({reinterpret_cast<StereoSample*>(soundBuffer), numSamples}, true, 2);
 	}
 
 	for (size_t i = 0; i < numSamples; ++i) {

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2450,7 +2450,10 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
 		recorder->feedAudio(soundBuffer, numSamples, true, 2);
 	}
-	addAudio((StereoSample*)soundBuffer, outputBuffer, numSamples);
+
+	for (size_t i = 0; i < numSamples; ++i) {
+		outputBuffer[i] += reinterpret_cast<StereoSample*>(soundBuffer)[i];
+	}
 
 	postReverbVolumeLastTime = postReverbVolume;
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2429,12 +2429,12 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	int32_t modFXDepth = paramFinalValues[params::GLOBAL_MOD_FX_DEPTH - params::FIRST_GLOBAL];
 	int32_t modFXRate = paramFinalValues[params::GLOBAL_MOD_FX_RATE - params::FIRST_GLOBAL];
 
-	processSRRAndBitcrushing((StereoSample*)soundBuffer, numSamples, &postFXVolume, paramManager);
-	processFX((StereoSample*)soundBuffer, numSamples, modFXType_, modFXRate, modFXDepth, delayWorkingState,
+	processSRRAndBitcrushing({(StereoSample*)soundBuffer, numSamples}, &postFXVolume, paramManager);
+	processFX({(StereoSample*)soundBuffer, numSamples}, modFXType_, modFXRate, modFXDepth, delayWorkingState,
 	          &postFXVolume, paramManager, numVoicesAssigned != 0, reverbSendAmount >> 1);
-	processStutter((StereoSample*)soundBuffer, numSamples, paramManager);
+	processStutter({(StereoSample*)soundBuffer, numSamples}, paramManager);
 
-	processReverbSendAndVolume((StereoSample*)soundBuffer, numSamples, reverbBuffer, postFXVolume, postReverbVolume,
+	processReverbSendAndVolume({(StereoSample*)soundBuffer, numSamples}, reverbBuffer, postFXVolume, postReverbVolume,
 	                           reverbSendAmount, 0, true);
 
 	q31_t compThreshold = paramManager->getUnpatchedParamSet()->getValue(params::UNPATCHED_COMPRESSOR_THRESHOLD);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -58,6 +58,8 @@
 #include "util/firmware_version.h"
 #include "util/functions.h"
 #include "util/misc.h"
+#include <algorithm>
+#include <limits>
 
 namespace params = deluge::modulation::params;
 
@@ -2294,7 +2296,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 	delayWorkingState.delayFeedbackAmount = paramFinalValues[params::GLOBAL_DELAY_FEEDBACK - params::FIRST_GLOBAL];
 	if (shouldLimitDelayFeedback) {
 		delayWorkingState.delayFeedbackAmount =
-		    std::min(delayWorkingState.delayFeedbackAmount, (int32_t)(1 << 30) - (1 << 26));
+		    std::min(delayWorkingState.delayFeedbackAmount, (q31_t)(1 << 30) - (1 << 26));
 	}
 	delayWorkingState.userDelayRate = paramFinalValues[params::GLOBAL_DELAY_RATE - params::FIRST_GLOBAL];
 	uint32_t timePerTickInverse = playbackHandler.getTimePerInternalTickInverse(true);
@@ -2302,9 +2304,15 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 	delayWorkingState.analog_saturation = 8;
 
 	// Render each voice into a local buffer here
-	bool renderingInStereo = renderingVoicesInStereo(modelStackWithSoundFlags);
-	static int32_t soundBuffer[SSI_TX_BUFFER_NUM_SAMPLES * 2];
-	memset(soundBuffer, 0, (output.size() * sizeof(int32_t)) << renderingInStereo);
+	bool voice_rendered_in_stereo = renderingVoicesInStereo(modelStackWithSoundFlags);
+
+	// FIXME(@stellar-aria): if we have simulataneous sounds rendering, they'll overwrite
+	// each other in this buffer. It probably should be object or thread-local
+	alignas(CACHE_LINE_SIZE) static q31_t sound_memory[SSI_TX_BUFFER_NUM_SAMPLES * 2];
+	memset(sound_memory, 0, output.size() * sizeof(q31_t) * (voice_rendered_in_stereo ? 2 : 1));
+
+	std::span sound_mono{sound_memory, output.size()};
+	std::span sound_stereo{(StereoSample*)sound_memory, output.size()};
 
 	if (numVoicesAssigned) {
 
@@ -2319,39 +2327,25 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 		q31_t lpfFreq = getSmoothedPatchedParamValue(params::LOCAL_LPF_FREQ, paramManager);
 		q31_t hpfMorph = getSmoothedPatchedParamValue(params::LOCAL_HPF_MORPH, paramManager);
 		q31_t hpfFreq = getSmoothedPatchedParamValue(params::LOCAL_HPF_FREQ, paramManager);
-		bool doLPF = (thisHasFilters
-		              && (lpfMode == FilterMode::TRANSISTOR_24DB_DRIVE
-		                  || paramManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(params::LOCAL_LPF_FREQ)
-		                  || (lpfFreq < 2147483602) || (lpfMorph > -2147483648)));
-		bool doHPF = (thisHasFilters
-		              && (paramManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(params::LOCAL_HPF_FREQ)
-		                  || (hpfFreq != -2147483648) || (hpfMorph > -2147483648)));
-		// Each voice will potentially alter the "sources changed" flags, so store a backup to restore between each
-		// voice
-		/*
-		bool backedUpSourcesChanged[FIRST_UNCHANGEABLE_SOURCE - Local::FIRST_SOURCE];
-		bool doneFirstVoice = false;
-		*/
+		bool doLPF = thisHasFilters
+		             && (lpfMode == FilterMode::TRANSISTOR_24DB_DRIVE
+		                 || paramManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(params::LOCAL_LPF_FREQ)
+		                 || (lpfFreq < 0x7FFFFFD2) || (lpfMorph > std::numeric_limits<q31_t>::min()));
+		bool doHPF =
+		    thisHasFilters
+		    && (paramManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(params::LOCAL_HPF_FREQ)
+		        || (hpfFreq != std::numeric_limits<q31_t>::min()) || (hpfMorph > std::numeric_limits<q31_t>::min()));
 
 		int32_t ends[2];
 		AudioEngine::activeVoices.getRangeForSound(this, ends);
 		for (int32_t v = ends[0]; v < ends[1]; v++) {
 			Voice* thisVoice = AudioEngine::activeVoices.getVoice(v);
-			/*
-			if (!doneFirstVoice) {
-			    if (numVoicesAssigned > 1) {
-			        memcpy(backedUpSourcesChanged, &sourcesChanged[Local::FIRST_SOURCE], FIRST_UNCHANGEABLE_SOURCE -
-			Local::FIRST_SOURCE); doneFirstVoice = true;
-			    }
-			}
-			else memcpy(&sourcesChanged[Local::FIRST_SOURCE], backedUpSourcesChanged, FIRST_UNCHANGEABLE_SOURCE -
-			Local::FIRST_SOURCE);
-			*/
 
 			ModelStackWithVoice* modelStackWithVoice = modelStackWithSoundFlags->addVoice(thisVoice);
 
-			bool stillGoing = thisVoice->render(modelStackWithVoice, soundBuffer, output.size(), renderingInStereo,
-			                                    applyingPanAtVoiceLevel, sourcesChanged, doLPF, doHPF, pitchAdjust);
+			bool stillGoing =
+			    thisVoice->render(modelStackWithVoice, sound_mono.data(), sound_mono.size(), voice_rendered_in_stereo,
+			                      applyingPanAtVoiceLevel, sourcesChanged, doLPF, doHPF, pitchAdjust);
 			if (!stillGoing) {
 				AudioEngine::activeVoices.checkVoiceExists(thisVoice, this, "E201");
 				AudioEngine::unassignVoice(thisVoice, this, modelStackWithSoundFlags);
@@ -2360,52 +2354,34 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 			}
 		}
 
-		// If just rendered in mono, double that up to stereo now
-		if (!renderingInStereo) {
-			// We know that nothing's patched to pan, so can read it in this very basic way.
-			int32_t pan = paramManager->getPatchedParamSet()->getValue(params::LOCAL_PAN) >> 1;
+		// We know that nothing's patched to pan, so can read it in this very basic way.
+		int32_t pan = paramManager->getPatchedParamSet()->getValue(params::LOCAL_PAN) >> 1;
+		int32_t amplitudeL, amplitudeR;
+		bool doPanning = AudioEngine::renderInStereo && shouldDoPanning(pan, &amplitudeL, &amplitudeR);
 
-			int32_t amplitudeL, amplitudeR;
-			bool doPanning;
-			doPanning = (AudioEngine::renderInStereo && shouldDoPanning(pan, &amplitudeL, &amplitudeR));
+		// If just rendered in mono, double that up to stereo now
+		if (!voice_rendered_in_stereo) {
 			if (doPanning) {
-				for (int32_t i = output.size() - 1; i >= 0; i--) {
-					int32_t sampleValue = soundBuffer[i];
-					soundBuffer[(i << 1)] = multiply_32x32_rshift32(sampleValue, amplitudeL) << 2;
-					soundBuffer[(i << 1) + 1] = multiply_32x32_rshift32(sampleValue, amplitudeR) << 2;
-				}
+				// right to left because of in-place mono to stereo expansion
+				std::transform(sound_mono.rbegin(), sound_mono.rend(), sound_stereo.rbegin(), [=](q31_t sample) {
+					return StereoSample{
+					    .l = multiply_32x32_rshift32(sample, amplitudeL) << 2,
+					    .r = multiply_32x32_rshift32(sample, amplitudeR) << 2,
+					};
+				});
 			}
 			else {
-				for (int32_t i = output.size() - 1; i >= 0; i--) {
-					int32_t sampleValue = soundBuffer[i];
-					soundBuffer[(i << 1)] = sampleValue;
-					soundBuffer[(i << 1) + 1] = sampleValue;
-				}
+				// right to left because of in-place mono to stereo expansion
+				std::transform(sound_mono.rbegin(), sound_mono.rend(), sound_stereo.rbegin(), StereoSample::fromMono);
 			}
 		}
 
 		// Or if rendered in stereo...
-		else {
-			// And if we're only applying pan here at the Sound level...
-			if (!applyingPanAtVoiceLevel) {
-
-				// We know that nothing's patched to pan, so can read it in this very basic way.
-				int32_t pan = paramManager->getPatchedParamSet()->getValue(params::LOCAL_PAN) >> 1;
-
-				int32_t amplitudeL, amplitudeR;
-				bool doPanning;
-				doPanning = (AudioEngine::renderInStereo && shouldDoPanning(pan, &amplitudeL, &amplitudeR));
-				if (doPanning) {
-					int32_t* thisSample = soundBuffer;
-					int32_t* endSamples = thisSample + (output.size() << 1);
-					do {
-						*thisSample = multiply_32x32_rshift32(*thisSample, amplitudeL) << 2;
-						thisSample++;
-
-						*thisSample = multiply_32x32_rshift32(*thisSample, amplitudeR) << 2;
-						thisSample++;
-					} while (thisSample != endSamples);
-				}
+		// And if we're only applying pan here at the Sound level...
+		else if (!applyingPanAtVoiceLevel && doPanning) {
+			for (StereoSample& sample : sound_stereo) {
+				sample.l = multiply_32x32_rshift32(sample.l, amplitudeL) << 2;
+				sample.r = multiply_32x32_rshift32(sample.r, amplitudeR) << 2;
 			}
 		}
 	}
@@ -2414,8 +2390,9 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 			reassessRenderSkippingStatus(modelStackWithSoundFlags);
 		}
 
-		if (!renderingInStereo) {
-			memset(&soundBuffer[output.size()], 0, output.size() * sizeof(int32_t));
+		if (!voice_rendered_in_stereo) {
+			// Clear the non-overlapping portion of the stereo buffer (yes this is janky)
+			memset(&sound_mono[sound_mono.size()], 0, sound_stereo.size_bytes() - sound_mono.size_bytes());
 		}
 	}
 
@@ -2429,18 +2406,17 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 	int32_t modFXDepth = paramFinalValues[params::GLOBAL_MOD_FX_DEPTH - params::FIRST_GLOBAL];
 	int32_t modFXRate = paramFinalValues[params::GLOBAL_MOD_FX_RATE - params::FIRST_GLOBAL];
 
-	processSRRAndBitcrushing({(StereoSample*)soundBuffer, output.size()}, &postFXVolume, paramManager);
-	processFX({(StereoSample*)soundBuffer, output.size()}, modFXType_, modFXRate, modFXDepth, delayWorkingState,
-	          &postFXVolume, paramManager, numVoicesAssigned != 0, reverbSendAmount >> 1);
-	processStutter({(StereoSample*)soundBuffer, output.size()}, paramManager);
+	processSRRAndBitcrushing(sound_stereo, &postFXVolume, paramManager);
+	processFX(sound_stereo, modFXType_, modFXRate, modFXDepth, delayWorkingState, &postFXVolume, paramManager,
+	          numVoicesAssigned != 0, reverbSendAmount >> 1);
+	processStutter(sound_stereo, paramManager);
 
-	processReverbSendAndVolume({(StereoSample*)soundBuffer, output.size()}, reverbBuffer, postFXVolume,
-	                           postReverbVolume, reverbSendAmount, 0, true);
+	processReverbSendAndVolume(sound_stereo, reverbBuffer, postFXVolume, postReverbVolume, reverbSendAmount, 0, true);
 
 	q31_t compThreshold = paramManager->getUnpatchedParamSet()->getValue(params::UNPATCHED_COMPRESSOR_THRESHOLD);
 	compressor.setThreshold(compThreshold);
 	if (compThreshold > 0) {
-		compressor.renderVolNeutral({(StereoSample*)soundBuffer, output.size()}, postFXVolume);
+		compressor.renderVolNeutral(sound_stereo, postFXVolume);
 	}
 	else {
 		compressor.reset();
@@ -2448,12 +2424,11 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 
 	if (recorder && recorder->status < RecorderStatus::FINISHED_CAPTURING_BUT_STILL_WRITING) {
 		// we need to double it because for reasons I don't understand audio clips max volume is half the sample volume
-		recorder->feedAudio({reinterpret_cast<StereoSample*>(soundBuffer), output.size()}, true, 2);
+		recorder->feedAudio(sound_stereo, true, 2);
 	}
 
-	for (size_t i = 0; i < output.size(); ++i) {
-		output[i] += reinterpret_cast<StereoSample*>(soundBuffer)[i];
-	}
+	// add the sound to the output, i.e. output = output + sound
+	std::ranges::transform(output, sound_stereo, output.begin(), std::plus{});
 
 	postReverbVolumeLastTime = postReverbVolume;
 

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2440,7 +2440,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, StereoSample* outp
 	q31_t compThreshold = paramManager->getUnpatchedParamSet()->getValue(params::UNPATCHED_COMPRESSOR_THRESHOLD);
 	compressor.setThreshold(compThreshold);
 	if (compThreshold > 0) {
-		compressor.renderVolNeutral((StereoSample*)soundBuffer, numSamples, postFXVolume);
+		compressor.renderVolNeutral({(StereoSample*)soundBuffer, numSamples}, postFXVolume);
 	}
 	else {
 		compressor.reset();

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -162,8 +162,8 @@ public:
 
 	void patchedParamPresetValueChanged(uint8_t p, ModelStackWithSoundFlags* modelStack, int32_t oldValue,
 	                                    int32_t newValue);
-	void render(ModelStackWithThreeMainThings* modelStack, StereoSample* outputBuffer, int32_t numSamples,
-	            int32_t* reverbBuffer, int32_t sideChainHitPending, int32_t reverbAmountAdjust = 134217728,
+	void render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSample> output, int32_t* reverbBuffer,
+	            int32_t sideChainHitPending, int32_t reverbAmountAdjust = 134217728,
 	            bool shouldLimitDelayFeedback = false, int32_t pitchAdjust = kMaxSampleValue,
 	            SampleRecorder* recorder = nullptr);
 	void unassignAllVoices();

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -107,8 +107,8 @@ void SoundInstrument::renderOutput(ModelStack* modelStack, std::span<StereoSampl
 		compressor.gainReduction = 0;
 	}
 	else {
-		Sound::render(modelStackWithThreeMainThings, output.data(), output.size(), reverbBuffer, sideChainHitPending,
-		              reverbAmountAdjust, shouldLimitDelayFeedback, kMaxSampleValue, recorder);
+		Sound::render(modelStackWithThreeMainThings, output, reverbBuffer, sideChainHitPending, reverbAmountAdjust,
+		              shouldLimitDelayFeedback, kMaxSampleValue, recorder);
 	}
 
 	if (playbackHandler.isEitherClockActive() && !playbackHandler.ticksLeftInCountIn && isClipActive) {

--- a/src/deluge/processing/sound/sound_instrument.cpp
+++ b/src/deluge/processing/sound/sound_instrument.cpp
@@ -17,6 +17,7 @@
 
 #include "processing/sound/sound_instrument.h"
 #include "definitions_cxx.hpp"
+#include "dsp/stereo_sample.h"
 #include "gui/views/view.h"
 #include "model/clip/instrument_clip.h"
 #include "model/model_stack.h"
@@ -89,9 +90,9 @@ void SoundInstrument::cutAllSound() {
 	Sound::unassignAllVoices();
 }
 
-void SoundInstrument::renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos,
-                                   int32_t numSamples, int32_t* reverbBuffer, int32_t reverbAmountAdjust,
-                                   int32_t sideChainHitPending, bool shouldLimitDelayFeedback, bool isClipActive) {
+void SoundInstrument::renderOutput(ModelStack* modelStack, std::span<StereoSample> output, int32_t* reverbBuffer,
+                                   int32_t reverbAmountAdjust, int32_t sideChainHitPending,
+                                   bool shouldLimitDelayFeedback, bool isClipActive) {
 	// this should only happen in the rare case that this is called while replacing an instrument but after the clips
 	// have been cleared
 	if (!activeClip) [[unlikely]] {
@@ -106,7 +107,7 @@ void SoundInstrument::renderOutput(ModelStack* modelStack, StereoSample* startPo
 		compressor.gainReduction = 0;
 	}
 	else {
-		Sound::render(modelStackWithThreeMainThings, startPos, numSamples, reverbBuffer, sideChainHitPending,
+		Sound::render(modelStackWithThreeMainThings, output.data(), output.size(), reverbBuffer, sideChainHitPending,
 		              reverbAmountAdjust, shouldLimitDelayFeedback, kMaxSampleValue, recorder);
 	}
 
@@ -126,7 +127,7 @@ void SoundInstrument::renderOutput(ModelStack* modelStack, StereoSample* startPo
 		}
 		if (anyInterpolating) {
 yesTickParamManagerForClip:
-			modelStackWithThreeMainThings->paramManager->toForTimeline()->tickSamples(numSamples,
+			modelStackWithThreeMainThings->paramManager->toForTimeline()->tickSamples(output.size(),
 			                                                                          modelStackWithThreeMainThings);
 		}
 		else {
@@ -193,7 +194,7 @@ yesTickParamManagerForClip:
 			if (result) {
 				modelStackWithThreeMainThings->setNoteRow(thisNoteRow, thisNoteRow->y);
 				modelStackWithThreeMainThings->paramManager = &thisNoteRow->paramManager;
-				thisNoteRow->paramManager.tickSamples(numSamples, modelStackWithThreeMainThings);
+				thisNoteRow->paramManager.tickSamples(output.size(), modelStackWithThreeMainThings);
 			}
 		}
 	}

--- a/src/deluge/processing/sound/sound_instrument.h
+++ b/src/deluge/processing/sound/sound_instrument.h
@@ -35,9 +35,9 @@ public:
 	void cutAllSound() override;
 	bool noteIsOn(int32_t noteCode, bool resetTimeEntered);
 
-	void renderOutput(ModelStack* modelStack, StereoSample* startPos, StereoSample* endPos, int32_t numSamples,
-	                  int32_t* reverbBuffer, int32_t reverbAmountAdjust, int32_t sideChainHitPending,
-	                  bool shouldLimitDelayFeedback, bool isClipActive) override;
+	void renderOutput(ModelStack* modelStack, std::span<StereoSample> buffer, int32_t* reverbBuffer,
+	                  int32_t reverbAmountAdjust, int32_t sideChainHitPending, bool shouldLimitDelayFeedback,
+	                  bool isClipActive) override;
 
 	// A timelineCounter is required
 	void offerReceivedCCToLearnedParams(MIDICable& cable, uint8_t channel, uint8_t ccNumber, uint8_t value,

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -254,20 +254,6 @@ int32_t getFinalParameterValueExpWithDumbEnvelopeHack(int32_t paramNeutralValue,
 	return getFinalParameterValueExp(paramNeutralValue, patchedValue);
 }
 
-void addAudio(StereoSample* inputBuffer, StereoSample* outputBuffer, int32_t numSamples) {
-	StereoSample* inputSample = inputBuffer;
-	StereoSample* outputSample = outputBuffer;
-
-	StereoSample* inputBufferEnd = inputBuffer + numSamples;
-
-	do {
-		outputSample->l += inputSample->l;
-		outputSample->r += inputSample->r;
-
-		outputSample++;
-	} while (++inputSample != inputBufferEnd);
-}
-
 int32_t cableToLinearParamShortcut(int32_t sourceValue) {
 	return sourceValue >> 2;
 }

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -218,8 +218,6 @@ int32_t getFinalParameterValueHybrid(int32_t paramNeutralValue, int32_t patchedV
 int32_t getFinalParameterValueExp(int32_t paramNeutralValue, int32_t patchedValue);
 int32_t getFinalParameterValueExpWithDumbEnvelopeHack(int32_t paramNeutralValue, int32_t patchedValue, int32_t p);
 
-void addAudio(StereoSample* inputBuffer, StereoSample* outputBuffer, int32_t numSamples);
-
 char const* getSourceDisplayNameForOLED(PatchSource s);
 
 char const* sourceToString(PatchSource source);


### PR DESCRIPTION
Simplifies most of the audio pipeline buffer parameters to std::spans. Notably does not touch Voice or FilterSet.

It's been tested on a number of problem songs and doesn't have any sound changes, now. Recording/monitoring should probably be tested too.

![Monty_Python_Span](https://github.com/user-attachments/assets/0eadbad5-5def-4f68-a40f-8203ffca8cd4)
