### PR TITLE
Check resources prior to running tasks

### DIFF
--- a/src/OSLikeStuff/scheduler_api.h
+++ b/src/OSLikeStuff/scheduler_api.h
@@ -29,7 +29,13 @@ extern "C" {
 typedef void (*TaskHandle)();
 typedef bool (*RunCondition)();
 typedef int8_t TaskID;
-
+typedef uint32_t ResourceID;
+#define NO_RESOURCE 0
+// for actually reading the SD
+#define SD 1
+#define USB 2
+// for things that can't run in the SD routine
+#define SD_ROUTINE 4
 /// Schedule a task that will be called at a regular interval.
 ///
 /// The scheduler will try to run the task at a regular cadence such that the time between start of calls to the
@@ -44,15 +50,17 @@ typedef int8_t TaskID;
 /// @param priority Priority of the task. Tasks with lower numbers are given preference over tasks with higher numbers.
 /// @param backOffTime Minimum time from completing the task to calling it again in seconds.
 /// @param targetTimeBetweenCalls Desired time between calls to the task, including the runtime for the task itself.
+/// @param resource
 uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, double targetTimeBetweenCalls,
-                         double maxTimeBetweenCalls, const char* name);
+                         double maxTimeBetweenCalls, const char* name, ResourceID resource);
 
 /// Add a task to run once, aiming to run at current time + timeToWait and worst case run at timeToWait*10
-uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name);
+uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name, ResourceID resources);
 
 /// add a task that runs only after the condition returns true. Condition checks should be very fast or they could
 /// interfere with scheduling
-uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name);
+uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name,
+                           ResourceID resources);
 void ignoreForStats();
 double getAverageRunTimeforCurrentTask();
 double getSystemTime();

--- a/src/OSLikeStuff/scheduler_api.h
+++ b/src/OSLikeStuff/scheduler_api.h
@@ -30,12 +30,13 @@ typedef void (*TaskHandle)();
 typedef bool (*RunCondition)();
 typedef int8_t TaskID;
 typedef uint32_t ResourceID;
-#define NO_RESOURCE 0
+#define RESOURCE_NONE 0
 // for actually reading the SD
-#define SD 1
-#define USB 2
+#define RESOURCE_SD 1
+#define RESOURCE_USB 2
 // for things that can't run in the SD routine
-#define SD_ROUTINE 4
+#define RESOURCE_SD_ROUTINE 4
+
 /// Schedule a task that will be called at a regular interval.
 ///
 /// The scheduler will try to run the task at a regular cadence such that the time between start of calls to the

--- a/src/OSLikeStuff/task_scheduler/resource_checker.h
+++ b/src/OSLikeStuff/task_scheduler/resource_checker.h
@@ -1,0 +1,39 @@
+//
+// Created by mark on 18/01/25.
+//
+
+#ifndef RESOURCE_CHECKER_H
+#define RESOURCE_CHECKER_H
+#include <OSLikeStuff/scheduler_api.h>
+#include <bitset>
+#include <extern.h>
+extern uint8_t currentlyAccessingCard;
+extern uint32_t usbLock;
+// this is basically a bitset however the enums need to be exposed to C code and this is easier to keep synced
+class ResourceChecker {
+	uint32_t resources_{0};
+
+public:
+	ResourceChecker() = default;
+	ResourceChecker(ResourceID resources) : resources_(resources) {};
+	/// returns whether all resources are available. This is basically shitty priority ceiling to avoid the potential of
+	/// a task locking one resource and then trying to yield while it waits for another
+	bool checkResources() const {
+		if (resources_ == NO_RESOURCE) {
+			return true;
+		}
+		bool anythingLocked = false;
+		if ((resources_ & SD) != 0u) {
+			anythingLocked |= currentlyAccessingCard;
+		}
+		if ((resources_ & USB) != 0u) {
+			anythingLocked |= usbLock;
+		}
+		if ((resources_ & SD_ROUTINE) != 0u) {
+			anythingLocked |= sdRoutineLock;
+		}
+		return !anythingLocked;
+	}
+};
+
+#endif // RESOURCE_CHECKER_H

--- a/src/OSLikeStuff/task_scheduler/resource_checker.h
+++ b/src/OSLikeStuff/task_scheduler/resource_checker.h
@@ -1,7 +1,19 @@
-//
-// Created by mark on 18/01/25.
-//
-
+/*
+ * Copyright © 2025 Mark Adams
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
 #ifndef RESOURCE_CHECKER_H
 #define RESOURCE_CHECKER_H
 #include <OSLikeStuff/scheduler_api.h>

--- a/src/OSLikeStuff/task_scheduler/resource_checker.h
+++ b/src/OSLikeStuff/task_scheduler/resource_checker.h
@@ -31,17 +31,17 @@ public:
 	/// returns whether all resources are available. This is basically shitty priority ceiling to avoid the potential of
 	/// a task locking one resource and then trying to yield while it waits for another
 	bool checkResources() const {
-		if (resources_ == NO_RESOURCE) {
+		if (resources_ == RESOURCE_NONE) {
 			return true;
 		}
 		bool anythingLocked = false;
-		if ((resources_ & SD) != 0u) {
+		if ((resources_ & RESOURCE_SD) != 0u) {
 			anythingLocked |= currentlyAccessingCard;
 		}
-		if ((resources_ & USB) != 0u) {
+		if ((resources_ & RESOURCE_USB) != 0u) {
 			anythingLocked |= usbLock;
 		}
-		if ((resources_ & SD_ROUTINE) != 0u) {
+		if ((resources_ & RESOURCE_SD_ROUTINE) != 0u) {
 			anythingLocked |= sdRoutineLock;
 		}
 		return !anythingLocked;

--- a/src/OSLikeStuff/task_scheduler/task.h
+++ b/src/OSLikeStuff/task_scheduler/task.h
@@ -109,7 +109,7 @@ struct Task {
 	[[nodiscard]] bool isReady(Time currentTime) const {
 		return state == State::READY && isReleased(currentTime) && resourcesAvailable();
 	};
-	[[nodiscard]] bool isRunnable() const { return state == State::READY; }
+	[[nodiscard]] bool isRunnable() const { return state == State::READY && resourcesAvailable(); }
 	[[nodiscard]] bool isReleased(Time currentTime) const {
 		return currentTime - lastFinishTime > schedule.backOffPeriod;
 	}

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -20,7 +20,6 @@
 #include "io/debug/log.h"
 #include "resource_checker.h"
 #include <algorithm>
-#include <iostream>
 
 #if !IN_UNIT_TESTS
 #include "memory/general_memory_allocator.h"

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -18,6 +18,7 @@
 #include "OSLikeStuff/task_scheduler/task_scheduler.h"
 
 #include "io/debug/log.h"
+#include "resource_checker.h"
 #include <algorithm>
 #include <iostream>
 
@@ -90,6 +91,9 @@ TaskID TaskManager::chooseBestTask(Time deadline) {
 		// first look based on target time
 		for (int i = (numActiveTasks - 1); i >= 0; i--) {
 			struct Task* t = &list[sortedList[i].task];
+			if (!t->isRunnable()) {
+				continue;
+			}
 			struct TaskSchedule* s = &t->schedule;
 			if (currentTime + t->durationStats.average < nextFinishTime
 			    && currentTime - t->lastFinishTime > s->targetInterval
@@ -100,6 +104,9 @@ TaskID TaskManager::chooseBestTask(Time deadline) {
 		// then look based on min time just to avoid busy waiting
 		for (int i = (numActiveTasks - 1); i >= 0; i--) {
 			struct Task* t = &list[sortedList[i].task];
+			if (!t->isRunnable()) {
+				continue;
+			}
 			struct TaskSchedule* s = &t->schedule;
 			if (currentTime + t->durationStats.average < nextFinishTime
 			    && currentTime - t->lastFinishTime > s->backOffPeriod) {
@@ -124,33 +131,36 @@ TaskID TaskManager::insertTaskToList(Task task) {
 	return index;
 };
 
-TaskID TaskManager::addRepeatingTask(TaskHandle task, TaskSchedule schedule, const char* name) {
+TaskID TaskManager::addRepeatingTask(TaskHandle task, TaskSchedule schedule, const char* name,
+                                     ResourceChecker resources) {
 	if (numRegisteredTasks >= (kMaxTasks)) {
 		return -1;
 	}
 
-	TaskID index = insertTaskToList(Task{task, schedule, name});
+	TaskID index = insertTaskToList(Task{task, schedule, name, resources});
 
 	createSortedList();
 	return index;
 }
 
-TaskID TaskManager::addOnceTask(TaskHandle task, uint8_t priority, Time timeToWait, const char* name) {
+TaskID TaskManager::addOnceTask(TaskHandle task, uint8_t priority, Time timeToWait, const char* name,
+                                ResourceChecker resources) {
 	if (numRegisteredTasks >= (kMaxTasks)) {
 		return -1;
 	}
 	Time timeToStart = running ? getSecondsFromStart() : Time(0);
-	TaskID index = insertTaskToList(Task{task, priority, timeToStart, timeToWait, name});
+	TaskID index = insertTaskToList(Task{task, priority, timeToStart, timeToWait, name, resources});
 
 	createSortedList();
 	return index;
 }
 
-TaskID TaskManager::addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name) {
+TaskID TaskManager::addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name,
+                                       ResourceChecker resources) {
 	if (numRegisteredTasks >= (kMaxTasks)) {
 		return -1;
 	}
-	TaskID index = insertTaskToList(Task{task, priority, condition, name});
+	TaskID index = insertTaskToList(Task{task, priority, condition, name, resources});
 	createSortedList();
 	return index;
 }

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.h
@@ -25,10 +25,11 @@ struct TaskManager {
 	void removeTask(TaskID id);
 	void runTask(TaskID id);
 	TaskID chooseBestTask(Time deadline);
-	TaskID addRepeatingTask(TaskHandle task, TaskSchedule schedule, const char* name);
+	TaskID addRepeatingTask(TaskHandle task, TaskSchedule schedule, const char* name, ResourceChecker resources);
 
-	TaskID addOnceTask(TaskHandle task, uint8_t priority, Time timeToWait, const char* name);
-	TaskID addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name);
+	TaskID addOnceTask(TaskHandle task, uint8_t priority, Time timeToWait, const char* name, ResourceChecker resources);
+	TaskID addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name,
+	                          ResourceChecker resources);
 
 	void createSortedList();
 	TaskID insertTaskToList(Task task);

--- a/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
@@ -3,6 +3,7 @@
 //
 #include "OSLikeStuff/scheduler_api.h"
 #include "OSLikeStuff/task_scheduler/task_scheduler.h"
+#include "resource_checker.h"
 
 extern TaskManager taskManager;
 
@@ -23,16 +24,18 @@ void setNextRunTimeforCurrentTask(double seconds) {
 }
 
 uint8_t addRepeatingTask(TaskHandle task, uint8_t priority, double backOffTime, double targetTimeBetweenCalls,
-                         double maxTimeBetweenCalls, const char* name) {
+                         double maxTimeBetweenCalls, const char* name, ResourceID resources) {
 	return taskManager.addRepeatingTask(
-	    task, TaskSchedule{priority, backOffTime, targetTimeBetweenCalls, maxTimeBetweenCalls}, name);
+	    task, TaskSchedule{priority, backOffTime, targetTimeBetweenCalls, maxTimeBetweenCalls}, name,
+	    ResourceChecker{resources});
 }
-uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name) {
-	return taskManager.addOnceTask(task, priority, timeToWait, name);
+uint8_t addOnceTask(TaskHandle task, uint8_t priority, double timeToWait, const char* name, ResourceID resources) {
+	return taskManager.addOnceTask(task, priority, timeToWait, name, ResourceChecker{resources});
 }
 
-uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name) {
-	return taskManager.addConditionalTask(task, priority, condition, name);
+uint8_t addConditionalTask(TaskHandle task, uint8_t priority, RunCondition condition, const char* name,
+                           ResourceID resources) {
+	return taskManager.addConditionalTask(task, priority, condition, name, ResourceChecker{resources});
 }
 
 void yield(RunCondition until) {

--- a/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
@@ -1,6 +1,20 @@
-//
-// Created by Mark Adams on 2024-12-05.
-//
+/*
+ * Copyright © 2025 Mark Adams
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "OSLikeStuff/scheduler_api.h"
 #include "OSLikeStuff/task_scheduler/task_scheduler.h"
 #include "resource_checker.h"

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -577,47 +577,53 @@ void registerTasks() {
 
 	// 0-9: High priority (10 for dyn tasks)
 	uint8_t p = 0;
-	addRepeatingTask(&(AudioEngine::routine), p++, 0.00001, 16 / 44100., 24 / 44100., "audio  routine");
+	addRepeatingTask(&(AudioEngine::routine), p++, 0.00001, 16 / 44100., 24 / 44100., "audio  routine", NO_RESOURCE);
 	// this one runs quickly and frequently to check for encoder changes
-	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders");
+	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders", NO_RESOURCE);
 	// formerly part of audio routine, updates midi and clock
-	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 2 / 44100., 16 / 44100, 32 / 44100., "playback routine");
+	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 2 / 44100., 16 / 44100, 32 / 44100., "playback routine",
+	                 NO_RESOURCE);
+	addRepeatingTask([]() { playbackHandler.midiRoutine(); }, p++, 2 / 44100., 16 / 44100, 32 / 44100.,
+	                 "playback routine", SD | USB);
 	addRepeatingTask([]() { audioFileManager.loadAnyEnqueuedClusters(128, false); }, p++, 0.00001, 0.00001, 0.00002,
-	                 "load clusters");
+	                 "load clusters", NO_RESOURCE);
 	// handles sd card recorders
 	// named "slow" but isn't actually, it handles audio recording setup
-	addRepeatingTask(&AudioEngine::slowRoutine, p++, 0.001, 0.005, 0.05, "audio slow");
-	addRepeatingTask(&(readButtonsAndPadsOnce), p++, 0.005, 0.005, 0.01, "buttons and pads");
+	addRepeatingTask(&AudioEngine::slowRoutine, p++, 0.001, 0.005, 0.05, "audio slow", NO_RESOURCE);
+	addRepeatingTask(&(readButtonsAndPadsOnce), p++, 0.005, 0.005, 0.01, "buttons and pads", NO_RESOURCE);
 
 	// 11-19: Medium priority (20 for dyn tasks)
 	p = 11;
-	addRepeatingTask([]() { encoders::interpretEncoders(true); }, p++, 0.005, 0.005, 0.01, "interpret encoders fast");
+	addRepeatingTask([]() { encoders::interpretEncoders(true); }, p++, 0.005, 0.005, 0.01, "interpret encoders fast",
+	                 NO_RESOURCE);
 	// 30 Hz update desired?
-	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI");
+	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI", NO_RESOURCE);
 	// this one actually actions them
-	addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow");
+	addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
+	                 SD_ROUTINE);
 
 	// Check for and handle queued SysEx traffic
-	addRepeatingTask([]() { smSysex::handleNextSysEx(); }, p++, 0.0002, 0.0002, 0.01, "Handle pending SysEx traffic.");
+	addRepeatingTask([]() { smSysex::handleNextSysEx(); }, p++, 0.0002, 0.0002, 0.01, "Handle pending SysEx traffic.",
+	                 SD);
 
 	// 21-29: Low priority (30 for dyn tasks)
 	p = 21;
 	// these ones are actually "slow" -> file manager just checks if an sd card has been inserted, audio recorder checks
 	// if recordings are finished
-	addRepeatingTask([]() { audioFileManager.slowRoutine(); }, p++, 0.1, 0.1, 0.2, "audio file slow");
-	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "audio recorder slow");
+	addRepeatingTask([]() { audioFileManager.slowRoutine(); }, p++, 0.1, 0.1, 0.2, "audio file slow", SD);
+	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "audio recorder slow", NO_RESOURCE);
 	// formerly part of cluster loading (why? no idea), actions undo/redo midi commands
-	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "playback routine");
+	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "playback routine", SD);
 	// 31-39: Idle priority (40 for dyn tasks)
 	p = 31;
-	addRepeatingTask(&(PIC::flush), p++, 0.001, 0.001, 0.02, "PIC flush");
+	addRepeatingTask(&(PIC::flush), p++, 0.001, 0.001, 0.02, "PIC flush", NO_RESOURCE);
 	if (hid::display::have_oled_screen) {
-		addRepeatingTask(&(oledRoutine), p++, 0.01, 0.01, 0.02, "oled routine");
+		addRepeatingTask(&(oledRoutine), p++, 0.01, 0.01, 0.02, "oled routine", NO_RESOURCE);
 	}
 	// needs to be called very frequently,
 	// handles animations and checks on the timers for any infrequent actions
 	// long term this should probably be made into an idle task
-	addRepeatingTask([]() { uiTimerManager.routine(); }, p++, 0.0001, 0.0007, 0.01, "ui routine");
+	addRepeatingTask([]() { uiTimerManager.routine(); }, p++, 0.0001, 0.0007, 0.01, "ui routine", NO_RESOURCE);
 
 	// addRepeatingTask([]() { AudioEngine::routineWithClusterLoading(true); }, 0, 1 / 44100., 16 / 44100., 32 / 44100.,
 	// true); addRepeatingTask(&(AudioEngine::routine), 0, 16 / 44100., 64 / 44100., true);
@@ -868,7 +874,7 @@ extern "C" int32_t deluge_main(void) {
 	midiFollow.readDefaultsFromFile();
 	PadLEDs::setBrightnessLevel(FlashStorage::defaultPadBrightness);
 	setupBlankSong(); // we always need to do this
-	addConditionalTask(setupStartupSong, 100, isCardReady, "load startup song");
+	addConditionalTask(setupStartupSong, 100, isCardReady, "load startup song", SD | SD_ROUTINE);
 
 #ifdef TEST_VECTOR
 	NoteVector noteVector;

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -577,53 +577,53 @@ void registerTasks() {
 
 	// 0-9: High priority (10 for dyn tasks)
 	uint8_t p = 0;
-	addRepeatingTask(&(AudioEngine::routine), p++, 0.00001, 16 / 44100., 24 / 44100., "audio  routine", NO_RESOURCE);
+	addRepeatingTask(&(AudioEngine::routine), p++, 0.00001, 16 / 44100., 24 / 44100., "audio  routine", RESOURCE_NONE);
 	// this one runs quickly and frequently to check for encoder changes
-	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders", NO_RESOURCE);
+	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0005, 0.001, 0.001, "read encoders", RESOURCE_NONE);
 	// formerly part of audio routine, updates midi and clock
 	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 2 / 44100., 16 / 44100, 32 / 44100., "playback routine",
-	                 NO_RESOURCE);
+	                 RESOURCE_NONE);
 	addRepeatingTask([]() { playbackHandler.midiRoutine(); }, p++, 2 / 44100., 16 / 44100, 32 / 44100.,
-	                 "playback routine", SD | USB);
+	                 "playback routine", RESOURCE_SD | RESOURCE_USB);
 	addRepeatingTask([]() { audioFileManager.loadAnyEnqueuedClusters(128, false); }, p++, 0.00001, 0.00001, 0.00002,
-	                 "load clusters", NO_RESOURCE);
+	                 "load clusters", RESOURCE_NONE);
 	// handles sd card recorders
 	// named "slow" but isn't actually, it handles audio recording setup
-	addRepeatingTask(&AudioEngine::slowRoutine, p++, 0.001, 0.005, 0.05, "audio slow", NO_RESOURCE);
-	addRepeatingTask(&(readButtonsAndPadsOnce), p++, 0.005, 0.005, 0.01, "buttons and pads", NO_RESOURCE);
+	addRepeatingTask(&AudioEngine::slowRoutine, p++, 0.001, 0.005, 0.05, "audio slow", RESOURCE_NONE);
+	addRepeatingTask(&(readButtonsAndPadsOnce), p++, 0.005, 0.005, 0.01, "buttons and pads", RESOURCE_NONE);
 
 	// 11-19: Medium priority (20 for dyn tasks)
 	p = 11;
 	addRepeatingTask([]() { encoders::interpretEncoders(true); }, p++, 0.005, 0.005, 0.01, "interpret encoders fast",
-	                 NO_RESOURCE);
+	                 RESOURCE_NONE);
 	// 30 Hz update desired?
-	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI", NO_RESOURCE);
+	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI", RESOURCE_NONE);
 	// this one actually actions them
 	addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
-	                 SD_ROUTINE);
+	                 RESOURCE_SD_ROUTINE);
 
 	// Check for and handle queued SysEx traffic
 	addRepeatingTask([]() { smSysex::handleNextSysEx(); }, p++, 0.0002, 0.0002, 0.01, "Handle pending SysEx traffic.",
-	                 SD);
+	                 RESOURCE_SD);
 
 	// 21-29: Low priority (30 for dyn tasks)
 	p = 21;
 	// these ones are actually "slow" -> file manager just checks if an sd card has been inserted, audio recorder checks
 	// if recordings are finished
-	addRepeatingTask([]() { audioFileManager.slowRoutine(); }, p++, 0.1, 0.1, 0.2, "audio file slow", SD);
-	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "audio recorder slow", NO_RESOURCE);
+	addRepeatingTask([]() { audioFileManager.slowRoutine(); }, p++, 0.1, 0.1, 0.2, "audio file slow", RESOURCE_SD);
+	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "audio recorder slow", RESOURCE_NONE);
 	// formerly part of cluster loading (why? no idea), actions undo/redo midi commands
-	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "playback routine", SD);
+	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.1, 0.1, "playback routine", RESOURCE_SD);
 	// 31-39: Idle priority (40 for dyn tasks)
 	p = 31;
-	addRepeatingTask(&(PIC::flush), p++, 0.001, 0.001, 0.02, "PIC flush", NO_RESOURCE);
+	addRepeatingTask(&(PIC::flush), p++, 0.001, 0.001, 0.02, "PIC flush", RESOURCE_NONE);
 	if (hid::display::have_oled_screen) {
-		addRepeatingTask(&(oledRoutine), p++, 0.01, 0.01, 0.02, "oled routine", NO_RESOURCE);
+		addRepeatingTask(&(oledRoutine), p++, 0.01, 0.01, 0.02, "oled routine", RESOURCE_NONE);
 	}
 	// needs to be called very frequently,
 	// handles animations and checks on the timers for any infrequent actions
 	// long term this should probably be made into an idle task
-	addRepeatingTask([]() { uiTimerManager.routine(); }, p++, 0.0001, 0.0007, 0.01, "ui routine", NO_RESOURCE);
+	addRepeatingTask([]() { uiTimerManager.routine(); }, p++, 0.0001, 0.0007, 0.01, "ui routine", RESOURCE_NONE);
 
 	// addRepeatingTask([]() { AudioEngine::routineWithClusterLoading(true); }, 0, 1 / 44100., 16 / 44100., 32 / 44100.,
 	// true); addRepeatingTask(&(AudioEngine::routine), 0, 16 / 44100., 64 / 44100., true);
@@ -874,7 +874,7 @@ extern "C" int32_t deluge_main(void) {
 	midiFollow.readDefaultsFromFile();
 	PadLEDs::setBrightnessLevel(FlashStorage::defaultPadBrightness);
 	setupBlankSong(); // we always need to do this
-	addConditionalTask(setupStartupSong, 100, isCardReady, "load startup song", SD | SD_ROUTINE);
+	addConditionalTask(setupStartupSong, 100, isCardReady, "load startup song", RESOURCE_SD | RESOURCE_SD_ROUTINE);
 
 #ifdef TEST_VECTOR
 	NoteVector noteVector;

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -120,9 +120,7 @@ extern "C" uint32_t triggerClockRisingEdgeTimes[];
 extern "C" uint32_t triggerClockRisingEdgesReceived;
 extern "C" uint32_t triggerClockRisingEdgesProcessed;
 
-// This function will be called repeatedly, at all times, to see if it's time to do a tick, and such
-void PlaybackHandler::routine() {
-
+void PlaybackHandler::midiRoutine() {
 	// Check incoming USB MIDI
 	midiEngine.checkIncomingUsbMidi();
 
@@ -130,6 +128,10 @@ void PlaybackHandler::routine() {
 	for (int32_t i = 0; i < 12 && midiEngine.checkIncomingSerialMidi(); i++) {
 		;
 	}
+}
+
+// This function will be called repeatedly, at all times, to see if it's time to do a tick, and such
+void PlaybackHandler::routine() {
 
 	// Check analog clock input
 	if (triggerClockRisingEdgesProcessed != triggerClockRisingEdgesReceived) {

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -54,6 +54,7 @@ constexpr uint16_t metronomeValueBoundaries[16] = {
 class PlaybackHandler {
 public:
 	PlaybackHandler();
+	void midiRoutine();
 	void routine();
 
 	void playButtonPressed(int32_t buttonPressLatency);

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -14,7 +14,7 @@
 #endif
 
 uint8_t currentlyAccessingCard = false;
-uint32_t  usbLock = false;
+uint32_t usbLock = false;
 bool sdRoutineLock = false;
 namespace {
 
@@ -83,7 +83,8 @@ TEST(Scheduler, schedule) {
 TEST(Scheduler, remove) {
 	static SelfRemoving selfRemoving;
 
-	TaskID id = addRepeatingTask([]() { selfRemoving.runFiveTimes(); }, 0, 0.001, 0.001, 0.001, "run five times", NO_RESOURCE);
+	TaskID id =
+	    addRepeatingTask([]() { selfRemoving.runFiveTimes(); }, 0, 0.001, 0.001, 0.001, "run five times", NO_RESOURCE);
 	selfRemoving.id = id;
 	mock().clear();
 	// will be called one less time due to the time the sleep takes not being zero

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -74,7 +74,7 @@ TEST(Scheduler, schedule) {
 	mock().clear();
 	// will be called one less time due to the time the sleep takes not being zero
 	mock().expectNCalls(0.01 / 0.001 - 1, "sleep_50ns");
-	addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sleep_50ns", NO_RESOURCE);
+	addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sleep_50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -84,7 +84,7 @@ TEST(Scheduler, remove) {
 	static SelfRemoving selfRemoving;
 
 	TaskID id =
-	    addRepeatingTask([]() { selfRemoving.runFiveTimes(); }, 0, 0.001, 0.001, 0.001, "run five times", NO_RESOURCE);
+	    addRepeatingTask([]() { selfRemoving.runFiveTimes(); }, 0, 0.001, 0.001, 0.001, "run five times", RESOURCE_NONE);
 	selfRemoving.id = id;
 	mock().clear();
 	// will be called one less time due to the time the sleep takes not being zero
@@ -99,7 +99,7 @@ TEST(Scheduler, scheduleOnce) {
 	mock().clear();
 	// will be called one less time due to the time the sleep takes not being zero
 	mock().expectNCalls(1, "sleep_50ns");
-	addOnceTask(sleep_50ns, 0, 0.001, "sleep 50ns", NO_RESOURCE);
+	addOnceTask(sleep_50ns, 0, 0.001, "sleep 50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -109,7 +109,7 @@ TEST(Scheduler, scheduleConditional) {
 	mock().clear();
 	mock().expectNCalls(1, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns", NO_RESOURCE);
+	addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -119,7 +119,7 @@ TEST(Scheduler, scheduleConditionalDoesntRun) {
 	mock().clear();
 	mock().expectNCalls(0, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns", NO_RESOURCE);
+	addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -129,7 +129,7 @@ TEST(Scheduler, backOffTime) {
 	mock().clear();
 	// will be called one less time due to the time the sleep takes not being zero
 	mock().expectNCalls(9, "sleep_50ns");
-	addRepeatingTask(sleep_50ns, 1, 0.01, 0.001, 1.0, "sleep_50ns", NO_RESOURCE);
+	addRepeatingTask(sleep_50ns, 1, 0.01, 0.001, 1.0, "sleep_50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.1);
 	mock().checkExpectations();
@@ -141,8 +141,8 @@ TEST(Scheduler, scheduleOnceWithRepeating) {
 	mock().expectNCalls(0.01 / 0.001 - 2, "sleep_50ns");
 	mock().expectNCalls(1, "sleep_2ms");
 	// every 1ms sleep for 50ns and 10ns
-	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep_50ns", NO_RESOURCE);
-	addOnceTask(sleep_2ms, 11, 0, "sleep 2ms", NO_RESOURCE);
+	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep_50ns", RESOURCE_NONE);
+	addOnceTask(sleep_2ms, 11, 0, "sleep 2ms", RESOURCE_NONE);
 	// run the scheduler for 10ms
 	taskManager.start(0.01);
 	mock().checkExpectations();
@@ -154,8 +154,8 @@ TEST(Scheduler, yield) {
 	mock().expectNCalls(0.01 / 0.001 - 1, "sleep_50ns");
 	mock().expectNCalls(1, "yield_2ms");
 	// every 1ms sleep for 50ns and 10ns
-	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep_50ns", NO_RESOURCE);
-	addOnceTask(yield_2ms, 2, 0, "sleep 2ms", NO_RESOURCE);
+	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep_50ns", RESOURCE_NONE);
+	addOnceTask(yield_2ms, 2, 0, "sleep 2ms", RESOURCE_NONE);
 	// run the scheduler for 10ms
 	taskManager.start(0.01);
 	mock().checkExpectations();
@@ -166,11 +166,11 @@ TEST(Scheduler, removeWithPriZero) {
 	mock().expectNCalls((0.01 - 0.002) / 0.001 - 1, "sleep_50ns");
 	mock().expectNCalls(2, "sleep_2ms");
 	// every 1ms sleep for 50ns and 10ns
-	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep 50ns", NO_RESOURCE);
-	addRepeatingTask([]() { passMockTime(0.00001); }, 0, 0.001, 0.001, 0.001, "mock time", NO_RESOURCE);
-	addOnceTask(sleep_2ms, 11, 0.002, "sleep 2 ms", NO_RESOURCE);
-	addRepeatingTask([]() { passMockTime(0.00003); }, 0, 0.001, 0.001, 0.001, "mock time", NO_RESOURCE);
-	addOnceTask(sleep_2ms, 11, 0.009, "sleep 2ms", NO_RESOURCE);
+	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep 50ns", RESOURCE_NONE);
+	addRepeatingTask([]() { passMockTime(0.00001); }, 0, 0.001, 0.001, 0.001, "mock time", RESOURCE_NONE);
+	addOnceTask(sleep_2ms, 11, 0.002, "sleep 2 ms", RESOURCE_NONE);
+	addRepeatingTask([]() { passMockTime(0.00003); }, 0, 0.001, 0.001, 0.001, "mock time", RESOURCE_NONE);
+	addOnceTask(sleep_2ms, 11, 0.009, "sleep 2ms", RESOURCE_NONE);
 	// run the scheduler for 10ms
 	taskManager.start(0.01);
 	mock().checkExpectations();
@@ -183,7 +183,7 @@ TEST(Scheduler, tooManyTasks) {
 	mock().expectNCalls(kMaxTasks, "sleep_50ns");
 	// more than allowed
 	for (int i = 0; i <= kMaxTasks + 10; i++) {
-		addOnceTask(sleep_50ns, 0, 0.001, "sleep 50ns", NO_RESOURCE);
+		addOnceTask(sleep_50ns, 0, 0.001, "sleep 50ns", RESOURCE_NONE);
 	}
 
 	// run the scheduler for 10ms
@@ -198,7 +198,7 @@ void reAdd50() {
 	passMockTime(0.00002);
 	numCalls += 1;
 	if (numCalls < 50) {
-		TaskID id = addOnceTask(reAdd50, 0, 0, "reAdd 50", NO_RESOURCE);
+		TaskID id = addOnceTask(reAdd50, 0, 0, "reAdd 50", RESOURCE_NONE);
 	}
 };
 /// dynamically schedules more than kMaxTask tasks while remaining under kMaxTasks at all times
@@ -206,7 +206,7 @@ TEST(Scheduler, moreThanMaxTotal) {
 	numCalls = 0;
 	mock().clear();
 	mock().expectNCalls(50, "reAdd50");
-	addOnceTask(reAdd50, 0, 0, "reAdd50", NO_RESOURCE);
+	addOnceTask(reAdd50, 0, 0, "reAdd50", RESOURCE_NONE);
 	taskManager.start(0.01);
 	mock().checkExpectations();
 }
@@ -217,9 +217,9 @@ TEST(Scheduler, scheduleMultiple) {
 	mock().expectNCalls(0.01 / 0.001 - 1, "sleep_20ns");
 	mock().expectNCalls(1, "sleep_2ms");
 	// every 1ms sleep for 50ns and 10ns
-	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep 50ns", NO_RESOURCE);
-	addRepeatingTask(sleep_20ns, 0, 0.001, 0.001, 0.001, "sleep 20ns", NO_RESOURCE);
-	addOnceTask(sleep_2ms, 11, 0.0094, "sleep 2ms", NO_RESOURCE);
+	addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep 50ns", RESOURCE_NONE);
+	addRepeatingTask(sleep_20ns, 0, 0.001, 0.001, 0.001, "sleep 20ns", RESOURCE_NONE);
+	addOnceTask(sleep_2ms, 11, 0.0094, "sleep 2ms", RESOURCE_NONE);
 	// run the scheduler for 10ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -235,9 +235,9 @@ TEST(Scheduler, overSchedule) {
 	mock().expectNCalls(0.006 / 0.001, "sleep_20ns");
 
 	// every 1ms sleep for 50ns and 10ns
-	auto fiftynshandle = addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep 50ns", NO_RESOURCE);
-	auto tennshandle = addRepeatingTask(sleep_20ns, 0, 0.001, 0.001, 0.001, "sleep 20ns", NO_RESOURCE);
-	auto twomsHandle = addRepeatingTask(sleep_2ms, 100, 0.001, 0.002, 0.005, "sleep 2ms", NO_RESOURCE);
+	auto fiftynshandle = addRepeatingTask(sleep_50ns, 10, 0.001, 0.001, 0.001, "sleep 50ns", RESOURCE_NONE);
+	auto tennshandle = addRepeatingTask(sleep_20ns, 0, 0.001, 0.001, 0.001, "sleep 20ns", RESOURCE_NONE);
+	auto twomsHandle = addRepeatingTask(sleep_2ms, 100, 0.001, 0.002, 0.005, "sleep 2ms", RESOURCE_NONE);
 	// run the scheduler for 10ms
 	taskManager.start(0.0099);
 
@@ -249,9 +249,9 @@ TEST(Scheduler, yield_with_lock) {
 	mock().expectNCalls(0, "sleep_50ns");
 	mock().expectNCalls(1, "yield_2ms");
 	// every 1ms sleep for 50ns and 10ns
-	addRepeatingTask(sleep_50ns, 10, 0.0001, 0.0001, 0.0001, "sleep_50ns", USB);
+	addRepeatingTask(sleep_50ns, 10, 0.0001, 0.0001, 0.0001, "sleep_50ns", RESOURCE_USB);
 
-	addOnceTask(yield_2ms_with_lock, 2, 0, "sleep 2ms", USB);
+	addOnceTask(yield_2ms_with_lock, 2, 0, "sleep 2ms", RESOURCE_USB);
 	// run the scheduler for 10ms
 	taskManager.start(0.002);
 	mock().checkExpectations();


### PR DESCRIPTION
Make sure that all of a tasks resources are available before trying to start it

This avoids deadlock from two tasks waiting on each other (it's essentially priority ceiling if all tasks had the same priority) as well as preventing multiple access to single resources
