### PR TITLE
Interrupt-driven encoders

### DIFF
--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
@@ -32,6 +32,16 @@ void clearIRQInterrupt(int irqNumber) {
 	}
 }
 
+void setIRQInterruptBothEdges(int irqNumber) {
+	// ICR1 holds two mode bits per IRQn channel (00=low level, 01=falling,
+	// 10=rising, 11=both-edge).
+	uint16_t shift = (uint16_t)(irqNumber * 2);
+	uint16_t mask = (uint16_t)(0x3u << shift);
+	uint16_t val = INTC.ICR1;
+	val = (uint16_t)((val & ~mask) | (0x3u << shift));
+	INTC.ICR1 = val;
+}
+
 void setupTimerWithInterruptHandler(int timerNo, int scale, void (*handler)(uint32_t intSense), uint8_t priority) {
 	disableTimer(timerNo);
 	*TCNT[timerNo] = 0u;

--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
@@ -55,6 +55,11 @@ static inline __attribute__((no_instrument_function)) void ENABLE_INTERRUPTS() {
 }
 void clearIRQInterrupt(int irqNumber);
 
+/// Configure external interrupt `irqNumber` (0–7) for both-edge detection.
+/// Read-modify-write of `INTC.ICR1` so the other channels are preserved
+/// (e.g. the trigger-clock channel programmed in main()).
+void setIRQInterruptBothEdges(int irqNumber);
+
 /// sets up a timer with an interrupt and handler but does not enable the timer
 /// Valid scale values are 1, 4, 16, 64 for all timers 0-4. Timer 1, 3, 4 support 256. Timer 2, 3, 4 support 1024.
 /// resulting frequency is 33.33MHz/scale

--- a/src/RZA1/gpio/gpio.c
+++ b/src/RZA1/gpio/gpio.c
@@ -52,6 +52,11 @@ void setPinAsInput(uint8_t p, uint8_t q)
     ioRegSet(&GPIO.PIBC1, p, q, 1);
 }
 
+void enableInputBuffer(uint8_t p, uint8_t q)
+{
+    ioRegSet(&GPIO.PIBC1, p, q, 1);
+}
+
 void setOutputState(uint8_t p, uint8_t q, uint16_t state)
 {
     ioRegSet(&GPIO.P1, p, q, state);

--- a/src/RZA1/gpio/gpio.h
+++ b/src/RZA1/gpio/gpio.h
@@ -23,6 +23,7 @@
 void setPinMux(uint8_t p, uint8_t q, uint8_t mux);
 void setPinAsOutput(uint8_t p, uint8_t q);
 void setPinAsInput(uint8_t p, uint8_t q);
+void enableInputBuffer(uint8_t p, uint8_t q);
 uint16_t getOutputState(uint8_t p, uint8_t q);
 void setOutputState(uint8_t p, uint8_t q, uint16_t state);
 uint16_t readInput(uint8_t p, uint8_t q);

--- a/src/deluge/hid/encoder.cpp
+++ b/src/deluge/hid/encoder.cpp
@@ -27,84 +27,35 @@ extern "C" {
 Encoder::Encoder() {
 	encPos = 0;
 	detentPos = 0;
-	encLastChange = 0;
-	pinALastSwitch = 1;
-	pinBLastSwitch = 1;
-	pinALastRead = 1;
-	pinBLastRead = 1;
+	edgeAccumulator = 0;
 	doDetents = true;
-	valuesNow[0] = true;
-	valuesNow[1] = true;
-}
-
-void Encoder::read() {
-	bool pinANewVal = readInput(portA, pinA);
-	bool pinBNewVal = readInput(portB, pinB);
-
-	// If they've both changed...
-	if (pinANewVal != pinALastSwitch && pinBNewVal != pinBLastSwitch) {
-
-		int32_t change = 0;
-
-		// Had pin A changed first?
-		if (pinALastRead != pinALastSwitch) {
-			change = (pinALastSwitch == pinBLastSwitch) ? -1 : 1;
-			pinALastSwitch = pinANewVal;
-		}
-
-		// Or had pin B changed first?
-		else if (pinBLastRead != pinBLastSwitch) {
-			change = (pinALastSwitch == pinBLastSwitch) ? 1 : -1;
-			pinBLastSwitch = pinBNewVal;
-		}
-
-		// Or if they both changed at the same time
-		else {
-
-			// If detents, we have to do a thing to ensure we don't end up "in between" detents
-			if (doDetents) {
-				change = (encLastChange >= 0) ? 2 : -2;
-			}
-			pinALastSwitch = pinANewVal;
-			pinBLastSwitch = pinBNewVal;
-		}
-
-		if (change != 0) {
-
-			encPos += change;
-
-			if (doDetents) {
-				while (encPos > 2) {
-					encPos -= 4;
-					detentPos += 1;
-				}
-
-				while (encPos < -2) {
-					encPos += 4;
-					detentPos -= 1;
-				}
-			}
-			encLastChange = change;
-		}
-	}
-
-	pinALastRead = pinANewVal;
-	pinBLastRead = pinBNewVal;
 }
 
 void Encoder::setPins(uint8_t pinA1New, uint8_t pinA2New, uint8_t pinB1New, uint8_t pinB2New) {
-	portA = pinA1New;
-	pinA = pinA2New;
-	portB = pinB1New;
-	pinB = pinB2New;
-	setPinAsInput(portA, pinA);
-	setPinAsInput(portB, pinB);
+	setPinAsInput(pinA1New, pinA2New);
+	setPinAsInput(pinB1New, pinB2New);
 }
 
 void Encoder::setNonDetentMode() {
 	doDetents = false;
-	pinALastSwitch = readInput(portA, pinA);
-	pinBLastSwitch = readInput(portB, pinB);
+}
+
+void Encoder::applyEdges(int8_t edges) {
+	if (edges == 0) {
+		return;
+	}
+	// Two A-pin edges per quadrature cycle, one quadrature cycle per detent click on the
+	// Deluge encoders. Same halving as the embassy `take_detents()` does.
+	edgeAccumulator += edges;
+	int8_t ticks = edgeAccumulator / 2;
+	if (ticks == 0) {
+		return;
+	}
+	edgeAccumulator -= ticks * 2;
+	if (doDetents) {
+		detentPos += ticks;
+	}
+	encPos += ticks;
 }
 
 int32_t Encoder::getLimitedDetentPosAndReset() {

--- a/src/deluge/hid/encoder.h
+++ b/src/deluge/hid/encoder.h
@@ -31,24 +31,18 @@ public:
 	Encoder& operator=(Encoder& other) = delete;
 	Encoder&& operator=(Encoder&& other) = delete;
 
-	void read();
+	/// Fold a number of A-pin edges (signed; from the IRQ accumulator) into encPos / detentPos.
+	/// Two edges = one detent step (or one raw tick for non-detent gold knobs), matching the
+	/// "1 quadrature cycle per detent" wiring on the Deluge encoders.
+	void applyEdges(int8_t edges);
 	void setPins(uint8_t pinA1New, uint8_t pinA2New, uint8_t pinB1New, uint8_t pinB2New);
 	void setNonDetentMode();
 	int32_t getLimitedDetentPosAndReset();
 	int8_t encPos;    // Keeps track of knob's position relative to centre of closest detent
 	int8_t detentPos; // Number of full detents offset since functions last dealt with
 private:
-	uint8_t portA;
-	uint8_t pinA;
-	uint8_t portB;
-	uint8_t pinB;
-	bool pinALastSwitch;
-	bool pinBLastSwitch;
-	bool pinALastRead;
-	bool pinBLastRead;
-	int8_t encLastChange; // The "change" applied on the most recently detected action on this knob. Probably 1 or -1.
+	int8_t edgeAccumulator; // Leftover edges from applyEdges() that haven't yet formed a tick.
 	bool doDetents;
-	bool valuesNow[2];
 };
 
 } // namespace deluge::hid::encoders

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "hid/encoders.h"
+#include "OSLikeStuff/timers_interrupts/timers_interrupts.h"
 #include "definitions_cxx.hpp"
 #include "extern.h"
 #include "gui/ui/ui.h"
@@ -31,7 +32,13 @@
 #include "processing/engines/audio_engine.h"
 #include "processing/stem_export/stem_export.h"
 #include "util/functions.h"
+#include <atomic>
 #include <new>
+
+extern "C" {
+#include "RZA1/gpio/gpio.h"
+#include "RZA1/intc/devdrv_intc.h"
+}
 
 namespace deluge::hid::encoders {
 
@@ -44,6 +51,69 @@ uint32_t timeNextSDTestAction = 0;
 int32_t nextSDTestDirection = 1;
 
 uint32_t encodersWaitingForCardRoutineEnd;
+
+namespace {
+constexpr size_t kNumEncoders = util::to_underlying(EncoderName::MAX_ENCODER);
+struct EncoderIrqEntry {
+	/// @brief  A-side pin that's routed via PFC alt-2 to RZ/A1L IRQn.
+	uint8_t irqPin;
+
+	/// @brief companion (B-side) pin, read as plain GPIO inside the ISR.
+	uint8_t compPin;
+	uint8_t irqNum;
+
+	/// @brief flip the direction sense when the A/B wiring is swapped relative to the polled order in `setPins(...)`.
+	bool invert;
+};
+
+constexpr EncoderIrqEntry kEncoderIrqMap[kNumEncoders] = {
+    [util::to_underlying(EncoderName::SCROLL_Y)] = {.irqPin = 8, .compPin = 10, .irqNum = 0, .invert = false},
+    [util::to_underlying(EncoderName::SCROLL_X)] = {.irqPin = 11, .compPin = 12, .irqNum = 3, .invert = false},
+    [util::to_underlying(EncoderName::TEMPO)] = {.irqPin = 6, .compPin = 7, .irqNum = 2, .invert = true},
+    [util::to_underlying(EncoderName::SELECT)] = {.irqPin = 3, .compPin = 2, .irqNum = 7, .invert = true},
+    [util::to_underlying(EncoderName::MOD_1)] = {.irqPin = 5, .compPin = 4, .irqNum = 1, .invert = false},
+    [util::to_underlying(EncoderName::MOD_0)] = {.irqPin = 0, .compPin = 15, .irqNum = 4, .invert = false},
+};
+
+/// Atomic edge counters written by ISRs, drained by `readEncoders()`.
+std::atomic<int8_t> encoderEdgeDeltas[kNumEncoders] = {};
+
+template <size_t IDX>
+void encoderIrqHandler(uint32_t /*sense*/) {
+	constexpr EncoderIrqEntry m = kEncoderIrqMap[IDX];
+	bool a = readInput(1, m.irqPin) != 0;
+	bool b = readInput(1, m.compPin) != 0;
+	bool cw = m.invert ? (a != b) : (a == b);
+	int8_t inc = cw ? +1 : -1;
+	encoderEdgeDeltas[IDX].fetch_add(inc, std::memory_order_relaxed);
+	clearIRQInterrupt(m.irqNum);
+}
+
+using IrqHandler = void (*)(uint32_t);
+constexpr IrqHandler kEncoderIrqHandlers[kNumEncoders] = {
+    &encoderIrqHandler<0>, &encoderIrqHandler<1>, &encoderIrqHandler<2>,
+    &encoderIrqHandler<3>, &encoderIrqHandler<4>, &encoderIrqHandler<5>,
+};
+
+constexpr uint8_t kEncoderIrqPriority = 14;
+
+void initInterrupts() {
+	for (size_t i = 0; i < kNumEncoders; i++) {
+		const auto& m = kEncoderIrqMap[i];
+
+		// Route the A-side pin to its IRQn input via PFC alt-function 2.
+		setPinMux(1, m.irqPin, 2);
+		enableInputBuffer(1, m.irqPin);
+
+		setPinAsInput(1, m.compPin);
+
+		setIRQInterruptBothEdges(m.irqNum);
+
+		clearIRQInterrupt(m.irqNum);
+		setupAndEnableInterrupt(kEncoderIrqHandlers[i], INTC_ID_IRQ0 + m.irqNum, kEncoderIrqPriority);
+	}
+}
+} // namespace
 
 Encoder& getEncoder(EncoderName which) {
 	return encoders[util::to_underlying(which)];
@@ -59,11 +129,16 @@ void init() {
 
 	getEncoder(EncoderName::MOD_0).setNonDetentMode();
 	getEncoder(EncoderName::MOD_1).setNonDetentMode();
+
+	initInterrupts();
 }
 
 void readEncoders() {
-	for (auto& encoder : encoders) {
-		encoder.read();
+	for (size_t i = 0; i < util::to_underlying(EncoderName::MAX_ENCODER); i++) {
+		int8_t edges = encoderEdgeDeltas[i].exchange(0, std::memory_order_acquire);
+		if (edges != 0) {
+			encoders[i].applyEdges(edges);
+		}
 	}
 }
 

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -135,7 +135,7 @@ void init() {
 
 void readEncoders() {
 	for (size_t i = 0; i < util::to_underlying(EncoderName::MAX_ENCODER); i++) {
-		int8_t edges = encoderEdgeDeltas[i].exchange(0, std::memory_order_acquire);
+		int8_t edges = encoderEdgeDeltas[i].exchange(0, std::memory_order_relaxed);
 		if (edges != 0) {
 			encoders[i].applyEdges(edges);
 		}

--- a/tests/32bit_unit_tests/mocks/mock_encoder.cpp
+++ b/tests/32bit_unit_tests/mocks/mock_encoder.cpp
@@ -1,19 +1,12 @@
 #include "hid/encoder.h"
-#include "processing/engines/audio_engine.h"
 
 namespace deluge::hid::encoders {
 
 Encoder::Encoder() {
 	encPos = 0;
 	detentPos = 0;
-	encLastChange = 0;
-	pinALastSwitch = 1;
-	pinBLastSwitch = 1;
-	pinALastRead = 1;
-	pinBLastRead = 1;
+	edgeAccumulator = 0;
 	doDetents = true;
-	valuesNow[0] = true;
-	valuesNow[1] = true;
 }
 
 } // namespace deluge::hid::encoders


### PR DESCRIPTION
Switch the encoder hardware backend from polling to interrupt driven via IRQs. Note that this does not decrease the (perceived) user latency yet, since interpretEncoders is still called at the same rates. It _should_ prevent "missed" detents, though. 