### PR TITLE
Fix/ Restore arranger view automation default behaviour when inserting/deleting time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 #### <ins>Arranger View</ins>
 - Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
   - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
+- Restored original behaviour which enabled you to insert / delete time for all automated parameters using shift + <>
 
 #### <ins>Song View</ins>
 - Doubled the number of Song View sections from 12 to 24.
@@ -208,6 +209,9 @@ at velocity 0 it would look the same as its tail (but you can't have 0 velocity)
   - Values for program, bank and sub-bank were previously shown as 1-128, but now reflect the actual transmitted MIDI values.
 
 #### <ins>Automation View</ins>
+
+##### Defaults
+- The `Settings/Defaults/Automation/Shift` toggle now only applies to Clip View. In Arranger View if you use shift + <> to insert / delete time at a specific point in the arrangement, all parameter automation will also be impacted (maintaining previously recorded automation before and after that point in time).
 
 ##### Parameters
 - Added Vibrato and Sidechain patch cables to Automation View Overview and Grid Shortcuts

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -2783,81 +2783,9 @@ ActionResult ArrangerView::horizontalEncoderAction(int32_t offset) {
 					action = actionLogger.getNewAction(actionType, ActionAddition::NOT_ALLOWED);
 				}
 
-				// if this setting is on, shifting of automation is restricted to automation view
-				if (!FlashStorage::automationShift) {
-					ParamCollectionSummary* unpatchedParamsSummary =
-					    currentSong->paramManager.getUnpatchedParamSetSummary();
-					UnpatchedParamSet* unpatchedParams = (UnpatchedParamSet*)unpatchedParamsSummary->paramCollection;
+				shiftAutomationHorizontally(offset, scroll_amount, action);
 
-					char modelStackMemory[MODEL_STACK_MAX_SIZE];
-					ModelStackWithParamCollection* modelStackWithUnpatchedParams =
-					    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory)
-					        ->addParamCollection(unpatchedParams, unpatchedParamsSummary);
-
-					if (offset >= 0) {
-						void* consMemory =
-						    GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceArrangerParamsTimeInserted));
-						if (consMemory) {
-							ConsequenceArrangerParamsTimeInserted* consequence = new (consMemory)
-							    ConsequenceArrangerParamsTimeInserted(currentSong->xScroll[NAVIGATION_ARRANGEMENT],
-							                                          scroll_amount);
-							action->addConsequence(consequence);
-						}
-						unpatchedParams->insertTime(modelStackWithUnpatchedParams,
-						                            currentSong->xScroll[NAVIGATION_ARRANGEMENT], scroll_amount);
-					}
-					else {
-						if (action) {
-							unpatchedParams->backUpAllAutomatedParamsToAction(action, modelStackWithUnpatchedParams);
-						}
-						unpatchedParams->deleteTime(modelStackWithUnpatchedParams,
-						                            currentSong->xScroll[NAVIGATION_ARRANGEMENT], -scroll_amount);
-					}
-				}
-
-				for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
-					int32_t i = thisOutput->clipInstances.search(currentSong->xScroll[NAVIGATION_ARRANGEMENT],
-					                                             GREATER_OR_EQUAL);
-
-					bool movedOneYet = false;
-
-					// And move the successive ones.
-					while (i < thisOutput->clipInstances.getNumElements()) {
-						ClipInstance* instance = thisOutput->clipInstances.getElement(i);
-
-						// If contracting time and this bit has to be deleted...
-						if (offset < 0
-						    && instance->pos + scroll_amount < currentSong->xScroll[NAVIGATION_ARRANGEMENT]) {
-							deleteClipInstance(thisOutput, i, instance, action);
-							// Don't increment i, because we deleted an element
-						}
-
-						// Otherwise, just move it
-						else {
-
-							int32_t new_pos = instance->pos + scroll_amount;
-
-							// If contracting time, shorten the previous ClipInstance only if the ClipInstances we're
-							// moving will eat into its tail. Otherwise, leave the tail there. Perhaps it'd make more
-							// sense to cut the tail off regardless, but possibly just due to me not thinking about it,
-							// this was not done in pre-V4 firmware, and actually having it this way probably helps
-							// users.
-							if (!movedOneYet && offset < 0 && i > 0) {
-								movedOneYet = true;
-								ClipInstance* prevInstance = (ClipInstance*)thisOutput->clipInstances.getElement(i - 1);
-								int32_t maxLength = new_pos - prevInstance->pos;
-								if (prevInstance->length > maxLength) {
-									prevInstance->change(action, thisOutput, prevInstance->pos, maxLength,
-									                     prevInstance->clip);
-								}
-							}
-
-							instance->change(action, thisOutput, new_pos, instance->length, instance->clip);
-
-							i++;
-						}
-					}
-				}
+				shiftClipsHorizontally(offset, scroll_amount, action);
 
 				lastInteractedPos += scroll_amount;
 
@@ -2897,6 +2825,79 @@ ActionResult ArrangerView::horizontalEncoderAction(int32_t offset) {
 	}
 
 	return ActionResult::DEALT_WITH;
+}
+
+// This function will shift automation horizontally at a specific point in time by inserting / deleting time
+void ArrangerView::shiftAutomationHorizontally(int32_t offset, int32_t scroll_amount, Action* action) {
+	ParamCollectionSummary* unpatchedParamsSummary = currentSong->paramManager.getUnpatchedParamSetSummary();
+	UnpatchedParamSet* unpatchedParams = (UnpatchedParamSet*)unpatchedParamsSummary->paramCollection;
+
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithParamCollection* modelStackWithUnpatchedParams =
+	    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory)
+	        ->addParamCollection(unpatchedParams, unpatchedParamsSummary);
+
+	if (offset >= 0) {
+		void* consMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(ConsequenceArrangerParamsTimeInserted));
+		if (consMemory) {
+			ConsequenceArrangerParamsTimeInserted* consequence = new (consMemory)
+			    ConsequenceArrangerParamsTimeInserted(currentSong->xScroll[NAVIGATION_ARRANGEMENT], scroll_amount);
+			action->addConsequence(consequence);
+		}
+		unpatchedParams->insertTime(modelStackWithUnpatchedParams, currentSong->xScroll[NAVIGATION_ARRANGEMENT],
+		                            scroll_amount);
+	}
+	else {
+		if (action) {
+			unpatchedParams->backUpAllAutomatedParamsToAction(action, modelStackWithUnpatchedParams);
+		}
+		unpatchedParams->deleteTime(modelStackWithUnpatchedParams, currentSong->xScroll[NAVIGATION_ARRANGEMENT],
+		                            -scroll_amount);
+	}
+}
+
+// This function will shift clips horizontally at a specific point in time by inserting / deleting time
+void ArrangerView::shiftClipsHorizontally(int32_t offset, int32_t scroll_amount, Action* action) {
+	for (Output* thisOutput = currentSong->firstOutput; thisOutput; thisOutput = thisOutput->next) {
+		int32_t i = thisOutput->clipInstances.search(currentSong->xScroll[NAVIGATION_ARRANGEMENT], GREATER_OR_EQUAL);
+
+		bool movedOneYet = false;
+
+		// And move the successive ones.
+		while (i < thisOutput->clipInstances.getNumElements()) {
+			ClipInstance* instance = thisOutput->clipInstances.getElement(i);
+
+			// If contracting time and this bit has to be deleted...
+			if (offset < 0 && instance->pos + scroll_amount < currentSong->xScroll[NAVIGATION_ARRANGEMENT]) {
+				deleteClipInstance(thisOutput, i, instance, action);
+				// Don't increment i, because we deleted an element
+			}
+
+			// Otherwise, just move it
+			else {
+
+				int32_t new_pos = instance->pos + scroll_amount;
+
+				// If contracting time, shorten the previous ClipInstance only if the ClipInstances we're
+				// moving will eat into its tail. Otherwise, leave the tail there. Perhaps it'd make more
+				// sense to cut the tail off regardless, but possibly just due to me not thinking about it,
+				// this was not done in pre-V4 firmware, and actually having it this way probably helps
+				// users.
+				if (!movedOneYet && offset < 0 && i > 0) {
+					movedOneYet = true;
+					ClipInstance* prevInstance = (ClipInstance*)thisOutput->clipInstances.getElement(i - 1);
+					int32_t maxLength = new_pos - prevInstance->pos;
+					if (prevInstance->length > maxLength) {
+						prevInstance->change(action, thisOutput, prevInstance->pos, maxLength, prevInstance->clip);
+					}
+				}
+
+				instance->change(action, thisOutput, new_pos, instance->length, instance->clip);
+
+				i++;
+			}
+		}
+	}
 }
 
 ActionResult ArrangerView::horizontalScrollOneSquare(int32_t direction) {

--- a/src/deluge/gui/views/arranger_view.h
+++ b/src/deluge/gui/views/arranger_view.h
@@ -58,6 +58,8 @@ public:
 	               uint8_t thisOccupancyMask[], int32_t renderWidth);
 	void editPadAction(int32_t x, int32_t y, bool on);
 	ActionResult horizontalEncoderAction(int32_t offset) override;
+	void shiftAutomationHorizontally(int32_t offset, int32_t scroll_amount, Action* action);
+	void shiftClipsHorizontally(int32_t offset, int32_t scroll_amount, Action* action);
 	uint32_t getMaxLength() override;
 	uint32_t getMaxZoom() override;
 	void graphicsRoutine() override;

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -2370,6 +2370,7 @@ void AutoParam::transposeCCValuesToChannelPressureValues() {
 	currentValue = (currentValue >> 1) + (1 << 30);
 }
 
+/// this is used in arranger view to delete time between automation nodes (shift + <>)
 void AutoParam::deleteTime(int32_t startPos, int32_t lengthToDelete, ModelStackWithAutoParam* modelStack) {
 
 	// No need to do any revertability with an Action here - ParamCollection::backUpAllAutomatedParamsToAction() should
@@ -2442,6 +2443,7 @@ allDeleted:
 	}
 }
 
+/// this is used in arranger view to insert time between automation nodes (shift + <>)
 void AutoParam::insertTime(int32_t pos, int32_t lengthToInsert) {
 	int32_t start = nodes.search(pos, GREATER_OR_EQUAL);
 

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -308,6 +308,7 @@ void ParamSet::deleteAllAutomation(Action* action, ModelStackWithParamCollection
 	modelStack->summary->resetInterpolationRecord(topUintToRepParams);
 }
 
+/// this is used in arranger view to insert time between automation nodes (shift = <>)
 void ParamSet::insertTime(ModelStackWithParamCollection* modelStack, int32_t pos, int32_t lengthToInsert) {
 
 	FOR_EACH_FLAGGED_PARAM(modelStack->summary->whichParamsAreAutomated);
@@ -317,6 +318,7 @@ void ParamSet::insertTime(ModelStackWithParamCollection* modelStack, int32_t pos
 	FOR_EACH_PARAM_END
 }
 
+/// this is used in arranger view to delete time between automation nodes (shift + <>)
 void ParamSet::deleteTime(ModelStackWithParamCollection* modelStack, int32_t startPos, int32_t lengthToDelete) {
 
 	FOR_EACH_FLAGGED_PARAM(modelStack->summary->whichParamsAreAutomated);

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -163,6 +163,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 - Added ability to start / restart arrangement playback from the clip pad you're holding in arranger.
   - Note: you need to select a pad of any clip in arranger in order for this to work (it cannot be an empty pad)
+- Restored original behaviour which enabled you to insert / delete time for all automated parameters using `shift + <>`
 
 #### <ins>Song View</ins>
 
@@ -264,6 +265,10 @@ A `Favourites` feature has been added to the browser for most file types. The `F
   - Values for program, bank and sub-bank were previously shown as 1-128, but now reflect the actual transmitted MIDI values.
 
 #### <ins>Automation View</ins>
+
+##### Defaults
+
+- The `Settings/Defaults/Automation/Shift` toggle now only applies to Clip View. In Arranger View if you use `shift + <>` to insert / delete time at a specific point in the arrangement, all paramet[...]
 
 ##### Parameters
 

--- a/website/src/content/docs/features/automation_view.mdx
+++ b/website/src/content/docs/features/automation_view.mdx
@@ -405,11 +405,9 @@ Through the `Settings/Defaults/Automation/Clear` submenu, you can disable this c
 
 ### Shifting Automation Horizontally
 
-Currently in the Arranger View if you press down on Shift and turn the Horizontal Encoder, it will shift the arrangement of clips and ALL Automations of the entire arranagement horizontally.
+Currently in the Clip View if you press down on the Vertical Encoder and turn the Horizontal Encoder or hold shift , it will shift Notes / Audio File AND the ALL Automations of the entire clip horizontally.
 
-Currently in the Instrument Clip View if you press down on the Vertical Encoder and turn the Horizontal Encoder or hold shift , it will shift Notes AND the ALL Automations of the entire clip horizontally.
-
-This default setting will disable the shifting of Automations within the existing Arranger / Clip Views and leave that behaviour to the Automation View.
+This default setting will disable the shifting of Automations within the existing Clip Views and leave that behaviour to the Automation View.
 
 In the Automation View, functionality is provided to shift automations at the parameter level.
 


### PR DESCRIPTION
Issue: when inserting time / deleting time in arranger view (using shift + <>), automation would not respond the same (no time inserted / deleted) because of a default toggle "automationShift" which disabled that behaviour. As the original behaviour is the desired behaviour and the alternative behaviour is not desired, I have removed that default from being used in Arranger View only (it still has an effect in clip view).

I also refactored code for shifting automation and shifting clips in ArrangerView::horizontalEncoderAction into separate functions for cleanliness.