### PR TITLE
Fix changelog ordering of feature

### DIFF
--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -195,6 +195,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 ##### Kit
 
+- Midi and Gate kit rows now are arpeggiator-enabled, and they have each a menu to set it up.
 - Extended the ability to batch change all drum sounds, by holding :key[AffectEntire] while editing a parameter (indicated by flashing the :key[AffectEntire] button), from the initially available handful of sample-related parameters, to ALL sound parameters (except for `Oscillator Type` and patch cable strengths).
 - Updated shortcuts for randomizing drum samples:
   - When no audition pads are pressed, randomize just the selected drum by pressing :key[Load + Random Pad]
@@ -232,7 +233,6 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 ##### Kits
 
 - Added ability to change the pad size in the `KIT VELOCITY KEYBOARD VIEW` using the Zoom In/Out shortcut by `Pressing + Turning <>`
-- Midi and Gate kit rows now are arpeggiator-enabled, and they have each a menu to set it up.
 - `KIT VELOCITY KEYBOARD VIEW` Changes:
   - Additional shortcut of `Pressing + Turning <>` to change the pad size using the Zoom In/Out.
   - Went from 8 zoom levels to 13, with mostly smaller jumps in size and number of drum pads between levels.


### PR DESCRIPTION
Some Kit clip changes were listed under the Keyboards->kits