### PR TITLE
MidiProgramMenu::isRelevant() // avoids showing in CV menu

### DIFF
--- a/src/deluge/gui/menu_item/midi/program.h
+++ b/src/deluge/gui/menu_item/midi/program.h
@@ -1,0 +1,17 @@
+#include "gui/menu_item/submenu.h"
+
+namespace deluge::gui::menu_item::midi {
+
+class ProgramSubMenu : public HorizontalMenu {
+public:
+	ProgramSubMenu(l10n::String newName, std::initializer_list<MenuItem*> newItems, Layout layout, uint32_t initSelect)
+	    : HorizontalMenu(newName, newItems, layout) {
+		initial_index_ = initSelect;
+	}
+
+	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
+		return getCurrentOutputType() == OutputType::MIDI_OUT;
+	}
+};
+
+} // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -107,11 +107,6 @@ public:
 	HorizontalMenu(l10n::String newName, l10n::String newTitle, std::initializer_list<MenuItem*> newItems,
 	               Layout layout)
 	    : Submenu(newName, newTitle, newItems), horizontalMenuLayout(layout), paging{} {}
-	HorizontalMenu(l10n::String newName, std::initializer_list<MenuItem*> newItems, Layout layout,
-	               uint32_t initialSelection)
-	    : Submenu(newName, newItems), horizontalMenuLayout(layout), paging{} {
-		initial_index_ = initialSelection;
-	}
 
 	RenderingStyle renderingStyle() const override;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -103,6 +103,7 @@
 #include "gui/menu_item/midi/follow/follow_kit_root_note.h"
 #include "gui/menu_item/midi/mpe_to_mono.h"
 #include "gui/menu_item/midi/pgm.h"
+#include "gui/menu_item/midi/program.h"
 #include "gui/menu_item/midi/sound/channel.h"
 #include "gui/menu_item/midi/sound/note_for_drum.h"
 #include "gui/menu_item/midi/sub.h"
@@ -1526,14 +1527,14 @@ menu_item::Submenu noteRowEditorRootMenu{
     },
 };
 
-HorizontalMenu midiProgramMenu{STRING_FOR_MIDI_PROGRAM_MENU_TITLE,
-                               {
-                                   &midiBankMenu,
-                                   &midiSubMenu,
-                                   &midiPGMMenu,
-                               },
-                               HorizontalMenu::Layout::FIXED,
-                               2};
+menu_item::midi::ProgramSubMenu midiProgramMenu{STRING_FOR_MIDI_PROGRAM_MENU_TITLE,
+                                                {
+                                                    &midiBankMenu,
+                                                    &midiSubMenu,
+                                                    &midiPGMMenu,
+                                                },
+                                                HorizontalMenu::Layout::FIXED,
+                                                2};
 
 // Root menu for MIDI / CV
 menu_item::Submenu soundEditorRootMenuMIDIOrCV{


### PR DESCRIPTION
Since introducing the Program menu in #3700, the "MIDI PROGRAM" menu was also being shown on CV clips, rather than only on MIDI clips. We're resolving that here by implementing a subclass of `HorizontalMenu` for the program menu that overrides `isRelevant()`.

This is an explicit solution to the problem stated. A more general solution might consider checking each item in the submenu's `isRelevant()`.