### PR TITLE
Fix/ grid view track creation ui bug

### DIFF
--- a/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
+++ b/src/deluge/gui/context_menu/clip_settings/new_clip_type.cpp
@@ -147,9 +147,6 @@ bool NewClipType::acceptCurrentOption() {
 ActionResult NewClipType::padAction(int32_t x, int32_t y, int32_t on) {
 	ActionResult result = sessionView.padAction(x, y, on); // let the grid handle this
 
-	display->setNextTransitionDirection(-1);
-	close();
-
 	return result;
 }
 

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -4082,6 +4082,8 @@ ActionResult SessionView::clipCreationButtonPressed(hid::Button i, bool on, bool
 	return ActionResult::NOT_DEALT_WITH;
 }
 void SessionView::exitTrackCreation() {
+	display->setNextTransitionDirection(-1);
+	getCurrentUI()->close();
 	indicator_leds::setLedState(IndicatorLED::SYNTH, false, false);
 	indicator_leds::setLedState(IndicatorLED::MIDI, false, false);
 	indicator_leds::setLedState(IndicatorLED::KIT, false, false);

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -174,6 +174,10 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 #### <ins>Song Grid View</ins>
 
+##### General
+
+- Fixed UI bug which would cause the Grid View UI to remain dim after creating a new clip in a new track in blue mode.
+
 ##### Entering Clips
 
 - Added ability to enter clips in `Song Grid View Green Mode` by `Pressing a Clip Pad` + `Pressing the Clip button` if you have `Select in Green Mode` enabled in the `SETTINGS > DEFAULTS > UI > SONG > GRID` menu.


### PR DESCRIPTION
Fixed rendering bug when creating new clip in new track in blue mode

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3893