### PR TITLE
Fixed Arp Seq Length functionality

### DIFF
--- a/src/deluge/modulation/arpeggiator.h
+++ b/src/deluge/modulation/arpeggiator.h
@@ -266,8 +266,9 @@ protected:
 	void resetBase();
 	void resetRatchet();
 	void executeArpStep(ArpeggiatorSettings* settings, uint8_t numActiveNotes, bool isRatchet,
-	                    uint32_t maxSequenceLength, uint32_t rhythm, bool shouldCarryOnRhythmNote, bool shouldPlayNote,
-	                    bool shouldPlayBassNote, bool shouldPlayReverseNote, bool shouldPlayChordNote);
+	                    uint32_t maxSequenceLength, uint32_t rhythm, bool* shouldCarryOnRhythmNote,
+	                    bool* shouldPlayNote, bool* shouldPlayBassNote, bool* shouldPlayReverseNote,
+	                    bool* shouldPlayChordNote);
 	void increasePatternIndexes(uint8_t numStepRepeats);
 	void increaseSequenceIndexes(uint32_t maxSequenceLength, uint32_t rhythm);
 	void maybeSetupNewRatchet(ArpeggiatorSettings* settings);


### PR DESCRIPTION
This bug was introduce in the big refactor made when adding Reverse Probability.

This PR fixes the bug where the Arp length was not correctly applied if there were silences in the Rhythm