### PR TITLE
MIDI Program menu shows values as 0-127

### DIFF
--- a/src/deluge/gui/menu_item/midi/preset.h
+++ b/src/deluge/gui/menu_item/midi/preset.h
@@ -38,7 +38,7 @@ public:
 			text = l10n::get(l10n::String::STRING_FOR_NONE);
 		}
 		else {
-			intToString(this->getValue() + 1, buffer, 1);
+			intToString(this->getValue(), buffer, 1);
 			text = buffer;
 		}
 		canvas.drawStringCentred(text, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
@@ -49,7 +49,7 @@ public:
 			display->setText(l10n::get(l10n::String::STRING_FOR_NONE));
 		}
 		else {
-			display->setTextAsNumber(this->getValue() + 1);
+			display->setTextAsNumber(this->getValue());
 		}
 	}
 
@@ -80,7 +80,7 @@ public:
 			sizeY = kTextSpacingY;
 		}
 		else {
-			paramValue.appendInt(getValue() + 1);
+			paramValue.appendInt(getValue());
 			sizeX = kTextTitleSpacingX;
 			sizeY = kTextTitleSizeY;
 		}

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -208,6 +208,8 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 - Added ability to rename MIDI CC's in MIDI clips. Changes are saved by Instrument (e.g. per MIDI channel). Changes can be saved to a `MIDI preset`, with the `Song`, or to a `MIDI device definition file`. See documentation on [MIDI Device Definition Files](/features/midi_device_definition_files) for more info.
 - Added MIDI CC numbers and labels to `Gold (Mod) Encoder` popups.
+- Updated MIDI Program menu to show values 0-127.
+  - Values for program, bank and sub-bank were previously shown as 1-128, but now reflect the actual transmitted MIDI values.
 
 #### <ins>Automation View</ins>
 


### PR DESCRIPTION
We have decided to show the transmitted MIDI value in the MIDI Program menu so it will better align with how we display other MIDI values such as in the Automation view.

Previously, program changes were shown as 1-128 from this menu, which reflects how some external gear shows patch values on their displays. We will eventually allow the user to specify whether to show 0-127 or 1-128 for program changes and banks through MIDI Device Definitions, since each device may have different notions of what should be displayed.

- Adds a note to the changelog under "MIDI Clips"