### PR TITLE
Fix GranularProcessor copy constructor uninitialized grainBuffer

### DIFF
--- a/src/deluge/dsp/granular/GranularProcessor.cpp
+++ b/src/deluge/dsp/granular/GranularProcessor.cpp
@@ -338,6 +338,7 @@ GranularProcessor::GranularProcessor(const GranularProcessor& other) {
 	_pitchRandomness = other._pitchRandomness;
 	grainLastTickCountIsZero = true;
 	grainInitialized = false;
+	grainBuffer = nullptr;
 	getBuffer();
 }
 void GranularProcessor::startSkippingRendering() {


### PR DESCRIPTION
Initialize `grainBuffer = nullptr` in the copy constructor before calling `getBuffer()`, matching the default constructor. Without this, `getBuffer()` may dereference an indeterminate pointer.

Fixes #4356.

## Test plan
- [ ] Duplicate a preset using granular FX → verify no crash