### PR TITLE
[DRAFT] Fix text search unable to find last file in folder (#4039)

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -503,7 +503,7 @@ Error Browser::setFileByFullPath(OutputType outputType, char const* fullPath) {
 
 	//  Get the File Index
 	fileIndexSelected = fileItems.search(fileName);
-	if (fileIndexSelected > fileItems.getNumElements()) {
+	if (fileIndexSelected >= fileItems.getNumElements()) {
 		return Error::FILE_NOT_FOUND;
 	}
 
@@ -1415,7 +1415,8 @@ doSearch:
 	int32_t i = fileItems.search(searchString.get());
 
 	// If that search takes us off the right-hand end of the list...
-	if (i >= fileItems.getNumElements()) {
+	// Note: i == numElements is valid when the last item matches our search prefix
+	if (i > fileItems.getNumElements()) {
 
 		// If we haven't yet done a whole new read from the SD card etc, from within this function, do that now.
 		if (!doneNewRead) {


### PR DESCRIPTION
### *WIP: currently not working, needs some more investigation*

**Bug:** The alphanumeric text search could not find the last file in any folder. When typing the first letters of the last file's name (e.g., 'X' for 'Xylophone'), it would not appear in search results.

**Root cause:** In predictExtendedText(), when searching for a prefix like 'X', the code appends `~` to create `X~` and uses binary search to find where this would be inserted. For the last file, this correctly returns `index == numElements`. However, the condition `i >= numElements` incorrectly treated this valid case as 'not found'.

**Fix:** Changed the condition from `i >= numElements` to `i > numElements` at line 1412. This allows the valid case where i == numElements, which occurs when the last item matches the search prefix. The subsequent `i--` then correctly selects the last file.

Also fixed a similar bounds check issue in setFileByFullPath() at line 506, changing from `i > numElements` to `i >= numElements` for proper validation of exact file searches.

Fixes #4039