### PR TITLE
Add Start Marker Editing in Audio Clip View

### DIFF
--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2023 Synthstrom Audible Limited
+ * Copyright 2019-2023 Synthstrom Audible Limited
  *
  * This file is part of The Synthstrom Audible Deluge Firmware.
  *
@@ -68,9 +68,12 @@ private:
 	int32_t lastTickSquare;
 	bool mustRedrawTickSquares;
 	bool endMarkerVisible;
+	bool startMarkerVisible;
 	bool blinkOn;
 	void changeUnderlyingSampleLength(AudioClip* clip, const Sample* sample, int32_t newLength, int32_t oldLength,
 	                                  uint64_t oldLengthSamples) const;
+	void changeUnderlyingSampleStartPos(AudioClip* clip, const Sample* sample, int32_t newStartPos, int32_t oldStartPos,
+	                                     uint64_t oldStartPosSamples) const;
 };
 
 extern AudioClipView audioClipView;

--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -74,6 +74,8 @@ private:
 	                                  uint64_t oldLengthSamples) const;
 	void changeUnderlyingSampleStartPos(AudioClip* clip, const Sample* sample, int32_t newStartPos, int32_t oldStartPos,
 	                                     uint64_t oldStartPosSamples) const;
+	void changeUnderlyingSampleEndPos(AudioClip* clip, const Sample* sample, int32_t newEndPos, int32_t oldEndPos,
+	                                  uint64_t oldEndPosSamples) const;
 };
 
 extern AudioClipView audioClipView;

--- a/src/deluge/model/clip/audio_clip.h
+++ b/src/deluge/model/clip/audio_clip.h
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2023 Synthstrom Audible Limited
+ * Copyright 2019-2023 Synthstrom Audible Limited
  *
  * This file is part of The Synthstrom Audible Deluge Firmware.
  *
@@ -84,7 +84,7 @@ public:
 	bool willCloneOutputForOverdub() override { return overdubsShouldCloneOutput; }
 	void sampleZoneChanged(ModelStackWithTimelineCounter const* modelStack);
 	int64_t getNumSamplesTilLoop(ModelStackWithTimelineCounter* modelStack);
-	void setPos(ModelStackWithTimelineCounter* modelStack, int32_t newPos, bool useActualPosForParamManagers) override;
+	void setPos(ModelStackWithTimelineCounter* modelStack, int32_t startPos, bool useActualPosForParamManagers) override;
 	/// Return true if successfully shifted, as clip cannot be shifted past beginning
 	bool shiftHorizontally(ModelStackWithTimelineCounter* modelStack, int32_t amount, bool shiftAutomation,
 	                       bool shiftSequenceAndMPE) override;


### PR DESCRIPTION
Adds the ability to edit the starting point of audio clips directly from the clip view, similar to how end points are currently edited. This makes manipulating audio clip trimming more intuitive and efficient and removes the need for the "reverse the clip then crop the end, revert reverse" workaround. See: https://www.youtube.com/watch?v=JoLCEb-pv-A&t=1304s. Here's another workaround using Arranger view: https://www.youtube.com/watch?v=iWhVUsx40Mg&t=76s .

### Changes

* Added startMarkerVisible state to track when start marker is being edited
*  Implemented start marker showing in blue (end marker stays red)
*  Modified waveform rendering to respect both start and end markers
*  Added proper cleanup of clip playback state during marker edits

### Usage

**To edit the start point:**
1. Press any pad in the first column where your audio clip starts
2. The start marker will appear in blue
3. Press another pad to move the start point
4. Press the same pad again to hide the marker

**To edit the end point (unchanged):**
1. Press any pad in the last column where your audio clip ends
2. The end marker will appear in red
3. Press another pad to move the end point
4. Press the same pad again to hide the marker