### PR TITLE
kit sound display name fixes

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -994,7 +994,7 @@ doLoadAsSample:
 				drum->name.clear();
 
 				String newName;
-				if (!numCharsInPrefix) {
+				if (!numCharsInPrefix || display->haveOLED()) {
 					newName.set(&enteredText);
 				}
 				else {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2187,6 +2187,11 @@ ActionResult InstrumentClipView::potentiallyRandomizeDrumSample(Kit* kit, Drum* 
 		afh->filePath.concatenate(chosenFilename);
 		afh->loadFile(false, true, true, 1, nullptr, false);
 
+		char* dot = strrchr(chosenFilename, '.');
+		if (dot) {
+			// Remove the extension (e.g., ".WAV", ".AIFF") from chosenFilename before assigning as name
+			*dot = '\0';
+		}
 		soundDrum->name.set(chosenFilename);
 		kit->beenEdited();
 		*slashAddress = '/';
@@ -3657,37 +3662,41 @@ bool InstrumentClipView::handleNoteRowEditorPadAction(int32_t x, int32_t y, int3
 	return true;
 }
 
-// handles editing notes on the grid
+// handles editing notes if shift is pressed
 bool InstrumentClipView::handleNoteRowEditorMainPadAction(int32_t x, int32_t y, int32_t on) {
-	bool wasntHoldingNote = !isUIModeActive(UI_MODE_NOTES_PRESSED);
+	// if shift is active, allow editing notes on the grid
+	if (Buttons::isShiftButtonPressed()) {
+		bool wasntHoldingNote = !isUIModeActive(UI_MODE_NOTES_PRESSED);
 
-	editPadAction(on, y, x, currentSong->xZoom[NAVIGATION_CLIP]);
+		editPadAction(on, y, x, currentSong->xZoom[NAVIGATION_CLIP]);
 
-	bool nowHoldingNote = isUIModeActive(UI_MODE_NOTES_PRESSED);
+		bool nowHoldingNote = isUIModeActive(UI_MODE_NOTES_PRESSED);
 
-	// toggle note menu if you weren't holding note and now you are
-	// or if you were holding note and now you aren't
-	bool toggleMenu = (wasntHoldingNote && nowHoldingNote) || (!wasntHoldingNote && !nowHoldingNote);
+		// toggle note menu if you weren't holding note and now you are
+		// or if you were holding note and now you aren't
+		bool toggleMenu = (wasntHoldingNote && nowHoldingNote) || (!wasntHoldingNote && !nowHoldingNote);
 
-	// if we selected a note / created a note
-	// update the row selection
-	// so that menu can be potentially refreshed
-	if (lastSelectedNoteYDisplay != kNoSelection) {
-		handleNoteRowEditorAuditionPadAction(lastSelectedNoteYDisplay);
+		// if we selected a note / created a note
+		// update the row selection
+		// so that menu can be potentially refreshed
+		if (lastSelectedNoteYDisplay != kNoSelection) {
+			handleNoteRowEditorAuditionPadAction(lastSelectedNoteYDisplay);
+		}
+
+		if (toggleMenu) {
+			// toggle showing note editor param menu while holding / release note pad
+			soundEditor.toggleNoteEditorParamMenu(on);
+		}
+		else {
+			// if you were holding a note and are still holding a note
+			// it means you were holding more than one note and released one
+			// so refresh parameter menu so it reflects the note remaining
+			soundEditor.getCurrentMenuItem()->readValueAgain();
+		}
+
+		return true;
 	}
-
-	if (toggleMenu) {
-		// toggle showing note editor param menu while holding / release note pad
-		soundEditor.toggleNoteEditorParamMenu(on);
-	}
-	else {
-		// if you were holding a note and are still holding a note
-		// it means you were holding more than one note and released one
-		// so refresh parameter menu so it reflects the note remaining
-		soundEditor.getCurrentMenuItem()->readValueAgain();
-	}
-
-	return true;
+	return false;
 }
 
 void InstrumentClipView::handleNoteRowEditorAuditionPadAction(int32_t y) {


### PR DESCRIPTION
- When loading new samples using the drum randomizer function, remove the file extension for the assigned display name.
- On the OLED version only, for the regular kit sound loading, always assign the full file name for the display name instead of removing the prefix for samples in folders where all the samples have a common prefix.