### PR TITLE
Bugfix/ Fix incorrect mod encoder popups

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1107,7 +1107,7 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 			}
 			parameter_name.append(modulation::params::getPatchedParamShortName(paramID));
 		}
-		else if (getCurrentOutputType() == OutputType::MIDI_OUT) {
+		else if (isClipContext() && getCurrentOutputType() == OutputType::MIDI_OUT) {
 			MIDIInstrument* midiInstrument = (MIDIInstrument*)getCurrentOutput();
 			if (kind == params::Kind::EXPRESSION) {
 				if (paramID == X_PITCH_BEND) {


### PR DESCRIPTION
If the last selected clip is a midi clip, the mod encoder popups in song view do not display the correct parameter name

Fix this by checking that that you're dealing with the clip context

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3982

Fix #3232