### PR TITLE
fix(docs): Add redirect from `/docs/features`

### DIFF
--- a/docs/features/Moved to delugecommunity.com.md
+++ b/docs/features/Moved to delugecommunity.com.md
@@ -1,0 +1,5 @@
+# Documentation has been moved
+
+Documentation has been moved to the [delugecommunity.com](https://delugecommunity.com) website:
+
+https://delugecommunity.com/features/community_features/


### PR DESCRIPTION
Combating link rot one link at a time

Linked to from
https://www.reddit.com/r/DelugeUsers/comments/1i7y1de/manualquick_reference_for_community_firmware/