### PR TITLE
Fix/ Increase grid view pad brightness

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3355,11 +3355,6 @@ RGB SessionView::gridRenderClipColor(Clip* clip, int32_t x, int32_t y, bool rend
 	}
 
 	RGB resultColour = RGB::fromHue(clip->output->colour);
-	// when selecting a clip, dim all other clip pads a bit
-	// so that the selected clip pad can be lit a bit brighter
-	if (renderPulse && (x != gridFirstPressedX || y != gridFirstPressedY)) {
-		resultColour = resultColour.adjust(255, 2);
-	}
 
 	// Black phase of arm flashing
 	if (view.clipArmFlashOn && clip->armState != ArmState::OFF) {


### PR DESCRIPTION
Removed grid view pad brightness adjustment which was added when the "selected clip pulsing" feature was added (to add greater focus on the selected clip).

I don't think it's absolutely necessary to do that, and since we've received complaints about the brightness, I am removing the adjustment

Fix #3894