### PR TITLE
resolve `-Wodr` warnings in menus.cpp

### DIFF
--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -107,11 +107,11 @@ extern MenuItem* paramShortcutsForAudioClips[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForSongView[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForKitGlobalFX[kDisplayWidth][kDisplayHeight];
 
-extern const std::array<gui::menu_item::HorizontalMenu*, 17> horizontalMenusChainForSound;
-extern const std::array<gui::menu_item::HorizontalMenu*, 12> horizontalMenusChainForKit;
-extern const std::array<gui::menu_item::HorizontalMenu*, 9> horizontalMenusChainForSong;
-extern const std::array<gui::menu_item::HorizontalMenu*, 11> horizontalMenusChainForAudioClip;
-extern const std::array<gui::menu_item::HorizontalMenu*, 2> horizontalMenusChainForMidiOrCv;
+extern std::array<gui::menu_item::HorizontalMenu*, 17> horizontalMenusChainForSound;
+extern std::array<gui::menu_item::HorizontalMenu*, 12> horizontalMenusChainForKit;
+extern std::array<gui::menu_item::HorizontalMenu*, 9> horizontalMenusChainForSong;
+extern std::array<gui::menu_item::HorizontalMenu*, 11> horizontalMenusChainForAudioClip;
+extern std::array<gui::menu_item::HorizontalMenu*, 2> horizontalMenusChainForMidiOrCv;
 
 extern gui::menu_item::HorizontalMenuGroup sourceMenuGroup;
 extern gui::menu_item::HorizontalMenu audioClipSampleMenu;


### PR DESCRIPTION
This resolves compiler warnings about "previous declaration" and "the C++ One Definition Rule" by removing the `const` from the `extern` definitions in `menus.h`.

~@soymonitus:~ @lburygin: just want to make sure this change is fine.
