### PR TITLE
Don't highlight icon of vertical menu's selected item

### DIFF
--- a/src/deluge/gui/menu_item/modulator/destination.h
+++ b/src/deluge/gui/menu_item/modulator/destination.h
@@ -65,7 +65,7 @@ public:
 	}
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {
 		Sound* sound = static_cast<Sound*>(modControllable);
-		return (whichThing == 1 && sound->synthMode == SynthMode::FM);
+		return sound->synthMode == SynthMode::FM;
 	}
 };
 

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1522,10 +1522,10 @@ void Browser::currentFileDeleted() {
 void Browser::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	canvas.drawScreenTitle(title);
 
-	int32_t textStartX = 15;
-	int32_t iconStartX = 2;
+	int32_t textStartX = 14;
+	int32_t iconStartX = 1;
 	if (FlashStorage::accessibilityMenuHighlighting == MenuHighlighting::NO_INVERSION) {
-		textStartX += kTextSpacingX - 1;
+		textStartX += kTextSpacingX;
 		iconStartX = kTextSpacingX;
 	}
 

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -133,9 +133,7 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 	char const* displayName = enteredText.get();
 	int32_t displayStringLength = enteredText.getLength();
 
-	bool atVeryEnd = (enteredTextEditPos == displayStringLength);
-
-	int32_t xScrollHere = 0;
+	bool atVeryEnd = enteredTextEditPos == displayStringLength;
 
 	// Prevent being scrolled too far left.
 	int32_t minXScroll = std::min(enteredTextEditPos + 3 - maxNumChars, displayStringLength - maxNumChars + atVeryEnd);
@@ -159,7 +157,16 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 		}
 	}
 	else {
-		canvas.invertLeftEdgeForMenuHighlighting(0, xPixelMax, yPixel, yPixel + kTextSpacingY - 1);
+		int32_t highlightStartX;
+		int32_t scrollAmount = enteredTextEditPos - scrollPosHorizontal;
+		if (FlashStorage::accessibilityMenuHighlighting == MenuHighlighting::NO_INVERSION && !scrollAmount) {
+			highlightStartX = 0;
+		}
+		else {
+			highlightStartX = xPixel + kTextSpacingX * scrollAmount - 2;
+		}
+		canvas.invertLeftEdgeForMenuHighlighting(highlightStartX, xPixelMax - highlightStartX, yPixel,
+		                                         yPixel + kTextSpacingY - 1);
 	}
 }
 


### PR DESCRIPTION
Icons in a vertical menu's selected item are excluded from highlighting based on ok reza's feedback

Additionally, fixed a small bug where the fm modulator 2 destination parameter could be not displayed in a corresponding horizontal menu