### PR TITLE
Fix wodr warning for Note Editor menus (#4167)

### DIFF
--- a/src/deluge/gui/ui/menus.h
+++ b/src/deluge/gui/ui/menus.h
@@ -68,7 +68,7 @@ extern gui::menu_item::randomizer::midi_cv::SpreadVelocity spreadVelocityMenuMID
 extern gui::menu_item::randomizer::midi_cv::NoteProbability randomizerNoteProbabilityMenuMIDIOrCV;
 
 // note editor menu's
-extern gui::menu_item::Submenu noteEditorRootMenu;
+extern gui::menu_item::HorizontalMenu noteEditorRootMenu;
 extern gui::menu_item::note::Probability noteProbabilityMenu;
 extern gui::menu_item::note::IterancePreset noteIteranceMenu;
 extern gui::menu_item::note::IteranceDivisor noteCustomIteranceDivisor;
@@ -82,7 +82,7 @@ extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep7;
 extern gui::menu_item::note::IteranceStepToggle noteCustomIteranceStep8;
 extern gui::menu_item::note::Fill noteFillMenu;
 // note row editor menu's
-extern gui::menu_item::Submenu noteRowEditorRootMenu;
+extern gui::menu_item::HorizontalMenu noteRowEditorRootMenu;
 extern gui::menu_item::note_row::Probability noteRowProbabilityMenu;
 extern gui::menu_item::note_row::IterancePreset noteRowIteranceMenu;
 extern gui::menu_item::note_row::IteranceDivisor noteRowCustomIteranceDivisor;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -24,6 +24,7 @@
 #include "gui/l10n/l10n.h"
 #include "gui/menu_item/colour.h"
 #include "gui/menu_item/file_selector.h"
+#include "gui/menu_item/horizontal_menu.h"
 #include "gui/menu_item/multi_range.h"
 #include "gui/ui/audio_recorder.h"
 #include "gui/ui/browser/sample_browser.h"


### PR DESCRIPTION
Fixed a warning for type mismatch between header and cpp files