### PR TITLE
DX7 Algorithms: Operator numbering in wrong order fix

### DIFF
--- a/src/deluge/gui/menu_item/dx/param.cpp
+++ b/src/deluge/gui/menu_item/dx/param.cpp
@@ -493,7 +493,7 @@ static void renderAlgorithm(uint8_t* params) {
 
 	FmAlgorithm a = FmCore::algorithms[params[134]];
 	for (int i = 0; i < 6; i++) {
-		int f = a.ops[i];
+		int f = a.ops[5 - i]; // compensate for inverted op order
 		char buffer[12];
 		int inbus = (f >> 4) & 3;
 		int outbus = f & 3;
@@ -501,11 +501,11 @@ static void renderAlgorithm(uint8_t* params) {
 		const char ob[] = {'c', 'x', 'y', 'q'};
 		buffer[0] = '1' + i;
 		buffer[1] = ':';
-		buffer[2] = ' ';
-		buffer[3] = ib[inbus];
-		buffer[4] = (f & OUT_BUS_ADD) ? '+' : '>';
-		buffer[5] = ob[outbus];
-		buffer[6] = (f & (FB_IN | FB_OUT)) ? 'f' : ' ';
+		buffer[2] = ib[inbus];
+		buffer[3] = (f & OUT_BUS_ADD) ? '+' : '>';
+		buffer[4] = ob[outbus];
+		buffer[5] = (f & (FB_IN | FB_OUT)) ? 'f' : ' ';
+		buffer[6] = ' ';
 		buffer[7] = 0;
 
 		int r = i / 3, c = i % 3;


### PR DESCRIPTION
**Bug:** 
This is intended to fix #3222, in which the algorithm routings displayed in the DX7 Parameters > Algorithm menu on the OLED have an operator numbering order that is inverted with respect to the DX7 front panel.

**Root cause:** indexing of the in/out routing for operators appears to be inverted in the algorithms array in  fm_core.cpp with respect to the numbering on the DX7 front panel. The menu items for Operator 1-6 settings have an additional index inversion, so the operator-specific menu parameters are displayed correctly for each operator as compared to the same syx bank & patch loaded/displayed in Dexed. 

**Fix:**
This PR implements a minimal fix to the rendering of the DX7 algorithm routing for the OLED display, by inverting the index used to lookup the operator routing for the selected algorithm. Minor whitespace changes were also found to be necessary (a space was removed after the ':') to allow everything to fit comfortably on the OLED after addressing the operator order. May be some opportunity for refactoring so that the rendering code doesn't have to concern itself with performing the inversions, etc, but this is my first PR here and I'm still getting familiar with the codebase.

**Test:**
Create new DX7 synth with "Custom 1" + "Synth" buttons simultaneously pressed. Scroll to and select "DX7 Parameters" then select "Algorithm". Scroll through all 32 algorithms and compare algorithm routing display on emulated OLED to diagrams on DX7 front panel.

<img width="960" height="540" alt="dx7algs" src="https://github.com/user-attachments/assets/09f0e00b-f6f7-48e9-9d37-d2cb3385d2bb" />
