### PR TITLE
Loading animation on popup layer

### DIFF
--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -61,9 +61,9 @@ oled_canvas::Canvas OLED::console;
 
 bool OLED::needsSending;
 
-int32_t working_animation_count;
-bool started_animation;
-bool loading;
+static int32_t working_animation_count;
+static bool started_animation;
+static bool loading;
 
 int32_t sideScrollerDirection; // 0 means none active
 
@@ -580,32 +580,48 @@ void OLED::popupText(std::string_view text, bool persistent, PopupType type) {
 	}
 }
 
+// Draws a cyclic animation while the Deluge is working on a loading or saving operation
 void updateWorkingAnimation() {
-	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
-
-	int32_t w1 = 5;          // spacing between rectangles
-	int32_t w2 = 5;          // width of animated portion of rectangle
-	int32_t h = 8;           // height of rectangle
+	const int32_t w1 = 5;    // spacing between rectangles
+	const int32_t w2 = 5;    // width of animated portion of rectangle
+	const int32_t h = 8;     // height of rectangle
 	int32_t offset = w2 - 2; // causes shifting lines to overlap by 2 pixels
-	int32_t x_max = OLED_MAIN_WIDTH_PIXELS - 1;
-	int32_t x_min = x_max - (w1 + w2 * 2);
-	int32_t x2 = x_max - w2;                  // starting position of right rectangle
-	int32_t y1 = OLED_MAIN_TOPMOST_PIXEL + 2; // top of rectangles
-	int32_t y2 = y1 + h - 1;                  // bottom of rectangles
-	int32_t h2;                               // height of animated portion (will increase over time)
-	// position of left side of starting stack that will be shifted over
-	int32_t x_pos2 = loading ? x2 - working_animation_count + 1 : x_min + 1 + working_animation_count;
-	int32_t t_reset = w1 + w2 + (h - 2) * offset;
+
+	const int32_t animation_width = w1 + w2 * 2 + 2;
+	const int32_t animation_height = h + 1;
+	const int32_t popupX = OLED_MAIN_WIDTH_PIXELS - 1 - animation_width;
+	const int32_t popupY = OLED_MAIN_TOPMOST_PIXEL + 2;
+
 	if (!started_animation) { // initialize the animation
 		started_animation = true;
+
+		deluge::hid::display::OLED::setupPopup(PopupType::NOTIFICATION, animation_width, animation_height, popupX,
+		                                       popupY);
+	}
+
+	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::popup;
+
+	// Calculate positions using absolute coordinates (popup coordinates)
+	const int32_t x_max = popupX + animation_width;
+	const int32_t x_min = x_max - (w1 + w2 * 2); // this has to be out farther for the movement sequence
+	const int32_t x2 = x_max - w2;               // starting position of right rectangle
+	const int32_t y1 = popupY;                   // top of rectangles (absolute coordinates)
+	const int32_t y2 = y1 + h - 1;               // bottom of rectangles
+	int32_t h2;                                  // height of animated portion (will increase over time)
+	// position of left side of starting stack that will be shifted over
+	const int32_t x_pos2 = loading ? x2 - working_animation_count + 1 : x_min + 1 + working_animation_count;
+	const int32_t t_reset = w1 + w2 + (h - 2) * offset;
+
+	if (working_animation_count == 1) { // first frame after initialization
 		// clear space and draw outer borders that will not change during the animation
-		image.clearAreaExact(x_min - 1, OLED_MAIN_TOPMOST_PIXEL, x_max, y2 + 1);
+		image.clearAreaExact(popupX, popupY, popupX + animation_width - 1, popupY + animation_height - 1);
 		image.drawRectangle(x_min, y1, x_max, y2);
-		image.clearAreaExact(x_min + w2 + 1, OLED_MAIN_TOPMOST_PIXEL, x_max - w2 - 1, y2 + 1);
+		image.clearAreaExact(x_min + w2 + 1, popupY, x_max - w2 - 1, popupY + animation_height - 1);
 		h2 = h - 2; // will cause rectangle to be filled in at the start
 	}
-	else
+	else {
 		h2 = std::min((working_animation_count + 2) / offset, h - 2);
+	}
 
 	// clears the area gradually on subsequent loops.
 	image.clearAreaExact(x_min + 1, y1 + 1, x_max - 1, y1 + h2);
@@ -642,8 +658,9 @@ void updateWorkingAnimation() {
 
 void OLED::displayWorkingAnimation(std::string_view word) {
 	loading = (word == "Loading");
-	if (working_animation_count)
+	if (working_animation_count) {
 		uiTimerManager.unsetTimer(TimerName::LOADING_ANIMATION);
+	}
 	working_animation_count = 1;
 	started_animation = false;
 	updateWorkingAnimation();
@@ -652,13 +669,10 @@ void OLED::displayWorkingAnimation(std::string_view word) {
 
 void OLED::removeWorkingAnimation() {
 	// return; // infinite animation duration for debugging purposes
-	if (hasPopupOfType(PopupType::LOADING)) {
+	if (hasPopupOfType(PopupType::NOTIFICATION)) {
 		removePopup();
 	}
 	if (working_animation_count) {
-		deluge::hid::display::OLED::main.clearAreaExact(OLED_MAIN_WIDTH_PIXELS - 18, OLED_MAIN_TOPMOST_PIXEL,
-		                                                OLED_MAIN_WIDTH_PIXELS, OLED_MAIN_TOPMOST_PIXEL + 10);
-		markChanged();
 		uiTimerManager.unsetTimer(TimerName::LOADING_ANIMATION);
 		working_animation_count = 0;
 	}


### PR DESCRIPTION
- Set the loading animation onto a notification type popup layer to prevent issues with main canvas interfering with it or vice versa. No need for a clearAreaExact() to remove it.
- set variables to constant or static where possible to make it more efficient.
- comment additions/adjustments for clarity.