### PR TITLE
Bugfix: send note off before replacing note in case of duplicate

### DIFF
--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -531,6 +531,11 @@ void MelodicInstrument::beginAuditioningForNote(ModelStack* modelStack, int32_t 
 	if (!activeClip) {
 		return;
 	}
+	if (isNoteAuditioning(note)) {
+		//@todo this could definitely be handled better. Ideally we track both notes.
+		// if we don't do this then duplicate mpe notes get stuck
+		endAuditioningForNote(modelStack, note, 64);
+	}
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = modelStack->addTimelineCounter(activeClip);
 	ModelStackWithNoteRow* modelStackWithNoteRow =
 	    ((InstrumentClip*)activeClip)->getNoteRowForYNote(note, modelStackWithTimelineCounter);


### PR DESCRIPTION
When both sending and receiving from MPE the deluge could cause dropped notes when the same note code is sent on two different channels. Easy fix is turning off the first note (matches what the internal synth engine does). 