### PR TITLE
Update shortcuts for randomizing drum samples (#3546)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,10 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
 
 ##### Kit
 - Extended the ability to batch change all drum sounds, by holding `Affect-Entire` while editing a parameter (indicated by flashing the `Affect-Entire` button), from the initially available handful of sample-related parameters, to ALL sound parameters (except for `Oscillator Type` and patch cable strengths).
+- Updated shortcuts for randomizing drum samples:
+  - When no audition pads are pressed, randomize just the selected drum by: Pressing `LOAD` + `RANDOM`
+  - To randomize more than one selected drum at a time: Press `LOAD` + `AUDITION PADS` + `RANDOM`
+  - To randomize all active drums (not muted and have notes playing): Press `LOAD` + `AFFECT ENTIRE` + `RANDOM`
 
 ##### CV Clips
 - Added the ability to set a CV instrument to use both 1 and 2 channels, which makes the cv2 source selectable between mod wheel, velocity, and aftertouch

--- a/docs/community_features.md
+++ b/docs/community_features.md
@@ -1162,10 +1162,12 @@ as an oscillator type within the subtractive engine, so it can be combined with 
 
 #### 4.6.2 - Drum Randomizer / Load Random Samples
 
-- ([#122]) Pressing `AUDITION` + `RANDOM` on a drum kit row will load a random sample from the same folder as the
-  currently enabled sample and load it as the sound for that row.
-    - This feature is `ON` by default and can be set to `ON` or `OFF` via `SETTINGS > COMMUNITY FEATURES`.
-- ([#955]) Pressing `SHIFT` + `RANDOM` randomizes all non-muted drum kit rows.
+- ([#122],[#955]): Add drum randomizer feature to load a random sample into one or more drum kit rows.
+  - This feature is `ON` by default and can be set to `ON` or `OFF` via `SETTINGS > COMMUNITY FEATURES`.
+  - Commands are:
+    - When no audition pads are pressed, randomize just the selected drum by: Pressing `LOAD` + `RANDOM`
+    - To randomize more than one selected drum at a time: Press `LOAD` + `AUDITION PADS` + `RANDOM`
+    - To randomize all active drums (not muted and have notes playing): Press `LOAD` + `AFFECT ENTIRE` + `RANDOM`
 
 #### 4.6.3 - Manual Slicing / Lazy Chop
 

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -83,6 +83,8 @@ public:
 	// PAD ACTION pad press / release handling
 
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
+	ActionResult potentiallyRandomizeDrumSamples();
+	ActionResult potentiallyRandomizeDrumSample(Kit* kit, Drum* drum, char* chosenFilename);
 
 	// SCALE MODE related commands.
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -319,7 +319,7 @@ doEndMidiLearnPressSession:
 						indicator_leds::setLedState(IndicatorLED::LOAD, false);
 					}
 				}
-				else if (currentUIMode == UI_MODE_NONE) {
+				else if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING) {
 					indicator_leds::setLedState(IndicatorLED::LOAD, false);
 				}
 			}


### PR DESCRIPTION
- Updated shortcuts for randomizing drum samples:
  - When no audition pads are pressed, randomize just the selected drum by: Pressing `LOAD` + `RANDOM`
  - To randomize more than one selected drum at a time: Press `LOAD` + `AUDITION PADS` + `RANDOM`
  - To randomize all active drums (not muted and have notes playing): Press `LOAD` + `AFFECT ENTIRE` + `RANDOM`