### PR TITLE
Prevent the creation of "NO SOUND" kit rows

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4151,7 +4151,7 @@ doDisplayError:
 		}
 	}
 
-	// If a kit, add scrolling limits to keep at least the top row or bottom row of the kit on the screen
+	// If a kit, prevents creating a new kit row beyond the adjacent empty rows
 	else {
 		// If it's more than one row below, we can't do it
 		if (yDisplay < -1 - clip->yScroll) {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -4151,7 +4151,7 @@ doDisplayError:
 		}
 	}
 
-	// Or, if a kit
+	// If a kit, add scrolling limits to keep at least the top row or bottom row of the kit on the screen
 	else {
 		// If it's more than one row below, we can't do it
 		if (yDisplay < -1 - clip->yScroll) {
@@ -4161,16 +4161,6 @@ doDisplayError:
 		// If it's more than one row above, we can't do it
 		if (yDisplay > clip->getNumNoteRows() - clip->yScroll) {
 			goto getOut;
-		}
-
-		noteRow = createNewNoteRowForKit(modelStack, yDisplay, &noteRowId);
-
-		if (!noteRow) {
-			goto doDisplayError;
-		}
-
-		else {
-			uiNeedsRendering(this, 0, 1 << yDisplay);
 		}
 	}
 


### PR DESCRIPTION
Prevent the creation of a kit row upon pressing a pad in the main screen outside of the bounds of the current kit. Instead, now it will simply deselect any selected rows.

That kind of empty row with "NO SOUND" does not act like the other types of kit row, cannot be moved up and down within the kit, and when you try to change it to another type, it doesn't properly take, and instead either creates an additional row, or causes things to glitch and often eventually crash. Glitches included freezing certain inputs, and the sticky shift getting stuck on without the indicator light on the shift button. This type of glitchy kit row has been an issue since at least v1.1. 

You can still create an empty row by pressing audition+kit and then backing out without selecting anything, and it will display U1, U2, U3, etc. even though it doesn't have a sound associated with it. That type of placeholder kit row doesn't seem to have any of the issues associated with a "NO SOUND" kit row.