### PR TITLE
Revert "Fix grainBufferStolen() leaving processor in stale state"

### DIFF
--- a/src/deluge/dsp/granular/GranularProcessor.h
+++ b/src/deluge/dsp/granular/GranularProcessor.h
@@ -59,15 +59,7 @@ public:
 	                    q31_t reverbAmount);
 
 	void clearGrainFXBuffer();
-	void grainBufferStolen() {
-		grainBuffer = nullptr;
-		wrapsToShutdown = 0;
-		grainInitialized = false;
-		bufferFull = false;
-		for (auto& grain : grains) {
-			grain.length = 0;
-		}
-	}
+	void grainBufferStolen() { grainBuffer = nullptr; }
 
 private:
 	void setupGrainFX(int32_t grainRate, int32_t grainMix, int32_t grainDensity, int32_t pitchRandomness,


### PR DESCRIPTION
Reverts SynthstromAudible/DelugeFirmware#4361

Took a closer look and this is duplicate code. It's reset when getBuffer is called in the next render