### PR TITLE
Updated horizontal menu controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,17 +34,15 @@ set the stutter configuration independently of the song configuration if you wis
   - LFO 1-4.
   - Arpegiattor
 - Horizontal Menu controls. There are two different behaviours that can be toggled between to edit values and select menu items within the horizontal menu. You can toggle between them by going to the `SETTINGS > DEFAULTS -> UI -> HORIZONTAL MENU (HORZ)` and toggling `Alternative Select Behaviour (SELE)` on or off.
+  - Note: regardless of the behaviour toggle selected, you will always be able to change the selected horizontal menu's item's value by turning the select encoder when you're holding audition pad or sticky shift is enabled.
+    - Whenever you're holding audition pad or sticky shift is enabled, you can change the selected horizontal menu by `Pressing + Turning the select encoder`
+  - If you're not holding an audition pad or sticky shift is disabled, then the following select behaviours apply.
   - With `Alternative Select Behaviour (SELE)` DISABLED:
-    - `Hold audition pad` + turn select encoder to edit the value of the selected menu item
-    - With `Sticky Shift Enabled`:
-      - `Turn select encoder` to edit the value of the selected menu item
-      - `Hold shift + turn select encoder` OR `Press + Turn select encoder` to change the selected menu item
-    - With `Sticky Shift Disabled`:
-      - `Hold shift + turn select encoder` OR `Press + Turn select encoder` to change the value of the selected menu item
-      - `Turn select encoder` to change the selected menu item
+    - `Turn select encoder` to change the selected menu item
+    - `Press + Turn select encoder` to change the value of the selected menu item
   - With `Alternative Select Behaviour (SELE)` ENABLED:
-    - `Don't hold shift + turn select encoder` or `Hold shift + Press + Turn select encoder` to change the value of the selected menu item
-    - `Hold shift + turn select encoder` OR `Press + Turn select encoder` to change the selected menu item
+    - `Turn select encoder` to change the value of the selected menu item
+    - `Press + Turn select encoder` to change the selected menu item
 
 #### <ins>Clip Name Display & Copying</ins>
 - If a clip has no named "SECTION N" is displayed in place of the clip name, indicating which section the clip is in.

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -39,17 +39,15 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
   - LFO 1-4.
   - Arpegiattor
 - Horizontal Menu controls. There are two different behaviours that can be toggled between to edit values and select menu items within the horizontal menu. You can toggle between them by going to the `SETTINGS > DEFAULTS -> UI -> HORIZONTAL MENU (HORZ)` and toggling `Alternative Select Behaviour (SELE)` on or off.
+  - Note: regardless of the behaviour toggle selected, you will always be able to change the selected horizontal menu's item's value by turning the select encoder when you're holding audition pad or sticky shift is enabled.
+    - Whenever you're holding audition pad or sticky shift is enabled, you can change the selected horizontal menu by `Pressing + Turning the select encoder`
+  - If you're not holding an audition pad or sticky shift is disabled, then the following select behaviours apply.
   - With `Alternative Select Behaviour (SELE)` DISABLED:
-    - `Hold audition pad` + turn select encoder to edit the value of the selected menu item
-    - With `Sticky Shift Enabled`:
-      - `Turn select encoder` to edit the value of the selected menu item
-      - `Hold shift + turn select encoder` OR `Press + Turn select encoder` to change the selected menu item
-    - With `Sticky Shift Disabled`:
-      - `Hold shift + turn select encoder` OR `Press + Turn select encoder` to change the value of the selected menu item
-      - `Turn select encoder` to change the selected menu item
+    - `Turn select encoder` to change the selected menu item
+    - `Press + Turn select encoder` to change the value of the selected menu item
   - With `Alternative Select Behaviour (SELE)` ENABLED:
-    - `Don't hold shift + turn select encoder` or `Hold shift + Press + Turn select encoder` to change the value of the selected menu item
-    - `Hold shift + turn select encoder` OR `Press + Turn select encoder` to change the selected menu item
+    - `Turn select encoder` to change the value of the selected menu item
+    - `Press + Turn select encoder` to change the selected menu item
 
 #### 2.3 Favourites
 A Favourites-Feature has been added to the Load-UIs for most File-Types. The Favourites are displayed above the Keyboard and are only visible when the keyboard is shown. Favourites can be configured to either offer 16 Favourites (default), 16 Banks with 16 Favourites or be completely disabled via `SETTINGS > DEFAULTS -> UI -> KEYBOARD -> FAVOURITES`.

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -196,17 +196,12 @@ void Submenu::selectEncoderAction(int32_t offset) {
 	bool selectButtonPressed = Buttons::selectButtonPressUsedUp = Buttons::isButtonPressed(hid::button::SELECT_ENC);
 
 	/* turning select encoder while any of these conditions are true can change horizontal menu value
-	        i) Shift Button is stuck but not pressed; or
-	        ii) Shift button pressed but not stuck and alternative select encoder behaviour is disabled; or
-	        iii) Audition pad pressed and alternative select encoder behaviour is disabled; or
-	        iii) You're not holding shift button and Horizontal menu alternative select
-	 encoder behaviour is enabled
+	    i) Shift Button is stuck; or
+	    ii) Audition pad pressed; or
+	    iii) Horizontal menu alternative select encoder behaviour is enabled
 	*/
-	bool horizontalMenuValueChangeModifierEnabled =
-	    Buttons::isShiftStuckButNotPressed()
-	    || (Buttons::isShiftPressedButNotStuck() && !FlashStorage::defaultAlternativeSelectEncoderBehaviour)
-	    || (isUIModeActive(UI_MODE_AUDITIONING) && !FlashStorage::defaultAlternativeSelectEncoderBehaviour)
-	    || (!Buttons::isButtonPressed(hid::button::SHIFT) && FlashStorage::defaultAlternativeSelectEncoderBehaviour);
+	bool horizontalMenuValueChangeModifierEnabled = Buttons::isShiftStuck() || isUIModeActive(UI_MODE_AUDITIONING)
+	                                                || FlashStorage::defaultAlternativeSelectEncoderBehaviour;
 
 	// change horizontal menu value when either:
 	// A) You're not pressing select encoder AND value change modifier is true

--- a/src/deluge/hid/buttons.cpp
+++ b/src/deluge/hid/buttons.cpp
@@ -311,6 +311,10 @@ bool isShiftButtonPressed() {
 	return shiftCurrentlyPressed;
 }
 
+bool isShiftStuck() {
+	return shiftCurrentlyStuck;
+}
+
 bool isShiftStuckButNotPressed() {
 	return (shiftCurrentlyStuck && !isButtonPressed(deluge::hid::button::SHIFT));
 }

--- a/src/deluge/hid/buttons.h
+++ b/src/deluge/hid/buttons.h
@@ -26,6 +26,7 @@ namespace Buttons {
 ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 bool isButtonPressed(deluge::hid::Button b);
 bool isShiftButtonPressed();
+bool isShiftStuck();
 bool isShiftStuckButNotPressed();
 bool isShiftPressedButNotStuck();
 void noPressesHappening(bool inCardRoutine);


### PR DESCRIPTION
Updated horizontal menu controls to remove "holding shift" as a modifier for select encoder behavioural changes

Updated description:

- Horizontal Menu controls. There are two different behaviours that can be toggled between to edit values and select menu items within the horizontal menu. You can toggle between them by going to the `SETTINGS > DEFAULTS -> UI -> HORIZONTAL MENU (HORZ)` and toggling `Alternative Select Behaviour (SELE)` on or off.
  - Note: regardless of the behaviour toggle selected, you will always be able to change the selected horizontal menu's item's value by turning the select encoder when you're holding audition pad or sticky shift is enabled.
    - Whenever you're holding audition pad or sticky shift is enabled, you can change the selected horizontal menu by `Pressing + Turning the select encoder`
  - If you're not holding an audition pad or sticky shift is disabled, then the following select behaviours apply.
  - With `Alternative Select Behaviour (SELE)` DISABLED:
    - `Turn select encoder` to change the selected menu item
    - `Press + Turn select encoder` to change the value of the selected menu item
  - With `Alternative Select Behaviour (SELE)` ENABLED:
    - `Turn select encoder` to change the value of the selected menu item
    - `Press + Turn select encoder` to change the selected menu item