### PR TITLE
BugFix/ routineWithClusterLoading Audio Clicks (#3680)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 > To find a detailed list of how to use each feature, check here: [Community Features](docs/community_features.md)
 
+## c1.2.1 Chopin
+
+### Sound Engine
+
+- Fixed a bug that was causing audio clicks when recording audio and when scrolling / zooming in song row view and the audio waveform renderer.
+
 ## c1.2.0 Chopin
 
 ### Sound Engine

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -41,6 +41,7 @@
 #include "storage/audio/audio_file_manager.h"
 #include "storage/multi_range/multisample_range.h"
 #include "storage/storage_manager.h"
+#include "task_scheduler.h"
 #include <string.h>
 
 AudioRecorder audioRecorder{};
@@ -186,8 +187,11 @@ void AudioRecorder::slowRoutine() {
 
 void AudioRecorder::process() {
 	while (true) {
-
-		AudioEngine::routineWithClusterLoading();
+		if (!AudioEngine::audioRoutineLocked) {
+			// Sean: replace routineWithClusterLoading call, yield until AudioRoutine is called
+			AudioEngine::routineBeenCalled = false;
+			yield([]() { return (AudioEngine::routineBeenCalled == true); });
+		}
 
 		uiTimerManager.routine();
 

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -555,8 +555,11 @@ cantReadData:
 			if (nextCluster) {
 				audioFileManager.removeReasonFromCluster(nextCluster, "9700");
 			}
-			// just yield to run a single thing (probably audio)
-			yield([]() { return true; });
+			if (!AudioEngine::audioRoutineLocked) {
+				// Sean: replace routineWithClusterLoading call, yield until AudioRoutine is called
+				AudioEngine::routineBeenCalled = false;
+				yield([]() { return (AudioEngine::routineBeenCalled == true); });
+			}
 		}
 	}
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -996,7 +996,6 @@ void routine() {
 			}
 #endif
 			routine_();
-			routineBeenCalled = true;
 			numRoutines += 1;
 		}
 	}
@@ -1023,6 +1022,7 @@ void routine() {
 		}
 	}
 	audioRoutineLocked = false;
+	routineBeenCalled = true;
 }
 
 int32_t getNumSamplesLeftToOutputFromPreviousRender() {

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -193,6 +193,7 @@ extern uint32_t i2sRXBufferPos;
 extern int32_t cpuDireness;
 extern InputMonitoringMode inputMonitoringMode;
 extern bool audioRoutineLocked;
+extern bool routineBeenCalled;
 extern uint8_t numHopsEndedThisRoutineCall;
 extern SideChain reverbSidechain;
 extern uint32_t timeThereWasLastSomeReverb;


### PR DESCRIPTION
Fixed some routineWithClusterLoading clicks specifically around audio recording and singleRow / waveform rendering by yielding until the audio routine has been called.

Cherry picked to 1.2 branch so we can release a 1.2.1 bug fix.