### PR TITLE
Fix grainBufferStolen() leaving processor in stale state

### DIFF
--- a/src/deluge/dsp/granular/GranularProcessor.h
+++ b/src/deluge/dsp/granular/GranularProcessor.h
@@ -59,7 +59,15 @@ public:
 	                    q31_t reverbAmount);
 
 	void clearGrainFXBuffer();
-	void grainBufferStolen() { grainBuffer = nullptr; }
+	void grainBufferStolen() {
+		grainBuffer = nullptr;
+		wrapsToShutdown = 0;
+		grainInitialized = false;
+		bufferFull = false;
+		for (auto& grain : grains) {
+			grain.length = 0;
+		}
+	}
 
 private:
 	void setupGrainFX(int32_t grainRate, int32_t grainMix, int32_t grainDensity, int32_t pitchRandomness,


### PR DESCRIPTION
## Summary

- Reset `wrapsToShutdown`, `grainInitialized`, `bufferFull`, and all grain lengths when the grain buffer is stolen
- Previously only `grainBuffer` was set to nullptr, leaving stale state that caused `processGrainFX()` to read from a freshly allocated uninitialized buffer at stale offsets

Fixes #4357

## Test plan

- [ ] Trigger memory pressure to force grain buffer steal (e.g., load many samples)
- [ ] Verify granular FX recovers cleanly after buffer is stolen and re-allocated
- [ ] No audio glitches or crashes from stale grain state