### PR TITLE
Fix song search with numbers not working in browser

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1277,7 +1277,8 @@ gotErrorAfterAllocating:
 	else {
 		i--;
 		// If it didn't match exactly, try some other stuff before accepting that result.
-		if (memcasecmp(((FileItem*)fileItems.getElementAddress(i))->displayName, enteredText.get(), enteredTextEditPos)) {
+		if (memcasecmp(((FileItem*)fileItems.getElementAddress(i))->displayName, enteredText.get(),
+		               enteredTextEditPos)) {
 			if (numExtraZeroesAdded < 4) {
 				error = searchString.concatenateAtPos("0", searchString.getLength() - 1, 1);
 				if (error != Error::NONE) {


### PR DESCRIPTION
Numeric prefix search in the browser failed because `strcmpspecial`'s natural number ordering caused the "~" upper-bound trick to sort before higher-numbered items (e.g., "1~" < "15.XML"). Adds a forward prefix check at position `i` in addition to the existing backward check at `i-1`.

Depends on #4341. Fixes #4105.

## Test plan
- [ ] Type "1" in song browser → finds first song starting with "1"
- [ ] Alphabetic prefix search still works