### PR TITLE
Horizontal Menus/ Partial inversion tweaks

### DIFF
--- a/src/deluge/gui/menu_item/envelope/envelope_menu.h
+++ b/src/deluge/gui/menu_item/envelope/envelope_menu.h
@@ -49,7 +49,7 @@ public:
 
 		// Calculate widths
 		const float attack_width = attack / 50.0f * max_segment_width;
-		const float decay_normalized = sigmoidLikeCurve(decay, 50.0f, 10.0f); // Maps 0-50 to 0-1 range with steep start
+		const float decay_normalized = sigmoidLikeCurve(decay, 50.0f, 8.0f); // Maps 0-50 to 0-1 range with steep start
 		const float decay_width = decay_normalized * max_segment_width;
 
 		// X positions

--- a/src/deluge/gui/menu_item/filter_route.h
+++ b/src/deluge/gui/menu_item/filter_route.h
@@ -56,11 +56,12 @@ public:
 	}
 
 	deluge::vector<std::string_view> getOptions(OptType optType) override {
-		(void)optType;
-		return {"HPF2LPF", "LPF2HPF", l10n::getView(l10n::String::STRING_FOR_PARALLEL)};
+		// Despite SHORT optType we use a long string for this menu specifically cause it occupies 4 slots
+		return {optType == OptType::SHORT ? "HPF > LPF" : "HPF2LPF",
+		        optType == OptType::SHORT ? "LPF > HPF" : "LPF2HPF", l10n::getView(l10n::String::STRING_FOR_PARALLEL)};
 	}
 
-	[[nodiscard]] int32_t getColumnSpan() const override { return 2; }
+	[[nodiscard]] int32_t getColumnSpan() const override { return 4; }
 	[[nodiscard]] bool showColumnLabel() const override { return false; }
 	[[nodiscard]] bool showNotification() const override { return false; }
 
@@ -70,7 +71,45 @@ public:
 		DEF_STACK_STRING_BUF(shortOpt, kShortStringBufferSize);
 		getShortOption(shortOpt);
 
-		image.drawStringCentered(shortOpt, startX, startY + 8, kTextSpacingX, kTextSpacingY, width);
+		constexpr int32_t arrow_space = 10;
+
+		// Get the main text width and trim if needed
+		int32_t text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
+		while (text_width >= width - 2 * arrow_space) {
+			shortOpt.truncate(shortOpt.size() - 1);
+			text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
+		}
+
+		const int32_t text_start_x = startX + (width - text_width) / 2 + 1;
+		const int32_t text_start_y = startY + (height - kTextSpacingY) / 2 + 1;
+
+		// Draw the left arrow
+		if (getValue() > 0) {
+			image.drawString("<", startX + 5, text_start_y, kTextTitleSpacingX, kTextTitleSizeY);
+		}
+
+		// Draw main text
+		image.drawString(shortOpt.c_str(), text_start_x, text_start_y, kTextSpacingX, kTextSpacingY);
+
+		// Highlight the text
+		constexpr int32_t highlight_offset = 21;
+		switch (FlashStorage::accessibilityMenuHighlighting) {
+		case MenuHighlighting::FULL_INVERSION:
+			image.invertAreaRounded(startX + highlight_offset, width - highlight_offset * 2, text_start_y - 2,
+			                        text_start_y + kTextSpacingY + 1);
+			break;
+		case MenuHighlighting::PARTIAL_INVERSION:
+		case MenuHighlighting::NO_INVERSION:
+			image.drawRectangleRounded(startX + highlight_offset, text_start_y - 4, startX + width - highlight_offset,
+			                           text_start_y + kTextSpacingY + 3, oled_canvas::BorderRadius::BIG);
+			break;
+		}
+
+		// Draw the right arrow
+		if (getValue() < size() - 1) {
+			image.drawString(">", OLED_MAIN_WIDTH_PIXELS - arrow_space, text_start_y, kTextTitleSpacingX,
+			                 kTextTitleSizeY);
+		}
 	}
 };
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -211,7 +211,6 @@ void HorizontalMenu::renderMenuItems(std::span<MenuItem*> items, const MenuItem*
 		// Highlight the selected item if it doesn't occupy the whole page
 		if (is_selected && (items.size() > 1 || items[0]->getColumnSpan() < 4)) {
 			switch (FlashStorage::accessibilityMenuHighlighting) {
-
 			case MenuHighlighting::FULL_INVERSION: {
 				// Highlight by inversion of the label or whole slot
 				const bool highlight_whole_slot = !item->showColumnLabel() || item->isSubmenu();
@@ -221,22 +220,11 @@ void HorizontalMenu::renderMenuItems(std::span<MenuItem*> items, const MenuItem*
 				break;
 			}
 
-			case MenuHighlighting::PARTIAL_INVERSION: {
-				// Highlight by drawing outline
-				constexpr uint8_t y_top = base_y - 3;
-				const uint8_t max_x = current_x + box_width - 2;
-				image.drawRectangleRounded(current_x, y_top, max_x, base_y + box_height + 1,
-				                           oled_canvas::BorderRadius::BIG);
-				for (uint8_t x = current_x; x <= max_x; x++) {
-					image.clearPixel(x, y_top - 1);
-					image.clearPixel(x, y_top - 2);
-				}
-				break;
-			}
-
+			case MenuHighlighting::PARTIAL_INVERSION:
 			case MenuHighlighting::NO_INVERSION:
 				// Highlight by drawing a line below the item
-				image.invertArea(current_x, box_width - 1, base_y + box_height, OLED_MAIN_VISIBLE_HEIGHT + 1);
+				constexpr uint8_t line_y = OLED_MAIN_VISIBLE_HEIGHT + 2;
+				image.invertArea(current_x, box_width - 1, line_y, line_y);
 				break;
 			}
 		}

--- a/src/deluge/gui/menu_item/mod_fx/type.h
+++ b/src/deluge/gui/menu_item/mod_fx/type.h
@@ -80,44 +80,44 @@ public:
 		DEF_STACK_STRING_BUF(shortOpt, kShortStringBufferSize);
 		getShortOption(shortOpt);
 
-		constexpr int32_t arrowSpace = 10;
+		constexpr int32_t arrow_space = 10;
 
 		// Get the main text width and trim if needed
-		int32_t textWidth = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
-		while (textWidth >= width - 2 * arrowSpace) {
+		int32_t text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
+		while (text_width >= width - 2 * arrow_space) {
 			shortOpt.truncate(shortOpt.size() - 1);
-			textWidth = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
+			text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
 		}
 
-		const int32_t textStartX = startX + (width - textWidth) / 2 + 1;
-		const int32_t textStartY = startY + (height - kTextSpacingY) / 2 + 1;
+		const int32_t text_start_x = startX + (width - text_width) / 2 + 1;
+		const int32_t text_start_y = startY + (height - kTextSpacingY) / 2 + 1;
 
-		// Draw arrows if needed
+		// Draw the left arrow
 		if (getValue() > 0) {
-			image.drawString("<", startX + 5, textStartY, kTextTitleSpacingX, kTextTitleSizeY);
+			image.drawString("<", startX + 5, text_start_y, kTextTitleSpacingX, kTextTitleSizeY);
 		}
 
 		// Draw main text
-		image.drawString(shortOpt.c_str(), textStartX, textStartY, kTextSpacingX, kTextSpacingY);
+		image.drawString(shortOpt.c_str(), text_start_x, text_start_y, kTextSpacingX, kTextSpacingY);
 
 		// Highlight the text
-		constexpr int32_t highlightOffset = 21;
+		constexpr int32_t highlight_offset = 21;
 		switch (FlashStorage::accessibilityMenuHighlighting) {
 		case MenuHighlighting::FULL_INVERSION:
-			image.invertAreaRounded(startX + highlightOffset, width - highlightOffset * 2, textStartY - 2,
-			                        textStartY + kTextSpacingY + 1);
+			image.invertAreaRounded(startX + highlight_offset, width - highlight_offset * 2, text_start_y - 2,
+			                        text_start_y + kTextSpacingY + 1);
 			break;
 		case MenuHighlighting::PARTIAL_INVERSION:
-			image.drawRectangleRounded(startX + highlightOffset, textStartY - 3, startX + width - highlightOffset,
-			                           textStartY + kTextSpacingY + 2, oled_canvas::BorderRadius::BIG);
-			break;
 		case MenuHighlighting::NO_INVERSION:
+			image.drawRectangleRounded(startX + highlight_offset, text_start_y - 4, startX + width - highlight_offset,
+			                           text_start_y + kTextSpacingY + 3, oled_canvas::BorderRadius::BIG);
 			break;
 		}
 
-		// Draw arrows if needed
+		// Draw the right arrow
 		if (getValue() < size() - 1) {
-			image.drawString(">", OLED_MAIN_WIDTH_PIXELS - arrowSpace, textStartY, kTextTitleSpacingX, kTextTitleSizeY);
+			image.drawString(">", OLED_MAIN_WIDTH_PIXELS - arrow_space, text_start_y, kTextTitleSpacingX,
+			                 kTextTitleSizeY);
 		}
 	}
 };

--- a/src/deluge/gui/menu_item/number.cpp
+++ b/src/deluge/gui/menu_item/number.cpp
@@ -241,7 +241,8 @@ void Number::drawPan(int32_t start_x, int32_t start_y, int32_t slot_width, int32
 	oled_canvas::Canvas& image = OLED::main;
 
 	// Draw the half-cylinder base (easier to have a bitmap for that)
-	image.drawIconCentered(OLED::panHalfCylinderIcon, start_x, slot_width, start_y - 1);
+	const uint8_t pan_start_y = start_y + kHorizontalMenuSlotYOffset - 4;
+	image.drawIconCentered(OLED::panHalfCylinderIcon, start_x, slot_width, pan_start_y);
 
 	const int32_t value = getValue();
 	const int8_t direction = (value > 0) - (value < 0);
@@ -259,7 +260,7 @@ void Number::drawPan(int32_t start_x, int32_t start_y, int32_t slot_width, int32
 	float cos_a = cos(beginning_angle * M_PI / 180.0f);
 	float sin_a = sin(beginning_angle * M_PI / 180.0f);
 	const int32_t center_x = start_x + slot_width / 2;
-	const int32_t center_y = start_y + radius;
+	const int32_t center_y = pan_start_y + radius;
 
 	constexpr uint8_t angle_step = 1;
 	constexpr float step_rad = angle_step * M_PI / 180.0f;

--- a/src/deluge/gui/menu_item/osc/audio_recorder.h
+++ b/src/deluge/gui/menu_item/osc/audio_recorder.h
@@ -73,11 +73,11 @@ public:
 		// Draw record icon
 		int32_t x = startX + 5;
 		int32_t y = startY + 5;
-		const Icon& recIcon = OLED::recordIcon;
-		image.drawIcon(recIcon, x, y);
+		const Icon& rec_icon = OLED::recordIcon;
+		image.drawIcon(rec_icon, x, y);
 
 		// Draw a "rec" string nearby
-		x += recIcon.width + 3;
+		x += rec_icon.width + 3;
 		y += 3;
 		image.drawString("rec", x, y, kTextSpacingX, kTextSpacingY);
 
@@ -85,12 +85,22 @@ public:
 		x += kTextSpacingX * 3 + 3;
 		image.drawGraphicMultiLine(OLED::submenuArrowIconBold, x, y, 7);
 
-		// Draw a big source number
-		x = startX + width - kTextBigSpacingX - 3;
-		y = startY + 6;
 		DEF_STACK_STRING_BUF(sourceNumberBuf, kShortStringBufferSize);
 		sourceNumberBuf.appendInt(source_id_ + 1);
-		image.drawString(sourceNumberBuf.data(), x, y, kTextBigSpacingX, kTextBigSizeY);
+
+		if (FlashStorage::accessibilityMenuHighlighting == MenuHighlighting::FULL_INVERSION
+		    || parent->getCurrentItem() == this) {
+			// Draw a big source number
+			x = startX + width - kTextBigSpacingX - 3;
+			y = startY + 6;
+			image.drawString(sourceNumberBuf.data(), x, y, kTextBigSpacingX, kTextBigSizeY);
+		}
+		else {
+			// Draw a smaller source number
+			x = startX + width - kTextBigSpacingX - 2;
+			y = startY + 8;
+			image.drawString(sourceNumberBuf.data(), x, y, kTextSpacingX, kTextSpacingY);
+		}
 	}
 
 private:

--- a/src/deluge/gui/menu_item/reverb/pan.h
+++ b/src/deluge/gui/menu_item/reverb/pan.h
@@ -44,10 +44,6 @@ public:
 
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxMenuRelativeValue; }
 	[[nodiscard]] int32_t getMinValue() const override { return kMinMenuRelativeValue; }
-
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
-		// lift the pan graphics up a bit to align better with HPF and LPF elements
-		drawPan(startX, startY - 1, width, height);
-	}
+	[[nodiscard]] RenderingStyle getRenderingStyle() const override { return PAN; }
 };
 } // namespace deluge::gui::menu_item::reverb

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -1355,11 +1355,11 @@ PatchCables patchCablesMenu{STRING_FOR_MOD_MATRIX};
 
 HorizontalMenu soundMasterMenu{
     STRING_FOR_MASTER,
-    {&volumeMenu, &panMenu, &synthModeMenu, &masterTransposeMenu, &vibratoMenu},
+    {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu, &vibratoMenu},
 };
 HorizontalMenu soundMasterMenuWithoutVibrato{
     STRING_FOR_MASTER,
-    {&volumeMenu, &panMenu, &synthModeMenu, &masterTransposeMenu},
+    {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu},
 };
 
 HorizontalMenuGroup sourceMenuGroup{


### PR DESCRIPTION
1. Instead of drawing an outline for `Menu highlighting: Partial inversion` option, I draw a bottom line for both `Partial` and `No invertion` options
2. Made the filter routing menu look the same as mod-fx type menu
3. Added little more sensitivity to the envelope's decay line in the range of 1-6
4. Little tweaks for recorder menu in case `Partial` or `No invertion` option is selected, to better distinguish between the selected sample number