### PR TITLE
fix wavetable bug in nightly (issue #4103)

### DIFF
--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -496,7 +496,7 @@ gotError5:
 			// Read all the data we can before reaching either the end of the cycle, or the end of the file cluster
 			while (source < sourceStopAt) {
 				int32_t value32 = *(int32_t*)source;
-				convert_and_store_sample(reinterpret_cast<const int32_t&>(source));
+				convert_and_store_sample(*reinterpret_cast<const int32_t*>(source));
 				source += byteDepth;
 			}
 


### PR DESCRIPTION
- wavetables weren't playing because their samples weren't actually getting loaded. The pointer needed to be dereferenced. It was just passing the address of the source as sample data, rather than the actual data at that address.