### PR TITLE
Fix metronome playing during count-in when toggled off

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -910,7 +910,9 @@ void PlaybackHandler::actionSwungTick() {
 				display->displayPopup(buffer, 0, true, 255, 2);
 			}
 			swungTicksTilNextEvent = 2147483647;
-			goto doMetronome;
+			if (metronomeOn) {
+				goto doMetronome;
+			}
 		}
 	}
 


### PR DESCRIPTION
The `goto doMetronome` at the end of the count-in block served two purposes: playing the metronome click AND skipping past playback tick processing (`considerLaunchEvent`/`doTickForward`) that shouldn't run during count-in.

Wrapping the goto with `if (metronomeOn)` fixes the metronome sound but when metronome is off, execution falls through into playback processing, which prevents recording from ever starting.

Fix: wrap goto with metronome guard + add early return for the metronome-off case so playback processing is correctly skipped during count-in regardless of metronome state.

Fixes #3250.

## Test plan
- [ ] Metronome OFF + count-in → silent count-in, recording starts normally
- [ ] Metronome ON + count-in → clicks during countdown, recording starts normally
- [ ] No count-in + metronome ON → metronome works as before
- [ ] No count-in + metronome OFF → silent, playback works as before