### PR TITLE
initialize everything

### DIFF
--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -39,9 +39,7 @@ enum class RawDataFormat : uint8_t {
 	ENDIANNESS_WRONG_32 = 5,
 };
 
-#define MIDI_NOTE_UNSET -999
-#define MIDI_NOTE_ERROR -1000
-
+enum { MIDI_NOTE_UNSET = (-999), MIDI_NOTE_ERROR = (-1000) };
 class LoadedSamplePosReason;
 class SampleCache;
 class MultisampleRange;
@@ -107,11 +105,11 @@ public:
 	}
 
 	String tempFilePathForRecording;
-	uint8_t byteDepth;
-	uint32_t sampleRate;
+	uint8_t byteDepth{0};
+	uint32_t sampleRate{44100};
 	uint32_t audioDataStartPosBytes; // That is, the offset from the start of the WAV file
 	uint64_t audioDataLengthBytes;
-	uint32_t bitMask;
+	uint32_t bitMask{0};
 	bool audioStartDetected;
 
 	uint64_t lengthInSamples;
@@ -124,11 +122,11 @@ public:
 
 	RawDataFormat rawDataFormat;
 
-	bool unloadable; // Only gets set to true if user has re-inserted the card and the sample appears to have been
-	                 // deleted / moved / modified
-	bool unplayable;
+	bool unloadable{false}; // Only gets set to true if user has re-inserted the card and the sample appears to have
+	                        // been deleted / moved / modified
+	bool unplayable{false};
 	bool partOfFolderBeingLoaded;
-	bool fileExplicitlySpecifiesSelfAsWaveTable;
+	bool fileExplicitlySpecifiesSelfAsWaveTable{false};
 
 #if SAMPLE_DO_LOCKS
 	bool lock;
@@ -142,16 +140,16 @@ public:
 
 	OrderedResizeableArrayWithMultiWordKey caches;
 
-	uint8_t* percCacheMemory[2];                          // One for each play-direction: 0=forwards; 1=reversed
+	uint8_t* percCacheMemory[2]{nullptr, nullptr};        // One for each play-direction: 0=forwards; 1=reversed
 	OrderedResizeableArrayWith32bitKey percCacheZones[2]; // One for each play-direction: 0=forwards; 1=reversed
 
-	Cluster** percCacheClusters[2]; // One for each play-direction: 0=forwards; 1=reversed
-	int32_t numPercCacheClusters;
+	Cluster** percCacheClusters[2]{nullptr, nullptr}; // One for each play-direction: 0=forwards; 1=reversed
+	int32_t numPercCacheClusters{};
 
 	int32_t beginningOffsetForPitchDetection;
 	bool beginningOffsetForPitchDetectionFound;
 
-	uint32_t waveTableCycleSize; // In case this later gets used for a WaveTable
+	uint32_t waveTableCycleSize{0}; // In case this later gets used for a WaveTable
 
 	SampleClusterArray clusters;
 

--- a/src/deluge/model/sample/sample_holder_for_voice.cpp
+++ b/src/deluge/model/sample/sample_holder_for_voice.cpp
@@ -35,8 +35,8 @@ SampleHolderForVoice::SampleHolderForVoice() {
 	startMSec = 0;
 	endMSec = 0;
 
-	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
-		clustersForLoopStart[l] = nullptr;
+	for (auto& l : clustersForLoopStart) {
+		l = nullptr;
 	}
 }
 

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -77,23 +77,23 @@ public:
 
 	Patcher patcher;
 
-	ParamLPF paramLPF;
+	ParamLPF paramLPF{};
 
 	Source sources[kNumSources];
 
 	// This is for the *global* params only, and begins with FIRST_GLOBAL_PARAM, so subtract that from your p value
 	// before accessing this array!
 	std::array<int32_t, deluge::modulation::params::kNumParams - deluge::modulation::params::FIRST_GLOBAL>
-	    paramFinalValues;
-	std::array<int32_t, util::to_underlying(kFirstLocalSource)> globalSourceValues;
+	    paramFinalValues{};
+	std::array<int32_t, util::to_underlying(kFirstLocalSource)> globalSourceValues{};
 
-	uint32_t sourcesChanged; // Applies from first source up to FIRST_UNCHANGEABLE_SOURCE
+	uint32_t sourcesChanged{}; // Applies from first source up to FIRST_UNCHANGEABLE_SOURCE
 
 	LFO globalLFO1;
 	LFO globalLFO3;
 	LFOConfig lfoConfig[LFO_COUNT];
 
-	bool invertReversed; // Used by the arpeggiator to invert the reverse flag just for the current voice
+	bool invertReversed{}; // Used by the arpeggiator to invert the reverse flag just for the current voice
 
 	// December 3, 2024
 	// @todo
@@ -131,12 +131,12 @@ public:
 	PhaseIncrementFineTuner modulatorTransposers[kNumModulators];
 
 	PhaseIncrementFineTuner unisonDetuners[kMaxNumVoicesUnison];
-	int32_t unisonPan[kMaxNumVoicesUnison];
+	int32_t unisonPan[kMaxNumVoicesUnison]{};
 
 	SynthMode synthMode = SynthMode::SUBTRACTIVE;
 	bool modulator1ToModulator0 = false;
 
-	int32_t volumeNeutralValueForUnison;
+	int32_t volumeNeutralValueForUnison{0};
 
 	int32_t lastNoteCode = std::numeric_limits<int32_t>::min();
 
@@ -146,19 +146,19 @@ public:
 
 	bool skippingRendering = true;
 
-	std::bitset<kNumExpressionDimensions> expressionSourcesChangedAtSynthLevel;
+	std::bitset<kNumExpressionDimensions> expressionSourcesChangedAtSynthLevel{0};
 
 	// I really didn't want to store these here, since they're stored in the ParamManager, but.... complications! Always
 	// 0 for Drums - that was part of the problem - a Drum's main ParamManager's expression data has been sent to the
 	// "polyphonic" bit, and we don't want it to get referred to twice. These get manually refreshed in setActiveClip().
-	std::array<int32_t, kNumExpressionDimensions> monophonicExpressionValues;
+	std::array<int32_t, kNumExpressionDimensions> monophonicExpressionValues{};
 
-	std::array<uint32_t, kNumSources> oscRetriggerPhase; // 4294967295 means "off"
-	std::array<uint32_t, kNumModulators> modulatorRetriggerPhase;
+	std::array<uint32_t, kNumSources> oscRetriggerPhase{}; // 4294967295 means "off"
+	std::array<uint32_t, kNumModulators> modulatorRetriggerPhase{};
 
-	uint32_t timeStartedSkippingRenderingModFX;
-	uint32_t timeStartedSkippingRenderingLFO;
-	uint32_t timeStartedSkippingRenderingArp;
+	uint32_t timeStartedSkippingRenderingModFX{0};
+	uint32_t timeStartedSkippingRenderingLFO{0};
+	uint32_t timeStartedSkippingRenderingArp{0};
 	uint32_t startSkippingRenderingAtTime = 0; // Valid when not 0. Allows a wait-time before render skipping starts,
 	                                           // for if mod fx are on
 

--- a/src/deluge/storage/audio/audio_file.h
+++ b/src/deluge/storage/audio/audio_file.h
@@ -41,7 +41,7 @@ public:
 	String filePath;
 
 	const AudioFileType type;
-	uint8_t numChannels;
+	uint8_t numChannels{};
 	String loadedFromAlternatePath; // We now need to store this, since "alternate" files can now just have the same
 	                                // filename (in special folder) as the original. So we need to remember which format
 	                                // the name took.


### PR DESCRIPTION
Fix #3541 

Initializing monophonic expression values fixes the bug, but also initialize all the other things in voice that clang tidy is warning about just in case