### PR TITLE
Fix song browser looping within subset of songs

### DIFF
--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -273,18 +273,87 @@ void LoadSongUI::doQueueLoadNextSongIfAvailable(int8_t offset) {
 	outputTypeToLoad = OutputType::NONE;
 	currentDir.set(&currentSong->dirPath);
 
+	shouldInterpretNoteNames = false;
+	octaveStartsFromA = false;
+
 	int32_t currentFileIndexSelected = fileIndexSelected;
 
 	bool songFound = false;
 	do {
 		fileIndexSelected = fileIndexSelected + offset;
+
+		// When navigating past the edge of the loaded file item window,
+		// reload from disk if more files exist, or wrap to the other end
 		if (fileIndexSelected < 0) {
-			fileIndexSelected = fileItems.getNumElements() - 1;
+			if (numFileItemsDeletedAtStart) {
+				// More files exist before the current window — reload centered on current position
+				Error error =
+				    readFileItemsFromFolderAndMemory(currentSong, outputTypeToLoad, nullptr, enteredText.get(), nullptr,
+				                                     true, Availability::ANY, CATALOG_SEARCH_BOTH);
+				if (error != Error::NONE) {
+					break;
+				}
+				fileIndexSelected = fileItems.search(enteredText.get()) + offset;
+				if (fileIndexSelected < 0) {
+					// Still at the very start of all files — wrap to end
+					Error error =
+					    readFileItemsFromFolderAndMemory(currentSong, outputTypeToLoad, nullptr, nullptr, nullptr, true,
+					                                     Availability::ANY, CATALOG_SEARCH_LEFT);
+					if (error != Error::NONE) {
+						break;
+					}
+					fileIndexSelected = fileItems.getNumElements() - 1;
+				}
+			}
+			else {
+				// All files at the start are loaded — wrap to end
+				if (numFileItemsDeletedAtEnd) {
+					Error error =
+					    readFileItemsFromFolderAndMemory(currentSong, outputTypeToLoad, nullptr, nullptr, nullptr, true,
+					                                     Availability::ANY, CATALOG_SEARCH_LEFT);
+					if (error != Error::NONE) {
+						break;
+					}
+				}
+				fileIndexSelected = fileItems.getNumElements() - 1;
+			}
 		}
 		else if (fileIndexSelected >= fileItems.getNumElements()) {
-			fileIndexSelected = 0;
+			if (numFileItemsDeletedAtEnd) {
+				// More files exist after the current window — reload centered on current position
+				Error error =
+				    readFileItemsFromFolderAndMemory(currentSong, outputTypeToLoad, nullptr, enteredText.get(), nullptr,
+				                                     true, Availability::ANY, CATALOG_SEARCH_BOTH);
+				if (error != Error::NONE) {
+					break;
+				}
+				fileIndexSelected = fileItems.search(enteredText.get()) + offset;
+				if (fileIndexSelected >= fileItems.getNumElements()) {
+					// Still at the very end of all files — wrap to start
+					Error error =
+					    readFileItemsFromFolderAndMemory(currentSong, outputTypeToLoad, nullptr, nullptr, nullptr, true,
+					                                     Availability::ANY, CATALOG_SEARCH_RIGHT);
+					if (error != Error::NONE) {
+						break;
+					}
+					fileIndexSelected = 0;
+				}
+			}
+			else {
+				// All files at the end are loaded — wrap to start
+				if (numFileItemsDeletedAtStart) {
+					Error error =
+					    readFileItemsFromFolderAndMemory(currentSong, outputTypeToLoad, nullptr, nullptr, nullptr, true,
+					                                     Availability::ANY, CATALOG_SEARCH_RIGHT);
+					if (error != Error::NONE) {
+						break;
+					}
+				}
+				fileIndexSelected = 0;
+			}
 		}
-		Browser::setEnteredTextFromCurrentFilename();
+
+		setEnteredTextFromCurrentFilename();
 
 		FileItem* currentFileItem = getCurrentFileItem();
 


### PR DESCRIPTION
Song browser queue-next navigation looped within the 20-item in-memory window instead of traversing the full folder. Now reloads file items from disk when navigating past window boundaries, matching `Browser::selectEncoderAction()`.

Fixes #4125.

## Test plan
- [ ] Folder with 20+ songs: queue-next-song traverses the entire folder
- [ ] Wrapping from last→first and first→last works correctly