### PR TITLE
Fix long-press back in browser loading the previewed preset

### DIFF
--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -104,7 +104,7 @@ public:
 
 	// ui
 	bool exitUI() override {
-		Browser::close();
+		exitAction();
 		return true;
 	}
 


### PR DESCRIPTION
`Browser::exitUI()` (long-press back) called `close()` directly, bypassing the virtual `exitAction()` where subclasses revert state. For `LoadInstrumentPresetUI`, this skipped `revertToInitialPreset()`, loading the previewed preset instead of restoring the original. Changed to call `exitAction()`.

Fixes #4038.

## Test plan
- [ ] Enter preset browser → scroll to different preset → long-press back → original preset restored