### PR TITLE
Bugfix/stuck notes with drones

### DIFF
--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -23,6 +23,7 @@
 #include "model/iterance/iterance.h"
 #include "model/note/note_vector.h"
 #include "modulation/params/param_manager.h"
+#include "processing/sound/sound_instrument.h"
 
 #define SQUARE_NEW_NOTE 1
 #define SQUARE_NOTE_HEAD 2
@@ -247,6 +248,7 @@ private:
 	                  PendingNoteOnList* pendingNoteOnList = nullptr);
 	void findNextNoteToPlay(uint32_t);
 	void attemptLateStartOfNextNoteToPlay(ModelStackWithNoteRow* modelStack, Note* note);
+	bool check_for_note_still_sounding(ModelStackWithNoteRow* modelStack, SoundInstrument* output);
 	bool noteRowMayMakeSound(bool);
 	void drawTail(int32_t startTail, int32_t endTail, uint8_t squareColour[], bool overwriteExisting,
 	              uint8_t image[][3], uint8_t occupancyMask[]);

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -90,7 +90,7 @@ Voice::Voice(Sound& sound) : patcher(kPatcherConfigForVoice, sourceValues, param
 void Voice::setAsUnassigned(ModelStackWithSoundFlags* modelStack, bool deletingSong) {
 
 	unassignStuff(deletingSong);
-
+	delete_this_voice_ = true;
 	if (!deletingSong) {
 		this->sound.voiceUnassigned(modelStack);
 	}

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -2453,7 +2453,7 @@ bool Voice::forceNormalRelease() {
 	if (doneFirstRender) {
 		// If no release-stage, we'll stop as soon as we can
 		if (!hasReleaseStage()) {
-			envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE);
+			envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, SOFT_CULL_INCREMENT);
 		}
 		// otherwise we'll just let it get there on its own
 		else {

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -81,7 +81,6 @@ public:
 	std::array<uint32_t, kNumSources> sourceWaveIndexesLastTime;
 
 	int32_t filterGainLastTime;
-
 	bool doneFirstRender;
 	bool previouslyIgnoredNoteOff;
 
@@ -124,6 +123,7 @@ public:
 	bool forceNormalRelease();
 
 	bool speedUpRelease();
+	bool shouldBeDeleted() { return delete_this_voice_; }
 
 	// This compares based on the priority of two voices
 	[[nodiscard]] std::strong_ordering operator<=>(const Voice& other) const {
@@ -133,6 +133,7 @@ public:
 private:
 	// inline int32_t doFM(uint32_t *carrierPhase, uint32_t* lastShiftedPhase, uint32_t carrierPhaseIncrement, uint32_t
 	// phaseShift);
+	bool delete_this_voice_{false};
 
 	void renderBasicSource(Sound& sound, ParamManagerForTimeline* paramManager, int32_t s, int32_t* oscBuffer,
 	                       int32_t numSamples, bool stereoBuffer, int32_t sourceAmplitude,

--- a/src/deluge/modulation/envelope.cpp
+++ b/src/deluge/modulation/envelope.cpp
@@ -157,6 +157,11 @@ void Envelope::resetTimeEntered() {
 void Envelope::setState(EnvelopeStage newState) {
 	state = newState;
 	timeEnteredState = AudioEngine::nextVoiceState++;
+	if (newState == EnvelopeStage::FAST_RELEASE) {
+		if (fastReleaseIncrement < 65536) {
+			D_PRINTLN("fast releasing slowly");
+		}
+	}
 }
 
 void Envelope::unconditionalOff() {
@@ -165,14 +170,13 @@ void Envelope::unconditionalOff() {
 }
 
 void Envelope::unconditionalRelease(EnvelopeStage typeOfRelease, uint32_t newFastReleaseIncrement) {
+
+	fastReleaseIncrement = newFastReleaseIncrement;
+
 	if (state != typeOfRelease) {
 		setState(typeOfRelease);
 		pos = 0;
 		lastValuePreCurrentStage = lastValue;
-	}
-
-	if (typeOfRelease == EnvelopeStage::FAST_RELEASE) {
-		fastReleaseIncrement = newFastReleaseIncrement;
 	}
 }
 

--- a/src/deluge/modulation/envelope.h
+++ b/src/deluge/modulation/envelope.h
@@ -41,7 +41,7 @@ public:
 	int32_t render(uint32_t numSamples, uint32_t attack, uint32_t decay, uint32_t sustain, uint32_t release,
 	               const uint16_t* releaseTable);
 	void unconditionalRelease(EnvelopeStage typeOfRelease = EnvelopeStage::RELEASE,
-	                          uint32_t newFastReleaseIncrement = 4096);
+	                          uint32_t newFastReleaseIncrement = SOFT_CULL_INCREMENT);
 	void unconditionalOff();
 	void resumeAttack(int32_t oldLastValue);
 	void resetTimeEntered();

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2494,7 +2494,7 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 		    thisHasFilters
 		    && (paramManager->getPatchCableSet()->doesParamHaveSomethingPatchedToIt(params::LOCAL_HPF_FREQ)
 		        || (hpfFreq != std::numeric_limits<q31_t>::min()) || (hpfMorph > std::numeric_limits<q31_t>::min()));
-
+		size_t num_to_delete = 0;
 		for (auto it = voices_.begin(); it != voices_.end();) {
 			ActiveVoice& voice = *it;
 
@@ -2504,13 +2504,14 @@ void Sound::render(ModelStackWithThreeMainThings* modelStack, std::span<StereoSa
 			if (!stillGoing) {
 				this->checkVoiceExists(voice, "E201");
 				this->freeActiveVoice(voice, modelStackWithSoundFlags, false);
-				it = voices_.erase(it);
+				num_to_delete++;
 			}
-			else {
-				it++;
-			}
+			++it;
 		}
-
+		auto num = std::erase_if(voices_, [](const ActiveVoice& voice) { return voice->shouldBeDeleted(); });
+		if (num_to_delete != num) {
+			FREEZE_WITH_ERROR("oh no");
+		}
 		// We know that nothing's patched to pan, so can read it in this very basic way.
 		int32_t pan = paramManager->getPatchedParamSet()->getValue(params::LOCAL_PAN) >> 1;
 		int32_t amplitudeL, amplitudeR;


### PR DESCRIPTION
Fix #3880 (but not the overlap with #3993)

Simplifies the voice render logic to delete all finished voices at once after rendering all of them, eliding copies for the simple case where lots of notes start/stop together

Fixes a bug where certain combinations of culling and parameters led to a fast release being started with a very slow rate

there's a remaining bug where note deferring bypasses some checks because `attemptLateStartOfNextNoteToPlay` and `playNote` have different semantics. It definitely impacts drone notes but I suspect it impacts fill as well

I need to cherry pick this to community as well, went the other way to make sure it would be fixed in beta