### PR TITLE
Fix occasional crash on accessing non-relevant FM-synth params via shortcuts

### DIFF
--- a/src/deluge/gui/menu_item/horizontal_menu_group.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu_group.cpp
@@ -66,8 +66,9 @@ bool HorizontalMenuGroup::focusChild(const MenuItem* child) {
 		}
 
 		// Child is not relevant — find first relevant among all items
-		current_item_ = std::ranges::find_if(items, isItemRelevant);
-		if (current_item_ != items.end()) {
+		it = std::ranges::find_if(items, isItemRelevant);
+		if (it != items.end()) {
+			current_item_ = it;
 			return true;
 		}
 	}


### PR DESCRIPTION
Fixed crash when the sourceMenuGroup is open and synth mode is not FM and FM params being accessed via shortcuts