### PR TITLE
Bugfix/unreachable perc cache code

### DIFF
--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -274,8 +274,7 @@ Error Sample::fillPercCache(TimeStretcher* timeStretcher, int32_t startPosSample
 	uint16_t startTime = MTU2.TCNT_0;
 #endif
 
-	int32_t reversed = (playDirection == 1) ? 0 : 1;
-
+	auto reversed = static_cast<int32_t>(playDirection != 1);
 	// If the start pos is already beyond the waveform, we can get out right now!
 	if (!reversed) {
 		if (startPosSamples >= lengthInSamples) {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2369,7 +2369,7 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 		AudioEngine::logAction(buf);
 #endif
 	}
-
+	AudioEngine::logAction("done rendering outputs");
 	// If recording the "MIX", this is the place where we want to grab it - before any master FX or volume applied
 	// Go through each SampleRecorder, feeding them audio
 	for (SampleRecorder* recorder = AudioEngine::firstRecorder; recorder; recorder = recorder->next) {
@@ -2382,6 +2382,7 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 			recorder->feedAudio(outputBuffer, true);
 		}
 	}
+	AudioEngine::logAction("done recorders");
 
 	Delay::State delayWorkingState = globalEffectable.createDelayWorkingState(paramManager);
 
@@ -2398,6 +2399,7 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 
 	globalEffectable.processReverbSendAndVolume(outputBuffer, reverbBuffer, volumePostFX, postReverbVolume,
 	                                            reverbSendAmount >> 1);
+	AudioEngine::logAction("done global effectables");
 
 	if (playbackHandler.isEitherClockActive() && !playbackHandler.ticksLeftInCountIn
 	    && currentPlaybackMode == &arrangement) {
@@ -2410,6 +2412,7 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 			paramManager.tickSamples(outputBuffer.size(), modelStackWithThreeMainThings);
 		}
 	}
+	AudioEngine::logAction("done render");
 }
 
 void Song::setTimePerTimerTick(uint64_t newTimeBig, bool shouldLogAction) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -508,6 +508,7 @@ void tickSongFinalizeWindows(size_t& numSamples, int32_t& timeWithinWindowAtWhic
 void flushMIDIGateBuffers();
 void renderAudio(size_t numSamples);
 void renderAudioForStemExport(size_t numSamples);
+void dumpAudioLog();
 /// inner loop of audio rendering, deliberately not in header
 [[gnu::hot]] void routine_() {
 
@@ -1211,7 +1212,7 @@ void dumpAudioLog() {
 	uint16_t currentTime = *TCNT[TIMER_SYSTEM_FAST];
 	uint16_t timePassedA = (uint16_t)currentTime - lastRoutineTime;
 	uint32_t timePassedUSA = fastTimerCountToUS(timePassedA);
-	if (definitelyLog || timePassedUSA > (StorageManager::devVarA * 10)) {
+	if (definitelyLog || timePassedUSA > (1000)) {
 
 		D_PRINTLN("");
 		for (int32_t i = 0; i < numAudioLogItems; i++) {


### PR DESCRIPTION
I'm not certain what was wrong with the ternary but it lead the compiler to believe that reversed is always false and optimize out huge parts of the perc cache code. With this fix it now seems to properly find and mark percussive points and pitch shifting is a lot better