### PR TITLE
Chore/Clean up kit render output

### DIFF
--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -103,7 +103,6 @@ public:
 	void processParamFromInputMIDIChannel(int32_t cc, int32_t newValue,
 	                                      ModelStackWithTimelineCounter* modelStack) override {}
 
-	ArpeggiatorSettings* getArpSettings(InstrumentClip* clip = nullptr);
 	void beenEdited(bool shouldMoveToEmptySlot = true) override;
 	void choke();
 	void resyncLFOs() override;
@@ -180,4 +179,10 @@ private:
 	void removeDrumFromLinkedList(Drum* drum);
 	void drumRemoved(Drum* drum);
 	void possiblySetSelectedDrumAndRefreshUI(Drum* thisDrum);
+
+	// Kit Arp
+	void setupAndRenderArpPreOutput(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
+	                                ParamManager* paramManager, std::span<StereoSample> output);
+	ArpeggiatorSettings* getArpSettings(InstrumentClip* clip = nullptr);
+	void renderNonAudioArpPostOutput(std::span<StereoSample> output);
 };


### PR DESCRIPTION
Cleaned up kit::renderOutput function by refactoring kit arp code to separate functions

Created new PR because other one bugged out