### PR TITLE
Bugfix/restore sample cluster array

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -645,7 +645,7 @@ enum class MIDITransposeControlMethod : uint8_t {
 };
 constexpr auto kNumMIDITransposeControlMethods = util::to_underlying(MIDITransposeControlMethod::CHORD) + 1;
 
-constexpr size_t kNumClustersLoadedAhead = 2;
+constexpr int32_t kNumClustersLoadedAhead = 2;
 
 enum class InputMonitoringMode : uint8_t {
 	SMART,

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -720,7 +720,7 @@ startSearch:
 				}
 
 				int32_t whichCluster = readByte[i] >> Cluster::size_magnitude;
-				Cluster* cluster = sample->clusters[whichCluster].cluster;
+				Cluster* cluster = sample->clusters.getElement(whichCluster)->cluster;
 				if (!cluster || !cluster->loaded) {
 					goto skipSearch;
 				}
@@ -1128,7 +1128,7 @@ void TimeStretcher::updateClustersForPercLookahead(Sample* sample, uint32_t sour
 				break; // If no more Clusters
 			}
 			clustersForPercLookahead[l] =
-			    sample->clusters[nextClusterIndex].getCluster(sample, nextClusterIndex, CLUSTER_ENQUEUE);
+			    sample->clusters.getElement(nextClusterIndex)->getCluster(sample, nextClusterIndex, CLUSTER_ENQUEUE);
 			if (!clustersForPercLookahead[l]) {
 				break;
 			}

--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -19,6 +19,7 @@
 
 #include "definitions_cxx.hpp"
 #include "model/sample/sample_cluster.h"
+#include "model/sample/sample_cluster_array.h"
 #include "storage/audio/audio_file.h"
 #include "util/container/array/ordered_resizeable_array.h"
 #include "util/container/array/ordered_resizeable_array_with_multi_word_key.h"
@@ -151,7 +152,7 @@ public:
 
 	uint32_t waveTableCycleSize{0}; // In case this later gets used for a WaveTable
 
-	std::vector<SampleCluster> clusters;
+	SampleClusterArray clusters;
 
 	// Stealable Implementation
 	bool mayBeStolen(void* thingNotToStealFrom = nullptr) override;

--- a/src/deluge/model/sample/sample_cluster.h
+++ b/src/deluge/model/sample/sample_cluster.h
@@ -22,8 +22,11 @@
 class Cluster;
 class Sample;
 
-// This is a quick list item within Sample storing minimal info about one Cluster (which often won't be loaded yet) of
-// audio data for that Sample.
+/// This is a quick list item within Sample storing minimal info about one Cluster (which often won't be loaded yet) of
+/// audio data for that Sample.
+///
+/// Safety: This class must be safe to move via memcpy. The destructor/constructor will only be called when it is
+/// actually being deallocated, not when the array holding it resizes
 class SampleCluster {
 public:
 	SampleCluster() = default;

--- a/src/deluge/model/sample/sample_cluster_array.cpp
+++ b/src/deluge/model/sample/sample_cluster_array.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2019-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "model/sample/sample_cluster_array.h"
+#include "definitions_cxx.hpp"
+#include "model/sample/sample_cluster.h"
+#include <new>
+
+SampleClusterArray::SampleClusterArray() : ResizeableArray(sizeof(SampleCluster)) {
+}
+
+Error SampleClusterArray::insertSampleClustersAtEnd(int32_t numToInsert) {
+	int32_t oldNum = getNumElements();
+	Error error = insertAtIndex(oldNum, numToInsert);
+	if (error != Error::NONE) {
+		return error;
+	}
+
+	for (int32_t i = oldNum; i < oldNum + numToInsert; i++) {
+		void* address = getElementAddress(i);
+		SampleCluster* sampleCluster = new (address) SampleCluster();
+	}
+
+	return Error::NONE;
+}
+
+SampleCluster* SampleClusterArray::getElement(int32_t i) {
+	return (SampleCluster*)getElementAddress(i);
+}

--- a/src/deluge/model/sample/sample_cluster_array.h
+++ b/src/deluge/model/sample/sample_cluster_array.h
@@ -21,7 +21,8 @@
 #include "util/container/array/resizeable_array.h"
 
 class SampleCluster;
-
+/// This class is similar to a vector but is optimised for the case of copyable types. It avoids the
+/// constructor/destructor call that would otherwise be needed to move a SampleCluster.
 class SampleClusterArray : public ResizeableArray {
 public:
 	SampleClusterArray();

--- a/src/deluge/model/sample/sample_cluster_array.h
+++ b/src/deluge/model/sample/sample_cluster_array.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2019-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "definitions_cxx.hpp"
+#include "util/container/array/resizeable_array.h"
+
+class SampleCluster;
+
+class SampleClusterArray : public ResizeableArray {
+public:
+	SampleClusterArray();
+	Error insertSampleClustersAtEnd(int32_t numToInsert);
+	SampleCluster* getElement(int32_t i);
+};

--- a/src/deluge/model/sample/sample_holder_for_voice.cpp
+++ b/src/deluge/model/sample/sample_holder_for_voice.cpp
@@ -93,7 +93,7 @@ void SampleHolderForVoice::claimClusterReasons(bool reversed, int32_t clusterLoa
 		                             clusterLoadInstruction);
 	}
 
-	else if (((Sample*)audioFile)->clusters.size() <= 4) {
+	else if (((Sample*)audioFile)->clusters.getNumElements() <= 4) {
 		// claim the next few reasons for the sample instead since we can keep it all cached
 		int32_t nextClusterStartByte = (((Sample*)audioFile)->audioDataStartPosBytes + Cluster::size_magnitude) << 1;
 

--- a/src/deluge/model/sample/sample_low_level_reader.cpp
+++ b/src/deluge/model/sample/sample_low_level_reader.cpp
@@ -105,7 +105,7 @@ bool SampleLowLevelReader::reassessReassessmentLocation(SamplePlaybackGuide* gui
 	int32_t finalClusterIndex = guide->getFinalClusterIndex(sample, shouldObeyMarkers());
 	if ((clusterIndex - finalClusterIndex) * guide->playDirection > 0) {
 		D_PRINTLN("saving from being past finalCluster");
-		Cluster* finalCluster = sample->clusters[finalClusterIndex].cluster;
+		Cluster* finalCluster = sample->clusters.getElement(finalClusterIndex)->cluster;
 		if (!finalCluster) {
 			return false;
 		}
@@ -301,7 +301,8 @@ bool SampleLowLevelReader::assignClusters(SamplePlaybackGuide* guide, Sample* sa
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
 
 		// Grab it.
-		clusters[l] = sample->clusters[clusterIndex].getCluster(sample, clusterIndex, CLUSTER_ENQUEUE, priorityRating);
+		clusters[l] = sample->clusters.getElement(clusterIndex)
+		                  ->getCluster(sample, clusterIndex, CLUSTER_ENQUEUE, priorityRating);
 
 		// The first one is required to not only have returned an object to us (which it might not have if insufficient
 		// RAM or maybe other reasons), but also to be fully loaded.
@@ -377,7 +378,8 @@ bool SampleLowLevelReader::moveOnToNextCluster(SamplePlaybackGuide* guide, Sampl
 
 			// Grab it.
 			clusters[kNumClustersLoadedAhead - 1] =
-			    sample->clusters[newClusterIndex].getCluster(sample, newClusterIndex, CLUSTER_ENQUEUE, priorityRating);
+			    sample->clusters.getElement(newClusterIndex)
+			        ->getCluster(sample, newClusterIndex, CLUSTER_ENQUEUE, priorityRating);
 
 			// If that failed (because no free RAM), no damage gets done.
 		}

--- a/src/deluge/model/sample/sample_reader.cpp
+++ b/src/deluge/model/sample/sample_reader.cpp
@@ -45,8 +45,8 @@ Error SampleReader::readNewCluster() {
 
 	auto& sampleFile = static_cast<Sample&>(*audioFile);
 
-	currentCluster =
-	    sampleFile.clusters[currentClusterIndex].getCluster(&sampleFile, currentClusterIndex, CLUSTER_LOAD_IMMEDIATELY);
+	currentCluster = sampleFile.clusters.getElement(currentClusterIndex)
+	                     ->getCluster(&sampleFile, currentClusterIndex, CLUSTER_LOAD_IMMEDIATELY);
 	if (currentCluster == nullptr) {
 		return Error::SD_CARD; // Failed to load cluster from card
 	}

--- a/src/deluge/model/sample/sample_recorder.h
+++ b/src/deluge/model/sample/sample_recorder.h
@@ -78,7 +78,7 @@ public:
 
 	uint32_t numSamplesExtraToCaptureAtEndSyncingWise;
 
-	size_t firstUnwrittenClusterIndex = 0;
+	int32_t firstUnwrittenClusterIndex = 0;
 
 	// Put things in valid state so if we get destructed before any recording, it's all ok
 	int32_t currentRecordClusterIndex = -1;

--- a/src/deluge/model/voice/voice_sample.cpp
+++ b/src/deluge/model/voice/voice_sample.cpp
@@ -198,7 +198,7 @@ LateStartAttemptStatus VoiceSample::attemptLateSampleStart(SamplePlaybackGuide* 
 	for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
 
 		// Grab it.
-		newClusters[l] = sample->clusters[clusterIndex].getCluster(sample, clusterIndex, CLUSTER_ENQUEUE);
+		newClusters[l] = sample->clusters.getElement(clusterIndex)->getCluster(sample, clusterIndex, CLUSTER_ENQUEUE);
 
 		// If failure (would only happen in insanely rare case where there's no free RAM)
 		if (l == 0 && !newClusters[l]) {
@@ -842,8 +842,8 @@ readCachedWindow:
 
 				int32_t nextUncachedClusterIndex = uncachedClusterIndex;
 				for (int32_t l = 0; l < kNumClustersLoadedAhead; l++) {
-					clusters[l] = sample->clusters[nextUncachedClusterIndex].getCluster(
-					    sample, nextUncachedClusterIndex, CLUSTER_ENQUEUE);
+					clusters[l] = sample->clusters.getElement(nextUncachedClusterIndex)
+					                  ->getCluster(sample, nextUncachedClusterIndex, CLUSTER_ENQUEUE);
 					if (!clusters[l]) {
 						break;
 					}

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -166,7 +166,7 @@ clusterSizeChangedButItsOk:
 
 			// If address of first sector remained unchanged, we can be sure enough that the file hasn't been
 			// changed
-			if (firstSector == thisSample->clusters[0].sdAddress) {}
+			if (firstSector == thisSample->clusters.getElement(0)->sdAddress) {}
 
 			// Otherwise
 			else {
@@ -776,7 +776,8 @@ ramError:
 
 		while (true) {
 
-			((Sample*)audioFile)->clusters[currentClusterIndex].sdAddress = clst2sect(&fileSystem, currentSDCluster);
+			((Sample*)audioFile)->clusters.getElement(currentClusterIndex)->sdAddress =
+			    clst2sect(&fileSystem, currentSDCluster);
 
 			currentClusterIndex++;
 			if (currentClusterIndex >= numClusters) {
@@ -950,8 +951,8 @@ getOutEarly:
 	}
 #endif
 
-	DRESULT result = disk_read_without_streaming_first(SD_PORT, (BYTE*)cluster.data,
-	                                                   sample->clusters[cluster.clusterIndex].sdAddress, numSectors);
+	DRESULT result = disk_read_without_streaming_first(
+	    SD_PORT, (BYTE*)cluster.data, sample->clusters.getElement(cluster.clusterIndex)->sdAddress, numSectors);
 
 #if REPORT_LOAD_TIME
 	uint16_t endTime = MTU2.TCNT_0;
@@ -992,7 +993,7 @@ getOutEarly:
 
 	// Give extra bytes to previous Cluster
 	if (clusterIndex > 0) {
-		Cluster* prevCluster = sample->clusters[cluster.clusterIndex - 1].cluster;
+		Cluster* prevCluster = sample->clusters.getElement(cluster.clusterIndex - 1)->cluster;
 
 		if (prevCluster && prevCluster->loaded) {
 
@@ -1058,8 +1059,8 @@ getOutEarly:
 	}
 
 	// Grab extra bytes from next Cluster
-	if (clusterIndex < sample->clusters.size() - 1) {
-		Cluster* nextCluster = sample->clusters[cluster.clusterIndex + 1].cluster;
+	if (clusterIndex < sample->clusters.getNumElements() - 1) {
+		Cluster* nextCluster = sample->clusters.getElement(cluster.clusterIndex + 1)->cluster;
 
 		if (nextCluster && nextCluster->loaded) {
 
@@ -1178,7 +1179,7 @@ copy7ToMe:
 	if (cluster.numReasonsToBeLoaded < minNumReasonsAfter) {
 		FREEZE_WITH_ERROR("i037");
 	}
-	if (cluster.sample->clusters[cluster.clusterIndex].cluster != &cluster) {
+	if (cluster.sample->clusters.getElement(cluster.clusterIndex)->cluster != &cluster) {
 		FREEZE_WITH_ERROR("E438");
 	}
 #endif
@@ -1346,7 +1347,7 @@ void AudioFileManager::removeReasonFromCluster(Cluster& cluster, char const* err
 		if (loadingQueue.erase(cluster) || deletingSong) {
 
 			// Tell its Cluster to forget it exists
-			cluster.sample->clusters[cluster.clusterIndex].cluster = nullptr;
+			cluster.sample->clusters.getElement(cluster.clusterIndex)->cluster = nullptr;
 
 			delete &cluster; // It contains nothing, so completely recycle it
 		}

--- a/src/deluge/storage/cluster/cluster.cpp
+++ b/src/deluge/storage/cluster/cluster.cpp
@@ -197,9 +197,8 @@ void Cluster::steal(char const* errorCode) {
 	case Type::SAMPLE:
 		if (ALPHA_OR_BETA_VERSION && sample == nullptr) {
 			FREEZE_WITH_ERROR("E181");
-			std::terminate();
 		}
-		sample->clusters[clusterIndex].cluster = nullptr;
+		sample->clusters.getElement(clusterIndex)->cluster = nullptr;
 		break;
 
 	case Type::SAMPLE_CACHE:

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -389,13 +389,13 @@ gotError5:
 				if (clusterIndex != clusterIndexCurrentlyLoaded) {
 
 					// First, unload the old Cluster if there was one
-					if (cluster != nullptr) {
+					if (cluster) {
 						audioFileManager.removeReasonFromCluster(*cluster, "E385");
 					}
 
-					cluster = sample->clusters[clusterIndex].getCluster(sample, clusterIndex, CLUSTER_LOAD_IMMEDIATELY,
-					                                                    0, &error);
-					if (cluster == nullptr) {
+					cluster = sample->clusters.getElement(clusterIndex)
+					              ->getCluster(sample, clusterIndex, CLUSTER_LOAD_IMMEDIATELY, 0, &error);
+					if (!cluster) {
 						goto gotError5;
 					}
 


### PR DESCRIPTION
Vectors destruct and then construct their elements on resize. This causes additional unneeded overhead and breaks the reason counting logic within SampleCluster as there are briefly no reasons on the associated cluster, causing it to be deallocated and then allocated again while recording

Fix #3928