### PR TITLE
Bugfix/ Fixed unstable menu item selection in the Combined horizontal menus

### DIFF
--- a/src/deluge/gui/menu_item/horizontal_menu.h
+++ b/src/deluge/gui/menu_item/horizontal_menu.h
@@ -45,14 +45,15 @@ protected:
 	Layout layout = DYNAMIC;
 	int32_t lastSelectedItemPosition = kNoSelection;
 
-	ActionResult selectMenuItemOnVisiblePage(int32_t selectedColumn);
-	ActionResult switchVisiblePage(int32_t direction);
+private:
 	virtual void renderMenuItems(std::span<MenuItem*> items, const MenuItem* currentItem);
 	virtual Paging splitMenuItemsByPages(MenuItem* currentItem);
-	static void displayPopup(MenuItem* menuItem);
-
-private:
+	virtual ActionResult selectMenuItem(std::span<MenuItem*> pageItems, const MenuItem* previous,
+	                                    int32_t selectedColumn);
 	void updateSelectedMenuItemLED(int32_t itemNumber);
+	ActionResult switchVisiblePage(int32_t direction);
+
+	static void displayPopup(MenuItem* menuItem);
 	static void renderColumnLabel(MenuItem* menuItem, int32_t labelY, int32_t slotStartX, int32_t slotWidth,
 	                              bool isSelected);
 };

--- a/src/deluge/gui/menu_item/submenu/reverb_sidechain.h
+++ b/src/deluge/gui/menu_item/submenu/reverb_sidechain.h
@@ -20,8 +20,7 @@
 #include "processing/engines/audio_engine.h"
 
 namespace deluge::gui::menu_item::submenu {
-
-class Reverb final : public HorizontalMenu {
+class ReverbSidechain final : public HorizontalMenu {
 public:
 	using HorizontalMenu::HorizontalMenu;
 
@@ -30,5 +29,4 @@ public:
 		Submenu::beginSession(navigatedBackwardFrom);
 	}
 };
-
 } // namespace deluge::gui::menu_item::submenu

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -202,7 +202,7 @@
 #include "gui/menu_item/submenu/bend.h"
 #include "gui/menu_item/submenu/mod_fx.h"
 #include "gui/menu_item/submenu/modulator.h"
-#include "gui/menu_item/submenu/reverb.h"
+#include "gui/menu_item/submenu/reverb_sidechain.h"
 #include "gui/menu_item/submenu/sidechain.h"
 #include "gui/menu_item/swing/interval.h"
 #include "gui/menu_item/synth_mode.h"
@@ -642,16 +642,16 @@ submenu::Sidechain sidechainMenu{STRING_FOR_SIDECHAIN,
                                      &sidechainShapeMenu,
                                  }};
 
-submenu::Reverb reverbSidechainMenu{STRING_FOR_REVERB_SIDECHAIN,
-                                    STRING_FOR_REVERB_SIDECH_MENU_TITLE,
-                                    {
-                                        &reverbSidechainVolumeMenu,
-                                        &reverbSidechainShapeMenu,
-                                        &sidechainAttackMenu,
-                                        &sidechainReleaseMenu,
-                                        &sidechainSyncMenu,
-                                    },
-                                    HorizontalMenu::FIXED};
+submenu::ReverbSidechain reverbSidechainMenu{STRING_FOR_REVERB_SIDECHAIN,
+                                             STRING_FOR_REVERB_SIDECH_MENU_TITLE,
+                                             {
+                                                 &reverbSidechainVolumeMenu,
+                                                 &reverbSidechainShapeMenu,
+                                                 &sidechainAttackMenu,
+                                                 &sidechainReleaseMenu,
+                                                 &sidechainSyncMenu,
+                                             },
+                                             HorizontalMenu::FIXED};
 
 // Reverb ----------------------------------------------------------------------------------
 reverb::Amount reverbAmountMenu{STRING_FOR_AMOUNT, STRING_FOR_REVERB_AMOUNT, params::GLOBAL_REVERB_AMOUNT};
@@ -677,8 +677,7 @@ HorizontalMenu reverbMenu{
         &reverbSidechainMenu,
     },
 };
-
-submenu::Reverb reverbMenuWithoutSidechain{
+HorizontalMenu reverbMenuWithoutSidechain{
     STRING_FOR_REVERB,
     {&reverbAmountMenu, &reverbRoomSizeMenu, &reverbDampingMenu, &reverbWidthMenu, &reverbModelMenu, &reverbPanMenu,
      &reverbHPFMenu, &reverbLPFMenu},
@@ -854,7 +853,7 @@ HorizontalMenu globalReverbMenu{
     },
 };
 
-submenu::Reverb globalReverbMenuWithoutSidechain{
+HorizontalMenu globalReverbMenuWithoutSidechain{
     STRING_FOR_REVERB,
     {
         &globalReverbSendAmountMenu,


### PR DESCRIPTION
Fix for a couple of bugs in the new Combined horizontal menus:

- Selected page was getting reset on page switching if target position was pointing to non-relevant item
- Selected item was getting reset if user selected non-relevant item