### PR TITLE
Fix compressor sidechain HPF using same filter for both channels

### DIFF
--- a/src/deluge/dsp/compressor/rms_feedback.cpp
+++ b/src/deluge/dsp/compressor/rms_feedback.cpp
@@ -147,7 +147,7 @@ float RMSFeedbackCompressor::calcRMS(std::span<StereoSample> buffer) {
 
 	for (StereoSample sample : buffer) {
 		q31_t l = sample.l - hpfL.doFilter(sample.l, hpfA_);
-		q31_t r = sample.r - hpfL.doFilter(sample.r, hpfA_);
+		q31_t r = sample.r - hpfR.doFilter(sample.r, hpfA_);
 		q31_t s = std::max(std::abs(l), std::abs(r));
 		sum += multiply_32x32_rshift32(s, s);
 	}


### PR DESCRIPTION
The RMS sidechain high-pass filter in calcRMS() uses one filter, hpfL, for both the left and right channels. This is causing RMS to get calculated incorrectly as hpfL's memory gets updated by audio from both channels. This is probably a typo; rms_feedback.h defines hpfR but rms_feedback.cpp never uses it.

I center pan bass instruments but...