### PR TITLE
[DRAFT] Feature : Navigate between clips and tracks from ClipView in SongMode and grid mode

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2000,7 +2000,7 @@ void AutomationView::handleClipButtonAction(bool on, bool isAudioClip) {
 		uiNeedsRendering(this);
 	}
 	// go back to clip view
-	else if (on && (currentUIMode == UI_MODE_NONE || (currentUIMode == UI_MODE_NOTES_PRESSED && padSelectionOn))) {
+	else if (!on && (currentUIMode == UI_MODE_NONE || (currentUIMode == UI_MODE_NOTES_PRESSED && padSelectionOn))) {
 		if (padSelectionOn) {
 			initPadSelection();
 		}

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -239,6 +239,8 @@ public:
 	// Archaic leftover feature that users wouldn't let me get rid of
 	bool fileBrowserShouldNotPreview;
 
+	bool toggleNavigateBetweenClipsOnButtonRelease;
+
 	int16_t mpeValuesAtHighestPressure[MPE_RECORD_LENGTH_FOR_NOTE_EDITING][kNumExpressionDimensions];
 	int16_t mpeMostRecentPressure;
 	uint32_t mpeRecordLastUpdateTime;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4650,6 +4650,27 @@ int32_t SessionView::gridSectionFromY(uint32_t y) {
 	return result;
 }
 
+Clip* SessionView::getClipFromSection(Output* track, uint8_t section) {
+	uint8_t maxSection = 0;
+	Clip* lastClipFromTrack = nullptr;
+
+	for (int32_t idxClip = 0; idxClip < currentSong->sessionClips.getNumElements(); ++idxClip) {
+		Clip* clip = currentSong->sessionClips.getClipAtIndex(idxClip);
+		if (clip->output == track) {
+			if (section == kMaxNumSections) {
+				if (clip->section >= maxSection) {
+					lastClipFromTrack = clip;
+					maxSection = lastClipFromTrack->section;
+				}
+			}
+			else if (clip->section == section) {
+				return clip;
+			}
+		}
+	}
+	return lastClipFromTrack;
+}
+
 int32_t SessionView::gridXFromTrack(uint32_t trackIndex) {
 	int32_t result = trackIndex - currentSong->songGridScrollX;
 	if (result >= kDisplayWidth) {

--- a/src/deluge/gui/views/session_view.h
+++ b/src/deluge/gui/views/session_view.h
@@ -160,6 +160,13 @@ public:
 	// pulse selected clip in grid view
 	void gridPulseSelectedClip();
 
+	Clip* gridClipFromCoords(uint32_t x, uint32_t y);
+	[[nodiscard]] const size_t gridTrackCount() const;
+	Cartesian gridXYFromClip(Clip& clip);
+	uint32_t gridClipCountForTrack(Output* track);
+	Clip* getClipFromSection(Output* track, uint8_t section = kMaxNumSections);
+	Output* gridTrackFromX(uint32_t x, uint32_t maxTrack);
+
 private:
 	// These and other (future) commandXXX methods perform actions triggered by HID, but contain
 	// no dispatch logic.
@@ -255,18 +262,13 @@ private:
 	void gridStartSection(uint32_t section, bool instant);
 	void gridToggleClipPlay(Clip* clip, bool instant);
 
-	[[nodiscard]] const size_t gridTrackCount() const;
-	uint32_t gridClipCountForTrack(Output* track);
 	uint32_t gridTrackIndexFromTrack(Output* track, uint32_t maxTrack);
 	Output* gridTrackFromIndex(uint32_t trackIndex, uint32_t maxTrack);
 	int32_t gridYFromSection(uint32_t section);
 	int32_t gridSectionFromY(uint32_t y);
 	int32_t gridXFromTrack(uint32_t trackIndex);
 	int32_t gridTrackIndexFromX(uint32_t x, uint32_t maxTrack);
-	Output* gridTrackFromX(uint32_t x, uint32_t maxTrack);
-	Clip* gridClipFromCoords(uint32_t x, uint32_t y);
 	int32_t gridClipIndexFromCoords(uint32_t x, uint32_t y);
-	Cartesian gridXYFromClip(Clip& clip);
 
 	void gridSetDefaultMode() {
 		switch (FlashStorage::defaultGridActiveMode) {

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -26,6 +26,15 @@ import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
 
 - Various structural improvements to Sound Engine architecture which may result in performance improvements.
 
+### CLIP VIEW :
+
+- Ability to navigate between clips from clip view :
+  - Grid Mode :
+    - using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` : Navigate previous/next track clip.
+    - using `VERTICAL ENCODER ◀︎▶︎` + `CLIP` : Navigate previous/next clip within the track.
+  - Song Mode :
+    - using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` : Navigate previous/next track clip.
+
 ## c1.3.0 <Badge text="Upcoming" variant="tip" />
 
 ### Sound Engine

--- a/website/src/content/docs/features/community_features.md
+++ b/website/src/content/docs/features/community_features.md
@@ -1211,10 +1211,10 @@ to each individual note onset. (#1978)
   In case of drums, it is like having a Sound row + a Midi row together triggering at the same time. And in case of synths, it is like
   having a Synth clip + a Midi clip together triggering at the same time. This feature is limited to regular MIDI (that is, not for MPE).
 
-
 #### 4.5.12 - Ability to navigate between clips from clip view :
-  - In Grid Mode, using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` will navigate to previous/next track clip, using `VERTICAL ENCODER ◀︎▶︎` + `CLIP` will navigate to previous/next clip within the track.
-  - In Song Mode using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` : will navigate to previous/next track clip.
+
+- In Grid Mode, using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` will navigate to previous/next track clip, using `VERTICAL ENCODER ◀︎▶︎` + `CLIP` will navigate to previous/next clip within the track.
+- In Song Mode using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` : will navigate to previous/next track clip.
 
 ### 4.6 - Instrument Clip View - Kit Clip Features
 

--- a/website/src/content/docs/features/community_features.md
+++ b/website/src/content/docs/features/community_features.md
@@ -1211,6 +1211,11 @@ to each individual note onset. (#1978)
   In case of drums, it is like having a Sound row + a Midi row together triggering at the same time. And in case of synths, it is like
   having a Synth clip + a Midi clip together triggering at the same time. This feature is limited to regular MIDI (that is, not for MPE).
 
+
+#### 4.5.12 - Ability to navigate between clips from clip view :
+  - In Grid Mode, using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` will navigate to previous/next track clip, using `VERTICAL ENCODER ◀︎▶︎` + `CLIP` will navigate to previous/next clip within the track.
+  - In Song Mode using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` : will navigate to previous/next track clip.
+
 ### 4.6 - Instrument Clip View - Kit Clip Features
 
 #### 4.6.1 - Keyboard View


### PR DESCRIPTION
- Ability to navigate between clips from clip view :
  - Grid Mode :
    - using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` : Navigate previous/next track clip.
    - using `VERTICAL ENCODER ◀︎▶︎` + `CLIP` : Navigate previous/next clip within the track.
  - Song Mode :
    - using `HORIZONTAL ENCODER ◀︎▶︎` + `CLIP` : Navigate previous/next track clip.