### PR TITLE
Feature/ Fixed layout for horizontal menus

### DIFF
--- a/src/deluge/gui/menu_item/generate/dmenus/filter/hpf.py
+++ b/src/deluge/gui/menu_item/generate/dmenus/filter/hpf.py
@@ -67,7 +67,7 @@ morph = MultiModeMenu(
 menu = Submenu(
     "HorizontalMenu",
     "hpfMenu",
-    ["{title}", "%%CHILDREN%%"],
+    ["{title}", "%%CHILDREN%%", "HorizontalMenu::Layout::FIXED"],
     "filter/hpf/index.md",
     [freq, res, morph, mode],
     name="STRING_FOR_HPF",

--- a/src/deluge/gui/menu_item/generate/dmenus/filter/lpf.py
+++ b/src/deluge/gui/menu_item/generate/dmenus/filter/lpf.py
@@ -67,7 +67,7 @@ morph = MultiModeMenu(
 menu = Submenu(
     "HorizontalMenu",
     "lpfMenu",
-    ["{title}", "%%CHILDREN%%"],
+    ["{title}", "%%CHILDREN%%", "HorizontalMenu::Layout::FIXED"],
     "filter/lpf/index.md",
     [freq, res, morph, mode],
     name="STRING_FOR_LPF",

--- a/src/deluge/gui/menu_item/generate/g_menus.inc
+++ b/src/deluge/gui/menu_item/generate/g_menus.inc
@@ -9,7 +9,7 @@ std::array<MenuItem*, 4> child0 = {
     &lpfMorphMenu,
     &lpfModeMenu,
 };
-HorizontalMenu lpfMenu{STRING_FOR_LPF, child0};
+HorizontalMenu lpfMenu{STRING_FOR_LPF, child0, HorizontalMenu::Layout::FIXED};
 filter::FilterParam hpfFreqMenu{STRING_FOR_FREQUENCY, STRING_FOR_HPF_FREQUENCY, params::LOCAL_HPF_FREQ, filter::FilterSlot::HPF, filter::FilterParamType::FREQUENCY};
 filter::FilterParam hpfResMenu{STRING_FOR_RESONANCE, STRING_FOR_HPF_RESONANCE, params::LOCAL_HPF_RESONANCE, filter::FilterSlot::HPF, filter::FilterParamType::RESONANCE};
 filter::FilterParam hpfMorphMenu{STRING_FOR_HPF_MORPH, params::LOCAL_HPF_MORPH, filter::FilterSlot::HPF, filter::FilterParamType::MORPH};
@@ -20,7 +20,7 @@ std::array<MenuItem*, 4> child1 = {
     &hpfMorphMenu,
     &hpfModeMenu,
 };
-HorizontalMenu hpfMenu{STRING_FOR_HPF, child1};
+HorizontalMenu hpfMenu{STRING_FOR_HPF, child1, HorizontalMenu::Layout::FIXED};
 FilterRouting filterRoutingMenu{STRING_FOR_FILTER_ROUTE};
 std::array<MenuItem*, 3> child2 = {
     &lpfMenu,

--- a/src/deluge/gui/menu_item/lfo/type.cpp
+++ b/src/deluge/gui/menu_item/lfo/type.cpp
@@ -49,20 +49,20 @@ void Type::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY,
 	int32_t phaseIncrement;
 	int32_t extraScaling = 1;
 	if (wave == LFOType::RANDOM_WALK) {
-		phaseIncrement = UINT32_MAX / (plotWidth / 12);
+		phaseIncrement = UINT32_MAX / (plotWidth / 9);
 		// RANDOM walk range is smaller, so we magnify for display.
 		extraScaling = 5;
 	}
 	else if (wave == LFOType::SAMPLE_AND_HOLD) {
-		phaseIncrement = UINT32_MAX / (plotWidth / 12);
+		phaseIncrement = UINT32_MAX / (plotWidth / 9);
 	}
 	else if (wave == LFOType::WARBLER) {
-		phaseIncrement = UINT32_MAX / (plotWidth / 12);
+		phaseIncrement = UINT32_MAX / (plotWidth / 9);
 		// warbler is very peaky, so despite using the full range it's frequently filtered out by the resolution
 		extraScaling = 15;
 	}
 	else {
-		phaseIncrement = UINT32_MAX / (plotWidth / 3);
+		phaseIncrement = UINT32_MAX / (plotWidth / 2.4);
 	}
 	bool first = true;
 	int32_t prevY = 0;

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -249,6 +249,11 @@ public:
 	/// By default this redirects to getName(), but can be overriden.
 	virtual void getColumnLabel(StringBuf& label) { label.append(getName().data()); }
 
+	/// @brief Get the number of occupied virtual columns in the horizontal menu.
+	///
+	/// 1 by default, but can be overridden
+	[[nodiscard]] virtual int32_t getColumnSpan() const { return 1; };
+
 	/// @brief Check if this MenuItem should show up in a containing deluge::gui::menu_item::Submenu.
 	///
 	/// @param sound Sound we would edit if we were to be entered.

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -56,6 +56,7 @@ public:
 	void learnKnob(MIDICable* cable, int32_t whichKnob, int32_t modKnobMode, int32_t midiChannel) final;
 	void learnProgramChange(MIDICable& cable, int32_t channel, int32_t programNumber) override;
 	bool learnNoteOn(MIDICable& cable, int32_t channel, int32_t noteCode) final;
+	virtual RenderingStyle renderingStyle() { return RenderingStyle::VERTICAL; };
 	void drawPixelsForOled() override;
 	void drawSubmenuItemsForOled(std::span<MenuItem*> options, const int32_t selectedOption);
 	/// @brief 	Indicates if the menu-like object should wrap-around. Destined to be virtualized.
@@ -63,19 +64,12 @@ public:
 	bool wrapAround();
 	bool isSubmenu() override { return true; }
 	virtual bool focusChild(const MenuItem* child);
-	/// Submenus which support horizontal rendering need to override this.
-	virtual bool supportsHorizontalRendering() { return false; }
-	RenderingStyle renderingStyle();
 	void updatePadLights() override;
 	MenuItem* patchingSourceShortcutPress(PatchSource s, bool previousPressStillActive = false) override;
 	deluge::modulation::params::Kind getParamKind() override;
 	uint32_t getParamIndex() override;
 
 protected:
-	void drawVerticalMenu();
-	void drawHorizontalMenu();
-	void updateSelectedHorizontalMenuItemLED(int32_t itemNumber);
-	int32_t lastSelectedHorizontalMenuItemPosition = kNoSelection;
 	std::optional<uint8_t> thingIndex = std::nullopt;
 	deluge::vector<MenuItem*> items;
 	typename decltype(items)::iterator current_item_;
@@ -86,21 +80,25 @@ private:
 
 class HorizontalMenu : public Submenu {
 public:
-	HorizontalMenu(l10n::String newName, std::initializer_list<MenuItem*> newItems) : Submenu(newName, newItems) {}
-	HorizontalMenu(l10n::String newName, std::span<MenuItem*> newItems) : Submenu(newName, newItems) {}
-	HorizontalMenu(l10n::String newName, l10n::String title, std::initializer_list<MenuItem*> newItems)
-	    : Submenu(newName, title, newItems) {}
-	HorizontalMenu(l10n::String newName, l10n::String title, std::span<MenuItem*> newItems)
-	    : Submenu(newName, title, newItems) {}
-	HorizontalMenu(l10n::String newName, std::span<MenuItem*> newItems, int32_t newThingIndex)
-	    : Submenu(newName, newItems, newThingIndex) {}
-	HorizontalMenu(l10n::String newName, std::initializer_list<MenuItem*> newItems, int32_t newThingIndex)
-	    : Submenu(newName, newItems, newThingIndex) {}
+	enum Layout { FIXED, DYNAMIC };
 
-	bool supportsHorizontalRendering() { return true; }
+	using Submenu::Submenu;
+
+	HorizontalMenu(l10n::String newName, std::span<MenuItem*> newItems, Layout layout)
+	    : Submenu(newName, newItems), horizontalMenuLayout(layout) {}
+	HorizontalMenu(l10n::String newName, std::initializer_list<MenuItem*> newItems, Layout layout)
+	    : Submenu(newName, newItems), horizontalMenuLayout(layout) {}
+
+	RenderingStyle renderingStyle() override;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
-	ActionResult selectHorizontalMenuItemOnVisiblePage(int32_t itemNumber);
+	void drawPixelsForOled() override;
 	void endSession() override;
+
+private:
+	ActionResult selectHorizontalMenuItemOnVisiblePage(int32_t itemNumber);
+	void updateSelectedHorizontalMenuItemLED(int32_t itemNumber);
+	int32_t lastSelectedHorizontalMenuItemPosition = kNoSelection;
+	Layout horizontalMenuLayout = Layout::DYNAMIC;
 };
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/sync_level.h
+++ b/src/deluge/gui/menu_item/sync_level.h
@@ -31,6 +31,7 @@ public:
 	size_t size() override { return NUM_SYNC_VALUES; }
 	/// Implementation of Enumeration::getShortOption(): note length name or OFF
 	void getShortOption(StringBuf&) override;
+	int32_t getColumnSpan() const override { return 2; };
 
 protected:
 	void drawValue() final;

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -299,11 +299,13 @@ arpeggiator::midi_cv::SpreadOctave arpSpreadOctaveMenuMIDIOrCV{STRING_FOR_SPREAD
                                                                STRING_FOR_ARP_SPREAD_OCTAVE_MENU_TITLE};
 
 // Arp: Basic
-HorizontalMenu arpBasicMenu{STRING_FOR_BASIC,
-                            {// Gate
-                             &arpGateMenu, &arpGateMenuMIDIOrCV,
-                             // Sync
-                             &arpSyncMenu, &arpRateMenu, &arpKitRateMenu, &arpRateMenuMIDIOrCV}};
+HorizontalMenu arpBasicMenu{
+    STRING_FOR_BASIC, {&arpGateMenu, &arpSyncMenu, &arpRateMenu}, HorizontalMenu::Layout::FIXED};
+HorizontalMenu arpBasicMenuKit{
+    STRING_FOR_BASIC, {&arpGateMenu, &arpSyncMenu, &arpKitRateMenu}, HorizontalMenu::Layout::FIXED};
+HorizontalMenu arpBasicMenuMIDIOrCV{
+    STRING_FOR_BASIC, {&arpGateMenuMIDIOrCV, &arpSyncMenu, &arpRateMenuMIDIOrCV}, HorizontalMenu::Layout::FIXED};
+
 // Arp: Pattern
 HorizontalMenu arpPatternMenu{STRING_FOR_PATTERN,
                               {// Pattern
@@ -369,13 +371,31 @@ Submenu arpMenu{
     },
 };
 
+Submenu arpMenuMIDIOrCV{
+    STRING_FOR_ARPEGGIATOR,
+    {
+        // Mode
+        &arpModeMenu,
+        // Basic
+        &arpBasicMenuMIDIOrCV,
+        // Pattern
+        &arpPatternMenu,
+        // Randomizer
+        &arpRandomizerMenu,
+        // MPE
+        &arpMpeMenu,
+        // Include in kit arp
+        &arpIncludeInKitArpMenu,
+    },
+};
+
 Submenu kitArpMenu{
     STRING_FOR_KIT_ARPEGGIATOR,
     {
         // Mode
         &arpModeMenu,
         // Basic
-        &arpBasicMenu,
+        &arpBasicMenuKit,
         // Pattern
         &arpPatternMenu,
         // Randomizer
@@ -410,14 +430,14 @@ lfo::Type lfo1TypeMenu{STRING_FOR_SHAPE, STRING_FOR_LFO1_TYPE, LFO1_ID};
 lfo::Rate lfo1RateMenu{STRING_FOR_RATE, STRING_FOR_LFO1_RATE, params::GLOBAL_LFO_FREQ_1, LFO1_ID};
 lfo::Sync lfo1SyncMenu{STRING_FOR_SYNC, STRING_FOR_LFO1_SYNC, LFO1_ID};
 
-HorizontalMenu lfo1Menu{STRING_FOR_LFO1, {&lfo1TypeMenu, &lfo1SyncMenu, &lfo1RateMenu}};
+HorizontalMenu lfo1Menu{STRING_FOR_LFO1, {&lfo1TypeMenu, &lfo1SyncMenu, &lfo1RateMenu}, HorizontalMenu::Layout::FIXED};
 
 // LFO2 menu ---------------------------------------------------------------------------------
 lfo::Type lfo2TypeMenu{STRING_FOR_SHAPE, STRING_FOR_LFO2_TYPE, LFO2_ID};
 lfo::Rate lfo2RateMenu{STRING_FOR_RATE, STRING_FOR_LFO2_RATE, params::LOCAL_LFO_LOCAL_FREQ_1, LFO2_ID};
 lfo::Sync lfo2SyncMenu{STRING_FOR_SYNC, STRING_FOR_LFO2_SYNC, LFO2_ID};
 
-HorizontalMenu lfo2Menu{STRING_FOR_LFO2, {&lfo2TypeMenu, &lfo2SyncMenu, &lfo2RateMenu}};
+HorizontalMenu lfo2Menu{STRING_FOR_LFO2, {&lfo2TypeMenu, &lfo2SyncMenu, &lfo2RateMenu}, HorizontalMenu::Layout::FIXED};
 
 // LFO3 menu ---------------------------------------------------------------------------------
 
@@ -425,14 +445,14 @@ lfo::Type lfo3TypeMenu{STRING_FOR_SHAPE, STRING_FOR_LFO3_TYPE, LFO3_ID};
 lfo::Rate lfo3RateMenu{STRING_FOR_RATE, STRING_FOR_LFO3_RATE, params::GLOBAL_LFO_FREQ_2, LFO3_ID};
 lfo::Sync lfo3SyncMenu{STRING_FOR_SYNC, STRING_FOR_LFO3_SYNC, LFO3_ID};
 
-HorizontalMenu lfo3Menu{STRING_FOR_LFO3, {&lfo3TypeMenu, &lfo3SyncMenu, &lfo3RateMenu}};
+HorizontalMenu lfo3Menu{STRING_FOR_LFO3, {&lfo3TypeMenu, &lfo3SyncMenu, &lfo3RateMenu}, HorizontalMenu::Layout::FIXED};
 
 // LFO4 menu ---------------------------------------------------------------------------------
 lfo::Type lfo4TypeMenu{STRING_FOR_SHAPE, STRING_FOR_LFO4_TYPE, LFO4_ID};
 lfo::Rate lfo4RateMenu{STRING_FOR_RATE, STRING_FOR_LFO4_RATE, params::LOCAL_LFO_LOCAL_FREQ_2, LFO4_ID};
 lfo::Sync lfo4SyncMenu{STRING_FOR_SYNC, STRING_FOR_LFO4_SYNC, LFO4_ID};
 
-HorizontalMenu lfo4Menu{STRING_FOR_LFO4, {&lfo4TypeMenu, &lfo4SyncMenu, &lfo4RateMenu}};
+HorizontalMenu lfo4Menu{STRING_FOR_LFO4, {&lfo4TypeMenu, &lfo4SyncMenu, &lfo4RateMenu}, HorizontalMenu::Layout::FIXED};
 
 // Mod FX ----------------------------------------------------------------------------------
 mod_fx::Type modFXTypeMenu{STRING_FOR_TYPE, STRING_FOR_MODFX_TYPE};
@@ -662,15 +682,14 @@ filter::UnpatchedFilterParam globalLPFResMenu{STRING_FOR_RESONANCE, STRING_FOR_L
                                               filter::FilterSlot::LPF, filter::FilterParamType::RESONANCE};
 filter::UnpatchedFilterParam globalLPFMorphMenu{STRING_FOR_MORPH, STRING_FOR_LPF_MORPH, params::UNPATCHED_LPF_MORPH,
                                                 filter::FilterSlot::LPF, filter::FilterParamType::MORPH};
-HorizontalMenu globalLPFMenu{
-    STRING_FOR_LPF,
-    {
-        &globalLPFFreqMenu,
-        &globalLPFResMenu,
-        &globalLPFMorphMenu,
-        &lpfModeMenu,
-    },
-};
+HorizontalMenu globalLPFMenu{STRING_FOR_LPF,
+                             {
+                                 &globalLPFFreqMenu,
+                                 &globalLPFResMenu,
+                                 &globalLPFMorphMenu,
+                                 &lpfModeMenu,
+                             },
+                             HorizontalMenu::Layout::FIXED};
 
 // HPF Menu
 filter::UnpatchedFilterParam globalHPFFreqMenu{STRING_FOR_FREQUENCY, STRING_FOR_HPF_FREQUENCY,
@@ -681,15 +700,14 @@ filter::UnpatchedFilterParam globalHPFResMenu{STRING_FOR_RESONANCE, STRING_FOR_H
 filter::UnpatchedFilterParam globalHPFMorphMenu{STRING_FOR_MORPH, STRING_FOR_HPF_MORPH, params::UNPATCHED_HPF_MORPH,
                                                 filter::FilterSlot::HPF, filter::FilterParamType::MORPH};
 
-HorizontalMenu globalHPFMenu{
-    STRING_FOR_HPF,
-    {
-        &globalHPFFreqMenu,
-        &globalHPFResMenu,
-        &globalHPFMorphMenu,
-        &hpfModeMenu,
-    },
-};
+HorizontalMenu globalHPFMenu{STRING_FOR_HPF,
+                             {
+                                 &globalHPFFreqMenu,
+                                 &globalHPFResMenu,
+                                 &globalHPFMorphMenu,
+                                 &hpfModeMenu,
+                             },
+                             HorizontalMenu::Layout::FIXED};
 
 Submenu globalFiltersMenu{
     STRING_FOR_FILTERS,
@@ -1496,7 +1514,7 @@ menu_item::Submenu soundEditorRootMenuMIDIOrCV{
         &midiPGMMenu,
         &midiBankMenu,
         &midiSubMenu,
-        &arpMenu,
+        &arpMenuMIDIOrCV,
         &globalRandomizerMenu,
         &bendMenu,
         &cv2SourceMenu,
@@ -1510,14 +1528,14 @@ menu_item::Submenu soundEditorRootMenuMIDIOrCV{
 menu_item::Submenu soundEditorRootMenuMidiDrum{
     STRING_FOR_MIDI,
     {
-        &arpMenu,
+        &arpMenuMIDIOrCV,
         &globalRandomizerMenu,
     },
 };
 menu_item::Submenu soundEditorRootMenuGateDrum{
     STRING_FOR_GATE,
     {
-        &arpMenu,
+        &arpMenuMIDIOrCV,
         &globalRandomizerMenu,
     },
 };
@@ -1788,7 +1806,7 @@ PLACE_SDRAM_DATA Submenu* parentsForKitGlobalFXShortcuts[][kDisplayHeight] = {
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        &globalLPFMenu,              &globalLPFMenu,         &globalLPFMenu,           &globalLPFMenu,                    },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        &globalHPFMenu,              &globalHPFMenu,         &globalHPFMenu,           &globalHPFMenu,                    },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
-    {&arpBasicMenu,           &arpBasicMenu,           &arpBasicMenu,                  &arpPatternMenu,                &arpPresetAndRandomizerMenu, nullptr,                nullptr,                  nullptr,                           },
+    {&arpBasicMenuKit,        &arpBasicMenuKit,        &arpBasicMenuKit,               &arpPatternMenu,                &arpPresetAndRandomizerMenu, nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
@@ -1806,7 +1824,7 @@ PLACE_SDRAM_DATA Submenu* parentsForMidiOrCVParamShortcuts[][kDisplayHeight] = {
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
-    {&arpBasicMenu,           &arpBasicMenu,           &arpBasicMenu,                  &arpPatternMenu,                &arpPresetAndRandomizerMenu, nullptr,                nullptr,                  nullptr,                           },
+    {&arpBasicMenuMIDIOrCV,   &arpBasicMenuMIDIOrCV,   &arpBasicMenuMIDIOrCV,          &arpPatternMenu,                &arpPresetAndRandomizerMenu, nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },
     {nullptr,                 nullptr,                 nullptr,                        nullptr,                        nullptr,                     nullptr,                nullptr,                  nullptr,                           },


### PR DESCRIPTION
### **Layout modes**
Two layout modes are introduced for the horizontal menus:
1. `HorizontalMenu::Layout::FIXED`:
![photo_2025-05-07 01 00 28](https://github.com/user-attachments/assets/0bc81b0d-4b6e-4352-bfb6-ac68b36b4871)
In this mode all defined menu items get rendered, even if they aren't relevant; for non-relevant menu items the value gets rendered as dash to indicate that the menu item is disabled currently.

2. `HorizontalMenu::Layout::DYNAMIC`:
Default mode, only relevant items get rendered (works as before the PR). Suitable if you have submenu configuration such that menu items relevance depends on external conditions and not related to params of other menu-items in the group. The arp randomizer is a good example

Currently the FIXED mode applied to the following menus: LPF, global LPF, HPF, global HPF, LFO1-4, arp basic

### **Column span for menu items**
Added ability to set column span for concrete menu item, to specify that it should occupy N virtual "columns".

**Example**: 
We have the LFO1 menu with items: TYPE, SYNC, RATE
By default they will be divided equally since the default column span is 1:
```
TYPE SYNC RATE
  1    1    1
```
I made the SYNC menu item wider to properly render all sync values by setting the column span to 2:
```
TYPE SYNC SYNC RATE
  1      2      1
```
Here is how it looks
<img width="360" alt="image" src="https://github.com/user-attachments/assets/6fe39293-5000-4578-93d7-536d38fc0b4a" />

### **Other**
- LFO waves rendering adjusted to look better on the narrower LFO type menu
- Some of the horizontal menu related functions extracted from base Submenu class and moved to HorizontalMenu class, redundant functions removed
