### PR TITLE
Fix crash exiting Settings menu with rapid back presses

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -377,6 +377,11 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 					goUpOneLevel();
 				}
 
+				// goUpOneLevel() may have called exitCompletely(), closing this UI
+				if (getCurrentUI() != this) {
+					return ActionResult::DEALT_WITH;
+				}
+
 				handlePotentialParamMenuChange(b, inCardRoutine, currentMenuItem, getCurrentMenuItem(), false);
 
 				if (currentUIMode == UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR
@@ -419,6 +424,11 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				}
 				else {
 					goUpOneLevel();
+				}
+
+				// goUpOneLevel() may have called exitCompletely(), closing this UI (fixes #3898, #2759)
+				if (getCurrentUI() != this) {
+					return ActionResult::DEALT_WITH;
 				}
 
 				handlePotentialParamMenuChange(b, inCardRoutine, currentMenuItem, getCurrentMenuItem(), false);


### PR DESCRIPTION
Rapid back presses in the Settings menu could crash because `goUpOneLevel()` at `navigationDepth==0` calls `exitCompletely()`, closing the SoundEditor UI. Subsequent code then dereferences `getCurrentMenuItem()` on a closed UI. Adds a `getCurrentUI() != this` guard after `goUpOneLevel()` in both the BACK and SELECT_ENC button paths.

Fixes #3898, fixes #2759.

## Test plan
- [ ] Navigate several levels deep in Settings, press BACK rapidly → no crash
- [ ] Normal Settings navigation still works