### PR TITLE
Integrate encoder actioning with scheduler

### DIFF
--- a/src/OSLikeStuff/scheduler_api.h
+++ b/src/OSLikeStuff/scheduler_api.h
@@ -70,6 +70,7 @@ void setNextRunTimeforCurrentTask(double seconds);
 void removeTask(TaskID id);
 void boostTask(TaskID id);
 void runTask(TaskID id);
+void runBlockedTask(TaskID id);
 void yield(RunCondition until);
 /// timeout in seconds, returns whether the condition was met
 bool yieldWithTimeout(RunCondition until, double timeout);

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -201,6 +201,16 @@ void TaskManager::setNextRunTimeforCurrentTask(Time seconds) {
 	currentTask->schedule.maxInterval = seconds;
 }
 
+void TaskManager::unblockTask(TaskID id) {
+	auto* current_task = &list[id];
+	current_task->state = State::READY;
+}
+
+void TaskManager::blockTask(TaskID id) {
+	auto* current_task = &list[id];
+	current_task->state = State::BLOCKED;
+}
+
 void TaskManager::runTask(TaskID id) {
 	countThisTask = true;
 	currentID = id;

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.h
@@ -23,6 +23,8 @@ struct TaskManager {
 	void removeTask(TaskID id);
 	void boostTask(TaskID id);
 	void runTask(TaskID id);
+	void blockTask(TaskID id);
+	void unblockTask(TaskID id);
 	void runHighestPriTask();
 	TaskID chooseBestTask(Time deadline);
 	TaskID addRepeatingTask(TaskHandle task, TaskSchedule schedule, const char* name, ResourceChecker resources);

--- a/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
@@ -81,6 +81,12 @@ void runTask(TaskID id) {
 	taskManager.runTask(id);
 }
 
+void runBlockedTask(TaskID id) {
+	taskManager.unblockTask(id);
+	taskManager.runTask(id);
+	taskManager.blockTask(id);
+}
+
 double getSystemTime() {
 	return taskManager.getSecondsFromStart();
 }

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -544,8 +544,9 @@ void registerTasks() {
 	// 30 Hz update desired?
 	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI", RESOURCE_NONE);
 	// this one actually actions them
-	addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
+	TaskID encoders_action_task_id = addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
 	                 RESOURCE_SD_ROUTINE);
+	encoders::setActionTaskID(encoders_action_task_id);
 
 	// Check for and handle queued SysEx traffic
 	addRepeatingTask([]() { smSysex::handleNextSysEx(); }, p++, 0.0002, 0.0002, 0.01, "Handle pending SysEx traffic.",

--- a/src/deluge/hid/encoder.cpp
+++ b/src/deluge/hid/encoder.cpp
@@ -40,22 +40,24 @@ void Encoder::setNonDetentMode() {
 	doDetents = false;
 }
 
-void Encoder::applyEdges(int8_t edges) {
+int8_t Encoder::applyEdges(int8_t edges) {
 	if (edges == 0) {
-		return;
+		return 0;
 	}
 	// Two A-pin edges per quadrature cycle, one quadrature cycle per detent click on the
 	// Deluge encoders. Same halving as the embassy `take_detents()` does.
 	edgeAccumulator += edges;
 	int8_t ticks = edgeAccumulator / 2;
 	if (ticks == 0) {
-		return;
+		return 0;
 	}
 	edgeAccumulator -= ticks * 2;
 	if (doDetents) {
 		detentPos += ticks;
 	}
 	encPos += ticks;
+
+	return std::abs(ticks);
 }
 
 int32_t Encoder::getLimitedDetentPosAndReset() {

--- a/src/deluge/hid/encoder.h
+++ b/src/deluge/hid/encoder.h
@@ -34,7 +34,7 @@ public:
 	/// Fold a number of A-pin edges (signed; from the IRQ accumulator) into encPos / detentPos.
 	/// Two edges = one detent step (or one raw tick for non-detent gold knobs), matching the
 	/// "1 quadrature cycle per detent" wiring on the Deluge encoders.
-	void applyEdges(int8_t edges);
+	int8_t applyEdges(int8_t edges);
 	void setPins(uint8_t pinA1New, uint8_t pinA2New, uint8_t pinB1New, uint8_t pinB2New);
 	void setNonDetentMode();
 	int32_t getLimitedDetentPosAndReset();

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -49,6 +49,8 @@ int8_t modEncoderInitialTurnDirection[2];
 
 uint32_t encodersWaitingForCardRoutineEnd;
 
+TaskID action_task_id = -1;
+
 namespace {
 constexpr size_t kNumEncoders = util::to_underlying(EncoderName::MAX_ENCODER);
 struct EncoderIrqEntry {
@@ -131,12 +133,25 @@ void init() {
 }
 
 void readEncoders() {
+	int8_t ticksAccumulated = 0;
 	for (size_t i = 0; i < util::to_underlying(EncoderName::MAX_ENCODER); i++) {
 		int8_t edges = encoderEdgeDeltas[i].exchange(0, std::memory_order_relaxed);
 		if (edges != 0) {
-			encoders[i].applyEdges(edges);
+			ticksAccumulated += encoders[i].applyEdges(edges);
 		}
 	}
+	// did we touch any of the encoders?
+	if (ticksAccumulated > 0) {
+		// check if we've setup the action encoders task
+		if (action_task_id != -1) [[likely]] {
+			// run Encoders::interpretEncoders(false) task so that scheduler is aware
+			runBlockedTask(action_task_id);
+		}
+	}
+}
+
+void setActionTaskID(TaskID id) {
+	action_task_id = id;
 }
 
 bool interpretEncoders(bool skipActioning) {

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "hid/encoder.h"
+#include "OSLikeStuff/scheduler_api.h"
 #include "util/misc.h"
 #include <array>
 
@@ -45,6 +46,7 @@ extern uint32_t timeModEncoderLastTurned[];
 void init();
 void readEncoders();
 bool interpretEncoders(bool skipActioning = false);
+void setActionTaskID(TaskID id);
 
 Encoder& getEncoder(EncoderName which);
 } // namespace deluge::hid::encoders


### PR DESCRIPTION
Encoder actioning is now integrated with the scheduler such that you only action encoders when ticks have been accumulated.