### PR TITLE
Fix link to Getting Started with Deluge Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,6 @@ The hardware is built around a Renesas RZ/A1L processor with an Arm® Cortex®-A
 * For acquiring and using the firmware visit the [community firmware website](https://synthstromaudible.github.io/DelugeFirmware)
 * Once you have the firmware, consult our detailed [update guide](https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide) for instructions on how to install it
 * To contribute to the project with code, bug reports, suggestions, and feedback see: [How to contribute to Deluge Firmware](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/CONTRIBUTING.md)
-* To learn about the toolchain, application, and to start working on the code continue with: [Getting Started with Deluge Development](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/dev/getting_started.md)
+* To learn about the toolchain, application, and to start working on the code continue with: [Getting Started with Deluge Development](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/dev/getting_started.md)
 * Please also visit the [Synthstrom Forum](https://forums.synthstrom.com/) and the community [Discord](https://discord.gg/BnRcyFSgaT) to interact with other users and the developers
 * You can donate to the project using the [Synthstrom Patreon](https://www.patreon.com/Synthstrom)


### PR DESCRIPTION
current url leads to 404 error