### PR TITLE
Fix bug with patch cable menu items being not properly set up sometimes in a horizontal menu

### DIFF
--- a/src/deluge/gui/menu_item/horizontal_menu.h
+++ b/src/deluge/gui/menu_item/horizontal_menu.h
@@ -54,9 +54,9 @@ public:
 	void renderOLED() override;
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
 	void endSession() override;
+	bool focusChild(const MenuItem* child) override;
 
 	virtual bool hasItem(const MenuItem* item);
-	virtual void setCurrentItem(const MenuItem* item);
 	decltype(items)& getItems() { return items; }
 	MenuItem* getCurrentItem() const { return *current_item_; }
 
@@ -81,6 +81,7 @@ private:
 	static void renderPageCounters(const Paging& paging);
 	static void renderColumnLabel(MenuItem* menuItem, int32_t labelY, int32_t slotStartX, int32_t slotWidth,
 	                              bool isSelected);
+	static void initializeItem(MenuItem* menuItem);
 
 	double currentKnobSpeed{0.0};
 	double calcNextKnobSpeed(int8_t offset);

--- a/src/deluge/gui/menu_item/horizontal_menu_group.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu_group.cpp
@@ -205,13 +205,4 @@ bool HorizontalMenuGroup::hasItem(const MenuItem* item) {
 	return std::ranges::any_of(menus_, [&](auto menu) { return menu->hasItem(item); });
 }
 
-void HorizontalMenuGroup::setCurrentItem(const MenuItem* item) {
-	for (auto* menu : menus_) {
-		current_item_ = std::ranges::find(menu->items, item);
-		if (current_item_ != menu->items.end()) {
-			return;
-		}
-	}
-}
-
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/horizontal_menu_group.h
+++ b/src/deluge/gui/menu_item/horizontal_menu_group.h
@@ -33,7 +33,6 @@ public:
 	void beginSession(MenuItem* navigatedBackwardFrom) override;
 	void endSession() override;
 	bool hasItem(const MenuItem* item) override;
-	void setCurrentItem(const MenuItem* item) override;
 
 protected:
 	void renderMenuItems(std::span<MenuItem*> items, const MenuItem* currentItem) override;


### PR DESCRIPTION
As title says, if a menu item is a patch cable menu item, we need to call checkPermissionToBeginSession on it, otherwise the actual patch cable that we're controlling can be random