### PR TITLE
clang-tidy: ignore magic numbers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -35,7 +35,8 @@ Checks: >
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-avoid-magic-numbers,  
-  -readability-identifier-length
+  -readability-identifier-length,
+  -readability-magic-numbers,
 WarningsAsErrors: false # should be true once we get there
 HeaderFileExtensions:         ['h','hh','hpp','hxx']
 ImplementationFileExtensions: ['c','cc','cpp','cxx']

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -38,10 +38,10 @@ Checks: >
   -readability-identifier-length,
   -readability-magic-numbers,
 WarningsAsErrors: false # should be true once we get there
-HeaderFileExtensions:         ['h','hh','hpp','hxx']
-ImplementationFileExtensions: ['c','cc','cpp','cxx']
+HeaderFileExtensions: ["h", "hh", "hpp", "hxx"]
+ImplementationFileExtensions: ["c", "cc", "cpp", "cxx"]
 HeaderFilterRegex: "^((?!lib|RZA1|NE10|fatfs).)*$" # don't touch external files
-ExtraArgs: ['-Wno-unknown-argument', '-Wno-unknown-warning-option', '-W']
+ExtraArgs: ["-Wno-unknown-argument", "-Wno-unknown-warning-option", "-W"]
 FormatStyle: file
 CheckOptions:
   - key: cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
@@ -54,6 +54,8 @@ CheckOptions:
     value: google
   - key: modernize-replace-auto-ptr.IncludeStyle
     value: google
+  - key: readability-function-cognitive-complexity.DescribeBasicIncrements
+    value: false
   - { key: readability-identifier-naming.NamespaceCase,       value: lower_case }
   - { key: readability-identifier-naming.ClassCase,           value: CamelCase  }
   - { key: readability-identifier-naming.ClassMemberCase,     value: lower_case }

--- a/tests/spec/string_spec.cpp
+++ b/tests/spec/string_spec.cpp
@@ -5,6 +5,7 @@ extern "C" void putchar_(char c) {
 	putchar(c);
 }
 
+// clang-format off
 describe string("deluge::string", ${
 	using namespace deluge;
 	using namespace std::literals;


### PR DESCRIPTION
Will reduce the number of spurious errors and warnings in the clang-tidy lint action due to magic numbers, which are prolific in our codebase