### PR TITLE
[DRAFT] Fix/ Add centered scrolling to file browsers

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1145,12 +1145,11 @@ searchFromOneEnd:
 		else {
 			scrollPosVertical = 9999;
 
-			if (numFileItemsDeletedAtStart) {
+			bool reachedEnd = newFileIndex >= fileItems.getNumElements();
+
+			if (numFileItemsDeletedAtStart && reachedEnd) {
 				newCatalogSearchDirection = CATALOG_SEARCH_RIGHT;
 				goto searchFromOneEnd;
-			}
-			else {
-				newFileIndex = 0;
 			}
 		}
 	}

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1160,11 +1160,16 @@ searchFromOneEnd:
 
 	fileIndexSelected = newFileIndex;
 
-	if (scrollPosVertical > fileIndexSelected) {
-		scrollPosVertical = fileIndexSelected;
+	if (display->haveOLED()) {
+		scrollPosVertical = std::clamp<int>(newFileIndex - 1, 0, maxNumFileItemsNow - kOLEDMenuNumOptionsVisible);
 	}
-	else if (scrollPosVertical < fileIndexSelected - NUM_FILES_ON_SCREEN + 1) {
-		scrollPosVertical = fileIndexSelected - NUM_FILES_ON_SCREEN + 1;
+	else {
+		if (scrollPosVertical > fileIndexSelected) {
+			scrollPosVertical = fileIndexSelected;
+		}
+		else if (scrollPosVertical < fileIndexSelected - NUM_FILES_ON_SCREEN + 1) {
+			scrollPosVertical = fileIndexSelected - NUM_FILES_ON_SCREEN + 1;
+		}
 	}
 
 	enteredTextEditPos = 0;

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1130,7 +1130,8 @@ searchFromOneEnd:
 		}
 	}
 
-	else if (newFileIndex >= fileItems.getNumElements()) {
+	// we try to have 1 beyond the current index
+	else if ((newFileIndex + 1) >= fileItems.getNumElements()) {
 		D_PRINTLN("out of file items");
 		if (numFileItemsDeletedAtEnd) {
 			scrollPosVertical = 0;


### PR DESCRIPTION
For consistency with other menus, the file item selected in the file browers on OLED is vertically centered

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2767

To do: last item in the file browser should not be centered and currently an issue with selecting it as well