### PR TITLE
Envelope menu: sigmoid-like curve for the sustain line for better correlation with sound changes

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/arp_unpatched_param.h
+++ b/src/deluge/gui/menu_item/arpeggiator/arp_unpatched_param.h
@@ -29,10 +29,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingCVOrMIDIClip() && !soundEditor.editingNonAudioDrumRow();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 	[[nodiscard]] NumberStyle getNumberStyle() const override { return style_; }
@@ -48,10 +45,7 @@ public:
 		return !soundEditor.editingCVOrMIDIClip() && !soundEditor.editingKitAffectEntire()
 		       && !soundEditor.editingNonAudioDrumRow();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::getView(deluge::l10n::built_in::seven_segment, this->name).data());
 	}
 };
@@ -66,10 +60,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingCVOrMIDIClip() && !soundEditor.editingKit();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 	[[nodiscard]] NumberStyle getNumberStyle() const override { return style_; }

--- a/src/deluge/gui/menu_item/arpeggiator/chord_type.h
+++ b/src/deluge/gui/menu_item/arpeggiator/chord_type.h
@@ -62,10 +62,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return soundEditor.editingKitRow() && !soundEditor.editingGateDrumRow();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 

--- a/src/deluge/gui/menu_item/arpeggiator/include_in_kit_arp.h
+++ b/src/deluge/gui/menu_item/arpeggiator/include_in_kit_arp.h
@@ -82,10 +82,7 @@ public:
 		return soundEditor.editingKitRow();
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::getView(deluge::l10n::built_in::seven_segment, this->name).data());
 	}
 

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/arp_integer.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/arp_integer.h
@@ -27,10 +27,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return soundEditor.editingCVOrMIDIClip() || soundEditor.editingNonAudioDrumRow();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 };

--- a/src/deluge/gui/menu_item/arpeggiator/note_mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/note_mode.h
@@ -37,10 +37,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingKitRow();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 

--- a/src/deluge/gui/menu_item/arpeggiator/note_mode_for_drums.h
+++ b/src/deluge/gui/menu_item/arpeggiator/note_mode_for_drums.h
@@ -59,10 +59,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return soundEditor.editingKitRow() && !soundEditor.editingGateDrumRow();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 

--- a/src/deluge/gui/menu_item/arpeggiator/octave_mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/octave_mode.h
@@ -60,10 +60,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingGateDrumRow() && !soundEditor.editingKitAffectEntire();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 

--- a/src/deluge/gui/menu_item/arpeggiator/octaves.h
+++ b/src/deluge/gui/menu_item/arpeggiator/octaves.h
@@ -55,10 +55,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingGateDrumRow() && !soundEditor.editingKitAffectEntire();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 

--- a/src/deluge/gui/menu_item/arpeggiator/randomizer_lock.h
+++ b/src/deluge/gui/menu_item/arpeggiator/randomizer_lock.h
@@ -57,10 +57,7 @@ public:
 		};
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 

--- a/src/deluge/gui/menu_item/arpeggiator/step_repeat.h
+++ b/src/deluge/gui/menu_item/arpeggiator/step_repeat.h
@@ -56,10 +56,7 @@ public:
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return !soundEditor.editingGateDrumRow();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(deluge::l10n::built_in::seven_segment, this->name));
 	}
 

--- a/src/deluge/gui/menu_item/envelope/envelope_menu.h
+++ b/src/deluge/gui/menu_item/envelope/envelope_menu.h
@@ -21,9 +21,9 @@
 #include "segment.h"
 
 using namespace deluge::hid::display;
-using namespace gui::menu_item::envelope;
 
-class EnvelopeMenu final : public gui::menu_item::HorizontalMenu {
+namespace deluge::gui::menu_item::envelope {
+class EnvelopeMenu final : public HorizontalMenu {
 public:
 	using HorizontalMenu::HorizontalMenu;
 
@@ -66,7 +66,8 @@ public:
 
 		// Calculate widths
 		const float attackWidth = (attack / 50.0f) * maxSegmentWidth;
-		const float decayWidth = (decay / 50.0f) * maxSegmentWidth;
+		const float decayNormalized = sigmoidLikeCurve(decay / 5.0f, 1.5f); // Maps 0-50 to 0-1 range with steep start
+		const float decayWidth = decayNormalized * maxSegmentWidth;
 
 		// X positions
 		const float attackX = round(drawX + attackWidth);
@@ -144,4 +145,9 @@ private:
 		// Draw a transition square
 		image.drawRectangle(ix - squareSize, iy - squareSize, ix + squareSize, iy + squareSize);
 	};
+
+	// --- Helper functions ----
+	static float sigmoidLikeCurve(const float x, const float softening) { return x / (x + softening); };
 };
+
+} // namespace deluge::gui::menu_item::envelope

--- a/src/deluge/gui/menu_item/envelope/segment.h
+++ b/src/deluge/gui/menu_item/envelope/segment.h
@@ -25,10 +25,7 @@ class Segment : public source::PatchedParam {
 public:
 	using PatchedParam::PatchedParam;
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		const auto& shortNameString = getShortEnvelopeParamName(menu_item::PatchedParam::getP());
 		label.append(deluge::l10n::get(shortNameString));
 	}

--- a/src/deluge/gui/menu_item/eq/eq_unpatched_param.h
+++ b/src/deluge/gui/menu_item/eq/eq_unpatched_param.h
@@ -25,12 +25,7 @@ public:
 	    : UnpatchedParam(name, newP), columnLabel_{columnLabel} {}
 	EqUnpatchedParam(l10n::String name, int32_t newP) : UnpatchedParam(name, newP), columnLabel_{name} {}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
-		label.append(deluge::l10n::getView(columnLabel_));
-	}
+	void getColumnLabel(StringBuf& label) override { label.append(deluge::l10n::getView(columnLabel_)); }
 
 private:
 	l10n::String columnLabel_;

--- a/src/deluge/gui/menu_item/filter/param.h
+++ b/src/deluge/gui/menu_item/filter/param.h
@@ -41,9 +41,7 @@ public:
 	[[nodiscard]] bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return info.isOn();
 	}
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(info.getMorphNameOr(patched_param::Integer::getName(), !forSmallFont));
-	}
+	void getColumnLabel(StringBuf& label) override { label.append(info.getMorphNameOr(Integer::getName(), true)); }
 
 private:
 	FilterInfo info;

--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -360,7 +360,7 @@ HorizontalMenu::ColumnLabelPosition HorizontalMenu::renderColumnLabel(MenuItem* 
 	hid::display::oled_canvas::Canvas& image = hid::display::OLED::main;
 
 	DEF_STACK_STRING_BUF(label, kShortStringBufferSize);
-	menuItem->getColumnLabel(label, false);
+	menuItem->getColumnLabel(label);
 
 	// Remove any spaces
 	label.removeSpaces();

--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -70,9 +70,9 @@ void HorizontalMenu::drawPixelsForOled() {
 		updateSelectedMenuItemLED(posOnPage);
 	}
 
-	constexpr int32_t baseY = 13 + OLED_MAIN_TOPMOST_PIXEL;
+	constexpr int32_t baseY = 14 + OLED_MAIN_TOPMOST_PIXEL;
 	constexpr int32_t boxHeight = 25;
-	constexpr int32_t labelHeight = 9;
+	constexpr int32_t labelHeight = kTextSpacingY;
 	constexpr int32_t labelY = baseY + boxHeight - labelHeight;
 	int32_t currentX = 0;
 

--- a/src/deluge/gui/menu_item/integer.h
+++ b/src/deluge/gui/menu_item/integer.h
@@ -30,7 +30,7 @@ protected:
 	virtual int32_t getDisplayValue() { return this->getValue(); }
 	virtual const char* getUnit() { return ""; }
 
-	void drawPixelsForOled();
+	void drawPixelsForOled() override;
 	virtual void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel);
 
 	// 7Seg Only
@@ -51,7 +51,7 @@ public:
 	using Integer::Integer;
 
 protected:
-	void drawPixelsForOled();
+	void drawPixelsForOled() override;
 };
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -283,7 +283,7 @@ public:
 	/// @brief Get the name for use on horizontal menus.
 	///
 	/// By default this redirects to getName(), but can be overridden.
-	virtual void getColumnLabel(StringBuf& label, bool forSmallFont) { label.append(getName().data()); }
+	virtual void getColumnLabel(StringBuf& label) { label.append(getName().data()); }
 
 	/// @brief Show a label for the parameter in the horizontal menu
 	///

--- a/src/deluge/gui/menu_item/midi/preset.h
+++ b/src/deluge/gui/menu_item/midi/preset.h
@@ -31,7 +31,7 @@ public:
 	[[nodiscard]] int32_t getMaxValue() const override { return 128; } // Probably not needed cos we override below...
 
 	void drawInteger(int32_t textWidth, int32_t textHeight, int32_t yPixel) override {
-		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
+		oled_canvas::Canvas& canvas = OLED::main;
 		char buffer[12];
 		char const* text;
 		if (this->getValue() == 128) {
@@ -68,11 +68,11 @@ public:
 		Number::selectEncoderAction(offset);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
-		hid::display::oled_canvas::Canvas& image = hid::display::OLED::main;
+	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+		oled_canvas::Canvas& image = OLED::main;
 
 		DEF_STACK_STRING_BUF(paramValue, 5);
-		int sizeX, sizeY;
+		int32_t sizeX, sizeY;
 		if (this->getValue() == 128) {
 			paramValue.append(l10n::get(l10n::String::STRING_FOR_NONE));
 			sizeX = kTextSpacingX;
@@ -83,7 +83,9 @@ public:
 			sizeX = kTextTitleSpacingX;
 			sizeY = kTextTitleSizeY;
 		}
-		image.drawStringCentered(paramValue, startX, startY + sizeY + 2, sizeX, sizeY, width);
+		image.drawStringCentered(paramValue, startX, startY + 2, sizeX, sizeY, width);
 	}
+
+	[[nodiscard]] bool showPopup() const override { return false; }
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/mod_fx/depth_patched.h
+++ b/src/deluge/gui/menu_item/mod_fx/depth_patched.h
@@ -36,9 +36,8 @@ public:
 	}
 	[[nodiscard]] virtual std::string_view getTitle() const { return getName(); }
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(
-		    modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::DEPTH, !forSmallFont));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::DEPTH, true));
 	}
 
 	[[nodiscard]] NumberStyle getNumberStyle() const override { return VERTICAL_BAR; }

--- a/src/deluge/gui/menu_item/mod_fx/depth_unpatched.h
+++ b/src/deluge/gui/menu_item/mod_fx/depth_unpatched.h
@@ -37,9 +37,8 @@ public:
 
 	[[nodiscard]] NumberStyle getNumberStyle() const override { return VERTICAL_BAR; }
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(
-		    modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::DEPTH, !forSmallFont));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::DEPTH, true));
 	}
 };
 } // namespace deluge::gui::menu_item::mod_fx

--- a/src/deluge/gui/menu_item/mod_fx/feedback.h
+++ b/src/deluge/gui/menu_item/mod_fx/feedback.h
@@ -34,9 +34,9 @@ public:
 	}
 	[[nodiscard]] virtual std::string_view getTitle() const { return getName(); }
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::FEEDBACK,
-		                                 !forSmallFont));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(
+		    modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::FEEDBACK, true));
 	}
 };
 } // namespace deluge::gui::menu_item::mod_fx

--- a/src/deluge/gui/menu_item/mod_fx/offset.h
+++ b/src/deluge/gui/menu_item/mod_fx/offset.h
@@ -36,9 +36,8 @@ public:
 	}
 	[[nodiscard]] virtual std::string_view getTitle() const { return getName(); }
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(
-		    modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::OFFSET, !forSmallFont));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(modfx::getParamName(soundEditor.currentModControllable->getModFXType(), ModFXParam::OFFSET, true));
 	}
 };
 

--- a/src/deluge/gui/menu_item/reverb/model.h
+++ b/src/deluge/gui/menu_item/reverb/model.h
@@ -21,10 +21,7 @@ public:
 		        l10n::getView(STRING_FOR_DIGITAL)};
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		if (forSmallFont) {
-			return label.append(getName().data());
-		}
+	void getColumnLabel(StringBuf& label) override {
 		label.append(deluge::l10n::get(l10n::String::STRING_FOR_MODEL_SHORT));
 	}
 };

--- a/src/deluge/gui/menu_item/reverb/sidechain/shape.h
+++ b/src/deluge/gui/menu_item/reverb/sidechain/shape.h
@@ -38,9 +38,8 @@ public:
 		return (AudioEngine::reverbSidechainVolume >= 0);
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(
-		    deluge::l10n::get(forSmallFont ? l10n::String::STRING_FOR_SHAPE : l10n::String::STRING_FOR_SHAPE_SHORT));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(deluge::l10n::get(l10n::String::STRING_FOR_SHAPE_SHORT));
 	}
 };
 } // namespace deluge::gui::menu_item::reverb::sidechain

--- a/src/deluge/gui/menu_item/reverb/sidechain/volume.h
+++ b/src/deluge/gui/menu_item/reverb/sidechain/volume.h
@@ -63,9 +63,8 @@ public:
 		}
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(deluge::l10n::get(forSmallFont ? l10n::String::STRING_FOR_VOLUME_DUCKING
-		                                            : l10n::String::STRING_FOR_VOLUME_DUCKING_SHORT));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(deluge::l10n::get(l10n::String::STRING_FOR_VOLUME_DUCKING_SHORT));
 	}
 
 	void getValueForPopup(StringBuf& valueBuf) override {

--- a/src/deluge/gui/menu_item/reverb/width.h
+++ b/src/deluge/gui/menu_item/reverb/width.h
@@ -41,7 +41,7 @@ public:
 	}
 	[[nodiscard]] std::string_view getTitle() const override { return getName(); }
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
+	void getColumnLabel(StringBuf& label) override {
 		using enum l10n::String;
 		switch (AudioEngine::reverb.getModel()) {
 		case dsp::Reverb::Model::DIGITAL:
@@ -50,7 +50,7 @@ public:
 			label.append(deluge::l10n::get(STRING_FOR_DIFFUSION));
 			break;
 		default:
-			label.append(deluge::l10n::get(forSmallFont ? STRING_FOR_WIDTH : STRING_FOR_WIDTH_SHORT));
+			label.append(deluge::l10n::get(STRING_FOR_WIDTH_SHORT));
 			break;
 		}
 	}

--- a/src/deluge/gui/menu_item/sidechain/attack.h
+++ b/src/deluge/gui/menu_item/sidechain/attack.h
@@ -61,9 +61,8 @@ public:
 		return !soundEditor.editingReverbSidechain() || AudioEngine::reverbSidechainVolume >= 0;
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(
-		    deluge::l10n::get(forSmallFont ? l10n::String::STRING_FOR_ATTACK : l10n::String::STRING_FOR_ATTACK_SHORT));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(deluge::l10n::get(l10n::String::STRING_FOR_ATTACK_SHORT));
 	}
 };
 } // namespace deluge::gui::menu_item::sidechain

--- a/src/deluge/gui/menu_item/sidechain/release.h
+++ b/src/deluge/gui/menu_item/sidechain/release.h
@@ -61,9 +61,8 @@ public:
 		return !soundEditor.editingReverbSidechain() || AudioEngine::reverbSidechainVolume >= 0;
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(deluge::l10n::get(forSmallFont ? l10n::String::STRING_FOR_RELEASE
-		                                            : l10n::String::STRING_FOR_RELEASE_SHORT));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(deluge::l10n::get(l10n::String::STRING_FOR_RELEASE_SHORT));
 	}
 };
 } // namespace deluge::gui::menu_item::sidechain

--- a/src/deluge/gui/menu_item/stutter/rate.h
+++ b/src/deluge/gui/menu_item/stutter/rate.h
@@ -32,9 +32,7 @@ public:
 	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
 	void getValueForPopup(StringBuf& valueBuf) override;
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(deluge::l10n::get(l10n::String::STRING_FOR_RATE));
-	}
+	void getColumnLabel(StringBuf& label) override { label.append(deluge::l10n::get(l10n::String::STRING_FOR_RATE)); }
 
 private:
 	int32_t getClosestQuantizedOptionIndex(int32_t value) const;

--- a/src/deluge/gui/menu_item/sync_level.cpp
+++ b/src/deluge/gui/menu_item/sync_level.cpp
@@ -48,13 +48,12 @@ void SyncLevel::drawPixelsForOled() {
 	hid::display::OLED::main.drawStringCentred(text, 20 + OLED_MAIN_TOPMOST_PIXEL, kTextBigSpacingX, kTextBigSizeY);
 }
 
-void SyncLevel::getColumnLabel(StringBuf& label, bool forSmallFont) {
+void SyncLevel::getColumnLabel(StringBuf& label) {
 	const int32_t value = getValue();
 	const ::SyncLevel level = syncValueToSyncLevel(value);
 
 	if (level == SYNC_LEVEL_NONE) {
-		Enumeration::getColumnLabel(label, forSmallFont);
-		return;
+		return Enumeration::getColumnLabel(label);
 	}
 
 	// Draw the sync level as a label

--- a/src/deluge/gui/menu_item/sync_level.h
+++ b/src/deluge/gui/menu_item/sync_level.h
@@ -38,7 +38,7 @@ protected:
 	virtual void getNoteLengthName(StringBuf& buffer);
 	void drawPixelsForOled() override;
 	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override;
+	void getColumnLabel(StringBuf& label) override;
 	[[nodiscard]] bool showValueInPopup() const override { return true; };
 
 private:

--- a/src/deluge/gui/menu_item/unison/count.h
+++ b/src/deluge/gui/menu_item/unison/count.h
@@ -64,9 +64,8 @@ public:
 	[[nodiscard]] int32_t getMinValue() const override { return 1; }
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxNumVoicesUnison; }
 
-	void getColumnLabel(StringBuf& buf, bool forSmallFont) override {
-		buf.append(l10n::getView(forSmallFont ? l10n::String::STRING_FOR_UNISON
-		                                      : l10n::String::STRING_FOR_UNISON_NUMBER_SHORT));
+	void getColumnLabel(StringBuf& buf) override {
+		buf.append(l10n::getView(l10n::String::STRING_FOR_UNISON_NUMBER_SHORT));
 	}
 
 	NumberStyle getNumberStyle() const override { return NUMBER; }

--- a/src/deluge/gui/menu_item/voice/polyphony.h
+++ b/src/deluge/gui/menu_item/voice/polyphony.h
@@ -70,9 +70,8 @@ public:
 		return (sound->polyphonic == PolyphonyMode::POLY);
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(deluge::l10n::get(forSmallFont ? l10n::String::STRING_FOR_MAX_VOICES
-		                                            : l10n::String::STRING_FOR_MAX_VOICES_SHORT));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(deluge::l10n::get(l10n::String::STRING_FOR_MAX_VOICES_SHORT));
 	}
 };
 
@@ -125,9 +124,8 @@ public:
 		return Selection::selectButtonPress();
 	}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(deluge::l10n::get(forSmallFont ? l10n::String::STRING_FOR_POLYPHONY
-		                                            : l10n::String::STRING_FOR_POLYPHONY_SHORT));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(deluge::l10n::get(l10n::String::STRING_FOR_POLYPHONY_SHORT));
 	}
 };
 } // namespace deluge::gui::menu_item::voice

--- a/src/deluge/gui/menu_item/voice/portamento.h
+++ b/src/deluge/gui/menu_item/voice/portamento.h
@@ -26,9 +26,8 @@ public:
 
 	Portamento(l10n::String newName) : UnpatchedParam(newName, deluge::modulation::params::UNPATCHED_PORTAMENTO) {}
 
-	void getColumnLabel(StringBuf& label, bool forSmallFont) override {
-		label.append(deluge::l10n::get(forSmallFont ? l10n::String::STRING_FOR_PORTAMENTO
-		                                            : l10n::String::STRING_FOR_PORTAMENTO_SHORT));
+	void getColumnLabel(StringBuf& label) override {
+		label.append(deluge::l10n::get(l10n::String::STRING_FOR_PORTAMENTO_SHORT));
 	}
 };
 

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -458,7 +458,8 @@ envelope::Segment env1DecayMenu{STRING_FOR_DECAY, STRING_FOR_ENV1_DECAY_MENU_TIT
 envelope::Segment env1SustainMenu{STRING_FOR_SUSTAIN, STRING_FOR_ENV1_SUSTAIN_MENU_TITLE, params::LOCAL_ENV_0_SUSTAIN};
 envelope::Segment env1ReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_ENV1_RELEASE_MENU_TITLE, params::LOCAL_ENV_0_RELEASE};
 
-EnvelopeMenu env1Menu{STRING_FOR_ENVELOPE_1, {&env1AttackMenu, &env1DecayMenu, &env1SustainMenu, &env1ReleaseMenu}, 0};
+envelope::EnvelopeMenu env1Menu{
+    STRING_FOR_ENVELOPE_1, {&env1AttackMenu, &env1DecayMenu, &env1SustainMenu, &env1ReleaseMenu}, 0};
 
 // Envelope 2 menu ---------------------------------------------------------------------------------
 envelope::Segment env2AttackMenu{STRING_FOR_ATTACK, STRING_FOR_ENV2_ATTACK_MENU_TITLE, params::LOCAL_ENV_0_ATTACK};
@@ -466,7 +467,8 @@ envelope::Segment env2DecayMenu{STRING_FOR_DECAY, STRING_FOR_ENV2_DECAY_MENU_TIT
 envelope::Segment env2SustainMenu{STRING_FOR_SUSTAIN, STRING_FOR_ENV2_SUSTAIN_MENU_TITLE, params::LOCAL_ENV_0_SUSTAIN};
 envelope::Segment env2ReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_ENV2_RELEASE_MENU_TITLE, params::LOCAL_ENV_0_RELEASE};
 
-EnvelopeMenu env2Menu{STRING_FOR_ENVELOPE_2, {&env2AttackMenu, &env2DecayMenu, &env2SustainMenu, &env2ReleaseMenu}, 1};
+envelope::EnvelopeMenu env2Menu{
+    STRING_FOR_ENVELOPE_2, {&env2AttackMenu, &env2DecayMenu, &env2SustainMenu, &env2ReleaseMenu}, 1};
 
 // Envelope 3 menu ---------------------------------------------------------------------------------
 envelope::Segment env3AttackMenu{STRING_FOR_ATTACK, STRING_FOR_ENV3_ATTACK_MENU_TITLE, params::LOCAL_ENV_0_ATTACK};
@@ -474,7 +476,8 @@ envelope::Segment env3DecayMenu{STRING_FOR_DECAY, STRING_FOR_ENV3_DECAY_MENU_TIT
 envelope::Segment env3SustainMenu{STRING_FOR_SUSTAIN, STRING_FOR_ENV3_SUSTAIN_MENU_TITLE, params::LOCAL_ENV_0_SUSTAIN};
 envelope::Segment env3ReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_ENV3_RELEASE_MENU_TITLE, params::LOCAL_ENV_0_RELEASE};
 
-EnvelopeMenu env3Menu{STRING_FOR_ENVELOPE_3, {&env3AttackMenu, &env3DecayMenu, &env3SustainMenu, &env3ReleaseMenu}, 2};
+envelope::EnvelopeMenu env3Menu{
+    STRING_FOR_ENVELOPE_3, {&env3AttackMenu, &env3DecayMenu, &env3SustainMenu, &env3ReleaseMenu}, 2};
 
 // Envelope 4 menu ---------------------------------------------------------------------------------
 envelope::Segment env4AttackMenu{STRING_FOR_ATTACK, STRING_FOR_ENV4_ATTACK_MENU_TITLE, params::LOCAL_ENV_0_ATTACK};
@@ -482,7 +485,8 @@ envelope::Segment env4DecayMenu{STRING_FOR_DECAY, STRING_FOR_ENV4_DECAY_MENU_TIT
 envelope::Segment env4SustainMenu{STRING_FOR_SUSTAIN, STRING_FOR_ENV4_SUSTAIN_MENU_TITLE, params::LOCAL_ENV_0_SUSTAIN};
 envelope::Segment env4ReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_ENV4_RELEASE_MENU_TITLE, params::LOCAL_ENV_0_RELEASE};
 
-EnvelopeMenu env4Menu{STRING_FOR_ENVELOPE_4, {&env4AttackMenu, &env4DecayMenu, &env4SustainMenu, &env4ReleaseMenu}, 3};
+envelope::EnvelopeMenu env4Menu{
+    STRING_FOR_ENVELOPE_4, {&env4AttackMenu, &env4DecayMenu, &env4SustainMenu, &env4ReleaseMenu}, 3};
 
 // LFO1 menu ---------------------------------------------------------------------------------
 

--- a/src/deluge/hid/display/oled_canvas/canvas.cpp
+++ b/src/deluge/hid/display/oled_canvas/canvas.cpp
@@ -564,9 +564,8 @@ void Canvas::drawGraphicMultiLine(uint8_t const* graphic, int32_t startX, int32_
 ///
 /// @param text Title text
 void Canvas::drawScreenTitle(std::string_view title, bool drawSeparator) {
-	int32_t extraY = (OLED_MAIN_HEIGHT_PIXELS == 64) ? 0 : 1;
-
-	int32_t startY = extraY + OLED_MAIN_TOPMOST_PIXEL;
+	constexpr int32_t extraY = 1;
+	constexpr int32_t startY = extraY + OLED_MAIN_TOPMOST_PIXEL;
 
 	drawString(title, 0, startY, kTextTitleSpacingX, kTextTitleSizeY);
 	if (drawSeparator) {
@@ -601,44 +600,14 @@ void Canvas::invertArea(int32_t xMin, int32_t width, int32_t startY, int32_t end
 }
 
 void Canvas::invertAreaRounded(int32_t xMin, int32_t width, int32_t startY, int32_t endY) {
-	int32_t xMax = xMin + width - 1;
+	invertArea(xMin, width, startY, endY);
 
-	int32_t firstRowY = startY >> 3;
-	int32_t lastRowY = endY >> 3;
-
-	uint8_t startMask = 0xFF << (startY & 7);
-	uint8_t endMask = 0xFF >> (7 - (endY & 7));
-
-	for (int32_t rowY = firstRowY; rowY <= lastRowY; ++rowY) {
-		uint8_t rowMask = 0xFF;
-
-		if (rowY == firstRowY) {
-			rowMask &= startMask;
-		}
-		else if (rowY == lastRowY) {
-			rowMask &= endMask;
-		}
-
-		int32_t yBase = rowY << 3;
-
-		for (int32_t x = xMin; x <= xMax; ++x) {
-			uint8_t mask = rowMask;
-
-			// Mask out any rounded corner pixels
-			if (x == xMin || x == xMax) {
-				if (startY >= yBase && startY < yBase + 8) {
-					mask &= ~(1 << (startY & 7)); // top corners
-				}
-				if (endY >= yBase && endY < yBase + 8) {
-					mask &= ~(1 << (endY & 7)); // bottom corners
-				}
-			}
-
-			if (mask) {
-				image_[rowY][x] ^= mask;
-			}
-		}
-	}
+	// restore corners back
+	const int32_t xMax = xMin + width - 1;
+	invertArea(xMin, 1, startY, startY);
+	invertArea(xMax, 1, startY, startY);
+	invertArea(xMin, 1, endY, endY);
+	invertArea(xMax, 1, endY, endY);
 }
 
 /// inverts just the left edge


### PR DESCRIPTION
As title says. 

Additionally, wrapped the new EnvelopeMenu class into missing namespace, and did a small refactor for invertAreaRounded: reused the current implementation; and removed redundant code for small font labels support. 

Also moved things a lil bit down (1px) in the horizontal menu to better balance between visibility (still looks clear from an angle) and cramping things, previously it was a bit too high