### PR TITLE
fix sysex sends on the third USB MIDI interface

### DIFF
--- a/src/deluge/io/midi/root_complex/usb_peripheral.cpp
+++ b/src/deluge/io/midi/root_complex/usb_peripheral.cpp
@@ -186,7 +186,9 @@ Error MIDIRootComplexUSBPeripheral::poll() {
 }
 
 MIDICable* MIDIRootComplexUSBPeripheral::getCable(size_t index) {
-	if (index < 0 || index >= getNumCables()) {
+	// We need to use cables_.size() instead of getNumCables(), as that one doesn't
+	// admit that the last cable exists, since it's a secret one!
+	if (index < 0 || index >= cables_.size()) {
 		return nullptr;
 	}
 	return &cables_[index];


### PR DESCRIPTION
MIDIRootComplexUSBPeripheral has three cables. The third one is sysex infrastructure one, and because it's secret getNumCables() only returns 2 instead of the correct 3.

Unfortunately getCable() believes what getNumCables() returns, and doesn't return the cable even to callers that know to ask for it - like configuredAsPeripheral().

...o the third cable never gets connectionFlags set up, which in turn leads MIDICableUSB::sendSysex() to bail out.

This fixes #3998 by using .size() instead of getNumCables() in getCable().