### PR TITLE
Fix crash on menu exit

### DIFF
--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -103,9 +103,9 @@ public:
 	static char const* filenameToStartSearchAt;
 
 	// ui
-	bool exitUI() override {
+	ActionResult exitUI() override {
 		Browser::close();
-		return true;
+		return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 	}
 
 protected:

--- a/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/column_controls.cpp
@@ -86,7 +86,7 @@ void ColumnControlsKeyboard::evaluatePads(PressedPad presses[kMaxNumKeyboardPadP
 					if (runtimeFeatureSettings.get(RuntimeFeatureSettingType::EnableKeyboardViewSidebarMenuExit)
 					    == RuntimeFeatureStateToggle::On) {
 						// minimize happy path time since most of the time this will be a normal press
-						if (getCurrentUI()->exitUI()) [[unlikely]] {
+						if (getCurrentUI()->exitUI() == ActionResult::ACTIONED_AND_CAUSED_CHANGE) [[unlikely]] {
 							keyboardScreen.killColumnSwitchKey(LEFT_COL);
 							continue;
 						}

--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -91,10 +91,10 @@ void RenameUI::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
 	drawTextForOLEDEditing(charsStartPixel, OLED_MAIN_WIDTH_PIXELS - charsStartPixel + 1, 27, maxNumChars, canvas);
 }
 
-bool RenameUI::exitUI() {
+ActionResult RenameUI::exitUI() {
 	display->setNextTransitionDirection(-1);
 	close();
-	return true;
+	return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 }
 
 ActionResult RenameUI::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {

--- a/src/deluge/gui/ui/rename/rename_ui.h
+++ b/src/deluge/gui/ui/rename/rename_ui.h
@@ -26,7 +26,7 @@ public:
 	void displayText(bool blinkImmediately = false) override;
 	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 	bool getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) override;
-	bool exitUI() override;
+	ActionResult exitUI() override;
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	ActionResult padAction(int32_t x, int32_t y, int32_t velocity) override;
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;

--- a/src/deluge/gui/ui/sample_marker_editor.cpp
+++ b/src/deluge/gui/ui/sample_marker_editor.cpp
@@ -688,10 +688,10 @@ ActionResult SampleMarkerEditor::buttonAction(deluge::hid::Button b, bool on, bo
 	return ActionResult::DEALT_WITH;
 }
 
-bool SampleMarkerEditor::exitUI() {
+ActionResult SampleMarkerEditor::exitUI() {
 	display->setNextTransitionDirection(-1);
 	close();
-	return true;
+	return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 }
 
 static const uint32_t zoomUIModes[] = {UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON, UI_MODE_AUDITIONING, 0};

--- a/src/deluge/gui/ui/sample_marker_editor.h
+++ b/src/deluge/gui/ui/sample_marker_editor.h
@@ -68,7 +68,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::SAMPLE_MARKER_EDITOR; }
-	bool exitUI() override;
+	ActionResult exitUI() override;
 
 private:
 	static constexpr int32_t kInvalidColumn = -2147483648;

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -659,10 +659,16 @@ void SoundEditor::goUpOneLevel() {
 	beginScreen(oldItem);
 }
 
-void SoundEditor::exitCompletely() {
+ActionResult SoundEditor::exitCompletely() {
+
 	if (inSettingsMenu()) {
 		// First, save settings
-
+		if (sdRoutineLock) {
+			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+		}
+		else {
+			uiTimerManager.unsetTimer(TimerName::BACK_MENU_EXIT);
+		}
 		display->displayLoadingAnimationText("Saving settings");
 
 		FlashStorage::writeSettings();
@@ -691,6 +697,7 @@ void SoundEditor::exitCompletely() {
 	setupKitGlobalFXMenu = false;
 
 	currentUIMode = UI_MODE_NONE;
+	return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 }
 
 bool SoundEditor::findPatchedParam(int32_t paramLookingFor, int32_t* xout, int32_t* yout, bool* isSecondLayerParamOut) {

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -127,11 +127,8 @@ public:
 	MenuItem* getCurrentMenuItem();
 	bool inSettingsMenu();
 	bool setupKitGlobalFXMenu;
-	bool exitUI() override {
-		exitCompletely();
-		return true;
-	};
-	void exitCompletely();
+	ActionResult exitUI() override { return exitCompletely(); };
+	ActionResult exitCompletely();
 	void goUpOneLevel();
 	void enterSubmenu(MenuItem* newItem);
 	bool pcReceivedForMidiLearn(MIDICable& cable, int32_t channel, int32_t program) override;

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -151,7 +151,7 @@ public:
 	}
 	// called when back is held, used to exit menus or similar full screen views completely
 	/// returns whether a UI exited
-	virtual bool exitUI() { return false; };
+	virtual ActionResult exitUI() { return ActionResult::DEALT_WITH; };
 	void close();
 
 	virtual void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) = 0;

--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -151,8 +151,10 @@ void UITimerManager::routine() {
 					break;
 				}
 				case TimerName::BACK_MENU_EXIT: {
-
-					getCurrentUI()->exitUI();
+					ActionResult result = getCurrentUI()->exitUI();
+					if (result == ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE) {
+						timer.active = true;
+					}
 					break;
 				}
 


### PR DESCRIPTION
- refactor to return if exiting ui needs to be delayed
- return remind outside card routine to timer if required
- unset timer when menu is completely exiting


Fixes: #3898, #2759