### PR TITLE
Guard against null PatchCableSet on MIDI->Synth clip conversion (#4014)

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1718,8 +1718,12 @@ Error InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelStack
 
 		SoundInstrument* synth = (SoundInstrument*)newInstrument;
 
-		paramManager.getPatchCableSet()->grabVelocityToLevelFromMIDIInput(
-		    &synth->midiInput); // Should happen before we call setupPatching().
+		// Guard against a null PatchCableSet. Can occur when converting a duplicated MIDI clip to
+		// Synth (#4014) — the paramManager ends up without patch cables in that path.
+		PatchCableSet* pcs = paramManager.getPatchCableSetAllowJibberish();
+		if (pcs != nullptr) {
+			pcs->grabVelocityToLevelFromMIDIInput(&synth->midiInput); // Should happen before setupPatching().
+		}
 
 		// Set up patching now. If a Kit, we do the drums individually below.
 		synth->setupPatching(modelStack);


### PR DESCRIPTION
When a MIDI clip is duplicated and the duplicate is then changed to Synth type, paramManager.getPatchCableSet() can return null, causing a crash (null dereference in release builds, E412 freeze in debug) either during the conversion or when the song is subsequently saved.

Replace the bare getPatchCableSet()->grab... call with a null-guarded path using getPatchCableSetAllowJibberish(), skipping the velocity- to-level grab when patch cables are unavailable rather than crashing. The setupPatching() call that follows is unaffected.

Fix #4014