### PR TITLE
Update downloads.mdx on website for 1.2.1 release

### DIFF
--- a/website/src/content/docs/downloads.mdx
+++ b/website/src/content/docs/downloads.mdx
@@ -18,7 +18,7 @@ Please report any bugs [on github](https://github.com/SynthstromAudible/DelugeFi
     target="_blank"
     rel="noopener noreferrer"
   >
-    Download 1.2 (Chopin)
+    Download 1.2.1 (Chopin)
   </a>
   <a
     className="btn"
@@ -145,29 +145,6 @@ We hope you enjoy using the community firmware as much as we enjoy working on it
 
 ## Older releases
 
-### Release 1.2.0 (Chopin)
-
-Released Dec 25th, 2024.
-
-<div className="button-group">
-  <a
-    className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/releases/tag/v1.2.0"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Release notes
-  </a>
-  <a
-    className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/releases/download/v1.2.0/deluge-community-release-1_2_0.zip"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Download 1.2.0 (Chopin)
-  </a>
-</div>
-
 ### Release 1.1.1 (Beethoven)
 
 Released Aug 25th, 2024.
@@ -191,29 +168,6 @@ Released Aug 25th, 2024.
   </a>
 </div>
 
-### Release 1.1.0 (Beethoven)
-
-Released June 30th, 2024.
-
-<div className="button-group">
-  <a
-    className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/releases/tag/release_1_1_0"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Release Notes
-  </a>
-  <a
-    className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/releases/download/release_1_1_0/deluge-community-release-1_1_0.zip"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Download c1.1.0
-  </a>
-</div>
-
 ### Release 1.0.1 (Amadeus)
 
 Released January 7th, 2024.
@@ -234,28 +188,5 @@ Released January 7th, 2024.
     rel="noopener noreferrer"
   >
     Download c1.0.1
-  </a>
-</div>
-
-### Release 1.0.0 (Amadeus)
-
-Released December 3rd, 2023.
-
-<div className="button-group">
-  <a
-    className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/releases/tag/release_1_0"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Release Notes
-  </a>
-  <a
-    className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/releases/download/release_1_0/deluge-c1_0_0.bin"
-    target="_blank"
-    rel="noopener noreferrer"
-  >
-    Download c1.0.0
   </a>
 </div>


### PR DESCRIPTION
Minor nitpick fix to the website

Rename Download 1.2 to Download 1.2.1
Only show .1 releases on the Downloads page (e.g. 1.2.1, 1.1.1, 1.0.1)
