### PR TITLE
Fix mod knob mappings overwritten when selecting new wavetable

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -861,6 +861,7 @@ doLoadAsWaveTable:
 			    goto doLoadAsSample;
 			}
 			*/
+			bool wasAlreadyWavetable = (soundEditor.currentSource->oscType == OscType::WAVETABLE);
 			soundEditor.currentSource->setOscType(OscType::WAVETABLE);
 
 			error = claimAudioFileForInstrument(makeWaveTableWorkAtAllCosts);
@@ -890,21 +891,25 @@ doLoadAsWaveTable:
 
 			// Alright, if we're still here, it was successfully loaded as a WaveTable!
 
-			if (soundEditor.currentSourceIndex == 0) { // Osc 1
-				soundEditor.currentSound->modKnobs[7][1].paramDescriptor.setToHaveParamOnly(
-				    params::LOCAL_OSC_A_WAVE_INDEX);
+			// Only set default mod knob mappings when transitioning to wavetable,
+			// not when the oscillator was already a wavetable (preserves user mappings).
+			if (!wasAlreadyWavetable) {
+				if (soundEditor.currentSourceIndex == 0) { // Osc 1
+					soundEditor.currentSound->modKnobs[7][1].paramDescriptor.setToHaveParamOnly(
+					    params::LOCAL_OSC_A_WAVE_INDEX);
 
-				if (!soundEditor.currentSound->modKnobs[7][0].paramDescriptor.isSetToParamWithNoSource(
-				        params::LOCAL_OSC_B_WAVE_INDEX)) {
-					soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamAndSource(
-					    params::LOCAL_OSC_A_WAVE_INDEX, PatchSource::LFO_LOCAL_1);
+					if (!soundEditor.currentSound->modKnobs[7][0].paramDescriptor.isSetToParamWithNoSource(
+					        params::LOCAL_OSC_B_WAVE_INDEX)) {
+						soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamAndSource(
+						    params::LOCAL_OSC_A_WAVE_INDEX, PatchSource::LFO_LOCAL_1);
+					}
 				}
+				else { // Osc 2
+					soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamOnly(
+					    params::LOCAL_OSC_B_WAVE_INDEX);
+				}
+				getCurrentOutput()->modKnobMode = 7;
 			}
-			else { // Osc 2
-				soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamOnly(
-				    params::LOCAL_OSC_B_WAVE_INDEX);
-			}
-			getCurrentOutput()->modKnobMode = 7;
 			view.setKnobIndicatorLevels(); // Visually update.
 			view.setModLedStates();
 		}


### PR DESCRIPTION
Selecting a new wavetable file overwrote custom mod knob mappings (Custom 2-3) with defaults. The default wavetable mappings (OSC position + OSC→LFO2) are now only applied when the oscillator type is *transitioning to* wavetable, not when it already is one.

Fixes #2042.

## Test plan
- [ ] OSC already wavetable → customize mod knobs → select new wavetable → mappings preserved
- [ ] OSC is sample/sine → select wavetable → default mappings applied correctly