### PR TITLE
Revert "Move String backing storage to shared ptr"

### DIFF
--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
@@ -43,7 +43,7 @@ String RenameMidiCCUI::getName() const {
 	int32_t cc = clip->lastSelectedParamID;
 	std::string_view name = midiInstrument->getNameFromCC(cc);
 	String name_string;
-	name_string.set({name.data(), name.length()});
+	name_string.set(name.data(), name.length());
 	return name_string;
 }
 

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -24,38 +24,166 @@
 
 const char nothing = 0;
 
-Error String::set(std::string_view newChars) {
-	if (newChars.empty()) {
+String::~String() {
+	clear(true);
+}
+
+int32_t String::getNumReasons() {
+	return *std::bit_cast<intptr_t*>(stringMemory - 4);
+}
+
+void String::setNumReasons(int32_t newNum) {
+	*std::bit_cast<intptr_t*>(stringMemory - 4) = newNum;
+}
+
+void String::clear(bool destructing) {
+	if (stringMemory) {
+		int32_t numReasons = getNumReasons();
+		if (numReasons > 1) {
+			setNumReasons(numReasons - 1);
+		}
+		else {
+			delugeDealloc(stringMemory - 4);
+		}
+
+		if (!destructing) {
+			stringMemory = nullptr;
+		}
+	}
+}
+
+Error String::set(char const* newChars, int32_t newLength) {
+
+	if (newLength == -1) {
+		newLength = strlen(newChars);
+	}
+
+	if (!newLength) {
 		clear();
 		return Error::NONE;
 	}
 
 	// If we're here, new length is not 0
-	if (stringMemory.use_count() > 1) {
-		stringMemory = std::make_shared<std::string>(newChars);
+
+	// If already got some memory...
+	if (stringMemory) {
+
+		{
+			// If it's shared with another object, can't use it
+			int32_t numReasons = getNumReasons();
+			if (numReasons > 1) {
+				goto clearAndAllocateNew;
+			}
+
+			// If we're here, the memory is exclusively ours (1 reason)
+
+			int32_t allocatedSize = GeneralMemoryAllocator::get().getAllocatedSize(stringMemory - 4);
+
+			int32_t extraMemoryNeeded = newLength + 1 + 4 - allocatedSize;
+
+			// Either it's enough for new string...
+			if (extraMemoryNeeded <= 0) {
+				goto doCopy;
+			}
+
+			else {
+				// Try extending
+				uint32_t amountExtendedLeft, amountExtendedRight;
+				GeneralMemoryAllocator::get().extend(stringMemory - 4, extraMemoryNeeded, extraMemoryNeeded,
+				                                     &amountExtendedLeft, &amountExtendedRight);
+
+				stringMemory -= amountExtendedLeft;
+
+				// If that gave us enough...
+				if (amountExtendedLeft + amountExtendedRight >= extraMemoryNeeded) {
+					goto doCopy;
+				}
+			}
+		}
+
+		// Or it's not and we have to clear
+clearAndAllocateNew:
+		clear();
 	}
-	else {
-		stringMemory->assign(newChars);
+
+	{
+		void* newMemory = GeneralMemoryAllocator::get().allocExternal(newLength + 1 + 4);
+		if (!newMemory) {
+			return Error::INSUFFICIENT_RAM;
+		}
+		stringMemory = (char*)newMemory + 4;
 	}
+
+doCopy:
+	memcpy(stringMemory, newChars, newLength);
+	stringMemory[newLength] = 0;
+	setNumReasons(1);
 	return Error::NONE;
 }
 
 // This one can't fail!
 void String::set(String const* otherString) {
-	stringMemory = otherString->stringMemory;
+	char* sm = otherString->stringMemory;
+#if ALPHA_OR_BETA_VERSION
+	// if the other string has memory and it's not in the non audio region
+	if (sm != nullptr) {
+		if (!(EXTERNAL_MEMORY_END - RESERVED_EXTERNAL_ALLOCATOR < (uint32_t)sm && (uint32_t)sm < EXTERNAL_MEMORY_END)) {
+			FREEZE_WITH_ERROR("S001");
+			return;
+		}
+		// or if it doesn't have an allocation
+		if (!GeneralMemoryAllocator::get().getAllocatedSize(sm)) {
+			FREEZE_WITH_ERROR("S002");
+			return;
+		}
+	}
+#endif
+	clear();
+	stringMemory = sm;
+
+	beenCloned();
 }
 
-size_t String::getLength() const {
-	return stringMemory->length();
+void String::beenCloned() {
+	if (stringMemory != nullptr) {
+		setNumReasons(getNumReasons() + 1);
+	}
+}
+
+size_t String::getLength() {
+	if (stringMemory == nullptr) {
+		return 0;
+	}
+	return strlen(stringMemory);
 }
 
 Error String::shorten(int32_t newLength) {
-	if (newLength == 0) {
-		this->clear();
+	if (!newLength) {
+		clear();
 	}
 	else {
-		unique().resize(newLength);
+
+		int32_t oldNumReasons = getNumReasons();
+
+		// If reasons, we have to do a clone
+		if (oldNumReasons > 1) {
+			void* newMemory = GeneralMemoryAllocator::get().allocExternal(newLength + 1 + 4);
+			if (!newMemory) {
+				return Error::INSUFFICIENT_RAM;
+			}
+
+			setNumReasons(oldNumReasons - 1); // Reduce reasons on old memory
+
+			char* newStringMemory = (char*)newMemory + 4;
+			memcpy(newStringMemory, stringMemory, newLength); // The ending 0 will get set below
+			stringMemory = newStringMemory;
+
+			setNumReasons(1); // Set num reasons on new memory
+		}
+
+		stringMemory[newLength] = 0;
 	}
+
 	return Error::NONE;
 }
 
@@ -74,15 +202,73 @@ Error String::concatenate(char const* newChars) {
 
 Error String::concatenateAtPos(char const* newChars, int32_t pos, int32_t newCharsLength) {
 	if (pos == 0) {
-		if (newCharsLength < 0) {
-			newCharsLength = strlen(newChars);
-		}
-		return set({newChars, static_cast<size_t>(newCharsLength)});
+		return set(newChars, newCharsLength);
 	}
 
-	unique().resize(pos);
+	if (newCharsLength == -1) {
+		newCharsLength = strlen(newChars);
+	}
 
-	unique() += newChars;
+	if (newCharsLength == 0) {
+		return shorten(pos);
+	}
+
+	int32_t oldNumReasons = getNumReasons();
+
+	int32_t requiredSize = pos + newCharsLength + 4 + 1;
+	int32_t extraBytesNeeded;
+	bool deallocateAfter = true;
+
+	// If additional reasons, we definitely have to allocate afresh
+	if (oldNumReasons > 1) {
+		deallocateAfter = false;
+		setNumReasons(oldNumReasons - 1);
+		goto allocateNewMemory;
+	}
+
+	extraBytesNeeded = requiredSize - GeneralMemoryAllocator::get().getAllocatedSize(stringMemory - 4);
+
+	// If not enough memory allocated...
+	if (extraBytesNeeded > 0) {
+
+		// See if we can extend
+		uint32_t amountExtendedLeft, amountExtendedRight;
+		GeneralMemoryAllocator::get().extend(stringMemory - 4, extraBytesNeeded, extraBytesNeeded, &amountExtendedLeft,
+		                                     &amountExtendedRight);
+
+		// If that worked...
+		if (amountExtendedLeft || amountExtendedRight) {
+
+			// If extended left, gotta move stuff
+			if (amountExtendedLeft) {
+				memmove(stringMemory - amountExtendedLeft - 4, stringMemory - 4,
+				        pos + 4); // Moves the stored num reasons, too
+				stringMemory -= amountExtendedLeft;
+			}
+		}
+
+		// Otherwise, gotta allocate brand new memory
+		else {
+allocateNewMemory:
+			void* newMemory = GeneralMemoryAllocator::get().allocExternal(requiredSize);
+			if (!newMemory) {
+				return Error::INSUFFICIENT_RAM;
+			}
+
+			char* newStringMemory = (char*)newMemory + 4;
+
+			// Copy the bit we want to keep of the old memory
+			memcpy(newStringMemory, stringMemory, pos);
+
+			if (deallocateAfter) {
+				delugeDealloc(stringMemory - 4);
+			}
+			stringMemory = newStringMemory;
+			setNumReasons(1);
+		}
+	}
+	memcpy(&stringMemory[pos], newChars, newCharsLength);
+	stringMemory[pos + newCharsLength] = 0;
 
 	return Error::NONE;
 }
@@ -100,15 +286,37 @@ Error String::setInt(int32_t number, int32_t minNumDigits) {
 }
 
 Error String::setChar(char newChar, int32_t pos) {
-	unique().at(pos) = newChar;
+
+	// If any additional reasons, we gotta clone the memory first
+	int32_t oldNumReasons = getNumReasons();
+	if (oldNumReasons > 1) {
+
+		int32_t length = getLength();
+
+		int32_t requiredSize = length + 4 + 1;
+		void* newMemory = GeneralMemoryAllocator::get().allocExternal(requiredSize);
+		if (!newMemory) {
+			return Error::INSUFFICIENT_RAM;
+		}
+
+		char* newStringMemory = (char*)newMemory + 4;
+
+		// Copy the old memory
+		memcpy(newStringMemory, stringMemory, length + 1); // Copies 0 at end, too
+		setNumReasons(oldNumReasons - 1);                  // Reduce reasons on old memory
+		stringMemory = newStringMemory;
+		setNumReasons(1); // Set reasons on new memory
+	}
+
+	stringMemory[pos] = newChar;
 	return Error::NONE;
 }
 
-bool String::equals(char const* otherChars) const {
-	return *stringMemory == otherChars;
+bool String::equals(char const* otherChars) {
+	return !strcmp(get(), otherChars);
 }
 
-bool String::equalsCaseIrrespective(char const* otherChars) const {
+bool String::equalsCaseIrrespective(char const* otherChars) {
 	return !strcasecmp(get(), otherChars);
 }
 

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -20,8 +20,6 @@
 #include "definitions_cxx.hpp"
 #include <cstdint>
 #include <cstring>
-#include <memory>
-#include <string_view>
 
 extern "C" {
 #include "util/cfunctions.h"
@@ -46,13 +44,15 @@ extern const char nothing;
 
 class String {
 public:
-	String() : stringMemory(std::make_shared<std::string>()) {};
-
-	void clear() { unique().clear(); }
-
-	Error set(std::string_view otherString);
+	String() = default;
+	// String(String* otherString); // BEWARE - using this on stack instances sometimes just caused crashes and stuff.
+	// Made no sense. Instead, constructing then calling set() works
+	~String();
+	void clear(bool destructing = false);
+	Error set(char const* newChars, int32_t newLength = -1);
 	void set(String const* otherString);
-	size_t getLength() const;
+	void beenCloned();
+	size_t getLength();
 	Error shorten(int32_t newLength);
 	Error concatenateAtPos(char const* newChars, int32_t pos, int32_t newCharsLength = -1);
 	Error concatenateInt(int32_t number, int32_t minNumDigits = 1);
@@ -60,11 +60,11 @@ public:
 	Error setChar(char newChar, int32_t pos);
 	Error concatenate(String* otherString);
 	Error concatenate(char const* newChars);
-	bool equals(char const* otherChars) const;
-	bool equalsCaseIrrespective(char const* otherChars) const;
+	bool equals(char const* otherChars);
+	bool equalsCaseIrrespective(char const* otherChars);
 
-	bool contains(const char* otherChars) const { return stringMemory->contains(otherChars); }
-	bool equals(String* otherString) const {
+	inline bool contains(const char* otherChars) { return strstr(stringMemory, otherChars) != NULL; }
+	inline bool equals(String* otherString) {
 		if (stringMemory == otherString->stringMemory) {
 			return true; // Works if both lengths are 0, too
 		}
@@ -74,7 +74,7 @@ public:
 		return equals(otherString->get());
 	}
 
-	bool equalsCaseIrrespective(String* otherString) const {
+	inline bool equalsCaseIrrespective(String* otherString) {
 		if (stringMemory == otherString->stringMemory) {
 			return true; // Works if both lengths are 0, too
 		}
@@ -84,25 +84,20 @@ public:
 		return equalsCaseIrrespective(otherString->get());
 	}
 
-	char const* get() const {
+	inline char const* get() {
 		if (!stringMemory) {
 			return &nothing;
 		}
-		return stringMemory->c_str();
+		return stringMemory;
 	}
 
-	bool isEmpty() const { return stringMemory->empty(); }
+	inline bool isEmpty() { return !stringMemory; }
 
 private:
-	std::string& unique() noexcept(false) {
-		// If any additional reasons, we gotta clone the memory first
-		if (stringMemory.use_count() > 1) {
-			stringMemory = std::make_shared<std::string>(*stringMemory);
-		}
-		return *stringMemory;
-	}
+	int32_t getNumReasons();
+	void setNumReasons(int32_t newNum);
 
-	std::shared_ptr<std::string> stringMemory;
+	char* stringMemory = nullptr;
 };
 
 /// A string buffer with utility functions to append and format contents.


### PR DESCRIPTION
#3219

This reverts commit cb286e and 64ebcdca (bugfix for concatenation)

In discussion with @stellar-aria we'll move towards just using std string and a small object allocator to avoid the need for CoW strings in the first place -  Rohan used them to avoid fragmentation but improvements to the allocation strategy since then likely make it unneeded if we just separate strings (or all small objects?) from the main external allocator