### PR TITLE
Bugfix: give strings constructors and fix some other errors

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -504,6 +504,7 @@ enum class Error {
 	INVALID_PATTERN_VERSION,
 	OUT_OF_BUFFER_SPACE,
 	INVALID_SYSEX_FORMAT,
+	POS_PAST_STRING,
 };
 
 enum class SampleRepeatMode {

--- a/src/deluge/gui/l10n/english.json
+++ b/src/deluge/gui/l10n/english.json
@@ -24,6 +24,7 @@
         "STRING_FOR_ERROR_SD_CARD_FULL": "SD card full",
         "STRING_FOR_ERROR_FILE_NOT_LOADABLE_AS_WAVETABLE": "File does not contain wavetable data",
         "STRING_FOR_ERROR_FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO": "Stereo files cannot be used as wavetables",
+        "STRING_FOR_STRING_ERROR": "Messed up moving strings around",
         "STRING_FOR_ERROR_WRITE_PROTECTED": "Card is write-protected",
         "STRING_FOR_ERROR_GENERIC": "You've encountered an unspecified error. Please report this bug.",
 

--- a/src/deluge/gui/l10n/g_english.cpp
+++ b/src/deluge/gui/l10n/g_english.cpp
@@ -37,6 +37,7 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_ERROR_SD_CARD_FULL, "SD card full"},
         {STRING_FOR_ERROR_FILE_NOT_LOADABLE_AS_WAVETABLE, "File does not contain wavetable data"},
         {STRING_FOR_ERROR_FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO, "Stereo files cannot be used as wavetables"},
+        {STRING_FOR_STRING_ERROR, "Messed up moving strings around"},
         {STRING_FOR_ERROR_WRITE_PROTECTED, "Card is write-protected"},
         {STRING_FOR_ERROR_GENERIC, "You've encountered an unspecified error. Please report this bug."},
         {STRING_FOR_PATCH_SOURCE_LFO_GLOBAL_1, "LFO1"},

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -30,6 +30,7 @@ enum class String : size_t {
 	STRING_FOR_ERROR_FILE_NOT_LOADABLE_AS_WAVETABLE,
 	STRING_FOR_ERROR_FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO,
 	STRING_FOR_ERROR_WRITE_PROTECTED,
+	STRING_FOR_STRING_ERROR, // note this is different because string_for_string_error seems wrong
 	STRING_FOR_ERROR_GENERIC,
 
 	// Param sources (from functions.cpp)

--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -35,8 +35,7 @@ bool RenameUI::opened() {
 	}
 
 	String name = getName();
-	enteredText.clear();
-	enteredText.concatenate(&name);
+	enteredText.set(&name);
 
 	displayText();
 	drawKeys();

--- a/src/deluge/hid/display/display.cpp
+++ b/src/deluge/hid/display/display.cpp
@@ -73,6 +73,8 @@ std::string_view getErrorMessage(Error error) {
 
 	case Error::WRITE_PROTECTED:
 		return l10n::getView(STRING_FOR_ERROR_WRITE_PROTECTED);
+	case Error::POS_PAST_STRING:
+		return l10n::getView(STRING_FOR_STRING_ERROR);
 
 	default:
 		return l10n::getView(STRING_FOR_ERROR_GENERIC);

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -41,13 +41,16 @@ extern const char nothing;
 class String {
 public:
 	String() = default;
+	String(const String& other);
+	String& operator=(const String& other);
+
 	// String(String* otherString); // BEWARE - using this on stack instances sometimes just caused crashes and stuff.
 	// Made no sense. Instead, constructing then calling set() works
 	~String();
 	void clear(bool destructing = false);
 	Error set(char const* newChars, int32_t newLength = -1);
 	void set(String const* otherString);
-	void beenCloned();
+	void beenCloned() const;
 	size_t getLength();
 	Error shorten(int32_t newLength);
 	Error concatenateAtPos(char const* newChars, int32_t pos, int32_t newCharsLength = -1);
@@ -56,6 +59,7 @@ public:
 	Error setChar(char newChar, int32_t pos);
 	Error concatenate(String* otherString);
 	Error concatenate(char const* newChars);
+	Error get_new_memory(int32_t newCharsLength);
 	bool equals(char const* otherChars);
 	bool equalsCaseIrrespective(char const* otherChars);
 
@@ -88,10 +92,10 @@ public:
 	}
 
 	inline bool isEmpty() { return !stringMemory; }
+	int32_t getNumReasons() const;
 
 private:
-	int32_t getNumReasons();
-	void setNumReasons(int32_t newNum);
+	void setNumReasons(int32_t newNum) const;
 
 	char* stringMemory = nullptr;
 };


### PR DESCRIPTION
Fix 3419 and 3588 

Strings didn't have copy or assignment constructors so their reference counts could get messed up. This hopefully removes a lot of string errors

Fix the order of incrementing the ref count and deallocating to avoid future issues with threading

Also adds some checking for errors in concatenation