### PR TITLE
Feature/transpose screen

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -31,22 +31,18 @@
 #include "gui/ui/keyboard/keyboard_screen.h"
 #include "gui/ui/load/load_instrument_preset_ui.h"
 #include "gui/ui/menus.h"
-#include "gui/ui/rename/rename_clip_ui.h"
 #include "gui/ui/rename/rename_drum_ui.h"
 #include "gui/ui/sample_marker_editor.h"
 #include "gui/ui/save/save_kit_row_ui.h"
 #include "gui/ui/sound_editor.h"
 #include "gui/ui/ui.h"
 #include "gui/ui_timer_manager.h"
-#include "gui/views/arranger_view.h"
 #include "gui/views/automation_view.h"
-#include "gui/views/session_view.h"
 #include "gui/views/timeline_view.h"
 #include "gui/views/view.h"
 #include "hid/buttons.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
-#include "hid/encoders.h"
 #include "hid/led/indicator_leds.h"
 #include "hid/led/pad_leds.h"
 #include "hid/matrix/matrix_driver.h"
@@ -64,7 +60,6 @@
 #include "model/consequence/consequence_note_array_change.h"
 #include "model/consequence/consequence_note_row_horizontal_shift.h"
 #include "model/consequence/consequence_note_row_length.h"
-#include "model/consequence/consequence_note_row_mute.h"
 #include "model/drum/drum.h"
 #include "model/drum/midi_drum.h"
 #include "model/instrument/kit.h"
@@ -93,21 +88,16 @@
 #include "storage/audio/audio_file_holder.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/multi_range/multi_range.h"
-#include "storage/multi_range/multisample_range.h"
 #include "storage/storage_manager.h"
-#include "util/cfunctions.h"
 #include "util/comparison.h"
 #include "util/functions.h"
 #include "util/lookuptables/lookuptables.h"
 #include "util/try.h"
-#include <limits>
 #include <new>
-#include <stdint.h>
 #include <string.h>
+#include <vector>
 
-extern "C" {
-#include "RZA1/uart/sio_char.h"
-}
+extern "C" {}
 
 using namespace deluge::gui;
 
@@ -116,18 +106,16 @@ constexpr uint8_t kVelocityShortcutY = 1;
 
 PLACE_SDRAM_DATA InstrumentClipView instrumentClipView{};
 
-InstrumentClipView::InstrumentClipView() {
+InstrumentClipView::InstrumentClipView() : numEditPadPresses(0) {
 
-	numEditPadPresses = 0;
-
-	for (int32_t i = 0; i < kEditPadPressBufferSize; i++) {
-		editPadPresses[i].isActive = false;
+	for (auto& edit_pad_pressed : editPadPresses) {
+		edit_pad_pressed.isActive = false;
 	}
 
-	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-		numEditPadPressesPerNoteRowOnScreen[yDisplay] = 0;
-		lastAuditionedVelocityOnScreen[yDisplay] = 255;
-		auditionPadIsPressed[yDisplay] = 0;
+	for (int32_t y_display = 0; y_display < kDisplayHeight; y_display++) {
+		numEditPadPressesPerNoteRowOnScreen[y_display] = 0;
+		lastAuditionedVelocityOnScreen[y_display] = 255;
+		auditionPadIsPressed[y_display] = 0;
 	}
 
 	auditioningSilently = false;
@@ -152,7 +140,7 @@ bool InstrumentClipView::opened() {
 }
 
 void InstrumentClipView::openedInBackground() {
-	bool renderingToStore = (currentUIMode == UI_MODE_ANIMATION_FADE);
+	bool rendering_to_store = (currentUIMode == UI_MODE_ANIMATION_FADE);
 
 	recalculateColours();
 
@@ -160,7 +148,7 @@ void InstrumentClipView::openedInBackground() {
 
 	AudioEngine::logAction("InstrumentClipView::beginSession 2");
 
-	if (renderingToStore) {
+	if (rendering_to_store) {
 		renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[kDisplayHeight], &PadLEDs::occupancyMaskStore[kDisplayHeight],
 		               true);
 		renderSidebar(0xFFFFFFFF, &PadLEDs::imageStore[kDisplayHeight], &PadLEDs::occupancyMaskStore[kDisplayHeight]);
@@ -976,7 +964,6 @@ void InstrumentClipView::createDrumForAuditionedNoteRow(DrumType drumType) {
 		if (!noteRow) {
 ramError:
 			error = Error::INSUFFICIENT_RAM;
-someError:
 			display->displayError(Error::INSUFFICIENT_RAM);
 			return;
 		}
@@ -3910,38 +3897,38 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 
 	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE);
 
-	uint16_t originalParameter;
-	bool parameterHasBeenEdited = false;
-	int32_t parameterValue;
+	uint16_t original_parameter{0};
+	bool parameter_has_been_edited = false;
+	int32_t parameter_value{0};
 
 	if (withOffset != 0) {
 		if (changeType == CORRESPONDING_NOTES_SET_PROBABILITY) {
-			originalParameter = noteRow->probabilityValue;
-			parameterValue = originalParameter & 127; // probability param is 8 bits
+			original_parameter = noteRow->probabilityValue;
+			parameter_value = original_parameter & 127; // probability param is 8 bits
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-			originalParameter = noteRow->iteranceValue.toInt();
-			parameterValue = originalParameter; // iterance param is 16 bits
+			original_parameter = noteRow->iteranceValue.toInt();
+			parameter_value = original_parameter; // iterance param is 16 bits
 			// transform into preset index temporarily, to inc/dec offset
-			parameterValue = Iterance::fromInt(parameterValue).toPresetIndex();
+			parameter_value = Iterance::fromInt(parameter_value).toPresetIndex();
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
-			originalParameter = noteRow->fillValue;
-			parameterValue = originalParameter & 127; // fill param is 8 bits
+			original_parameter = noteRow->fillValue;
+			parameter_value = original_parameter & 127; // fill param is 8 bits
 		}
 	}
 	else if (withFinalValue >= 0) {
 		if (changeType == CORRESPONDING_NOTES_SET_PROBABILITY) {
-			originalParameter = noteRow->probabilityValue;
+			original_parameter = noteRow->probabilityValue;
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-			originalParameter = noteRow->iteranceValue.toInt();
+			original_parameter = noteRow->iteranceValue.toInt();
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
-			originalParameter = noteRow->fillValue;
+			original_parameter = noteRow->fillValue;
 		}
-		parameterValue = withFinalValue;
-		parameterHasBeenEdited = originalParameter != withFinalValue;
+		parameter_value = withFinalValue;
+		parameter_has_been_edited = original_parameter != withFinalValue;
 	}
 
 	bool inNoteRowEditor = getCurrentUI() == &soundEditor && soundEditor.inNoteRowEditor();
@@ -3963,64 +3950,64 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 		if (withOffset != 0) {
 			// Incrementing
 			if (withOffset == 1) {
-				if (parameterValue < parameterMaxValue) {
+				if (parameter_value < parameterMaxValue) {
 					if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-						bool isLastPreset = parameterValue == kNumIterancePresets;
+						bool isLastPreset = parameter_value == kNumIterancePresets;
 						if (!isLastPreset || allowTogglingBetweenPresetsAndCustom) {
-							parameterValue++;
-							parameterHasBeenEdited = true;
+							parameter_value++;
+							parameter_has_been_edited = true;
 						}
 					}
 					else {
-						parameterValue++;
-						parameterHasBeenEdited = true;
+						parameter_value++;
+						parameter_has_been_edited = true;
 					}
 				}
 			}
 			// Decrementing
 			else {
-				if (parameterValue > parameterMinValue) {
+				if (parameter_value > parameterMinValue) {
 					if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-						bool isCustom = parameterValue == kCustomIterancePreset;
+						bool isCustom = parameter_value == kCustomIterancePreset;
 						if (!isCustom || allowTogglingBetweenPresetsAndCustom) {
-							parameterValue--;
-							parameterHasBeenEdited = true;
+							parameter_value--;
+							parameter_has_been_edited = true;
 						}
 					}
 					else {
-						parameterValue--;
-						parameterHasBeenEdited = true;
+						parameter_value--;
+						parameter_has_been_edited = true;
 					}
 				}
 			}
 			if (changeType == CORRESPONDING_NOTES_SET_PROBABILITY) {
-				noteRow->probabilityValue = parameterValue;
+				noteRow->probabilityValue = parameter_value;
 			}
 			else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
 				// transform back from preset to real value (only if not CUSTOM)
-				if (parameterHasBeenEdited) {
-					parameterValue = Iterance::fromPresetIndex(parameterValue).toInt();
+				if (parameter_has_been_edited) {
+					parameter_value = Iterance::fromPresetIndex(parameter_value).toInt();
 				}
 				else {
 					// Respect the original iterance (could be a Custom one)
-					parameterValue = originalParameter;
+					parameter_value = original_parameter;
 				}
-				noteRow->iteranceValue = Iterance::fromInt(parameterValue);
+				noteRow->iteranceValue = Iterance::fromInt(parameter_value);
 			}
 			else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
-				noteRow->fillValue = parameterValue;
+				noteRow->fillValue = parameter_value;
 			}
 		}
 		// Covers probability, iterance, and fill (set based on final value)
 		else if (withFinalValue >= 0) {
 			if (changeType == CORRESPONDING_NOTES_SET_PROBABILITY) {
-				noteRow->probabilityValue = parameterValue;
+				noteRow->probabilityValue = parameter_value;
 			}
 			else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-				noteRow->iteranceValue = Iterance::fromInt(parameterValue);
+				noteRow->iteranceValue = Iterance::fromInt(parameter_value);
 			}
 			else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
-				noteRow->fillValue = parameterValue;
+				noteRow->fillValue = parameter_value;
 			}
 		}
 
@@ -4028,13 +4015,13 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 		for (int i = 0; i < numNotes; i++) {
 			Note* note = noteRow->notes.getElement(i);
 			if (changeType == CORRESPONDING_NOTES_SET_PROBABILITY) {
-				note->setProbability(parameterValue);
+				note->setProbability(parameter_value);
 			}
 			else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-				note->setIterance(Iterance::fromInt(parameterValue));
+				note->setIterance(Iterance::fromInt(parameter_value));
 			}
 			else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
-				note->setFill(parameterValue);
+				note->setFill(parameter_value);
 			}
 		}
 	}
@@ -4042,20 +4029,20 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 		// In the case the operation didn't change anything, we need to transform Iterance back from preset
 		// to real value anyway, for the Popup code at the end of this method
 		if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-			parameterValue = Iterance::fromPresetIndex(parameterValue).toInt();
+			parameter_value = Iterance::fromPresetIndex(parameter_value).toInt();
 		}
 	}
 
 	if (!inNoteRowEditor) {
 		if (changeType == CORRESPONDING_NOTES_SET_PROBABILITY) {
-			displayProbability(parameterValue, false);
+			displayProbability(parameter_value, false);
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
-			displayIterance(Iterance::fromInt(parameterValue));
+			displayIterance(Iterance::fromInt(parameter_value));
 		}
 	}
 
-	return parameterValue;
+	return parameter_value;
 }
 
 void InstrumentClipView::mutePadPress(uint8_t yDisplay) {
@@ -6125,8 +6112,16 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
+	// If horizontal encoder button pressed, rotate notes within octave
+	if (Buttons::isButtonPressed(deluge::hid::button::X_ENC)) {
+		if (getCurrentOutputType() != OutputType::KIT) {
+			commandRotateInCurrentOctave(offset);
+			return ActionResult::DEALT_WITH;
+		}
+	}
+
 	// If encoder button pressed
-	if (Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
+	else if (Buttons::isButtonPressed(deluge::hid::button::Y_ENC)) {
 		// User may be trying to move a noteCode...
 		if (isUIModeActiveExclusively(UI_MODE_AUDITIONING)) {
 			commandEuclidean(offset);
@@ -6182,6 +6177,158 @@ ActionResult InstrumentClipView::commandTransposeKey(int32_t offset, bool inCard
 	uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0xFFFFFFFF);
 
 	return ActionResult::DEALT_WITH;
+}
+
+void InstrumentClipView::commandRotateInCurrentOctave(int32_t offset) {
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
+	InstrumentClip* clip = getCurrentInstrumentClip();
+
+	// Stop all currently playing notes
+	clip->stopAllNotesPlaying(modelStack);
+
+	// Calculate horizontal bounds of current screen
+	int32_t xScroll = currentSong->xScroll[NAVIGATION_CLIP];
+	uint32_t xZoom = currentSong->xZoom[NAVIGATION_CLIP];
+	int32_t screenStartPos = xScroll;
+	int32_t screenEndPos = xScroll + (xZoom * kDisplayWidth);
+
+	// Collect all notes from visible rows that need to be moved
+	struct NoteToMove {
+		int32_t sourceYNote;
+		int32_t destYNote;
+		int32_t pos;
+		int32_t length;
+		uint8_t velocity;
+		uint8_t lift;
+		uint8_t probability;
+		Iterance iterance;
+		uint8_t fill;
+		StolenParamNodes stolenMPE[kNumExpressionDimensions]{0};
+	};
+
+	std::vector<NoteToMove> notesToMove;
+	// allocate enough to probably not need to expand if there's lots of notes
+	notesToMove.reserve(100);
+	// First pass: collect all notes from visible rows within screen bounds
+	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
+
+	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
+		ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(yDisplay, modelStack);
+		NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
+
+		if (noteRow && !noteRow->hasNoNotes()) {
+			int32_t currentYNote = noteRow->y;
+			auto destYNote = currentSong->incrementYNoteInKey(currentYNote, offset, true);
+			D_PRINTLN("Moving note from row %i to %i", currentYNote, destYNote);
+
+			// Skip if note would stay in same row
+			if (destYNote == currentYNote) {
+				continue;
+			}
+
+			// Collect only notes that are within the current horizontal screen position
+			for (int32_t i = 0; i < noteRow->notes.getNumElements(); i++) {
+				Note* note = noteRow->notes.getElement(i);
+
+				// Check if note is within screen bounds
+				if (note->pos >= screenStartPos && note->pos < screenEndPos) {
+					NoteToMove ntm;
+					ntm.sourceYNote = currentYNote;
+					ntm.destYNote = destYNote;
+					ntm.pos = note->pos;
+					ntm.length = note->length;
+					ntm.velocity = note->velocity;
+					ntm.lift = note->lift;
+					ntm.probability = note->probability;
+					ntm.iterance = note->iterance;
+					ntm.fill = note->fill;
+
+					// Steal expression/MPE parameter data
+					ParamCollectionSummary* mpeParamsSummary = noteRow->paramManager.getExpressionParamSetSummary();
+					ExpressionParamSet* mpeParams = (ExpressionParamSet*)mpeParamsSummary->paramCollection;
+					if (mpeParams) {
+						int32_t distanceToNextNote = noteRow->getDistanceToNextNote(note->pos, modelStackWithNoteRow);
+						int32_t loopLength = modelStackWithNoteRow->getLoopLength();
+						ModelStackWithParamCollection* modelStackWithParamCollection =
+						    modelStackWithNoteRow->addOtherTwoThingsAutomaticallyGivenNoteRow()->addParamCollection(
+						        mpeParams, mpeParamsSummary);
+
+						for (int32_t m = 0; m < kNumExpressionDimensions; m++) {
+							AutoParam* param = &mpeParams->params[m];
+							ModelStackWithAutoParam* modelStackWithAutoParam =
+							    modelStackWithParamCollection->addAutoParam(m, param);
+
+							param->stealNodes(modelStackWithAutoParam, note->pos, distanceToNextNote, loopLength,
+							                  action, &ntm.stolenMPE[m]);
+						}
+					}
+
+					notesToMove.push_back(ntm);
+				}
+			}
+		}
+	}
+
+	// Second pass: delete all source notes (from screen positions). Can't do it safely while iterating
+	for (const auto& ntm : notesToMove) {
+		ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowForYNote(ntm.sourceYNote, modelStack);
+		NoteRow* sourceRow = modelStackWithNoteRow->getNoteRowAllowNull();
+		if (sourceRow) {
+			sourceRow->deleteNoteByPos(modelStackWithNoteRow, ntm.pos, action);
+		}
+	}
+
+	// Third pass: add notes to destination rows
+	for (auto& ntm : notesToMove) {
+		// Get or create destination row
+		ModelStackWithNoteRow* destModelStack = clip->getOrCreateNoteRowForYNote(ntm.destYNote, modelStack, action);
+		if (destModelStack) {
+			NoteRow* destRow = destModelStack->getNoteRowAllowNull();
+			if (destRow) {
+				// Use attemptNoteAdd like scrollVertical_placeNotesPressed does
+				bool success = destRow->attemptNoteAdd(ntm.pos, ntm.length, ntm.velocity, ntm.probability, ntm.iterance,
+				                                       ntm.fill, destModelStack, action);
+
+				if (success) {
+					// Check if there are any MPE nodes to restore
+					int32_t anyActualNodes = 0;
+					for (int32_t m = 0; m < kNumExpressionDimensions; m++) {
+						anyActualNodes += ntm.stolenMPE[m].num;
+					}
+
+					if (anyActualNodes) {
+						// Ensure expression param set exists
+						destRow->paramManager.ensureExpressionParamSetExists(false);
+					}
+
+					ParamCollectionSummary* mpeParamsSummary = destRow->paramManager.getExpressionParamSetSummary();
+					ExpressionParamSet* mpeParams = (ExpressionParamSet*)mpeParamsSummary->paramCollection;
+
+					if (mpeParams) {
+						ModelStackWithParamCollection* modelStackWithParamCollection =
+						    destModelStack->addOtherTwoThingsAutomaticallyGivenNoteRow()->addParamCollection(
+						        mpeParams, mpeParamsSummary);
+
+						int32_t distanceToNextNote = destRow->getDistanceToNextNote(ntm.pos, destModelStack);
+						int32_t loopLength = destModelStack->getLoopLength();
+
+						for (int32_t m = 0; m < kNumExpressionDimensions; m++) {
+							AutoParam* param = &mpeParams->params[m];
+							ModelStackWithAutoParam* modelStackWithAutoParam =
+							    modelStackWithParamCollection->addAutoParam(m, param);
+
+							param->insertStolenNodes(modelStackWithAutoParam, ntm.pos, distanceToNextNote, loopLength,
+							                         action, &ntm.stolenMPE[m]);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	recalculateColours();
+	uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0xFFFFFFFF);
 }
 
 void InstrumentClipView::commandShiftColour(int32_t offset) {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -6180,6 +6180,7 @@ ActionResult InstrumentClipView::commandTransposeKey(int32_t offset, bool inCard
 }
 
 void InstrumentClipView::commandRotateInCurrentOctave(int32_t offset) {
+	bool inOctave = Buttons::isButtonPressed(hid::button::Y_ENC);
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 	InstrumentClip* clip = getCurrentInstrumentClip();
@@ -6219,7 +6220,7 @@ void InstrumentClipView::commandRotateInCurrentOctave(int32_t offset) {
 
 		if (noteRow && !noteRow->hasNoNotes()) {
 			int32_t currentYNote = noteRow->y;
-			auto destYNote = currentSong->incrementYNoteInKey(currentYNote, offset, true);
+			auto destYNote = currentSong->incrementYNoteInKey(currentYNote, offset, inOctave);
 			D_PRINTLN("Moving note from row %i to %i", currentYNote, destYNote);
 
 			// Skip if note would stay in same row

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -6185,9 +6185,6 @@ void InstrumentClipView::commandRotateInCurrentOctave(int32_t offset) {
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 	InstrumentClip* clip = getCurrentInstrumentClip();
 
-	// Stop all currently playing notes
-	clip->stopAllNotesPlaying(modelStack);
-
 	// Calculate horizontal bounds of current screen
 	int32_t xScroll = currentSong->xScroll[NAVIGATION_CLIP];
 	uint32_t xZoom = currentSong->xZoom[NAVIGATION_CLIP];

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -6214,9 +6214,10 @@ void InstrumentClipView::commandRotateInCurrentOctave(int32_t offset) {
 	// First pass: collect all notes from visible rows within screen bounds
 	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
 
-	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-		ModelStackWithNoteRow* modelStackWithNoteRow = clip->getNoteRowOnScreen(yDisplay, modelStack);
-		NoteRow* noteRow = modelStackWithNoteRow->getNoteRowAllowNull();
+	auto num_note_rows = clip->getNumNoteRows();
+	for (int32_t index = 0; index < num_note_rows; index++) {
+		NoteRow* noteRow = clip->noteRows.getElement(index);
+		ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(noteRow->y, noteRow);
 
 		if (noteRow && !noteRow->hasNoNotes()) {
 			int32_t currentYNote = noteRow->y;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -6115,7 +6115,7 @@ ActionResult InstrumentClipView::verticalEncoderAction(int32_t offset, bool inCa
 	// If horizontal encoder button pressed, rotate notes within octave
 	if (Buttons::isButtonPressed(deluge::hid::button::X_ENC)) {
 		if (getCurrentOutputType() != OutputType::KIT) {
-			commandRotateInCurrentOctave(offset);
+			commandTransposeScreen(offset, Buttons::isButtonPressed(hid::button::Y_ENC));
 			return ActionResult::DEALT_WITH;
 		}
 	}
@@ -6179,8 +6179,7 @@ ActionResult InstrumentClipView::commandTransposeKey(int32_t offset, bool inCard
 	return ActionResult::DEALT_WITH;
 }
 
-void InstrumentClipView::commandRotateInCurrentOctave(int32_t offset) {
-	bool inOctave = Buttons::isButtonPressed(hid::button::Y_ENC);
+void InstrumentClipView::commandTransposeScreen(int32_t offset, bool inOctave) {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 	InstrumentClip* clip = getCurrentInstrumentClip();

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -73,7 +73,7 @@ public:
 	InstrumentClipView();
 	bool opened() override;
 	void focusRegained() override;
-	void displayOrLanguageChanged() final;
+	void displayOrLanguageChanged() override;
 
 	// BUTTON ACTION button press / release handling
 
@@ -114,6 +114,7 @@ public:
 	/// VERTICAL ENCODER ACTION related
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
 	ActionResult commandTransposeKey(int32_t offset, bool inCardRoutine);
+	void commandRotateInCurrentOctave(int32_t offset);
 	void commandShiftColour(int32_t offset);
 	ActionResult scrollVertical(int32_t scrollAmount, bool inCardRoutine, bool draggingNoteRow = false,
 	                            ModelStackWithTimelineCounter* modelStack = nullptr);
@@ -236,33 +237,33 @@ public:
 		InstrumentClipMinder::renderOLED(canvas);
 	}
 
-	CopiedParamAutomation copiedParamAutomation;
+	CopiedParamAutomation copiedParamAutomation{};
 	// Sometimes the user will want to hold an audition pad without actually sounding the note, by holding an encoder
-	bool auditioningSilently;
+	bool auditioningSilently{};
 	// Archaic leftover feature that users wouldn't let me get rid of
-	bool fileBrowserShouldNotPreview;
+	bool fileBrowserShouldNotPreview{};
 
-	int16_t mpeValuesAtHighestPressure[MPE_RECORD_LENGTH_FOR_NOTE_EDITING][kNumExpressionDimensions];
-	int16_t mpeMostRecentPressure;
-	uint32_t mpeRecordLastUpdateTime;
+	int16_t mpeValuesAtHighestPressure[MPE_RECORD_LENGTH_FOR_NOTE_EDITING][kNumExpressionDimensions]{};
+	int16_t mpeMostRecentPressure{};
+	uint32_t mpeRecordLastUpdateTime{};
 
 	// made these public so they can be accessed by the automation clip view
 	EditPadPress editPadPresses[kEditPadPressBufferSize];
-	uint8_t lastAuditionedVelocityOnScreen[kDisplayHeight]; // 255 seems to mean none
-	uint8_t auditionPadIsPressed[kDisplayHeight];
-	uint8_t numEditPadPressesPerNoteRowOnScreen[kDisplayHeight];
-	uint8_t lastAuditionedYDisplay;
+	uint8_t lastAuditionedVelocityOnScreen[kDisplayHeight]{}; // 255 seems to mean none
+	uint8_t auditionPadIsPressed[kDisplayHeight]{};
+	uint8_t numEditPadPressesPerNoteRowOnScreen[kDisplayHeight]{};
+	uint8_t lastAuditionedYDisplay{};
 	uint8_t numEditPadPresses;
 	uint32_t timeLastEditPadPress;
-	uint32_t timeFirstEditPadPress;
+	uint32_t timeFirstEditPadPress{};
 	// Only to be looked at if shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress is true after they
 	// rotated a NoteRow and might now be wanting to instead edit its length after releasing the knob
-	uint32_t timeHorizontalKnobLastReleased;
-	bool shouldIgnoreVerticalScrollKnobActionIfNotAlsoPressedForThisNotePress;
-	bool shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress;
+	uint32_t timeHorizontalKnobLastReleased{};
+	bool shouldIgnoreVerticalScrollKnobActionIfNotAlsoPressedForThisNotePress{};
+	bool shouldIgnoreHorizontalScrollKnobActionIfNotAlsoPressedForThisNotePress{};
 	// Because in this case we can assume that if they press a main pad while auditioning, they're not intending to do
 	// that shortcut into the SoundEditor!
-	bool editedAnyPerNoteRowStuffSinceAuditioningBegan;
+	bool editedAnyPerNoteRowStuffSinceAuditioningBegan{};
 	// made these public so they can be accessed by the automation clip view
 
 	// ui
@@ -278,7 +279,7 @@ public:
 	ActionResult handleNoteEditorHorizontalEncoderAction(int32_t offset);
 	ActionResult handleNoteEditorButtonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 
-	SquareInfo gridSquareInfo[kDisplayHeight][kDisplayWidth];
+	SquareInfo gridSquareInfo[kDisplayHeight][kDisplayWidth]{};
 	int32_t lastSelectedNoteXDisplay;
 	int32_t lastSelectedNoteYDisplay;
 
@@ -350,18 +351,18 @@ public:
 	void enterDrumCreator(ModelStackWithNoteRow* modelStack, bool doRecording = false);
 
 private:
-	bool doneAnyNudgingSinceFirstEditPadPress;
-	bool offsettingNudgeNumberDisplay;
+	bool doneAnyNudgingSinceFirstEditPadPress{};
+	bool offsettingNudgeNumberDisplay{};
 
-	uint8_t flashScaleModeLedErrorCount;
+	uint8_t flashScaleModeLedErrorCount{};
 
-	Drum* selectedDrum;
+	Drum* selectedDrum{};
 
-	Drum* drumForNewNoteRow;
-	uint8_t yDisplayOfNewNoteRow;
+	Drum* drumForNewNoteRow{};
+	uint8_t yDisplayOfNewNoteRow{};
 
-	int32_t quantizeAmount;
-	uint32_t timeSongButtonPressed;
+	int32_t quantizeAmount{};
+	uint32_t timeSongButtonPressed{};
 
 	std::array<RGB, kDisplayHeight> rowColour;
 	std::array<RGB, kDisplayHeight> rowTailColour;
@@ -378,9 +379,9 @@ private:
 	                bool previewOnly = false, bool selectedDrumOnly = false);
 	void deleteCopiedNoteRows();
 	CopiedNoteRow* firstCopiedNoteRow;
-	int32_t copiedScreenWidth;
-	ScaleType copiedScaleType;
-	int16_t copiedYNoteOfBottomRow;
+	int32_t copiedScreenWidth{};
+	ScaleType copiedScaleType{};
+	int16_t copiedYNoteOfBottomRow{};
 
 	void rotateNoteRowHorizontally(ModelStackWithNoteRow* modelStack, int32_t offset, int32_t yDisplay,
 	                               bool shouldDisplayDirectionEvenIfNoNoteRow = false);

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -114,7 +114,7 @@ public:
 	/// VERTICAL ENCODER ACTION related
 	ActionResult verticalEncoderAction(int32_t offset, bool inCardRoutine) override;
 	ActionResult commandTransposeKey(int32_t offset, bool inCardRoutine);
-	void commandRotateInCurrentOctave(int32_t offset);
+	void commandTransposeScreen(int32_t offset, bool inOctave);
 	void commandShiftColour(int32_t offset);
 	ActionResult scrollVertical(int32_t scrollAmount, bool inCardRoutine, bool draggingNoteRow = false,
 	                            ModelStackWithTimelineCounter* modelStack = nullptr);

--- a/src/deluge/model/clip/instrument_clip_minder.h
+++ b/src/deluge/model/clip/instrument_clip_minder.h
@@ -36,11 +36,11 @@ class InstrumentClipMinder : public ClipMinder {
 public:
 	InstrumentClipMinder();
 	static void redrawNumericDisplay();
-	void displayOrLanguageChanged();
+	virtual void displayOrLanguageChanged();
 	bool createNewInstrument(OutputType newOutputType, bool is_dx = false);
 	void setLedStates();
-	void focusRegained();
-	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
+	virtual void focusRegained();
+	virtual ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine);
 	void calculateDefaultRootNote();
 	void drawActualNoteCode(int16_t noteCode);
 	void cycleThroughScales();

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -714,17 +714,19 @@ int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctav
 }
 
 int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctave, const MusicalKey& key) {
+	D_PRINTLN("Incrementing note %i by %i", yNote, increment);
 	auto inc = std::clamp<int32_t>(increment, -1, 1);
 	auto num_scale_notes = key.modeNotes.count();
 	int32_t y_note_relative_to_root = yNote - key.rootNote;
 	int32_t y_note_within_octave = (uint16_t)(y_note_relative_to_root + 120) % 12;
 
 	int32_t octave = ((uint16_t)(y_note_relative_to_root + 120 - y_note_within_octave) / 12) - 10;
-
+	auto old_octave = octave;
 	int32_t y_visual_within_octave = 0;
 	for (int32_t i = 0; i < num_scale_notes && key.modeNotes[i] <= y_note_within_octave; i++) {
 		y_visual_within_octave = i;
 	}
+	auto old_mode_note = y_visual_within_octave;
 	if (inOctave) {
 		y_visual_within_octave = (y_visual_within_octave + inc) % num_scale_notes;
 		if (y_visual_within_octave < 0) {
@@ -733,7 +735,7 @@ int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctav
 	}
 	else {
 		y_visual_within_octave = y_visual_within_octave + inc;
-		if (y_visual_within_octave > num_scale_notes) {
+		if (y_visual_within_octave >= num_scale_notes) {
 			y_visual_within_octave = y_visual_within_octave - num_scale_notes;
 			octave++;
 		}
@@ -743,7 +745,13 @@ int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctav
 		}
 	}
 	auto new_note = key.modeNotes[y_visual_within_octave] + (octave * 12) + key.rootNote;
+	if (std::abs(new_note - yNote) > 2) {
+		D_PRINTLN("new note is too different");
+	}
 	D_PRINTLN("incremented from %i to %i", yNote, new_note);
+	D_PRINTLN("Octave %i, mode_note %i, old_octave %i, old mode note % i", octave, y_visual_within_octave, old_octave,
+	          old_mode_note);
+
 	return new_note;
 }
 

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -709,6 +709,33 @@ int32_t Song::getYVisualFromYNote(int32_t yNote, bool inKeyMode, const MusicalKe
 	return yVisualWithinOctave + octave * key.modeNotes.count() + key.rootNote;
 }
 
+int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode) const {
+	return incrementYNoteInKey(yNote, increment, inKeyMode, key);
+}
+
+int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode, const MusicalKey& key) {
+	auto inc = std::clamp<int32_t>(increment, -1, 1);
+	if (!inKeyMode) {
+		return yNote + inc;
+	}
+	int32_t y_note_relative_to_root = yNote - key.rootNote;
+	int32_t y_note_within_octave = (uint16_t)(y_note_relative_to_root + 120) % 12;
+
+	int32_t octave = ((uint16_t)(y_note_relative_to_root + 120 - y_note_within_octave) / 12) - 10;
+
+	int32_t y_visual_within_octave = 0;
+	for (int32_t i = 0; i < key.modeNotes.count() && key.modeNotes[i] <= y_note_within_octave; i++) {
+		y_visual_within_octave = i;
+	}
+	y_visual_within_octave = (y_visual_within_octave + inc) % key.modeNotes.count();
+	if (y_visual_within_octave < 0) {
+		octave += 1;
+	}
+	auto new_note = y_visual_within_octave + (octave * key.modeNotes.count()) + key.rootNote;
+	D_PRINTLN("incremented from %i to %i", yNote, new_note);
+	return new_note;
+}
+
 int32_t Song::getYNoteFromYVisual(int32_t yVisual, bool inKeyMode) {
 	return getYNoteFromYVisual(yVisual, inKeyMode, key);
 }

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -709,29 +709,40 @@ int32_t Song::getYVisualFromYNote(int32_t yNote, bool inKeyMode, const MusicalKe
 	return yVisualWithinOctave + octave * key.modeNotes.count() + key.rootNote;
 }
 
-int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode) const {
-	return incrementYNoteInKey(yNote, increment, inKeyMode, key);
+int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctave) const {
+	return incrementYNoteInKey(yNote, increment, inOctave, key);
 }
 
-int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode, const MusicalKey& key) {
+int32_t Song::incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctave, const MusicalKey& key) {
 	auto inc = std::clamp<int32_t>(increment, -1, 1);
-	if (!inKeyMode) {
-		return yNote + inc;
-	}
+	auto num_scale_notes = key.modeNotes.count();
 	int32_t y_note_relative_to_root = yNote - key.rootNote;
 	int32_t y_note_within_octave = (uint16_t)(y_note_relative_to_root + 120) % 12;
 
 	int32_t octave = ((uint16_t)(y_note_relative_to_root + 120 - y_note_within_octave) / 12) - 10;
 
 	int32_t y_visual_within_octave = 0;
-	for (int32_t i = 0; i < key.modeNotes.count() && key.modeNotes[i] <= y_note_within_octave; i++) {
+	for (int32_t i = 0; i < num_scale_notes && key.modeNotes[i] <= y_note_within_octave; i++) {
 		y_visual_within_octave = i;
 	}
-	y_visual_within_octave = (y_visual_within_octave + inc) % key.modeNotes.count();
-	if (y_visual_within_octave < 0) {
-		octave += 1;
+	if (inOctave) {
+		y_visual_within_octave = (y_visual_within_octave + inc) % num_scale_notes;
+		if (y_visual_within_octave < 0) {
+			y_visual_within_octave = y_visual_within_octave + num_scale_notes;
+		}
 	}
-	auto new_note = y_visual_within_octave + (octave * key.modeNotes.count()) + key.rootNote;
+	else {
+		y_visual_within_octave = y_visual_within_octave + inc;
+		if (y_visual_within_octave > num_scale_notes) {
+			y_visual_within_octave = y_visual_within_octave - num_scale_notes;
+			octave++;
+		}
+		else if (y_visual_within_octave < 0) {
+			y_visual_within_octave = y_visual_within_octave + num_scale_notes;
+			octave--;
+		}
+	}
+	auto new_note = key.modeNotes[y_visual_within_octave] + (octave * 12) + key.rootNote;
 	D_PRINTLN("incremented from %i to %i", yNote, new_note);
 	return new_note;
 }

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -114,8 +114,8 @@ public:
 	void replaceMusicalMode(const ScaleChange& changes, bool affectMIDITranspose);
 	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode);
 	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode, const MusicalKey& key);
-	int32_t incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode) const;
-	static int32_t incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode, const MusicalKey& key);
+	int32_t incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctave) const;
+	static int32_t incrementYNoteInKey(int32_t yNote, int32_t increment, bool inOctave, const MusicalKey& key);
 	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode);
 	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode, const MusicalKey& key);
 	bool mayMoveModeNote(int16_t yVisualWithinOctave, int8_t newOffset);

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -114,6 +114,8 @@ public:
 	void replaceMusicalMode(const ScaleChange& changes, bool affectMIDITranspose);
 	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode);
 	int32_t getYVisualFromYNote(int32_t yNote, bool inKeyMode, const MusicalKey& key);
+	int32_t incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode) const;
+	static int32_t incrementYNoteInKey(int32_t yNote, int32_t increment, bool inKeyMode, const MusicalKey& key);
 	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode);
 	int32_t getYNoteFromYVisual(int32_t yVisual, bool inKeyMode, const MusicalKey& key);
 	bool mayMoveModeNote(int16_t yVisualWithinOctave, int8_t newOffset);

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,7 +2,14 @@
 title: Deluge Community Firmware Change Log
 ---
 
+<<<<<<< Updated upstream
 import { Aside, LinkButton } from "@astrojs/starlight/components"
+=======
+
+
+
+import {Aside, LinkButton} from "@astrojs/starlight/components"
+>>>>>>> Stashed changes
 
 [//]: # "TODO: Split this into one page per version"
 
@@ -215,7 +222,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 - Hold <> and turn ^v to transpose the notes on the current screen only. If you also hold ^v it locks the notes into their original octave so you get pseudo voice leading
 
-##### Randomizer submenu
+#### Randomizer submenu
 
 - Added a new submenu to the `Sound` menu called `Randomizer`. This menu gives you access to the following parameters (which affect both sequenced and arpeggiated notes):
   - `Lock`: This parameter allows you to freeze the current set of randomized values so the sequence has a repeatable pattern.

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,7 +2,9 @@
 title: Deluge Community Firmware Change Log
 ---
 
-import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
+
+
+import {Aside, LinkButton} from "@astrojs/starlight/components"
 
 [//]: # "TODO: Split this into one page per version"
 
@@ -210,6 +212,10 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 - If scale mode is active, you can now check the current root note and scale by long pressing the scale button. On 7SEG it will display the root note on press and scale on release.
 - Long pressing the scale button will not result in entering or exiting scale mode so you can safely check the current root note and scale without accidentally exiting scale mode.
+
+#### Screen Transpose
+
+- Hold <> and turn ^v to transpose the notes on the current screen only. If you also hold ^v it locks the notes into their original octave so you get pseudo voice leading
 
 ##### Randomizer submenu
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,9 +2,7 @@
 title: Deluge Community Firmware Change Log
 ---
 
-
-
-import {Aside, LinkButton} from "@astrojs/starlight/components"
+import { Aside, LinkButton } from "@astrojs/starlight/components"
 
 [//]: # "TODO: Split this into one page per version"
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,8 +2,7 @@
 title: Deluge Community Firmware Change Log
 ---
 
-
-import {Aside, LinkButton} from "@astrojs/starlight/components"
+import { Aside, LinkButton } from "@astrojs/starlight/components"
 
 [//]: # "TODO: Split this into one page per version"
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -6,8 +6,6 @@ title: Deluge Community Firmware Change Log
 import { Aside, LinkButton } from "@astrojs/starlight/components"
 =======
 
-
-
 import {Aside, LinkButton} from "@astrojs/starlight/components"
 >>>>>>> Stashed changes
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,12 +2,8 @@
 title: Deluge Community Firmware Change Log
 ---
 
-<<<<<<< Updated upstream
-import { Aside, LinkButton } from "@astrojs/starlight/components"
-=======
 
 import {Aside, LinkButton} from "@astrojs/starlight/components"
->>>>>>> Stashed changes
 
 [//]: # "TODO: Split this into one page per version"
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,7 +2,8 @@
 title: Deluge Community Firmware Change Log
 ---
 
-import { Aside, LinkButton } from "@astrojs/starlight/components"
+
+import {Aside, LinkButton} from "@astrojs/starlight/components"
 
 [//]: # "TODO: Split this into one page per version"
 
@@ -211,11 +212,11 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 - If scale mode is active, you can now check the current root note and scale by long pressing the scale button. On 7SEG it will display the root note on press and scale on release.
 - Long pressing the scale button will not result in entering or exiting scale mode so you can safely check the current root note and scale without accidentally exiting scale mode.
 
-#### Screen Transpose
+##### Screen Transpose
 
 - Hold <> and turn ^v to transpose the notes on the current screen only. If you also hold ^v it locks the notes into their original octave so you get pseudo voice leading
 
-#### Randomizer submenu
+##### Randomizer submenu
 
 - Added a new submenu to the `Sound` menu called `Randomizer`. This menu gives you access to the following parameters (which affect both sequenced and arpeggiated notes):
   - `Lock`: This parameter allows you to freeze the current set of randomized values so the sequence has a repeatable pattern.

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,8 +2,7 @@
 title: Deluge Community Firmware Change Log
 ---
 
-
-import {Aside, LinkButton} from "@astrojs/starlight/components"
+import { Aside, LinkButton, Badge } from "@astrojs/starlight/components"
 
 [//]: # "TODO: Split this into one page per version"
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -2,7 +2,8 @@
 title: Deluge Community Firmware Change Log
 ---
 
-import { Aside, LinkButton } from "@astrojs/starlight/components"
+
+import {Aside, LinkButton} from "@astrojs/starlight/components"
 
 [//]: # "TODO: Split this into one page per version"
 
@@ -213,7 +214,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 ##### Screen Transpose
 
-- Hold <> and turn ^v to transpose the notes on the current screen only. If you also hold ^v it locks the notes into their original octave so you get pseudo voice leading
+- :key[Horizontal + Turn Vertical] to transpose the notes on the current screen only. :key[Horizontal + Press Turn Vertical] locks the notes into their original octave so you get pseudo voice leading
 
 ##### Randomizer submenu
 

--- a/website/src/content/docs/manual/device_overview/controls.mdx
+++ b/website/src/content/docs/manual/device_overview/controls.mdx
@@ -4,8 +4,7 @@ sidebar:
   order: 7
 ---
 
-
-import {Card, Steps} from "@astrojs/starlight/components"
+import { Card, Steps } from "@astrojs/starlight/components"
 
 This page provides information on the physical hardware controls used to interact with the Deluge's firmware user interface. This includes:
 

--- a/website/src/content/docs/manual/device_overview/controls.mdx
+++ b/website/src/content/docs/manual/device_overview/controls.mdx
@@ -4,8 +4,8 @@ sidebar:
   order: 7
 ---
 
-import { Card } from "@astrojs/starlight/components"
-import { Steps } from "@astrojs/starlight/components"
+
+import {Card, Steps} from "@astrojs/starlight/components"
 
 This page provides information on the physical hardware controls used to interact with the Deluge's firmware user interface. This includes:
 
@@ -315,9 +315,11 @@ The other way that the scale may be altered and customized is by sharpening or f
 
 For songs with multiple clips, all clips that are in scale mode are always locked to the same scale, for convenience. Any change that you make to the scale while editing one clip will affect all others that are also in scale mode. Correspondingly, when the Deluge guesses the scale and root note when re-entering scale mode, the contents of all scale clips will be considered. So if you’re wondering why the Deluge threw some extra notes into your scale that you didn’t expect, it’s likely because you have a different clip which contains those notes!
 
-If you wish to transpose a clip up or down, this can be achieved by holding down the ▼▲ knob and turning it. Doing this alone will transpose a whole octave at a time. If you wish to transpose just a semitone, then hold down the shift button as well while turning.
+If you wish to transpose a clip up or down, this can be achieved by holding down the ▼▲ knob and turning it. Doing this alone will transpose a whole octave at a time. If you wish to transpose by scale degrees instead, then hold down the shift button as well while turning.
 
-If you transpose by semitones while in scale mode, then any other clips that are also in scale mode will also be transposed.
+To transpose just the current screen, hold down the ◄► knob and turn the ▼▲ knob. If you additionally hold down the ▼▲ knob while turning it, notes will be locked into their current octave for a voice leading style effect.
+
+Transpose will be in scale degrees if scale mode is active and semitones otherwise
 
 ### :key[Crossscreen]
 

--- a/website/src/content/docs/reference/shortcuts.mdx
+++ b/website/src/content/docs/reference/shortcuts.mdx
@@ -10,30 +10,30 @@ Shortcuts are the fastest way to execute actions on the Deluge. <Badge text="Upd
 
 ## All Views
 
-| Context    | Action                    | Shortcut                                                        |
-| ---------- | ------------------------- | --------------------------------------------------------------- |
-| System     | Adjust brightness         | :key[SHIFT] + :key[LEARN] + :key[TURN HORIZONTAL]               |
-| System     | Settings menu             | :key[SHIFT] + :key[SELECT]                                      |
-| System     | Undo                      | :key[BACK]                                                      |
-| System     | Redo                      | :key[SHIFT] + :key[BACK]                                        |
-| System     | Tempo change              | :key[TURN TEMPO]                                                |
-| System     | Tempo change 1BPM inc     | :key[PRESS TURN TEMPO] <br/> Configurable in Community Features |
-| System     | Swing adjustment          | :key[SHIFT] + :key[TURN TEMPO]                                  |
-| System     | Metronome on/off          | :key[SHIFT] + :key[TAPTEMPO]                                    |
-| Navigation | Check current zoom level  | :key[HORIZONTAL]                                                |
-| Navigation | Change current zoom level | :key[PRESS TURN HORIZONTAL]                                     |
-| Navigation | Scroll left or right      | :key[TURN HORIZONTAL]                                           |
-| Navigation | Scroll up or down         | :key[TURN VERTICAL]                                             |
-| Navigation | Transpose screen          | :key[HORIZONTAL] + :key[TURN VERTICAL]                          |
+| Context    | Action                     | Shortcut                                                        |
+| ---------- | -------------------------- | --------------------------------------------------------------- |
+| System     | Adjust brightness          | :key[SHIFT] + :key[LEARN] + :key[TURN HORIZONTAL]               |
+| System     | Settings menu              | :key[SHIFT] + :key[SELECT]                                      |
+| System     | Undo                       | :key[BACK]                                                      |
+| System     | Redo                       | :key[SHIFT] + :key[BACK]                                        |
+| System     | Tempo change               | :key[TURN TEMPO]                                                |
+| System     | Tempo change 1BPM inc      | :key[PRESS TURN TEMPO] <br/> Configurable in Community Features |
+| System     | Swing adjustment           | :key[SHIFT] + :key[TURN TEMPO]                                  |
+| System     | Metronome on/off           | :key[SHIFT] + :key[TAPTEMPO]                                    |
+| Navigation | Check current zoom level   | :key[HORIZONTAL]                                                |
+| Navigation | Change current zoom level  | :key[PRESS TURN HORIZONTAL]                                     |
+| Navigation | Scroll left or right       | :key[TURN HORIZONTAL]                                           |
+| Navigation | Scroll up or down          | :key[TURN VERTICAL]                                             |
+| Navigation | Transpose screen           | :key[HORIZONTAL] + :key[TURN VERTICAL]                          |
 | Navigation | Transpose screen in octave | :key[HORIZONTAL] + :key[PRESS TURN VERTICAL]                    |
-| Song       | Load song (saved tempo)   | :key[LOAD] + :key[TURN SELECT], then :key[LOAD]                 |
-| Song       | Load song (current tempo) | :key[LOAD] + :key[TURN SELECT], then :key[TEMPO] + :key[LOAD]   |
-| Song       | Delete song               | :key[SHIFT] + :key[SAVE]                                        |
-| Song       | New song                  | :key[SHIFT] + :key[LOAD], then :key[LOAD]                       |
-| Song       | Delay load                | :key[LOAD], Then :key[TURN SELECT]                              |
-| Sampling   | Loop resample             | :key[RECORD] + :key[PLAY] then :key[RECORD] + :key[PLAY]        |
-| Sampling   | Resample                  | :key[SHIFT] + :key[RECORD]                                      |
-| Sequencer  | Nudge clock               | :key[HORIZONTAL] + :key[TURN TEMPO]                             |
+| Song       | Load song (saved tempo)    | :key[LOAD] + :key[TURN SELECT], then :key[LOAD]                 |
+| Song       | Load song (current tempo)  | :key[LOAD] + :key[TURN SELECT], then :key[TEMPO] + :key[LOAD]   |
+| Song       | Delete song                | :key[SHIFT] + :key[SAVE]                                        |
+| Song       | New song                   | :key[SHIFT] + :key[LOAD], then :key[LOAD]                       |
+| Song       | Delay load                 | :key[LOAD], Then :key[TURN SELECT]                              |
+| Sampling   | Loop resample              | :key[RECORD] + :key[PLAY] then :key[RECORD] + :key[PLAY]        |
+| Sampling   | Resample                   | :key[SHIFT] + :key[RECORD]                                      |
+| Sequencer  | Nudge clock                | :key[HORIZONTAL] + :key[TURN TEMPO]                             |
 
 ## Parameter Control - Rotary Push Controls - Toggle Options
 

--- a/website/src/content/docs/reference/shortcuts.mdx
+++ b/website/src/content/docs/reference/shortcuts.mdx
@@ -24,6 +24,8 @@ Shortcuts are the fastest way to execute actions on the Deluge. <Badge text="Upd
 | Navigation | Change current zoom level | :key[PRESS TURN HORIZONTAL]                                     |
 | Navigation | Scroll left or right      | :key[TURN HORIZONTAL]                                           |
 | Navigation | Scroll up or down         | :key[TURN VERTICAL]                                             |
+| Navigation | Transpose screen          | :key[HORIZONTAL] + :key[TURN VERTICAL]                          |
+| Navigation | Transpose screen in octave | :key[HORIZONTAL] + :key[PRESS TURN VERTICAL]                    |
 | Song       | Load song (saved tempo)   | :key[LOAD] + :key[TURN SELECT], then :key[LOAD]                 |
 | Song       | Load song (current tempo) | :key[LOAD] + :key[TURN SELECT], then :key[TEMPO] + :key[LOAD]   |
 | Song       | Delete song               | :key[SHIFT] + :key[SAVE]                                        |


### PR DESCRIPTION
Hold <> and turn ^v to transpose the notes on the current screen only. If you also hold ^v it locks the notes into their original octave so you get pseudo voice leading 