### PR TITLE
Fix broken audio threshold recording

### DIFF
--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -1046,8 +1046,6 @@ doFinishCapturing:
 					}
 				}
 			}
-			// update our input view to exclude the chunk we just processed
-			input = input.subspan(numSamplesThisCycle);
 
 			// if we're not threshold recording or we're threshold recording and detected audio
 			if (!thresholdRecording || sample->audioStartDetected) {
@@ -1064,6 +1062,9 @@ doFinishCapturing:
 					sample->audioStartDetected = true;
 				}
 			}
+
+			// update our input view to exclude the chunk we just processed
+			input = input.subspan(numSamplesThisCycle);
 		}
 
 		numSamplesBeenRunning += numSamplesThisCycle;


### PR DESCRIPTION
Fix a bug where the deluge doesn't record anything if threshold recording was active. 