### PR TITLE
Load DX7 - Allow loading to continue for checksum errors

### DIFF
--- a/src/deluge/gui/menu_item/dx/cartridge.cpp
+++ b/src/deluge/gui/menu_item/dx/cartridge.cpp
@@ -71,8 +71,11 @@ static bool openFile(std::string_view path, DX7Cartridge* data) {
 
 	error = data->load(readbuffer);
 	if (error != EMPTY_STRING) {
-		display->displayPopup(l10n::get(error), 3);
-		return false;
+		// Allow loading to continue for checksum errors, but fail for other errors
+		if (error != deluge::l10n::String::STRING_FOR_DX_ERROR_CHECKSUM_FAIL) {
+			display->displayPopup(l10n::get(error), 3);
+			return false;
+		}
 	}
 
 	return true;


### PR DESCRIPTION
### DX7 Cartridge Checksum Error Fix

### Problem
Previously, DX7 cartridge files with checksum errors would fail to load entirely, showing an error popup and preventing users from accessing potentially valid patch data. This was overly strict since checksum errors don't necessarily indicate unusable patch data - they might just indicate the file was created by less strict tools or has minor corruption that doesn't affect the actual synthesizer parameters.

### Solution
Allow DX7 cartridge files with checksum errors to load successfully while maintaining strict validation for all other SYSEX format issues.
What the Fix Does
Before: Any checksum error → File fails to load with popup error
After: Checksum error → File loads successfully (silently ignores checksum issue)

**Images:**
<img width="572" height="220" alt="image" src="https://github.com/user-attachments/assets/ef819191-121c-4309-9ed4-f59b7ecbd8e7" />

**Test Files:**
[DX7_test_files.zip](https://github.com/user-attachments/files/24043292/DX7_test_files.zip)

**Testing:**
Attached are example files for each issue...
bad_checksum.syx - When trying to load this file before the fix a checksum error message will be displayed.  After the fix the presets are loaded successfully.
missing_end.syx - This file is corrupted and missing the end.  Trying to load this file will display the missing end error message as expected.
missing_start.syx - This file is corrupted and missing the start.  Trying to load this file will display the missing start error message as expected.
too_small.syx - This file has a start and end but it too small. If a file is too small to hold even a single preset then it must be corrupted.  Trying to load this file will show the too small error.

**Other testing and validation:**
I have converted thousands of syx from DX7_AllTheWeb.zip file on the internet and they all converted successfully with this change.  Hundreds of the files had bad checksum values but could still be loaded.



