### PR TITLE
kit sound display name fixes

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -994,7 +994,7 @@ doLoadAsSample:
 				drum->name.clear();
 
 				String newName;
-				if (!numCharsInPrefix) {
+				if (!numCharsInPrefix || display->haveOLED()) {
 					newName.set(&enteredText);
 				}
 				else {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2135,6 +2135,11 @@ ActionResult InstrumentClipView::potentiallyRandomizeDrumSample(Kit* kit, Drum* 
 		afh->filePath.concatenate(chosenFilename);
 		afh->loadFile(false, true, true, 1, nullptr, false);
 
+		char* dot = strrchr(chosenFilename, '.');
+		if (dot) {
+			// Remove the extension (e.g., ".WAV", ".AIFF") from chosenFilename before assigning as name
+			*dot = '\0';
+		}
 		soundDrum->name.set(chosenFilename);
 		kit->beenEdited();
 		*slashAddress = '/';


### PR DESCRIPTION
- When loading new samples using the drum randomizer function, remove the file extension for the assigned display name.
- On the OLED version only, for the regular kit sound loading, always assign the full file name for the display name instead of removing the prefix for samples in folders where all the samples have a common prefix.

Note: I made this on the 1.3 branch first, so this is just needed to put it on the community branch as well.