### PR TITLE
Fix/ Update UI switching behaviour for Automation View and Arranger/Session View

### DIFF
--- a/src/deluge/gui/menu_item/automation/automation.cpp
+++ b/src/deluge/gui/menu_item/automation/automation.cpp
@@ -67,44 +67,24 @@ ActionResult Automation::buttonAction(deluge::hid::Button b, bool on, bool inCar
 
 	// Clip or Song button
 	// Used to enter automation view from sound editor
-	if ((b == CLIP_VIEW && clipMinder) || (b == SESSION_VIEW && arrangerView)) {
-		if (on) {
-			// if we're not in automation view yet
-			// save current UI so you can switch back to it once we exit out of current menu
-			// flag automation view as onMenuView so we know that we're dealing with the background
-			// automation view used exclusively with the menu
-			if (rootUI != &automationView) {
-				automationView.onMenuView = true;
-				automationView.previousUI = rootUI;
-				selectAutomationViewParameter(clipMinder);
-				swapOutRootUILowLevel(&automationView);
-				automationView.initializeView();
-				automationView.openedInBackground();
-			}
-			// if we're in automation view and it's the menu view
-			// swap out background UI from automation view to the previous UI
-			else if (automationView.onMenuView) {
-				automationView.onMenuView = false;
-				automationView.resetInterpolationShortcutBlinking();
-				automationView.resetPadSelectionShortcutBlinking();
-				swapOutRootUILowLevel(automationView.previousUI);
-				uiNeedsRendering(automationView.previousUI);
-				view.setKnobIndicatorLevels();
-			}
-			view.setModLedStates();
-			PadLEDs::reassessGreyout();
-		}
-		return ActionResult::DEALT_WITH;
-	}
-	// Select encoder button, used to change current parameter selection in automation view
-	// Back button, used to back out of current automatable parameter menu
-	else if ((b == SELECT_ENC || b == BACK) && (clipMinder || arrangerView)) {
-		if (on) {
-			if (rootUI == &automationView) {
-				// if we got here, and we're in the automation menu view
-				// then we want to reset the background root UI to the previous UI
-				// because you just entered a new menu or backed out of the current param menu
-				if (automationView.onMenuView) {
+	if (clipMinder || arrangerView) {
+		if (b == CLIP_VIEW) {
+			if (on) {
+				// if we're not in automation view yet
+				// save current UI so you can switch back to it once we exit out of current menu
+				// flag automation view as onMenuView so we know that we're dealing with the background
+				// automation view used exclusively with the menu
+				if (rootUI != &automationView) {
+					automationView.onMenuView = true;
+					automationView.previousUI = rootUI;
+					selectAutomationViewParameter(clipMinder);
+					swapOutRootUILowLevel(&automationView);
+					automationView.initializeView();
+					automationView.openedInBackground();
+				}
+				// if we're in automation view and it's the menu view
+				// swap out background UI from automation view to the previous UI
+				else if (automationView.onMenuView) {
 					automationView.onMenuView = false;
 					automationView.resetInterpolationShortcutBlinking();
 					automationView.resetPadSelectionShortcutBlinking();
@@ -112,22 +92,44 @@ ActionResult Automation::buttonAction(deluge::hid::Button b, bool on, bool inCar
 					uiNeedsRendering(automationView.previousUI);
 					view.setKnobIndicatorLevels();
 				}
-				// if you are already in automation view and entered an automatable parameter menu
-				else {
-					selectAutomationViewParameter(clipMinder);
-					uiNeedsRendering(rootUI);
-				}
 				view.setModLedStates();
 				PadLEDs::reassessGreyout();
 			}
-		}
-		return ActionResult::DEALT_WITH;
-	}
-	else if ((b == X_ENC) && (clipMinder || arrangerView)) {
-		// Horizontal encoder button to zoom in/out of underlying automation view
-		if (rootUI == &automationView) {
-			automationView.buttonAction(b, on, inCardRoutine);
 			return ActionResult::DEALT_WITH;
+		}
+		// Select encoder button, used to change current parameter selection in automation view
+		// Back button, used to back out of current automatable parameter menu
+		else if (b == SELECT_ENC || b == BACK) {
+			if (on) {
+				if (rootUI == &automationView) {
+					// if we got here, and we're in the automation menu view
+					// then we want to reset the background root UI to the previous UI
+					// because you just entered a new menu or backed out of the current param menu
+					if (automationView.onMenuView) {
+						automationView.onMenuView = false;
+						automationView.resetInterpolationShortcutBlinking();
+						automationView.resetPadSelectionShortcutBlinking();
+						swapOutRootUILowLevel(automationView.previousUI);
+						uiNeedsRendering(automationView.previousUI);
+						view.setKnobIndicatorLevels();
+					}
+					// if you are already in automation view and entered an automatable parameter menu
+					else {
+						selectAutomationViewParameter(clipMinder);
+						uiNeedsRendering(rootUI);
+					}
+					view.setModLedStates();
+					PadLEDs::reassessGreyout();
+				}
+			}
+			return ActionResult::DEALT_WITH;
+		}
+		else if (b == X_ENC) {
+			// Horizontal encoder button to zoom in/out of underlying automation view
+			if (rootUI == &automationView) {
+				automationView.buttonAction(b, on, inCardRoutine);
+				return ActionResult::DEALT_WITH;
+			}
 		}
 	}
 	return ActionResult::NOT_DEALT_WITH;

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -551,6 +551,19 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 		}
 	}
 
+	// exit menu to arranger view or session view
+	else if (b == SESSION_VIEW) {
+		if (on && currentUIMode == UI_MODE_NONE) {
+			exitCompletely();
+			if (currentSong->lastClipInstanceEnteredStartPos != -1) {
+				changeRootUI(&arrangerView);
+			}
+			else {
+				changeRootUI(&sessionView);
+			}
+		}
+	}
+
 	else if (inNoteEditor()) {
 		return instrumentClipView.handleNoteEditorButtonAction(b, on, inCardRoutine);
 	}

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -208,16 +208,23 @@ ActionResult ArrangerView::buttonAction(deluge::hid::Button b, bool on, bool inC
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
 			if (currentUIMode == UI_MODE_NONE) {
-				if (Buttons::isShiftButtonPressed()) {
-					automationView.onArrangerView = true;
-					changeRootUI(&automationView);
-				}
-				else {
-					goToSongView();
-				}
+				goToSongView();
 			}
 			else if (currentUIMode == UI_MODE_HOLDING_ARRANGEMENT_ROW) {
 				moveClipToSession();
+			}
+		}
+	}
+
+	// Clip button
+	else if (b == CLIP_VIEW) {
+		if (on) {
+			if (inCardRoutine) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			}
+			if (currentUIMode == UI_MODE_NONE) {
+				automationView.onArrangerView = true;
+				changeRootUI(&automationView);
 			}
 		}
 	}
@@ -503,6 +510,7 @@ void ArrangerView::clearArrangement() {
 }
 
 bool ArrangerView::opened() {
+	automationView.onArrangerView = false;
 
 	mustRedrawTickSquares = true;
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -1140,13 +1140,8 @@ ActionResult AutomationView::buttonAction(hid::Button b, bool on, bool inCardRou
 	bool isAudioClip = clip->type == ClipType::AUDIO;
 
 	// these button actions are not used in the audio clip automation view
-	if (isAudioClip || onArrangerView) {
-		if (b == SCALE_MODE || b == KEYBOARD || b == KIT || b == SYNTH || b == MIDI || b == CV) {
-			return ActionResult::DEALT_WITH;
-		}
-	}
-	if (onArrangerView) {
-		if (b == CLIP_VIEW) {
+	if (isAudioClip) {
+		if (b == SCALE_MODE || b == KIT || b == SYNTH || b == MIDI || b == CV) {
 			return ActionResult::DEALT_WITH;
 		}
 	}
@@ -1302,7 +1297,6 @@ void AutomationView::handleSessionButtonAction(Clip* clip, bool on) {
 		}
 		// automation arranger view transitioning back to arranger view
 		if (onArrangerView) {
-			onArrangerView = false;
 			changeRootUI(&arrangerView);
 		}
 		// automation clip view transitioning back to arranger or session view
@@ -1319,7 +1313,13 @@ void AutomationView::handleKeyboardButtonAction(bool on) {
 		if (padSelectionOn) {
 			initPadSelection();
 		}
-		changeRootUI(&keyboardScreen);
+		if (onArrangerView) {
+			performanceView.timeKeyboardShortcutPress = AudioEngine::audioSampleTimer;
+			changeRootUI(&performanceView);
+		}
+		else {
+			changeRootUI(&keyboardScreen);
+		}
 		// reset blinking if you're leaving automation view for keyboard view
 		// blinking will be reset when you come back
 		resetShortcutBlinking();
@@ -1339,9 +1339,15 @@ void AutomationView::handleClipButtonAction(bool on, bool isAudioClip) {
 		if (padSelectionOn) {
 			initPadSelection();
 		}
-		if (isAudioClip) {
+		// automation arranger view transitioning back to arranger view
+		if (onArrangerView) {
+			changeRootUI(&arrangerView);
+		}
+		// automation audio clip view transitioning back to audio clip view
+		else if (isAudioClip) {
 			changeRootUI(&audioClipView);
 		}
+		// automation instrument clip view transitioning back to instrument clip view
 		else {
 			changeRootUI(&instrumentClipView);
 		}

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -732,7 +732,10 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
 			releaseViewOnExit(modelStack);
-			sessionView.transitionToViewForClip(); // May fail if no currentClip
+			// only allow transitioning from performance view to clip in session view
+			if (currentSong->lastClipInstanceEnteredStartPos == -1) {
+				sessionView.transitionToViewForClip(); // May fail if no currentClip
+			}
 		}
 	}
 
@@ -920,7 +923,12 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 			else {
 				releaseViewOnExit(modelStack);
 				if (currentSong->lastClipInstanceEnteredStartPos != -1) {
-					changeRootUI(&arrangerView);
+					if (automationView.onArrangerView) {
+						changeRootUI(&automationView);
+					}
+					else {
+						changeRootUI(&arrangerView);
+					}
 				}
 				else {
 					changeRootUI(&sessionView);
@@ -933,7 +941,12 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 			if (((AudioEngine::audioSampleTimer - timeKeyboardShortcutPress) >= FlashStorage::holdTime)) {
 				releaseViewOnExit(modelStack);
 				if (currentSong->lastClipInstanceEnteredStartPos != -1) {
-					changeRootUI(&arrangerView);
+					if (automationView.onArrangerView) {
+						changeRootUI(&automationView);
+					}
+					else {
+						changeRootUI(&arrangerView);
+					}
 				}
 				else {
 					changeRootUI(&sessionView);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1515,16 +1515,13 @@ void View::setModLedStates() {
 	RootUI* rootUI = getRootUI();
 	UIType uiType = UIType::NONE;
 	UIType uiContextType = UIType::NONE;
-	UIModControllableContext uiModControllableContext = UIModControllableContext::NONE;
 	if (rootUI) {
 		uiType = rootUI->getUIType();
 		uiContextType = rootUI->getUIContextType();
-		uiModControllableContext = rootUI->getUIModControllableContext();
 	}
 
 	// here we will set a boolean flag to let the function know whether we are dealing with the Song context
-	bool itsTheSong = ((activeModControllableModelStack.getTimelineCounterAllowNull() == currentSong)
-	                   || (uiModControllableContext == UIModControllableContext::SONG));
+	bool itsTheSong = !isClipContext();
 
 	// here we will set a boolean flag to let the function know if affect entire is enabled
 	// so that it can correctly illuminate the affect entire LED indicator
@@ -1545,8 +1542,14 @@ void View::setModLedStates() {
 	bool onAutomationClipView = false;
 
 	// turn off Clip LED indicator if we're in a song UI
+	// unless you're in automation arranger view, where we blink the Clip LED indicator
 	if (itsTheSong) {
-		indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, false);
+		if ((uiType == UIType::AUTOMATION) || (uiContextType == UIType::ARRANGER && automationView.onArrangerView)) {
+			indicator_leds::blinkLed(IndicatorLED::CLIP_VIEW);
+		}
+		else {
+			indicator_leds::setLedState(IndicatorLED::CLIP_VIEW, false);
+		}
 	}
 	// we're in a clip or we've selected a clip
 	// here we're going to see if we should blink the CLIP LED if we're in automation view

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -57,6 +57,7 @@ Added main grid pad shortcuts for the following parameters:
   - Note: :key[AUDITION PAD] + :key[RANDOM PAD] is reserved for future functionality
 - `VELOCITY PROBABILITY`: accessed using :key[SHIFT] + :key[VELOCITY PAD] in the `PATCH SOURCE` column between :key[AFTERTOUCH PAD] and :key[RANDOM PAD]
   - Note: :key[AUDITION PAD] + :key[VELOCITY PAD] is reserved for entering the Velocity Automation View
+- Press :key[SONG] while in the Menu to exit the menu and enter Arranger / Song view
 
 #### <ins>Layered Shortcuts</ins>
 

--- a/website/src/content/docs/features/automation_view.mdx
+++ b/website/src/content/docs/features/automation_view.mdx
@@ -32,7 +32,7 @@ Automation View that has been added in Clip and Arranger Views to edit parameter
 
 Automation View is a new view that complements the existing Arranger and Clip Views.
 
-- The Automation Arranger View is accessed from within Arranger View by pressing :key[Shift + Song]
+- The Automation Arranger View is accessed from within Arranger View by pressing :key[Clip]
   - Note: the automation arranger view editor for a specific parameter can be accessed directly from the arranger song menu for that parameter (e.g., the one you would access by pressing :key[Select] or by using the :key[Shift + Pad] shortcut) by pressing the :key[Song] button while in the parameter value.
 - The Automation Clip View is accessed from within the Clip View by pressing the Clip button
   - Note: the automation clip view editor for a specific parameter can be accessed directly from the clip sound menu for that parameter (e.g., the one you would access by pressing on select encoder or by using the :key[Shift + Pad] shortcut) by pressing the :key[Clip] button while in the parameter value.
@@ -138,7 +138,7 @@ A more detailed break-down of the above sections is found below.
 
 ## Enter/Exit Automation View
 
-The Automation Arranger View can be accessed from the Arranger View by pressing the :key[Shift + Song] buttons.
+The Automation Arranger View can be accessed from the Arranger View by pressing the :key[Clip] button.
 
 The Automation Clip View can be accessed from the Clip View by pressing on the :key[Clip] button. The :key[Clip] button will flash when you are in the Automation Clip View
 


### PR DESCRIPTION
Update behaviour to enter / exit automation view from arranger / arranger performance view + fixed mod led blinking for automation view

Update behaviour for switching to arranger / session views from menu

automation.cpp:
- Handles entering/exiting automation menu view. Removed handling for "session view" button press. You now enter/exit automation menu view only using the clip button. Cleaned up some of the code by removing some of the duplicate checks.

arranger_view.cpp:
- Removed shift + song command to enter automation view
- Added clip button command to enter automation view
- Pressing song button now takes you to song view instead of automation view
- Add reset of "AutomationView.onArrangerView" flag when entering arranger view

automation_view.cpp:
- Enabled entering performance view from arranger automation view by pressing keyboard button
- Enabled returning to arranger view using the clip button

performance_view.cpp:
- Enabled returning to arranger automation view by pressing keyboard button when you entered arranger performance view from arranger automation view
- Disabled pressing clip button in arranger performance view (in session view it returns you to the selected clip, but not in arranger view)

view.cpp:
- Fixed blinking of clip button led so that it blinks when you're selecting a clip where the onAutomationClipView flag is set
- Fixed blinking of clip button led so that it blinks when you're in arranger automation view

sound_editor.cpp:
- By updating the button shortcut for entering / exiting automation view, we can now enable return to arranger view or session view while in the menu using the song button.
- This was requested by Reza.