### PR TITLE
Bugfix - only add spacing if not the last character

### DIFF
--- a/src/deluge/hid/display/oled_canvas/canvas.cpp
+++ b/src/deluge/hid/display/oled_canvas/canvas.cpp
@@ -165,7 +165,7 @@ void Canvas::drawRectangle(int32_t minX, int32_t minY, int32_t maxX, int32_t max
 
 void Canvas::drawString(std::string_view string, int32_t pixelX, int32_t pixelY, int32_t textWidth, int32_t textHeight,
                         int32_t scrollPos, int32_t endX, bool useTextWidth) {
-	int32_t stringLength = string.length();
+	int32_t lastIndex = string.length() - 1;
 	int32_t charIdx = 0;
 	int32_t charWidth = textWidth;
 	// if the string is currently scrolling we want to identify the number of characters
@@ -179,7 +179,7 @@ void Canvas::drawString(std::string_view string, int32_t pixelX, int32_t pixelY,
 		int32_t charStartX = 0;
 		for (char const c : string) {
 			if (!useTextWidth) {
-				int32_t charSpacing = getCharSpacingInPixels(c, textHeight, charIdx == stringLength);
+				int32_t charSpacing = getCharSpacingInPixels(c, textHeight, charIdx == lastIndex);
 				charWidth = getCharWidthInPixels(c, textHeight) + charSpacing;
 			}
 			charStartX += charWidth;
@@ -201,7 +201,7 @@ void Canvas::drawString(std::string_view string, int32_t pixelX, int32_t pixelY,
 		// adjust scroll position to indicate how far we've scrolled
 		scrollPos -= widthOfCharsToChopOff;
 		// calculate new string length
-		stringLength = string.length();
+		lastIndex = string.length() - 1;
 		// reset index
 		charIdx = 0;
 	}
@@ -210,7 +210,7 @@ void Canvas::drawString(std::string_view string, int32_t pixelX, int32_t pixelY,
 	// here we're going to draw the remaining characters in the string
 	for (char const c : string) {
 		if (!useTextWidth) {
-			int32_t charSpacing = getCharSpacingInPixels(c, textHeight, charIdx == stringLength);
+			int32_t charSpacing = getCharSpacingInPixels(c, textHeight, charIdx == lastIndex);
 			charWidth = getCharWidthInPixels(c, textHeight) + charSpacing;
 		}
 		drawChar(c, pixelX, pixelY, charWidth, textHeight, scrollPos, endX);


### PR DESCRIPTION
Fix #3776 

6 extra pixel columns were being cleared when the last character was a space, but weren't included when breaking the line. This resulted in clearing beyond the max popup width and overwriting random memory