### PR TITLE
Change to using an animated SD card icon instead of a loading or saving popup

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -168,8 +168,8 @@ constexpr int32_t kNoteRowCollapseSpeed = 150;
 constexpr int32_t kGreyoutSpeed = (300 * 44);
 
 constexpr int32_t kInitialFlashTime = 250;
-constexpr int32_t kFlashTime = 110;
-constexpr int32_t kFastFlashTime = 60;
+constexpr int32_t kFlashTime = 150;
+constexpr int32_t kFastFlashTime = 100;
 constexpr int32_t kSampleMarkerBlinkTime = 200;
 
 constexpr int32_t kScrollTime = 400;

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -104,9 +104,6 @@ public:
 	static const uint8_t uncheckedBoxIcon[];
 	static const uint8_t submenuArrowIcon[];
 	static const uint8_t metronomeIcon[];
-	static const uint8_t SD_icon1[];
-	static const uint8_t SD_icon2[];
-	static const uint8_t blank_icon[];
 
 	void removeWorkingAnimation() override;
 	void timerRoutine() override;

--- a/src/deluge/hid/display/oled.h
+++ b/src/deluge/hid/display/oled.h
@@ -104,6 +104,9 @@ public:
 	static const uint8_t uncheckedBoxIcon[];
 	static const uint8_t submenuArrowIcon[];
 	static const uint8_t metronomeIcon[];
+	static const uint8_t SD_icon1[];
+	static const uint8_t SD_icon2[];
+	static const uint8_t blank_icon[];
 
 	void removeWorkingAnimation() override;
 	void timerRoutine() override;


### PR DESCRIPTION
The loading animation was not working as intended, because a timer was only set once for the standard popup time. It needed to be set for a short duration, then set again once it runs out and an update is made. During the discovering of this, I created a better way to indicate loading, that doesn't block the name of the thing you are loading. I made a small SD card icon that shows up in the upper right corner. It only displays when loading or saving time exceeds 350ms. Then it will display a static icon for 750ms. Then it will load an alternate SD card icon that has the empty inner portion filled with a checkerboard. Then it will alternate between the two images every 250 ms, causing a blink to occur every 500ms (2Hz). 

Also reduced text scrolling and light blinking speeds slightly to make things easier to track and less distracting.