### PR TITLE
Horizontal menus/ Fix crash on switching to the next menu if the menu has no relevant items

### DIFF
--- a/src/deluge/gui/menu_item/horizontal_menu.h
+++ b/src/deluge/gui/menu_item/horizontal_menu.h
@@ -68,8 +68,7 @@ protected:
 	                                         int32_t pressedButtonPosition);
 	virtual void selectMenuItem(int32_t pageNumber, int32_t itemPos);
 	virtual void switchVisiblePage(int32_t direction);
-	virtual void switchHorizontalMenu(int32_t direction, std::span<HorizontalMenu* const> chain,
-	                                  bool forceSelectFirstItem = false);
+	virtual void switchHorizontalMenu(int32_t direction, std::span<HorizontalMenu* const> chain);
 
 private:
 	void updateSelectedMenuItemLED(int32_t itemNumber) const;

--- a/src/deluge/gui/menu_item/horizontal_menu_group.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu_group.cpp
@@ -40,13 +40,6 @@ void HorizontalMenuGroup::beginSession(MenuItem* navigatedBackwardFrom) {
 	HorizontalMenu::beginSession(navigatedBackwardFrom);
 	navigated_backward_from = navigatedBackwardFrom;
 	lastSelectedItemPosition = kNoSelection;
-
-	// A horizontal menu can modify soundEditor parameters at the beginning of a session,
-	// which in their turn can affect whether an item is relevant or not.
-	// So we need to begin a session for each menu beforehand to ensure pages are counted correctly
-	for (const auto menu : menus_) {
-		menu->beginSession(navigatedBackwardFrom);
-	}
 }
 
 bool HorizontalMenuGroup::focusChild(const MenuItem* child) {
@@ -170,12 +163,6 @@ void HorizontalMenuGroup::switchVisiblePage(int32_t direction) {
 	// Move to the next / previous menu
 	menuIndex += direction;
 
-	// If we're outside the current menu group, switch to the next / previous menu from the chain
-	const auto chain = soundEditor.getCurrentHorizontalMenusChain();
-	if (chain.has_value() && (menuIndex < 0 || menuIndex > static_cast<int32_t>(menus_.size()) - 1)) {
-		return switchHorizontalMenu(std::clamp<int32_t>(direction, -1, 1), chain.value());
-	}
-
 	// Wrap around
 	const int32_t count = static_cast<int32_t>(menus_.size());
 	menuIndex = (menuIndex % count + count) % count;
@@ -184,7 +171,7 @@ void HorizontalMenuGroup::switchVisiblePage(int32_t direction) {
 	const auto pagesCount = newMenu->preparePaging(newMenu->items, nullptr).totalPages;
 	if (pagesCount == 0) {
 		// No relevant items on the switched menu, go to the next menu
-		return switchVisiblePage(direction >= 0 ? direction + 1 : direction - 1);
+		return switchVisiblePage(direction >= 0 ? ++direction : --direction);
 	}
 
 	// Select an item with the same position as on the previously selected page if possible

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -438,6 +438,7 @@ HorizontalMenu voiceMenu{STRING_FOR_VOICE,
 HorizontalMenu voiceMenuWithoutUnison{STRING_FOR_VOICE,
                                       {&priorityMenu, &polyphonyMenu, &voice::polyphonicVoiceCountMenu, &portaMenu},
                                       HorizontalMenu::Layout::FIXED};
+HorizontalMenuGroup voiceMenuGroup{{&unisonMenu, &voiceMenuWithoutUnison}};
 
 // Envelope 1-4 menu -----------------------------------------------------------------------------
 HorizontalMenuGroup envMenuGroup{{&env1Menu, &env2Menu, &env3Menu, &env4Menu}};
@@ -1358,9 +1359,13 @@ patched_param::Pan panMenu{STRING_FOR_PAN, params::LOCAL_PAN};
 
 PatchCables patchCablesMenu{STRING_FOR_MOD_MATRIX};
 
-HorizontalMenu soundMasterMenu{
+Submenu soundMasterMenu{
     STRING_FOR_MASTER,
     {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu, &vibratoMenu},
+};
+HorizontalMenu soundMasterMenuWithoutVibrato{
+    STRING_FOR_MASTER,
+    {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu},
 };
 
 HorizontalMenuGroup sourceMenuGroup{{&source0Menu, &source1Menu, &modulator0Menu, &modulator1Menu, &oscMixerMenu}};
@@ -1806,10 +1811,10 @@ PLACE_SDRAM_DATA MenuItem* paramShortcutsForKitGlobalFX[][kDisplayHeight] = {
     {nullptr,          	     &spreadVelocityMenu,	  &randomizerLockMenu,            &randomizerNoteProbabilityMenu,        nullptr,                     nullptr,                nullptr,                  nullptr                            },
 };
 
-PLACE_SDRAM_DATA std::array<HorizontalMenu*, 18> horizontalMenusChainForSound = {
+PLACE_SDRAM_DATA std::array<HorizontalMenu*, 17> horizontalMenusChainForSound = {
 	&arpMenuGroup, &randomizerMenu,
-	&voiceMenuWithoutUnison, &soundMasterMenu, &recorderMenu, &sourceMenuGroup,
-	&unisonMenu, &envMenuGroup, &lfoMenuGroup,
+	&soundMasterMenuWithoutVibrato, &recorderMenu,
+	&sourceMenuGroup, &voiceMenuGroup, &envMenuGroup, &lfoMenuGroup,
 	&filtersMenuGroup, &eqMenu, &modFXMenu,
 	&reverbMenuGroup, &delayMenu, &soundDistortionMenu,
 	&sidechainMenu, &audioCompMenu, &stutterMenu

--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -106,7 +106,7 @@ extern MenuItem* paramShortcutsForAudioClips[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForSongView[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForKitGlobalFX[kDisplayWidth][kDisplayHeight];
 
-extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 18> horizontalMenusChainForSound;
+extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 17> horizontalMenusChainForSound;
 extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 12> horizontalMenusChainForKit;
 extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 9> horizontalMenusChainForSong;
 extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 11> horizontalMenusChainForAudioClip;


### PR DESCRIPTION
As title says, additionally:
- removed "autoswitch to the next menu when reaching the last page" behavior in favour of manual switching using SHIFT + SCALE / SHIFT + CROSS-SCREEN combo
- excluded vibrato menu from the horizontal menu. For vibrato, since we now have polarity options, it's better to show a full patch cable UI

TODO:
- update documentation 