### PR TITLE
Fix velocity view blocking multi-note deletion

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2747,18 +2747,15 @@ void AutomationView::velocityEditPadAction(ModelStackWithNoteRow* modelStackWith
 	bool refreshVelocityEditor = false;
 	bool showNewVelocity = true;
 
-	// For simultaneous presses at the velocity head (within 80ms), skip multi-pad logic
-	// so each press is registered independently for deletion on short release.
-	// The 80ms threshold matches editPadAction's length-edit timing guard.
-	bool isSimultaneousVelocityHeadPress =
-	    velocity && squareInfo.numNotes != 0
-	    && (int32_t)(instrumentClipView.timeLastEditPadPress + 80 * 44 - AudioEngine::audioSampleTimer) >= 0
-	    && nonPatchCableMinPadDisplayValues[y] <= squareInfo.averageVelocity
-	    && squareInfo.averageVelocity <= nonPatchCableMaxPadDisplayValues[y];
+	// If pressing at the velocity head (pad y matches note's current velocity), this is a delete-intent press.
+	// Skip multi-pad ramp logic so each such press is registered independently for deletion on short release.
+	bool isVelocityHeadPress = velocity && squareInfo.numNotes != 0
+	                           && nonPatchCableMinPadDisplayValues[y] <= squareInfo.averageVelocity
+	                           && squareInfo.averageVelocity <= nonPatchCableMaxPadDisplayValues[y];
 
-	// check for middle or multi pad press (but not for simultaneous velocity-head presses)
+	// check for middle or multi pad press (but not for velocity-head presses, which are delete-intent)
 	if (velocity && squareInfo.numNotes != 0 && instrumentClipView.numEditPadPresses == 1
-	    && !isSimultaneousVelocityHeadPress) {
+	    && !isVelocityHeadPress) {
 		// Find that original press
 		for (int32_t i = 0; i < kEditPadPressBufferSize; i++) {
 			if (instrumentClipView.editPadPresses[i].isActive) {


### PR DESCRIPTION
In velocity/note editor view, pressing multiple velocity pads for deletion was blocked by the multi-pad ramp logic. Pads at the velocity head position (where the note's current velocity sits) now bypass ramp logic and register independently for deletion on release. Also clears `deleteOnDepress` in `setVelocityRamp` to prevent accidental deletion after applying a ramp.

Fixes #3985.

## Test plan
- [ ] Hold velocity-head pad on one note, press velocity-head pad on another → both delete on release
- [ ] Velocity ramp (hold one column, press different Y on another) still works
- [ ] After applying a ramp, releasing pads does not delete notes