### PR TITLE
Bugfix/ Fix crash when entering horizontal menus via the select knob menu for a clip

### DIFF
--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -18,6 +18,8 @@ namespace deluge::gui::menu_item {
 using namespace hid::display;
 
 void HorizontalMenu::beginSession(MenuItem* navigatedBackwardFrom) {
+	Submenu::beginSession(navigatedBackwardFrom);
+
 	for (const auto it : items) {
 		if (it->checkPermissionToBeginSession(soundEditor.currentModControllable, soundEditor.currentSourceIndex,
 		                                      &soundEditor.currentMultiRange)


### PR DESCRIPTION
Fixes #3959 