### PR TITLE
Fix clang-tidy action from external repos

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,8 +1,5 @@
 name: Clang Tidy
 on:
-  pull_request:
-    branches:
-      - "community"
   pull_request_target: # Required to post comments on PR from forks
 jobs:
   clang-tidy-review:
@@ -53,7 +50,7 @@ jobs:
         run: |
           review \
             --token=${{ secrets.GITHUB_TOKEN }} \
-            --repo=${{ github.event.pull_request.head.repo.full_name }} \
+            --repo=${{ github.event.pull_request.base.repo.full_name }} \
             --pr=${{ github.event.pull_request.number }} \
             --split_workflow=True \
             --clang_tidy_binary=clang-tidy-19 \
@@ -65,4 +62,4 @@ jobs:
           USER: ${{ github.event.pull_request.user.login }}
 
       - name: Post review
-        run: post --token=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.event.pull_request.head.repo.full_name }} --lgtm-comment-body="" --num-comments-as-exitcode=True clang-tidy-review-output.json
+        run: post --token=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.event.pull_request.base.repo.full_name }} --lgtm-comment-body="" --num-comments-as-exitcode=True clang-tidy-review-output.json

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,6 +1,10 @@
 name: Clang Tidy
 on:
   pull_request_target: # Required to post comments on PR from forks
+  pull_request:
+    branches:
+      - "community"
+      - "release/**"
 jobs:
   clang-tidy-review:
     runs-on: ubuntu-latest

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,6 +13,11 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           submodules: recursive
 
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
+
       - name: Install clang-tidy
         run: |
           sudo debconf-communicate <<< "set man-db/auto-update false"
@@ -50,7 +55,7 @@ jobs:
         run: |
           review \
             --token=${{ secrets.GITHUB_TOKEN }} \
-            --repo=${{ github.event.pull_request.base.repo.full_name }} \
+            --repo=${{ github.event.pull_request.head.repo.full_name }} \
             --pr=${{ github.event.pull_request.number }} \
             --split_workflow=True \
             --clang_tidy_binary=clang-tidy-19 \

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,10 +1,6 @@
 name: Clang Tidy
 on:
   pull_request_target: # Required to post comments on PR from forks
-  pull_request:
-    branches:
-      - "community"
-      - "release/**"
 jobs:
   clang-tidy-review:
     runs-on: ubuntu-latest
@@ -59,7 +55,7 @@ jobs:
         run: |
           review \
             --token=${{ secrets.GITHUB_TOKEN }} \
-            --repo=${{ github.event.pull_request.head.repo.full_name }} \
+            --repo=${{ github.event.pull_request.base.repo.full_name }} \
             --pr=${{ github.event.pull_request.number }} \
             --split_workflow=True \
             --clang_tidy_binary=clang-tidy-19 \
@@ -71,4 +67,10 @@ jobs:
           USER: ${{ github.event.pull_request.user.login }}
 
       - name: Post review
-        run: post --token=${{ secrets.GITHUB_TOKEN }} --repo=${{ github.event.pull_request.base.repo.full_name }} --lgtm-comment-body="" --num-comments-as-exitcode=True clang-tidy-review-output.json
+        run: |
+          post \
+            --token=${{ secrets.GITHUB_TOKEN }} \
+            --repo=${{ github.event.pull_request.base.repo.full_name }} \
+            --lgtm-comment-body="" \
+            --num-comments-as-exitcode=True \
+            clang-tidy-review-output.json

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -114,7 +114,7 @@ void Submenu::drawHorizontalMenu() {
 	int32_t pageStart = currentPage * pageSize;
 
 	// Scan to beginning of the visible page:
-	auto it = std::find_if(items.begin(), items.end(), isItemRelevant);
+	auto it = std::find_if(items.begin(), items.end(), isItemRelevant); // find first relevant item
 	for (size_t n = 0; n < pageStart; n++) {
 		it = std::find_if(std::next(it), items.end(), isItemRelevant);
 	}


### PR DESCRIPTION
This is good to go despite failing due to the action not running from the PR, but from the target (and thus not currently including any of the changes in this PR)