### PR TITLE
BugFix/ routineWithClusterLoading audio clicks

### DIFF
--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -189,8 +189,11 @@ void AudioRecorder::slowRoutine() {
 
 void AudioRecorder::process() {
 	while (true) {
-
-		AudioEngine::routineWithClusterLoading();
+		if (!AudioEngine::audioRoutineLocked) {
+			// Sean: replace routineWithClusterLoading call, yield until AudioRoutine is called
+			AudioEngine::routineBeenCalled = false;
+			yield([]() { return (AudioEngine::routineBeenCalled == true); });
+		}
 
 		uiTimerManager.routine();
 

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -542,8 +542,11 @@ cantReadData:
 			if (nextCluster != nullptr) {
 				audioFileManager.removeReasonFromCluster(*nextCluster, "9700");
 			}
-			// Sean: replace routineWithClusterLoading call, just yield to run a single thing (probably audio)
-			yield([]() { return true; });
+			if (!AudioEngine::audioRoutineLocked) {
+				// Sean: replace routineWithClusterLoading call, yield until AudioRoutine is called
+				AudioEngine::routineBeenCalled = false;
+				yield([]() { return (AudioEngine::routineBeenCalled == true); });
+			}
 		}
 	}
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1445,8 +1445,11 @@ bool InstrumentClip::renderAsSingleRow(ModelStackWithTimelineCounter* modelStack
 		NoteRow* thisNoteRow = noteRows.getElement(i);
 
 		if (!(i & 15)) {
-			// Sean: replace routineWithClusterLoading call, just yield to run a single thing (probably audio)
-			yield([]() { return true; });
+			if (!AudioEngine::audioRoutineLocked) {
+				// Sean: replace routineWithClusterLoading call, yield until AudioRoutine is called
+				AudioEngine::routineBeenCalled = false;
+				yield([]() { return (AudioEngine::routineBeenCalled == true); });
+			}
 			AudioEngine::logAction("renderAsSingleRow still");
 		}
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -986,7 +986,6 @@ void routine() {
 			}
 #endif
 			routine_();
-			routineBeenCalled = true;
 			numRoutines += 1;
 		}
 	}
@@ -1013,6 +1012,7 @@ void routine() {
 		}
 	}
 	audioRoutineLocked = false;
+	routineBeenCalled = true;
 }
 
 int32_t getNumSamplesLeftToOutputFromPreviousRender() {

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -196,6 +196,7 @@ extern uint32_t i2sRXBufferPos;
 extern int32_t cpuDireness;
 extern InputMonitoringMode inputMonitoringMode;
 extern bool audioRoutineLocked;
+extern bool routineBeenCalled;
 extern uint8_t numHopsEndedThisRoutineCall;
 extern SideChain reverbSidechain;
 extern uint32_t timeThereWasLastSomeReverb;


### PR DESCRIPTION
Fixed some routineWithClusterLoading clicks specifically around audio recording and singleRow / waveform rendering by yielding until the audio routine has been called.

p.s. nightly build is very broken atm so only way to properly test this is to cherry pick it to a 1.3 branch.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3327

Will test dropping this down to 1.2 as well so we can release a 1.2.1 hot fix that will tide people over until 1.3 is ready 