### PR TITLE
Remove Volume Post Reverb Send from automation view and midi follow

### DIFF
--- a/docs/features/automation_view.md
+++ b/docs/features/automation_view.md
@@ -13,7 +13,7 @@ Automatable Parameters are broken down into four categories for Automation View 
 
 1. Automatable Clip View Parameters for Synths and Kits with a row selected and affect entire DISABLED
 
-> The 71 parameters that can be edited are:
+> The 81 parameters that can be edited are:
 >
 > - **Master** Level, Pitch, Pan
 > - **LPF** Frequency, Resonance, Morph
@@ -29,10 +29,14 @@ Automatable Parameters are broken down into four categories for Automation View 
 > - **FM Mod 2** Level, Pitch, Feedback
 > - **Env 1** Attack, Decay, Sustain, Release
 > - **Env 2** Attack, Decay, Sustain, Release
+> - **Env 3** Attack, Decay, Sustain, Release
+> - **Env 4** Attack, Decay, Sustain, Release
 > - **LFO 1** Rate
 > - **LFO 2** Rate
+> - **LFO 3** Rate
+> - **LFO 4** Rate
 > - **Mod FX** Offset, Feedback, Depth, Rate
-> - **Arp** Rate, Gate, Note Probability, Reverse Probability, Bass Probability, Ratchet Amount, Ratchet Probability, Chord Probability, Chord Polyphony, Rhythm, Sequence Length, Spread Velocity, Spread Gate, Spread Octave
+> - **Arp** Rate, Gate, Spread Gate, Spread Octave, Spread Velocity, Ratchet Amount, Ratchet Probability, Chord Polyphony, Chord Probability, Note Probability, Bass Probability, Reverse Probability, Rhythm, Sequence Length
 > - **Noise** Level
 > - **Portamento**
 > - **Stutter** Rate

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -121,7 +121,7 @@ const uint32_t mutePadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITION
 
 const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_RECORD_COUNT_IN, 0};
 
-constexpr int32_t kNumNonGlobalParamsForAutomation = 82;
+constexpr int32_t kNumNonGlobalParamsForAutomation = 81;
 constexpr int32_t kNumGlobalParamsForAutomation = 26;
 constexpr int32_t kParamNodeWidth = 3;
 
@@ -151,7 +151,6 @@ const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutom
     {params::Kind::PATCHED, params::GLOBAL_DELAY_RATE},
     {params::Kind::PATCHED, params::GLOBAL_DELAY_FEEDBACK},
     // Sidechain Shape
-    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_REVERB_SEND},
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SIDECHAIN_SHAPE},
     // Decimation, Bitcrush, Wavefolder
     {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SAMPLE_RATE_REDUCTION},

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -185,8 +185,6 @@ void MidiFollow::initDefaultMappings() {
 	soundParamToCC[params::LOCAL_LFO_LOCAL_FREQ_1] = 59;
 	ccToSoundParam[60] = params::UNPATCHED_START + params::UNPATCHED_SIDECHAIN_SHAPE;
 	soundParamToCC[params::UNPATCHED_START + params::UNPATCHED_SIDECHAIN_SHAPE] = 60;
-	ccToSoundParam[61] = params::GLOBAL_VOLUME_POST_REVERB_SEND;
-	soundParamToCC[params::GLOBAL_VOLUME_POST_REVERB_SEND] = 61;
 	ccToSoundParam[62] = params::UNPATCHED_START + params::UNPATCHED_BITCRUSHING;
 	soundParamToCC[params::UNPATCHED_START + params::UNPATCHED_BITCRUSHING] = 62;
 	ccToSoundParam[63] = params::UNPATCHED_START + params::UNPATCHED_SAMPLE_RATE_REDUCTION;

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -185,6 +185,9 @@ void MidiFollow::initDefaultMappings() {
 	soundParamToCC[params::LOCAL_LFO_LOCAL_FREQ_1] = 59;
 	ccToSoundParam[60] = params::UNPATCHED_START + params::UNPATCHED_SIDECHAIN_SHAPE;
 	soundParamToCC[params::UNPATCHED_START + params::UNPATCHED_SIDECHAIN_SHAPE] = 60;
+	// TODO: replace this with the patch cable from sidechain to volume, once midi follow supports patch cables
+	// ccToSoundParam[61] = params::GLOBAL_VOLUME_POST_REVERB_SEND;
+	// soundParamToCC[params::GLOBAL_VOLUME_POST_REVERB_SEND] = 61;
 	ccToSoundParam[62] = params::UNPATCHED_START + params::UNPATCHED_BITCRUSHING;
 	soundParamToCC[params::UNPATCHED_START + params::UNPATCHED_BITCRUSHING] = 62;
 	ccToSoundParam[63] = params::UNPATCHED_START + params::UNPATCHED_SAMPLE_RATE_REDUCTION;


### PR DESCRIPTION
We should instead add the patch cable from sidechain to volume, once patch cables for midi follow is implemented.