### PR TITLE
Refactor/ automation view and velocity view

### DIFF
--- a/src/deluge/gui/views/automation/editor_layout.h
+++ b/src/deluge/gui/views/automation/editor_layout.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/views/automation_view.h"
+
+namespace deluge::gui::views::automation {
+
+class AutomationEditorLayout {
+public:
+	AutomationEditorLayout() = default;
+	virtual ~AutomationEditorLayout() {}
+
+	// get automationView class info
+protected:
+	// get AutomationView UI
+	inline RootUI* getAutomationView() { return &automationView; }
+	inline AutomationParamType& getAutomationParamType() { return automationView.automationParamType; }
+	inline bool& getOnArrangerView() { return automationView.onArrangerView; }
+	inline int32_t& getNavSysId() { return automationView.navSysId; }
+
+	// display / LED indicators / pad rendering
+	inline void renderDisplay(int32_t knobPosLeft = kNoSelection, int32_t knobPosRight = kNoSelection,
+	                          bool modEncoderAction = false) {
+		automationView.renderDisplay(knobPosLeft, knobPosRight, modEncoderAction);
+	}
+	inline void displayAutomation(bool padSelected = false, bool updateDisplay = true) {
+		automationView.displayAutomation(padSelected, updateDisplay);
+	}
+	inline void renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_t lengthToDisplay,
+	                                RGB image[][kDisplayWidth + kSideBarWidth],
+	                                uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t imageWidth,
+	                                TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay) {
+		automationView.renderUndefinedArea(xScroll, xZoom, lengthToDisplay, image, occupancyMask, imageWidth,
+		                                   timelineView, tripletsOnHere, xDisplay);
+	}
+
+	// interpolation
+	inline void initInterpolation() { automationView.initInterpolation(); }
+	inline void resetInterpolationShortcutBlinking() { automationView.resetInterpolationShortcutBlinking(); }
+	inline void blinkInterpolationShortcut() { automationView.blinkInterpolationShortcut(); }
+	inline bool& getInterpolation() { return automationView.interpolation; }
+	inline bool& getInterpolationBefore() { return automationView.interpolationBefore; }
+	inline bool& getInterpolationAfter() { return automationView.interpolationAfter; }
+
+	// pad selection mode
+	inline bool& getPadSelectionOn() { return automationView.padSelectionOn; }
+	inline void initPadSelection() { automationView.initPadSelection(); }
+	inline void blinkPadSelectionShortcut() { automationView.blinkPadSelectionShortcut(); }
+
+	// pad press
+	inline int32_t getPosFromSquare(int32_t square, int32_t localScroll = -1) const {
+		return automationView.getPosFromSquare(square, localScroll);
+	}
+	inline int32_t getPosFromSquare(int32_t square, int32_t xScroll, uint32_t xZoom) const {
+		return automationView.getPosFromSquare(square, xScroll, xZoom);
+	}
+	inline bool& getMultiPadPressActive() { return automationView.multiPadPressActive; }
+	inline bool& getMultiPadPressSelected() { return automationView.multiPadPressSelected; }
+	inline bool& getMiddlePadPressSelected() { return automationView.middlePadPressSelected; }
+	inline int32_t& getLeftPadSelectedX() { return automationView.leftPadSelectedX; }
+	inline int32_t& getLeftPadSelectedY() { return automationView.leftPadSelectedY; }
+	inline int32_t& getRightPadSelectedX() { return automationView.rightPadSelectedX; }
+	inline int32_t& getRightPadSelectedY() { return automationView.rightPadSelectedY; }
+	inline int32_t& getLastPadSelectedKnobPos() { return automationView.lastPadSelectedKnobPos; }
+
+	// mod encoder
+	inline CopiedParamAutomation* getCopiedParamAutomation() { return &automationView.copiedParamAutomation; }
+
+	// model stack
+	inline ModelStackWithAutoParam*
+	getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelStack, Clip* clip,
+	                              int32_t paramID = deluge::modulation::params::kNoParamID,
+	                              deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE) {
+		return automationView.getModelStackWithParamForClip(modelStack, clip, paramID, paramKind);
+	}
+};
+
+}; // namespace deluge::gui::views::automation

--- a/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
@@ -1,0 +1,1470 @@
+/*
+ * Copyright (c) 2023 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gui/views/automation/editor_layout/mod_controllable.h"
+#include "gui/views/instrument_clip_view.h"
+#include "gui/views/view.h"
+#include "hid/display/display.h"
+#include "hid/led/indicator_leds.h"
+#include "model/action/action_logger.h"
+#include "model/clip/clip.h"
+#include "model/instrument/midi_instrument.h"
+#include "model/song/song.h"
+#include "modulation/patch/patch_cable_set.h"
+#include "playback/mode/playback_mode.h"
+#include "playback/playback_handler.h"
+
+namespace deluge::gui::views::automation::editor_layout {
+
+namespace params = deluge::modulation::params;
+
+using namespace deluge::gui;
+
+constexpr int32_t kParamNodeWidth = 3;
+
+// VU meter style colours for the automation editor
+
+const RGB rowColour[kDisplayHeight] = {{0, 255, 0},   {36, 219, 0}, {73, 182, 0}, {109, 146, 0},
+                                       {146, 109, 0}, {182, 73, 0}, {219, 36, 0}, {255, 0, 0}};
+
+const RGB rowTailColour[kDisplayHeight] = {{2, 53, 2},  {9, 46, 2},  {17, 38, 2}, {24, 31, 2},
+                                           {31, 24, 2}, {38, 17, 2}, {46, 9, 2},  {53, 2, 2}};
+
+const RGB rowBlurColour[kDisplayHeight] = {{71, 111, 71}, {72, 101, 66}, {73, 90, 62}, {74, 80, 57},
+                                           {76, 70, 53},  {77, 60, 48},  {78, 49, 44}, {79, 39, 39}};
+
+const RGB rowBipolarDownColour[kDisplayHeight / 2] = {{255, 0, 0}, {182, 73, 0}, {73, 182, 0}, {0, 255, 0}};
+
+const RGB rowBipolarDownTailColour[kDisplayHeight / 2] = {{53, 2, 2}, {38, 17, 2}, {17, 38, 2}, {2, 53, 2}};
+
+const RGB rowBipolarDownBlurColour[kDisplayHeight / 2] = {{79, 39, 39}, {77, 60, 48}, {73, 90, 62}, {71, 111, 71}};
+
+// lookup tables for the values that are set when you press the pads in each row of the grid
+const int32_t nonPatchCablePadPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
+const int32_t patchCablePadPressValues[kDisplayHeight] = {-128, -90, -60, -30, 30, 60, 90, 128};
+
+// lookup tables for the min value of each pad's value range used to display automation on each row of the grid
+const int32_t nonPatchCableMinPadDisplayValues[kDisplayHeight] = {0, 17, 33, 49, 65, 81, 97, 113};
+const int32_t patchCableMinPadDisplayValues[kDisplayHeight] = {-128, -96, -64, -32, 1, 33, 65, 97};
+
+// lookup tables for the max value of each pad's value range used to display automation on each row of the grid
+const int32_t nonPatchCableMaxPadDisplayValues[kDisplayHeight] = {16, 32, 48, 64, 80, 96, 112, 128};
+const int32_t patchCableMaxPadDisplayValues[kDisplayHeight] = {-97, -65, -33, -1, 32, 64, 96, 128};
+
+// summary of pad ranges and press values (format: MIN < PRESS < MAX)
+// patch cable:
+// y = 7 ::   97 <  128 < 128
+// y = 6 ::   65 <   90 <  96
+// y = 5 ::   33 <   60 <  64
+// y = 4 ::    1 <   30 <  32
+// y = 3 ::  -32 <  -30 <  -1
+// y = 2 ::  -64 <  -60 < -33
+// y = 1 ::  -96 <  -90 < -65
+// y = 0 :: -128 < -128 < -97
+
+// non-patch cable:
+// y = 7 :: 113 < 128 < 128
+// y = 6 ::  97 < 110 < 112
+// y = 5 ::  81 <  91 <  96
+// y = 4 ::  65 <  73 <  80
+// y = 3 ::  49 <  55 <  64
+// y = 2 ::  33 <  37 <  48
+// y = 1 ::  17 <  18 <  32
+// y = 0 ::  0  <   0 <  16
+
+PLACE_SDRAM_BSS AutomationEditorLayoutModControllable automationEditorLayoutModControllable{};
+
+// gets the length of the clip, renders the pads corresponding to current parameter values set up to the
+// clip length renders the undefined area of the clip that the user can't interact with
+void AutomationEditorLayoutModControllable::renderAutomationEditor(
+    ModelStackWithAutoParam* modelStackWithParam, Clip* clip, RGB image[][kDisplayWidth + kSideBarWidth],
+    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth, int32_t xScroll, uint32_t xZoom,
+    int32_t effectiveLength, int32_t xDisplay, bool drawUndefinedArea, params::Kind kind, bool isBipolar) {
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+		renderAutomationColumn(modelStackWithParam, image, occupancyMask, effectiveLength, xDisplay,
+		                       modelStackWithParam->autoParam->isAutomated(), xScroll, xZoom, kind, isBipolar);
+	}
+	if (drawUndefinedArea) {
+		renderUndefinedArea(xScroll, xZoom, effectiveLength, image, occupancyMask, renderWidth,
+		                    getAutomationView()->toTimelineView(), currentSong->tripletsOn, xDisplay);
+	}
+}
+
+/// render each square in each column of the automation editor grid
+void AutomationEditorLayoutModControllable::renderAutomationColumn(
+    ModelStackWithAutoParam* modelStackWithParam, RGB image[][kDisplayWidth + kSideBarWidth],
+    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t lengthToDisplay, int32_t xDisplay, bool isAutomated,
+    int32_t xScroll, int32_t xZoom, params::Kind kind, bool isBipolar) {
+
+	uint32_t squareStart = getMiddlePosFromSquare(xDisplay, lengthToDisplay, xScroll, xZoom);
+	int32_t knobPos = getAutomationParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
+
+	// iterate through each square
+	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+		if (isBipolar) {
+			renderAutomationBipolarSquare(image, occupancyMask, xDisplay, yDisplay, isAutomated, kind, knobPos);
+		}
+		else {
+			renderAutomationUnipolarSquare(image, occupancyMask, xDisplay, yDisplay, isAutomated, knobPos);
+		}
+	}
+}
+
+/// render column for bipolar params - e.g. pan, pitch, patch cable
+void AutomationEditorLayoutModControllable::renderAutomationBipolarSquare(
+    RGB image[][kDisplayWidth + kSideBarWidth], uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+    int32_t xDisplay, int32_t yDisplay, bool isAutomated, params::Kind kind, int32_t knobPos) {
+	RGB& pixel = image[yDisplay][xDisplay];
+
+	int32_t middleKnobPos;
+
+	// for patch cable that has a range of -128 to + 128, the middle point is 0
+	if (kind == params::Kind::PATCH_CABLE) {
+		middleKnobPos = 0;
+	}
+	// for non-patch cable that has a range of 0 to 128, the middle point is 64
+	else {
+		middleKnobPos = 64;
+	}
+
+	// if it's bipolar, only render grid rows above or below middle value
+	if (((knobPos > middleKnobPos) && (yDisplay < 4)) || ((knobPos < middleKnobPos) && (yDisplay > 3))) {
+		pixel = colours::black; // erase pad
+		return;
+	}
+
+	bool doRender = false;
+
+	// determine whether or not you should render a row based on current value
+	if (knobPos != middleKnobPos) {
+		if (kind == params::Kind::PATCH_CABLE) {
+			if (knobPos > middleKnobPos) {
+				doRender = (knobPos >= patchCableMinPadDisplayValues[yDisplay]);
+			}
+			else {
+				doRender = (knobPos <= patchCableMaxPadDisplayValues[yDisplay]);
+			}
+		}
+		else {
+			if (knobPos > middleKnobPos) {
+				doRender = (knobPos >= nonPatchCableMinPadDisplayValues[yDisplay]);
+			}
+			else {
+				doRender = (knobPos <= nonPatchCableMaxPadDisplayValues[yDisplay]);
+			}
+		}
+	}
+
+	// render automation lane
+	if (doRender) {
+		if (isAutomated) { // automated, render bright colour
+			if (knobPos > middleKnobPos) {
+				pixel = rowBipolarDownColour[-yDisplay + 7];
+			}
+			else {
+				pixel = rowBipolarDownColour[yDisplay];
+			}
+		}
+		else { // not automated, render less bright tail colour
+			if (knobPos > middleKnobPos) {
+				pixel = rowBipolarDownTailColour[-yDisplay + 7];
+			}
+			else {
+				pixel = rowBipolarDownTailColour[yDisplay];
+			}
+		}
+		occupancyMask[yDisplay][xDisplay] = 64;
+	}
+	else {
+		pixel = colours::black; // erase pad
+	}
+
+	// pad selection mode, render cursor
+	if (getPadSelectionOn() && ((xDisplay == getLeftPadSelectedX()) || (xDisplay == getRightPadSelectedX()))) {
+		if (doRender) {
+			if (knobPos > middleKnobPos) {
+				pixel = rowBipolarDownBlurColour[-yDisplay + 7];
+			}
+			else {
+				pixel = rowBipolarDownBlurColour[yDisplay];
+			}
+		}
+		else {
+			pixel = colours::grey;
+		}
+		occupancyMask[yDisplay][xDisplay] = 64;
+	}
+}
+
+/// render column for unipolar params (e.g. not pan, pitch, or patch cables)
+void AutomationEditorLayoutModControllable::renderAutomationUnipolarSquare(
+    RGB image[][kDisplayWidth + kSideBarWidth], uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+    int32_t xDisplay, int32_t yDisplay, bool isAutomated, int32_t knobPos) {
+	RGB& pixel = image[yDisplay][xDisplay];
+
+	// determine whether or not you should render a row based on current value
+	bool doRender = false;
+	if (knobPos) {
+		doRender = (knobPos >= nonPatchCableMinPadDisplayValues[yDisplay]);
+	}
+
+	// render square
+	if (doRender) {
+		if (isAutomated) { // automated, render bright colour
+			pixel = rowColour[yDisplay];
+		}
+		else { // not automated, render less bright tail colour
+			pixel = rowTailColour[yDisplay];
+		}
+		occupancyMask[yDisplay][xDisplay] = 64;
+	}
+	else {
+		pixel = colours::black; // erase pad
+	}
+
+	// pad selection mode, render cursor
+	if (getPadSelectionOn() && ((xDisplay == getLeftPadSelectedX()) || (xDisplay == getRightPadSelectedX()))) {
+		if (doRender) {
+			pixel = rowBlurColour[yDisplay];
+		}
+		else {
+			pixel = colours::grey;
+		}
+		occupancyMask[yDisplay][xDisplay] = 64;
+	}
+}
+
+void AutomationEditorLayoutModControllable::renderAutomationEditorDisplayOLED(
+    deluge::hid::display::oled_canvas::Canvas& canvas, Clip* clip, OutputType outputType, int32_t knobPosLeft,
+    int32_t knobPosRight) {
+	// display parameter name
+	DEF_STACK_STRING_BUF(parameterName, 30);
+	getAutomationParameterName(clip, outputType, parameterName);
+
+#if OLED_MAIN_HEIGHT_PIXELS == 64
+	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
+#else
+	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
+#endif
+	canvas.drawStringCentredShrinkIfNecessary(parameterName.c_str(), yPos, kTextSpacingX, kTextSpacingY);
+
+	// display automation status
+	yPos = yPos + 12;
+
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	if (getOnArrangerView()) {
+		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+		    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
+
+		modelStackWithParam =
+		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
+	}
+	else {
+		ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+		modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
+	}
+
+	char const* isAutomated;
+
+	// check if Parameter is currently automated so that the automation status can be drawn on
+	// the screen with the Parameter Name
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+		if (modelStackWithParam->autoParam->isAutomated()) {
+			isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_ON);
+		}
+		else {
+			isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_OFF);
+		}
+	}
+
+	canvas.drawStringCentred(isAutomated, yPos, kTextSpacingX, kTextSpacingY);
+
+	// display parameter value
+	yPos = yPos + 12;
+
+	if (knobPosRight != kNoSelection) {
+		char bufferLeft[10];
+		bufferLeft[0] = 'L';
+		bufferLeft[1] = ':';
+		bufferLeft[2] = ' ';
+		intToString(knobPosLeft, &bufferLeft[3]);
+		canvas.drawString(bufferLeft, 0, yPos, kTextSpacingX, kTextSpacingY);
+
+		char bufferRight[10];
+		bufferRight[0] = 'R';
+		bufferRight[1] = ':';
+		bufferRight[2] = ' ';
+		intToString(knobPosRight, &bufferRight[3]);
+		canvas.drawStringAlignRight(bufferRight, yPos, kTextSpacingX, kTextSpacingY);
+	}
+	else {
+		char buffer[5];
+		intToString(knobPosLeft, buffer);
+		canvas.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
+	}
+}
+
+void AutomationEditorLayoutModControllable::renderAutomationEditorDisplay7SEG(Clip* clip, OutputType outputType,
+                                                                              int32_t knobPosLeft,
+                                                                              bool modEncoderAction) {
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+	ModelStackWithAutoParam* modelStackWithParam = nullptr;
+
+	if (getOnArrangerView()) {
+		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
+		    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
+
+		modelStackWithParam =
+		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
+	}
+	else {
+		modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
+	}
+
+	bool padSelected = (!getPadSelectionOn() && isUIModeActive(UI_MODE_NOTES_PRESSED)) || getPadSelectionOn();
+
+	/* check if you're holding a pad
+	 * if yes, store pad press knob position in getLastPadSelectedKnobPos()
+	 * so that it can be used next time as the knob position if returning here
+	 * to display parameter value after another popup has been cancelled (e.g. audition pad)
+	 */
+	if (padSelected) {
+		if (knobPosLeft != kNoSelection) {
+			getLastPadSelectedKnobPos() = knobPosLeft;
+		}
+		else if (getLastPadSelectedKnobPos() != kNoSelection) {
+			params::Kind lastSelectedParamKind = params::Kind::NONE;
+			int32_t lastSelectedParamID = kNoSelection;
+			if (getOnArrangerView()) {
+				lastSelectedParamKind = currentSong->lastSelectedParamKind;
+				lastSelectedParamID = currentSong->lastSelectedParamID;
+			}
+			else {
+				lastSelectedParamKind = clip->lastSelectedParamKind;
+				lastSelectedParamID = clip->lastSelectedParamID;
+			}
+			knobPosLeft = view.calculateKnobPosForDisplay(lastSelectedParamKind, lastSelectedParamID,
+			                                              getLastPadSelectedKnobPos());
+		}
+	}
+
+	bool isAutomated =
+	    modelStackWithParam && modelStackWithParam->autoParam && modelStackWithParam->autoParam->isAutomated();
+	bool playbackStarted = playbackHandler.isEitherClockActive();
+
+	// display parameter value if knobPos is provided
+	if ((knobPosLeft != kNoSelection) && (padSelected || (playbackStarted && isAutomated) || modEncoderAction)) {
+		char buffer[5];
+		intToString(knobPosLeft, buffer);
+		if (modEncoderAction && !padSelected) {
+			display->displayPopup(buffer, 3, true);
+		}
+		else {
+			display->setText(buffer, true, 255, false);
+		}
+	}
+	// display parameter name
+	else if (knobPosLeft == kNoSelection) {
+		DEF_STACK_STRING_BUF(parameterName, 30);
+		getAutomationParameterName(clip, outputType, parameterName);
+		// if playback is running and there is automation, the screen will display the
+		// current automation value at the playhead position
+		// when changing to a parameter with automation, flash the parameter name first
+		// before the value is displayed
+		// otherwise if there's no automation, just scroll the parameter name
+		if (padSelected || (playbackStarted && isAutomated)) {
+			display->displayPopup(parameterName.c_str(), 3, true, isAutomated ? 3 : 255);
+		}
+		else {
+			display->setScrollingText(parameterName.c_str(), 0, 600, -1, isAutomated ? 3 : 255);
+		}
+	}
+}
+
+// get's the name of the Parameter being edited so it can be displayed on the screen
+void AutomationEditorLayoutModControllable::getAutomationParameterName(Clip* clip, OutputType outputType,
+                                                                       StringBuf& parameterName) {
+	if (getOnArrangerView() || outputType != OutputType::MIDI_OUT) {
+		params::Kind lastSelectedParamKind = params::Kind::NONE;
+		int32_t lastSelectedParamID = kNoSelection;
+		PatchSource lastSelectedPatchSource = PatchSource::NONE;
+		if (getOnArrangerView()) {
+			lastSelectedParamKind = currentSong->lastSelectedParamKind;
+			lastSelectedParamID = currentSong->lastSelectedParamID;
+		}
+		else {
+			lastSelectedParamKind = clip->lastSelectedParamKind;
+			lastSelectedParamID = clip->lastSelectedParamID;
+			lastSelectedPatchSource = clip->lastSelectedPatchSource;
+		}
+		if (lastSelectedParamKind == params::Kind::PATCH_CABLE) {
+			PatchSource source2 = PatchSource::NONE;
+			ParamDescriptor paramDescriptor;
+			paramDescriptor.data = lastSelectedParamID;
+			if (!paramDescriptor.hasJustOneSource()) {
+				source2 = paramDescriptor.getTopLevelSource();
+			}
+
+			parameterName.append(sourceToStringShort(lastSelectedPatchSource));
+
+			if (display->haveOLED()) {
+				parameterName.append(" -> ");
+			}
+			else {
+				parameterName.append(" - ");
+			}
+
+			if (source2 != PatchSource::NONE) {
+				parameterName.append(sourceToStringShort(source2));
+				parameterName.append(display->haveOLED() ? " -> " : " - ");
+			}
+
+			parameterName.append(params::getPatchedParamShortName(lastSelectedParamID));
+		}
+		else {
+			parameterName.append(getParamDisplayName(lastSelectedParamKind, lastSelectedParamID));
+		}
+	}
+	else {
+		if (clip->lastSelectedParamID == CC_NUMBER_NONE) {
+			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_PARAM));
+		}
+		else if (clip->lastSelectedParamID == CC_NUMBER_PITCH_BEND) {
+			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
+		}
+		else if (clip->lastSelectedParamID == CC_NUMBER_AFTERTOUCH) {
+			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
+		}
+		else if (clip->lastSelectedParamID == CC_EXTERNAL_MOD_WHEEL || clip->lastSelectedParamID == CC_NUMBER_Y_AXIS) {
+			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
+		}
+		else {
+			MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
+			bool appendedName = false;
+
+			if (clip->lastSelectedParamID >= 0 && clip->lastSelectedParamID < kNumRealCCNumbers) {
+				std::string_view name = midiInstrument->getNameFromCC(clip->lastSelectedParamID);
+				// if we have a name for this midi cc set by the user, display that instead of the cc number
+				if (!name.empty()) {
+					parameterName.append(name.data());
+					appendedName = true;
+				}
+			}
+
+			// if we don't have a midi cc name set, draw CC number instead
+			if (!appendedName) {
+				if (display->haveOLED()) {
+					parameterName.append("CC ");
+					parameterName.appendInt(clip->lastSelectedParamID);
+				}
+				else {
+					if (clip->lastSelectedParamID < 100) {
+						parameterName.append("CC");
+					}
+					else {
+						parameterName.append("C");
+					}
+					parameterName.appendInt(clip->lastSelectedParamID);
+				}
+			}
+		}
+	}
+}
+
+/// toggle automation interpolation on / off
+bool AutomationEditorLayoutModControllable::toggleAutomationInterpolation() {
+	if (getInterpolation()) {
+		getInterpolation() = false;
+		initInterpolation();
+		resetInterpolationShortcutBlinking();
+
+		display->displayPopup(l10n::get(l10n::String::STRING_FOR_INTERPOLATION_DISABLED));
+	}
+	else {
+		getInterpolation() = true;
+		blinkInterpolationShortcut();
+
+		display->displayPopup(l10n::get(l10n::String::STRING_FOR_INTERPOLATION_ENABLED));
+	}
+	return true;
+}
+
+/// toggle automation pad selection mode on / off
+bool AutomationEditorLayoutModControllable::toggleAutomationPadSelectionMode(
+    ModelStackWithAutoParam* modelStackWithParam, int32_t effectiveLength, int32_t xScroll, int32_t xZoom) {
+	// enter/exit pad selection mode
+	if (getPadSelectionOn()) {
+		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_OFF));
+
+		initPadSelection();
+		displayAutomation(true, !display->have7SEG());
+	}
+	else {
+		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_ON));
+
+		getPadSelectionOn() = true;
+		blinkPadSelectionShortcut();
+
+		getMultiPadPressSelected() = false;
+		getMultiPadPressActive() = false;
+
+		// display only left cursor initially
+		getLeftPadSelectedX() = 0;
+		getRightPadSelectedX() = kNoSelection;
+
+		uint32_t squareStart = getMiddlePosFromSquare(getLeftPadSelectedX(), effectiveLength, xScroll, xZoom);
+
+		updateAutomationModPosition(modelStackWithParam, squareStart, true, true);
+	}
+	uiNeedsRendering(getAutomationView());
+	return true;
+}
+
+// automation edit pad action
+// handles single and multi pad presses for automation editing
+// stores pad presses in the EditPadPresses struct of the instrument clip view
+void AutomationEditorLayoutModControllable::automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam,
+                                                                    Clip* clip, int32_t xDisplay, int32_t yDisplay,
+                                                                    int32_t velocity, int32_t effectiveLength,
+                                                                    int32_t xScroll, int32_t xZoom) {
+	// If button down
+	if (velocity) {
+		// If this is a automation-length-edit press...
+		// needed for Automation
+		if (instrumentClipView.numEditPadPresses == 1) {
+
+			int32_t firstPadX = 255;
+			int32_t firstPadY = 255;
+
+			// Find that original press
+			int32_t i;
+			for (i = 0; i < kEditPadPressBufferSize; i++) {
+				if (instrumentClipView.editPadPresses[i].isActive) {
+
+					firstPadX = instrumentClipView.editPadPresses[i].xDisplay;
+					firstPadY = instrumentClipView.editPadPresses[i].yDisplay;
+
+					break;
+				}
+			}
+
+			if (firstPadX != 255 && firstPadY != 255) {
+				if (firstPadX != xDisplay) {
+					recordAutomationSinglePadPress(xDisplay, yDisplay);
+
+					getMultiPadPressSelected() = true;
+					getMultiPadPressActive() = true;
+
+					// the long press logic calculates and renders the interpolation as if the press was
+					// entered in a forward fashion (where the first pad is to the left of the second
+					// pad). if the user happens to enter a long press backwards then we fix that entry
+					// by re-ordering the pad presses so that it is forward again
+					getLeftPadSelectedX() = firstPadX > xDisplay ? xDisplay : firstPadX;
+					getLeftPadSelectedY() = firstPadX > xDisplay ? yDisplay : firstPadY;
+					getRightPadSelectedX() = firstPadX > xDisplay ? firstPadX : xDisplay;
+					getRightPadSelectedY() = firstPadX > xDisplay ? firstPadY : yDisplay;
+
+					// if you're not in pad selection mode, allow user to enter a long press
+					if (!getPadSelectionOn()) {
+						handleAutomationMultiPadPress(modelStackWithParam, clip, getLeftPadSelectedX(),
+						                              getLeftPadSelectedY(), getRightPadSelectedX(),
+						                              getRightPadSelectedY(), effectiveLength, xScroll, xZoom);
+					}
+					else {
+						uiNeedsRendering(getAutomationView());
+					}
+
+					// set led indicators to left / right pad selection values
+					// and update display
+					renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom,
+					                                        xDisplay);
+				}
+				else {
+					getLeftPadSelectedY() = firstPadY;
+					getMiddlePadPressSelected() = true;
+					goto singlePadPressAction;
+				}
+			}
+		}
+
+		// Or, if this is a regular create-or-select press...
+		else {
+singlePadPressAction:
+			if (recordAutomationSinglePadPress(xDisplay, yDisplay)) {
+				getMultiPadPressActive() = false;
+				handleAutomationSinglePadPress(modelStackWithParam, clip, xDisplay, yDisplay, effectiveLength, xScroll,
+				                               xZoom);
+			}
+		}
+	}
+
+	// Or if pad press ended...
+	else {
+		// Find the corresponding press, if there is one
+		int32_t i;
+		for (i = 0; i < kEditPadPressBufferSize; i++) {
+			if (instrumentClipView.editPadPresses[i].isActive
+			    && instrumentClipView.editPadPresses[i].yDisplay == yDisplay
+			    && instrumentClipView.editPadPresses[i].xDisplay == xDisplay) {
+				break;
+			}
+		}
+
+		// If we found it...
+		if (i < kEditPadPressBufferSize) {
+			instrumentClipView.endEditPadPress(i);
+
+			instrumentClipView.checkIfAllEditPadPressesEnded();
+		}
+
+		// outside pad selection mode, exit multi pad press once you've let go of the first pad in the
+		// long press
+		if (!getPadSelectionOn() && getMultiPadPressSelected() && (currentUIMode != UI_MODE_NOTES_PRESSED)) {
+			initPadSelection();
+		}
+		// switch from long press selection to short press selection in pad selection mode
+		else if (getPadSelectionOn() && getMultiPadPressSelected() && !getMultiPadPressActive()
+		         && (currentUIMode != UI_MODE_NOTES_PRESSED)
+		         && ((AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress) < kShortPressTime)) {
+
+			getMultiPadPressSelected() = false;
+
+			getLeftPadSelectedX() = xDisplay;
+			getRightPadSelectedX() = kNoSelection;
+
+			uiNeedsRendering(getAutomationView());
+		}
+
+		if (currentUIMode != UI_MODE_NOTES_PRESSED) {
+			getLastPadSelectedKnobPos() = kNoSelection;
+			if (getMultiPadPressSelected()) {
+				renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom,
+				                                        xDisplay);
+			}
+			else if (!getPadSelectionOn() && !playbackHandler.isEitherClockActive()) {
+				displayAutomation();
+			}
+		}
+
+		getMiddlePadPressSelected() = false;
+	}
+}
+
+bool AutomationEditorLayoutModControllable::recordAutomationSinglePadPress(int32_t xDisplay, int32_t yDisplay) {
+	instrumentClipView.timeLastEditPadPress = AudioEngine::audioSampleTimer;
+	// Find an empty space in the press buffer, if there is one
+	int32_t i;
+	for (i = 0; i < kEditPadPressBufferSize; i++) {
+		if (!instrumentClipView.editPadPresses[i].isActive) {
+			break;
+		}
+	}
+	if (i < kEditPadPressBufferSize) {
+		instrumentClipView.shouldIgnoreVerticalScrollKnobActionIfNotAlsoPressedForThisNotePress = false;
+
+		// If this is the first press, record the time
+		if (instrumentClipView.numEditPadPresses == 0) {
+			instrumentClipView.timeFirstEditPadPress = AudioEngine::audioSampleTimer;
+			instrumentClipView.shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress = false;
+		}
+
+		instrumentClipView.editPadPresses[i].isActive = true;
+		instrumentClipView.editPadPresses[i].yDisplay = yDisplay;
+		instrumentClipView.editPadPresses[i].xDisplay = xDisplay;
+		instrumentClipView.numEditPadPresses++;
+		instrumentClipView.numEditPadPressesPerNoteRowOnScreen[yDisplay]++;
+		enterUIMode(UI_MODE_NOTES_PRESSED);
+
+		return true;
+	}
+	return false;
+}
+
+bool AutomationEditorLayoutModControllable::automationModEncoderActionForSelectedPad(
+    ModelStackWithAutoParam* modelStackWithParam, int32_t whichModEncoder, int32_t offset, int32_t effectiveLength) {
+	Clip* clip = getCurrentClip();
+
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+
+		int32_t xDisplay = 0;
+
+		// for a multi pad press, adjust value of first or last pad depending on mod encoder turned
+		if (getMultiPadPressSelected()) {
+			if (whichModEncoder == 0) {
+				xDisplay = getLeftPadSelectedX();
+			}
+			else if (whichModEncoder == 1) {
+				xDisplay = getRightPadSelectedX();
+			}
+		}
+
+		// if not multi pad press, but in pad selection mode, then just adjust the single selected pad
+		else if (getPadSelectionOn()) {
+			xDisplay = getLeftPadSelectedX();
+		}
+
+		// otherwise if not in pad selection mode, adjust the value of the pad currently being held
+		else {
+			// find pads that are currently pressed
+			int32_t i;
+			for (i = 0; i < kEditPadPressBufferSize; i++) {
+				if (instrumentClipView.editPadPresses[i].isActive) {
+					xDisplay = instrumentClipView.editPadPresses[i].xDisplay;
+				}
+			}
+		}
+
+		uint32_t squareStart = 0;
+
+		int32_t xScroll = currentSong->xScroll[getNavSysId()];
+		int32_t xZoom = currentSong->xZoom[getNavSysId()];
+
+		// for the second pad pressed in a long press, the square start position is set to the very last
+		// nodes position
+		if (getMultiPadPressSelected() && (whichModEncoder == 1)) {
+			int32_t squareRightEdge = getPosFromSquare(xDisplay + 1, xScroll, xZoom);
+			squareStart = std::min(effectiveLength, squareRightEdge) - kParamNodeWidth;
+		}
+		else {
+			squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
+		}
+
+		if (squareStart < effectiveLength) {
+
+			int32_t knobPos = getAutomationParameterKnobPos(modelStackWithParam, squareStart);
+
+			int32_t newKnobPos = calculateAutomationKnobPosForModEncoderTurn(modelStackWithParam, knobPos, offset);
+
+			// ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
+			// if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a
+			// value change gets recorded if newKnobPos exceeds 127, then it means current knobPos was
+			// 127 and it was increased to 128. In which case, ignore value change
+			if (!getOnArrangerView() && ((clip->output->type == OutputType::MIDI_OUT) && (newKnobPos == 64))) {
+				return true;
+			}
+
+			// use default interpolation settings
+			initInterpolation();
+
+			setAutomationParameterValue(modelStackWithParam, newKnobPos, squareStart, xDisplay, effectiveLength,
+			                            xScroll, xZoom, true);
+
+			view.potentiallyMakeItHarderToTurnKnob(whichModEncoder, modelStackWithParam, newKnobPos);
+
+			// once first or last pad in a multi pad press is adjusted, re-render calculate multi pad
+			// press based on revised start/ending values
+			if (getMultiPadPressSelected()) {
+
+				handleAutomationMultiPadPress(modelStackWithParam, clip, getLeftPadSelectedX(), 0,
+				                              getRightPadSelectedX(), 0, effectiveLength, xScroll, xZoom, true);
+
+				renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom,
+				                                        xDisplay, true);
+
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+void AutomationEditorLayoutModControllable::automationModEncoderActionForUnselectedPad(
+    ModelStackWithAutoParam* modelStackWithParam, int32_t whichModEncoder, int32_t offset, int32_t effectiveLength) {
+	Clip* clip = getCurrentClip();
+
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+
+		if (modelStackWithParam->getTimelineCounter()
+		    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+
+			int32_t knobPos = getAutomationParameterKnobPos(modelStackWithParam, view.modPos);
+
+			int32_t newKnobPos = calculateAutomationKnobPosForModEncoderTurn(modelStackWithParam, knobPos, offset);
+
+			// ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
+			// if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a
+			// value change gets recorded if newKnobPos exceeds 127, then it means current knobPos was
+			// 127 and it was increased to 128. In which case, ignore value change
+			if (!getOnArrangerView() && ((clip->output->type == OutputType::MIDI_OUT) && (newKnobPos == 64))) {
+				return;
+			}
+
+			int32_t newValue =
+			    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
+
+			// use default interpolation settings
+			initInterpolation();
+
+			modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, view.modPos,
+			                                                          view.modLength);
+
+			if (!getOnArrangerView()) {
+				modelStackWithParam->getTimelineCounter()->instrumentBeenEdited();
+			}
+
+			if (!playbackHandler.isEitherClockActive() || !modelStackWithParam->autoParam->isAutomated()) {
+				int32_t knobPos = newKnobPos + kKnobPosOffset;
+				renderDisplay(knobPos, kNoSelection, true);
+				setAutomationKnobIndicatorLevels(modelStackWithParam, knobPos, knobPos);
+			}
+
+			view.potentiallyMakeItHarderToTurnKnob(whichModEncoder, modelStackWithParam, newKnobPos);
+
+			// midi follow and midi feedback enabled
+			// re-send midi cc because learned parameter value has changed
+			view.sendMidiFollowFeedback(modelStackWithParam, newKnobPos);
+		}
+	}
+}
+
+void AutomationEditorLayoutModControllable::copyAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
+                                                           int32_t xScroll, int32_t xZoom) {
+	if (getCopiedParamAutomation()->nodes) {
+		delugeDealloc(getCopiedParamAutomation()->nodes);
+		getCopiedParamAutomation()->nodes = nullptr;
+		getCopiedParamAutomation()->numNodes = 0;
+	}
+
+	int32_t startPos = getPosFromSquare(0, xScroll, xZoom);
+	int32_t endPos = getPosFromSquare(kDisplayWidth, xScroll, xZoom);
+	if (startPos == endPos) {
+		return;
+	}
+
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+
+		bool isPatchCable = (modelStackWithParam->paramCollection
+		                     == modelStackWithParam->paramManager->getPatchCableSetAllowJibberish());
+		// Ok this is cursed, but will work fine so long as
+		// the possibly invalid memory here doesn't accidentally
+		// equal modelStack->paramCollection.
+
+		modelStackWithParam->autoParam->copy(startPos, endPos, getCopiedParamAutomation(), isPatchCable,
+		                                     modelStackWithParam);
+
+		if (getCopiedParamAutomation()->nodes) {
+			display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_COPIED));
+			return;
+		}
+	}
+
+	display->displayPopup(l10n::get(l10n::String::STRING_FOR_NO_AUTOMATION_TO_COPY));
+}
+
+void AutomationEditorLayoutModControllable::pasteAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
+                                                            int32_t effectiveLength, int32_t xScroll, int32_t xZoom) {
+	if (!getCopiedParamAutomation()->nodes) {
+		display->displayPopup(l10n::get(l10n::String::STRING_FOR_NO_AUTOMATION_TO_PASTE));
+		return;
+	}
+
+	int32_t startPos = getPosFromSquare(0, xScroll, xZoom);
+	int32_t endPos = getPosFromSquare(kDisplayWidth, xScroll, xZoom);
+
+	int32_t pastedAutomationWidth = endPos - startPos;
+	if (pastedAutomationWidth == 0) {
+		return;
+	}
+
+	float scaleFactor = (float)pastedAutomationWidth / getCopiedParamAutomation()->width;
+
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+		Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_PASTE);
+
+		if (action) {
+			action->recordParamChangeIfNotAlreadySnapshotted(modelStackWithParam, false);
+		}
+
+		bool isPatchCable = (modelStackWithParam->paramCollection
+		                     == modelStackWithParam->paramManager->getPatchCableSetAllowJibberish());
+		// Ok this is cursed, but will work fine so long as
+		// the possibly invalid memory here doesn't accidentally
+		// equal modelStack->paramCollection.
+
+		modelStackWithParam->autoParam->paste(startPos, endPos, scaleFactor, modelStackWithParam,
+		                                      getCopiedParamAutomation(), isPatchCable);
+
+		display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_PASTED));
+
+		if (playbackHandler.isEitherClockActive()) {
+			currentPlaybackMode->reversionDone(); // Re-gets automation and stuff
+		}
+		else {
+			if (getPadSelectionOn()) {
+				if (getMultiPadPressSelected()) {
+					renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom);
+				}
+				else {
+					uint32_t squareStart =
+					    getMiddlePosFromSquare(getLeftPadSelectedX(), effectiveLength, xScroll, xZoom);
+
+					updateAutomationModPosition(modelStackWithParam, squareStart);
+				}
+			}
+			else {
+				displayAutomation();
+			}
+		}
+
+		return;
+	}
+
+	display->displayPopup(l10n::get(l10n::String::STRING_FOR_CANT_PASTE_AUTOMATION));
+}
+
+uint32_t AutomationEditorLayoutModControllable::getSquareWidth(int32_t square, int32_t effectiveLength, int32_t xScroll,
+                                                               int32_t xZoom) {
+	int32_t squareRightEdge = getPosFromSquare(square + 1, xScroll, xZoom);
+	return std::min(effectiveLength, squareRightEdge) - getPosFromSquare(square, xScroll, xZoom);
+}
+
+// when pressing on a single pad, you want to display the value of the middle node within that square
+// as that is the most accurate value that represents that square
+uint32_t AutomationEditorLayoutModControllable::getMiddlePosFromSquare(int32_t xDisplay, int32_t effectiveLength,
+                                                                       int32_t xScroll, int32_t xZoom) {
+	uint32_t squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
+	uint32_t squareWidth = getSquareWidth(xDisplay, effectiveLength, xScroll, xZoom);
+	if (squareWidth != 3) {
+		squareStart = squareStart + (squareWidth / 2);
+	}
+
+	return squareStart;
+}
+
+// this function obtains a parameters value and converts it to a knobPos
+// the knobPos is used for rendering the current parameter values in the automation editor
+// it's also used for obtaining the start and end position values for a multi pad press
+// and also used for increasing/decreasing parameter values with the mod encoders
+int32_t AutomationEditorLayoutModControllable::getAutomationParameterKnobPos(ModelStackWithAutoParam* modelStack,
+                                                                             uint32_t squareStart) {
+	// obtain value corresponding to the two pads that were pressed in a multi pad press action
+	int32_t currentValue = modelStack->autoParam->getValuePossiblyAtPos(squareStart, modelStack);
+	int32_t knobPos = modelStack->paramCollection->paramValueToKnobPos(currentValue, modelStack);
+
+	return knobPos;
+}
+
+// this function is based off the code in AutoParam::getValueAtPos, it was tweaked to just return
+// interpolation status of the left node or right node (depending on the reversed parameter which is
+// used to indicate what node in what direction we are looking for (e.g. we want status of left node, or
+// right node, relative to the current pos we are looking at
+bool AutomationEditorLayoutModControllable::getAutomationNodeInterpolation(ModelStackWithAutoParam* modelStack,
+                                                                           int32_t pos, bool reversed) {
+
+	if (!modelStack->autoParam->nodes.getNumElements()) {
+		return false;
+	}
+
+	int32_t rightI = modelStack->autoParam->nodes.search(pos + (int32_t)!reversed, GREATER_OR_EQUAL);
+	if (rightI >= modelStack->autoParam->nodes.getNumElements()) {
+		rightI = 0;
+	}
+	ParamNode* rightNode = modelStack->autoParam->nodes.getElement(rightI);
+
+	int32_t leftI = rightI - 1;
+	if (leftI < 0) {
+		leftI += modelStack->autoParam->nodes.getNumElements();
+	}
+	ParamNode* leftNode = modelStack->autoParam->nodes.getElement(leftI);
+
+	if (reversed) {
+		return leftNode->interpolated;
+	}
+	else {
+		return rightNode->interpolated;
+	}
+}
+
+// this function writes the new values calculated by the handleAutomationSinglePadPress and
+// handleAutomationMultiPadPress functions
+void AutomationEditorLayoutModControllable::setAutomationParameterValue(ModelStackWithAutoParam* modelStack,
+                                                                        int32_t knobPos, int32_t squareStart,
+                                                                        int32_t xDisplay, int32_t effectiveLength,
+                                                                        int32_t xScroll, int32_t xZoom,
+                                                                        bool modEncoderAction) {
+
+	int32_t newValue = modelStack->paramCollection->knobPosToParamValue(knobPos, modelStack);
+
+	uint32_t squareWidth = 0;
+
+	// for a multi pad press, the beginning and ending pad presses are set with a square width of 3 (1
+	// node).
+	if (getMultiPadPressSelected()) {
+		squareWidth = kParamNodeWidth;
+	}
+	else {
+		squareWidth = getSquareWidth(xDisplay, effectiveLength, xScroll, xZoom);
+	}
+
+	// if you're doing a single pad press, you don't want the values around that single press position
+	// to change they will change if those nodes around the single pad press were created with
+	// interpolation turned on to fix this, re-create those nodes with their current value with
+	// interpolation off
+
+	getInterpolationBefore() = getAutomationNodeInterpolation(modelStack, squareStart, true);
+	getInterpolationAfter() = getAutomationNodeInterpolation(modelStack, squareStart, false);
+
+	// create a node to the left with the current interpolation status
+	int32_t squareNodeLeftStart = squareStart - kParamNodeWidth;
+	if (squareNodeLeftStart >= 0) {
+		int32_t currentValue = modelStack->autoParam->getValuePossiblyAtPos(squareNodeLeftStart, modelStack);
+		modelStack->autoParam->setValuePossiblyForRegion(currentValue, modelStack, squareNodeLeftStart,
+		                                                 kParamNodeWidth);
+	}
+
+	// create a node to the right with the current interpolation status
+	int32_t squareNodeRightStart = squareStart + kParamNodeWidth;
+	if (squareNodeRightStart < effectiveLength) {
+		int32_t currentValue = modelStack->autoParam->getValuePossiblyAtPos(squareNodeRightStart, modelStack);
+		modelStack->autoParam->setValuePossiblyForRegion(currentValue, modelStack, squareNodeRightStart,
+		                                                 kParamNodeWidth);
+	}
+
+	// reset interpolation to false for the single pad we're changing (so that the nodes around it don't
+	// also change)
+	initInterpolation();
+
+	// called twice because there was a weird bug where for some reason the first call wasn't taking
+	// effect on one pad (and whatever pad it was changed every time)...super weird...calling twice
+	// fixed it...
+	modelStack->autoParam->setValuePossiblyForRegion(newValue, modelStack, squareStart, squareWidth);
+	modelStack->autoParam->setValuePossiblyForRegion(newValue, modelStack, squareStart, squareWidth);
+
+	if (!getOnArrangerView()) {
+		modelStack->getTimelineCounter()->instrumentBeenEdited();
+	}
+
+	// in a multi pad press, no need to display all the values calculated
+	if (!getMultiPadPressSelected()) {
+		int32_t newKnobPos = knobPos + kKnobPosOffset;
+		renderDisplay(newKnobPos, kNoSelection, modEncoderAction);
+		setAutomationKnobIndicatorLevels(modelStack, newKnobPos, newKnobPos);
+	}
+
+	// midi follow and midi feedback enabled
+	// re-send midi cc because learned parameter value has changed
+	view.sendMidiFollowFeedback(modelStack, knobPos);
+}
+
+// sets both knob indicators to the same value when pressing single pad,
+// deleting automation, or displaying current parameter value
+// multi pad presses don't use this function
+void AutomationEditorLayoutModControllable::setAutomationKnobIndicatorLevels(ModelStackWithAutoParam* modelStack,
+                                                                             int32_t knobPosLeft,
+                                                                             int32_t knobPosRight) {
+	params::Kind kind = modelStack->paramCollection->getParamKind();
+	bool isBipolar = isParamBipolar(kind, modelStack->paramId);
+
+	// if you're dealing with a patch cable which has a -128 to +128 range
+	// we'll need to convert it to a 0 - 128 range for purpose of rendering on knob indicators
+	if (kind == params::Kind::PATCH_CABLE) {
+		knobPosLeft = view.convertPatchCableKnobPosToIndicatorLevel(knobPosLeft);
+		knobPosRight = view.convertPatchCableKnobPosToIndicatorLevel(knobPosRight);
+	}
+
+	bool isBlinking = indicator_leds::isKnobIndicatorBlinking(0) || indicator_leds::isKnobIndicatorBlinking(1);
+
+	if (!isBlinking) {
+		indicator_leds::setKnobIndicatorLevel(0, knobPosLeft, isBipolar);
+		indicator_leds::setKnobIndicatorLevel(1, knobPosRight, isBipolar);
+	}
+}
+
+// updates the position that the active mod controllable stack is pointing to
+// this sets the current value for the active parameter so that it can be auditioned
+void AutomationEditorLayoutModControllable::updateAutomationModPosition(ModelStackWithAutoParam* modelStack,
+                                                                        uint32_t squareStart, bool updateDisplay,
+                                                                        bool updateIndicatorLevels) {
+
+	if (!playbackHandler.isEitherClockActive() || getPadSelectionOn()) {
+		if (modelStack && modelStack->autoParam) {
+			if (modelStack->getTimelineCounter()
+			    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
+
+				view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
+				    squareStart, &view.activeModControllableModelStack);
+
+				int32_t knobPos = getAutomationParameterKnobPos(modelStack, squareStart) + kKnobPosOffset;
+
+				if (updateDisplay) {
+					renderDisplay(knobPos);
+				}
+
+				if (updateIndicatorLevels) {
+					setAutomationKnobIndicatorLevels(modelStack, knobPos, knobPos);
+				}
+			}
+		}
+	}
+}
+
+// takes care of setting the automation value for the single pad that was pressed
+void AutomationEditorLayoutModControllable::handleAutomationSinglePadPress(ModelStackWithAutoParam* modelStackWithParam,
+                                                                           Clip* clip, int32_t xDisplay,
+                                                                           int32_t yDisplay, int32_t effectiveLength,
+                                                                           int32_t xScroll, int32_t xZoom) {
+
+	Output* output = clip->output;
+	OutputType outputType = output->type;
+
+	// this means you are editing a parameter's value
+	handleAutomationParameterChange(modelStackWithParam, clip, outputType, xDisplay, yDisplay, effectiveLength, xScroll,
+	                                xZoom);
+
+	uiNeedsRendering(getAutomationView());
+}
+
+// called by handle single pad press when it is determined that you are editing parameter automation
+// using the grid
+void AutomationEditorLayoutModControllable::handleAutomationParameterChange(
+    ModelStackWithAutoParam* modelStackWithParam, Clip* clip, OutputType outputType, int32_t xDisplay, int32_t yDisplay,
+    int32_t effectiveLength, int32_t xScroll, int32_t xZoom) {
+	if (getPadSelectionOn()) {
+		// display pad's value
+		uint32_t squareStart = 0;
+
+		// if a long press is selected and you're checking value of start or end pad
+		// display value at very first or very last node
+		if (getMultiPadPressSelected()
+		    && ((getLeftPadSelectedX() == xDisplay) || (getRightPadSelectedX() == xDisplay))) {
+			if (getLeftPadSelectedX() == xDisplay) {
+				squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
+			}
+			else {
+				int32_t squareRightEdge = getPosFromSquare(getRightPadSelectedX() + 1, xScroll, xZoom);
+				squareStart = std::min(effectiveLength, squareRightEdge) - kParamNodeWidth;
+			}
+		}
+		// display pad's middle value
+		else {
+			squareStart = getMiddlePosFromSquare(xDisplay, effectiveLength, xScroll, xZoom);
+		}
+
+		updateAutomationModPosition(modelStackWithParam, squareStart);
+
+		if (!getMultiPadPressSelected()) {
+			getLeftPadSelectedX() = xDisplay;
+		}
+	}
+
+	else if (modelStackWithParam && modelStackWithParam->autoParam) {
+
+		uint32_t squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
+
+		if (squareStart < effectiveLength) {
+			// use default interpolation settings
+			initInterpolation();
+
+			int32_t newKnobPos = calculateAutomationKnobPosForPadPress(modelStackWithParam, outputType, yDisplay);
+			setAutomationParameterValue(modelStackWithParam, newKnobPos, squareStart, xDisplay, effectiveLength,
+			                            xScroll, xZoom);
+		}
+	}
+}
+
+int32_t AutomationEditorLayoutModControllable::calculateAutomationKnobPosForPadPress(
+    ModelStackWithAutoParam* modelStackWithParam, OutputType outputType, int32_t yDisplay) {
+
+	int32_t newKnobPos = 0;
+	params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+
+	if (getMiddlePadPressSelected()) {
+		newKnobPos = calculateAutomationKnobPosForMiddlePadPress(kind, yDisplay);
+	}
+	else {
+		newKnobPos = calculateAutomationKnobPosForSinglePadPress(kind, yDisplay);
+	}
+
+	// for Midi Clips, maxKnobPos = 127
+	if (outputType == OutputType::MIDI_OUT && newKnobPos == kMaxKnobPos) {
+		newKnobPos -= 1; // 128 - 1 = 127
+	}
+
+	// in the deluge knob positions are stored in the range of -64 to + 64, so need to adjust newKnobPos
+	// set above.
+	newKnobPos = newKnobPos - kKnobPosOffset;
+
+	return newKnobPos;
+}
+
+// calculates what the new parameter value is when you press a second pad in the same column
+// middle value is calculated by taking average of min and max value of the range for the two pad
+// presses
+int32_t AutomationEditorLayoutModControllable::calculateAutomationKnobPosForMiddlePadPress(params::Kind kind,
+                                                                                           int32_t yDisplay) {
+	int32_t newKnobPos = 0;
+
+	int32_t yMin = yDisplay < getLeftPadSelectedY() ? yDisplay : getLeftPadSelectedY();
+	int32_t yMax = yDisplay > getLeftPadSelectedY() ? yDisplay : getLeftPadSelectedY();
+	int32_t minKnobPos = 0;
+	int32_t maxKnobPos = 0;
+
+	if (kind == params::Kind::PATCH_CABLE) {
+		minKnobPos = patchCableMinPadDisplayValues[yMin];
+		maxKnobPos = patchCableMaxPadDisplayValues[yMax];
+	}
+	else {
+		minKnobPos = nonPatchCableMinPadDisplayValues[yMin];
+		maxKnobPos = nonPatchCableMaxPadDisplayValues[yMax];
+	}
+
+	newKnobPos = (minKnobPos + maxKnobPos) >> 1;
+
+	return newKnobPos;
+}
+
+// calculates what the new parameter value is when you press a single pad
+int32_t AutomationEditorLayoutModControllable::calculateAutomationKnobPosForSinglePadPress(params::Kind kind,
+                                                                                           int32_t yDisplay) {
+	int32_t newKnobPos = 0;
+
+	// patch cable
+	if (kind == params::Kind::PATCH_CABLE) {
+		newKnobPos = patchCablePadPressValues[yDisplay];
+	}
+	// non patch cable
+	else {
+		newKnobPos = nonPatchCablePadPressValues[yDisplay];
+	}
+
+	return newKnobPos;
+}
+
+// takes care of setting the automation values for the two pads pressed and the pads in between
+void AutomationEditorLayoutModControllable::handleAutomationMultiPadPress(
+    ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t firstPadX, int32_t firstPadY, int32_t secondPadX,
+    int32_t secondPadY, int32_t effectiveLength, int32_t xScroll, int32_t xZoom, bool modEncoderAction) {
+
+	int32_t secondPadLeftEdge = getPosFromSquare(secondPadX, xScroll, xZoom);
+
+	if (effectiveLength <= 0 || secondPadLeftEdge > effectiveLength) {
+		return;
+	}
+
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+		int32_t firstPadLeftEdge = getPosFromSquare(firstPadX, xScroll, xZoom);
+		int32_t secondPadRightEdge = getPosFromSquare(secondPadX + 1, xScroll, xZoom);
+
+		int32_t firstPadValue = 0;
+		int32_t secondPadValue = 0;
+
+		// if we're updating the long press values via mod encoder action, then get current values of
+		// pads pressed and re-interpolate
+		if (modEncoderAction) {
+			firstPadValue = getAutomationParameterKnobPos(modelStackWithParam, firstPadLeftEdge) + kKnobPosOffset;
+
+			uint32_t squareStart = std::min(effectiveLength, secondPadRightEdge) - kParamNodeWidth;
+
+			secondPadValue = getAutomationParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
+		}
+
+		// otherwise if it's a regular long press, calculate values from the y position of the pads
+		// pressed
+		else {
+			OutputType outputType = clip->output->type;
+			firstPadValue =
+			    calculateAutomationKnobPosForPadPress(modelStackWithParam, outputType, firstPadY) + kKnobPosOffset;
+			secondPadValue =
+			    calculateAutomationKnobPosForPadPress(modelStackWithParam, outputType, secondPadY) + kKnobPosOffset;
+		}
+
+		// clear existing nodes from long press range
+
+		// reset interpolation settings to default
+		initInterpolation();
+
+		// set value for beginning pad press at the very first node position within that pad
+		setAutomationParameterValue(modelStackWithParam, firstPadValue - kKnobPosOffset, firstPadLeftEdge, firstPadX,
+		                            effectiveLength, xScroll, xZoom);
+
+		// set value for ending pad press at the very last node position within that pad
+		int32_t squareStart = std::min(effectiveLength, secondPadRightEdge) - kParamNodeWidth;
+		setAutomationParameterValue(modelStackWithParam, secondPadValue - kKnobPosOffset, squareStart, secondPadX,
+		                            effectiveLength, xScroll, xZoom);
+
+		// converting variables to float for more accurate interpolation calculation
+		float firstPadValueFloat = static_cast<float>(firstPadValue);
+		float firstPadXFloat = static_cast<float>(firstPadLeftEdge);
+		float secondPadValueFloat = static_cast<float>(secondPadValue);
+		float secondPadXFloat = static_cast<float>(squareStart);
+
+		// loop from first pad to last pad, setting values for nodes in between
+		// these values will serve as "key frames" for the interpolation to flow through
+		for (int32_t x = firstPadX; x <= secondPadX; x++) {
+
+			int32_t newKnobPos = 0;
+			uint32_t squareWidth = 0;
+
+			// we've already set the value for the very first node corresponding to the first pad above
+			// now we will set the value for the remaining nodes within the first pad
+			if (x == firstPadX) {
+				squareStart = getPosFromSquare(x, xScroll, xZoom) + kParamNodeWidth;
+				squareWidth = getSquareWidth(x, effectiveLength, xScroll, xZoom) - kParamNodeWidth;
+			}
+
+			// we've already set the value for the very last node corresponding to the second pad above
+			// now we will set the value for the remaining nodes within the second pad
+			else if (x == secondPadX) {
+				squareStart = getPosFromSquare(x, xScroll, xZoom);
+				squareWidth = getSquareWidth(x, effectiveLength, xScroll, xZoom) - kParamNodeWidth;
+			}
+
+			// now we will set the values for the nodes between the first and second pad's pressed
+			else {
+				squareStart = getPosFromSquare(x, xScroll, xZoom);
+				squareWidth = getSquareWidth(x, effectiveLength, xScroll, xZoom);
+			}
+
+			// linear interpolation formula to calculate the value of the pads
+			// f(x) = A + (x - Ax) * ((B - A) / (Bx - Ax))
+			float newKnobPosFloat = std::round(firstPadValueFloat
+			                                   + (((squareStart - firstPadXFloat) / kParamNodeWidth)
+			                                      * ((secondPadValueFloat - firstPadValueFloat)
+			                                         / ((secondPadXFloat - firstPadXFloat) / kParamNodeWidth))));
+
+			newKnobPos = static_cast<int32_t>(newKnobPosFloat);
+			newKnobPos = newKnobPos - kKnobPosOffset;
+
+			// if interpolation is off, values for nodes in between first and second pad will not be set
+			// in a staggered/step fashion
+			if (getInterpolation()) {
+				getInterpolationBefore() = true;
+				getInterpolationAfter() = true;
+			}
+
+			// set value for pads in between
+			int32_t newValue =
+			    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
+			modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, squareStart,
+			                                                          squareWidth);
+			modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, squareStart,
+			                                                          squareWidth);
+
+			if (!getOnArrangerView()) {
+				modelStackWithParam->getTimelineCounter()->instrumentBeenEdited();
+			}
+		}
+
+		// reset interpolation settings to off
+		initInterpolation();
+
+		// render the multi pad press
+		uiNeedsRendering(getAutomationView());
+	}
+}
+
+// new function to render display when a long press is active
+// on OLED this will display the left and right position in a long press on the screen
+// on 7SEG this will display the position of the last selected pad
+// also updates LED indicators. bottom LED indicator = left pad, top LED indicator = right pad
+void AutomationEditorLayoutModControllable::renderAutomationDisplayForMultiPadPress(
+    ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
+    int32_t xDisplay, bool modEncoderAction) {
+
+	int32_t secondPadLeftEdge = getPosFromSquare(getRightPadSelectedX(), xScroll, xZoom);
+
+	if (effectiveLength <= 0 || secondPadLeftEdge > effectiveLength) {
+		return;
+	}
+
+	if (modelStackWithParam && modelStackWithParam->autoParam) {
+		int32_t firstPadLeftEdge = getPosFromSquare(getLeftPadSelectedX(), xScroll, xZoom);
+		int32_t secondPadRightEdge = getPosFromSquare(getRightPadSelectedX() + 1, xScroll, xZoom);
+
+		int32_t knobPosLeft = getAutomationParameterKnobPos(modelStackWithParam, firstPadLeftEdge) + kKnobPosOffset;
+
+		uint32_t squareStart = std::min(effectiveLength, secondPadRightEdge) - kParamNodeWidth;
+		int32_t knobPosRight = getAutomationParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
+
+		if (xDisplay != kNoSelection) {
+			if (getLeftPadSelectedX() == xDisplay) {
+				squareStart = firstPadLeftEdge;
+				getLastPadSelectedKnobPos() = knobPosLeft;
+			}
+			else {
+				getLastPadSelectedKnobPos() = knobPosRight;
+			}
+		}
+
+		if (display->haveOLED()) {
+			renderDisplay(knobPosLeft, knobPosRight);
+		}
+		// display pad value of second pad pressed
+		else {
+			if (modEncoderAction) {
+				renderDisplay(getLastPadSelectedKnobPos());
+			}
+			else {
+				renderDisplay();
+			}
+		}
+
+		setAutomationKnobIndicatorLevels(modelStackWithParam, knobPosLeft, knobPosRight);
+
+		// update position of mod controllable stack
+		updateAutomationModPosition(modelStackWithParam, squareStart, false, false);
+	}
+}
+
+// used to calculate new knobPos when you turn the mod encoders (gold knobs)
+int32_t AutomationEditorLayoutModControllable::calculateAutomationKnobPosForModEncoderTurn(
+    ModelStackWithAutoParam* modelStackWithParam, int32_t knobPos, int32_t offset) {
+
+	// adjust the current knob so that it is within the range of 0-128 for calculation purposes
+	knobPos = knobPos + kKnobPosOffset;
+
+	int32_t newKnobPos = 0;
+
+	if ((knobPos + offset) < 0) {
+		params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
+		if (kind == params::Kind::PATCH_CABLE) {
+			if ((knobPos + offset) >= -kMaxKnobPos) {
+				newKnobPos = knobPos + offset;
+			}
+			else if ((knobPos + offset) < -kMaxKnobPos) {
+				newKnobPos = -kMaxKnobPos;
+			}
+			else {
+				newKnobPos = knobPos;
+			}
+		}
+		else {
+			newKnobPos = knobPos;
+		}
+	}
+	else if ((knobPos + offset) <= kMaxKnobPos) {
+		newKnobPos = knobPos + offset;
+	}
+	else if ((knobPos + offset) > kMaxKnobPos) {
+		newKnobPos = kMaxKnobPos;
+	}
+	else {
+		newKnobPos = knobPos;
+	}
+
+	// in the deluge knob positions are stored in the range of -64 to + 64, so need to adjust newKnobPos
+	// set above.
+	newKnobPos = newKnobPos - kKnobPosOffset;
+
+	return newKnobPos;
+}
+
+}; // namespace deluge::gui::views::automation::editor_layout

--- a/src/deluge/gui/views/automation/editor_layout/mod_controllable.h
+++ b/src/deluge/gui/views/automation/editor_layout/mod_controllable.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/views/automation/editor_layout.h"
+
+namespace deluge::gui::views::automation::editor_layout {
+
+class AutomationEditorLayoutModControllable : public AutomationEditorLayout {
+public:
+	AutomationEditorLayoutModControllable() = default;
+
+public:
+	// LED indicators
+	void setAutomationKnobIndicatorLevels(ModelStackWithAutoParam* modelStack, int32_t knobPosLeft,
+	                                      int32_t knobPosRight);
+
+	// edit pad action
+	bool toggleAutomationInterpolation();
+	bool toggleAutomationPadSelectionMode(ModelStackWithAutoParam* modelStackWithParam, int32_t effectiveLength,
+	                                      int32_t xScroll, int32_t xZoom);
+	void automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
+	                             int32_t yDisplay, int32_t velocity, int32_t effectiveLength, int32_t xScroll,
+	                             int32_t xZoom);
+
+private:
+	bool recordAutomationSinglePadPress(int32_t xDisplay, int32_t yDisplay);
+
+public:
+	// Automation View Render Grid Functions
+	void renderAutomationEditor(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
+	                            RGB image[][kDisplayWidth + kSideBarWidth],
+	                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
+	                            int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
+	                            bool drawUndefinedArea, deluge::modulation::params::Kind kind, bool isBipolar);
+
+private:
+	void renderAutomationColumn(ModelStackWithAutoParam* modelStackWithParam,
+	                            RGB image[][kDisplayWidth + kSideBarWidth],
+	                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t lengthToDisplay,
+	                            int32_t xDisplay, bool isAutomated, int32_t xScroll, int32_t xZoom,
+	                            deluge::modulation::params::Kind kind, bool isBipolar);
+	void renderAutomationBipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+	                                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
+	                                   int32_t yDisplay, bool isAutomated, deluge::modulation::params::Kind kind,
+	                                   int32_t knobPos);
+	void renderAutomationUnipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+	                                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
+	                                    int32_t yDisplay, bool isAutomated, int32_t knobPos);
+
+public:
+	// OLED/7Seg Display
+	void renderAutomationEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas, Clip* clip,
+	                                       OutputType outputType, int32_t knobPosLeft, int32_t knobPosRight);
+	void renderAutomationEditorDisplay7SEG(Clip* clip, OutputType outputType, int32_t knobPosLeft,
+	                                       bool modEncoderAction);
+	void renderAutomationDisplayForMultiPadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
+	                                             int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
+	                                             int32_t xDisplay = kNoSelection, bool modEncoderAction = false);
+
+private:
+	void getAutomationParameterName(Clip* clip, OutputType outputType, StringBuf& parameterName);
+
+public:
+	// Mod Encoder Action
+	bool automationModEncoderActionForSelectedPad(ModelStackWithAutoParam* modelStackWithParam, int32_t whichModEncoder,
+	                                              int32_t offset, int32_t effectiveLength);
+	void automationModEncoderActionForUnselectedPad(ModelStackWithAutoParam* modelStackWithParam,
+	                                                int32_t whichModEncoder, int32_t offset, int32_t effectiveLength);
+
+	// Mod Encoder Button Action
+	void copyAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xScroll, int32_t xZoom);
+	void pasteAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t effectiveLength,
+	                     int32_t xScroll, int32_t xZoom);
+
+	// Automation Lanes Functions
+	int32_t getAutomationParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t pos);
+
+private:
+	uint32_t getSquareWidth(int32_t square, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
+	uint32_t getMiddlePosFromSquare(int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
+	bool getAutomationNodeInterpolation(ModelStackWithAutoParam* modelStack, int32_t pos, bool reversed);
+	void setAutomationParameterValue(ModelStackWithAutoParam* modelStack, int32_t knobPos, int32_t squareStart,
+	                                 int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
+	                                 bool modEncoderAction = false);
+	void updateAutomationModPosition(ModelStackWithAutoParam* modelStack, uint32_t squareStart,
+	                                 bool updateDisplay = true, bool updateIndicatorLevels = true);
+
+	void handleAutomationSinglePadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
+	                                    int32_t yDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
+	void handleAutomationParameterChange(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
+	                                     OutputType outputType, int32_t xDisplay, int32_t yDisplay,
+	                                     int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
+	int32_t calculateAutomationKnobPosForPadPress(ModelStackWithAutoParam* modelStackWithParam, OutputType outputType,
+	                                              int32_t yDisplay);
+	int32_t calculateAutomationKnobPosForMiddlePadPress(deluge::modulation::params::Kind kind, int32_t yDisplay);
+	int32_t calculateAutomationKnobPosForSinglePadPress(deluge::modulation::params::Kind kind, int32_t yDisplay);
+
+	void handleAutomationMultiPadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t firstPadX,
+	                                   int32_t firstPadY, int32_t secondPadX, int32_t secondPadY,
+	                                   int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
+	                                   bool modEncoderAction = false);
+	int32_t calculateAutomationKnobPosForModEncoderTurn(ModelStackWithAutoParam* modelStackWithParam, int32_t knobPos,
+	                                                    int32_t offset);
+};
+}; // namespace deluge::gui::views::automation::editor_layout
+
+extern deluge::gui::views::automation::editor_layout::AutomationEditorLayoutModControllable
+    automationEditorLayoutModControllable;

--- a/src/deluge/gui/views/automation/editor_layout/note.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/note.cpp
@@ -1,0 +1,636 @@
+/*
+ * Copyright (c) 2023 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gui/views/automation/editor_layout/note.h"
+#include "gui/views/instrument_clip_view.h"
+#include "model/action/action_logger.h"
+#include "model/clip/instrument_clip.h"
+#include "model/note/note.h"
+
+namespace deluge::gui::views::automation::editor_layout {
+
+using namespace deluge::gui;
+
+// colours for the velocity editor
+
+const RGB velocityRowColour[kDisplayHeight] = {{0, 0, 255},   {36, 0, 219}, {73, 0, 182}, {109, 0, 146},
+                                               {146, 0, 109}, {182, 0, 73}, {219, 0, 36}, {255, 0, 0}};
+
+const RGB velocityRowTailColour[kDisplayHeight] = {{2, 2, 53},  {9, 2, 46},  {17, 2, 38}, {24, 2, 31},
+                                                   {31, 2, 24}, {38, 2, 17}, {46, 2, 9},  {53, 2, 2}};
+
+const RGB velocityRowBlurColour[kDisplayHeight] = {{71, 71, 111}, {72, 66, 101}, {73, 62, 90}, {74, 57, 80},
+                                                   {76, 53, 70},  {77, 48, 60},  {78, 44, 49}, {79, 39, 39}};
+
+constexpr uint8_t kVelocityShortcutX = 15;
+constexpr uint8_t kVelocityShortcutY = 1;
+
+// lookup tables for the values that are set when you press the pads in each row of the grid
+const int32_t padPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
+
+// lookup tables for the min value of each pad's value range used to display automation on each row of the grid
+const int32_t minPadDisplayValues[kDisplayHeight] = {0, 17, 33, 49, 65, 81, 97, 113};
+
+// lookup tables for the max value of each pad's value range used to display automation on each row of the grid
+const int32_t maxPadDisplayValues[kDisplayHeight] = {16, 32, 48, 64, 80, 96, 112, 128};
+
+// summary of pad ranges and press values (format: MIN < PRESS < MAX)
+// y = 7 :: 113 < 128 < 128
+// y = 6 ::  97 < 110 < 112
+// y = 5 ::  81 <  91 <  96
+// y = 4 ::  65 <  73 <  80
+// y = 3 ::  49 <  55 <  64
+// y = 2 ::  33 <  37 <  48
+// y = 1 ::  17 <  18 <  32
+// y = 0 ::  0  <   0 <  16
+
+PLACE_SDRAM_BSS AutomationEditorLayoutNote automationEditorLayoutNote{};
+
+// gets the length of the note row, renders the pads corresponding to current note parameter values set up to the
+// note row length renders the undefined area of the note row that the user can't interact with
+void AutomationEditorLayoutNote::renderNoteEditor(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
+                                                  RGB image[][kDisplayWidth + kSideBarWidth],
+                                                  uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+                                                  int32_t renderWidth, int32_t xScroll, uint32_t xZoom,
+                                                  int32_t effectiveLength, int32_t xDisplay, bool drawUndefinedArea,
+                                                  SquareInfo& squareInfo) {
+	if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+		renderNoteColumn(modelStackWithNoteRow, clip, image, occupancyMask, xDisplay, xScroll, xZoom, squareInfo);
+	}
+	if (drawUndefinedArea) {
+		renderUndefinedArea(xScroll, xZoom, effectiveLength, image, occupancyMask, renderWidth,
+		                    getAutomationView()->toTimelineView(), currentSong->tripletsOn, xDisplay);
+	}
+}
+
+/// render each square in each column of the note editor grid
+void AutomationEditorLayoutNote::renderNoteColumn(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
+                                                  RGB image[][kDisplayWidth + kSideBarWidth],
+                                                  uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+                                                  int32_t xDisplay, int32_t xScroll, int32_t xZoom,
+                                                  SquareInfo& squareInfo) {
+	int32_t value = 0;
+
+	if (getAutomationParamType() == AutomationParamType::NOTE_VELOCITY) {
+		value = squareInfo.averageVelocity;
+	}
+
+	// iterate through each square
+	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+		renderNoteSquare(image, occupancyMask, xDisplay, yDisplay, squareInfo.squareType, value);
+	}
+}
+
+/// render column for note parameter
+void AutomationEditorLayoutNote::renderNoteSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+                                                  uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
+                                                  int32_t xDisplay, int32_t yDisplay, uint8_t squareType,
+                                                  int32_t value) {
+	RGB& pixel = image[yDisplay][xDisplay];
+	bool doRender = false;
+
+	if (squareType == SQUARE_NO_NOTE) {
+		pixel = colours::black; // erase pad
+	}
+	else {
+		// render square
+		if (value >= minPadDisplayValues[yDisplay]) {
+			doRender = true;
+			if (squareType == SQUARE_NOTE_HEAD) {
+				pixel = velocityRowColour[yDisplay];
+			}
+			else if (squareType == SQUARE_NOTE_TAIL) {
+				pixel = velocityRowTailColour[yDisplay];
+			}
+			else if (squareType == SQUARE_BLURRED) {
+				pixel = velocityRowBlurColour[yDisplay];
+			}
+			occupancyMask[yDisplay][xDisplay] = 64;
+		}
+		else {
+			pixel = colours::black; // erase pad
+		}
+	}
+}
+
+void AutomationEditorLayoutNote::renderNoteEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas,
+                                                             InstrumentClip* clip, OutputType outputType,
+                                                             int32_t knobPosLeft, int32_t knobPosRight) {
+	// display note parameter name
+	DEF_STACK_STRING_BUF(parameterName, 30);
+	if (getAutomationParamType() == AutomationParamType::NOTE_VELOCITY) {
+		parameterName.append("Velocity");
+	}
+
+#if OLED_MAIN_HEIGHT_PIXELS == 64
+	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
+#else
+	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
+#endif
+	canvas.drawStringCentredShrinkIfNecessary(parameterName.c_str(), yPos, kTextSpacingX, kTextSpacingY);
+
+	// display note / drum name
+	yPos = yPos + 12;
+
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+	bool isKit = outputType == OutputType::KIT;
+
+	ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
+	                                                                        modelStack); // don't create
+	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+		if (!isKit) {
+			modelStackWithNoteRow =
+			    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
+		}
+	}
+
+	char noteRowName[50];
+
+	if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+		if (isKit) {
+			DEF_STACK_STRING_BUF(drumName, 50);
+			instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
+			strncpy(noteRowName, drumName.c_str(), 49);
+		}
+		else {
+			int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
+			noteCodeToString(modelStackWithNoteRow->getNoteRow()->getNoteCode(), noteRowName, &isNatural);
+		}
+	}
+	else {
+		if (isKit) {
+			strncpy(noteRowName, "(Select Drum)", 49);
+		}
+		else {
+			strncpy(noteRowName, "(Select Note)", 49);
+		}
+	}
+
+	canvas.drawStringCentred(noteRowName, yPos, kTextSpacingX, kTextSpacingY);
+
+	// display parameter value
+	yPos = yPos + 12;
+
+	if (getAutomationParamType() == AutomationParamType::NOTE_VELOCITY) {
+		if (knobPosRight != kNoSelection) {
+			char bufferLeft[10];
+			bufferLeft[0] = 'L';
+			bufferLeft[1] = ':';
+			bufferLeft[2] = ' ';
+			intToString(knobPosLeft, &bufferLeft[3]);
+			canvas.drawString(bufferLeft, 0, yPos, kTextSpacingX, kTextSpacingY);
+
+			char bufferRight[10];
+			bufferRight[0] = 'R';
+			bufferRight[1] = ':';
+			bufferRight[2] = ' ';
+			intToString(knobPosRight, &bufferRight[3]);
+			canvas.drawStringAlignRight(bufferRight, yPos, kTextSpacingX, kTextSpacingY);
+		}
+		else if (knobPosLeft != kNoSelection) {
+			char buffer[5];
+			intToString(knobPosLeft, buffer);
+			canvas.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
+		}
+		else {
+			char buffer[5];
+			intToString(getCurrentInstrument()->defaultVelocity, buffer);
+			canvas.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
+		}
+	}
+}
+
+void AutomationEditorLayoutNote::renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputType outputType,
+                                                             int32_t knobPosLeft) {
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+	bool isKit = outputType == OutputType::KIT;
+
+	ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
+	                                                                        modelStack); // don't create
+	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
+		if (!isKit) {
+			modelStackWithNoteRow =
+			    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
+		}
+	}
+
+	if (knobPosLeft != kNoSelection) {
+		char buffer[5];
+		intToString(knobPosLeft, buffer);
+		display->setText(buffer, true, 255, false);
+	}
+	else {
+		// display note / drum name
+		char noteRowName[50];
+		if (modelStackWithNoteRow->getNoteRowAllowNull()) {
+			if (isKit) {
+				DEF_STACK_STRING_BUF(drumName, 50);
+				instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
+				strncpy(noteRowName, drumName.c_str(), 49);
+			}
+			else {
+				int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
+				noteCodeToString(modelStackWithNoteRow->getNoteRow()->getNoteCode(), noteRowName, &isNatural);
+			}
+		}
+		else {
+			if (isKit) {
+				strncpy(noteRowName, "(Select Drum)", 49);
+			}
+			else {
+				strncpy(noteRowName, "(Select Note)", 49);
+			}
+		}
+		display->setScrollingText(noteRowName);
+	}
+}
+
+// note edit pad action
+// handles single and multi pad presses for note parameter editing (e.g. velocity)
+// stores pad presses in the EditPadPresses struct of the instrument clip view
+void AutomationEditorLayoutNote::noteEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
+                                                   InstrumentClip* clip, int32_t x, int32_t y, int32_t velocity,
+                                                   int32_t effectiveLength, SquareInfo& squareInfo) {
+	if (getAutomationParamType() == AutomationParamType::NOTE_VELOCITY) {
+		velocityEditPadAction(modelStackWithNoteRow, noteRow, clip, x, y, velocity, effectiveLength, squareInfo);
+	}
+}
+
+// velocity edit pad action
+void AutomationEditorLayoutNote::velocityEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
+                                                       InstrumentClip* clip, int32_t x, int32_t y, int32_t velocity,
+                                                       int32_t effectiveLength, SquareInfo& squareInfo) {
+	// save pad selected
+	getLeftPadSelectedX() = x;
+
+	// calculate new velocity based on Y of pad pressed
+	int32_t newVelocity = getVelocityFromY(y);
+
+	// middle pad press variables
+	getMiddlePadPressSelected() = false;
+
+	// multi pad press variables
+	getMultiPadPressSelected() = false;
+	SquareInfo rowSquareInfo[kDisplayWidth];
+	int32_t multiPadPressVelocityIncrement = 0;
+
+	// update velocity editor rendering
+	bool refreshVelocityEditor = false;
+	bool showNewVelocity = true;
+
+	// check for middle or multi pad press
+	if (velocity && squareInfo.numNotes != 0 && instrumentClipView.numEditPadPresses == 1) {
+		// Find that original press
+		for (int32_t i = 0; i < kEditPadPressBufferSize; i++) {
+			if (instrumentClipView.editPadPresses[i].isActive) {
+				// if found, calculate middle velocity between two velocity pad presses
+				if (instrumentClipView.editPadPresses[i].xDisplay == x) {
+					// the last pad press will have updated the default velocity
+					// so get it as it will be used to calculate average between previous and new velocity
+					int32_t previousVelocity = getCurrentInstrument()->defaultVelocity;
+
+					// calculate middle velocity (average of two pad presses in a column)
+					newVelocity = (newVelocity + previousVelocity) / 2;
+
+					// update middle pad press selection indicator
+					getMiddlePadPressSelected() = true;
+
+					break;
+				}
+				// found a second press that isn't in the same column as the first press
+				else {
+					int32_t firstPadX = instrumentClipView.editPadPresses[i].xDisplay;
+
+					// get note info on all the squares in the note row
+					noteRow->getRowSquareInfo(effectiveLength, rowSquareInfo);
+
+					// the long press logic calculates and renders the interpolation as if the press was
+					// entered in a forward fashion (where the first pad is to the left of the second
+					// pad). if the user happens to enter a long press backwards then we fix that entry
+					// by re-ordering the pad presses so that it is forward again
+					getLeftPadSelectedX() = firstPadX > x ? x : firstPadX;
+					getRightPadSelectedX() = firstPadX > x ? firstPadX : x;
+
+					int32_t numSquares = 0;
+					// find total number of notes in note row (excluding the first note)
+					for (int32_t i = getLeftPadSelectedX(); i <= getRightPadSelectedX(); i++) {
+						// don't include note tails in note count
+						if (rowSquareInfo[i].numNotes != 0 && rowSquareInfo[i].squareType != SQUARE_NOTE_TAIL) {
+							numSquares++;
+						}
+					}
+
+					//	DEF_STACK_STRING_BUF(numSquare, 50);
+					//	numSquare.append("Squares: ");
+					//	numSquare.appendInt(numSquares);
+					//	numSquare.append("\n");
+
+					// calculate start and end velocity for long press
+					int32_t leftPadSelectedVelocity;
+					int32_t rightPadSelectedVelocity;
+
+					if (getLeftPadSelectedX() == firstPadX) { // then left pad is the first press
+						leftPadSelectedVelocity = rowSquareInfo[getLeftPadSelectedX()].averageVelocity;
+						getLeftPadSelectedY() = getYFromVelocity(leftPadSelectedVelocity);
+						rightPadSelectedVelocity = getVelocityFromY(y);
+						getRightPadSelectedY() = y;
+					}
+					else { // then left pad is the second press
+						leftPadSelectedVelocity = getVelocityFromY(y);
+						getLeftPadSelectedY() = y;
+						rightPadSelectedVelocity = rowSquareInfo[getRightPadSelectedX()].averageVelocity;
+						getRightPadSelectedY() = getYFromVelocity(rightPadSelectedVelocity);
+					}
+
+					//	numSquare.append("L: ");
+					//	numSquare.appendInt(leftPadSelectedVelocity);
+					//	numSquare.append(" R: ");
+					//	numSquare.appendInt(rightPadSelectedVelocity);
+					//	numSquare.append("\n");
+
+					// calculate increment from first pad to last pad
+					float multiPadPressVelocityIncrementFloat =
+					    static_cast<float>((rightPadSelectedVelocity - leftPadSelectedVelocity)) / (numSquares - 1);
+					multiPadPressVelocityIncrement =
+					    static_cast<int32_t>(std::round(multiPadPressVelocityIncrementFloat));
+					// if ramp is upwards, make increment positive
+					if (leftPadSelectedVelocity < rightPadSelectedVelocity) {
+						multiPadPressVelocityIncrement = std::abs(multiPadPressVelocityIncrement);
+					}
+
+					//	numSquare.append("Inc: ");
+					//	numSquare.appendInt(multiPadPressVelocityIncrement);
+					//	display->displayPopup(numSquare.c_str());
+
+					// update multi pad press selection indicator
+					getMultiPadPressSelected() = true;
+					getMultiPadPressActive() = true;
+
+					break;
+				}
+			}
+		}
+	}
+
+	// if middle pad press was selected, set the velocity to middle velocity between two pads pressed
+	if (getMiddlePadPressSelected()) {
+		setVelocity(modelStackWithNoteRow, noteRow, x, newVelocity);
+		refreshVelocityEditor = true;
+	}
+	// if multi pad (long) press was selected, set the velocity of all the notes between the two pad presses
+	else if (getMultiPadPressSelected()) {
+		setVelocityRamp(modelStackWithNoteRow, noteRow, rowSquareInfo, multiPadPressVelocityIncrement);
+		refreshVelocityEditor = true;
+	}
+	// otherwise, it's a regular velocity pad action
+	else {
+		// no existing notes in square pressed
+		// add note and set velocity
+		if (squareInfo.numNotes == 0) {
+			addNoteWithNewVelocity(x, velocity, newVelocity);
+			refreshVelocityEditor = true;
+		}
+		// pressing pad corresponding to note's current averageVelocity, remove note
+		else if (minPadDisplayValues[y] <= squareInfo.averageVelocity
+		         && squareInfo.averageVelocity <= maxPadDisplayValues[y]) {
+			recordNoteEditPadAction(x, velocity);
+			refreshVelocityEditor = true;
+			showNewVelocity = false;
+		}
+		// note(s) exists, adjust velocity of existing notes
+		else {
+			adjustNoteVelocity(modelStackWithNoteRow, noteRow, x, velocity, newVelocity, squareInfo.squareType);
+			refreshVelocityEditor = true;
+		}
+	}
+	// if no note exists and you're trying to remove a note (y == 0 && squareInfo.numNotes == 0),
+	// well no need to do anything
+
+	if (getMultiPadPressActive() && !isUIModeActive(UI_MODE_NOTES_PRESSED)) {
+		getMultiPadPressActive() = false;
+	}
+
+	if (refreshVelocityEditor) {
+		// refresh grid and update default velocity on the display
+		uiNeedsRendering(getAutomationView(), 0xFFFFFFFF, 0);
+		// if holding a multi pad press, render left and right velocity of the multi pad press
+		if (getMultiPadPressActive()) {
+			int32_t leftPadSelectedVelocity = getVelocityFromY(getLeftPadSelectedY());
+			int32_t rightPadSelectedVelocity = getVelocityFromY(getRightPadSelectedY());
+			if (display->haveOLED()) {
+				renderDisplay(leftPadSelectedVelocity, rightPadSelectedVelocity);
+			}
+			else {
+				// for 7seg, render value of last pad pressed
+				renderDisplay(getLeftPadSelectedX() == x ? leftPadSelectedVelocity : rightPadSelectedVelocity);
+			}
+		}
+		else {
+			if (velocity) {
+				renderDisplay(showNewVelocity ? newVelocity : squareInfo.averageVelocity);
+			}
+			else {
+				renderDisplay();
+			}
+		}
+	}
+}
+
+// convert y of pad press into velocity value between 1 and 127
+int32_t AutomationEditorLayoutNote::getVelocityFromY(int32_t y) {
+	int32_t velocity = std::clamp<int32_t>(padPressValues[y], 1, 127);
+	return velocity;
+}
+
+// convert velocity of a square into y
+int32_t AutomationEditorLayoutNote::getYFromVelocity(int32_t velocity) {
+	for (int32_t i = 0; i < kDisplayHeight; i++) {
+		if (minPadDisplayValues[i] <= velocity && velocity <= maxPadDisplayValues[i]) {
+			return i;
+		}
+	}
+	return kNoSelection;
+}
+
+// add note and set velocity
+void AutomationEditorLayoutNote::addNoteWithNewVelocity(int32_t x, int32_t velocity, int32_t newVelocity) {
+	if (velocity) {
+		// we change the instrument default velocity because it is used for new notes
+		getCurrentInstrument()->defaultVelocity = newVelocity;
+	}
+
+	// record pad press and release
+	// adds note with new velocity set
+	recordNoteEditPadAction(x, velocity);
+}
+
+// adjust velocity of existing notes
+void AutomationEditorLayoutNote::adjustNoteVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
+                                                    int32_t x, int32_t velocity, int32_t newVelocity,
+                                                    uint8_t squareType) {
+	if (velocity) {
+		// record pad press
+		recordNoteEditPadAction(x, velocity);
+
+		// adjust velocities of notes within pressed pad square
+		setVelocity(modelStackWithNoteRow, noteRow, x, newVelocity);
+	}
+	else {
+		// record pad release
+		recordNoteEditPadAction(x, velocity);
+	}
+}
+
+// set velocity of notes within pressed pad square
+void AutomationEditorLayoutNote::setVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x,
+                                             int32_t newVelocity) {
+	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
+	if (!action) {
+		return;
+	}
+
+	int32_t velocityValue = 0;
+
+	for (int32_t i = 0; i < kEditPadPressBufferSize; i++) {
+		bool foundPadPress = instrumentClipView.editPadPresses[i].isActive;
+
+		// if we found an active pad press and we're looking for a pad press with a specific xDisplay
+		// see if the active pad press is the one we are looking for
+		if (foundPadPress && (x != kNoSelection)) {
+			foundPadPress = (instrumentClipView.editPadPresses[i].xDisplay == x);
+		}
+
+		if (foundPadPress) {
+			instrumentClipView.editPadPresses[i].deleteOnDepress = false;
+
+			// Multiple notes in square
+			if (instrumentClipView.editPadPresses[i].isBlurredSquare) {
+
+				uint32_t velocitySumThisSquare = 0;
+				uint32_t numNotesThisSquare = 0;
+
+				int32_t noteI =
+				    noteRow->notes.search(instrumentClipView.editPadPresses[i].intendedPos, GREATER_OR_EQUAL);
+				Note* note = noteRow->notes.getElement(noteI);
+				while (note
+				       && note->pos - instrumentClipView.editPadPresses[i].intendedPos
+				              < instrumentClipView.editPadPresses[i].intendedLength) {
+					noteRow->changeNotesAcrossAllScreens(note->pos, modelStackWithNoteRow, action,
+					                                     CORRESPONDING_NOTES_SET_VELOCITY, newVelocity);
+
+					instrumentClipView.updateVelocityValue(velocityValue, note->getVelocity());
+
+					numNotesThisSquare++;
+					velocitySumThisSquare += note->getVelocity();
+
+					noteI++;
+					note = noteRow->notes.getElement(noteI);
+				}
+
+				// Rohan: Get the average. Ideally we'd have done this when first selecting the note too, but I
+				// didn't
+
+				// Sean: not sure how getting the average when first selecting the note would help because the
+				// average will change based on the velocity adjustment happening here.
+
+				// We're adjusting the intendedVelocity here because this is the velocity that is used to audition
+				// the pad press note so you can hear the velocity changes as you're holding the note down
+				instrumentClipView.editPadPresses[i].intendedVelocity = velocitySumThisSquare / numNotesThisSquare;
+			}
+
+			// Only one note in square
+			else {
+				// We're adjusting the intendedVelocity here because this is the velocity that is used to audition
+				// the pad press note so you can hear the velocity changes as you're holding the note down
+				instrumentClipView.editPadPresses[i].intendedVelocity = newVelocity;
+				noteRow->changeNotesAcrossAllScreens(instrumentClipView.editPadPresses[i].intendedPos,
+				                                     modelStackWithNoteRow, action, CORRESPONDING_NOTES_SET_VELOCITY,
+				                                     newVelocity);
+
+				instrumentClipView.updateVelocityValue(velocityValue,
+				                                       instrumentClipView.editPadPresses[i].intendedVelocity);
+			}
+		}
+	}
+
+	instrumentClipView.displayVelocity(velocityValue, 0);
+
+	instrumentClipView.reassessAllAuditionStatus();
+}
+
+// set velocity of notes between pressed squares
+void AutomationEditorLayoutNote::setVelocityRamp(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
+                                                 SquareInfo rowSquareInfo[kDisplayWidth], int32_t velocityIncrement) {
+	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
+	if (!action) {
+		return;
+	}
+
+	int32_t startVelocity = getVelocityFromY(getLeftPadSelectedY());
+	int32_t velocityValue = 0;
+	int32_t squaresProcessed = 0;
+
+	for (int32_t i = getLeftPadSelectedX(); i <= getRightPadSelectedX(); i++) {
+		if (rowSquareInfo[i].numNotes != 0) {
+			int32_t intendedPos = rowSquareInfo[i].squareStartPos;
+
+			// Multiple notes in square
+			if (rowSquareInfo[i].numNotes > 1) {
+				int32_t intendedLength = rowSquareInfo[i].squareEndPos - intendedPos;
+
+				int32_t noteI = noteRow->notes.search(intendedPos, GREATER_OR_EQUAL);
+
+				Note* note = noteRow->notes.getElement(noteI);
+
+				while (note && note->pos - intendedPos < intendedLength) {
+					int32_t intendedVelocity =
+					    std::clamp<int32_t>(startVelocity + (velocityIncrement * squaresProcessed), 1, 127);
+
+					noteRow->changeNotesAcrossAllScreens(note->pos, modelStackWithNoteRow, action,
+					                                     CORRESPONDING_NOTES_SET_VELOCITY, intendedVelocity);
+
+					noteI++;
+
+					note = noteRow->notes.getElement(noteI);
+				}
+			}
+			// one note in square
+			else {
+				int32_t intendedVelocity =
+				    std::clamp<int32_t>(startVelocity + (velocityIncrement * squaresProcessed), 1, 127);
+
+				noteRow->changeNotesAcrossAllScreens(intendedPos, modelStackWithNoteRow, action,
+				                                     CORRESPONDING_NOTES_SET_VELOCITY, intendedVelocity);
+			}
+
+			// don't include note tails in note count
+			if (rowSquareInfo[i].squareType != SQUARE_NOTE_TAIL) {
+				squaresProcessed++;
+			}
+		}
+	}
+}
+
+// call instrument clip view edit pad action function to process velocity pad press actions
+void AutomationEditorLayoutNote::recordNoteEditPadAction(int32_t x, int32_t velocity) {
+	instrumentClipView.editPadAction(velocity, instrumentClipView.lastAuditionedYDisplay, x,
+	                                 currentSong->xZoom[NAVIGATION_CLIP]);
+}
+
+}; // namespace deluge::gui::views::automation::editor_layout

--- a/src/deluge/gui/views/automation/editor_layout/note.h
+++ b/src/deluge/gui/views/automation/editor_layout/note.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "gui/views/automation/editor_layout.h"
+
+namespace deluge::gui::views::automation::editor_layout {
+
+class AutomationEditorLayoutNote : public AutomationEditorLayout {
+public:
+	AutomationEditorLayoutNote() = default;
+
+	// edit pad action
+	void noteEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, InstrumentClip* clip,
+	                       int32_t x, int32_t y, int32_t velocity, int32_t effectiveLength, SquareInfo& squareInfo);
+	void velocityEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, InstrumentClip* clip,
+	                           int32_t x, int32_t y, int32_t velocity, int32_t effectiveLength, SquareInfo& squareInfo);
+
+private:
+	int32_t getVelocityFromY(int32_t y);
+	int32_t getYFromVelocity(int32_t velocity);
+	void addNoteWithNewVelocity(int32_t x, int32_t velocity, int32_t newVelocity);
+	void adjustNoteVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x, int32_t velocity,
+	                        int32_t newVelocity, uint8_t squareType);
+	void setVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x, int32_t newVelocity);
+	void setVelocityRamp(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
+	                     SquareInfo rowSquareInfo[kDisplayWidth], int32_t velocityIncrement);
+	void recordNoteEditPadAction(int32_t x, int32_t velocity);
+
+public:
+	// Automation View Render Functions
+	void renderNoteEditor(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
+	                      RGB image[][kDisplayWidth + kSideBarWidth],
+	                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth, int32_t xScroll,
+	                      uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay, bool drawUndefinedArea,
+	                      SquareInfo& squareInfo);
+
+private:
+	void renderNoteColumn(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
+	                      RGB image[][kDisplayWidth + kSideBarWidth],
+	                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay, int32_t xScroll,
+	                      int32_t xZoom, SquareInfo& squareInfo);
+	void renderNoteSquare(RGB image[][kDisplayWidth + kSideBarWidth],
+	                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay, int32_t yDisplay,
+	                      uint8_t squareType, int32_t value);
+
+public:
+	void renderNoteEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas, InstrumentClip* clip,
+	                                 OutputType outputType, int32_t knobPosLeft, int32_t knobPosRight);
+	void renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputType outputType, int32_t knobPosLeft);
+};
+
+}; // namespace deluge::gui::views::automation::editor_layout
+
+extern deluge::gui::views::automation::editor_layout::AutomationEditorLayoutNote automationEditorLayoutNote;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -408,8 +408,6 @@ AutomationView::AutomationView() {
 	rightPadSelectedX = kNoSelection;
 	rightPadSelectedY = kNoSelection;
 	lastPadSelectedKnobPos = kNoSelection;
-	numNotesSelected = 0;
-	selectedPadPressed = 0;
 	playbackStopped = false;
 	onArrangerView = false;
 	onMenuView = false;
@@ -1179,16 +1177,6 @@ void AutomationView::renderNoteSquare(RGB image[][kDisplayWidth + kSideBarWidth]
 		else {
 			pixel = colours::black; // erase pad
 		}
-	}
-	// pad selection mode, render cursor
-	if (padSelectionOn && ((xDisplay == leftPadSelectedX) || (xDisplay == rightPadSelectedX))) {
-		if (doRender) {
-			pixel = velocityRowBlurColour[yDisplay];
-		}
-		else {
-			pixel = colours::grey;
-		}
-		occupancyMask[yDisplay][xDisplay] = 64;
 	}
 }
 
@@ -2473,21 +2461,16 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 		if (Buttons::isShiftButtonPressed()
 		    || (isUIModeActive(UI_MODE_AUDITIONING) && !FlashStorage::automationDisableAuditionPadShortcuts)) {
 
-			// toggle interpolation on / off
-			// not relevant for note editor because interpolation doesn't apply to note params
-			if (!inNoteEditor() && (x == kInterpolationShortcutX && y == kInterpolationShortcutY)) {
-				return toggleAutomationInterpolation();
-			}
-			// toggle pad selection on / off
-			else if (!onAutomationOverview()) {
-				if (x == kPadSelectionShortcutX && y == kPadSelectionShortcutY) {
-					//	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-					//		return toggleVelocityPadSelectionMode(squareInfo);
-					//	}
-					//	else {
-					if (inAutomationEditor()) {
-						return toggleAutomationPadSelectionMode(modelStackWithParam, effectiveLength, xScroll, xZoom);
-					}
+			if (!inNoteEditor()) {
+				// toggle interpolation on / off
+				// not relevant for note editor because interpolation doesn't apply to note params
+				if ((x == kInterpolationShortcutX && y == kInterpolationShortcutY)) {
+					return toggleAutomationInterpolation();
+				}
+				// toggle pad selection on / off
+				// not relevant for note editor because pad selection mode was deemed unnecessary
+				else if (inAutomationEditor() && (x == kPadSelectionShortcutX && y == kPadSelectionShortcutY)) {
+					return toggleAutomationPadSelectionMode(modelStackWithParam, effectiveLength, xScroll, xZoom);
 				}
 			}
 
@@ -2533,40 +2516,6 @@ bool AutomationView::toggleAutomationInterpolation() {
 
 		display->displayPopup(l10n::get(l10n::String::STRING_FOR_INTERPOLATION_ENABLED));
 	}
-	return true;
-}
-
-/// toggle velocity pad selection mode on / off
-bool AutomationView::toggleVelocityPadSelectionMode(SquareInfo& squareInfo) {
-	// enter/exit pad selection mode
-	if (padSelectionOn) {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_OFF));
-
-		initPadSelection();
-	}
-	else {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_ON));
-
-		padSelectionOn = true;
-		blinkPadSelectionShortcut();
-
-		// display only left cursor
-		leftPadSelectedX = 0;
-		rightPadSelectedX = kNoSelection;
-		numNotesSelected = squareInfo.numNotes;
-
-		// when entering velocity pad selection mode, record note selection
-		// but don't record pad press yet if there are no notes in this square
-		// because recording a pad press for an empty square creates a note, and we don't want that yet
-		// (we'll do that when we try to adjust square velocity)
-		if (numNotesSelected != 0) {
-			// select note if there are notes in this square
-			recordNoteEditPadAction(leftPadSelectedX, 1);
-			instrumentClipView.dontDeleteNotesOnDepress();
-		}
-	}
-	uiNeedsRendering(this);
-	renderDisplay();
 	return true;
 }
 
@@ -2733,9 +2682,6 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	if (inNoteEditor()) {
 		automationParamType = AutomationParamType::PER_SOUND;
 		instrumentClipView.resetSelectedNoteRowBlinking();
-		if (padSelectionOn) {
-			initPadSelection();
-		}
 	}
 	blinkShortcuts();
 	if (display->have7SEG()) {
@@ -2757,52 +2703,8 @@ void AutomationView::noteEditPadAction(ModelStackWithNoteRow* modelStackWithNote
                                        InstrumentClip* clip, int32_t x, int32_t y, int32_t velocity,
                                        int32_t effectiveLength, SquareInfo& squareInfo) {
 	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-		if (padSelectionOn) {
-			velocityPadSelectionAction(modelStackWithNoteRow, clip, x, y, velocity, squareInfo);
-		}
-		else {
-			velocityEditPadAction(modelStackWithNoteRow, noteRow, clip, x, y, velocity, effectiveLength, squareInfo);
-		}
+		velocityEditPadAction(modelStackWithNoteRow, noteRow, clip, x, y, velocity, effectiveLength, squareInfo);
 	}
-}
-
-// handle's what happens when you select columns in velocity pad selection mode
-void AutomationView::velocityPadSelectionAction(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
-                                                int32_t x, int32_t y, int32_t velocity, SquareInfo& squareInfo) {
-
-	if (velocity) {
-		// if selection has changed and note was previously selected, release previous press
-		// if we recorded the previous pad that was pressed
-		if (leftPadSelectedX != kNoSelection && isUIModeActive(UI_MODE_NOTES_PRESSED)) {
-			recordNoteEditPadAction(leftPadSelectedX, 0);
-		}
-
-		// if we selected a new pad, record new press
-		// don't record pad press yet if there are no notes in this square
-		// because recording a pad press for an empty square creates a note, and we don't want that yet
-		// (we'll do that when we try to adjust square velocity)
-		if (leftPadSelectedX != x && squareInfo.numNotes != 0) {
-			// record new note selection
-			recordNoteEditPadAction(x, 1);
-			instrumentClipView.dontDeleteNotesOnDepress();
-		}
-
-		if (leftPadSelectedX != x) {
-			// store new pad selection
-			leftPadSelectedX = x;
-			numNotesSelected = squareInfo.numNotes;
-		}
-		else {
-			// de-select pad selection
-			leftPadSelectedX = kNoSelection;
-			numNotesSelected = 0;
-		}
-
-		// refresh grid and display
-		uiNeedsRendering(this, 0xFFFFFFFF, 0);
-	}
-	selectedPadPressed = velocity;
-	renderDisplay();
 }
 
 // velocity edit pad action
@@ -3171,9 +3073,6 @@ void AutomationView::recordNoteEditPadAction(int32_t x, int32_t velocity) {
 void AutomationView::automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
                                              int32_t yDisplay, int32_t velocity, int32_t effectiveLength,
                                              int32_t xScroll, int32_t xZoom) {
-	if (padSelectionOn) {
-		selectedPadPressed = velocity;
-	}
 	// If button down
 	if (velocity) {
 		// If this is a automation-length-edit press...
@@ -3594,30 +3493,10 @@ ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 
 	// fine tune note velocity
 	// If holding down notes and nothing else is held down, adjust velocity
-	// or if in pad selection mode, create note or adjust velocity
-	else if (inNoteEditor()
-	         && (isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)
-	             || (currentUIMode == UI_MODE_NONE && padSelectionOn && leftPadSelectedX != kNoSelection))) {
+	else if (inNoteEditor() && isUIModeActiveExclusively(UI_MODE_NOTES_PRESSED)) {
 		if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
 			if (!instrumentClipView.shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress) {
-				// adjust velocity faster in pad selection mode while holding shift
-				if (padSelectionOn && Buttons::isShiftButtonPressed()) {
-					offset = offset * 5;
-				}
-
-				// if we had selected a pad without any notes in it yet
-				// and we're trying to increase velocity of that pad
-				// then let's create a note first
-				if (padSelectionOn && (offset > 0) && numNotesSelected == 0) {
-					// record pad press
-					// this will create a new note at default velocity
-					recordNoteEditPadAction(leftPadSelectedX, 1);
-					numNotesSelected = 1;
-				}
-				// note exists in the pad selected, so let's adjust its velocity
-				else {
-					instrumentClipView.adjustVelocity(offset);
-				}
+				instrumentClipView.adjustVelocity(offset);
 				renderDisplay(getCurrentInstrument()->defaultVelocity);
 				uiNeedsRendering(this, 0xFFFFFFFF, 0);
 			}
@@ -3704,40 +3583,12 @@ ActionResult AutomationView::verticalEncoderAction(int32_t offset, bool inCardRo
 		if (isUIModeWithinRange(verticalScrollUIModes)) {
 			if ((!instrumentClipView.shouldIgnoreVerticalScrollKnobActionIfNotAlsoPressedForThisNotePress
 			     || (!isUIModeActive(UI_MODE_NOTES_PRESSED) && !isUIModeActive(UI_MODE_AUDITIONING)))
-			    && (!(isUIModeActive(UI_MODE_NOTES_PRESSED) && inNoteEditor() && !padSelectionOn))) {
-				// if we're in the note editor pad selection mode and vertical scrolling,
-				// we want to end any presses first (which will end any note auditioning as well)
-				if (inNoteEditor() && padSelectionOn) {
-					instrumentClipView.endAllEditPadPresses();
-				}
-
+			    && (!(isUIModeActive(UI_MODE_NOTES_PRESSED) && inNoteEditor()))) {
 				instrumentClipView.scrollVertical(offset, inCardRoutine, false, modelStack);
 
-				// if we're in note editor pad selection mode, scrolling vertically will change note selected
+				// if we're in note editor scrolling vertically will change note selected
 				// so we want to re-render the display to show the updated note
 				if (inNoteEditor()) {
-					// if we're in pad selection mode, we will have de-selected the pad presses above
-					// and now we want to re-instate the pad press for the selected note row
-					// so that we can re-audition the selected note
-					if (padSelectionOn && leftPadSelectedX != kNoSelection) {
-						ModelStackWithNoteRow* modelStackWithNoteRow =
-						    ((InstrumentClip*)clip)
-						        ->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
-						                             modelStack); // don't create
-						if (modelStackWithNoteRow->getNoteRowAllowNull()) {
-							NoteRow* noteRow = modelStackWithNoteRow->getNoteRow();
-							int32_t effectiveLength = modelStackWithNoteRow->getLoopLength();
-							SquareInfo squareInfo;
-							noteRow->getSquareInfo(leftPadSelectedX, effectiveLength, squareInfo);
-							numNotesSelected = squareInfo.numNotes;
-
-							if (numNotesSelected != 0) {
-								// select note if there are notes in this square
-								recordNoteEditPadAction(leftPadSelectedX, 1);
-								instrumentClipView.dontDeleteNotesOnDepress();
-							}
-						}
-					}
 					renderDisplay();
 				}
 			}
@@ -4654,16 +4505,6 @@ void AutomationView::initPadSelection() {
 	leftPadSelectedX = kNoSelection;
 	rightPadSelectedX = kNoSelection;
 	lastPadSelectedKnobPos = kNoSelection;
-
-	resetPadSelectionShortcutBlinking();
-
-	numNotesSelected = 0;
-	selectedPadPressed = 0;
-
-	// make sure no active presses remain when exiting pad selection mode
-	if (inNoteEditor() && isUIModeActive(UI_MODE_NOTES_PRESSED)) {
-		instrumentClipView.endAllEditPadPresses();
-	}
 
 	resetPadSelectionShortcutBlinking();
 }

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -36,6 +36,8 @@
 #include "gui/ui_timer_manager.h"
 #include "gui/views/arranger_view.h"
 #include "gui/views/audio_clip_view.h"
+#include "gui/views/automation/editor_layout/mod_controllable.h"
+#include "gui/views/automation/editor_layout/note.h"
 #include "gui/views/instrument_clip_view.h"
 #include "gui/views/session_view.h"
 #include "gui/views/timeline_view.h"
@@ -123,7 +125,6 @@ const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIO
 
 constexpr int32_t kNumNonGlobalParamsForAutomation = 83;
 constexpr int32_t kNumGlobalParamsForAutomation = 39;
-constexpr int32_t kParamNodeWidth = 3;
 
 // synth and kit rows FX - sorted in the order that Parameters are scrolled through on the display
 const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutomation> nonGlobalParamsForAutomation{{
@@ -301,67 +302,6 @@ const std::array<std::pair<params::Kind, ParamType>, kNumGlobalParamsForAutomati
     {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
 }};
 
-// VU meter style colours for the automation editor
-
-const RGB rowColour[kDisplayHeight] = {{0, 255, 0},   {36, 219, 0}, {73, 182, 0}, {109, 146, 0},
-                                       {146, 109, 0}, {182, 73, 0}, {219, 36, 0}, {255, 0, 0}};
-
-const RGB rowTailColour[kDisplayHeight] = {{2, 53, 2},  {9, 46, 2},  {17, 38, 2}, {24, 31, 2},
-                                           {31, 24, 2}, {38, 17, 2}, {46, 9, 2},  {53, 2, 2}};
-
-const RGB rowBlurColour[kDisplayHeight] = {{71, 111, 71}, {72, 101, 66}, {73, 90, 62}, {74, 80, 57},
-                                           {76, 70, 53},  {77, 60, 48},  {78, 49, 44}, {79, 39, 39}};
-
-const RGB rowBipolarDownColour[kDisplayHeight / 2] = {{255, 0, 0}, {182, 73, 0}, {73, 182, 0}, {0, 255, 0}};
-
-const RGB rowBipolarDownTailColour[kDisplayHeight / 2] = {{53, 2, 2}, {38, 17, 2}, {17, 38, 2}, {2, 53, 2}};
-
-const RGB rowBipolarDownBlurColour[kDisplayHeight / 2] = {{79, 39, 39}, {77, 60, 48}, {73, 90, 62}, {71, 111, 71}};
-
-// colours for the velocity editor
-
-const RGB velocityRowColour[kDisplayHeight] = {{0, 0, 255},   {36, 0, 219}, {73, 0, 182}, {109, 0, 146},
-                                               {146, 0, 109}, {182, 0, 73}, {219, 0, 36}, {255, 0, 0}};
-
-const RGB velocityRowTailColour[kDisplayHeight] = {{2, 2, 53},  {9, 2, 46},  {17, 2, 38}, {24, 2, 31},
-                                                   {31, 2, 24}, {38, 2, 17}, {46, 2, 9},  {53, 2, 2}};
-
-const RGB velocityRowBlurColour[kDisplayHeight] = {{71, 71, 111}, {72, 66, 101}, {73, 62, 90}, {74, 57, 80},
-                                                   {76, 53, 70},  {77, 48, 60},  {78, 44, 49}, {79, 39, 39}};
-
-// lookup tables for the values that are set when you press the pads in each row of the grid
-const int32_t nonPatchCablePadPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
-const int32_t patchCablePadPressValues[kDisplayHeight] = {-128, -90, -60, -30, 30, 60, 90, 128};
-
-// lookup tables for the min value of each pad's value range used to display automation on each row of the grid
-const int32_t nonPatchCableMinPadDisplayValues[kDisplayHeight] = {0, 17, 33, 49, 65, 81, 97, 113};
-const int32_t patchCableMinPadDisplayValues[kDisplayHeight] = {-128, -96, -64, -32, 1, 33, 65, 97};
-
-// lookup tables for the max value of each pad's value range used to display automation on each row of the grid
-const int32_t nonPatchCableMaxPadDisplayValues[kDisplayHeight] = {16, 32, 48, 64, 80, 96, 112, 128};
-const int32_t patchCableMaxPadDisplayValues[kDisplayHeight] = {-97, -65, -33, -1, 32, 64, 96, 128};
-
-// summary of pad ranges and press values (format: MIN < PRESS < MAX)
-// patch cable:
-// y = 7 ::   97 <  128 < 128
-// y = 6 ::   65 <   90 <  96
-// y = 5 ::   33 <   60 <  64
-// y = 4 ::    1 <   30 <  32
-// y = 3 ::  -32 <  -30 <  -1
-// y = 2 ::  -64 <  -60 < -33
-// y = 1 ::  -96 <  -90 < -65
-// y = 0 :: -128 < -128 < -97
-
-// non-patch cable:
-// y = 7 :: 113 < 128 < 128
-// y = 6 ::  97 < 110 < 112
-// y = 5 ::  81 <  91 <  96
-// y = 4 ::  65 <  73 <  80
-// y = 3 ::  49 <  55 <  64
-// y = 2 ::  33 <  37 <  48
-// y = 1 ::  17 <  18 <  32
-// y = 0 ::  0  <   0 <  16
-
 // shortcuts for toggling interpolation and pad selection mode
 constexpr uint8_t kInterpolationShortcutX = 0;
 constexpr uint8_t kInterpolationShortcutY = 6;
@@ -408,7 +348,6 @@ AutomationView::AutomationView() {
 	rightPadSelectedX = kNoSelection;
 	rightPadSelectedY = kNoSelection;
 	lastPadSelectedKnobPos = kNoSelection;
-	playbackStopped = false;
 	onArrangerView = false;
 	onMenuView = false;
 	navSysId = NAVIGATION_CLIP;
@@ -577,7 +516,7 @@ void AutomationView::focusRegained() {
 	}
 
 	// don't reset shortcut blinking if were still in the menu
-	if (getCurrentUI() == this) {
+	if (getCurrentUI() == &automationView) {
 		// blink timer got reset by view.focusRegained() above
 		parameterShortcutBlinking = false;
 		interpolationShortcutBlinking = false;
@@ -624,7 +563,7 @@ void AutomationView::openedInBackground() {
 		}
 	}
 	else {
-		uiNeedsRendering(this);
+		uiNeedsRendering(&automationView);
 	}
 
 	// setup interpolation shortcut blinking when entering automation view from menu
@@ -685,13 +624,13 @@ bool AutomationView::possiblyRefreshAutomationEditorGrid(Clip* clip, params::Kin
 		}
 	}
 	if (doRefreshGrid) {
-		uiNeedsRendering(this);
+		uiNeedsRendering(&automationView);
 		return true;
 	}
 	return false;
 }
 
-// called whenever you call uiNeedsRendering(this) somewhere else
+// called whenever you call uiNeedsRendering(&automationView) somewhere else
 // used to render automation overview, automation editor
 // used to setup the shortcut blinking
 bool AutomationView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
@@ -798,14 +737,16 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 
 			// if parameter has been selected, show Automation Editor
 			if (inAutomationEditor() && !isMIDICVDrum) {
-				renderAutomationEditor(modelStackWithParam, clip, image, occupancyMask, renderWidth, xScroll, xZoom,
-				                       effectiveLength, xDisplay, drawUndefinedArea, kind, isBipolar);
+				automationEditorLayoutModControllable.renderAutomationEditor(
+				    modelStackWithParam, clip, image, occupancyMask, renderWidth, xScroll, xZoom, effectiveLength,
+				    xDisplay, drawUndefinedArea, kind, isBipolar);
 			}
 
 			// if note parameter has been selected, show Note Editor
 			else if (inNoteEditor()) {
-				renderNoteEditor(modelStackWithNoteRow, (InstrumentClip*)clip, image, occupancyMask, renderWidth,
-				                 xScroll, xZoom, effectiveLength, xDisplay, drawUndefinedArea, rowSquareInfo[xDisplay]);
+				automationEditorLayoutNote.renderNoteEditor(modelStackWithNoteRow, (InstrumentClip*)clip, image,
+				                                            occupancyMask, renderWidth, xScroll, xZoom, effectiveLength,
+				                                            xDisplay, drawUndefinedArea, rowSquareInfo[xDisplay]);
 			}
 
 			// if not editing a parameter, show Automation Overview
@@ -952,234 +893,6 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 	}
 }
 
-// gets the length of the clip, renders the pads corresponding to current parameter values set up to the
-// clip length renders the undefined area of the clip that the user can't interact with
-void AutomationView::renderAutomationEditor(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-                                            RGB image[][kDisplayWidth + kSideBarWidth],
-                                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
-                                            int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
-                                            bool drawUndefinedArea, params::Kind kind, bool isBipolar) {
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-		renderAutomationColumn(modelStackWithParam, image, occupancyMask, effectiveLength, xDisplay,
-		                       modelStackWithParam->autoParam->isAutomated(), xScroll, xZoom, kind, isBipolar);
-	}
-	if (drawUndefinedArea) {
-		renderUndefinedArea(xScroll, xZoom, effectiveLength, image, occupancyMask, renderWidth, this,
-		                    currentSong->tripletsOn, xDisplay);
-	}
-}
-
-/// render each square in each column of the automation editor grid
-void AutomationView::renderAutomationColumn(ModelStackWithAutoParam* modelStackWithParam,
-                                            RGB image[][kDisplayWidth + kSideBarWidth],
-                                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
-                                            int32_t lengthToDisplay, int32_t xDisplay, bool isAutomated,
-                                            int32_t xScroll, int32_t xZoom, params::Kind kind, bool isBipolar) {
-
-	uint32_t squareStart = getMiddlePosFromSquare(xDisplay, lengthToDisplay, xScroll, xZoom);
-	int32_t knobPos = getAutomationParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
-
-	// iterate through each square
-	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-		if (isBipolar) {
-			renderAutomationBipolarSquare(image, occupancyMask, xDisplay, yDisplay, isAutomated, kind, knobPos);
-		}
-		else {
-			renderAutomationUnipolarSquare(image, occupancyMask, xDisplay, yDisplay, isAutomated, knobPos);
-		}
-	}
-}
-
-/// render column for bipolar params - e.g. pan, pitch, patch cable
-void AutomationView::renderAutomationBipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
-                                                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
-                                                   int32_t xDisplay, int32_t yDisplay, bool isAutomated,
-                                                   params::Kind kind, int32_t knobPos) {
-	RGB& pixel = image[yDisplay][xDisplay];
-
-	int32_t middleKnobPos;
-
-	// for patch cable that has a range of -128 to + 128, the middle point is 0
-	if (kind == params::Kind::PATCH_CABLE) {
-		middleKnobPos = 0;
-	}
-	// for non-patch cable that has a range of 0 to 128, the middle point is 64
-	else {
-		middleKnobPos = 64;
-	}
-
-	// if it's bipolar, only render grid rows above or below middle value
-	if (((knobPos > middleKnobPos) && (yDisplay < 4)) || ((knobPos < middleKnobPos) && (yDisplay > 3))) {
-		pixel = colours::black; // erase pad
-		return;
-	}
-
-	bool doRender = false;
-
-	// determine whether or not you should render a row based on current value
-	if (knobPos != middleKnobPos) {
-		if (kind == params::Kind::PATCH_CABLE) {
-			if (knobPos > middleKnobPos) {
-				doRender = (knobPos >= patchCableMinPadDisplayValues[yDisplay]);
-			}
-			else {
-				doRender = (knobPos <= patchCableMaxPadDisplayValues[yDisplay]);
-			}
-		}
-		else {
-			if (knobPos > middleKnobPos) {
-				doRender = (knobPos >= nonPatchCableMinPadDisplayValues[yDisplay]);
-			}
-			else {
-				doRender = (knobPos <= nonPatchCableMaxPadDisplayValues[yDisplay]);
-			}
-		}
-	}
-
-	// render automation lane
-	if (doRender) {
-		if (isAutomated) { // automated, render bright colour
-			if (knobPos > middleKnobPos) {
-				pixel = rowBipolarDownColour[-yDisplay + 7];
-			}
-			else {
-				pixel = rowBipolarDownColour[yDisplay];
-			}
-		}
-		else { // not automated, render less bright tail colour
-			if (knobPos > middleKnobPos) {
-				pixel = rowBipolarDownTailColour[-yDisplay + 7];
-			}
-			else {
-				pixel = rowBipolarDownTailColour[yDisplay];
-			}
-		}
-		occupancyMask[yDisplay][xDisplay] = 64;
-	}
-	else {
-		pixel = colours::black; // erase pad
-	}
-
-	// pad selection mode, render cursor
-	if (padSelectionOn && ((xDisplay == leftPadSelectedX) || (xDisplay == rightPadSelectedX))) {
-		if (doRender) {
-			if (knobPos > middleKnobPos) {
-				pixel = rowBipolarDownBlurColour[-yDisplay + 7];
-			}
-			else {
-				pixel = rowBipolarDownBlurColour[yDisplay];
-			}
-		}
-		else {
-			pixel = colours::grey;
-		}
-		occupancyMask[yDisplay][xDisplay] = 64;
-	}
-}
-
-/// render column for unipolar params (e.g. not pan, pitch, or patch cables)
-void AutomationView::renderAutomationUnipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
-                                                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth],
-                                                    int32_t xDisplay, int32_t yDisplay, bool isAutomated,
-                                                    int32_t knobPos) {
-	RGB& pixel = image[yDisplay][xDisplay];
-
-	// determine whether or not you should render a row based on current value
-	bool doRender = false;
-	if (knobPos) {
-		doRender = (knobPos >= nonPatchCableMinPadDisplayValues[yDisplay]);
-	}
-
-	// render square
-	if (doRender) {
-		if (isAutomated) { // automated, render bright colour
-			pixel = rowColour[yDisplay];
-		}
-		else { // not automated, render less bright tail colour
-			pixel = rowTailColour[yDisplay];
-		}
-		occupancyMask[yDisplay][xDisplay] = 64;
-	}
-	else {
-		pixel = colours::black; // erase pad
-	}
-
-	// pad selection mode, render cursor
-	if (padSelectionOn && ((xDisplay == leftPadSelectedX) || (xDisplay == rightPadSelectedX))) {
-		if (doRender) {
-			pixel = rowBlurColour[yDisplay];
-		}
-		else {
-			pixel = colours::grey;
-		}
-		occupancyMask[yDisplay][xDisplay] = 64;
-	}
-}
-
-// gets the length of the note row, renders the pads corresponding to current note parameter values set up to the
-// note row length renders the undefined area of the note row that the user can't interact with
-void AutomationView::renderNoteEditor(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
-                                      RGB image[][kDisplayWidth + kSideBarWidth],
-                                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
-                                      int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
-                                      bool drawUndefinedArea, SquareInfo& squareInfo) {
-	if (modelStackWithNoteRow->getNoteRowAllowNull()) {
-		renderNoteColumn(modelStackWithNoteRow, clip, image, occupancyMask, xDisplay, xScroll, xZoom, squareInfo);
-	}
-	if (drawUndefinedArea) {
-		renderUndefinedArea(xScroll, xZoom, effectiveLength, image, occupancyMask, renderWidth, this,
-		                    currentSong->tripletsOn, xDisplay);
-	}
-}
-
-/// render each square in each column of the note editor grid
-void AutomationView::renderNoteColumn(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
-                                      RGB image[][kDisplayWidth + kSideBarWidth],
-                                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
-                                      int32_t xScroll, int32_t xZoom, SquareInfo& squareInfo) {
-	int32_t value = 0;
-
-	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-		value = squareInfo.averageVelocity;
-	}
-
-	// iterate through each square
-	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-		renderNoteSquare(image, occupancyMask, xDisplay, yDisplay, squareInfo.squareType, value);
-	}
-}
-
-/// render column for note parameter
-void AutomationView::renderNoteSquare(RGB image[][kDisplayWidth + kSideBarWidth],
-                                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
-                                      int32_t yDisplay, uint8_t squareType, int32_t value) {
-	RGB& pixel = image[yDisplay][xDisplay];
-	bool doRender = false;
-
-	if (squareType == SQUARE_NO_NOTE) {
-		pixel = colours::black; // erase pad
-	}
-	else {
-		// render square
-		if (value >= nonPatchCableMinPadDisplayValues[yDisplay]) {
-			doRender = true;
-			if (squareType == SQUARE_NOTE_HEAD) {
-				pixel = velocityRowColour[yDisplay];
-			}
-			else if (squareType == SQUARE_NOTE_TAIL) {
-				pixel = velocityRowTailColour[yDisplay];
-			}
-			else if (squareType == SQUARE_BLURRED) {
-				pixel = velocityRowBlurColour[yDisplay];
-			}
-			occupancyMask[yDisplay][xDisplay] = 64;
-		}
-		else {
-			pixel = colours::black; // erase pad
-		}
-	}
-}
-
 // occupancyMask now optional
 void AutomationView::renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_t lengthToDisplay,
                                          RGB image[][kDisplayWidth + kSideBarWidth],
@@ -1248,7 +961,7 @@ DisplayParameterName */
 void AutomationView::renderDisplay(int32_t knobPosLeft, int32_t knobPosRight, bool modEncoderAction) {
 	// don't refresh display if we're not current in the automation view UI
 	// (e.g. if you're editing automation while in the menu)
-	if (getCurrentUI() != this) {
+	if (getCurrentUI() != &automationView) {
 		return;
 	}
 
@@ -1296,10 +1009,12 @@ void AutomationView::renderDisplayOLED(Clip* clip, Output* output, OutputType ou
 	}
 	else {
 		if (inAutomationEditor()) {
-			renderAutomationEditorDisplayOLED(canvas, clip, outputType, knobPosLeft, knobPosRight);
+			automationEditorLayoutModControllable.renderAutomationEditorDisplayOLED(canvas, clip, outputType,
+			                                                                        knobPosLeft, knobPosRight);
 		}
 		else {
-			renderNoteEditorDisplayOLED(canvas, (InstrumentClip*)clip, outputType, knobPosLeft, knobPosRight);
+			automationEditorLayoutNote.renderNoteEditorDisplayOLED(canvas, (InstrumentClip*)clip, outputType,
+			                                                       knobPosLeft, knobPosRight);
 		}
 	}
 
@@ -1327,166 +1042,6 @@ void AutomationView::renderAutomationOverviewDisplayOLED(deluge::hid::display::o
 	}
 }
 
-void AutomationView::renderAutomationEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas, Clip* clip,
-                                                       OutputType outputType, int32_t knobPosLeft,
-                                                       int32_t knobPosRight) {
-	// display parameter name
-	DEF_STACK_STRING_BUF(parameterName, 30);
-	getAutomationParameterName(clip, outputType, parameterName);
-
-#if OLED_MAIN_HEIGHT_PIXELS == 64
-	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
-#else
-	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
-#endif
-	canvas.drawStringCentredShrinkIfNecessary(parameterName.c_str(), yPos, kTextSpacingX, kTextSpacingY);
-
-	// display automation status
-	yPos = yPos + 12;
-
-	char modelStackMemory[MODEL_STACK_MAX_SIZE];
-	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	if (onArrangerView) {
-		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-		    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-
-		modelStackWithParam =
-		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
-	}
-	else {
-		ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-		modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
-	}
-
-	char const* isAutomated;
-
-	// check if Parameter is currently automated so that the automation status can be drawn on
-	// the screen with the Parameter Name
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-		if (modelStackWithParam->autoParam->isAutomated()) {
-			isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_ON);
-		}
-		else {
-			isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_OFF);
-		}
-	}
-
-	canvas.drawStringCentred(isAutomated, yPos, kTextSpacingX, kTextSpacingY);
-
-	// display parameter value
-	yPos = yPos + 12;
-
-	if (knobPosRight != kNoSelection) {
-		char bufferLeft[10];
-		bufferLeft[0] = 'L';
-		bufferLeft[1] = ':';
-		bufferLeft[2] = ' ';
-		intToString(knobPosLeft, &bufferLeft[3]);
-		canvas.drawString(bufferLeft, 0, yPos, kTextSpacingX, kTextSpacingY);
-
-		char bufferRight[10];
-		bufferRight[0] = 'R';
-		bufferRight[1] = ':';
-		bufferRight[2] = ' ';
-		intToString(knobPosRight, &bufferRight[3]);
-		canvas.drawStringAlignRight(bufferRight, yPos, kTextSpacingX, kTextSpacingY);
-	}
-	else {
-		char buffer[5];
-		intToString(knobPosLeft, buffer);
-		canvas.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
-	}
-}
-
-void AutomationView::renderNoteEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas,
-                                                 InstrumentClip* clip, OutputType outputType, int32_t knobPosLeft,
-                                                 int32_t knobPosRight) {
-	// display note parameter name
-	DEF_STACK_STRING_BUF(parameterName, 30);
-	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-		parameterName.append("Velocity");
-	}
-
-#if OLED_MAIN_HEIGHT_PIXELS == 64
-	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 12;
-#else
-	int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 3;
-#endif
-	canvas.drawStringCentredShrinkIfNecessary(parameterName.c_str(), yPos, kTextSpacingX, kTextSpacingY);
-
-	// display note / drum name
-	yPos = yPos + 12;
-
-	char modelStackMemory[MODEL_STACK_MAX_SIZE];
-	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-	bool isKit = outputType == OutputType::KIT;
-
-	ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
-	                                                                        modelStack); // don't create
-	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
-		if (!isKit) {
-			modelStackWithNoteRow =
-			    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
-		}
-	}
-
-	char noteRowName[50];
-
-	if (modelStackWithNoteRow->getNoteRowAllowNull()) {
-		if (isKit) {
-			DEF_STACK_STRING_BUF(drumName, 50);
-			instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
-			strncpy(noteRowName, drumName.c_str(), 49);
-		}
-		else {
-			int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
-			noteCodeToString(modelStackWithNoteRow->getNoteRow()->getNoteCode(), noteRowName, &isNatural);
-		}
-	}
-	else {
-		if (isKit) {
-			strncpy(noteRowName, "(Select Drum)", 49);
-		}
-		else {
-			strncpy(noteRowName, "(Select Note)", 49);
-		}
-	}
-
-	canvas.drawStringCentred(noteRowName, yPos, kTextSpacingX, kTextSpacingY);
-
-	// display parameter value
-	yPos = yPos + 12;
-
-	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-		if (knobPosRight != kNoSelection) {
-			char bufferLeft[10];
-			bufferLeft[0] = 'L';
-			bufferLeft[1] = ':';
-			bufferLeft[2] = ' ';
-			intToString(knobPosLeft, &bufferLeft[3]);
-			canvas.drawString(bufferLeft, 0, yPos, kTextSpacingX, kTextSpacingY);
-
-			char bufferRight[10];
-			bufferRight[0] = 'R';
-			bufferRight[1] = ':';
-			bufferRight[2] = ' ';
-			intToString(knobPosRight, &bufferRight[3]);
-			canvas.drawStringAlignRight(bufferRight, yPos, kTextSpacingX, kTextSpacingY);
-		}
-		else if (knobPosLeft != kNoSelection) {
-			char buffer[5];
-			intToString(knobPosLeft, buffer);
-			canvas.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
-		}
-		else {
-			char buffer[5];
-			intToString(getCurrentInstrument()->defaultVelocity, buffer);
-			canvas.drawStringCentred(buffer, yPos, kTextSpacingX, kTextSpacingY);
-		}
-	}
-}
-
 void AutomationView::renderDisplay7SEG(Clip* clip, Output* output, OutputType outputType, int32_t knobPosLeft,
                                        bool modEncoderAction) {
 	// display OVERVIEW
@@ -1495,10 +1050,11 @@ void AutomationView::renderDisplay7SEG(Clip* clip, Output* output, OutputType ou
 	}
 	else {
 		if (inAutomationEditor()) {
-			renderAutomationEditorDisplay7SEG(clip, outputType, knobPosLeft, modEncoderAction);
+			automationEditorLayoutModControllable.renderAutomationEditorDisplay7SEG(clip, outputType, knobPosLeft,
+			                                                                        modEncoderAction);
 		}
 		else {
-			renderNoteEditorDisplay7SEG((InstrumentClip*)clip, outputType, knobPosLeft);
+			automationEditorLayoutNote.renderNoteEditorDisplay7SEG((InstrumentClip*)clip, outputType, knobPosLeft);
 		}
 	}
 }
@@ -1512,217 +1068,6 @@ void AutomationView::renderAutomationOverviewDisplay7SEG(Output* output, OutputT
 		overviewText = l10n::get(l10n::String::STRING_FOR_AUTOMATION);
 	}
 	display->setScrollingText(overviewText);
-}
-
-void AutomationView::renderAutomationEditorDisplay7SEG(Clip* clip, OutputType outputType, int32_t knobPosLeft,
-                                                       bool modEncoderAction) {
-	char modelStackMemory[MODEL_STACK_MAX_SIZE];
-	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-
-	if (onArrangerView) {
-		ModelStackWithThreeMainThings* modelStackWithThreeMainThings =
-		    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-
-		modelStackWithParam =
-		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
-	}
-	else {
-		modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
-	}
-
-	bool padSelected = (!padSelectionOn && isUIModeActive(UI_MODE_NOTES_PRESSED)) || padSelectionOn;
-
-	/* check if you're holding a pad
-	 * if yes, store pad press knob position in lastPadSelectedKnobPos
-	 * so that it can be used next time as the knob position if returning here
-	 * to display parameter value after another popup has been cancelled (e.g. audition pad)
-	 */
-	if (padSelected) {
-		if (knobPosLeft != kNoSelection) {
-			lastPadSelectedKnobPos = knobPosLeft;
-		}
-		else if (lastPadSelectedKnobPos != kNoSelection) {
-			params::Kind lastSelectedParamKind = params::Kind::NONE;
-			int32_t lastSelectedParamID = kNoSelection;
-			if (onArrangerView) {
-				lastSelectedParamKind = currentSong->lastSelectedParamKind;
-				lastSelectedParamID = currentSong->lastSelectedParamID;
-			}
-			else {
-				lastSelectedParamKind = clip->lastSelectedParamKind;
-				lastSelectedParamID = clip->lastSelectedParamID;
-			}
-			knobPosLeft =
-			    view.calculateKnobPosForDisplay(lastSelectedParamKind, lastSelectedParamID, lastPadSelectedKnobPos);
-		}
-	}
-
-	bool isAutomated =
-	    modelStackWithParam && modelStackWithParam->autoParam && modelStackWithParam->autoParam->isAutomated();
-	bool playbackStarted = playbackHandler.isEitherClockActive();
-
-	// display parameter value if knobPos is provided
-	if ((knobPosLeft != kNoSelection) && (padSelected || (playbackStarted && isAutomated) || modEncoderAction)) {
-		char buffer[5];
-		intToString(knobPosLeft, buffer);
-		if (modEncoderAction && !padSelected) {
-			display->displayPopup(buffer, 3, true);
-		}
-		else {
-			display->setText(buffer, true, 255, false);
-		}
-	}
-	// display parameter name
-	else if (knobPosLeft == kNoSelection) {
-		DEF_STACK_STRING_BUF(parameterName, 30);
-		getAutomationParameterName(clip, outputType, parameterName);
-		// if playback is running and there is automation, the screen will display the
-		// current automation value at the playhead position
-		// when changing to a parameter with automation, flash the parameter name first
-		// before the value is displayed
-		// otherwise if there's no automation, just scroll the parameter name
-		if (padSelected || (playbackStarted && isAutomated)) {
-			display->displayPopup(parameterName.c_str(), 3, true, isAutomated ? 3 : 255);
-		}
-		else {
-			display->setScrollingText(parameterName.c_str(), 0, 600, -1, isAutomated ? 3 : 255);
-		}
-	}
-}
-
-void AutomationView::renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputType outputType, int32_t knobPosLeft) {
-	char modelStackMemory[MODEL_STACK_MAX_SIZE];
-	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-	bool isKit = outputType == OutputType::KIT;
-
-	ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
-	                                                                        modelStack); // don't create
-	if (!modelStackWithNoteRow->getNoteRowAllowNull()) {
-		if (!isKit) {
-			modelStackWithNoteRow =
-			    instrumentClipView.createNoteRowForYDisplay(modelStack, instrumentClipView.lastAuditionedYDisplay);
-		}
-	}
-
-	if (knobPosLeft != kNoSelection) {
-		char buffer[5];
-		intToString(knobPosLeft, buffer);
-		display->setText(buffer, true, 255, false);
-	}
-	else {
-		// display note / drum name
-		char noteRowName[50];
-		if (modelStackWithNoteRow->getNoteRowAllowNull()) {
-			if (isKit) {
-				DEF_STACK_STRING_BUF(drumName, 50);
-				instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
-				strncpy(noteRowName, drumName.c_str(), 49);
-			}
-			else {
-				int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
-				noteCodeToString(modelStackWithNoteRow->getNoteRow()->getNoteCode(), noteRowName, &isNatural);
-			}
-		}
-		else {
-			if (isKit) {
-				strncpy(noteRowName, "(Select Drum)", 49);
-			}
-			else {
-				strncpy(noteRowName, "(Select Note)", 49);
-			}
-		}
-		display->setScrollingText(noteRowName);
-	}
-}
-
-// get's the name of the Parameter being edited so it can be displayed on the screen
-void AutomationView::getAutomationParameterName(Clip* clip, OutputType outputType, StringBuf& parameterName) {
-	if (onArrangerView || outputType != OutputType::MIDI_OUT) {
-		params::Kind lastSelectedParamKind = params::Kind::NONE;
-		int32_t lastSelectedParamID = kNoSelection;
-		PatchSource lastSelectedPatchSource = PatchSource::NONE;
-		if (onArrangerView) {
-			lastSelectedParamKind = currentSong->lastSelectedParamKind;
-			lastSelectedParamID = currentSong->lastSelectedParamID;
-		}
-		else {
-			lastSelectedParamKind = clip->lastSelectedParamKind;
-			lastSelectedParamID = clip->lastSelectedParamID;
-			lastSelectedPatchSource = clip->lastSelectedPatchSource;
-		}
-		if (lastSelectedParamKind == params::Kind::PATCH_CABLE) {
-			PatchSource source2 = PatchSource::NONE;
-			ParamDescriptor paramDescriptor;
-			paramDescriptor.data = lastSelectedParamID;
-			if (!paramDescriptor.hasJustOneSource()) {
-				source2 = paramDescriptor.getTopLevelSource();
-			}
-
-			parameterName.append(sourceToStringShort(lastSelectedPatchSource));
-
-			if (display->haveOLED()) {
-				parameterName.append(" -> ");
-			}
-			else {
-				parameterName.append(" - ");
-			}
-
-			if (source2 != PatchSource::NONE) {
-				parameterName.append(sourceToStringShort(source2));
-				parameterName.append(display->haveOLED() ? " -> " : " - ");
-			}
-
-			parameterName.append(params::getPatchedParamShortName(lastSelectedParamID));
-		}
-		else {
-			parameterName.append(getParamDisplayName(lastSelectedParamKind, lastSelectedParamID));
-		}
-	}
-	else {
-		if (clip->lastSelectedParamID == CC_NUMBER_NONE) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_PARAM));
-		}
-		else if (clip->lastSelectedParamID == CC_NUMBER_PITCH_BEND) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
-		}
-		else if (clip->lastSelectedParamID == CC_NUMBER_AFTERTOUCH) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
-		}
-		else if (clip->lastSelectedParamID == CC_EXTERNAL_MOD_WHEEL || clip->lastSelectedParamID == CC_NUMBER_Y_AXIS) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
-		}
-		else {
-			MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
-			bool appendedName = false;
-
-			if (clip->lastSelectedParamID >= 0 && clip->lastSelectedParamID < kNumRealCCNumbers) {
-				std::string_view name = midiInstrument->getNameFromCC(clip->lastSelectedParamID);
-				// if we have a name for this midi cc set by the user, display that instead of the cc number
-				if (!name.empty()) {
-					parameterName.append(name.data());
-					appendedName = true;
-				}
-			}
-
-			// if we don't have a midi cc name set, draw CC number instead
-			if (!appendedName) {
-				if (display->haveOLED()) {
-					parameterName.append("CC ");
-					parameterName.appendInt(clip->lastSelectedParamID);
-				}
-				else {
-					if (clip->lastSelectedParamID < 100) {
-						parameterName.append("CC");
-					}
-					else {
-						parameterName.append("C");
-					}
-					parameterName.appendInt(clip->lastSelectedParamID);
-				}
-			}
-		}
-	}
 }
 
 // adjust the LED meters and update the display
@@ -1909,7 +1254,7 @@ passToOthers:
 			renderDisplay();
 		}
 
-		uiNeedsRendering(this);
+		uiNeedsRendering(&automationView);
 
 		ActionResult result;
 		if (onArrangerView) {
@@ -1936,7 +1281,7 @@ passToOthers:
 	}
 
 	if (on && (b != KEYBOARD && b != CLIP_VIEW && b != SESSION_VIEW)) {
-		uiNeedsRendering(this);
+		uiNeedsRendering(&automationView);
 	}
 
 	return ActionResult::DEALT_WITH;
@@ -1948,7 +1293,7 @@ void AutomationView::handleSessionButtonAction(Clip* clip, bool on) {
 	if (on && Buttons::isShiftButtonPressed()) {
 		initParameterSelection();
 		blinkShortcuts();
-		uiNeedsRendering(this);
+		uiNeedsRendering(&automationView);
 	}
 	// go back to song / arranger view
 	else if (on && (currentUIMode == UI_MODE_NONE || (currentUIMode == UI_MODE_NOTES_PRESSED && padSelectionOn))) {
@@ -1987,7 +1332,7 @@ void AutomationView::handleClipButtonAction(bool on, bool isAudioClip) {
 	if (on && (currentUIMode == UI_MODE_AUDITIONING || Buttons::isShiftButtonPressed())) {
 		initParameterSelection();
 		blinkShortcuts();
-		uiNeedsRendering(this);
+		uiNeedsRendering(&automationView);
 	}
 	// go back to clip view
 	else if (on && (currentUIMode == UI_MODE_NONE || (currentUIMode == UI_MODE_NOTES_PRESSED && padSelectionOn))) {
@@ -2129,11 +1474,12 @@ bool AutomationView::handleHorizontalEncoderButtonAction(bool on, bool isAudioCl
 
 			if (Buttons::isShiftButtonPressed()) {
 				// paste within Automation Editor
-				pasteAutomation(modelStackWithParam, clip, effectiveLength, xScroll, xZoom);
+				automationEditorLayoutModControllable.pasteAutomation(modelStackWithParam, clip, effectiveLength,
+				                                                      xScroll, xZoom);
 			}
 			else {
 				// copy within Automation Editor
-				copyAutomation(modelStackWithParam, clip, xScroll, xZoom);
+				automationEditorLayoutModControllable.copyAutomation(modelStackWithParam, clip, xScroll, xZoom);
 			}
 		}
 		return false;
@@ -2293,7 +1639,7 @@ void AutomationView::handleVerticalEncoderButtonAction(bool on) {
 void AutomationView::handleSelectEncoderButtonAction(bool on) {
 	if (on && (currentUIMode == UI_MODE_NONE || (currentUIMode == UI_MODE_NOTES_PRESSED && padSelectionOn))) {
 		initParameterSelection();
-		uiNeedsRendering(this);
+		uiNeedsRendering(&automationView);
 
 		if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
 			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_RECORDING_TO_ARRANGEMENT));
@@ -2436,12 +1782,13 @@ ActionResult AutomationView::handleEditPadAction(ModelStackWithAutoParam* modelS
 	// regular automation / note editing action
 	if (isUIModeWithinRange(editPadActionUIModes) && isSquareDefined(x, xScroll, xZoom)) {
 		if (inAutomationEditor()) {
-			automationEditPadAction(modelStackWithParam, clip, x, y, velocity, effectiveLength, xScroll, xZoom);
+			automationEditorLayoutModControllable.automationEditPadAction(modelStackWithParam, clip, x, y, velocity,
+			                                                              effectiveLength, xScroll, xZoom);
 		}
 		else if (inNoteEditor()) {
 			if (noteRow) {
-				noteEditPadAction(modelStackWithNoteRow, noteRow, (InstrumentClip*)clip, x, y, velocity,
-				                  effectiveLength, squareInfo);
+				automationEditorLayoutNote.noteEditPadAction(modelStackWithNoteRow, noteRow, (InstrumentClip*)clip, x,
+				                                             y, velocity, effectiveLength, squareInfo);
 			}
 		}
 	}
@@ -2465,12 +1812,13 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 				// toggle interpolation on / off
 				// not relevant for note editor because interpolation doesn't apply to note params
 				if ((x == kInterpolationShortcutX && y == kInterpolationShortcutY)) {
-					return toggleAutomationInterpolation();
+					return automationEditorLayoutModControllable.toggleAutomationInterpolation();
 				}
 				// toggle pad selection on / off
 				// not relevant for note editor because pad selection mode was deemed unnecessary
 				else if (inAutomationEditor() && (x == kPadSelectionShortcutX && y == kPadSelectionShortcutY)) {
-					return toggleAutomationPadSelectionMode(modelStackWithParam, effectiveLength, xScroll, xZoom);
+					return automationEditorLayoutModControllable.toggleAutomationPadSelectionMode(
+					    modelStackWithParam, effectiveLength, xScroll, xZoom);
 				}
 			}
 
@@ -2501,55 +1849,6 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 	return false;
 }
 
-/// toggle automation interpolation on / off
-bool AutomationView::toggleAutomationInterpolation() {
-	if (interpolation) {
-		interpolation = false;
-		initInterpolation();
-		resetInterpolationShortcutBlinking();
-
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_INTERPOLATION_DISABLED));
-	}
-	else {
-		interpolation = true;
-		blinkInterpolationShortcut();
-
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_INTERPOLATION_ENABLED));
-	}
-	return true;
-}
-
-/// toggle automation pad selection mode on / off
-bool AutomationView::toggleAutomationPadSelectionMode(ModelStackWithAutoParam* modelStackWithParam,
-                                                      int32_t effectiveLength, int32_t xScroll, int32_t xZoom) {
-	// enter/exit pad selection mode
-	if (padSelectionOn) {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_OFF));
-
-		initPadSelection();
-		displayAutomation(true, !display->have7SEG());
-	}
-	else {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_PAD_SELECTION_ON));
-
-		padSelectionOn = true;
-		blinkPadSelectionShortcut();
-
-		multiPadPressSelected = false;
-		multiPadPressActive = false;
-
-		// display only left cursor initially
-		leftPadSelectedX = 0;
-		rightPadSelectedX = kNoSelection;
-
-		uint32_t squareStart = getMiddlePosFromSquare(leftPadSelectedX, effectiveLength, xScroll, xZoom);
-
-		updateAutomationModPosition(modelStackWithParam, squareStart, true, true);
-	}
-	uiNeedsRendering(this);
-	return true;
-}
-
 // called by shortcutPadAction when it is determined that you are selecting a parameter on automation
 // overview or by using a grid shortcut combo
 void AutomationView::handleParameterSelection(Clip* clip, Output* output, OutputType outputType, int32_t xDisplay,
@@ -2569,7 +1868,7 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 				clip->lastSelectedParamShortcutY = yDisplay;
 				blinkShortcuts();
 				renderDisplay();
-				uiNeedsRendering(this);
+				uiNeedsRendering(&automationView);
 				// if you're in note editor, turn led on
 				if (((InstrumentClip*)clip)->wrapEditing) {
 					indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, true);
@@ -2689,541 +1988,11 @@ void AutomationView::handleParameterSelection(Clip* clip, Output* output, Output
 	}
 	displayAutomation(true);
 	view.setModLedStates();
-	uiNeedsRendering(this);
+	uiNeedsRendering(&automationView);
 	// turn off cross screen LED in automation editor
 	if (clip && clip->type == ClipType::INSTRUMENT && ((InstrumentClip*)clip)->wrapEditing) {
 		indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, false);
 	}
-}
-
-// note edit pad action
-// handles single and multi pad presses for note parameter editing (e.g. velocity)
-// stores pad presses in the EditPadPresses struct of the instrument clip view
-void AutomationView::noteEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
-                                       InstrumentClip* clip, int32_t x, int32_t y, int32_t velocity,
-                                       int32_t effectiveLength, SquareInfo& squareInfo) {
-	if (automationParamType == AutomationParamType::NOTE_VELOCITY) {
-		velocityEditPadAction(modelStackWithNoteRow, noteRow, clip, x, y, velocity, effectiveLength, squareInfo);
-	}
-}
-
-// velocity edit pad action
-void AutomationView::velocityEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
-                                           InstrumentClip* clip, int32_t x, int32_t y, int32_t velocity,
-                                           int32_t effectiveLength, SquareInfo& squareInfo) {
-	// save pad selected
-	leftPadSelectedX = x;
-
-	// calculate new velocity based on Y of pad pressed
-	int32_t newVelocity = getVelocityFromY(y);
-
-	// middle pad press variables
-	middlePadPressSelected = false;
-
-	// multi pad press variables
-	multiPadPressSelected = false;
-	SquareInfo rowSquareInfo[kDisplayWidth];
-	int32_t multiPadPressVelocityIncrement = 0;
-
-	// update velocity editor rendering
-	bool refreshVelocityEditor = false;
-	bool showNewVelocity = true;
-
-	// check for middle or multi pad press
-	if (velocity && squareInfo.numNotes != 0 && instrumentClipView.numEditPadPresses == 1) {
-		// Find that original press
-		for (int32_t i = 0; i < kEditPadPressBufferSize; i++) {
-			if (instrumentClipView.editPadPresses[i].isActive) {
-				// if found, calculate middle velocity between two velocity pad presses
-				if (instrumentClipView.editPadPresses[i].xDisplay == x) {
-					// the last pad press will have updated the default velocity
-					// so get it as it will be used to calculate average between previous and new velocity
-					int32_t previousVelocity = getCurrentInstrument()->defaultVelocity;
-
-					// calculate middle velocity (average of two pad presses in a column)
-					newVelocity = (newVelocity + previousVelocity) / 2;
-
-					// update middle pad press selection indicator
-					middlePadPressSelected = true;
-
-					break;
-				}
-				// found a second press that isn't in the same column as the first press
-				else {
-					int32_t firstPadX = instrumentClipView.editPadPresses[i].xDisplay;
-
-					// get note info on all the squares in the note row
-					noteRow->getRowSquareInfo(effectiveLength, rowSquareInfo);
-
-					// the long press logic calculates and renders the interpolation as if the press was
-					// entered in a forward fashion (where the first pad is to the left of the second
-					// pad). if the user happens to enter a long press backwards then we fix that entry
-					// by re-ordering the pad presses so that it is forward again
-					leftPadSelectedX = firstPadX > x ? x : firstPadX;
-					rightPadSelectedX = firstPadX > x ? firstPadX : x;
-
-					int32_t numSquares = 0;
-					// find total number of notes in note row (excluding the first note)
-					for (int32_t i = leftPadSelectedX; i <= rightPadSelectedX; i++) {
-						// don't include note tails in note count
-						if (rowSquareInfo[i].numNotes != 0 && rowSquareInfo[i].squareType != SQUARE_NOTE_TAIL) {
-							numSquares++;
-						}
-					}
-
-					//	DEF_STACK_STRING_BUF(numSquare, 50);
-					//	numSquare.append("Squares: ");
-					//	numSquare.appendInt(numSquares);
-					//	numSquare.append("\n");
-
-					// calculate start and end velocity for long press
-					int32_t leftPadSelectedVelocity;
-					int32_t rightPadSelectedVelocity;
-
-					if (leftPadSelectedX == firstPadX) { // then left pad is the first press
-						leftPadSelectedVelocity = rowSquareInfo[leftPadSelectedX].averageVelocity;
-						leftPadSelectedY = getYFromVelocity(leftPadSelectedVelocity);
-						rightPadSelectedVelocity = getVelocityFromY(y);
-						rightPadSelectedY = y;
-					}
-					else { // then left pad is the second press
-						leftPadSelectedVelocity = getVelocityFromY(y);
-						leftPadSelectedY = y;
-						rightPadSelectedVelocity = rowSquareInfo[rightPadSelectedX].averageVelocity;
-						rightPadSelectedY = getYFromVelocity(rightPadSelectedVelocity);
-					}
-
-					//	numSquare.append("L: ");
-					//	numSquare.appendInt(leftPadSelectedVelocity);
-					//	numSquare.append(" R: ");
-					//	numSquare.appendInt(rightPadSelectedVelocity);
-					//	numSquare.append("\n");
-
-					// calculate increment from first pad to last pad
-					float multiPadPressVelocityIncrementFloat =
-					    static_cast<float>((rightPadSelectedVelocity - leftPadSelectedVelocity)) / (numSquares - 1);
-					multiPadPressVelocityIncrement =
-					    static_cast<int32_t>(std::round(multiPadPressVelocityIncrementFloat));
-					// if ramp is upwards, make increment positive
-					if (leftPadSelectedVelocity < rightPadSelectedVelocity) {
-						multiPadPressVelocityIncrement = std::abs(multiPadPressVelocityIncrement);
-					}
-
-					//	numSquare.append("Inc: ");
-					//	numSquare.appendInt(multiPadPressVelocityIncrement);
-					//	display->displayPopup(numSquare.c_str());
-
-					// update multi pad press selection indicator
-					multiPadPressSelected = true;
-					multiPadPressActive = true;
-
-					break;
-				}
-			}
-		}
-	}
-
-	// if middle pad press was selected, set the velocity to middle velocity between two pads pressed
-	if (middlePadPressSelected) {
-		setVelocity(modelStackWithNoteRow, noteRow, x, newVelocity);
-		refreshVelocityEditor = true;
-	}
-	// if multi pad (long) press was selected, set the velocity of all the notes between the two pad presses
-	else if (multiPadPressSelected) {
-		setVelocityRamp(modelStackWithNoteRow, noteRow, rowSquareInfo, multiPadPressVelocityIncrement);
-		refreshVelocityEditor = true;
-	}
-	// otherwise, it's a regular velocity pad action
-	else {
-		// no existing notes in square pressed
-		// add note and set velocity
-		if (squareInfo.numNotes == 0) {
-			addNoteWithNewVelocity(x, velocity, newVelocity);
-			refreshVelocityEditor = true;
-		}
-		// pressing pad corresponding to note's current averageVelocity, remove note
-		else if (nonPatchCableMinPadDisplayValues[y] <= squareInfo.averageVelocity
-		         && squareInfo.averageVelocity <= nonPatchCableMaxPadDisplayValues[y]) {
-			recordNoteEditPadAction(x, velocity);
-			refreshVelocityEditor = true;
-			showNewVelocity = false;
-		}
-		// note(s) exists, adjust velocity of existing notes
-		else {
-			adjustNoteVelocity(modelStackWithNoteRow, noteRow, x, velocity, newVelocity, squareInfo.squareType);
-			refreshVelocityEditor = true;
-		}
-	}
-	// if no note exists and you're trying to remove a note (y == 0 && squareInfo.numNotes == 0),
-	// well no need to do anything
-
-	if (multiPadPressActive && !isUIModeActive(UI_MODE_NOTES_PRESSED)) {
-		multiPadPressActive = false;
-	}
-
-	if (refreshVelocityEditor) {
-		// refresh grid and update default velocity on the display
-		uiNeedsRendering(this, 0xFFFFFFFF, 0);
-		// if holding a multi pad press, render left and right velocity of the multi pad press
-		if (multiPadPressActive) {
-			int32_t leftPadSelectedVelocity = getVelocityFromY(leftPadSelectedY);
-			int32_t rightPadSelectedVelocity = getVelocityFromY(rightPadSelectedY);
-			if (display->haveOLED()) {
-				renderDisplay(leftPadSelectedVelocity, rightPadSelectedVelocity);
-			}
-			else {
-				// for 7seg, render value of last pad pressed
-				renderDisplay(leftPadSelectedX == x ? leftPadSelectedVelocity : rightPadSelectedVelocity);
-			}
-		}
-		else {
-			if (velocity) {
-				renderDisplay(showNewVelocity ? newVelocity : squareInfo.averageVelocity);
-			}
-			else {
-				renderDisplay();
-			}
-		}
-	}
-}
-
-// convert y of pad press into velocity value between 1 and 127
-int32_t AutomationView::getVelocityFromY(int32_t y) {
-	int32_t velocity = std::clamp<int32_t>(nonPatchCablePadPressValues[y], 1, 127);
-	return velocity;
-}
-
-// convert velocity of a square into y
-int32_t AutomationView::getYFromVelocity(int32_t velocity) {
-	for (int32_t i = 0; i < kDisplayHeight; i++) {
-		if (nonPatchCableMinPadDisplayValues[i] <= velocity && velocity <= nonPatchCableMaxPadDisplayValues[i]) {
-			return i;
-		}
-	}
-	return kNoSelection;
-}
-
-// add note and set velocity
-void AutomationView::addNoteWithNewVelocity(int32_t x, int32_t velocity, int32_t newVelocity) {
-	if (velocity) {
-		// we change the instrument default velocity because it is used for new notes
-		getCurrentInstrument()->defaultVelocity = newVelocity;
-	}
-
-	// record pad press and release
-	// adds note with new velocity set
-	recordNoteEditPadAction(x, velocity);
-}
-
-// adjust velocity of existing notes
-void AutomationView::adjustNoteVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x,
-                                        int32_t velocity, int32_t newVelocity, uint8_t squareType) {
-	if (velocity) {
-		// record pad press
-		recordNoteEditPadAction(x, velocity);
-
-		// adjust velocities of notes within pressed pad square
-		setVelocity(modelStackWithNoteRow, noteRow, x, newVelocity);
-	}
-	else {
-		// record pad release
-		recordNoteEditPadAction(x, velocity);
-	}
-}
-
-// set velocity of notes within pressed pad square
-void AutomationView::setVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x,
-                                 int32_t newVelocity) {
-	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
-	if (!action) {
-		return;
-	}
-
-	int32_t velocityValue = 0;
-
-	for (int32_t i = 0; i < kEditPadPressBufferSize; i++) {
-		bool foundPadPress = instrumentClipView.editPadPresses[i].isActive;
-
-		// if we found an active pad press and we're looking for a pad press with a specific xDisplay
-		// see if the active pad press is the one we are looking for
-		if (foundPadPress && (x != kNoSelection)) {
-			foundPadPress = (instrumentClipView.editPadPresses[i].xDisplay == x);
-		}
-
-		if (foundPadPress) {
-			instrumentClipView.editPadPresses[i].deleteOnDepress = false;
-
-			// Multiple notes in square
-			if (instrumentClipView.editPadPresses[i].isBlurredSquare) {
-
-				uint32_t velocitySumThisSquare = 0;
-				uint32_t numNotesThisSquare = 0;
-
-				int32_t noteI =
-				    noteRow->notes.search(instrumentClipView.editPadPresses[i].intendedPos, GREATER_OR_EQUAL);
-				Note* note = noteRow->notes.getElement(noteI);
-				while (note
-				       && note->pos - instrumentClipView.editPadPresses[i].intendedPos
-				              < instrumentClipView.editPadPresses[i].intendedLength) {
-					noteRow->changeNotesAcrossAllScreens(note->pos, modelStackWithNoteRow, action,
-					                                     CORRESPONDING_NOTES_SET_VELOCITY, newVelocity);
-
-					instrumentClipView.updateVelocityValue(velocityValue, note->getVelocity());
-
-					numNotesThisSquare++;
-					velocitySumThisSquare += note->getVelocity();
-
-					noteI++;
-					note = noteRow->notes.getElement(noteI);
-				}
-
-				// Rohan: Get the average. Ideally we'd have done this when first selecting the note too, but I
-				// didn't
-
-				// Sean: not sure how getting the average when first selecting the note would help because the
-				// average will change based on the velocity adjustment happening here.
-
-				// We're adjusting the intendedVelocity here because this is the velocity that is used to audition
-				// the pad press note so you can hear the velocity changes as you're holding the note down
-				instrumentClipView.editPadPresses[i].intendedVelocity = velocitySumThisSquare / numNotesThisSquare;
-			}
-
-			// Only one note in square
-			else {
-				// We're adjusting the intendedVelocity here because this is the velocity that is used to audition
-				// the pad press note so you can hear the velocity changes as you're holding the note down
-				instrumentClipView.editPadPresses[i].intendedVelocity = newVelocity;
-				noteRow->changeNotesAcrossAllScreens(instrumentClipView.editPadPresses[i].intendedPos,
-				                                     modelStackWithNoteRow, action, CORRESPONDING_NOTES_SET_VELOCITY,
-				                                     newVelocity);
-
-				instrumentClipView.updateVelocityValue(velocityValue,
-				                                       instrumentClipView.editPadPresses[i].intendedVelocity);
-			}
-		}
-	}
-
-	instrumentClipView.displayVelocity(velocityValue, 0);
-
-	instrumentClipView.reassessAllAuditionStatus();
-}
-
-// set velocity of notes between pressed squares
-void AutomationView::setVelocityRamp(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
-                                     SquareInfo rowSquareInfo[kDisplayWidth], int32_t velocityIncrement) {
-	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
-	if (!action) {
-		return;
-	}
-
-	int32_t startVelocity = getVelocityFromY(leftPadSelectedY);
-	int32_t velocityValue = 0;
-	int32_t squaresProcessed = 0;
-
-	for (int32_t i = leftPadSelectedX; i <= rightPadSelectedX; i++) {
-		if (rowSquareInfo[i].numNotes != 0) {
-			int32_t intendedPos = rowSquareInfo[i].squareStartPos;
-
-			// Multiple notes in square
-			if (rowSquareInfo[i].numNotes > 1) {
-				int32_t intendedLength = rowSquareInfo[i].squareEndPos - intendedPos;
-
-				int32_t noteI = noteRow->notes.search(intendedPos, GREATER_OR_EQUAL);
-
-				Note* note = noteRow->notes.getElement(noteI);
-
-				while (note && note->pos - intendedPos < intendedLength) {
-					int32_t intendedVelocity =
-					    std::clamp<int32_t>(startVelocity + (velocityIncrement * squaresProcessed), 1, 127);
-
-					noteRow->changeNotesAcrossAllScreens(note->pos, modelStackWithNoteRow, action,
-					                                     CORRESPONDING_NOTES_SET_VELOCITY, intendedVelocity);
-
-					noteI++;
-
-					note = noteRow->notes.getElement(noteI);
-				}
-			}
-			// one note in square
-			else {
-				int32_t intendedVelocity =
-				    std::clamp<int32_t>(startVelocity + (velocityIncrement * squaresProcessed), 1, 127);
-
-				noteRow->changeNotesAcrossAllScreens(intendedPos, modelStackWithNoteRow, action,
-				                                     CORRESPONDING_NOTES_SET_VELOCITY, intendedVelocity);
-			}
-
-			// don't include note tails in note count
-			if (rowSquareInfo[i].squareType != SQUARE_NOTE_TAIL) {
-				squaresProcessed++;
-			}
-		}
-	}
-}
-
-// call instrument clip view edit pad action function to process velocity pad press actions
-void AutomationView::recordNoteEditPadAction(int32_t x, int32_t velocity) {
-	instrumentClipView.editPadAction(velocity, instrumentClipView.lastAuditionedYDisplay, x,
-	                                 currentSong->xZoom[NAVIGATION_CLIP]);
-}
-
-// automation edit pad action
-// handles single and multi pad presses for automation editing
-// stores pad presses in the EditPadPresses struct of the instrument clip view
-void AutomationView::automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
-                                             int32_t yDisplay, int32_t velocity, int32_t effectiveLength,
-                                             int32_t xScroll, int32_t xZoom) {
-	// If button down
-	if (velocity) {
-		// If this is a automation-length-edit press...
-		// needed for Automation
-		if (instrumentClipView.numEditPadPresses == 1) {
-
-			int32_t firstPadX = 255;
-			int32_t firstPadY = 255;
-
-			// Find that original press
-			int32_t i;
-			for (i = 0; i < kEditPadPressBufferSize; i++) {
-				if (instrumentClipView.editPadPresses[i].isActive) {
-
-					firstPadX = instrumentClipView.editPadPresses[i].xDisplay;
-					firstPadY = instrumentClipView.editPadPresses[i].yDisplay;
-
-					break;
-				}
-			}
-
-			if (firstPadX != 255 && firstPadY != 255) {
-				if (firstPadX != xDisplay) {
-					recordAutomationSinglePadPress(xDisplay, yDisplay);
-
-					multiPadPressSelected = true;
-					multiPadPressActive = true;
-
-					// the long press logic calculates and renders the interpolation as if the press was
-					// entered in a forward fashion (where the first pad is to the left of the second
-					// pad). if the user happens to enter a long press backwards then we fix that entry
-					// by re-ordering the pad presses so that it is forward again
-					leftPadSelectedX = firstPadX > xDisplay ? xDisplay : firstPadX;
-					leftPadSelectedY = firstPadX > xDisplay ? yDisplay : firstPadY;
-					rightPadSelectedX = firstPadX > xDisplay ? firstPadX : xDisplay;
-					rightPadSelectedY = firstPadX > xDisplay ? firstPadY : yDisplay;
-
-					// if you're not in pad selection mode, allow user to enter a long press
-					if (!padSelectionOn) {
-						handleAutomationMultiPadPress(modelStackWithParam, clip, leftPadSelectedX, leftPadSelectedY,
-						                              rightPadSelectedX, rightPadSelectedY, effectiveLength, xScroll,
-						                              xZoom);
-					}
-					else {
-						uiNeedsRendering(this);
-					}
-
-					// set led indicators to left / right pad selection values
-					// and update display
-					renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom,
-					                                        xDisplay);
-				}
-				else {
-					leftPadSelectedY = firstPadY;
-					middlePadPressSelected = true;
-					goto singlePadPressAction;
-				}
-			}
-		}
-
-		// Or, if this is a regular create-or-select press...
-		else {
-singlePadPressAction:
-			if (recordAutomationSinglePadPress(xDisplay, yDisplay)) {
-				multiPadPressActive = false;
-				handleAutomationSinglePadPress(modelStackWithParam, clip, xDisplay, yDisplay, effectiveLength, xScroll,
-				                               xZoom);
-			}
-		}
-	}
-
-	// Or if pad press ended...
-	else {
-		// Find the corresponding press, if there is one
-		int32_t i;
-		for (i = 0; i < kEditPadPressBufferSize; i++) {
-			if (instrumentClipView.editPadPresses[i].isActive
-			    && instrumentClipView.editPadPresses[i].yDisplay == yDisplay
-			    && instrumentClipView.editPadPresses[i].xDisplay == xDisplay) {
-				break;
-			}
-		}
-
-		// If we found it...
-		if (i < kEditPadPressBufferSize) {
-			instrumentClipView.endEditPadPress(i);
-
-			instrumentClipView.checkIfAllEditPadPressesEnded();
-		}
-
-		// outside pad selection mode, exit multi pad press once you've let go of the first pad in the
-		// long press
-		if (!padSelectionOn && multiPadPressSelected && (currentUIMode != UI_MODE_NOTES_PRESSED)) {
-			initPadSelection();
-		}
-		// switch from long press selection to short press selection in pad selection mode
-		else if (padSelectionOn && multiPadPressSelected && !multiPadPressActive
-		         && (currentUIMode != UI_MODE_NOTES_PRESSED)
-		         && ((AudioEngine::audioSampleTimer - instrumentClipView.timeLastEditPadPress) < kShortPressTime)) {
-
-			multiPadPressSelected = false;
-
-			leftPadSelectedX = xDisplay;
-			rightPadSelectedX = kNoSelection;
-
-			uiNeedsRendering(this);
-		}
-
-		if (currentUIMode != UI_MODE_NOTES_PRESSED) {
-			lastPadSelectedKnobPos = kNoSelection;
-			if (multiPadPressSelected) {
-				renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom,
-				                                        xDisplay);
-			}
-			else if (!padSelectionOn && !playbackHandler.isEitherClockActive()) {
-				displayAutomation();
-			}
-		}
-
-		middlePadPressSelected = false;
-	}
-}
-
-bool AutomationView::recordAutomationSinglePadPress(int32_t xDisplay, int32_t yDisplay) {
-	instrumentClipView.timeLastEditPadPress = AudioEngine::audioSampleTimer;
-	// Find an empty space in the press buffer, if there is one
-	int32_t i;
-	for (i = 0; i < kEditPadPressBufferSize; i++) {
-		if (!instrumentClipView.editPadPresses[i].isActive) {
-			break;
-		}
-	}
-	if (i < kEditPadPressBufferSize) {
-		instrumentClipView.shouldIgnoreVerticalScrollKnobActionIfNotAlsoPressedForThisNotePress = false;
-
-		// If this is the first press, record the time
-		if (instrumentClipView.numEditPadPresses == 0) {
-			instrumentClipView.timeFirstEditPadPress = AudioEngine::audioSampleTimer;
-			instrumentClipView.shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress = false;
-		}
-
-		instrumentClipView.editPadPresses[i].isActive = true;
-		instrumentClipView.editPadPresses[i].yDisplay = yDisplay;
-		instrumentClipView.editPadPresses[i].xDisplay = xDisplay;
-		instrumentClipView.numEditPadPresses++;
-		instrumentClipView.numEditPadPressesPerNoteRowOnScreen[yDisplay]++;
-		enterUIMode(UI_MODE_NOTES_PRESSED);
-
-		return true;
-	}
-	return false;
 }
 
 // called by pad action when pressing a pad in the mute column (x = kDisplayWidth)
@@ -3231,7 +2000,7 @@ ActionResult AutomationView::handleMutePadAction(ModelStackWithTimelineCounter* 
                                                  InstrumentClip* instrumentClip, Output* output, OutputType outputType,
                                                  int32_t y, int32_t velocity) {
 	if (onArrangerView) {
-		return arrangerView.handleStatusPadAction(y, velocity, this);
+		return arrangerView.handleStatusPadAction(y, velocity, &automationView);
 	}
 	else {
 		if (currentUIMode == UI_MODE_MIDI_LEARN) [[unlikely]] {
@@ -3268,13 +2037,13 @@ ActionResult AutomationView::handleAuditionPadAction(InstrumentClip* instrumentC
                                                      OutputType outputType, int32_t y, int32_t velocity) {
 	if (onArrangerView) {
 		if (onAutomationOverview()) {
-			return arrangerView.handleAuditionPadAction(y, velocity, this);
+			return arrangerView.handleAuditionPadAction(y, velocity, &automationView);
 		}
 	}
 	else {
 		// "Learning" to this audition pad:
 		if (isUIModeActiveExclusively(UI_MODE_MIDI_LEARN)) [[unlikely]] {
-			if (getCurrentUI() == this) {
+			if (getCurrentUI() == &automationView) {
 				return instrumentClipView.commandLearnAuditionPad(instrumentClip, output, outputType, y, velocity);
 			}
 		}
@@ -3498,7 +2267,7 @@ ActionResult AutomationView::horizontalEncoderAction(int32_t offset) {
 			if (!instrumentClipView.shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress) {
 				instrumentClipView.adjustVelocity(offset);
 				renderDisplay(getCurrentInstrument()->defaultVelocity);
-				uiNeedsRendering(this, 0xFFFFFFFF, 0);
+				uiNeedsRendering(&automationView, 0xFFFFFFFF, 0);
 			}
 		}
 		return ActionResult::DEALT_WITH;
@@ -3527,7 +2296,7 @@ void AutomationView::shiftAutomationHorizontally(ModelStackWithAutoParam* modelS
 		modelStackWithParam->autoParam->shiftHorizontally(offset, effectiveLength);
 	}
 
-	uiNeedsRendering(this);
+	uiNeedsRendering(&automationView);
 }
 
 // vertical encoder action
@@ -3651,8 +2420,8 @@ void AutomationView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 		         && ((int32_t)(instrumentClipView.timeLastEditPadPress + 80 * 44 - AudioEngine::audioSampleTimer) < 0))
 		        || padSelectionOn)) {
 
-			if (automationModEncoderActionForSelectedPad(modelStackWithParam, whichModEncoder, offset,
-			                                             effectiveLength)) {
+			if (automationEditorLayoutModControllable.automationModEncoderActionForSelectedPad(
+			        modelStackWithParam, whichModEncoder, offset, effectiveLength)) {
 				return;
 			}
 		}
@@ -3665,158 +2434,19 @@ void AutomationView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 	// the parameter at the current mod position
 	else {
 		if (inAutomationEditor()) {
-			automationModEncoderActionForUnselectedPad(modelStackWithParam, whichModEncoder, offset, effectiveLength);
+			automationEditorLayoutModControllable.automationModEncoderActionForUnselectedPad(
+			    modelStackWithParam, whichModEncoder, offset, effectiveLength);
 		}
 		else {
 			goto followOnAction;
 		}
 	}
 
-	uiNeedsRendering(this);
+	uiNeedsRendering(&automationView);
 	return;
 
 followOnAction:
 	ClipNavigationTimelineView::modEncoderAction(whichModEncoder, offset);
-}
-
-bool AutomationView::automationModEncoderActionForSelectedPad(ModelStackWithAutoParam* modelStackWithParam,
-                                                              int32_t whichModEncoder, int32_t offset,
-                                                              int32_t effectiveLength) {
-	Clip* clip = getCurrentClip();
-
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-
-		int32_t xDisplay = 0;
-
-		// for a multi pad press, adjust value of first or last pad depending on mod encoder turned
-		if (multiPadPressSelected) {
-			if (whichModEncoder == 0) {
-				xDisplay = leftPadSelectedX;
-			}
-			else if (whichModEncoder == 1) {
-				xDisplay = rightPadSelectedX;
-			}
-		}
-
-		// if not multi pad press, but in pad selection mode, then just adjust the single selected pad
-		else if (padSelectionOn) {
-			xDisplay = leftPadSelectedX;
-		}
-
-		// otherwise if not in pad selection mode, adjust the value of the pad currently being held
-		else {
-			// find pads that are currently pressed
-			int32_t i;
-			for (i = 0; i < kEditPadPressBufferSize; i++) {
-				if (instrumentClipView.editPadPresses[i].isActive) {
-					xDisplay = instrumentClipView.editPadPresses[i].xDisplay;
-				}
-			}
-		}
-
-		uint32_t squareStart = 0;
-
-		int32_t xScroll = currentSong->xScroll[navSysId];
-		int32_t xZoom = currentSong->xZoom[navSysId];
-
-		// for the second pad pressed in a long press, the square start position is set to the very last
-		// nodes position
-		if (multiPadPressSelected && (whichModEncoder == 1)) {
-			int32_t squareRightEdge = getPosFromSquare(xDisplay + 1, xScroll, xZoom);
-			squareStart = std::min(effectiveLength, squareRightEdge) - kParamNodeWidth;
-		}
-		else {
-			squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
-		}
-
-		if (squareStart < effectiveLength) {
-
-			int32_t knobPos = getAutomationParameterKnobPos(modelStackWithParam, squareStart);
-
-			int32_t newKnobPos = calculateAutomationKnobPosForModEncoderTurn(modelStackWithParam, knobPos, offset);
-
-			// ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
-			// if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a
-			// value change gets recorded if newKnobPos exceeds 127, then it means current knobPos was
-			// 127 and it was increased to 128. In which case, ignore value change
-			if (!onArrangerView && ((clip->output->type == OutputType::MIDI_OUT) && (newKnobPos == 64))) {
-				return true;
-			}
-
-			// use default interpolation settings
-			initInterpolation();
-
-			setAutomationParameterValue(modelStackWithParam, newKnobPos, squareStart, xDisplay, effectiveLength,
-			                            xScroll, xZoom, true);
-
-			view.potentiallyMakeItHarderToTurnKnob(whichModEncoder, modelStackWithParam, newKnobPos);
-
-			// once first or last pad in a multi pad press is adjusted, re-render calculate multi pad
-			// press based on revised start/ending values
-			if (multiPadPressSelected) {
-
-				handleAutomationMultiPadPress(modelStackWithParam, clip, leftPadSelectedX, 0, rightPadSelectedX, 0,
-				                              effectiveLength, xScroll, xZoom, true);
-
-				renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom,
-				                                        xDisplay, true);
-
-				return true;
-			}
-		}
-	}
-
-	return false;
-}
-
-void AutomationView::automationModEncoderActionForUnselectedPad(ModelStackWithAutoParam* modelStackWithParam,
-                                                                int32_t whichModEncoder, int32_t offset,
-                                                                int32_t effectiveLength) {
-	Clip* clip = getCurrentClip();
-
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-
-		if (modelStackWithParam->getTimelineCounter()
-		    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
-
-			int32_t knobPos = getAutomationParameterKnobPos(modelStackWithParam, view.modPos);
-
-			int32_t newKnobPos = calculateAutomationKnobPosForModEncoderTurn(modelStackWithParam, knobPos, offset);
-
-			// ignore modEncoderTurn for Midi CC if current or new knobPos exceeds 127
-			// if current knobPos exceeds 127, e.g. it's 128, then it needs to drop to 126 before a
-			// value change gets recorded if newKnobPos exceeds 127, then it means current knobPos was
-			// 127 and it was increased to 128. In which case, ignore value change
-			if (!onArrangerView && ((clip->output->type == OutputType::MIDI_OUT) && (newKnobPos == 64))) {
-				return;
-			}
-
-			int32_t newValue =
-			    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
-
-			// use default interpolation settings
-			initInterpolation();
-
-			modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, view.modPos,
-			                                                          view.modLength);
-
-			if (!onArrangerView) {
-				modelStackWithParam->getTimelineCounter()->instrumentBeenEdited();
-			}
-
-			if (!playbackHandler.isEitherClockActive() || !modelStackWithParam->autoParam->isAutomated()) {
-				int32_t knobPos = newKnobPos + kKnobPosOffset;
-				renderDisplay(knobPos, kNoSelection, true);
-				setAutomationKnobIndicatorLevels(modelStackWithParam, knobPos, knobPos);
-			}
-
-			view.potentiallyMakeItHarderToTurnKnob(whichModEncoder, modelStackWithParam, newKnobPos);
-
-			// midi follow and midi feedback enabled
-			// re-send midi cc because learned parameter value has changed
-			view.sendMidiFollowFeedback(modelStackWithParam, newKnobPos);
-		}
-	}
 }
 
 // used to copy paste automation or to delete automation of the current selected parameter
@@ -3850,7 +2480,8 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 			if (Buttons::isShiftButtonPressed()) {
 				// paste within Automation Editor
 				if (inAutomationEditor()) {
-					pasteAutomation(modelStackWithParam, clip, effectiveLength, xScroll, xZoom);
+					automationEditorLayoutModControllable.pasteAutomation(modelStackWithParam, clip, effectiveLength,
+					                                                      xScroll, xZoom);
 				}
 				// paste on Automation Overview / Note Editor
 				else {
@@ -3860,7 +2491,7 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 			else {
 				// copy within Automation Editor
 				if (inAutomationEditor()) {
-					copyAutomation(modelStackWithParam, clip, xScroll, xZoom);
+					automationEditorLayoutModControllable.copyAutomation(modelStackWithParam, clip, xScroll, xZoom);
 				}
 				// copy on Automation Overview / Note Editor
 				else {
@@ -3889,107 +2520,13 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 		goto followOnAction;
 	}
 
-	uiNeedsRendering(this);
+	uiNeedsRendering(&automationView);
 	return;
 
 followOnAction: // it will come here when you are on the automation overview / in note editor iscreen
 
 	view.modEncoderButtonAction(whichModEncoder, on);
-	uiNeedsRendering(this);
-}
-
-void AutomationView::copyAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xScroll,
-                                    int32_t xZoom) {
-	if (copiedParamAutomation.nodes) {
-		delugeDealloc(copiedParamAutomation.nodes);
-		copiedParamAutomation.nodes = nullptr;
-		copiedParamAutomation.numNodes = 0;
-	}
-
-	int32_t startPos = getPosFromSquare(0, xScroll, xZoom);
-	int32_t endPos = getPosFromSquare(kDisplayWidth, xScroll, xZoom);
-	if (startPos == endPos) {
-		return;
-	}
-
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-
-		bool isPatchCable = (modelStackWithParam->paramCollection
-		                     == modelStackWithParam->paramManager->getPatchCableSetAllowJibberish());
-		// Ok this is cursed, but will work fine so long as
-		// the possibly invalid memory here doesn't accidentally
-		// equal modelStack->paramCollection.
-
-		modelStackWithParam->autoParam->copy(startPos, endPos, &copiedParamAutomation, isPatchCable,
-		                                     modelStackWithParam);
-
-		if (copiedParamAutomation.nodes) {
-			display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_COPIED));
-			return;
-		}
-	}
-
-	display->displayPopup(l10n::get(l10n::String::STRING_FOR_NO_AUTOMATION_TO_COPY));
-}
-
-void AutomationView::pasteAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t effectiveLength,
-                                     int32_t xScroll, int32_t xZoom) {
-	if (!copiedParamAutomation.nodes) {
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_NO_AUTOMATION_TO_PASTE));
-		return;
-	}
-
-	int32_t startPos = getPosFromSquare(0, xScroll, xZoom);
-	int32_t endPos = getPosFromSquare(kDisplayWidth, xScroll, xZoom);
-
-	int32_t pastedAutomationWidth = endPos - startPos;
-	if (pastedAutomationWidth == 0) {
-		return;
-	}
-
-	float scaleFactor = (float)pastedAutomationWidth / copiedParamAutomation.width;
-
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-		Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_PASTE);
-
-		if (action) {
-			action->recordParamChangeIfNotAlreadySnapshotted(modelStackWithParam, false);
-		}
-
-		bool isPatchCable = (modelStackWithParam->paramCollection
-		                     == modelStackWithParam->paramManager->getPatchCableSetAllowJibberish());
-		// Ok this is cursed, but will work fine so long as
-		// the possibly invalid memory here doesn't accidentally
-		// equal modelStack->paramCollection.
-
-		modelStackWithParam->autoParam->paste(startPos, endPos, scaleFactor, modelStackWithParam,
-		                                      &copiedParamAutomation, isPatchCable);
-
-		display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_PASTED));
-
-		if (playbackHandler.isEitherClockActive()) {
-			currentPlaybackMode->reversionDone(); // Re-gets automation and stuff
-		}
-		else {
-			if (padSelectionOn) {
-				if (multiPadPressSelected) {
-					renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom);
-				}
-				else {
-					uint32_t squareStart = getMiddlePosFromSquare(leftPadSelectedX, effectiveLength, xScroll, xZoom);
-
-					updateAutomationModPosition(modelStackWithParam, squareStart);
-				}
-			}
-			else {
-				displayAutomation();
-			}
-		}
-
-		return;
-	}
-
-	display->displayPopup(l10n::get(l10n::String::STRING_FOR_CANT_PASTE_AUTOMATION));
+	uiNeedsRendering(&automationView);
 }
 
 // select encoder action
@@ -4088,7 +2625,8 @@ void AutomationView::selectEncoderAction(int8_t offset) {
 		int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 		int32_t xScroll = currentSong->xScroll[navSysId];
 		int32_t xZoom = currentSong->xZoom[navSysId];
-		renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip, effectiveLength, xScroll, xZoom);
+		automationEditorLayoutModControllable.renderAutomationDisplayForMultiPadPress(modelStackWithParam, clip,
+		                                                                              effectiveLength, xScroll, xZoom);
 	}
 	else {
 		displayAutomation(true, !display->have7SEG());
@@ -4096,7 +2634,7 @@ void AutomationView::selectEncoderAction(int8_t offset) {
 	resetParameterShortcutBlinking();
 	blinkShortcuts();
 	view.setModLedStates();
-	uiNeedsRendering(this);
+	uiNeedsRendering(&automationView);
 }
 
 // used with SelectEncoderAction to get the next arranger / audio clip / kit affect entire parameter
@@ -4510,9 +3048,8 @@ void AutomationView::initPadSelection() {
 }
 
 void AutomationView::initInterpolation() {
-
-	automationView.interpolationBefore = false;
-	automationView.interpolationAfter = false;
+	interpolationBefore = false;
+	interpolationAfter = false;
 }
 
 // get's the modelstack for the parameters that are being edited
@@ -4535,6 +3072,22 @@ ModelStackWithAutoParam* AutomationView::getModelStackWithParamForClip(ModelStac
 	    clip->output->getModelStackWithParam(modelStack, clip, paramID, paramKind, getAffectEntire(), inSoundMenu);
 
 	return modelStackWithParam;
+}
+
+// this function obtains a parameters value and converts it to a knobPos
+// the knobPos is used for rendering the current parameter values in the automation editor
+// it's also used for obtaining the start and end position values for a multi pad press
+// and also used for increasing/decreasing parameter values with the mod encoders
+int32_t AutomationView::getAutomationParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t squareStart) {
+	return automationEditorLayoutModControllable.getAutomationParameterKnobPos(modelStack, squareStart);
+}
+
+// sets both knob indicators to the same value when pressing single pad,
+// deleting automation, or displaying current parameter value
+// multi pad presses don't use this function
+void AutomationView::setAutomationKnobIndicatorLevels(ModelStackWithAutoParam* modelStack, int32_t knobPosLeft,
+                                                      int32_t knobPosRight) {
+	automationEditorLayoutModControllable.setAutomationKnobIndicatorLevels(modelStack, knobPosLeft, knobPosRight);
 }
 
 // calculates the length of the arrangement timeline, clip or the length of the kit row
@@ -4587,535 +3140,6 @@ int32_t AutomationView::getNavSysId() const {
 	else {
 		return NAVIGATION_CLIP;
 	}
-}
-
-uint32_t AutomationView::getSquareWidth(int32_t square, int32_t effectiveLength, int32_t xScroll, int32_t xZoom) {
-	int32_t squareRightEdge = getPosFromSquare(square + 1, xScroll, xZoom);
-	return std::min(effectiveLength, squareRightEdge) - getPosFromSquare(square, xScroll, xZoom);
-}
-
-// when pressing on a single pad, you want to display the value of the middle node within that square
-// as that is the most accurate value that represents that square
-uint32_t AutomationView::getMiddlePosFromSquare(int32_t xDisplay, int32_t effectiveLength, int32_t xScroll,
-                                                int32_t xZoom) {
-	uint32_t squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
-	uint32_t squareWidth = getSquareWidth(xDisplay, effectiveLength, xScroll, xZoom);
-	if (squareWidth != 3) {
-		squareStart = squareStart + (squareWidth / 2);
-	}
-
-	return squareStart;
-}
-
-// this function obtains a parameters value and converts it to a knobPos
-// the knobPos is used for rendering the current parameter values in the automation editor
-// it's also used for obtaining the start and end position values for a multi pad press
-// and also used for increasing/decreasing parameter values with the mod encoders
-int32_t AutomationView::getAutomationParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t squareStart) {
-	// obtain value corresponding to the two pads that were pressed in a multi pad press action
-	int32_t currentValue = modelStack->autoParam->getValuePossiblyAtPos(squareStart, modelStack);
-	int32_t knobPos = modelStack->paramCollection->paramValueToKnobPos(currentValue, modelStack);
-
-	return knobPos;
-}
-
-// this function is based off the code in AutoParam::getValueAtPos, it was tweaked to just return
-// interpolation status of the left node or right node (depending on the reversed parameter which is
-// used to indicate what node in what direction we are looking for (e.g. we want status of left node, or
-// right node, relative to the current pos we are looking at
-bool AutomationView::getAutomationNodeInterpolation(ModelStackWithAutoParam* modelStack, int32_t pos, bool reversed) {
-
-	if (!modelStack->autoParam->nodes.getNumElements()) {
-		return false;
-	}
-
-	int32_t rightI = modelStack->autoParam->nodes.search(pos + (int32_t)!reversed, GREATER_OR_EQUAL);
-	if (rightI >= modelStack->autoParam->nodes.getNumElements()) {
-		rightI = 0;
-	}
-	ParamNode* rightNode = modelStack->autoParam->nodes.getElement(rightI);
-
-	int32_t leftI = rightI - 1;
-	if (leftI < 0) {
-		leftI += modelStack->autoParam->nodes.getNumElements();
-	}
-	ParamNode* leftNode = modelStack->autoParam->nodes.getElement(leftI);
-
-	if (reversed) {
-		return leftNode->interpolated;
-	}
-	else {
-		return rightNode->interpolated;
-	}
-}
-
-// this function writes the new values calculated by the handleAutomationSinglePadPress and
-// handleAutomationMultiPadPress functions
-void AutomationView::setAutomationParameterValue(ModelStackWithAutoParam* modelStack, int32_t knobPos,
-                                                 int32_t squareStart, int32_t xDisplay, int32_t effectiveLength,
-                                                 int32_t xScroll, int32_t xZoom, bool modEncoderAction) {
-
-	int32_t newValue = modelStack->paramCollection->knobPosToParamValue(knobPos, modelStack);
-
-	uint32_t squareWidth = 0;
-
-	// for a multi pad press, the beginning and ending pad presses are set with a square width of 3 (1
-	// node).
-	if (multiPadPressSelected) {
-		squareWidth = kParamNodeWidth;
-	}
-	else {
-		squareWidth = getSquareWidth(xDisplay, effectiveLength, xScroll, xZoom);
-	}
-
-	// if you're doing a single pad press, you don't want the values around that single press position
-	// to change they will change if those nodes around the single pad press were created with
-	// interpolation turned on to fix this, re-create those nodes with their current value with
-	// interpolation off
-
-	interpolationBefore = getAutomationNodeInterpolation(modelStack, squareStart, true);
-	interpolationAfter = getAutomationNodeInterpolation(modelStack, squareStart, false);
-
-	// create a node to the left with the current interpolation status
-	int32_t squareNodeLeftStart = squareStart - kParamNodeWidth;
-	if (squareNodeLeftStart >= 0) {
-		int32_t currentValue = modelStack->autoParam->getValuePossiblyAtPos(squareNodeLeftStart, modelStack);
-		modelStack->autoParam->setValuePossiblyForRegion(currentValue, modelStack, squareNodeLeftStart,
-		                                                 kParamNodeWidth);
-	}
-
-	// create a node to the right with the current interpolation status
-	int32_t squareNodeRightStart = squareStart + kParamNodeWidth;
-	if (squareNodeRightStart < effectiveLength) {
-		int32_t currentValue = modelStack->autoParam->getValuePossiblyAtPos(squareNodeRightStart, modelStack);
-		modelStack->autoParam->setValuePossiblyForRegion(currentValue, modelStack, squareNodeRightStart,
-		                                                 kParamNodeWidth);
-	}
-
-	// reset interpolation to false for the single pad we're changing (so that the nodes around it don't
-	// also change)
-	initInterpolation();
-
-	// called twice because there was a weird bug where for some reason the first call wasn't taking
-	// effect on one pad (and whatever pad it was changed every time)...super weird...calling twice
-	// fixed it...
-	modelStack->autoParam->setValuePossiblyForRegion(newValue, modelStack, squareStart, squareWidth);
-	modelStack->autoParam->setValuePossiblyForRegion(newValue, modelStack, squareStart, squareWidth);
-
-	if (!onArrangerView) {
-		modelStack->getTimelineCounter()->instrumentBeenEdited();
-	}
-
-	// in a multi pad press, no need to display all the values calculated
-	if (!multiPadPressSelected) {
-		int32_t newKnobPos = knobPos + kKnobPosOffset;
-		renderDisplay(newKnobPos, kNoSelection, modEncoderAction);
-		setAutomationKnobIndicatorLevels(modelStack, newKnobPos, newKnobPos);
-	}
-
-	// midi follow and midi feedback enabled
-	// re-send midi cc because learned parameter value has changed
-	view.sendMidiFollowFeedback(modelStack, knobPos);
-}
-
-// sets both knob indicators to the same value when pressing single pad,
-// deleting automation, or displaying current parameter value
-// multi pad presses don't use this function
-void AutomationView::setAutomationKnobIndicatorLevels(ModelStackWithAutoParam* modelStack, int32_t knobPosLeft,
-                                                      int32_t knobPosRight) {
-	params::Kind kind = modelStack->paramCollection->getParamKind();
-	bool isBipolar = isParamBipolar(kind, modelStack->paramId);
-
-	// if you're dealing with a patch cable which has a -128 to +128 range
-	// we'll need to convert it to a 0 - 128 range for purpose of rendering on knob indicators
-	if (kind == params::Kind::PATCH_CABLE) {
-		knobPosLeft = view.convertPatchCableKnobPosToIndicatorLevel(knobPosLeft);
-		knobPosRight = view.convertPatchCableKnobPosToIndicatorLevel(knobPosRight);
-	}
-
-	bool isBlinking = indicator_leds::isKnobIndicatorBlinking(0) || indicator_leds::isKnobIndicatorBlinking(1);
-
-	if (!isBlinking) {
-		indicator_leds::setKnobIndicatorLevel(0, knobPosLeft, isBipolar);
-		indicator_leds::setKnobIndicatorLevel(1, knobPosRight, isBipolar);
-	}
-}
-
-// updates the position that the active mod controllable stack is pointing to
-// this sets the current value for the active parameter so that it can be auditioned
-void AutomationView::updateAutomationModPosition(ModelStackWithAutoParam* modelStack, uint32_t squareStart,
-                                                 bool updateDisplay, bool updateIndicatorLevels) {
-
-	if (!playbackHandler.isEitherClockActive() || padSelectionOn) {
-		if (modelStack && modelStack->autoParam) {
-			if (modelStack->getTimelineCounter()
-			    == view.activeModControllableModelStack.getTimelineCounterAllowNull()) {
-
-				view.activeModControllableModelStack.paramManager->toForTimeline()->grabValuesFromPos(
-				    squareStart, &view.activeModControllableModelStack);
-
-				int32_t knobPos = getAutomationParameterKnobPos(modelStack, squareStart) + kKnobPosOffset;
-
-				if (updateDisplay) {
-					renderDisplay(knobPos);
-				}
-
-				if (updateIndicatorLevels) {
-					setAutomationKnobIndicatorLevels(modelStack, knobPos, knobPos);
-				}
-			}
-		}
-	}
-}
-
-// takes care of setting the automation value for the single pad that was pressed
-void AutomationView::handleAutomationSinglePadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-                                                    int32_t xDisplay, int32_t yDisplay, int32_t effectiveLength,
-                                                    int32_t xScroll, int32_t xZoom) {
-
-	Output* output = clip->output;
-	OutputType outputType = output->type;
-
-	// this means you are editing a parameter's value
-	if (inAutomationEditor()) {
-		handleAutomationParameterChange(modelStackWithParam, clip, outputType, xDisplay, yDisplay, effectiveLength,
-		                                xScroll, xZoom);
-	}
-
-	uiNeedsRendering(this);
-}
-
-// called by handle single pad press when it is determined that you are editing parameter automation
-// using the grid
-void AutomationView::handleAutomationParameterChange(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-                                                     OutputType outputType, int32_t xDisplay, int32_t yDisplay,
-                                                     int32_t effectiveLength, int32_t xScroll, int32_t xZoom) {
-	if (padSelectionOn) {
-		// display pad's value
-		uint32_t squareStart = 0;
-
-		// if a long press is selected and you're checking value of start or end pad
-		// display value at very first or very last node
-		if (multiPadPressSelected && ((leftPadSelectedX == xDisplay) || (rightPadSelectedX == xDisplay))) {
-			if (leftPadSelectedX == xDisplay) {
-				squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
-			}
-			else {
-				int32_t squareRightEdge = getPosFromSquare(rightPadSelectedX + 1, xScroll, xZoom);
-				squareStart = std::min(effectiveLength, squareRightEdge) - kParamNodeWidth;
-			}
-		}
-		// display pad's middle value
-		else {
-			squareStart = getMiddlePosFromSquare(xDisplay, effectiveLength, xScroll, xZoom);
-		}
-
-		updateAutomationModPosition(modelStackWithParam, squareStart);
-
-		if (!multiPadPressSelected) {
-			leftPadSelectedX = xDisplay;
-		}
-	}
-
-	else if (modelStackWithParam && modelStackWithParam->autoParam) {
-
-		uint32_t squareStart = getPosFromSquare(xDisplay, xScroll, xZoom);
-
-		if (squareStart < effectiveLength) {
-			// use default interpolation settings
-			initInterpolation();
-
-			int32_t newKnobPos = calculateAutomationKnobPosForPadPress(modelStackWithParam, outputType, yDisplay);
-			setAutomationParameterValue(modelStackWithParam, newKnobPos, squareStart, xDisplay, effectiveLength,
-			                            xScroll, xZoom);
-		}
-	}
-}
-
-int32_t AutomationView::calculateAutomationKnobPosForPadPress(ModelStackWithAutoParam* modelStackWithParam,
-                                                              OutputType outputType, int32_t yDisplay) {
-
-	int32_t newKnobPos = 0;
-	params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-
-	if (middlePadPressSelected) {
-		newKnobPos = calculateAutomationKnobPosForMiddlePadPress(kind, yDisplay);
-	}
-	else {
-		newKnobPos = calculateAutomationKnobPosForSinglePadPress(kind, yDisplay);
-	}
-
-	// for Midi Clips, maxKnobPos = 127
-	if (outputType == OutputType::MIDI_OUT && newKnobPos == kMaxKnobPos) {
-		newKnobPos -= 1; // 128 - 1 = 127
-	}
-
-	// in the deluge knob positions are stored in the range of -64 to + 64, so need to adjust newKnobPos
-	// set above.
-	newKnobPos = newKnobPos - kKnobPosOffset;
-
-	return newKnobPos;
-}
-
-// calculates what the new parameter value is when you press a second pad in the same column
-// middle value is calculated by taking average of min and max value of the range for the two pad
-// presses
-int32_t AutomationView::calculateAutomationKnobPosForMiddlePadPress(params::Kind kind, int32_t yDisplay) {
-	int32_t newKnobPos = 0;
-
-	int32_t yMin = yDisplay < leftPadSelectedY ? yDisplay : leftPadSelectedY;
-	int32_t yMax = yDisplay > leftPadSelectedY ? yDisplay : leftPadSelectedY;
-	int32_t minKnobPos = 0;
-	int32_t maxKnobPos = 0;
-
-	if (kind == params::Kind::PATCH_CABLE) {
-		minKnobPos = patchCableMinPadDisplayValues[yMin];
-		maxKnobPos = patchCableMaxPadDisplayValues[yMax];
-	}
-	else {
-		minKnobPos = nonPatchCableMinPadDisplayValues[yMin];
-		maxKnobPos = nonPatchCableMaxPadDisplayValues[yMax];
-	}
-
-	newKnobPos = (minKnobPos + maxKnobPos) >> 1;
-
-	return newKnobPos;
-}
-
-// calculates what the new parameter value is when you press a single pad
-int32_t AutomationView::calculateAutomationKnobPosForSinglePadPress(params::Kind kind, int32_t yDisplay) {
-	int32_t newKnobPos = 0;
-
-	// patch cable
-	if (kind == params::Kind::PATCH_CABLE) {
-		newKnobPos = patchCablePadPressValues[yDisplay];
-	}
-	// non patch cable
-	else {
-		newKnobPos = nonPatchCablePadPressValues[yDisplay];
-	}
-
-	return newKnobPos;
-}
-
-// takes care of setting the automation values for the two pads pressed and the pads in between
-void AutomationView::handleAutomationMultiPadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-                                                   int32_t firstPadX, int32_t firstPadY, int32_t secondPadX,
-                                                   int32_t secondPadY, int32_t effectiveLength, int32_t xScroll,
-                                                   int32_t xZoom, bool modEncoderAction) {
-
-	int32_t secondPadLeftEdge = getPosFromSquare(secondPadX, xScroll, xZoom);
-
-	if (effectiveLength <= 0 || secondPadLeftEdge > effectiveLength) {
-		return;
-	}
-
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-		int32_t firstPadLeftEdge = getPosFromSquare(firstPadX, xScroll, xZoom);
-		int32_t secondPadRightEdge = getPosFromSquare(secondPadX + 1, xScroll, xZoom);
-
-		int32_t firstPadValue = 0;
-		int32_t secondPadValue = 0;
-
-		// if we're updating the long press values via mod encoder action, then get current values of
-		// pads pressed and re-interpolate
-		if (modEncoderAction) {
-			firstPadValue = getAutomationParameterKnobPos(modelStackWithParam, firstPadLeftEdge) + kKnobPosOffset;
-
-			uint32_t squareStart = std::min(effectiveLength, secondPadRightEdge) - kParamNodeWidth;
-
-			secondPadValue = getAutomationParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
-		}
-
-		// otherwise if it's a regular long press, calculate values from the y position of the pads
-		// pressed
-		else {
-			OutputType outputType = clip->output->type;
-			firstPadValue =
-			    calculateAutomationKnobPosForPadPress(modelStackWithParam, outputType, firstPadY) + kKnobPosOffset;
-			secondPadValue =
-			    calculateAutomationKnobPosForPadPress(modelStackWithParam, outputType, secondPadY) + kKnobPosOffset;
-		}
-
-		// clear existing nodes from long press range
-
-		// reset interpolation settings to default
-		initInterpolation();
-
-		// set value for beginning pad press at the very first node position within that pad
-		setAutomationParameterValue(modelStackWithParam, firstPadValue - kKnobPosOffset, firstPadLeftEdge, firstPadX,
-		                            effectiveLength, xScroll, xZoom);
-
-		// set value for ending pad press at the very last node position within that pad
-		int32_t squareStart = std::min(effectiveLength, secondPadRightEdge) - kParamNodeWidth;
-		setAutomationParameterValue(modelStackWithParam, secondPadValue - kKnobPosOffset, squareStart, secondPadX,
-		                            effectiveLength, xScroll, xZoom);
-
-		// converting variables to float for more accurate interpolation calculation
-		float firstPadValueFloat = static_cast<float>(firstPadValue);
-		float firstPadXFloat = static_cast<float>(firstPadLeftEdge);
-		float secondPadValueFloat = static_cast<float>(secondPadValue);
-		float secondPadXFloat = static_cast<float>(squareStart);
-
-		// loop from first pad to last pad, setting values for nodes in between
-		// these values will serve as "key frames" for the interpolation to flow through
-		for (int32_t x = firstPadX; x <= secondPadX; x++) {
-
-			int32_t newKnobPos = 0;
-			uint32_t squareWidth = 0;
-
-			// we've already set the value for the very first node corresponding to the first pad above
-			// now we will set the value for the remaining nodes within the first pad
-			if (x == firstPadX) {
-				squareStart = getPosFromSquare(x, xScroll, xZoom) + kParamNodeWidth;
-				squareWidth = getSquareWidth(x, effectiveLength, xScroll, xZoom) - kParamNodeWidth;
-			}
-
-			// we've already set the value for the very last node corresponding to the second pad above
-			// now we will set the value for the remaining nodes within the second pad
-			else if (x == secondPadX) {
-				squareStart = getPosFromSquare(x, xScroll, xZoom);
-				squareWidth = getSquareWidth(x, effectiveLength, xScroll, xZoom) - kParamNodeWidth;
-			}
-
-			// now we will set the values for the nodes between the first and second pad's pressed
-			else {
-				squareStart = getPosFromSquare(x, xScroll, xZoom);
-				squareWidth = getSquareWidth(x, effectiveLength, xScroll, xZoom);
-			}
-
-			// linear interpolation formula to calculate the value of the pads
-			// f(x) = A + (x - Ax) * ((B - A) / (Bx - Ax))
-			float newKnobPosFloat = std::round(firstPadValueFloat
-			                                   + (((squareStart - firstPadXFloat) / kParamNodeWidth)
-			                                      * ((secondPadValueFloat - firstPadValueFloat)
-			                                         / ((secondPadXFloat - firstPadXFloat) / kParamNodeWidth))));
-
-			newKnobPos = static_cast<int32_t>(newKnobPosFloat);
-			newKnobPos = newKnobPos - kKnobPosOffset;
-
-			// if interpolation is off, values for nodes in between first and second pad will not be set
-			// in a staggered/step fashion
-			if (interpolation) {
-				interpolationBefore = true;
-				interpolationAfter = true;
-			}
-
-			// set value for pads in between
-			int32_t newValue =
-			    modelStackWithParam->paramCollection->knobPosToParamValue(newKnobPos, modelStackWithParam);
-			modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, squareStart,
-			                                                          squareWidth);
-			modelStackWithParam->autoParam->setValuePossiblyForRegion(newValue, modelStackWithParam, squareStart,
-			                                                          squareWidth);
-
-			if (!onArrangerView) {
-				modelStackWithParam->getTimelineCounter()->instrumentBeenEdited();
-			}
-		}
-
-		// reset interpolation settings to off
-		initInterpolation();
-
-		// render the multi pad press
-		uiNeedsRendering(this);
-	}
-}
-
-// new function to render display when a long press is active
-// on OLED this will display the left and right position in a long press on the screen
-// on 7SEG this will display the position of the last selected pad
-// also updates LED indicators. bottom LED indicator = left pad, top LED indicator = right pad
-void AutomationView::renderAutomationDisplayForMultiPadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-                                                             int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
-                                                             int32_t xDisplay, bool modEncoderAction) {
-
-	int32_t secondPadLeftEdge = getPosFromSquare(rightPadSelectedX, xScroll, xZoom);
-
-	if (effectiveLength <= 0 || secondPadLeftEdge > effectiveLength) {
-		return;
-	}
-
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-		int32_t firstPadLeftEdge = getPosFromSquare(leftPadSelectedX, xScroll, xZoom);
-		int32_t secondPadRightEdge = getPosFromSquare(rightPadSelectedX + 1, xScroll, xZoom);
-
-		int32_t knobPosLeft = getAutomationParameterKnobPos(modelStackWithParam, firstPadLeftEdge) + kKnobPosOffset;
-
-		uint32_t squareStart = std::min(effectiveLength, secondPadRightEdge) - kParamNodeWidth;
-		int32_t knobPosRight = getAutomationParameterKnobPos(modelStackWithParam, squareStart) + kKnobPosOffset;
-
-		if (xDisplay != kNoSelection) {
-			if (leftPadSelectedX == xDisplay) {
-				squareStart = firstPadLeftEdge;
-				lastPadSelectedKnobPos = knobPosLeft;
-			}
-			else {
-				lastPadSelectedKnobPos = knobPosRight;
-			}
-		}
-
-		if (display->haveOLED()) {
-			renderDisplay(knobPosLeft, knobPosRight);
-		}
-		// display pad value of second pad pressed
-		else {
-			if (modEncoderAction) {
-				renderDisplay(lastPadSelectedKnobPos);
-			}
-			else {
-				renderDisplay();
-			}
-		}
-
-		setAutomationKnobIndicatorLevels(modelStackWithParam, knobPosLeft, knobPosRight);
-
-		// update position of mod controllable stack
-		updateAutomationModPosition(modelStackWithParam, squareStart, false, false);
-	}
-}
-
-// used to calculate new knobPos when you turn the mod encoders (gold knobs)
-int32_t AutomationView::calculateAutomationKnobPosForModEncoderTurn(ModelStackWithAutoParam* modelStackWithParam,
-                                                                    int32_t knobPos, int32_t offset) {
-
-	// adjust the current knob so that it is within the range of 0-128 for calculation purposes
-	knobPos = knobPos + kKnobPosOffset;
-
-	int32_t newKnobPos = 0;
-
-	if ((knobPos + offset) < 0) {
-		params::Kind kind = modelStackWithParam->paramCollection->getParamKind();
-		if (kind == params::Kind::PATCH_CABLE) {
-			if ((knobPos + offset) >= -kMaxKnobPos) {
-				newKnobPos = knobPos + offset;
-			}
-			else if ((knobPos + offset) < -kMaxKnobPos) {
-				newKnobPos = -kMaxKnobPos;
-			}
-			else {
-				newKnobPos = knobPos;
-			}
-		}
-		else {
-			newKnobPos = knobPos;
-		}
-	}
-	else if ((knobPos + offset) <= kMaxKnobPos) {
-		newKnobPos = knobPos + offset;
-	}
-	else if ((knobPos + offset) > kMaxKnobPos) {
-		newKnobPos = kMaxKnobPos;
-	}
-	else {
-		newKnobPos = knobPos;
-	}
-
-	// in the deluge knob positions are stored in the range of -64 to + 64, so need to adjust newKnobPos
-	// set above.
-	newKnobPos = newKnobPos - kKnobPosOffset;
-
-	return newKnobPos;
 }
 
 // used to render automation overview
@@ -5179,7 +3203,7 @@ bool AutomationView::getAffectEntire() {
 }
 
 void AutomationView::blinkShortcuts() {
-	if (getCurrentUI() == this) {
+	if (getCurrentUI() == &automationView) {
 		int32_t lastSelectedParamShortcutX = kNoSelection;
 		int32_t lastSelectedParamShortcutY = kNoSelection;
 		if (onArrangerView) {

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -352,8 +352,6 @@ private:
 	int32_t rightPadSelectedX;
 	int32_t rightPadSelectedY;
 	int32_t lastPadSelectedKnobPos;
-	int32_t numNotesSelected;
-	int32_t selectedPadPressed;
 
 	bool playbackStopped;
 

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -78,6 +78,10 @@ public:
 	bool possiblyRefreshAutomationEditorGrid(Clip* clip, deluge::modulation::params::Kind paramKind, int32_t paramID);
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
 	                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], bool drawUndefinedArea = true) override;
+	void renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_t lengthToDisplay,
+	                         RGB image[][kDisplayWidth + kSideBarWidth],
+	                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t imageWidth,
+	                         TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay);
 	bool renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) override;
 	void renderDisplay(int32_t knobPosLeft = kNoSelection, int32_t knobPosRight = kNoSelection,
@@ -126,7 +130,7 @@ public:
 	bool interpolationBefore;
 	bool interpolationAfter;
 
-	// public to midi follow can access it
+	// public to midi follow and editor layouts can access it
 	ModelStackWithAutoParam*
 	getModelStackWithParamForClip(ModelStackWithTimelineCounter* modelStack, Clip* clip,
 	                              int32_t paramID = deluge::modulation::params::kNoParamID,
@@ -136,23 +140,35 @@ public:
 	void initParameterSelection(bool updateDisplay = true);
 	bool onArrangerView;
 
-	// public so uiTimerManager can access it
+	// public so uiTimerManager and editor layouts can access it
 	void blinkInterpolationShortcut();
 	void blinkPadSelectionShortcut();
 
-	// public so menu can access it
+	// public so menu and editor layouts can access it
 	bool onMenuView;
 	UI* previousUI; // previous UI so you can swap back UI after exiting menu
 	int32_t getAutomationParameterKnobPos(ModelStackWithAutoParam* modelStack, uint32_t pos);
 	void setAutomationKnobIndicatorLevels(ModelStackWithAutoParam* modelStack, int32_t knobPosLeft,
 	                                      int32_t knobPosRight);
+	void initInterpolation();
 	void resetInterpolationShortcutBlinking();
+	void initPadSelection();
 	void resetPadSelectionShortcutBlinking();
+
 	AutomationParamType automationParamType;
 	bool getAffectEntire() override;
 
 	// public so action logger can access it
 	void resetShortcutBlinking();
+
+	bool padSelectionOn;
+	bool multiPadPressActive;
+	bool middlePadPressSelected;
+	int32_t leftPadSelectedX;
+	int32_t leftPadSelectedY;
+	int32_t rightPadSelectedX;
+	int32_t rightPadSelectedY;
+	int32_t lastPadSelectedKnobPos;
 
 private:
 	// button action functions
@@ -178,32 +194,8 @@ private:
 	bool shortcutPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, Output* output,
 	                       OutputType outputType, int32_t effectiveLength, int32_t x, int32_t y, int32_t velocity,
 	                       int32_t xScroll, int32_t xZoom, SquareInfo& squareInfo);
-	bool toggleAutomationInterpolation();
-	bool toggleVelocityPadSelectionMode(SquareInfo& squareInfo);
-	bool toggleAutomationPadSelectionMode(ModelStackWithAutoParam* modelStackWithParam, int32_t effectiveLength,
-	                                      int32_t xScroll, int32_t xZoom);
 	void handleParameterSelection(Clip* clip, Output* output, OutputType outputType, int32_t xDisplay,
 	                              int32_t yDisplay);
-	void noteEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, InstrumentClip* clip,
-	                       int32_t x, int32_t y, int32_t velocity, int32_t effectiveLength, SquareInfo& squareInfo);
-	void velocityPadSelectionAction(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip, int32_t x,
-	                                int32_t y, int32_t velocity, SquareInfo& squareInfo);
-	void velocityEditPadAction(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, InstrumentClip* clip,
-	                           int32_t x, int32_t y, int32_t velocity, int32_t effectiveLength, SquareInfo& squareInfo);
-	int32_t getVelocityFromY(int32_t y);
-	int32_t getYFromVelocity(int32_t velocity);
-	void addNoteWithNewVelocity(int32_t x, int32_t velocity, int32_t newVelocity);
-	void adjustNoteVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x, int32_t velocity,
-	                        int32_t newVelocity, uint8_t squareType);
-	void setVelocity(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow, int32_t x, int32_t newVelocity);
-	void setVelocityRamp(ModelStackWithNoteRow* modelStackWithNoteRow, NoteRow* noteRow,
-	                     SquareInfo rowSquareInfo[kDisplayWidth], int32_t velocityIncrement);
-	void recordNoteEditPadAction(int32_t x, int32_t velocity);
-	void automationEditPadAction(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
-	                             int32_t yDisplay, int32_t velocity, int32_t effectiveLength, int32_t xScroll,
-	                             int32_t xZoom);
-	bool recordAutomationSinglePadPress(int32_t xDisplay, int32_t yDisplay);
-
 	// mute pad action
 	ActionResult handleMutePadAction(ModelStackWithTimelineCounter* modelStackWithTimelineCounter,
 	                                 InstrumentClip* instrumentClip, Output* output, OutputType outputType, int32_t y,
@@ -224,68 +216,17 @@ private:
 	                              OutputType outputType, RGB image[][kDisplayWidth + kSideBarWidth],
 	                              uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
 	                              bool isMIDICVDrum);
-	void renderAutomationEditor(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-	                            RGB image[][kDisplayWidth + kSideBarWidth],
-	                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth,
-	                            int32_t xScroll, uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay,
-	                            bool drawUndefinedArea, deluge::modulation::params::Kind kind, bool isBipolar);
-	void renderAutomationColumn(ModelStackWithAutoParam* modelStackWithParam,
-	                            RGB image[][kDisplayWidth + kSideBarWidth],
-	                            uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t lengthToDisplay,
-	                            int32_t xDisplay, bool isAutomated, int32_t xScroll, int32_t xZoom,
-	                            deluge::modulation::params::Kind kind, bool isBipolar);
-	void renderAutomationBipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
-	                                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
-	                                   int32_t yDisplay, bool isAutomated, deluge::modulation::params::Kind kind,
-	                                   int32_t knobPos);
-	void renderAutomationUnipolarSquare(RGB image[][kDisplayWidth + kSideBarWidth],
-	                                    uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay,
-	                                    int32_t yDisplay, bool isAutomated, int32_t knobPos);
-	void renderNoteEditor(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
-	                      RGB image[][kDisplayWidth + kSideBarWidth],
-	                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t renderWidth, int32_t xScroll,
-	                      uint32_t xZoom, int32_t effectiveLength, int32_t xDisplay, bool drawUndefinedArea,
-	                      SquareInfo& squareInfo);
-	void renderNoteColumn(ModelStackWithNoteRow* modelStackWithNoteRow, InstrumentClip* clip,
-	                      RGB image[][kDisplayWidth + kSideBarWidth],
-	                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay, int32_t xScroll,
-	                      int32_t xZoom, SquareInfo& squareInfo);
-	void renderNoteSquare(RGB image[][kDisplayWidth + kSideBarWidth],
-	                      uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t xDisplay, int32_t yDisplay,
-	                      uint8_t squareType, int32_t value);
-	void renderUndefinedArea(int32_t xScroll, uint32_t xZoom, int32_t lengthToDisplay,
-	                         RGB image[][kDisplayWidth + kSideBarWidth],
-	                         uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth], int32_t imageWidth,
-	                         TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay);
 	void renderDisplayOLED(Clip* clip, Output* output, OutputType outputType, int32_t knobPosLeft = kNoSelection,
 	                       int32_t knobPosRight = kNoSelection);
 	void renderAutomationOverviewDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas, Output* output,
 	                                         OutputType outputType);
-	void renderAutomationEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas, Clip* clip,
-	                                       OutputType outputType, int32_t knobPosLeft, int32_t knobPosRight);
-	void renderNoteEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas, InstrumentClip* clip,
-	                                 OutputType outputType, int32_t knobPosLeft, int32_t knobPosRight);
 	void renderDisplay7SEG(Clip* clip, Output* output, OutputType outputType, int32_t knobPosLeft = kNoSelection,
 	                       bool modEncoderAction = false);
 	void renderAutomationOverviewDisplay7SEG(Output* output, OutputType outputType);
-	void renderAutomationEditorDisplay7SEG(Clip* clip, OutputType outputType, int32_t knobPosLeft,
-	                                       bool modEncoderAction);
-	void renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputType outputType, int32_t knobPosLeft);
 
 	// Horizontal Encoder Action
 	void shiftAutomationHorizontally(ModelStackWithAutoParam* modelStackWithParam, int32_t offset,
 	                                 int32_t effectiveLength);
-
-	// Mod Encoder Action
-	bool automationModEncoderActionForSelectedPad(ModelStackWithAutoParam* modelStackWithParam, int32_t whichModEncoder,
-	                                              int32_t offset, int32_t effectiveLength);
-	void automationModEncoderActionForUnselectedPad(ModelStackWithAutoParam* modelStackWithParam,
-	                                                int32_t whichModEncoder, int32_t offset, int32_t effectiveLength);
-
-	// Mod Encoder Button Action
-	void copyAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xScroll, int32_t xZoom);
-	void pasteAutomation(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t effectiveLength,
-	                     int32_t xScroll, int32_t xZoom);
 
 	// Select Encoder Action
 	void selectGlobalParam(int32_t offset, Clip* clip);
@@ -298,62 +239,13 @@ private:
 	void getLastSelectedNonGlobalParamArrayPosition(Clip* clip);
 	void getLastSelectedGlobalParamArrayPosition(Clip* clip);
 
-	// Automation Lanes Functions
-	void initPadSelection();
-	void initInterpolation();
-	ParamManagerForTimeline* getParamManagerForClip(Clip* clip);
-	int32_t getEffectiveLength(ModelStackWithTimelineCounter* modelStack);
-	uint32_t getSquareWidth(int32_t square, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
-	uint32_t getMiddlePosFromSquare(int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
-
-	void getAutomationParameterName(Clip* clip, OutputType outputType, StringBuf& parameterName);
-
-	bool getAutomationNodeInterpolation(ModelStackWithAutoParam* modelStack, int32_t pos, bool reversed);
-	void setAutomationParameterValue(ModelStackWithAutoParam* modelStack, int32_t knobPos, int32_t squareStart,
-	                                 int32_t xDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
-	                                 bool modEncoderAction = false);
-	void updateAutomationModPosition(ModelStackWithAutoParam* modelStack, uint32_t squareStart,
-	                                 bool updateDisplay = true, bool updateIndicatorLevels = true);
-
-	void handleAutomationSinglePadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t xDisplay,
-	                                    int32_t yDisplay, int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
-	void handleAutomationParameterChange(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-	                                     OutputType outputType, int32_t xDisplay, int32_t yDisplay,
-	                                     int32_t effectiveLength, int32_t xScroll, int32_t xZoom);
-	int32_t calculateAutomationKnobPosForPadPress(ModelStackWithAutoParam* modelStackWithParam, OutputType outputType,
-	                                              int32_t yDisplay);
-	int32_t calculateAutomationKnobPosForMiddlePadPress(deluge::modulation::params::Kind kind, int32_t yDisplay);
-	int32_t calculateAutomationKnobPosForSinglePadPress(deluge::modulation::params::Kind kind, int32_t yDisplay);
-
-	void handleAutomationMultiPadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip, int32_t firstPadX,
-	                                   int32_t firstPadY, int32_t secondPadX, int32_t secondPadY,
-	                                   int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
-	                                   bool modEncoderAction = false);
-	void renderAutomationDisplayForMultiPadPress(ModelStackWithAutoParam* modelStackWithParam, Clip* clip,
-	                                             int32_t effectiveLength, int32_t xScroll, int32_t xZoom,
-	                                             int32_t xDisplay = kNoSelection, bool modEncoderAction = false);
-
-	int32_t calculateAutomationKnobPosForModEncoderTurn(ModelStackWithAutoParam* modelStackWithParam, int32_t knobPos,
-	                                                    int32_t offset);
-
 	void blinkShortcuts();
 	void resetParameterShortcutBlinking();
-
 	bool parameterShortcutBlinking;
-
 	bool interpolationShortcutBlinking;
 	bool padSelectionShortcutBlinking;
 
-	bool padSelectionOn;
-	bool multiPadPressActive;
-	bool middlePadPressSelected;
-	int32_t leftPadSelectedX;
-	int32_t leftPadSelectedY;
-	int32_t rightPadSelectedX;
-	int32_t rightPadSelectedY;
-	int32_t lastPadSelectedKnobPos;
-
-	bool playbackStopped;
+	int32_t getEffectiveLength(ModelStackWithTimelineCounter* modelStack);
 
 	// grid sized array to assign midi cc values to each pad on the grid
 	void initMIDICCShortcutsForAutomation();


### PR DESCRIPTION
Starts to address #2051

1st in what will be a series of refactorings
- refactored automation editor and note velocity editor code to separate classes
- the start of creating "automation editor layouts", we now have a mod controllable editor class and note editor class which inherit rom an automation editor layout class

future PR stuff to do:
- create a "currentEditorLayout" pointer in the Automation View class
- replace the direct calls to the mod controllable and note editor classes with api calls via currentEditorLayout
- initialize the layouts from AutomationView class
- maybe refactor velocity view specific stuff out to AutomationEditorLayoutNoteVelocity class
- refactor automation overview to overview layout class?