### PR TITLE
Fix/ arranger automation bug incorrectly getting sequence direction by casting song timeline counter as clip

### DIFF
--- a/src/deluge/model/clip/clip.h
+++ b/src/deluge/model/clip/clip.h
@@ -181,11 +181,6 @@ public:
 
 	LearnedMIDI muteMIDICommand;
 
-#if HAVE_SEQUENCE_STEP_CONTROL
-	bool currentlyPlayingReversed;
-	SequenceDirection sequenceDirectionMode;
-#endif
-
 	int32_t loopLength;
 
 	// Before linear recording of this Clip began, and this Clip started getting extended to multiples of this

--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -63,13 +63,12 @@ ModelStackWithNoteRow* ModelStackWithNoteRowId::automaticallyAddNoteRowFromId() 
 }
 
 bool ModelStackWithNoteRow::isCurrentlyPlayingReversed() const {
-
-	// Under a few different conditions, we just use the parent Clip's reversing status.
+	// Under a few different conditions, we just use the Song's or the parent Clip's reversing status.
 	if (!noteRow
 	    || (noteRow->sequenceDirectionMode == SequenceDirection::OBEY_PARENT
 	        && (!noteRow->loopLengthIfIndependent
-	            || ((Clip*)getTimelineCounter())->sequenceDirectionMode != SequenceDirection::PINGPONG))) {
-		return ((Clip*)getTimelineCounter())->currentlyPlayingReversed;
+	            || getTimelineCounter()->sequenceDirectionMode != SequenceDirection::PINGPONG))) {
+		return getTimelineCounter()->currentlyPlayingReversed;
 	}
 
 	// Otherwise, we use the NoteRow's local one.

--- a/src/deluge/model/timeline_counter.h
+++ b/src/deluge/model/timeline_counter.h
@@ -50,4 +50,9 @@ public:
 
 	ParamManagerForTimeline paramManager;
 	bool armedForRecording{true};
+
+#if HAVE_SEQUENCE_STEP_CONTROL
+	bool currentlyPlayingReversed;
+	SequenceDirection sequenceDirectionMode;
+#endif
 };

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -1119,6 +1119,7 @@ int32_t AutoParam::homogenizeRegion(ModelStackWithAutoParam const* modelStack, i
 	else {
 		if constexpr (ALPHA_OR_BETA_VERSION) {
 			if (startPos < posAtWhichClipWillCut) {
+				// Sean: potentially solved by PR https://github.com/SynthstromAudible/DelugeFirmware/pull/4445
 				FREEZE_WITH_ERROR("E445");
 			}
 		}


### PR DESCRIPTION
**This seems to be a long standing bug in arranger automation view, dating back to official firmware.**

Official: 
- https://github.com/SynthstromAudible/DelugeFirmware/blob/695b22af1e9fcc060e59868c83cf8e504bd57ff1/src/AutoParam.cpp#L913
- https://github.com/SynthstromAudible/DelugeFirmware/blob/695b22af1e9fcc060e59868c83cf8e504bd57ff1/src/AutoParam.cpp#L146
- https://github.com/SynthstromAudible/DelugeFirmware/blob/695b22af1e9fcc060e59868c83cf8e504bd57ff1/src/ModelStack.cpp#L63

Main:
- https://github.com/SynthstromAudible/DelugeFirmware/blob/4ab93c5308319e018ccee84caae4756d94732162/src/deluge/modulation/automation/auto_param.cpp#L1118
- https://github.com/SynthstromAudible/DelugeFirmware/blob/4ab93c5308319e018ccee84caae4756d94732162/src/deluge/modulation/automation/auto_param.cpp#L156
- https://github.com/SynthstromAudible/DelugeFirmware/blob/4ab93c5308319e018ccee84caae4756d94732162/src/deluge/model/model_stack.cpp#L67

**Issue:**

- Error "E445" is triggered in arranger view by trying to record delay amount automation is found in auto_param.cpp.
- When you look at the code, it falls under a branch that says "// Or, playing reversed..."
- Well this is a red flag ... arranger view playback is never reversed.

**Cause:**
- Following the code back up, we find where the "reversed" flag is set:
- In void AutoParam::setCurrentValueInResponseToUserInput:
- bool reversed = modelStack->isCurrentlyPlayingReversed();
- So then I went and checked isCurrentlyPlayingReversed, and it doesn't check the song's timeline counter, which is what is used when recording song automation.
- Instead it was always casting the timeline counter as a clip and returnin the reversed flag of the clip.
- Well that's wrong..

**Solution:**
- To avoid casting the timeline counter to the wrong type, I moved sequence direction mode and reversing status to the timeline counter class which both clips and the song inherit from.
- This fixed the E445 crash and maybe some other gremlins resulting from landing in that "reversed" branch.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4020