### PR TITLE
Revert "Convert oscillator storage functions to std::span"

### DIFF
--- a/src/deluge/processing/render_wave.h
+++ b/src/deluge/processing/render_wave.h
@@ -41,11 +41,15 @@ startRenderingASync:
 	uint32_t distanceTilNextCrossoverSample = -resetterPhase - (resetterPhaseIncrement >> 1);
 	samplesIncludingNextCrossoverSample += (uint32_t)(distanceTilNextCrossoverSample - 1) / resetterPhaseIncrement;
 	bool shouldBeginNextSyncAfter = (numSamplesThisOscSyncSession >= samplesIncludingNextCrossoverSample);
-	size_t numSamplesThisSyncRender = shouldBeginNextSyncAfter
-	                                      ? samplesIncludingNextCrossoverSample
-	                                      : numSamplesThisOscSyncSession; /* Just limit it, basically. */
+	int32_t numSamplesThisSyncRender = shouldBeginNextSyncAfter
+	                                       ? samplesIncludingNextCrossoverSample
+	                                       : numSamplesThisOscSyncSession; /* Just limit it, basically. */
 
-	storageFunction(std::span{bufferStartThisSync, numSamplesThisSyncRender}, phase);
+	int32_t const* const bufferEndThisSyncRender = bufferStartThisSync + numSamplesThisSyncRender;
+	uint32_t phaseTemp = phase;
+	int32_t* __restrict__ writePos = bufferStartThisSync;
+
+	storageFunction(bufferEndThisSyncRender, phaseTemp, writePos);
 
 	/* Sort out the crossover sample at the *start* of that window we just did, if there was one. */
 	if (renderedASyncFromItsStartYet) {

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -1111,8 +1111,8 @@ startRenderingACycle:
 				uint32_t resetterPhase = resetterPhaseThisCycle;
 				int32_t numSamplesThisOscSyncSession = numSamplesThisCycle;
 				renderOscSync(
-				    [&](std::span<q31_t> buffer, uint32_t phase) {
-					    doRenderingLoop(bufferStartThisSync, &*buffer.end(), firstCycleNumber, bandHere, phase,
+				    [&](int32_t const* const bufferEndThisSyncRender, uint32_t phase, int32_t* __restrict__ writePos) {
+					    doRenderingLoop(bufferStartThisSync, bufferEndThisSyncRender, firstCycleNumber, bandHere, phase,
 					                    phaseIncrement, crossCycleStrength2, crossCycleStrength2Increment, kernel);
 				    },
 				    [&](uint32_t samplesIncludingNextCrossoverSample) {
@@ -1147,9 +1147,9 @@ doneRenderingACycle:
 			uint32_t resetterPhase = resetterPhaseThisCycle;
 			int32_t numSamplesThisOscSyncSession = numSamples;
 			renderOscSync(
-			    [&](std::span<q31_t> buffer, uint32_t phase) {
-				    doRenderingLoopSingleCycle(bufferStartThisSync, &*buffer.end(), bandHere, phase, phaseIncrement,
-				                               kernel);
+			    [&](int32_t const* const bufferEndThisSyncRender, uint32_t phase, int32_t* __restrict__ writePos) {
+				    doRenderingLoopSingleCycle(bufferStartThisSync, bufferEndThisSyncRender, bandHere, phase,
+				                               phaseIncrement, kernel);
 			    },
 			    [](uint32_t) {}, phase, phaseIncrement, resetterPhase, resetterPhaseIncrement,
 			    resetterDivideByPhaseIncrement, retriggerPhase, numSamplesThisOscSyncSession, bufferStartThisSync);


### PR DESCRIPTION
Reverts SynthstromAudible/DelugeFirmware#3441

Fixes messed up phases in osc sync rendering (also used for PWM with non pulse waves)

I think argon::vectorize might be broken