### PR TITLE
Fix poly aftertouch

### DIFF
--- a/src/deluge/model/instrument/cv_instrument.cpp
+++ b/src/deluge/model/instrument/cv_instrument.cpp
@@ -32,8 +32,10 @@ void CVInstrument::noteOnPostArp(int32_t noteCodePostArp, ArpNote* arpNote, int3
 	// First update pitch bend for the new note
 	polyPitchBendValue = (int32_t)arpNote->mpeValues[0] << 16;
 	updatePitchBendOutput(false);
+	auto channel = getPitchChannel();
+	arpNote->outputMemberChannel[noteIndex] = channel;
 
-	cvEngine.sendNote(true, getPitchChannel(), noteCodePostArp);
+	cvEngine.sendNote(true, channel, noteCodePostArp);
 	if (cvmode[1] == CVMode::velocity) {
 		cvEngine.sendVoltageOut(1, arpNote->velocity << 8);
 	}

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -826,6 +826,7 @@ void MIDIInstrument::noteOnPostArp(int32_t noteCodePostArp, ArpNote* arpNote, in
 	// If no MPE, nice and simple.
 	if (!sendsToMPE()) {
 		outputMemberChannel = channel;
+		arpNote->outputMemberChannel[noteIndex] = outputMemberChannel;
 	}
 
 	// Or if MPE, we have to decide on a member channel to assign note to...


### PR DESCRIPTION
Poly aftertouch output stopped working as the arp now needs the output member channel to be set before sending note expression, and it wasn't for non-mpe notes.

Fix it to always give arp note the correct channel even if not an MPE output