### PR TITLE
Bugfix/volume part two electric bugaloo

### DIFF
--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -370,17 +370,18 @@ void PatchCableStrength::updateAutomationViewParameter() {
 }
 
 void PatchCableStrength::updatePolarity(Polarity newPolarity) {
-	polarity_ = newPolarity;
-
-	auto* patchCableSet = soundEditor.currentParamManager->getPatchCableSet();
-	if (const int32_t index = patchCableSet->getPatchCableIndex(getS(), getDestinationDescriptor());
-	    index != kNoSelection) {
-		patchCableSet->patchCables[index].polarity = newPolarity;
+	if (PatchCable::hasPolarity(getS())) {
+		polarity_ = newPolarity;
+		auto* patchCableSet = soundEditor.currentParamManager->getPatchCableSet();
+		if (const int32_t index = patchCableSet->getPatchCableIndex(getS(), getDestinationDescriptor());
+		    index != kNoSelection) {
+			patchCableSet->patchCables[index].polarity = polarity_;
+		}
 	}
 
 	if (display->haveOLED()) {
-		setLedState(IndicatorLED::MIDI, newPolarity == Polarity::BIPOLAR);
-		setLedState(IndicatorLED::CV, newPolarity == Polarity::UNIPOLAR);
+		setLedState(IndicatorLED::MIDI, polarity_ == Polarity::BIPOLAR);
+		setLedState(IndicatorLED::CV, polarity_ == Polarity::UNIPOLAR);
 		renderUIsForOled();
 	}
 	else {

--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -74,6 +74,8 @@ protected:
 
 private:
 	void updatePolarity(Polarity newPolarity);
+	// if polarity is set before the patch cable is created then we'll need to update the patch cable when it exists
+	bool patchCableExists_ = false;
 };
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/modulation/patch/patch_cable.cpp
+++ b/src/deluge/modulation/patch/patch_cable.cpp
@@ -51,6 +51,14 @@ std::string_view polarityToStringShort(const Polarity polarity) {
 	}
 }
 
+bool PatchCable::hasPolarity(PatchSource source) {
+	if (source == PatchSource::Y || source == PatchSource::X) {
+		// these can't be converted so they ignore the actual setting
+		return false;
+	}
+	return true;
+}
+
 Polarity PatchCable::getDefaultPolarity(PatchSource source) {
 	if (source == PatchSource::AFTERTOUCH) {
 		// Aftertouch is stored unipolar, using bipolar here causes near zero volume with the default patch to level

--- a/src/deluge/modulation/patch/patch_cable.h
+++ b/src/deluge/modulation/patch/patch_cable.h
@@ -38,6 +38,8 @@ std::string_view polarityToStringShort(const Polarity polarity);
 class PatchCable {
 public:
 	PatchCable() = default;
+	void setDefaultPolarity();
+	static Polarity getDefaultPolarity(PatchSource source);
 	void setup(PatchSource newFrom, uint8_t newTo, int32_t newAmount);
 	bool isActive();
 	void initAmount(int32_t value);

--- a/src/deluge/modulation/patch/patch_cable.h
+++ b/src/deluge/modulation/patch/patch_cable.h
@@ -39,6 +39,7 @@ class PatchCable {
 public:
 	PatchCable() = default;
 	void setDefaultPolarity();
+	static bool hasPolarity(PatchSource source);
 	static Polarity getDefaultPolarity(PatchSource source);
 	void setup(PatchSource newFrom, uint8_t newTo, int32_t newAmount);
 	bool isActive();

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -437,7 +437,7 @@ claimPatchCable:
 		patchCables[c].initAmount(0);
 		patchCables[c].from = from;
 		patchCables[c].destinationParamDescriptor = destinationParamDescriptor;
-
+		patchCables[c].setDefaultPolarity();
 		// Re-setup the patching, to place this cable where it needs to be
 		if (modelStack) {
 			setupPatching(modelStack);


### PR DESCRIPTION
- Fix menus to respect the patch cable polarity and only use the default when creating a new patch cable
- 
- Fix patch cables to be created with the default in all situations
- 
- Make the default respect parameters that need to be locked one way or the other
- 
- Disallow changing polarity for sources that are always bipolar