### PR TITLE
Fix looping sample playback regression (#3768)

### DIFF
--- a/src/deluge/model/sample/sample_playback_guide.h
+++ b/src/deluge/model/sample/sample_playback_guide.h
@@ -34,8 +34,8 @@ public:
 		return endPlaybackAtByte;
 	} // This is actually an important function whose output is the basis for a lot of stuff
 	virtual void setupPlaybackBounds(bool reversed);
-	virtual uint32_t getLoopStartPlaybackAtByte() { return startPlaybackAtByte; }
-	virtual uint32_t getLoopEndPlaybackAtByte() { return endPlaybackAtByte; }
+	[[nodiscard]] virtual uint32_t getLoopStartPlaybackAtByte() const { return startPlaybackAtByte; }
+	[[nodiscard]] virtual uint32_t getLoopEndPlaybackAtByte() const { return endPlaybackAtByte; }
 	uint64_t getSyncedNumSamplesIn();
 	int32_t getNumSamplesLaggingBehindSync(VoiceSample* voiceSample);
 	int32_t adjustPitchToCorrectDriftFromSync(VoiceSample* voiceSample, int32_t phaseIncrement);

--- a/src/deluge/model/voice/voice_sample_playback_guide.h
+++ b/src/deluge/model/voice/voice_sample_playback_guide.h
@@ -34,8 +34,8 @@ public:
 	int32_t getBytePosToEndOrLoopPlayback() override;
 	LoopType getLoopingType(const Source& source) const;
 
-	uint32_t getLoopStartPlaybackAtByte() const { return loopStartPlaybackAtByte; }
-	uint32_t getLoopEndPlaybackAtByte() const {
+	[[nodiscard]] uint32_t getLoopStartPlaybackAtByte() const override { return loopStartPlaybackAtByte; }
+	[[nodiscard]] uint32_t getLoopEndPlaybackAtByte() const override {
 		return loopEndPlaybackAtByte ? loopEndPlaybackAtByte : endPlaybackAtByte;
 	}
 


### PR DESCRIPTION
One of the changes in commit 95311abaf7969ee4ad2cd5b78d69e47e97f3723c was making getLoopStartPlaybackAtByte() and getLoopEndPlaybackAtByte() of VoiceSamplePlaybackGuide const, but this causes their signature to differ from the parent class SamplePlaybackGuide versions. Which in the case of getLoopStartPlaybackAtByte() at least, causes the wrong (parent class) version to be called, and causing the samples to loop from the beginning instead of their designated loop starting point.

Make the SamplePlaybackGuide versions const as well to get the signatures match again to fix it, and mark the VoiceSamplePlaybackGuide versions as overrides to prevent such issues in the future.

Add [[nodiscard]] too to appease clang-tidy.

Fixes: #3768