### PR TITLE
Change horizontal menu default select encoder behaviour

### DIFF
--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -255,7 +255,7 @@ ThresholdRecordingMode defaultThresholdRecordingMode = ThresholdRecordingMode::O
 
 GlobalMIDICommand defaultLoopRecordingCommand = GlobalMIDICommand::LOOP_CONTINUOUS_LAYERING;
 
-bool defaultAlternativeSelectEncoderBehaviour = false;
+bool defaultAlternativeSelectEncoderBehaviour = true;
 
 void resetSettings() {
 
@@ -364,7 +364,7 @@ void resetSettings() {
 
 	defaultLoopRecordingCommand = GlobalMIDICommand::LOOP_CONTINUOUS_LAYERING;
 
-	defaultAlternativeSelectEncoderBehaviour = false;
+	defaultAlternativeSelectEncoderBehaviour = true;
 }
 
 void resetMidiFollowSettings() {
@@ -800,7 +800,7 @@ void readSettings() {
 	}
 
 	if (buffer[187] != 0 && buffer[187] != 1) {
-		defaultAlternativeSelectEncoderBehaviour = false;
+		defaultAlternativeSelectEncoderBehaviour = true;
 	}
 	else {
 		defaultAlternativeSelectEncoderBehaviour = buffer[187];


### PR DESCRIPTION
Changed default horizontal menu select encoder behaviour.

`Alternative Select Behaviour (SELE)` in `SETTINGS > DEFAULTS -> UI -> HORIZONTAL MENU (HORZ)` is now enabled by default.