### PR TITLE
hoist loop for saturation calculation

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -119,9 +119,10 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 
 	// Render saturation
 	if (clippingAmount != 0u) {
+		int32_t shiftAmount = getShiftAmountForSaturation();
 		for (StereoSample& sample : global_effectable_audio) {
-			sample.l = saturate(sample.l, &lastSaturationTanHWorkingValue[0]);
-			sample.r = saturate(sample.r, &lastSaturationTanHWorkingValue[1]);
+			sample.l = saturate(sample.l, &lastSaturationTanHWorkingValue[0], shiftAmount);
+			sample.r = saturate(sample.r, &lastSaturationTanHWorkingValue[1], shiftAmount);
 		}
 	}
 

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.h
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.h
@@ -43,14 +43,13 @@ public:
 	                            GlobalEffectableForClip** globalEffectableWithMostReverb,
 	                            int32_t* highestReverbAmountFound);
 
-	[[gnu::always_inline]] q31_t saturate(q31_t data, uint32_t* workingValue) {
+	int32_t getShiftAmountForSaturation() { return (clippingAmount >= 3) ? (clippingAmount - 3) : 0; }
+
+	/// clipping amount must be greater than 0! Check before calling
+	/// Shift amount is givben by getShiftAmountForSaturation
+	[[gnu::always_inline]] q31_t saturate(q31_t data, uint32_t* workingValue, int32_t shiftAmount) {
 		// Clipping
-		if (clippingAmount != 0u) {
-			int32_t shiftAmount = (clippingAmount >= 3) ? (clippingAmount - 3) : 0;
-			//*data = getTanHUnknown(*data, 5 + clippingAmount) << (shiftAmount);
-			return getTanHAntialiased(data, workingValue, 3 + clippingAmount) << (shiftAmount);
-		}
-		return data;
+		return getTanHAntialiased(data, workingValue, 3 + clippingAmount) << (shiftAmount);
 	}
 
 	std::array<uint32_t, 2> lastSaturationTanHWorkingValue = {2147483648u, 2147483648u};

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -1537,6 +1537,7 @@ skipUnisonPart: {}
 			int32_t const* __restrict__ oscBufferPos = oscBuffer; // For traversal
 			StereoSample* __restrict__ outputSample = (StereoSample*)soundBuffer;
 			int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
+			int32_t shiftAmount = sound.getShiftAmountForSaturation();
 
 			do {
 				int32_t outputSampleL = *(oscBufferPos++);
@@ -1548,8 +1549,8 @@ skipUnisonPart: {}
 					outputSampleR = multiply_32x32_rshift32_rounded(outputSampleR, overallOscAmplitudeNow) << 1;
 				}
 
-				sound.saturate(&outputSampleL, &lastSaturationTanHWorkingValue[0]);
-				sound.saturate(&outputSampleR, &lastSaturationTanHWorkingValue[1]);
+				sound.saturate(&outputSampleL, &lastSaturationTanHWorkingValue[0], shiftAmount);
+				sound.saturate(&outputSampleR, &lastSaturationTanHWorkingValue[1], shiftAmount);
 
 				// Write to the output buffer, panning or not
 				if (doPanning) {
@@ -1621,6 +1622,7 @@ skipUnisonPart: {}
 			int32_t* __restrict__ outputSample = soundBuffer;
 			int32_t overallOscAmplitudeNow = overallOscAmplitudeLastTime;
 
+			auto clippingAmount = sound.getShiftAmountForSaturation();
 			do {
 				int32_t output = *oscBufferPos;
 
@@ -1629,7 +1631,7 @@ skipUnisonPart: {}
 					output = multiply_32x32_rshift32_rounded(output, overallOscAmplitudeNow) << 1;
 				}
 
-				sound.saturate(&output, &lastSaturationTanHWorkingValue[0]);
+				sound.saturate(&output, &lastSaturationTanHWorkingValue[0], clippingAmount);
 
 				if (soundRenderingInStereo) {
 					if (doPanning) {

--- a/src/deluge/processing/sound/sound.h
+++ b/src/deluge/processing/sound/sound.h
@@ -283,13 +283,14 @@ public:
 	virtual ArpeggiatorBase* getArp() = 0;
 	void possiblySetupDefaultExpressionPatching(ParamManager* paramManager);
 
-	[[gnu::always_inline]] void saturate(int32_t* data, uint32_t* workingValue) {
+	int32_t getShiftAmountForSaturation() const { return (clippingAmount >= 2) ? (clippingAmount - 2) : 0; }
+
+	///	clipping amount must be greater than 0! Check before calling
+	/// Shift amount is givben by getShiftAmountForSaturation
+	[[gnu::always_inline]] void saturate(int32_t* data, uint32_t* workingValue, int32_t shiftAmount) {
 		// Clipping
-		if (clippingAmount != 0u) {
-			int32_t shiftAmount = (clippingAmount >= 2) ? (clippingAmount - 2) : 0;
-			//*data = getTanHUnknown(*data, 5 + clippingAmount) << (shiftAmount);
-			*data = getTanHAntialiased(*data, workingValue, 5 + clippingAmount) << (shiftAmount);
-		}
+		//*data = getTanHUnknown(*data, 5 + clippingAmount) << (shiftAmount);
+		*data = getTanHAntialiased(*data, workingValue, 5 + clippingAmount) << (shiftAmount);
 	}
 	uint32_t getSyncedLFOPhaseIncrement(const LFOConfig& config);
 


### PR DESCRIPTION
Moves the checks for clipping amount out of the hot loop so it's once per buffer instead of once per sample. It may or may not get done by the optimizer, checking the output it looks like it was being hoisted automatically for audio clips but not sounds. This way guarantees it either way though