### PR TITLE
Refactor/ Reduce memory allocation for the Combined horizontal menus

### DIFF
--- a/src/deluge/gui/menu_item/envelope/envelope_menu.h
+++ b/src/deluge/gui/menu_item/envelope/envelope_menu.h
@@ -27,12 +27,12 @@ class EnvelopeMenu final : public HorizontalMenu {
 public:
 	using HorizontalMenu::HorizontalMenu;
 
-	void renderMenuItems(std::span<MenuItem*> menuItems, const MenuItem* currentItem) override {
+	void renderMenuItems(std::span<MenuItem*> items, const MenuItem* currentItem) override {
 		// Get the values in 0-50 range
-		const int32_t attack = static_cast<Segment*>(menuItems[0])->getValue();
-		const int32_t decay = static_cast<Segment*>(menuItems[1])->getValue();
-		const int32_t sustain = static_cast<Segment*>(menuItems[2])->getValue();
-		const int32_t release = static_cast<Segment*>(menuItems[3])->getValue();
+		const int32_t attack = static_cast<Segment*>(items[0])->getValue();
+		const int32_t decay = static_cast<Segment*>(items[1])->getValue();
+		const int32_t sustain = static_cast<Segment*>(items[2])->getValue();
+		const int32_t release = static_cast<Segment*>(items[3])->getValue();
 
 		// Constants
 		constexpr int32_t totalWidth = OLED_MAIN_WIDTH_PIXELS;
@@ -84,7 +84,7 @@ public:
 
 		// Draw transition squares
 		selectedX = -1, selectedY = -1;
-		const int32_t selectedPos = std::distance(menuItems.begin(), std::ranges::find(menuItems, currentItem));
+		const int32_t selectedPos = std::distance(items.begin(), std::ranges::find(items, currentItem));
 
 		// Attack → Decay
 		drawTransitionSquare(attackX, peakY, selectedPos == 0);

--- a/src/deluge/gui/menu_item/horizontal_menu.h
+++ b/src/deluge/gui/menu_item/horizontal_menu.h
@@ -45,14 +45,14 @@ protected:
 	Layout layout = DYNAMIC;
 	int32_t lastSelectedItemPosition = kNoSelection;
 
-private:
 	virtual void renderMenuItems(std::span<MenuItem*> items, const MenuItem* currentItem);
-	virtual Paging splitMenuItemsByPages(MenuItem* currentItem);
-	virtual ActionResult selectMenuItem(std::span<MenuItem*> pageItems, const MenuItem* previous,
-	                                    int32_t selectedColumn);
-	void updateSelectedMenuItemLED(int32_t itemNumber);
-	ActionResult switchVisiblePage(int32_t direction);
+	virtual Paging splitMenuItemsByPages(std::span<MenuItem*> items, const MenuItem* currentItem);
+	virtual ActionResult selectMenuItem(std::span<MenuItem*> pageItems, const MenuItem* previous, int32_t selectedColumn);
 
+private:
+	void updateSelectedMenuItemLED(int32_t itemNumber);
+	void renderPageCounters() const;
+	ActionResult switchVisiblePage(int32_t direction);
 	static void displayPopup(MenuItem* menuItem);
 	static void renderColumnLabel(MenuItem* menuItem, int32_t labelY, int32_t slotStartX, int32_t slotWidth,
 	                              bool isSelected);

--- a/src/deluge/gui/menu_item/horizontal_menu_combined.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu_combined.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "horizontal_menu_combined.h"
+#include "deluge/gui/menu_item/submenu.h"
+#include <gui/menu_item/horizontal_menu.h>
+#include <string_view>
+
+namespace deluge::gui::menu_item {
+
+std::string_view HorizontalMenuCombined::getTitle() const {
+	return current_submenu_->getTitle();
+}
+
+void HorizontalMenuCombined::beginSession(MenuItem* navigatedBackwardFrom) {
+	navigated_backward_from = navigatedBackwardFrom;
+
+	// Some submenus modify soundEditor parameters at the start of the session,
+	// so we need to call it for each submenu to ensure pages are counted correctly
+	for (const auto submenu : submenus_) {
+		submenu->beginSession();
+	}
+}
+
+bool HorizontalMenuCombined::focusChild(const MenuItem* child) {
+	if (child == nullptr) {
+		return true;
+	}
+
+	// Try to select the specified child if it's among the submenu items
+	for (auto* submenu : submenus_) {
+		auto& items = submenu->items;
+
+		auto it = std::ranges::find(items, child);
+		if (it == items.end())
+			continue;
+
+		// Found the child
+		if (isItemRelevant(*it)) {
+			current_item_ = it;
+			return true;
+		}
+
+		// Child is not relevant — search left for the closest relevant item
+		for (int32_t i = std::distance(items.begin(), it); i >= 0; --i) {
+			if (isItemRelevant(items[i])) {
+				current_item_ = items.begin() + i;
+				return true;
+			}
+		}
+	}
+	return true;
+}
+
+void HorizontalMenuCombined::renderMenuItems(std::span<MenuItem*> items, const MenuItem*) {
+	current_submenu_->renderMenuItems(items, *current_item_);
+}
+
+ActionResult HorizontalMenuCombined::selectMenuItem(std::span<MenuItem*> pageItems, const MenuItem* previous,
+                                                    int32_t selectedColumn) {
+	const auto result = current_submenu_->selectMenuItem(pageItems, previous, selectedColumn);
+	current_item_ = current_submenu_->current_item_;
+	return result;
+}
+
+HorizontalMenu::Paging HorizontalMenuCombined::splitMenuItemsByPages(std::span<MenuItem*>, const MenuItem*) {
+	// Combine all pages of all submenus into one list
+	std::vector<Page> pages{};
+	current_submenu_ = nullptr;
+
+	int32_t visiblePageNumber = 0;
+	int32_t selectedItemPositionOnPage = 0;
+	int32_t currentPage = 0;
+
+	for (const auto& submenu : submenus_) {
+		auto submenuPaging = submenu->splitMenuItemsByPages(submenu->items, *current_item_);
+
+		for (const auto& page : submenuPaging.pages) {
+			pages.push_back({currentPage, page.items});
+
+			if (current_submenu_ == nullptr
+			    && std::ranges::any_of(page.items, [&](const auto& item) { return item == *current_item_; })) {
+				current_submenu_ = submenu;
+				current_submenu_->beginSession(navigated_backward_from);
+				navigated_backward_from = nullptr;
+
+				visiblePageNumber = currentPage;
+				selectedItemPositionOnPage = submenuPaging.selectedItemPositionOnPage;
+			}
+
+			currentPage++;
+		}
+	}
+	return Paging{visiblePageNumber, selectedItemPositionOnPage, pages};
+}
+
+} // namespace deluge::gui::menu_item


### PR DESCRIPTION
Previously each HorizontalMenuCombined instance copied and stored all MenuItem pointers from each submenu.

Now it's zero overhead by memory