### PR TITLE
Guard against null currentModControllable in MIDI CC learning (#3640)

### DIFF
--- a/src/deluge/gui/menu_item/menu_item_with_cc_learning.cpp
+++ b/src/deluge/gui/menu_item/menu_item_with_cc_learning.cpp
@@ -27,6 +27,9 @@ void MenuItemWithCCLearning::unlearnAction() {
 
 	// If it was a reasonable-ish request...
 	if (!paramDescriptor.isNull()) {
+		if (!soundEditor.currentModControllable) {
+			return;
+		}
 		bool success = soundEditor.currentModControllable->unlearnKnobs(paramDescriptor, currentSong);
 
 		if (success) {
@@ -39,6 +42,10 @@ void MenuItemWithCCLearning::unlearnAction() {
 
 void MenuItemWithCCLearning::learnKnob(MIDICable* cable, int32_t whichKnob, int32_t modKnobMode, int32_t midiChannel) {
 	ParamDescriptor paramDescriptor = getLearningThing();
+
+	if (!soundEditor.currentModControllable) {
+		return;
+	}
 
 	bool success = soundEditor.currentModControllable->learnKnob(cable, paramDescriptor, whichKnob, modKnobMode,
 	                                                             midiChannel, currentSong);


### PR DESCRIPTION
MenuItemWithCCLearning::learnKnob() and unlearnAction() dereferenced soundEditor.currentModControllable without a null check. For Kit clips in per-drum mode when no SoundDrum is selected, currentModControllable is null, causing a crash when MIDI-learning any parameter (including clip master level via SHIFT+MASTER LEVEL).

Add early-return guards in both learnKnob() and unlearnAction() so the MIDI learn silently no-ops instead of crashing when there is no controllable object to learn into.

Fix #3640