### PR TITLE
fix(browser): cache FilePointer on Instrument to avoid repeated SD reads

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -418,7 +418,13 @@ void Browser::deleteFolderAndDuplicateItems(Availability instrumentAvailabilityR
 			else if (readItem->instrument) {
 				if (!nextItem->instrument && !nextItem->isFolder) {
 					if (!strcasecmp(readItem->displayName, nextItem->displayName)) {
-						// if (readItem->filename.equalsCaseIrrespective(&nextItem->filename)) {
+						// Copy the directory-sourced FilePointer to the instrument FileItem
+						// before destroying it. This avoids a redundant SD card read.
+						if (nextItem->filePointer.sclust != 0 && readItem->filePointer.sclust == 0) {
+							readItem->filePointer = nextItem->filePointer;
+							// Also cache on the instrument itself for future browser invocations.
+							readItem->instrument->filePointer = nextItem->filePointer;
+						}
 						nextItem->~FileItem();
 						readI++;
 						nextItem = (FileItem*)fileItems.getElementAddress(readI + 1);
@@ -445,6 +451,11 @@ deleteThisItem:
 			// Or if next item has an Instrument, and we're just a file...
 			else if (nextItem->instrument) {
 				if (!strcasecmp(readItem->displayName, nextItem->displayName)) { // And if same name...
+					// Copy the directory-sourced FilePointer to the instrument FileItem before deleting.
+					if (readItem->filePointer.sclust != 0 && nextItem->filePointer.sclust == 0) {
+						nextItem->filePointer = readItem->filePointer;
+						nextItem->instrument->filePointer = readItem->filePointer;
+					}
 					goto deleteThisItem;
 				}
 			}

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -947,6 +947,8 @@ giveUsedError:
 		if (doClone) {
 			newInstrument->name.set(&clonedName);
 			newInstrument->editedByUser = true;
+			// Invalidate cached FilePointer — it points to the original file, not the clone.
+			newInstrument->filePointer = {0};
 		}
 	}
 	display->displayLoadingAnimationText("Loading", false, true);

--- a/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/save/save_instrument_preset_ui.cpp
@@ -209,6 +209,8 @@ fail:
 	instrumentToSave->name.set(&enteredText);
 	instrumentToSave->dirPath.set(&currentDir);
 	instrumentToSave->existsOnCard = true;
+	// Invalidate cached FilePointer — the FAT cluster may have changed after writing.
+	instrumentToSave->filePointer = {0};
 
 	// There's now no chance that we saved over a preset that's already in use in the song, because we didn't allow the
 	// user to select such a slot

--- a/src/deluge/model/instrument/instrument.h
+++ b/src/deluge/model/instrument/instrument.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
+#include "fatfs/ff.h"
 #include "io/midi/learned_midi.h"
 #include "model/clip/clip_instance_vector.h"
 #include "model/output.h"
@@ -49,6 +50,11 @@ public:
 	// not do this, partly because I don't want it doing memory allocation, and also because in many cases, the function
 	// creating the object hard-sets this anyway.
 	String dirPath;
+
+	// Cached FAT cluster pointer for this instrument's preset file on the SD card.
+	// Avoids repeated f_open() calls when the browser builds its file list.
+	// Zero means uncached — setupWithInstrument() will resolve it once via f_open().
+	FilePointer filePointer{0};
 
 	bool editedByUser = false;
 	bool existsOnCard = false;

--- a/src/deluge/storage/file_item.cpp
+++ b/src/deluge/storage/file_item.cpp
@@ -32,17 +32,28 @@ Error FileItem::setupWithInstrument(Instrument* newInstrument, bool hibernating)
 	instrumentAlreadyInSong = !hibernating;
 	displayName = filename.get();
 	if (newInstrument->existsOnCard && filePointer.sclust == 0) {
-		String tempFilePath;
-		tempFilePath.set(newInstrument->dirPath.get());
-		tempFilePath.concatenate("/");
-		tempFilePath.concatenate(filename.get());
-		existsOnCard = StorageManager::fileExists(tempFilePath.get(), &filePointer);
-		if (!existsOnCard) {
-			// this is recoverable later - will make a default synth or browse from top folder when encountering the
-			// null filepointer
-			D_PRINTLN("couldn't get filepath for file %s", filename.get());
-			// so we don't look for it again
-			newInstrument->existsOnCard = false;
+		// Use the instrument's cached FilePointer if available, avoiding an SD card read.
+		if (newInstrument->filePointer.sclust != 0) {
+			filePointer = newInstrument->filePointer;
+			existsOnCard = true;
+		}
+		else {
+			String tempFilePath;
+			tempFilePath.set(newInstrument->dirPath.get());
+			tempFilePath.concatenate("/");
+			tempFilePath.concatenate(filename.get());
+			existsOnCard = StorageManager::fileExists(tempFilePath.get(), &filePointer);
+			if (existsOnCard) {
+				// Cache the resolved pointer on the instrument for future calls.
+				newInstrument->filePointer = filePointer;
+			}
+			else {
+				// this is recoverable later - will make a default synth or browse from top folder when
+				// encountering the null filepointer
+				D_PRINTLN("couldn't get filepath for file %s", filename.get());
+				// so we don't look for it again
+				newInstrument->existsOnCard = false;
+			}
 		}
 	}
 	else {

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -413,6 +413,7 @@ paramManagersMissing:
 	newInstrument->name.set(name);
 	newInstrument->dirPath.set(dirPath);
 	newInstrument->existsOnCard = true;
+	newInstrument->filePointer = *filePointer;
 	newInstrument->loadAllAudioFiles(mayReadSamplesFromFiles); // Needs name, directory and slots set first, above.
 
 	*getInstrument = newInstrument;


### PR DESCRIPTION
Addresses #4199.

`setupWithInstrument()` calls `f_open()` for every in-memory instrument each time
the browser builds its file list. With N instruments, creating a new clip triggers
N SD reads, making each successive creation slower.

Cache the FAT `FilePointer` on `Instrument`. Invalidate on save and clone.
Copy from directory-read FileItems during dedup when available.

Tested with ~60 loaded instruments — clip creation near-instant regardless of count.