### PR TITLE
fix: add missing return for std::unexpected in string.cpp

### DIFF
--- a/src/deluge/util/string.cpp
+++ b/src/deluge/util/string.cpp
@@ -22,7 +22,7 @@ std::expected<char*, std::errc> to_chars(char* first, char* last, float value, i
 
 	int written = snprintf_(first, buffer_size, format.data(), value);
 	if (written < 0 || static_cast<size_t>(written) >= buffer_size) {
-		std::unexpected{std::errc::no_buffer_space};
+		return std::unexpected{std::errc::no_buffer_space};
 	}
 	return first + written;
 }


### PR DESCRIPTION
## Summary

`to_chars()` in `string.cpp` constructs a `std::unexpected{std::errc::no_buffer_space}` on snprintf overflow but doesn't return it. The error is silently discarded and the function falls through to return a bogus pointer past the end of the buffer.

## Changes

- Add missing `return` keyword in `src/deluge/util/string.cpp`

## Test plan

- [x] Verified snprintf overflow path now returns the error instead of falling through

Fixes #4372