### PR TITLE
Fix grid view pads staying dim after creating clip in new track

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4494,6 +4494,7 @@ void SessionView::gridTransitionToSessionView() {
 }
 
 void SessionView::gridTransitionToViewForClip(Clip* clip) {
+	PadLEDs::skipGreyoutFade();
 	currentUIMode = UI_MODE_EXPLODE_ANIMATION;
 
 	auto clipX = std::clamp<int32_t>(gridXFromTrack(gridTrackIndexFromTrack(getCurrentOutput(), gridTrackCount())), 0,


### PR DESCRIPTION
After creating a new clip in a new track (grid blue mode), pads stayed dim. The NewClipType context menu greyed out all columns; the subsequent explode animation took over the timer, preventing the greyout fade-out from completing. Calls `PadLEDs::skipGreyoutFade()` before the explode animation starts.

Fixes #3893.

## Test plan
- [ ] Grid blue mode → press empty pad in new track → select clip type → pads are not dimmed