### PR TITLE
Fix for scrolling-in-folders-that-have-2-items bug

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1337,12 +1337,18 @@ void Browser::updateUIState() {
 		    std::clamp(scrollPosVertical, fileIndexSelected - NUM_FILES_ON_SCREEN + 1, fileIndexSelected);
 	}
 	else {
-		scrollPosVertical = fileIndexSelected - 1;
-		if (scrollPosVertical < 0 && numFileItemsDeletedAtStart == 0) {
+		// For folders with fewer items than display slots, always start from index 0
+		if (fileItems.getNumElements() <= NUM_FILES_ON_SCREEN) {
 			scrollPosVertical = 0;
 		}
-		else if (fileIndexSelected == fileItems.getNumElements() - 1 && numFileItemsDeletedAtEnd == 0) {
-			scrollPosVertical--;
+		else {
+			scrollPosVertical = fileIndexSelected - 1;
+			if (scrollPosVertical < 0 && numFileItemsDeletedAtStart == 0) {
+				scrollPosVertical = 0;
+			}
+			else if (fileIndexSelected == fileItems.getNumElements() - 1 && numFileItemsDeletedAtEnd == 0) {
+				scrollPosVertical--;
+			}
 		}
 	}
 
@@ -1545,7 +1551,7 @@ void Browser::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 			{
 				int32_t i = o + scrollPosVertical;
 
-				if (i >= fileItems.getNumElements()) {
+				if (i < 0 || i >= fileItems.getNumElements()) {
 					break;
 				}
 


### PR DESCRIPTION
When doing regular scrolling with the new centered scrolling behavior in folders that have exactly two items, it was looking for a third file that wasn't there, and it would somehow pull another item from a higher level directory, though it would only display it, not allow it to be selected. This change prevents that issue. Also does some proactive edge case protection.