### PR TITLE
Fixing index into gridSquareInfo which caused unrelated memory locati…

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2735,7 +2735,7 @@ void InstrumentClipView::checkIfAllEditPadPressesEnded(bool mayRenderSidebar) {
 		actionLogger.closeAction(ActionType::NOTE_EDIT);
 		quantizeAmount = 0;
 		if (lastSelectedNoteXDisplay != kNoSelection && lastSelectedNoteYDisplay != kNoSelection) {
-			gridSquareInfo[lastSelectedNoteXDisplay][lastSelectedNoteYDisplay].isValid = false;
+			gridSquareInfo[lastSelectedNoteYDisplay][lastSelectedNoteXDisplay].isValid = false;
 			lastSelectedNoteXDisplay = kNoSelection;
 			lastSelectedNoteYDisplay = kNoSelection;
 		}
@@ -3500,7 +3500,7 @@ void InstrumentClipView::exitNoteEditor() {
 		if (isUIModeActive(UI_MODE_NOTES_PRESSED)) {
 			editPadAction(0, lastSelectedNoteYDisplay, lastSelectedNoteXDisplay, currentSong->xZoom[NAVIGATION_CLIP]);
 		}
-		gridSquareInfo[lastSelectedNoteXDisplay][lastSelectedNoteYDisplay].isValid = false;
+		gridSquareInfo[lastSelectedNoteYDisplay][lastSelectedNoteXDisplay].isValid = false;
 		lastSelectedNoteXDisplay = kNoSelection;
 		lastSelectedNoteYDisplay = kNoSelection;
 	}


### PR DESCRIPTION
…ons to be modified

Fix bug described in https://github.com/SynthstromAudible/DelugeFirmware/issues/4132

Essentially, we were indexing into gridSquareInfo array incorrectly, which was causing an element of the rowColour array to be modified. Some memory management business. 