### PR TITLE
Cherry pick midi interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 ##### Parameters
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts
 - Added ability to automate all Monophonic (Channel) Expression parameters (X - Pitch Bend, Y - Mod Wheel, Z - Channel Pressure / Aftertouch) in Synth / Kit Row (with Affect Entire Off) / MIDI / CV
+- Fixed interpolation for MIDI CC's in MIDI clips
 
 ##### Copy/Paste
 - Added same shortcut that is used for copy / pasting notes in Instrument Clip View to Automation View to copy / paste automation. While in the Automation Editor, Copy with `Learn + <>`. Paste with `Shift + Learn + <>`.

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -279,7 +279,6 @@ bool MIDIInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, Pg
 		else {
 			allNotesOff();
 			for (int i = 0; i < kNumExpressionDimensions; i++) {
-				lastMonoExpression[i] = 0;
 				lastCombinedPolyExpression[i] = 0;
 				sendMonophonicExpressionEvent(i);
 			}

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -125,6 +125,19 @@ public:
 	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,
 	                                                bool affectEntire, bool useMenuStack) override;
 
+	bool valueChangedEnoughToMatter(int32_t old_value, int32_t new_value, deluge::modulation::params::Kind kind,
+	                                uint32_t paramID) override {
+		if (kind == deluge::modulation::params::Kind::EXPRESSION) {
+			if (paramID == X_PITCH_BEND) {
+				// pitch is in 14 bit instead of 7
+				return old_value >> 18 != new_value >> 18;
+			}
+			// aftertouch and mod wheel are positive only and recorded into a smaller range than CCs
+			return old_value >> 24 != new_value >> 24;
+		}
+		return old_value >> 25 != new_value >> 25;
+	}
+
 protected:
 	void polyphonicExpressionEventPostArpeggiator(int32_t newValue, int32_t noteCodeAfterArpeggiation,
 	                                              int32_t expressionDimension, ArpNote* arpNote,

--- a/src/deluge/model/instrument/non_audio_instrument.cpp
+++ b/src/deluge/model/instrument/non_audio_instrument.cpp
@@ -30,7 +30,6 @@
 void NonAudioInstrument::renderOutput(ModelStack* modelStack, std::span<StereoSample> output, int32_t* reverbBuffer,
                                       int32_t reverbAmountAdjust, int32_t sideChainHitPending,
                                       bool shouldLimitDelayFeedback, bool isClipActive) {
-
 	// MIDI / CV arpeggiator
 	if (activeClip) {
 		InstrumentClip* activeInstrumentClip = (InstrumentClip*)activeClip;

--- a/src/deluge/model/mod_controllable/mod_controllable.h
+++ b/src/deluge/model/mod_controllable/mod_controllable.h
@@ -56,6 +56,10 @@ public:
 	virtual bool isKit() { return false; }
 	virtual bool isSong() { return false; }
 	virtual bool isEditingComp() { return false; }
+	virtual bool valueChangedEnoughToMatter(int32_t old_value, int32_t new_value, deluge::modulation::params::Kind kind,
+	                                        uint32_t paramID) {
+		return old_value != new_value;
+	}
 	virtual int32_t getKnobPosForNonExistentParam(
 	    int32_t whichModEncoder,
 	    ModelStackWithAutoParam* modelStack); // modelStack->autoParam will be NULL in this rare case!!

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -827,7 +827,6 @@ void AutoParam::setupInterpolation(ParamNode* nextNodeInOurDirection, int32_t ef
 	}
 }
 
-// Returns whether a change was made to currentValue
 bool AutoParam::tickSamples(int32_t numSamples) {
 	if (!valueIncrementPerHalfTick) {
 		return false;
@@ -844,6 +843,16 @@ bool AutoParam::tickSamples(int32_t numSamples) {
 		currentValue = (valueIncrementPerHalfTick >= 0) ? 2147483647 : -2147483648;
 		valueIncrementPerHalfTick = 0;
 	}
+
+	return true;
+}
+
+bool AutoParam::tickTicks(int32_t numTicks) {
+	if (valueIncrementPerHalfTick == 0) {
+		return false;
+	}
+
+	currentValue = add_saturate(currentValue, valueIncrementPerHalfTick * numTicks * 2);
 
 	return true;
 }

--- a/src/deluge/modulation/automation/auto_param.h
+++ b/src/deluge/modulation/automation/auto_param.h
@@ -56,7 +56,10 @@ public:
 	void setValuePossiblyForRegion(int32_t value, ModelStackWithAutoParam const* modelStack, int32_t pos,
 	                               int32_t length, bool mayDeleteNodesInLinearRun = true);
 	int32_t getValueAtPos(uint32_t pos, ModelStackWithAutoParam const* modelStack, bool reversed = false);
+	/// tick the interolator by a number of samples - used for internal synths
 	bool tickSamples(int32_t numSamples);
+	/// tick the interpolator by a number of ticks - used for midi
+	bool tickTicks(int32_t numTicks);
 	void setPlayPos(uint32_t pos, ModelStackWithAutoParam const* modelStack, bool reversed);
 	bool grabValueFromPos(uint32_t pos, ModelStackWithAutoParam const* modelStack);
 	void generateRepeats(uint32_t oldLength, uint32_t newLength, bool shouldPingpong);

--- a/src/deluge/modulation/midi/midi_param_collection.h
+++ b/src/deluge/modulation/midi/midi_param_collection.h
@@ -31,8 +31,11 @@ class MIDIParamCollection final : public ParamCollection {
 public:
 	MIDIParamCollection(ParamCollectionSummary* summary);
 	~MIDIParamCollection() override;
+	/// to avoid spamming midi we interpolate in ticks instead of in samples like internal synths. This is mostly
+	/// unnoticeable but limits the amount of data sent
+	void tickTicks(int32_t numSamples, ModelStackWithParamCollection* modelStack) override;
 
-	void tickSamples(int32_t numSamples, ModelStackWithParamCollection* modelStack) override {}
+	void tickSamples(int32_t numSamples, ModelStackWithParamCollection* modelStack) override {};
 	void setPlayPos(uint32_t pos, ModelStackWithParamCollection* modelStack, bool reversed) override;
 	void playbackHasEnded(ModelStackWithParamCollection* modelStack) override {}
 	void generateRepeats(ModelStackWithParamCollection* modelStack, uint32_t oldLength, uint32_t newLength,
@@ -52,6 +55,7 @@ public:
 	void nudgeNonInterpolatingNodesAtPos(int32_t pos, int32_t offset, int32_t lengthBeforeLoop, Action* action,
 	                                     ModelStackWithParamCollection* modelStack) override;
 	ModelStackWithAutoParam* getAutoParamFromId(ModelStackWithParamId* modelStack, bool allowCreation = true) override;
+	static int32_t autoparamValueToCC(int32_t newValue);
 
 	void cloneFrom(ParamCollection* otherParamSet, bool copyAutomation);
 	void beenCloned(bool copyAutomation, int32_t reverseDirectionWithLength) override;

--- a/src/deluge/modulation/params/param_collection.h
+++ b/src/deluge/modulation/params/param_collection.h
@@ -42,7 +42,12 @@ public:
 	virtual ~ParamCollection();
 
 	virtual void beenCloned(bool copyAutomation, int32_t reverseDirectionWithLength = 0) = 0;
+
+	/// tick interpolation by a number of ticks
 	virtual void tickSamples(int32_t numSamples, ModelStackWithParamCollection* modelStack) = 0;
+
+	/// tick interpolation by a number of ticks
+	virtual void tickTicks(int32_t numSamples, ModelStackWithParamCollection* modelStack) = 0;
 	virtual void setPlayPos(uint32_t pos, ModelStackWithParamCollection* modelStack, bool reversed);
 	virtual void playbackHasEnded(ModelStackWithParamCollection* modelStack) = 0;
 	virtual void grabValuesFromPos(uint32_t pos, ModelStackWithParamCollection* modelStack) = 0;

--- a/src/deluge/modulation/params/param_manager.cpp
+++ b/src/deluge/modulation/params/param_manager.cpp
@@ -379,7 +379,12 @@ void ParamManagerForTimeline::processCurrentPos(ModelStackWithThreeMainThings* m
 		FOR_EACH_AUTOMATED_PARAM_COLLECTION_DEFINITELY_SOME_START
 
 		summary->paramCollection->processCurrentPos(modelStackWithParamCollection, ticksSkipped, reversed, didPingpong,
-		                                            mayInterpolate);
+		                                            true);
+		// if we can't interpolate by samples then we'll interpolate by ticks here instead
+		if (!mayInterpolate && (summary->whichParamsAreInterpolating[0] != 0u)) {
+			summary->paramCollection->tickTicks(ticksSkipped, modelStackWithParamCollection);
+			ticksTilNextEvent = 0;
+		}
 		ticksTilNextEvent = std::min(ticksTilNextEvent, summary->paramCollection->ticksTilNextEvent);
 
 		FOR_EACH_AUTOMATED_PARAM_COLLECTION_DEFINITELY_SOME_END

--- a/src/deluge/modulation/params/param_set.h
+++ b/src/deluge/modulation/params/param_set.h
@@ -50,6 +50,7 @@ public:
 	                           bool onlyIfContainsSomething = false, int32_t* valuesForOverride = nullptr);
 	void readParam(Deserializer& reader, ParamCollectionSummary* summary, int32_t p, int32_t readAutomationUpToPos);
 	void tickSamples(int32_t numSamples, ModelStackWithParamCollection* modelStack) final;
+	void tickTicks(int32_t numTicks, ModelStackWithParamCollection* modelStack) final;
 	void setPlayPos(uint32_t pos, ModelStackWithParamCollection* modelStack, bool reversed) final;
 	void playbackHasEnded(ModelStackWithParamCollection* modelStack) final;
 	void grabValuesFromPos(uint32_t pos, ModelStackWithParamCollection* modelStack) final;

--- a/src/deluge/modulation/patch/patch_cable_set.h
+++ b/src/deluge/modulation/patch/patch_cable_set.h
@@ -57,6 +57,7 @@ public:
 	bool doesParamHaveSomethingPatchedToIt(int32_t p);
 
 	void tickSamples(int32_t numSamples, ModelStackWithParamCollection* modelStack) override;
+	void tickTicks(int32_t numSamples, ModelStackWithParamCollection* modelStack) override {};
 	void setPlayPos(uint32_t pos, ModelStackWithParamCollection* modelStack, bool reversed) override;
 	void playbackHasEnded(ModelStackWithParamCollection* modelStack) override;
 	void grabValuesFromPos(uint32_t pos, ModelStackWithParamCollection* modelStack) override;


### PR DESCRIPTION
Cherry pick #3531 

Enables midi interpolation. In order to limit bandwidth there's a new check for whether a param needs to be updated that's aware of the output resolution, so it won't send the same value twice.

Additionally non audio instruments are limited to interpolating in ticks during the song update rather than in samples during the audio rendering routine.