### PR TITLE
Fix memory leak in sample clusters

### DIFF
--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -1235,7 +1235,7 @@ SampleLowLevelReader::SampleLowLevelReader(SampleLowLevelReader&& other) noexcep
 	steal_clusters(other, true);
 }
 SampleLowLevelReader& SampleLowLevelReader::operator=(SampleLowLevelReader&& other) noexcept {
-	if (this != &other) {
+	if (this == &other) {
 		return *this;
 	}
 	oscPos = other.oscPos;

--- a/src/deluge/model/sample/sample_low_level_reader.h
+++ b/src/deluge/model/sample/sample_low_level_reader.h
@@ -36,10 +36,11 @@ class SamplePlaybackGuide;
 class SampleLowLevelReader {
 public:
 	SampleLowLevelReader() = default;
-	~SampleLowLevelReader() = default;
+	virtual ~SampleLowLevelReader() { unassignAllReasons(false); };
 	explicit SampleLowLevelReader(SampleLowLevelReader&, bool stealReasons = false);
-	SampleLowLevelReader(SampleLowLevelReader&& other) noexcept = default;
-	SampleLowLevelReader& operator=(const SampleLowLevelReader& other) = default;
+	SampleLowLevelReader(SampleLowLevelReader&& other) noexcept;
+	SampleLowLevelReader& operator=(const SampleLowLevelReader& other) = delete;
+	SampleLowLevelReader& operator=(SampleLowLevelReader&& other) noexcept;
 
 	void unassignAllReasons(bool wontBeUsedAgain);
 	void jumpForwardLinear(int32_t numChannels, int32_t byteDepth, uint32_t bitMask, int32_t jumpAmount,
@@ -88,18 +89,19 @@ public:
 	                                  bool loopingAtLowLevel, int32_t jumpAmount, int32_t bufferSize,
 	                                  TimeStretcher* timeStretcher, bool bufferingToTimeStretcher,
 	                                  int32_t whichPlayHead, int32_t whichKernel, int32_t priorityRating);
+	void steal_clusters(SampleLowLevelReader& other, bool stealReasons);
 
 	void bufferIndividualSampleForInterpolation(int32_t numChannels, int32_t byteDepth, char* playPosNow);
 	void bufferZeroForInterpolation(int32_t numChannels);
 
-	uint32_t oscPos;
-	char* currentPlayPos;
-	char* reassessmentLocation;
-	char* clusterStartLocation; // You're allowed to read from this location, but not move any further "back" past it
-	uint8_t reassessmentAction;
-	int8_t interpolationBufferSizeLastTime; // 0 if was previously switched off
+	uint32_t oscPos{};
+	char* currentPlayPos{};
+	char* reassessmentLocation{};
+	char* clusterStartLocation{}; // You're allowed to read from this location, but not move any further "back" past it
+	uint8_t reassessmentAction{};
+	int8_t interpolationBufferSizeLastTime{}; // 0 if was previously switched off
 
-	deluge::dsp::Interpolator interpolator_;
+	deluge::dsp::Interpolator interpolator_{};
 
 	std::array<Cluster*, kNumClustersLoadedAhead> clusters = {nullptr, nullptr};
 

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -35,7 +35,7 @@ using namespace deluge;
 class Voice final {
 public:
 	Voice(Sound& sound);
-
+	~Voice() { setAsUnassigned(nullptr); }
 	Patcher patcher;
 
 	// Stores all oscillator positions and stuff, for each Source within each Unison too

--- a/src/deluge/model/voice/voice_sample.h
+++ b/src/deluge/model/voice/voice_sample.h
@@ -38,6 +38,9 @@ public:
 	VoiceSample() = default;
 	explicit VoiceSample(VoiceSample& other) = default;
 	VoiceSample(SampleLowLevelReader&& other) : SampleLowLevelReader{std::move(other)} {}
+	~VoiceSample() override { endTimeStretching(); }
+	VoiceSample& operator=(const VoiceSample& other) = delete;
+	VoiceSample& operator=(VoiceSample&& other) = default;
 
 	void noteOn(SamplePlaybackGuide* guide, uint32_t samplesLate, int32_t priorityRating);
 	bool noteOffWhenLoopEndPointExists(Voice* voice, VoiceSamplePlaybackGuide* voiceSource);

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -1363,7 +1363,8 @@ void AudioFileManager::removeReasonFromCluster(Cluster& cluster, char const* err
 	else if (cluster.numReasonsToBeLoaded < 0) {
 #if ALPHA_OR_BETA_VERSION
 		if (cluster.sample != nullptr) { // "Should" always be true...
-			D_PRINTLN("reason remains on cluster of sample:  %d", cluster.sample->filePath.get());
+			D_PRINTLN("negative reasons on cluster %x from call %s for sample %s", (uintptr_t)&cluster, errorCode,
+			          cluster.sample->filePath.get());
 		}
 		FREEZE_WITH_ERROR(errorCode);
 #else


### PR DESCRIPTION
* remove reasons from clusters in voice destructor to fix memory leak

* fix move constructors to avoid double decrementing the reason count in the copy constructor

