### PR TITLE
Bugfix/ Fixed crash when using any of mod-fx shortcuts the first time right after booting up

### DIFF
--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -33,16 +33,15 @@ void Submenu::beginSession(MenuItem* navigatedBackwardFrom) {
 
 bool Submenu::focusChild(const MenuItem* child) {
 	if (child != nullptr) {
-		// if the specific child is passed, try to find it
-		// in case we didn't find it, we just do nothing and keep the previous selection
+		// if the specific child is passed, try to find it among the items
+		// if not found or not relevant, keep the previous selection
 		auto candidate = std::find(items.begin(), items.end(), child);
 		if (candidate != items.end() && isItemRelevant(*candidate)) {
 			current_item_ = candidate;
 		}
-		return true;
 	}
 
-	// If the current item is not set or isn't relevant, set to first relevant one instead.
+	// If the current item isn't valid or isn't relevant, set to first relevant one instead.
 	if (current_item_ == items.end() || !isItemRelevant(*current_item_)) {
 		current_item_ = std::ranges::find_if(items, isItemRelevant); // Find first relevant item.
 	}
@@ -617,7 +616,7 @@ bool Submenu::learnNoteOn(MIDICable& cable, int32_t channel, int32_t noteCode) {
 	return false;
 }
 
-Submenu::RenderingStyle HorizontalMenu::renderingStyle() {
+Submenu::RenderingStyle HorizontalMenu::renderingStyle() const {
 	if (display->haveOLED() && runtimeFeatureSettings.isOn(RuntimeFeatureSettingType::HorizontalMenus)) {
 		return RenderingStyle::HORIZONTAL;
 	}

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -56,7 +56,7 @@ public:
 	void learnKnob(MIDICable* cable, int32_t whichKnob, int32_t modKnobMode, int32_t midiChannel) final;
 	void learnProgramChange(MIDICable& cable, int32_t channel, int32_t programNumber) override;
 	bool learnNoteOn(MIDICable& cable, int32_t channel, int32_t noteCode) final;
-	virtual RenderingStyle renderingStyle() { return RenderingStyle::VERTICAL; };
+	virtual RenderingStyle renderingStyle() const { return RenderingStyle::VERTICAL; };
 	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
 	void drawPixelsForOled() override;
 	void drawSubmenuItemsForOled(std::span<MenuItem*> options, const int32_t selectedOption);
@@ -113,7 +113,7 @@ public:
 		initial_index_ = initialSelection;
 	}
 
-	RenderingStyle renderingStyle() override;
+	RenderingStyle renderingStyle() const override;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	void renderOLED() override;
 	void drawPixelsForOled() override;

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1267,14 +1267,6 @@ doSetup:
 						return ActionResult::DEALT_WITH;
 					}
 
-					// If we're on OLED, a parent menu & horizontal menus are in play,
-					// then we swap the parent in place of the child.
-					if (parent != nullptr && parent->renderingStyle() == Submenu::RenderingStyle::HORIZONTAL) {
-						if (parent->focusChild(item)) {
-							item = parent;
-						}
-					}
-
 					// if we're in the menu and automation view is the root (background) UI
 					// and you're using a grid shortcut, only allow use of shortcuts for parameters / patch cables
 					MenuItem* newItem;
@@ -1304,11 +1296,11 @@ doSetup:
 						}
 					}
 
-					bool setupSuccess = setup(getCurrentClip(), item, thingIndex);
+					bool setupSuccess = setup(getCurrentClip(), item, parent, thingIndex);
 
 					if (!setupSuccess && item == &modulatorVolume && currentSource->oscType == OscType::DX7) {
 						item = &dxParam;
-						setupSuccess = setup(getCurrentClip(), item, thingIndex);
+						setupSuccess = setup(getCurrentClip(), item, parent, thingIndex);
 					}
 
 					if (!setupSuccess) {
@@ -1567,7 +1559,7 @@ void SoundEditor::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 	}
 }
 
-bool SoundEditor::setup(Clip* clip, const MenuItem* item, int32_t sourceIndex) {
+bool SoundEditor::setup(Clip* clip, const MenuItem* item, Submenu* parent, int32_t sourceIndex) {
 
 	Sound* newSound = nullptr;
 	ParamManagerForTimeline* newParamManager = nullptr;
@@ -1724,16 +1716,26 @@ doMIDIOrCV:
 		}
 	}
 
+	// This isn't a very nice solution, but we have to set currentParamManager before calling
+	// checkPermissionToBeginSession(), because in a minority of cases, like "patch cable strength" / "modulation
+	// depth", it needs this.
+	currentParamManager = newParamManager;
+	// And we also have to set currentModControllable before focusing on the child item in a horizontal menu
+	currentModControllable = newModControllable;
+
+	// If we're on OLED, a parent menu & horizontal menus are in play,
+	// then we swap the parent in place of the child.
+	if (parent != nullptr && parent->renderingStyle() == Submenu::RenderingStyle::HORIZONTAL) {
+		if (parent->focusChild(newItem)) {
+			newItem = parent;
+		}
+	}
+
 	::MultiRange* newRange = currentMultiRange;
 
 	if ((currentUI != &soundEditor && currentUI != &sampleMarkerEditor) || sourceIndex != currentSourceIndex) {
 		newRange = nullptr;
 	}
-
-	// This isn't a very nice solution, but we have to set currentParamManager before calling
-	// checkPermissionToBeginSession(), because in a minority of cases, like "patch cable strength" / "modulation
-	// depth", it needs this.
-	currentParamManager = newParamManager;
 
 	MenuPermission result = newItem->checkPermissionToBeginSession(newModControllable, sourceIndex, &newRange);
 
@@ -1764,7 +1766,6 @@ doMIDIOrCV:
 	currentSound = newSound;
 	currentArpSettings = newArpSettings;
 	currentMultiRange = newRange;
-	currentModControllable = newModControllable;
 
 	if (currentModControllable) {
 		currentSidechain = &currentModControllable->sidechain;

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -19,7 +19,6 @@
 
 #include "definitions_cxx.hpp"
 #include "gui/menu_item/menu_item.h"
-#include "gui/menu_item/submenu.h"
 #include "gui/ui/ui.h"
 #include "hid/button.h"
 #include "modulation/arpeggiator.h"
@@ -46,9 +45,11 @@ class ModControllableAudio;
 class ModelStackWithThreeMainThings;
 class AudioFileHolder;
 class MIDICable;
+
 namespace deluge::gui::menu_item {
+class Submenu;
 enum class RangeEdit : uint8_t;
-}
+} // namespace deluge::gui::menu_item
 
 class SoundEditor final : public UI {
 public:
@@ -116,7 +117,8 @@ public:
 	bool pitchBendReceived(MIDICable& cable, uint8_t channel, uint8_t data1, uint8_t data2);
 	void selectEncoderAction(int8_t offset) override;
 	bool canSeeViewUnderneath() override { return true; }
-	bool setup(Clip* clip = nullptr, const MenuItem* item = nullptr, int32_t sourceIndex = 0);
+	bool setup(Clip* clip = nullptr, const MenuItem* item = nullptr, deluge::gui::menu_item::Submenu* parent = nullptr,
+	           int32_t sourceIndex = 0);
 	void enterOrUpdateSoundEditor(bool on);
 	void blinkShortcut();
 	ActionResult potentialShortcutPadAction(int32_t x, int32_t y, bool on);


### PR DESCRIPTION
Steps to reproduce:

1. Enable the horizontal menus feature
2. Turn off the deluge
3. Turn on the deluge
4. Open a synth clip if not opened already
5. Press any of mod-fx shortcuts except mod-fx type shortcut
6. Crash

The issue was that we're focusing the child item in the parent horizontal menu before modControllable gets initialized properly, so it was crashing on the isRelevant() checks