### PR TITLE
fix(audio): clear recording-from state when switching away from Specific Track

### DIFF
--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -112,6 +112,12 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 
 	auto valueOption = static_cast<Value>(currentOption);
 
+	// When switching away from SPECIFIC_OUTPUT, clear the recording-from state
+	// so the previously-selected track is no longer silently muted
+	if (audioOutput->inputChannel == AudioInputChannel::SPECIFIC_OUTPUT && valueOption != Value::TRACK) {
+		audioOutput->clearRecordingFrom();
+	}
+
 	switch (valueOption) {
 
 	case Value::LEFT:


### PR DESCRIPTION
## Summary
- When changing an audio clip's source from "Specific Track" to any other input (e.g. Stereo Input), the previously-selected track's `recorderIsEchoing` flag was never cleared
- This caused the track to silently stop rendering audio, even though it wasn't visually marked as muted
- Calls `clearRecordingFrom()` before overwriting `inputChannel` so the old target track resumes normal audio output

Fixes #4359

## Test plan
- [ ] Create a synth track with an audible patch
- [ ] Create an audio clip, set source to "Specific Track", select the synth track
- [ ] Change the audio source back to "Stereo Input"
- [ ] Verify the synth track still produces sound (previously it would go silent)
- [ ] Verify deleting the audio clip is no longer needed to restore audio
- [ ] Verify selecting "Specific Track" again still works correctly