### PR TITLE
Fix: Changing midi cannel reorders clips #4386

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2370,7 +2370,16 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 				else if (availabilityRequirement == Availability::INSTRUMENT_AVAILABLE_IN_SESSION) {
 					if (!modelStack->song->doesNonAudioSlotHaveActiveClipInSession(outputType, newChannel,
 					                                                               newChannelSuffix)) {
-						break;
+						// When the old instrument can be replaced in-place (it has no other clips),
+						// also require the target slot to have no existing instrument. If there is one,
+						// the in-place replacement can't happen: the clip would end up sharing the
+						// existing instrument, and any further navigation would create a new instrument
+						// appended to the end of the output list, reordering tracks in the grid view.
+						if (!oldInstrumentCanBeReplaced
+						    || !modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, newChannelSuffix,
+						                                                      nullptr, nullptr, false)) {
+							break;
+						}
 					}
 				}
 				else if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {


### PR DESCRIPTION
This is a ai written bugfix for #4386 
I verified on the device that the change did fix the issue, but i haven't checked the source code if it's a appropriate bugfix. 

This is what claude thinks is the problem:

```
The channel navigation loop uses doesNonAudioSlotHaveActiveClipInSession to determine whether a slot is available. This check only counts active clips, so a slot occupied by an inactive clip is treated as free.

e.g. with an existing and inactive midi clip a on channel 5:
When a new clip B navigates through channel 5, it gets silently reassigned to clip A's existing instrument (MIDI ch5), because the slot passes the availability check. At this point the two clips share one instrument, which means clip B's instrument can no longer be modified in-place. When clip B moves on to "5a", a brand-new instrument is created and appended to the end of the output list. Since the grid view derives column order from the output linked list, this moves clip B's track to the last column.

Fix:
In src/deluge/gui/views/view.cpp, in the INSTRUMENT_AVAILABLE_IN_SESSION navigation branch: when the old instrument can be replaced in-place (oldInstrumentCanBeReplaced == true), also require that the candidate slot has no existing instrument — not just no active clip. This keeps the in-place replacement behaviour intact and prevents track reordering.  
```