### PR TITLE
Bugfix: default settings for upstream usb port 2

### DIFF
--- a/src/deluge/gui/l10n/english.json
+++ b/src/deluge/gui/l10n/english.json
@@ -202,6 +202,8 @@
     "STRING_FOR_V_TRIGGER": "V-trig",
     "STRING_FOR_S_TRIGGER": "S-trig",
     "STRING_FOR_CLOCK": "Clock",
+    "STRING_FOR_CLOCK_OUT": "Clock Out",
+    "STRING_FOR_CLOCK_IN": "Clock In",
     "STRING_FOR_RUN_SIGNAL": "Run signal",
     "STRING_FOR_GATE_MODE_TITLE": "Gate out* mode",
     "STRING_FOR_GATE_OUTPUT_1": "Gate output 1",

--- a/src/deluge/gui/l10n/g_english.cpp
+++ b/src/deluge/gui/l10n/g_english.cpp
@@ -215,6 +215,8 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_V_TRIGGER, "V-trig"},
         {STRING_FOR_S_TRIGGER, "S-trig"},
         {STRING_FOR_CLOCK, "Clock"},
+        {STRING_FOR_CLOCK_OUT, "Clock Out"},
+        {STRING_FOR_CLOCK_IN, "Clock In"},
         {STRING_FOR_RUN_SIGNAL, "Run signal"},
         {STRING_FOR_GATE_MODE_TITLE, "Gate out* mode"},
         {STRING_FOR_GATE_OUTPUT_1, "Gate output 1"},

--- a/src/deluge/gui/l10n/g_seven_segment.cpp
+++ b/src/deluge/gui/l10n/g_seven_segment.cpp
@@ -110,6 +110,8 @@ PLACE_SDRAM_DATA Language seven_segment{
         {STRING_FOR_V_TRIGGER, "VTRI"},
         {STRING_FOR_S_TRIGGER, "STRI"},
         {STRING_FOR_CLOCK, "CLK"},
+        {STRING_FOR_CLOCK_OUT, "CLKO"},
+        {STRING_FOR_CLOCK_IN, "CLKI"},
         {STRING_FOR_RUN_SIGNAL, "RUN"},
         {STRING_FOR_GATE_MODE_TITLE, ""},
         {STRING_FOR_GATE_OUTPUT_1, "OUT1"},

--- a/src/deluge/gui/l10n/seven_segment.json
+++ b/src/deluge/gui/l10n/seven_segment.json
@@ -114,6 +114,9 @@
         "STRING_FOR_V_TRIGGER": "VTRI",
         "STRING_FOR_S_TRIGGER": "STRI",
         "STRING_FOR_CLOCK": "CLK",
+        "STRING_FOR_CLOCK_OUT": "CLKO",
+        "STRING_FOR_CLOCK_IN": "CLKI",
+
         "STRING_FOR_RUN_SIGNAL": "RUN",
 
         "STRING_FOR_GATE_MODE_TITLE": "",

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -215,6 +215,8 @@ enum class String : size_t {
 	STRING_FOR_V_TRIGGER,
 	STRING_FOR_S_TRIGGER,
 	STRING_FOR_CLOCK,
+	STRING_FOR_CLOCK_OUT,
+	STRING_FOR_CLOCK_IN,
 	STRING_FOR_RUN_SIGNAL,
 
 	// gui/menu_item/gate/selection.h

--- a/src/deluge/gui/menu_item/midi/device_receive_clock.h
+++ b/src/deluge/gui/menu_item/midi/device_receive_clock.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2014-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+#include "gui/menu_item/toggle.h"
+#include "gui/ui/sound_editor.h"
+#include "io/midi/midi_device.h"
+#include "io/midi/midi_device_manager.h"
+
+namespace deluge::gui::menu_item::midi {
+class ReceiveClock final : public Toggle {
+public:
+	using Toggle::Toggle;
+	void readCurrentValue() override { this->setValue(soundEditor.currentMIDICable->receiveClock); }
+	void writeCurrentValue() override {
+		soundEditor.currentMIDICable->receiveClock = this->getValue();
+		MIDIDeviceManager::anyChangesToSave = true;
+	}
+};
+} // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -96,6 +96,7 @@
 #include "gui/menu_item/midi/device.h"
 #include "gui/menu_item/midi/device_definition/linked.h"
 #include "gui/menu_item/midi/device_definition/submenu.h"
+#include "gui/menu_item/midi/device_receive_clock.h"
 #include "gui/menu_item/midi/device_send_clock.h"
 #include "gui/menu_item/midi/devices.h"
 #include "gui/menu_item/midi/follow/follow_channel.h"
@@ -1086,13 +1087,15 @@ Submenu midiCommandsMenu{
 // MIDI device submenu - for after we've selected which device we want it for
 
 midi::DefaultVelocityToLevel defaultVelocityToLevelMenu{STRING_FOR_VELOCITY};
-midi::SendClock sendClockMenu{STRING_FOR_CLOCK};
+midi::SendClock sendClockMenu{STRING_FOR_CLOCK_OUT};
+midi::ReceiveClock receiveClockMenu{STRING_FOR_CLOCK_IN};
 midi::Device midiDeviceMenu{
     EMPTY_STRING,
     {
         &mpe::directionSelectorMenu,
         &defaultVelocityToLevelMenu,
         &sendClockMenu,
+        &receiveClockMenu,
     },
 };
 

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -33,6 +33,7 @@ extern "C" {
 MIDICable::MIDICable() {
 	connectionFlags = 0;
 	sendClock = true;
+	receiveClock = true;
 	defaultVelocityToLevel = 0; // Means none set.
 
 	// These defaults for MPE are prescribed in the MPE standard. Wish we had the same for regular MIDI
@@ -204,6 +205,10 @@ void MIDICable::readFromFile(Deserializer& reader) {
 			sendClock = reader.readTagOrAttributeValueInt();
 		}
 
+		else if (!strcmp(tagName, "receiveClock")) {
+			receiveClock = reader.readTagOrAttributeValueInt();
+		}
+
 		reader.exitTag();
 	}
 }
@@ -214,6 +219,7 @@ void MIDICable::writeDefinitionAttributesToFile(Serializer& writer) {
 		writer.writeAttribute("defaultVolumeVelocitySensitivity", defaultVelocityToLevel);
 	}
 	writer.writeAttribute("sendClock", sendClock);
+	writer.writeAttribute("receiveClock", receiveClock);
 }
 
 void MIDICable::writeToFile(Serializer& writer, char const* tagName) {

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -90,6 +90,8 @@ public:
  * See MIDIDeviceManager or midiengine.cpp for details
  */
 
+enum class clock_setting { NONE, RECEIVE, SEND, BOTH };
+
 /// A MIDI cable connection. Stores all state specific to a given cable and its contained ports and channels.
 class MIDICable {
 public:
@@ -152,7 +154,8 @@ public:
 	// 0 if not connected. For USB devices, the bits signal a connection of the corresponding connectedUSBMIDIDevices[].
 	// Of course there'll usually just be one bit set, unless two of the same device are connected.
 	uint8_t connectionFlags;
-	bool sendClock; // whether to send clocks to this device
+	bool sendClock;    // whether to send clocks to this device
+	bool receiveClock; // whether to receive clocks from this device
 	uint8_t incomingSysexBuffer[1024];
 	int32_t incomingSysexPos = 0;
 

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -321,7 +321,7 @@ void MidiEngine::midiMessageReceived(MIDICable& cable, uint8_t statusType, uint8
 	uint8_t originalStatusType = statusType;
 	uint8_t originalData2 = data2;
 
-	if (statusType == 0x0F) {
+	if (statusType == 0x0F && cable.receiveClock) {
 		if (channel == 0x02) {
 			if (currentSong) {
 				playbackHandler.positionPointerReceived(data1, data2);

--- a/src/deluge/io/midi/root_complex/usb_peripheral.cpp
+++ b/src/deluge/io/midi/root_complex/usb_peripheral.cpp
@@ -65,6 +65,8 @@ MIDIRootComplexUSBPeripheral::MIDIRootComplexUSBPeripheral() : cables_{0, 1, 2} 
 		port.mpeLowerZoneLastMemberChannel = 7;
 		port.mpeUpperZoneLastMemberChannel = 8;
 	}
+
+	cable_two->receiveClock = false;
 }
 
 MIDIRootComplexUSBPeripheral::~MIDIRootComplexUSBPeripheral() {


### PR DESCRIPTION
If the usb device file fails to be read  (like switching between stable/alpha/nightly) then port 2 would be set to the same as port 1, all non MPE. Set it up to be MPE as intended so that it works as intuitively as possible in this case

Also adds a clock receive toggle to fix the common case of doubled clock speeds