### PR TITLE
Fix occasional crash when pressing song button from instrument clip view

### DIFF
--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -95,10 +95,10 @@ enum SessionMacroKind : int8_t {
 };
 
 struct SessionMacro {
-	SessionMacroKind kind;
-	Clip* clip;
-	Output* output;
-	uint8_t section;
+	SessionMacroKind kind{NO_MACRO};
+	Clip* clip{nullptr};
+	Output* output{nullptr};
+	uint8_t section{0};
 };
 
 class Song final : public TimelineCounter {
@@ -257,7 +257,7 @@ public:
 
 	String dirPath;
 
-	SessionMacro sessionMacros[8];
+	std::array<SessionMacro, 8> sessionMacros{};
 
 	bool getAnyClipsSoloing() const;
 	Clip* getCurrentClip();


### PR DESCRIPTION
initialize the session macros to prevent a crash which occurs when they are default initialized as clip launch with an invalid clip