### PR TITLE
Horizontal Menus/ Do not show max value in the bar

### DIFF
--- a/src/deluge/gui/menu_item/delay/amount.h
+++ b/src/deluge/gui/menu_item/delay/amount.h
@@ -33,7 +33,7 @@ public:
 	}
 
 	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
-		drawBar(startX, startY, width, height, false);
+		drawBar(startX, startY, width, height);
 
 		if (getValue() > max_value_in_horizontal_menu) {
 			// Draw exclamation mark

--- a/src/deluge/gui/menu_item/delay/amount_unpatched.h
+++ b/src/deluge/gui/menu_item/delay/amount_unpatched.h
@@ -29,7 +29,7 @@ public:
 	}
 
 	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
-		drawBar(startX, startY, width, height, false);
+		drawBar(startX, startY, width, height);
 
 		if (getValue() > max_value_in_horizontal_menu) {
 			// Draw exclamation mark

--- a/src/deluge/gui/menu_item/number.cpp
+++ b/src/deluge/gui/menu_item/number.cpp
@@ -151,7 +151,7 @@ void Number::drawKnob(int32_t start_x, int32_t start_y, int32_t width, int32_t h
 	}
 }
 
-void Number::drawBar(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height, bool show_max_value) {
+void Number::drawBar(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height) {
 	oled_canvas::Canvas& image = OLED::main;
 
 	constexpr uint8_t bar_width = 23;
@@ -162,13 +162,8 @@ void Number::drawBar(int32_t start_x, int32_t start_y, int32_t slot_width, int32
 	const uint8_t bar_end_x = bar_start_x + bar_width;
 	const uint8_t bar_end_y = bar_start_y + bar_height - 1;
 
-	const float value = getNormalizedValue();
-	if (value == 1.f && show_max_value) {
-		image.drawStringCentered(std::to_string(getValue()).data(), start_x - 1, bar_start_y, kTextSpacingX,
-		                         kTextSpacingY, slot_width);
-	}
-
 	// Bar fill
+	const float value = getNormalizedValue();
 	const uint8_t fill_width = value > 0.f ? std::ceil(value * bar_width) : 0;
 	image.invertArea(bar_start_x, fill_width, bar_start_y, bar_end_y);
 

--- a/src/deluge/gui/menu_item/number.h
+++ b/src/deluge/gui/menu_item/number.h
@@ -37,7 +37,7 @@ protected:
 
 	void renderInHorizontalMenu(int32_t start_x, int32_t width, int32_t start_y, int32_t height) override;
 	void drawKnob(int32_t start_x, int32_t start_y, int32_t width, int32_t height);
-	void drawBar(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height, bool show_max_value = true);
+	void drawBar(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
 	void drawPercent(int32_t start_x, int32_t start_y, int32_t width, int32_t height);
 	void drawSlider(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
 	void drawLengthSlider(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height,


### PR DESCRIPTION
A small follow up for #4127 PR: do not show max value in the bar graphics (based on the feedback in the discord thread)