### PR TITLE
Bugfix/ Fixed crash when using any of mod-fx shortcuts the first time right after booting up

### DIFF
--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -34,12 +34,11 @@ void Submenu::beginSession(MenuItem* navigatedBackwardFrom) {
 bool Submenu::focusChild(const MenuItem* child) {
 	if (child != nullptr) {
 		// if the specific child is passed, try to find it
-		// in case we didn't find it, we just do nothing and keep the previous selection
+		// in case we didn't find it, keep the previous selection
 		auto candidate = std::find(items.begin(), items.end(), child);
 		if (candidate != items.end() && isItemRelevant(*candidate)) {
 			current_item_ = candidate;
 		}
-		return true;
 	}
 
 	// If the current item is not set or isn't relevant, set to first relevant one instead.

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -33,15 +33,15 @@ void Submenu::beginSession(MenuItem* navigatedBackwardFrom) {
 
 bool Submenu::focusChild(const MenuItem* child) {
 	if (child != nullptr) {
-		// if the specific child is passed, try to find it
-		// in case we didn't find it, keep the previous selection
+		// if the specific child is passed, try to find it among the items
+		// if not found or not relevant, keep the previous selection
 		auto candidate = std::find(items.begin(), items.end(), child);
 		if (candidate != items.end() && isItemRelevant(*candidate)) {
 			current_item_ = candidate;
 		}
 	}
 
-	// If the current item is not set or isn't relevant, set to first relevant one instead.
+	// If the current item isn't valid or isn't relevant, set to first relevant one instead.
 	if (current_item_ == items.end() || !isItemRelevant(*current_item_)) {
 		current_item_ = std::ranges::find_if(items, isItemRelevant); // Find first relevant item.
 	}
@@ -616,7 +616,7 @@ bool Submenu::learnNoteOn(MIDICable& cable, int32_t channel, int32_t noteCode) {
 	return false;
 }
 
-Submenu::RenderingStyle HorizontalMenu::renderingStyle() {
+Submenu::RenderingStyle HorizontalMenu::renderingStyle() const {
 	if (display->haveOLED() && runtimeFeatureSettings.isOn(RuntimeFeatureSettingType::HorizontalMenus)) {
 		return RenderingStyle::HORIZONTAL;
 	}

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -56,7 +56,7 @@ public:
 	void learnKnob(MIDICable* cable, int32_t whichKnob, int32_t modKnobMode, int32_t midiChannel) final;
 	void learnProgramChange(MIDICable& cable, int32_t channel, int32_t programNumber) override;
 	bool learnNoteOn(MIDICable& cable, int32_t channel, int32_t noteCode) final;
-	virtual RenderingStyle renderingStyle() { return RenderingStyle::VERTICAL; };
+	virtual RenderingStyle renderingStyle() const { return RenderingStyle::VERTICAL; };
 	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
 	void drawPixelsForOled() override;
 	void drawSubmenuItemsForOled(std::span<MenuItem*> options, const int32_t selectedOption);
@@ -113,7 +113,7 @@ public:
 		initial_index_ = initialSelection;
 	}
 
-	RenderingStyle renderingStyle() override;
+	RenderingStyle renderingStyle() const override;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	void renderOLED() override;
 	void drawPixelsForOled() override;

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -116,7 +116,8 @@ public:
 	bool pitchBendReceived(MIDICable& cable, uint8_t channel, uint8_t data1, uint8_t data2);
 	void selectEncoderAction(int8_t offset) override;
 	bool canSeeViewUnderneath() override { return true; }
-	bool setup(Clip* clip = nullptr, const MenuItem* item = nullptr, int32_t sourceIndex = 0);
+	bool setup(Clip* clip = nullptr, const MenuItem* item = nullptr, const MenuItem* parent = nullptr,
+	           int32_t sourceIndex = 0);
 	void enterOrUpdateSoundEditor(bool on);
 	void blinkShortcut();
 	ActionResult potentialShortcutPadAction(int32_t x, int32_t y, bool on);


### PR DESCRIPTION
Steps to reproduce:
- Enable the horizontal menus feature
- Turn off the deluge
- Turn on the deluge
- Open a synth clip if not opened already
- Press any of mod-fx shortcuts except mod-fx type shortcut
- Crash

The issue was that we're focusing the child item in the parent horizontal menu before modControllable gets initialized properly, so it was crashing on the isRelevant() checks

Also this fix has a nice effect: if you press a non-relevant shortcut now, popup will be displayed saying "parameter is not applicable". This is consistent behaviour with 7seg and with vertical menus, previously it would just silently switch to the first relevant item in the horz menu