### PR TITLE
Fix GranularProcessor destructor to use correct deallocator

### DIFF
--- a/src/deluge/dsp/granular/GranularProcessor.cpp
+++ b/src/deluge/dsp/granular/GranularProcessor.cpp
@@ -318,7 +318,10 @@ void GranularProcessor::getBuffer() {
 	bufferWriteIndex = 0;
 }
 GranularProcessor::~GranularProcessor() {
-	delete grainBuffer;
+	if (grainBuffer) {
+		grainBuffer->~GrainBuffer();
+		delugeDealloc(grainBuffer);
+	}
 }
 GranularProcessor::GranularProcessor(const GranularProcessor& other) {
 	wrapsToShutdown = other.wrapsToShutdown;


### PR DESCRIPTION
## Summary

- Replace `delete grainBuffer` with explicit destructor call + `delugeDealloc()` to match the placement-new allocation via `GeneralMemoryAllocator::allocStealable()`
- Using `delete` on placement-new'd memory from a custom allocator is undefined behavior

Fixes #4358

## Test plan

- [ ] Verify granular FX can be created and destroyed without memory corruption
- [ ] Test preset changes that destroy and recreate GranularProcessor
- [ ] No crashes on song load/unload with granular effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)