### PR TITLE
Horizontal Menus/ Fix visual bug in the pan graphics, separate notification from content in "no inversion" mode, refactoring

### DIFF
--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/rhythm.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/rhythm.h
@@ -47,23 +47,23 @@ public:
 		                         textHeight);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		const auto value = this->getValue();
 		const auto pattern = std::string_view(arpRhythmPatternNames[value]);
 		if (value == 0) {
-			return image.drawStringCentered(pattern.data(), startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			                                kTextSpacingY, width);
+			return image.drawStringCentered(pattern.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+			                                kTextSpacingX, kTextSpacingY, slot.width);
 		}
 
 		constexpr int32_t paddingBetween = 2;
 		const int32_t rhythmWidth = pattern.size() * kTextSpacingX + pattern.size() * paddingBetween;
 
-		int32_t x = startX + (width - rhythmWidth) / 2 + 1;
+		int32_t x = slot.start_x + (slot.width - rhythmWidth) / 2 + 1;
 		for (const char character : pattern) {
-			image.drawChar(character == '0' ? 'X' : character, x, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			               kTextSpacingY);
+			image.drawChar(character == '0' ? 'X' : character, x, slot.start_y + kHorizontalMenuSlotYOffset,
+			               kTextSpacingX, kTextSpacingY);
 			x += kTextSpacingX + paddingBetween;
 		}
 	}

--- a/src/deluge/gui/menu_item/arpeggiator/midi_cv/sequence_length.h
+++ b/src/deluge/gui/menu_item/arpeggiator/midi_cv/sequence_length.h
@@ -35,13 +35,13 @@ public:
 
 	[[nodiscard]] RenderingStyle getRenderingStyle() const override { return NUMBER; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		if (getValue() == 0) {
-			const auto offString = l10n::get(l10n::String::STRING_FOR_OFF);
-			return OLED::main.drawStringCentered(offString, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			                                     kTextSpacingY, width);
+			const auto off_string = l10n::get(l10n::String::STRING_FOR_OFF);
+			return OLED::main.drawStringCentered(off_string, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+			                                     kTextSpacingX, kTextSpacingY, slot.width);
 		}
-		ArpNonSoundInteger::renderInHorizontalMenu(startX, width, startY, height);
+		ArpNonSoundInteger::renderInHorizontalMenu(slot);
 	}
 
 	void getNotificationValue(StringBuf& valueBuf) override {

--- a/src/deluge/gui/menu_item/arpeggiator/preset_mode.h
+++ b/src/deluge/gui/menu_item/arpeggiator/preset_mode.h
@@ -121,14 +121,14 @@ public:
 
 	void getColumnLabel(StringBuf& label) override { label.append(l10n::get(l10n::String::STRING_FOR_MODE)); }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		using namespace deluge::hid::display;
 		oled_canvas::Canvas& image = OLED::main;
 
 		if (this->getValue<ArpPreset>() == ArpPreset::OFF) {
 			const auto off = l10n::get(l10n::String::STRING_FOR_OFF);
-			return image.drawStringCentered(off, startX, startY + kHorizontalMenuSlotYOffset + 5, kTextTitleSpacingX,
-			                                kTextTitleSizeY, width);
+			return image.drawStringCentered(off, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset + 5,
+			                                kTextTitleSpacingX, kTextTitleSizeY, slot.width);
 		}
 
 		const auto arpPreset = getValue<ArpPreset>();
@@ -151,7 +151,7 @@ public:
 		}();
 
 		const bool reversed = arpPreset == ArpPreset::DOWN;
-		image.drawIconCentered(icon, startX, width, startY + kHorizontalMenuSlotYOffset + 1, reversed);
+		image.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y + kHorizontalMenuSlotYOffset + 1, reversed);
 	}
 };
 } // namespace deluge::gui::menu_item::arpeggiator

--- a/src/deluge/gui/menu_item/arpeggiator/rhythm.h
+++ b/src/deluge/gui/menu_item/arpeggiator/rhythm.h
@@ -42,23 +42,23 @@ public:
 		OLED::main.drawStringCentred(name, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		const auto value = this->getValue();
 		const auto pattern = std::string_view(arpRhythmPatternNames[value]);
 		if (value == 0) {
-			return image.drawStringCentered(pattern.data(), startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			                                kTextSpacingY, width);
+			return image.drawStringCentered(pattern.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+			                                kTextSpacingX, kTextSpacingY, slot.width);
 		}
 
 		constexpr int32_t paddingBetween = 2;
 		const int32_t rhythmWidth = pattern.size() * kTextSpacingX + pattern.size() * paddingBetween;
 
-		int32_t x = startX + (width - rhythmWidth) / 2 + 2;
+		int32_t x = slot.start_x + (slot.width - rhythmWidth) / 2 + 2;
 		for (const char character : pattern) {
-			image.drawChar(character == '0' ? 'X' : character, x, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			               kTextSpacingY);
+			image.drawChar(character == '0' ? 'X' : character, x, slot.start_y + kHorizontalMenuSlotYOffset,
+			               kTextSpacingX, kTextSpacingY);
 			x += kTextSpacingX + paddingBetween;
 		}
 	}

--- a/src/deluge/gui/menu_item/arpeggiator/sequence_length.h
+++ b/src/deluge/gui/menu_item/arpeggiator/sequence_length.h
@@ -24,13 +24,13 @@ public:
 
 	[[nodiscard]] RenderingStyle getRenderingStyle() const override { return NUMBER; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		if (getValue() == 0) {
-			const auto offString = l10n::get(l10n::String::STRING_FOR_OFF);
-			return OLED::main.drawStringCentered(offString, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			                                     kTextSpacingY, width);
+			const auto off_string = l10n::get(l10n::String::STRING_FOR_OFF);
+			return OLED::main.drawStringCentered(off_string, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+			                                     kTextSpacingX, kTextSpacingY, slot.width);
 		}
-		ArpUnpatchedParam::renderInHorizontalMenu(startX, width, startY, height);
+		ArpUnpatchedParam::renderInHorizontalMenu(slot);
 	}
 
 	void getNotificationValue(StringBuf& valueBuf) override {

--- a/src/deluge/gui/menu_item/audio_clip/reverse.h
+++ b/src/deluge/gui/menu_item/audio_clip/reverse.h
@@ -64,9 +64,10 @@ public:
 		}
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		const bool reversed = getValue();
-		OLED::main.drawIconCentered(OLED::directionIcon, startX, width, startY + kHorizontalMenuSlotYOffset, reversed);
+		OLED::main.drawIconCentered(OLED::directionIcon, slot.start_x, slot.width,
+		                            slot.start_y + kHorizontalMenuSlotYOffset, reversed);
 	}
 
 	void getColumnLabel(StringBuf& label) override { label.append(l10n::get(l10n::String::STRING_FOR_PLAY)); }

--- a/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.cpp
+++ b/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.cpp
@@ -50,17 +50,16 @@ void SampleMarkerEditor::beginSession(MenuItem* navigatedBackwardFrom) {
 	}
 }
 
-void SampleMarkerEditor::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void SampleMarkerEditor::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	using namespace hid::display;
 	oled_canvas::Canvas& image = OLED::main;
 
-	const int32_t lineX = startX + width - 6;
-	for (int32_t y = startY + 1; y <= startY + height - 5; y += 2) {
-		image.drawPixel(lineX, y);
+	const int32_t line_x = slot.start_x + slot.width - 6;
+	for (int32_t y = slot.start_y + 1; y <= slot.start_y + slot.height - 5; y += 2) {
+		image.drawPixel(line_x, y);
 	}
 
-	const Icon& icon = OLED::loopPointIcon;
-	image.drawIcon(icon, startX + 5, startY + kHorizontalMenuSlotYOffset, true);
+	image.drawIcon(OLED::loopPointIcon, slot.start_x + 5, slot.start_y + kHorizontalMenuSlotYOffset, true);
 }
 
 void SampleMarkerEditor::getColumnLabel(StringBuf& label) {

--- a/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.h
+++ b/src/deluge/gui/menu_item/audio_clip/sample_marker_editor.h
@@ -32,7 +32,7 @@ public:
 	                                             ::MultiRange** currentRange) override;
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
 	[[nodiscard]] bool allowToBeginSessionFromHorizontalMenu() override { return true; }
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 	void getColumnLabel(StringBuf& label) override;
 
 	MarkerType whichMarker;

--- a/src/deluge/gui/menu_item/decimal.cpp
+++ b/src/deluge/gui/menu_item/decimal.cpp
@@ -219,9 +219,9 @@ int32_t Decimal::getNumNonZeroDecimals(int32_t value) {
 	return remainingBuf.size() - 2;
 }
 
-void Decimal::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void Decimal::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	if (getRenderingStyle() != NUMBER) {
-		return Number::renderInHorizontalMenu(startX, width, startY, height);
+		return Number::renderInHorizontalMenu(slot);
 	}
 
 	DEF_STACK_STRING_BUF(valueBuf, 10);
@@ -231,8 +231,9 @@ void Decimal::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t star
 		valueBuf.truncate(3);
 	}
 
-	return hid::display::OLED::main.drawStringCentered(valueBuf.data(), startX, startY + kHorizontalMenuSlotYOffset,
-	                                                   kTextSpacingX, kTextSpacingY, width);
+	return hid::display::OLED::main.drawStringCentered(valueBuf.data(), slot.start_x,
+	                                                   slot.start_y + kHorizontalMenuSlotYOffset, kTextSpacingX,
+	                                                   kTextSpacingY, slot.width);
 }
 
 void DecimalWithoutScrolling::selectEncoderAction(int32_t offset) {

--- a/src/deluge/gui/menu_item/decimal.h
+++ b/src/deluge/gui/menu_item/decimal.h
@@ -27,7 +27,7 @@ public:
 	void beginSession(MenuItem* navigatedBackwardFrom = nullptr) override;
 	void selectEncoderAction(int32_t offset) override;
 	void horizontalEncoderAction(int32_t offset) override;
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 	void getNotificationValue(StringBuf& valueBuf) override { valueBuf.appendFloat(getValue() / 100.f, 2, 2); }
 	[[nodiscard]] RenderingStyle getRenderingStyle() const override { return NUMBER; }
 

--- a/src/deluge/gui/menu_item/delay/amount.h
+++ b/src/deluge/gui/menu_item/delay/amount.h
@@ -27,23 +27,23 @@ class Amount final : public patched_param::Integer {
 public:
 	using Integer::Integer;
 
-	float getNormalizedValue() override {
-		const int32_t clamped = std::clamp<int32_t>(getValue(), 0, max_value_in_horizontal_menu);
+	float normalize(int32_t value) override {
+		const int32_t clamped = std::clamp<int32_t>(value, 0, max_value_in_horizontal_menu);
 		return clamped / static_cast<float>(max_value_in_horizontal_menu);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
-		drawBar(startX, startY, width, height);
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
+		drawBar(slot);
 
 		if (getValue() > max_value_in_horizontal_menu) {
 			// Draw exclamation mark
 			oled_canvas::Canvas& image = OLED::main;
 			constexpr uint8_t excl_mark_width = 3;
 			constexpr uint8_t excl_mark_height = 9;
-			const uint8_t center_x = startX + width / 2;
-			const uint8_t excl_mark_start_y = startY + kHorizontalMenuSlotYOffset;
+			const uint8_t center_x = slot.start_x + slot.width / 2;
+			const uint8_t excl_mark_start_y = slot.start_y + kHorizontalMenuSlotYOffset;
 			const uint8_t excl_mark_end_y = excl_mark_start_y + excl_mark_height - 1;
-			const uint8_t excl_mark_start_x = startX + width / 2 - 1;
+			const uint8_t excl_mark_start_x = center_x - 1;
 
 			// Fill the mark area
 			for (uint8_t x = center_x - 2; x <= center_x + 2; x++) {

--- a/src/deluge/gui/menu_item/delay/amount_unpatched.h
+++ b/src/deluge/gui/menu_item/delay/amount_unpatched.h
@@ -23,23 +23,23 @@ class Amount_Unpatched final : public UnpatchedParam {
 public:
 	using UnpatchedParam::UnpatchedParam;
 
-	float getNormalizedValue() override {
-		const int32_t clamped = std::clamp<int32_t>(getValue(), 0, max_value_in_horizontal_menu);
+	float normalize(int32_t value) override {
+		const int32_t clamped = std::clamp<int32_t>(value, 0, max_value_in_horizontal_menu);
 		return clamped / static_cast<float>(max_value_in_horizontal_menu);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
-		drawBar(startX, startY, width, height);
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
+		drawBar(slot);
 
 		if (getValue() > max_value_in_horizontal_menu) {
 			// Draw exclamation mark
 			oled_canvas::Canvas& image = OLED::main;
 			constexpr uint8_t excl_mark_width = 3;
 			constexpr uint8_t excl_mark_height = 9;
-			const uint8_t center_x = startX + width / 2;
-			const uint8_t excl_mark_start_y = startY + kHorizontalMenuSlotYOffset;
+			const uint8_t center_x = slot.start_x + slot.width / 2;
+			const uint8_t excl_mark_start_y = slot.start_y + kHorizontalMenuSlotYOffset;
 			const uint8_t excl_mark_end_y = excl_mark_start_y + excl_mark_height - 1;
-			const uint8_t excl_mark_start_x = startX + width / 2 - 1;
+			const uint8_t excl_mark_start_x = center_x - 1;
 
 			// Fill the mark area
 			for (uint8_t x = center_x - 2; x <= center_x + 2; x++) {

--- a/src/deluge/gui/menu_item/delay/ping_pong.h
+++ b/src/deluge/gui/menu_item/delay/ping_pong.h
@@ -60,10 +60,10 @@ public:
 		};
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		using namespace deluge::hid::display;
 		const Icon& icon = getValue() ? OLED::switcherIconOn : OLED::switcherIconOff;
-		OLED::main.drawIconCentered(icon, startX, width, startY - 1);
+		OLED::main.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y - 1);
 	}
 };
 

--- a/src/deluge/gui/menu_item/enumeration.cpp
+++ b/src/deluge/gui/menu_item/enumeration.cpp
@@ -49,15 +49,15 @@ void Enumeration::getShortOption(StringBuf& opt) {
 	opt.appendInt(getValue());
 }
 
-void Enumeration::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
-	deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
+void Enumeration::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
+	hid::display::oled_canvas::Canvas& image = hid::display::OLED::main;
 
 	// Render current value
 	DEF_STACK_STRING_BUF(shortOpt, kShortStringBufferSize);
 	getShortOption(shortOpt);
 
-	image.drawStringCentered(shortOpt, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX, kTextSpacingY,
-	                         width);
+	image.drawStringCentered(shortOpt, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset, kTextSpacingX,
+	                         kTextSpacingY, slot.width);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/enumeration.h
+++ b/src/deluge/gui/menu_item/enumeration.h
@@ -14,7 +14,7 @@ public:
 	virtual size_t size() = 0;
 	/// @brief  Should this menu wrap around?
 	virtual bool wrapAround();
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 
 protected:
 	void drawPixelsForOled() override = 0;

--- a/src/deluge/gui/menu_item/file_selector.cpp
+++ b/src/deluge/gui/menu_item/file_selector.cpp
@@ -92,9 +92,9 @@ MenuPermission FileSelector::checkPermissionToBeginSession(ModControllableAudio*
 	return soundEditor.checkPermissionToBeginSessionForRangeSpecificParam(sound, sourceId_, currentRange);
 }
 
-void FileSelector::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void FileSelector::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	using namespace hid::display;
-	OLED::main.drawIconCentered(OLED::folderIconBig, startX, width, startY - 1);
+	OLED::main.drawIconCentered(OLED::folderIconBig, slot.start_x, slot.width, slot.start_y - 1);
 }
 
 void FileSelector::getColumnLabel(StringBuf& label) {

--- a/src/deluge/gui/menu_item/file_selector.h
+++ b/src/deluge/gui/menu_item/file_selector.h
@@ -33,7 +33,7 @@ public:
 	                                             MultiRange** currentRange) override;
 
 	[[nodiscard]] bool allowToBeginSessionFromHorizontalMenu() override { return true; }
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 	void getColumnLabel(StringBuf& label) override;
 
 private:

--- a/src/deluge/gui/menu_item/filter/info.h
+++ b/src/deluge/gui/menu_item/filter/info.h
@@ -83,13 +83,9 @@ public:
 		}
 		return alt;
 	}
-
-	[[nodiscard]] RenderingStyle getNumberStyle() const {
+	[[nodiscard]] bool isMorphable() const {
 		auto filter = dsp::filter::SpecificFilter(getMode());
-		if (filter.getFamily() == dsp::filter::FilterFamily::SVF) {
-			return SLIDER;
-		}
-		return BAR;
+		return filter.getFamily() == dsp::filter::FilterFamily::SVF;
 	}
 
 	bool isOn() const { return getMode() != ::FilterMode::OFF; }

--- a/src/deluge/gui/menu_item/filter/param.h
+++ b/src/deluge/gui/menu_item/filter/param.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "gui/menu_item/filter/info.h"
+#include "gui/menu_item/horizontal_menu.h"
 #include "gui/menu_item/patched_param/integer_non_fm.h"
 #include "gui/menu_item/unpatched_param.h"
 #include "gui/menu_item/value_scaling.h"
@@ -41,10 +42,33 @@ public:
 	[[nodiscard]] bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return info.isOn();
 	}
+	[[nodiscard]] FilterInfo const& getFilterInfo() const { return info; }
 
 	void getColumnLabel(StringBuf& label) override { label.append(info.getMorphNameOr(Integer::getName(), true)); }
-	[[nodiscard]] RenderingStyle getRenderingStyle() const override { return info.getNumberStyle(); }
-	[[nodiscard]] FilterInfo const& getFilterInfo() const { return info; }
+
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
+		if (info.getFilterParamType() == FilterParamType::MORPH && info.isMorphable()) {
+			int32_t value = getValue();
+			if (info.getSlot() == FilterSlot::HPF) {
+				// Treat HPF as fully morphed LPF visually
+				value = 50 - value;
+			}
+			drawSlider(slot, value);
+		}
+		else {
+			drawBar(slot);
+		}
+	}
+
+	void selectEncoderAction(int32_t offset) override {
+		if (parent != nullptr && parent->renderingStyle() == Submenu::RenderingStyle::HORIZONTAL
+		    && info.getFilterParamType() == FilterParamType::MORPH && info.isMorphable()
+		    && info.getSlot() == FilterSlot::HPF) {
+			// Treat HPF as fully morphed LPF visually, reverse direction
+			offset *= -1;
+		}
+		Integer::selectEncoderAction(offset);
+	}
 
 private:
 	FilterInfo info;
@@ -55,14 +79,37 @@ public:
 	UnpatchedFilterParam(l10n::String newName, l10n::String title, int32_t newP, FilterSlot slot_,
 	                     FilterParamType type_)
 	    : UnpatchedParam{newName, title, newP}, info{slot_, type_} {}
+
 	[[nodiscard]] std::string_view getName() const override { return info.getMorphNameOr(UnpatchedParam::getName()); }
 	[[nodiscard]] std::string_view getTitle() const override { return info.getMorphNameOr(UnpatchedParam::getTitle()); }
 	[[nodiscard]] bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		return info.isOn();
 	}
 	void getColumnLabel(StringBuf& label) override { label.append(info.getMorphNameOr(Integer::getName(), true)); }
-	[[nodiscard]] RenderingStyle getRenderingStyle() const override { return info.getNumberStyle(); }
 	[[nodiscard]] FilterInfo const& getFilterInfo() const { return info; }
+
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
+		if (info.getFilterParamType() == FilterParamType::MORPH && info.isMorphable()) {
+			int32_t value = getValue();
+			if (info.getSlot() == FilterSlot::HPF) {
+				// Treat HPF as fully morphed LPF visually
+				value = 50 - value;
+			}
+			drawSlider(slot, value);
+		}
+		else {
+			drawBar(slot);
+		}
+	}
+	void selectEncoderAction(int32_t offset) override {
+		if (parent != nullptr && parent->renderingStyle() == Submenu::RenderingStyle::HORIZONTAL
+		    && info.getFilterParamType() == FilterParamType::MORPH && info.isMorphable()
+		    && info.getSlot() == FilterSlot::HPF) {
+			// Treat HPF as fully morphed LPF visually, reverse direction
+			offset *= -1;
+		}
+		Integer::selectEncoderAction(offset);
+	}
 
 private:
 	FilterInfo info;

--- a/src/deluge/gui/menu_item/filter_route.h
+++ b/src/deluge/gui/menu_item/filter_route.h
@@ -65,7 +65,7 @@ public:
 	[[nodiscard]] bool showColumnLabel() const override { return false; }
 	[[nodiscard]] bool showNotification() const override { return false; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		DEF_STACK_STRING_BUF(shortOpt, kShortStringBufferSize);
@@ -75,17 +75,17 @@ public:
 
 		// Get the main text width and trim if needed
 		int32_t text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
-		while (text_width >= width - 2 * arrow_space) {
+		while (text_width >= slot.width - 2 * arrow_space) {
 			shortOpt.truncate(shortOpt.size() - 1);
 			text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
 		}
 
-		const int32_t text_start_x = startX + (width - text_width) / 2 + 1;
-		const int32_t text_start_y = startY + (height - kTextSpacingY) / 2 + 1;
+		const int32_t text_start_x = slot.start_x + (slot.width - text_width) / 2 + 1;
+		const int32_t text_start_y = slot.start_y + (slot.height - kTextSpacingY) / 2 + 1;
 
 		// Draw the left arrow
 		if (getValue() > 0) {
-			image.drawString("<", startX + 5, text_start_y, kTextTitleSpacingX, kTextTitleSizeY);
+			image.drawString("<", slot.start_x + 5, text_start_y, kTextTitleSpacingX, kTextTitleSizeY);
 		}
 
 		// Draw main text
@@ -95,13 +95,14 @@ public:
 		constexpr int32_t highlight_offset = 21;
 		switch (FlashStorage::accessibilityMenuHighlighting) {
 		case MenuHighlighting::FULL_INVERSION:
-			image.invertAreaRounded(startX + highlight_offset, width - highlight_offset * 2, text_start_y - 2,
-			                        text_start_y + kTextSpacingY + 1);
+			image.invertAreaRounded(slot.start_x + highlight_offset, slot.width - highlight_offset * 2,
+			                        text_start_y - 2, text_start_y + kTextSpacingY + 1);
 			break;
 		case MenuHighlighting::PARTIAL_INVERSION:
 		case MenuHighlighting::NO_INVERSION:
-			image.drawRectangleRounded(startX + highlight_offset, text_start_y - 4, startX + width - highlight_offset,
-			                           text_start_y + kTextSpacingY + 3, oled_canvas::BorderRadius::BIG);
+			image.drawRectangleRounded(slot.start_x + highlight_offset, text_start_y - 4,
+			                           slot.start_x + slot.width - highlight_offset, text_start_y + kTextSpacingY + 3,
+			                           oled_canvas::BorderRadius::BIG);
 			break;
 		}
 

--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -162,18 +162,18 @@ void HorizontalMenu::renderMenuItems(std::span<MenuItem*> items, const MenuItem*
 
 	constexpr int32_t base_y = 14 + OLED_MAIN_TOPMOST_PIXEL;
 	constexpr int32_t column_width = OLED_MAIN_WIDTH_PIXELS / 4;
-	int32_t current_x = 0;
+	uint8_t current_x = 0;
 
 	for (auto it = items.begin(); it != items.end();) {
 		MenuItem* item = *it;
 		const bool is_selected = item == currentItem;
 		const bool is_relevant = isItemRelevant(item);
 
-		const int32_t box_width = column_width * item->getColumnSpan();
-		constexpr int32_t box_height = 25;
-		constexpr int32_t label_height = kTextSpacingY;
-		constexpr int32_t label_y = base_y + box_height - label_height;
-		int32_t content_height = box_height;
+		const uint8_t box_width = column_width * item->getColumnSpan();
+		constexpr uint8_t box_height = 25;
+		constexpr uint8_t label_height = kTextSpacingY;
+		constexpr uint8_t label_y = base_y + box_height - label_height;
+		uint8_t content_height = box_height;
 
 		if (containers_map.contains(item) && is_relevant) {
 			// If item belongs to a container, delegate rendering to that container
@@ -205,7 +205,10 @@ void HorizontalMenu::renderMenuItems(std::span<MenuItem*> items, const MenuItem*
 		}
 		else {
 			// Draw content of the menu item
-			item->renderInHorizontalMenu(current_x, box_width - 1, base_y, content_height);
+			item->renderInHorizontalMenu({.start_x = current_x,
+			                              .start_y = base_y,
+			                              .width = static_cast<uint8_t>(box_width - 1),
+			                              .height = content_height});
 		}
 
 		// Highlight the selected item if it doesn't occupy the whole page
@@ -223,8 +226,7 @@ void HorizontalMenu::renderMenuItems(std::span<MenuItem*> items, const MenuItem*
 			case MenuHighlighting::PARTIAL_INVERSION:
 			case MenuHighlighting::NO_INVERSION:
 				// Highlight by drawing a line below the item
-				constexpr uint8_t line_y = OLED_MAIN_VISIBLE_HEIGHT + 2;
-				image.invertArea(current_x, box_width - 1, line_y, line_y);
+				image.drawHorizontalLine(OLED_MAIN_VISIBLE_HEIGHT + 2, current_x, current_x + box_width - 2);
 				break;
 			}
 		}

--- a/src/deluge/gui/menu_item/lfo/type.h
+++ b/src/deluge/gui/menu_item/lfo/type.h
@@ -77,7 +77,8 @@ public:
 	}
 
 	[[nodiscard]] bool showColumnLabel() const override { return false; }
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		const Icon& icon = [&] {
@@ -100,7 +101,7 @@ public:
 			return OLED::sineIcon;
 		}();
 
-		image.drawIconCentered(icon, startX, width, startY + kHorizontalMenuSlotYOffset + 2);
+		image.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y + kHorizontalMenuSlotYOffset + 2);
 	}
 
 private:

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -30,6 +30,13 @@ enum class MenuPermission {
 	MUST_SELECT_RANGE,
 };
 
+struct HorizontalMenuSlotParams {
+	uint8_t start_x{0};
+	uint8_t start_y{0};
+	uint8_t width{0};
+	uint8_t height{0};
+};
+
 class Sound;
 class MultiRange;
 class MIDICable;
@@ -310,7 +317,7 @@ public:
 	/// Needs to be overridden
 	virtual void getNotificationValue(StringBuf& valueBuf) {}
 
-	virtual void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {};
+	virtual void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {};
 
 	deluge::gui::menu_item::HorizontalMenu* parent{nullptr};
 

--- a/src/deluge/gui/menu_item/midi/preset.h
+++ b/src/deluge/gui/menu_item/midi/preset.h
@@ -68,22 +68,23 @@ public:
 		Number::selectEncoderAction(offset);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		DEF_STACK_STRING_BUF(paramValue, 5);
-		int32_t sizeX, sizeY;
+		int32_t size_x, size_y;
 		if (this->getValue() == 128) {
 			paramValue.append(l10n::get(l10n::String::STRING_FOR_NONE));
-			sizeX = kTextSpacingX;
-			sizeY = kTextSpacingY;
+			size_x = kTextSpacingX;
+			size_y = kTextSpacingY;
 		}
 		else {
 			paramValue.appendInt(getValue());
-			sizeX = kTextTitleSpacingX;
-			sizeY = kTextTitleSizeY;
+			size_x = kTextTitleSpacingX;
+			size_y = kTextTitleSizeY;
 		}
-		image.drawStringCentered(paramValue, startX, startY + 2, sizeX, sizeY, width);
+		image.drawStringCentered(paramValue, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset, size_x, size_y,
+		                         slot.width);
 	}
 
 	[[nodiscard]] bool showNotification() const override { return false; }

--- a/src/deluge/gui/menu_item/mod_fx/type.h
+++ b/src/deluge/gui/menu_item/mod_fx/type.h
@@ -74,7 +74,7 @@ public:
 	[[nodiscard]] bool showNotification() const override { return false; }
 	[[nodiscard]] bool showColumnLabel() const override { return false; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		DEF_STACK_STRING_BUF(shortOpt, kShortStringBufferSize);
@@ -84,17 +84,17 @@ public:
 
 		// Get the main text width and trim if needed
 		int32_t text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
-		while (text_width >= width - 2 * arrow_space) {
+		while (text_width >= slot.width - 2 * arrow_space) {
 			shortOpt.truncate(shortOpt.size() - 1);
 			text_width = image.getStringWidthInPixels(shortOpt.c_str(), kTextSpacingY);
 		}
 
-		const int32_t text_start_x = startX + (width - text_width) / 2 + 1;
-		const int32_t text_start_y = startY + (height - kTextSpacingY) / 2 + 1;
+		const int32_t text_start_x = slot.start_x + (slot.width - text_width) / 2 + 1;
+		const int32_t text_start_y = slot.start_y + (slot.height - kTextSpacingY) / 2 + 1;
 
 		// Draw the left arrow
 		if (getValue() > 0) {
-			image.drawString("<", startX + 5, text_start_y, kTextTitleSpacingX, kTextTitleSizeY);
+			image.drawString("<", slot.start_x + 5, text_start_y, kTextTitleSpacingX, kTextTitleSizeY);
 		}
 
 		// Draw main text
@@ -104,13 +104,14 @@ public:
 		constexpr int32_t highlight_offset = 21;
 		switch (FlashStorage::accessibilityMenuHighlighting) {
 		case MenuHighlighting::FULL_INVERSION:
-			image.invertAreaRounded(startX + highlight_offset, width - highlight_offset * 2, text_start_y - 2,
-			                        text_start_y + kTextSpacingY + 1);
+			image.invertAreaRounded(slot.start_x + highlight_offset, slot.width - highlight_offset * 2,
+			                        text_start_y - 2, text_start_y + kTextSpacingY + 1);
 			break;
 		case MenuHighlighting::PARTIAL_INVERSION:
 		case MenuHighlighting::NO_INVERSION:
-			image.drawRectangleRounded(startX + highlight_offset, text_start_y - 4, startX + width - highlight_offset,
-			                           text_start_y + kTextSpacingY + 3, oled_canvas::BorderRadius::BIG);
+			image.drawRectangleRounded(slot.start_x + highlight_offset, text_start_y - 4,
+			                           slot.start_x + slot.width - highlight_offset, text_start_y + kTextSpacingY + 3,
+			                           oled_canvas::BorderRadius::BIG);
 			break;
 		}
 

--- a/src/deluge/gui/menu_item/note/fill.h
+++ b/src/deluge/gui/menu_item/note/fill.h
@@ -62,18 +62,18 @@ public:
 		                             kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		const uint8_t value = getValue();
 		const std::string str = value == OFF ? "OFF" : "FILL";
-		image.drawStringCentered(str.data(), startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX, kTextSpacingY,
-		                         width);
+		image.drawStringCentered(str.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset, kTextSpacingX,
+		                         kTextSpacingY, slot.width);
 
 		if (value == NOT_FILL) {
-			const uint8_t center_y = startY + 6;
-			const uint8_t line_start_x = startX + 2;
-			const uint8_t line_end_x = startX + width - 4;
+			const uint8_t center_y = slot.start_y + kHorizontalMenuSlotYOffset + 4;
+			const uint8_t line_start_x = slot.start_x + 2;
+			const uint8_t line_end_x = slot.start_x + slot.width - 4;
 			for (uint8_t x = line_start_x; x <= line_end_x; x++) {
 				image.clearPixel(x, center_y - 1);
 				image.clearPixel(x, center_y + 1);

--- a/src/deluge/gui/menu_item/note/iterance_preset.h
+++ b/src/deluge/gui/menu_item/note/iterance_preset.h
@@ -71,10 +71,10 @@ public:
 		OLED::main.drawStringCentred(value.data(), 18 + OLED_MAIN_TOPMOST_PIXEL, kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		const std::string value = getIteranceDisplayValue("%d:%d");
-		OLED::main.drawStringCentered(value.data(), startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-		                              kTextSpacingY, width);
+		OLED::main.drawStringCentered(value.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+		                              kTextSpacingX, kTextSpacingY, slot.width);
 	}
 
 	void drawValue() override {

--- a/src/deluge/gui/menu_item/note/probability.h
+++ b/src/deluge/gui/menu_item/note/probability.h
@@ -67,15 +67,15 @@ public:
 		OLED::main.drawStringCentred(buffer, 18 + OLED_MAIN_TOPMOST_PIXEL, kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		char buffer[20];
 		bool latching = false;
 
 		intToString(getProbabilityValue(latching), buffer);
 		strcat(buffer, latching ? "L" : "%");
 
-		OLED::main.drawStringCentered(buffer, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX, kTextSpacingY,
-		                              width);
+		OLED::main.drawStringCentered(buffer, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset, kTextSpacingX,
+		                              kTextSpacingY, slot.width);
 	}
 
 	void drawValue() override {

--- a/src/deluge/gui/menu_item/note_row/fill.h
+++ b/src/deluge/gui/menu_item/note_row/fill.h
@@ -69,18 +69,18 @@ public:
 		                             kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
 		const uint8_t value = getValue();
 		const std::string str = value == OFF ? "OFF" : "FILL";
-		image.drawStringCentered(str.data(), startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX, kTextSpacingY,
-		                         width);
+		image.drawStringCentered(str.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset, kTextSpacingX,
+		                         kTextSpacingY, slot.width);
 
 		if (value == NOT_FILL) {
-			const uint8_t center_y = startY + 6;
-			const uint8_t line_start_x = startX + 2;
-			const uint8_t line_end_x = startX + width - 4;
+			const uint8_t center_y = slot.start_y + kHorizontalMenuSlotYOffset + 4;
+			const uint8_t line_start_x = slot.start_x + 2;
+			const uint8_t line_end_x = slot.start_x + slot.width - 4;
 			for (uint8_t x = line_start_x; x <= line_end_x; x++) {
 				image.clearPixel(x, center_y - 1);
 				image.clearPixel(x, center_y + 1);

--- a/src/deluge/gui/menu_item/note_row/iterance_preset.h
+++ b/src/deluge/gui/menu_item/note_row/iterance_preset.h
@@ -84,10 +84,10 @@ public:
 		OLED::main.drawStringCentred(value.data(), 18 + OLED_MAIN_TOPMOST_PIXEL, kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		const std::string value = getIteranceDisplayValue("%d:%d");
-		OLED::main.drawStringCentered(value.data(), startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-		                              kTextSpacingY, width);
+		OLED::main.drawStringCentered(value.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+		                              kTextSpacingX, kTextSpacingY, slot.width);
 	}
 
 	void drawValue() override {

--- a/src/deluge/gui/menu_item/note_row/probability.h
+++ b/src/deluge/gui/menu_item/note_row/probability.h
@@ -73,15 +73,15 @@ public:
 		OLED::main.drawStringCentred(buffer, 18 + OLED_MAIN_TOPMOST_PIXEL, kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		char buffer[20];
 		bool latching = false;
 
 		intToString(getProbabilityValue(latching), buffer);
 		strcat(buffer, latching ? "L" : "%");
 
-		OLED::main.drawStringCentered(buffer, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX, kTextSpacingY,
-		                              width);
+		OLED::main.drawStringCentered(buffer, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset, kTextSpacingX,
+		                              kTextSpacingY, slot.width);
 	}
 
 	void drawValue() override {

--- a/src/deluge/gui/menu_item/number.h
+++ b/src/deluge/gui/menu_item/number.h
@@ -46,22 +46,21 @@ protected:
 	[[nodiscard]] virtual int32_t getMaxValue() const = 0;
 	[[nodiscard]] virtual int32_t getMinValue() const { return 0; }
 	[[nodiscard]] virtual RenderingStyle getRenderingStyle() const { return KNOB; }
-	virtual float getNormalizedValue();
+	virtual float normalize(int32_t value);
 
 	// Horizontal menus ------
-	void renderInHorizontalMenu(int32_t start_x, int32_t width, int32_t start_y, int32_t height) override;
-	void drawKnob(int32_t start_x, int32_t start_y, int32_t width, int32_t height);
-	void drawBar(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
-	void drawPercent(int32_t start_x, int32_t start_y, int32_t width, int32_t height);
-	void drawSlider(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
-	void drawLengthSlider(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height,
-	                      bool min_slider_pos = 3);
-	void drawPan(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
-	void drawLpf(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
-	void drawHpf(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
-	void drawAttack(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
-	void drawRelease(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
-	void drawSidechainDucking(int32_t start_x, int32_t start_y, int32_t slot_width, int32_t slot_height);
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
+	void drawKnob(const HorizontalMenuSlotParams& slot);
+	void drawBar(const HorizontalMenuSlotParams& slot);
+	void drawPercent(const HorizontalMenuSlotParams& slot);
+	void drawSlider(const HorizontalMenuSlotParams& slot, std::optional<int32_t> value = std::nullopt);
+	void drawLengthSlider(const HorizontalMenuSlotParams& slot, bool min_slider_pos = 3);
+	void drawPan(const HorizontalMenuSlotParams& slot);
+	void drawLpf(const HorizontalMenuSlotParams& slot);
+	void drawHpf(const HorizontalMenuSlotParams& slot);
+	void drawAttack(const HorizontalMenuSlotParams& slot);
+	void drawRelease(const HorizontalMenuSlotParams& slot);
+	void drawSidechainDucking(const HorizontalMenuSlotParams& slot);
 	void getNotificationValue(StringBuf& value) override;
 };
 

--- a/src/deluge/gui/menu_item/osc/pulse_width.h
+++ b/src/deluge/gui/menu_item/osc/pulse_width.h
@@ -52,28 +52,28 @@ public:
 		       && oscType != OscType::INPUT_STEREO;
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
-		const float valueNormalized = getValue() / 50.0f;
+		const float norm = getValue() / 50.0f;
 
-		constexpr int32_t xPadding = 4;
-		width -= xPadding * 2 + 1;
+		constexpr int32_t x_padding = 4;
+		const uint8_t width = slot.width - x_padding * 2;
 
-		int32_t xStart = startX + xPadding;
-		int32_t xEnd = xStart + width;
-		int32_t yStart = startY + kHorizontalMenuSlotYOffset;
-		int32_t yEnd = startY + height - 5;
+		int32_t start_x = slot.start_x + x_padding;
+		int32_t end_x = start_x + width - 1;
+		int32_t start_y = slot.start_y + kHorizontalMenuSlotYOffset;
+		int32_t end_y = slot.start_y + slot.height - 5;
 
-		int32_t pwMinX = xStart + 2;
-		int32_t pwMaxX = xStart + width / 2;
-		int32_t pwWidth = pwMaxX - pwMinX;
-		int32_t pwX = pwMaxX - pwWidth * valueNormalized;
+		int32_t pw_min_x = start_x + 2;
+		int32_t pw_max_x = start_x + width / 2;
+		int32_t pw_width = pw_max_x - pw_min_x;
+		int32_t pw_x = pw_max_x - pw_width * norm;
 
-		image.drawVerticalLine(xStart, yStart, yEnd);
-		image.drawHorizontalLine(yStart, xStart, pwX);
-		image.drawVerticalLine(pwX, yStart, yEnd);
-		image.drawHorizontalLine(yEnd, pwX, xEnd);
+		image.drawVerticalLine(start_x, start_y, end_y);
+		image.drawHorizontalLine(start_y, start_x, pw_x);
+		image.drawVerticalLine(pw_x, start_y, end_y);
+		image.drawHorizontalLine(end_y, pw_x, end_x);
 	}
 };
 

--- a/src/deluge/gui/menu_item/osc/retrigger_phase.h
+++ b/src/deluge/gui/menu_item/osc/retrigger_phase.h
@@ -111,15 +111,15 @@ public:
 		Decimal::selectEncoderAction(offset);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& canvas = OLED::main;
 		if (this->getValue() < 0) {
 			const char* off = l10n::get(l10n::String::STRING_FOR_OFF);
-			return canvas.drawStringCentered(off, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			                                 kTextSpacingY, width);
+			return canvas.drawStringCentered(off, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+			                                 kTextSpacingX, kTextSpacingY, slot.width);
 		}
 
-		return Decimal::renderInHorizontalMenu(startX, width, startY, height);
+		return Decimal::renderInHorizontalMenu(slot);
 	}
 
 	void getNotificationValue(StringBuf& valueBuf) override {

--- a/src/deluge/gui/menu_item/osc/tracking.h
+++ b/src/deluge/gui/menu_item/osc/tracking.h
@@ -48,10 +48,10 @@ public:
 		Toggle::selectEncoderAction(offset);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		using namespace deluge::hid::display;
 		const auto& icon = getValue() ? OLED::oscTrackingEnabledIcon : OLED::oscTrackingDisabledIcon;
-		OLED::main.drawIconCentered(icon, startX, width, startY - 1);
+		OLED::main.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y - 1);
 	}
 
 private:

--- a/src/deluge/gui/menu_item/osc/type.h
+++ b/src/deluge/gui/menu_item/osc/type.h
@@ -126,18 +126,18 @@ public:
 
 	[[nodiscard]] bool showColumnLabel() const override { return false; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
-		const OscType oscType = soundEditor.currentSound->sources[sourceId_].oscType;
-		if (oscType == OscType::DX7) {
+		const OscType osc_type = soundEditor.currentSound->sources[sourceId_].oscType;
+		if (osc_type == OscType::DX7) {
 			const auto option = getOptions(OptType::FULL)[getValue()].data();
-			return image.drawStringCentered(option, startX, startY + kHorizontalMenuSlotYOffset + 5, kTextTitleSpacingX,
-			                                kTextTitleSizeY, width);
+			return image.drawStringCentered(option, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset + 5,
+			                                kTextTitleSpacingX, kTextTitleSizeY, slot.width);
 		}
 
 		const Icon& icon = [&] {
-			switch (oscType) {
+			switch (osc_type) {
 			case OscType::SINE:
 				return OLED::sineIcon;
 			case OscType::TRIANGLE:
@@ -161,10 +161,10 @@ public:
 			}
 		}();
 
-		image.drawIconCentered(icon, startX, width, startY + kHorizontalMenuSlotYOffset + 2);
+		image.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y + kHorizontalMenuSlotYOffset + 2);
 
-		if (oscType == OscType::ANALOG_SQUARE || oscType == OscType::ANALOG_SAW_2) {
-			const int32_t x = startX + 4;
+		if (osc_type == OscType::ANALOG_SQUARE || osc_type == OscType::ANALOG_SAW_2) {
+			const int32_t x = slot.start_x + 4;
 			constexpr int32_t y = OLED_MAIN_HEIGHT_PIXELS - kTextSpacingY - 8;
 			image.clearAreaExact(x - 1, y - 1, x + kTextSpacingX + 1, y + kTextSpacingY + 1);
 			image.drawChar('A', x, y, kTextSpacingX, kTextSpacingY);

--- a/src/deluge/gui/menu_item/randomizer/randomizer_lock.h
+++ b/src/deluge/gui/menu_item/randomizer/randomizer_lock.h
@@ -66,10 +66,10 @@ public:
 	// don't enter menu on select button press
 	bool shouldEnterSubmenu() override { return false; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		using namespace deluge::hid::display;
 		const Icon& icon = getValue() ? OLED::randomizerLockOnIcon : OLED::randomizerLockOffIcon;
-		OLED::main.drawIconCentered(icon, startX, width, startY - 1);
+		OLED::main.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y - 1);
 	}
 };
 } // namespace deluge::gui::menu_item::randomizer

--- a/src/deluge/gui/menu_item/reverb/sidechain/volume.h
+++ b/src/deluge/gui/menu_item/reverb/sidechain/volume.h
@@ -52,15 +52,15 @@ public:
 		}
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& canvas = OLED::main;
 		if (getValue() < 0) {
 			const char* string_for_auto = l10n::get(l10n::String::STRING_FOR_AUTO);
-			canvas.drawStringCentered(string_for_auto, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-			                          kTextSpacingY, width);
+			canvas.drawStringCentered(string_for_auto, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+			                          kTextSpacingX, kTextSpacingY, slot.width);
 		}
 		else {
-			drawSidechainDucking(startX, startY, width, height);
+			drawSidechainDucking(slot);
 		}
 	}
 

--- a/src/deluge/gui/menu_item/sample/loop_point.cpp
+++ b/src/deluge/gui/menu_item/sample/loop_point.cpp
@@ -72,21 +72,21 @@ void LoopPoint::beginSession(MenuItem* navigatedBackwardFrom) {
 		uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 	}
 }
-void LoopPoint::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void LoopPoint::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	using namespace hid::display;
 	oled_canvas::Canvas& image = OLED::main;
 
-	const bool isStartMarker = markerType == MarkerType::START;
-	const int32_t lineX = isStartMarker ? startX + 8 : startX + width - 12;
+	const bool is_start_marker = markerType == MarkerType::START;
+	const int32_t line_x = is_start_marker ? slot.start_x + 8 : slot.start_x + slot.width - 12;
 
-	for (int32_t y = startY + 1; y <= startY + height - 5; y += 2) {
-		image.drawPixel(lineX, y);
+	for (int32_t y = slot.start_y + kHorizontalMenuSlotYOffset - 1; y <= slot.start_y + slot.height - 5; y += 2) {
+		image.drawPixel(line_x, y);
 	}
 
 	const Icon& icon = OLED::loopPointIcon;
-	const int32_t iconX = isStartMarker ? lineX + 4 : startX - 2;
-	const int32_t iconY = startY + kHorizontalMenuSlotYOffset;
-	image.drawIcon(icon, iconX, iconY, !isStartMarker);
+	const int32_t icon_x = is_start_marker ? line_x + 4 : slot.start_x - 2;
+	const int32_t icon_y = slot.start_y + kHorizontalMenuSlotYOffset;
+	image.drawIcon(icon, icon_x, icon_y, !is_start_marker);
 }
 
 void LoopPoint::getColumnLabel(StringBuf& label) {

--- a/src/deluge/gui/menu_item/sample/loop_point.h
+++ b/src/deluge/gui/menu_item/sample/loop_point.h
@@ -31,7 +31,7 @@ public:
 	bool isRangeDependent() final { return true; }
 	MenuPermission checkPermissionToBeginSession(ModControllableAudio* modControllable, int32_t whichThing,
 	                                             ::MultiRange** currentRange) final;
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 	void getColumnLabel(StringBuf& label) override;
 
 	int32_t xZoom{0};

--- a/src/deluge/gui/menu_item/sample/pitch_speed.h
+++ b/src/deluge/gui/menu_item/sample/pitch_speed.h
@@ -67,9 +67,9 @@ public:
 		return {l10n::getView(l10n::String::STRING_FOR_LINKED), l10n::getView(l10n::String::STRING_FOR_INDEPENDENT)};
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		const Icon& icon = getValue() ? OLED::pitchSpeedIndependentIcon : OLED::pitchSpeedLinkedIcon;
-		OLED::main.drawIconCentered(icon, startX, width, startY - 1);
+		OLED::main.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y - 1);
 	}
 
 	void getColumnLabel(StringBuf& label) override {

--- a/src/deluge/gui/menu_item/sample/repeat.h
+++ b/src/deluge/gui/menu_item/sample/repeat.h
@@ -113,7 +113,7 @@ public:
 		};
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		const auto& source = soundEditor.currentSound->sources[source_id_];
 		const Icon& icon = [&] {
 			switch (source.repeatMode) {
@@ -128,7 +128,7 @@ public:
 			}
 			return OLED::sampleModeCutIcon;
 		}();
-		OLED::main.drawIcon(icon, startX + 4, startY - 2);
+		OLED::main.drawIcon(icon, slot.start_x + 4, slot.start_y + kHorizontalMenuSlotYOffset - 4);
 	}
 
 	void getColumnLabel(StringBuf& label) override { label.append(getOptions(OptType::SHORT)[getValue()]); }

--- a/src/deluge/gui/menu_item/sample/reverse.h
+++ b/src/deluge/gui/menu_item/sample/reverse.h
@@ -66,10 +66,11 @@ public:
 		}
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		const bool reversed = getValue();
 		const Icon& icon = OLED::directionIcon;
-		OLED::main.drawIconCentered(icon, startX, width, startY + kHorizontalMenuSlotYOffset, reversed);
+		OLED::main.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y + kHorizontalMenuSlotYOffset,
+		                            reversed);
 	}
 
 	void getColumnLabel(StringBuf& label) override { label.append(l10n::get(l10n::String::STRING_FOR_PLAY)); }

--- a/src/deluge/gui/menu_item/sequence/direction.h
+++ b/src/deluge/gui/menu_item/sequence/direction.h
@@ -120,22 +120,22 @@ public:
 		return MenuPermission::YES;
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		using namespace deluge::hid::display;
 		oled_canvas::Canvas& image = OLED::main;
 
 		const auto current_value = this->getValue<SequenceDirection>();
 		if (current_value == SequenceDirection::OBEY_PARENT) {
-			return Selection::renderInHorizontalMenu(startX, width, startY, height);
+			return Selection::renderInHorizontalMenu(slot);
 		}
 
-		const uint8_t icon_y = startY + kHorizontalMenuSlotYOffset;
+		const uint8_t icon_y = slot.start_y + kHorizontalMenuSlotYOffset;
 		if (current_value == SequenceDirection::PINGPONG) {
-			image.drawIconCentered(OLED::directionIcon, startX + 2, width, icon_y);
-			image.drawIconCentered(OLED::directionIcon, startX - 2, width, icon_y, true);
+			image.drawIconCentered(OLED::directionIcon, slot.start_x + 2, slot.width, icon_y);
+			image.drawIconCentered(OLED::directionIcon, slot.start_x - 2, slot.width, icon_y, true);
 		}
 		else {
-			image.drawIconCentered(OLED::directionIcon, startX, width, icon_y,
+			image.drawIconCentered(OLED::directionIcon, slot.start_x, slot.width, icon_y,
 			                       current_value == SequenceDirection::REVERSE);
 		}
 	}

--- a/src/deluge/gui/menu_item/stutter/direction.h
+++ b/src/deluge/gui/menu_item/stutter/direction.h
@@ -121,27 +121,28 @@ private:
 		valueBuf.append(getOptions(OptType::SHORT)[value]);
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		using namespace deluge::hid::display;
 		oled_canvas::Canvas& image = OLED::main;
 
 		const auto value = getValue();
 
 		if (value == USE_SONG_STUTTER) {
-			image.drawStringCentered("song", startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX, kTextSpacingY,
-			                         width);
+			image.drawStringCentered("song", slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset, kTextSpacingX,
+			                         kTextSpacingY, slot.width);
 			return;
 		}
 
 		// Draw the direction icon centered
 		const bool reversed = value == REVERSED || value == REVERSED_PING_PONG;
-		image.drawIconCentered(OLED::directionIcon, startX, width, startY + kHorizontalMenuSlotYOffset, reversed);
+		image.drawIconCentered(OLED::directionIcon, slot.start_x, slot.width, slot.start_y + kHorizontalMenuSlotYOffset,
+		                       reversed);
 
 		if (value == FORWARD_PING_PONG || value == REVERSED_PING_PONG) {
 			// Draw ping-pong dots
-			const int32_t centerX = startX + width / 2;
-			image.drawPixel(centerX, startY + kHorizontalMenuSlotYOffset);
-			image.drawPixel(centerX, startY + 9);
+			const int32_t center_x = slot.start_x + slot.width / 2;
+			image.drawPixel(center_x, slot.start_y + kHorizontalMenuSlotYOffset);
+			image.drawPixel(center_x, slot.start_y + kHorizontalMenuSlotYOffset + 7);
 		}
 	}
 };

--- a/src/deluge/gui/menu_item/stutter/rate.cpp
+++ b/src/deluge/gui/menu_item/stutter/rate.cpp
@@ -60,16 +60,14 @@ void Rate::drawPixelsForOled() {
 	                                                   kTextHugeSizeY);
 }
 
-void Rate::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void Rate::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	if (!isStutterQuantized()) {
-		return UnpatchedParam::renderInHorizontalMenu(startX, width, startY, height);
+		return UnpatchedParam::renderInHorizontalMenu(slot);
 	}
 
-	hid::display::oled_canvas::Canvas& image = hid::display::OLED::main;
-
-	// Render current value
 	const char* label = getQuantizedOptionLabel();
-	image.drawStringCentered(label, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX, kTextSpacingY, width);
+	hid::display::OLED::main.drawStringCentered(label, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+	                                            kTextSpacingX, kTextSpacingY, slot.width);
 }
 
 void Rate::getNotificationValue(StringBuf& valueBuf) {

--- a/src/deluge/gui/menu_item/stutter/rate.h
+++ b/src/deluge/gui/menu_item/stutter/rate.h
@@ -26,10 +26,10 @@ public:
 	Rate(l10n::String newName, l10n::String title)
 	    : UnpatchedParam(newName, title, deluge::modulation::params::UNPATCHED_STUTTER_RATE) {}
 
-	void selectEncoderAction(int32_t offset);
+	void selectEncoderAction(int32_t offset) override;
 	void drawValue() override;
 	void drawPixelsForOled() override;
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 	void getNotificationValue(StringBuf& valueBuf) override;
 
 	void getColumnLabel(StringBuf& label) override { label.append(deluge::l10n::get(l10n::String::STRING_FOR_RATE)); }

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -52,13 +52,13 @@ void Submenu::updateDisplay() {
 	}
 }
 
-void Submenu::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void Submenu::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	hid::display::oled_canvas::Canvas& image = hid::display::OLED::main;
 
 	// Draw arrow icon centered indicating that there is another layer
-	const int32_t arrowY = startY + kHorizontalMenuSlotYOffset;
-	const int32_t arrowX = startX + (width - kSubmenuIconSpacingX) / 2 - 1;
-	image.drawGraphicMultiLine(hid::display::OLED::submenuArrowIconBold, arrowX, arrowY, kSubmenuIconSpacingX);
+	const int32_t arrow_y = slot.start_y + kHorizontalMenuSlotYOffset;
+	const int32_t arrow_x = slot.start_x + (slot.width - kSubmenuIconSpacingX) / 2 - 1;
+	image.drawGraphicMultiLine(hid::display::OLED::submenuArrowIconBold, arrow_x, arrow_y, kSubmenuIconSpacingX);
 }
 
 void Submenu::drawPixelsForOled() {

--- a/src/deluge/gui/menu_item/submenu.h
+++ b/src/deluge/gui/menu_item/submenu.h
@@ -51,7 +51,7 @@ public:
 	void learnProgramChange(MIDICable& cable, int32_t channel, int32_t programNumber) override;
 	bool learnNoteOn(MIDICable& cable, int32_t channel, int32_t noteCode) final;
 	virtual RenderingStyle renderingStyle() const { return RenderingStyle::VERTICAL; };
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 	void drawPixelsForOled() override;
 	void drawSubmenuItemsForOled(std::span<MenuItem*> options, const int32_t selectedOption);
 	/// @brief 	Indicates if the menu-like object should wrap-around. Destined to be virtualized.

--- a/src/deluge/gui/menu_item/sync_level.cpp
+++ b/src/deluge/gui/menu_item/sync_level.cpp
@@ -60,20 +60,20 @@ void SyncLevel::getColumnLabel(StringBuf& label) {
 	syncValueToStringForHorzMenuLabel(syncValueToSyncType(value), level, label, currentSong->getInputTickMagnitude());
 }
 
-void SyncLevel::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void SyncLevel::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	using namespace deluge::hid::display;
 	oled_canvas::Canvas& image = OLED::main;
 
 	const int32_t value = getValue();
 
 	if (const ::SyncLevel level = syncValueToSyncLevel(value); level == SYNC_LEVEL_NONE) {
-		const auto offString = l10n::get(l10n::String::STRING_FOR_OFF);
-		return image.drawStringCentered(offString, startX, startY + kHorizontalMenuSlotYOffset, kTextSpacingX,
-		                                kTextSpacingY, width);
+		const auto off_string = l10n::get(l10n::String::STRING_FOR_OFF);
+		return image.drawStringCentered(off_string, slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
+		                                kTextSpacingX, kTextSpacingY, slot.width);
 	}
 
 	// Draw only the sync type icon, sync level already drawn as a label
-	const Icon& typeIcon = [&] {
+	const Icon& type_icon = [&] {
 		switch (syncValueToSyncType(getValue())) {
 		case SYNC_TYPE_EVEN:
 			return OLED::syncTypeEvenIcon;
@@ -84,7 +84,7 @@ void SyncLevel::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t st
 		}
 		return OLED::syncTypeEvenIcon;
 	}();
-	image.drawIconCentered(typeIcon, startX, width, startY - 1);
+	image.drawIconCentered(type_icon, slot.start_x, slot.width, slot.start_y + kHorizontalMenuSlotYOffset - 3);
 }
 
 int32_t SyncLevel::syncTypeAndLevelToMenuOption(::SyncType type, ::SyncLevel level) {

--- a/src/deluge/gui/menu_item/sync_level.h
+++ b/src/deluge/gui/menu_item/sync_level.h
@@ -37,7 +37,7 @@ protected:
 	void drawValue() final;
 	virtual void getNoteLengthName(StringBuf& buffer);
 	void drawPixelsForOled() override;
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 	void getColumnLabel(StringBuf& label) override;
 };
 

--- a/src/deluge/gui/menu_item/toggle.cpp
+++ b/src/deluge/gui/menu_item/toggle.cpp
@@ -70,10 +70,10 @@ void Toggle::renderSubmenuItemTypeForOled(int32_t yPixel) {
 	                           kSubmenuIconSpacingX);
 }
 
-void Toggle::renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) {
+void Toggle::renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) {
 	using namespace deluge::hid::display;
 	const Icon& icon = getValue() ? OLED::switcherIconOn : OLED::switcherIconOff;
-	OLED::main.drawIconCentered(icon, startX, width, startY - 1);
+	OLED::main.drawIconCentered(icon, slot.start_x, slot.width, slot.start_y - 1);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/toggle.h
+++ b/src/deluge/gui/menu_item/toggle.h
@@ -14,7 +14,7 @@ public:
 	virtual void drawValue();
 	void drawPixelsForOled();
 	void displayToggleValue();
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override;
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override;
 
 	// don't enter menu on select button press
 	bool shouldEnterSubmenu() override { return false; }

--- a/src/deluge/gui/menu_item/unison/count.h
+++ b/src/deluge/gui/menu_item/unison/count.h
@@ -65,11 +65,11 @@ public:
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxNumVoicesUnison; }
 	[[nodiscard]] bool showColumnLabel() const override { return false; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		DEF_STACK_STRING_BUF(paramValue, 2);
 		paramValue.appendInt(getValue());
-		return OLED::main.drawStringCentered(paramValue, startX + 1, startY + 5, kTextBigSpacingX, kTextBigSizeY,
-		                                     width);
+		OLED::main.drawStringCentered(paramValue, slot.start_x + 1, slot.start_y + kHorizontalMenuSlotYOffset + 3,
+		                              kTextBigSpacingX, kTextBigSizeY, slot.width);
 	}
 };
 

--- a/src/deluge/gui/menu_item/unison/detune.h
+++ b/src/deluge/gui/menu_item/unison/detune.h
@@ -60,30 +60,30 @@ public:
 	}
 	[[nodiscard]] int32_t getMaxValue() const override { return kMaxUnisonDetune; }
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		oled_canvas::Canvas& image = OLED::main;
 
-		const float t = getValue() / 50.0f;
+		const float norm = normalize(getValue());
 
 		for (int i = 0; i < 3; ++i) {
-			constexpr int32_t lineSpacing = 5;
-			constexpr int32_t maxYOffset = 4;
+			constexpr int32_t line_spacing = 5;
+			constexpr int32_t max_y_offset = 4;
 
-			const int32_t y = startY + 1 + i * lineSpacing;
-			const int32_t x0 = startX + 6;
-			const int32_t x1 = startX + width - 7;
+			const int32_t y = slot.start_y + kHorizontalMenuSlotYOffset + i * line_spacing;
+			const int32_t x0 = slot.start_x + 6;
+			const int32_t x1 = slot.start_x + slot.width - 7;
 
 			if (i == 0) {
 				// Top line
-				const int32_t offset = static_cast<int32_t>(maxYOffset * t * 0.30f);
+				const int32_t offset = static_cast<int32_t>(max_y_offset * norm * 0.30f);
 				image.drawLine(x0, y, x1, y + offset);
 			}
 			else if (i == 1) {
 				// Middle line
-				const int32_t offset = static_cast<int32_t>(maxYOffset * t * 0.5f);
+				const int32_t offset = static_cast<int32_t>(max_y_offset * norm * 0.5f);
 				image.drawLine(x0, y - offset, x1, y + offset);
 
-				if (t > 0.7 && t < 1) {
+				if (norm > 0.7 && norm < 1) {
 					image.clearPixel(x0, y - offset);
 					image.clearPixel(x1, y + offset);
 					image.drawPixel(x0, y - offset - 1);
@@ -92,8 +92,8 @@ public:
 			}
 			else if (i == 2) {
 				// Bottom line
-				int32_t offset = y - static_cast<int32_t>(maxYOffset * t * 0.8f);
-				if (t > 0 && offset == y) {
+				int32_t offset = y - static_cast<int32_t>(max_y_offset * norm * 0.8f);
+				if (norm > 0 && offset == y) {
 					offset -= 1;
 				}
 

--- a/src/deluge/gui/menu_item/voice/polyphony.h
+++ b/src/deluge/gui/menu_item/voice/polyphony.h
@@ -85,11 +85,12 @@ public:
 		}
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		if (getValue() == 0) {
-			return OLED::main.drawIconCentered(OLED::infinityIcon, startX, width, startY + 3);
+			return OLED::main.drawIconCentered(OLED::infinityIcon, slot.start_x, slot.width,
+			                                   slot.start_y + kHorizontalMenuSlotYOffset + 1);
 		}
-		IntegerWithOff::renderInHorizontalMenu(startX, width, startY, height);
+		IntegerWithOff::renderInHorizontalMenu(slot);
 	}
 };
 

--- a/src/deluge/gui/menu_item/voice/portamento.h
+++ b/src/deluge/gui/menu_item/voice/portamento.h
@@ -31,20 +31,20 @@ public:
 		label.append(deluge::l10n::get(l10n::String::STRING_FOR_PORTAMENTO_SHORT));
 	}
 
-	void renderInHorizontalMenu(int32_t startX, int32_t width, int32_t startY, int32_t height) override {
+	void renderInHorizontalMenu(const HorizontalMenuSlotParams& slot) override {
 		using namespace deluge::hid::display;
 		oled_canvas::Canvas& image = OLED::main;
 
 		constexpr uint8_t porta_graphics_width = 25;
-		const uint8_t center_x = startX + width / 2;
-		const uint8_t porta_start_x = startX + 2;
+		const uint8_t center_x = slot.start_x + slot.width / 2;
+		const uint8_t porta_start_x = slot.start_x + 2;
 		const uint8_t porta_end_x = porta_start_x + porta_graphics_width - 1;
 
 		constexpr uint8_t porta_graphics_height = 11;
-		const uint8_t porta_start_y = startY + 1;
+		const uint8_t porta_start_y = slot.start_y + kHorizontalMenuSlotYOffset - 1;
 		const uint8_t porta_end_y = porta_start_y + porta_graphics_height - 1;
 
-		const float norm = getNormalizedValue();
+		const float norm = normalize(getValue());
 		constexpr uint8_t porta_line_width = 9;
 		const uint8_t porta_x0 = std::lerp(center_x, center_x - porta_line_width, norm);
 		const uint8_t porta_x1 = std::lerp(center_x, center_x + porta_line_width, norm);

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -705,16 +705,23 @@ void OLED::displayNotification(std::string_view param_title, std::optional<std::
 	setupPopup(PopupType::NOTIFICATION, width - 1, height, start_x, start_y);
 
 	// Draw the title and value
-	popup.drawString(titleBuf.data(), padding_left, start_y + 1, kTextSpacingX, kTextSpacingY);
+	const bool no_inversion = FlashStorage::accessibilityMenuHighlighting == MenuHighlighting::NO_INVERSION;
+	constexpr uint8_t title_start_x = padding_left;
+	const uint8_t title_start_y = no_inversion ? start_y : start_y + 1;
+	popup.drawString(titleBuf.data(), title_start_x, title_start_y, kTextSpacingX, kTextSpacingY);
 
 	if (value_width > 0) {
-		popup.drawChar(':', padding_left + title_width, start_y + 1, kTextSpacingX, kTextSpacingY);
-		popup.drawString(param_value.value().data(), padding_left + title_width + 8, start_y + 1, kTextSpacingX,
+		popup.drawChar(':', title_start_x + title_width, title_start_y, kTextSpacingX, kTextSpacingY);
+		popup.drawString(param_value.value().data(), title_start_x + title_width + 8, title_start_y, kTextSpacingX,
 		                 kTextSpacingY);
 	}
 
-	if (FlashStorage::accessibilityMenuHighlighting != MenuHighlighting::NO_INVERSION) {
-		// Make the notification inverted
+	if (no_inversion) {
+		for (uint8_t x = start_x + 1; x < end_x; x += 2) {
+			popup.drawPixel(x, end_y);
+		}
+	}
+	else {
 		popup.invertAreaRounded(start_x, width, start_y, end_y);
 		popup.drawPixel(start_x, start_y);
 		popup.drawPixel(end_x, start_y);


### PR DESCRIPTION
- Fixed visual bug for panning caused by my previous PR:
<img width="512" height="192" alt="deluge-screenshot-2025-11-02T12-44-59-548Z" src="https://github.com/user-attachments/assets/f970ce82-2fc2-4d6d-af1f-286a14afa79e" />

- Cleaner separation for notification vs content if "no inversion" accessibility mode is selected:
<img width="512" height="192" alt="deluge-screenshot-2025-11-02T12-52-21-766Z" src="https://github.com/user-attachments/assets/7b1609e0-47d0-4a9a-8fde-0b0a7e130b34" />


- Changed behavior of the HPF morph slider to match filter graphics: if the slider goes left, then the filter morphs left as well, and vise versa:
<img width="512" height="192" alt="deluge-screenshot-2025-11-02T12-49-46-808Z" src="https://github.com/user-attachments/assets/8e8830a6-81ce-4e71-b000-f05586127088" />

- Refactored the signature of `renderInHorizontalMenu` member to reduce arguments bloat

