### PR TITLE
Apply edges in the interrupt handler

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -524,8 +524,6 @@ void registerTasks() {
 	AudioEngine::routine_task_id = addRepeatingTask(&(AudioEngine::routine_task), p++, 8 / 44100., 64 / 44100.,
 	                                                128 / 44100., "audio  routine", RESOURCE_NONE);
 	addRepeatingTask(MidiEngine::check_incoming_usb, p++, 0.0005, 0.0005, 0.001, "check usb midi", RESOURCE_USB);
-	// this one runs quickly and frequently to check for encoder changes
-	addRepeatingTask([]() { encoders::readEncoders(); }, p++, 0.0002, 0.0004, 0.0005, "read encoders", RESOURCE_NONE);
 	// formerly part of audio routine, updates midi and clock
 	addRepeatingTask([]() { playbackHandler.routine(); }, p++, 0.0005, 0.001, 0.002, "playback routine", RESOURCE_NONE);
 	midiEngine.routine_task_id = addRepeatingTask([]() { playbackHandler.midiRoutine(); }, p++, 0.0005, 0.001, 0.002,
@@ -595,7 +593,6 @@ void mainLoop() {
 			count++;
 		}
 
-		encoders::readEncoders();
 		bool anything = encoders::interpretEncoders();
 		if (anything) {
 			AudioEngine::routineWithClusterLoading(true);
@@ -961,7 +958,6 @@ extern "C" void routineForSD(void) {
 		step = UIStage::readEnc;
 		break;
 	case UIStage::readEnc:
-		encoders::readEncoders();
 		encoders::interpretEncoders(true);
 		step = UIStage::readButtons;
 		break;

--- a/src/deluge/hid/encoder.cpp
+++ b/src/deluge/hid/encoder.cpp
@@ -44,18 +44,15 @@ void Encoder::applyEdges(int8_t edges) {
 	if (edges == 0) {
 		return;
 	}
-	// Two A-pin edges per quadrature cycle, one quadrature cycle per detent click on the
-	// Deluge encoders. Same halving as the embassy `take_detents()` does.
-	edgeAccumulator += edges;
-	int8_t ticks = edgeAccumulator / 2;
-	if (ticks == 0) {
-		return;
-	}
-	edgeAccumulator -= ticks * 2;
+	encPos += edges;
 	if (doDetents) {
+		// Two A-pin edges per quadrature cycle, one quadrature cycle per detent click on the
+		// Deluge encoders. Same halving as the embassy `take_detents()` does.
+		edgeAccumulator += edges;
+		int8_t ticks = edgeAccumulator / 2;
+		edgeAccumulator -= ticks * 2;
 		detentPos += ticks;
 	}
-	encPos += ticks;
 }
 
 int32_t Encoder::getLimitedDetentPosAndReset() {

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -72,9 +72,6 @@ constexpr EncoderIrqEntry kEncoderIrqMap[kNumEncoders] = {
     [util::to_underlying(EncoderName::MOD_0)] = {.irqPin = 0, .compPin = 15, .irqNum = 4, .invert = false},
 };
 
-/// Atomic edge counters written by ISRs, drained by `readEncoders()`.
-std::atomic<int8_t> encoderEdgeDeltas[kNumEncoders] = {};
-
 template <size_t IDX>
 void encoderIrqHandler(uint32_t /*sense*/) {
 	constexpr EncoderIrqEntry m = kEncoderIrqMap[IDX];
@@ -129,15 +126,6 @@ void init() {
 	getEncoder(EncoderName::MOD_1).setNonDetentMode();
 
 	initInterrupts();
-}
-
-void readEncoders() {
-	for (size_t i = 0; i < util::to_underlying(EncoderName::MAX_ENCODER); i++) {
-		int8_t edges = encoderEdgeDeltas[i].exchange(0, std::memory_order_relaxed);
-		if (edges != 0) {
-			encoders[i].applyEdges(edges);
-		}
-	}
 }
 
 bool interpretEncoders(bool skipActioning) {
@@ -252,7 +240,6 @@ checkResult:
 
 			// If encoder turned...
 			if (encoder.encPos != 0) {
-				D_PRINTLN("mod encoder %d turned %d", e, encoder.encPos);
 				anything = true;
 
 				bool turnedRecently = (AudioEngine::audioSampleTimer - timeModEncoderLastTurned[e] < kShortPressTime);

--- a/src/deluge/hid/encoders.cpp
+++ b/src/deluge/hid/encoders.cpp
@@ -82,7 +82,8 @@ void encoderIrqHandler(uint32_t /*sense*/) {
 	bool b = readInput(1, m.compPin) != 0;
 	bool cw = m.invert ? (a != b) : (a == b);
 	int8_t inc = cw ? +1 : -1;
-	encoderEdgeDeltas[IDX].fetch_add(inc, std::memory_order_relaxed);
+	encoders[IDX].applyEdges(inc);
+
 	clearIRQInterrupt(m.irqNum);
 }
 
@@ -251,6 +252,7 @@ checkResult:
 
 			// If encoder turned...
 			if (encoder.encPos != 0) {
+				D_PRINTLN("mod encoder %d turned %d", e, encoder.encPos);
 				anything = true;
 
 				bool turnedRecently = (AudioEngine::audioSampleTimer - timeModEncoderLastTurned[e] < kShortPressTime);

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -43,7 +43,6 @@ enum class EncoderName {
 extern uint32_t timeModEncoderLastTurned[];
 
 void init();
-// void readEncoders();
 bool interpretEncoders(bool skipActioning = false);
 
 Encoder& getEncoder(EncoderName which);

--- a/src/deluge/hid/encoders.h
+++ b/src/deluge/hid/encoders.h
@@ -43,7 +43,7 @@ enum class EncoderName {
 extern uint32_t timeModEncoderLastTurned[];
 
 void init();
-void readEncoders();
+// void readEncoders();
 bool interpretEncoders(bool skipActioning = false);
 
 Encoder& getEncoder(EncoderName which);


### PR DESCRIPTION
Gonna do a follow up PR to tweak the scheduler and encoder handling to be ran by the scheduler after this interrupt completes

Major props to @stellar-aria for setting this up, huge improvement over the polling