### PR TITLE
Back menu exit, don't remind, unset timer

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -409,6 +409,12 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 		    || currentUIMode == UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR) {
 			if (on) {
 				if (inCardRoutine) {
+					// At navigationDepth 0, exitCompletely() is already in progress (it does
+					// card writes that yield via routineForSD). Consuming the press avoids a
+					// deferred replay that would re-enter the card writes and crash.
+					if (navigationDepth == 0) {
+						return ActionResult::DEALT_WITH;
+					}
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 				}
 


### PR DESCRIPTION
Two crash paths can reach exitCompletely() and write to the card re-entrantly.

1. A short press of back button from navigationDepth == 0 gets deferred as REMIND_ME_OUTSIDE_CARD_ROUTINE. This causes exitCompletely() to get called again when the back button press is replayed. This happens outside of a card routine, but that is not enough, because the replay is between two of them. exitCompletely() calls _two_ functions that both write to the card; presumably the replay calls exitCompletely() a second time once the first call's first write finished, during the first call's second write. Fix returns DEALT_WITH for a back button press at navigationDepth == 0 if inCardRoutine is true. If you press back at that depth of the menu while you are already using the card, you don't want to use the card again, just exit the menu. That press should not get replayed. There may still be the possibility of a rare unlucky press, in the brief moment between those two functions that write (inCardRoutine = false), but the existing code guarantees a crash by replaying the press for you as soon as it thinks it can.
2. If BACK_EXIT_MENU timer is set and you press the back button enough times to call exitCompletely(), you can have another call to exitCompletely() during the button press triggered card write, when the timer fires and calls exitCompletely() again. Fix unsets the timer before calling the functions that write to the card. Once you reach the point of writing, you do not want the timer to write again.

I see the first one as the primary cause, perhaps in practice the sole one, but found the second one along the way.

Tried other approaches that deferred the extra write. These fixes should mean no extra write at all.

Fixes: https://github.com/SynthstromAudible/DelugeFirmware/issues/3898, https://github.com/SynthstromAudible/DelugeFirmware/issues/2759