### PR TITLE
Enable audio output mode scrolling in arranger view

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -99,9 +99,14 @@ void ArrangerView::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas)
 		else {
 			stemExport.displayStemExportProgressOLED(StemExportType::TRACK);
 		}
-		return;
 	}
-	sessionView.renderOLED(canvas);
+	else if (currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW_AUDITION) {
+		Output* output = outputsOnScreen[yPressedEffective];
+		view.displayOutputName(output);
+	}
+	else {
+		sessionView.renderOLED(canvas);
+	}
 }
 
 void ArrangerView::moveClipToSession() {
@@ -2517,6 +2522,8 @@ void ArrangerView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 void ArrangerView::navigateThroughPresets(int32_t offset) {
 	Output* output = outputsOnScreen[yPressedEffective];
 	if (output->type == OutputType::AUDIO) {
+		auto ao = (AudioOutput*)output;
+		ao->scrollAudioOutputMode(offset);
 		return;
 	}
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1336,7 +1336,6 @@ void SessionView::commandChangeClipPreset(int8_t offset) {
 	else {
 		auto ao = (AudioOutput*)clip->output;
 		ao->scrollAudioOutputMode(offset);
-		renderUIsForOled();
 	}
 }
 


### PR DESCRIPTION
Enabled audio output scrolling in arranger view

Removed an unnecessary OLED render call in session view as well