### PR TITLE
fix override

### DIFF
--- a/src/deluge/dsp/reverb/digital.hpp
+++ b/src/deluge/dsp/reverb/digital.hpp
@@ -27,7 +27,7 @@ class Digital : public Mutable {
 	constexpr static size_t max_excursion = 16.f * kRatio;
 
 public:
-	void Process(std::span<q31_t> in, std::span<StereoSample> output) {
+	void process(std::span<q31_t> in, std::span<StereoSample> output) override {
 		typename FxEngine::Context c;
 
 		typename FxEngine::AllPass ap1(142 * kRatio);


### PR DESCRIPTION
There's a typo in the  digital verb function name so it doesn't get called