### PR TITLE
gross but functional handling of cv 1+2

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2250,7 +2250,14 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 					break;
 				}
 				else if (availabilityRequirement == Availability::INSTRUMENT_AVAILABLE_IN_SESSION) {
-					if (!modelStack->song->doesNonAudioSlotHaveActiveClipInSession(outputType, newChannel)) {
+					int channelToSearch = newChannel;
+					if (newChannel == CVInstrumentMode::both) {
+						// in this case we just need to make sure the one were not about to give up is free
+						// there probably should be a gatekeeper managing the cv/gate resources but that's a lot to
+						// change and this doesn't matter much
+						channelToSearch = oldNonAudioInstrument->getChannel() == 0 ? 1 : 0;
+					}
+					if (!modelStack->song->doesNonAudioSlotHaveActiveClipInSession(outputType, channelToSearch)) {
 						break;
 					}
 				}
@@ -2334,6 +2341,10 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 
 		newInstrument = modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix, nullptr,
 		                                                              nullptr, false);
+		// this can happen specifically with cv to handle channels 1+2 together
+		if (newInstrument == oldInstrument) {
+			newInstrument = nullptr;
+		}
 
 		shouldReplaceWholeInstrument = (oldInstrumentCanBeReplaced && !newInstrument);
 

--- a/src/deluge/model/instrument/cv_instrument.h
+++ b/src/deluge/model/instrument/cv_instrument.h
@@ -23,7 +23,6 @@
 class ParamManagerForTimeline;
 class ModelStackWithThreeMainThings;
 class ModelStackWithSoundFlags;
-
 enum class CVMode : uint8_t { off, pitch, mod, aftertouch, velocity };
 enum class GateMode : uint8_t { off, gate, trigger };
 enum CVInstrumentMode { one, two, both };
@@ -54,7 +53,7 @@ public:
 		bool match{false};
 		if (type == otherType) {
 			auto ourChannel = getChannel();
-			match = ourChannel == otherChannel || ourChannel == 3 || otherChannel == 3; // 3 means both
+			match = ourChannel == otherChannel || ourChannel == both || otherChannel == both; // 3 means both
 		}
 		return match;
 	}


### PR DESCRIPTION
Fix #3351

All better solutions require a much bigger rewrite  than  I'm prepared to  do. This hacks around the fact that CV outputs are only controlled by searching the song for a cv instrument using them by searching for whichever channel they need to add instead (e.g. channel 1 searches for channel 2 when changing into channel 1+2)