### PR TITLE
fix(midi): boost midi performance when doing sysex loading

### DIFF
--- a/src/OSLikeStuff/scheduler_api.h
+++ b/src/OSLikeStuff/scheduler_api.h
@@ -68,6 +68,7 @@ double getAverageRunTimeforCurrentTask();
 double getSystemTime();
 void setNextRunTimeforCurrentTask(double seconds);
 void removeTask(TaskID id);
+void boostTask(TaskID id);
 void yield(RunCondition until);
 /// timeout in seconds, returns whether the condition was met
 bool yieldWithTimeout(RunCondition until, double timeout);

--- a/src/OSLikeStuff/task_scheduler/task.h
+++ b/src/OSLikeStuff/task_scheduler/task.h
@@ -128,6 +128,7 @@ struct Task {
 	Time latestCallTime{0};
 	Time lastCallTime{0};
 	Time lastFinishTime{0};
+	bool boosted{false};
 
 	StatBlock durationStats;
 #if SCHEDULER_DETAILED_STATS

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -172,6 +172,16 @@ void TaskManager::removeTask(TaskID id) {
 	createSortedList();
 	return;
 }
+
+void TaskManager::boostTask(TaskID id) {
+	auto* task = &list[id];
+	if (!task->boosted) {
+		task->boosted = true;
+		task->schedule.backOffPeriod *= 0.1;
+		task->schedule.targetInterval *= 0.1;
+	}
+}
+
 void TaskManager::ignoreForStats() {
 	countThisTask = false;
 }

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.h
@@ -21,6 +21,7 @@ struct TaskManager {
 
 	void start(Time duration = 0);
 	void removeTask(TaskID id);
+	void boostTask(TaskID id);
 	void runTask(TaskID id);
 	void runHighestPriTask();
 	TaskID chooseBestTask(Time deadline);

--- a/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
@@ -72,6 +72,9 @@ bool yieldToIdle(RunCondition until) {
 void removeTask(TaskID id) {
 	taskManager.removeTask(id);
 }
+void boostTask(TaskID id) {
+	taskManager.boostTask(id);
+}
 double getSystemTime() {
 	return taskManager.getSecondsFromStart();
 }

--- a/src/OSLikeStuff/timers_interrupts/clock_type.h
+++ b/src/OSLikeStuff/timers_interrupts/clock_type.h
@@ -46,6 +46,10 @@ public:
 		time = time + r.time;
 		return *this;
 	}
+	constexpr Time& operator*=(double r) {
+		time = time * r;
+		return *this;
+	}
 };
 
 #endif

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -611,8 +611,8 @@ void registerTasks() {
 	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0002, 0.0004, 0.0005, "read encoders", RESOURCE_NONE);
 	// formerly part of audio routine, updates midi and clock
 	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 0.0005, 0.001, 0.002, "playback routine", RESOURCE_NONE);
-	addRepeatingTask([]() { playbackHandler.midiRoutine(); }, p++, 0.0005, 0.001, 0.002, "midi routine",
-	                 RESOURCE_SD | RESOURCE_USB);
+	midiEngine.routine_task_id = addRepeatingTask([]() { playbackHandler.midiRoutine(); }, p++, 0.0005, 0.001, 0.002,
+	                                              "midi routine", RESOURCE_SD | RESOURCE_USB);
 	addRepeatingTask([]() { audioFileManager.loadAnyEnqueuedClusters(128, false); }, p++, 0.0001, 0.0001, 0.0002,
 	                 "load clusters", RESOURCE_NONE);
 	// handles sd card recorders

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -19,6 +19,7 @@
 
 #ifdef __cplusplus
 
+#include "OSLikeStuff/scheduler_api.h"
 #include "definitions_cxx.hpp"
 #include "io/midi/learned_midi.h"
 #include "playback/playback_handler.h"
@@ -102,6 +103,7 @@ public:
 	bool midiFollowFeedbackFilter;
 	MIDITakeoverMode midiTakeover;
 	bool midiSelectKitRow;
+	TaskID routine_task_id;
 
 	// shared buffer for formatting sysex messages.
 	// Not safe for use in interrupts.

--- a/src/deluge/io/midi/sysex.cpp
+++ b/src/deluge/io/midi/sysex.cpp
@@ -125,6 +125,8 @@ static void firstPacket(uint8_t* data, int32_t len) {
 	PadLEDs::sendOutSidebarColours();
 	deluge::hid::display::OLED::clearMainImage();
 	deluge::hid::display::OLED::sendMainImage();
+
+	boostTask(midiEngine.routine_task_id);
 }
 
 void Debug::loadPacketReceived(uint8_t* data, int32_t len) {


### PR DESCRIPTION
I haven't bisected it exactly yet but the performance of sysex firmware loading became very slow a few months ago. I get the sense that MIDI processing is polling driven now which means MIDI is being throttled by the scheduler. Is is probably a good default but makes the MIDI engine really struggle with processing multiple megabytes of data.

As an easy hack, tenfold the target speed of the MIDI engine task when an update is incoming (only when compile time enabled) I kinda expeted just lowering the `backOffPeriod` should be enough for when playback is not active and nothing really should compete with the CPU, but I had to decrease the `targetInterval` as well.

Perhaps there is a less special cased way e.g. the MIDI engine could observe that more data is being queued on the hardware level and request the next callback to happen ASAP. I could investigate more.