### PR TITLE
Horizontal menus: accessibility option support

### DIFF
--- a/src/deluge/gui/menu_item/envelope/envelope_menu.h
+++ b/src/deluge/gui/menu_item/envelope/envelope_menu.h
@@ -66,8 +66,7 @@ public:
 
 		// Calculate widths
 		const float attackWidth = (attack / 50.0f) * maxSegmentWidth;
-		const float decayNormalized =
-		    sigmoidLikeCurve(decay, 10.0f, 50.0f); // Maps 0-50 to 0-1 range with steep start
+		const float decayNormalized = sigmoidLikeCurve(decay, 10.0f, 50.0f); // Maps 0-50 to 0-1 range with steep start
 		const float decayWidth = decayNormalized * maxSegmentWidth;
 
 		// X positions

--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -87,7 +87,8 @@ void HorizontalMenu::drawPixelsForOled() {
 		int32_t contentHeight = boxHeight;
 
 		constexpr int32_t labelHeight = kTextSpacingY;
-		constexpr int32_t labelY = baseY + boxHeight - labelHeight;;
+		constexpr int32_t labelY = baseY + boxHeight - labelHeight;
+		;
 		std::optional<ColumnLabelPosition> labelPos;
 
 		if (item->showColumnLabel()) {


### PR DESCRIPTION
Highlight the selected item in the horz menus by drawing a line if the accessibility option is enabled

Additionally adjusted the sustain line in the envelope menu to reach full width at 50 value (there was a small bug)