### PR TITLE
Bugfix/ Fixed incorrect diffusion label for digital & mutable reverb in the horizontal menu

### DIFF
--- a/src/deluge/gui/menu_item/reverb/width.h
+++ b/src/deluge/gui/menu_item/reverb/width.h
@@ -45,6 +45,7 @@ public:
 		using enum l10n::String;
 		switch (AudioEngine::reverb.getModel()) {
 		case dsp::Reverb::Model::DIGITAL:
+			[[fallthrough]];
 		case dsp::Reverb::Model::MUTABLE:
 			label.append(deluge::l10n::get(l10n::String::STRING_FOR_DIFFUSION));
 			break;

--- a/src/deluge/gui/menu_item/reverb/width.h
+++ b/src/deluge/gui/menu_item/reverb/width.h
@@ -42,7 +42,14 @@ public:
 	[[nodiscard]] std::string_view getTitle() const override { return getName(); }
 
 	void getColumnLabel(StringBuf& label) override {
-		label.append(deluge::l10n::get(l10n::String::STRING_FOR_WIDTH_SHORT));
+		using enum l10n::String;
+		switch (AudioEngine::reverb.getModel()) {
+		case dsp::Reverb::Model::DIGITAL:
+		case dsp::Reverb::Model::MUTABLE:
+			label.append(deluge::l10n::get(l10n::String::STRING_FOR_DIFFUSION));
+		default:
+			label.append(deluge::l10n::get(l10n::String::STRING_FOR_WIDTH_SHORT));
+		}
 	}
 };
 } // namespace deluge::gui::menu_item::reverb

--- a/src/deluge/gui/menu_item/reverb/width.h
+++ b/src/deluge/gui/menu_item/reverb/width.h
@@ -47,8 +47,10 @@ public:
 		case dsp::Reverb::Model::DIGITAL:
 		case dsp::Reverb::Model::MUTABLE:
 			label.append(deluge::l10n::get(l10n::String::STRING_FOR_DIFFUSION));
+			break;
 		default:
 			label.append(deluge::l10n::get(l10n::String::STRING_FOR_WIDTH_SHORT));
+			break;
 		}
 	}
 };


### PR DESCRIPTION
For digital & mutable reverb models width param was displayed as WDTH instead of DIFF