### PR TITLE
Fix MIDI program change off-by-one and missed clip activations

### DIFF
--- a/src/deluge/gui/menu_item/midi/bank.h
+++ b/src/deluge/gui/menu_item/midi/bank.h
@@ -22,12 +22,6 @@ class Bank final : public Preset {
 public:
 	using Preset::Preset;
 	void readCurrentValue() override { this->setValue(getCurrentInstrumentClip()->midiBank); }
-	void writeCurrentValue() override {
-		auto& currentClip = *getCurrentInstrumentClip();
-		currentClip.midiBank = this->getValue();
-		if (currentClip.isActiveOnOutput()) {
-			currentClip.sendMIDIPGM();
-		}
-	}
+	void writeCurrentValue() override { getCurrentInstrumentClip()->midiBank = this->getValue(); }
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/midi/pgm.h
+++ b/src/deluge/gui/menu_item/midi/pgm.h
@@ -22,12 +22,6 @@ class PGM final : public Preset {
 public:
 	using Preset::Preset;
 	void readCurrentValue() override { this->setValue(getCurrentInstrumentClip()->midiPGM); }
-	void writeCurrentValue() override {
-		auto& currentClip = *getCurrentInstrumentClip();
-		currentClip.midiPGM = this->getValue();
-		if (currentClip.isActiveOnOutput()) {
-			currentClip.sendMIDIPGM();
-		}
-	}
+	void writeCurrentValue() override { getCurrentInstrumentClip()->midiPGM = this->getValue(); }
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/midi/preset.h
+++ b/src/deluge/gui/menu_item/midi/preset.h
@@ -38,7 +38,7 @@ public:
 			text = l10n::get(l10n::String::STRING_FOR_NONE);
 		}
 		else {
-			intToString(this->getValue(), buffer, 1);
+			intToString(this->getValue() + 1, buffer, 1); // show 1-based
 			text = buffer;
 		}
 		canvas.drawStringCentred(text, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
@@ -49,7 +49,7 @@ public:
 			display->setText(l10n::get(l10n::String::STRING_FOR_NONE));
 		}
 		else {
-			display->setTextAsNumber(this->getValue());
+			display->setTextAsNumber(this->getValue() + 1); // MIDI programs are 0-indexed internally; show 1-based
 		}
 	}
 
@@ -79,7 +79,7 @@ public:
 			size_y = kTextSpacingY;
 		}
 		else {
-			paramValue.appendInt(getValue());
+			paramValue.appendInt(getValue() + 1); // show 1-based
 			size_x = kTextTitleSpacingX;
 			size_y = kTextTitleSizeY;
 		}

--- a/src/deluge/gui/menu_item/midi/preset.h
+++ b/src/deluge/gui/menu_item/midi/preset.h
@@ -38,7 +38,8 @@ public:
 			text = l10n::get(l10n::String::STRING_FOR_NONE);
 		}
 		else {
-			intToString(this->getValue() + 1, buffer, 1); // show 1-based
+			// Show 1-based to match the synth/DAW convention: wire byte 0 is "Patch 1" everywhere.
+			intToString(this->getValue() + 1, buffer, 1);
 			text = buffer;
 		}
 		canvas.drawStringCentred(text, yPixel + OLED_MAIN_TOPMOST_PIXEL, textWidth, textHeight);
@@ -49,7 +50,8 @@ public:
 			display->setText(l10n::get(l10n::String::STRING_FOR_NONE));
 		}
 		else {
-			display->setTextAsNumber(this->getValue() + 1); // MIDI programs are 0-indexed internally; show 1-based
+			// Show 1-based; storage and the wire stay 0-127 per the MIDI spec.
+			display->setTextAsNumber(this->getValue() + 1);
 		}
 	}
 

--- a/src/deluge/gui/menu_item/midi/sub.h
+++ b/src/deluge/gui/menu_item/midi/sub.h
@@ -22,12 +22,6 @@ class Sub final : public Preset {
 public:
 	using Preset::Preset;
 	void readCurrentValue() { this->setValue(getCurrentInstrumentClip()->midiSub); }
-	void writeCurrentValue() {
-		auto& currentClip = *getCurrentInstrumentClip();
-		currentClip.midiSub = this->getValue();
-		if (currentClip.isActiveOnOutput()) {
-			currentClip.sendMIDIPGM();
-		}
-	}
+	void writeCurrentValue() { getCurrentInstrumentClip()->midiSub = this->getValue(); }
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -252,12 +252,13 @@ bool MIDIInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack, Pg
 	bool shouldSendPGMs;
 	if (modelStack) {
 		InstrumentClip* newInstrumentClip = (InstrumentClip*)modelStack->getTimelineCounter();
-		InstrumentClip* oldInstrumentClip = (InstrumentClip*)activeClip;
 
-		shouldSendPGMs = (maySendMIDIPGMs != PgmChangeSend::NEVER && activeClip && activeClip != newInstrumentClip
-		                  && (newInstrumentClip->midiPGM != oldInstrumentClip->midiPGM
-		                      || newInstrumentClip->midiSub != oldInstrumentClip->midiSub
-		                      || newInstrumentClip->midiBank != oldInstrumentClip->midiBank));
+		// Send PC whenever switching to a different clip that has any program/bank/sub configured.
+		// Previously required activeClip != nullptr AND a value change between clips, which meant the
+		// first clip activation never sent a PC and grid-view re-launches with the same PGM didn't fire.
+		shouldSendPGMs = (maySendMIDIPGMs != PgmChangeSend::NEVER && newInstrumentClip != activeClip
+		                  && (newInstrumentClip->midiPGM != 128 || newInstrumentClip->midiSub != 128
+		                      || newInstrumentClip->midiBank != 128));
 	}
 	else {
 		shouldSendPGMs = false;


### PR DESCRIPTION
Two related fixes for MIDI program/bank/sub-bank handling:

1. Display off-by-one (preset.h): drawValue, drawInteger, and renderInHorizontalMenu showed the raw 0-indexed stored value, so users saw 0 when their synth was on Program 1. Display getValue()+1 for the program number range while keeping storage and the wire value at the spec-compliant 0-127 range. NONE (128) unchanged.

2. PC not firing on first activation / grid view (midi_instrument.cpp): shouldSendPGMs required activeClip != nullptr AND that the new clip had a different PGM/Sub/Bank than the previous clip. The first activation of a MIDI clip never met the first condition, and re-launching a clip with the same program in grid view never met the second. Replace with: send whenever switching to a different clip that has any of PGM/Sub/Bank configured.