### PR TITLE
Bugfix - crash on check for second level shortcut when entering menu

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1227,7 +1227,7 @@ getOut:
 
 					// Replace with the second layer shortcut (e.g. env3 attack, lfo3 rate) if the pad was pressed twice
 					secondLayerShortcutsToggled =
-					    x == currentParamShorcutX && y == currentParamShorcutY
+					    (getCurrentMenuItem() != nullptr) && x == currentParamShorcutX && y == currentParamShorcutY
 					            && getCurrentMenuItem()->getParamKind() != modulation::params::Kind::PATCH_CABLE
 					        ? !secondLayerShortcutsToggled
 					        : false;


### PR DESCRIPTION
Null dereference occurs if there's no menu open yet. Fix with a check for null pointer first