### PR TITLE
Add MIDI Devices page to Resources Section

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -114,6 +114,10 @@ const config = defineConfig({
                 autogenerate: { directory: "resources/applications" },
               },
               {
+                label: "MIDI Devices",
+                autogenerate: { directory: "resources/midi_devices" },
+              },
+              {
                 label: "Tutorials",
                 link: "/resources/tutorials",
               },

--- a/website/src/content/docs/resources/midi_devices/definitions.mdx
+++ b/website/src/content/docs/resources/midi_devices/definitions.mdx
@@ -1,0 +1,9 @@
+---
+title: MIDI Device Definition Files
+sidebar:
+  order: 1
+  label: Definition Files
+---
+
+MIDI Device Definition Files can be found here: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/sd_card/MIDI_DEVICES/DEFINITION
+

--- a/website/src/content/docs/resources/midi_devices/definitions.mdx
+++ b/website/src/content/docs/resources/midi_devices/definitions.mdx
@@ -6,4 +6,3 @@ sidebar:
 ---
 
 MIDI Device Definition Files can be found here: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/sd_card/MIDI_DEVICES/DEFINITION
-

--- a/website/src/content/docs/resources/midi_devices/presets.mdx
+++ b/website/src/content/docs/resources/midi_devices/presets.mdx
@@ -1,0 +1,8 @@
+---
+title: MIDI Device Preset Files
+sidebar:
+  order: 2
+  label: Preset Files
+---
+
+MIDI Device Preset Files can be found here: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/sd_card/MIDI


### PR DESCRIPTION
Added MIDI Devices section to Resources page of the website to link to community created MIDI Device Definition and Preset files