### PR TITLE
Fix fast scrolling (SHIFT+SELECT) in mod matrix and DX7 menus

### DIFF
--- a/src/deluge/gui/menu_item/dx/cartridge.cpp
+++ b/src/deluge/gui/menu_item/dx/cartridge.cpp
@@ -169,6 +169,9 @@ void DxCartridge::selectEncoderAction(int32_t offset) {
 		}
 		else if (currentValue >= scrollPos + kOLEDMenuNumOptionsVisible) {
 			scrollPos = currentValue - kOLEDMenuNumOptionsVisible + 1;
+			if (scrollPos < 0) {
+				scrollPos = 0;
+			}
 		}
 	}
 

--- a/src/deluge/gui/menu_item/dx/global_params.cpp
+++ b/src/deluge/gui/menu_item/dx/global_params.cpp
@@ -94,6 +94,9 @@ void DxGlobalParams::selectEncoderAction(int32_t offset) {
 		}
 		else if (currentValue >= scrollPos + kOLEDMenuNumOptionsVisible) {
 			scrollPos = currentValue - kOLEDMenuNumOptionsVisible + 1;
+			if (scrollPos < 0) {
+				scrollPos = 0;
+			}
 		}
 	}
 

--- a/src/deluge/gui/menu_item/dx/operator_params.cpp
+++ b/src/deluge/gui/menu_item/dx/operator_params.cpp
@@ -96,6 +96,9 @@ void DxOperatorParams::selectEncoderAction(int32_t offset) {
 		}
 		else if (currentValue >= scrollPos + kOLEDMenuNumOptionsVisible) {
 			scrollPos = currentValue - kOLEDMenuNumOptionsVisible + 1;
+			if (scrollPos < 0) {
+				scrollPos = 0;
+			}
 		}
 	}
 

--- a/src/deluge/gui/menu_item/patch_cables.cpp
+++ b/src/deluge/gui/menu_item/patch_cables.cpp
@@ -135,6 +135,9 @@ void PatchCables::selectEncoderAction(int32_t offset) {
 		}
 		else if (currentValue >= scrollPos + kOLEDMenuNumOptionsVisible) {
 			scrollPos = currentValue - kOLEDMenuNumOptionsVisible + 1;
+			if (scrollPos < 0) {
+				scrollPos = 0;
+			}
 		}
 	}
 


### PR DESCRIPTION
SHIFT+SELECT fast scrolling in scrollable menus used `scrollPos++` which only moved the display by 1, while the selection jumped by 5 — causing display/selection desync. Replaces with `scrollPos = currentValue - kOLEDMenuNumOptionsVisible + 1` in 4 files (patch cables, DX7 cartridge, DX7 operator params, DX7 global params).

Fixes #3899.

## Test plan
- [ ] Create 6+ patch cables, SHIFT+SELECT forward → display keeps selection visible
- [ ] DX7 menus: SHIFT+SELECT scrolls correctly