### PR TITLE
Revert "Convert MIDIParamVector to STL Map (#3131)"

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -44,6 +44,7 @@
 #include "model/scale/utils.h"
 #include "model/song/song.h"
 #include "modulation/arpeggiator.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "modulation/patch/patch_cable_set.h"
 #include "processing/engines/audio_engine.h"
@@ -3052,12 +3053,12 @@ expressionParam:
 									goto expressionParam;
 								}
 							}
-							auto maybeMidiParam =
-							    paramManager.getMIDIParamCollection()->getOrCreateParamFromCC(paramId);
-							if (!maybeMidiParam) {
-								return maybeMidiParam.error();
+							MIDIParam* midiParam =
+							    paramManager.getMIDIParamCollection()->params.getOrCreateParamFromCC(paramId, 0);
+							if (!midiParam) {
+								return Error::INSUFFICIENT_RAM;
 							}
-							param = &maybeMidiParam.value()->second;
+							param = &midiParam->param;
 						}
 					}
 					reader.exitTag("cc");

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -46,6 +46,7 @@
 #include "model/instrument/midi_instrument.h"
 #include "model/scale/preset_scales.h"
 #include "model/song/song.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "playback/mode/arrangement.h"
 #include "processing/engines/cv_engine.h"

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -28,6 +28,7 @@
 #include "model/clip/instrument_clip.h"
 #include "model/song/song.h"
 #include "modulation/arpeggiator.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "modulation/params/param_set.h"
 #include "storage/storage_manager.h"
@@ -581,12 +582,12 @@ Error MIDIInstrument::readMIDIParamFromFile(Deserializer& reader, int32_t readAu
 		else if (!strcmp(tagName, "value")) {
 			if (cc != CC_NUMBER_NONE && midiParamCollection) {
 
-				auto maybeMidiParam = midiParamCollection->getOrCreateParamFromCC(cc);
-				if (!maybeMidiParam) {
-					return maybeMidiParam.error();
+				MIDIParam* midiParam = midiParamCollection->params.getOrCreateParamFromCC(cc, 0);
+				if (!midiParam) {
+					return Error::INSUFFICIENT_RAM;
 				}
 
-				Error error = maybeMidiParam.value()->second.readFromFile(reader, readAutomationUpToPos);
+				Error error = midiParam->param.readFromFile(reader, readAutomationUpToPos);
 				if (error != Error::NONE) {
 					return error;
 				}
@@ -675,7 +676,7 @@ Error MIDIInstrument::moveAutomationToDifferentCC(int32_t oldCC, int32_t newCC,
 
 	// CC (besides 74)
 	if (modelStackWithAutoParam->paramCollection == midiParamCollection) {
-		midiParamCollection->params.erase(oldCC);
+		midiParamCollection->params.deleteAtKey(oldCC);
 	}
 
 	// Expression param

--- a/src/deluge/modulation/midi/midi_param.cpp
+++ b/src/deluge/modulation/midi/midi_param.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2018-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "modulation/midi/midi_param.h"
+
+MIDIParam::MIDIParam() {
+	// TODO Auto-generated constructor stub
+}

--- a/src/deluge/modulation/midi/midi_param.h
+++ b/src/deluge/modulation/midi/midi_param.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2018-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "modulation/automation/auto_param.h"
+
+class MIDIParam {
+public:
+	MIDIParam();
+
+	uint8_t cc;
+	AutoParam param;
+};

--- a/src/deluge/modulation/midi/midi_param_collection.h
+++ b/src/deluge/modulation/midi/midi_param_collection.h
@@ -19,8 +19,8 @@
 
 #include "definitions_cxx.hpp"
 #include "io/midi/midi_engine.h"
+#include "modulation/midi/midi_param_vector.h"
 #include "modulation/params/param_collection.h"
-#include "util/containers.h"
 
 class Clip;
 class ModelStackWithParamCollection;
@@ -71,11 +71,8 @@ public:
 
 	deluge::modulation::params::Kind getParamKind() override { return deluge::modulation::params::Kind::MIDI; }
 
-	/// A map between the CC value and the Automatable Param
-	deluge::fast_map<uint8_t, AutoParam> params;
-
-	std::expected<typename decltype(params)::iterator, Error> getOrCreateParamFromCC(int32_t cc);
+	MIDIParamVector params;
 
 private:
-	void deleteAllParams(Action* action = nullptr);
+	void deleteAllParams(Action* action = NULL, bool deleteStorageToo = true);
 };

--- a/src/deluge/modulation/midi/midi_param_vector.cpp
+++ b/src/deluge/modulation/midi/midi_param_vector.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright © 2018-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "modulation/midi/midi_param_vector.h"
+#include "modulation/midi/midi_param.h"
+#include <new>
+
+MIDIParamVector::MIDIParamVector() : OrderedResizeableArray(sizeof(MIDIParam), 8) {
+}
+
+MIDIParam* MIDIParamVector::getParamFromCC(int32_t cc) {
+	int32_t i = searchExact(cc);
+	if (i == -1) {
+		return NULL;
+	}
+	else {
+		return getElement(i);
+	}
+}
+
+MIDIParam* MIDIParamVector::getOrCreateParamFromCC(int32_t cc, int32_t defaultValue, bool allowCreation) {
+	int32_t i = search(cc, GREATER_OR_EQUAL);
+	MIDIParam* param;
+	if (i >= getNumElements()) {
+doesntExistYet:
+		if (!allowCreation) {
+			return NULL;
+		}
+		param = insertParam(i);
+		if (!param) {
+			return NULL;
+		}
+		param->cc = cc;
+		param->param.setCurrentValueBasicForSetup(defaultValue);
+	}
+	else {
+		param = getElement(i);
+		if (param->cc != cc) {
+			goto doesntExistYet;
+		}
+	}
+	return param;
+}
+
+MIDIParam* MIDIParamVector::insertParam(int32_t i) {
+	Error error = insertAtIndex(i);
+	if (error != Error::NONE) {
+		return NULL;
+	}
+	else {
+		void* address = getElementAddress(i);
+		MIDIParam* param = new (address) MIDIParam();
+		return param;
+	}
+}
+
+MIDIParam* MIDIParamVector::getElement(int32_t i) {
+	return (MIDIParam*)getElementAddress(i);
+}

--- a/src/deluge/modulation/midi/midi_param_vector.h
+++ b/src/deluge/modulation/midi/midi_param_vector.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2018-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "util/container/array/ordered_resizeable_array.h"
+
+class MIDIParam;
+
+class MIDIParamVector : public OrderedResizeableArray {
+public:
+	MIDIParamVector();
+	MIDIParam* getElement(int32_t i);
+	MIDIParam* getParamFromCC(int32_t cc);
+	MIDIParam* insertParam(int32_t i);
+	MIDIParam* getOrCreateParamFromCC(int32_t cc, int32_t defaultValue = 0, bool allowCreation = true);
+};

--- a/src/deluge/storage/Deserializer.cpp
+++ b/src/deluge/storage/Deserializer.cpp
@@ -30,6 +30,7 @@
 #include "model/instrument/kit.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/song/song.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/sound/sound_drum.h"

--- a/src/deluge/storage/JSONSerializer.cpp
+++ b/src/deluge/storage/JSONSerializer.cpp
@@ -30,6 +30,7 @@
 #include "model/instrument/kit.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/song/song.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/sound/sound_drum.h"

--- a/src/deluge/storage/JsonDeserializer.cpp
+++ b/src/deluge/storage/JsonDeserializer.cpp
@@ -30,6 +30,7 @@
 #include "model/instrument/kit.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/song/song.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/sound/sound_drum.h"

--- a/src/deluge/storage/Serializer.cpp
+++ b/src/deluge/storage/Serializer.cpp
@@ -30,6 +30,7 @@
 #include "model/instrument/kit.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/song/song.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/sound/sound_drum.h"

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -32,6 +32,7 @@
 #include "model/instrument/kit.h"
 #include "model/instrument/midi_instrument.h"
 #include "model/song/song.h"
+#include "modulation/midi/midi_param.h"
 #include "modulation/midi/midi_param_collection.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/sound/sound_drum.h"


### PR DESCRIPTION
This reverts commit a4e8d2449f61d39dec2259eb1c53e26aff094b9d.

As much as I want to prefer leveraging STL, and I appreciate the effort that went into committing this change, I think there's a stronger case to be made for minimizing crashes by prioritizing bug-fixes. We can revisit the usage of STL Map at a later time, or I'm also open to sagely advice in this PR for how to resolve the problem described in the issue without reverting the entire commit.

Resolves https://github.com/SynthstromAudible/DelugeFirmware/issues/3861.