### PR TITLE
Bugfix  - Enable midi interpolation for non expression params

### DIFF
--- a/src/deluge/modulation/midi/midi_param_collection.cpp
+++ b/src/deluge/modulation/midi/midi_param_collection.cpp
@@ -138,8 +138,9 @@ void MIDIParamCollection::processCurrentPos(ModelStackWithParamCollection* model
                                             bool reversed, bool didPingpong, bool mayInterpolate) {
 
 	ticksTilNextEvent -= ticksSkipped;
-	bool interpolating = false;
 	if (ticksTilNextEvent <= 0) {
+		bool interpolating = false;
+
 		ticksTilNextEvent = 2147483647;
 
 		for (auto& [cc, param] : params) {
@@ -152,8 +153,8 @@ void MIDIParamCollection::processCurrentPos(ModelStackWithParamCollection* model
 				interpolating = true;
 			}
 		}
+		modelStack->summary->whichParamsAreInterpolating[0] = static_cast<uint32_t>(interpolating);
 	}
-	modelStack->summary->whichParamsAreInterpolating[0] = static_cast<uint32_t>(interpolating);
 }
 
 void MIDIParamCollection::remotelySwapParamState(AutoParamState* state, ModelStackWithParamId* modelStack) {


### PR DESCRIPTION
Midi interpolation flag could be cleared when interpolation active but not changing the value on every tick. At default song resolution a full bar sweep only changes the param every 6 ticks so this is a normal case. Fix that so it's only cleared when we're about to look for interpolation again