### PR TITLE
Update shortcuts for randomizing drum samples

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -83,6 +83,8 @@ public:
 	// PAD ACTION pad press / release handling
 
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
+	ActionResult potentiallyRandomizeDrumSamples();
+	ActionResult potentiallyRandomizeDrumSample(Kit* kit, Drum* drum, char* chosenFilename);
 
 	// SCALE MODE related commands.
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -319,7 +319,7 @@ doEndMidiLearnPressSession:
 						indicator_leds::setLedState(IndicatorLED::LOAD, false);
 					}
 				}
-				else if (currentUIMode == UI_MODE_NONE) {
+				else if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING) {
 					indicator_leds::setLedState(IndicatorLED::LOAD, false);
 				}
 			}

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -186,6 +186,10 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 ##### Kit
 
 - Extended the ability to batch change all drum sounds, by holding `Affect-Entire` while editing a parameter (indicated by flashing the `Affect-Entire` button), from the initially available handful of sample-related parameters, to ALL sound parameters (except for `Oscillator Type` and patch cable strengths).
+- Updated shortcuts for randomizing drum samples:
+  - When no audition pads are pressed, randomize just the selected drum by: Pressing `LOAD` + `RANDOM`
+  - To randomize more than one selected drum at a time: Press `LOAD` + `AUDITION PADS` + `RANDOM`
+  - To randomize all active drums (not muted and have notes playing): Press `LOAD` + `AFFECT ENTIRE` + `RANDOM`
 
 ##### CV Clips
 
@@ -207,6 +211,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
 - Added ability to automate all Monophonic (Channel) Expression parameters (X - Pitch Bend, Y - Mod Wheel, Z - Channel Pressure / Aftertouch) in Synth / Kit Row (with Affect Entire Off) / MIDI / CV
+- Fixed interpolation for MIDI CC's in MIDI clips
 
 ##### Copy/Paste
 

--- a/website/src/content/docs/features/community_features.md
+++ b/website/src/content/docs/features/community_features.md
@@ -1203,10 +1203,12 @@ to each individual note onset. (#1978)
 
 #### 4.6.2 - Drum Randomizer / Load Random Samples
 
-- (#122) Pressing `AUDITION` + `RANDOM` on a drum kit row will load a random sample from the same folder as the
-  currently enabled sample and load it as the sound for that row.
+- (#122) (#955): Add drum randomizer feature to load a random sample into one or more drum kit rows.
   - This feature is `ON` by default and can be set to `ON` or `OFF` via `SETTINGS > COMMUNITY FEATURES`.
-- (#955) Pressing `SHIFT` + `RANDOM` randomizes all non-muted drum kit rows.
+  - Commands are:
+    - When no audition pads are pressed, randomize just the selected drum by: Pressing `LOAD` + `RANDOM`
+    - To randomize more than one selected drum at a time: Press `LOAD` + `AUDITION PADS` + `RANDOM`
+    - To randomize all active drums (not muted and have notes playing): Press `LOAD` + `AFFECT ENTIRE` + `RANDOM`
 
 #### 4.6.3 - Manual Slicing / Lazy Chop
 


### PR DESCRIPTION
Randomizing drum samples was too easy previously with the existing Audition + Random / Shift + Random shortcuts. Changing the shortcut confirms the intention and aligns the shortcut with the Deluge's UX guidelines. Using affect entire to change all drum rows is also an already established shortcut.

- Updated shortcuts for randomizing drum samples:
  - When no audition pads are pressed, randomize just the selected drum by: Pressing `LOAD` + `RANDOM`
  - To randomize more than one selected drum at a time: Press `LOAD` + `AUDITION PADS` + `RANDOM`
  - To randomize all active drums (not muted and have notes playing): Press `LOAD` + `AFFECT ENTIRE` + `RANDOM`