### PR TITLE
Bugfix/revert argon upgrade

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -4,7 +4,7 @@ include(FetchContent)
 
 FetchContent_Declare(argon
         GIT_REPOSITORY https://github.com/stellar-aria/argon
-        GIT_TAG 48fa025cabe1cd6de08177908598901ef42d91df
+        GIT_TAG 3779c5315a978a2f8c892e320ac12ecbb77c3759
 )
 FetchContent_MakeAvailable(argon)
 

--- a/src/deluge/dsp/interpolate/interpolate.cpp
+++ b/src/deluge/dsp/interpolate/interpolate.cpp
@@ -31,7 +31,7 @@ StereoSample Interpolator::interpolate(size_t channels, int32_t whichKernel, uin
 		auto value2 = Argon<int16_t>::Load(&windowedSincKernel[whichKernel][progressSmall + 1][i * 8]);
 
 		// standard linear a + (b - a) * fractional
-		kernelVector[i] = value1.MultiplyAddQMax((value2 - value1), strength2);
+		kernelVector[i] = value1.MultiplyAddFixedPoint((value2 - value1), strength2);
 	}
 
 	Argon<int32_t> multiplied = 0;

--- a/src/deluge/dsp/oscillators/basic_waves.cpp
+++ b/src/deluge/dsp/oscillators/basic_waves.cpp
@@ -22,7 +22,6 @@
 #include "util/functions.h"
 #include "util/lookuptables/lookuptables.h"
 #include <argon.hpp>
-#include <argon/vectorize/load_store.hpp>
 namespace deluge::dsp {
 /* Before calling, you must:
     amplitude <<= 1; ( so that it is q31)
@@ -35,12 +34,12 @@ void renderWave(const int16_t* __restrict__ table, int32_t table_size_magnitude,
 	Argon<q31_t> amplitude_vector = createAmplitudeVector(amplitude, amplitude_increment);
 	Argon<q31_t> amplitude_increment_vector = amplitude_increment << 1;
 
-	for (Argon<q31_t>& sample_vector : argon::vectorize::load_store(buffer)) {
+	for (Argon<q31_t>& sample_vector : argon::vectorize(buffer)) {
 		auto [value_vector, new_phase] =
 		    waveRenderingFunctionGeneral(phase, phase_increment, phase_to_add, table, table_size_magnitude);
 
 		if (apply_amplitude) {
-			value_vector = sample_vector.MultiplyAddQMax(value_vector, amplitude_vector);
+			value_vector = sample_vector.MultiplyAddFixedPoint(value_vector, amplitude_vector);
 			amplitude_vector = amplitude_vector + amplitude_increment_vector;
 		}
 
@@ -59,12 +58,12 @@ void renderPulseWave(const int16_t* __restrict__ table, int32_t table_size_magni
 	Argon<q31_t> amplitude_vector = createAmplitudeVector(amplitude, amplitude_increment);
 	Argon<q31_t> amplitude_increment_vector = amplitude_increment << 1;
 
-	for (Argon<q31_t>& sample_vector : argon::vectorize::load_store(buffer)) {
+	for (Argon<q31_t>& sample_vector : argon::vectorize(buffer)) {
 		auto [value_vector, new_phase] =
 		    waveRenderingFunctionPulse(phase, phase_increment, phase_to_add, table, table_size_magnitude);
 
 		if (apply_amplitude) {
-			value_vector = sample_vector.MultiplyAddQMax(value_vector, amplitude_vector);
+			value_vector = sample_vector.MultiplyAddFixedPoint(value_vector, amplitude_vector);
 			amplitude_vector = amplitude_vector + amplitude_increment_vector;
 		}
 

--- a/src/deluge/dsp/oscillators/oscillator.cpp
+++ b/src/deluge/dsp/oscillators/oscillator.cpp
@@ -20,7 +20,6 @@
 #include "processing/render_wave.h"
 #include "storage/wave_table/wave_table.h"
 #include "util/fixedpoint.h"
-#include <argon/vectorize/store.hpp>
 
 namespace deluge::dsp {
 PLACE_INTERNAL_FRUNK int32_t oscSyncRenderingBuffer[SSI_TX_BUFFER_NUM_SAMPLES + 4]
@@ -428,7 +427,7 @@ doSaw:
 						int32_t* bufferStartThisSync = applyAmplitude ? oscSyncRenderingBuffer : bufferStart;
 						int32_t numSamplesThisOscSyncSession = numSamples;
 						auto storeVectorWaveForOneSync = [&](std::span<q31_t> buffer, uint32_t phase) {
-							for (Argon<q31_t>& value_vector : argon::vectorize::store(buffer)) {
+							for (Argon<q31_t>& value_vector : argon::vectorize(buffer)) {
 								std::tie(value_vector, phase) = waveRenderingFunctionPulse(
 								    phase, phaseIncrement, phaseToAdd, table, tableSizeMagnitude);
 							}
@@ -473,7 +472,7 @@ callRenderWave:
 			int32_t numSamplesThisOscSyncSession = numSamples;
 			auto storeVectorWaveForOneSync = //<
 			    [&](std::span<q31_t> buffer, uint32_t phase) {
-				    for (Argon<q31_t>& value_vector : argon::vectorize::store(buffer)) {
+				    for (Argon<q31_t>& value_vector : argon::vectorize(buffer)) {
 					    std::tie(value_vector, phase) =
 					        waveRenderingFunctionGeneral(phase, phaseIncrement, phaseToAdd, table, tableSizeMagnitude);
 				    }

--- a/src/deluge/dsp/oscillators/sine_osc.h
+++ b/src/deluge/dsp/oscillators/sine_osc.h
@@ -11,7 +11,7 @@ class [[gnu::hot]] SineOsc {
 	static std::array<int16_t, 512> sineWaveDiff;
 
 public:
-	static int32_t doFMNew(uint32_t carrierPhase, uint32_t phaseShift) {
+	static inline int32_t doFMNew(uint32_t carrierPhase, uint32_t phaseShift) {
 		// return getSineNew((((*carrierPhase += carrierPhaseIncrement) >> 8) + phaseShift) & 16777215, 24);
 
 		uint32_t phaseSmall = (carrierPhase >> 8) + phaseShift;
@@ -30,7 +30,7 @@ public:
 		// create a vector containing a ramp of incrementing phases:
 		// {phase + (phaseIncrement * 1), phase + (phaseIncrement * 2), phase + (phaseIncrement * 3), phase +
 		// (phaseIncrement * 4)}
-		auto phaseVector = Argon<uint32_t>::LoadCopy(thisPhase).MultiplyAdd(phaseIncrement, Argon<uint32_t>::Iota(1));
+		auto phaseVector = Argon<uint32_t>::LoadCopy(thisPhase).MultiplyAdd(uint32x4_t{1, 2, 3, 4}, phaseIncrement);
 		*thisPhase = *thisPhase + phaseIncrement * 4;
 
 		return render(phaseVector);
@@ -52,8 +52,7 @@ private:
 		Argon<uint32_t> indices = (phase >> (32 - kSineTableSizeMagnitude)) << 1;
 
 		//  load our two relevent table components
-		auto [sine, diff] =
-		    ArgonHalf<int16_t>::LoadGatherOffsetIndexInterleaved<2>(sineWaveDiff.data(), indices.Narrow());
+		auto [sine, diff] = ArgonHalf<int16_t>::LoadGatherInterleaved<2>(sineWaveDiff.data(), indices);
 
 		// Essentially a MultiplyAddFixedPoint, but without the reduction back down to q31
 		return sine.ShiftLeftLong<16>().MultiplyDoubleAddSaturateLong(diff, strength2);

--- a/src/deluge/dsp/reverb/cosine_oscillator.hpp
+++ b/src/deluge/dsp/reverb/cosine_oscillator.hpp
@@ -12,7 +12,7 @@ public:
 	enum class Mode { APPROX, EXACT };
 
 	template <Mode mode = Mode::APPROX>
-	constexpr DualCosineOscillator(std::array<float, 2> frequencies) : frequencies_(frequencies[0], frequencies[1]) {
+	constexpr DualCosineOscillator(std::array<float, 2> frequencies) : frequencies_(frequencies) {
 		Init<mode>();
 	}
 	~DualCosineOscillator() = default;

--- a/src/deluge/processing/vector_rendering_function.h
+++ b/src/deluge/processing/vector_rendering_function.h
@@ -24,14 +24,27 @@
 [[gnu::always_inline]] static inline std::pair<Argon<int32_t>, uint32_t> //<
 waveRenderingFunctionGeneral(uint32_t phase, int32_t phaseIncrement, uint32_t _phaseToAdd, const int16_t* table,
                              int32_t tableSizeMagnitude) {
-	Argon<uint32_t> phaseVector = Argon<uint32_t>{phase}.MultiplyAdd(Argon<uint32_t>{1U, 2U, 3U, 4U}, phaseIncrement);
-	Argon<uint32_t> indices = phaseVector >> (32 - tableSizeMagnitude);
-	ArgonHalf<uint16_t> strength2 = indices.ShiftRightNarrow<16>() >> 1;
-	auto [value1, value2] = ArgonHalf<int16_t>::LoadGatherInterleaved<2>(table, indices);
+	Argon<uint32_t> readValue = 0U;
+	ArgonHalf<uint16_t> strength2 = 0U;
 
-	// this is a standard linear interpolation of a + (b - a) * fractional
-	auto output = value1.ShiftLeftLong<16>().MultiplyDoubleAddSaturateLong(value2 - value1, strength2.As<int16_t>());
-	return {output, phase + phaseIncrement * 4};
+	util::constexpr_for<0, 4, 1>([&]<int i>() {
+		phase += phaseIncrement;
+		uint32_t rshifted = phase >> (32 - 16 - tableSizeMagnitude);
+		strength2[i] = rshifted;
+
+		uint32_t whichValue = phase >> (32 - tableSizeMagnitude);
+		uint32_t* readAddress = (uint32_t*)((uint32_t)table + (whichValue << 1));
+		readValue[i].Load(readAddress);
+	});
+
+	strength2 = strength2 >> 1;
+	ArgonHalf<int16_t> value1 = readValue.Narrow().As<int16_t>();
+	ArgonHalf<int16_t> value2 = readValue.ShiftRightNarrow<16>().As<int16_t>();
+	Argon<int32_t> value1Big = value1.ShiftLeftLong<16>();
+
+	ArgonHalf<int16_t> difference = value2 - value1;
+	auto output = value1Big.MultiplyDoubleAddSaturateLong(difference, strength2.As<int16_t>());
+	return {output, phase};
 }
 
 // Renders 4 wave values (a "vector") together in one go - special case for pulse waves with variable width.

--- a/src/deluge/processing/vector_rendering_function.h
+++ b/src/deluge/processing/vector_rendering_function.h
@@ -27,7 +27,7 @@ waveRenderingFunctionGeneral(uint32_t phase, int32_t phaseIncrement, uint32_t _p
 	Argon<uint32_t> phaseVector = Argon<uint32_t>{phase}.MultiplyAdd(Argon<uint32_t>{1U, 2U, 3U, 4U}, phaseIncrement);
 	Argon<uint32_t> indices = phaseVector >> (32 - tableSizeMagnitude);
 	ArgonHalf<uint16_t> strength2 = indices.ShiftRightNarrow<16>() >> 1;
-	auto [value1, value2] = ArgonHalf<int16_t>::LoadGatherOffsetIndexInterleaved<2>(table, indices.Narrow());
+	auto [value1, value2] = ArgonHalf<int16_t>::LoadGatherInterleaved<2>(table, indices);
 
 	// this is a standard linear interpolation of a + (b - a) * fractional
 	auto output = value1.ShiftLeftLong<16>().MultiplyDoubleAddSaturateLong(value2 - value1, strength2.As<int16_t>());
@@ -47,12 +47,12 @@ waveRenderingFunctionPulse(uint32_t phase, int32_t phaseIncrement, uint32_t phas
 	Argon<uint32_t> indicesA = phaseVector >> (32 - tableSizeMagnitude);
 	ArgonHalf<int16_t> rshiftedA =
 	    indicesA.ShiftRightNarrow<16>().BitwiseAnd(std::numeric_limits<int16_t>::max()).As<int16_t>();
-	auto [valueA1, valueA2] = ArgonHalf<int16_t>::LoadGatherOffsetIndexInterleaved<2>(table, indicesA.Narrow());
+	auto [valueA1, valueA2] = ArgonHalf<int16_t>::LoadGatherInterleaved<2>(table, indicesA);
 
 	Argon<uint32_t> indicesB = phaseLater >> (32 - tableSizeMagnitude);
 	ArgonHalf<int16_t> rshiftedB =
 	    indicesB.ShiftRightNarrow<16>().BitwiseAnd(std::numeric_limits<int16_t>::max()).As<int16_t>();
-	auto [valueB1, valueB2] = ArgonHalf<int16_t>::LoadGatherOffsetIndexInterleaved<2>(table, indicesB.Narrow());
+	auto [valueB1, valueB2] = ArgonHalf<int16_t>::LoadGatherInterleaved<2>(table, indicesB);
 
 	/* Sneakily do this backwards to flip the polarity of the output, which we need to do anyway */
 	ArgonHalf<int16_t> strengthA1 = rshiftedA | std::numeric_limits<int16_t>::min();
@@ -69,6 +69,6 @@ waveRenderingFunctionPulse(uint32_t phase, int32_t phaseIncrement, uint32_t phas
 	                             .MultiplyDoubleSaturateLong(valueB2) //<
 	                             .MultiplyDoubleAddSaturateLong(strengthB1, valueB1);
 
-	auto output = outputA.MultiplyRoundQMax(outputB) << 1; // (a *. b) << 1 (average?)
+	auto output = outputA.MultiplyRoundFixedPoint(outputB) << 1; // (a *. b) << 1 (average?)
 	return {output, phase + phaseIncrement * 4};
 }

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -975,7 +975,7 @@ WaveTable::doRenderingLoop(int32_t* __restrict__ thisSample, int32_t const* buff
 			auto value2 = Argon<int16_t>::Load(sincKernelReadPos + 16 + (i * 8));
 
 			auto difference = value2 - value1;
-			auto multipliedDifference = difference.MultiplyQMax(strength2);
+			auto multipliedDifference = difference.MultiplyFixedPoint(strength2);
 			kernelVector[i] = value1 + multipliedDifference;
 		}
 


### PR DESCRIPTION
Revert #3612 

I've ran through this code a few times this week and can't find where the bug comes from. Reverting for now so that nightly is usable again 

Fix #3646 
Fix #3557 
Fix #3551 
Fix #3577 
Fix #3742 

I'll open a second PR with the same fix for beta since it doesn't need argon reverted first 