### PR TITLE
skip rendering if no sound is coming in or the effect is off

### DIFF
--- a/src/deluge/model/global_effectable/global_effectable.cpp
+++ b/src/deluge/model/global_effectable/global_effectable.cpp
@@ -1105,9 +1105,19 @@ void GlobalEffectable::compensateVolumeForResonance(ParamManagerForTimeline* par
 }
 
 ModFXType GlobalEffectable::getActiveModFXType(ParamManager* paramManager) {
-	// todo: should this have a per modfx switch of whether they're active for given parameter values?
-	// otoh we offer disabled as an explicit option now so shouldn't be needed
-	return modFXType_;
+	ModFXType modFXTypeNow = modFXType_;
+
+	UnpatchedParamSet* unpatchedParams = paramManager->getUnpatchedParamSet();
+
+	if ((currentModFXParam == ModFXParam::DEPTH
+	     && unpatchedParams->getValue(params::UNPATCHED_MOD_FX_DEPTH) == -2147483648)
+	    || (currentModFXParam == ModFXParam::FEEDBACK
+	        && unpatchedParams->getValue(params::UNPATCHED_MOD_FX_FEEDBACK) == -2147483648)
+	    || (currentModFXParam == ModFXParam::OFFSET
+	        && unpatchedParams->getValue(params::UNPATCHED_MOD_FX_OFFSET) == -2147483648)) {
+		modFXTypeNow = ModFXType::NONE;
+	}
+	return modFXTypeNow;
 }
 
 Delay::State GlobalEffectable::createDelayWorkingState(ParamManager& paramManager, bool shouldLimitDelayFeedback,

--- a/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
+++ b/src/deluge/model/global_effectable/global_effectable_for_clip.cpp
@@ -126,11 +126,14 @@ GlobalEffectableForClip::GlobalEffectableForClip() {
 		}
 	}
 
-	// Render filters
-	processFilters(global_effectable_audio);
+	if (renderedLastTime) {
+		// Render filters
+		processFilters(global_effectable_audio);
 
-	// Render FX
-	processSRRAndBitcrushing(global_effectable_audio, &volumePostFX, paramManagerForClip);
+		// Render FX
+		processSRRAndBitcrushing(global_effectable_audio, &volumePostFX, paramManagerForClip);
+	}
+
 	processFXForGlobalEffectable(global_effectable_audio, &volumePostFX, paramManagerForClip, delayWorkingState,
 	                             renderedLastTime, reverbSendAmount);
 	processStutter(global_effectable_audio, paramManagerForClip);

--- a/src/deluge/model/mod_controllable/ModFXProcessor.cpp
+++ b/src/deluge/model/mod_controllable/ModFXProcessor.cpp
@@ -28,7 +28,9 @@
 void ModFXProcessor::processModFX(std::span<StereoSample> buffer, const ModFXType& modFXType, int32_t modFXRate,
                                   int32_t modFXDepth, int32_t* postFXVolume, UnpatchedParamSet* unpatchedParams,
                                   bool anySoundComingIn) {
-
+	// if nothing rendered into the clip then we can just return
+	if (anySoundComingIn == false)
+		return;
 	if (modFXType != ModFXType::NONE) {
 
 		LFOType modFXLFOWaveType{};


### PR DESCRIPTION
undoes #3854

Fixes a huge performance regression for songs with lots of kits