### PR TITLE
Fixed Rhythm menu items so they span always to two columns so they look good even for Kit Midi and Gate rows

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rhythm.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rhythm.h
@@ -52,15 +52,11 @@ public:
 		// Render current value
 
 		DEF_STACK_STRING_BUF(shortOpt, kShortStringBufferSize);
-		if (soundEditor.editingKit() && !soundEditor.editingGateDrumRow()) {
-			shortOpt.append(arpRhythmPatternNames[this->getValue()]);
-		}
-		else {
-			char name[12];
-			// Index:Name
-			snprintf(name, sizeof(name), "%d: %s", this->getValue(), arpRhythmPatternNames[this->getValue()]);
-			shortOpt.append(name);
-		}
+		char name[12];
+		// Index:Name
+		snprintf(name, sizeof(name), "%d: %s", this->getValue(), arpRhythmPatternNames[this->getValue()]);
+		shortOpt.append(name);
+
 		int32_t pxLen;
 		// Trim characters from the end until it fits.
 		while ((pxLen = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY)) >= width - 2) {
@@ -71,5 +67,8 @@ public:
 		image.drawString(shortOpt.c_str(), startX + pad, startY + kTextSpacingY + 3, kTextSpacingX, kTextSpacingY, 0,
 		                 startX + width - kTextSpacingX);
 	}
+
+protected:
+	[[nodiscard]] int32_t getColumnSpan() const override { return 2; }
 };
 } // namespace deluge::gui::menu_item::arpeggiator::midi_cv

--- a/src/deluge/gui/menu_item/arpeggiator/rhythm.h
+++ b/src/deluge/gui/menu_item/arpeggiator/rhythm.h
@@ -49,15 +49,10 @@ public:
 		// Render current value
 
 		DEF_STACK_STRING_BUF(shortOpt, kShortStringBufferSize);
-		if (soundEditor.editingKit() && !soundEditor.editingGateDrumRow()) {
-			shortOpt.append(arpRhythmPatternNames[this->getValue()]);
-		}
-		else {
-			char name[12];
-			// Index:Name
-			snprintf(name, sizeof(name), "%d: %s", this->getValue(), arpRhythmPatternNames[this->getValue()]);
-			shortOpt.append(name);
-		}
+		char name[12];
+		// Index:Name
+		snprintf(name, sizeof(name), "%d: %s", this->getValue(), arpRhythmPatternNames[this->getValue()]);
+		shortOpt.append(name);
 
 		int32_t pxLen;
 		// Trim characters from the end until it fits.
@@ -73,6 +68,9 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingCVOrMIDIClip() && !soundEditor.editingNonAudioDrumRow();
 	}
+
+protected:
+	[[nodiscard]] int32_t getColumnSpan() const override { return 2; }
 };
 
 } // namespace deluge::gui::menu_item::arpeggiator


### PR DESCRIPTION
Also always show the index number “24: 0-0–00” now that we always have room for it!