### PR TITLE
Fix/ Integrate encoder actioning with scheduler + accelerate gold knobs

### DIFF
--- a/src/OSLikeStuff/scheduler_api.h
+++ b/src/OSLikeStuff/scheduler_api.h
@@ -70,6 +70,8 @@ void setNextRunTimeforCurrentTask(double seconds);
 void removeTask(TaskID id);
 void boostTask(TaskID id);
 void runTask(TaskID id);
+void unblockTask(TaskID id);
+void blockTask(TaskID id);
 void yield(RunCondition until);
 /// timeout in seconds, returns whether the condition was met
 bool yieldWithTimeout(RunCondition until, double timeout);

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -201,6 +201,16 @@ void TaskManager::setNextRunTimeforCurrentTask(Time seconds) {
 	currentTask->schedule.maxInterval = seconds;
 }
 
+void TaskManager::unblockTask(TaskID id) {
+	auto* current_task = &list[id];
+	current_task->state = State::READY;
+}
+
+void TaskManager::blockTask(TaskID id) {
+	auto* current_task = &list[id];
+	current_task->state = State::BLOCKED;
+}
+
 void TaskManager::runTask(TaskID id) {
 	countThisTask = true;
 	currentID = id;

--- a/src/OSLikeStuff/task_scheduler/task_scheduler.h
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.h
@@ -23,6 +23,8 @@ struct TaskManager {
 	void removeTask(TaskID id);
 	void boostTask(TaskID id);
 	void runTask(TaskID id);
+	void blockTask(TaskID id);
+	void unblockTask(TaskID id);
 	void runHighestPriTask();
 	TaskID chooseBestTask(Time deadline);
 	TaskID addRepeatingTask(TaskHandle task, TaskSchedule schedule, const char* name, ResourceChecker resources);

--- a/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler_c_api.cpp
@@ -81,6 +81,14 @@ void runTask(TaskID id) {
 	taskManager.runTask(id);
 }
 
+void unblockTask(TaskID id) {
+	taskManager.unblockTask(id);
+}
+
+void blockTask(TaskID id) {
+	taskManager.blockTask(id);
+}
+
 double getSystemTime() {
 	return taskManager.getSecondsFromStart();
 }

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -544,8 +544,9 @@ void registerTasks() {
 	// 30 Hz update desired?
 	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI", RESOURCE_NONE);
 	// this one actually actions them
-	addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
+	TaskID encoders_action_task_id = addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
 	                 RESOURCE_SD_ROUTINE);
+	encoders::setActionTaskID(encoders_action_task_id);
 
 	// Check for and handle queued SysEx traffic
 	addRepeatingTask([]() { smSysex::handleNextSysEx(); }, p++, 0.0002, 0.0002, 0.01, "Handle pending SysEx traffic.",

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -544,8 +544,8 @@ void registerTasks() {
 	// 30 Hz update desired?
 	addRepeatingTask(&doAnyPendingUIRendering, p++, 0.01, 0.01, 0.03, "pending UI", RESOURCE_NONE);
 	// this one actually actions them
-	TaskID encoders_action_task_id = addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005, 0.01, "interpret encoders slow",
-	                 RESOURCE_SD_ROUTINE);
+	TaskID encoders_action_task_id = addRepeatingTask([]() { encoders::interpretEncoders(false); }, p++, 0.005, 0.005,
+	                                                  0.01, "interpret encoders slow", RESOURCE_SD_ROUTINE);
 	encoders::setActionTaskID(encoders_action_task_id);
 
 	// Check for and handle queued SysEx traffic

--- a/src/deluge/hid/encoder.cpp
+++ b/src/deluge/hid/encoder.cpp
@@ -40,22 +40,24 @@ void Encoder::setNonDetentMode() {
 	doDetents = false;
 }
 
-void Encoder::applyEdges(int8_t edges) {
+int8_t Encoder::applyEdges(int8_t edges) {
 	if (edges == 0) {
-		return;
+		return 0;
 	}
 	// Two A-pin edges per quadrature cycle, one quadrature cycle per detent click on the
 	// Deluge encoders. Same halving as the embassy `take_detents()` does.
 	edgeAccumulator += edges;
 	int8_t ticks = edgeAccumulator / 2;
 	if (ticks == 0) {
-		return;
+		return 0;
 	}
 	edgeAccumulator -= ticks * 2;
 	if (doDetents) {
 		detentPos += ticks;
 	}
 	encPos += ticks;
+
+	return std::abs(ticks);
 }
 
 int32_t Encoder::getLimitedDetentPosAndReset() {

--- a/src/deluge/hid/encoder.h
+++ b/src/deluge/hid/encoder.h
@@ -34,7 +34,7 @@ public:
 	/// Fold a number of A-pin edges (signed; from the IRQ accumulator) into encPos / detentPos.
 	/// Two edges = one detent step (or one raw tick for non-detent gold knobs), matching the
 	/// "1 quadrature cycle per detent" wiring on the Deluge encoders.
-	void applyEdges(int8_t edges);
+	int8_t applyEdges(int8_t edges);
 	void setPins(uint8_t pinA1New, uint8_t pinA2New, uint8_t pinB1New, uint8_t pinB2New);
 	void setNonDetentMode();
 	int32_t getLimitedDetentPosAndReset();

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -50,6 +50,7 @@ int8_t modEncoderInitialTurnDirection[2];
 uint32_t encodersWaitingForCardRoutineEnd;
 
 TaskID action_task_id = -1;
+double currentKnobSpeed{0.0};
 
 namespace {
 constexpr size_t kNumEncoders = util::to_underlying(EncoderName::MAX_ENCODER);
@@ -276,7 +277,7 @@ checkResult:
 
 					// Do it, only if
 					if (encoder.encPos + modEncoderInitialTurnDirection[e] != 0) {
-						getCurrentUI()->modEncoderAction(e, encoder.encPos);
+						getCurrentUI()->modEncoderAction(e, encoder.encPos * calcNextKnobSpeed(encoder.encPos));
 						modEncoderInitialTurnDirection[e] = 0;
 					}
 
@@ -316,6 +317,39 @@ checkResult:
 	}
 
 	return anything;
+}
+
+double calcNextKnobSpeed(int8_t offset) {
+	// - inertia and acceleration control how fast the knob speeds up in horizontal menus
+	// - speedScale controls how we go from "raw speed" to speed used as offset multiplier
+	// - min and max speed clamp the max effective speed
+	//
+	// current values have been tuned to be slow enough to feel easy to control, but fast
+	// enough to go from 0 to 50 with one fast turn of the encoder. speedScale and min/max
+	// could potentially be user-configurable in a small range.
+	constexpr double acceleration = 0.1;
+	constexpr double inertia = 1.0 - acceleration;
+	constexpr double speed_scale = 0.15;
+	constexpr double min_speed = 1.0;
+	constexpr double max_speed = 5.0;
+	constexpr double reset_speed_time_threshold = 0.3;
+
+	// lastOffset and lastEncoderTime keep track of our direction and time
+	static int8_t last_offset = 0;
+	static double last_encoder_time = 0.0;
+	const double time = getSystemTime();
+
+	if (time - last_encoder_time >= reset_speed_time_threshold || offset != last_offset) {
+		// too much time passed, or the knob direction changed, reset the speed
+		currentKnobSpeed = 0.0;
+	}
+	else {
+		// moving in the same direction, update speed
+		currentKnobSpeed = currentKnobSpeed * inertia + 1.0 / (time - last_encoder_time) * acceleration;
+	}
+	last_encoder_time = time;
+	last_offset = offset;
+	return std::clamp((currentKnobSpeed * speed_scale), min_speed, max_speed);
 }
 
 } // namespace deluge::hid::encoders

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -49,6 +49,8 @@ int8_t modEncoderInitialTurnDirection[2];
 
 uint32_t encodersWaitingForCardRoutineEnd;
 
+TaskID action_task_id = -1;
+
 namespace {
 constexpr size_t kNumEncoders = util::to_underlying(EncoderName::MAX_ENCODER);
 struct EncoderIrqEntry {
@@ -131,12 +133,22 @@ void init() {
 }
 
 void readEncoders() {
+	int8_t ticksAccumulated = 0;
 	for (size_t i = 0; i < util::to_underlying(EncoderName::MAX_ENCODER); i++) {
 		int8_t edges = encoderEdgeDeltas[i].exchange(0, std::memory_order_relaxed);
 		if (edges != 0) {
-			encoders[i].applyEdges(edges);
+			ticksAccumulated += encoders[i].applyEdges(edges);
 		}
 	}
+	// did we touch any of the encoders and we've setup the action encoders task?
+	if (ticksAccumulated > 0 && action_task_id != -1) {
+		// run Encoders::interpretEncoders(false) task so that scheduler is aware
+		unblockTask(action_task_id);
+	}
+}
+
+void setActionTaskID(TaskID id) {
+	action_task_id = id;
 }
 
 bool interpretEncoders(bool skipActioning) {
@@ -295,6 +307,12 @@ checkResult:
 				encoder.encPos = 0;
 			}
 		}
+	}
+
+	// did we try to action anything and we've setup the actioning task?
+	if (!skipActioning && action_task_id != -1) {
+		// re-block the task so that it is only actioned when it needs to
+		blockTask(action_task_id);
 	}
 
 	return anything;

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "hid/encoder.h"
+#include "OSLikeStuff/scheduler_api.h"
 #include "util/misc.h"
 #include <array>
 
@@ -45,6 +46,7 @@ extern uint32_t timeModEncoderLastTurned[];
 void init();
 void readEncoders();
 bool interpretEncoders(bool skipActioning = false);
+void setActionTaskID(TaskID id);
 
 Encoder& getEncoder(EncoderName which);
 } // namespace deluge::hid::encoders

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -47,6 +47,7 @@ void init();
 void readEncoders();
 bool interpretEncoders(bool skipActioning = false);
 void setActionTaskID(TaskID id);
+double calcNextKnobSpeed(int8_t offset);
 
 Encoder& getEncoder(EncoderName which);
 } // namespace deluge::hid::encoders

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include "hid/encoder.h"
 #include "OSLikeStuff/scheduler_api.h"
+#include "hid/encoder.h"
 #include "util/misc.h"
 #include <array>
 


### PR DESCRIPTION
Encoder actioning is now integrated with the scheduler such that you only action encoders when ticks have been accumulated.

Add gold knob acceleration