### PR TITLE
C-style arrays for horizontalMenuChainFor*

### DIFF
--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -1811,7 +1811,7 @@ PLACE_SDRAM_DATA MenuItem* paramShortcutsForKitGlobalFX[][kDisplayHeight] = {
     {nullptr,          	     &spreadVelocityMenu,	  &randomizerLockMenu,            &randomizerNoteProbabilityMenu,        nullptr,                     nullptr,                nullptr,                  nullptr                            },
 };
 
-PLACE_SDRAM_DATA std::array<HorizontalMenu*, 17> horizontalMenusChainForSound = {
+PLACE_SDRAM_DATA HorizontalMenu* horizontalMenusChainForSound[17] = {
 	&soundMasterMenuWithoutVibrato, &recorderMenu,
 	&sourceMenuGroup, &voiceMenuGroup, &envMenuGroup, &lfoMenuGroup,
 	&filtersMenuGroup, &eqMenu, &modFXMenu,
@@ -1820,7 +1820,7 @@ PLACE_SDRAM_DATA std::array<HorizontalMenu*, 17> horizontalMenusChainForSound = 
 	&arpMenuGroup, &randomizerMenu
 };
 
-PLACE_SDRAM_DATA std::array<HorizontalMenu*, 12> horizontalMenusChainForKit = {
+PLACE_SDRAM_DATA HorizontalMenu* horizontalMenusChainForKit[12] = {
 	&kitClipMasterMenu,
 	&globalFiltersMenuGroup, &globalEQMenu, &globalModFXMenu,
 	&globalReverbMenuGroup, &globalDelayMenu, &globalDistortionMenu,
@@ -1828,21 +1828,21 @@ PLACE_SDRAM_DATA std::array<HorizontalMenu*, 12> horizontalMenusChainForKit = {
 	&arpMenuGroupKit, &randomizerMenu
 };
 
-PLACE_SDRAM_DATA std::array<HorizontalMenu*, 9> horizontalMenusChainForSong = {
+PLACE_SDRAM_DATA HorizontalMenu* horizontalMenusChainForSong[9] = {
 	&songMasterMenu,
 	&globalFiltersMenuGroup, &globalEQMenu, &globalModFXMenu,
 	&globalReverbMenuGroup, &globalDelayMenu, &globalDistortionMenu,
 	&audioCompMenu, &stutterMenu
 };
 
-PLACE_SDRAM_DATA std::array<HorizontalMenu*, 11> horizontalMenusChainForAudioClip = {
+PLACE_SDRAM_DATA HorizontalMenu* horizontalMenusChainForAudioClip[11] = {
 	&audioClipMasterMenu, &audioClipSampleMenu,
 	&globalFiltersMenuGroup, &eqMenu, &globalModFXMenu,
 	&globalReverbMenuGroup, &globalDelayMenu, &audioClipDistortionMenu,
 	&globalSidechainMenu, &audioCompMenu, &stutterMenu
 };
 
-PLACE_SDRAM_DATA std::array<HorizontalMenu*, 2> horizontalMenusChainForMidiOrCv = {
+PLACE_SDRAM_DATA HorizontalMenu* horizontalMenusChainForMidiOrCv[2] = {
 	&arpMenuGroupMIDIOrCV, &randomizerMenu
 };
 

--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -107,11 +107,11 @@ extern MenuItem* paramShortcutsForAudioClips[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForSongView[kDisplayWidth][kDisplayHeight];
 extern MenuItem* paramShortcutsForKitGlobalFX[kDisplayWidth][kDisplayHeight];
 
-extern std::array<gui::menu_item::HorizontalMenu*, 17> horizontalMenusChainForSound;
-extern std::array<gui::menu_item::HorizontalMenu*, 12> horizontalMenusChainForKit;
-extern std::array<gui::menu_item::HorizontalMenu*, 9> horizontalMenusChainForSong;
-extern std::array<gui::menu_item::HorizontalMenu*, 11> horizontalMenusChainForAudioClip;
-extern std::array<gui::menu_item::HorizontalMenu*, 2> horizontalMenusChainForMidiOrCv;
+extern gui::menu_item::HorizontalMenu* horizontalMenusChainForSound[17];
+extern gui::menu_item::HorizontalMenu* horizontalMenusChainForKit[12];
+extern gui::menu_item::HorizontalMenu* horizontalMenusChainForSong[9];
+extern gui::menu_item::HorizontalMenu* horizontalMenusChainForAudioClip[11];
+extern gui::menu_item::HorizontalMenu* horizontalMenusChainForMidiOrCv[2];
 
 extern gui::menu_item::HorizontalMenuGroup sourceMenuGroup;
 extern gui::menu_item::HorizontalMenu audioClipSampleMenu;


### PR DESCRIPTION
Resolves the `bugprone-dynamic-static-initializers` clang-tidy's warning