### PR TITLE
Revert "Remove AlignedBuf and replace with alignas(n) std::array"

### DIFF
--- a/src/deluge/dsp/dx/EngineMkI.cpp
+++ b/src/deluge/dsp/dx/EngineMkI.cpp
@@ -31,7 +31,7 @@
 using std::max;
 using std::min;
 
-alignas(16) const int32_t zeros[DX_MAX_N] = {0};
+const int32_t __attribute__((aligned(16))) zeros[DX_MAX_N] = {0};
 
 static const uint16_t NEGATIVE_BIT = 0x8000;
 static const uint16_t ENV_BITDEPTH = 14;
@@ -255,7 +255,7 @@ void EngineMkI::render(int32_t* output, int n, FmOpParams* params, int algorithm
 		FmOpParams& param = params[op];
 		int inbus = (flags >> 4) & 3;
 		int outbus = flags & 3;
-		int32_t* outptr = (outbus == 0) ? output : buf_[outbus - 1].data();
+		int32_t* outptr = (outbus == 0) ? output : buf_[outbus - 1].get();
 		int32_t gain1 = param.gain_out == 0 ? (ENV_MAX - 1) : param.gain_out;
 		int32_t gain2 = ENV_MAX - (param.level_in >> (28 - ENV_BITDEPTH));
 		param.gain_out = gain2;
@@ -303,7 +303,7 @@ void EngineMkI::render(int32_t* output, int n, FmOpParams* params, int algorithm
 				}
 			}
 			else {
-				compute(outptr, n, buf_[inbus - 1].data(), param.phase, param.freq, gain1, gain2, dgain, add);
+				compute(outptr, n, buf_[inbus - 1].get(), param.phase, param.freq, gain1, gain2, dgain, add);
 			}
 
 			has_contents[outbus] = true;

--- a/src/deluge/dsp/dx/EngineMkI.h
+++ b/src/deluge/dsp/dx/EngineMkI.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include "aligned_buf.h"
 #include "fm_core.h"
 #include "fm_op_kernel.h"
 

--- a/src/deluge/dsp/dx/aligned_buf.h
+++ b/src/deluge/dsp/dx/aligned_buf.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2013 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// A convenient wrapper for buffers with alignment constraints
+
+// Note that if we were on C++11, we'd use aligned_storage or somesuch.
+
+#pragma once
+
+#include <stddef.h>
+
+template <typename T, size_t size, size_t alignment = 16>
+class AlignedBuf {
+public:
+	T* get() { return (T*)((((intptr_t)storage_) + alignment - 1) & -alignment); }
+
+private:
+	unsigned char storage_[size * sizeof(T) + alignment];
+};

--- a/src/deluge/dsp/dx/fm_core.cpp
+++ b/src/deluge/dsp/dx/fm_core.cpp
@@ -82,7 +82,7 @@ void FmCore::render(int32_t* output, int n, FmOpParams* params, int algorithm, i
 		FmOpParams& param = params[op];
 		int inbus = (flags >> 4) & 3;
 		int outbus = flags & 3;
-		int32_t* outptr = (outbus == 0) ? output : buf_[outbus - 1].data();
+		int32_t* outptr = (outbus == 0) ? output : buf_[outbus - 1].get();
 		int32_t gain1 = param.gain_out;
 		int32_t gain2 = Exp2::lookup(param.level_in - (14 * (1 << 24)));
 		param.gain_out = gain2;
@@ -106,8 +106,8 @@ void FmCore::render(int32_t* output, int n, FmOpParams* params, int algorithm, i
 			}
 			else {
 				// cout << op << " normal " << inbus << outbus << " " << param.freq << add << endl;
-				FmOpKernel::compute(outptr, simd_n, buf_[inbus - 1].data(), param.phase, param.freq, gain1, gain2,
-				                    dgain, add, neon);
+				FmOpKernel::compute(outptr, simd_n, buf_[inbus - 1].get(), param.phase, param.freq, gain1, gain2, dgain,
+				                    add, neon);
 			}
 			has_contents[outbus] = true;
 		}

--- a/src/deluge/dsp/dx/fm_core.h
+++ b/src/deluge/dsp/dx/fm_core.h
@@ -16,8 +16,8 @@
 
 #pragma once
 
+#include "aligned_buf.h"
 #include "fm_op_kernel.h"
-#include <array>
 
 #define div_n(base, inv_n) ((int)((((int64_t)(base)) * (int64_t)(inv_n)) >> 30))
 
@@ -59,5 +59,5 @@ public:
 	bool neon = false;
 
 protected:
-	alignas(16) std::array<int32_t, DX_MAX_N> buf_[2];
+	AlignedBuf<int32_t, DX_MAX_N> buf_[2];
 };


### PR DESCRIPTION
Reverts SynthstromAudible/DelugeFirmware#3411 as it causes memory corruption and runtime crashing 