### PR TITLE
Fix sample browser & sample start/end point shortcuts behavior

### DIFF
--- a/src/deluge/gui/menu_item/audio_clip/reverse.h
+++ b/src/deluge/gui/menu_item/audio_clip/reverse.h
@@ -15,7 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 #pragma once
-#include "gui/menu_item/submenu.h"
+#include "gui/menu_item/horizontal_menu.h"
 #include "gui/menu_item/toggle.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/views/audio_clip_view.h"

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -25,7 +25,7 @@
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
 #include "hid/led/indicator_leds.h"
-#include "submenu.h"
+#include "horizontal_menu.h"
 #include "util/cfunctions.h"
 #include "util/functions.h"
 

--- a/src/deluge/gui/menu_item/file_selector.cpp
+++ b/src/deluge/gui/menu_item/file_selector.cpp
@@ -22,6 +22,7 @@
 #include "gui/ui/sound_editor.h"
 #include "gui/ui_timer_manager.h"
 #include "gui/views/view.h"
+#include "horizontal_menu.h"
 #include "model/clip/clip.h"
 #include "model/song/song.h"
 #include "processing/sound/sound.h"
@@ -41,10 +42,22 @@ void FileSelector::beginSession(MenuItem* navigatedBackwardFrom) {
 	if (getRootUI() == &keyboardScreen && currentUIMode == UI_MODE_AUDITIONING) {
 		keyboardScreen.exitAuditionMode();
 	}
+
+	if (parent != nullptr && parent->renderingStyle() == Submenu::RenderingStyle::HORIZONTAL) {
+		sampleBrowser.menuItemHeadingTo = this;
+		sampleBrowser.parentMenuHeadingTo = parent;
+	}
+
 	if (!openUI(&sampleBrowser)) {
 		uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 	}
 }
+
+MenuItem* FileSelector::selectButtonPress() {
+	beginSession(nullptr);
+	return NO_NAVIGATION;
+}
+
 bool FileSelector::isRelevant(ModControllableAudio* modControllable, int32_t whichThing) {
 	if (getCurrentClip()->type == ClipType::AUDIO) {
 		return true;

--- a/src/deluge/gui/menu_item/file_selector.h
+++ b/src/deluge/gui/menu_item/file_selector.h
@@ -28,6 +28,7 @@ public:
 	FileSelector(l10n::String newName, uint8_t sourceId) : MenuItem(newName), sourceId_{sourceId} {}
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override;
+	MenuItem* selectButtonPress() override;
 	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
 	                                             MultiRange** currentRange) override;
 

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -36,7 +36,8 @@ class MIDICable;
 
 namespace deluge::gui::menu_item {
 class Submenu;
-}
+class HorizontalMenu;
+} // namespace deluge::gui::menu_item
 
 /// Base class for all menu items.
 class MenuItem {
@@ -314,7 +315,7 @@ public:
 
 	virtual void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {};
 
-	deluge::gui::menu_item::Submenu* parent{nullptr};
+	deluge::gui::menu_item::HorizontalMenu* parent{nullptr};
 
 	/// @}
 };

--- a/src/deluge/gui/menu_item/patch_cable_strength.cpp
+++ b/src/deluge/gui/menu_item/patch_cable_strength.cpp
@@ -17,7 +17,6 @@
 
 #include "patch_cable_strength.h"
 #include "definitions_cxx.hpp"
-#include "gui/l10n/l10n.h"
 #include "gui/menu_item/menu_item.h"
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/sound_editor.h"
@@ -26,6 +25,8 @@
 #include "hid/buttons.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
+#include "hid/led/indicator_leds.h"
+#include "horizontal_menu.h"
 #include "model/model_stack.h"
 #include "model/song/song.h"
 #include "modulation/params/param_descriptor.h"
@@ -34,11 +35,7 @@
 #include "processing/sound/sound.h"
 #include "source_selection.h"
 #include "source_selection/range.h"
-#include "submenu.h"
 #include "util/functions.h"
-
-#include <hid/led/indicator_leds.h>
-#include <util/comparison.h>
 
 using hid::display::OLED;
 

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -27,6 +27,7 @@
 #include "gui/context_menu/sample_browser/kit.h"
 #include "gui/context_menu/sample_browser/synth.h"
 #include "gui/l10n/l10n.h"
+#include "gui/menu_item/horizontal_menu.h"
 #include "gui/menu_item/multi_range.h"
 #include "gui/ui/audio_recorder.h"
 #include "gui/ui/browser/sample_browser.h"
@@ -44,7 +45,6 @@
 #include "hid/display/oled.h"
 #include "hid/led/indicator_leds.h"
 #include "hid/led/pad_leds.h"
-#include "hid/matrix/matrix_driver.h"
 #include "io/debug/log.h"
 #include "memory/general_memory_allocator.h"
 #include "model/action/action_logger.h"
@@ -69,7 +69,6 @@
 #include "storage/flash_storage.h"
 #include "storage/multi_range/multisample_range.h"
 #include "storage/storage_manager.h"
-#include "storage/wave_table/wave_table.h"
 #include "util/d_string.h"
 #include "util/functions.h"
 #include <cstring>
@@ -368,7 +367,6 @@ void SampleBrowser::enterKeyPress() {
 		if (error != Error::NONE) {
 			display->displayError(error);
 			close(); // Don't use goBackToSoundEditor() because that would do a left-scroll
-			return;
 		}
 	}
 
@@ -1074,6 +1072,17 @@ doLoadAsSample:
 
 	if (!loadWithoutExiting) {
 		exitAndNeverDeleteDrum();
+
+		if (menuItemHeadingTo != nullptr && parentMenuHeadingTo != nullptr) {
+			parentMenuHeadingTo->focusChild(menuItemHeadingTo);
+			soundEditor.menuItemNavigationRecord[0] = parentMenuHeadingTo;
+			soundEditor.navigationDepth = 0;
+			openUI(&soundEditor);
+
+			parentMenuHeadingTo = nullptr;
+			menuItemHeadingTo = nullptr;
+		}
+
 		uiNeedsRendering(&audioClipView);
 	}
 	display->removeWorkingAnimation();

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -36,6 +36,10 @@ class Source;
 class Sample;
 class MenuItem;
 
+namespace deluge::gui::menu_item {
+class HorizontalMenu;
+}
+
 class SampleBrowser final : public Browser {
 public:
 	SampleBrowser();
@@ -60,6 +64,10 @@ public:
 	void exitAndNeverDeleteDrum();
 
 	String lastFilePathLoaded;
+
+	// menus to open when a sample file is selected
+	deluge::gui::menu_item::HorizontalMenu* parentMenuHeadingTo{nullptr};
+	MenuItem* menuItemHeadingTo{nullptr};
 
 	// ui
 	UIType getUIType() override { return UIType::SAMPLE_BROWSER; }

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -1812,19 +1812,20 @@ PLACE_SDRAM_DATA MenuItem* paramShortcutsForKitGlobalFX[][kDisplayHeight] = {
 };
 
 PLACE_SDRAM_DATA std::array<HorizontalMenu*, 17> horizontalMenusChainForSound = {
-	&arpMenuGroup, &randomizerMenu,
 	&soundMasterMenuWithoutVibrato, &recorderMenu,
 	&sourceMenuGroup, &voiceMenuGroup, &envMenuGroup, &lfoMenuGroup,
 	&filtersMenuGroup, &eqMenu, &modFXMenu,
 	&reverbMenuGroup, &delayMenu, &soundDistortionMenu,
-	&sidechainMenu, &audioCompMenu, &stutterMenu
+	&sidechainMenu, &audioCompMenu, &stutterMenu,
+	&arpMenuGroup, &randomizerMenu
 };
 
 PLACE_SDRAM_DATA std::array<HorizontalMenu*, 12> horizontalMenusChainForKit = {
-	&arpMenuGroupKit, &randomizerMenu, &kitClipMasterMenu,
+	&kitClipMasterMenu,
 	&globalFiltersMenuGroup, &globalEQMenu, &globalModFXMenu,
 	&globalReverbMenuGroup, &globalDelayMenu, &globalDistortionMenu,
-	&globalSidechainMenu, &audioCompMenu, &stutterMenu
+	&globalSidechainMenu, &audioCompMenu, &stutterMenu,
+	&arpMenuGroupKit, &randomizerMenu
 };
 
 PLACE_SDRAM_DATA std::array<HorizontalMenu*, 9> horizontalMenusChainForSong = {

--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -30,72 +30,73 @@
 
 namespace deluge::gui::menu_item {
 class HorizontalMenu;
-}
+class HorizontalMenuGroup;
+} // namespace deluge::gui::menu_item
 
-extern deluge::gui::menu_item::patched_param::IntegerNonFM noiseMenu;
-extern deluge::gui::menu_item::osc::Sync oscSyncMenu;
-extern deluge::gui::menu_item::osc::source::WaveIndex source0WaveIndexMenu;
-extern deluge::gui::menu_item::osc::source::WaveIndex source1WaveIndexMenu;
+extern gui::menu_item::patched_param::IntegerNonFM noiseMenu;
+extern gui::menu_item::osc::Sync oscSyncMenu;
+extern gui::menu_item::osc::source::WaveIndex source0WaveIndexMenu;
+extern gui::menu_item::osc::source::WaveIndex source1WaveIndexMenu;
 
-extern deluge::gui::menu_item::sample::Start sample0StartMenu;
-extern deluge::gui::menu_item::sample::Start sample1StartMenu;
-extern deluge::gui::menu_item::sample::End sample0EndMenu;
-extern deluge::gui::menu_item::sample::End sample1EndMenu;
-extern deluge::gui::menu_item::audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuStart;
-extern deluge::gui::menu_item::audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuEnd;
-extern deluge::gui::menu_item::EditName nameEditMenu;
-extern deluge::gui::menu_item::Submenu dxMenu;
-extern deluge::gui::menu_item::Submenu stemExportMenu;
-extern deluge::gui::menu_item::stem_export::Start startStemExportMenu;
+extern gui::menu_item::sample::Start sample0StartMenu;
+extern gui::menu_item::sample::Start sample1StartMenu;
+extern gui::menu_item::sample::End sample0EndMenu;
+extern gui::menu_item::sample::End sample1EndMenu;
+extern gui::menu_item::audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuStart;
+extern gui::menu_item::audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuEnd;
+extern gui::menu_item::EditName nameEditMenu;
+extern gui::menu_item::Submenu dxMenu;
+extern gui::menu_item::Submenu stemExportMenu;
+extern gui::menu_item::stem_export::Start startStemExportMenu;
 
-extern deluge::gui::menu_item::firmware::Version firmwareVersionMenu;
-extern deluge::gui::menu_item::sequence::Direction sequenceDirectionMenu;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenuMIDIOrCV;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenuMidiDrum;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenuGateDrum;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenuAudioClip;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenuPerformanceView;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenuSongView;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenuKitGlobalFX;
-extern deluge::gui::menu_item::Submenu soundEditorRootMenu;
-extern deluge::gui::menu_item::Submenu settingsRootMenu;
+extern gui::menu_item::firmware::Version firmwareVersionMenu;
+extern gui::menu_item::sequence::Direction sequenceDirectionMenu;
+extern gui::menu_item::Submenu soundEditorRootMenuMIDIOrCV;
+extern gui::menu_item::Submenu soundEditorRootMenuMidiDrum;
+extern gui::menu_item::Submenu soundEditorRootMenuGateDrum;
+extern gui::menu_item::Submenu soundEditorRootMenuAudioClip;
+extern gui::menu_item::Submenu soundEditorRootMenuPerformanceView;
+extern gui::menu_item::Submenu soundEditorRootMenuSongView;
+extern gui::menu_item::Submenu soundEditorRootMenuKitGlobalFX;
+extern gui::menu_item::Submenu soundEditorRootMenu;
+extern gui::menu_item::Submenu settingsRootMenu;
 
-extern deluge::gui::menu_item::randomizer::RandomizerLock randomizerLockMenu;
-extern deluge::gui::menu_item::randomizer::midi_cv::SpreadVelocity spreadVelocityMenuMIDIOrCV;
-extern deluge::gui::menu_item::randomizer::midi_cv::NoteProbability randomizerNoteProbabilityMenuMIDIOrCV;
+extern gui::menu_item::randomizer::RandomizerLock randomizerLockMenu;
+extern gui::menu_item::randomizer::midi_cv::SpreadVelocity spreadVelocityMenuMIDIOrCV;
+extern gui::menu_item::randomizer::midi_cv::NoteProbability randomizerNoteProbabilityMenuMIDIOrCV;
 
 // note editor menu's
-extern deluge::gui::menu_item::Submenu noteEditorRootMenu;
-extern deluge::gui::menu_item::note::Probability noteProbabilityMenu;
-extern deluge::gui::menu_item::note::IterancePreset noteIteranceMenu;
-extern deluge::gui::menu_item::note::IteranceDivisor noteCustomIteranceDivisor;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep1;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep2;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep3;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep4;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep5;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep6;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep7;
-extern deluge::gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep8;
-extern deluge::gui::menu_item::note::Fill noteFillMenu;
+extern gui::menu_item::Submenu noteEditorRootMenu;
+extern gui::menu_item::note::Probability noteProbabilityMenu;
+extern gui::menu_item::note::IterancePreset noteIteranceMenu;
+extern gui::menu_item::note::IteranceDivisor noteCustomIteranceDivisor;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep1;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep2;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep3;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep4;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep5;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep6;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep7;
+extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep8;
+extern gui::menu_item::note::Fill noteFillMenu;
 // note row editor menu's
-extern deluge::gui::menu_item::Submenu noteRowEditorRootMenu;
-extern deluge::gui::menu_item::note_row::Probability noteRowProbabilityMenu;
-extern deluge::gui::menu_item::note_row::IterancePreset noteRowIteranceMenu;
-extern deluge::gui::menu_item::note_row::IteranceDivisor noteRowCustomIteranceDivisor;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep1;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep2;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep3;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep4;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep5;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep6;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep7;
-extern deluge::gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep8;
-extern deluge::gui::menu_item::note_row::Fill noteRowFillMenu;
+extern gui::menu_item::Submenu noteRowEditorRootMenu;
+extern gui::menu_item::note_row::Probability noteRowProbabilityMenu;
+extern gui::menu_item::note_row::IterancePreset noteRowIteranceMenu;
+extern gui::menu_item::note_row::IteranceDivisor noteRowCustomIteranceDivisor;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep1;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep2;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep3;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep4;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep5;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep6;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep7;
+extern gui::menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep8;
+extern gui::menu_item::note_row::Fill noteRowFillMenu;
 
-extern deluge::gui::menu_item::PatchCables patchCablesMenu;
-extern deluge::gui::menu_item::source::patched_param::ModulatorLevel modulator0Volume;
-extern deluge::gui::menu_item::source::patched_param::ModulatorLevel modulator1Volume;
+extern gui::menu_item::PatchCables patchCablesMenu;
+extern gui::menu_item::source::patched_param::ModulatorLevel modulator0Volume;
+extern gui::menu_item::source::patched_param::ModulatorLevel modulator1Volume;
 
 extern MenuItem* midiOrCVParamShortcuts[kDisplayHeight];
 
@@ -106,8 +107,11 @@ extern MenuItem* paramShortcutsForAudioClips[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForSongView[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForKitGlobalFX[kDisplayWidth][kDisplayHeight];
 
-extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 17> horizontalMenusChainForSound;
-extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 12> horizontalMenusChainForKit;
-extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 9> horizontalMenusChainForSong;
-extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 11> horizontalMenusChainForAudioClip;
-extern const std::array<deluge::gui::menu_item::HorizontalMenu*, 2> horizontalMenusChainForMidiOrCv;
+extern const std::array<gui::menu_item::HorizontalMenu*, 17> horizontalMenusChainForSound;
+extern const std::array<gui::menu_item::HorizontalMenu*, 12> horizontalMenusChainForKit;
+extern const std::array<gui::menu_item::HorizontalMenu*, 9> horizontalMenusChainForSong;
+extern const std::array<gui::menu_item::HorizontalMenu*, 11> horizontalMenusChainForAudioClip;
+extern const std::array<gui::menu_item::HorizontalMenu*, 2> horizontalMenusChainForMidiOrCv;
+
+extern gui::menu_item::HorizontalMenuGroup sourceMenuGroup;
+extern gui::menu_item::HorizontalMenu audioClipSampleMenu;


### PR DESCRIPTION
- open the sample horizontal menu only if a sample was selected in the browser
- fixed the waveform editor UI being not opened when accessed via shortcuts