### PR TITLE
fix browser to always delegate to qwertyui

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1618,7 +1618,7 @@ ActionResult Browser::padAction(int32_t x, int32_t y, int32_t on) {
 		favouritesChanged();
 		return ActionResult::DEALT_WITH;
 	}
-	if (qwertyVisible) {
+	else {
 		return QwertyUI::padAction(x, y, on);
 	}
 	return ActionResult::DEALT_WITH;


### PR DESCRIPTION
Fixes an issue where the keyboard could be visible but not respond to input