### PR TITLE
Refactor/ Add UI Context Types

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -226,10 +226,10 @@ enum class UIType : uint8_t {
 	NONE = 255,
 };
 
-enum class AutomationSubType : uint8_t {
-	ARRANGER,
-	INSTRUMENT,
-	AUDIO,
+// used for determining the active mod controllable context for a UI
+enum class UIModControllableContext : uint8_t {
+	SONG,
+	CLIP,
 	NONE = 255,
 };
 

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.h
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.h
@@ -61,6 +61,8 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::KEYBOARD_SCREEN; }
+	UIType getUIContextType() override { return UIType::INSTRUMENT_CLIP; }
+	UIModControllableContext getUIModControllableContext() override { return UIModControllableContext::CLIP; }
 	void checkNewInstrument(Instrument* newInstrument);
 
 private:

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -784,9 +784,14 @@ bool SoundEditor::beginScreen(MenuItem* oldMenuItem) {
 }
 
 void SoundEditor::possibleChangeToCurrentRangeDisplay() {
-	uiNeedsRendering(&instrumentClipView, 0, 0xFFFFFFFF);
-	uiNeedsRendering(&automationView, 0, 0xFFFFFFFF);
-	uiNeedsRendering(&keyboardScreen, 0xFFFFFFFF, 0);
+	RootUI* rootUI = getRootUI();
+
+	if (rootUI == &keyboardScreen) {
+		uiNeedsRendering(&keyboardScreen, 0xFFFFFFFF, 0);
+	}
+	else if (rootUI->getUIContextType() == UIType::INSTRUMENT_CLIP) {
+		uiNeedsRendering(rootUI, 0, 0xFFFFFFFF);
+	}
 }
 
 void SoundEditor::setupShortcutBlink(int32_t x, int32_t y, int32_t frequency) {

--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -96,9 +96,10 @@ bool changeUIAtLevel(UI* newUI, int32_t level) {
 	return success;
 }
 
-// Called when we navigate between "root" UIs, like sessionView, instrumentClipView, automationInstrumentClipView,
+// Called when we navigate between "root" UIs, like sessionView, instrumentClipView, automationView,
 // performanceView, etc.
 void changeRootUI(UI* newUI) {
+	newUI = newUI->getUI();
 	uiNavigationHierarchy[0] = newUI;
 	numUIsOpen = 1;
 
@@ -115,12 +116,14 @@ void changeRootUI(UI* newUI) {
 
 // Only called when setting up blank song, so don't worry about this
 void setRootUILowLevel(UI* newUI) {
+	newUI = newUI->getUI();
 	uiNavigationHierarchy[0] = newUI;
 	numUIsOpen = 1;
 	PadLEDs::reassessGreyout();
 }
 
 bool changeUISideways(UI* newUI) {
+	newUI = newUI->getUI();
 	bool success = changeUIAtLevel(newUI, numUIsOpen - 1);
 	if (display->haveOLED()) {
 		renderUIsForOled();
@@ -146,15 +149,16 @@ RootUI* getRootUI() {
 
 bool currentUIIsClipMinderScreen() {
 	UI* currentUI = getCurrentUI();
-	return (currentUI && currentUI->toClipMinder());
+	return (currentUI != nullptr && (currentUI->toClipMinder() != nullptr));
 }
 
 bool rootUIIsClipMinderScreen() {
 	UI* rootUI = getRootUI();
-	return (rootUI && rootUI->toClipMinder());
+	return (rootUI != nullptr && (rootUI->toClipMinder() != nullptr));
 }
 
 void swapOutRootUILowLevel(UI* newUI) {
+	newUI = newUI->getUI();
 	uiNavigationHierarchy[0] = newUI;
 }
 
@@ -221,6 +225,7 @@ void closeUI(UI* uiToClose) {
 }
 
 bool openUI(UI* newUI) {
+	newUI = newUI->getUI();
 	UI* oldUI = getCurrentUI();
 	uiNavigationHierarchy[numUIsOpen] = newUI;
 	numUIsOpen++;

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -156,7 +156,17 @@ public:
 	virtual void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) = 0;
 	bool oledShowsUIUnderneath;
 
+	/// \brief When entering a UI (e.g. automationView), you may wish to open a different UI
+	///        based on the current context (e.g. automationViewArranger, automationViewAudioClip, etc.)
+	virtual UI* getUI() { return this; }
+	/// \brief What type of UI is this? e.g. UIType::ARRANGER
 	virtual UIType getUIType() = 0;
+	/// \brief What context does UI relate to? e.g. UIType could be AUTOMATION but UIContextType could be
+	///		   ARRANGER, AUDIO CLIP, INSTRUMENT CLIP
+	virtual UIType getUIContextType() { return getUIType(); }
+	/// \brief What mod controllable context is this UI using? E.g. Automation View can use the Song
+	///		   ModControllable when in Arranger but the Clip ModControllable when in a Clip.
+	virtual UIModControllableContext getUIModControllableContext() { return UIModControllableContext::NONE; }
 #if ENABLE_MATRIX_DEBUG
 	const char* getUIName();
 #endif

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -76,11 +76,11 @@ void UITimerManager::routine() {
 					break;
 
 				case TimerName::DEFAULT_ROOT_NOTE:
-					if (getCurrentUI() == &instrumentClipView || getCurrentUI() == &automationView) {
-						instrumentClipView.flashDefaultRootNote();
-					}
-					else if (getCurrentUI() == &keyboardScreen) {
+					if (getCurrentUI() == &keyboardScreen) {
 						keyboardScreen.flashDefaultRootNote();
+					}
+					else if (getCurrentUI()->getUIContextType() == UIType::INSTRUMENT_CLIP) {
+						instrumentClipView.flashDefaultRootNote();
 					}
 					break;
 

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -119,6 +119,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::ARRANGER; }
+	UIModControllableContext getUIModControllableContext() override { return UIModControllableContext::SONG; }
 
 	Clip* getClipForSelection();
 

--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -61,6 +61,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::AUDIO_CLIP; }
+	UIModControllableContext getUIModControllableContext() override { return UIModControllableContext::CLIP; }
 
 private:
 	uint32_t timeSongButtonPressed;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -655,16 +655,16 @@ void AutomationView::graphicsRoutine() {
 
 // used to return whether Automation View is in the AUTOMATION_ARRANGER_VIEW UI Type, AUTOMATION_INSTRUMENT_CLIP_VIEW or
 // AUTOMATION_AUDIO_CLIP_VIEW UI Type
-AutomationSubType AutomationView::getAutomationSubType() {
+UIType AutomationView::getUIContextType() {
 	if (onArrangerView) {
-		return AutomationSubType::ARRANGER;
+		return UIType::ARRANGER;
 	}
 	else {
 		if (getCurrentClip()->type == ClipType::AUDIO) {
-			return AutomationSubType::AUDIO;
+			return UIType::AUDIO_CLIP;
 		}
 		else {
-			return AutomationSubType::INSTRUMENT;
+			return UIType::INSTRUMENT_CLIP;
 		}
 	}
 }

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -60,7 +60,19 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::AUTOMATION; }
-	AutomationSubType getAutomationSubType();
+	UIType getUIContextType() override;
+	UIModControllableContext getUIModControllableContext() override {
+		return getUIContextType() == UIType::ARRANGER ? UIModControllableContext::SONG : UIModControllableContext::CLIP;
+	}
+
+	// used to identify the UI as a clip UI or not.
+	ClipMinder* toClipMinder() override { return getUIContextType() == UIType::ARRANGER ? nullptr : this; }
+
+	void setAutomationParamType();
+
+	bool onAutomationOverview();
+	bool inAutomationEditor();
+	bool inNoteEditor();
 
 	// rendering
 	bool possiblyRefreshAutomationEditorGrid(Clip* clip, deluge::modulation::params::Kind paramKind, int32_t paramID);
@@ -110,17 +122,6 @@ public:
 
 	// called by playback_handler.cpp
 	void notifyPlaybackBegun() override;
-
-	// used to identify the UI as a clip UI or not.
-	ClipMinder* toClipMinder() override {
-		return getAutomationSubType() == AutomationSubType::ARRANGER ? nullptr : this;
-	}
-
-	void setAutomationParamType();
-
-	bool onAutomationOverview();
-	bool inAutomationEditor();
-	bool inNoteEditor();
 
 	bool interpolation;
 	bool interpolationBefore;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -5875,7 +5875,7 @@ drawNormally:
 			// we turn it off when affect entire is on because the selected drum is not relevant in that context
 			// e.g. if you're in the affect entire menu, you're not editing params for the selected drum
 			UI* currentUI = getCurrentUI();
-			bool isInstrumentClipView = ((currentUI == &instrumentClipView) || (currentUI == &automationView));
+			bool isInstrumentClipView = (currentUI->getUIContextType() == UIType::INSTRUMENT_CLIP);
 			if (!isInstrumentClipView && getAffectEntire()) {
 				thisColour = colours::black;
 				return;

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -221,6 +221,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::INSTRUMENT_CLIP; }
+	UIModControllableContext getUIModControllableContext() override { return UIModControllableContext::CLIP; }
 
 	// note editor
 	bool enterNoteEditor();

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -298,6 +298,16 @@ void PerformanceView::focusRegained() {
 	uiNeedsRendering(this);
 }
 
+UIType PerformanceView::getUIContextType() {
+	// if performanceView was entered from arranger
+	if (currentSong->lastClipInstanceEnteredStartPos != -1) {
+		return UIType::ARRANGER;
+	}
+	else {
+		return UIType::SESSION;
+	}
+}
+
 void PerformanceView::graphicsRoutine() {
 	static int counter = 0;
 	if (currentUIMode == UI_MODE_NONE) {

--- a/src/deluge/gui/views/performance_view.h
+++ b/src/deluge/gui/views/performance_view.h
@@ -67,6 +67,8 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::PERFORMANCE; }
+	UIType getUIContextType() override;
+	UIModControllableContext getUIModControllableContext() override { return UIModControllableContext::SONG; }
 	[[nodiscard]] int32_t getNavSysId() const override;
 
 	// rendering

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -129,6 +129,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::SESSION; }
+	UIModControllableContext getUIModControllableContext() override { return UIModControllableContext::SONG; }
 
 	Clip* createNewClip(OutputType outputType, int32_t yDisplay);
 	bool createClip{false};

--- a/src/deluge/io/midi/midi_transpose.cpp
+++ b/src/deluge/io/midi/midi_transpose.cpp
@@ -16,6 +16,7 @@ namespace MIDITranspose {
 MIDITransposeControlMethod controlMethod;
 
 void doTranspose(bool on, int32_t newNoteOrCC) {
+	bool doRender = false;
 
 	if (on) {
 		if (!currentSong->hasBeenTransposed) {
@@ -48,17 +49,32 @@ void doTranspose(bool on, int32_t newNoteOrCC) {
 
 				currentSong->transposeAllScaleModeClips(steps, false);
 
-				uiNeedsRendering(&keyboardScreen, 0xFFFFFFFF, 0);
-				uiNeedsRendering(&instrumentClipView);
-				uiNeedsRendering(&automationView, 0, 0xFFFFFFFF);
+				doRender = true;
 			}
 		}
 		else {
 			currentSong->transposeAllScaleModeClips(semitones, true);
 
-			uiNeedsRendering(&keyboardScreen, 0xFFFFFFFF, 0);
-			uiNeedsRendering(&instrumentClipView);
-			uiNeedsRendering(&automationView, 0, 0xFFFFFFFF);
+			doRender = true;
+		}
+		if (doRender) {
+			RootUI* rootUI = getRootUI();
+			if (rootUI->getUIContextType() == UIType::INSTRUMENT_CLIP) {
+				switch (rootUI->getUIType()) {
+				case UIType::KEYBOARD_SCREEN:
+					uiNeedsRendering(rootUI, 0xFFFFFFFF, 0);
+					break;
+				case UIType::INSTRUMENT_CLIP:
+					uiNeedsRendering(rootUI);
+					break;
+				case UIType::AUTOMATION:
+					uiNeedsRendering(rootUI, 0, 0xFFFFFFFF);
+					break;
+				default:
+				    // fallthrough for everything else -- to many UIs to list explicitly
+				    ;
+				}
+			}
 		}
 	}
 	else {
@@ -77,7 +93,7 @@ void doTranspose(bool on, int32_t newNoteOrCC) {
 }
 
 void exitScaleModeForMIDITransposeClips() {
-	if (currentUIMode == UI_MODE_NONE && getRootUI() == &instrumentClipView) {
+	if (currentUIMode == UI_MODE_NONE && getRootUI()->getUIContextType() == UIType::INSTRUMENT_CLIP) {
 		InstrumentClip* clip = getCurrentInstrumentClip();
 
 		if (clip != nullptr) {

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -655,18 +655,19 @@ currentClipSwitchedOver:
 	}
 
 	if (updateVisually) {
+		UI* currentUI = getCurrentUI();
 
-		if (getCurrentUI() == &instrumentClipView) {
+		if (currentUI == &instrumentClipView) {
 			// If we're not animating away from this view (but something like scrolling sideways would be allowed)
 			if (whichAnimation != Animation::CLIP_MINDER_TO_SESSION
 			    && whichAnimation != Animation::CLIP_MINDER_TO_ARRANGEMENT) {
 				instrumentClipView.recalculateColours();
 				if (whichAnimation == Animation::NONE) {
-					uiNeedsRendering(&instrumentClipView);
+					uiNeedsRendering(currentUI);
 				}
 			}
 		}
-		else if (getCurrentUI() == &automationView) {
+		else if (currentUI == &automationView) {
 			// If we're not animating away from this view (but something like scrolling sideways would be allowed)
 			if (whichAnimation != Animation::CLIP_MINDER_TO_SESSION
 			    && whichAnimation != Animation::CLIP_MINDER_TO_ARRANGEMENT) {
@@ -674,26 +675,26 @@ currentClipSwitchedOver:
 					instrumentClipView.recalculateColours();
 				}
 				if (whichAnimation == Animation::NONE) {
-					uiNeedsRendering(&automationView);
+					uiNeedsRendering(currentUI);
 				}
 			}
 		}
-		else if (getCurrentUI() == &audioClipView) {
+		else if (currentUI == &audioClipView) {
 			if (whichAnimation == Animation::NONE) {
-				uiNeedsRendering(&audioClipView);
+				uiNeedsRendering(currentUI);
 			}
 		}
-		else if (getCurrentUI() == &keyboardScreen) {
+		else if (currentUI == &keyboardScreen) {
 			if (whichAnimation != Animation::ENTER_KEYBOARD_VIEW) {
-				uiNeedsRendering(&keyboardScreen, 0xFFFFFFFF, 0);
+				uiNeedsRendering(currentUI, 0xFFFFFFFF, 0);
 			}
 		}
 		// Got to try this even if we're supposedly doing a horizontal scroll animation or something cos that may have
 		// failed if the Clip wasn't long enough before we did the action->revert() ...
-		else if (getCurrentUI() == &sessionView) {
-			uiNeedsRendering(&sessionView, 0xFFFFFFFF, 0xFFFFFFFF);
+		else if (currentUI == &sessionView) {
+			uiNeedsRendering(currentUI, 0xFFFFFFFF, 0xFFFFFFFF);
 		}
-		else if (getCurrentUI() == &arrangerView) {
+		else if (currentUI == &arrangerView) {
 			arrangerView.repopulateOutputsOnScreen(whichAnimation == Animation::NONE);
 		}
 

--- a/src/deluge/model/drum/midi_drum.cpp
+++ b/src/deluge/model/drum/midi_drum.cpp
@@ -140,10 +140,7 @@ int8_t MIDIDrum::modEncoderAction(ModelStackWithThreeMainThings* modelStack, int
 
 	NonAudioDrum::modEncoderAction(modelStack, offset, whichModEncoder);
 
-	if ((getCurrentUI() == &instrumentClipView
-	     || (getCurrentUI() == &automationView
-	         && automationView.getAutomationSubType() == AutomationSubType::INSTRUMENT))
-	    && currentUIMode == UI_MODE_AUDITIONING) {
+	if ((getCurrentUI()->getUIContextType() == UIType::INSTRUMENT_CLIP) && (currentUIMode == UI_MODE_AUDITIONING)) {
 		if (whichModEncoder == 1) {
 			modChange(modelStack, offset, &noteEncoderCurrentOffset, &note, 128);
 		}

--- a/src/deluge/model/drum/non_audio_drum.cpp
+++ b/src/deluge/model/drum/non_audio_drum.cpp
@@ -33,10 +33,7 @@ void NonAudioDrum::killAllVoices() {
 int8_t NonAudioDrum::modEncoderAction(ModelStackWithThreeMainThings* modelStack, int8_t offset,
                                       uint8_t whichModEncoder) {
 
-	if ((getCurrentUI() == &instrumentClipView
-	     || (getCurrentUI() == &automationView
-	         && automationView.getAutomationSubType() == AutomationSubType::INSTRUMENT))
-	    && currentUIMode == UI_MODE_AUDITIONING) {
+	if ((getCurrentUI()->getUIContextType() == UIType::INSTRUMENT_CLIP) && (currentUIMode == UI_MODE_AUDITIONING)) {
 		if (whichModEncoder == 0) {
 			modChange(modelStack, offset, &channelEncoderCurrentOffset, &channel, getNumChannels());
 		}

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -1521,12 +1521,9 @@ void Kit::offerReceivedNote(ModelStackWithTimelineCounter* modelStack, MIDICable
 			if (thisNoteRow) {
 				instrumentClip->toggleNoteRowMute(modelStackWithNoteRow);
 
-				if (getCurrentUI() == &automationView
-				    && automationView.getAutomationSubType() == AutomationSubType::INSTRUMENT) {
-					uiNeedsRendering(&automationView, 0, 0xFFFFFFFF);
-				}
-				else {
-					uiNeedsRendering(&instrumentClipView, 0, 0xFFFFFFFF);
+				UI* currentUI = getCurrentUI();
+				if (currentUI->getUIContextType() == UIType::INSTRUMENT_CLIP) {
+					uiNeedsRendering(currentUI, 0, 0xFFFFFFFF);
 				}
 			}
 		}


### PR DESCRIPTION
Added Context Types to simplify logic for identifying the mod controllable context and the related clip type of the UI you are in.

This is more stuff I pulled out of my upcoming automation view refactoring PR

There will be more follow-up PR's that build upon this cleanup