### PR TITLE
Fix aftertouch polarity default

### DIFF
--- a/src/deluge/modulation/patch/patch_cable.cpp
+++ b/src/deluge/modulation/patch/patch_cable.cpp
@@ -53,6 +53,7 @@ void PatchCable::setup(PatchSource newFrom, uint8_t newTo, int32_t newAmount) {
 	from = newFrom;
 	destinationParamDescriptor.setToHaveParamOnly(newTo);
 	initAmount(newAmount);
+	initPolarity(newFrom);
 }
 
 bool PatchCable::isActive() {

--- a/src/deluge/modulation/patch/patch_cable.h
+++ b/src/deluge/modulation/patch/patch_cable.h
@@ -42,6 +42,13 @@ public:
 	bool isActive();
 	void initAmount(int32_t value);
 	void makeUnusable();
+	/// @brief Initialize patch cable polarity
+	/// This is only needed for aftertouch where bipolar default is not correct
+	void initPolarity(PatchSource newFrom) {
+		if (newFrom == PatchSource::AFTERTOUCH) {
+			polarity = Polarity::UNIPOLAR;
+		}
+	}
 	/// @brief Converts a patch cable source to the correct polarity.
 	/// The source is required because some sources are stored unipolar
 	int32_t toPolarity(int32_t value) {

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -5,8 +5,8 @@
 #include "cstdint"
 #include "mocks/timer_mocks.h"
 #include <iostream>
-#include <stdlib.h>
 #include <print>
+#include <stdlib.h>
 #ifdef _WIN32
 #include <Windows.h>
 #else


### PR DESCRIPTION
When creating a new init synth, after touch patch cables should be setup with a unipolar polarity