### PR TITLE
Fixed typo and two formatting errors in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Added main grid pad shortcuts for the following parameters:
 
 #### <ins>Audio Export</ins>
 - Added `EXPORT MIXDOWN` configuration option which provides the ability to export all unmuted tracks in Arranger View as a single stereo file. This is disabled by default but can be enabled in the export configuration menu located at: `SONG\EXPORT AUDIO\CONFIGURE EXPORT\EXPORT MIXDOWN`
-- Added `AUDIO EXPORT` for `KIT DRUMS`, an automated process for exporting `DRUM's` while in `KIT INSTRUMENT CLIP VIEW`. Press :key[SAVE] + :key[RECORD] to start exporting.
+- Added `AUDIO EXPORT` for `KIT DRUMS`, an automated process for exporting `DRUM's` while in `KIT INSTRUMENT CLIP VIEW`. Press `SAVE` + `RECORD` to start exporting.
 - Added Tempo, Root Note and Scale Information to file names
 
 
@@ -109,7 +109,7 @@ Added main grid pad shortcuts for the following parameters:
 - Added ability to save / load Pattern-Files to Files. A Pattern represents all Notes of the actual Deluge Screen including Velocity, Probability, Lift, Iterance and Fill. The Patterns can be either of Type melodic Instrument (Synt, Midi, CV) or rhythmic Instrument (Kit, Drum). It's also possible to convert Midi-Files to patterns, which can then be used on the Deluge. See documentation at [Save / Load Patterns feature ](docs/features/save_load_patterns.md) for more info.
 
 #### <ins>Favourites</ins>
-A `Favourites` feature has been added to the browser for most file types. The `Favourites` are displayed above the QWERTY Keyboard and are only visible when that keyboard is shown. `Favourites` can be configured to either offer 16 favourites (default), 16 banks with 16 favourites each or be completely disabled via `SETTINGS > DEFAULTS -> UT -> KEYBOARD -> FAVOURITES`. Now also when pressing the `KEYBOARD` button, you can pin the QWERTY keyboard so it is not hidden every time you select a sample.
+A `Favourites` feature has been added to the browser for most file types. The `Favourites` are displayed above the QWERTY Keyboard and are only visible when that keyboard is shown. `Favourites` can be configured to either offer 16 favourites (default), 16 banks with 16 favourites each or be completely disabled via `SETTINGS > DEFAULTS -> UI -> KEYBOARD -> FAVOURITES`. Now also when pressing the `KEYBOARD` button, you can pin the QWERTY keyboard so it is not hidden every time you select a sample.
 
 #### <ins>Arranger View</ins>
 - Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.


### PR DESCRIPTION
Changed "Press :key[SAVE] + :key[RECORD]" to "Press `SAVE` + `RECORD`" Changed "DEFAULTS -> UT ->" to "DEFAULTS -> UI ->"