### PR TITLE
Chore/Delete stale velocity view pad selection mode code

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -408,8 +408,6 @@ AutomationView::AutomationView() {
 	rightPadSelectedX = kNoSelection;
 	rightPadSelectedY = kNoSelection;
 	lastPadSelectedKnobPos = kNoSelection;
-	numNotesSelected = 0;
-	selectedPadPressed = 0;
 	playbackStopped = false;
 	onArrangerView = false;
 	onMenuView = false;
@@ -1179,16 +1177,6 @@ void AutomationView::renderNoteSquare(RGB image[][kDisplayWidth + kSideBarWidth]
 		else {
 			pixel = colours::black; // erase pad
 		}
-	}
-	// pad selection mode, render cursor
-	if (padSelectionOn && ((xDisplay == leftPadSelectedX) || (xDisplay == rightPadSelectedX))) {
-		if (doRender) {
-			pixel = velocityRowBlurColour[yDisplay];
-		}
-		else {
-			pixel = colours::grey;
-		}
-		occupancyMask[yDisplay][xDisplay] = 64;
 	}
 }
 
@@ -2473,21 +2461,16 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 		if (Buttons::isShiftButtonPressed()
 		    || (isUIModeActive(UI_MODE_AUDITIONING) && !FlashStorage::automationDisableAuditionPadShortcuts)) {
 
-			// toggle interpolation on / off
-			// not relevant for note editor because interpolation doesn't apply to note params
-			if (!inNoteEditor() && (x == kInterpolationShortcutX && y == kInterpolationShortcutY)) {
-				return toggleAutomationInterpolation();
-			}
-			// toggle pad selection on / off
-			else if (!onAutomationOverview()) {
-				if (x == kPadSelectionShortcutX && y == kPadSelectionShortcutY) {
-					//	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-					//		return toggleVelocityPadSelectionMode(squareInfo);
-					//	}
-					//	else {
-					if (inAutomationEditor()) {
-						return toggleAutomationPadSelectionMode(modelStackWithParam, effectiveLength, xScroll, xZoom);
-					}
+			if (!inNoteEditor()) {
+				// toggle interpolation on / off
+				// not relevant for note editor because interpolation doesn't apply to note params
+				if ((x == kInterpolationShortcutX && y == kInterpolationShortcutY)) {
+					return toggleAutomationInterpolation();
+				}
+				// toggle pad selection on / off
+				// not relevant for note editor because pad selection mode was deemed unnecessary
+				else if (inAutomationEditor() && (x == kPadSelectionShortcutX && y == kPadSelectionShortcutY)) {
+					return toggleAutomationPadSelectionMode(modelStackWithParam, effectiveLength, xScroll, xZoom);
 				}
 			}
 
@@ -2533,40 +2516,6 @@ bool AutomationView::toggleAutomationInterpolation() {
 
 		display->displayPopup(l10n::get(l10n::String::STRING_FOR_INTERPOLATION_ENABLED));
 	}
-	return true;
-}
-
-/// toggle velocity pad selection mode on / off
-bool AutomationView::toggleVelocityPadSelectionMode(SquareInfo& squareInfo) {
-	// enter/exit pad selection mode
-	if (padSelectionOn) {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_OFF));
-
-		initPadSelection();
-	}
-	else {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_ON));
-
-		padSelectionOn = true;
-		blinkPadSelectionShortcut();
-
-		// display only left cursor
-		leftPadSelectedX = 0;
-		rightPadSelectedX = kNoSelection;
-		numNotesSelected = squareInfo.numNotes;
-
-		// when entering velocity pad selection mode, record note selection
-		// but don't record pad press yet if there are no notes in this square
-		// because recording a pad press for an empty square creates a note, and we don't want that yet
-		// (we'll do that when we try to adjust square velocity)
-		if (numNotesSelected != 0) {
-			// select note if there are notes in this square
-			recordNoteEditPadAction(leftPadSelectedX, 1);
-			instrumentClipView.dontDeleteNotesOnDepress();
-		}
-	}
-	uiNeedsRendering(this);
-	renderDisplay();
 	return true;
 }
 
@@ -2733,9 +2682,6 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	if (inNoteEditor()) {
 		automationParamType = AutomationParamType::PER_SOUND;
 		instrumentClipView.resetSelectedNoteRowBlinking();
-		if (padSelectionOn) {
-			initPadSelection();
-		}
 	}
 	blinkShortcuts();
 	if (display->have7SEG()) {
@@ -2757,52 +2703,8 @@ void AutomationView::noteEditPadAction(ModelStackWithNoteRow* modelStackWithNote
                                        InstrumentClip* clip, int32_t x, int32_t y, int32_t velocity,
                                        int32_t effectiveLength, SquareInfo& squareInfo) {
 	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-		if (padSelectionOn) {
-			velocityPadSelectionAction(modelStackWithNoteRow, clip, x, y, velocity, squareInfo);
-		}
-		else {
-			velocityEditPadAction(modelStackWithNoteRow, noteRow, clip, x, y, velocity, effectiveLength, squareInfo);
-		}
+		velocityEditPadAction(modelStackWithNoteRow, noteRow, clip, x, y, velocity, effectiveLength, squareInfo);
 	}
-}
-
-// handle's what happens when you select columns in velocity pad selection mode
-void AutomationView::velocityPadSelectionAction(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
-                                                int32_t x, int32_t y, int32_t velocity, SquareInfo& squareInfo) {
-
-	if (velocity) {
-		// if selection has changed and note was previously selected, release previous press
-		// if we recorded the previous pad that was pressed
-		if (leftPadSelectedX != kNoSelection && isUIModeActive(UI_MODE_NOTES_PRESSED)) {
-			recordNoteEditPadAction(leftPadSelectedX, 0);
-		}
-
-		// if we selected a new pad, record new press
-		// don't record pad press yet if there are no notes in this square
-		// because recording a pad press for an empty square creates a note, and we don't want that yet
-		// (we'll do that when we try to adjust square velocity)
-		if (leftPadSelectedX != x && squareInfo.numNotes != 0) {
-			// record new note selection
-			recordNoteEditPadAction(x, 1);
-			instrumentClipView.dontDeleteNotesOnDepress();
-		}
-
-		if (leftPadSelectedX != x) {
-			// store new pad selection
-			leftPadSelectedX = x;
-			numNotesSelected = squareInfo.numNotes;
-		}
-		else {
-			// de-select pad selection
-			leftPadSelectedX = kNoSelection;
-			numNotesSelected = 0;
-		}
-
-		// refresh grid and display
-		uiNeedsRendering(this, 0xFFFFFFFF, 0);
-	}
-	selectedPadPressed = velocity;
-	renderDisplay();
 }
 
 // velocity edit pad action
@@ -3171,9 +3073,6 @@ void AutomationView::recordNoteEditPadAction(int32_t x, int32_t velocity) {
 void AutomationView::automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
                                              int32_t yDisplay, int32_t velocity, int32_t effectiveLength,
                                              int32_t xScroll, int32_t xZoom) {
-	if (padSelectionOn) {
-		selectedPadPressed = velocity;
-	}
 	// If button down
 	if (velocity) {
 		// If this is a automation-length-edit press...
@@ -3594,30 +3493,10 @@ ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 
 	// fine tune note velocity
 	// If holding down notes and nothing else is held down, adjust velocity
-	// or if in pad selection mode, create note or adjust velocity
-	else if (inNoteEditor()
-	         && (isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)
-	             || (currentUIMode == UI_MODE_NONE && padSelectionOn && leftPadSelectedX != kNoSelection))) {
+	else if (inNoteEditor() && isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)) {
 		if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
 			if (!instrumentClipView.shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress) {
-				// adjust velocity faster in pad selection mode while holding shift
-				if (padSelectionOn && Buttons::isShiftButtonPressed()) {
-					offset = offset * 5;
-				}
-
-				// if we had selected a pad without any notes in it yet
-				// and we're trying to increase velocity of that pad
-				// then let's create a note first
-				if (padSelectionOn && (offset > 0) && numNotesSelected == 0) {
-					// record pad press
-					// this will create a new note at default velocity
-					recordNoteEditPadAction(leftPadSelectedX, 1);
-					numNotesSelected = 1;
-				}
-				// note exists in the pad selected, so let's adjust its velocity
-				else {
-					instrumentClipView.adjustVelocity(offset);
-				}
+				instrumentClipView.adjustVelocity(offset);
 				renderDisplay(getCurrentInstrument()->defaultVelocity);
 				uiNeedsRendering(this, 0xFFFFFFFF, 0);
 			}
@@ -3704,40 +3583,12 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 		if (isUIModeWithinRange(verticalScrollUIModes)) {
 			if ((!instrumentClipView.shouldIgnoreVerticalScrollKnobActionIfNotAlsoPressedForThisNotePress
 			     || (!isUIModeActive(UI_MODE_NOTES_PRESSED) && !isUIModeActive(UI_MODE_AUDITIONING)))
-			    && (!(isUIModeActive(UI_MODE_NOTES_PRESSED) && inNoteEditor() && !padSelectionOn))) {
-				// if we're in the note editor pad selection mode and vertical scrolling,
-				// we want to end any presses first (which will end any note auditioning as well)
-				if (inNoteEditor() && padSelectionOn) {
-					instrumentClipView.endAllEditPadPresses();
-				}
-
+			    && (!(isUIModeActive(UI_MODE_NOTES_PRESSED) && inNoteEditor()))) {
 				instrumentClipView.scrollVertical(offset, inCardRoutine, false, modelStack);
 
-				// if we're in note editor pad selection mode, scrolling vertically will change note selected
+				// if we're in note editor scrolling vertically will change note selected
 				// so we want to re-render the display to show the updated note
 				if (inNoteEditor()) {
-					// if we're in pad selection mode, we will have de-selected the pad presses above
-					// and now we want to re-instate the pad press for the selected note row
-					// so that we can re-audition the selected note
-					if (padSelectionOn && leftPadSelectedX != kNoSelection) {
-						ModelStackWithNoteRow* modelStackWithNoteRow =
-						    ((InstrumentClip*)clip)
-						        ->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
-						                             modelStack); // don't create
-						if (modelStackWithNoteRow->getNoteRowAllowNull()) {
-							NoteRow* noteRow = modelStackWithNoteRow->getNoteRow();
-							int32_t effectiveLength = modelStackWithNoteRow->getLoopLength();
-							SquareInfo squareInfo;
-							noteRow->getSquareInfo(leftPadSelectedX, effectiveLength, squareInfo);
-							numNotesSelected = squareInfo.numNotes;
-
-							if (numNotesSelected != 0) {
-								// select note if there are notes in this square
-								recordNoteEditPadAction(leftPadSelectedX, 1);
-								instrumentClipView.dontDeleteNotesOnDepress();
-							}
-						}
-					}
 					renderDisplay();
 				}
 			}
@@ -4654,16 +4505,6 @@ void AutomationView::initPadSelection() {
 	leftPadSelectedX = kNoSelection;
 	rightPadSelectedX = kNoSelection;
 	lastPadSelectedKnobPos = kNoSelection;
-
-	resetPadSelectionShortcutBlinking();
-
-	numNotesSelected = 0;
-	selectedPadPressed = 0;
-
-	// make sure no active presses remain when exiting pad selection mode
-	if (inNoteEditor() && isUIModeActive(UI_MODE_NOTES_PRESSED)) {
-		instrumentClipView.endAllEditPadPresses();
-	}
 
 	resetPadSelectionShortcutBlinking();
 }

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -179,15 +179,12 @@ private:
 	                       OutputType outputType, int32_t effectiveLength, int32_t x, int32_t y, int32_t velocity,
 	                       int32_t xScroll, int32_t xZoom, SquareInfo& squareInfo);
 	bool toggleAutomationInterpolation();
-	bool toggleVelocityPadSelectionMode(SquareInfo& squareInfo);
 	bool toggleAutomationPadSelectionMode(ModelStackWithAutoParam* modelStackWithParam, int32_t effectiveLength,
 	                                      int32_t xScroll, int32_t xZoom);
 	void handleParameterSelection(Clip* clip, Output* output, OutputType outputType, int32_t xDisplay,
 	                              int32_t yDisplay);
 	void noteEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, InstrumentClip* clip,
 	                       int32_t x, int32_t y, int32_t velocity, int32_t effectiveLength, SquareInfo& squareInfo);
-	void velocityPadSelectionAction(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip, int32_t x,
-	                                int32_t y, int32_t velocity, SquareInfo& squareInfo);
 	void velocityEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, InstrumentClip* clip,
 	                           int32_t x, int32_t y, int32_t velocity, int32_t effectiveLength, SquareInfo& squareInfo);
 	int32_t getVelocityFromY(int32_t y);
@@ -352,8 +349,6 @@ private:
 	int32_t rightPadSelectedX;
 	int32_t rightPadSelectedY;
 	int32_t lastPadSelectedKnobPos;
-	int32_t numNotesSelected;
-	int32_t selectedPadPressed;
 
 	bool playbackStopped;
 


### PR DESCRIPTION
Deleted stale velocity view pad selection mode code.

Pad selection mode was ultimately not implemented in velocity view as it was deemed unnecessary and was buggy.

If it's really needed it could be looked at again in the future. but for now, deleting the excess code.