### PR TITLE
BugFix/ vertical scrolling note dropping bug in automation view

### DIFF
--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -91,7 +91,7 @@ public:
 
 	// vertical encoder action
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	ActionResult scrollVertical(int32_t scrollAmount);
+	ActionResult scrollVertical(int32_t scrollAmount, ModelStackWithTimelineCounter* modelStack);
 	void potentiallyVerticalScrollToSelectedDrum(InstrumentClip* clip, Output* output);
 
 	// mod encoder action


### PR DESCRIPTION
Fixed bug where vertical scrolling in automation view would turn notes off. when i copied the initial vertical scroll logic from instrument clip view, i seemingly forgot a check that resulted in it always calling this to turn note's off

`instrumentClipView.sendAuditionNote(false, yDisplay, 127, 0); `

Also removed an extra call to create the model stack in scrollVertical that was unnecessary.

Future to do: consolidate scrollVertical function logic between automation view and instrument clip view. The code is basically the same, just a few exceptions.