### PR TITLE
Fix: links to development docs no longer in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ The hardware is built around a Renesas RZ/A1L processor with an Arm® Cortex®-A
 * For acquiring and using the firmware visit the [community firmware website](https://synthstromaudible.github.io/DelugeFirmware)
 * Once you have the firmware, consult our detailed [update guide](https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide) for instructions on how to install it
 * To contribute to the project with code, bug reports, suggestions, and feedback see: [How to contribute to Deluge Firmware](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/CONTRIBUTING.md)
-* To learn about the toolchain, application, and to start working on the code continue with: [Getting Started with Deluge Development](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/dev/getting_started.md)
+* To learn about the toolchain, application, and to start working on the code continue with: [Getting Started with Deluge Development](https://delugecommunity.com/development/deluge/getting_started/)
 * Please also visit the [Synthstrom Forum](https://forums.synthstrom.com/) and the community [Discord](https://discord.gg/BnRcyFSgaT) to interact with other users and the developers
 * You can donate to the project using the [Synthstrom Patreon](https://www.patreon.com/Synthstrom)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -51,8 +51,8 @@ appreciated.
 * Code reviews are intended to increase quality and should not go into nitpicking, please remember
   the [Code of Conduct](CODE_OF_CONDUCT.md).
 * Final decisions about merging of Pull requests is up to the code owners, see [Governance](GOVERNANCE.md).
-* If you have a contribution to make then review the [Guidelines for Repository Contributions](/website/src/content/docs/development/guidelines.md). 
+* If you have a contribution to make then review the [Guidelines for Repository Contributions](https://delugecommunity.com/development/deluge/guidelines/). 
 
 ## Additional Developer Resources
 
-* Access more developer resources in [Additional Information](/website/src/content/docs/development/additional_info.md).
+* Access more developer resources in [Additional Information](https://delugecommunity.com/development/deluge/additional_info/).


### PR DESCRIPTION
Updating some links that were giving 404