### PR TITLE
move critical section entry to function and clean up names

### DIFF
--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
@@ -24,7 +24,38 @@
 extern "C" {
 #endif
 
-atomic_int interrupt_depth = 0;
+atomic_int critical_section_depth = 0;
+
+void ENTER_CRITICAL_SECTION() {
+	atomic_int expected = 0;
+	atomic_int desired = 1;
+	// if we go from 0 to 1 then we need to issue the barrier instructions, otherwise just increment depth
+	if (atomic_compare_exchange_strong(&critical_section_depth, &expected, desired)) {
+		// memory creates a memory barrier in GCC to avoid reordering
+		// http://www.ibiblio.org/gferg/ldp/GCC-Inline-Assembly-HOWTO.html#ss5.3
+		__asm volatile("CPSID i" ::: "memory");
+		__asm volatile("DSB");
+		__asm volatile("ISB");
+	}
+	else {
+		critical_section_depth++;
+	}
+}
+
+void EXIT_CRITICAL_SECTION() {
+
+	/// if the section depth is greater than 0 then we are guaranteed to be in a critical section and therefore
+	/// can't have a toctou issue here
+	if (critical_section_depth > 0) {
+		atomic_fetch_sub(&critical_section_depth, 1);
+		if (critical_section_depth == 0) {
+			__asm volatile("CPSIE i" ::: "memory");
+			__asm volatile("DSB");
+			__asm volatile("ISB");
+		}
+	}
+}
+
 void clearIRQInterrupt(int irqNumber) {
 	uint16_t flagRead = INTC.IRQRR.WORD;
 	if (flagRead & (1 << irqNumber)) {

--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
@@ -18,44 +18,55 @@
 #include "timers_interrupts.h"
 
 #include "RZA1/system/r_typedefs.h"
-#include "RZA1/uart/sio_char.h"
-#include "deluge/deluge.h"
+#include "definitions.h"
 #include "deluge/drivers/mtu/mtu.h"
 #include "stdatomic.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-atomic_int critical_section_depth = 0;
+_Atomic int32_t critical_section_depth = 0;
 
 void ENTER_CRITICAL_SECTION() {
-	atomic_int expected = 0;
-	atomic_int desired = 1;
-	// if we go from 0 to 1 then we need to issue the barrier instructions, otherwise just increment depth
-	if (atomic_compare_exchange_strong(&critical_section_depth, &expected, desired)) {
+	int32_t expected = 0;
+	int32_t desired = 1;
+	// if we go from 0 to 1 then we need to issue the synchronization instructions, otherwise just increment depth
+	// avoids having to clear the full pipeline
+	if (atomic_compare_exchange_strong_explicit(&critical_section_depth, &expected, desired, memory_order_relaxed,
+	                                            memory_order_relaxed)) {
 		// memory creates a memory barrier in GCC to avoid reordering
 		// http://www.ibiblio.org/gferg/ldp/GCC-Inline-Assembly-HOWTO.html#ss5.3
 		__asm volatile("CPSID i" ::: "memory");
 		__asm volatile("DSB");
 		__asm volatile("ISB");
 	}
+	// in this case we're already in a critical section so just increment the count
 	else {
-		critical_section_depth++;
+		atomic_fetch_add_explicit(&critical_section_depth, 1, memory_order_relaxed);
 	}
 }
 
 void EXIT_CRITICAL_SECTION() {
 
-	/// if the section depth is greater than 0 then we are guaranteed to be in a critical section and therefore
-	/// can't have a toctou issue here
-	if (critical_section_depth > 0) {
-		atomic_fetch_sub(&critical_section_depth, 1);
-		if (critical_section_depth == 0) {
-			__asm volatile("CPSIE i" ::: "memory");
-			__asm volatile("DSB");
-			__asm volatile("ISB");
-		}
+	int32_t expected = 1;
+	int32_t desired = 0;
+	// if we go from 1 to 0 then exit the critical section. In any other case just decrement the counter
+	if (atomic_compare_exchange_strong_explicit(&critical_section_depth, &expected, desired, memory_order_relaxed,
+	                                            memory_order_relaxed)) {
+		__asm volatile("DSB");
+		__asm volatile("ISB");
+		__asm volatile("CPSIE i" ::: "memory");
 	}
+	// if that fails we're still in a critical section so just decrement the count
+	else {
+		atomic_fetch_sub_explicit(&critical_section_depth, 1, memory_order_relaxed);
+	}
+
+#if ALPHA_OR_BETA_VERSTION
+	if (atomic_load_explicit(&critical_section_depth, memory_order_relaxed) < 0) {
+		FREEZE_WITH_ERROR("OH NO");
+	}
+#endif
 }
 
 void clearIRQInterrupt(int irqNumber) {

--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.c
@@ -16,10 +16,12 @@
  */
 
 #include "timers_interrupts.h"
+
 #include "RZA1/system/r_typedefs.h"
 #include "RZA1/uart/sio_char.h"
 #include "deluge/deluge.h"
 #include "deluge/drivers/mtu/mtu.h"
+#include "stdatomic.h"
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
@@ -30,29 +30,14 @@ extern "C" {
 // ref http://www.rdrop.com/users/paulmck/scalability/paper/whymb.2010.07.23a.pdf
 // in future if we start using user mode this won't work from there
 
-/// disable all interrupts - must be in system mode
-extern atomic_int interrupt_depth;
-static inline __attribute__((no_instrument_function)) void DISABLE_ALL_INTERRUPTS() {
-	interrupt_depth++;
-	// memory creates a memory barrier in GCC to avoid reordering
-	// http://www.ibiblio.org/gferg/ldp/GCC-Inline-Assembly-HOWTO.html#ss5.3
-	__asm volatile("CPSID i" ::: "memory");
-	__asm volatile("DSB");
-	__asm volatile("ISB");
-}
+/// enter critical section - must be in system mode, and must be paired with EXIT_CRITICAL_SECTION()
+/// these can be nested, but you must exit the same number of times as you enter
+/// use the RAII CriticalSectionGuard from C++ code instead to avoid manual management
+void ENTER_CRITICAL_SECTION();
 
-/// enable all interrupts - must be in system mode
-static inline __attribute__((no_instrument_function)) void ENABLE_INTERRUPTS() {
+/// exit critical section - ensure it's paired with ENTER_CRITICAL_SECTION()
+void EXIT_CRITICAL_SECTION();
 
-	if (interrupt_depth > 0) {
-		atomic_fetch_sub(&interrupt_depth, 1);
-		if (interrupt_depth == 0) {
-			__asm volatile("CPSIE i" ::: "memory");
-			__asm volatile("DSB");
-			__asm volatile("ISB");
-		}
-	}
-}
 void clearIRQInterrupt(int irqNumber);
 
 /// sets up a timer with an interrupt and handler but does not enable the timer
@@ -70,8 +55,8 @@ void setupAndEnableInterrupt(void (*handler)(uint32_t), uint16_t interruptID, ui
 #ifdef __cplusplus
 
 struct CriticalSectionGuard {
-	CriticalSectionGuard() { DISABLE_ALL_INTERRUPTS(); }
-	~CriticalSectionGuard() { ENABLE_INTERRUPTS(); }
+	CriticalSectionGuard() { ENTER_CRITICAL_SECTION(); }
+	~CriticalSectionGuard() { EXIT_CRITICAL_SECTION(); }
 };
 }
 #endif

--- a/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
+++ b/src/OSLikeStuff/timers_interrupts/timers_interrupts.h
@@ -19,7 +19,6 @@
 #define DELUGE_TIMERS_INTERRUPTS_H
 
 #include "RZA1/system/r_typedefs.h"
-#include "stdatomic.h"
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/deluge/drivers/oled/oled.c
+++ b/src/deluge/drivers/oled/oled.c
@@ -132,7 +132,7 @@ void enqueueSPITransfer(int32_t destinationId, union SpiTransferData image) {
 		return;
 	}
 
-	DISABLE_ALL_INTERRUPTS();
+	ENTER_CRITICAL_SECTION();
 	// First check there isn't already an identical transfer enqueued.
 	auto current_item = spiTransferQueue[spiTransferQueueReadPos];
 	if (equals(destinationId, image, current_item)) {
@@ -178,7 +178,7 @@ void enqueueSPITransfer(int32_t destinationId, union SpiTransferData image) {
 		sendSPITransferFromQueue();
 	}
 exit:
-	ENABLE_INTERRUPTS();
+	EXIT_CRITICAL_SECTION();
 	return;
 }
 

--- a/src/deluge/dsp/delay/delay.cpp
+++ b/src/deluge/dsp/delay/delay.cpp
@@ -241,7 +241,7 @@ void Delay::process(std::span<StereoSample> buffer, const State& delayWorkingSta
 		if (primaryBuffer.resampling() || delayWorkingState.userDelayRate != primaryBuffer.nativeRate()) {
 
 			// If delay speed has settled for a split second...
-			if (countCyclesWithoutChange >= (kSampleRate >> 5)) {
+			if (countCyclesWithoutChange >= (kSampleRate >> 3)) {
 				// D_PRINTLN("settling");
 				initializeSecondaryBuffer(delayWorkingState.userDelayRate, true);
 			}

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -2419,12 +2419,12 @@ void Song::renderAudio(std::span<StereoSample> outputBuffer, int32_t* reverbBuff
 
 		bool isClipActiveNow =
 		    (output->getActiveClip() && isClipActive(output->getActiveClip()->getClipBeingRecordedFrom()));
-		DISABLE_ALL_INTERRUPTS();
+		ENTER_CRITICAL_SECTION();
 		if (output->shouldRenderInSong()) {
 			output->renderOutput(modelStack, outputBuffer, reverbBuffer, volumePostFX >> 1, sideChainHitPending,
 			                     !isClipActiveNow, isClipActiveNow);
 		}
-		ENABLE_INTERRUPTS();
+		EXIT_CRITICAL_SECTION();
 #if DO_AUDIO_LOG
 		char buf[64];
 		snprintf(buf, sizeof(buf), "complete: %s", output->name.get());

--- a/src/deluge/util/chainload.cpp
+++ b/src/deluge/util/chainload.cpp
@@ -36,7 +36,7 @@ void chainload_from_buf(uint8_t* buffer, int buf_size) {
 
 	// Disable interrupts so we don't get interrupted during the chainload
 #if defined(__arm__)
-	DISABLE_ALL_INTERRUPTS();
+	ENTER_CRITICAL_SECTION();
 #endif
 	// Disable timers
 	disableTimer(TIMER_MIDI_GATE_OUTPUT);

--- a/src/main.c
+++ b/src/main.c
@@ -131,7 +131,7 @@ int main(void) {
 	INTC.ICR1 = 0b0101010101010101;
 	// this is the same priority as the midi/gate interrupt despite the comment saying they need to be different
 	setupAndEnableInterrupt(triggerClockInputHandler, IRQ_INTERRUPT_0 + 6, 5);
-	ENABLE_INTERRUPTS();
+	EXIT_CRITICAL_SECTION();
 	deluge_main();
 
 	while (1) {


### PR DESCRIPTION
Fix bug introduced yesterday where c and c++ atomic_int means different things