### PR TITLE
Fix shortcut blinking

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -615,7 +615,8 @@ void SoundEditor::setupShortcutsBlinkFromTable(MenuItem const* const currentItem
 }
 
 void SoundEditor::updatePadLightsFor(MenuItem* currentItem) {
-
+	resetSourceBlinks();
+	uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 	if (!inSettingsMenu() && !inNoteEditor() && currentItem != &sampleStartMenu && currentItem != &sampleEndMenu
 	    && currentItem != &audioClipSampleMarkerEditorMenuStart && currentItem != &audioClipSampleMarkerEditorMenuEnd
 	    && currentItem != &fileSelectorMenu && currentItem != static_cast<void*>(&nameEditMenu)) {


### PR DESCRIPTION
clear shortcut blinks when entering sound editor to prevent double blinking and resetting. It's especially required to clear the blink colour since that seems to have weird side effects and mess up the PIC if there's a leftover colour from another menu