### PR TITLE
Bugfix/ mod encoder pop up in automation view

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2437,7 +2437,7 @@ void AutomationView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 				return;
 			}
 		}
-		else {
+		else if (inNoteEditor()) {
 			goto followOnAction;
 		}
 	}


### PR DESCRIPTION
Fixed bug where you could edit parameters assigned to gold knobs while holding a step in automation view

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4053