### PR TITLE
Docker for building and running unit tests on osx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  tests:
+    build:
+      context: tests
+      dockerfile: Dockerfile
+    working_dir: /src
+    volumes:
+      - .:/src
+    command: >
+      bash -c "cmake -B /tmp/build -S tests -G Ninja -DSKIP_32BIT_TESTS=ON &&
+               cmake --build /tmp/build &&
+               ctest --test-dir /tmp/build --output-on-failure"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,8 +11,9 @@ set(DELUGE_C_STANDARD 23)
 set(DELUGE_CXX_STANDARD 23)
 
 enable_testing()
+option(SKIP_32BIT_TESTS "Skip 32-bit unit tests (use when running under emulation)" OFF)
 #needs to support -m32 since the memory tests assume a 32 bit architecture
-if (UNIX AND NOT APPLE)
+if (UNIX AND NOT APPLE AND NOT SKIP_32BIT_TESTS)
     add_compile_options(-m32 -Og -ggdb3)
     add_link_options(-m32)
     add_subdirectory(32bit_unit_tests)

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        cmake \
+        ninja-build \
+        gcc-14 \
+        g++-14 \
+        git \
+        ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV CC=gcc-14 \
+    CXX=g++-14 \
+    GIT_CONFIG_COUNT=1 \
+    GIT_CONFIG_KEY_0=safe.directory \
+    GIT_CONFIG_VALUE_0=/src


### PR DESCRIPTION
Was noticing that `./dbt test` doesnt run on osx due to apple chips not being supported due to QEMU emulation issues.

Added SKIP_32BIT_TESTS cmake option to exclude the 32-bit memory tests when running in docker on osx.

```
  Usage: docker compose run --rm tests
```

Wanting to try working on some bigger features and having unit tests will help me.