### PR TITLE
Fix volume

### DIFF
--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -818,6 +818,9 @@ void PatchCableSet::readPatchCablesFromFile(Deserializer& reader, int32_t readAu
 			while (*(tagName = reader.readNextTagOrAttributeName())) {
 				if (!strcmp(tagName, "source")) {
 					source = stringToSource(reader.readTagOrAttributeValue());
+					if (source == PatchSource::AFTERTOUCH) {
+						polarity = Polarity::UNIPOLAR;
+					}
 				}
 				else if (!strcmp(tagName, "destination")) {
 					destinationParamDescriptor.setToHaveParamOnly(params::fileStringToParam(


### PR DESCRIPTION
default aftertouch to unipolar

Audition pads set aftertouch to zero which is stored as 0. When converted to bipolar that becomes -2^30 and it's patched to volume by default