### PR TITLE
allow naming MIDI & gate drums

### DIFF
--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -93,7 +93,7 @@ gotError:
 			goto gotError;
 		}
 
-		drum->name.set(&newName);
+		drum->drumName = newName.get();
 	}
 
 	PadLEDs::clearTickSquares(true);

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -999,7 +999,7 @@ doLoadAsSample:
 				autoDetectSideChainSending(drum, soundEditor.currentSource, enteredText.get());
 
 				// Give Drum no name, momentarily. We don't want it to show up when we're searching for duplicates
-				drum->name.clear();
+				drum->drumName.clear();
 
 				String newName;
 				if (!numCharsInPrefix || display->haveOLED()) {
@@ -1023,7 +1023,7 @@ doLoadAsSample:
 					}
 				}
 
-				drum->name.set(&newName);
+				drum->drumName = newName.get();
 			}
 
 			// If a synth...
@@ -2009,7 +2009,7 @@ getOut:
 					}
 				}
 
-				drum->name.set(&newName);
+				drum->drumName = newName.get();
 			}
 skipNameStuff:
 

--- a/src/deluge/gui/ui/browser/slot_browser.cpp
+++ b/src/deluge/gui/ui/browser/slot_browser.cpp
@@ -170,39 +170,23 @@ void SlotBrowser::convertToPrefixFormatIfPossible() {
 	}
 }
 
-Error SlotBrowser::getCurrentFilenameWithoutExtension(String* filenameWithoutExtension) {
-	Error error;
+std::string SlotBrowser::getCurrentFilenameWithoutExtension() {
 	if (display->have7SEG()) {
 		// If numeric...
 		Slot slot = getSlot(enteredText.get());
 		if (slot.slot != -1) {
-			error = filenameWithoutExtension->set(filePrefix);
-			if (error != Error::NONE) {
-				return error;
-			}
-			error = filenameWithoutExtension->concatenateInt(slot.slot, 3);
-			if (error != Error::NONE) {
-				return error;
-			}
+			std::string filenameWithoutExtension{filePrefix};
+			filenameWithoutExtension.append(deluge::string::fromInt(slot.slot, 3));
 			if (slot.subSlot != -1) {
 				char buffer[2];
 				buffer[0] = 'A' + slot.subSlot;
 				buffer[1] = 0;
-				error = filenameWithoutExtension->concatenate(buffer);
-				if (error != Error::NONE) {
-					return error;
-				}
+				filenameWithoutExtension.append(buffer);
 			}
-		}
-		else {
-			filenameWithoutExtension->set(&enteredText);
+			return filenameWithoutExtension;
 		}
 	}
-	else {
-		filenameWithoutExtension->set(&enteredText);
-	}
-
-	return Error::NONE;
+	return enteredText.get();
 }
 
 Error SlotBrowser::getCurrentFilePath(String* path) {
@@ -213,13 +197,9 @@ Error SlotBrowser::getCurrentFilePath(String* path) {
 		return error;
 	}
 
-	String filenameWithoutExtension;
-	error = getCurrentFilenameWithoutExtension(&filenameWithoutExtension);
-	if (error != Error::NONE) {
-		return error;
-	}
+	std::string filenameWithoutExtension = getCurrentFilenameWithoutExtension();
 
-	error = path->concatenate(&filenameWithoutExtension);
+	error = path->concatenate(filenameWithoutExtension);
 	if (error != Error::NONE) {
 		return error;
 	}

--- a/src/deluge/gui/ui/browser/slot_browser.h
+++ b/src/deluge/gui/ui/browser/slot_browser.h
@@ -39,7 +39,7 @@ protected:
 	virtual void predictExtendedTextFromMemory() {}
 	void convertToPrefixFormatIfPossible();
 	void enterKeyPress() override;
-	Error getCurrentFilenameWithoutExtension(String* filename);
+	std::string getCurrentFilenameWithoutExtension();
 
 	static bool currentFileHasSuffixFormatNameImplied;
 

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -74,7 +74,7 @@ bool LoadInstrumentPresetUI::opened() {
 	if (loadingSynthToKitRow) {
 		initialOutputType = outputTypeToLoad = OutputType::SYNTH;
 		if (soundDrumToReplace) {
-			initialName.set(&soundDrumToReplace->name);
+			initialName.set(soundDrumToReplace->drumName);
 		}
 		else {
 			initialName.set("");
@@ -209,10 +209,9 @@ Error LoadInstrumentPresetUI::setupForOutputType() {
 	else {
 		if (loadingSynthToKitRow && soundDrumToReplace) {
 
-			if (&soundDrumToReplace->name) {
-				String* name = &soundDrumToReplace->name;
-				enteredText.set(name);
-				searchFilename.set(name);
+			if (!soundDrumToReplace->drumName.empty()) {
+				enteredText.set(soundDrumToReplace->drumName);
+				searchFilename.set(soundDrumToReplace->drumName);
 			}
 
 			if (&soundDrumToReplace->path) {
@@ -1086,7 +1085,7 @@ Error LoadInstrumentPresetUI::performLoadSynthToKit() {
 	soundDrumToReplace->loadAllSamples(true);
 
 	// soundDrumToReplace->name.set(getCurrentFilenameWithoutExtension());
-	getCurrentFilenameWithoutExtension(&soundDrumToReplace->name);
+	soundDrumToReplace->drumName = getCurrentFilenameWithoutExtension();
 	soundDrumToReplace->path.set(&currentDir);
 	ParamManager* paramManager =
 	    currentSong->getBackedUpParamManagerPreferablyWithClip(soundDrumToReplace, instrumentClipToLoadFor);

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -413,7 +413,7 @@ fail:
 		}
 
 		error = audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath,
-		                                                    currentDir.get(), currentFilenameWithoutExtension);
+		                                                    currentDir.get(), currentFilenameWithoutExtension.get());
 		if (error != Error::NONE) {
 			goto gotErrorAfterCreatingSong;
 		}
@@ -476,7 +476,7 @@ gotErrorAfterCreatingSong:
 	}
 
 	error = audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath, currentDir.get(),
-	                                                    currentFilenameWithoutExtension);
+	                                                    currentFilenameWithoutExtension.get());
 	if (error != Error::NONE) {
 		goto gotErrorAfterCreatingSong;
 	}

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -898,13 +898,13 @@ PLACE_SDRAM_DATA const MenuItem* midiOrCVParamShortcuts[kDisplayHeight] = {
     nullptr,
 };
 
-PLACE_SDRAM_DATA const MenuItem* gateDrumParamShortcuts[8] = {
+PLACE_SDRAM_DATA const MenuItem* gateDrumParamShortcuts[kDisplayHeight] = {
     &arpRateMenuMIDIOrCV,
     &arpSyncMenu,
     &arpGateMenuMIDIOrCV,
     &arpRhythmMenuMIDIOrCV,
     &arpModeMenu,
-    nullptr,
+    &nameEditMenu,
     nullptr,
     nullptr,
 };

--- a/src/deluge/gui/ui/rename/rename_clip_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.cpp
@@ -27,17 +27,16 @@
 
 RenameClipUI renameClipUI{"Clip Name"};
 
-String RenameClipUI::getName() const {
-	return clip->name;
+std::string_view RenameClipUI::getCurrentName() const {
+	return clip->name.get();
 }
 
-bool RenameClipUI::trySetName(String* name) {
+bool RenameClipUI::trySetName(std::string_view name) {
 	// Don't allow duplicate names on clips of a single output.
-	if (!clip->name.equalsCaseIrrespective(name)) {
-		if (clip->output->getClipFromName(name)) {
-			display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
-			return false;
-		}
+	Clip* other = clip->output->getClipFromName(name);
+	if (other != nullptr && other != clip) {
+		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
+		return false;
 	}
 	clip->name.set(name);
 	return true;

--- a/src/deluge/gui/ui/rename/rename_clip_ui.h
+++ b/src/deluge/gui/ui/rename/rename_clip_ui.h
@@ -27,8 +27,8 @@ public:
 	Clip* clip;
 
 protected:
-	bool trySetName(String*) override;
-	String getName() const override;
+	bool trySetName(std::string_view) override;
+	std::string_view getCurrentName() const override;
 };
 
 extern RenameClipUI renameClipUI;

--- a/src/deluge/gui/ui/rename/rename_drum_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.cpp
@@ -29,20 +29,27 @@
 
 RenameDrumUI renameDrumUI{"Drum Name"};
 
-String RenameDrumUI::getName() const {
-	return getDrum()->name;
+std::string_view RenameDrumUI::getCurrentName() const {
+	Kit* kit = getCurrentKit();
+	if (kit == nullptr || kit->selectedDrum == nullptr) {
+		FREEZE_WITH_ERROR("RN01");
+		return "NONE";
+	}
+	return kit->selectedDrum->drumName;
 }
 
-SoundDrum* RenameDrumUI::getDrum() const {
-	return (SoundDrum*)soundEditor.currentSound;
-}
-
-bool RenameDrumUI::trySetName(String* name) {
-	// don't let user set a name that is a duplicate of another name that has been set for another drum
-	if (!getDrum()->name.equalsCaseIrrespective(name) && getCurrentKit()->getDrumFromName(name->get())) {
+bool RenameDrumUI::trySetName(std::string_view name) {
+	Kit* kit = getCurrentKit();
+	if (kit == nullptr || kit->selectedDrum == nullptr) {
+		FREEZE_WITH_ERROR("RN02");
+		return false;
+	}
+	Drum* other = kit->getDrumFromName(name);
+	if (other != nullptr && other != kit->selectedDrum) {
+		// We only allow renaming if there are no other drums with the same name.
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 		return false;
 	}
-	getDrum()->name.set(name);
+	kit->selectedDrum->drumName = name;
 	return true;
 }

--- a/src/deluge/gui/ui/rename/rename_drum_ui.h
+++ b/src/deluge/gui/ui/rename/rename_drum_ui.h
@@ -27,12 +27,9 @@ public:
 	RenameDrumUI(const char* title_) : RenameUI(title_) {};
 
 protected:
-	bool trySetName(String*) override;
-	String getName() const override;
+	bool trySetName(std::string_view name) override;
+	std::string_view getCurrentName() const override;
 	bool allowEmpty() const override { return false; }
-
-private:
-	SoundDrum* getDrum() const;
 };
 
 extern RenameDrumUI renameDrumUI;

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.cpp
@@ -37,23 +37,20 @@ bool RenameMidiCCUI::canRename() const {
 	return cc >= 0 && cc != CC_EXTERNAL_MOD_WHEEL && cc < kNumRealCCNumbers;
 }
 
-String RenameMidiCCUI::getName() const {
+std::string_view RenameMidiCCUI::getCurrentName() const {
 	Clip* clip = getCurrentClip();
 	MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
 	int32_t cc = clip->lastSelectedParamID;
-	std::string_view name = midiInstrument->getNameFromCC(cc);
-	String name_string;
-	name_string.set(name.data(), name.length());
-	return name_string;
+	return midiInstrument->getNameFromCC(cc);
 }
 
-bool RenameMidiCCUI::trySetName(String* name) {
+bool RenameMidiCCUI::trySetName(std::string_view name) {
 
 	Clip* clip = getCurrentClip();
 	MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
 	int32_t cc = clip->lastSelectedParamID;
 
-	midiInstrument->setNameForCC(cc, enteredText.get());
+	midiInstrument->setNameForCC(cc, name);
 	midiInstrument->editedByUser = true; // need to set this to true so that the name gets saved with the song / preset
 
 	return true;

--- a/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
+++ b/src/deluge/gui/ui/rename/rename_midi_cc_ui.h
@@ -28,8 +28,8 @@ public:
 	RenameMidiCCUI(const char* title_) : RenameUI(title_) {}
 
 protected:
-	bool trySetName(String*) override;
-	String getName() const override;
+	bool trySetName(std::string_view) override;
+	std::string_view getCurrentName() const override;
 	bool canRename() const override;
 };
 

--- a/src/deluge/gui/ui/rename/rename_output_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_output_ui.cpp
@@ -27,13 +27,14 @@
 
 RenameOutputUI renameOutputUI{"Track name"};
 
-String RenameOutputUI::getName() const {
-	return output->name;
+std::string_view RenameOutputUI::getCurrentName() const {
+	return output->name.get();
 }
 
-bool RenameOutputUI::trySetName(String* name) {
+bool RenameOutputUI::trySetName(std::string_view name) {
 	// Duplicate names not allowed for audio outputs.
-	if (!output->name.equalsCaseIrrespective(name) && currentSong->getAudioOutputFromName(name)) {
+	void* other = currentSong->getAudioOutputFromName(name);
+	if (other != nullptr && other != output) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_DUPLICATE_NAMES));
 		return false;
 	}

--- a/src/deluge/gui/ui/rename/rename_output_ui.h
+++ b/src/deluge/gui/ui/rename/rename_output_ui.h
@@ -29,8 +29,8 @@ public:
 	Output* output;
 
 protected:
-	bool trySetName(String* name) override;
-	String getName() const override;
+	bool trySetName(std::string_view name) override;
+	std::string_view getCurrentName() const override;
 };
 
 extern RenameOutputUI renameOutputUI;

--- a/src/deluge/gui/ui/rename/rename_ui.cpp
+++ b/src/deluge/gui/ui/rename/rename_ui.cpp
@@ -34,8 +34,7 @@ bool RenameUI::opened() {
 		return false;
 	}
 
-	String name = getName();
-	enteredText.set(&name);
+	enteredText.set(getCurrentName());
 
 	displayText();
 	drawKeys();
@@ -47,7 +46,7 @@ void RenameUI::enterKeyPress() {
 	if (enteredText.isEmpty() && !allowEmpty()) {
 		return;
 	}
-	if (trySetName(&enteredText)) {
+	if (trySetName(enteredText.get())) {
 		exitUI();
 	}
 }

--- a/src/deluge/gui/ui/rename/rename_ui.h
+++ b/src/deluge/gui/ui/rename/rename_ui.h
@@ -34,8 +34,8 @@ public:
 
 protected:
 	void enterKeyPress() override;
-	virtual bool trySetName(String*) = 0;
-	virtual String getName() const = 0;
+	virtual bool trySetName(std::string_view) = 0;
+	virtual std::string_view getCurrentName() const = 0;
 	virtual bool canRename() const { return true; }
 	virtual bool allowEmpty() const { return true; }
 };

--- a/src/deluge/gui/ui/save/save_kit_row_ui.cpp
+++ b/src/deluge/gui/ui/save/save_kit_row_ui.cpp
@@ -58,7 +58,7 @@ doReturnFalse:
 		return false;
 	}
 
-	enteredText.set(&soundDrumToSave->name);
+	enteredText.set(soundDrumToSave->drumName);
 	enteredTextEditPos = enteredText.getLength();
 	currentFolderIsEmpty = false;
 
@@ -152,7 +152,7 @@ fail:
 	}
 
 	// Give the Instrument in memory its new slot
-	soundDrumToSave->name.set(&enteredText);
+	soundDrumToSave->drumName = enteredText.get();
 	soundDrumToSave->path.set(&currentDir);
 
 	// There's now no chance that we saved over a preset that's already in use in the song, because we didn't allow the

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -161,14 +161,10 @@ gotError:
 	// Create sample dir
 	String newSongAlternatePath;
 
-	String filenameWithoutExtension;
-	error = getCurrentFilenameWithoutExtension(&filenameWithoutExtension);
-	if (error != Error::NONE) {
-		goto gotError;
-	}
+	std::string filenameWithoutExtension = getCurrentFilenameWithoutExtension();
 
-	error =
-	    audioFileManager.setupAlternateAudioFileDir(newSongAlternatePath, currentDir.get(), filenameWithoutExtension);
+	error = audioFileManager.setupAlternateAudioFileDir(newSongAlternatePath, currentDir.get(),
+	                                                    filenameWithoutExtension.c_str());
 	if (error != Error::NONE) {
 		goto gotError;
 	}

--- a/src/deluge/gui/ui/slicer.cpp
+++ b/src/deluge/gui/ui/slicer.cpp
@@ -447,7 +447,7 @@ void Slicer::preview(int64_t startPoint, int64_t endPoint, int32_t transpose, in
 		ModelStackWithThreeMainThings* modelStack = soundEditor.getCurrentModelStack(modelStackMemory);
 
 		MultisampleRange* range = (MultisampleRange*)drum->sources[0].getOrCreateFirstRange();
-		drum->name.set("1");
+		drum->drumName = "1";
 		drum->sources[0].repeatMode = SampleRepeatMode::ONCE;
 
 		if (!waveformBasicNavigator.sample->filePath.equals(&range->sampleHolder.filePath)) {
@@ -608,7 +608,7 @@ getOut:
 		SoundDrum* firstDrum = (SoundDrum*)soundEditor.currentSound;
 
 		if (firstDrum->nameIsDiscardable) {
-			firstDrum->name.set("1");
+			firstDrum->drumName = "1";
 		}
 
 		MultisampleRange* firstRange = (MultisampleRange*)firstDrum->sources[0].getOrCreateFirstRange();
@@ -678,12 +678,7 @@ ramError2:
 				goto ramError;
 			}
 
-			char newName[5];
-			intToString(i + 1, newName);
-			error = newDrum->name.set(newName);
-			if (error != Error::NONE) {
-				goto ramError2;
-			}
+			newDrum->drumName = deluge::string::fromInt(i + 1);
 
 			Sound::initParams(&paramManager);
 

--- a/src/deluge/gui/views/automation/editor_layout/note.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/note.cpp
@@ -19,6 +19,7 @@
 #include "gui/views/automation/editor_layout/note/velocity.h"
 #include "gui/views/instrument_clip_view.h"
 #include "model/clip/instrument_clip.h"
+#include "model/drum/drum.h"
 
 // namespace deluge::gui::views::automation::editor_layout {
 
@@ -78,29 +79,8 @@ void AutomationEditorLayoutNote::renderNoteEditorDisplayOLED(deluge::hid::displa
 		}
 	}
 
-	char noteRowName[50];
-
-	if (modelStackWithNoteRow->getNoteRowAllowNull()) {
-		if (isKit) {
-			DEF_STACK_STRING_BUF(drumName, 50);
-			instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
-			strncpy(noteRowName, drumName.c_str(), 49);
-		}
-		else {
-			int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
-			noteCodeToString(modelStackWithNoteRow->getNoteRow()->getNoteCode(), noteRowName, &isNatural);
-		}
-	}
-	else {
-		if (isKit) {
-			strncpy(noteRowName, "(Select Drum)", 49);
-		}
-		else {
-			strncpy(noteRowName, "(Select Note)", 49);
-		}
-	}
-
-	canvas.drawStringCentred(noteRowName, yPos, kTextSpacingX, kTextSpacingY);
+	std::string noteRowName = getNoteRowName(modelStackWithNoteRow->getNoteRowAllowNull(), isKit);
+	canvas.drawStringCentred(noteRowName.c_str(), yPos, kTextSpacingX, kTextSpacingY);
 
 	// display parameter value
 	yPos = yPos + 12;
@@ -131,28 +111,38 @@ void AutomationEditorLayoutNote::renderNoteEditorDisplay7SEG(InstrumentClip* cli
 		display->setText(buffer, true, 255, false);
 	}
 	else {
-		// display note / drum name
-		char noteRowName[50];
-		if (modelStackWithNoteRow->getNoteRowAllowNull()) {
-			if (isKit) {
-				DEF_STACK_STRING_BUF(drumName, 50);
-				instrumentClipView.getDrumName(modelStackWithNoteRow->getNoteRow()->drum, drumName);
-				strncpy(noteRowName, drumName.c_str(), 49);
+		std::string noteRowName = getNoteRowName(modelStackWithNoteRow->getNoteRowAllowNull(), isKit);
+		display->setScrollingText(noteRowName.c_str());
+	}
+}
+
+std::string AutomationEditorLayoutNote::getNoteRowName(NoteRow* noteRow, bool isKit) {
+	if (noteRow != nullptr) {
+		if (isKit) {
+			Drum* drum = noteRow->drum;
+			if (drum != nullptr) {
+				return drum->getDrumName();
 			}
 			else {
-				int32_t isNatural = 1; // gets modified inside noteCodeToString to be 0 if sharp.
-				noteCodeToString(modelStackWithNoteRow->getNoteRow()->getNoteCode(), noteRowName, &isNatural);
+				return "NONE";
 			}
 		}
 		else {
+			return deluge::string::fromNoteCode(noteRow->getNoteCode());
+		}
+	}
+	else {
+		if (display->haveOLED()) {
 			if (isKit) {
-				strncpy(noteRowName, "(Select Drum)", 49);
+				return "(Select Drum)";
 			}
 			else {
-				strncpy(noteRowName, "(Select Note)", 49);
+				return "(Select Note)";
 			}
 		}
-		display->setScrollingText(noteRowName);
+		else {
+			return "NONE";
+		}
 	}
 }
 

--- a/src/deluge/gui/views/automation/editor_layout/note.h
+++ b/src/deluge/gui/views/automation/editor_layout/note.h
@@ -42,6 +42,9 @@ public:
 	void renderNoteEditorDisplayOLED(deluge::hid::display::oled_canvas::Canvas& canvas, InstrumentClip* clip,
 	                                 OutputType outputType, int32_t knobPosLeft, int32_t knobPosRight);
 	void renderNoteEditorDisplay7SEG(InstrumentClip* clip, OutputType outputType, int32_t knobPosLeft);
+
+private:
+	std::string getNoteRowName(NoteRow* noteRow, bool isKit);
 };
 
 // }; // namespace deluge::gui::views::automation::editor_layout

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2141,7 +2141,7 @@ ActionResult InstrumentClipView::potentiallyRandomizeDrumSample(Kit* kit, Drum* 
 			// Remove the extension (e.g., ".WAV", ".AIFF") from chosenFilename before assigning as name
 			*dot = '\0';
 		}
-		soundDrum->name.set(chosenFilename);
+		soundDrum->drumName = chosenFilename;
 		kit->beenEdited();
 		*slashAddress = '/';
 
@@ -5436,7 +5436,7 @@ doDisplayError:
 
 	modelStack->song->backUpParamManager(newDrum, modelStack->song->getCurrentClip(), &paramManager, true);
 
-	newDrum->name.set(&soundName);
+	newDrum->drumName = soundName.get();
 	newDrum->nameIsDiscardable = true;
 
 	kit->addDrum(newDrum);
@@ -5566,9 +5566,13 @@ void InstrumentClipView::drawNoteCode(uint8_t yDisplay) {
 }
 
 void InstrumentClipView::drawDrumName(Drum* drum, bool justPopUp) {
-	DEF_STACK_STRING_BUF(drumName, 50);
-
-	getDrumName(drum, drumName);
+	std::string drumName;
+	if (drum != nullptr) {
+		drumName = drum->getDrumName();
+	}
+	else {
+		drumName = "NONE";
+	}
 
 	if (display->haveOLED()) {
 		display->popupText(drumName.c_str());
@@ -5595,53 +5599,6 @@ void InstrumentClipView::drawDrumName(Drum* drum, bool justPopUp) {
 		}
 		else if (drum->type == DrumType::GATE) {
 			indicator_leds::blinkLed(IndicatorLED::CV, 1, 1);
-		}
-	}
-}
-
-void InstrumentClipView::getDrumName(Drum* drum, StringBuf& drumName) {
-	if (display->haveOLED()) {
-		if (!drum) {
-			drumName.append("No sound");
-		}
-		else if (drum->type == DrumType::SOUND) {
-			drumName.append(((SoundDrum*)drum)->name.get());
-		}
-		else {
-			if (drum->type == DrumType::GATE) {
-				drumName.append("Gate channel ");
-				drumName.appendInt(((GateDrum*)drum)->channel + 1);
-			}
-			else { // MIDI
-				drumName.append("CH: ");
-				drumName.appendInt(((MIDIDrum*)drum)->channel + 1);
-				drumName.append(" N#: ");
-				drumName.appendInt(((MIDIDrum*)drum)->note);
-				drumName.append("\n");
-
-				char noteLabel[5];
-				noteCodeToString(((MIDIDrum*)drum)->note, noteLabel);
-
-				drumName.append(noteLabel);
-			}
-		}
-	}
-	else {
-		if (!drum) {
-			drumName.append("NONE");
-		}
-		else {
-			if (drum->type != DrumType::SOUND) {
-				char buffer[7];
-				drum->getName(buffer);
-				drumName.append(buffer);
-			}
-			else {
-				// If we're here, it's a SoundDrum
-				SoundDrum* soundDrum = (SoundDrum*)drum;
-
-				drumName.append(soundDrum->name.get());
-			}
 		}
 	}
 }

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -189,7 +189,6 @@ public:
 
 	void tellMatrixDriverWhichRowsContainSomethingZoomable() override;
 	void drawDrumName(Drum* drum, bool justPopUp = false);
-	void getDrumName(Drum* drum, StringBuf& drumName);
 	void notifyPlaybackBegun() override;
 	void openedInBackground();
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -3631,7 +3631,7 @@ void SessionView::copyClipName(Clip* source, Clip* target, Output* targetOutput)
 	// Keep trying until we have a name that's unique on the output.
 	String newNameString;
 	newNameString.set(newName.data());
-	while (targetOutput->getClipFromName(&newNameString) != nullptr) {
+	while (targetOutput->getClipFromName(newNameString.get()) != nullptr) {
 		newName.truncate(end);
 		newName.appendInt(counter++);
 		newNameString.set(newName.data());

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1210,7 +1210,7 @@ someError:
 
 Error AudioClip::claimOutput(ModelStackWithTimelineCounter* modelStack) {
 
-	output = modelStack->song->getAudioOutputFromName(&outputNameWhileLoading);
+	output = modelStack->song->getAudioOutputFromName(outputNameWhileLoading.get());
 
 	if (!output) {
 		return Error::FILE_CORRUPTED;

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1057,7 +1057,7 @@ ModelStackWithNoteRow* InstrumentClip::getNoteRowForDrumName(ModelStackWithTimel
 		    && thisNoteRow->drum->type == DrumType::SOUND) {
 			SoundDrum* thisDrum = (SoundDrum*)thisNoteRow->drum;
 
-			if (thisDrum->name.equalsCaseIrrespective(name)) {
+			if (deluge::string::caselessEquals(thisDrum->drumName, name)) {
 				goto foundIt;
 			}
 		}
@@ -1761,7 +1761,7 @@ Error InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelStack
 			for (DrumName* oldDrumName = thisNoteRow->firstOldDrumName; oldDrumName; oldDrumName = oldDrumName->next) {
 
 				// See if a Drum (which hasn't been assigned yet) has this name
-				SoundDrum* thisDrum = kit->getDrumFromName(oldDrumName->name.get(), true);
+				Drum* thisDrum = kit->getDrumFromName(oldDrumName->name.get(), true);
 
 				// If so, and if it's not already assigned to another NoteRow...
 				if (thisDrum) {
@@ -1947,7 +1947,7 @@ bool InstrumentClip::possiblyDeleteEmptyNoteRow(NoteRow* noteRow, bool onlyIfNoD
 			return false;
 		}
 
-		if (onlyIfNonNumeric && drum->type == DrumType::SOUND && stringIsNumericChars(((SoundDrum*)drum)->name.get())) {
+		if (onlyIfNonNumeric && drum->type == DrumType::SOUND && stringIsNumericChars(drum->drumName.c_str())) {
 			return false;
 		}
 

--- a/src/deluge/model/drum/drum.cpp
+++ b/src/deluge/model/drum/drum.cpp
@@ -20,6 +20,7 @@
 #include "definitions_cxx.hpp"
 #include "gui/views/instrument_clip_view.h"
 #include "gui/views/view.h"
+#include "hid/display/display.h"
 #include "memory/general_memory_allocator.h"
 #include "model/clip/instrument_clip.h"
 #include "model/note/note_row.h"
@@ -43,23 +44,29 @@ Drum::Drum(DrumType newType) : type(newType), arpeggiator(), arpSettings() {
 	memset(lastExpressionInputsReceived, 0, sizeof(lastExpressionInputsReceived));
 }
 
+void Drum::writeDrumTagsToFile(Serializer& writer) {
+	// Called by subclasses to handle all the shared tags (except for MIDI commands).
+	writer.writeAttribute("name", drumName.c_str());
+}
+
 void Drum::writeMIDICommandsToFile(Serializer& writer) {
 	midiInput.writeNoteToFile(writer, "midiInput");
 	muteMIDICommand.writeNoteToFile(writer, "midiMuteCommand");
 }
 
 bool Drum::readDrumTagFromFile(Deserializer& reader, char const* tagName) {
-
-	if (!strcmp(tagName, "midiMuteCommand")) {
+	if (!strcmp(tagName, "name")) {
+		reader.readTagOrAttributeValueString(drumName);
+		reader.exitTag("name");
+	}
+	else if (!strcmp(tagName, "midiMuteCommand")) {
 		muteMIDICommand.readNoteFromFile(reader);
 		reader.exitTag();
 	}
-
 	else if (!strcmp(tagName, "midiInput")) {
 		midiInput.readNoteFromFile(reader);
 		reader.exitTag();
 	}
-
 	else {
 		return false;
 	}

--- a/src/deluge/model/drum/drum.h
+++ b/src/deluge/model/drum/drum.h
@@ -46,6 +46,7 @@ public:
 	Drum(DrumType newType);
 	~Drum() override = default;
 
+	std::string drumName;
 	Kit* kit;
 
 	const DrumType type;
@@ -77,10 +78,11 @@ public:
 	virtual void writeToFile(Serializer& writer, bool savingSong, ParamManager* paramManager) = 0;
 	virtual Error readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos) = 0;
 	virtual void drumWontBeRenderedForAWhile();
-
-	virtual void getName(char* buffer) = 0; // May return up to 5 actual characters, so supply at least a char[6]
+	virtual std::string getDrumName() = 0;
 	virtual void choke(ModelStackWithSoundFlags* modelStack) {} // modelStack can be NULL if you really insist
+
 	void writeMIDICommandsToFile(Serializer& writer);
+	void writeDrumTagsToFile(Serializer& writer);
 	bool readDrumTagFromFile(Deserializer& reader, char const* tagName);
 	void recordNoteOnEarly(int32_t velocity, bool noteTailsAllowed);
 	void expressionEventPossiblyToRecord(ModelStackWithTimelineCounter* modelStack, int16_t newValue,

--- a/src/deluge/model/drum/drum_name.cpp
+++ b/src/deluge/model/drum/drum_name.cpp
@@ -19,7 +19,7 @@
 #include <cstdint>
 #include <string.h>
 
-DrumName::DrumName(String* newName) {
+DrumName::DrumName(std::string_view newName) {
 	next = nullptr;
 	name.set(newName);
 }

--- a/src/deluge/model/drum/drum_name.h
+++ b/src/deluge/model/drum/drum_name.h
@@ -21,7 +21,7 @@
 
 class DrumName {
 public:
-	DrumName(String* newName);
+	DrumName(std::string_view newName);
 	virtual ~DrumName();
 
 	String name;

--- a/src/deluge/model/drum/gate_drum.cpp
+++ b/src/deluge/model/drum/gate_drum.cpp
@@ -17,9 +17,12 @@
 
 #include "model/drum/gate_drum.h"
 #include "definitions_cxx.hpp"
+#include "hid/display/display.h"
 #include "model/drum/non_audio_drum.h"
 #include "processing/engines/cv_engine.h"
 #include "storage/storage_manager.h"
+#include "util/string.h"
+
 #include <cstring>
 
 GateDrum::GateDrum() : NonAudioDrum(DrumType::GATE) {
@@ -72,7 +75,7 @@ void GateDrum::killAllVoices() {
 
 void GateDrum::writeToFile(Serializer& writer, bool savingSong, ParamManager* paramManager) {
 	writer.writeOpeningTagBeginning("gateOutput", true);
-
+	writeDrumTagsToFile(writer);
 	writer.writeAttribute("channel", channel, false);
 	writer.writeOpeningTagEnd();
 
@@ -97,9 +100,22 @@ Error GateDrum::readFromFile(Deserializer& reader, Song* song, Clip* clip, int32
 	return Error::NONE;
 }
 
-void GateDrum::getName(char* buffer) {
-	strcpy(buffer, "GAT");
-	intToString(channel + 1, &buffer[3]);
+std::string GateDrum::getDrumName() {
+	std::string buffer;
+	if (display->haveOLED()) {
+		if (!drumName.empty()) {
+			buffer.append(drumName);
+			buffer.append("\n");
+		}
+		buffer.append("GATE ");
+	}
+	else {
+		buffer = "GAT";
+	}
+
+	buffer.append(deluge::string::fromInt(channel + 1));
+
+	return buffer;
 }
 
 int32_t GateDrum::getNumChannels() {

--- a/src/deluge/model/drum/gate_drum.h
+++ b/src/deluge/model/drum/gate_drum.h
@@ -36,7 +36,7 @@ public:
 	void noteOff(ModelStackWithThreeMainThings* modelStack, int32_t velocity = kDefaultLiftValue) override;
 	void writeToFile(Serializer& writer, bool savingSong, ParamManager* paramManager) override;
 	Error readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos) override;
-	void getName(char* buffer) override;
+	std::string getDrumName() override;
 	int32_t getNumChannels() override;
 	void killAllVoices() override;
 };

--- a/src/deluge/model/drum/midi_drum.cpp
+++ b/src/deluge/model/drum/midi_drum.cpp
@@ -18,9 +18,12 @@
 #include "model/drum/midi_drum.h"
 #include "gui/views/automation_view.h"
 #include "gui/views/instrument_clip_view.h"
+#include "hid/display/display.h"
 #include "io/midi/midi_engine.h"
 #include "model/drum/non_audio_drum.h"
 #include "storage/storage_manager.h"
+#include "util/string.h"
+
 #include <string.h>
 
 MIDIDrum::MIDIDrum() : NonAudioDrum(DrumType::MIDI) {
@@ -84,7 +87,7 @@ void MIDIDrum::killAllVoices() {
 
 void MIDIDrum::writeToFile(Serializer& writer, bool savingSong, ParamManager* paramManager) {
 	writer.writeOpeningTagBeginning("midiOutput", true);
-
+	writeDrumTagsToFile(writer);
 	writer.writeAttribute("channel", channel, false);
 	writer.writeAttribute("note", note, false);
 	writer.writeOpeningTagEnd();
@@ -114,33 +117,49 @@ Error MIDIDrum::readFromFile(Deserializer& reader, Song* song, Clip* clip, int32
 	return Error::NONE;
 }
 
-void MIDIDrum::getName(char* buffer) {
-
+std::string MIDIDrum::getDrumName() {
 	int32_t channelToDisplay = channel + 1;
+	std::string buffer;
 
-	if (channelToDisplay < 10 && note < 100) {
-		strcpy(buffer, " ");
+	if (display->haveOLED()) {
+		if (!drumName.empty()) {
+			buffer.append(drumName);
+			buffer.append("\n");
+		}
+		buffer.append("MIDI CH");
+		buffer.append(deluge::string::fromInt(channelToDisplay));
+		buffer.append(": ");
+		buffer.append(deluge::string::fromInt(note));
+		buffer.append(" (");
+		char noteLabel[5];
+		noteCodeToString(note, noteLabel);
+		buffer.append(noteLabel);
+		buffer.append(")");
 	}
 	else {
-		buffer[0] = 0;
+
+		// Old 7-seg logic adapted to std::string.
+		if (channelToDisplay < 10 && note < 100) {
+			buffer = " ";
+		}
+
+		// If can't fit everything on display, show channel as hexadecimal
+		if (channelToDisplay >= 10 && note >= 100) {
+			buffer.push_back('A' + channelToDisplay - 10);
+		}
+		else {
+			buffer.append(deluge::string::fromInt(channelToDisplay));
+		}
+
+		buffer.push_back('.');
+
+		if (note < 10 && channelToDisplay < 100) {
+			buffer.push_back(' ');
+		}
+		buffer.append(deluge::string::fromInt(note));
 	}
 
-	// If can't fit everything on display, show channel as hexadecimal
-	if (channelToDisplay >= 10 && note >= 100) {
-		buffer[0] = 'A' + channelToDisplay - 10;
-		buffer[1] = 0;
-	}
-	else {
-		intToString(channelToDisplay, &buffer[strlen(buffer)]);
-	}
-
-	strcat(buffer, ".");
-
-	if (note < 10 && channelToDisplay < 100) {
-		strcat(buffer, " ");
-	}
-
-	intToString(note, &buffer[strlen(buffer)]);
+	return buffer;
 }
 
 int8_t MIDIDrum::modEncoderAction(ModelStackWithThreeMainThings* modelStack, int8_t offset, uint8_t whichModEncoder) {

--- a/src/deluge/model/drum/midi_drum.h
+++ b/src/deluge/model/drum/midi_drum.h
@@ -31,7 +31,7 @@ public:
 	void noteOffPostArp(int32_t noteCodePostArp) override;
 	void writeToFile(Serializer& writer, bool savingSong, ParamManager* paramManager) override;
 	Error readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos) override;
-	void getName(char* buffer) override;
+	std::string getDrumName() override;
 	int32_t getNumChannels() override { return 16; }
 	void killAllVoices() override;
 

--- a/src/deluge/model/instrument/instrument.cpp
+++ b/src/deluge/model/instrument/instrument.cpp
@@ -185,8 +185,8 @@ Clip* Instrument::createNewClipForArrangementRecording(ModelStack* modelStack) {
 
 Error Instrument::setupDefaultAudioFileDir() {
 	char const* dirPathChars = dirPath.get();
-	auto result =
-	    audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath, dirPathChars, name);
+	auto result = audioFileManager.setupAlternateAudioFileDir(audioFileManager.alternateAudioFileLoadPath, dirPathChars,
+	                                                          name.get());
 	if (result != Error::NONE) {
 		return result;
 	}

--- a/src/deluge/model/instrument/kit.cpp
+++ b/src/deluge/model/instrument/kit.cpp
@@ -506,15 +506,15 @@ Drum* Kit::getDrumFromIndexAllowNull(int32_t index) {
 	return nullptr;
 }
 
-SoundDrum* Kit::getDrumFromName(char const* name, bool onlyIfNoNoteRow) {
+Drum* Kit::getDrumFromName(std::string_view name, bool onlyIfNoNoteRow) {
 	for (Drum* thisDrum = firstDrum; thisDrum; thisDrum = thisDrum->next) {
 
 		if (onlyIfNoNoteRow && thisDrum->noteRowAssignedTemp) {
 			continue;
 		}
 
-		if (thisDrum->type == DrumType::SOUND && ((SoundDrum*)thisDrum)->name.equalsCaseIrrespective(name)) {
-			return (SoundDrum*)thisDrum;
+		if (deluge::string::caselessEquals(name, thisDrum->drumName)) {
+			return thisDrum;
 		}
 	}
 

--- a/src/deluge/model/instrument/kit.h
+++ b/src/deluge/model/instrument/kit.h
@@ -109,7 +109,7 @@ public:
 	void removeDrumFromKitArpeggiator(int32_t drumIndex);
 	void removeDrum(Drum* drum);
 	ModControllable* toModControllable() override;
-	SoundDrum* getDrumFromName(char const* name, bool onlyIfNoNoteRow = false);
+	Drum* getDrumFromName(std::string_view name, bool onlyIfNoNoteRow = false);
 	Error makeDrumNameUnique(String* name, int32_t startAtNumber);
 	bool setActiveClip(ModelStackWithTimelineCounter* modelStack, PgmChangeSend maySendMIDIPGMs) override;
 	void setupPatching(ModelStackWithTimelineCounter* modelStack) override;

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3858,7 +3858,7 @@ void NoteRow::rememberDrumName() {
 		SoundDrum* soundDrum = (SoundDrum*)drum;
 
 		// If it's all numeric (most likely meaning it's a slice), don't store it
-		if (stringIsNumericChars(soundDrum->name.get())) {
+		if (stringIsNumericChars(soundDrum->drumName)) {
 			return;
 		}
 
@@ -3867,7 +3867,7 @@ void NoteRow::rememberDrumName() {
 		while (*prevPointer) {
 
 			// If we'd already stored the name we were gonna store now, no need to do anything
-			if ((*prevPointer)->name.equalsCaseIrrespective(&soundDrum->name)) {
+			if (deluge::string::caselessEquals((*prevPointer)->name.get(), soundDrum->drumName)) {
 				return;
 			}
 
@@ -3878,7 +3878,7 @@ void NoteRow::rememberDrumName() {
 		// to the end of the list now Paul: Might make sense to put these into Internal?
 		void* drumNameMemory = GeneralMemoryAllocator::get().allocLowSpeed(sizeof(DrumName));
 		if (drumNameMemory) {
-			*prevPointer = new (drumNameMemory) DrumName(&soundDrum->name);
+			*prevPointer = new (drumNameMemory) DrumName(soundDrum->drumName);
 		}
 	}
 }

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -53,9 +53,9 @@ Output::~Output() {
 	}
 }
 
-Clip* Output::getClipFromName(String* name) {
+Clip* Output::getClipFromName(std::string_view name) {
 	for (Clip* clip : AllClips::everywhere(currentSong)) {
-		if (clip->output == this && clip->name.equalsCaseIrrespective(name)) {
+		if (clip->output == this && deluge::string::caselessEquals(clip->name.get(), name)) {
 			return clip;
 		}
 	}

--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -137,7 +137,7 @@ public:
 	                                    GlobalEffectableForClip** globalEffectableWithMostReverb,
 	                                    int32_t* highestReverbAmountFound) {}
 	/// If there's a clip matching the name on this output, returns it.
-	Clip* getClipFromName(String* name);
+	Clip* getClipFromName(std::string_view name);
 
 	/// Pitch bend is available in the mod matrix as X and shouldn't be learned to params anymore (post 4.0)
 	virtual bool offerReceivedPitchBendToLearnedParams(MIDICable& cable, uint8_t channel, uint8_t data1, uint8_t data2,

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3575,10 +3575,10 @@ void Song::markAllInstrumentsAsEdited() {
 
 // used with the renameOutputUI class to check if you're trying to rename an output to the same
 // name as another output
-AudioOutput* Song::getAudioOutputFromName(String* name) {
+AudioOutput* Song::getAudioOutputFromName(std::string_view name) {
 	for (Output* thisOutput = firstOutput; thisOutput; thisOutput = thisOutput->next) {
 		if (thisOutput->type == OutputType::AUDIO) {
-			if (thisOutput->name.equalsCaseIrrespective(name)) {
+			if (deluge::string::caselessEquals(thisOutput->name.get(), name)) {
 				return (AudioOutput*)thisOutput;
 			}
 		}

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -166,7 +166,7 @@ public:
 	Instrument* getInstrumentFromPresetSlot(OutputType outputType, int32_t presetNumber, int32_t presetSubSlotNumber,
 	                                        char const* name, char const* dirPath, bool searchHibernatingToo = true,
 	                                        bool searchNonHibernating = true);
-	AudioOutput* getAudioOutputFromName(String* name);
+	AudioOutput* getAudioOutputFromName(std::string_view name);
 	void setupPatchingForAllParamManagers();
 	void replaceInstrument(Instrument* oldInstrument, Instrument* newInstrument, bool keepNoteRowsWithMIDIInput = true);
 	void stopAllMIDIAndGateNotesPlaying();

--- a/src/deluge/processing/sound/sound_drum.cpp
+++ b/src/deluge/processing/sound/sound_drum.cpp
@@ -32,16 +32,13 @@
 #include <new>
 
 bool SoundDrum::readTagFromFile(Deserializer& reader, char const* tagName) {
-	if (!strcmp(tagName, "name")) {
-		reader.readTagOrAttributeValueString(&name);
-		reader.exitTag("name");
-	}
-	else if (!strcmp(tagName, "path")) {
+	if (!strcmp(tagName, "path")) {
 		reader.readTagOrAttributeValueString(&path);
 		reader.exitTag("path");
 	}
-
-	else if (readDrumTagFromFile(reader, tagName)) {}
+	else if (readDrumTagFromFile(reader, tagName)) {
+		// Delegation is also considered a success.
+	}
 	else {
 		return false;
 	}
@@ -133,7 +130,7 @@ void SoundDrum::writeToFileAsInstrument(bool savingSong, ParamManager* paramMana
 
 void SoundDrum::writeToFile(Serializer& writer, bool savingSong, ParamManager* paramManager) {
 	writer.writeOpeningTagBeginning("sound", true);
-	writer.writeAttribute("name", name.get());
+	writeDrumTagsToFile(writer);
 
 	Sound::writeToFile(writer, savingSong, paramManager, &arpSettings, path.get());
 
@@ -186,4 +183,8 @@ uint8_t* SoundDrum::getModKnobMode() {
 
 void SoundDrum::drumWontBeRenderedForAWhile() {
 	Sound::wontBeRenderedForAWhile();
+}
+
+std::string SoundDrum::getDrumName() {
+	return drumName;
 }

--- a/src/deluge/processing/sound/sound_drum.h
+++ b/src/deluge/processing/sound/sound_drum.h
@@ -27,7 +27,6 @@ class ModelStackWithTimelineCounter;
 
 class SoundDrum final : public Sound, public Drum {
 public:
-	String name;
 	String path;
 	bool nameIsDiscardable = false;
 
@@ -50,7 +49,7 @@ public:
 	Error loadAllSamples(bool mayActuallyReadFiles) override;
 	void writeToFile(Serializer& writer, bool savingSong, ParamManager* paramManager) override;
 	void writeToFileAsInstrument(bool savingSong, ParamManager* paramManager);
-	void getName(char* buffer) override {}
+	std::string getDrumName() override;
 	Error readFromFile(Deserializer& reader, Song* song, Clip* clip, int32_t readAutomationUpToPos) override;
 	void choke(ModelStackWithSoundFlags* modelStack) override;
 	void setSkippingRendering(bool newSkipping) override;
@@ -66,5 +65,5 @@ public:
 	ArpeggiatorBase* getArp() override { return &arpeggiator; }
 	ArpeggiatorSettings* getArpSettings(InstrumentClip* clip = nullptr) override { return &arpSettings; }
 	void resetTimeEnteredState();
-	const char* getName() override { return name.get(); }
+	const char* getName() override { return drumName.c_str(); }
 };

--- a/src/deluge/processing/stem_export/stem_export.cpp
+++ b/src/deluge/processing/stem_export/stem_export.cpp
@@ -1129,8 +1129,8 @@ void StemExport::setWavFileNameForStemExport(StemExportType stemExportType, Outp
 	}
 	// wavFileNameForStemExport = /OutputType_StemExportType_OutputName_DrumName_tempo_noteName-scaleName_###.WAV
 	else if (stemExportType == StemExportType::DRUM) {
-		sprintf(fileName, "%s_%s_%s_%s_%dBPM_%s-%s_%03d.WAV", outputType, exportType, outputName, drum->name.get(),
-		        tempo, noteName, scaleName, fileNumber);
+		sprintf(fileName, "%s_%s_%s_%s_%dBPM_%s-%s_%03d.WAV", outputType, exportType, outputName,
+		        drum->drumName.c_str(), tempo, noteName, scaleName, fileNumber);
 	}
 	// wavFileNameForStemExport = /OutputType_StemExportType_OutputName_tempo_noteName-scaleName_###.WAV
 	else {

--- a/src/deluge/storage/audio/audio_file_manager.cpp
+++ b/src/deluge/storage/audio/audio_file_manager.cpp
@@ -429,7 +429,7 @@ bool AudioFileManager::ensureEnoughMemoryForOneMoreAudioFile() {
 }
 
 Error AudioFileManager::setupAlternateAudioFileDir(String& newPath, char const* rootDir,
-                                                   String& songFilenameWithoutExtension) {
+                                                   const char* songFilenameWithoutExtension) {
 
 	Error error = newPath.set(rootDir);
 	if (error != Error::NONE) {
@@ -441,7 +441,7 @@ Error AudioFileManager::setupAlternateAudioFileDir(String& newPath, char const* 
 		return error;
 	}
 
-	error = newPath.concatenate(&songFilenameWithoutExtension);
+	error = newPath.concatenate(songFilenameWithoutExtension);
 	if (error != Error::NONE) {
 		return error;
 	}

--- a/src/deluge/storage/audio/audio_file_manager.h
+++ b/src/deluge/storage/audio/audio_file_manager.h
@@ -97,7 +97,7 @@ public:
 	void slowRoutine();
 
 	Error setupAlternateAudioFilePath(String& newPath, int32_t dirPathLength, String& oldPath);
-	Error setupAlternateAudioFileDir(String& newPath, char const* rootDir, String& songFilenameWithoutExtension);
+	Error setupAlternateAudioFileDir(String& newPath, char const* rootDir, const char* songFilenameWithoutExtension);
 	bool loadingQueueHasAnyLowestPriorityElements();
 	/// If songname isn't supplied the file is placed in the main recording folder and named as samples/folder/REC###.
 	/// If song and channel are supplied then it's placed in samples/folder/song/channel_###

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -201,6 +201,15 @@ public:
 	virtual void exitTag(char const* exitTagName = NULL, bool closeObject = false) = 0;
 
 	virtual void reset() = 0;
+
+	Error readTagOrAttributeValueString(std::string& string) {
+		String tmp;
+		Error error = readTagOrAttributeValueString(&tmp);
+		if (error == Error::NONE) {
+			string = tmp.get();
+		}
+		return error;
+	}
 };
 
 class FileDeserializer : public Deserializer, public FileReader {

--- a/src/deluge/util/d_string.cpp
+++ b/src/deluge/util/d_string.cpp
@@ -212,8 +212,8 @@ Error String::concatenate(String* otherString) {
 	return concatenate(otherString->get());
 }
 
-Error String::concatenate(char const* newChars) {
-	return concatenateAtPos(newChars, getLength());
+Error String::concatenate(std::string_view newChars) {
+	return concatenateAtPos(newChars.data(), getLength(), newChars.size());
 }
 
 Error String::concatenateAtPos(char const* newChars, int32_t pos, int32_t newCharsLength) {

--- a/src/deluge/util/d_string.h
+++ b/src/deluge/util/d_string.h
@@ -31,7 +31,7 @@ extern "C" {
 }
 
 bool memIsNumericChars(char const* mem, int32_t size);
-bool stringIsNumericChars(char const* str);
+bool stringIsNumericChars(std::string_view str);
 
 void byteToHex(uint8_t number, char* buffer);
 uint8_t hexToByte(char const* firstChar);
@@ -49,6 +49,7 @@ public:
 	~String();
 	void clear(bool destructing = false);
 	Error set(char const* newChars, int32_t newLength = -1);
+	Error set(std::string_view newStr) { return set(newStr.data(), newStr.size()); }
 	void set(String const* otherString);
 	void beenCloned() const;
 	size_t getLength();
@@ -58,7 +59,7 @@ public:
 	Error setInt(int32_t number, int32_t minNumDigits = 1);
 	Error setChar(char newChar, int32_t pos);
 	Error concatenate(String* otherString);
-	Error concatenate(char const* newChars);
+	Error concatenate(std::string_view newChars);
 	Error get_new_memory(int32_t newCharsLength);
 	bool equals(char const* otherChars);
 	bool equalsCaseIrrespective(char const* otherChars);

--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -582,8 +582,8 @@ bool memIsNumericChars(char const* mem, int32_t size) {
 	return true;
 }
 
-bool stringIsNumericChars(char const* str) {
-	return memIsNumericChars(str, strlen(str));
+bool stringIsNumericChars(std::string_view str) {
+	return memIsNumericChars(str.data(), str.size());
 }
 
 char const* getThingName(OutputType outputType) {

--- a/src/deluge/util/string.cpp
+++ b/src/deluge/util/string.cpp
@@ -84,4 +84,12 @@ std::string fromNoteCode(int32_t noteCode, size_t* getLengthWithoutDot, bool app
 	return output;
 }
 
+bool caselessEquals(std::string_view a, std::string_view b) {
+	size_t n = a.size();
+	if (b.size() != n) {
+		return false;
+	}
+	return strncasecmp(a.data(), b.data(), n) == 0;
+}
+
 } // namespace deluge::string

--- a/src/deluge/util/string.h
+++ b/src/deluge/util/string.h
@@ -16,4 +16,6 @@ std::string fromFloat(float number, int32_t precision);
 std::string fromSlot(int32_t slot, int32_t sub_slot, size_t min_num_digits = 1);
 std::string fromNoteCode(int32_t noteCode, size_t* getLengthWithoutDot = nullptr, bool appendOctaveNo = true);
 
+bool caselessEquals(std::string_view a, std::string_view b);
+
 } // namespace deluge::string

--- a/tests/spec/string_spec.cpp
+++ b/tests/spec/string_spec.cpp
@@ -58,6 +58,19 @@ describe string("deluge::string", ${
 			expect(length).to_equal(2);
 		});
 	});
+
+	context("caselessEquals", _ {
+		it("compares two equal strings", _ {
+			expect(string::caselessEquals("a123!", "A123!")).to_equal(true);
+			expect(string::caselessEquals("", "")).to_equal(true);
+			expect(string::caselessEquals("hapsf8asg ", "hapsf8asg ")).to_equal(true);
+		});
+		it("compares to unequal strings", _ {
+			expect(string::caselessEquals("a123!", "A123! ")).to_equal(false);
+			expect(string::caselessEquals("a123!", "A123")).to_equal(false);
+			expect(string::caselessEquals("a123!", "A123?")).to_equal(false);
+		});
+	});
 });
 
 CPPSPEC_SPEC(string);


### PR DESCRIPTION
- name storage moves from SoundDrum to Drum, changes to std::string, which causes much fallout - but hopefully less bugs. Member storing it renamed to drumName and getter follows suit: this can be undone, but it added some clarity when dealing with the fallout - easier to know we're actually dealing with drum names...

- MIDI drum description squeezed to one line, so that it still fits nicely when we add then name
