### PR TITLE
[DRAFT] Feature : Ability to solo or mute a clip from ClipView

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -297,7 +297,16 @@ ActionResult InstrumentClipView::buttonAction(deluge::hid::Button b, bool on, bo
 	// Clip view button
 	else if (b == CLIP_VIEW) {
 		D_PRINTLN("InstrumentClipView::buttonAction(CLIP_VIEW) %d", (int)b);
+		if (on) {
+			if (Buttons::isButtonPressed(deluge::hid::button::X_ENC)
+			    || Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
+				auto soloMode = Buttons::isButtonPressed(deluge::hid::button::X_ENC);
+				sessionView.soloOrMuteClip(getCurrentClip(), soloMode, Buttons::isShiftButtonPressed());
+				return ActionResult::DEALT_WITH;
+			}
+		}
 		if (on && currentUIMode == UI_MODE_NONE) {
+
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4283,6 +4283,15 @@ ActionResult SessionView::gridHandlePadsLaunchWithSelection(int32_t x, int32_t y
 	return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 }
 
+void SessionView::soloOrMuteClip(Clip* clip, bool isSolo, bool immediate) {
+	if (isSolo) {
+		session.soloClipAction(clip, kInternalButtonPressLatency);
+	}
+	else {
+		session.toggleClipStatus(clip, nullptr, immediate, kInternalButtonPressLatency);
+	}
+}
+
 void SessionView::gridHandlePadsLaunchToggleArming(Clip* clip, bool immediate) {
 	if (immediate) {
 		if (horizontalEncoderPressed) {

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -48,6 +48,7 @@ public:
 	bool opened() override;
 	void focusRegained() override;
 
+	void soloOrMuteClip(Clip* clip, bool isSolo, bool immediate);
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	ActionResult clipCreationButtonPressed(hid::Button i, bool on, bool routine);
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;

--- a/src/deluge/playback/mode/session.h
+++ b/src/deluge/playback/mode/session.h
@@ -102,10 +102,11 @@ public:
 	int16_t numRepeatsTilLaunch;
 	int32_t currentArmedLaunchLengthForOneRepeat;
 	bool switchToArrangementAtLaunchEvent;
+	void armClipToStopAction(Clip* clip);
 
 private:
 	bool giveClipOpportunityToBeginLinearRecording(Clip* clip, int32_t clipIndex, int32_t buttonPressLatency);
-	void armClipToStopAction(Clip* clip);
+
 	void cancelArmingForClip(Clip* clip, int32_t* clipIndex);
 	void armSectionWhenNeitherClockActive(ModelStack* modelStack, int32_t section, bool stopAllOtherClips);
 	void armClipsAlongWithExistingLaunching(ArmState armState, uint8_t section, Clip* clip);

--- a/src/deluge/playback/mode/session.h
+++ b/src/deluge/playback/mode/session.h
@@ -102,11 +102,10 @@ public:
 	int16_t numRepeatsTilLaunch;
 	int32_t currentArmedLaunchLengthForOneRepeat;
 	bool switchToArrangementAtLaunchEvent;
-	void armClipToStopAction(Clip* clip);
 
 private:
 	bool giveClipOpportunityToBeginLinearRecording(Clip* clip, int32_t clipIndex, int32_t buttonPressLatency);
-
+	void armClipToStopAction(Clip* clip);
 	void cancelArmingForClip(Clip* clip, int32_t* clipIndex);
 	void armSectionWhenNeitherClockActive(ModelStack* modelStack, int32_t section, bool stopAllOtherClips);
 	void armClipsAlongWithExistingLaunching(ArmState armState, uint8_t section, Clip* clip);

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -110,6 +110,13 @@ import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
 - If a clip has a name, it is displayed with a number prefix, indicating its section, eg. "3: CHORUS".
 - When clips are copied, the clip name is copied as well. If the target track already has a clip with the same name, an integer suffix starting from 2 is added unless the name already has an integer suffix. This integer suffix is incremented until the clip name is unique on the target track. Ie. copying a clip named "BRIDGE" to the same otherwise empty track will first create "BRIDGE2", then "BRIDGE3", etc.
 
+#### <ins>Solo/Mute clip from ClipView</ins>
+
+- Added community feature to be able to solo or mute a clip from its clipview.
+- From Clip view :
+  - Press Horizontal Encoder + clip : solo or unsolo the active clip. Combine with Shift button to make it immediate.
+  - Press Vertical Encoder + clip : mute or unmute the active clip. Combine with Shift button to make it immediate.
+
 #### <ins>Tempo</ins>
 
 - Added Community Feature toggle (`Settings > Community Features > Alternative Tap Tempo Behaviour (TAPT)`) to adjust number of `TAP TEMPO` button presses to engage `TAP TEMPO` to `FOUR (4)` to avoid mistakingly changing tempo.

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -29,6 +29,7 @@ import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
 ### Clip View
 
 #### <ins>Solo/Mute clip from ClipView</ins>
+
 - Added community feature to be able to solo or mute a clip from its clip view :
   - Press `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP`: solo or unsolo the active clip. Combine with Shift button to make it immediate.
   - Press `VERTICAL ENCODER ◀︎▶︎` + `CLIP` : mute or unmute the active clip. Combine with Shift button to make it immediate.

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -26,6 +26,13 @@ import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
 
 - Various structural improvements to Sound Engine architecture which may result in performance improvements.
 
+### Clip View
+
+#### <ins>Solo/Mute clip from ClipView</ins>
+- Added community feature to be able to solo or mute a clip from its clip view :
+  - Press `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP`: solo or unsolo the active clip. Combine with Shift button to make it immediate.
+  - Press `VERTICAL ENCODER ◀︎▶︎` + `CLIP` : mute or unmute the active clip. Combine with Shift button to make it immediate.
+
 ## c1.3.0 <Badge text="Upcoming" variant="tip" />
 
 ### Sound Engine
@@ -109,13 +116,6 @@ import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
 - If a clip has no named "SECTION N" is displayed in place of the clip name, indicating which section the clip is in.
 - If a clip has a name, it is displayed with a number prefix, indicating its section, eg. "3: CHORUS".
 - When clips are copied, the clip name is copied as well. If the target track already has a clip with the same name, an integer suffix starting from 2 is added unless the name already has an integer suffix. This integer suffix is incremented until the clip name is unique on the target track. Ie. copying a clip named "BRIDGE" to the same otherwise empty track will first create "BRIDGE2", then "BRIDGE3", etc.
-
-#### <ins>Solo/Mute clip from ClipView</ins>
-
-- Added community feature to be able to solo or mute a clip from its clipview.
-- From Clip view :
-  - Press Horizontal Encoder + clip : solo or unsolo the active clip. Combine with Shift button to make it immediate.
-  - Press Vertical Encoder + clip : mute or unmute the active clip. Combine with Shift button to make it immediate.
 
 #### <ins>Tempo</ins>
 

--- a/website/src/content/docs/features/community_features.md
+++ b/website/src/content/docs/features/community_features.md
@@ -1212,10 +1212,10 @@ to each individual note onset. (#1978)
   having a Synth clip + a Midi clip together triggering at the same time. This feature is limited to regular MIDI (that is, not for MPE).
 
 #### 4.5.11 - Solo/Mute clip from ClipView
+
 - (#3823) Added community feature to be able to solo or mute a clip from its clip view :
   - Press `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP`: solo or unsolo the active clip. Combine with Shift button to make it immediate.
   - Press `VERTICAL ENCODER ◀︎▶︎` + `CLIP` : mute or unmute the active clip. Combine with Shift button to make it immediate.
-
 
 ### 4.6 - Instrument Clip View - Kit Clip Features
 

--- a/website/src/content/docs/features/community_features.md
+++ b/website/src/content/docs/features/community_features.md
@@ -1211,6 +1211,12 @@ to each individual note onset. (#1978)
   In case of drums, it is like having a Sound row + a Midi row together triggering at the same time. And in case of synths, it is like
   having a Synth clip + a Midi clip together triggering at the same time. This feature is limited to regular MIDI (that is, not for MPE).
 
+#### 4.5.11 - Solo/Mute clip from ClipView
+- (#3823) Added community feature to be able to solo or mute a clip from its clip view :
+  - Press `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP`: solo or unsolo the active clip. Combine with Shift button to make it immediate.
+  - Press `VERTICAL ENCODER ◀︎▶︎` + `CLIP` : mute or unmute the active clip. Combine with Shift button to make it immediate.
+
+
 ### 4.6 - Instrument Clip View - Kit Clip Features
 
 #### 4.6.1 - Keyboard View


### PR DESCRIPTION
- Added community feature to be able to solo or mute a clip from its clipview.
- From Clip view :
  - Press Horizontal Encoder + clip : solo or unsolo the active clip. Combine with Shift button to make it immediate.
  - Press Vertical Encoder + clip : mute or unmute the active clip. Combine with Shift button to make it immediate.