### PR TITLE
Fix/Remove PLACE_SDRAM_DATA tag from ssiRxBuffer

### DIFF
--- a/src/deluge/drivers/ssi/ssi.c
+++ b/src/deluge/drivers/ssi/ssi.c
@@ -22,8 +22,7 @@
 
 int32_t ssiTxBuffer[SSI_TX_BUFFER_NUM_SAMPLES * NUM_MONO_OUTPUT_CHANNELS] __attribute__((aligned(CACHE_LINE_SIZE)));
 
-PLACE_SDRAM_DATA int32_t ssiRxBuffer[SSI_RX_BUFFER_NUM_SAMPLES * NUM_MONO_INPUT_CHANNELS]
-    __attribute__((aligned(CACHE_LINE_SIZE)));
+int32_t ssiRxBuffer[SSI_RX_BUFFER_NUM_SAMPLES * NUM_MONO_INPUT_CHANNELS] __attribute__((aligned(CACHE_LINE_SIZE)));
 
 const uint32_t ssiDmaTxLinkDescriptor[] __attribute__((aligned(CACHE_LINE_SIZE))) = {
     0b1101,                                                                          // Header


### PR DESCRIPTION
Removed PLACE_SDRAM_DATA incorrectly added to ssiRxBuffer