### PR TITLE
Bugfix - fix time stretchers

### DIFF
--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -1235,7 +1235,7 @@ SampleLowLevelReader::SampleLowLevelReader(SampleLowLevelReader&& other) noexcep
 	steal_clusters(other, true);
 }
 SampleLowLevelReader& SampleLowLevelReader::operator=(SampleLowLevelReader&& other) noexcept {
-	if (this != &other) {
+	if (this == &other) {
 		return *this;
 	}
 	oscPos = other.oscPos;


### PR DESCRIPTION
Logic was backwards, this check is to see if an object is being set to itself