### PR TITLE
Add visual press feedback to macro keyboard column

### DIFF
--- a/src/deluge/gui/ui/keyboard/column_controls/session.cpp
+++ b/src/deluge/gui/ui/keyboard/column_controls/session.cpp
@@ -30,6 +30,9 @@ void SessionColumn::renderColumn(RGB image[][kDisplayWidth + kSideBarWidth], int
 	bool armed = false;
 	for (int32_t y = 0; y < kDisplayHeight; ++y) {
 		armed |= view.renderMacros(column, y, -1, image, nullptr);
+		if (y != activePad) {
+			image[y][column] = image[y][column].dim();
+		}
 	}
 	if (armed) {
 		view.flashPlayEnable();
@@ -76,8 +79,11 @@ void SessionColumn::handleLeavingColumn(ModelStackWithTimelineCounter* modelStac
 void SessionColumn::handlePad(ModelStackWithTimelineCounter* modelStackWithTimelineCounter, PressedPad pad,
                               KeyboardLayout* layout) {
 
-	if (pad.active) {}
+	if (pad.active) {
+		activePad = pad.y;
+	}
 	else {
+		activePad = -1;
 		view.activateMacro(pad.y);
 	}
 	view.flashPlayEnable();

--- a/src/deluge/gui/ui/keyboard/column_controls/session.h
+++ b/src/deluge/gui/ui/keyboard/column_controls/session.h
@@ -37,6 +37,7 @@ public:
 	Clip* findNextClipForOutput(SessionMacro& m, PressedPad pad);
 
 private:
+	int8_t activePad = -1;
 };
 
 } // namespace deluge::gui::ui::keyboard::controls


### PR DESCRIPTION
Macro pads in the keyboard view's session column had no press feedback. Now renders macro pads dimmed by default and at full brightness when pressed, using `RGB::dim()` and an `activePad` tracker in `SessionColumn`.

Fixes #3244.

## Test plan
- [ ] Macro pads show at half brightness by default
- [ ] Pressed macro pad brightens to full color while held