### PR TITLE
FixedPoint/Intrinsics improvements.

### DIFF
--- a/src/deluge/memory/memory_region.cpp
+++ b/src/deluge/memory/memory_region.cpp
@@ -70,7 +70,7 @@ uint32_t MemoryRegion::padSize(uint32_t requiredSize) {
 		}
 		// if it's not a power of 2 go up to the next power of 2
 		if (!((requiredSize & (requiredSize - 1)) == 0)) {
-			int magnitude = 32 - clz(requiredSize);
+			int magnitude = 32 - std::countl_zero(requiredSize);
 			requiredSize = 1 << magnitude;
 		}
 		requiredSize += extraSize;

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -94,7 +94,7 @@ void ParamSet::paramHasNoAutomationNow(ModelStackWithParamCollection const* mode
 	for (int32_t i = topUintToRepParams; i >= 0; i--) {                                                                \
 		uint32_t whichParamsHere = whichParams[i];                                                                     \
 		while (whichParamsHere) {                                                                                      \
-			int32_t whichBit = 31 - clz(whichParamsHere);                                                              \
+			int32_t whichBit = 31 - std::countl_zero(whichParamsHere);                                                 \
 			whichParamsHere &= ~((uint32_t)1 << whichBit);                                                             \
 			int32_t p = whichBit + (i << 5);
 

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -547,7 +547,7 @@ void PatchCableSet::removeAllPatchingToParam(ModelStackWithParamCollection* mode
 	for (int32_t i = kNumUnsignedIntegersToRepPatchCables - 1; i >= 0; i--) {                                          \
 		uint32_t whichParamsHere = whichParams[i];                                                                     \
 		while (whichParamsHere) {                                                                                      \
-			int32_t whichBit = 31 - clz(whichParamsHere);                                                              \
+			int32_t whichBit = 31 - std::countl_zero(whichParamsHere);                                                 \
 			whichParamsHere &= ~((uint32_t)1 << whichBit);                                                             \
 			int32_t c = whichBit + (i << 5);
 

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -23,6 +23,7 @@
 #include "storage/audio/audio_file_manager.h"
 #include "util/misc.h"
 #include <algorithm>
+#include <bit>
 #include <cstddef>
 #include <cstring>
 
@@ -34,7 +35,7 @@ void Cluster::setSize(size_t size) {
 	Cluster::size = size;
 
 	// Find the highest bit set
-	Cluster::size_magnitude = 32 - __builtin_clz(size) - 1;
+	Cluster::size_magnitude = 32 - std::countl_zero(size) - 1;
 }
 
 Cluster* Cluster::create(Cluster::Type type, bool shouldAddReasons, void* dontStealFromThing) {

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -19,6 +19,7 @@
 #include <bit>
 #include <cmath>
 #include <compare>
+#include <concepts>
 #include <cstdint>
 #include <limits>
 #include <type_traits>
@@ -42,16 +43,22 @@ static inline q31_t toPositive(q31_t a) {
 #if defined(__arm__)
 // This multiplies two numbers in signed Q31 fixed point as if they were q32, so the return value is half what it should
 // be. Use this when several corrective shifts can be accumulated and then combined
-static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) __attribute__((always_inline, unused));
-static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) {
+static constexpr q31_t multiply_32x32_rshift32(q31_t a, q31_t b) __attribute__((always_inline, unused));
+static constexpr q31_t multiply_32x32_rshift32(q31_t a, q31_t b) {
+	if constexpr (std::is_constant_evaluated()) {
+		return (int32_t)(((int64_t)a * b) >> 32);
+	}
 	q31_t out;
 	asm("smmul %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
 	return out;
 }
 
 // This multiplies two numbers in signed Q31 fixed point and rounds the result
-static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) __attribute__((always_inline, unused));
-static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
+static constexpr q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) __attribute__((always_inline, unused));
+static constexpr q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
+	if constexpr (std::is_constant_evaluated()) {
+		return (int32_t)(((int64_t)a * b + 0x80000000) >> 32);
+	}
 	q31_t out;
 	asm("smmulr %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
 	return out;
@@ -59,43 +66,47 @@ static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
 
 // This multiplies two numbers in signed Q31 fixed point, returning the result in q31. This is more useful for readable
 // multiplies
-static inline q31_t q31_mult(q31_t a, q31_t b) __attribute__((always_inline, unused));
-static inline q31_t q31_mult(q31_t a, q31_t b) {
+static constexpr q31_t q31_mult(q31_t a, q31_t b) __attribute__((always_inline, unused));
+static constexpr q31_t q31_mult(q31_t a, q31_t b) {
+	if constexpr (std::is_constant_evaluated()) {
+		return (int32_t)(((int64_t)a * b) >> 31);
+	}
 	q31_t out;
 	asm("smmul %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
 	return out * 2;
 }
 
-// This multiplies a number in q31 by a number in q32 (e.g. unsigned, 2^32 representing one), returning a scaled value a
-static inline q31_t q31tRescale(q31_t a, uint32_t proportion) __attribute__((always_inline, unused));
-static inline q31_t q31tRescale(q31_t a, uint32_t proportion) {
-	q31_t out;
-	asm("smmul %0, %1, %2" : "=r"(out) : "r"(a), "r"(proportion));
-	return out;
-}
-
 // Multiplies A and B, adds to sum, and returns output
-static inline q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
+static constexpr q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
     __attribute__((always_inline, unused));
-static inline q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
+static constexpr q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
+	if constexpr (std::is_constant_evaluated()) {
+		return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b) + 0x80000000) >> 32);
+	}
 	q31_t out;
 	asm("smmlar %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
 	return out;
 }
 
 // Multiplies A and B, adds to sum, and returns output
-static inline q31_t multiply_accumulate_32x32_rshift32(q31_t sum, q31_t a, q31_t b)
+static constexpr q31_t multiply_accumulate_32x32_rshift32(q31_t sum, q31_t a, q31_t b)
     __attribute__((always_inline, unused));
-static inline q31_t multiply_accumulate_32x32_rshift32(q31_t sum, q31_t a, q31_t b) {
+static constexpr q31_t multiply_accumulate_32x32_rshift32(q31_t sum, q31_t a, q31_t b) {
+	if constexpr (std::is_constant_evaluated()) {
+		return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b)) >> 32);
+	}
 	q31_t out;
 	asm("smmla %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
 	return out;
 }
 
 // Multiplies A and B, subtracts from sum, and returns output
-static inline q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
+static constexpr q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
     __attribute__((always_inline, unused));
-static inline q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
+static constexpr q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
+	if constexpr (std::is_constant_evaluated()) {
+		return (int32_t)((((((int64_t)sum) << 32) - ((int64_t)a * b)) + 0x80000000) >> 32);
+	}
 	q31_t out;
 	asm("smmlsr %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
 	return out;
@@ -225,12 +236,18 @@ inline int32_t clz(uint32_t input) {
 }
 #endif
 
+template <size_t bit, typename T>
+requires(bit > 0)
+[[nodiscard]] constexpr T roundToBit(T value) {
+	return value + (T{1} << bit) - T{1};
+}
+
 /// @brief Fixed point number with a configurable number of fractional bits
 /// @note This class only supports 32-bit signed fixed point numbers
 /// @tparam FractionalBits The number of fractional bits
 /// @tparam Rounded Whether to round the result when performing operations
 /// @tparam FastApproximation Whether to use a fast approximation for operations
-template <std::size_t FractionalBits, bool Rounded = false, bool FastApproximation = true>
+template <std::size_t FractionalBits, bool Rounded = true, bool FastApproximation = true>
 class FixedPoint {
 	static_assert(FractionalBits > 0, "FractionalBits must be greater than 0");
 	static_assert(FractionalBits < 32, "FractionalBits must be less than 32");
@@ -258,20 +275,18 @@ class FixedPoint {
 		}
 	}
 
-	static constexpr BaseType one() noexcept {
-		if constexpr (fractional_bits == 31) {
-			return std::numeric_limits<BaseType>::max();
-		}
-		else {
-			return 1 << fractional_bits;
-		}
+public:
+	static constexpr uint32_t one() noexcept {
+		return 1 << FractionalBits; // 1.0 in fixed point representation
 	}
 
-public:
 	constexpr static std::size_t fractional_bits = FractionalBits;
 	constexpr static std::size_t integral_bits = 32 - FractionalBits;
 	constexpr static bool rounded = Rounded;
 	constexpr static bool fast_approximation = FastApproximation;
+
+	constexpr static FixedPoint max() noexcept { return FixedPoint::from_raw(std::numeric_limits<BaseType>::max()); }
+	constexpr static FixedPoint min() noexcept { return FixedPoint::from_raw(std::numeric_limits<BaseType>::min()); }
 
 	/// @brief Default constructor
 	constexpr FixedPoint() = default;
@@ -292,12 +307,18 @@ public:
 		else if constexpr (rounded) {
 			// round
 			constexpr int32_t shift = OtherFractionalBits - FractionalBits;
-			value_ >>= shift + ((1 << shift) - 1);
+			value_ += ((1 << shift) - 1);
+			value_ >>= shift;
 		}
 		else {
 			// truncate
 			value_ >>= (OtherFractionalBits - FractionalBits);
 		}
+	}
+
+	template <std::size_t OtherFractionalBits>
+	constexpr operator FixedPoint<OtherFractionalBits>() const {
+		return FixedPoint<OtherFractionalBits>{*this};
 	}
 
 	/// @brief Convert an integer to a fixed point number
@@ -307,9 +328,9 @@ public:
 
 	/// @brief Convert from a float to a fixed point number
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	constexpr explicit FixedPoint(float value) noexcept {
+	constexpr FixedPoint(float value) noexcept {
 		if constexpr (std::is_constant_evaluated()) {
-			value *= FixedPoint::one();
+			value *= static_cast<float>(FixedPoint::one());
 			// convert from floating-point to fixed point
 			if constexpr (rounded) {
 				value_ = static_cast<BaseType>((value >= 0.0) ? std::ceil(value) : std::floor(value));
@@ -324,9 +345,14 @@ public:
 		}
 	}
 
+	template <std::size_t OtherFractionalBits, bool OtherRounded = Rounded, bool OtherApproximating = FastApproximation>
+	constexpr operator FixedPoint<OtherFractionalBits, OtherRounded, OtherApproximating>() const {
+		return FixedPoint<OtherFractionalBits, OtherRounded, OtherApproximating>{*this};
+	}
+
 	/// @brief Explicit conversion to float
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	constexpr explicit operator float() const noexcept {
+	explicit constexpr operator float() const noexcept {
 		if constexpr (std::is_constant_evaluated()) {
 			return static_cast<float>(value_) / FixedPoint::one();
 		}
@@ -337,7 +363,7 @@ public:
 
 	/// @brief Convert from a double to a fixed point number
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	constexpr explicit FixedPoint(double value) noexcept {
+	constexpr FixedPoint(double value) noexcept {
 		if constexpr (std::is_constant_evaluated()) {
 			value *= FixedPoint::one();
 			// convert from floating-point to fixed point
@@ -491,12 +517,51 @@ public:
 	}
 
 	/// @brief Division operator
+	/// Divide two fixed point numbers with different number of fractional bits
+	template <std::size_t OtherFractionalBits,
+	          std::size_t ResultFractionalBits = std::max(FractionalBits, OtherFractionalBits)
+	                                             - std::min(FractionalBits, OtherFractionalBits)>
+
+	requires(ResultFractionalBits < std::max(FractionalBits, OtherFractionalBits))
+	        && (ResultFractionalBits > std::min(FractionalBits, OtherFractionalBits))
+	constexpr FixedPoint<ResultFractionalBits, Rounded, FastApproximation>
+	operator/(const FixedPoint<OtherFractionalBits>& rhs) const {
+		if (rhs.raw() == 0) {
+			return FixedPoint<ResultFractionalBits>::from_raw(std::numeric_limits<BaseType>::max());
+		}
+
+		constexpr int shift = static_cast<int32_t>(FractionalBits) - OtherFractionalBits;
+		IntermediateType result{};
+		if constexpr (shift > 0) {
+			// this means we have more fractional bits than the divisor
+			result = (static_cast<IntermediateType>(value_) << shift) / rhs.raw();
+		}
+		else if constexpr (shift < 0) {
+			// this means we have less fractional bits than the divisor
+			result = (static_cast<IntermediateType>(value_) / (rhs.raw() << -shift));
+		}
+		else {
+			// same number of fractional bits
+			result = static_cast<IntermediateType>(value_) / rhs.raw();
+		}
+		size_t result_shift = std::max(FractionalBits, OtherFractionalBits) - ResultFractionalBits;
+
+		if constexpr (rounded) {
+			// round the result
+			result += (1 << (result_shift - 1)); // add half to round
+		}
+		return FixedPoint<ResultFractionalBits, Rounded, FastApproximation>::from_raw(
+		    result >> result_shift); // shift to get the correct number of fractional bits
+	}
+
+	/// @brief Division operator
 	/// Divide two fixed point numbers with the same number of fractional bits
 	constexpr FixedPoint operator/=(const FixedPoint& rhs) {
 		value_ = this->operator/(rhs).value_;
 		return *this;
 	}
 
+	/// a + b * c
 	/// @brief Fused multiply-add operation for fixed point numbers with a different number of fractional bits
 	template <std::size_t OtherFractionalBitsA, std::size_t OtherFractionalBitsB>
 	constexpr FixedPoint MultiplyAdd(const FixedPoint<OtherFractionalBitsA>& a,
@@ -509,6 +574,7 @@ public:
 		return *this + static_cast<FixedPoint>(a * b);
 	}
 
+	/// a + b * c
 	/// @brief Fused multiply-add operation for fixed point numbers with the same number of fractional bits
 	constexpr FixedPoint MultiplyAdd(const FixedPoint& a, const FixedPoint& b) const {
 		if constexpr (fast_approximation && (((FractionalBits * 2) - 32) == (FractionalBits - 1))) {
@@ -531,6 +597,15 @@ public:
 		int fractional_value = value_ & ((1 << fractional_bits) - 1);              // Mask out the integral part
 		int other_fractional_value = rhs.raw() & ((1 << OtherFractionalBits) - 1); // Mask out the integral parts
 
+		if constexpr (rounded) {
+			if (fractional_bits > OtherFractionalBits) {
+				fractional_value += (1 << (fractional_bits - OtherFractionalBits)) - 1;
+			}
+			else {
+				other_fractional_value += (1 << (OtherFractionalBits - fractional_bits)) - 1;
+			}
+		}
+
 		// Shift the fractional part if the number of fractional bits is different
 		if (fractional_bits > OtherFractionalBits) {
 			fractional_value >>= fractional_bits - OtherFractionalBits;
@@ -550,6 +625,15 @@ public:
 		int other_integral_value = rhs.raw() >> OtherFractionalBits;
 		int fractional_value = value_ & ((1 << fractional_bits) - 1);              // Mask out the integral part
 		int other_fractional_value = rhs.raw() & ((1 << OtherFractionalBits) - 1); // Mask out the integral part
+
+		if constexpr (rounded) {
+			if (fractional_bits > OtherFractionalBits) {
+				fractional_value += (1 << (fractional_bits - OtherFractionalBits)) - 1;
+			}
+			else {
+				other_fractional_value += (1 << (OtherFractionalBits - fractional_bits)) - 1;
+			}
+		}
 
 		// Shift the fractional part if the number of fractional bits is different
 		if (fractional_bits > OtherFractionalBits) {
@@ -578,9 +662,58 @@ public:
 	template <typename T>
 	requires std::integral<T> || std::floating_point<T>
 	constexpr bool operator==(const T& rhs) const noexcept {
-		return value_ == FixedPoint(rhs).value_;
+		return value_ == FixedPoint{rhs}.value_;
 	}
+
+	/// @brief Multiply by an integral type
+	template <std::integral T>
+	constexpr FixedPoint MultiplyInt(const T& rhs) const {
+		return FixedPoint::from_raw(value_ * static_cast<BaseType>(rhs));
+	}
+
+	/// @brief Divide by an integral type
+	template <std::integral T>
+	constexpr FixedPoint DivideInt(const T& rhs) const {
+		return FixedPoint::from_raw(value_ / static_cast<BaseType>(rhs));
+	}
+
+	template <std::integral T>
+	constexpr FixedPoint operator*(const T& rhs) const {
+		return MultiplyInt(rhs);
+	}
+
+	template <std::integral T>
+	constexpr FixedPoint operator/(const T& rhs) {
+		return DivideInt(rhs);
+	}
+
+	[[nodiscard]] constexpr int32_t integral() const { return static_cast<int32_t>(value_ >> fractional_bits); }
 
 private:
 	BaseType value_{0};
 };
+
+/// @brief Multiply by an integral type
+template <std::integral T, std::size_t FractionalBits, bool Rounded, bool FastApproximation>
+constexpr FixedPoint<FractionalBits, Rounded, FastApproximation>
+operator*(const T& lhs, const FixedPoint<FractionalBits, Rounded, FastApproximation>& rhs) {
+	return rhs.MultiplyInt(lhs);
+}
+
+template <std::floating_point T, std::size_t FractionalBits, bool Rounded, bool FastApproximation>
+constexpr FixedPoint<FractionalBits, Rounded, FastApproximation>
+operator+(const T& lhs, const FixedPoint<FractionalBits, Rounded, FastApproximation>& rhs) {
+	return rhs + lhs;
+}
+
+template <std::floating_point T, std::size_t FractionalBits, bool Rounded, bool FastApproximation>
+constexpr FixedPoint<FractionalBits, Rounded, FastApproximation>
+operator-(const T& lhs, const FixedPoint<FractionalBits, Rounded, FastApproximation>& rhs) {
+	return FixedPoint<FractionalBits, Rounded, FastApproximation>{lhs} - rhs;
+}
+
+template <std::floating_point T, std::size_t FractionalBits, bool Rounded, bool FastApproximation>
+constexpr FixedPoint<FractionalBits, Rounded, FastApproximation>
+operator*(const T& lhs, const FixedPoint<FractionalBits, Rounded, FastApproximation>& rhs) {
+	return rhs * lhs;
+}

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -151,7 +151,7 @@ public:
 
 	/// @brief Explicit conversion to float
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	[[gnu::always_inline]] constexpr FixedPoint to_float() noexcept {
+	[[gnu::always_inline]] [[nodiscard]] constexpr float to_float() const noexcept {
 		if constexpr (std::is_constant_evaluated() || !ARMv7a) {
 			return static_cast<float>(value_) / FixedPoint::one();
 		}

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -16,230 +16,24 @@
  */
 #pragma once
 
+#include "intrinsics.h"
 #include <bit>
 #include <cmath>
 #include <compare>
 #include <concepts>
-#include <cstdint>
 #include <limits>
-#include <type_traits>
 
-// signed 31 fractional bits (e.g. one would be 1<<31 but can't be represented)
 using q31_t = int32_t;
 
-constexpr q31_t ONE_Q31{2147483647};
-constexpr float ONE_Q31f{2147483647.0f};
-constexpr q31_t ONE_Q15{65536};
-constexpr q31_t NEGATIVE_ONE_Q31{-2147483648};
-constexpr q31_t ONE_OVER_SQRT2_Q31{1518500250};
+template <size_t bit, typename T>
+requires(bit > 0 && bit < 32)
+[[gnu::always_inline]] [[nodiscard]] constexpr T roundToBit(T value) {
+	return value + (T{1} << bit) - T{1};
+}
 
 // This converts the range -2^31 to 2^31 to the range 0-2^31
-static inline q31_t toPositive(q31_t a) __attribute__((always_inline, unused));
-static inline q31_t toPositive(q31_t a) {
+[[gnu::always_inline]] static inline int32_t toPositive(int32_t a) {
 	return ((a / 2) + (1073741824));
-}
-
-// this is only defined for 32 bit arm
-#if defined(__arm__)
-// This multiplies two numbers in signed Q31 fixed point as if they were q32, so the return value is half what it should
-// be. Use this when several corrective shifts can be accumulated and then combined
-static constexpr q31_t multiply_32x32_rshift32(q31_t a, q31_t b) __attribute__((always_inline, unused));
-static constexpr q31_t multiply_32x32_rshift32(q31_t a, q31_t b) {
-	if constexpr (std::is_constant_evaluated()) {
-		return (int32_t)(((int64_t)a * b) >> 32);
-	}
-	q31_t out;
-	asm("smmul %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
-	return out;
-}
-
-// This multiplies two numbers in signed Q31 fixed point and rounds the result
-static constexpr q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) __attribute__((always_inline, unused));
-static constexpr q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
-	if constexpr (std::is_constant_evaluated()) {
-		return (int32_t)(((int64_t)a * b + 0x80000000) >> 32);
-	}
-	q31_t out;
-	asm("smmulr %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
-	return out;
-}
-
-// This multiplies two numbers in signed Q31 fixed point, returning the result in q31. This is more useful for readable
-// multiplies
-static constexpr q31_t q31_mult(q31_t a, q31_t b) __attribute__((always_inline, unused));
-static constexpr q31_t q31_mult(q31_t a, q31_t b) {
-	if constexpr (std::is_constant_evaluated()) {
-		return (int32_t)(((int64_t)a * b) >> 31);
-	}
-	q31_t out;
-	asm("smmul %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
-	return out * 2;
-}
-
-// Multiplies A and B, adds to sum, and returns output
-static constexpr q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
-    __attribute__((always_inline, unused));
-static constexpr q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
-	if constexpr (std::is_constant_evaluated()) {
-		return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b) + 0x80000000) >> 32);
-	}
-	q31_t out;
-	asm("smmlar %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
-	return out;
-}
-
-// Multiplies A and B, adds to sum, and returns output
-static constexpr q31_t multiply_accumulate_32x32_rshift32(q31_t sum, q31_t a, q31_t b)
-    __attribute__((always_inline, unused));
-static constexpr q31_t multiply_accumulate_32x32_rshift32(q31_t sum, q31_t a, q31_t b) {
-	if constexpr (std::is_constant_evaluated()) {
-		return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b)) >> 32);
-	}
-	q31_t out;
-	asm("smmla %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
-	return out;
-}
-
-// Multiplies A and B, subtracts from sum, and returns output
-static constexpr q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b)
-    __attribute__((always_inline, unused));
-static constexpr q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
-	if constexpr (std::is_constant_evaluated()) {
-		return (int32_t)((((((int64_t)sum) << 32) - ((int64_t)a * b)) + 0x80000000) >> 32);
-	}
-	q31_t out;
-	asm("smmlsr %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
-	return out;
-}
-
-// computes limit((val >> rshift), 2**bits)
-template <uint8_t bits>
-static inline int32_t signed_saturate(int32_t val) __attribute__((always_inline, unused));
-template <uint8_t bits>
-static inline int32_t signed_saturate(int32_t val) {
-	int32_t out;
-	asm("ssat %0, %1, %2" : "=r"(out) : "I"(bits), "r"(val));
-	return out;
-}
-
-static inline int32_t add_saturate(int32_t a, int32_t b) __attribute__((always_inline, unused));
-static inline int32_t add_saturate(int32_t a, int32_t b) {
-	int32_t out;
-	asm("qadd %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
-	return out;
-}
-
-static inline int32_t subtract_saturate(int32_t a, int32_t b) __attribute__((always_inline, unused));
-static inline int32_t subtract_saturate(int32_t a, int32_t b) {
-	int32_t out;
-	asm("qsub %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
-	return out;
-}
-
-inline int32_t clz(uint32_t input) {
-	int32_t out;
-	asm("clz %0, %1" : "=r"(out) : "r"(input));
-	return out;
-}
-
-///@brief Convert from a float to a q31 value, saturating above 1.0
-///@note VFP instruction - 1 cycle for issue, 4 cycles result latency
-static inline q31_t q31_from_float(float value) {
-	asm("vcvt.s32.f32 %0, %0, #31" : "=t"(value) : "t"(value));
-	return std::bit_cast<q31_t>(value);
-}
-
-///@brief Convert from a q31 to a float
-///@note VFP instruction - 1 cycle for issue, 4 cycles result latency
-static inline float q31_to_float(q31_t value) {
-	asm("vcvt.f32.s32 %0, %0, #31" : "=t"(value) : "t"(value));
-	return std::bit_cast<float>(value);
-}
-#else
-
-static inline q31_t multiply_32x32_rshift32(q31_t a, q31_t b) {
-	return (int32_t)(((int64_t)a * b) >> 32);
-}
-
-// This multiplies two numbers in signed Q31 fixed point and rounds the result
-static inline q31_t multiply_32x32_rshift32_rounded(q31_t a, q31_t b) {
-	return (int32_t)(((int64_t)a * b + 0x80000000) >> 32);
-}
-
-// Multiplies A and B, adds to sum, and returns output
-static inline q31_t multiply_accumulate_32x32_rshift32(q31_t sum, q31_t a, q31_t b) {
-	return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b)) >> 32);
-}
-
-// Multiplies A and B, adds to sum, and returns output, rounding
-static inline q31_t multiply_accumulate_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
-	return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b) + 0x80000000) >> 32);
-}
-
-// Multiplies A and B, subtracts from sum, and returns output
-static inline q31_t multiply_subtract_32x32_rshift32(q31_t sum, q31_t a, q31_t b) {
-	return (int32_t)(((((int64_t)sum) << 32) - ((int64_t)a * b)) >> 32);
-}
-
-// Multiplies A and B, subtracts from sum, and returns output, rounding
-static inline q31_t multiply_subtract_32x32_rshift32_rounded(q31_t sum, q31_t a, q31_t b) {
-	return (int32_t)((((((int64_t)sum) << 32) - ((int64_t)a * b)) + 0x80000000) >> 32);
-}
-
-// computes limit((val >> rshift), 2**bits)
-template <uint8_t bits>
-static inline int32_t signed_saturate(int32_t val) {
-	return std::min(val, 1 << bits);
-}
-
-static inline int32_t add_saturate(int32_t a, int32_t b) __attribute__((always_inline, unused));
-static inline int32_t add_saturate(int32_t a, int32_t b) {
-	return a + b;
-}
-
-static inline int32_t subtract_saturate(int32_t a, int32_t b) __attribute__((always_inline, unused));
-static inline int32_t subtract_saturate(int32_t a, int32_t b) {
-	return a - b;
-}
-
-inline int32_t clz(uint32_t input) {
-	return __builtin_clz(input);
-}
-
-[[gnu::always_inline]] constexpr q31_t q31_from_float(float value) {
-	// A float is represented as 32 bits:
-	// 1-bit sign, 8-bit exponent, 24-bit mantissa
-
-	auto bits = std::bit_cast<uint32_t>(value);
-
-	// Sign bit being 1 indicates negative value
-	bool negative = bits & 0x80000000;
-
-	// Extract exponent and adjust for bias (IEEE 754)
-	int32_t exponent = static_cast<int32_t>((bits >> 23) & 0xFF) - 127;
-
-	q31_t output_value = 0;
-
-	// saturate if above 1.f
-	if (exponent >= 0) {
-		output_value = std::numeric_limits<q31_t>::max();
-	}
-
-	// extract mantissa
-	else {
-		uint32_t mantissa = (bits << 8) | 0x80000000;
-		output_value = static_cast<q31_t>(mantissa >> -exponent);
-	}
-
-	// Sign bit
-	return (negative) ? -output_value : output_value;
-}
-#endif
-
-template <size_t bit, typename T>
-requires(bit > 0)
-[[nodiscard]] constexpr T roundToBit(T value) {
-	return value + (T{1} << bit) - T{1};
 }
 
 /// @brief Fixed point number with a configurable number of fractional bits
@@ -247,7 +41,7 @@ requires(bit > 0)
 /// @tparam FractionalBits The number of fractional bits
 /// @tparam Rounded Whether to round the result when performing operations
 /// @tparam FastApproximation Whether to use a fast approximation for operations
-template <std::size_t FractionalBits, bool Rounded = true, bool FastApproximation = true>
+template <std::size_t FractionalBits, bool Rounded = true, bool FastApproximation = (FractionalBits == 31 && ARMv7a)>
 class FixedPoint {
 	static_assert(FractionalBits > 0, "FractionalBits must be greater than 0");
 	static_assert(FractionalBits < 32, "FractionalBits must be less than 32");
@@ -276,7 +70,7 @@ class FixedPoint {
 	}
 
 public:
-	static constexpr uint32_t one() noexcept {
+	static consteval uint32_t one() noexcept {
 		return 1 << FractionalBits; // 1.0 in fixed point representation
 	}
 
@@ -294,24 +88,23 @@ public:
 	/// @brief Construct a fixed point number from another fixed point number
 	/// @note This will saturate or truncate (and/or round) the value if the number of fractional bits is different
 	template <std::size_t OtherFractionalBits>
-	constexpr explicit FixedPoint(FixedPoint<OtherFractionalBits> other) noexcept : value_(other.raw()) {
+	[[gnu::always_inline]] constexpr explicit FixedPoint(FixedPoint<OtherFractionalBits> other) noexcept
+	    : value_(other.raw()) {
 		if constexpr (FractionalBits == OtherFractionalBits) {
 			return;
 		}
 		else if constexpr (FractionalBits > OtherFractionalBits) {
-			// saturate
+			// saturate (shift left)
 			constexpr int32_t shift = FractionalBits - OtherFractionalBits;
-			value_ = signed_saturate<32 - shift>(value_);
-			value_ = (value_ << shift) + (value_ % 2);
+			value_ = shift_left_saturate<shift>(value_) + (value_ % 2);
 		}
 		else if constexpr (rounded) {
-			// round
+			// round (shift right)
 			constexpr int32_t shift = OtherFractionalBits - FractionalBits;
-			value_ += ((1 << shift) - 1);
-			value_ >>= shift;
+			value_ = roundToBit<shift>(value_) >> shift;
 		}
 		else {
-			// truncate
+			// truncate (shift right)
 			value_ >>= (OtherFractionalBits - FractionalBits);
 		}
 	}
@@ -328,16 +121,18 @@ public:
 
 	/// @brief Convert from a float to a fixed point number
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	constexpr FixedPoint(float value) noexcept {
-		if constexpr (std::is_constant_evaluated()) {
-			value *= static_cast<float>(FixedPoint::one());
+	[[gnu::always_inline]] constexpr FixedPoint(float value) noexcept {
+		if constexpr (std::is_constant_evaluated() || !ARMv7a) {
+			value *= static_cast<double>(FixedPoint::one());
 			// convert from floating-point to fixed point
 			if constexpr (rounded) {
-				value_ = static_cast<BaseType>((value >= 0.0) ? std::ceil(value) : std::floor(value));
+				value = (value > 0.0) ? std::ceil(value) : std::floor(value);
 			}
-			else {
-				value_ = static_cast<BaseType>(value);
-			}
+
+			// saturate
+			value_ = static_cast<BaseType>(std::clamp<int64_t>(static_cast<int64_t>(value),
+			                                                   std::numeric_limits<BaseType>::min(),
+			                                                   std::numeric_limits<BaseType>::max()));
 		}
 		else {
 			asm("vcvt.s32.f32 %0, %1, %2" : "=t"(value) : "t"(value), "I"(fractional_bits));
@@ -352,27 +147,35 @@ public:
 
 	/// @brief Explicit conversion to float
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	explicit constexpr operator float() const noexcept {
-		if constexpr (std::is_constant_evaluated()) {
+	[[gnu::always_inline]] explicit constexpr operator float() const noexcept { return to_float(); }
+
+	/// @brief Explicit conversion to float
+	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
+	[[gnu::always_inline]] constexpr FixedPoint to_float() noexcept {
+		if constexpr (std::is_constant_evaluated() || !ARMv7a) {
 			return static_cast<float>(value_) / FixedPoint::one();
 		}
-		int32_t output = value_;
-		asm("vcvt.f32.s32 %0, %1, %2" : "=t"(output) : "t"(output), "I"(fractional_bits));
-		return std::bit_cast<float>(output);
+		else {
+			int32_t output = value_;
+			asm("vcvt.f32.s32 %0, %1, %2" : "=t"(output) : "t"(output), "I"(fractional_bits));
+			return std::bit_cast<float>(output);
+		}
 	}
 
 	/// @brief Convert from a double to a fixed point number
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	constexpr FixedPoint(double value) noexcept {
-		if constexpr (std::is_constant_evaluated()) {
+	[[gnu::always_inline]] constexpr FixedPoint(double value) noexcept {
+		if constexpr (std::is_constant_evaluated() || !ARMv7a) {
 			value *= FixedPoint::one();
 			// convert from floating-point to fixed point
 			if constexpr (rounded) {
-				value_ = static_cast<BaseType>((value >= 0.0) ? std::ceil(value) : std::floor(value));
+				value_ = (value > 0.0) ? std::ceil(value) : std::floor(value);
 			}
-			else {
-				value_ = static_cast<BaseType>(value);
-			}
+
+			// saturate
+			value_ = static_cast<BaseType>(std::clamp<int64_t>(static_cast<int64_t>(value),
+			                                                   std::numeric_limits<BaseType>::min(),
+			                                                   std::numeric_limits<BaseType>::max()));
 		}
 		else {
 			auto output = std::bit_cast<int64_t>(value);
@@ -383,37 +186,46 @@ public:
 
 	/// @brief Explicit conversion to double
 	/// @note VFP instruction - 1 cycle for issue, 4 cycles result latency
-	explicit operator double() const noexcept {
-		if constexpr (std::is_constant_evaluated()) {
+	[[gnu::always_inline]] explicit operator double() const noexcept {
+		if constexpr (std::is_constant_evaluated() || !ARMv7a) {
 			return static_cast<double>(value_) / FixedPoint::one();
 		}
-		auto output = std::bit_cast<double>((int64_t)value_);
-		asm("vcvt.f64.s32 %0, %1, %2" : "=w"(output) : "w"(output), "I"(fractional_bits));
-		return output;
+		else {
+			auto output = std::bit_cast<double>((int64_t)value_);
+			asm("vcvt.f64.s32 %0, %1, %2" : "=w"(output) : "w"(output), "I"(fractional_bits));
+			return output;
+		}
 	}
 
 	/// @brief Convert to a fixed point number with a different number of fractional bits
 	template <std::size_t OutputFractionalBits>
-	constexpr FixedPoint<OutputFractionalBits> as() const {
+	[[gnu::always_inline]] constexpr FixedPoint<OutputFractionalBits> as() const {
 		return static_cast<FixedPoint<OutputFractionalBits>>(*this);
 	}
 
 	/// @brief Explicit conversion to integer
-	template <std::integral T>
-	explicit operator T() const noexcept {
-		return static_cast<T>(value_ >> fractional_bits);
+	template <std::signed_integral T>
+	constexpr explicit operator T() const noexcept {
+		if constexpr (rounded) {
+			// round to nearest integer
+			return static_cast<T>(roundToBit<fractional_bits>(value_) >> fractional_bits);
+		}
+		else {
+			// return the integral
+			return integral();
+		}
 	}
 
-	explicit operator bool() const noexcept { return value_ != 0; }
+	constexpr explicit operator bool() const noexcept { return value_ != 0; }
 
 	/// @brief Negation operator
-	constexpr FixedPoint operator-() const { return FixedPoint::from_raw(-value_); }
+	[[gnu::always_inline]] [[nodiscard]] constexpr FixedPoint operator-() const { return from_raw(-value_); }
 
 	/// @brief Get the internal value
-	[[nodiscard]] constexpr BaseType raw() const noexcept { return value_; }
+	[[gnu::always_inline]] [[nodiscard]] constexpr BaseType raw() const noexcept { return value_; }
 
 	/// @brief Construct from a raw value
-	static constexpr FixedPoint from_raw(BaseType raw) noexcept {
+	[[gnu::always_inline]] static constexpr FixedPoint from_raw(BaseType raw) noexcept {
 		FixedPoint result{};
 		result.value_ = raw;
 		return result;
@@ -421,49 +233,51 @@ public:
 
 	/// @brief Addition operator
 	/// Add two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator+(const FixedPoint& rhs) const { return from_raw(add_saturate(value_, rhs.value_)); }
+	[[gnu::always_inline]] constexpr FixedPoint operator+(const FixedPoint& rhs) const {
+		return from_raw(add_saturate(value_, rhs.value_));
+	}
 
 	/// @brief Addition operator
 	/// Add two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator+=(const FixedPoint& rhs) {
+	[[gnu::always_inline]] constexpr FixedPoint operator+=(const FixedPoint& rhs) {
 		value_ = add_saturate(value_, rhs.value_);
 		return *this;
 	}
 
 	/// @brief Subtraction operator
 	/// Subtract two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator-(const FixedPoint& rhs) const {
+	[[gnu::always_inline]] constexpr FixedPoint operator-(const FixedPoint& rhs) const {
 		return from_raw(subtract_saturate(value_, rhs.value_));
 	}
 
 	/// @brief Subtraction operator
 	/// Subtract two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator-=(const FixedPoint& rhs) {
+	[[gnu::always_inline]] constexpr FixedPoint operator-=(const FixedPoint& rhs) {
 		value_ = subtract_saturate(value_, rhs.value_);
 		return *this;
 	}
 
 	/// @brief Multiplication operator
 	/// Multiply two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator*(const FixedPoint& rhs) const {
+	[[gnu::always_inline]] constexpr FixedPoint operator*(const FixedPoint& rhs) const {
 		if constexpr (fast_approximation && fractional_bits > 16) {
 			// less than 16 would mean no fractional bits remain after right shift by 32
 			constexpr int32_t shift = fractional_bits - ((fractional_bits * 2) - 32);
 			return from_raw(signed_most_significant_word_multiply(value_, rhs.value_) << shift);
 		}
-
-		if constexpr (rounded) {
+		else if constexpr (rounded) {
 			IntermediateType value = (static_cast<IntermediateType>(value_) * rhs.value_) >> (fractional_bits - 1);
 			return from_raw(static_cast<BaseType>((value >> 1) + (value % 2)));
 		}
-
-		IntermediateType value = (static_cast<IntermediateType>(value_) * rhs.value_) >> fractional_bits;
-		return from_raw(static_cast<BaseType>(value));
+		else {
+			IntermediateType value = (static_cast<IntermediateType>(value_) * rhs.value_) >> fractional_bits;
+			return from_raw(static_cast<BaseType>(value));
+		}
 	}
 
 	/// @brief Multiplication operator
 	/// Multiply two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator*=(const FixedPoint& rhs) {
+	[[gnu::always_inline]] constexpr FixedPoint operator*=(const FixedPoint& rhs) {
 		value_ = this->operator*(rhs).value_;
 		return *this;
 	}
@@ -496,24 +310,22 @@ public:
 	/// @brief Multiplication operator
 	/// Multiply two fixed point numbers with different number of fractional bits
 	template <std::size_t OtherFractionalBits>
-	constexpr FixedPoint operator*=(const FixedPoint<OtherFractionalBits>& rhs) {
+	[[gnu::always_inline]] constexpr FixedPoint operator*=(const FixedPoint<OtherFractionalBits>& rhs) {
 		value_ = this->operator*(rhs).value_;
 		return *this;
 	}
 
 	/// @brief Division operator
 	/// Divide two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator/(const FixedPoint& rhs) const {
-		if (rhs.value_ == 0) {
-			return from_raw(std::numeric_limits<BaseType>::max());
-		}
+	[[gnu::always_inline]] constexpr FixedPoint operator/(const FixedPoint& rhs) const {
 		if constexpr (rounded) {
 			IntermediateType value = (static_cast<IntermediateType>(value_) << (fractional_bits + 1)) / rhs.value_;
 			return from_raw(static_cast<BaseType>((value / 2) + (value % 2)));
 		}
-
-		IntermediateType value = (static_cast<IntermediateType>(value_) << fractional_bits) / rhs.value_;
-		return from_raw(static_cast<BaseType>(value));
+		else {
+			IntermediateType value = (static_cast<IntermediateType>(value_) << fractional_bits) / rhs.value_;
+			return from_raw(static_cast<BaseType>(value));
+		}
 	}
 
 	/// @brief Division operator
@@ -550,13 +362,13 @@ public:
 			// round the result
 			result += (1 << (result_shift - 1)); // add half to round
 		}
-		return FixedPoint<ResultFractionalBits, Rounded, FastApproximation>::from_raw(
-		    result >> result_shift); // shift to get the correct number of fractional bits
+		// shift to get the correct number of fractional bits
+		return FixedPoint<ResultFractionalBits, Rounded, FastApproximation>::from_raw(result >> result_shift);
 	}
 
 	/// @brief Division operator
 	/// Divide two fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint operator/=(const FixedPoint& rhs) {
+	[[gnu::always_inline]] constexpr FixedPoint operator/=(const FixedPoint& rhs) {
 		value_ = this->operator/(rhs).value_;
 		return *this;
 	}
@@ -569,22 +381,29 @@ public:
 		// ensure that the number of fractional bits in the addend is equal to the sum of the number of fractional bits
 		// in multiplicands, minus 32 (due to right shift) before using smmla/smmlar
 		if constexpr (fast_approximation && (OtherFractionalBitsA + OtherFractionalBitsB) - 32 == FractionalBits) {
-			return FixedPoint::from_raw(signed_most_significant_word_multiply_add(value_, a.raw(), b.raw()));
+			return from_raw(signed_most_significant_word_multiply_add(value_, a.raw(), b.raw()));
 		}
-		return *this + static_cast<FixedPoint>(a * b);
+		else {
+			return *this + static_cast<FixedPoint>(a * b);
+		}
 	}
 
 	/// a + b * c
 	/// @brief Fused multiply-add operation for fixed point numbers with the same number of fractional bits
-	constexpr FixedPoint MultiplyAdd(const FixedPoint& a, const FixedPoint& b) const {
-		if constexpr (fast_approximation && (((FractionalBits * 2) - 32) == (FractionalBits - 1))) {
-			return from_raw(static_cast<FixedPoint<FractionalBits - 1>>(*this).MultiplyAdd(a, b).raw() << 1);
+	[[nodiscard]] constexpr FixedPoint MultiplyAdd(const FixedPoint& a, const FixedPoint& b) const {
+		if constexpr (fast_approximation && (((fractional_bits * 2) - 32) == (fractional_bits - 1))) {
+			// fractional_bits - 1 is due to the left shift
+			return from_raw(signed_most_significant_word_multiply_add(value_, a.raw(), b.raw()) << 1);
 		}
-		return *this + (a * b);
+		else {
+			return *this + (a * b);
+		}
 	}
 
 	/// @brief Equality operator
-	constexpr bool operator==(const FixedPoint& rhs) const noexcept { return value_ == rhs.value_; }
+	[[gnu::always_inline]] constexpr bool operator==(const FixedPoint& rhs) const noexcept {
+		return value_ == rhs.value_;
+	}
 
 	/// @brief Three-way comparison operator
 	constexpr std::strong_ordering operator<=>(const FixedPoint& rhs) const noexcept { return value_ <=> rhs.value_; }
@@ -598,16 +417,16 @@ public:
 		int other_fractional_value = rhs.raw() & ((1 << OtherFractionalBits) - 1); // Mask out the integral parts
 
 		if constexpr (rounded) {
-			if (fractional_bits > OtherFractionalBits) {
-				fractional_value += (1 << (fractional_bits - OtherFractionalBits)) - 1;
+			if constexpr (fractional_bits > OtherFractionalBits) {
+				fractional_value = roundToBit<fractional_bits - OtherFractionalBits>(fractional_value);
 			}
 			else {
-				other_fractional_value += (1 << (OtherFractionalBits - fractional_bits)) - 1;
+				other_fractional_value = roundToBit<OtherFractionalBits - fractional_bits>(other_fractional_value);
 			}
 		}
 
 		// Shift the fractional part if the number of fractional bits is different
-		if (fractional_bits > OtherFractionalBits) {
+		if constexpr (fractional_bits > OtherFractionalBits) {
 			fractional_value >>= fractional_bits - OtherFractionalBits;
 		}
 		else {
@@ -660,34 +479,46 @@ public:
 
 	/// @brief Equality operator for integers and floating point numbers
 	template <typename T>
-	requires std::integral<T> || std::floating_point<T>
-	constexpr bool operator==(const T& rhs) const noexcept {
+	requires std::floating_point<T>
+	[[gnu::always_inline]] constexpr bool operator==(const T& rhs) const noexcept {
 		return value_ == FixedPoint{rhs}.value_;
 	}
 
 	/// @brief Multiply by an integral type
 	template <std::integral T>
-	constexpr FixedPoint MultiplyInt(const T& rhs) const {
+	[[gnu::always_inline]] constexpr FixedPoint MultiplyInt(const T& rhs) const {
 		return FixedPoint::from_raw(value_ * static_cast<BaseType>(rhs));
 	}
 
 	/// @brief Divide by an integral type
 	template <std::integral T>
-	constexpr FixedPoint DivideInt(const T& rhs) const {
+	[[gnu::always_inline]] constexpr FixedPoint DivideInt(const T& rhs) const {
 		return FixedPoint::from_raw(value_ / static_cast<BaseType>(rhs));
 	}
 
 	template <std::integral T>
-	constexpr FixedPoint operator*(const T& rhs) const {
+	[[gnu::always_inline]] constexpr FixedPoint operator*(const T& rhs) const {
 		return MultiplyInt(rhs);
 	}
 
 	template <std::integral T>
-	constexpr FixedPoint operator/(const T& rhs) {
+	[[gnu::always_inline]] constexpr FixedPoint operator/(const T& rhs) {
 		return DivideInt(rhs);
 	}
 
-	[[nodiscard]] constexpr int32_t integral() const { return static_cast<int32_t>(value_ >> fractional_bits); }
+	[[gnu::always_inline]] [[nodiscard]] constexpr int32_t integral() const {
+		return static_cast<int32_t>(value_ >> fractional_bits);
+	}
+
+	[[gnu::always_inline]] constexpr FixedPoint absolute() const noexcept {
+		if constexpr (fractional_bits == 31) {
+			// This converts the range -2^31 to 2^31 to the range 0-2^31
+			return from_raw((value_ / 2) + (1073741824));
+		}
+		else {
+			return from_raw(value_ < 0 ? -value_ : value_);
+		}
+	}
 
 private:
 	BaseType value_{0};
@@ -717,3 +548,9 @@ constexpr FixedPoint<FractionalBits, Rounded, FastApproximation>
 operator*(const T& lhs, const FixedPoint<FractionalBits, Rounded, FastApproximation>& rhs) {
 	return rhs * lhs;
 }
+
+constexpr int32_t ONE_Q31 = FixedPoint<31>{1.f}.raw();
+constexpr float ONE_Q31f = static_cast<float>(ONE_Q31);
+constexpr int32_t ONE_Q15 = FixedPoint<15>{1.f}.raw();
+constexpr int32_t NEGATIVE_ONE_Q31 = FixedPoint<31>{-1.f}.raw();
+constexpr int32_t ONE_OVER_SQRT2_Q31 = FixedPoint<31>{1 / std::numbers::sqrt2}.raw();

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -126,7 +126,7 @@ public:
 			value *= static_cast<double>(FixedPoint::one());
 			// convert from floating-point to fixed point
 			if constexpr (rounded) {
-				value = (value > 0.0) ? std::ceil(value) : std::floor(value);
+				value = std::round(value);
 			}
 
 			// saturate
@@ -169,7 +169,7 @@ public:
 			value *= FixedPoint::one();
 			// convert from floating-point to fixed point
 			if constexpr (rounded) {
-				value_ = (value > 0.0) ? std::ceil(value) : std::floor(value);
+				value = std::round(value);
 			}
 
 			// saturate

--- a/src/deluge/util/fixedpoint.h
+++ b/src/deluge/util/fixedpoint.h
@@ -96,7 +96,8 @@ public:
 		else if constexpr (FractionalBits > OtherFractionalBits) {
 			// saturate (shift left)
 			constexpr int32_t shift = FractionalBits - OtherFractionalBits;
-			value_ = shift_left_saturate<shift>(value_) + (value_ % 2);
+			value_ = signed_saturate<32 - shift>(value_);
+			value_ = (value_ << shift) + (value_ % 2);
 		}
 		else if constexpr (rounded) {
 			// round (shift right)
@@ -416,15 +417,6 @@ public:
 		int fractional_value = value_ & ((1 << fractional_bits) - 1);              // Mask out the integral part
 		int other_fractional_value = rhs.raw() & ((1 << OtherFractionalBits) - 1); // Mask out the integral parts
 
-		if constexpr (rounded) {
-			if constexpr (fractional_bits > OtherFractionalBits) {
-				fractional_value = roundToBit<fractional_bits - OtherFractionalBits>(fractional_value);
-			}
-			else {
-				other_fractional_value = roundToBit<OtherFractionalBits - fractional_bits>(other_fractional_value);
-			}
-		}
-
 		// Shift the fractional part if the number of fractional bits is different
 		if constexpr (fractional_bits > OtherFractionalBits) {
 			fractional_value >>= fractional_bits - OtherFractionalBits;
@@ -444,15 +436,6 @@ public:
 		int other_integral_value = rhs.raw() >> OtherFractionalBits;
 		int fractional_value = value_ & ((1 << fractional_bits) - 1);              // Mask out the integral part
 		int other_fractional_value = rhs.raw() & ((1 << OtherFractionalBits) - 1); // Mask out the integral part
-
-		if constexpr (rounded) {
-			if (fractional_bits > OtherFractionalBits) {
-				fractional_value += (1 << (fractional_bits - OtherFractionalBits)) - 1;
-			}
-			else {
-				other_fractional_value += (1 << (OtherFractionalBits - fractional_bits)) - 1;
-			}
-		}
 
 		// Shift the fractional part if the number of fractional bits is different
 		if (fractional_bits > OtherFractionalBits) {

--- a/src/deluge/util/functions.h
+++ b/src/deluge/util/functions.h
@@ -392,11 +392,11 @@ int32_t divide_round_negative(int32_t dividend, int32_t divisor);
 }
 
 [[gnu::always_inline]] inline int32_t getMagnitudeOld(uint32_t input) {
-	return 32 - clz(input);
+	return 32 - std::countl_zero(input);
 }
 
 [[gnu::always_inline]] inline int32_t getMagnitude(uint32_t input) {
-	return 31 - clz(input);
+	return 31 - std::countl_zero(input);
 }
 
 [[gnu::always_inline]] inline bool isPowerOfTwo(uint32_t input) {

--- a/src/deluge/util/intrinsics.h
+++ b/src/deluge/util/intrinsics.h
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2025 Katherine Whitlock
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <algorithm>
+#include <cstdint>
+#include <type_traits>
+
+#ifdef __GNUC__
+#ifdef __clang__
+#define COMPILER_CLANG 1
+#define COMPILER_GCC 0
+#else
+#define COMPILER_CLANG 0
+#define COMPILER_GCC 1
+#endif
+#endif
+
+#ifndef __ARM_ARCH
+#define __ARM_ARCH 0
+#endif
+
+#ifndef __ARM_ARCH_7A__
+#define __ARM_ARCH_7A__ 0
+#endif
+
+constexpr bool ARMv7a = (__ARM_ARCH == 7 && __ARM_ARCH_7A__);
+constexpr bool kCompilerClang = COMPILER_CLANG;
+
+// This multiplies two numbers in signed Q31 fixed point as if they were q32, so the return value is half what it should
+// be. Use this when several corrective shifts can be accumulated and then combined
+[[gnu::always_inline]] static constexpr int32_t multiply_32x32_rshift32(int32_t a, int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a || kCompilerClang) {
+		return (int32_t)(((int64_t)a * b) >> 32);
+	}
+}
+
+// This multiplies two numbers in signed Q31 fixed point and rounds the result
+[[gnu::always_inline]] static constexpr int32_t multiply_32x32_rshift32_rounded(int32_t a, int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a || kCompilerClang) {
+		return (int32_t)(((int64_t)a * b + 0x80000000) >> 32);
+	}
+	else {
+		int32_t out;
+		asm("smmulr %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
+		return out;
+	}
+}
+
+/// @brief This multiplies two numbers in signed Q31 fixed point, returning the result in Q31.
+/// @deprecated This function is deprecated. Use FixedPoint<31>::multiply instead.
+/// @note deprecated because the two branches perform different operations and cannot be relied on for testing
+[[gnu::always_inline]] static constexpr int32_t q31_mult(int32_t a, int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a) {
+		return (int32_t)(((int64_t)a * b) >> 31);
+	}
+	else {
+		return multiply_32x32_rshift32(a, b) << 1;
+	}
+}
+
+// Multiplies A and B, adds to sum, and returns output
+[[gnu::always_inline]] static constexpr int32_t multiply_accumulate_32x32_rshift32_rounded(int32_t sum, int32_t a,
+                                                                                           int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a || kCompilerClang) {
+		return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b) + 0x80000000) >> 32);
+	}
+	else {
+		int32_t out;
+		asm("smmlar %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
+		return out;
+	}
+}
+
+// Multiplies A and B, adds to sum, and returns output
+[[gnu::always_inline]] static constexpr int32_t multiply_accumulate_32x32_rshift32(int32_t sum, int32_t a, int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a || kCompilerClang) {
+		return (int32_t)(((((int64_t)sum) << 32) + ((int64_t)a * b)) >> 32);
+	}
+	else {
+		int32_t out;
+		asm("smmla %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
+		return out;
+	}
+}
+
+// Multiplies A and B, subtracts from sum, and returns output
+[[gnu::always_inline]] static constexpr int32_t multiply_subtract_32x32_rshift32_rounded(int32_t sum, int32_t a,
+                                                                                         int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a || kCompilerClang) {
+		return (int32_t)((((((int64_t)sum) << 32) - ((int64_t)a * b)) + 0x80000000) >> 32);
+	}
+	else {
+		int32_t out;
+		asm("smmlsr %0, %1, %2, %3" : "=r"(out) : "r"(a), "r"(b), "r"(sum));
+		return out;
+	}
+}
+
+// computes limit((val >> rshift), 2**bits)
+template <size_t bits>
+requires(bits < 32)
+[[gnu::always_inline]] static constexpr int32_t signed_saturate(int32_t val) {
+	/// https://developer.arm.com/documentation/ddi0406/c/Application-Level-Architecture/Instruction-Details/Alphabetical-list-of-instructions/SSAT
+	return std::clamp<int32_t>(val, -(1LL << (bits - 1)), (1LL << (bits - 1)) - 1);
+
+	/// GCC and Clang both properly reduce this to a single SSAT instruction, so there's no need to use inline asm
+	/// See: https://gcc.godbolt.org/z/e5chEzej6
+}
+
+template <size_t bits>
+requires(bits <= 32)
+[[gnu::always_inline]] static constexpr uint32_t unsigned_saturate(uint32_t val) {
+	/// https://developer.arm.com/documentation/ddi0406/c/Application-Level-Architecture/Instruction-Details/Alphabetical-list-of-instructions/USAT
+	if constexpr (std::is_constant_evaluated() || !ARMv7a) {
+		return std::clamp<uint32_t>(val, 0u, (1uL << bits) - 1);
+	}
+	else {
+		uint32_t out;
+		asm("usat %0, %1, %2" : "=r"(out) : "I"(bits), "r"(val));
+		return out;
+	}
+}
+
+template <size_t shift, size_t bits = 32>
+requires(shift < 32 && bits <= 32)
+[[gnu::always_inline]] static constexpr int32_t shift_left_saturate(int32_t val) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a) {
+		return std::clamp<int64_t>((int64_t)val << shift, -(1LL << (bits - 1)), (1LL << (bits - 1)) - 1);
+	}
+	else {
+		int32_t out;
+		asm("ssat %0, %1, %2, LSL %3" : "=r"(out) : "I"(bits), "r"(val), "I"(shift));
+		return out;
+	}
+}
+
+template <size_t shift, size_t bits = 32>
+requires(shift < 32 && bits <= 32)
+[[gnu::always_inline]] static constexpr uint32_t shift_left_saturate(uint32_t val) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a) {
+		return std::clamp<uint64_t>((uint64_t)val << shift, 0u, (1uLL << bits) - 1);
+	}
+	else {
+		uint32_t out;
+		asm("usat %0, %1, %2, LSL %3" : "=r"(out) : "I"(bits), "r"(val), "I"(shift));
+		return out;
+	}
+}
+
+[[gnu::always_inline]] static constexpr int32_t add_saturate(int32_t a, int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a) {
+		return std::clamp<int64_t>(a + b, -(1LL << 31), (1LL << 31) - 1);
+	}
+	else {
+		int32_t out;
+		asm("qadd %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
+		return out;
+	}
+}
+
+[[gnu::always_inline]] static constexpr int32_t subtract_saturate(int32_t a, int32_t b) {
+	if constexpr (std::is_constant_evaluated() || !ARMv7a) {
+		return std::clamp<int64_t>(a - b, -(1LL << 31), (1LL << 31) - 1);
+	}
+	else {
+		int32_t out;
+		asm("qsub %0, %1, %2" : "=r"(out) : "r"(a), "r"(b));
+		return out;
+	}
+}
+
+/// clz removed as std::countl_zero reduces to the same instruction
+/// See: https://gcc.godbolt.org/z/xzns6neaq
+
+///@brief Convert from a float to a q31 value, saturating above 1.0
+///@note VFP instruction - 1 cycle for issue, 4 cycles result latency
+///@deprecated This function is deprecated. Use FixedPoint<31>::FixedPoint instead.
+static inline int32_t q31_from_float(float value) {
+	asm("vcvt.s32.f32 %0, %0, #31" : "=t"(value) : "t"(value));
+	return std::bit_cast<int32_t>(value);
+}
+
+///@brief Convert from a q31 to a float
+///@note VFP instruction - 1 cycle for issue, 4 cycles result latency
+///@deprecated This function is deprecated. Use FixedPoint<31>::to_float instead.
+static inline float int32_to_float(int32_t value) {
+	asm("vcvt.f32.s32 %0, %0, #31" : "=t"(value) : "t"(value));
+	return std::bit_cast<float>(value);
+}

--- a/tests/qemu/spec/fixedpoint_spec.cpp
+++ b/tests/qemu/spec/fixedpoint_spec.cpp
@@ -59,7 +59,7 @@ describe fixedpoint("FixedPoint", ${
 	context("==", _ {
 		it("the original integer", _ {
 			FixedPoint<16> fp{42};
-			expect(fp).to_equal(42);
+			expect(fp).to_equal(42.f);
 		});
 
 		it("the original float", _ {
@@ -118,7 +118,7 @@ describe fixedpoint("FixedPoint", ${
 		it("adds another FixedPoint with an integral value", _ {
 			FixedPoint<16> fp1{42};
 			FixedPoint<16> fp2{2};
-			expect(fp1 + fp2).to_equal(44);
+			expect(fp1 + fp2).to_equal(44.f);
 		});
 
 		it("adds another FixedPoint with a fractional value", _ {
@@ -132,7 +132,7 @@ describe fixedpoint("FixedPoint", ${
 		it("subtracts another FixedPoint with an integral value", _ {
 			FixedPoint<16> fp1{42};
 			FixedPoint<16> fp2{2};
-			expect(fp1 - fp2).to_equal(40);
+			expect(fp1 - fp2).to_equal(40.f);
 		});
 
 		it("subtracts another FixedPoint with a fractional value", _ {
@@ -148,13 +148,13 @@ describe fixedpoint("FixedPoint", ${
 				it("multiplies by another FixedPoint with an integral value", _ {
 					FixedPoint<16> fp1{42};
 					FixedPoint<16> fp2{2};
-					expect(fp1 * fp2).to_equal(84);
+					expect(fp1 * fp2).to_equal(84.f);
 				});
 
 				it("multiplies by another FixedPoint with a fractional value", _ {
 					FixedPoint<16> fp1{42};
 					FixedPoint<16> fp2{2.5f};
-					expect(fp1 * fp2).to_equal(105);
+					expect(fp1 * fp2).to_equal(105.f);
 				});
 			});
 
@@ -162,13 +162,13 @@ describe fixedpoint("FixedPoint", ${
 				it("multiplies by another FixedPoint with an integral value", _ {
 					FixedPoint<16> fp1{42};
 					FixedPoint<28> fp2{2};
-					expect(fp1 * fp2).to_equal(84);
+					expect(fp1 * fp2).to_equal(84.f);
 				});
 
 				it("multiplies by another FixedPoint with a fractional value", _ {
 					FixedPoint<16> fp1{42};
 					FixedPoint<28> fp2{2.5f};
-					expect(fp1 * fp2).to_equal(105);
+					expect(fp1 * fp2).to_equal(105.f);
 				});
 			});
 		});
@@ -178,13 +178,13 @@ describe fixedpoint("FixedPoint", ${
 				it("multiplies by another FixedPoint with an integral value", _ {
 					FixedPointAccurate<16> fp1{42};
 					FixedPointAccurate<16> fp2{2};
-					expect(fp1 * fp2).to_equal(84);
+					expect(fp1 * fp2).to_equal(84.f);
 				});
 
 				it("multiplies by another FixedPoint with a fractional value", _ {
 					FixedPointAccurate<16> fp1{42};
 					FixedPointAccurate<16> fp2{2.5f};
-					expect(fp1 * fp2).to_equal(105);
+					expect(fp1 * fp2).to_equal(105.f);
 				});
 			});
 
@@ -192,13 +192,13 @@ describe fixedpoint("FixedPoint", ${
 				it("multiplies by another FixedPoint with an integral value", _ {
 					FixedPointAccurate<16> fp1{42};
 					FixedPointAccurate<28> fp2{2};
-					expect(fp1 * fp2).to_equal(84);
+					expect(fp1 * fp2).to_equal(84.f);
 				});
 
 				it("multiplies by another FixedPoint with a fractional value", _ {
 					FixedPointAccurate<16> fp1{42};
 					FixedPointAccurate<28> fp2{2.5f};
-					expect(fp1 * fp2).to_equal(105);
+					expect(fp1 * fp2).to_equal(105.f);
 				});
 			});
 		});
@@ -208,7 +208,7 @@ describe fixedpoint("FixedPoint", ${
 		it("divides by another FixedPoint with an integral value", _ {
 			FixedPoint<16> fp1{42};
 			FixedPoint<16> fp2{2};
-			expect(fp1 / fp2).to_equal(21);
+			expect(fp1 / fp2).to_equal(21.f);
 		});
 
 		it("divides by another FixedPoint with a fractional value", _ {
@@ -224,7 +224,7 @@ describe fixedpoint("FixedPoint", ${
 				FixedPoint<16> fp1{42};
 				FixedPoint<17> fp2{2};
 				FixedPoint<17> fp3{3};
-				expect(fp1.MultiplyAdd(fp2, fp3)).to_equal(48);
+				expect(fp1.MultiplyAdd(fp2, fp3)).to_equal(48.f);
 			});
 
 			it("multiplies and adds another FixedPoint with a fractional value", _ {

--- a/tests/qemu/spec/fixedpoint_spec.cpp
+++ b/tests/qemu/spec/fixedpoint_spec.cpp
@@ -29,6 +29,16 @@ describe fixedpoint("FixedPoint", ${
 			FixedPoint<31> fp{0.5f};
 			expect(fp.raw()).to_equal(0x40000000);
 		});
+
+		it("from another FixedPoint upwards", _ {
+			FixedPoint<31> fp = FixedPoint<30>{1.f};
+			expect(fp.raw()).to_equal(0x7fffffff);
+		});
+
+		it("from another FixedPoint downwards", _ {
+			FixedPoint<16> fp = FixedPoint<30>{1.f};
+			expect(fp.raw()).to_equal(FixedPoint<16>::one());
+		});	
 	});
 
 	context("copy constructor", _ {


### PR DESCRIPTION
Originally part of #3519, separated here for ease of review, I'll rebase once this is merged.

Summary:
- General FixedPoint class improvements
- Unification of ARMv7 intrinsics with portable code.
- Separation of intrinsics from fixedpoint.h
- Re-target current Q31 macros onto FixedPoint in preparation for eventual migration
- Swap asm clz out with std::countl_zero. These are instruction-identical (see godbolt link in docstring)
- Remove inline asm for SSAT for equivalent std::clamp (see godbolt link)