### PR TITLE
Feature/unipolar modulators

### DIFF
--- a/src/deluge/modulation/patch/patch_cable.cpp
+++ b/src/deluge/modulation/patch/patch_cable.cpp
@@ -20,12 +20,14 @@
 #include "util/fixedpoint.h"
 
 Polarity stringToPolarity(const std::string_view string) {
-	switch (string) {
-	case "unipolar":
+	if (string == "unipolar") {
 		return Polarity::UNIPOLAR;
-	case "bipolar":
+	}
+	else if (string == "bipolar") {
 		return Polarity::BIPOLAR;
-	default:
+	}
+	else {
+
 		return Polarity::BIPOLAR; // Default to bipolar
 	}
 }

--- a/src/deluge/modulation/patch/patch_cable.cpp
+++ b/src/deluge/modulation/patch/patch_cable.cpp
@@ -19,6 +19,26 @@
 #include "definitions_cxx.hpp"
 #include "util/fixedpoint.h"
 
+Polarity stringToPolarity(const std::string_view string) {
+	switch (string) {
+	case "unipolar":
+		return Polarity::UNIPOLAR;
+	case "bipolar":
+		return Polarity::BIPOLAR;
+	default:
+		return Polarity::BIPOLAR; // Default to bipolar
+	}
+}
+std::string_view polarityToString(const Polarity polarity) {
+	switch (polarity) {
+	case Polarity::UNIPOLAR:
+		return "unipolar";
+	case Polarity::BIPOLAR:
+		return "bipolar";
+	default:
+		return "bipolar";
+	}
+}
 void PatchCable::setup(PatchSource newFrom, uint8_t newTo, int32_t newAmount) {
 	from = newFrom;
 	destinationParamDescriptor.setToHaveParamOnly(newTo);

--- a/src/deluge/modulation/patch/patch_cable.h
+++ b/src/deluge/modulation/patch/patch_cable.h
@@ -30,6 +30,8 @@ enum class Polarity : uint8_t {
 	UNIPOLAR = 0,
 	BIPOLAR = 1,
 };
+Polarity stringToPolarity(std::string_view string);
+std::string_view polarityToString(Polarity polarity);
 
 class PatchCable {
 public:

--- a/src/deluge/modulation/patch/patch_cable.h
+++ b/src/deluge/modulation/patch/patch_cable.h
@@ -26,6 +26,11 @@ class Sound;
 class ParamManagerForTimeline;
 class InstrumentClip;
 
+enum class Polarity : uint8_t {
+	UNIPOLAR = 0,
+	BIPOLAR = 1,
+};
+
 class PatchCable {
 public:
 	PatchCable() = default;
@@ -33,13 +38,29 @@ public:
 	bool isActive();
 	void initAmount(int32_t value);
 	void makeUnusable();
-
+	/// @brief Converts a patch cable source to the correct polarity.
+	/// The source is required because some sources are stored unipolar
+	int32_t toPolarity(int32_t value) {
+		// aftertouch is stored unipolar, all others are stored bipolar
+		if (from == PatchSource::AFTERTOUCH) {
+			if (polarity == Polarity::UNIPOLAR) {
+				return value;
+			}
+			return (value - (std::numeric_limits<int32_t>::max() / 2)) * 2; // Convert from unipolar to bipolar
+		}
+		// Because unipolar mod wheel and bipolar MPE y share the same mod source we can't convert :(
+		if (from == PatchSource::Y || polarity == Polarity::BIPOLAR) {
+			return value;
+		}
+		return (value / 2) + (std::numeric_limits<int32_t>::max() / 2); // Convert from bipolar to unipolar
+	}
 	[[gnu::always_inline]] [[nodiscard]] int32_t applyRangeAdjustment(int32_t value) const {
 		int32_t small = multiply_32x32_rshift32(value, *this->rangeAdjustmentPointer);
 		return signed_saturate<32 - 5>(small) << 3; // Not sure if these limits are as wide as they could be...
 	}
 
-	PatchSource from;
+	PatchSource from{PatchSource::NONE};
+	Polarity polarity{Polarity::BIPOLAR};
 	ParamDescriptor destinationParamDescriptor;
 	AutoParam param; // Amounts have to be within +1073741824 and -1073741824
 	int32_t const* rangeAdjustmentPointer = nullptr;

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -813,7 +813,7 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 			ParamDescriptor destinationParamDescriptor;
 			destinationParamDescriptor.setToNull();
 			AutoParam tempParam;
-
+			Polarity polarity = Polarity::BIPOLAR;
 			bool rangeAdjustable = false;
 			while (*(tagName = reader.readNextTagOrAttributeName())) {
 				if (!strcmp(tagName, "source")) {
@@ -829,6 +829,9 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 				else if (!strcmp(tagName, "rangeAdjustable")) { // Files before V3.2 had this
 					rangeAdjustable = reader.readTagOrAttributeValueInt();
 				}
+				else if (!strcmp(tagName, "polarity")) {
+					polarity = stringToPolarity(reader.readTagOrAttributeValue());
+				}
 				else if (!strcmp(tagName, "depthControlledBy")) {
 					reader.match('[');
 					while (reader.match('{') && *(tagName = reader.readNextTagOrAttributeName())
@@ -837,7 +840,7 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 							reader.match('{');
 							PatchSource rangeSource = PatchSource::NONE;
 							AutoParam tempRangeParam;
-							Polarity polarity = Polarity::BIPOLAR;
+							Polarity rangePolarity = Polarity::BIPOLAR;
 							while (*(tagName = reader.readNextTagOrAttributeName())) {
 								if (!strcmp(tagName, "source")) {
 									rangeSource = stringToSource(reader.readTagOrAttributeValue());
@@ -846,7 +849,7 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 									tempRangeParam.readFromFile(reader, readAutomationUpToPos);
 								}
 								else if (!strcmp(tagName, "polarity")) {
-									polarity = stringToPolarity(reader.readTagOrAttributeValue());
+									rangePolarity = stringToPolarity(reader.readTagOrAttributeValue());
 								}
 								reader.exitTag();
 							}
@@ -863,7 +866,7 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 								// And write this range-adjusting cable's details
 								patchCables[numPatchCables].from = rangeSource;
 								patchCables[numPatchCables].param.cloneFrom(&tempRangeParam, true);
-								patchCables[numPatchCables].polarity = polarity;
+								patchCables[numPatchCables].polarity = rangePolarity;
 								numPatchCables++;
 							}
 						} // end of patchcable
@@ -912,7 +915,7 @@ doneWithThisRangeCable:
 				patchCables[numPatchCables].from = source;
 				patchCables[numPatchCables].destinationParamDescriptor = destinationParamDescriptor;
 				patchCables[numPatchCables].param.cloneFrom(&tempParam, true);
-
+				patchCables[numPatchCables].polarity = polarity;
 				numPatchCables++;
 			}
 			else {
@@ -959,10 +962,7 @@ void PatchCableSet::writePatchCablesToFile(Serializer& writer, bool writeAutomat
 		writer.writeAttribute("destination",
 		                      params::paramNameForFile(params::Kind::UNPATCHED_SOUND,
 		                                               patchCables[c].destinationParamDescriptor.getJustTheParam()));
-		writer.writeAttribute(
-		    "polarity",
-		    polarityToString(patchCables[c].polarity).data()); // If this is a range-adjusting cable, this will
-		                                                       // be BIPOLAR, otherwise it will be UNIPOLAR.)
+		writer.writeAttribute("polarity", polarityToString(patchCables[c].polarity).data());
 		writer.insertCommaIfNeeded();
 		writer.write("\n");
 		writer.printIndents();
@@ -985,6 +985,7 @@ void PatchCableSet::writePatchCablesToFile(Serializer& writer, bool writeAutomat
 
 				writer.writeOpeningTagBeginning("patchCable", true);
 				writer.writeAttribute("source", sourceToString(patchCables[d].from));
+				writer.writeAttribute("polarity", polarityToString(patchCables[c].polarity).data());
 				writer.insertCommaIfNeeded();
 				writer.write("\n");
 				writer.printIndents();

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -837,12 +837,16 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 							reader.match('{');
 							PatchSource rangeSource = PatchSource::NONE;
 							AutoParam tempRangeParam;
+							Polarity polarity = Polarity::BIPOLAR;
 							while (*(tagName = reader.readNextTagOrAttributeName())) {
 								if (!strcmp(tagName, "source")) {
 									rangeSource = stringToSource(reader.readTagOrAttributeValue());
 								}
 								else if (!strcmp(tagName, "amount")) {
 									tempRangeParam.readFromFile(reader, readAutomationUpToPos);
+								}
+								else if (!strcmp(tagName, "polarity")) {
+									polarity = stringToPolarity(reader.readTagOrAttributeValue());
 								}
 								reader.exitTag();
 							}
@@ -859,7 +863,7 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 								// And write this range-adjusting cable's details
 								patchCables[numPatchCables].from = rangeSource;
 								patchCables[numPatchCables].param.cloneFrom(&tempRangeParam, true);
-
+								patchCables[numPatchCables].polarity = polarity;
 								numPatchCables++;
 							}
 						} // end of patchcable
@@ -955,6 +959,10 @@ void PatchCableSet::writePatchCablesToFile(Serializer& writer, bool writeAutomat
 		writer.writeAttribute("destination",
 		                      params::paramNameForFile(params::Kind::UNPATCHED_SOUND,
 		                                               patchCables[c].destinationParamDescriptor.getJustTheParam()));
+		writer.writeAttribute(
+		    "polarity",
+		    polarityToString(patchCables[c].polarity).data()); // If this is a range-adjusting cable, this will
+		                                                       // be BIPOLAR, otherwise it will be UNIPOLAR.)
 		writer.insertCommaIfNeeded();
 		writer.write("\n");
 		writer.printIndents();

--- a/src/deluge/modulation/patch/patcher.cpp
+++ b/src/deluge/modulation/patch/patcher.cpp
@@ -191,6 +191,9 @@ int32_t Patcher::cableToExpParam(int32_t running_total, const PatchCable& patch_
 		if (source == PatchSource::AFTERTOUCH) {
 			source_value = (source_value - 1073741824) << 1;
 		}
+		else {
+			source_value = patch_cable.toPolarity(source_value);
+		}
 
 		int32_t cable_strength = patch_cable.param.getCurrentValue();
 		running_total = cableToLinearParamWithoutRangeAdjustment(running_total, source_value, cable_strength);
@@ -221,7 +224,7 @@ int32_t Patcher::cableToExpParam(int32_t running_total, const PatchCable& patch_
 			PatchCable& patch_cable = patch_cable_set.patchCables[cable];
 			PatchSource source = patch_cable.from;
 			int32_t source_value = source_values_[std::to_underlying(source)];
-
+			source_value = patch_cable.toPolarity(source_value);
 			int32_t cable_strength = patch_cable.param.getCurrentValue();
 			running_total = cableToLinearParam(running_total, patch_cable, source_value, cable_strength);
 		}
@@ -246,7 +249,7 @@ int32_t Patcher::cableToExpParam(int32_t running_total, const PatchCable& patch_
 		for (int32_t c = destination->firstCable; c < destination->endCable; c++) {
 			PatchCable& patch_cable = patch_cable_set.patchCables[c];
 			int32_t source_value = source_values_[std::to_underlying(patch_cable.from)];
-
+			source_value = patch_cable.toPolarity(source_value);
 			int32_t cable_strength = patch_cable_set.getModifiedPatchCableAmount(c, param);
 			running_total = cableToExpParam(running_total, patch_cable, source_value, cable_strength);
 		}

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -36,6 +36,7 @@ import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
 - Added LPF to Mutable Instruments Reverb
 - Added two more envelopes (Envelope 3 and Envelope 4)
 - Added two more LFOs (LFO 3 -global- and LFO 4 -per voice-)
+- Patch cables can be toggled to unipolar or bipolar mode. Cross screen will toggle the mode of the currently selected patch cable, and is lit in unipolar mode. (UI will be improved later)
 
 #### <ins>Per-clip Stutter with options: Direction and Quantize</ins>
 

--- a/website/src/content/docs/features/community_features.md
+++ b/website/src/content/docs/features/community_features.md
@@ -141,20 +141,17 @@ Here is a list of general improvements that have been made, ordered from newest 
   **2. `PICKUP`:** The Deluge will ignore changes to its internal encoder position/Parameter value until the MIDI
   encoder/Fader's position is equal to the Deluge encoder position. After which the MIDI encoder/Fader will move in sync
   with the Deluge.
-
   - Note: this mode will behave like the `JUMP` mode when you are recording or step editing automation.
 
   **3. `SCALE`:** The Deluge will increase/decrease its internal encoder position/Parameter value relative to the change
   of the MIDI encoder/Fader position and the amount of "runway" remaining on the MIDI controller. Once the MIDI
   controller reaches its maximum or minimum position, the MIDI encoder/Fader will move in sync with the Deluge. The
   Deluge value will always decrease/increase in the same direction as the MIDI controller.
-
   - Note: this mode will behave like the `JUMP` mode when you are recording or step editing automation.
 
   **4. `RELATIVE`:** The Deluge will increase/decrease its internal encoder position/Parameter value using the relative value changes (offset) sent by the controller. The controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
 
 - (#837) `MIDI control over transpose / scale.`
-
   - Accessed via external MIDI via a new learnable global MIDI command in `SETTINGS > MIDI > CMD > TRANSPOSE`. It
     learns the entire channel, not just a single note.
   - Accessed internally from a MIDI clip. Turn the channel to the end of the list past the MPE zones to 'Transpose'.
@@ -187,7 +184,6 @@ Here is a list of general improvements that have been made, ordered from newest 
 
 - (#889) `Master MIDI Follow Mode` whereby after setting a master MIDI follow channel for Synth/MIDI/CV clips, Kit
   clips, and for Parameters, all MIDI (notes + cc’s) received will be directed to control the active or selected clip).
-
   - For a detailed description of this feature, please refer to the feature
     documentation: [MIDI Follow Mode Documentation](/features/midi_follow_mode)
   - Comes with a MIDI feedback mode to send updated parameter values on the MIDI follow channel for learned MIDI cc's.
@@ -233,7 +229,6 @@ Here is a list of general improvements that have been made, ordered from newest 
 - (#178) New option (`FINE TEMPO` in the `COMMUNITY FEATURES` menu). Inverts the push+turn behavior of the `TEMPO`
   encoder. With this option enabled the tempo changes by 1 when unpushed and ~4 when pushed (vs ~4 unpushed and 1 pushed
   in the official firmware).
-
   - This feature is `ON` by default and can be set to `ON` or `OFF` via `SETTINGS > COMMUNITY FEATURES`.
 
 - (#2264) Swing interval can now be changed by holding `TAP TEMPO` button while turning the `TEMPO` encoder. To view current
@@ -348,7 +343,6 @@ Here is a list of general improvements that have been made, ordered from newest 
 - (#2371) Source can now also be set to a specific track on the deluge. This enables an additional TRACK menu to choose
   which track to record from. The source can also be selected by pressing a clip's pad while in the audio source selection menu.
 - (#2702) Monitoring is now set by the audio output mode. This is done by turning the select encoder
-
   - Player: Monitoring is off, overdubs work by cloning. This is intended to be used for playing a static audio file or recording without monitoring.
 
   - Sampler: Monitoring is on, monitoring turns off after recording, overdubs work by cloning. This is intended to be used for sampling from an ongoing audio stream where you only want to hear the part you're looping afterwards
@@ -498,7 +492,6 @@ Here is a list of features that have been added to the firmware as a list, group
   milliseconds) and Sidechain `HPF` (shown in Hz). The sidechain HPF is useful to remove some bass from the compressor
   level detection, which sounds like an increase in bass allowed through the compression. There is also a blend control
   to allow parallel compression.
-
   - `ATTACK`: 0ms - 63ms
 
   - `RELEASE`: 50ms - 363ms
@@ -525,7 +518,6 @@ Here is a list of features that have been added to the firmware as a list, group
 - (#196 and #1018) Holding a clip in `SONG GRID VIEW` or the status pad for a clip in `SONG ROW VIEW` and pressing :key[Select] brings up a `CLIP SETTINGS` menu. In this menu, you will find a submenu for `CLIP MODE`.
 
   The `CLIP MODE` menu enables you the set the following launch style options for a clip:
-
   - **`INFINITE (INF)`** - the default Deluge launch style.
   - **`Fill (FILL)`** - Fill clip.
     - When launched it will schedule itself to start at such a time that it _finishes_ at the start of the next
@@ -739,7 +731,6 @@ In `KEYBOARD VIEW`, macros are available as a sidebar control.
 #### 4.2.5 - Grain FX
 
 - (#363 and #2815) New `GRAIN` added to Mod FX.
-
   - Parameters:
     - **`MOD RATE`:** Sets Grain Rate (0.5hz - 180hz)
     - **`MOD DEPTH - GRAIN AMOUNT (AMNT)`:** Controls Grain Volume / Dry Wet Mix
@@ -768,7 +759,6 @@ In `KEYBOARD VIEW`, macros are available as a sidebar control.
 #### 4.2.9 - Reverb Improvements
 
 - (#1065) New reverb models are available for selection inside of the `FX > REVERB > MODEL` menu. These include:
-
   - Freeverb (the original Deluge reverb)
   - Mutable (an adapted version of the reverb found in Mutable Instruments' Rings module)
     - The Mutable reverb model has been set as the default reverb model for new songs. Old songs will respect the
@@ -1022,7 +1012,6 @@ to each individual note onset. (#1978)
 
 - (#250) Enables keyboard layout which emulates a monome grid for monome norns using Midigrid mod on norns by
   rendering incoming MIDI notes on channel 16 as white pads using velocity for pad brightness.
-
   - This feature is `OFF` by default and can be set to `ON` or `OFF` in the `COMMUNITY FEATURES` menu (
     via `SETTINGS > COMMUNITY FEATURES`).
   - Deluge has multiple USB ports, 3 as of this writing. Use Deluge 1 as the device on norns.
@@ -1053,7 +1042,6 @@ to each individual note onset. (#1978)
 
 - (#901) In the keyboard view, a control can be mapped to each column of pads in the sidebar. You can change which
   control is selected by holding the top pad and turning the horizontal encoder. Controls include:
-
   - **`Velocity (VEL - Red):`** Low velocity is on the bottom pad and high on the top pad scaled linearly.
     The range can be adjusted by holding the top or bottom pad and scrolling the vertical encoder.
     Hold a pad down to change the velocity of notes played while held. The velocity will return to
@@ -1115,7 +1103,6 @@ to each individual note onset. (#1978)
 #### 4.4.2 - Scales
 
 - (#991) Added new scales for instrument clips.
-
   - The new set of scales is:
     - `7-note scales:` Major, Minor, Dorian, Phrygian, Lydian, Mixolydian, Locrian, Melodic Minor, Hungarian Minor,
       Marva (Indian), Arabian
@@ -1134,7 +1121,6 @@ to each individual note onset. (#1978)
     Major scale).
 
 - (#2365) Added learning a user specified scale.
-
   - Press :key[Learn + Scale] while in clip view. Notes from current clip & all scale mode clips are learned as the "USER"
     scale. This scale is part of the normal scale rotation, accessible with :key[Shift + Scale], and saved as part of the song.
     If another user scale is learned, the previous one is overwritten: currently each song can only have one user scale.
@@ -1191,7 +1177,6 @@ to each individual note onset. (#1978)
 
 - (#1114) A new synth type is added fully compatible with DX7 patches, including editing of all DX7 parameters. This is implemented
   as an oscillator type within the subtractive engine, so it can be combined with filters and other features of this engine.
-
   - Patches can be imported from the common 32-patch bank syx-file format, and afterwards saved as SYNTH presets or as part of songs.
 
   - As the UI and implementation is still experimental, a community setting has to be activated to create new DX7 patches. See the separate document for details.

--- a/website/src/content/docs/features/looping_in_grid_view.mdx
+++ b/website/src/content/docs/features/looping_in_grid_view.mdx
@@ -42,7 +42,6 @@ https://github.com/user-attachments/assets/be1862c0-ef45-45fa-911b-8ec588246280
 To use the technique shown in the video above, you must follow these steps:
 
 - Enable Create + Record:
-
   - Enter `SETTINGS > DEFAULTS > UI > SONG > GRID > EMPTY PADS > CREATE + RECORD` and select `ENABLED`
   - Exit Settings menu to save settings
 

--- a/website/src/content/docs/features/save_load_patterns.md
+++ b/website/src/content/docs/features/save_load_patterns.md
@@ -70,17 +70,14 @@ Press and hold `PLAY` while in Pattern-Load Menu
 **For Rhythmic Instruments (Kit, Drums)**
 
 - Save Kit Pattern:
-
   1. Enable `AFFECT_ENTIRE`
   2. `SAVE+PUSH_HORIZONTAL_ENCODER`
 
 - Load Kit Pattern:
-
   1. Enable `AFFECT_ENTIRE`
   2. `LOAD+PUSH_HORIZONTAL_ENCODER`
 
 - Load Kit Pattern without overwriting existing Notes:
-
   1. Enable `AFFECT_ENTIRE`
   2. `LOAD+CROSS_SCREEN+PUSH_HORIZONTAL_ENCODER`
 
@@ -94,19 +91,16 @@ _Remark: If noScaling is set, Pattern will allways overwrite existing Notes and 
   Press and hold `PLAY` while in Pattern-Load Menu
 
 - Save Drum Pattern:
-
   1. Disable `AFFECT_ENTIRE`
   2. Select Drum Row to save (Audition Pad)
   3. `SAVE+PUSH_HORIZONTAL_ENCODER`
 
 - Load Drum Pattern:
-
   1. Disable `AFFECT_ENTIRE`
   2. Select Drum Row to save (Audition Pad)
   3. `LOAD+PUSH_HORIZONTAL_ENCODER`
 
 - Load Drum Pattern without overwriting existing Notes:
-
   1. Disable `AFFECT_ENTIRE`
   2. Select Drum Row to save (Audition Pad)
   3. `LOAD+CROSS_SCREEN+PUSH_HORIZONTAL_ENCODER`

--- a/website/src/content/docs/reference/menu_hierarchies.md
+++ b/website/src/content/docs/reference/menu_hierarchies.md
@@ -576,11 +576,9 @@ The Song menu contains the following menu hierarchy:
 - LPF (if Mutable is Selected)
 - Pan
 - Reverb Sidechain (SIDE)
-
   - Volume Ducking (VOLU)
 
 - Stutter (STUT)
-
   - Quantize (QTZ)
   - Reverse (REVE)
   - Ping-Pong (PING)
@@ -866,11 +864,9 @@ The Sound menu contains the following menu hierarchy:
 - LPF (if Mutable is Selected)
 - Pan
 - Reverb Sidechain (SIDE)
-
   - Volume Ducking (VOLU)
 
 - Stutter (STUT)
-
   - Use Song Settings (SONG)
   - Quantize (QTZ)
   - Reverse (REVE)
@@ -941,7 +937,6 @@ The Sound menu contains the following menu hierarchy:
 <details><summary>Oscillator 1 (OSC1) </summary>
 
 - Type
-
   - Sine
   - Triangle (TRIA)
   - Square (SQUA)
@@ -980,7 +975,6 @@ The Sound menu contains the following menu hierarchy:
 <details><summary>Oscillator 2 (OSC2) </summary>
 
 - Type
-
   - Sine
   - Triangle (TRIA)
   - Square (SQUA)
@@ -1133,7 +1127,6 @@ The Sound menu contains the following menu hierarchy:
 - Max Voices (VCNT)
 - Portamento (PORT)
 - Unison (UNIS)
-
   - Unison Number (NUM)
   - Unison Detune (DETU)
   - Unison Stereo Spread (SPRE)
@@ -1935,11 +1928,9 @@ The Audio Clip menu contains the following menu hierarchy:
 - LPF (if Mutable is Selected)
 - Pan
 - Reverb Sidechain (SIDE)
-
   - Volume Ducking (VOLU)
 
 - Stutter (STUT)
-
   - Use Song Settings (SONG)
   - Quantize (QTZ)
   - Reverse (REVE)


### PR DESCRIPTION
Allows patch cables to be changed from bipolar to unipolar on a per cable basis

temporary UI is press cross screen while in patch cable menu to toggle from unipolar to bipolar