### PR TITLE
reduce allocation size changes for resizeable array

### DIFF
--- a/src/deluge/model/voice/voice_vector.h
+++ b/src/deluge/model/voice/voice_vector.h
@@ -28,6 +28,7 @@ struct VoiceVectorElement {
 };
 
 struct VoiceVector : OrderedResizeableArrayWithMultiWordKey {
+	VoiceVector() { emptyingShouldFreeMemory = false; }
 	void getRangeForSound(Sound* sound, int32_t* __restrict__ ends);
 	void checkVoiceExists(Voice* voice, Sound* sound, char const* errorCode);
 

--- a/src/deluge/util/container/array/resizeable_array.cpp
+++ b/src/deluge/util/container/array/resizeable_array.cpp
@@ -209,7 +209,7 @@ void ResizeableArray::swapStateWith(ResizeableArray* other) {
 }
 
 void ResizeableArray::attemptMemoryShorten() {
-	if (staticMemoryAllocationSize) {
+	if (staticMemoryAllocationSize || !emptyingShouldFreeMemory) {
 		return;
 	}
 	if ((uint32_t)memoryAllocationStart >= (uint32_t)INTERNAL_MEMORY_BEGIN) {


### PR DESCRIPTION
Only shrink the memory if we're using less than half of it, when growing the memory always at least double it. This reduces the overall changes to array size

If emptying the array shouldn't free memory then don't shorten the allocation either - we'll probably need it again soon

Keep the voice vector from shrinking since it causes memory thrashing