### PR TITLE
Fix arp params not loading for MIDI clips

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2647,8 +2647,8 @@ someError:
 			reader.match('{');
 			while (*(tagName = reader.readNextTagOrAttributeName())) {
 				bool readAndExited = arpSettings.readCommonTagsFromFile(reader, tagName, nullptr);
-
-				if (!readAndExited && (output->type == OutputType::MIDI_OUT || output->type == OutputType::CV)) {
+				if (!readAndExited
+				    && (outputTypeWhileLoading == OutputType::MIDI_OUT || outputTypeWhileLoading == OutputType::CV)) {
 					readAndExited = arpSettings.readNonAudioTagsFromFile(reader, tagName);
 				}
 


### PR DESCRIPTION
Fixes issue where Midi clips don't load the arpeggiator randomizer params