### PR TITLE
Stem Export keeps MIDI Global Transpose Enabled - Arrange View

### DIFF
--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -29,6 +29,7 @@
 #include "hid/led/indicator_leds.h"
 #include "model/clip/clip.h"
 #include "model/clip/instrument_clip.h"
+#include "model/instrument/non_audio_instrument.h"
 #include "model/note/note_row.h"
 #include "model/song/song.h"
 #include "playback/mode/arrangement.h"
@@ -295,9 +296,12 @@ int32_t StemExport::disarmAllInstrumentsForStemExport(StemExportType stemExportT
 				}
 				// if we're not exporting the mixdown,
 				// then we want to mute all the tracks as we'll be exporting them individually
+				// except for the MIDI transpose track, which must remain enabled for proper transposition
 				if (stemExportType != StemExportType::MIXDOWN) {
 					output->mutedInArrangementModeBeforeStemExport = output->mutedInArrangementMode;
-					output->mutedInArrangementMode = true;
+					output->mutedInArrangementMode =
+					    (output->type != OutputType::MIDI_OUT
+					     || ((NonAudioInstrument*)output)->getChannel() != MIDI_CHANNEL_TRANSPOSE);
 				}
 				output->recordingInArrangement = false;
 				output->armedForRecording = false;


### PR DESCRIPTION
This fix keeps the midi transpose track enabled (unmuted) during stem export.  Currently stems are exported without the proper note transposition when internal midi transposition is used because the midi transpose track is muted.

This fix only applies to arranger view.  There is likely a similar issue for clip view stem export which would need to be fixed separately and require different handling since there can be multiple transpose clips within the same view for different clip colors.

**Testing:**
To test this create an arrangement with internal synths an a global midi transpose track.  Export stems before the fix with the midi transpose track enabled the listen to the stems to see that the transposition is not applied.  Redo the same with the fix and see that the transposition is applied.

Clip stem export has been crashing for me in community but it seems unrelated to this change since it crashes without it.
