### PR TITLE
Tooling/ update clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,20 +4,20 @@ TabWidth: 4
 UseTab: ForIndentation
 BreakBeforeBraces: Custom
 BraceWrapping:
-  BeforeElse: True
+  BeforeElse: true
 ColumnLimit: 120
-ReflowComments: True
+ReflowComments: true
 AllowShortBlocksOnASingleLine: Empty
 AllowShortFunctionsOnASingleLine: InlineOnly
 AllowShortIfStatementsOnASingleLine: Never
-AllowShortEnumsOnASingleLine: True
-IndentGotoLabels: False
+AllowShortEnumsOnASingleLine: true
+IndentGotoLabels: false
 PointerAlignment: Left
 BreakBeforeBinaryOperators: NonAssignment
-BreakBeforeTernaryOperators: True
+BreakBeforeTernaryOperators: true
 AccessModifierOffset: -4
 AlwaysBreakTemplateDeclarations: Yes
-IndentRequiresClause: False
+IndentRequiresClause: false
 RequiresClausePosition: OwnLine
 
 SortIncludes: CaseSensitive


### PR DESCRIPTION
I encountered the following error when I ran `dbt format`:
```
Error reading /Users/leonid/Projects/DelugeFirmware/.clang-format: Invalid argument
/Users/leonid/Projects/DelugeFirmware/.clang-format:9:17: error: unknown enumerated scalar
ReflowComments: True
                ^~~~
```
I researched a bit and found that YAML spec is different between 1.1 and 1.2 version:
1.1 - https://yaml.org/type/bool.html
1.2 - https://yaml.org/spec/1.2.2/#10212-boolean

For 1.2 version it is more strict and allows only `true` and `false` literals. I changed the config option to
`ReflowComments: true`, that resolved the error. 

Though it's unclear why the script only complains about ReflowComments option (there are other booleans), but I assume for future proofing it's better to make all booleans in lowercase

P.S. I'm still unsure about the PR so feel free to decline

