### PR TITLE
Bugfix/ Fix stem export skipping

### DIFF
--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -79,8 +79,11 @@ StemExport::StemExport() {
 }
 
 /// starts stem export process which includes setting up UI mode, timer, and preparing
-/// instruments / clips for exporting
+/// instruments / clips / kit rows for exporting
 void StemExport::startStemExportProcess(StemExportType stemExportType) {
+	// in case playback is active when you start stem export, stop it.
+	stopPlayback();
+
 	currentStemExportType = stemExportType;
 	processStarted = true;
 
@@ -147,6 +150,7 @@ void StemExport::startStemExportProcess(StemExportType stemExportType) {
 void StemExport::stopStemExportProcess() {
 	exitUIMode(UI_MODE_STEM_EXPORT);
 	stopPlayback();
+	highestUsedStemFolderNumber++;
 	display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_STOP_EXPORT_STEMS), 6);
 	indicator_leds::setLedState(IndicatorLED::BACK, false);
 }
@@ -184,7 +188,6 @@ void StemExport::stopPlayback() {
 	if (playbackHandler.isEitherClockActive()) {
 		playbackHandler.playButtonPressed(kInternalButtonPressLatency);
 	}
-	highestUsedStemFolderNumber++;
 }
 
 /// simulate pressing record


### PR DESCRIPTION
Fixed issue where export would skip a stem if playback was enabled when you started the stem export process

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3946