### PR TITLE
Reduce firmware size/ Move data and bss from internal to external (nightly)

### DIFF
--- a/src/deluge/drivers/ssi/ssi.c
+++ b/src/deluge/drivers/ssi/ssi.c
@@ -20,10 +20,9 @@
 #include "RZA1/system/iodefines/ssif_iodefine.h"
 #include "definitions.h"
 
+// note: don't put these buffers in external ram as they are used for rendering audio
 int32_t ssiTxBuffer[SSI_TX_BUFFER_NUM_SAMPLES * NUM_MONO_OUTPUT_CHANNELS] __attribute__((aligned(CACHE_LINE_SIZE)));
-
-PLACE_SDRAM_DATA int32_t ssiRxBuffer[SSI_RX_BUFFER_NUM_SAMPLES * NUM_MONO_INPUT_CHANNELS]
-    __attribute__((aligned(CACHE_LINE_SIZE)));
+int32_t ssiRxBuffer[SSI_RX_BUFFER_NUM_SAMPLES * NUM_MONO_INPUT_CHANNELS] __attribute__((aligned(CACHE_LINE_SIZE)));
 
 const uint32_t ssiDmaTxLinkDescriptor[] __attribute__((aligned(CACHE_LINE_SIZE))) = {
     0b1101,                                                                          // Header

--- a/src/deluge/gui/l10n/g_english.cpp
+++ b/src/deluge/gui/l10n/g_english.cpp
@@ -12,7 +12,7 @@
 // clang-format off
 namespace deluge::l10n::built_in {
 using enum String;
-PLACE_SDRAM_DATA Language english{
+PLACE_SDRAM_RODATA Language english{
     "English",
     {
         {EMPTY_STRING, ""},

--- a/src/deluge/gui/l10n/g_seven_segment.cpp
+++ b/src/deluge/gui/l10n/g_seven_segment.cpp
@@ -12,7 +12,7 @@
 // clang-format off
 namespace deluge::l10n::built_in {
 using enum String;
-PLACE_SDRAM_DATA Language seven_segment{
+PLACE_SDRAM_RODATA Language seven_segment{
     "Seven Segment",
     {
         {STRING_FOR_ERROR_INSUFFICIENT_RAM, "RAM"},

--- a/src/deluge/gui/l10n/generate.py
+++ b/src/deluge/gui/l10n/generate.py
@@ -23,7 +23,7 @@ using enum String;\n"""
 
     type_name = input["type_name"]
     language_name = input["language_name"]
-    output.write(f"PLACE_SDRAM_DATA Language {type_name}{{\n")
+    output.write(f"PLACE_SDRAM_RODATA Language {type_name}{{\n")
     output.write(f'    "{language_name}",\n')
     output.write("    {\n")
 

--- a/src/deluge/gui/menu_item/dx/param.cpp
+++ b/src/deluge/gui/menu_item/dx/param.cpp
@@ -252,26 +252,27 @@ bool DxParam::potentialShortcutPadAction(int32_t x, int32_t y, bool on) {
 	return true;
 }
 
-const char* desc_op_long[] = {"env rate1",   "env rate2",  "env rate3",  "env rate4",     "env level1",  "env level2",
-                              "env level3",  "env level4", "breakpoint", "left depth",    "right depth", "left curve",
-                              "right curve", "rate scale", "ampmod",     "velocity sens", "level",       "mode",
-                              "coarse",      "fine",       "detune"};
-const char* desc_op_short[] = {"rat1",   "rat2",      "rat3",     "rat4",     "lvl1",     "lvl2",     "lvl3",
-                               "lvl4",   "brkp",      "le depth", "ri depth", "le curve", "ri curve", "rate scale",
-                               "ampmod", "velo sens", "levl",     "mode",     "coar",     "fine",     "detune"};
+PLACE_SDRAM_RODATA const char* desc_op_long[] = {
+    "env rate1",  "env rate2",     "env rate3",  "env rate4",   "env level1", "env level2",  "env level3",
+    "env level4", "breakpoint",    "left depth", "right depth", "left curve", "right curve", "rate scale",
+    "ampmod",     "velocity sens", "level",      "mode",        "coarse",     "fine",        "detune"};
 
-const char* desc_global_long[]{"DX7 pitch R1", "DX7 pitch R2",     "DX7 pitch R3",  "DX7 pitch R4",  "DX7 pitch l1",
-                               "DX7 pitch l2", "DX7 pitch l3",     "DX7 pitch l4",  "DX7 algorithm", "DX7 feedback",
-                               "DX7 osc Sync", "DX7 LFO rate",     "DX7 LFO delay", "DX7 LFO pitch", "DX7 LFO amp",
-                               "DX7 LFO sync", "DX7 LFO waveform", "DX7 pitch sens"};
+PLACE_SDRAM_RODATA const char* desc_op_short[] = {
+    "rat1",     "rat2",     "rat3",       "rat4",   "lvl1",      "lvl2", "lvl3", "lvl4", "brkp", "le depth", "ri depth",
+    "le curve", "ri curve", "rate scale", "ampmod", "velo sens", "levl", "mode", "coar", "fine", "detune"};
 
-const char* desc_global_short[]{"piR1",       "piR2",      "piR3",    "piR4",     "pil1",     "pil2",
-                                "pil3",       "pil4",      "algo",    "fdbk",     "oscSync",  "LFO rate",
-                                " LFO delay", "LFO pitch", "LFO amp", "LFO sync", "LFO wave", "pitch sens"};
+PLACE_SDRAM_RODATA const char* desc_global_long[] = {
+    "DX7 pitch R1",  "DX7 pitch R2",  "DX7 pitch R3",  "DX7 pitch R4", "DX7 pitch l1",     "DX7 pitch l2",
+    "DX7 pitch l3",  "DX7 pitch l4",  "DX7 algorithm", "DX7 feedback", "DX7 osc Sync",     "DX7 LFO rate",
+    "DX7 LFO delay", "DX7 LFO pitch", "DX7 LFO amp",   "DX7 LFO sync", "DX7 LFO waveform", "DX7 pitch sens"};
 
-const char* curves[]{"lin-", "exp-", "exp+", "lin+", "????"};
-const char* shapes_long[]{"tri", "saw down", "saw up", "square", "sin", "s-hold"};
-const char* shapes_short[]{"tri", "sawd", "sawu", "sqre", "sin", "shld"};
+PLACE_SDRAM_RODATA const char* desc_global_short[] = {
+    "piR1", "piR2",    "piR3",     "piR4",       "pil1",      "pil2",    "pil3",     "pil4",     "algo",
+    "fdbk", "oscSync", "LFO rate", " LFO delay", "LFO pitch", "LFO amp", "LFO sync", "LFO wave", "pitch sens"};
+
+PLACE_SDRAM_RODATA const char* curves[] = {"lin-", "exp-", "exp+", "lin+", "????"};
+PLACE_SDRAM_RODATA const char* shapes_long[] = {"tri", "saw down", "saw up", "square", "sin", "s-hold"};
+PLACE_SDRAM_RODATA const char* shapes_short[] = {"tri", "sawd", "sawu", "sqre", "sin", "shld"};
 
 [[nodiscard]] std::string_view DxParam::getTitle() const {
 	static char buffer[25];

--- a/src/deluge/gui/ui/keyboard/chords.cpp
+++ b/src/deluge/gui/ui/keyboard/chords.cpp
@@ -126,186 +126,186 @@ int8_t ChordList::validateChordNo(int8_t chordNo) {
 	return chordNo;
 }
 // ChordList
-PLACE_SDRAM_DATA const Chord kEmptyChord = {"", NoteSet({ROOT}), {{0, NONE, NONE, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMajor = {"M",
-                                       NoteSet({ROOT, MAJ3, P5}),
-                                       {{ROOT, MAJ3, P5, NONE, NONE, NONE, NONE},
-                                        {ROOT, OCT + MAJ3, P5, NONE, NONE, NONE, NONE},
-                                        {ROOT, OCT + MAJ3, P5, -OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor = {"-",
-                                       NoteSet({ROOT, MIN3, P5}),
-                                       {{ROOT, MIN3, P5, NONE, NONE, NONE, NONE},
-                                        {ROOT, OCT + MIN3, P5, NONE, NONE, NONE, NONE},
-                                        {ROOT, OCT + MIN3, P5, -OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kDim = {"DIM",
-                                     NoteSet({ROOT, MIN3, DIM5}),
-                                     {{ROOT, MIN3, DIM5, NONE, NONE, NONE, NONE},
-                                      {ROOT, OCT + MIN3, DIM5, NONE, NONE, NONE, NONE},
-                                      {ROOT, OCT + MIN3, DIM5, -OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kFullDim = {
+PLACE_SDRAM_RODATA const Chord kEmptyChord = {"", NoteSet({ROOT}), {{0, NONE, NONE, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMajor = {"M",
+                                         NoteSet({ROOT, MAJ3, P5}),
+                                         {{ROOT, MAJ3, P5, NONE, NONE, NONE, NONE},
+                                          {ROOT, OCT + MAJ3, P5, NONE, NONE, NONE, NONE},
+                                          {ROOT, OCT + MAJ3, P5, -OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor = {"-",
+                                         NoteSet({ROOT, MIN3, P5}),
+                                         {{ROOT, MIN3, P5, NONE, NONE, NONE, NONE},
+                                          {ROOT, OCT + MIN3, P5, NONE, NONE, NONE, NONE},
+                                          {ROOT, OCT + MIN3, P5, -OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kDim = {"DIM",
+                                       NoteSet({ROOT, MIN3, DIM5}),
+                                       {{ROOT, MIN3, DIM5, NONE, NONE, NONE, NONE},
+                                        {ROOT, OCT + MIN3, DIM5, NONE, NONE, NONE, NONE},
+                                        {ROOT, OCT + MIN3, DIM5, -OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kFullDim = {
     "FULLDIM", NoteSet({ROOT, MIN3, DIM5, DIM7}), {{ROOT, MIN3, DIM5, DIM7, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kAug = {"AUG",
-                                     NoteSet({ROOT, MIN3, AUG5}),
-                                     {{ROOT, MIN3, AUG5, NONE, NONE, NONE, NONE},
-                                      {ROOT, OCT + MIN3, AUG5, NONE, NONE, NONE, NONE},
-                                      {ROOT, OCT + MIN3, AUG5, -OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kSus2 = {"SUS2",
-                                      NoteSet({ROOT, MAJ2, P5}),
-                                      {{ROOT, MAJ2, P5, NONE, NONE, NONE, NONE},
-                                       {ROOT, MAJ2 + OCT, P5, NONE, NONE, NONE, NONE},
-                                       {ROOT, MAJ2 + OCT, P5, -OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kSus4 = {"SUS4",
-                                      NoteSet({ROOT, P4, P5}),
-                                      {{ROOT, P4, P5, NONE, NONE, NONE, NONE},
-                                       {ROOT, P4 + OCT, P5, NONE, NONE, NONE, NONE},
-                                       {ROOT, P4 + OCT, P5, -OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord k7 = {"7",
-                                   NoteSet({ROOT, MAJ3, P5, MIN7}),
-                                   {{ROOT, MAJ3, P5, MIN7, NONE, NONE, NONE},
-                                    {ROOT, MAJ3 + OCT, P5, MIN7, NONE, NONE, NONE},
-                                    {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord k7Sus4 = {"7SUS4",
-                                       NoteSet({ROOT, P4, P5, MIN7}),
-                                       {{ROOT, P4, P5, MIN7, NONE, NONE, NONE},
-                                        {ROOT, P4 + OCT, P5, MIN7, NONE, NONE, NONE},
-                                        {ROOT, P4 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord k7Sus2 = {"7SUS2",
-                                       NoteSet({ROOT, MAJ2, P5, MIN7}),
-                                       {{ROOT, MAJ2, P5, MIN7, NONE, NONE, NONE},
-                                        {ROOT, MAJ2 + OCT, P5, MIN7, NONE, NONE, NONE},
-                                        {ROOT, MAJ2 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kM7 = {"M7",
-                                    NoteSet({ROOT, MAJ3, P5, MAJ7}),
-                                    {{ROOT, MAJ3, P5, MAJ7, NONE, NONE, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MAJ7, NONE, NONE, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor7 = {"-7",
-                                        NoteSet({ROOT, MIN3, P5, MIN7}),
-                                        {{ROOT, MIN3, P5, MIN7, NONE, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5, MIN7, NONE, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor2 = {"-2",
-                                        NoteSet({ROOT, MIN3, P5, MAJ2}),
-                                        {{ROOT, MIN3, P5, MAJ2, NONE, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5, MAJ2, NONE, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5 + OCT, MAJ2, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor4 = {"-4",
-                                        NoteSet({ROOT, MIN3, P5, P4}),
-                                        {{ROOT, MIN3, P5, P4, NONE, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5, P4, NONE, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5 + OCT, P4, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinorMaj7 = {"-M7",
-                                           NoteSet({ROOT, MIN3, P5, MAJ7}),
-                                           {{ROOT, MIN3, P5, MAJ7, NONE, NONE, NONE},
-                                            {ROOT, MIN3 + OCT, P5, MAJ7, NONE, NONE, NONE},
-                                            {ROOT, MIN3 + OCT, P5, MAJ7 + OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor7b5 = {"-7" FLAT_CHAR_STR "5",
-                                          NoteSet({ROOT, MIN3, DIM5, MIN7}),
-                                          {{ROOT, MIN3, DIM5, MIN7, NONE, NONE, NONE},
-                                           {ROOT, MIN3 + OCT, DIM5, MIN7, NONE, NONE, NONE},
-                                           {ROOT, MIN3 + OCT, DIM5, MIN7 + OCT, NONE, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor9b5 = {
+PLACE_SDRAM_RODATA const Chord kAug = {"AUG",
+                                       NoteSet({ROOT, MIN3, AUG5}),
+                                       {{ROOT, MIN3, AUG5, NONE, NONE, NONE, NONE},
+                                        {ROOT, OCT + MIN3, AUG5, NONE, NONE, NONE, NONE},
+                                        {ROOT, OCT + MIN3, AUG5, -OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kSus2 = {"SUS2",
+                                        NoteSet({ROOT, MAJ2, P5}),
+                                        {{ROOT, MAJ2, P5, NONE, NONE, NONE, NONE},
+                                         {ROOT, MAJ2 + OCT, P5, NONE, NONE, NONE, NONE},
+                                         {ROOT, MAJ2 + OCT, P5, -OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kSus4 = {"SUS4",
+                                        NoteSet({ROOT, P4, P5}),
+                                        {{ROOT, P4, P5, NONE, NONE, NONE, NONE},
+                                         {ROOT, P4 + OCT, P5, NONE, NONE, NONE, NONE},
+                                         {ROOT, P4 + OCT, P5, -OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord k7 = {"7",
+                                     NoteSet({ROOT, MAJ3, P5, MIN7}),
+                                     {{ROOT, MAJ3, P5, MIN7, NONE, NONE, NONE},
+                                      {ROOT, MAJ3 + OCT, P5, MIN7, NONE, NONE, NONE},
+                                      {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord k7Sus4 = {"7SUS4",
+                                         NoteSet({ROOT, P4, P5, MIN7}),
+                                         {{ROOT, P4, P5, MIN7, NONE, NONE, NONE},
+                                          {ROOT, P4 + OCT, P5, MIN7, NONE, NONE, NONE},
+                                          {ROOT, P4 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord k7Sus2 = {"7SUS2",
+                                         NoteSet({ROOT, MAJ2, P5, MIN7}),
+                                         {{ROOT, MAJ2, P5, MIN7, NONE, NONE, NONE},
+                                          {ROOT, MAJ2 + OCT, P5, MIN7, NONE, NONE, NONE},
+                                          {ROOT, MAJ2 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kM7 = {"M7",
+                                      NoteSet({ROOT, MAJ3, P5, MAJ7}),
+                                      {{ROOT, MAJ3, P5, MAJ7, NONE, NONE, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MAJ7, NONE, NONE, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor7 = {"-7",
+                                          NoteSet({ROOT, MIN3, P5, MIN7}),
+                                          {{ROOT, MIN3, P5, MIN7, NONE, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5, MIN7, NONE, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5, MIN7 + OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor2 = {"-2",
+                                          NoteSet({ROOT, MIN3, P5, MAJ2}),
+                                          {{ROOT, MIN3, P5, MAJ2, NONE, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5, MAJ2, NONE, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5 + OCT, MAJ2, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor4 = {"-4",
+                                          NoteSet({ROOT, MIN3, P5, P4}),
+                                          {{ROOT, MIN3, P5, P4, NONE, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5, P4, NONE, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5 + OCT, P4, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinorMaj7 = {"-M7",
+                                             NoteSet({ROOT, MIN3, P5, MAJ7}),
+                                             {{ROOT, MIN3, P5, MAJ7, NONE, NONE, NONE},
+                                              {ROOT, MIN3 + OCT, P5, MAJ7, NONE, NONE, NONE},
+                                              {ROOT, MIN3 + OCT, P5, MAJ7 + OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor7b5 = {"-7" FLAT_CHAR_STR "5",
+                                            NoteSet({ROOT, MIN3, DIM5, MIN7}),
+                                            {{ROOT, MIN3, DIM5, MIN7, NONE, NONE, NONE},
+                                             {ROOT, MIN3 + OCT, DIM5, MIN7, NONE, NONE, NONE},
+                                             {ROOT, MIN3 + OCT, DIM5, MIN7 + OCT, NONE, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor9b5 = {
     "-9" FLAT_CHAR_STR "5", NoteSet({ROOT, MIN3, DIM5, MIN7, MAJ2}), {{ROOT, MIN3, DIM5, MIN7, MAJ9, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor7b5b9 = {"-7" FLAT_CHAR_STR "5" FLAT_CHAR_STR "9",
-                                            NoteSet({ROOT, MIN3, DIM5, MIN7, MIN2}),
-                                            {{ROOT, MIN3, DIM5, MIN7, MIN9, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord k9 = {"9",
-                                   NoteSet({ROOT, MAJ3, P5, MIN7, MAJ2}),
-                                   {{ROOT, MAJ3, P5, MIN7, MAJ9, NONE, NONE},
-                                    {ROOT, MAJ3 + OCT, P5, MIN7, MAJ9, NONE, NONE},
-                                    {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, MAJ9, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kM9 = {"M9",
-                                    NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2}),
-                                    {{ROOT, MAJ3, P5, MAJ7, MAJ9, NONE, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, NONE, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor9 = {"-9",
-                                        NoteSet({ROOT, MIN3, P5, MIN7, MAJ2}),
-                                        {{ROOT, MIN3, P5, MIN7, MAJ9, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5, MIN7, MAJ9, NONE, NONE},
-                                         {ROOT, MIN3 + OCT, P5, MIN7 + OCT, MAJ9, NONE, NONE}}};
-PLACE_SDRAM_DATA const Chord k11 = {"11",
-                                    NoteSet({ROOT, MAJ3, P5, MIN7, MAJ2, P4}),
-                                    {{ROOT, MAJ3, P5, MIN7, MAJ9, P11, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MIN7, MAJ9, P11, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, MAJ9, P11, NONE}}};
-PLACE_SDRAM_DATA const Chord kM11 = {"M11",
-                                     NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2, P4}),
-                                     {{ROOT, MAJ3, P5, MAJ7, MAJ9, P11, NONE},
-                                      {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, P11, NONE},
-                                      {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, P11, NONE}}};
-PLACE_SDRAM_DATA const Chord kMinor11 = {"-11",
-                                         NoteSet({ROOT, MIN3, P5, MIN7, MAJ2, P4}),
-                                         {{ROOT, MIN3, P5, MIN7, MAJ9, P11, NONE},
-                                          {{ROOT, P4, MIN7, MIN3 + OCT, P5 + OCT, NONE, NONE}, "SO WHAT"},
-                                          {ROOT, MIN3 + OCT, P5, MIN7, MAJ9, P11, NONE},
-                                          {ROOT, MIN3 + OCT, P5, MIN7 + OCT, MAJ9, P11, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor7b5b9 = {"-7" FLAT_CHAR_STR "5" FLAT_CHAR_STR "9",
+                                              NoteSet({ROOT, MIN3, DIM5, MIN7, MIN2}),
+                                              {{ROOT, MIN3, DIM5, MIN7, MIN9, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord k9 = {"9",
+                                     NoteSet({ROOT, MAJ3, P5, MIN7, MAJ2}),
+                                     {{ROOT, MAJ3, P5, MIN7, MAJ9, NONE, NONE},
+                                      {ROOT, MAJ3 + OCT, P5, MIN7, MAJ9, NONE, NONE},
+                                      {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, MAJ9, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kM9 = {"M9",
+                                      NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2}),
+                                      {{ROOT, MAJ3, P5, MAJ7, MAJ9, NONE, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, NONE, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor9 = {"-9",
+                                          NoteSet({ROOT, MIN3, P5, MIN7, MAJ2}),
+                                          {{ROOT, MIN3, P5, MIN7, MAJ9, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5, MIN7, MAJ9, NONE, NONE},
+                                           {ROOT, MIN3 + OCT, P5, MIN7 + OCT, MAJ9, NONE, NONE}}};
+PLACE_SDRAM_RODATA const Chord k11 = {"11",
+                                      NoteSet({ROOT, MAJ3, P5, MIN7, MAJ2, P4}),
+                                      {{ROOT, MAJ3, P5, MIN7, MAJ9, P11, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MIN7, MAJ9, P11, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, MAJ9, P11, NONE}}};
+PLACE_SDRAM_RODATA const Chord kM11 = {"M11",
+                                       NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2, P4}),
+                                       {{ROOT, MAJ3, P5, MAJ7, MAJ9, P11, NONE},
+                                        {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, P11, NONE},
+                                        {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, P11, NONE}}};
+PLACE_SDRAM_RODATA const Chord kMinor11 = {"-11",
+                                           NoteSet({ROOT, MIN3, P5, MIN7, MAJ2, P4}),
+                                           {{ROOT, MIN3, P5, MIN7, MAJ9, P11, NONE},
+                                            {{ROOT, P4, MIN7, MIN3 + OCT, P5 + OCT, NONE, NONE}, "SO WHAT"},
+                                            {ROOT, MIN3 + OCT, P5, MIN7, MAJ9, P11, NONE},
+                                            {ROOT, MIN3 + OCT, P5, MIN7 + OCT, MAJ9, P11, NONE}}};
 // 11th are often omitted in 13th and M13th chords because they clash with the major 3rd
 // if anything, the 11th is often played as a #11
-PLACE_SDRAM_DATA const Chord k13 = {"13",
-                                    NoteSet({ROOT, MAJ3, P5, MIN7, MAJ2, MAJ6}),
-                                    {{ROOT, MAJ3, P5, MIN7, MAJ9, MAJ13, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MIN7, MAJ9, MAJ13, NONE},
-                                     {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, MAJ9, MAJ13, NONE}}};
-PLACE_SDRAM_DATA const Chord kM13 = {"M13",
-                                     NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2, MAJ6}),
-                                     {{ROOT, MAJ3, P5, MAJ7, MAJ9, MAJ13, NONE},
-                                      {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, MAJ13, NONE},
-                                      {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, MAJ13, NONE}}};
-PLACE_SDRAM_DATA const Chord kM13Sharp11 = {"M13#11",
-                                            NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2, MAJ6, AUG4}),
-                                            {{ROOT, MAJ3, P5, MAJ7, MAJ9, MAJ13, AUG11},
-                                             {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, MAJ13, AUG11},
-                                             {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, MAJ13, AUG11}}};
-PLACE_SDRAM_DATA const Chord kMinor13 = {"-13",
-                                         NoteSet({ROOT, MIN3, P5, MIN7, MAJ2, P4, MAJ6}),
-                                         {{ROOT, MIN3, P5, MIN7, MAJ9, P11, MAJ13},
-                                          {ROOT, MIN3 + OCT, P5, MIN7, MAJ9, P11, MAJ13},
-                                          {ROOT, MIN3 + OCT, P5, MIN7 + OCT, MAJ9, P11, MAJ13}}};
-PLACE_SDRAM_DATA const Chord k6 = {"6",
-                                   NoteSet({ROOT, MAJ3, P5, MAJ6}),
-                                   {
-                                       {ROOT, MAJ3, P5, MAJ6, NONE, NONE, NONE},
-                                   }};
-PLACE_SDRAM_DATA const Chord k2 = {"2",
-                                   NoteSet({ROOT, MAJ3, P5, MAJ2}),
-                                   {
-                                       {{ROOT, MAJ3 - OCT, P5, MAJ2, NONE, NONE, NONE}, "Open Mu"},
-                                       {{ROOT, MAJ3, P5, MAJ2, NONE, NONE, NONE}, "Mu"},
-                                   }};
-PLACE_SDRAM_DATA const Chord k69 = {"69",
-                                    NoteSet({ROOT, MAJ3, P5, MAJ6, MAJ2}),
-                                    {
-                                        {ROOT, MAJ3, P5, MAJ6, MAJ9, NONE, NONE},
-                                    }};
-PLACE_SDRAM_DATA const Chord kMinor6 = {"-6",
-                                        NoteSet({ROOT, MIN3, P5, MAJ6}),
-                                        {
-                                            {ROOT, MIN3, P5, MAJ6, NONE, NONE, NONE},
-                                        }};
+PLACE_SDRAM_RODATA const Chord k13 = {"13",
+                                      NoteSet({ROOT, MAJ3, P5, MIN7, MAJ2, MAJ6}),
+                                      {{ROOT, MAJ3, P5, MIN7, MAJ9, MAJ13, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MIN7, MAJ9, MAJ13, NONE},
+                                       {ROOT, MAJ3 + OCT, P5, MIN7 + OCT, MAJ9, MAJ13, NONE}}};
+PLACE_SDRAM_RODATA const Chord kM13 = {"M13",
+                                       NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2, MAJ6}),
+                                       {{ROOT, MAJ3, P5, MAJ7, MAJ9, MAJ13, NONE},
+                                        {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, MAJ13, NONE},
+                                        {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, MAJ13, NONE}}};
+PLACE_SDRAM_RODATA const Chord kM13Sharp11 = {"M13#11",
+                                              NoteSet({ROOT, MAJ3, P5, MAJ7, MAJ2, MAJ6, AUG4}),
+                                              {{ROOT, MAJ3, P5, MAJ7, MAJ9, MAJ13, AUG11},
+                                               {ROOT, MAJ3 + OCT, P5, MAJ7, MAJ9, MAJ13, AUG11},
+                                               {ROOT, MAJ3 + OCT, P5, MAJ7 + OCT, MAJ9, MAJ13, AUG11}}};
+PLACE_SDRAM_RODATA const Chord kMinor13 = {"-13",
+                                           NoteSet({ROOT, MIN3, P5, MIN7, MAJ2, P4, MAJ6}),
+                                           {{ROOT, MIN3, P5, MIN7, MAJ9, P11, MAJ13},
+                                            {ROOT, MIN3 + OCT, P5, MIN7, MAJ9, P11, MAJ13},
+                                            {ROOT, MIN3 + OCT, P5, MIN7 + OCT, MAJ9, P11, MAJ13}}};
+PLACE_SDRAM_RODATA const Chord k6 = {"6",
+                                     NoteSet({ROOT, MAJ3, P5, MAJ6}),
+                                     {
+                                         {ROOT, MAJ3, P5, MAJ6, NONE, NONE, NONE},
+                                     }};
+PLACE_SDRAM_RODATA const Chord k2 = {"2",
+                                     NoteSet({ROOT, MAJ3, P5, MAJ2}),
+                                     {
+                                         {{ROOT, MAJ3 - OCT, P5, MAJ2, NONE, NONE, NONE}, "Open Mu"},
+                                         {{ROOT, MAJ3, P5, MAJ2, NONE, NONE, NONE}, "Mu"},
+                                     }};
+PLACE_SDRAM_RODATA const Chord k69 = {"69",
+                                      NoteSet({ROOT, MAJ3, P5, MAJ6, MAJ2}),
+                                      {
+                                          {ROOT, MAJ3, P5, MAJ6, MAJ9, NONE, NONE},
+                                      }};
+PLACE_SDRAM_RODATA const Chord kMinor6 = {"-6",
+                                          NoteSet({ROOT, MIN3, P5, MAJ6}),
+                                          {
+                                              {ROOT, MIN3, P5, MAJ6, NONE, NONE, NONE},
+                                          }};
 
-PLACE_SDRAM_DATA const std::array<const Chord, 10> majorChords = {kMajor, kM7,  k6,    k2,    k69,
-                                                                  kM9,    kM13, kSus4, kSus2, kM13Sharp11};
+PLACE_SDRAM_RODATA const std::array<const Chord, 10> majorChords = {kMajor, kM7,  k6,    k2,    k69,
+                                                                    kM9,    kM13, kSus4, kSus2, kM13Sharp11};
 
-PLACE_SDRAM_DATA const std::array<const Chord, 10> minorChords = {
+PLACE_SDRAM_RODATA const std::array<const Chord, 10> minorChords = {
     kMinor, kMinor7, kMinor4, kMinor11, kMinor6, kMinor2, kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord,
 };
 
-PLACE_SDRAM_DATA const std::array<const Chord, 10> dominantChords = {
+PLACE_SDRAM_RODATA const std::array<const Chord, 10> dominantChords = {
     kMajor, k7, k69, k9, k7Sus4, k7Sus2, k11, k13, kEmptyChord, kEmptyChord,
 };
 
-PLACE_SDRAM_DATA const std::array<const Chord, 10> diminishedChords = {
+PLACE_SDRAM_RODATA const std::array<const Chord, 10> diminishedChords = {
     kDim,        kMinor7b5,   kMinor7b5b9, kEmptyChord, kEmptyChord,
     kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord,
 };
 
-PLACE_SDRAM_DATA const std::array<const Chord, 10> augmentedChords = {
+PLACE_SDRAM_RODATA const std::array<const Chord, 10> augmentedChords = {
     kAug,        kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord,
     kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord,
 };
 
-PLACE_SDRAM_DATA const std::array<const Chord, 10> otherChords = {
+PLACE_SDRAM_RODATA const std::array<const Chord, 10> otherChords = {
     kSus2,       kSus4,       kEmptyChord, kEmptyChord, kEmptyChord,
     kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord, kEmptyChord,
 };

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -57,14 +57,14 @@ PLACE_SDRAM_BSS deluge::gui::ui::keyboard::KeyboardScreen keyboardScreen{};
 
 namespace deluge::gui::ui::keyboard {
 
-PLACE_SDRAM_DATA layout::KeyboardLayoutIsomorphic keyboard_layout_isomorphic{};
-PLACE_SDRAM_DATA layout::KeyboardLayoutVelocityDrums keyboard_layout_velocity_drums{};
-PLACE_SDRAM_DATA layout::KeyboardLayoutInKey keyboard_layout_in_key{};
-PLACE_SDRAM_DATA layout::KeyboardLayoutPiano keyboard_layout_piano{};
-PLACE_SDRAM_DATA layout::KeyboardLayoutChord keyboard_layout_chord{};
-PLACE_SDRAM_DATA layout::KeyboardLayoutChordLibrary keyboard_layout_chord_library{};
-PLACE_SDRAM_DATA layout::KeyboardLayoutNorns keyboard_layout_norns{};
-PLACE_SDRAM_DATA std::array<KeyboardLayout*, KeyboardLayoutType::KeyboardLayoutTypeMaxElement> layout_list = {nullptr};
+PLACE_SDRAM_BSS layout::KeyboardLayoutIsomorphic keyboard_layout_isomorphic{};
+PLACE_SDRAM_BSS layout::KeyboardLayoutVelocityDrums keyboard_layout_velocity_drums{};
+PLACE_SDRAM_BSS layout::KeyboardLayoutInKey keyboard_layout_in_key{};
+PLACE_SDRAM_BSS layout::KeyboardLayoutPiano keyboard_layout_piano{};
+PLACE_SDRAM_BSS layout::KeyboardLayoutChord keyboard_layout_chord{};
+PLACE_SDRAM_BSS layout::KeyboardLayoutChordLibrary keyboard_layout_chord_library{};
+PLACE_SDRAM_BSS layout::KeyboardLayoutNorns keyboard_layout_norns{};
+PLACE_SDRAM_BSS std::array<KeyboardLayout*, KeyboardLayoutType::KeyboardLayoutTypeMaxElement> layout_list = {nullptr};
 
 KeyboardScreen::KeyboardScreen() {
 	layout_list[KeyboardLayoutType::KeyboardLayoutTypeIsomorphic] = &keyboard_layout_isomorphic;

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -240,151 +240,162 @@ namespace params = deluge::modulation::params;
 #include "gui/menu_item/midi/y_axis_to_cc1.h"
 
 // Arp --------------------------------------------------------------------------------------
-arpeggiator::PresetMode arpPresetModeMenu{STRING_FOR_PRESET, STRING_FOR_ARP_PRESET_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::PresetMode arpPresetModeMenu{STRING_FOR_PRESET, STRING_FOR_ARP_PRESET_MENU_TITLE};
 // Rate
-arpeggiator::Mode arpModeMenu{STRING_FOR_ENABLED, STRING_FOR_ARP_MODE_MENU_TITLE};
-arpeggiator::Sync arpSyncMenu{STRING_FOR_SYNC, STRING_FOR_ARP_SYNC_MENU_TITLE};
-arpeggiator::Rate arpRateMenu{STRING_FOR_RATE, STRING_FOR_ARP_RATE_MENU_TITLE, params::GLOBAL_ARP_RATE};
-arpeggiator::KitRate arpKitRateMenu{STRING_FOR_RATE, STRING_FOR_ARP_RATE_MENU_TITLE, params::UNPATCHED_ARP_RATE};
-arpeggiator::midi_cv::Rate arpRateMenuMIDIOrCV{STRING_FOR_RATE, STRING_FOR_ARP_RATE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::Mode arpModeMenu{STRING_FOR_ENABLED, STRING_FOR_ARP_MODE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::Sync arpSyncMenu{STRING_FOR_SYNC, STRING_FOR_ARP_SYNC_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::Rate arpRateMenu{STRING_FOR_RATE, STRING_FOR_ARP_RATE_MENU_TITLE, params::GLOBAL_ARP_RATE};
+PLACE_SDRAM_BSS arpeggiator::KitRate arpKitRateMenu{STRING_FOR_RATE, STRING_FOR_ARP_RATE_MENU_TITLE,
+                                                    params::UNPATCHED_ARP_RATE};
+PLACE_SDRAM_BSS arpeggiator::midi_cv::Rate arpRateMenuMIDIOrCV{STRING_FOR_RATE, STRING_FOR_ARP_RATE_MENU_TITLE};
 // Pattern
-arpeggiator::Octaves arpOctavesMenu{STRING_FOR_NUMBER_OF_OCTAVES, STRING_FOR_ARP_OCTAVES_MENU_TITLE};
-arpeggiator::OctaveMode arpOctaveModeMenu{STRING_FOR_OCTAVE_MODE, STRING_FOR_ARP_OCTAVE_MODE_MENU_TITLE};
-arpeggiator::OctaveModeToNoteMode arpeggiator::arpOctaveModeToNoteModeMenu{STRING_FOR_OCTAVE_MODE,
-                                                                           STRING_FOR_ARP_OCTAVE_MODE_MENU_TITLE};
-arpeggiator::OctaveModeToNoteModeForDrums arpeggiator::arpOctaveModeToNoteModeMenuForDrums{
+PLACE_SDRAM_BSS arpeggiator::Octaves arpOctavesMenu{STRING_FOR_NUMBER_OF_OCTAVES, STRING_FOR_ARP_OCTAVES_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::OctaveMode arpOctaveModeMenu{STRING_FOR_OCTAVE_MODE,
+                                                          STRING_FOR_ARP_OCTAVE_MODE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::OctaveModeToNoteMode arpeggiator::arpOctaveModeToNoteModeMenu{
     STRING_FOR_OCTAVE_MODE, STRING_FOR_ARP_OCTAVE_MODE_MENU_TITLE};
-arpeggiator::NoteMode arpNoteModeMenu{STRING_FOR_NOTE_MODE, STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
-arpeggiator::NoteModeForDrums arpNoteModeMenuForDrums{STRING_FOR_NOTE_MODE, STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
-arpeggiator::NoteModeFromOctaveMode arpeggiator::arpNoteModeFromOctaveModeMenu{STRING_FOR_NOTE_MODE,
-                                                                               STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
-arpeggiator::NoteModeFromOctaveModeForDrums arpeggiator::arpNoteModeFromOctaveModeMenuForDrums{
+PLACE_SDRAM_BSS arpeggiator::OctaveModeToNoteModeForDrums arpeggiator::arpOctaveModeToNoteModeMenuForDrums{
+    STRING_FOR_OCTAVE_MODE, STRING_FOR_ARP_OCTAVE_MODE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::NoteMode arpNoteModeMenu{STRING_FOR_NOTE_MODE, STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::NoteModeForDrums arpNoteModeMenuForDrums{STRING_FOR_NOTE_MODE,
+                                                                      STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::NoteModeFromOctaveMode arpeggiator::arpNoteModeFromOctaveModeMenu{
     STRING_FOR_NOTE_MODE, STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
-arpeggiator::ChordType arpChordSimulatorMenuKit{STRING_FOR_CHORD_SIMULATOR, STRING_FOR_ARP_CHORD_SIMULATOR_MENU_TITLE};
-arpeggiator::StepRepeat arpStepRepeatMenu{STRING_FOR_STEP_REPEAT, STRING_FOR_ARP_STEP_REPEAT_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::NoteModeFromOctaveModeForDrums arpeggiator::arpNoteModeFromOctaveModeMenuForDrums{
+    STRING_FOR_NOTE_MODE, STRING_FOR_ARP_NOTE_MODE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::ChordType arpChordSimulatorMenuKit{STRING_FOR_CHORD_SIMULATOR,
+                                                                STRING_FOR_ARP_CHORD_SIMULATOR_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::StepRepeat arpStepRepeatMenu{STRING_FOR_STEP_REPEAT,
+                                                          STRING_FOR_ARP_STEP_REPEAT_MENU_TITLE};
 // Note and rhythm settings
-arpeggiator::ArpUnpatchedParam arpGateMenu{STRING_FOR_GATE, STRING_FOR_ARP_GATE_MENU_TITLE, params::UNPATCHED_ARP_GATE,
-                                           RenderingStyle::LENGTH_SLIDER};
-arpeggiator::midi_cv::Gate arpGateMenuMIDIOrCV{STRING_FOR_GATE, STRING_FOR_ARP_GATE_MENU_TITLE};
-arpeggiator::Rhythm arpRhythmMenu{STRING_FOR_RHYTHM, STRING_FOR_ARP_RHYTHM_MENU_TITLE, params::UNPATCHED_ARP_RHYTHM};
-arpeggiator::midi_cv::Rhythm arpRhythmMenuMIDIOrCV{STRING_FOR_RHYTHM, STRING_FOR_ARP_RHYTHM_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::ArpUnpatchedParam arpGateMenu{STRING_FOR_GATE, STRING_FOR_ARP_GATE_MENU_TITLE,
+                                                           params::UNPATCHED_ARP_GATE, RenderingStyle::LENGTH_SLIDER};
+PLACE_SDRAM_BSS arpeggiator::midi_cv::Gate arpGateMenuMIDIOrCV{STRING_FOR_GATE, STRING_FOR_ARP_GATE_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::Rhythm arpRhythmMenu{STRING_FOR_RHYTHM, STRING_FOR_ARP_RHYTHM_MENU_TITLE,
+                                                  params::UNPATCHED_ARP_RHYTHM};
+PLACE_SDRAM_BSS arpeggiator::midi_cv::Rhythm arpRhythmMenuMIDIOrCV{STRING_FOR_RHYTHM, STRING_FOR_ARP_RHYTHM_MENU_TITLE};
 
-arpeggiator::SequenceLength arpSequenceLengthMenu{STRING_FOR_SEQUENCE_LENGTH, STRING_FOR_ARP_SEQUENCE_LENGTH_MENU_TITLE,
-                                                  params::UNPATCHED_ARP_SEQUENCE_LENGTH};
-arpeggiator::midi_cv::SequenceLength arpSequenceLengthMenuMIDIOrCV{STRING_FOR_SEQUENCE_LENGTH,
-                                                                   STRING_FOR_ARP_SEQUENCE_LENGTH_MENU_TITLE};
+PLACE_SDRAM_BSS arpeggiator::SequenceLength arpSequenceLengthMenu{
+    STRING_FOR_SEQUENCE_LENGTH, STRING_FOR_ARP_SEQUENCE_LENGTH_MENU_TITLE, params::UNPATCHED_ARP_SEQUENCE_LENGTH};
+PLACE_SDRAM_BSS arpeggiator::midi_cv::SequenceLength arpSequenceLengthMenuMIDIOrCV{
+    STRING_FOR_SEQUENCE_LENGTH, STRING_FOR_ARP_SEQUENCE_LENGTH_MENU_TITLE};
 
-arpeggiator::IncludeInKitArp arpIncludeInKitArpMenu{STRING_FOR_INCLUDE_IN_KIT_ARP, STRING_FOR_INCLUDE_IN_KIT_ARP};
+PLACE_SDRAM_BSS arpeggiator::IncludeInKitArp arpIncludeInKitArpMenu{STRING_FOR_INCLUDE_IN_KIT_ARP,
+                                                                    STRING_FOR_INCLUDE_IN_KIT_ARP};
 
 // Randomizer ---------------------------------
-randomizer::RandomizerLock randomizerLockMenu{STRING_FOR_RANDOMIZER_LOCK, STRING_FOR_ARP_RANDOMIZER_LOCK_TITLE};
-randomizer::RandomizerUnpatchedParam spreadGateMenu{STRING_FOR_SPREAD_GATE, STRING_FOR_ARP_SPREAD_GATE_MENU_TITLE,
-                                                    params::UNPATCHED_ARP_SPREAD_GATE, BAR};
-randomizer::midi_cv::SpreadGate spreadGateMenuMIDIOrCV{STRING_FOR_SPREAD_GATE, STRING_FOR_ARP_SPREAD_GATE_MENU_TITLE};
-randomizer::RandomizerSoundOnlyUnpatchedParam spreadOctaveMenu{
+PLACE_SDRAM_BSS randomizer::RandomizerLock randomizerLockMenu{STRING_FOR_RANDOMIZER_LOCK,
+                                                              STRING_FOR_ARP_RANDOMIZER_LOCK_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam spreadGateMenu{
+    STRING_FOR_SPREAD_GATE, STRING_FOR_ARP_SPREAD_GATE_MENU_TITLE, params::UNPATCHED_ARP_SPREAD_GATE, BAR};
+PLACE_SDRAM_BSS randomizer::midi_cv::SpreadGate spreadGateMenuMIDIOrCV{STRING_FOR_SPREAD_GATE,
+                                                                       STRING_FOR_ARP_SPREAD_GATE_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerSoundOnlyUnpatchedParam spreadOctaveMenu{
     STRING_FOR_SPREAD_OCTAVE, STRING_FOR_ARP_SPREAD_OCTAVE_MENU_TITLE, params::UNPATCHED_ARP_SPREAD_OCTAVE, BAR};
-randomizer::midi_cv::SpreadOctave spreadOctaveMenuMIDIOrCV{STRING_FOR_SPREAD_OCTAVE,
-                                                           STRING_FOR_ARP_SPREAD_OCTAVE_MENU_TITLE};
-randomizer::RandomizerUnpatchedParam spreadVelocityMenu{
+PLACE_SDRAM_BSS randomizer::midi_cv::SpreadOctave spreadOctaveMenuMIDIOrCV{STRING_FOR_SPREAD_OCTAVE,
+                                                                           STRING_FOR_ARP_SPREAD_OCTAVE_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam spreadVelocityMenu{
     STRING_FOR_SPREAD_VELOCITY, STRING_FOR_SPREAD_VELOCITY_MENU_TITLE, params::UNPATCHED_SPREAD_VELOCITY, BAR};
-randomizer::midi_cv::SpreadVelocity spreadVelocityMenuMIDIOrCV{STRING_FOR_SPREAD_VELOCITY,
-                                                               STRING_FOR_SPREAD_VELOCITY_MENU_TITLE};
-randomizer::RandomizerUnpatchedParam ratchetAmountMenu{
+PLACE_SDRAM_BSS randomizer::midi_cv::SpreadVelocity spreadVelocityMenuMIDIOrCV{STRING_FOR_SPREAD_VELOCITY,
+                                                                               STRING_FOR_SPREAD_VELOCITY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam ratchetAmountMenu{
     STRING_FOR_NUMBER_OF_RATCHETS, STRING_FOR_ARP_RATCHETS_MENU_TITLE, params::UNPATCHED_ARP_RATCHET_AMOUNT, BAR};
-randomizer::midi_cv::RatchetAmount ratchetAmountMenuMIDIOrCV{STRING_FOR_NUMBER_OF_RATCHETS,
-                                                             STRING_FOR_ARP_RATCHETS_MENU_TITLE};
-randomizer::RandomizerUnpatchedParam ratchetProbabilityMenu{STRING_FOR_RATCHET_PROBABILITY,
-                                                            STRING_FOR_ARP_RATCHET_PROBABILITY_MENU_TITLE,
-                                                            params::UNPATCHED_ARP_RATCHET_PROBABILITY, PERCENT};
-randomizer::midi_cv::RatchetProbability ratchetProbabilityMenuMIDIOrCV{STRING_FOR_RATCHET_PROBABILITY,
-                                                                       STRING_FOR_ARP_RATCHET_PROBABILITY_MENU_TITLE};
-randomizer::RandomizerNonKitSoundUnpatchedParam chordPolyphonyMenu{
+PLACE_SDRAM_BSS randomizer::midi_cv::RatchetAmount ratchetAmountMenuMIDIOrCV{STRING_FOR_NUMBER_OF_RATCHETS,
+                                                                             STRING_FOR_ARP_RATCHETS_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam ratchetProbabilityMenu{
+    STRING_FOR_RATCHET_PROBABILITY, STRING_FOR_ARP_RATCHET_PROBABILITY_MENU_TITLE,
+    params::UNPATCHED_ARP_RATCHET_PROBABILITY, PERCENT};
+PLACE_SDRAM_BSS randomizer::midi_cv::RatchetProbability ratchetProbabilityMenuMIDIOrCV{
+    STRING_FOR_RATCHET_PROBABILITY, STRING_FOR_ARP_RATCHET_PROBABILITY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerNonKitSoundUnpatchedParam chordPolyphonyMenu{
     STRING_FOR_CHORD_POLYPHONY, STRING_FOR_ARP_CHORD_POLYPHONY_MENU_TITLE, params::UNPATCHED_ARP_CHORD_POLYPHONY, BAR};
-randomizer::midi_cv::ChordPolyphony chordPolyphonyMenuMIDIOrCV{STRING_FOR_CHORD_POLYPHONY,
-                                                               STRING_FOR_ARP_CHORD_POLYPHONY_MENU_TITLE};
-randomizer::RandomizerNonKitSoundUnpatchedParam chordProbabilityMenu{STRING_FOR_CHORD_PROBABILITY,
-                                                                     STRING_FOR_ARP_CHORD_PROBABILITY_MENU_TITLE,
-                                                                     params::UNPATCHED_ARP_CHORD_PROBABILITY, PERCENT};
-randomizer::midi_cv::ChordProbability chordProbabilityMenuMIDIOrCV{STRING_FOR_CHORD_PROBABILITY,
-                                                                   STRING_FOR_ARP_CHORD_PROBABILITY_MENU_TITLE};
-randomizer::RandomizerUnpatchedParam randomizerNoteProbabilityMenu{
+PLACE_SDRAM_BSS randomizer::midi_cv::ChordPolyphony chordPolyphonyMenuMIDIOrCV{
+    STRING_FOR_CHORD_POLYPHONY, STRING_FOR_ARP_CHORD_POLYPHONY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerNonKitSoundUnpatchedParam chordProbabilityMenu{
+    STRING_FOR_CHORD_PROBABILITY, STRING_FOR_ARP_CHORD_PROBABILITY_MENU_TITLE, params::UNPATCHED_ARP_CHORD_PROBABILITY,
+    PERCENT};
+PLACE_SDRAM_BSS randomizer::midi_cv::ChordProbability chordProbabilityMenuMIDIOrCV{
+    STRING_FOR_CHORD_PROBABILITY, STRING_FOR_ARP_CHORD_PROBABILITY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam randomizerNoteProbabilityMenu{
     STRING_FOR_NOTE_PROBABILITY, STRING_FOR_NOTE_PROBABILITY_MENU_TITLE, params::UNPATCHED_NOTE_PROBABILITY, PERCENT};
-randomizer::midi_cv::NoteProbability randomizerNoteProbabilityMenuMIDIOrCV{STRING_FOR_NOTE_PROBABILITY,
-                                                                           STRING_FOR_NOTE_PROBABILITY_MENU_TITLE};
-randomizer::RandomizerUnpatchedParam swapProbabilityMenu{STRING_FOR_SWAP_PROBABILITY,
-                                                         STRING_FOR_ARP_SWAP_PROBABILITY_MENU_TITLE,
-                                                         params::UNPATCHED_ARP_SWAP_PROBABILITY, PERCENT};
-randomizer::midi_cv::SwapProbability swapProbabilityMenuMIDIOrCV{STRING_FOR_SWAP_PROBABILITY,
-                                                                 STRING_FOR_ARP_SWAP_PROBABILITY_MENU_TITLE};
-randomizer::RandomizerUnpatchedParam bassProbabilityMenu{STRING_FOR_BASS_PROBABILITY,
-                                                         STRING_FOR_ARP_BASS_PROBABILITY_MENU_TITLE,
-                                                         params::UNPATCHED_ARP_BASS_PROBABILITY, PERCENT};
-randomizer::midi_cv::BassProbability bassProbabilityMenuMIDIOrCV{STRING_FOR_BASS_PROBABILITY,
-                                                                 STRING_FOR_ARP_BASS_PROBABILITY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::midi_cv::NoteProbability randomizerNoteProbabilityMenuMIDIOrCV{
+    STRING_FOR_NOTE_PROBABILITY, STRING_FOR_NOTE_PROBABILITY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam swapProbabilityMenu{
+    STRING_FOR_SWAP_PROBABILITY, STRING_FOR_ARP_SWAP_PROBABILITY_MENU_TITLE, params::UNPATCHED_ARP_SWAP_PROBABILITY,
+    PERCENT};
+PLACE_SDRAM_BSS randomizer::midi_cv::SwapProbability swapProbabilityMenuMIDIOrCV{
+    STRING_FOR_SWAP_PROBABILITY, STRING_FOR_ARP_SWAP_PROBABILITY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam bassProbabilityMenu{
+    STRING_FOR_BASS_PROBABILITY, STRING_FOR_ARP_BASS_PROBABILITY_MENU_TITLE, params::UNPATCHED_ARP_BASS_PROBABILITY,
+    PERCENT};
+PLACE_SDRAM_BSS randomizer::midi_cv::BassProbability bassProbabilityMenuMIDIOrCV{
+    STRING_FOR_BASS_PROBABILITY, STRING_FOR_ARP_BASS_PROBABILITY_MENU_TITLE};
 
-randomizer::RandomizerUnpatchedParam glideProbabilityMenu{STRING_FOR_GLIDE_PROBABILITY,
-                                                          STRING_FOR_ARP_GLIDE_PROBABILITY_MENU_TITLE,
-                                                          params::UNPATCHED_ARP_GLIDE_PROBABILITY, PERCENT};
-randomizer::midi_cv::GlideProbability glideProbabilityMenuMIDIOrCV{STRING_FOR_GLIDE_PROBABILITY,
-                                                                   STRING_FOR_ARP_GLIDE_PROBABILITY_MENU_TITLE};
-randomizer::RandomizerUnpatchedParam reverseProbabilityMenu{STRING_FOR_REVERSE_PROBABILITY,
-                                                            STRING_FOR_REVERSE_PROBABILITY_MENU_TITLE,
-                                                            params::UNPATCHED_REVERSE_PROBABILITY, PERCENT};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam glideProbabilityMenu{
+    STRING_FOR_GLIDE_PROBABILITY, STRING_FOR_ARP_GLIDE_PROBABILITY_MENU_TITLE, params::UNPATCHED_ARP_GLIDE_PROBABILITY,
+    PERCENT};
+PLACE_SDRAM_BSS randomizer::midi_cv::GlideProbability glideProbabilityMenuMIDIOrCV{
+    STRING_FOR_GLIDE_PROBABILITY, STRING_FOR_ARP_GLIDE_PROBABILITY_MENU_TITLE};
+PLACE_SDRAM_BSS randomizer::RandomizerUnpatchedParam reverseProbabilityMenu{
+    STRING_FOR_REVERSE_PROBABILITY, STRING_FOR_REVERSE_PROBABILITY_MENU_TITLE, params::UNPATCHED_REVERSE_PROBABILITY,
+    PERCENT};
 
-HorizontalMenu randomizerMenu{STRING_FOR_RANDOMIZER,
-                              {// Lock
-                               &randomizerLockMenu,
-                               // Spreads
-                               &spreadGateMenu, &spreadGateMenuMIDIOrCV, &spreadOctaveMenu, &spreadOctaveMenuMIDIOrCV,
-                               &spreadVelocityMenu, &spreadVelocityMenuMIDIOrCV,
-                               // Ratchets: Amount
-                               &ratchetAmountMenu, &ratchetAmountMenuMIDIOrCV,
-                               // Ratchets: Probability
-                               &ratchetProbabilityMenu, &ratchetProbabilityMenuMIDIOrCV,
-                               // Chords: Polyphony
-                               &chordPolyphonyMenu, &chordPolyphonyMenuMIDIOrCV,
-                               // Chords: Probability
-                               &chordProbabilityMenu, &chordProbabilityMenuMIDIOrCV,
-                               // Note
-                               &randomizerNoteProbabilityMenu, &randomizerNoteProbabilityMenuMIDIOrCV,
-                               // Swap
-                               &swapProbabilityMenu, &swapProbabilityMenuMIDIOrCV,
-                               // Bass
-                               &bassProbabilityMenu, &bassProbabilityMenuMIDIOrCV,
-                               // Glide
-                               &glideProbabilityMenu, &glideProbabilityMenuMIDIOrCV,
-                               // Reverse
-                               &reverseProbabilityMenu}};
+PLACE_SDRAM_BSS HorizontalMenu randomizerMenu{STRING_FOR_RANDOMIZER,
+                                              {// Lock
+                                               &randomizerLockMenu,
+                                               // Spreads
+                                               &spreadGateMenu, &spreadGateMenuMIDIOrCV, &spreadOctaveMenu,
+                                               &spreadOctaveMenuMIDIOrCV, &spreadVelocityMenu,
+                                               &spreadVelocityMenuMIDIOrCV,
+                                               // Ratchets: Amount
+                                               &ratchetAmountMenu, &ratchetAmountMenuMIDIOrCV,
+                                               // Ratchets: Probability
+                                               &ratchetProbabilityMenu, &ratchetProbabilityMenuMIDIOrCV,
+                                               // Chords: Polyphony
+                                               &chordPolyphonyMenu, &chordPolyphonyMenuMIDIOrCV,
+                                               // Chords: Probability
+                                               &chordProbabilityMenu, &chordProbabilityMenuMIDIOrCV,
+                                               // Note
+                                               &randomizerNoteProbabilityMenu, &randomizerNoteProbabilityMenuMIDIOrCV,
+                                               // Swap
+                                               &swapProbabilityMenu, &swapProbabilityMenuMIDIOrCV,
+                                               // Bass
+                                               &bassProbabilityMenu, &bassProbabilityMenuMIDIOrCV,
+                                               // Glide
+                                               &glideProbabilityMenu, &glideProbabilityMenuMIDIOrCV,
+                                               // Reverse
+                                               &reverseProbabilityMenu}};
 
 // Arp: Basic
-HorizontalMenu arpBasicMenu{
+PLACE_SDRAM_BSS HorizontalMenu arpBasicMenu{
     STRING_FOR_BASIC, STRING_FOR_ARP_BASIC_MENU_TITLE, {&arpPresetModeMenu, &arpGateMenu, &arpSyncMenu, &arpRateMenu}};
-HorizontalMenu arpBasicMenuKit{STRING_FOR_BASIC,
-                               STRING_FOR_ARP_BASIC_MENU_TITLE,
-                               {&arpPresetModeMenu, &arpGateMenu, &arpSyncMenu, &arpKitRateMenu}};
-HorizontalMenu arpBasicMenuMIDIOrCV{STRING_FOR_BASIC,
-                                    STRING_FOR_ARP_BASIC_MENU_TITLE,
-                                    {&arpPresetModeMenu, &arpGateMenuMIDIOrCV, &arpSyncMenu, &arpRateMenuMIDIOrCV}};
+PLACE_SDRAM_BSS HorizontalMenu arpBasicMenuKit{STRING_FOR_BASIC,
+                                               STRING_FOR_ARP_BASIC_MENU_TITLE,
+                                               {&arpPresetModeMenu, &arpGateMenu, &arpSyncMenu, &arpKitRateMenu}};
+PLACE_SDRAM_BSS HorizontalMenu arpBasicMenuMIDIOrCV{
+    STRING_FOR_BASIC,
+    STRING_FOR_ARP_BASIC_MENU_TITLE,
+    {&arpPresetModeMenu, &arpGateMenuMIDIOrCV, &arpSyncMenu, &arpRateMenuMIDIOrCV}};
 
 // Arp: Pattern
-HorizontalMenu arpPatternMenu{STRING_FOR_PATTERN,
-                              STRING_FOR_ARP_PATTERN_MENU_TITLE,
-                              {// Pattern
-                               &arpOctavesMenu, &arpStepRepeatMenu, &arpOctaveModeMenu, &arpNoteModeMenu,
-                               &arpNoteModeMenuForDrums, &arpChordSimulatorMenuKit,
-                               // Note and rhythm settings
-                               &arpRhythmMenu, &arpRhythmMenuMIDIOrCV, &arpSequenceLengthMenu,
-                               &arpSequenceLengthMenuMIDIOrCV}};
+PLACE_SDRAM_BSS HorizontalMenu arpPatternMenu{STRING_FOR_PATTERN,
+                                              STRING_FOR_ARP_PATTERN_MENU_TITLE,
+                                              {// Pattern
+                                               &arpOctavesMenu, &arpStepRepeatMenu, &arpOctaveModeMenu,
+                                               &arpNoteModeMenu, &arpNoteModeMenuForDrums, &arpChordSimulatorMenuKit,
+                                               // Note and rhythm settings
+                                               &arpRhythmMenu, &arpRhythmMenuMIDIOrCV, &arpSequenceLengthMenu,
+                                               &arpSequenceLengthMenuMIDIOrCV}};
 
-HorizontalMenuGroup arpMenuGroup{{&arpBasicMenu, &arpPatternMenu}};
-HorizontalMenuGroup arpMenuGroupKit{{&arpBasicMenuKit, &arpPatternMenu}};
-HorizontalMenuGroup arpMenuGroupMIDIOrCV{{&arpBasicMenuMIDIOrCV, &arpPatternMenu}};
+PLACE_SDRAM_BSS HorizontalMenuGroup arpMenuGroup{{&arpBasicMenu, &arpPatternMenu}};
+PLACE_SDRAM_BSS HorizontalMenuGroup arpMenuGroupKit{{&arpBasicMenuKit, &arpPatternMenu}};
+PLACE_SDRAM_BSS HorizontalMenuGroup arpMenuGroupMIDIOrCV{{&arpBasicMenuMIDIOrCV, &arpPatternMenu}};
 
 // Arp: MPE
-arpeggiator::ArpMpeVelocity arpMpeVelocityMenu{STRING_FOR_VELOCITY, STRING_FOR_VELOCITY};
-submenu::ArpMpeSubmenu arpMpeMenu{STRING_FOR_MPE, {&arpMpeVelocityMenu}};
+PLACE_SDRAM_BSS arpeggiator::ArpMpeVelocity arpMpeVelocityMenu{STRING_FOR_VELOCITY, STRING_FOR_VELOCITY};
+PLACE_SDRAM_BSS submenu::ArpMpeSubmenu arpMpeMenu{STRING_FOR_MPE, {&arpMpeVelocityMenu}};
 
-Submenu arpMenu{
+PLACE_SDRAM_BSS Submenu arpMenu{
     STRING_FOR_ARPEGGIATOR,
     {
         // Mode
@@ -400,7 +411,7 @@ Submenu arpMenu{
     },
 };
 
-Submenu arpMenuMIDIOrCV{
+PLACE_SDRAM_BSS Submenu arpMenuMIDIOrCV{
     STRING_FOR_ARPEGGIATOR,
     {
         // Mode
@@ -416,7 +427,7 @@ Submenu arpMenuMIDIOrCV{
     },
 };
 
-Submenu kitArpMenu{
+PLACE_SDRAM_BSS Submenu kitArpMenu{
     STRING_FOR_KIT_ARPEGGIATOR,
     {
         // Mode
@@ -432,33 +443,38 @@ Submenu kitArpMenu{
 
 // Voice menu ----------------------------------------------------------------------------------------------------
 
-voice::PolyphonyType polyphonyMenu{STRING_FOR_POLYPHONY};
-voice::VoiceCount voice::polyphonicVoiceCountMenu{STRING_FOR_MAX_VOICES};
-voice::Portamento portaMenu{STRING_FOR_PORTAMENTO};
-voice::Priority priorityMenu{STRING_FOR_PRIORITY};
+PLACE_SDRAM_BSS voice::PolyphonyType polyphonyMenu{STRING_FOR_POLYPHONY};
+PLACE_SDRAM_BSS voice::VoiceCount voice::polyphonicVoiceCountMenu{STRING_FOR_MAX_VOICES};
+PLACE_SDRAM_BSS voice::Portamento portaMenu{STRING_FOR_PORTAMENTO};
+PLACE_SDRAM_BSS voice::Priority priorityMenu{STRING_FOR_PRIORITY};
 
-HorizontalMenu voiceMenu{STRING_FOR_VOICE,
-                         {&priorityMenu, &polyphonyMenu, &voice::polyphonicVoiceCountMenu, &portaMenu, &unisonMenu},
-                         HorizontalMenu::Layout::FIXED};
-HorizontalMenu voiceMenuWithoutUnison{STRING_FOR_VOICE,
-                                      {&priorityMenu, &polyphonyMenu, &voice::polyphonicVoiceCountMenu, &portaMenu},
-                                      HorizontalMenu::Layout::FIXED};
+PLACE_SDRAM_BSS HorizontalMenu voiceMenu{
+    STRING_FOR_VOICE,
+    {&priorityMenu, &polyphonyMenu, &voice::polyphonicVoiceCountMenu, &portaMenu, &unisonMenu},
+    HorizontalMenu::Layout::FIXED};
+PLACE_SDRAM_BSS HorizontalMenu voiceMenuWithoutUnison{
+    STRING_FOR_VOICE,
+    {&priorityMenu, &polyphonyMenu, &voice::polyphonicVoiceCountMenu, &portaMenu},
+    HorizontalMenu::Layout::FIXED};
 HorizontalMenuGroup voiceMenuGroup{{&unisonMenu, &voiceMenuWithoutUnison}};
 
 // Envelope 1-4 menu -----------------------------------------------------------------------------
-HorizontalMenuGroup envMenuGroup{{&env1Menu, &env2Menu, &env3Menu, &env4Menu}};
+PLACE_SDRAM_BSS HorizontalMenuGroup envMenuGroup{{&env1Menu, &env2Menu, &env3Menu, &env4Menu}};
 
 // LFO 1-4 menu -----------------------------------------------------------------------------
-HorizontalMenuGroup lfoMenuGroup{{&lfo1Menu, &lfo2Menu, &lfo3Menu, &lfo4Menu}};
+PLACE_SDRAM_BSS HorizontalMenuGroup lfoMenuGroup{{&lfo1Menu, &lfo2Menu, &lfo3Menu, &lfo4Menu}};
 
 // Mod FX ----------------------------------------------------------------------------------
-mod_fx::Type modFXTypeMenu{STRING_FOR_TYPE, STRING_FOR_MODFX_TYPE};
-mod_fx::Rate modFXRateMenu{STRING_FOR_RATE, STRING_FOR_MODFX_RATE, params::GLOBAL_MOD_FX_RATE};
-mod_fx::Feedback modFXFeedbackMenu{STRING_FOR_FEEDBACK, STRING_FOR_MODFX_FEEDBACK, params::UNPATCHED_MOD_FX_FEEDBACK};
-mod_fx::Depth_Patched modFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MODFX_DEPTH, params::GLOBAL_MOD_FX_DEPTH};
-mod_fx::Offset modFXOffsetMenu{STRING_FOR_OFFSET, STRING_FOR_MODFX_OFFSET, params::UNPATCHED_MOD_FX_OFFSET};
+PLACE_SDRAM_BSS mod_fx::Type modFXTypeMenu{STRING_FOR_TYPE, STRING_FOR_MODFX_TYPE};
+PLACE_SDRAM_BSS mod_fx::Rate modFXRateMenu{STRING_FOR_RATE, STRING_FOR_MODFX_RATE, params::GLOBAL_MOD_FX_RATE};
+PLACE_SDRAM_BSS mod_fx::Feedback modFXFeedbackMenu{STRING_FOR_FEEDBACK, STRING_FOR_MODFX_FEEDBACK,
+                                                   params::UNPATCHED_MOD_FX_FEEDBACK};
+PLACE_SDRAM_BSS mod_fx::Depth_Patched modFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MODFX_DEPTH,
+                                                     params::GLOBAL_MOD_FX_DEPTH};
+PLACE_SDRAM_BSS mod_fx::Offset modFXOffsetMenu{STRING_FOR_OFFSET, STRING_FOR_MODFX_OFFSET,
+                                               params::UNPATCHED_MOD_FX_OFFSET};
 
-submenu::ModFxHorizontalMenu modFXMenu{
+PLACE_SDRAM_BSS submenu::ModFxHorizontalMenu modFXMenu{
     STRING_FOR_MOD_FX,
     {
         &modFXTypeMenu,
@@ -470,14 +486,14 @@ submenu::ModFxHorizontalMenu modFXMenu{
 };
 
 // EQ -------------------------------------------------------------------------------------
-eq::EqUnpatchedParam bassMenu{STRING_FOR_BASS, params::UNPATCHED_BASS};
-eq::EqUnpatchedParam trebleMenu{STRING_FOR_TREBLE, params::UNPATCHED_TREBLE};
-eq::EqUnpatchedParam bassFreqMenu{STRING_FOR_BASS_FREQUENCY, STRING_FOR_BASS_FREQUENCY_SHORT,
-                                  params::UNPATCHED_BASS_FREQ};
-eq::EqUnpatchedParam trebleFreqMenu{STRING_FOR_TREBLE_FREQUENCY, STRING_FOR_TREBLE_FREQUENCY_SHORT,
-                                    params::UNPATCHED_TREBLE_FREQ};
+PLACE_SDRAM_BSS eq::EqUnpatchedParam bassMenu{STRING_FOR_BASS, params::UNPATCHED_BASS};
+PLACE_SDRAM_BSS eq::EqUnpatchedParam trebleMenu{STRING_FOR_TREBLE, params::UNPATCHED_TREBLE};
+PLACE_SDRAM_BSS eq::EqUnpatchedParam bassFreqMenu{STRING_FOR_BASS_FREQUENCY, STRING_FOR_BASS_FREQUENCY_SHORT,
+                                                  params::UNPATCHED_BASS_FREQ};
+PLACE_SDRAM_BSS eq::EqUnpatchedParam trebleFreqMenu{STRING_FOR_TREBLE_FREQUENCY, STRING_FOR_TREBLE_FREQUENCY_SHORT,
+                                                    params::UNPATCHED_TREBLE_FREQ};
 
-eq::EqMenu eqMenu{
+PLACE_SDRAM_BSS eq::EqMenu eqMenu{
     STRING_FOR_EQ,
     {
         &bassMenu,
@@ -488,13 +504,14 @@ eq::EqMenu eqMenu{
 };
 
 // Delay ---------------------------------------------------------------------------------
-delay::Amount delayFeedbackMenu{STRING_FOR_AMOUNT, STRING_FOR_DELAY_AMOUNT, params::GLOBAL_DELAY_FEEDBACK};
-patched_param::Integer delayRateMenu{STRING_FOR_RATE, STRING_FOR_DELAY_RATE, params::GLOBAL_DELAY_RATE};
-delay::PingPong delayPingPongMenu{STRING_FOR_PINGPONG, STRING_FOR_DELAY_PINGPONG};
-delay::Analog delayAnalogMenu{STRING_FOR_TYPE, STRING_FOR_DELAY_TYPE};
-delay::Sync delaySyncMenu{STRING_FOR_SYNC, STRING_FOR_DELAY_SYNC};
+PLACE_SDRAM_BSS delay::Amount delayFeedbackMenu{STRING_FOR_AMOUNT, STRING_FOR_DELAY_AMOUNT,
+                                                params::GLOBAL_DELAY_FEEDBACK};
+PLACE_SDRAM_BSS patched_param::Integer delayRateMenu{STRING_FOR_RATE, STRING_FOR_DELAY_RATE, params::GLOBAL_DELAY_RATE};
+PLACE_SDRAM_BSS delay::PingPong delayPingPongMenu{STRING_FOR_PINGPONG, STRING_FOR_DELAY_PINGPONG};
+PLACE_SDRAM_BSS delay::Analog delayAnalogMenu{STRING_FOR_TYPE, STRING_FOR_DELAY_TYPE};
+PLACE_SDRAM_BSS delay::Sync delaySyncMenu{STRING_FOR_SYNC, STRING_FOR_DELAY_SYNC};
 
-HorizontalMenu delayMenu{
+PLACE_SDRAM_BSS HorizontalMenu delayMenu{
     STRING_FOR_DELAY,
     {
         &delayFeedbackMenu,
@@ -506,20 +523,20 @@ HorizontalMenu delayMenu{
 };
 
 // Stutter ----------------------------------------------------------------------------------
-stutter::StutterDirection stutterDirectionMenu{STRING_FOR_DIRECTION, STRING_FOR_DIRECTION};
-stutter::QuantizedStutter stutterQuantizedMenu{STRING_FOR_QUANTIZE, STRING_FOR_QUANTIZE};
-stutter::Rate stutterRateMenu{STRING_FOR_RATE, STRING_FOR_STUTTER_RATE};
+PLACE_SDRAM_BSS stutter::StutterDirection stutterDirectionMenu{STRING_FOR_DIRECTION, STRING_FOR_DIRECTION};
+PLACE_SDRAM_BSS stutter::QuantizedStutter stutterQuantizedMenu{STRING_FOR_QUANTIZE, STRING_FOR_QUANTIZE};
+PLACE_SDRAM_BSS stutter::Rate stutterRateMenu{STRING_FOR_RATE, STRING_FOR_STUTTER_RATE};
 
-HorizontalMenu stutterMenu{STRING_FOR_STUTTER,
-                           {&stutterRateMenu, &stutterDirectionMenu, &stutterQuantizedMenu},
-                           HorizontalMenu::Layout::FIXED};
+PLACE_SDRAM_BSS HorizontalMenu stutterMenu{STRING_FOR_STUTTER,
+                                           {&stutterRateMenu, &stutterDirectionMenu, &stutterQuantizedMenu},
+                                           HorizontalMenu::Layout::FIXED};
 
 // Bend Ranges -------------------------------------------------------------------------------
 
-bend_range::Main mainBendRangeMenu{STRING_FOR_NORMAL};
-bend_range::PerFinger perFingerBendRangeMenu{STRING_FOR_POLY_FINGER_MPE};
+PLACE_SDRAM_BSS bend_range::Main mainBendRangeMenu{STRING_FOR_NORMAL};
+PLACE_SDRAM_BSS bend_range::PerFinger perFingerBendRangeMenu{STRING_FOR_POLY_FINGER_MPE};
 
-submenu::Bend bendMenu{
+PLACE_SDRAM_BSS submenu::Bend bendMenu{
     STRING_FOR_BEND_RANGE,
     {
         &mainBendRangeMenu,
@@ -529,56 +546,59 @@ submenu::Bend bendMenu{
 
 // Sidechain-----------------------------------------------------------------------
 
-sidechain::Send sidechainSendMenu{STRING_FOR_SEND_TO_SIDECHAIN, STRING_FOR_SEND_TO_SIDECH_MENU_TITLE};
-sidechain::VolumeShortcut sidechainVolumeShortcutMenu{STRING_FOR_VOLUME_DUCKING, params::GLOBAL_VOLUME_POST_REVERB_SEND,
-                                                      PatchSource::SIDECHAIN};
-sidechain::Sync sidechainSyncMenu{STRING_FOR_SYNC, STRING_FOR_SIDECHAIN_SYNC, false};
-sidechain::Attack sidechainAttackMenu{STRING_FOR_ATTACK, STRING_FOR_SIDECH_ATTACK_MENU_TITLE};
-sidechain::Release sidechainReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_SIDECH_RELEASE_MENU_TITLE};
-sidechain::Shape sidechainShapeMenu{STRING_FOR_SHAPE, STRING_FOR_SIDECH_SHAPE_MENU_TITLE,
-                                    params::UNPATCHED_SIDECHAIN_SHAPE};
+PLACE_SDRAM_BSS sidechain::Send sidechainSendMenu{STRING_FOR_SEND_TO_SIDECHAIN, STRING_FOR_SEND_TO_SIDECH_MENU_TITLE};
+PLACE_SDRAM_BSS sidechain::VolumeShortcut sidechainVolumeShortcutMenu{
+    STRING_FOR_VOLUME_DUCKING, params::GLOBAL_VOLUME_POST_REVERB_SEND, PatchSource::SIDECHAIN};
+PLACE_SDRAM_BSS sidechain::Sync sidechainSyncMenu{STRING_FOR_SYNC, STRING_FOR_SIDECHAIN_SYNC, false};
+PLACE_SDRAM_BSS sidechain::Attack sidechainAttackMenu{STRING_FOR_ATTACK, STRING_FOR_SIDECH_ATTACK_MENU_TITLE};
+PLACE_SDRAM_BSS sidechain::Release sidechainReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_SIDECH_RELEASE_MENU_TITLE};
+PLACE_SDRAM_BSS sidechain::Shape sidechainShapeMenu{STRING_FOR_SHAPE, STRING_FOR_SIDECH_SHAPE_MENU_TITLE,
+                                                    params::UNPATCHED_SIDECHAIN_SHAPE};
 
-HorizontalMenu sidechainMenu{STRING_FOR_SIDECHAIN,
-                             STRING_FOR_SIDECHAIN,
-                             {
-                                 &sidechainVolumeShortcutMenu,
-                                 &sidechainSyncMenu,
-                                 &sidechainShapeMenu,
-                                 &sidechainSendMenu,
-                                 &sidechainAttackMenu,
-                                 &sidechainReleaseMenu,
-                             }};
+PLACE_SDRAM_BSS HorizontalMenu sidechainMenu{STRING_FOR_SIDECHAIN,
+                                             STRING_FOR_SIDECHAIN,
+                                             {
+                                                 &sidechainVolumeShortcutMenu,
+                                                 &sidechainSyncMenu,
+                                                 &sidechainShapeMenu,
+                                                 &sidechainSendMenu,
+                                                 &sidechainAttackMenu,
+                                                 &sidechainReleaseMenu,
+                                             }};
 
 // Reverb sidechain -----------------------------------------------------------------------
 
-reverb::sidechain::Volume reverbSidechainVolumeMenu{STRING_FOR_VOLUME_DUCKING};
-sidechain::Sync reverbSidechainSyncMenu{STRING_FOR_SYNC, STRING_FOR_SIDECHAIN_SYNC, true};
-sidechain::Attack reverbSidechainAttackMenu{STRING_FOR_ATTACK, STRING_FOR_SIDECH_ATTACK_MENU_TITLE, true};
-sidechain::Release reverbSidechainReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_SIDECH_RELEASE_MENU_TITLE, true};
-reverb::sidechain::Shape reverbSidechainShapeMenu{STRING_FOR_SHAPE, STRING_FOR_SIDECH_SHAPE_MENU_TITLE};
+PLACE_SDRAM_BSS reverb::sidechain::Volume reverbSidechainVolumeMenu{STRING_FOR_VOLUME_DUCKING};
+PLACE_SDRAM_BSS sidechain::Sync reverbSidechainSyncMenu{STRING_FOR_SYNC, STRING_FOR_SIDECHAIN_SYNC, true};
+PLACE_SDRAM_BSS sidechain::Attack reverbSidechainAttackMenu{STRING_FOR_ATTACK, STRING_FOR_SIDECH_ATTACK_MENU_TITLE,
+                                                            true};
+PLACE_SDRAM_BSS sidechain::Release reverbSidechainReleaseMenu{STRING_FOR_RELEASE, STRING_FOR_SIDECH_RELEASE_MENU_TITLE,
+                                                              true};
+PLACE_SDRAM_BSS reverb::sidechain::Shape reverbSidechainShapeMenu{STRING_FOR_SHAPE, STRING_FOR_SIDECH_SHAPE_MENU_TITLE};
 
-HorizontalMenu reverbSidechainMenu{STRING_FOR_REVERB_SIDECHAIN,
-                                   STRING_FOR_REVERB_SIDECH_MENU_TITLE,
-                                   {
-                                       &reverbSidechainVolumeMenu,
-                                       &reverbSidechainShapeMenu,
-                                       &reverbSidechainAttackMenu,
-                                       &reverbSidechainReleaseMenu,
-                                       &reverbSidechainSyncMenu,
-                                   },
-                                   HorizontalMenu::FIXED};
+PLACE_SDRAM_BSS HorizontalMenu reverbSidechainMenu{STRING_FOR_REVERB_SIDECHAIN,
+                                                   STRING_FOR_REVERB_SIDECH_MENU_TITLE,
+                                                   {
+                                                       &reverbSidechainVolumeMenu,
+                                                       &reverbSidechainShapeMenu,
+                                                       &reverbSidechainAttackMenu,
+                                                       &reverbSidechainReleaseMenu,
+                                                       &reverbSidechainSyncMenu,
+                                                   },
+                                                   HorizontalMenu::FIXED};
 
 // Reverb ----------------------------------------------------------------------------------
-reverb::Amount reverbAmountMenu{STRING_FOR_AMOUNT, STRING_FOR_REVERB_AMOUNT, params::GLOBAL_REVERB_AMOUNT};
-reverb::RoomSize reverbRoomSizeMenu{STRING_FOR_ROOM_SIZE};
-reverb::Damping reverbDampingMenu{STRING_FOR_DAMPING};
-reverb::Width reverbWidthMenu{STRING_FOR_WIDTH, STRING_FOR_REVERB_WIDTH};
-reverb::Pan reverbPanMenu{STRING_FOR_PAN, STRING_FOR_REVERB_PAN};
-reverb::Model reverbModelMenu{STRING_FOR_MODEL};
-reverb::HPF reverbHPFMenu{STRING_FOR_HPF};
-reverb::LPF reverbLPFMenu{STRING_FOR_LPF};
+PLACE_SDRAM_BSS reverb::Amount reverbAmountMenu{STRING_FOR_AMOUNT, STRING_FOR_REVERB_AMOUNT,
+                                                params::GLOBAL_REVERB_AMOUNT};
+PLACE_SDRAM_BSS reverb::RoomSize reverbRoomSizeMenu{STRING_FOR_ROOM_SIZE};
+PLACE_SDRAM_BSS reverb::Damping reverbDampingMenu{STRING_FOR_DAMPING};
+PLACE_SDRAM_BSS reverb::Width reverbWidthMenu{STRING_FOR_WIDTH, STRING_FOR_REVERB_WIDTH};
+PLACE_SDRAM_BSS reverb::Pan reverbPanMenu{STRING_FOR_PAN, STRING_FOR_REVERB_PAN};
+PLACE_SDRAM_BSS reverb::Model reverbModelMenu{STRING_FOR_MODEL};
+PLACE_SDRAM_BSS reverb::HPF reverbHPFMenu{STRING_FOR_HPF};
+PLACE_SDRAM_BSS reverb::LPF reverbLPFMenu{STRING_FOR_LPF};
 
-HorizontalMenu reverbMenu{
+PLACE_SDRAM_BSS HorizontalMenu reverbMenu{
     STRING_FOR_REVERB,
     {
         &reverbAmountMenu,
@@ -592,24 +612,28 @@ HorizontalMenu reverbMenu{
         &reverbSidechainMenu,
     },
 };
-HorizontalMenu reverbMenuWithoutSidechain{
+
+PLACE_SDRAM_BSS HorizontalMenu reverbMenuWithoutSidechain{
     STRING_FOR_REVERB,
     {&reverbAmountMenu, &reverbRoomSizeMenu, &reverbDampingMenu, &reverbWidthMenu, &reverbModelMenu, &reverbPanMenu,
      &reverbHPFMenu, &reverbLPFMenu},
 };
-HorizontalMenuGroup reverbMenuGroup{{&reverbMenuWithoutSidechain, &reverbSidechainMenu}};
+
+PLACE_SDRAM_BSS HorizontalMenuGroup reverbMenuGroup{{&reverbMenuWithoutSidechain, &reverbSidechainMenu}};
 
 // Filters ------------------------------------------------------------------------------------
-HorizontalMenu routingHorizontal{STRING_FOR_FILTER_ROUTE, {&filterRoutingMenu}};
-HorizontalMenuGroup filtersMenuGroup{{&lpfMenu, &hpfMenu, &routingHorizontal}};
+PLACE_SDRAM_BSS HorizontalMenu routingHorizontal{STRING_FOR_FILTER_ROUTE, {&filterRoutingMenu}};
+PLACE_SDRAM_BSS HorizontalMenuGroup filtersMenuGroup{{&lpfMenu, &hpfMenu, &routingHorizontal}};
 
 // FX ----------------------------------------------------------------------------------------
-fx::Clipping clippingMenu{STRING_FOR_SATURATION};
-UnpatchedParam srrMenu{STRING_FOR_DECIMATION, params::UNPATCHED_SAMPLE_RATE_REDUCTION, RenderingStyle::BAR};
-UnpatchedParam bitcrushMenu{STRING_FOR_BITCRUSH, params::UNPATCHED_BITCRUSHING, RenderingStyle::BAR};
-patched_param::Integer foldMenu{STRING_FOR_WAVEFOLD, STRING_FOR_WAVEFOLD, params::LOCAL_FOLD, RenderingStyle::BAR};
+PLACE_SDRAM_BSS fx::Clipping clippingMenu{STRING_FOR_SATURATION};
+PLACE_SDRAM_BSS UnpatchedParam srrMenu{STRING_FOR_DECIMATION, params::UNPATCHED_SAMPLE_RATE_REDUCTION,
+                                       RenderingStyle::BAR};
+PLACE_SDRAM_BSS UnpatchedParam bitcrushMenu{STRING_FOR_BITCRUSH, params::UNPATCHED_BITCRUSHING, RenderingStyle::BAR};
+PLACE_SDRAM_BSS patched_param::Integer foldMenu{STRING_FOR_WAVEFOLD, STRING_FOR_WAVEFOLD, params::LOCAL_FOLD,
+                                                RenderingStyle::BAR};
 
-HorizontalMenu soundDistortionMenu{
+PLACE_SDRAM_BSS HorizontalMenu soundDistortionMenu{
     STRING_FOR_DISTORTION,
     {
         &clippingMenu,
@@ -620,46 +644,48 @@ HorizontalMenu soundDistortionMenu{
 };
 
 // Output MIDI for sound drums --------------------------------------------------------------
-midi::sound::OutputMidiChannel outputMidiChannelMenu{STRING_FOR_CHANNEL, STRING_FOR_CHANNEL};
-midi::sound::OutputMidiNoteForDrum outputMidiNoteForDrumMenu{STRING_FOR_NOTE, STRING_FOR_NOTE};
-Submenu outputMidiSubmenu{STRING_FOR_MIDI, {&outputMidiChannelMenu, &outputMidiNoteForDrumMenu}};
+PLACE_SDRAM_BSS midi::sound::OutputMidiChannel outputMidiChannelMenu{STRING_FOR_CHANNEL, STRING_FOR_CHANNEL};
+PLACE_SDRAM_BSS midi::sound::OutputMidiNoteForDrum outputMidiNoteForDrumMenu{STRING_FOR_NOTE, STRING_FOR_NOTE};
+PLACE_SDRAM_BSS Submenu outputMidiSubmenu{STRING_FOR_MIDI, {&outputMidiChannelMenu, &outputMidiNoteForDrumMenu}};
 
 // MIDIInstrument menu ----------------------------------------------------------------------
-midi::device_definition::Linked midiDeviceLinkedMenu{STRING_FOR_MIDI_DEVICE_DEFINITION_LINKED,
-                                                     STRING_FOR_MIDI_DEVICE_DEFINITION_LINKED};
+PLACE_SDRAM_BSS midi::device_definition::Linked midiDeviceLinkedMenu{STRING_FOR_MIDI_DEVICE_DEFINITION_LINKED,
+                                                                     STRING_FOR_MIDI_DEVICE_DEFINITION_LINKED};
 
-midi::device_definition::DeviceDefinitionSubmenu midiDeviceDefinitionMenu{
+PLACE_SDRAM_BSS midi::device_definition::DeviceDefinitionSubmenu midiDeviceDefinitionMenu{
     STRING_FOR_MIDI_DEVICE_DEFINITION,
     {
         &midiDeviceLinkedMenu,
     },
 };
 
-midi::Bank midiBankMenu{STRING_FOR_BANK, STRING_FOR_MIDI_BANK};
-midi::Sub midiSubMenu{STRING_FOR_SUB_BANK_SHORT, STRING_FOR_MIDI_SUB_BANK};
-midi::PGM midiPGMMenu{STRING_FOR_PGM, STRING_FOR_MIDI_PGM_NUMB_MENU_TITLE};
-midi::MPEYToModWheel mpeyToModWheelMenu{STRING_FOR_Y_AXIS_CONVERSION, STRING_FOR_Y_AXIS_CONVERSION};
-cv::DualCVSelection cv2SourceMenu{STRING_FOR_CV2_SOURCE};
-midi::AftertouchToMono midiAftertouchCollapseMenu{STRING_FOR_PATCH_SOURCE_AFTERTOUCH,
-                                                  STRING_FOR_PATCH_SOURCE_AFTERTOUCH};
-midi::MPEToMono midiMPECollapseMenu{STRING_FOR_MPE, STRING_FOR_MPE};
-submenu::PolyMonoConversion midiMPEMenu{STRING_FOR_MPE_MONO, {&midiAftertouchCollapseMenu, &midiMPECollapseMenu}};
+PLACE_SDRAM_BSS midi::Bank midiBankMenu{STRING_FOR_BANK, STRING_FOR_MIDI_BANK};
+PLACE_SDRAM_BSS midi::Sub midiSubMenu{STRING_FOR_SUB_BANK_SHORT, STRING_FOR_MIDI_SUB_BANK};
+PLACE_SDRAM_BSS midi::PGM midiPGMMenu{STRING_FOR_PGM, STRING_FOR_MIDI_PGM_NUMB_MENU_TITLE};
+PLACE_SDRAM_BSS midi::MPEYToModWheel mpeyToModWheelMenu{STRING_FOR_Y_AXIS_CONVERSION, STRING_FOR_Y_AXIS_CONVERSION};
+PLACE_SDRAM_BSS cv::DualCVSelection cv2SourceMenu{STRING_FOR_CV2_SOURCE};
+PLACE_SDRAM_BSS midi::AftertouchToMono midiAftertouchCollapseMenu{STRING_FOR_PATCH_SOURCE_AFTERTOUCH,
+                                                                  STRING_FOR_PATCH_SOURCE_AFTERTOUCH};
+PLACE_SDRAM_BSS midi::MPEToMono midiMPECollapseMenu{STRING_FOR_MPE, STRING_FOR_MPE};
+PLACE_SDRAM_BSS submenu::PolyMonoConversion midiMPEMenu{STRING_FOR_MPE_MONO,
+                                                        {&midiAftertouchCollapseMenu, &midiMPECollapseMenu}};
+
 // Clip-level stuff --------------------------------------------------------------------------
 
-sequence::Direction sequenceDirectionMenu{STRING_FOR_PLAY_DIRECTION};
+PLACE_SDRAM_BSS sequence::Direction sequenceDirectionMenu{STRING_FOR_PLAY_DIRECTION};
 
 // Global FX Menu
 
 // Volume
-UnpatchedParam globalLevelMenu{STRING_FOR_VOLUME_LEVEL, params::UNPATCHED_VOLUME, BAR};
+PLACE_SDRAM_BSS UnpatchedParam globalLevelMenu{STRING_FOR_VOLUME_LEVEL, params::UNPATCHED_VOLUME, BAR};
 
 // Pitch
-UnpatchedParam globalPitchMenu{STRING_FOR_PITCH, params::UNPATCHED_PITCH_ADJUST};
+PLACE_SDRAM_BSS UnpatchedParam globalPitchMenu{STRING_FOR_PITCH, params::UNPATCHED_PITCH_ADJUST};
 
 // Pan
-unpatched_param::Pan globalPanMenu{STRING_FOR_PAN, params::UNPATCHED_PAN};
+PLACE_SDRAM_BSS unpatched_param::Pan globalPanMenu{STRING_FOR_PAN, params::UNPATCHED_PAN};
 
-HorizontalMenu songMasterMenu{
+PLACE_SDRAM_BSS HorizontalMenu songMasterMenu{
     STRING_FOR_MASTER,
     {
         &globalLevelMenu,
@@ -667,7 +693,7 @@ HorizontalMenu songMasterMenu{
     },
 };
 
-HorizontalMenu kitClipMasterMenu{
+PLACE_SDRAM_BSS HorizontalMenu kitClipMasterMenu{
     STRING_FOR_MASTER,
     {
         &globalLevelMenu,
@@ -677,29 +703,33 @@ HorizontalMenu kitClipMasterMenu{
 };
 
 // LPF Menu
-filter::UnpatchedFilterParam globalLPFFreqMenu{STRING_FOR_FREQUENCY, STRING_FOR_LPF_FREQUENCY,
-                                               params::UNPATCHED_LPF_FREQ, filter::FilterSlot::LPF,
-                                               filter::FilterParamType::FREQUENCY};
-filter::UnpatchedFilterParam globalLPFResMenu{STRING_FOR_RESONANCE, STRING_FOR_LPF_RESONANCE, params::UNPATCHED_LPF_RES,
-                                              filter::FilterSlot::LPF, filter::FilterParamType::RESONANCE};
-filter::UnpatchedFilterParam globalLPFMorphMenu{STRING_FOR_MORPH, STRING_FOR_LPF_MORPH, params::UNPATCHED_LPF_MORPH,
-                                                filter::FilterSlot::LPF, filter::FilterParamType::MORPH};
-HorizontalMenu globalLPFMenu{STRING_FOR_LPF,
-                             {&lpfModeMenu, &globalLPFFreqMenu, &globalLPFResMenu, &globalLPFMorphMenu}};
+PLACE_SDRAM_BSS filter::UnpatchedFilterParam globalLPFFreqMenu{STRING_FOR_FREQUENCY, STRING_FOR_LPF_FREQUENCY,
+                                                               params::UNPATCHED_LPF_FREQ, filter::FilterSlot::LPF,
+                                                               filter::FilterParamType::FREQUENCY};
+PLACE_SDRAM_BSS filter::UnpatchedFilterParam globalLPFResMenu{STRING_FOR_RESONANCE, STRING_FOR_LPF_RESONANCE,
+                                                              params::UNPATCHED_LPF_RES, filter::FilterSlot::LPF,
+                                                              filter::FilterParamType::RESONANCE};
+PLACE_SDRAM_BSS filter::UnpatchedFilterParam globalLPFMorphMenu{STRING_FOR_MORPH, STRING_FOR_LPF_MORPH,
+                                                                params::UNPATCHED_LPF_MORPH, filter::FilterSlot::LPF,
+                                                                filter::FilterParamType::MORPH};
+PLACE_SDRAM_BSS HorizontalMenu globalLPFMenu{
+    STRING_FOR_LPF, {&lpfModeMenu, &globalLPFFreqMenu, &globalLPFResMenu, &globalLPFMorphMenu}};
 
 // HPF Menu
-filter::UnpatchedFilterParam globalHPFFreqMenu{STRING_FOR_FREQUENCY, STRING_FOR_HPF_FREQUENCY,
-                                               params::UNPATCHED_HPF_FREQ, filter::FilterSlot::HPF,
-                                               filter::FilterParamType::FREQUENCY};
-filter::UnpatchedFilterParam globalHPFResMenu{STRING_FOR_RESONANCE, STRING_FOR_HPF_RESONANCE, params::UNPATCHED_HPF_RES,
-                                              filter::FilterSlot::HPF, filter::FilterParamType::RESONANCE};
-filter::UnpatchedFilterParam globalHPFMorphMenu{STRING_FOR_MORPH, STRING_FOR_HPF_MORPH, params::UNPATCHED_HPF_MORPH,
-                                                filter::FilterSlot::HPF, filter::FilterParamType::MORPH};
+PLACE_SDRAM_BSS filter::UnpatchedFilterParam globalHPFFreqMenu{STRING_FOR_FREQUENCY, STRING_FOR_HPF_FREQUENCY,
+                                                               params::UNPATCHED_HPF_FREQ, filter::FilterSlot::HPF,
+                                                               filter::FilterParamType::FREQUENCY};
+PLACE_SDRAM_BSS filter::UnpatchedFilterParam globalHPFResMenu{STRING_FOR_RESONANCE, STRING_FOR_HPF_RESONANCE,
+                                                              params::UNPATCHED_HPF_RES, filter::FilterSlot::HPF,
+                                                              filter::FilterParamType::RESONANCE};
+PLACE_SDRAM_BSS filter::UnpatchedFilterParam globalHPFMorphMenu{STRING_FOR_MORPH, STRING_FOR_HPF_MORPH,
+                                                                params::UNPATCHED_HPF_MORPH, filter::FilterSlot::HPF,
+                                                                filter::FilterParamType::MORPH};
 
-HorizontalMenu globalHPFMenu{STRING_FOR_HPF,
-                             {&hpfModeMenu, &globalHPFFreqMenu, &globalHPFResMenu, &globalHPFMorphMenu}};
+PLACE_SDRAM_BSS HorizontalMenu globalHPFMenu{
+    STRING_FOR_HPF, {&hpfModeMenu, &globalHPFFreqMenu, &globalHPFResMenu, &globalHPFMorphMenu}};
 
-Submenu globalFiltersMenu{
+PLACE_SDRAM_BSS Submenu globalFiltersMenu{
     STRING_FOR_FILTERS,
     {
         &globalLPFMenu,
@@ -708,11 +738,11 @@ Submenu globalFiltersMenu{
     },
 };
 
-HorizontalMenuGroup globalFiltersMenuGroup{{&globalLPFMenu, &globalHPFMenu, &routingHorizontal}};
+PLACE_SDRAM_BSS HorizontalMenuGroup globalFiltersMenuGroup{{&globalLPFMenu, &globalHPFMenu, &routingHorizontal}};
 
 // EQ Menu
 
-eq::EqMenu globalEQMenu{
+PLACE_SDRAM_BSS eq::EqMenu globalEQMenu{
     STRING_FOR_EQ,
     {
         &bassMenu,
@@ -723,11 +753,12 @@ eq::EqMenu globalEQMenu{
 };
 
 // Delay Menu
-delay::Amount_Unpatched globalDelayFeedbackMenu{STRING_FOR_AMOUNT, STRING_FOR_DELAY_AMOUNT,
-                                                params::UNPATCHED_DELAY_AMOUNT};
-UnpatchedParam globalDelayRateMenu{STRING_FOR_RATE, STRING_FOR_DELAY_RATE, params::UNPATCHED_DELAY_RATE};
+PLACE_SDRAM_BSS delay::Amount_Unpatched globalDelayFeedbackMenu{STRING_FOR_AMOUNT, STRING_FOR_DELAY_AMOUNT,
+                                                                params::UNPATCHED_DELAY_AMOUNT};
+PLACE_SDRAM_BSS UnpatchedParam globalDelayRateMenu{STRING_FOR_RATE, STRING_FOR_DELAY_RATE,
+                                                   params::UNPATCHED_DELAY_RATE};
 
-HorizontalMenu globalDelayMenu{
+PLACE_SDRAM_BSS HorizontalMenu globalDelayMenu{
     STRING_FOR_DELAY,
     {
         &globalDelayFeedbackMenu,
@@ -740,13 +771,13 @@ HorizontalMenu globalDelayMenu{
 
 // Reverb Menu
 
-reverb::Amount_Unpatched globalReverbSendAmountMenu{
+PLACE_SDRAM_BSS reverb::Amount_Unpatched globalReverbSendAmountMenu{
     STRING_FOR_AMOUNT,
     STRING_FOR_REVERB_AMOUNT,
     params::UNPATCHED_REVERB_SEND_AMOUNT,
 };
 
-HorizontalMenu globalReverbMenu{
+PLACE_SDRAM_BSS HorizontalMenu globalReverbMenu{
     STRING_FOR_REVERB,
     {
         &globalReverbSendAmountMenu,
@@ -761,7 +792,7 @@ HorizontalMenu globalReverbMenu{
     },
 };
 
-HorizontalMenu globalReverbMenuWithoutSidechain{
+PLACE_SDRAM_BSS HorizontalMenu globalReverbMenuWithoutSidechain{
     STRING_FOR_REVERB,
     {
         &globalReverbSendAmountMenu,
@@ -774,14 +805,16 @@ HorizontalMenu globalReverbMenuWithoutSidechain{
         &reverbLPFMenu,
     },
 };
-HorizontalMenuGroup globalReverbMenuGroup{{&globalReverbMenuWithoutSidechain, &reverbSidechainMenu}};
+PLACE_SDRAM_BSS HorizontalMenuGroup globalReverbMenuGroup{{&globalReverbMenuWithoutSidechain, &reverbSidechainMenu}};
 
 // Mod FX Menu
 
-mod_fx::Depth_Unpatched globalModFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MOD_FX_DEPTH, params::UNPATCHED_MOD_FX_DEPTH};
-mod_fx::Rate_Unpatched globalModFXRateMenu{STRING_FOR_RATE, STRING_FOR_MOD_FX_RATE, params::UNPATCHED_MOD_FX_RATE};
+PLACE_SDRAM_BSS mod_fx::Depth_Unpatched globalModFXDepthMenu{STRING_FOR_DEPTH, STRING_FOR_MOD_FX_DEPTH,
+                                                             params::UNPATCHED_MOD_FX_DEPTH};
+PLACE_SDRAM_BSS mod_fx::Rate_Unpatched globalModFXRateMenu{STRING_FOR_RATE, STRING_FOR_MOD_FX_RATE,
+                                                           params::UNPATCHED_MOD_FX_RATE};
 
-submenu::ModFxHorizontalMenu globalModFXMenu{
+PLACE_SDRAM_BSS submenu::ModFxHorizontalMenu globalModFXMenu{
     STRING_FOR_MOD_FX,
     {
         &modFXTypeMenu,
@@ -792,7 +825,7 @@ submenu::ModFxHorizontalMenu globalModFXMenu{
     },
 };
 
-HorizontalMenu globalDistortionMenu{
+PLACE_SDRAM_BSS HorizontalMenu globalDistortionMenu{
     STRING_FOR_DISTORTION,
     {
         &srrMenu,
@@ -800,7 +833,7 @@ HorizontalMenu globalDistortionMenu{
     },
 };
 
-Submenu globalFXMenu{
+PLACE_SDRAM_BSS Submenu globalFXMenu{
     STRING_FOR_FX,
     {
         &globalEQMenu,
@@ -813,9 +846,10 @@ Submenu globalFXMenu{
 };
 
 // Sidechain menu
-sidechain::GlobalVolume globalSidechainVolumeMenu{STRING_FOR_VOLUME_DUCKING, params::UNPATCHED_SIDECHAIN_VOLUME};
+PLACE_SDRAM_BSS sidechain::GlobalVolume globalSidechainVolumeMenu{STRING_FOR_VOLUME_DUCKING,
+                                                                  params::UNPATCHED_SIDECHAIN_VOLUME};
 
-HorizontalMenu globalSidechainMenu{
+PLACE_SDRAM_BSS HorizontalMenu globalSidechainMenu{
     STRING_FOR_SIDECHAIN,
     {
         &globalSidechainVolumeMenu,
@@ -828,25 +862,26 @@ HorizontalMenu globalSidechainMenu{
 
 // AudioClip stuff ---------------------------------------------------------------------------
 
-audio_clip::SetClipLengthEqualToSampleLength setClipLengthMenu{STRING_FOR_SET_CLIP_LENGTH_EQUAL_TO_SAMPLE_LENGTH};
+PLACE_SDRAM_BSS audio_clip::SetClipLengthEqualToSampleLength setClipLengthMenu{
+    STRING_FOR_SET_CLIP_LENGTH_EQUAL_TO_SAMPLE_LENGTH};
 
-Submenu audioClipActionsMenu{
+PLACE_SDRAM_BSS Submenu audioClipActionsMenu{
     STRING_FOR_ACTIONS,
     {
         &setClipLengthMenu,
     },
 };
 
-audio_clip::AudioSourceSelector audioSourceSelectorMenu{STRING_FOR_AUDIO_SOURCE};
-audio_clip::SpecificSourceOutputSelector specificOutputSelectorMenu{STRING_FOR_TRACK};
-audio_clip::Transpose audioClipTransposeMenu{STRING_FOR_TRANSPOSE};
+PLACE_SDRAM_BSS audio_clip::AudioSourceSelector audioSourceSelectorMenu{STRING_FOR_AUDIO_SOURCE};
+PLACE_SDRAM_BSS audio_clip::SpecificSourceOutputSelector specificOutputSelectorMenu{STRING_FOR_TRACK};
+PLACE_SDRAM_BSS audio_clip::Transpose audioClipTransposeMenu{STRING_FOR_TRANSPOSE};
 
-HorizontalMenu audioClipMasterMenu{
+PLACE_SDRAM_BSS HorizontalMenu audioClipMasterMenu{
     STRING_FOR_MASTER,
     {&globalLevelMenu, &globalPanMenu},
 };
 
-HorizontalMenu audioClipDistortionMenu{
+PLACE_SDRAM_BSS HorizontalMenu audioClipDistortionMenu{
     STRING_FOR_DISTORTION,
     {
         &clippingMenu,
@@ -855,7 +890,7 @@ HorizontalMenu audioClipDistortionMenu{
     },
 };
 
-Submenu audioClipFXMenu{
+PLACE_SDRAM_BSS Submenu audioClipFXMenu{
     STRING_FOR_FX,
     {
         &eqMenu,
@@ -868,12 +903,12 @@ Submenu audioClipFXMenu{
 };
 
 // Sample Menu
-audio_clip::Reverse audioClipReverseMenu{STRING_FOR_REVERSE};
-audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuStart{EMPTY_STRING, MarkerType::START};
-audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuEnd{STRING_FOR_WAVEFORM, MarkerType::END};
-AudioInterpolation audioClipInterpolationMenu{STRING_FOR_INTERPOLATION, STRING_FOR_AUDIO_INTERPOLATION};
+PLACE_SDRAM_BSS audio_clip::Reverse audioClipReverseMenu{STRING_FOR_REVERSE};
+PLACE_SDRAM_BSS audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuStart{EMPTY_STRING, MarkerType::START};
+PLACE_SDRAM_BSS audio_clip::SampleMarkerEditor audioClipSampleMarkerEditorMenuEnd{STRING_FOR_WAVEFORM, MarkerType::END};
+PLACE_SDRAM_BSS AudioInterpolation audioClipInterpolationMenu{STRING_FOR_INTERPOLATION, STRING_FOR_AUDIO_INTERPOLATION};
 
-HorizontalMenu audioClipSampleMenu{
+PLACE_SDRAM_BSS HorizontalMenu audioClipSampleMenu{
     STRING_FOR_SAMPLE,
     {
         &file0SelectorMenu,
@@ -885,11 +920,11 @@ HorizontalMenu audioClipSampleMenu{
     },
 };
 
-audio_clip::Attack audioClipAttackMenu{STRING_FOR_ATTACK};
+PLACE_SDRAM_BSS audio_clip::Attack audioClipAttackMenu{STRING_FOR_ATTACK};
 
-menu_item::EditName nameEditMenu{STRING_FOR_RENAME_CLIP};
+PLACE_SDRAM_BSS menu_item::EditName nameEditMenu{STRING_FOR_RENAME_CLIP};
 
-PLACE_SDRAM_DATA const MenuItem* midiOrCVParamShortcuts[kDisplayHeight] = {
+PLACE_SDRAM_RODATA const MenuItem* midiOrCVParamShortcuts[kDisplayHeight] = {
     &arpRateMenuMIDIOrCV,
     &arpSyncMenu,
     &arpGateMenuMIDIOrCV,
@@ -900,7 +935,7 @@ PLACE_SDRAM_DATA const MenuItem* midiOrCVParamShortcuts[kDisplayHeight] = {
     nullptr,
 };
 
-PLACE_SDRAM_DATA const MenuItem* gateDrumParamShortcuts[8] = {
+PLACE_SDRAM_RODATA const MenuItem* gateDrumParamShortcuts[8] = {
     &arpRateMenuMIDIOrCV,
     &arpSyncMenu,
     &arpGateMenuMIDIOrCV,
@@ -912,28 +947,29 @@ PLACE_SDRAM_DATA const MenuItem* gateDrumParamShortcuts[8] = {
 };
 
 // Gate stuff
-gate::Mode gateModeMenu;
-gate::OffTime gateOffTimeMenu{EMPTY_STRING, STRING_FOR_MINIMUM_OFF_TIME};
+PLACE_SDRAM_BSS gate::Mode gateModeMenu;
+PLACE_SDRAM_BSS gate::OffTime gateOffTimeMenu{EMPTY_STRING, STRING_FOR_MINIMUM_OFF_TIME};
 
 // Root menu
 
 // CV Menu
-cv::Volts cvVoltsMenu{STRING_FOR_VOLTS_PER_OCTAVE, STRING_FOR_CV_V_PER_OCTAVE_MENU_TITLE};
-cv::Transpose cvTransposeMenu{STRING_FOR_TRANSPOSE, STRING_FOR_CV_TRANSPOSE_MENU_TITLE};
+PLACE_SDRAM_BSS cv::Volts cvVoltsMenu{STRING_FOR_VOLTS_PER_OCTAVE, STRING_FOR_CV_V_PER_OCTAVE_MENU_TITLE};
+PLACE_SDRAM_BSS cv::Transpose cvTransposeMenu{STRING_FOR_TRANSPOSE, STRING_FOR_CV_TRANSPOSE_MENU_TITLE};
 
-cv::Submenu cvSubmenu{STRING_FOR_CV_OUTPUT_N, {&cvVoltsMenu, &cvTransposeMenu}};
+PLACE_SDRAM_BSS cv::Submenu cvSubmenu{STRING_FOR_CV_OUTPUT_N, {&cvVoltsMenu, &cvTransposeMenu}};
 
-cv::Selection cvSelectionMenu{STRING_FOR_CV, STRING_FOR_CV_OUTPUTS};
-gate::Selection gateSelectionMenu{STRING_FOR_GATE, STRING_FOR_GATE_OUTPUTS};
+PLACE_SDRAM_BSS cv::Selection cvSelectionMenu{STRING_FOR_CV, STRING_FOR_CV_OUTPUTS};
+PLACE_SDRAM_BSS gate::Selection gateSelectionMenu{STRING_FOR_GATE, STRING_FOR_GATE_OUTPUTS};
 
-swing::Interval swingIntervalMenu{STRING_FOR_SWING_INTERVAL};
+PLACE_SDRAM_BSS swing::Interval swingIntervalMenu{STRING_FOR_SWING_INTERVAL};
 
 // Pads menu
-shortcuts::Version shortcutsVersionMenu{STRING_FOR_SHORTCUTS_VERSION, STRING_FOR_SHORTCUTS_VER_MENU_TITLE};
-menu_item::keyboard::Layout keyboardLayoutMenu{STRING_FOR_KEYBOARD_FOR_TEXT, STRING_FOR_KEY_LAYOUT};
+PLACE_SDRAM_BSS shortcuts::Version shortcutsVersionMenu{STRING_FOR_SHORTCUTS_VERSION,
+                                                        STRING_FOR_SHORTCUTS_VER_MENU_TITLE};
+PLACE_SDRAM_BSS menu_item::keyboard::Layout keyboardLayoutMenu{STRING_FOR_KEYBOARD_FOR_TEXT, STRING_FOR_KEY_LAYOUT};
 
 // Colours submenu
-Submenu coloursSubmenu{
+PLACE_SDRAM_BSS Submenu coloursSubmenu{
     STRING_FOR_COLOURS,
     {
         &activeColourMenu,
@@ -945,7 +981,7 @@ Submenu coloursSubmenu{
     },
 };
 
-Submenu padsSubmenu{
+PLACE_SDRAM_BSS Submenu padsSubmenu{
     STRING_FOR_PADS,
     {
         &shortcutsVersionMenu,
@@ -955,23 +991,25 @@ Submenu padsSubmenu{
 };
 
 // Record submenu
-record::Quantize recordQuantizeMenu{STRING_FOR_QUANTIZATION};
-ToggleBool recordMarginsMenu{STRING_FOR_LOOP_MARGINS, STRING_FOR_LOOP_MARGINS, FlashStorage::audioClipRecordMargins};
-record::CountIn recordCountInMenu{STRING_FOR_COUNT_IN, STRING_FOR_REC_COUNT_IN};
-monitor::Mode monitorModeMenu{STRING_FOR_SAMPLING_MONITORING, STRING_FOR_MONITORING};
+PLACE_SDRAM_BSS record::Quantize recordQuantizeMenu{STRING_FOR_QUANTIZATION};
+PLACE_SDRAM_BSS ToggleBool recordMarginsMenu{STRING_FOR_LOOP_MARGINS, STRING_FOR_LOOP_MARGINS,
+                                             FlashStorage::audioClipRecordMargins};
+PLACE_SDRAM_BSS record::CountIn recordCountInMenu{STRING_FOR_COUNT_IN, STRING_FOR_REC_COUNT_IN};
+PLACE_SDRAM_BSS monitor::Mode monitorModeMenu{STRING_FOR_SAMPLING_MONITORING, STRING_FOR_MONITORING};
 
-record::ThresholdMode defaultThresholdRecordingModeMenu{STRING_FOR_MODE, record::ThresholdMode::DEFAULT};
+PLACE_SDRAM_BSS record::ThresholdMode defaultThresholdRecordingModeMenu{STRING_FOR_MODE,
+                                                                        record::ThresholdMode::DEFAULT};
 
-Submenu defaultThresholdRecordingSubmenu{
+PLACE_SDRAM_BSS Submenu defaultThresholdRecordingSubmenu{
     STRING_FOR_THRESHOLD_RECORDING,
     {
         &defaultThresholdRecordingModeMenu,
     },
 };
 
-record::LoopCommand defaultLoopCommandMenu{STRING_FOR_LOOP_COMMAND, STRING_FOR_LOOP_COMMAND};
+PLACE_SDRAM_BSS record::LoopCommand defaultLoopCommandMenu{STRING_FOR_LOOP_COMMAND, STRING_FOR_LOOP_COMMAND};
 
-Submenu recordSubmenu{
+PLACE_SDRAM_BSS Submenu recordSubmenu{
     STRING_FOR_RECORDING,
     {
         &recordCountInMenu,
@@ -983,41 +1021,42 @@ Submenu recordSubmenu{
     },
 };
 
-sample::browser_preview::Mode sampleBrowserPreviewModeMenu{STRING_FOR_SAMPLE_PREVIEW};
+PLACE_SDRAM_BSS sample::browser_preview::Mode sampleBrowserPreviewModeMenu{STRING_FOR_SAMPLE_PREVIEW};
 
-flash::Status flashStatusMenu{STRING_FOR_PLAY_CURSOR};
+PLACE_SDRAM_BSS flash::Status flashStatusMenu{STRING_FOR_PLAY_CURSOR};
 
-firmware::Version firmwareVersionMenu{STRING_FOR_FIRMWARE_VERSION, STRING_FOR_FIRMWARE_VER_MENU_TITLE};
+PLACE_SDRAM_BSS firmware::Version firmwareVersionMenu{STRING_FOR_FIRMWARE_VERSION, STRING_FOR_FIRMWARE_VER_MENU_TITLE};
 
-battery::Level batteryLevelMenu{STRING_FOR_BATTERY_LEVEL, STRING_FOR_BATTERY_LEVEL_MENU_TITLE};
+PLACE_SDRAM_BSS battery::Level batteryLevelMenu{STRING_FOR_BATTERY_LEVEL, STRING_FOR_BATTERY_LEVEL_MENU_TITLE};
 
-runtime_feature::Settings runtimeFeatureSettingsMenu{STRING_FOR_COMMUNITY_FTS, STRING_FOR_COMMUNITY_FTS_MENU_TITLE};
+PLACE_SDRAM_BSS runtime_feature::Settings runtimeFeatureSettingsMenu{STRING_FOR_COMMUNITY_FTS,
+                                                                     STRING_FOR_COMMUNITY_FTS_MENU_TITLE};
 
 // CV menu
 
 // MIDI
 // MIDI thru
-ToggleBool midiThruMenu{STRING_FOR_MIDI_THRU, STRING_FOR_MIDI_THRU, midiEngine.midiThru};
+PLACE_SDRAM_BSS ToggleBool midiThruMenu{STRING_FOR_MIDI_THRU, STRING_FOR_MIDI_THRU, midiEngine.midiThru};
 
 // MIDI Takeover
-midi::Takeover midiTakeoverMenu{STRING_FOR_TAKEOVER};
+PLACE_SDRAM_BSS midi::Takeover midiTakeoverMenu{STRING_FOR_TAKEOVER};
 
 // MIDI Follow
-midi::FollowChannel midiFollowChannelAMenu{STRING_FOR_FOLLOW_CHANNEL_A, STRING_FOR_FOLLOW_CHANNEL_A,
-                                           MIDIFollowChannelType::A};
-midi::FollowChannel midiFollowChannelBMenu{STRING_FOR_FOLLOW_CHANNEL_B, STRING_FOR_FOLLOW_CHANNEL_B,
-                                           MIDIFollowChannelType::B};
-midi::FollowChannel midiFollowChannelCMenu{STRING_FOR_FOLLOW_CHANNEL_C, STRING_FOR_FOLLOW_CHANNEL_C,
-                                           MIDIFollowChannelType::C};
-midi::FollowKitRootNote midiFollowKitRootNoteMenu{STRING_FOR_FOLLOW_KIT_ROOT_NOTE};
-ToggleBool midiFollowDisplayParamMenu{STRING_FOR_FOLLOW_DISPLAY_PARAM, STRING_FOR_FOLLOW_DISPLAY_PARAM,
-                                      midiEngine.midiFollowDisplayParam};
-midi::FollowFeedbackChannelType midiFollowFeedbackChannelMenu{STRING_FOR_CHANNEL};
-midi::FollowFeedbackAutomation midiFollowFeedbackAutomationMenu{STRING_FOR_FOLLOW_FEEDBACK_AUTOMATION};
-ToggleBool midiFollowFeedbackFilterMenu{STRING_FOR_FOLLOW_FEEDBACK_FILTER, STRING_FOR_FOLLOW_FEEDBACK_FILTER,
-                                        midiEngine.midiFollowFeedbackFilter};
+PLACE_SDRAM_BSS midi::FollowChannel midiFollowChannelAMenu{STRING_FOR_FOLLOW_CHANNEL_A, STRING_FOR_FOLLOW_CHANNEL_A,
+                                                           MIDIFollowChannelType::A};
+PLACE_SDRAM_BSS midi::FollowChannel midiFollowChannelBMenu{STRING_FOR_FOLLOW_CHANNEL_B, STRING_FOR_FOLLOW_CHANNEL_B,
+                                                           MIDIFollowChannelType::B};
+PLACE_SDRAM_BSS midi::FollowChannel midiFollowChannelCMenu{STRING_FOR_FOLLOW_CHANNEL_C, STRING_FOR_FOLLOW_CHANNEL_C,
+                                                           MIDIFollowChannelType::C};
+PLACE_SDRAM_BSS midi::FollowKitRootNote midiFollowKitRootNoteMenu{STRING_FOR_FOLLOW_KIT_ROOT_NOTE};
+PLACE_SDRAM_BSS ToggleBool midiFollowDisplayParamMenu{STRING_FOR_FOLLOW_DISPLAY_PARAM, STRING_FOR_FOLLOW_DISPLAY_PARAM,
+                                                      midiEngine.midiFollowDisplayParam};
+PLACE_SDRAM_BSS midi::FollowFeedbackChannelType midiFollowFeedbackChannelMenu{STRING_FOR_CHANNEL};
+PLACE_SDRAM_BSS midi::FollowFeedbackAutomation midiFollowFeedbackAutomationMenu{STRING_FOR_FOLLOW_FEEDBACK_AUTOMATION};
+PLACE_SDRAM_BSS ToggleBool midiFollowFeedbackFilterMenu{
+    STRING_FOR_FOLLOW_FEEDBACK_FILTER, STRING_FOR_FOLLOW_FEEDBACK_FILTER, midiEngine.midiFollowFeedbackFilter};
 
-Submenu midiFollowChannelSubmenu{
+PLACE_SDRAM_BSS Submenu midiFollowChannelSubmenu{
     STRING_FOR_CHANNEL,
     STRING_FOR_CHANNEL,
     {
@@ -1027,7 +1066,7 @@ Submenu midiFollowChannelSubmenu{
     },
 };
 
-Submenu midiFollowFeedbackSubmenu{
+PLACE_SDRAM_BSS Submenu midiFollowFeedbackSubmenu{
     STRING_FOR_FOLLOW_FEEDBACK,
     STRING_FOR_FOLLOW_FEEDBACK,
     {
@@ -1037,7 +1076,7 @@ Submenu midiFollowFeedbackSubmenu{
     },
 };
 
-Submenu midiFollowSubmenu{
+PLACE_SDRAM_BSS Submenu midiFollowSubmenu{
     STRING_FOR_FOLLOW_TITLE,
     STRING_FOR_FOLLOW_TITLE,
     {
@@ -1049,13 +1088,14 @@ Submenu midiFollowSubmenu{
 };
 
 // MIDI select kit row
-ToggleBool midiSelectKitRowMenu{STRING_FOR_SELECT_KIT_ROW, STRING_FOR_SELECT_KIT_ROW, midiEngine.midiSelectKitRow};
+PLACE_SDRAM_BSS ToggleBool midiSelectKitRowMenu{STRING_FOR_SELECT_KIT_ROW, STRING_FOR_SELECT_KIT_ROW,
+                                                midiEngine.midiSelectKitRow};
 
 // MIDI transpose menu
 
-midi::Transpose midiTransposeMenu{STRING_FOR_TRANSPOSE};
+PLACE_SDRAM_BSS midi::Transpose midiTransposeMenu{STRING_FOR_TRANSPOSE};
 
-Submenu midiTransposeSubmenu{
+PLACE_SDRAM_BSS Submenu midiTransposeSubmenu{
     STRING_FOR_TRANSPOSE,
     STRING_FOR_TRANSPOSE,
     {
@@ -1064,19 +1104,20 @@ Submenu midiTransposeSubmenu{
 };
 
 // MIDI commands submenu
-midi::Command playbackRestartMidiCommand{STRING_FOR_RESTART, GlobalMIDICommand::PLAYBACK_RESTART};
-midi::Command playMidiCommand{STRING_FOR_PLAY, GlobalMIDICommand::PLAY};
-midi::Command recordMidiCommand{STRING_FOR_RECORD, GlobalMIDICommand::RECORD};
-midi::Command tapMidiCommand{STRING_FOR_TAP_TEMPO, GlobalMIDICommand::TAP};
-midi::Command undoMidiCommand{STRING_FOR_UNDO, GlobalMIDICommand::UNDO};
-midi::Command redoMidiCommand{STRING_FOR_REDO, GlobalMIDICommand::REDO};
-midi::Command loopMidiCommand{STRING_FOR_LOOP, GlobalMIDICommand::LOOP};
-midi::Command loopContinuousLayeringMidiCommand{STRING_FOR_LAYERING_LOOP, GlobalMIDICommand::LOOP_CONTINUOUS_LAYERING};
-midi::Command fillMidiCommand{STRING_FOR_FILL, GlobalMIDICommand::FILL};
-midi::Command transposeMidiCommand{STRING_FOR_TRANSPOSE, GlobalMIDICommand::TRANSPOSE};
-midi::Command nextSongMidiCommand{STRING_FOR_SONG_LOAD_NEXT, GlobalMIDICommand::NEXT_SONG};
+PLACE_SDRAM_BSS midi::Command playbackRestartMidiCommand{STRING_FOR_RESTART, GlobalMIDICommand::PLAYBACK_RESTART};
+PLACE_SDRAM_BSS midi::Command playMidiCommand{STRING_FOR_PLAY, GlobalMIDICommand::PLAY};
+PLACE_SDRAM_BSS midi::Command recordMidiCommand{STRING_FOR_RECORD, GlobalMIDICommand::RECORD};
+PLACE_SDRAM_BSS midi::Command tapMidiCommand{STRING_FOR_TAP_TEMPO, GlobalMIDICommand::TAP};
+PLACE_SDRAM_BSS midi::Command undoMidiCommand{STRING_FOR_UNDO, GlobalMIDICommand::UNDO};
+PLACE_SDRAM_BSS midi::Command redoMidiCommand{STRING_FOR_REDO, GlobalMIDICommand::REDO};
+PLACE_SDRAM_BSS midi::Command loopMidiCommand{STRING_FOR_LOOP, GlobalMIDICommand::LOOP};
+PLACE_SDRAM_BSS midi::Command loopContinuousLayeringMidiCommand{STRING_FOR_LAYERING_LOOP,
+                                                                GlobalMIDICommand::LOOP_CONTINUOUS_LAYERING};
+PLACE_SDRAM_BSS midi::Command fillMidiCommand{STRING_FOR_FILL, GlobalMIDICommand::FILL};
+PLACE_SDRAM_BSS midi::Command transposeMidiCommand{STRING_FOR_TRANSPOSE, GlobalMIDICommand::TRANSPOSE};
+PLACE_SDRAM_BSS midi::Command nextSongMidiCommand{STRING_FOR_SONG_LOAD_NEXT, GlobalMIDICommand::NEXT_SONG};
 
-Submenu midiCommandsMenu{
+PLACE_SDRAM_BSS Submenu midiCommandsMenu{
     STRING_FOR_COMMANDS,
     STRING_FOR_MIDI_COMMANDS,
     {&playMidiCommand, &playbackRestartMidiCommand, &recordMidiCommand, &tapMidiCommand, &undoMidiCommand,
@@ -1086,10 +1127,10 @@ Submenu midiCommandsMenu{
 
 // MIDI device submenu - for after we've selected which device we want it for
 
-midi::DefaultVelocityToLevel defaultVelocityToLevelMenu{STRING_FOR_VELOCITY};
-midi::SendClock sendClockMenu{STRING_FOR_CLOCK_OUT};
-midi::ReceiveClock receiveClockMenu{STRING_FOR_CLOCK_IN};
-midi::Device midiDeviceMenu{
+PLACE_SDRAM_BSS midi::DefaultVelocityToLevel defaultVelocityToLevelMenu{STRING_FOR_VELOCITY};
+PLACE_SDRAM_BSS midi::SendClock sendClockMenu{STRING_FOR_CLOCK_OUT};
+PLACE_SDRAM_BSS midi::ReceiveClock receiveClockMenu{STRING_FOR_CLOCK_IN};
+PLACE_SDRAM_BSS midi::Device midiDeviceMenu{
     EMPTY_STRING,
     {
         &mpe::directionSelectorMenu,
@@ -1100,21 +1141,24 @@ midi::Device midiDeviceMenu{
 };
 
 // MIDI input differentiation menu
-ToggleBool midiInputDifferentiationMenu{STRING_FOR_DIFFERENTIATE_INPUTS, STRING_FOR_DIFFERENTIATE_INPUTS,
-                                        MIDIDeviceManager::differentiatingInputsByDevice};
+PLACE_SDRAM_BSS ToggleBool midiInputDifferentiationMenu{
+    STRING_FOR_DIFFERENTIATE_INPUTS, STRING_FOR_DIFFERENTIATE_INPUTS, MIDIDeviceManager::differentiatingInputsByDevice};
 
 // MIDI clock menu
-ToggleBool midiClockOutStatusMenu{STRING_FOR_OUTPUT, STRING_FOR_MIDI_CLOCK_OUT, playbackHandler.midiOutClockEnabled};
-ToggleBool midiClockInStatusMenu{STRING_FOR_INPUT, STRING_FOR_MIDI_CLOCK_IN, playbackHandler.midiInClockEnabled};
-ToggleBool tempoMagnitudeMatchingMenu{STRING_FOR_TEMPO_MAGNITUDE_MATCHING, STRING_FOR_TEMPO_MAGNITUDE_MATCHING,
-                                      playbackHandler.tempoMagnitudeMatchingEnabled};
+PLACE_SDRAM_BSS ToggleBool midiClockOutStatusMenu{STRING_FOR_OUTPUT, STRING_FOR_MIDI_CLOCK_OUT,
+                                                  playbackHandler.midiOutClockEnabled};
+PLACE_SDRAM_BSS ToggleBool midiClockInStatusMenu{STRING_FOR_INPUT, STRING_FOR_MIDI_CLOCK_IN,
+                                                 playbackHandler.midiInClockEnabled};
+PLACE_SDRAM_BSS ToggleBool tempoMagnitudeMatchingMenu{STRING_FOR_TEMPO_MAGNITUDE_MATCHING,
+                                                      STRING_FOR_TEMPO_MAGNITUDE_MATCHING,
+                                                      playbackHandler.tempoMagnitudeMatchingEnabled};
 
 // Midi devices menu
-midi::Devices midi::devicesMenu{STRING_FOR_DEVICES, STRING_FOR_MIDI_DEVICES};
-mpe::DirectionSelector mpe::directionSelectorMenu{STRING_FOR_MPE};
+PLACE_SDRAM_BSS midi::Devices midi::devicesMenu{STRING_FOR_DEVICES, STRING_FOR_MIDI_DEVICES};
+PLACE_SDRAM_BSS mpe::DirectionSelector mpe::directionSelectorMenu{STRING_FOR_MPE};
 
 // MIDI menu
-Submenu midiClockMenu{
+PLACE_SDRAM_BSS Submenu midiClockMenu{
     STRING_FOR_CLOCK,
     STRING_FOR_MIDI_CLOCK,
     {
@@ -1123,7 +1167,8 @@ Submenu midiClockMenu{
         &tempoMagnitudeMatchingMenu,
     },
 };
-Submenu midiMenu{
+
+PLACE_SDRAM_BSS Submenu midiMenu{
     STRING_FOR_MIDI,
     {
         &midiClockMenu,
@@ -1140,10 +1185,10 @@ Submenu midiMenu{
 
 // Clock menu
 // Trigger clock in menu
-trigger::in::PPQN triggerInPPQNMenu{STRING_FOR_PPQN, STRING_FOR_INPUT_PPQN};
-ToggleBool triggerInAutoStartMenu{STRING_FOR_AUTO_START, STRING_FOR_AUTO_START,
-                                  playbackHandler.analogClockInputAutoStart};
-Submenu triggerClockInMenu{
+PLACE_SDRAM_BSS trigger::in::PPQN triggerInPPQNMenu{STRING_FOR_PPQN, STRING_FOR_INPUT_PPQN};
+PLACE_SDRAM_BSS ToggleBool triggerInAutoStartMenu{STRING_FOR_AUTO_START, STRING_FOR_AUTO_START,
+                                                  playbackHandler.analogClockInputAutoStart};
+PLACE_SDRAM_BSS Submenu triggerClockInMenu{
     STRING_FOR_INPUT,
     STRING_FOR_T_CLOCK_INPUT_MENU_TITLE,
     {
@@ -1153,8 +1198,8 @@ Submenu triggerClockInMenu{
 };
 
 // Trigger clock out menu
-trigger::out::PPQN triggerOutPPQNMenu{STRING_FOR_PPQN, STRING_FOR_OUTPUT_PPQN};
-Submenu triggerClockOutMenu{
+PLACE_SDRAM_BSS trigger::out::PPQN triggerOutPPQNMenu{STRING_FOR_PPQN, STRING_FOR_OUTPUT_PPQN};
+PLACE_SDRAM_BSS Submenu triggerClockOutMenu{
     STRING_FOR_OUTPUT,
     STRING_FOR_T_CLOCK_OUT_MENU_TITLE,
     {
@@ -1163,7 +1208,7 @@ Submenu triggerClockOutMenu{
 };
 
 // Trigger clock menu
-Submenu triggerClockMenu{
+PLACE_SDRAM_BSS Submenu triggerClockMenu{
     STRING_FOR_TRIGGER_CLOCK,
     {
         &triggerClockInMenu,
@@ -1172,106 +1217,112 @@ Submenu triggerClockMenu{
 };
 
 // Defaults menu
-defaults::KeyboardLayout defaultKeyboardLayoutMenu{STRING_FOR_DEFAULT_UI_LAYOUT, STRING_FOR_DEFAULT_UI_LAYOUT};
+PLACE_SDRAM_BSS defaults::KeyboardLayout defaultKeyboardLayoutMenu{STRING_FOR_DEFAULT_UI_LAYOUT,
+                                                                   STRING_FOR_DEFAULT_UI_LAYOUT};
 
-defaults::DefaultFavouritesLayout defaultFavouritesLayout{STRING_FOR_DEFAULT_UI_FAVOURITES,
-                                                          STRING_FOR_DEFAULT_UI_FAVOURITES};
+PLACE_SDRAM_BSS defaults::DefaultFavouritesLayout defaultFavouritesLayout{STRING_FOR_DEFAULT_UI_FAVOURITES,
+                                                                          STRING_FOR_DEFAULT_UI_FAVOURITES};
 
-InvertedToggleBool defaultUIKeyboardFunctionsVelocityGlide{STRING_FOR_DEFAULT_UI_KB_CONTROLS_VELOCITY_MOMENTARY,
-                                                           STRING_FOR_DEFAULT_UI_KB_CONTROLS_VELOCITY_MOMENTARY,
-                                                           // This control is inverted, as the default value is true
-                                                           // (Enabled) Glide mode is the opposite to Momentary mode
-                                                           FlashStorage::keyboardFunctionsVelocityGlide};
-InvertedToggleBool defaultUIKeyboardFunctionsModwheelGlide{STRING_FOR_DEFAULT_UI_KB_CONTROLS_MODWHEEL_MOMENTARY,
-                                                           STRING_FOR_DEFAULT_UI_KB_CONTROLS_MODWHEEL_MOMENTARY,
-                                                           // This control is inverted, as the default value is true
-                                                           // (Enabled) Glide mode is the opposite to Momentary mode
-                                                           FlashStorage::keyboardFunctionsModwheelGlide};
-Submenu defaultKeyboardFunctionsMenu{
+PLACE_SDRAM_BSS InvertedToggleBool defaultUIKeyboardFunctionsVelocityGlide{
+    STRING_FOR_DEFAULT_UI_KB_CONTROLS_VELOCITY_MOMENTARY, STRING_FOR_DEFAULT_UI_KB_CONTROLS_VELOCITY_MOMENTARY,
+    // This control is inverted, as the default value is true
+    // (Enabled) Glide mode is the opposite to Momentary mode
+    FlashStorage::keyboardFunctionsVelocityGlide};
+PLACE_SDRAM_BSS InvertedToggleBool defaultUIKeyboardFunctionsModwheelGlide{
+    STRING_FOR_DEFAULT_UI_KB_CONTROLS_MODWHEEL_MOMENTARY, STRING_FOR_DEFAULT_UI_KB_CONTROLS_MODWHEEL_MOMENTARY,
+    // This control is inverted, as the default value is true
+    // (Enabled) Glide mode is the opposite to Momentary mode
+    FlashStorage::keyboardFunctionsModwheelGlide};
+PLACE_SDRAM_BSS Submenu defaultKeyboardFunctionsMenu{
     STRING_FOR_DEFAULT_UI_KB_CONTROLS,
     {&defaultUIKeyboardFunctionsVelocityGlide, &defaultUIKeyboardFunctionsModwheelGlide},
 };
 
-Submenu defaultUIKeyboard{
+PLACE_SDRAM_BSS Submenu defaultUIKeyboard{
     STRING_FOR_DEFAULT_UI_KEYBOARD,
     {&defaultKeyboardLayoutMenu, &defaultKeyboardFunctionsMenu, &defaultFavouritesLayout},
 };
 
-ToggleBool defaultgridEmptyPadsUnarm{STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_UNARM,
-                                     STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_UNARM,
-                                     FlashStorage::gridEmptyPadsUnarm};
-ToggleBool defaultGridEmptyPadsCreateRec{STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_CREATE_REC,
-                                         STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_CREATE_REC,
-                                         FlashStorage::gridEmptyPadsCreateRec};
-Submenu defaultEmptyPadMenu{
+PLACE_SDRAM_BSS ToggleBool defaultgridEmptyPadsUnarm{STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_UNARM,
+                                                     STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_UNARM,
+                                                     FlashStorage::gridEmptyPadsUnarm};
+PLACE_SDRAM_BSS ToggleBool defaultGridEmptyPadsCreateRec{STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_CREATE_REC,
+                                                         STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS_CREATE_REC,
+                                                         FlashStorage::gridEmptyPadsCreateRec};
+PLACE_SDRAM_BSS Submenu defaultEmptyPadMenu{
     STRING_FOR_DEFAULT_UI_DEFAULT_GRID_EMPTY_PADS,
     {&defaultgridEmptyPadsUnarm, &defaultGridEmptyPadsCreateRec},
 };
 
-defaults::DefaultGridDefaultActiveMode defaultGridDefaultActiveMode{STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ACTIVE_MODE,
-                                                                    STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ACTIVE_MODE};
-ToggleBool defaultGridAllowGreenSelection{STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ALLOW_GREEN_SELECTION,
-                                          STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ALLOW_GREEN_SELECTION,
-                                          FlashStorage::gridAllowGreenSelection};
-Submenu defaultSessionGridMenu{
+PLACE_SDRAM_BSS defaults::DefaultGridDefaultActiveMode defaultGridDefaultActiveMode{
+    STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ACTIVE_MODE, STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ACTIVE_MODE};
+PLACE_SDRAM_BSS ToggleBool defaultGridAllowGreenSelection{STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ALLOW_GREEN_SELECTION,
+                                                          STRING_FOR_DEFAULT_UI_DEFAULT_GRID_ALLOW_GREEN_SELECTION,
+                                                          FlashStorage::gridAllowGreenSelection};
+PLACE_SDRAM_BSS Submenu defaultSessionGridMenu{
     STRING_FOR_DEFAULT_UI_GRID,
     {&defaultGridDefaultActiveMode, &defaultGridAllowGreenSelection, &defaultEmptyPadMenu},
 };
 
-defaults::SessionLayout defaultSessionLayoutMenu{STRING_FOR_DEFAULT_UI_LAYOUT, STRING_FOR_DEFAULT_UI_LAYOUT};
-Submenu defaultUISession{
+PLACE_SDRAM_BSS defaults::SessionLayout defaultSessionLayoutMenu{STRING_FOR_DEFAULT_UI_LAYOUT,
+                                                                 STRING_FOR_DEFAULT_UI_LAYOUT};
+
+PLACE_SDRAM_BSS Submenu defaultUISession{
     STRING_FOR_DEFAULT_UI_SONG,
     {&defaultSessionLayoutMenu, &defaultSessionGridMenu},
 };
 
-ToggleBool defaultAccessibilityShortcuts{STRING_FOR_DEFAULT_ACCESSIBILITY_SHORTCUTS,
-                                         STRING_FOR_DEFAULT_ACCESSIBILITY_SHORTCUTS,
-                                         FlashStorage::accessibilityShortcuts};
-defaults::AccessibilityMenuHighlighting defaultAccessibilityMenuHighlighting{
+PLACE_SDRAM_BSS ToggleBool defaultAccessibilityShortcuts{STRING_FOR_DEFAULT_ACCESSIBILITY_SHORTCUTS,
+                                                         STRING_FOR_DEFAULT_ACCESSIBILITY_SHORTCUTS,
+                                                         FlashStorage::accessibilityShortcuts};
+
+PLACE_SDRAM_BSS defaults::AccessibilityMenuHighlighting defaultAccessibilityMenuHighlighting{
     STRING_FOR_DEFAULT_ACCESSIBILITY_MENU_HIGHLIGHTING, STRING_FOR_DEFAULT_ACCESSIBILITY_MENU_HIGHLIGHTING};
 
-Submenu defaultAccessibilityMenu{STRING_FOR_DEFAULT_ACCESSIBILITY,
-                                 {
-                                     &defaultAccessibilityShortcuts,
-                                     &defaultAccessibilityMenuHighlighting,
-                                 }};
+PLACE_SDRAM_BSS Submenu defaultAccessibilityMenu{STRING_FOR_DEFAULT_ACCESSIBILITY,
+                                                 {
+                                                     &defaultAccessibilityShortcuts,
+                                                     &defaultAccessibilityMenuHighlighting,
+                                                 }};
 
-defaults::ui::clip_type::DefaultNewClipType defaultNewClipTypeMenu{STRING_FOR_DEFAULT_NEW_CLIP_TYPE,
-                                                                   STRING_FOR_DEFAULT_NEW_CLIP_TYPE};
-ToggleBool defaultUseLastClipTypeMenu{STRING_FOR_DEFAULT_USE_LAST_CLIP_TYPE, STRING_FOR_DEFAULT_USE_LAST_CLIP_TYPE,
-                                      FlashStorage::defaultUseLastClipType};
+PLACE_SDRAM_BSS defaults::ui::clip_type::DefaultNewClipType defaultNewClipTypeMenu{STRING_FOR_DEFAULT_NEW_CLIP_TYPE,
+                                                                                   STRING_FOR_DEFAULT_NEW_CLIP_TYPE};
+PLACE_SDRAM_BSS ToggleBool defaultUseLastClipTypeMenu{
+    STRING_FOR_DEFAULT_USE_LAST_CLIP_TYPE, STRING_FOR_DEFAULT_USE_LAST_CLIP_TYPE, FlashStorage::defaultUseLastClipType};
 
-Submenu defaultClipTypeMenu{STRING_FOR_DEFAULT_CLIP_TYPE,
-                            {
-                                &defaultNewClipTypeMenu,
-                                &defaultUseLastClipTypeMenu,
-                            }};
+PLACE_SDRAM_BSS Submenu defaultClipTypeMenu{STRING_FOR_DEFAULT_CLIP_TYPE,
+                                            {
+                                                &defaultNewClipTypeMenu,
+                                                &defaultUseLastClipTypeMenu,
+                                            }};
 
-ToggleBool defaultUseSharps{STRING_FOR_DEFAULT_UI_SHARPS, STRING_FOR_DEFAULT_UI_SHARPS, FlashStorage::defaultUseSharps};
+PLACE_SDRAM_BSS ToggleBool defaultUseSharps{STRING_FOR_DEFAULT_UI_SHARPS, STRING_FOR_DEFAULT_UI_SHARPS,
+                                            FlashStorage::defaultUseSharps};
 
-Submenu defaultUI{
+PLACE_SDRAM_BSS Submenu defaultUI{
     STRING_FOR_DEFAULT_UI,
     {&defaultAccessibilityMenu, &defaultUISession, &defaultUIKeyboard, &defaultClipTypeMenu, &defaultUseSharps},
 };
 
-ToggleBool defaultAutomationInterpolateMenu{STRING_FOR_DEFAULT_AUTOMATION_INTERPOLATION,
-                                            STRING_FOR_DEFAULT_AUTOMATION_INTERPOLATION,
-                                            FlashStorage::automationInterpolate};
+PLACE_SDRAM_BSS ToggleBool defaultAutomationInterpolateMenu{STRING_FOR_DEFAULT_AUTOMATION_INTERPOLATION,
+                                                            STRING_FOR_DEFAULT_AUTOMATION_INTERPOLATION,
+                                                            FlashStorage::automationInterpolate};
 
-ToggleBool defaultAutomationClearMenu{STRING_FOR_DEFAULT_AUTOMATION_CLEAR, STRING_FOR_DEFAULT_AUTOMATION_CLEAR,
-                                      FlashStorage::automationClear};
+PLACE_SDRAM_BSS ToggleBool defaultAutomationClearMenu{
+    STRING_FOR_DEFAULT_AUTOMATION_CLEAR, STRING_FOR_DEFAULT_AUTOMATION_CLEAR, FlashStorage::automationClear};
 
-ToggleBool defaultAutomationShiftMenu{STRING_FOR_DEFAULT_AUTOMATION_SHIFT, STRING_FOR_DEFAULT_AUTOMATION_SHIFT,
-                                      FlashStorage::automationShift};
+PLACE_SDRAM_BSS ToggleBool defaultAutomationShiftMenu{
+    STRING_FOR_DEFAULT_AUTOMATION_SHIFT, STRING_FOR_DEFAULT_AUTOMATION_SHIFT, FlashStorage::automationShift};
 
-ToggleBool defaultAutomationNudgeNoteMenu{STRING_FOR_DEFAULT_AUTOMATION_NUDGE_NOTE,
-                                          STRING_FOR_DEFAULT_AUTOMATION_NUDGE_NOTE, FlashStorage::automationNudgeNote};
+PLACE_SDRAM_BSS ToggleBool defaultAutomationNudgeNoteMenu{STRING_FOR_DEFAULT_AUTOMATION_NUDGE_NOTE,
+                                                          STRING_FOR_DEFAULT_AUTOMATION_NUDGE_NOTE,
+                                                          FlashStorage::automationNudgeNote};
 
-ToggleBool defaultAutomationDisableAuditionPadShortcutsMenu{
+PLACE_SDRAM_BSS ToggleBool defaultAutomationDisableAuditionPadShortcutsMenu{
     STRING_FOR_DEFAULT_AUTOMATION_DISABLE_AUDITION_PAD_SHORTCUTS,
     STRING_FOR_DEFAULT_AUTOMATION_DISABLE_AUDITION_PAD_SHORTCUTS, FlashStorage::automationDisableAuditionPadShortcuts};
 
-Submenu defaultAutomationMenu{
+PLACE_SDRAM_BSS Submenu defaultAutomationMenu{
     STRING_FOR_AUTOMATION,
     {
         &defaultAutomationInterpolateMenu,
@@ -1282,35 +1333,38 @@ Submenu defaultAutomationMenu{
     },
 };
 
-IntegerRange defaultTempoMenu{STRING_FOR_TEMPO, STRING_FOR_DEFAULT_TEMPO, 60, 240};
-IntegerRange defaultSwingAmountMenu{STRING_FOR_SWING_AMOUNT, STRING_FOR_DEFAULT_SWING, 1, 99};
-defaults::SwingInterval defaultSwingIntervalMenu{STRING_FOR_SWING_INTERVAL, STRING_FOR_DEFAULT_SWING};
-KeyRange defaultKeyMenu{STRING_FOR_KEY, STRING_FOR_DEFAULT_KEY};
-defaults::DefaultScale defaultScaleMenu{STRING_FOR_INIT_SCALE};
-defaults::Velocity defaultVelocityMenu{STRING_FOR_VELOCITY, STRING_FOR_DEFAULT_VELOC_MENU_TITLE};
-defaults::Magnitude defaultMagnitudeMenu{STRING_FOR_RESOLUTION, STRING_FOR_DEFAULT_RESOL_MENU_TITLE};
-defaults::BendRange defaultBendRangeMenu{STRING_FOR_BEND_RANGE, STRING_FOR_DEFAULT_BEND_R};
-defaults::MetronomeVolume defaultMetronomeVolumeMenu{STRING_FOR_METRONOME, STRING_FOR_DEFAULT_METRO_MENU_TITLE};
-defaults::PatchCablePolarity defaultPatchCablePolarityMenu{STRING_FOR_DEFAULT_POLARITY, STRING_FOR_DEFAULT_POLARITY};
-defaults::StartupSongModeMenu defaultStartupSongMenu{STRING_FOR_DEFAULT_UI_DEFAULT_STARTUP_SONG_MODE,
-                                                     STRING_FOR_DEFAULT_UI_DEFAULT_STARTUP_SONG_MODE};
-defaults::PadBrightness defaultPadBrightness{STRING_FOR_DEFAULT_PAD_BRIGHTNESS,
-                                             STRING_FOR_DEFAULT_PAD_BRIGHTNESS_MENU_TITLE};
-defaults::SliceMode defaultSliceMode{STRING_FOR_DEFAULT_SLICE_MODE, STRING_FOR_DEFAULT_SLICE_MODE_MENU_TITLE};
-ToggleBool defaultHighCPUUsageIndicatorMode{STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
-                                            STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
-                                            FlashStorage::highCPUUsageIndicator};
-defaults::HoldTime defaultHoldTimeMenu{STRING_FOR_HOLD_TIME, STRING_FOR_HOLD_TIME};
+PLACE_SDRAM_BSS IntegerRange defaultTempoMenu{STRING_FOR_TEMPO, STRING_FOR_DEFAULT_TEMPO, 60, 240};
+PLACE_SDRAM_BSS IntegerRange defaultSwingAmountMenu{STRING_FOR_SWING_AMOUNT, STRING_FOR_DEFAULT_SWING, 1, 99};
+PLACE_SDRAM_BSS defaults::SwingInterval defaultSwingIntervalMenu{STRING_FOR_SWING_INTERVAL, STRING_FOR_DEFAULT_SWING};
+PLACE_SDRAM_BSS KeyRange defaultKeyMenu{STRING_FOR_KEY, STRING_FOR_DEFAULT_KEY};
+PLACE_SDRAM_BSS defaults::DefaultScale defaultScaleMenu{STRING_FOR_INIT_SCALE};
+PLACE_SDRAM_BSS defaults::Velocity defaultVelocityMenu{STRING_FOR_VELOCITY, STRING_FOR_DEFAULT_VELOC_MENU_TITLE};
+PLACE_SDRAM_BSS defaults::Magnitude defaultMagnitudeMenu{STRING_FOR_RESOLUTION, STRING_FOR_DEFAULT_RESOL_MENU_TITLE};
+PLACE_SDRAM_BSS defaults::BendRange defaultBendRangeMenu{STRING_FOR_BEND_RANGE, STRING_FOR_DEFAULT_BEND_R};
+PLACE_SDRAM_BSS defaults::MetronomeVolume defaultMetronomeVolumeMenu{STRING_FOR_METRONOME,
+                                                                     STRING_FOR_DEFAULT_METRO_MENU_TITLE};
+PLACE_SDRAM_BSS defaults::PatchCablePolarity defaultPatchCablePolarityMenu{STRING_FOR_DEFAULT_POLARITY,
+                                                                           STRING_FOR_DEFAULT_POLARITY};
+PLACE_SDRAM_BSS defaults::StartupSongModeMenu defaultStartupSongMenu{STRING_FOR_DEFAULT_UI_DEFAULT_STARTUP_SONG_MODE,
+                                                                     STRING_FOR_DEFAULT_UI_DEFAULT_STARTUP_SONG_MODE};
+PLACE_SDRAM_BSS defaults::PadBrightness defaultPadBrightness{STRING_FOR_DEFAULT_PAD_BRIGHTNESS,
+                                                             STRING_FOR_DEFAULT_PAD_BRIGHTNESS_MENU_TITLE};
+PLACE_SDRAM_BSS defaults::SliceMode defaultSliceMode{STRING_FOR_DEFAULT_SLICE_MODE,
+                                                     STRING_FOR_DEFAULT_SLICE_MODE_MENU_TITLE};
+PLACE_SDRAM_BSS ToggleBool defaultHighCPUUsageIndicatorMode{STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
+                                                            STRING_FOR_DEFAULT_HIGH_CPU_USAGE_INDICATOR,
+                                                            FlashStorage::highCPUUsageIndicator};
+PLACE_SDRAM_BSS defaults::HoldTime defaultHoldTimeMenu{STRING_FOR_HOLD_TIME, STRING_FOR_HOLD_TIME};
 
-ActiveScaleMenu defaultActiveScaleMenu{STRING_FOR_ACTIVE_SCALES, ActiveScaleMenu::DEFAULT};
+PLACE_SDRAM_BSS ActiveScaleMenu defaultActiveScaleMenu{STRING_FOR_ACTIVE_SCALES, ActiveScaleMenu::DEFAULT};
 
-Submenu defaultScalesSubmenu{STRING_FOR_SCALE,
-                             {
-                                 &defaultScaleMenu,
-                                 &defaultActiveScaleMenu,
-                             }};
+PLACE_SDRAM_BSS Submenu defaultScalesSubmenu{STRING_FOR_SCALE,
+                                             {
+                                                 &defaultScaleMenu,
+                                                 &defaultActiveScaleMenu,
+                                             }};
 
-Submenu defaultsSubmenu{
+PLACE_SDRAM_BSS Submenu defaultsSubmenu{
     STRING_FOR_DEFAULTS,
     {
         &defaultUI,
@@ -1336,39 +1390,43 @@ Submenu defaultsSubmenu{
 // Sound editor menu -----------------------------------------------------------------------------
 
 // FM only
-std::array<MenuItem*, 3> dxMenuItems = {
+PLACE_SDRAM_RODATA std::array<MenuItem*, 3> dxMenuItems = {
     &dxBrowseMenu,
     &dxGlobalParams,
     &dxEngineSelect,
 };
-menu_item::Submenu dxMenu{STRING_FOR_DX_1, dxMenuItems};
+
+PLACE_SDRAM_BSS menu_item::Submenu dxMenu{STRING_FOR_DX_1, dxMenuItems};
 
 // Not FM
-MasterTranspose masterTransposeMenu{STRING_FOR_MASTER_TRANSPOSE, STRING_FOR_MASTER_TRAN_MENU_TITLE};
+PLACE_SDRAM_BSS MasterTranspose masterTransposeMenu{STRING_FOR_MASTER_TRANSPOSE, STRING_FOR_MASTER_TRAN_MENU_TITLE};
 
-patch_cable_strength::Fixed vibratoMenu{STRING_FOR_VIBRATO, params::LOCAL_PITCH_ADJUST, PatchSource::LFO_GLOBAL_1};
+PLACE_SDRAM_BSS patch_cable_strength::Fixed vibratoMenu{STRING_FOR_VIBRATO, params::LOCAL_PITCH_ADJUST,
+                                                        PatchSource::LFO_GLOBAL_1};
 
 // Synth only
-SynthModeSelection synthModeMenu{STRING_FOR_SYNTH_MODE};
-bend_range::PerFinger drumBendRangeMenu{STRING_FOR_BEND_RANGE}; // The single option available for Drums
-patched_param::Integer volumeMenu{STRING_FOR_VOLUME_LEVEL, STRING_FOR_MASTER_LEVEL, params::GLOBAL_VOLUME_POST_FX, BAR};
-patched_param::Pan panMenu{STRING_FOR_PAN, params::LOCAL_PAN};
+PLACE_SDRAM_BSS SynthModeSelection synthModeMenu{STRING_FOR_SYNTH_MODE};
+PLACE_SDRAM_BSS bend_range::PerFinger drumBendRangeMenu{STRING_FOR_BEND_RANGE}; // The single option available for Drums
+PLACE_SDRAM_BSS patched_param::Integer volumeMenu{STRING_FOR_VOLUME_LEVEL, STRING_FOR_MASTER_LEVEL,
+                                                  params::GLOBAL_VOLUME_POST_FX, BAR};
+PLACE_SDRAM_BSS patched_param::Pan panMenu{STRING_FOR_PAN, params::LOCAL_PAN};
 
-PatchCables patchCablesMenu{STRING_FOR_MOD_MATRIX};
+PLACE_SDRAM_BSS PatchCables patchCablesMenu{STRING_FOR_MOD_MATRIX};
 
-HorizontalMenu soundMasterMenu{
+PLACE_SDRAM_BSS HorizontalMenu soundMasterMenu{
     STRING_FOR_MASTER,
     {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu, &vibratoMenu},
 };
-HorizontalMenu soundMasterMenuWithoutVibrato{
+
+PLACE_SDRAM_BSS HorizontalMenu soundMasterMenuWithoutVibrato{
     STRING_FOR_MASTER,
     {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu},
 };
 
-HorizontalMenuGroup sourceMenuGroup{
+PLACE_SDRAM_BSS HorizontalMenuGroup sourceMenuGroup{
     {&source0Menu, &source1Menu, &modulator0Menu, &modulator1Menu, &oscMixerMenu, &oscTrackingMenu}};
 
-Submenu soundFXMenu{
+PLACE_SDRAM_BSS Submenu soundFXMenu{
     STRING_FOR_FX,
     {
         &eqMenu,
@@ -1381,12 +1439,12 @@ Submenu soundFXMenu{
     },
 };
 
-Submenu soundEditorRootActionsMenu{
+PLACE_SDRAM_BSS Submenu soundEditorRootActionsMenu{
     STRING_FOR_ACTIONS,
     {&nameEditMenu, &sample0RecorderMenu, &sample1RecorderMenu},
 };
 
-Submenu soundEditorRootMenu{
+PLACE_SDRAM_BSS Submenu soundEditorRootMenu{
     STRING_FOR_SOUND,
     {
         &soundEditorRootActionsMenu,
@@ -1420,26 +1478,26 @@ Submenu soundEditorRootMenu{
     },
 };
 
-menu_item::note::IteranceDivisor noteCustomIteranceDivisor{STRING_FOR_ITERANCE_DIVISOR};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep1{STRING_FOR_ITERATION_STEP_1, STRING_FOR_ITERATION_STEP_1,
-                                                            0};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep2{STRING_FOR_ITERATION_STEP_2, STRING_FOR_ITERATION_STEP_2,
-                                                            1};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep3{STRING_FOR_ITERATION_STEP_3, STRING_FOR_ITERATION_STEP_3,
-                                                            2};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep4{STRING_FOR_ITERATION_STEP_4, STRING_FOR_ITERATION_STEP_4,
-                                                            3};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep5{STRING_FOR_ITERATION_STEP_5, STRING_FOR_ITERATION_STEP_5,
-                                                            4};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep6{STRING_FOR_ITERATION_STEP_6, STRING_FOR_ITERATION_STEP_6,
-                                                            5};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep7{STRING_FOR_ITERATION_STEP_7, STRING_FOR_ITERATION_STEP_7,
-                                                            6};
-menu_item::note::IteranceStepToggle noteCustomIteranceStep8{STRING_FOR_ITERATION_STEP_8, STRING_FOR_ITERATION_STEP_8,
-                                                            7};
+PLACE_SDRAM_BSS menu_item::note::IteranceDivisor noteCustomIteranceDivisor{STRING_FOR_ITERANCE_DIVISOR};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep1{STRING_FOR_ITERATION_STEP_1,
+                                                                            STRING_FOR_ITERATION_STEP_1, 0};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep2{STRING_FOR_ITERATION_STEP_2,
+                                                                            STRING_FOR_ITERATION_STEP_2, 1};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep3{STRING_FOR_ITERATION_STEP_3,
+                                                                            STRING_FOR_ITERATION_STEP_3, 2};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep4{STRING_FOR_ITERATION_STEP_4,
+                                                                            STRING_FOR_ITERATION_STEP_4, 3};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep5{STRING_FOR_ITERATION_STEP_5,
+                                                                            STRING_FOR_ITERATION_STEP_5, 4};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep6{STRING_FOR_ITERATION_STEP_6,
+                                                                            STRING_FOR_ITERATION_STEP_6, 5};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep7{STRING_FOR_ITERATION_STEP_7,
+                                                                            STRING_FOR_ITERATION_STEP_7, 6};
+PLACE_SDRAM_BSS menu_item::note::IteranceStepToggle noteCustomIteranceStep8{STRING_FOR_ITERATION_STEP_8,
+                                                                            STRING_FOR_ITERATION_STEP_8, 7};
 
 // Root menu for note custom iterance
-menu_item::Submenu noteCustomIteranceRootMenu{
+PLACE_SDRAM_BSS menu_item::Submenu noteCustomIteranceRootMenu{
     STRING_FOR_CUSTOM,
     {
         &noteCustomIteranceDivisor,
@@ -1454,40 +1512,40 @@ menu_item::Submenu noteCustomIteranceRootMenu{
     },
 };
 
-menu_item::note::Velocity noteVelocityMenu{STRING_FOR_NOTE_EDITOR_VELOCITY};
-menu_item::note::Probability noteProbabilityMenu{STRING_FOR_NOTE_EDITOR_PROBABILITY};
-menu_item::note::IterancePreset noteIteranceMenu{STRING_FOR_NOTE_EDITOR_ITERANCE};
-menu_item::note::Fill noteFillMenu{STRING_FOR_NOTE_EDITOR_FILL};
+PLACE_SDRAM_BSS menu_item::note::Velocity noteVelocityMenu{STRING_FOR_NOTE_EDITOR_VELOCITY};
+PLACE_SDRAM_BSS menu_item::note::Probability noteProbabilityMenu{STRING_FOR_NOTE_EDITOR_PROBABILITY};
+PLACE_SDRAM_BSS menu_item::note::IterancePreset noteIteranceMenu{STRING_FOR_NOTE_EDITOR_ITERANCE};
+PLACE_SDRAM_BSS menu_item::note::Fill noteFillMenu{STRING_FOR_NOTE_EDITOR_FILL};
 
 // Root menu for Note Editor
-HorizontalMenu noteEditorRootMenu{STRING_FOR_NOTE_EDITOR,
-                                  {
-                                      &noteVelocityMenu,
-                                      &noteProbabilityMenu,
-                                      &noteIteranceMenu,
-                                      &noteFillMenu,
-                                  }};
+PLACE_SDRAM_BSS HorizontalMenu noteEditorRootMenu{STRING_FOR_NOTE_EDITOR,
+                                                  {
+                                                      &noteVelocityMenu,
+                                                      &noteProbabilityMenu,
+                                                      &noteIteranceMenu,
+                                                      &noteFillMenu,
+                                                  }};
 
-menu_item::note_row::IteranceDivisor noteRowCustomIteranceDivisor{STRING_FOR_ITERANCE_DIVISOR};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep1{STRING_FOR_ITERATION_STEP_1,
-                                                                   STRING_FOR_ITERATION_STEP_1, 0};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep2{STRING_FOR_ITERATION_STEP_2,
-                                                                   STRING_FOR_ITERATION_STEP_2, 1};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep3{STRING_FOR_ITERATION_STEP_3,
-                                                                   STRING_FOR_ITERATION_STEP_3, 2};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep4{STRING_FOR_ITERATION_STEP_4,
-                                                                   STRING_FOR_ITERATION_STEP_4, 3};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep5{STRING_FOR_ITERATION_STEP_5,
-                                                                   STRING_FOR_ITERATION_STEP_5, 4};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep6{STRING_FOR_ITERATION_STEP_6,
-                                                                   STRING_FOR_ITERATION_STEP_6, 5};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep7{STRING_FOR_ITERATION_STEP_7,
-                                                                   STRING_FOR_ITERATION_STEP_7, 6};
-menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep8{STRING_FOR_ITERATION_STEP_8,
-                                                                   STRING_FOR_ITERATION_STEP_8, 7};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceDivisor noteRowCustomIteranceDivisor{STRING_FOR_ITERANCE_DIVISOR};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep1{STRING_FOR_ITERATION_STEP_1,
+                                                                                   STRING_FOR_ITERATION_STEP_1, 0};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep2{STRING_FOR_ITERATION_STEP_2,
+                                                                                   STRING_FOR_ITERATION_STEP_2, 1};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep3{STRING_FOR_ITERATION_STEP_3,
+                                                                                   STRING_FOR_ITERATION_STEP_3, 2};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep4{STRING_FOR_ITERATION_STEP_4,
+                                                                                   STRING_FOR_ITERATION_STEP_4, 3};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep5{STRING_FOR_ITERATION_STEP_5,
+                                                                                   STRING_FOR_ITERATION_STEP_5, 4};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep6{STRING_FOR_ITERATION_STEP_6,
+                                                                                   STRING_FOR_ITERATION_STEP_6, 5};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep7{STRING_FOR_ITERATION_STEP_7,
+                                                                                   STRING_FOR_ITERATION_STEP_7, 6};
+PLACE_SDRAM_BSS menu_item::note_row::IteranceStepToggle noteRowCustomIteranceStep8{STRING_FOR_ITERATION_STEP_8,
+                                                                                   STRING_FOR_ITERATION_STEP_8, 7};
 
 // Root menu for note row custom iterance
-menu_item::Submenu noteRowCustomIteranceRootMenu{
+PLACE_SDRAM_BSS menu_item::Submenu noteRowCustomIteranceRootMenu{
     STRING_FOR_CUSTOM,
     {
         &noteRowCustomIteranceDivisor,
@@ -1502,30 +1560,30 @@ menu_item::Submenu noteRowCustomIteranceRootMenu{
     },
 };
 
-note_row::Probability noteRowProbabilityMenu{STRING_FOR_NOTE_ROW_EDITOR_PROBABILITY};
-note_row::IterancePreset noteRowIteranceMenu{STRING_FOR_NOTE_ROW_EDITOR_ITERANCE};
-note_row::Fill noteRowFillMenu{STRING_FOR_NOTE_ROW_EDITOR_FILL};
+PLACE_SDRAM_BSS note_row::Probability noteRowProbabilityMenu{STRING_FOR_NOTE_ROW_EDITOR_PROBABILITY};
+PLACE_SDRAM_BSS note_row::IterancePreset noteRowIteranceMenu{STRING_FOR_NOTE_ROW_EDITOR_ITERANCE};
+PLACE_SDRAM_BSS note_row::Fill noteRowFillMenu{STRING_FOR_NOTE_ROW_EDITOR_FILL};
 
 // Root menu for Note Row Editor
-HorizontalMenu noteRowEditorRootMenu{STRING_FOR_NOTE_ROW_EDITOR,
-                                     {
-                                         &sequenceDirectionMenu,
-                                         &noteRowProbabilityMenu,
-                                         &noteRowIteranceMenu,
-                                         &noteRowFillMenu,
-                                     }};
+PLACE_SDRAM_BSS HorizontalMenu noteRowEditorRootMenu{STRING_FOR_NOTE_ROW_EDITOR,
+                                                     {
+                                                         &sequenceDirectionMenu,
+                                                         &noteRowProbabilityMenu,
+                                                         &noteRowIteranceMenu,
+                                                         &noteRowFillMenu,
+                                                     }};
 
-menu_item::midi::ProgramSubMenu midiProgramMenu{STRING_FOR_MIDI_PROGRAM_MENU_TITLE,
-                                                {
-                                                    &midiBankMenu,
-                                                    &midiSubMenu,
-                                                    &midiPGMMenu,
-                                                },
-                                                HorizontalMenu::Layout::FIXED,
-                                                2};
+PLACE_SDRAM_BSS menu_item::midi::ProgramSubMenu midiProgramMenu{STRING_FOR_MIDI_PROGRAM_MENU_TITLE,
+                                                                {
+                                                                    &midiBankMenu,
+                                                                    &midiSubMenu,
+                                                                    &midiPGMMenu,
+                                                                },
+                                                                HorizontalMenu::Layout::FIXED,
+                                                                2};
 
 // Root menu for MIDI / CV
-menu_item::Submenu soundEditorRootMenuMIDIOrCV{
+PLACE_SDRAM_BSS menu_item::Submenu soundEditorRootMenuMIDIOrCV{
     STRING_FOR_MIDI_INST_MENU_TITLE,
     {
         &midiDeviceDefinitionMenu,
@@ -1541,14 +1599,15 @@ menu_item::Submenu soundEditorRootMenuMIDIOrCV{
 };
 
 // Root menu for NonAudioDrums (MIDI and Gate drums)
-menu_item::Submenu soundEditorRootMenuMidiDrum{
+PLACE_SDRAM_BSS menu_item::Submenu soundEditorRootMenuMidiDrum{
     STRING_FOR_MIDI,
     {
         &arpMenuMIDIOrCV,
         &randomizerMenu,
     },
 };
-menu_item::Submenu soundEditorRootMenuGateDrum{
+
+PLACE_SDRAM_BSS menu_item::Submenu soundEditorRootMenuGateDrum{
     STRING_FOR_GATE,
     {
         &arpMenuMIDIOrCV,
@@ -1557,7 +1616,7 @@ menu_item::Submenu soundEditorRootMenuGateDrum{
 };
 
 // Root menu for AudioClips
-menu_item::Submenu soundEditorRootMenuAudioClip{
+PLACE_SDRAM_BSS menu_item::Submenu soundEditorRootMenuAudioClip{
     STRING_FOR_AUDIO_CLIP,
     {
         &audioClipActionsMenu,
@@ -1575,10 +1634,10 @@ menu_item::Submenu soundEditorRootMenuAudioClip{
 };
 
 // Menu for Performance View Editing Mode
-menu_item::performance_session_view::EditingMode performEditorMenu{STRING_FOR_PERFORM_EDITOR};
+PLACE_SDRAM_BSS menu_item::performance_session_view::EditingMode performEditorMenu{STRING_FOR_PERFORM_EDITOR};
 
 // Root menu for Performance View
-menu_item::Submenu soundEditorRootMenuPerformanceView{
+PLACE_SDRAM_BSS menu_item::Submenu soundEditorRootMenuPerformanceView{
     STRING_FOR_PERFORM_FX,
     {
         &performEditorMenu,
@@ -1588,33 +1647,35 @@ menu_item::Submenu soundEditorRootMenuPerformanceView{
 };
 
 // Sub menu for Stem Export
-menu_item::stem_export::Start startStemExportMenu{STRING_FOR_START_EXPORT};
+PLACE_SDRAM_BSS menu_item::stem_export::Start startStemExportMenu{STRING_FOR_START_EXPORT};
 
-ToggleBool configureNormalizationMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION,
-                                      STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION, stemExport.allowNormalization};
-ToggleBool configureNormalizationForDrumsMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION,
-                                              STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION,
-                                              stemExport.allowNormalizationForDrums};
-ToggleBool configureSilenceMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_SILENCE, STRING_FOR_CONFIGURE_EXPORT_STEMS_SILENCE,
-                                stemExport.exportToSilence};
-ToggleBool configureSongFXMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_SONGFX, STRING_FOR_CONFIGURE_EXPORT_STEMS_SONGFX,
-                               stemExport.includeSongFX};
-ToggleBool configureKitFXMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_KITFX, STRING_FOR_CONFIGURE_EXPORT_STEMS_KITFX,
-                              stemExport.includeKitFX};
-ToggleBool configureOfflineRenderingMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_OFFLINE_RENDERING,
-                                         STRING_FOR_CONFIGURE_EXPORT_STEMS_OFFLINE_RENDERING, stemExport.renderOffline};
-ToggleBool configureMixdownMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_MIXDOWN, STRING_FOR_CONFIGURE_EXPORT_STEMS_MIXDOWN,
-                                stemExport.exportMixdown};
-menu_item::Submenu configureStemExportMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS,
-                                           {
-                                               &configureNormalizationMenu,
-                                               &configureSilenceMenu,
-                                               &configureSongFXMenu,
-                                               &configureOfflineRenderingMenu,
-                                               &configureMixdownMenu,
-                                           }};
+PLACE_SDRAM_BSS ToggleBool configureNormalizationMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION,
+                                                      STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION,
+                                                      stemExport.allowNormalization};
+PLACE_SDRAM_BSS ToggleBool configureNormalizationForDrumsMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION,
+                                                              STRING_FOR_CONFIGURE_EXPORT_STEMS_NORMALIZATION,
+                                                              stemExport.allowNormalizationForDrums};
+PLACE_SDRAM_BSS ToggleBool configureSilenceMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_SILENCE,
+                                                STRING_FOR_CONFIGURE_EXPORT_STEMS_SILENCE, stemExport.exportToSilence};
+PLACE_SDRAM_BSS ToggleBool configureSongFXMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_SONGFX,
+                                               STRING_FOR_CONFIGURE_EXPORT_STEMS_SONGFX, stemExport.includeSongFX};
+PLACE_SDRAM_BSS ToggleBool configureKitFXMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_KITFX,
+                                              STRING_FOR_CONFIGURE_EXPORT_STEMS_KITFX, stemExport.includeKitFX};
+PLACE_SDRAM_BSS ToggleBool configureOfflineRenderingMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_OFFLINE_RENDERING,
+                                                         STRING_FOR_CONFIGURE_EXPORT_STEMS_OFFLINE_RENDERING,
+                                                         stemExport.renderOffline};
+PLACE_SDRAM_BSS ToggleBool configureMixdownMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS_MIXDOWN,
+                                                STRING_FOR_CONFIGURE_EXPORT_STEMS_MIXDOWN, stemExport.exportMixdown};
+PLACE_SDRAM_BSS menu_item::Submenu configureStemExportMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS,
+                                                           {
+                                                               &configureNormalizationMenu,
+                                                               &configureSilenceMenu,
+                                                               &configureSongFXMenu,
+                                                               &configureOfflineRenderingMenu,
+                                                               &configureMixdownMenu,
+                                                           }};
 
-menu_item::Submenu stemExportMenu{
+PLACE_SDRAM_BSS menu_item::Submenu stemExportMenu{
     STRING_FOR_EXPORT_AUDIO,
     {
         &startStemExportMenu,
@@ -1622,16 +1683,16 @@ menu_item::Submenu stemExportMenu{
     },
 };
 
-menu_item::Submenu kitGlobalFXConfigureStemExportMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS,
-                                                      {
-                                                          &configureKitFXMenu,
-                                                          &configureNormalizationForDrumsMenu,
-                                                          &configureSilenceMenu,
-                                                          &configureSongFXMenu,
-                                                          &configureOfflineRenderingMenu,
-                                                      }};
+PLACE_SDRAM_BSS menu_item::Submenu kitGlobalFXConfigureStemExportMenu{STRING_FOR_CONFIGURE_EXPORT_STEMS,
+                                                                      {
+                                                                          &configureKitFXMenu,
+                                                                          &configureNormalizationForDrumsMenu,
+                                                                          &configureSilenceMenu,
+                                                                          &configureSongFXMenu,
+                                                                          &configureOfflineRenderingMenu,
+                                                                      }};
 
-menu_item::Submenu kitGlobalFXStemExportMenu{
+PLACE_SDRAM_BSS menu_item::Submenu kitGlobalFXStemExportMenu{
     STRING_FOR_EXPORT_AUDIO,
     {
         &startStemExportMenu,
@@ -1639,21 +1700,21 @@ menu_item::Submenu kitGlobalFXStemExportMenu{
     },
 };
 
-ActiveScaleMenu activeScaleMenu{STRING_FOR_ACTIVE_SCALES, ActiveScaleMenu::SONG};
-record::ThresholdMode songThresholdRecordingModeMenu{STRING_FOR_MODE, record::ThresholdMode::SONG};
+PLACE_SDRAM_BSS ActiveScaleMenu activeScaleMenu{STRING_FOR_ACTIVE_SCALES, ActiveScaleMenu::SONG};
+PLACE_SDRAM_BSS record::ThresholdMode songThresholdRecordingModeMenu{STRING_FOR_MODE, record::ThresholdMode::SONG};
 
-Submenu songThresholdRecordingSubmenu{
+PLACE_SDRAM_BSS Submenu songThresholdRecordingSubmenu{
     STRING_FOR_THRESHOLD_RECORDING,
     {
         &songThresholdRecordingModeMenu,
     },
 };
 
-song::ConfigureMacros configureSongMacrosMenu{STRING_FOR_CONFIGURE_SONG_MACROS};
-song::MidiLearn midiLearnMenu{STRING_FOR_MIDI_LEARN};
+PLACE_SDRAM_BSS song::ConfigureMacros configureSongMacrosMenu{STRING_FOR_CONFIGURE_SONG_MACROS};
+PLACE_SDRAM_BSS song::MidiLearn midiLearnMenu{STRING_FOR_MIDI_LEARN};
 
 // Root menu for Song View
-menu_item::Submenu soundEditorRootMenuSongView{
+PLACE_SDRAM_BSS menu_item::Submenu soundEditorRootMenuSongView{
     STRING_FOR_SONG,
     {
         &songMasterMenu,
@@ -1668,7 +1729,7 @@ menu_item::Submenu soundEditorRootMenuSongView{
     },
 };
 
-menu_item::Submenu kitGlobalFXActionsMenu{
+PLACE_SDRAM_BSS menu_item::Submenu kitGlobalFXActionsMenu{
     STRING_FOR_ACTIONS,
     {
         &kitGlobalFXStemExportMenu,
@@ -1676,7 +1737,7 @@ menu_item::Submenu kitGlobalFXActionsMenu{
 };
 
 // Root menu for Kit Global FX
-menu_item::Submenu soundEditorRootMenuKitGlobalFX{
+PLACE_SDRAM_BSS menu_item::Submenu soundEditorRootMenuKitGlobalFX{
     STRING_FOR_KIT_GLOBAL_FX,
     {
         &kitGlobalFXActionsMenu,
@@ -1690,7 +1751,7 @@ menu_item::Submenu soundEditorRootMenuKitGlobalFX{
 };
 
 // Root Menu
-Submenu settingsRootMenu{
+PLACE_SDRAM_BSS Submenu settingsRootMenu{
     STRING_FOR_SETTINGS,
     {
         &cvSelectionMenu,
@@ -1807,7 +1868,7 @@ PLACE_SDRAM_DATA MenuItem* paramShortcutsForKitGlobalFX[][kDisplayHeight] = {
     {nullptr,          	     &spreadVelocityMenu,	  &randomizerLockMenu,            &randomizerNoteProbabilityMenu,        nullptr,                     nullptr,                nullptr,                  nullptr                            },
 };
 
-deluge::vector<HorizontalMenu*> horizontalMenusChainForSound = {
+PLACE_SDRAM_RODATA deluge::vector<HorizontalMenu*> horizontalMenusChainForSound = {
 	&recorderMenu, &soundMasterMenuWithoutVibrato,
 	&sourceMenuGroup, &voiceMenuGroup, &envMenuGroup, &lfoMenuGroup,
 	&filtersMenuGroup, &eqMenu, &modFXMenu,
@@ -1816,7 +1877,7 @@ deluge::vector<HorizontalMenu*> horizontalMenusChainForSound = {
 	&arpMenuGroup, &randomizerMenu
 };
 
-deluge::vector<HorizontalMenu*> horizontalMenusChainForKit = {
+PLACE_SDRAM_RODATA deluge::vector<HorizontalMenu*> horizontalMenusChainForKit = {
 	&kitClipMasterMenu,
 	&globalFiltersMenuGroup, &globalEQMenu, &globalModFXMenu,
 	&globalReverbMenuGroup, &globalDelayMenu, &globalDistortionMenu,
@@ -1824,29 +1885,29 @@ deluge::vector<HorizontalMenu*> horizontalMenusChainForKit = {
 	&arpMenuGroupKit, &randomizerMenu
 };
 
-deluge::vector<HorizontalMenu*> horizontalMenusChainForSong = {
+PLACE_SDRAM_RODATA deluge::vector<HorizontalMenu*> horizontalMenusChainForSong = {
 	&songMasterMenu,
 	&globalFiltersMenuGroup, &globalEQMenu, &globalModFXMenu,
 	&globalReverbMenuGroup, &globalDelayMenu, &globalDistortionMenu,
 	&audioCompMenu, &stutterMenu
 };
 
-deluge::vector<HorizontalMenu*> horizontalMenusChainForAudioClip = {
+PLACE_SDRAM_RODATA deluge::vector<HorizontalMenu*> horizontalMenusChainForAudioClip = {
 	&audioClipMasterMenu, &audioClipSampleMenu,
 	&globalFiltersMenuGroup, &eqMenu, &globalModFXMenu,
 	&globalReverbMenuGroup, &globalDelayMenu, &audioClipDistortionMenu,
 	&globalSidechainMenu, &audioCompMenu, &stutterMenu
 };
 
-deluge::vector<HorizontalMenu*> horizontalMenusChainForMidiOrCv = {
+PLACE_SDRAM_RODATA deluge::vector<HorizontalMenu*> horizontalMenusChainForMidiOrCv = {
 	&arpMenuGroupMIDIOrCV, &randomizerMenu
 };
 
-filter::FilterContainer lpfContainer{{&lpfFreqMenu, &lpfResMenu}, &lpfMorphMenu};
-filter::FilterContainer hpfContainer{{&hpfFreqMenu, &hpfResMenu}, &hpfMorphMenu};
-filter::FilterContainer globalLpfContainer{{&globalLPFFreqMenu, &globalLPFResMenu}, &globalLPFMorphMenu};
-filter::FilterContainer globalHpfContainer{{&globalHPFFreqMenu, &globalHPFResMenu}, &globalHPFMorphMenu};
-deluge::vector<HorizontalMenuContainer*> horizontalMenuContainers{&lpfContainer, &hpfContainer, &globalLpfContainer, &globalHpfContainer};
+PLACE_SDRAM_BSS filter::FilterContainer lpfContainer{{&lpfFreqMenu, &lpfResMenu}, &lpfMorphMenu};
+PLACE_SDRAM_BSS filter::FilterContainer hpfContainer{{&hpfFreqMenu, &hpfResMenu}, &hpfMorphMenu};
+PLACE_SDRAM_BSS filter::FilterContainer globalLpfContainer{{&globalLPFFreqMenu, &globalLPFResMenu}, &globalLPFMorphMenu};
+PLACE_SDRAM_BSS filter::FilterContainer globalHpfContainer{{&globalHPFFreqMenu, &globalHPFResMenu}, &globalHPFMorphMenu};
+PLACE_SDRAM_BSS deluge::vector<HorizontalMenuContainer*> horizontalMenuContainers{&lpfContainer, &hpfContainer, &globalLpfContainer, &globalHpfContainer};
 
 //clang-format on
 

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -60,7 +60,7 @@ using namespace deluge::gui::menu_item;
 #define comingSoonMenu (MenuItem*)0xFFFFFFFF
 
 // 255 means none. 254 means soon
-PatchSource modSourceShortcuts[2][8] = {
+PLACE_SDRAM_DATA PatchSource modSourceShortcuts[2][8] = {
     {
         PatchSource::NOT_AVAILABLE,
         PatchSource::NOT_AVAILABLE,
@@ -83,7 +83,7 @@ PatchSource modSourceShortcuts[2][8] = {
     },
 };
 
-PatchSource modSourceShortcutsSecondLayer[2][8] = {
+PLACE_SDRAM_DATA PatchSource modSourceShortcutsSecondLayer[2][8] = {
     {
         PatchSource::NOT_AVAILABLE,
         PatchSource::NOT_AVAILABLE,

--- a/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
@@ -34,36 +34,39 @@ namespace params = deluge::modulation::params;
 
 using namespace deluge::gui;
 
-constexpr int32_t kParamNodeWidth = 3;
+PLACE_SDRAM_RODATA constexpr int32_t kParamNodeWidth = 3;
 
 // VU meter style colours for the automation editor
 
-const RGB rowColour[kDisplayHeight] = {{0, 255, 0},   {36, 219, 0}, {73, 182, 0}, {109, 146, 0},
-                                       {146, 109, 0}, {182, 73, 0}, {219, 36, 0}, {255, 0, 0}};
+PLACE_SDRAM_RODATA const RGB rowColour[kDisplayHeight] = {{0, 255, 0},   {36, 219, 0}, {73, 182, 0}, {109, 146, 0},
+                                                          {146, 109, 0}, {182, 73, 0}, {219, 36, 0}, {255, 0, 0}};
 
-const RGB rowTailColour[kDisplayHeight] = {{2, 53, 2},  {9, 46, 2},  {17, 38, 2}, {24, 31, 2},
-                                           {31, 24, 2}, {38, 17, 2}, {46, 9, 2},  {53, 2, 2}};
+PLACE_SDRAM_RODATA const RGB rowTailColour[kDisplayHeight] = {{2, 53, 2},  {9, 46, 2},  {17, 38, 2}, {24, 31, 2},
+                                                              {31, 24, 2}, {38, 17, 2}, {46, 9, 2},  {53, 2, 2}};
 
-const RGB rowBlurColour[kDisplayHeight] = {{71, 111, 71}, {72, 101, 66}, {73, 90, 62}, {74, 80, 57},
-                                           {76, 70, 53},  {77, 60, 48},  {78, 49, 44}, {79, 39, 39}};
+PLACE_SDRAM_RODATA const RGB rowBlurColour[kDisplayHeight] = {{71, 111, 71}, {72, 101, 66}, {73, 90, 62}, {74, 80, 57},
+                                                              {76, 70, 53},  {77, 60, 48},  {78, 49, 44}, {79, 39, 39}};
 
-const RGB rowBipolarDownColour[kDisplayHeight / 2] = {{255, 0, 0}, {182, 73, 0}, {73, 182, 0}, {0, 255, 0}};
+PLACE_SDRAM_RODATA const RGB rowBipolarDownColour[kDisplayHeight / 2] = {
+    {255, 0, 0}, {182, 73, 0}, {73, 182, 0}, {0, 255, 0}};
 
-const RGB rowBipolarDownTailColour[kDisplayHeight / 2] = {{53, 2, 2}, {38, 17, 2}, {17, 38, 2}, {2, 53, 2}};
+PLACE_SDRAM_RODATA const RGB rowBipolarDownTailColour[kDisplayHeight / 2] = {
+    {53, 2, 2}, {38, 17, 2}, {17, 38, 2}, {2, 53, 2}};
 
-const RGB rowBipolarDownBlurColour[kDisplayHeight / 2] = {{79, 39, 39}, {77, 60, 48}, {73, 90, 62}, {71, 111, 71}};
+PLACE_SDRAM_RODATA const RGB rowBipolarDownBlurColour[kDisplayHeight / 2] = {
+    {79, 39, 39}, {77, 60, 48}, {73, 90, 62}, {71, 111, 71}};
 
 // lookup tables for the values that are set when you press the pads in each row of the grid
-const int32_t nonPatchCablePadPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
-const int32_t patchCablePadPressValues[kDisplayHeight] = {-128, -90, -60, -30, 30, 60, 90, 128};
+PLACE_SDRAM_RODATA const int32_t nonPatchCablePadPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
+PLACE_SDRAM_RODATA const int32_t patchCablePadPressValues[kDisplayHeight] = {-128, -90, -60, -30, 30, 60, 90, 128};
 
 // lookup tables for the min value of each pad's value range used to display automation on each row of the grid
-const int32_t nonPatchCableMinPadDisplayValues[kDisplayHeight] = {0, 17, 33, 49, 65, 81, 97, 113};
-const int32_t patchCableMinPadDisplayValues[kDisplayHeight] = {-128, -96, -64, -32, 1, 33, 65, 97};
+PLACE_SDRAM_RODATA const int32_t nonPatchCableMinPadDisplayValues[kDisplayHeight] = {0, 17, 33, 49, 65, 81, 97, 113};
+PLACE_SDRAM_RODATA const int32_t patchCableMinPadDisplayValues[kDisplayHeight] = {-128, -96, -64, -32, 1, 33, 65, 97};
 
 // lookup tables for the max value of each pad's value range used to display automation on each row of the grid
-const int32_t nonPatchCableMaxPadDisplayValues[kDisplayHeight] = {16, 32, 48, 64, 80, 96, 112, 128};
-const int32_t patchCableMaxPadDisplayValues[kDisplayHeight] = {-97, -65, -33, -1, 32, 64, 96, 128};
+PLACE_SDRAM_RODATA const int32_t nonPatchCableMaxPadDisplayValues[kDisplayHeight] = {16, 32, 48, 64, 80, 96, 112, 128};
+PLACE_SDRAM_RODATA const int32_t patchCableMaxPadDisplayValues[kDisplayHeight] = {-97, -65, -33, -1, 32, 64, 96, 128};
 
 // summary of pad ranges and press values (format: MIN < PRESS < MAX)
 // patch cable:

--- a/src/deluge/gui/views/automation/editor_layout/note/velocity.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/note/velocity.cpp
@@ -27,23 +27,23 @@ using namespace deluge::gui;
 
 // colours for the velocity editor
 
-const RGB velocityRowColour[kDisplayHeight] = {{0, 0, 255},   {36, 0, 219}, {73, 0, 182}, {109, 0, 146},
-                                               {146, 0, 109}, {182, 0, 73}, {219, 0, 36}, {255, 0, 0}};
+PLACE_SDRAM_RODATA const RGB velocityRowColour[kDisplayHeight] = {
+    {0, 0, 255}, {36, 0, 219}, {73, 0, 182}, {109, 0, 146}, {146, 0, 109}, {182, 0, 73}, {219, 0, 36}, {255, 0, 0}};
 
-const RGB velocityRowTailColour[kDisplayHeight] = {{2, 2, 53},  {9, 2, 46},  {17, 2, 38}, {24, 2, 31},
-                                                   {31, 2, 24}, {38, 2, 17}, {46, 2, 9},  {53, 2, 2}};
+PLACE_SDRAM_RODATA const RGB velocityRowTailColour[kDisplayHeight] = {
+    {2, 2, 53}, {9, 2, 46}, {17, 2, 38}, {24, 2, 31}, {31, 2, 24}, {38, 2, 17}, {46, 2, 9}, {53, 2, 2}};
 
-const RGB velocityRowBlurColour[kDisplayHeight] = {{71, 71, 111}, {72, 66, 101}, {73, 62, 90}, {74, 57, 80},
-                                                   {76, 53, 70},  {77, 48, 60},  {78, 44, 49}, {79, 39, 39}};
+PLACE_SDRAM_RODATA const RGB velocityRowBlurColour[kDisplayHeight] = {
+    {71, 71, 111}, {72, 66, 101}, {73, 62, 90}, {74, 57, 80}, {76, 53, 70}, {77, 48, 60}, {78, 44, 49}, {79, 39, 39}};
 
 // lookup tables for the values that are set when you press the pads in each row of the grid
-const int32_t padPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
+PLACE_SDRAM_RODATA const int32_t padPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
 
 // lookup tables for the min value of each pad's value range used to display automation on each row of the grid
-const int32_t minPadDisplayValues[kDisplayHeight] = {0, 17, 33, 49, 65, 81, 97, 113};
+PLACE_SDRAM_RODATA const int32_t minPadDisplayValues[kDisplayHeight] = {0, 17, 33, 49, 65, 81, 97, 113};
 
 // lookup tables for the max value of each pad's value range used to display automation on each row of the grid
-const int32_t maxPadDisplayValues[kDisplayHeight] = {16, 32, 48, 64, 80, 96, 112, 128};
+PLACE_SDRAM_RODATA const int32_t maxPadDisplayValues[kDisplayHeight] = {16, 32, 48, 64, 80, 96, 112, 128};
 
 // summary of pad ranges and press values (format: MIN < PRESS < MAX)
 // y = 7 :: 113 < 128 < 128

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -110,205 +110,208 @@ using deluge::modulation::params::unpatchedNonGlobalParamShortcuts;
 
 using namespace deluge::gui;
 
-const uint32_t auditionPadActionUIModes[] = {UI_MODE_NOTES_PRESSED,
-                                             UI_MODE_AUDITIONING,
-                                             UI_MODE_HORIZONTAL_SCROLL,
-                                             UI_MODE_RECORD_COUNT_IN,
-                                             UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON,
-                                             0};
+PLACE_SDRAM_RODATA const uint32_t auditionPadActionUIModes[] = {UI_MODE_NOTES_PRESSED,
+                                                                UI_MODE_AUDITIONING,
+                                                                UI_MODE_HORIZONTAL_SCROLL,
+                                                                UI_MODE_RECORD_COUNT_IN,
+                                                                UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON,
+                                                                0};
 
-const uint32_t editPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};
+PLACE_SDRAM_RODATA const uint32_t editPadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};
 
-const uint32_t mutePadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};
+PLACE_SDRAM_RODATA const uint32_t mutePadActionUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, 0};
 
-const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING, UI_MODE_RECORD_COUNT_IN, 0};
+PLACE_SDRAM_RODATA const uint32_t verticalScrollUIModes[] = {UI_MODE_NOTES_PRESSED, UI_MODE_AUDITIONING,
+                                                             UI_MODE_RECORD_COUNT_IN, 0};
 
-constexpr int32_t kNumNonGlobalParamsForAutomation = 83;
-constexpr int32_t kNumGlobalParamsForAutomation = 39;
+PLACE_SDRAM_RODATA constexpr int32_t kNumNonGlobalParamsForAutomation = 83;
+PLACE_SDRAM_RODATA constexpr int32_t kNumGlobalParamsForAutomation = 39;
 
 // synth and kit rows FX - sorted in the order that Parameters are scrolled through on the display
-const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutomation> nonGlobalParamsForAutomation{{
-    // Master Volume, Pitch, Pan
-    {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_FX},
-    {params::Kind::PATCHED, params::LOCAL_PITCH_ADJUST},
-    {params::Kind::PATCHED, params::LOCAL_PAN},
-    // LPF Cutoff, Resonance, Morph
-    {params::Kind::PATCHED, params::LOCAL_LPF_FREQ},
-    {params::Kind::PATCHED, params::LOCAL_LPF_RESONANCE},
-    {params::Kind::PATCHED, params::LOCAL_LPF_MORPH},
-    // HPF Cutoff, Resonance, Morph
-    {params::Kind::PATCHED, params::LOCAL_HPF_FREQ},
-    {params::Kind::PATCHED, params::LOCAL_HPF_RESONANCE},
-    {params::Kind::PATCHED, params::LOCAL_HPF_MORPH},
-    // Bass, Bass Freq
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS_FREQ},
-    // Treble, Treble Freq
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE_FREQ},
-    // Reverb Amount
-    {params::Kind::PATCHED, params::GLOBAL_REVERB_AMOUNT},
-    // Delay Rate, Amount
-    {params::Kind::PATCHED, params::GLOBAL_DELAY_RATE},
-    {params::Kind::PATCHED, params::GLOBAL_DELAY_FEEDBACK},
-    // Sidechain Shape
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SIDECHAIN_SHAPE},
-    // Decimation, Bitcrush, Wavefolder
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SAMPLE_RATE_REDUCTION},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BITCRUSHING},
-    {params::Kind::PATCHED, params::LOCAL_FOLD},
-    // OSC 1 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
-    {params::Kind::PATCHED, params::LOCAL_OSC_A_VOLUME},
-    {params::Kind::PATCHED, params::LOCAL_OSC_A_PITCH_ADJUST},
-    {params::Kind::PATCHED, params::LOCAL_OSC_A_PHASE_WIDTH},
-    {params::Kind::PATCHED, params::LOCAL_CARRIER_0_FEEDBACK},
-    {params::Kind::PATCHED, params::LOCAL_OSC_A_WAVE_INDEX},
-    // OSC 2 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
-    {params::Kind::PATCHED, params::LOCAL_OSC_B_VOLUME},
-    {params::Kind::PATCHED, params::LOCAL_OSC_B_PITCH_ADJUST},
-    {params::Kind::PATCHED, params::LOCAL_OSC_B_PHASE_WIDTH},
-    {params::Kind::PATCHED, params::LOCAL_CARRIER_1_FEEDBACK},
-    {params::Kind::PATCHED, params::LOCAL_OSC_B_WAVE_INDEX},
-    // FM Mod 1 Volume, Pitch, Feedback
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_VOLUME},
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_PITCH_ADJUST},
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_FEEDBACK},
-    // FM Mod 2 Volume, Pitch, Feedback
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_VOLUME},
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_PITCH_ADJUST},
-    {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_FEEDBACK},
-    // Env 1 ADSR
-    {params::Kind::PATCHED, params::LOCAL_ENV_0_ATTACK},
-    {params::Kind::PATCHED, params::LOCAL_ENV_0_DECAY},
-    {params::Kind::PATCHED, params::LOCAL_ENV_0_SUSTAIN},
-    {params::Kind::PATCHED, params::LOCAL_ENV_0_RELEASE},
-    // Env 2 ADSR
-    {params::Kind::PATCHED, params::LOCAL_ENV_1_ATTACK},
-    {params::Kind::PATCHED, params::LOCAL_ENV_1_DECAY},
-    {params::Kind::PATCHED, params::LOCAL_ENV_1_SUSTAIN},
-    {params::Kind::PATCHED, params::LOCAL_ENV_1_RELEASE},
-    // Env 3 ADSR
-    {params::Kind::PATCHED, params::LOCAL_ENV_2_ATTACK},
-    {params::Kind::PATCHED, params::LOCAL_ENV_2_DECAY},
-    {params::Kind::PATCHED, params::LOCAL_ENV_2_SUSTAIN},
-    {params::Kind::PATCHED, params::LOCAL_ENV_2_RELEASE},
-    // Env 4 ADSR
-    {params::Kind::PATCHED, params::LOCAL_ENV_3_ATTACK},
-    {params::Kind::PATCHED, params::LOCAL_ENV_3_DECAY},
-    {params::Kind::PATCHED, params::LOCAL_ENV_3_SUSTAIN},
-    {params::Kind::PATCHED, params::LOCAL_ENV_3_RELEASE},
-    // LFO 1
-    {params::Kind::PATCHED, params::GLOBAL_LFO_FREQ_1},
-    // LFO 2
-    {params::Kind::PATCHED, params::LOCAL_LFO_LOCAL_FREQ_1},
-    // LFO 3
-    {params::Kind::PATCHED, params::GLOBAL_LFO_FREQ_2},
-    // LFO 4
-    {params::Kind::PATCHED, params::LOCAL_LFO_LOCAL_FREQ_2},
-    // Mod FX Offset, Feedback, Depth, Rate
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_OFFSET},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_FEEDBACK},
-    {params::Kind::PATCHED, params::GLOBAL_MOD_FX_DEPTH},
-    {params::Kind::PATCHED, params::GLOBAL_MOD_FX_RATE},
-    // Arp Rate, Gate, Rhythm, Chord Polyphony, Sequence Length, Ratchet Amount, Note Prob, Bass Prob, Chord Prob,
-    // Ratchet Prob, Spread Gate, Spread Octave, Spread Velocity
-    {params::Kind::PATCHED, params::GLOBAL_ARP_RATE},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_GATE},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SPREAD_GATE},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SPREAD_OCTAVE},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SPREAD_VELOCITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_AMOUNT},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_PROBABILITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_CHORD_POLYPHONY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_CHORD_PROBABILITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_NOTE_PROBABILITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_BASS_PROBABILITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SWAP_PROBABILITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_GLIDE_PROBABILITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_REVERSE_PROBABILITY},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RHYTHM},
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
-    // Noise
-    {params::Kind::PATCHED, params::LOCAL_NOISE_VOLUME},
-    // Portamento
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_PORTAMENTO},
-    // Stutter Rate
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE},
-    // Compressor Threshold
-    {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_COMPRESSOR_THRESHOLD},
-    // Mono Expression: X - Pitch Bend
-    {params::Kind::EXPRESSION, Expression::X_PITCH_BEND},
-    // Mono Expression: Y - Mod Wheel
-    {params::Kind::EXPRESSION, Expression::Y_SLIDE_TIMBRE},
-    // Mono Expression: Z - Channel Pressure
-    {params::Kind::EXPRESSION, Expression::Z_PRESSURE},
-}};
+PLACE_SDRAM_RODATA const std::array<std::pair<params::Kind, ParamType>, kNumNonGlobalParamsForAutomation>
+    nonGlobalParamsForAutomation{{
+        // Master Volume, Pitch, Pan
+        {params::Kind::PATCHED, params::GLOBAL_VOLUME_POST_FX},
+        {params::Kind::PATCHED, params::LOCAL_PITCH_ADJUST},
+        {params::Kind::PATCHED, params::LOCAL_PAN},
+        // LPF Cutoff, Resonance, Morph
+        {params::Kind::PATCHED, params::LOCAL_LPF_FREQ},
+        {params::Kind::PATCHED, params::LOCAL_LPF_RESONANCE},
+        {params::Kind::PATCHED, params::LOCAL_LPF_MORPH},
+        // HPF Cutoff, Resonance, Morph
+        {params::Kind::PATCHED, params::LOCAL_HPF_FREQ},
+        {params::Kind::PATCHED, params::LOCAL_HPF_RESONANCE},
+        {params::Kind::PATCHED, params::LOCAL_HPF_MORPH},
+        // Bass, Bass Freq
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BASS_FREQ},
+        // Treble, Treble Freq
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_TREBLE_FREQ},
+        // Reverb Amount
+        {params::Kind::PATCHED, params::GLOBAL_REVERB_AMOUNT},
+        // Delay Rate, Amount
+        {params::Kind::PATCHED, params::GLOBAL_DELAY_RATE},
+        {params::Kind::PATCHED, params::GLOBAL_DELAY_FEEDBACK},
+        // Sidechain Shape
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SIDECHAIN_SHAPE},
+        // Decimation, Bitcrush, Wavefolder
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SAMPLE_RATE_REDUCTION},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_BITCRUSHING},
+        {params::Kind::PATCHED, params::LOCAL_FOLD},
+        // OSC 1 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+        {params::Kind::PATCHED, params::LOCAL_OSC_A_VOLUME},
+        {params::Kind::PATCHED, params::LOCAL_OSC_A_PITCH_ADJUST},
+        {params::Kind::PATCHED, params::LOCAL_OSC_A_PHASE_WIDTH},
+        {params::Kind::PATCHED, params::LOCAL_CARRIER_0_FEEDBACK},
+        {params::Kind::PATCHED, params::LOCAL_OSC_A_WAVE_INDEX},
+        // OSC 2 Volume, Pitch, Pulse Width, Carrier Feedback, Wave Index
+        {params::Kind::PATCHED, params::LOCAL_OSC_B_VOLUME},
+        {params::Kind::PATCHED, params::LOCAL_OSC_B_PITCH_ADJUST},
+        {params::Kind::PATCHED, params::LOCAL_OSC_B_PHASE_WIDTH},
+        {params::Kind::PATCHED, params::LOCAL_CARRIER_1_FEEDBACK},
+        {params::Kind::PATCHED, params::LOCAL_OSC_B_WAVE_INDEX},
+        // FM Mod 1 Volume, Pitch, Feedback
+        {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_VOLUME},
+        {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_PITCH_ADJUST},
+        {params::Kind::PATCHED, params::LOCAL_MODULATOR_0_FEEDBACK},
+        // FM Mod 2 Volume, Pitch, Feedback
+        {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_VOLUME},
+        {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_PITCH_ADJUST},
+        {params::Kind::PATCHED, params::LOCAL_MODULATOR_1_FEEDBACK},
+        // Env 1 ADSR
+        {params::Kind::PATCHED, params::LOCAL_ENV_0_ATTACK},
+        {params::Kind::PATCHED, params::LOCAL_ENV_0_DECAY},
+        {params::Kind::PATCHED, params::LOCAL_ENV_0_SUSTAIN},
+        {params::Kind::PATCHED, params::LOCAL_ENV_0_RELEASE},
+        // Env 2 ADSR
+        {params::Kind::PATCHED, params::LOCAL_ENV_1_ATTACK},
+        {params::Kind::PATCHED, params::LOCAL_ENV_1_DECAY},
+        {params::Kind::PATCHED, params::LOCAL_ENV_1_SUSTAIN},
+        {params::Kind::PATCHED, params::LOCAL_ENV_1_RELEASE},
+        // Env 3 ADSR
+        {params::Kind::PATCHED, params::LOCAL_ENV_2_ATTACK},
+        {params::Kind::PATCHED, params::LOCAL_ENV_2_DECAY},
+        {params::Kind::PATCHED, params::LOCAL_ENV_2_SUSTAIN},
+        {params::Kind::PATCHED, params::LOCAL_ENV_2_RELEASE},
+        // Env 4 ADSR
+        {params::Kind::PATCHED, params::LOCAL_ENV_3_ATTACK},
+        {params::Kind::PATCHED, params::LOCAL_ENV_3_DECAY},
+        {params::Kind::PATCHED, params::LOCAL_ENV_3_SUSTAIN},
+        {params::Kind::PATCHED, params::LOCAL_ENV_3_RELEASE},
+        // LFO 1
+        {params::Kind::PATCHED, params::GLOBAL_LFO_FREQ_1},
+        // LFO 2
+        {params::Kind::PATCHED, params::LOCAL_LFO_LOCAL_FREQ_1},
+        // LFO 3
+        {params::Kind::PATCHED, params::GLOBAL_LFO_FREQ_2},
+        // LFO 4
+        {params::Kind::PATCHED, params::LOCAL_LFO_LOCAL_FREQ_2},
+        // Mod FX Offset, Feedback, Depth, Rate
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_OFFSET},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_MOD_FX_FEEDBACK},
+        {params::Kind::PATCHED, params::GLOBAL_MOD_FX_DEPTH},
+        {params::Kind::PATCHED, params::GLOBAL_MOD_FX_RATE},
+        // Arp Rate, Gate, Rhythm, Chord Polyphony, Sequence Length, Ratchet Amount, Note Prob, Bass Prob, Chord Prob,
+        // Ratchet Prob, Spread Gate, Spread Octave, Spread Velocity
+        {params::Kind::PATCHED, params::GLOBAL_ARP_RATE},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_GATE},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SPREAD_GATE},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SPREAD_OCTAVE},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_SPREAD_VELOCITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_AMOUNT},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RATCHET_PROBABILITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_CHORD_POLYPHONY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_CHORD_PROBABILITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_NOTE_PROBABILITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_BASS_PROBABILITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SWAP_PROBABILITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_GLIDE_PROBABILITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_REVERSE_PROBABILITY},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_RHYTHM},
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
+        // Noise
+        {params::Kind::PATCHED, params::LOCAL_NOISE_VOLUME},
+        // Portamento
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_PORTAMENTO},
+        // Stutter Rate
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_STUTTER_RATE},
+        // Compressor Threshold
+        {params::Kind::UNPATCHED_SOUND, params::UNPATCHED_COMPRESSOR_THRESHOLD},
+        // Mono Expression: X - Pitch Bend
+        {params::Kind::EXPRESSION, Expression::X_PITCH_BEND},
+        // Mono Expression: Y - Mod Wheel
+        {params::Kind::EXPRESSION, Expression::Y_SLIDE_TIMBRE},
+        // Mono Expression: Z - Channel Pressure
+        {params::Kind::EXPRESSION, Expression::Z_PRESSURE},
+    }};
 
 // global FX - sorted in the order that Parameters are scrolled through on the display
 // used with kit affect entire, audio clips, and arranger
-const std::array<std::pair<params::Kind, ParamType>, kNumGlobalParamsForAutomation> globalParamsForAutomation{{
-    // Master Volume, Pitch, Pan
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_VOLUME},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PITCH_ADJUST},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PAN},
-    // LPF Cutoff, Resonance
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_FREQ},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_RES},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_MORPH},
-    // HPF Cutoff, Resonance
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_FREQ},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_RES},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_MORPH},
-    // Bass, Bass Freq
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS_FREQ},
-    // Treble, Treble Freq
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE_FREQ},
-    // Reverb Amount
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_REVERB_SEND_AMOUNT},
-    // Delay Rate, Amount
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_RATE},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_AMOUNT},
-    // Sidechain Send, Shape
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_VOLUME},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_SHAPE},
-    // Decimation, Bitcrush
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SAMPLE_RATE_REDUCTION},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BITCRUSHING},
-    // Mod FX Offset, Feedback, Depth, Rate
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_OFFSET},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_FEEDBACK},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_DEPTH},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_RATE},
-    // Stutter Rate
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_STUTTER_RATE},
-    // Compressor Threshold
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_COMPRESSOR_THRESHOLD},
-    // Arp Rate, Gate, Rhythm, Chord Polyphony, Sequence Length, Ratchet Amount, Note Prob, Bass Prob, Chord Prob,
-    // Ratchet Prob, Spread Gate, Spread Octave, Spread Velocity
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RATE},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_GATE},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_SPREAD_GATE},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SPREAD_VELOCITY},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RATCHET_AMOUNT},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RATCHET_PROBABILITY},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_NOTE_PROBABILITY},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_BASS_PROBABILITY},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_SWAP_PROBABILITY},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_GLIDE_PROBABILITY},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_REVERSE_PROBABILITY},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RHYTHM},
-    {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
-}};
+PLACE_SDRAM_RODATA const std::array<std::pair<params::Kind, ParamType>, kNumGlobalParamsForAutomation>
+    globalParamsForAutomation{{
+        // Master Volume, Pitch, Pan
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_VOLUME},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PITCH_ADJUST},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_PAN},
+        // LPF Cutoff, Resonance
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_FREQ},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_RES},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_LPF_MORPH},
+        // HPF Cutoff, Resonance
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_FREQ},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_RES},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_HPF_MORPH},
+        // Bass, Bass Freq
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BASS_FREQ},
+        // Treble, Treble Freq
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_TREBLE_FREQ},
+        // Reverb Amount
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_REVERB_SEND_AMOUNT},
+        // Delay Rate, Amount
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_RATE},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_DELAY_AMOUNT},
+        // Sidechain Send, Shape
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_VOLUME},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SIDECHAIN_SHAPE},
+        // Decimation, Bitcrush
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SAMPLE_RATE_REDUCTION},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_BITCRUSHING},
+        // Mod FX Offset, Feedback, Depth, Rate
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_OFFSET},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_FEEDBACK},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_DEPTH},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_MOD_FX_RATE},
+        // Stutter Rate
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_STUTTER_RATE},
+        // Compressor Threshold
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_COMPRESSOR_THRESHOLD},
+        // Arp Rate, Gate, Rhythm, Chord Polyphony, Sequence Length, Ratchet Amount, Note Prob, Bass Prob, Chord Prob,
+        // Ratchet Prob, Spread Gate, Spread Octave, Spread Velocity
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RATE},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_GATE},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_SPREAD_GATE},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_SPREAD_VELOCITY},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RATCHET_AMOUNT},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RATCHET_PROBABILITY},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_NOTE_PROBABILITY},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_BASS_PROBABILITY},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_SWAP_PROBABILITY},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_GLIDE_PROBABILITY},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_REVERSE_PROBABILITY},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_RHYTHM},
+        {params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_ARP_SEQUENCE_LENGTH},
+    }};
 
 // shortcuts for toggling interpolation and pad selection mode
-constexpr uint8_t kInterpolationShortcutX = 0;
-constexpr uint8_t kInterpolationShortcutY = 6;
-constexpr uint8_t kPadSelectionShortcutX = 0;
-constexpr uint8_t kPadSelectionShortcutY = 7;
-constexpr uint8_t kVelocityShortcutX = 15;
-constexpr uint8_t kVelocityShortcutY = 1;
+PLACE_SDRAM_RODATA constexpr uint8_t kInterpolationShortcutX = 0;
+PLACE_SDRAM_RODATA constexpr uint8_t kInterpolationShortcutY = 6;
+PLACE_SDRAM_RODATA constexpr uint8_t kPadSelectionShortcutX = 0;
+PLACE_SDRAM_RODATA constexpr uint8_t kPadSelectionShortcutY = 7;
+PLACE_SDRAM_RODATA constexpr uint8_t kVelocityShortcutX = 15;
+PLACE_SDRAM_RODATA constexpr uint8_t kVelocityShortcutY = 1;
 
 PLACE_SDRAM_BSS AutomationView automationView{};
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -110,10 +110,10 @@ extern "C" {
 
 using namespace deluge::gui;
 
-constexpr uint8_t kVelocityShortcutX = 15;
-constexpr uint8_t kVelocityShortcutY = 1;
+PLACE_SDRAM_RODATA constexpr uint8_t kVelocityShortcutX = 15;
+PLACE_SDRAM_RODATA constexpr uint8_t kVelocityShortcutY = 1;
 
-PLACE_SDRAM_DATA InstrumentClipView instrumentClipView{};
+PLACE_SDRAM_BSS InstrumentClipView instrumentClipView{};
 
 InstrumentClipView::InstrumentClipView() {
 

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -71,10 +71,10 @@ using namespace gui;
 using namespace deluge::modulation::params;
 
 // Performance View constants
-constexpr int32_t kNumParamsForPerformance = 20;
+PLACE_SDRAM_RODATA constexpr int32_t kNumParamsForPerformance = 20;
 
 // list of parameters available for assignment to FX columns in performance view
-constexpr std::array<ParamsForPerformance, kNumParamsForPerformance> songParamsForPerformance = {{
+PLACE_SDRAM_RODATA constexpr std::array<ParamsForPerformance, kNumParamsForPerformance> songParamsForPerformance = {{
     {Kind::UNPATCHED_GLOBAL, UNPATCHED_LPF_FREQ, 8, 7, colours::red, colours::red.forTail()},
     {Kind::UNPATCHED_GLOBAL, UNPATCHED_LPF_RES, 8, 6, colours::red, colours::red.forTail()},
     {Kind::UNPATCHED_GLOBAL, UNPATCHED_LPF_MORPH, 8, 4, colours::red, colours::red.forTail()},
@@ -99,7 +99,7 @@ constexpr std::array<ParamsForPerformance, kNumParamsForPerformance> songParamsF
     {Kind::UNPATCHED_GLOBAL, UNPATCHED_STUTTER_RATE, 5, 7, colours::blue, colours::blue.forTail()},
 }};
 
-constexpr std::array<ParamsForPerformance, kDisplayWidth> defaultLayoutForPerformance = {{
+PLACE_SDRAM_RODATA constexpr std::array<ParamsForPerformance, kDisplayWidth> defaultLayoutForPerformance = {{
     {Kind::UNPATCHED_GLOBAL, UNPATCHED_LPF_FREQ, 8, 7, colours::red, colours::red.forTail()},
     {Kind::UNPATCHED_GLOBAL, UNPATCHED_LPF_RES, 8, 6, colours::red, colours::red.forTail()},
     {Kind::UNPATCHED_GLOBAL, UNPATCHED_HPF_FREQ, 9, 7, colours::pastel::orange, colours::pastel::orangeTail},
@@ -120,7 +120,7 @@ constexpr std::array<ParamsForPerformance, kDisplayWidth> defaultLayoutForPerfor
 }};
 
 // mapping shortcuts to paramKind
-constexpr Kind paramKindShortcutsForPerformanceView[kDisplayWidth][kDisplayHeight] = {
+PLACE_SDRAM_RODATA constexpr Kind paramKindShortcutsForPerformanceView[kDisplayWidth][kDisplayHeight] = {
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
     {Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE, Kind::NONE},
@@ -147,7 +147,7 @@ constexpr Kind paramKindShortcutsForPerformanceView[kDisplayWidth][kDisplayHeigh
 };
 
 // mapping shortcuts to paramID
-constexpr uint32_t paramIDShortcutsForPerformanceView[kDisplayWidth][kDisplayHeight] = {
+PLACE_SDRAM_RODATA constexpr uint32_t paramIDShortcutsForPerformanceView[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID},
     {kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID},
     {kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID, kNoParamID},
@@ -172,9 +172,9 @@ constexpr uint32_t paramIDShortcutsForPerformanceView[kDisplayWidth][kDisplayHei
 };
 
 // lookup tables for the values that are set when you press the pads in each row of the grid
-const int32_t nonDelayPadPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
-const int32_t delayPadPressValues[kDisplayHeight] = {0, 9, 18, 27, 36, 45, 54, 63};
-const int32_t quantizedStutterPressValues[kDisplayHeight] = {-52, -37, -22, -7, 8, 23, 38, 53};
+PLACE_SDRAM_RODATA const int32_t nonDelayPadPressValues[kDisplayHeight] = {0, 18, 37, 55, 73, 91, 110, 128};
+PLACE_SDRAM_RODATA const int32_t delayPadPressValues[kDisplayHeight] = {0, 9, 18, 27, 36, 45, 54, 63};
+PLACE_SDRAM_RODATA const int32_t quantizedStutterPressValues[kDisplayHeight] = {-52, -37, -22, -7, 8, 23, 38, 53};
 
 PLACE_SDRAM_BSS PerformanceView performanceView{};
 

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -92,7 +92,7 @@ namespace encoders = deluge::hid::encoders;
 using namespace deluge;
 using namespace gui;
 
-View view{};
+PLACE_SDRAM_BSS View view{};
 
 extern GlobalMIDICommand pendingGlobalMIDICommand;
 
@@ -1785,7 +1785,7 @@ bool View::potentiallyRenderVUMeter(RGB image[][kDisplayWidth + kSideBarWidth]) 
 }
 
 // lookup table for the min value of each pad's value range used to display vu meter on the grid
-const float dBFSForYDisplay[kDisplayHeight] = {-30.8, -26.4, -22.0, -17.6, -13.2, -8.8, -4.4, -0.2};
+PLACE_SDRAM_RODATA const float dBFSForYDisplay[kDisplayHeight] = {-30.8, -26.4, -22.0, -17.6, -13.2, -8.8, -4.4, -0.2};
 
 int32_t View::getMaxYDisplayForVUMeter(float level) {
 	// dBFS (dB below clipping) calculation

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -605,7 +605,7 @@ bool MidiFollow::isGlobalEffectableContext() {
 }
 
 /// used to store the clip's for each note received so that note off's can be sent to the right clip
-PLACE_SDRAM_DATA Clip* clipForLastNoteReceived[kMaxMIDIValue + 1] = {0};
+PLACE_SDRAM_BSS Clip* clipForLastNoteReceived[kMaxMIDIValue + 1] = {0};
 
 /// initializes the clipForLastNoteReceived array
 /// called when swapping songs to make sure that you aren't using clips from the old song

--- a/src/deluge/modulation/params/param.h
+++ b/src/deluge/modulation/params/param.h
@@ -295,12 +295,12 @@ char const* paramNameForFile(Kind kind, ParamType param);
 ParamType fileStringToParam(Kind kind, char const* name, bool allowPatched);
 
 /// Magic number which represents an invalid or missing param type
-constexpr uint32_t kNoParamID = 0xFFFFFFFF;
+PLACE_SDRAM_RODATA constexpr uint32_t kNoParamID = 0xFFFFFFFF;
 
 /// Grid sized array (patched param version) to assign automatable parameters to the grid
 /// used in automation view and in midi follow
 // clang-format off
-const uint32_t patchedParamShortcuts[kDisplayWidth][kDisplayHeight] = {
+PLACE_SDRAM_RODATA const uint32_t patchedParamShortcuts[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID              , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},
     {kNoParamID              , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},
     {LOCAL_OSC_A_VOLUME      , LOCAL_OSC_A_PITCH_ADJUST      , kNoParamID                    , LOCAL_OSC_A_PHASE_WIDTH, kNoParamID     , LOCAL_CARRIER_0_FEEDBACK  , LOCAL_OSC_A_WAVE_INDEX, LOCAL_NOISE_VOLUME},
@@ -319,7 +319,7 @@ const uint32_t patchedParamShortcuts[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID              , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID}
 };
 
-const uint32_t patchedParamShortcutsSecondLayer[kDisplayWidth][kDisplayHeight] = {
+PLACE_SDRAM_RODATA const uint32_t patchedParamShortcutsSecondLayer[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID              , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},
     {kNoParamID              , kNoParamID                    , kNoParamID                    , kNoParamID             , kNoParamID     , kNoParamID                , kNoParamID            , kNoParamID},
     {kNoParamID      		 , kNoParamID      				 , kNoParamID                    , kNoParamID			  , kNoParamID     , kNoParamID  			   , kNoParamID				, kNoParamID},
@@ -342,7 +342,7 @@ const uint32_t patchedParamShortcutsSecondLayer[kDisplayWidth][kDisplayHeight] =
 /// Grid sized array (unpatched, non-global) to assign automatable parameters to the grid
 /// used in automation view and in midi follow
 // clang-format off
-const uint32_t unpatchedNonGlobalParamShortcuts[kDisplayWidth][kDisplayHeight] = {
+PLACE_SDRAM_RODATA const uint32_t unpatchedNonGlobalParamShortcuts[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID          , kNoParamID, kNoParamID        , kNoParamID, kNoParamID                , kNoParamID                     , kNoParamID           , kNoParamID},
     {kNoParamID          , kNoParamID, kNoParamID        , kNoParamID, kNoParamID                , kNoParamID                     , kNoParamID           , kNoParamID},
     {kNoParamID          , kNoParamID, kNoParamID        , kNoParamID, kNoParamID                , kNoParamID                     , kNoParamID           , kNoParamID},
@@ -365,7 +365,7 @@ const uint32_t unpatchedNonGlobalParamShortcuts[kDisplayWidth][kDisplayHeight] =
 /// Grid sized array (unpatched, global) to assign automatable parameters to the grid
 /// used in automation view and in midi follow
 // clang-format off
-const uint32_t unpatchedGlobalParamShortcuts[kDisplayWidth][kDisplayHeight] = {
+PLACE_SDRAM_RODATA const uint32_t unpatchedGlobalParamShortcuts[kDisplayWidth][kDisplayHeight] = {
     {kNoParamID          , kNoParamID            , kNoParamID                , kNoParamID                  , kNoParamID				   , kNoParamID			   		 	, kNoParamID            , kNoParamID},
     {kNoParamID          , kNoParamID            , kNoParamID                , kNoParamID                  , kNoParamID				   , kNoParamID			   		 	, kNoParamID            , kNoParamID},
     {kNoParamID          , kNoParamID            , kNoParamID                , kNoParamID                  , kNoParamID				   , kNoParamID			   		 	, kNoParamID            , kNoParamID},


### PR DESCRIPTION
Fixed incorrect placement of audio rx buffer in external memory.

Moved constructors, arrays and some variables from internal data/bss to sdram data/bss

Fixed allocation to sdram data vs rodata. data section is for read-write while rodata is for read-only

**New bin size:** 1,648,608
**Previous bin size:** 1,674,136

| Section | Delta_KB |
| -- | -- | 
| .bss | +3.40 |
| .rodata | -5.12 |
| .sdram_data | -53.15 |
| .sdram_rodata | +9.15 |
| .sdram_bss | +21.03 |

<img width="725" height="497" alt="Screenshot 2026-01-03 at 4 39 28 PM" src="https://github.com/user-attachments/assets/8c268b84-6cee-4098-86e4-d6009a81b789" />

New section sizes:
<img width="618" height="521" alt="Screenshot 2026-01-03 at 4 39 55 PM" src="https://github.com/user-attachments/assets/494354f9-5f88-4cbc-858e-83234770d4ba" />

Previous section sizes:
<img width="603" height="516" alt="Screenshot 2026-01-02 at 1 24 41 PM" src="https://github.com/user-attachments/assets/0524d9f1-2ed6-4e7b-9e9a-eda3e7c2ae31" />
