### PR TITLE
Manage display notification updates for parameter value changes from gold knob encoders

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1090,9 +1090,6 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 	static uint32_t last_actual_display_time = 0; // Used for frequency throttling
 
 	// Timing constants for display arbitration (in AudioEngine sample units)
-	const uint32_t MIN_DISPLAY_OWNERSHIP_TIME = 44100; // 1000ms at 44.1kHz (minimum juggling time)
-	const uint32_t DISPLAY_TIMEOUT = 11025;            // 250ms at 44.1kHz (ball drop timeout)
-	const uint32_t MIN_UPDATE_INTERVAL = 2000;         // ~45ms at 44.1kHz (minimum perceptible update frequency)
 
 	uint32_t current_time = AudioEngine::audioSampleTimer;
 
@@ -2085,9 +2082,9 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 oledDrawString:
 			deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 #if OLED_MAIN_HEIGHT_PIXELS == 64
-			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 32;
+			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 30;
 #else
-			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 19;
+			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 17;
 #endif
 
 			int32_t stringLengthPixels = canvas.getStringWidthInPixels(nameToDraw, kTextTitleSizeY);
@@ -2114,7 +2111,7 @@ oledDrawString:
 					info.append(": ");
 					info.append(clip->name.get());
 				}
-				yPos = yPos + 13;
+				yPos = yPos + 14;
 				canvas.drawStringCentred(info.data(), yPos, kTextSpacingX, kTextSpacingY);
 				deluge::hid::display::OLED::setupSideScroller(1, info.data(), 0, OLED_MAIN_WIDTH_PIXELS, yPos,
 				                                              yPos + kTextSpacingY, kTextSpacingX, kTextSpacingY,

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1072,96 +1072,200 @@ void View::potentiallyMakeItHarderToTurnKnob(int32_t whichModEncoder, ModelStack
 
 void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32_t newKnobPos, PatchSource source1,
                                        PatchSource source2) {
-	DEF_STACK_STRING_BUF(parameterName, 40);
-	DEF_STACK_STRING_BUF(parameterValue, 40);
+
+	// Cache last displayed values to avoid unnecessary notifications
+	static params::Kind last_param_kind = params::Kind::NONE;
+	static int32_t last_param_id = -1;
+	static int32_t last_display_value = INT32_MIN;
+	static PatchSource last_source1 = PatchSource::NONE;
+	static PatchSource last_source2 = PatchSource::NONE;
+
+	// Display arbitration for multiple mod encoders ("juggling ball" system)
+	static params::Kind display_owner_kind = params::Kind::NONE;
+	static int32_t display_owner_param_id = -1;
+	static PatchSource display_owner_source1 = PatchSource::NONE;
+	static PatchSource display_owner_source2 = PatchSource::NONE;
+	static uint32_t display_ownership_start_time = 0;
+	static uint32_t last_display_update_time = 0; // Used for timeout detection in arbitration
+	static uint32_t last_actual_display_time = 0; // Used for frequency throttling
+
+	// Timing constants for display arbitration (in AudioEngine sample units)
+	const uint32_t MIN_DISPLAY_OWNERSHIP_TIME = 44100; // 1000ms at 44.1kHz (minimum juggling time)
+	const uint32_t DISPLAY_TIMEOUT = 11025;            // 250ms at 44.1kHz (ball drop timeout)
+	const uint32_t MIN_UPDATE_INTERVAL = 2000;         // ~45ms at 44.1kHz (minimum perceptible update frequency)
+
+	uint32_t current_time = AudioEngine::audioSampleTimer;
+
+	DEF_STACK_STRING_BUF(parameter_name, 40);
+	DEF_STACK_STRING_BUF(parameter_value, 40);
 
 	// On OLED, display the name of the parameter on the first line of the popup
 	if (display->haveOLED()) {
 		if (kind == params::Kind::PATCH_CABLE) {
-			parameterName.append(sourceToStringShort(source1));
-			parameterName.append("->");
+			parameter_name.append(sourceToStringShort(source1));
+			parameter_name.append("->");
 			if (source2 != PatchSource::NONE && source2 != PatchSource::NOT_AVAILABLE) {
-				parameterName.append(sourceToStringShort(source2));
-				parameterName.append("->");
+				parameter_name.append(sourceToStringShort(source2));
+				parameter_name.append("->");
 			}
-			parameterName.append(modulation::params::getPatchedParamShortName(paramID));
+			parameter_name.append(modulation::params::getPatchedParamShortName(paramID));
 		}
 		else if (getCurrentOutputType() == OutputType::MIDI_OUT) {
 			MIDIInstrument* midiInstrument = (MIDIInstrument*)getCurrentOutput();
 			if (kind == params::Kind::EXPRESSION) {
 				if (paramID == X_PITCH_BEND) {
-					parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
+					parameter_name.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
 				}
 				else if (paramID == Z_PRESSURE) {
-					parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
+					parameter_name.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
 				}
 				else if (paramID == Y_SLIDE_TIMBRE) {
 					// in mono expression this is mod wheel, and y-axis is not directly controllable
-					parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
+					parameter_name.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
 				}
 			}
 			else if (paramID >= 0 && paramID < kNumRealCCNumbers) {
 				std::string_view name = midiInstrument->getNameFromCC(paramID);
 				if (!name.empty()) {
-					parameterName.append(name.data());
+					parameter_name.append(name.data());
 				}
 				else {
-					parameterName.append("CC ");
-					parameterName.appendInt(paramID);
+					parameter_name.append("CC ");
+					parameter_name.appendInt(paramID);
 				}
 			}
 		}
 		else {
 			const char* name = getParamDisplayName(kind, paramID);
 			if (name != l10n::get(l10n::String::STRING_FOR_NONE)) {
-				parameterName.append(name);
+				parameter_name.append(name);
 			}
 		}
 	}
 
 	// if turning stutter mod encoder and stutter quantize is enabled
 	// display stutter quantization instead of knob position
+	// int32_t quantization_level = 0;
+	int32_t current_display_value = 0;
 	if (isParamQuantizedStutter(kind, paramID,
 	                            (ModControllableAudio*)view.activeModControllableModelStack.modControllable)
 	    && !isUIModeActive(UI_MODE_STUTTERING)) {
 		if (newKnobPos < -39) { // 4ths stutter: no leds turned on
-			parameterValue.append("4ths");
+			current_display_value = 4;
+			parameter_value.append("4ths");
 		}
 		else if (newKnobPos < -14) { // 8ths stutter: 1 led turned on
-			parameterValue.append("8ths");
+			current_display_value = 8;
+			parameter_value.append("8ths");
 		}
 		else if (newKnobPos < 14) { // 16ths stutter: 2 leds turned on
-			parameterValue.append("16ths");
+			current_display_value = 16;
+			parameter_value.append("16ths");
 		}
 		else if (newKnobPos < 39) { // 32nds stutter: 3 leds turned on
-			parameterValue.append("32nds");
+			current_display_value = 32;
+			parameter_value.append("32nds");
 		}
 		else { // 64ths stutter: all 4 leds turned on
-			parameterValue.append("64ths");
+			current_display_value = 64;
+			parameter_value.append("64ths");
 		}
 	}
 	// if turning arpeggiator rhythm mod encoder
 	else if (isParamArpRhythm(kind, paramID)) {
-		int valueForDisplay = calculateKnobPosForDisplay(kind, paramID, newKnobPos + kKnobPosOffset);
+		current_display_value = calculateKnobPosForDisplay(kind, paramID, newKnobPos + kKnobPosOffset);
 		if (display->haveOLED()) {
 			char name[12];
 			// Index: Name
-			snprintf(name, sizeof(name), "%d: %s", valueForDisplay, arpRhythmPatternNames[valueForDisplay]);
-			parameterValue.append(name);
+			snprintf(name, sizeof(name), "%d: %s", current_display_value, arpRhythmPatternNames[current_display_value]);
+			parameter_value.append(name);
 		}
 		else {
-			parameterValue.append(arpRhythmPatternNames[valueForDisplay]);
+			parameter_value.append(arpRhythmPatternNames[current_display_value]);
 		}
 	}
 	else {
-		int valueForDisplay = calculateKnobPosForDisplay(kind, paramID, newKnobPos + kKnobPosOffset);
-		parameterValue.appendInt(valueForDisplay);
+		current_display_value = calculateKnobPosForDisplay(kind, paramID, newKnobPos + kKnobPosOffset);
+		parameter_value.appendInt(current_display_value);
 	}
+
+	// Check if we need to update the notification (avoid excessive updates)
 	if (display->haveOLED()) {
-		display->displayNotification(parameterName.c_str(), parameterValue.c_str());
+
+		// Check if notification popup is active and if the parameter info has changed
+		bool has_param_info_changed = true;
+		bool has_min_time_elapsed = true;
+		if (display->hasPopupOfType(PopupType::NOTIFICATION)) {
+			has_param_info_changed =
+			    (kind != last_param_kind || paramID != last_param_id || current_display_value != last_display_value
+			     || source1 != last_source1 || source2 != last_source2);
+
+			// Check if enough time has passed since the last actual display update so we
+			// can still perceive the changes and so we don't exceed the screen's refresh rate.
+			uint32_t time_since_last_actual_display = current_time - last_actual_display_time;
+			has_min_time_elapsed = (time_since_last_actual_display >= MIN_UPDATE_INTERVAL);
+		}
+
+		// Display arbitration: check if this parameter currently owns the display
+		bool current_param_owns_display = (kind == display_owner_kind && paramID == display_owner_param_id
+		                                   && source1 == display_owner_source1 && source2 == display_owner_source2);
+
+		// Determine if this parameter can take control of the display
+		bool can_take_display_ownership = false;
+
+		if (!display->hasPopupOfType(PopupType::NOTIFICATION)) {
+			// No notification currently shown, so anything can take it
+			can_take_display_ownership = true;
+		}
+		else if (current_param_owns_display) {
+			// This parameter already owns the display
+			can_take_display_ownership = true;
+			last_display_update_time = current_time;
+		}
+		else {
+			// Different parameter wants to display - check arbitration rules
+			uint32_t time_since_ownership_start = current_time - display_ownership_start_time;
+			uint32_t time_since_last_update = current_time - last_display_update_time;
+
+			if (time_since_ownership_start >= MIN_DISPLAY_OWNERSHIP_TIME || time_since_last_update >= DISPLAY_TIMEOUT) {
+				// Current owner has had enough time juggling or has stopped updating, so pass it on
+				can_take_display_ownership = true;
+			}
+			// else: it's still the current owner's turn to juggle the ball, so keep it
+		}
+
+		// Only update notification if parameter info has changed AND we can take display ownership AND enough time has
+		// elapsed
+		if (has_param_info_changed && can_take_display_ownership && has_min_time_elapsed) {
+			display->displayNotification(parameter_name.c_str(), parameter_value.c_str());
+
+			// Update cached values
+			last_param_kind = kind;
+			last_param_id = paramID;
+			last_display_value = current_display_value;
+			last_source1 = source1;
+			last_source2 = source2;
+
+			// Update display ownership tracking
+			if (!current_param_owns_display) {
+				// New parameter taking ownership
+				display_owner_kind = kind;
+				display_owner_param_id = paramID;
+				display_owner_source1 = source1;
+				display_owner_source2 = source2;
+				display_ownership_start_time = current_time;
+			}
+			last_display_update_time = current_time;
+			last_actual_display_time = current_time; // Track when we actually updated the display
+		}
+		// Even if no display update needed, refresh timer if same parameter is being adjusted
+		else if (current_param_owns_display && display->hasPopupOfType(PopupType::NOTIFICATION)) {
+			uiTimerManager.setTimer(TimerName::DISPLAY, 1000);
+			last_display_update_time = current_time;
+		}
 	}
 	else {
-		display->displayPopup(parameterValue.c_str());
+		display->displayPopup(parameter_value.c_str());
 	}
 }
 
@@ -1981,9 +2085,9 @@ void View::drawOutputNameFromDetails(OutputType outputType, int32_t channel, int
 oledDrawString:
 			deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 #if OLED_MAIN_HEIGHT_PIXELS == 64
-			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 30;
+			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 32;
 #else
-			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 17;
+			int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 19;
 #endif
 
 			int32_t stringLengthPixels = canvas.getStringWidthInPixels(nameToDraw, kTextTitleSizeY);
@@ -2010,7 +2114,7 @@ oledDrawString:
 					info.append(": ");
 					info.append(clip->name.get());
 				}
-				yPos = yPos + 14;
+				yPos = yPos + 13;
 				canvas.drawStringCentred(info.data(), yPos, kTextSpacingX, kTextSpacingY);
 				deluge::hid::display::OLED::setupSideScroller(1, info.data(), 0, OLED_MAIN_WIDTH_PIXELS, yPos,
 				                                              yPos + kTextSpacingY, kTextSpacingX, kTextSpacingY,

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -172,6 +172,11 @@ private:
 	// mod encoder button action
 	void modEncoderButtonAction_deleteAutomation(uint8_t whichModEncoder);
 	void modEncoderButtonAction_changeModControllable(uint8_t whichModEncoder, bool on);
+
+	// Timing constants for display arbitration in displayModEncoderValuePopup (in AudioEngine sample units)
+	static constexpr uint32_t MIN_DISPLAY_OWNERSHIP_TIME = kSampleRate; // 1 second (minimum juggling time)
+	static constexpr uint32_t DISPLAY_TIMEOUT = kSampleRate / 4;        // 0.25 seconds (ball drop timeout)
+	static constexpr uint32_t MIN_UPDATE_INTERVAL = kSampleRate / 22;   // ~45ms (minimum perceptible update frequency)
 };
 
 extern View view;


### PR DESCRIPTION
- Added a throttling routine to reduce the maximum frequency of updates to something that the OLED display and CPU can handle, and that our eyes can actually have a chance of perceiving. In addition, it checks for whether what it wants to display has changed in any way that warrants an update. So if the value is already at 50 for example, it just extends the timer instead of asking for another update every tick. So the number of updates attempted in a fast turn from 0-50 in a second could be reduced from 150 (or 300 with two knobs) to only about 22. In testing, this appeared plenty smooth enough.
- Added an arbitration routine to pass the display notification ownership between the two encoders if they are being operated in tandem, like when adjusting LPF frequency and resonance, or any two custom parameters. This prevents them from rapidly alternating updates and making it unintelligible. Now, it will trade off every second, or 250 ms after the last input from the encoder that last had control, and it's great to use. 
- Because of the high resolution of the encoders, and it trying to send a screen update every tick, this throttling drastically reduces screen flickering that came from overloading of the system. This should also help avoid some potential performance issues during playback.
- also changed several parameter names involved in the function from camelCase to snake_case as per the new style guide.
- Recommended for cherry pick to 1.3 beta branch.