### PR TITLE
Fix incorrect recording status for the OLED when threshold recording is active

### DIFF
--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -127,7 +127,9 @@ gotError:
 }
 
 void AudioRecorder::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
-	canvas.drawStringCentred("Waiting", 19, kTextBigSpacingX, kTextBigSizeY);
+	if (!updatedRecordingStatus) {
+		canvas.drawStringCentred("Waiting", 19, kTextBigSpacingX, kTextBigSizeY);
+	}
 }
 
 bool AudioRecorder::setupRecordingToFile(AudioInputChannel newMode, int32_t newNumChannels,

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -127,7 +127,7 @@ gotError:
 }
 
 void AudioRecorder::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
-	auto currentStatusText = updatedRecordingStatus ? "Recording" : "Waiting";
+	const char* currentStatusText = updatedRecordingStatus ? "Recording" : "Waiting";
 	canvas.drawStringCentred(currentStatusText, 19, kTextBigSpacingX, kTextBigSizeY);
 }
 

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -127,8 +127,8 @@ gotError:
 }
 
 void AudioRecorder::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
-	const char* currentStatusText = updatedRecordingStatus ? "Recording" : "Waiting";
-	canvas.drawStringCentred(currentStatusText, 19, kTextBigSpacingX, kTextBigSizeY);
+	const char* current_status_text = updatedRecordingStatus ? "Recording" : "Waiting";
+	canvas.drawStringCentred(current_status_text, 19, kTextBigSpacingX, kTextBigSizeY);
 }
 
 bool AudioRecorder::setupRecordingToFile(AudioInputChannel newMode, int32_t newNumChannels,

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -127,9 +127,8 @@ gotError:
 }
 
 void AudioRecorder::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
-	if (!updatedRecordingStatus) {
-		canvas.drawStringCentred("Waiting", 19, kTextBigSpacingX, kTextBigSizeY);
-	}
+	auto currentStatusText = updatedRecordingStatus ? "Recording" : "Waiting";
+	canvas.drawStringCentred(currentStatusText, 19, kTextBigSpacingX, kTextBigSizeY);
 }
 
 bool AudioRecorder::setupRecordingToFile(AudioInputChannel newMode, int32_t newNumChannels,


### PR DESCRIPTION
 if audio input is high enough to pass the threshold, then the deluge starts recording immediatelly. In this case the `renderOLED` routine may be called _after_ we rendered 'RECORDING' status on the OLED, so we end up having displayed 'WAITING' status even though the deluge is still recording. This PR fixes incorrect displayed status