### PR TITLE
Fix ghost notes at start of linear MIDI recording (#4225)

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -461,13 +461,11 @@ Error InstrumentClip::beginLinearRecording(ModelStackWithTimelineCounter* modelS
 					Iterance iterance = noteRow->getDefaultIterance();
 					int32_t fill = noteRow->getDefaultFill(modelStackWithNoteRow);
 					noteRow->attemptNoteAdd(0, 1, velocity, probability, iterance, fill, modelStackWithNoteRow, action);
-					if (!thisDrum->earlyNoteStillActive) {
-						D_PRINTLN("skipping next note");
-
-						// We just inserted a note-on for an "early" note that is still sounding at time 0, so ignore
-						// note-ons until at least tick 1 to avoid double-playing that note
-						noteRow->ignoreNoteOnsBefore_ = 1;
-					}
+					// Always suppress re-trigger from the live MIDI stream: we just inserted this note at position 0
+					// via earlyNotes, so any note-on arriving before tick 1 (including clip-length-doubling replays)
+					// would produce a ghost note with zero/corrupted velocity. This applies whether or not the note
+					// is still physically held — note-offs and presses at tick >= 1 are unaffected.
+					noteRow->ignoreNoteOnsBefore_ = 1;
 				}
 			}
 		}
@@ -491,11 +489,10 @@ Error InstrumentClip::beginLinearRecording(ModelStackWithTimelineCounter* modelS
 					Iterance iterance = noteRow->getDefaultIterance();
 					int32_t fill = noteRow->getDefaultFill(modelStackWithNoteRow);
 					noteRow->attemptNoteAdd(0, 1, velocity, probability, iterance, fill, modelStackWithNoteRow, action);
-					if (!still_active) {
-						// We just inserted a note-on for an "early" note that is still sounding at time 0, so ignore
-						// note-ons until at least tick 1 to avoid double-playing that note
-						noteRow->ignoreNoteOnsBefore_ = 1;
-					}
+					// Always suppress re-trigger: note at position 0 came from earlyNotes; any live note-on arriving
+					// before tick 1 (including those caused by clip-length-doubling) would ghost-duplicate it.
+					// Note-offs and note-ons at tick >= 1 are not suppressed.
+					noteRow->ignoreNoteOnsBefore_ = 1;
 				}
 			}
 


### PR DESCRIPTION
When beginLinearRecording() inserts early-arrived notes at position 0, ignoreNoteOnsBefore_ was only set when the note had already been released (still_active == false). For still-held notes, the live MIDI stream (or the clip-length-doubling replay path) could fire another note-on before tick 1 and ghost-duplicate the note with zero or corrupted velocity.

Fix: always set ignoreNoteOnsBefore_ = 1 after inserting an early note at position 0, regardless of still_active / earlyNoteStillActive. The flag only suppresses note-ons before tick 1; note-offs and subsequent presses are unaffected, so held notes still release and re-trigger correctly.

Fix #4225