### PR TITLE
make UI destructor virtual

### DIFF
--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -91,6 +91,7 @@ extern bool pendingUIRenderingLock;
 #define LONG_PRESS_DURATION 400
 class UI {
 public:
+	virtual ~UI() = default;
 	UI();
 
 	virtual ActionResult padAction(int32_t x, int32_t y, int32_t velocity) { return ActionResult::DEALT_WITH; }


### PR DESCRIPTION
Just removing a footgun in case we ever want to stop statically allocating all UIs 