### PR TITLE
Revert "Switch to STL maps for file store in AudioFileManager (#3104)"

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -430,7 +430,7 @@ ActionResult SampleBrowser::buttonAction(deluge::hid::Button b, bool on, bool in
 						return ActionResult::DEALT_WITH;
 					}
 
-					bool allFine = audioFileManager.releaseSampleAtFilePath(filePath);
+					bool allFine = audioFileManager.tryToDeleteAudioFileFromMemoryIfItExists(filePath.get());
 
 					if (!allFine) {
 						display->displayPopup(
@@ -1243,17 +1243,22 @@ bool SampleBrowser::loadAllSamplesInFolder(bool detectPitch, int32_t* getNumSamp
 	if (false) {
 removeReasonsFromSamplesAndGetOut:
 		// Remove reasons from any samples we loaded in just before
-		for (Sample* thisSample : audioFileManager.sampleFiles | std::views::values) {
+		for (int32_t e = 0; e < audioFileManager.audioFiles.getNumElements(); e++) {
+			AudioFile* audioFile = (AudioFile*)audioFileManager.audioFiles.getElement(e);
 
-			// If this sample is one of the ones we loaded a moment ago...
-			if (thisSample->partOfFolderBeingLoaded) {
-				thisSample->partOfFolderBeingLoaded = false;
+			if (audioFile->type == AudioFileType::SAMPLE) {
+				Sample* thisSample = (Sample*)audioFile;
+
+				// If this sample is one of the ones we loaded a moment ago...
+				if (thisSample->partOfFolderBeingLoaded) {
+					thisSample->partOfFolderBeingLoaded = false;
 #if ALPHA_OR_BETA_VERSION
-				if (thisSample->numReasonsToBeLoaded <= 0) {
-					FREEZE_WITH_ERROR("E213"); // I put this here to try and catch an E004 Luc got
-				}
+					if (thisSample->numReasonsToBeLoaded <= 0) {
+						FREEZE_WITH_ERROR("E213"); // I put this here to try and catch an E004 Luc got
+					}
 #endif
-				thisSample->removeReason("E392"); // Remove that temporary reason we added
+					thisSample->removeReason("E392"); // Remove that temporary reason we added
+				}
 			}
 		}
 
@@ -1313,16 +1318,12 @@ removeReasonsFromSamplesAndGetOut:
 		filePath.concatenateAtPos(staticFNO.fname, dirWithSlashLength);
 
 		// We really want to be able to pass a file pointer in here
-		auto maybeNewSample =
-		    audioFileManager.getAudioFileFromFilename(filePath, true, &thisFilePointer, AudioFileType::SAMPLE);
-
-		if (!maybeNewSample.has_value() || maybeNewSample.value() == nullptr) {
-			error = maybeNewSample.error_or(Error::NONE);
+		auto* newSample = static_cast<Sample*>(
+		    audioFileManager.getAudioFileFromFilename(filePath, true, &error, &thisFilePointer, AudioFileType::SAMPLE));
+		if (error != Error::NONE || !newSample) {
 			staticDIR.close();
 			goto removeReasonsFromSamplesAndGetOut;
 		}
-
-		auto* newSample = static_cast<Sample*>(maybeNewSample.value());
 
 		newSample->addReason();
 		newSample->partOfFolderBeingLoaded = true;
@@ -1369,25 +1370,31 @@ removeReasonsFromSamplesAndGetOut:
 
 	// Go through each sample in memory that was from the folder in question, adding them to our pointer list
 	int32_t sampleI = 0;
-	for (Sample* thisSample : audioFileManager.sampleFiles | std::views::values) {
-		// If this sample is one of the ones we loaded a moment ago...
-		if (thisSample->partOfFolderBeingLoaded) {
-			thisSample->partOfFolderBeingLoaded = false;
+	for (int32_t e = 0; e < audioFileManager.audioFiles.getNumElements(); e++) {
+		AudioFile* audioFile = (AudioFile*)audioFileManager.audioFiles.getElement(e);
 
-			if (discardingMIDINoteFromFile) {
-				thisSample->midiNoteFromFile = -1;
-			}
+		if (audioFile->type == AudioFileType::SAMPLE) {
 
-			if (detectPitch) {
-				thisSample->workOutMIDINote(doingSingleCycle);
-			}
+			Sample* thisSample = (Sample*)audioFile;
+			// If this sample is one of the ones we loaded a moment ago...
+			if (thisSample->partOfFolderBeingLoaded) {
+				thisSample->partOfFolderBeingLoaded = false;
 
-			*thisSamplePointer = thisSample;
-			sampleI++;
-			thisSamplePointer++;
+				if (discardingMIDINoteFromFile) {
+					thisSample->midiNoteFromFile = -1;
+				}
 
-			if (sampleI == numSamples) {
-				break; // Just for safety
+				if (detectPitch) {
+					thisSample->workOutMIDINote(doingSingleCycle);
+				}
+
+				*thisSamplePointer = thisSample;
+				sampleI++;
+				thisSamplePointer++;
+
+				if (sampleI == numSamples) {
+					break; // Just for safety
+				}
 			}
 		}
 	}

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -45,7 +45,6 @@
 #include "storage/file_item.h"
 #include "storage/flash_storage.h"
 #include "storage/storage_manager.h"
-#include "util/try.h"
 #include <string.h>
 
 LoadSongUI loadSongUI{};
@@ -417,12 +416,11 @@ fail:
 			goto gotErrorAfterCreatingSong;
 		}
 
-		D_TRY_CATCH(audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath,
-		                                                        currentDir.get(), currentFilenameWithoutExtension),
-		            local_error, {
-			            error = local_error;
-			            goto gotErrorAfterCreatingSong;
-		            });
+		error = audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath,
+		                                                    currentDir.get(), currentFilenameWithoutExtension);
+		if (error != Error::NONE) {
+			goto gotErrorAfterCreatingSong;
+		}
 		audioFileManager.thingBeginningLoading(ThingType::SONG);
 
 		// Search existing RAM for all samples, to lay a claim to any which will be needed for this new Song.
@@ -481,13 +479,11 @@ gotErrorAfterCreatingSong:
 		goto gotErrorAfterCreatingSong;
 	}
 
-	D_TRY_CATCH(audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath,
-	                                                        currentDir.get(), currentFilenameWithoutExtension),
-	            local_error, {
-		            error = local_error;
-		            goto gotErrorAfterCreatingSong;
-	            });
-
+	error = audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath, currentDir.get(),
+	                                                    currentFilenameWithoutExtension);
+	if (error != Error::NONE) {
+		goto gotErrorAfterCreatingSong;
+	}
 	audioFileManager.thingBeginningLoading(ThingType::SONG);
 
 	// Search existing RAM for all samples, to lay a claim to any which will be needed for this new Song.

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -185,10 +185,10 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 
 Error Instrument::setupDefaultAudioFileDir() {
 	char const* dirPathChars = dirPath.get();
-	auto result =
+	Error error =
 	    audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath, dirPathChars, name);
-	if (!result.has_value()) {
-		return result.error();
+	if (error != Error::NONE) {
+		return error;
 	}
 
 	// TODO: (Kate) Why is OutputType getting converted to ThingType here???

--- a/src/deluge/model/sample/sample.cpp
+++ b/src/deluge/model/sample/sample.cpp
@@ -1790,26 +1790,3 @@ void Sample::numReasonsDecreasedToZero(char const* errorCode) {
 	}
 }
 #endif
-
-bool Sample::mayBeStolen(void* thingNotToStealFrom) {
-	if (numReasonsToBeLoaded > 0) {
-		return false;
-	}
-
-	// If we were stolen, sampleManager's sampleFiles would get an entry deleted from it, and that's not
-	// allowed while it's being inserted to, which is when we'd be provided it as the thingNotToStealFrom.
-	return (thingNotToStealFrom != &audioFileManager.sampleFiles);
-
-	// We don't have to worry about e.g. a Sample being stolen as we try to allocate a Cluster for it in the same way as
-	// we do with SampleCaches - because in a case like this, the Sample would have a reason and so not be stealable.
-}
-
-void Sample::steal(char const* errorCode) {
-	// The destructor is about to be called too, so we don't have to do too much.
-#if ALPHA_OR_BETA_VERSION
-	if (!audioFileManager.sampleFiles.contains(&this->filePath)) {
-		display->displayPopup(errorCode); // Jensg still getting.
-	}
-#endif
-	audioFileManager.sampleFiles.erase(&this->filePath);
-}

--- a/src/deluge/model/sample/sample.h
+++ b/src/deluge/model/sample/sample.h
@@ -154,10 +154,6 @@ public:
 
 	SampleClusterArray clusters;
 
-	// Stealable Implementation
-	bool mayBeStolen(void* thingNotToStealFrom = nullptr) override;
-	void steal(char const* errorCode) override;
-
 protected:
 #if ALPHA_OR_BETA_VERSION
 	void numReasonsDecreasedToZero(char const* errorCode) override;

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -27,8 +27,6 @@
 #include "util/misc.h"
 #include <cstring>
 
-#include <algorithm>
-
 #define MAX_NUM_MARKERS 8
 
 Error AudioFile::loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTableWorkAtAllCosts) {
@@ -506,6 +504,34 @@ void AudioFile::removeReason(char const* errorCode) {
 		FREEZE_WITH_ERROR("E004"); // Luc got this! And Paolo. (Must have been years ago :D)
 #endif
 		numReasonsToBeLoaded = 0; // Save it from crashing
+	}
+}
+
+bool AudioFile::mayBeStolen(void* thingNotToStealFrom) {
+
+	if (numReasonsToBeLoaded) {
+		return false;
+	}
+
+	// If we were stolen, sampleManager.audioFiles would get an entry deleted from it, and that's not allowed while it's
+	// being inserted to, which is when we'd be provided it as the thingNotToStealFrom.
+	return (thingNotToStealFrom != &audioFileManager.audioFiles);
+
+	// We don't have to worry about e.g. a Sample being stolen as we try to allocate a Cluster for it in the same way as
+	// we do with SampleCaches - because in a case like this, the Sample would have a reason and so not be stealable.
+}
+
+void AudioFile::steal(char const* errorCode) {
+	// The destructor is about to be called too, so we don't have to do too much.
+
+	int32_t i = audioFileManager.audioFiles.searchForExactObject(this);
+	if (i < 0) {
+#if ALPHA_OR_BETA_VERSION
+		display->displayPopup(errorCode); // Jensg still getting.
+#endif
+	}
+	else {
+		audioFileManager.audioFiles.removeElement(i);
 	}
 }
 

--- a/src/deluge/storage/audio/audio_file.h
+++ b/src/deluge/storage/audio/audio_file.h
@@ -34,9 +34,10 @@ public:
 	void addReason();
 	void removeReason(char const* errorCode);
 
-	// Stealable implementation (partial)
-	// Also implemented by children (WaveTable/Sample)
-	StealableQueue getAppropriateQueue() override;
+	// Stealable implementation
+	bool mayBeStolen(void* thingNotToStealFrom = NULL);
+	void steal(char const* errorCode);
+	StealableQueue getAppropriateQueue();
 
 	String filePath;
 
@@ -46,9 +47,6 @@ public:
 	                                // filename (in special folder) as the original. So we need to remember which format
 	                                // the name took.
 	int32_t numReasonsToBeLoaded{}; // This functionality should probably be merged between AudioFile and Cluster.
-
-	constexpr static bool isSample(const AudioFile* file) { return file->type == AudioFileType::SAMPLE; }
-	constexpr static bool isWaveTable(const AudioFile* file) { return file->type == AudioFileType::WAVETABLE; }
 
 protected:
 	virtual void numReasonsIncreasedFromZero() {}

--- a/src/deluge/storage/audio/audio_file_holder.cpp
+++ b/src/deluge/storage/audio/audio_file_holder.cpp
@@ -44,18 +44,19 @@ Error AudioFileHolder::loadFile(bool reversed, bool manuallySelected, bool mayAc
 		return Error::NONE; // This could happen if the filename tag wasn't present in the file
 	}
 
-	auto maybeNewAudioFile = audioFileManager.getAudioFileFromFilename(filePath, mayActuallyReadFile, filePointer,
-	                                                                   audioFileType, makeWaveTableWorkAtAllCosts);
+	Error error;
+	AudioFile* newAudioFile = audioFileManager.getAudioFileFromFilename(
+	    filePath, mayActuallyReadFile, &error, filePointer, audioFileType, makeWaveTableWorkAtAllCosts);
 
 	// If we found it...
-	if (maybeNewAudioFile.has_value() && maybeNewAudioFile.value() != nullptr) {
+	if (newAudioFile) {
 
 		// We only actually set it after already setting it up, processing the wavetable, etc. - so there's no risk of
 		// the audio routine trying to sound it before it's all set up.
-		setAudioFile(maybeNewAudioFile.value(), reversed, manuallySelected, clusterLoadInstruction);
+		setAudioFile(newAudioFile, reversed, manuallySelected, clusterLoadInstruction);
 	}
 
-	return maybeNewAudioFile.error_or(Error::NONE);
+	return error;
 }
 
 // For if we've already got a pointer to the AudioFile in memory.

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "storage/audio/audio_file_manager.h"
-#include "definitions.h"
 #include "definitions_cxx.hpp"
 #include "extern.h"
 #include "gui/l10n/l10n.h"
@@ -31,18 +30,14 @@
 #include "model/song/song.h"
 #include "playback/playback_handler.h"
 #include "processing/engines/audio_engine.h"
-#include "storage/audio/audio_file.h"
 #include "storage/cluster/cluster.h"
 #include "storage/storage_manager.h"
 #include "storage/wave_table/wave_table.h"
 #include "storage/wave_table/wave_table_reader.h"
-#include "util/containers.h"
-#include "util/exceptions.h"
 #include "util/try.h"
-#include <algorithm>
-#include <cstring>
+
 #include <new>
-#include <ranges>
+#include <string.h>
 
 extern "C" {
 #include "fatfs/diskio.h"
@@ -127,12 +122,21 @@ clusterSizeChangedButItsOk:
 		D_PRINTLN("cluster size changed, and smaller than original so it's ok");
 		AudioEngine::killAllVoices(); // Will also stop synth voices - too bad.
 
-		// If any files aren't currently used, take this opportunity to remove them from memory
-		releaseAllUnused();
+		for (int32_t e = 0; e < audioFiles.getNumElements(); e++) {
+			AudioFile* thisAudioFile = (AudioFile*)audioFiles.getElement(e);
 
-		// Otherwise, mark all remaining samples as unplayable
-		for (Sample* sample : sampleFiles | std::views::values) {
-			sample->unplayable = true;
+			// If AudioFile isn't used currently, take this opportunity to remove it from memory
+			if (!thisAudioFile->numReasonsToBeLoaded) {
+				deleteUnusedAudioFileFromMemory(*thisAudioFile, e);
+				e--;
+			}
+
+			// Otherwise, mark the sample as unplayable
+			else {
+				if (thisAudioFile->type == AudioFileType::SAMPLE) {
+					((Sample*)thisAudioFile)->unplayable = true;
+				}
+			}
 		}
 
 		// That was all a pain, but now we can update the cluster size
@@ -141,42 +145,53 @@ clusterSizeChangedButItsOk:
 
 	// Or if cluster size stayed the same...
 	else {
-		// If any files aren't currently used, take this opportunity to remove them from memory
-		releaseAllUnused();
-
 		// Go through every Sample in memory
-		for (Sample* thisSample : sampleFiles | std::views::values) {
-			// Check the Sample's file still exists
-			FIL sampleFile;
-			char const* filePath = thisSample->tempFilePathForRecording.get();
-			if (!*filePath) {
-				filePath = thisSample->filePath.get();
+		for (int32_t e = 0; e < audioFiles.getNumElements(); e++) {
+
+			AudioFile* thisAudioFile = (AudioFile*)audioFiles.getElement(e);
+
+			// If Sample isn't used currently, take this opportunity to remove it from memory
+			if (!thisAudioFile->numReasonsToBeLoaded) {
+				deleteUnusedAudioFileFromMemory(*thisAudioFile, e);
+				e--;
 			}
 
-			FRESULT result = f_open(&sampleFile, filePath, FA_READ);
-			if (result != FR_OK) {
-				D_PRINTLN("couldn't open file");
-				thisSample->markAsUnloadable();
-				continue;
-			}
-
-			uint32_t firstSector = clst2sect(&fileSystem, sampleFile.obj.sclust);
-
-			f_close(&sampleFile);
-
-			// If address of first sector remained unchanged, we can be sure enough that the file hasn't been
-			// changed
-			if (firstSector == thisSample->clusters.getElement(0)->sdAddress) {}
-
-			// Otherwise
+			// Or if it is still used by someone...
 			else {
-				thisSample->markAsUnloadable();
-				continue;
-			}
+				if (thisAudioFile->type == AudioFileType::SAMPLE) {
+					// Check the Sample's file still exists
+					FIL sampleFile;
+					char const* filePath = ((Sample*)thisAudioFile)->tempFilePathForRecording.get();
+					if (!*filePath) {
+						filePath = thisAudioFile->filePath.get();
+					}
 
-			// Or if we're still here, the file's fine - who knows, maybe it's even fine again after it wasn't
-			// for a while (e.g. if the user temporarily had a different card inserted)
-			thisSample->unloadable = false;
+					FRESULT result = f_open(&sampleFile, filePath, FA_READ);
+					if (result != FR_OK) {
+						D_PRINTLN("couldn't open file");
+						((Sample*)thisAudioFile)->markAsUnloadable();
+						continue;
+					}
+
+					uint32_t firstSector = clst2sect(&fileSystem, sampleFile.obj.sclust);
+
+					f_close(&sampleFile);
+
+					// If address of first sector remained unchanged, we can be sure enough that the file hasn't been
+					// changed
+					if (firstSector == ((Sample*)thisAudioFile)->clusters.getElement(0)->sdAddress) {}
+
+					// Otherwise
+					else {
+						((Sample*)thisAudioFile)->markAsUnloadable();
+						continue;
+					}
+
+					// Or if we're still here, the file's fine - who knows, maybe it's even fine again after it wasn't
+					// for a while (e.g. if the user temporarily had a different card inserted)
+					((Sample*)thisAudioFile)->unloadable = false;
+				}
+			}
 		}
 	}
 
@@ -194,27 +209,32 @@ void AudioFileManager::deleteAnyTempRecordedSamplesFromMemory() {
 	// SampleRecorder::cardRoutine() gets called first to "detach" the Sample from the recorder. So, do this:
 	AudioEngine::doRecorderCardRoutines();
 
-	for (Sample* sample : sampleFiles | std::views::values) {
-		// If it's a temp-recorded one
-		if (!sample->tempFilePathForRecording.isEmpty()) {
+	for (int32_t e = 0; e < audioFiles.getNumElements(); e++) {
+		AudioFile* audioFile = (AudioFile*)audioFiles.getElement(e);
 
-			// if (ALPHA_OR_BETA_VERSION && audioFile->numReasons) FREEZE_WITH_ERROR("E281"); // It definitely
-			// shouldn't still have any reasons
-			//  No - it could still have a reason - the reason of its SampleRecorder. Scenario where this happened
-			//  was: recording AudioClip (instance) into Arranger when loading a new song, first causes Arranger
-			//  playback to switch to Session playback, which causes finishLinearRecording() on AudioClip, so when
-			//  song-swap does happen, the AudioClip no longer has a recorder, so the recorder doesn't clear stuff,
-			//  and it's still not quite yet finalized the file, so still holds the "reason" to the Sample.
-			//  TODO: although the Sample doesn't store a pointer to the SampleRecorder, we could easily search for
-			//  it - and delete it and its "reason"?
+		if (audioFile->type == AudioFileType::SAMPLE) {
+			// If it's a temp-recorded one
+			if (!((Sample*)audioFile)->tempFilePathForRecording.isEmpty()) {
 
-			// We know Sample belonged to an AudioClip originally because only those ones can be TEMP
-			highestUsedAudioRecordingNumberNeedsReChecking[util::to_underlying(AudioRecordingFolder::CLIPS)] = true;
+				// if (ALPHA_OR_BETA_VERSION && audioFile->numReasons) FREEZE_WITH_ERROR("E281"); // It definitely
+				// shouldn't still have any reasons
+				//  No - it could still have a reason - the reason of its SampleRecorder. Scenario where this happened
+				//  was: recording AudioClip (instance) into Arranger when loading a new song, first causes Arranger
+				//  playback to switch to Session playback, which causes finishLinearRecording() on AudioClip, so when
+				//  song-swap does happen, the AudioClip no longer has a recorder, so the recorder doesn't clear stuff,
+				//  and it's still not quite yet finalized the file, so still holds the "reason" to the Sample.
+				//  TODO: although the Sample doesn't store a pointer to the SampleRecorder, we could easily search for
+				//  it - and delete it and its "reason"?
 
-			// We may have deleted several, so do make sure we go and re-check from 0
-			highestUsedAudioRecordingNumber[util::to_underlying(AudioRecordingFolder::CLIPS)] = -1;
+				// We know Sample belonged to an AudioClip originally because only those ones can be TEMP
+				highestUsedAudioRecordingNumberNeedsReChecking[util::to_underlying(AudioRecordingFolder::CLIPS)] = true;
 
-			releaseFile(*sample);
+				// We may have deleted several, so do make sure we go and re-check from 0
+				highestUsedAudioRecordingNumber[util::to_underlying(AudioRecordingFolder::CLIPS)] = -1;
+
+				deleteUnusedAudioFileFromMemory(*audioFile, e);
+				e--;
+			}
 		}
 	}
 }
@@ -359,74 +379,80 @@ Error AudioFileManager::getUnusedAudioRecordingFilePath(String& filePath, String
 }
 
 // Returns false if exists but can't be deleted
-bool AudioFileManager::releaseSampleAtFilePath(String& filePath) {
-	if (auto search = sampleFiles.find(&filePath); search != sampleFiles.end()) {
-		Sample& sample = *search->second;
+bool AudioFileManager::tryToDeleteAudioFileFromMemoryIfItExists(char const* filePath) {
+	bool foundExact;
+
+	for (int32_t t = 0; t < 2; t++) { // Got to do this twice, just in case there's a Sample and a WaveTable.
+
+		int32_t i = audioFiles.search(filePath, GREATER_OR_EQUAL, &foundExact);
+		if (!foundExact) {
+			return true; // We're fine, it didn't exist
+		}
 
 		// Ok, it's in memory. Can we delete it - is it unused?
-		if (sample.numReasonsToBeLoaded > 0) {
+		AudioFile* audioFile = (AudioFile*)audioFiles.getElement(i);
+		if (audioFile->numReasonsToBeLoaded) {
 			return false; // Alert - not only is it in memory, but it also can't be deleted
 		}
 
 		// Ok, it's unused. Delete it.
-		releaseFile(sample);
+		deleteUnusedAudioFileFromMemory(*audioFile, i);
 	}
 	return true; // We're fine - it got deleted
 }
 
-///@brief release unused sapmles and wavetables
-void AudioFileManager::releaseAllUnused() {
-	for (Sample* sample : sampleFiles | std::views::values) {
-		if (sample->numReasonsToBeLoaded <= 0) {
-			releaseFile(*sample);
-		}
+void AudioFileManager::deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile& audioFile) {
+	int32_t i = audioFiles.searchForExactObject(&audioFile);
+	if (i < 0) {
+#if ALPHA_OR_BETA_VERSION
+		FREEZE_WITH_ERROR("E401"); // Leo got. And me! But now I've solved.
+#endif
 	}
-
-	for (WaveTable* wavetable : wavetableFiles | std::views::values) {
-		if (wavetable->numReasonsToBeLoaded <= 0) {
-			releaseFile(*wavetable);
-		}
+	else {
+		deleteUnusedAudioFileFromMemory(audioFile, i);
 	}
 }
 
-void AudioFileManager::releaseFile(Sample& sample) {
-	sampleFiles.erase(&sample.filePath);
-	sample.~Sample();
-	delugeDealloc(&sample);
+void AudioFileManager::deleteUnusedAudioFileFromMemory(AudioFile& audioFile, int32_t i) {
+
+	// Remove AudioFile from memory
+	audioFiles.removeElement(i);
+	// audioFile->remove(); // Remove from the unused AudioFiles list, where this already must have been. Actually
+	// no, the destructor does this anyway.
+	audioFile.~AudioFile();
+	delugeDealloc(&audioFile);
 }
 
-void AudioFileManager::releaseFile(WaveTable& wavetable) {
-	wavetableFiles.erase(&wavetable.filePath);
-	wavetable.~WaveTable();
-	delugeDealloc(&wavetable);
+bool AudioFileManager::ensureEnoughMemoryForOneMoreAudioFile() {
+
+	return audioFiles.ensureEnoughSpaceAllocated(1);
 }
 
-std::expected<void, Error> AudioFileManager::setupAlternateAudioFileDir(String& newPath, char const* rootDir,
-                                                                        String& songFilenameWithoutExtension) {
+Error AudioFileManager::setupAlternateAudioFileDir(String& newPath, char const* rootDir,
+                                                   String& songFilenameWithoutExtension) {
 
 	Error error = newPath.set(rootDir);
 	if (error != Error::NONE) {
-		return std::unexpected(error);
+		return error;
 	}
 
 	error = newPath.concatenate("/");
 	if (error != Error::NONE) {
-		return std::unexpected(error);
+		return error;
 	}
 
 	error = newPath.concatenate(&songFilenameWithoutExtension);
 	if (error != Error::NONE) {
-		return std::unexpected(error);
+		return error;
 	}
 
-	return std::expected<void, Error>{};
+	return Error::NONE;
 }
 
-std::expected<void, Error> AudioFileManager::setupAlternateAudioFilePath(String& newPath, int32_t dirPathLength,
-                                                                         String& oldPath) {
+Error AudioFileManager::setupAlternateAudioFilePath(String& newPath, int32_t dirPathLength, String& oldPath) {
 	Error error = newPath.concatenateAtPos(&oldPath.get()[8], dirPathLength); // The [8] skips us past "SAMPLES/"
 	if (error != Error::NONE) {
-		return std::unexpected(error);
+		return error;
 	}
 
 	int32_t pos = dirPathLength;
@@ -440,98 +466,124 @@ std::expected<void, Error> AudioFileManager::setupAlternateAudioFilePath(String&
 		int32_t slashPos = (uint32_t)slashAddress - (uint32_t)newPathChars;
 		Error error = newPath.setChar('_', slashPos);
 		if (error != Error::NONE) {
-			return std::unexpected(error);
+			return error;
 		}
 		pos = slashPos + 1;
 	}
 
-	return std::expected<void, Error>{};
+	return Error::NONE;
 }
 
-std::expected<AudioFile*, Error> //
-AudioFileManager::getAudioFileFromFilename(String& filePath, bool mayReadCard, FilePointer* suppliedFilePointer,
-                                           AudioFileType type, bool makeWaveTableWorkAtAllCosts) {
-	Error error = Error::NONE;
+AudioFile* AudioFileManager::getAudioFileFromFilename(String& filePath, bool mayReadCard, Error* error,
+                                                      FilePointer* suppliedFilePointer, AudioFileType type,
+                                                      bool makeWaveTableWorkAtAllCosts) {
+
+	*error = Error::NONE;
+
 	String backedUpFilePath;
 
-	std::optional<AudioFile*> foundAudioFile{};
-
 	// See if it's already in memory.
-	if (type == AudioFileType::SAMPLE) {
-		if (auto search = sampleFiles.find(&filePath); search != sampleFiles.end()) {
-			return search->second;
+	bool foundExact;
+	int32_t audioFileI = audioFiles.search(filePath.get(), GREATER_OR_EQUAL, &foundExact);
+
+	// If that basic search by the file's "normal" path already found it, then great.
+	if (foundExact) {
+successfullyFoundInMemory:
+		AudioFile* foundAudioFile = (AudioFile*)audioFiles.getElement(audioFileI);
+
+		// If correct type...
+		if (foundAudioFile->type == type) {
+			return foundAudioFile;
 		}
-		// If we want Sample but got Wavetable, can't convert, so we'll have to load from file after all. Reset
-		// filePath if needed (pretty unlikely scenario).
-		if (wavetableFiles.contains(&filePath)) {
-			if (!backedUpFilePath.isEmpty()) {
-				filePath.set(&backedUpFilePath);
+
+		// Otherwise, see if a neighbouring one has the right type
+		int32_t tryOffset = -1;
+
+		if (audioFileI >= 1) {
+doTryOffset:
+			AudioFile* foundAudioFile2 = (AudioFile*)audioFiles.getElement(audioFileI + tryOffset);
+
+			if (foundAudioFile2->type == type && !strcasecmp(filePath.get(), foundAudioFile2->filePath.get())) {
+				return foundAudioFile2;
 			}
-			goto tryLoadingFromCard;
 		}
-	}
-	else if (type == AudioFileType::WAVETABLE) {
-		if (auto search = wavetableFiles.find(&filePath); search != wavetableFiles.end()) {
-			return search->second;
+
+		if (tryOffset == -1 && audioFileI < audioFiles.getNumElements() - 1) {
+			tryOffset = 1;
+			goto doTryOffset;
 		}
+
+		// If here, we didn't find the correct type, but we did find an AudioFile for the correct filePath, just the
+		// wrong type.
 
 		// If we want WaveTable but got Sample, we can convert. (Otherwise, we can't.)
-		if (auto search = sampleFiles.find(&filePath); search != sampleFiles.end()) {
-			Sample* foundSample = search->second;
+		if (type == AudioFileType::WAVETABLE) {
 
 			// Stereo files can never be WaveTables
-			if (foundSample->numChannels != 1) {
-				return std::unexpected(Error::FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO);
+			if (((Sample*)foundAudioFile)->numChannels != 1) {
+				*error = Error::FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO;
+				return NULL;
 			}
 
 			// And if the user isn't insisting, then some other signs show that we probably don't want to load this
 			// as a WaveTable
 			if (!makeWaveTableWorkAtAllCosts) {
-				if (isAiffFilename(foundSample->filePath.get())) {
-					return std::unexpected(Error::FILE_NOT_LOADABLE_AS_WAVETABLE);
+				if (isAiffFilename(foundAudioFile->filePath.get())) {
+notLoadableAsWaveTable:
+					*error = Error::FILE_NOT_LOADABLE_AS_WAVETABLE;
+					return NULL;
 				}
 
 				// If this isn't actually a wavetable-specifying file or at least a wavetable-looking length, and
 				// the user isn't insisting, then opt not to do it.
-				if (!foundSample->fileExplicitlySpecifiesSelfAsWaveTable && foundSample->lengthInSamples & 2047) {
-					return std::unexpected(Error::FILE_NOT_LOADABLE_AS_WAVETABLE);
+				if (!((Sample*)foundAudioFile)->fileExplicitlySpecifiesSelfAsWaveTable) {
+					if (((Sample*)foundAudioFile)->lengthInSamples & 2047) {
+						goto notLoadableAsWaveTable;
+					}
 				}
 			}
 
 			void* waveTableMemory = GeneralMemoryAllocator::get().allocStealable(sizeof(WaveTable));
 			if (!waveTableMemory) {
-				return std::unexpected(Error::INSUFFICIENT_RAM);
+				*error = Error::INSUFFICIENT_RAM;
+				return NULL;
 			}
 
-			auto* newWaveTable = new (waveTableMemory) WaveTable;
+			WaveTable* newWaveTable = new (waveTableMemory) WaveTable;
 
 			newWaveTable->addReason(); // So it's protected while setting up.
-			foundSample->addReason();
+			foundAudioFile->addReason();
 
-			error = newWaveTable->setup(foundSample);
-			if (error != Error::NONE) {
+			*error = newWaveTable->setup((Sample*)foundAudioFile);
+			if (*error != Error::NONE) {
+waveTableCloneError:
 				newWaveTable->~WaveTable();
 				delugeDealloc(waveTableMemory);
-				return std::unexpected(error);
+				return NULL;
 			}
 
-			try {
-				wavetableFiles[&newWaveTable->filePath] = newWaveTable;
-			} catch (deluge::exception e) {
-				if (e == deluge::exception::BAD_ALLOC) {
-					newWaveTable->~WaveTable();
-					delugeDealloc(waveTableMemory);
-					return std::unexpected(Error::INSUFFICIENT_RAM);
-				}
-				freezeWithError("EXAM");
-			}
+			*error = audioFiles.insertElement(newWaveTable);
+
 			newWaveTable->removeReason("E397");
-			foundSample->removeReason("E398");
+			foundAudioFile->removeReason("E398");
+
+			if (*error != Error::NONE) {
+				goto waveTableCloneError;
+			}
+
 			return newWaveTable;
+		}
+
+		// Or if we want Sample but got Wavetable, can't convert, so we'll have to load from file after all. Reset
+		// filePath if needed (pretty unlikely scenario).
+		else {
+			if (!backedUpFilePath.isEmpty()) {
+				filePath.set(&backedUpFilePath);
+			}
 		}
 	}
 
-	// If we didn't find the audio file in memory...
+	// Or, if that didn't find the audio file in memory...
 	else {
 
 		// If we're loading a preset (not a Song, and not just browsing audio files), we should search in memory for
@@ -539,36 +591,25 @@ AudioFileManager::getAudioFileFromFilename(String& filePath, bool mayReadCard, F
 		if (alternateLoadDirStatus == AlternateLoadDirStatus::MIGHT_EXIST
 		    || alternateLoadDirStatus == AlternateLoadDirStatus::DOES_EXIST) {
 			if (thingTypeBeingLoaded != ThingType::SONG) {
-				String alternateFilePath;
-				alternateFilePath.set(&alternateAudioFileLoadPath);
-				error = alternateFilePath.concatenate("/");
-				if (error != Error::NONE) {
+				String searchPath;
+				searchPath.set(&alternateAudioFileLoadPath);
+				*error = searchPath.concatenate("/");
+				if (*error != Error::NONE) {
 					goto tryLoadingFromCard;
 				}
 				char const* fileName = getFileNameFromEndOfPath(filePath.get());
-				error = alternateFilePath.concatenate(fileName);
-				if (error != Error::NONE) {
+				*error = searchPath.concatenate(fileName);
+				if (*error != Error::NONE) {
 					goto tryLoadingFromCard;
 				}
 
-				std::optional<AudioFile*> foundAudioFile{};
-				if (type == AudioFileType::WAVETABLE) {
-					if (auto search = wavetableFiles.find(&alternateFilePath); search != wavetableFiles.end()) {
-						foundAudioFile = search->second;
-					}
-				}
-				else if (type == AudioFileType::SAMPLE) {
-					if (auto search = sampleFiles.find(&alternateFilePath); search != sampleFiles.end()) {
-						foundAudioFile = search->second;
-					}
-				}
-
-				if (foundAudioFile) {
+				audioFileI = audioFiles.search(searchPath.get(), GREATER_OR_EQUAL, &foundExact);
+				if (foundExact) {
 					// Tiny bit cheeky, but we're going to update the file path actually stored in the AudioFile to
 					// reflect this alternate location, which will no longer be considered alternate.
 					backedUpFilePath.set(&filePath); // First we back up the original filePath.
-					filePath.set(&alternateFilePath);
-					return foundAudioFile.value();
+					filePath.set(&searchPath);
+					goto successfullyFoundInMemory;
 				}
 			}
 		}
@@ -577,11 +618,12 @@ AudioFileManager::getAudioFileFromFilename(String& filePath, bool mayReadCard, F
 tryLoadingFromCard:
 	// Otherwise, try and load it in
 	if (!mayReadCard) {
-		return nullptr;
+		return NULL;
 	}
 
 	if (cardDisabled) {
-		return std::unexpected(Error::SD_CARD);
+		*error = Error::SD_CARD;
+		return NULL;
 	}
 
 	// Deactivated this because it stuff up the sampleI we already found
@@ -623,9 +665,11 @@ tryAlternateDoesExist:
 				goto tryNextAlternate;
 			}
 
-			// This is to generate just the name of the file - not an entire path with folders -
-			// despite the function being called ...Path.
-			D_TRY(setupAlternateAudioFilePath(proposedFileName, 0, filePath));
+			*error = setupAlternateAudioFilePath(proposedFileName, 0, filePath);
+			if (*error != Error::NONE) {
+				return nullptr; // This is to generate just the name of the file - not an entire path with folders -
+				                // despite the function being called ...Path.
+			}
 
 			alreadyTriedSecondAlternate = false;
 
@@ -647,9 +691,9 @@ tryNextAlternate:
 					// have them load.
 					alreadyTriedSecondAlternate = true;
 					char const* fileName = getFileNameFromEndOfPath(filePath.get());
-					error = proposedFileName.set(fileName);
-					if (error != Error::NONE) {
-						return std::unexpected(error);
+					*error = proposedFileName.set(fileName);
+					if (*error != Error::NONE) {
+						return NULL;
 					}
 					goto tryAnAlternate;
 				}
@@ -666,13 +710,13 @@ tryNextAlternate:
 			effectiveFilePointer.objsize = ld_dword(alternateLoadDir.dir + DIR_FileSize);
 
 			usingAlternateLocation.set(&alternateAudioFileLoadPath);
-			error = usingAlternateLocation.concatenate("/");
-			if (error != Error::NONE) {
-				return std::unexpected(error);
+			*error = usingAlternateLocation.concatenate("/");
+			if (*error != Error::NONE) {
+				return NULL;
 			}
-			error = usingAlternateLocation.concatenate(&proposedFileName);
-			if (error != Error::NONE) {
-				return std::unexpected(error);
+			*error = usingAlternateLocation.concatenate(&proposedFileName);
+			if (*error != Error::NONE) {
+				return NULL;
 			}
 
 			if (thingTypeBeingLoaded == ThingType::SYNTH || thingTypeBeingLoaded == ThingType::KIT) {
@@ -707,7 +751,8 @@ tryRegular:
 				}
 
 notFound:
-				return std::unexpected(Error::FILE_UNREADABLE);
+				*error = Error::FILE_UNREADABLE;
+				return NULL;
 			}
 
 			// Ok, found file.
@@ -718,12 +763,16 @@ notFound:
 
 	// 0-byte files not allowed.
 	if (!effectiveFilePointer.objsize) {
-		return std::unexpected(Error::FILE_CORRUPTED);
+		*error = Error::FILE_CORRUPTED;
+cantLoadFile:
+		// if (!suppliedFilePointer) f_close(&fileSystemStuff.currentFile);
+		return NULL;
 	}
 
 	// Files bigger than 1GB not allowed
 	else if (effectiveFilePointer.objsize > kMaxFileSize) {
-		return std::unexpected(Error::FILE_TOO_BIG);
+		*error = Error::FILE_TOO_BIG;
+		goto cantLoadFile;
 	}
 
 	uint32_t numClusters = ((effectiveFilePointer.objsize - 1) >> Cluster::size_magnitude) + 1;
@@ -733,7 +782,8 @@ notFound:
 	void* audioFileMemory = GeneralMemoryAllocator::get().allocStealable(memorySizeNeeded);
 	if (!audioFileMemory) {
 ramError:
-		return std::unexpected(Error::INSUFFICIENT_RAM);
+		*error = Error::INSUFFICIENT_RAM;
+		goto cantLoadFile;
 	}
 
 	char readerMemory[sizeof(SampleReader)];
@@ -743,11 +793,11 @@ ramError:
 	if (type == AudioFileType::SAMPLE) {
 		audioFile = new (audioFileMemory) Sample;
 		audioFile->addReason(); // So it's protected while setting up. Must do this before calling initialize().
-		error = static_cast<Sample*>(audioFile)->initialize(numClusters);
-		if (error != Error::NONE) { // Very rare, only if not enough RAM
+		*error = ((Sample*)audioFile)->initialize(numClusters);
+		if (*error != Error::NONE) { // Very rare, only if not enough RAM
 			audioFile->~AudioFile();
 			delugeDealloc(audioFileMemory);
-			return std::unexpected(error);
+			goto cantLoadFile;
 		}
 
 		reader = new (readerMemory) SampleReader;
@@ -803,55 +853,45 @@ ramError:
 
 	// Read top-level RIFF headers
 	uint32_t topHeader[3];
-	error = reader->readBytes((char*)topHeader, 3 * 4);
-	if (error != Error::NONE) {
+	*error = reader->readBytes((char*)topHeader, 3 * 4);
+	if (*error != Error::NONE) {
 		goto ensureSafeThenCheckError;
 	}
 
 	if (topHeader[0] == 0x46464952       // "RIFF"
 	    && topHeader[2] == 0x45564157) { // "WAVE"
-		error = audioFile->loadFile(reader, false, makeWaveTableWorkAtAllCosts);
+		*error = audioFile->loadFile(reader, false, makeWaveTableWorkAtAllCosts);
 	}
 	else if (topHeader[0] == 0x4D524F46       // "FORM"
 	         && topHeader[2] == 0x46464941) { // "AIFF"
-		error = audioFile->loadFile(reader, true, makeWaveTableWorkAtAllCosts);
+		*error = audioFile->loadFile(reader, true, makeWaveTableWorkAtAllCosts);
 	}
 	else {
-		error = Error::FILE_UNSUPPORTED;
+		*error = Error::FILE_UNSUPPORTED;
 	}
 
 ensureSafeThenCheckError:
 	if (type == AudioFileType::SAMPLE) {
 		auto& sampleReader = static_cast<SampleReader&>(*reader);
-		if (sampleReader.currentCluster != nullptr) {
+		if (sampleReader.currentCluster) {
 			removeReasonFromCluster(*sampleReader.currentCluster, "E030");
 		}
 	}
+	else {
+		// f_close(&fileSystemStuff.currentFile);
+	}
 
-	if (error != Error::NONE) {
+	if (*error != Error::NONE) {
 audioFileError:
 		audioFile->~AudioFile(); // Have to call this! This removes the pointers back to the Sample / SampleClusters
 		                         // from any Clusters.
 		delugeDealloc(audioFileMemory);
-		return std::unexpected(error);
+		return NULL;
 	}
 
-	try {
-		if (audioFile->type == AudioFileType::SAMPLE) {
-			sampleFiles[&audioFile->filePath] = static_cast<Sample*>(audioFile);
-		}
-		else if (audioFile->type == AudioFileType::WAVETABLE) {
-			wavetableFiles[&audioFile->filePath] = static_cast<WaveTable*>(audioFile);
-		}
-
-	} catch (deluge::exception e) {
-		if (e == deluge::exception::BAD_ALLOC) {
-			audioFile->~AudioFile(); // Have to call this! This removes the pointers back to the Sample / SampleClusters
-			                         // from any Clusters.
-			delugeDealloc(audioFileMemory);
-			return std::unexpected(Error::INSUFFICIENT_RAM);
-		}
-		freezeWithError("EXAM");
+	*error = audioFiles.insertElement(audioFile);
+	if (*error != Error::NONE) {
+		goto audioFileError;
 	}
 
 	audioFile->finalizeAfterLoad(effectiveFilePointer.objsize);

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -16,14 +16,12 @@
  */
 
 #pragma once
-#include "audio_file.h"
 #include "definitions_cxx.hpp"
+#include "storage/audio/audio_file_vector.h"
 #include "storage/cluster/cluster.h"
 #include "storage/cluster/cluster_priority_queue.h"
 #include <array>
 #include <cstdint>
-#include <expected>
-#include <strings.h>
 
 extern "C" {
 #include "fatfs/ff.h"
@@ -34,7 +32,6 @@ class SampleCache;
 class String;
 class SampleRecorder;
 class Output;
-class WaveTable;
 
 enum class AlternateLoadDirStatus {
 	NONE_SET,
@@ -83,29 +80,24 @@ char const* const audioRecordingFolderNames[] = {
  */
 
 class AudioFileManager {
-	struct StringLessThan {
-		bool operator()(String* const& lhs, String* const& rhs) const { return strcasecmp(lhs->get(), rhs->get()) < 0; }
-	};
-
 public:
 	AudioFileManager();
 
-	deluge::fast_map<String*, Sample*, StringLessThan> sampleFiles;
-	deluge::fast_map<String*, WaveTable*, StringLessThan> wavetableFiles;
+	AudioFileVector audioFiles;
 
 	void init();
-	std::expected<AudioFile*, Error> getAudioFileFromFilename(String& fileName, bool mayReadCard,
-	                                                          FilePointer* filePointer, AudioFileType type,
-	                                                          bool makeWaveTableWorkAtAllCosts = false);
+	AudioFile* getAudioFileFromFilename(String& fileName, bool mayReadCard, Error* error, FilePointer* filePointer,
+	                                    AudioFileType type, bool makeWaveTableWorkAtAllCosts = false);
 	bool loadCluster(Cluster& cluster, int32_t minNumReasonsAfter = 0);
 	void loadAnyEnqueuedClusters(int32_t maxNum = 128, bool mayProcessUserActionsBetween = false);
 	void removeReasonFromCluster(Cluster& cluster, char const* errorCode, bool deletingSong = false);
 
+	bool ensureEnoughMemoryForOneMoreAudioFile();
+
 	void slowRoutine();
 
-	std::expected<void, Error> setupAlternateAudioFilePath(String& newPath, int32_t dirPathLength, String& oldPath);
-	std::expected<void, Error> setupAlternateAudioFileDir(String& newPath, char const* rootDir,
-	                                                      String& songFilenameWithoutExtension);
+	Error setupAlternateAudioFilePath(String& newPath, int32_t dirPathLength, String& oldPath);
+	Error setupAlternateAudioFileDir(String& newPath, char const* rootDir, String& songFilenameWithoutExtension);
 	bool loadingQueueHasAnyLowestPriorityElements();
 	/// If songname isn't supplied the file is placed in the main recording folder and named as samples/folder/REC###.
 	/// If song and channel are supplied then it's placed in samples/folder/song/channel_###
@@ -113,11 +105,9 @@ public:
 	                                      AudioRecordingFolder folder, uint32_t* getNumber, const char* channelName,
 	                                      String* songName);
 	void deleteAnyTempRecordedSamplesFromMemory();
-
-	void releaseFile(Sample& sample);
-	void releaseFile(WaveTable& wavetable);
-	bool releaseSampleAtFilePath(String& filePath);
-	void releaseAllUnused();
+	void deleteUnusedAudioFileFromMemory(AudioFile& audioFile, int32_t i);
+	void deleteUnusedAudioFileFromMemoryIndexUnknown(AudioFile& audioFile);
+	bool tryToDeleteAudioFileFromMemoryIfItExists(char const* filePath);
 
 	void thingBeginningLoading(ThingType newThingType);
 	void thingFinishedLoading();

--- a/src/deluge/storage/audio/audio_file_vector.cpp
+++ b/src/deluge/storage/audio/audio_file_vector.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2018-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "storage/audio/audio_file_vector.h"
+#include "storage/audio/audio_file.h"
+
+#pragma GCC diagnostic push
+// This is supported by GCC and other compilers should error (not warn), so turn off for this file
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+
+AudioFileVector::AudioFileVector() : NamedThingVector(__builtin_offsetof(AudioFile, filePath)) {
+}
+
+// Returns -1 if not found. All times this is called, it actually should get found - but some bugs remain, and the
+// caller must deal with these.
+int32_t AudioFileVector::searchForExactObject(AudioFile* audioFile) {
+	bool foundExactName;
+	int32_t i = search(audioFile->filePath.get(), GREATER_OR_EQUAL, &foundExactName);
+	if (!foundExactName) {
+		return -1;
+	}
+
+	AudioFile* foundAudioFile = (AudioFile*)getElement(i);
+
+	// If object doesn't match, then we were looking for a Sample and got a Wavetable, or vice versa. So check
+	// neighbours.
+	if (foundAudioFile != audioFile) {
+		if (i > 0) {
+			i--;
+			foundAudioFile = (AudioFile*)getElement(i);
+			if (foundAudioFile == audioFile) {
+				goto gotIt;
+			}
+			i++; // Put it back.
+		}
+		i++; // Increment it (again). It's gotta be there... Except, some bugs?
+
+		if (i >= getNumElements()) {
+			return -1;
+		}
+		foundAudioFile = (AudioFile*)getElement(i);
+		if (foundAudioFile != audioFile) {
+			return -1;
+		}
+	}
+
+gotIt:
+	return i;
+}
+#pragma GCC diagnostic pop

--- a/src/deluge/storage/audio/audio_file_vector.h
+++ b/src/deluge/storage/audio/audio_file_vector.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2018-2023 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "util/container/vector/named_thing_vector.h"
+
+class AudioFile;
+
+class AudioFileVector final : public NamedThingVector {
+public:
+	AudioFileVector();
+	int32_t searchForExactObject(AudioFile* audioFile);
+};

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -1214,26 +1214,3 @@ void WaveTable::numReasonsDecreasedToZero(char const* errorCode) {
 
     }
  */
-
-bool WaveTable::mayBeStolen(void* thingNotToStealFrom) {
-	if (numReasonsToBeLoaded > 0) {
-		return false;
-	}
-
-	// If we were stolen, sampleManager's wavetableFiles/sampleFiles would get an entry deleted from it, and that's not
-	// allowed while it's being inserted to, which is when we'd be provided it as the thingNotToStealFrom.
-	return (thingNotToStealFrom != &audioFileManager.wavetableFiles);
-
-	// We don't have to worry about e.g. a Sample being stolen as we try to allocate a Cluster for it in the same way as
-	// we do with SampleCaches - because in a case like this, the Sample would have a reason and so not be stealable.
-}
-
-void WaveTable::steal(char const* errorCode) {
-	// The destructor is about to be called too, so we don't have to do too much.
-#if ALPHA_OR_BETA_VERSION
-	if (!audioFileManager.wavetableFiles.contains(&this->filePath)) {
-		display->displayPopup(errorCode); // Jensg still getting.
-	}
-#endif
-	audioFileManager.wavetableFiles.erase(&this->filePath);
-}

--- a/src/deluge/storage/wave_table/wave_table.h
+++ b/src/deluge/storage/wave_table/wave_table.h
@@ -54,10 +54,6 @@ public:
 	void deleteAllBandsAndData();
 	void bandDataBeingStolen(WaveTableBandData* bandData);
 
-	// Stealable Implementation
-	bool mayBeStolen(void* thingNotToStealFrom = nullptr) override;
-	void steal(char const* errorCode) override;
-
 	int32_t numCycles;
 	int32_t numCyclesMagnitude;
 

--- a/src/deluge/storage/wave_table/wave_table_band_data.cpp
+++ b/src/deluge/storage/wave_table/wave_table_band_data.cpp
@@ -21,10 +21,11 @@
 #include "storage/wave_table/wave_table.h"
 
 bool WaveTableBandData::mayBeStolen(void* thingNotToStealFrom) {
-	// Because stealing us would mean the WaveTable being deleted too, we
-	// have to abide by this rule as found in WaveTable::mayBeStolen().
-	return waveTable != nullptr && (waveTable->numReasonsToBeLoaded > 0)
-	       && thingNotToStealFrom != &audioFileManager.wavetableFiles;
+	return (
+	    waveTable && !waveTable->numReasonsToBeLoaded
+	    && thingNotToStealFrom
+	           != &audioFileManager.audioFiles); // Because stealing us would mean the WaveTable being deleted too, we
+	                                             // have to abide by this rule as found in WaveTable::mayBeStolen().
 }
 
 void WaveTableBandData::steal(char const* errorCode) {
@@ -38,7 +39,7 @@ void WaveTableBandData::steal(char const* errorCode) {
 	waveTable->bandDataBeingStolen(this);
 
 	// Delete the WaveTable from memory - deallocating all other BandDatas and everything.
-	audioFileManager.releaseFile(*waveTable);
+	audioFileManager.deleteUnusedAudioFileFromMemoryIndexUnknown(*waveTable);
 }
 
 StealableQueue WaveTableBandData::getAppropriateQueue() {


### PR DESCRIPTION
This reverts commit 718cc959cd8599a42de21d378844fae6e7adbdcc.

This is one of a series commits from immediately before branching 1.3 which tanks performance 

I'm not bothering for nightly because this was already very manual. We need to kill nightly 