### PR TITLE
enable l2 cache

### DIFF
--- a/src/RZA1/cache/cache.c
+++ b/src/RZA1/cache/cache.c
@@ -31,6 +31,8 @@
 Includes   <System Includes> , "Project Includes"
 ******************************************************************************/
 #include "RZA1/cache/cache.h"
+
+#include "RZA1/compiler/asm/inc/asm.h"
 #include "RZA1/system/iodefine.h"
 #include "RZA1/system/r_typedefs.h"
 
@@ -240,10 +242,16 @@ void L2CacheFlushAll(void)
 void L2CacheEnable(void)
 {
     L2C.REG2_INT_CLEAR   = 0x000001FFuL; /* Clear the reg2_int_raw_status register */
-    L2C.REG9_D_LOCKDOWN0 = 0xFFFFFFFFuL; // lock the data cache - we need a lot of work around invalidating it with DMA
-                                         // before it can be used
+    L2C.REG9_D_LOCKDOWN0 = 0xFFFFFFFFuL; // lock the data cache - unlock late in boot sequence once everything is setup
     L2C.REG9_I_LOCKDOWN0 = 0x00000000uL; // unlock the instruction cache
-    L2C.REG1_CONTROL     = 0x00000001uL; /* Enable L2 cache */
+    L2C.REG1_AUX_CONTROL |= 0x30000000uL;
+    L2C.REG1_CONTROL = 0x00000001uL; /* Enable L2 cache */
+}
+
+void L2CacheUnlockData(void)
+{
+    L2CacheFlushAll();
+    L2C.REG9_D_LOCKDOWN0 = 0x00000000uL; // unlock the data cache
 }
 
 /******************************************************************************
@@ -262,6 +270,77 @@ void L2CacheInit(void)
     L2CacheDisable();
     L2CacheFlushAll();
     L2CacheEnable();
+}
+
+/******************************************************************************
+ * Function Name: L2CacheCleanRange
+ * Description  : Clean (flush dirty data to RAM) L2 cache lines by PA.
+ * Arguments    : start - start physical address
+ *                end   - end physical address (exclusive)
+ * Return Value : none
+ ******************************************************************************/
+void L2CacheCleanRange(uintptr_t start, uintptr_t end)
+{
+    uint32_t addr = start & ~31uL;
+    while (addr < end)
+    {
+        L2C.REG7_CLEAN_PA = addr;
+        while (L2C.REG7_CLEAN_PA & 1uL)
+        {
+        }
+        addr += 32;
+    }
+    L2C.REG7_CACHE_SYNC = 0;
+}
+
+/******************************************************************************
+ * Function Name: L2CacheInvalidateRange
+ * Description  : Invalidate L2 cache lines by PA (discard, no writeback).
+ * Arguments    : start - start physical address
+ *                end   - end physical address (exclusive)
+ * Return Value : none
+ ******************************************************************************/
+void L2CacheInvalidateRange(uintptr_t start, uintptr_t end)
+{
+
+    uint32_t addr = start & ~31uL;
+    while (addr < end)
+    {
+        L2C.REG7_INV_PA = addr;
+        while (L2C.REG7_INV_PA & 1uL)
+        {
+        }
+        addr += 32;
+    }
+    L2C.REG7_CACHE_SYNC = 0;
+}
+
+/******************************************************************************
+ * Function Name: L2CacheCleanInvalidateRange
+ * Description  : Clean and invalidate L2 cache lines by PA.
+ * Arguments    : start - start physical address
+ *                end   - end physical address (exclusive)
+ * Return Value : none
+ ******************************************************************************/
+void L2CacheCleanInvalidateRange(uintptr_t start, uintptr_t end)
+{
+    uint32_t addr = start & ~31uL;
+    while (addr < end)
+    {
+        L2C.REG7_CLEAN_INV_PA = addr;
+        while (L2C.REG7_CLEAN_INV_PA & 1uL)
+        {
+        }
+        addr += 32;
+    }
+    L2C.REG7_CACHE_SYNC = 0;
+}
+
+void invalidate_range_all_caches(uintptr_t start, uintptr_t end)
+{
+    v7_dma_flush_range(start, end);
+    L2CacheCleanInvalidateRange(start, end);
+    v7_dma_inv_range(start, end);
 }
 
 /* End of File */

--- a/src/RZA1/cache/cache.h
+++ b/src/RZA1/cache/cache.h
@@ -28,6 +28,11 @@
  ******************************************************************************/
 #ifndef CACHE_H
 #define CACHE_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <inttypes.h>
 
 /******************************************************************************
 Includes   <System Includes> , "Project Includes"
@@ -63,10 +68,15 @@ void L1PrefetchDisable(void);
 void L2CacheInit(void);
 void L2CacheFlushAll(void);
 void L2CacheEnable(void);
+void L2CacheUnlockData(void);
 void L2CacheDisable(void);
-void L2CacheInit(void);
-extern void R_CACHE_L1Init(void);
+void L2CacheCleanInvalidateRange(uintptr_t start, uintptr_t end);
+void invalidate_range_all_caches(uintptr_t start, uintptr_t end);
 
+extern void R_CACHE_L1Init(void);
+#ifdef __cplusplus
+}
+#endif
 #endif /* CACHE_H */
 
 /* End of File */

--- a/src/RZA1/sdhi/src/sd/access/sd_read.c
+++ b/src/RZA1/sdhi/src/sd/access/sd_read.c
@@ -41,6 +41,7 @@
 #include "RZA1/compiler/asm/inc/asm.h"
 #include "deluge/drivers/uart/uart.h"
 #include "deluge/deluge.h"
+#include "RZA1/cache/cache.h"
 
 #ifdef __CC_ARM
 #pragma arm section code = "CODE_SDHI"
@@ -82,7 +83,7 @@ int doActualReadRohan(int sd_port, SDHNDL *hndl, unsigned char *buff, long cnt, 
 		// for this memory which hasn't been written/flushed back out yet, and that happens during the DMA transfer, overwriting the audio data in actual RAM.
 		// https://support.xilinx.com/s/article/64839?language=en_US - seems to concur with this, and actually suggests that it is normal and necessary to
 		// invalidate both before and after transfer.
-		v7_dma_inv_range((intptr_t)buff, (intptr_t)(buff + cnt * 512));
+		invalidate_range_all_caches((intptr_t)buff, (intptr_t)(buff + cnt * 512));
 
 		/* ---- initialize DMAC ---- */
 		unsigned long reg_base_here = hndl->reg_base;
@@ -311,7 +312,7 @@ int sd_read_sect(int sd_port, unsigned char *buff,unsigned long psn,long cnt)
 
 		if (mode != SD_MODE_SW) {
 			// Invalidate ram
-			v7_dma_inv_range((uintptr_t)buff, (uintptr_t)(buff + cnt * 512));
+			invalidate_range_all_caches((uintptr_t)buff, (uintptr_t)(buff + cnt * 512));
 		}
 
 		/* clear All end bit */
@@ -536,7 +537,7 @@ static int _sd_single_read(SDHNDL *hndl,unsigned char *buff,unsigned long psn,
 
 	if (mode != SD_MODE_SW) {
 		// Invalidate ram
-		v7_dma_inv_range((uintptr_t)buff, (uintptr_t)(buff + 512));
+		invalidate_range_all_caches((uintptr_t)buff, (uintptr_t)(buff + 512));
 	}
 
 	/* clear All end bit */

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -69,6 +69,8 @@
 #include "util/pack.h"
 #include <stdlib.h>
 
+#include "RZA1/cache/cache.h"
+
 #if AUTOMATED_TESTER_ENABLED
 #include "testing/automated_tester.h"
 #endif
@@ -977,6 +979,7 @@ extern "C" int32_t deluge_main(void) {
 	uiTimerManager.setTimer(TimerName::GRAPHICS_ROUTINE, 50);
 
 	D_PRINTLN("going into main loop");
+	L2CacheUnlockData();
 	sdRoutineLock = false; // Allow SD routine to start happening
 
 #ifdef USE_TASK_MANAGER

--- a/src/fatfs/ff.h
+++ b/src/fatfs/ff.h
@@ -172,7 +172,7 @@ typedef struct {
 	LBA_t	bitbase;		/* Allocation bitmap base sector */
 #endif
 	LBA_t	winsect;		/* Current sector appearing in the win[] */
-	BYTE	dummy[32]; // Inserted by Rohan. This is the cache line size
+	BYTE	dummy[32] __attribute((aligned(32))); // Inserted by Rohan. This is the cache line size
 	BYTE	win[FF_MAX_SS];	/* Disk access window for Directory, FAT (and file data at tiny cfg) */
 	BYTE	dummy2[32]; // Inserted by Rohan. This somehow stops occasional intermittent errors
 } FATFS;
@@ -219,7 +219,7 @@ typedef struct {
 	DWORD*	cltbl;			/* Pointer to the cluster link map table (nulled on open, set by application) */
 #endif
 #if !FF_FS_TINY
-	BYTE	buf[FF_MAX_SS];	/* File private data read/write window */
+	BYTE	buf[FF_MAX_SS] __attribute((aligned(32)));	/* File private data read/write window */
 #endif
 } FIL;
 


### PR DESCRIPTION
Cleaned up version of the L2 cache enable done by @CaptPat and @kastenbalg 

It would probably be better to redirect all DMA usage via the uncached offset but clearing the range manually after each transfer seems to work fine in practice and is still a big improvement