### PR TITLE
Fix kit velocity drum info popup display glitches and crash

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1802,7 +1802,7 @@ void InstrumentClipView::selectEncoderAction(int8_t offset) {
 		}
 	}
 
-	// Or, if user holding a note(s) down, we'll adjust proability / iterance instead
+	// Or, if user holding a note(s) down, we'll adjust probability / iterance instead
 	else if (currentUIMode == UI_MODE_NOTES_PRESSED) {
 		bool hasProbabilityPopup = display->hasPopupOfType(PopupType::PROBABILITY);
 		bool hasIterancePopup = display->hasPopupOfType(PopupType::ITERANCE);
@@ -5313,9 +5313,6 @@ bool InstrumentClipView::startAuditioningRow(int32_t velocity, int32_t yDisplay,
 		enterUIMode(UI_MODE_AUDITIONING);
 	}
 
-	if (displayNoteCode) {
-		drawNoteCode(yDisplay);
-	}
 	bool lastAuditionedYDisplayChanged = lastAuditionedYDisplay != yDisplay;
 	lastAuditionedYDisplay = yDisplay;
 
@@ -5334,8 +5331,13 @@ bool InstrumentClipView::startAuditioningRow(int32_t velocity, int32_t yDisplay,
 
 	if (isKit) {
 		setSelectedDrum(drum);
+		drawNoteCode(yDisplay);
 		return false; // No need to redraw any squares, because setSelectedDrum() has done it
 	}
+	else {
+		drawNoteCode(yDisplay);
+	}
+
 	return true;
 }
 
@@ -5551,7 +5553,11 @@ void InstrumentClipView::drawNoteCode(uint8_t yDisplay) {
 		drawActualNoteCode(getCurrentInstrumentClip()->getYNoteFromYDisplay(yDisplay, currentSong));
 	}
 	else {
-		drawDrumName(getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, currentSong)->drum);
+		InstrumentClip* clip = getCurrentInstrumentClip();
+		Kit* thisKit = (Kit*)clip->output;
+		if (thisKit->selectedDrum != nullptr) {
+			drawDrumName(thisKit->selectedDrum);
+		}
 	}
 }
 


### PR DESCRIPTION
There was a bug where in a kit in velocity drum keyboard view, if a pad for one drum sound was held and then a pad for a different sound was pressed and released, for certain pairs, it sent a null pointer or other invalid drum object, which resulted in it displaying incorrect information (either midi info, "no sound", empty, or a different drum name from the kit), and if the second pad was pressed and released enough times, it would inevitably cause a crash. It was not obvious which pairs of kit sounds would cause issues or why, but it was always the same ones for a given kit, so it likely had something to do with the specific combination of memory addresses.

To remedy this issue, the drum object was replaced with the selectedDrum object, with a check for a nullptr. This required the drawNoteCode function call to be moved below the setSelectedDrum function call for when it is not in the velocity drum view.

This also has the effect of making the popup display stay stable when holding a pad for one sound down and then pressing and and releasing another sound's pad rapidly, rather than having it flicker back and forth rapidly between the two. This makes it easier to read and more pleasant to view.
