### PR TITLE
Fix crash with grid view loop recording

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3065,6 +3065,19 @@ Clip* SessionView::getClipForLayout() {
 	}
 }
 
+int32_t SessionView::getClipIndexForLayout() {
+	switch (currentSong->sessionLayout) {
+	case SessionLayoutType::SessionLayoutTypeGrid: {
+		return gridClipIndexFromCoords(gridFirstPressedX, gridFirstPressedY);
+		break;
+	}
+	case SessionLayoutType::SessionLayoutTypeRows:
+	default: {
+		return (sessionView.selectedClipPressYDisplay + currentSong->songViewYScroll);
+	}
+	}
+}
+
 void SessionView::selectLayout(int8_t offset) {
 	gridSetDefaultMode();
 	// only reset first pad if it's not still held
@@ -4662,6 +4675,7 @@ int32_t SessionView::gridTrackIndexFromX(uint32_t x, uint32_t maxTrack) {
 
 Output* SessionView::gridTrackFromX(uint32_t x, uint32_t maxTrack) {
 	auto trackIndex = gridTrackIndexFromX(x, maxTrack);
+
 	if (trackIndex < 0) {
 		return nullptr;
 	}
@@ -4672,6 +4686,7 @@ Output* SessionView::gridTrackFromX(uint32_t x, uint32_t maxTrack) {
 Clip* SessionView::gridClipFromCoords(uint32_t x, uint32_t y) {
 	auto maxTrack = gridTrackCount();
 	Output* track = gridTrackFromX(x, maxTrack);
+
 	if (track == nullptr) {
 		return nullptr;
 	}
@@ -4690,6 +4705,30 @@ Clip* SessionView::gridClipFromCoords(uint32_t x, uint32_t y) {
 
 	return nullptr;
 }
+
+int32_t SessionView::gridClipIndexFromCoords(uint32_t x, uint32_t y) {
+	auto maxTrack = gridTrackCount();
+	Output* track = gridTrackFromX(x, maxTrack);
+
+	if (track == nullptr) {
+		return -1;
+	}
+
+	auto section = gridSectionFromY(y);
+	if (section == -1) {
+		return -1;
+	}
+
+	for (int32_t idxClip = 0; idxClip < currentSong->sessionClips.getNumElements(); ++idxClip) {
+		Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
+		if (clip->output == track && clip->section == section) {
+			return idxClip;
+		}
+	}
+
+	return -1;
+}
+
 Output* SessionView::getOutputFromPad(int32_t x, int32_t y) {
 	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid) {
 		return gridTrackFromX(x, gridTrackCount());

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -118,6 +118,7 @@ public:
 	int8_t selectedMacro = -1;
 
 	Clip* getClipForLayout();
+	int32_t getClipIndexForLayout();
 
 	void copyClipName(Clip* source, Clip* target, Output* targetOutput);
 
@@ -263,6 +264,7 @@ private:
 	int32_t gridTrackIndexFromX(uint32_t x, uint32_t maxTrack);
 	Output* gridTrackFromX(uint32_t x, uint32_t maxTrack);
 	Clip* gridClipFromCoords(uint32_t x, uint32_t y);
+	int32_t gridClipIndexFromCoords(uint32_t x, uint32_t y);
 	Cartesian gridXYFromClip(Clip& clip);
 
 	void gridSetDefaultMode() {

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -3201,8 +3201,8 @@ doCreateNextOverdub:
 
 			// If we're holding down a Clip in Session View, prioritize that
 			if (getRootUI() == &sessionView && currentUIMode == UI_MODE_CLIP_PRESSED_IN_SONG_VIEW) {
-				clipToCreateOverdubFrom = sessionView.getClipOnScreen(sessionView.selectedClipPressYDisplay);
-				clipIndexToCreateOverdubFrom = sessionView.selectedClipPressYDisplay + currentSong->songViewYScroll;
+				clipToCreateOverdubFrom = sessionView.getClipForLayout();
+				clipIndexToCreateOverdubFrom = sessionView.getClipIndexForLayout();
 				sessionView.performActionOnPadRelease = false;
 			}
 


### PR DESCRIPTION
Fixed a crash in grid view when you held a clip and press record to trigger a loop recording

It was happening because it was using the wrong clip index.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3608