### PR TITLE
Feature/ Select horizontal menu item with synth-kit-midi-cv buttons

### DIFF
--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -111,6 +111,9 @@ public:
 	/// Should make sure the menu's internal state matches the system and redraw the display.
 	virtual void beginSession(MenuItem* navigatedBackwardFrom = nullptr) {};
 
+	/// @brief End an editing session with this menu item
+	virtual void endSession() {};
+
 	/// Re-read the value from the system and redraw the display to match.
 	virtual void readValueAgain() {}
 	/// Like readValueAgain, but does not redraw.

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -43,7 +43,7 @@ public:
 	void updateDisplay();
 	void selectEncoderAction(int32_t offset) final;
 	MenuItem* selectButtonPress() final;
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) final;
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	void readValueAgain() final { updateDisplay(); }
 	void unlearnAction() final;
 	bool usesAffectEntire() override;
@@ -69,11 +69,13 @@ public:
 protected:
 	void drawVerticalMenu();
 	void drawHorizontalMenu();
+	void updateSelectedHorizontalMenuItemLED(int32_t itemNumber);
+	int32_t lastSelectedHorizontalMenuItemPosition = kNoSelection;
+	deluge::vector<MenuItem*> items;
+	typename decltype(items)::iterator current_item_;
 
 private:
 	bool shouldForwardButtons();
-	deluge::vector<MenuItem*> items;
-	typename decltype(items)::iterator current_item_;
 };
 
 class HorizontalMenu : public Submenu {
@@ -85,6 +87,9 @@ public:
 	HorizontalMenu(l10n::String newName, l10n::String title, std::span<MenuItem*> newItems)
 	    : Submenu(newName, title, newItems) {}
 	bool supportsHorizontalRendering() { return true; }
+	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
+	ActionResult selectHorizontalMenuItemOnVisiblePage(int32_t itemNumber);
+	void endSession() override;
 };
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -266,11 +266,11 @@ void SoundEditor::displayOrLanguageChanged() {
 void SoundEditor::setLedStates() {
 	indicator_leds::setLedState(IndicatorLED::SAVE, false); // In case we came from the save-Instrument UI
 
-	indicator_leds::setLedState(IndicatorLED::SYNTH, !inSettingsMenu() && !editingKit() && currentSound);
-	indicator_leds::setLedState(IndicatorLED::KIT, !inSettingsMenu() && editingKit() && currentSound);
-	indicator_leds::setLedState(IndicatorLED::MIDI,
-	                            !inSettingsMenu() && getCurrentOutputType() == OutputType::MIDI_OUT);
-	indicator_leds::setLedState(IndicatorLED::CV, !inSettingsMenu() && getCurrentOutputType() == OutputType::CV);
+	// turn off all instrument LED's when entering menu
+	indicator_leds::setLedState(IndicatorLED::SYNTH, false);
+	indicator_leds::setLedState(IndicatorLED::KIT, false);
+	indicator_leds::setLedState(IndicatorLED::MIDI, false);
+	indicator_leds::setLedState(IndicatorLED::CV, false);
 
 	indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
 	indicator_leds::setLedState(IndicatorLED::SCALE_MODE, false);
@@ -286,6 +286,9 @@ void SoundEditor::setLedStates() {
 }
 
 void SoundEditor::enterSubmenu(MenuItem* newItem) {
+	// end current menu item session before beginning new menu item session
+	endScreen();
+
 	navigationDepth++;
 	menuItemNavigationRecord[navigationDepth] = newItem;
 	display->setNextTransitionDirection(1);
@@ -569,6 +572,9 @@ void SoundEditor::handlePotentialParamMenuChange(deluge::hid::Button b, bool on,
 }
 
 void SoundEditor::goUpOneLevel() {
+	// end current menu item session before beginning new menu item session
+	endScreen();
+
 	do {
 		if (navigationDepth == 0) {
 			exitCompletely();
@@ -605,6 +611,10 @@ void SoundEditor::exitCompletely() {
 	else if (inNoteRowEditor()) {
 		instrumentClipView.exitNoteRowEditor();
 	}
+
+	// end current menu item session before exiting
+	endScreen();
+
 	display->setNextTransitionDirection(-1);
 	close();
 	possibleChangeToCurrentRangeDisplay();
@@ -781,6 +791,14 @@ bool SoundEditor::beginScreen(MenuItem* oldMenuItem) {
 	possibleChangeToCurrentRangeDisplay();
 
 	return getCurrentUI() == &soundEditor;
+}
+
+/// end current menu item session before beginning new menu item session or exiting the sound editor
+void SoundEditor::endScreen() {
+	MenuItem* currentMenuItem = getCurrentMenuItem();
+	if (currentMenuItem != nullptr) {
+		currentMenuItem->endSession();
+	}
 }
 
 void SoundEditor::possibleChangeToCurrentRangeDisplay() {
@@ -1097,12 +1115,14 @@ getOut:
 
 					// Otherwise...
 					else {
-
 						// If we've been given a MenuItem to go into, do that
 						if (newMenuItem
 						    && newMenuItem->checkPermissionToBeginSession(currentModControllable, currentSourceIndex,
 						                                                  &currentMultiRange)
 						           != MenuPermission::NO) {
+							// end current menu item session before beginning new menu item session
+							endScreen();
+
 							modulationItemFound = true;
 							navigationDepth = newNavigationDepth + 1;
 							menuItemNavigationRecord[navigationDepth] = newMenuItem;
@@ -1683,10 +1703,12 @@ doMIDIOrCV:
 		currentPriority = &audioClip->voicePriority;
 	}
 
+	// end current menu item session before beginning new menu item session
+	endScreen();
+
 	navigationDepth = 0;
 	shouldGoUpOneLevelOnBegin = false;
 	menuItemNavigationRecord[navigationDepth] = newItem;
-
 	display->setNextTransitionDirection(1);
 
 	return true;

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -165,6 +165,7 @@ private:
 	void setupShortcutsBlinkFromTable(MenuItem const* currentItem,
 	                                  MenuItem const* const items[kDisplayWidth][kDisplayHeight]);
 	bool beginScreen(MenuItem* oldMenuItem = nullptr);
+	void endScreen();
 	uint8_t getActualParamFromScreen(uint8_t screen);
 	void setLedStates();
 	ActionResult handleAutomationViewPadAction(int32_t x, int32_t y, int32_t velocity);

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -71,6 +71,8 @@ import { Aside, Badge, Icon, LinkButton } from "@astrojs/starlight/components"
   - With `Alternative Select Behaviour (SELE)` ENABLED:
     - `Turn select encoder` to change the value of the selected menu item
     - `Press + Turn select encoder` to change the selected menu item
+  - You can select the different menu item's on the currently visible horizontal menu page using the `SYNTH`, `KIT`, `MIDI`, `CV` buttons
+    - When in a Horizontal menu, the selected instrument LED corresponding to the Horizontal Menu item selected will light up
 
 #### <ins>Clip Name Display & Copying</ins>
 

--- a/website/src/content/docs/features/community_features.md
+++ b/website/src/content/docs/features/community_features.md
@@ -52,6 +52,8 @@ back up your SD card!
   - With `Alternative Select Behaviour (SELE)` ENABLED:
     - `Turn select encoder` to change the value of the selected menu item
     - `Press + Turn select encoder` to change the selected menu item
+  - You can select the different menu item's on the currently visible horizontal menu page using the `SYNTH`, `KIT`, `MIDI`, `CV` buttons
+    - When in a Horizontal menu, the selected instrument LED corresponding to the Horizontal Menu item selected will light up
 
 #### 2.3 Favourites
 


### PR DESCRIPTION
You can select the different menu item's on the currently visible horizontal menu page using the `SYNTH`, `KIT`, `MIDI`, `CV` buttons
    - When in a Horizontal menu, the selected instrument LED corresponding to the Horizontal Menu item selected will light up