### PR TITLE
Refactor/ InstrumentClipView::scrollVertical

### DIFF
--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -103,7 +103,6 @@ public:
 
 	// vertical encoder action
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	ActionResult scrollVertical(int32_t scrollAmount, ModelStackWithTimelineCounter* modelStack);
 	void potentiallyVerticalScrollToSelectedDrum(InstrumentClip* clip, Output* output);
 
 	// mod encoder action

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -111,13 +111,35 @@ public:
 	/// Change current root note. AUDITION + SCALE or SCALE + AUDITION in scale mod.
 	ActionResult commandChangeRootNote(uint8_t yDisplay);
 
+	/// VERTICAL ENCODER ACTION related
+	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
+	ActionResult commandTransposeKey(int32_t offset, bool inCardRoutine);
+	void commandShiftColour(int32_t offset);
+	ActionResult scrollVertical(int32_t scrollAmount, bool inCardRoutine, bool draggingNoteRow = false,
+	                            ModelStackWithTimelineCounter* modelStack = nullptr);
+	ActionResult scrollVertical_limit(int32_t scrollAmount, bool inCardRoutine, bool draggingNoteRow,
+	                                  ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip, bool isKit,
+	                                  bool preventOverScrolling, int32_t& noteRowToShiftI, int32_t& noteRowToSwapWithI);
+	void scrollVertical_potentiallySwitchOffAuditionedNotes(bool draggingNoteRow,
+	                                                        ModelStackWithTimelineCounter* modelStack,
+	                                                        InstrumentClip* clip, bool currentClipIsActive);
+	void scrollVertical_grabNotesPressed(ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip);
+	void scrollVertical_dragSelectedNoteRow(InstrumentClip* clip, Output* output, bool isKit, int32_t noteRowToShiftI,
+	                                        int32_t noteRowToSwapWithI);
+	void scrollVertical_potentiallySwitchOnAuditionedNotes(bool draggingNoteRow,
+	                                                       ModelStackWithTimelineCounter* modelStack,
+	                                                       InstrumentClip* clip, Output* output, OutputType outputType,
+	                                                       bool isKit, bool inSoundEditor, bool currentClipIsActive,
+	                                                       bool renderDisplay, bool updateDrumSelection);
+	void scrollVertical_placeNotesPressed(ModelStackWithTimelineCounter* modelStack, InstrumentClip* clip, bool isKit);
+
+	/// OTHER uncategorized (yet)
 	uint8_t getEditPadPressXDisplayOnScreen(uint8_t yDisplay);
 	void editPadAction(bool state, uint8_t yDisplay, uint8_t xDisplay, uint32_t xZoom);
 	void mutePadPress(uint8_t yDisplay);
 	bool ensureNoteRowExistsForYDisplay(uint8_t yDisplay);
 	void recalculateColours();
 	void recalculateColour(uint8_t yDisplay);
-	ActionResult scrollVertical(int32_t scrollAmount, bool inCardRoutine, bool shiftingNoteRow = false);
 	void reassessAllAuditionStatus();
 	void reassessAuditionStatus(uint8_t yDisplay);
 	uint8_t getVelocityForAudition(uint8_t yDisplay, uint32_t* sampleSyncLength);
@@ -147,9 +169,6 @@ public:
 	void exitScaleMode();
 	void drawMuteSquare(NoteRow* thisNoteRow, RGB thisImage[], uint8_t thisOccupancyMask[]);
 	void cutAuditionedNotesToOne();
-	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
-	ActionResult commandTransposeKey(int32_t offset, bool inCardRoutine);
-	void commandShiftColour(int32_t offset);
 	ActionResult horizontalEncoderAction(int32_t offset) override;
 	void fillOffScreenImageStores();
 	void graphicsRoutine() override;

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -112,8 +112,7 @@ TEST(Scheduler, scheduleConditional) {
 	mock().clear();
 	mock().expectNCalls(1, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(
-	    sleep_50ns, 0, []() { return true; }, "sleep 50ns", RESOURCE_NONE);
+	addConditionalTask(sleep_50ns, 0, []() { return true; }, "sleep 50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();
@@ -123,8 +122,7 @@ TEST(Scheduler, scheduleConditionalDoesntRun) {
 	mock().clear();
 	mock().expectNCalls(0, "sleep_50ns");
 	// will load as blocked but immediately pass condition
-	addConditionalTask(
-	    sleep_50ns, 0, []() { return false; }, "sleep 50ns", RESOURCE_NONE);
+	addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
 	taskManager.start(0.0095);
 	mock().checkExpectations();


### PR DESCRIPTION
Refactored InstrumentClipView::scrollVertical into several sub-functions representing the different components of a vertical scroll action

Removed automationView::scrollVertical in favour of calling newly refactored instrument clip view scrollVertical