### PR TITLE
Tighten SysEx length check and add explicit break for Pong

### DIFF
--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -755,7 +755,11 @@ void MidiEngine::checkIncomingUsbSysex(uint8_t const* msg, int32_t ip, int32_t d
 bool developerSysexCodeReceived = false;
 
 void MidiEngine::midiSysexReceived(MIDICable& cable, uint8_t* data, int32_t len) {
-	if (len < 4) {
+	// All branches below dereference up to data[5], so require at least
+	// six bytes (F0 + ID + sub-id + sub-id2 + value + payload byte) before
+	// proceeding. Crafted SysEx with len 4 or 5 previously read past the
+	// end of the message into stale buffer bytes.
+	if (len < 6) {
 		return;
 	}
 	unsigned payloadOffset = 2;
@@ -823,6 +827,7 @@ void MidiEngine::midiSysexReceived(MIDICable& cable, uint8_t* data, int32_t len)
 
 	case SysEx::SysexCommands::Pong: // PONG, reserved
 		D_PRINTLN("Pong");
+		break;
 	default:
 		break;
 	}


### PR DESCRIPTION
## Summary

`MidiEngine::midiSysexReceived` previously enforced only `len >= 4`,
but every branch below it dereferences up to `data[5]`:

- the universal identity request branch reads `data[4]` to match the
  sub-id (`midi_engine.cpp:765`)
- the Synthstrom manufacturer-ID branch reads `data[3]` and `data[4]`
  to match `DELUGE_SYSEX_ID_BYTE2`/`BYTE3` (`midi_engine.cpp:784`)
- the subsequent payload dispatch reads `data[payloadOffset]`, which is
  `data[5]` once the manufacturer-ID match sets `payloadOffset = 5`

A SysEx message of length 4 or 5 therefore reads past the end of the
parsed message into stale bytes left over in the static
`incomingSysexBuffer` from a previous transfer. The dispatched command
byte and its inputs are then attacker-influenceable via earlier
traffic. Require at least six bytes up front so every existing access
stays in bounds.

While in the same switch, add an explicit `break` to the `Pong` arm.
It currently falls through to `default` which is harmless today, but
will silently misbehave the moment another case is added below it.

## Test plan

- [ ] Send a 4-byte SysEx \`F0 7E 7F F7\` and a 5-byte SysEx and confirm the device no longer dispatches based on uninitialised buffer bytes (was reproducible only after grooming the buffer with a prior longer SysEx).
- [ ] Send the standard Universal Non-RT identity request \`F0 7E 7F 06 01 F7\` and confirm the device still replies with the identity reply (the canonical 6-byte form is unaffected).
- [ ] Send a Synthstrom-ID Ping (\`F0 00 21 7B 01 00 F7\`) and confirm Pong is returned.
- [ ] Confirm clang-format passes (workflow already enforces).

## Notes for reviewers

This is the smallest fix that closes the OOB read without changing
the wire protocol or behaviour for any valid SysEx message. A separate
follow-up is wanted for \`sysex.cpp:firstPacket()\` (the firmware-load
size validation) which has a similar shape but is gated behind a
runtime feature flag and a handshake, and warrants its own discussion.