### PR TITLE
Add MIDI CC64 sustain pedal support for melodic instruments

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -716,6 +716,7 @@ enum class ExistenceChangeType {
 enum CCNumber {
 	/// note - only for incoming/outgoing midi. Internally use CC_NUMBER_Y_AXIS
 	CC_EXTERNAL_MOD_WHEEL = 1,
+	CC_EXTERNAL_SUSTAIN_PEDAL = 64,
 	CC_EXTERNAL_MPE_Y = 74,
 	CC_NUMBER_PITCH_BEND = 120,
 	CC_NUMBER_AFTERTOUCH = 121,

--- a/src/deluge/model/instrument/melodic_instrument.h
+++ b/src/deluge/model/instrument/melodic_instrument.h
@@ -67,7 +67,8 @@ public:
 	bool isAnyAuditioningHappening() final;
 	void beginAuditioningForNote(ModelStack* modelStack, int32_t note, int32_t velocity, int16_t const* mpeValues,
 	                             int32_t fromMIDIChannel = MIDI_CHANNEL_NONE, uint32_t sampleSyncLength = 0);
-	void endAuditioningForNote(ModelStack* modelStack, int32_t note, int32_t velocity = kDefaultLiftValue);
+	void endAuditioningForNote(ModelStack* modelStack, int32_t note, int32_t velocity = kDefaultLiftValue,
+	                          bool bypassSustain = false);
 	virtual ModelStackWithAutoParam* getParamToControlFromInputMIDIChannel(int32_t cc,
 	                                                                       ModelStackWithThreeMainThings* modelStack);
 	void processParamFromInputMIDIChannel(int32_t cc, int32_t newValue,
@@ -94,6 +95,15 @@ public:
 
 	deluge::fast_map<int16_t, EarlyNoteInfo> earlyNotes; // note value, velocity, still_active
 	deluge::fast_map<int16_t, EarlyNoteInfo> notesAuditioned;
+
+	// MIDI CC64 sustain pedal state
+	bool sustainPedalOn = false;
+	struct SustainedNoteInfo {
+		uint8_t velocity;
+		bool fromSequencer; // true = NoteRow::playNote(), false = auditioning/MIDI input
+	};
+	deluge::fast_map<int16_t, SustainedNoteInfo> sustainedNotes;
+	void sustainPedalRelease(ModelStackWithTimelineCounter* modelStack);
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
 	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,


### PR DESCRIPTION
## Summary

Adds standard piano-style **MIDI CC64 sustain pedal** support for internal synth and CV melodic instruments. When the sustain pedal is held (CC64 ≥ 64), note-offs are deferred until the pedal is released. This covers all three note-off paths in the firmware:

- **MIDI/pad input** — `endAuditioningForNote()` defers to `sustainedNotes` map
- **Sequencer playback** — `NoteRow::playNote()` note-off path defers to `sustainedNotes` map
- **Recording** — `recordNoteOff()` is deferred until pedal release, so sustained notes are recorded at their full sustained length

Per-instrument tracking via a `sustainedNotes` fast_map with `SustainedNoteInfo` struct that distinguishes auditioned vs sequencer-originated notes, so the release path uses the correct mechanism (`endAuditioningForNote` vs `sendNote`).

### Design decisions
- **Per-instrument sustain state** (not per-cable/channel) — simple, matches how the Deluge routes MIDI
- **Melodic instruments only** — Kit instruments are excluded; `SoundInstrument` inherits the behavior from `MelodicInstrument`
- **Voices stay alive by deferring `endAuditioningForNote()`** — no changes to Sound, Voice, or AudioEngine
- **MIDI-out passthrough** — CC64 is intercepted only for internal synths (`type != OutputType::MIDI_OUT`), so external gear still receives the raw CC

### Behavior notes — advantages and limitations
- **Recording with sustain**: When recording live, sustain makes notes record as longer notes (the note-off is deferred to pedal release). This differs from DAW behavior (where CC64 is recorded as separate automation), but is a natural fit for the Deluge's note-length visual representation
- **Track conversion to MIDI**: Converting a clip with sustained-length notes to MIDI does not crash and preserves the note lengths as recorded
- **Overdub limitation**: Holding the sustain pedal during overdub playback sustains notes *audibly* in real time, but does not retroactively extend already-recorded note lengths in the sequence. This is a known limitation — the sustain affects live voice output but not pre-existing NoteRow data
- **Re-strike**: Notes that are re-struck while sustained correctly clean up the pending sustain entry before re-triggering (both in `beginAuditioningForNote` and `NoteRow::playNote` note-on paths)

### Performance impact
- ~49-56 bytes static per `MelodicInstrument` (empty `fast_map` + bool), <1KB worst-case with active sustain across 12 instruments
- 1-2 cycle overhead on note-off hot path when pedal is OFF (single boolean check)
- Zero modifications to the audio engine or DSP loop

## Files changed (4 files, +111 -20)
- `src/definitions_cxx.hpp` — `CC_EXTERNAL_SUSTAIN_PEDAL = 64` in `CCNumber` enum
- `src/deluge/model/instrument/melodic_instrument.h` — `SustainedNoteInfo` struct, `sustainPedalRelease()`, `bypassSustain` parameter on `endAuditioningForNote()`
- `src/deluge/model/instrument/melodic_instrument.cpp` — CC64 handling in `receivedCC()`, sustain deferral in `endAuditioningForNote()` and `receivedNote()`, expanded `sustainPedalRelease()`, sequencer note cleanup in `stopAnyAuditioning()`
- `src/deluge/model/note/note_row.cpp` — Sustain check in `playNote()` note-off path, re-strike cleanup in note-on path