### PR TITLE
Add fuzz harnesses for SysEx pack/unpack and SemVer parser

### DIFF
--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,18 +1,48 @@
-cmake_minimum_required(VERSION 3.31)
-project(MemmoveFuzz)
+cmake_minimum_required(VERSION 3.24)
+project(DelugeFuzz LANGUAGES C CXX)
 
-add_executable(memmove_fuzz memmove_fuzz.c)
-set(options
-  -mfpu=neon
-  -mfloat-abi=hard
-  -funsafe-math-optimizations
-  -fsanitize=fuzzer #,undefined,signed-integer-overflow,null,alignment
-  -fno-omit-frame-pointer
-  -g
-  -O1
+# libFuzzer is only available with clang. The harnesses link against
+# real source from src/deluge/, so this directory is opt-in. To build
+# standalone from the repository root:
+#
+#   CC=clang CXX=clang++ cmake -B build/fuzz -S tests/fuzz
+#   cmake --build build/fuzz
+#
+# Then run any harness:
+#
+#   ./build/fuzz/pack_fuzz   -max_len=8192
+#   ./build/fuzz/semver_fuzz -max_len=128
+#   ./build/fuzz/memmove_fuzz -max_len=512
+
+if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang" OR NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    message(FATAL_ERROR
+        "Fuzz harnesses require clang (for -fsanitize=fuzzer). "
+        "Re-run cmake with CC=clang CXX=clang++.")
+endif()
+
+set(fuzz_flags
+    -fsanitize=fuzzer,address,undefined
+    -fno-omit-frame-pointer
+    -g
+    -O1
 )
 
+function(add_fuzz_target name)
+    set(srcs ${ARGN})
+    add_executable(${name} ${srcs})
+    target_compile_options(${name} PRIVATE ${fuzz_flags})
+    target_link_options(${name} PRIVATE ${fuzz_flags})
+endfunction()
+
+# Existing harness for the in-tree memmove implementation.
+add_fuzz_target(memmove_fuzz memmove_fuzz.c)
 target_compile_features(memmove_fuzz PUBLIC c_std_23)
 
-target_compile_options(memmove_fuzz PUBLIC ${options})
-target_link_options(memmove_fuzz PUBLIC ${options})
+# SysEx 7-bit pack / unpack / RLE. Pure C, no project deps beyond pack.{c,h}.
+add_fuzz_target(pack_fuzz pack_fuzz.c ../../src/deluge/util/pack.c)
+target_compile_features(pack_fuzz PUBLIC c_std_23)
+
+# Firmware version-string parser. Pure C++, stdlib-only deps.
+add_fuzz_target(semver_fuzz semver_fuzz.cpp ../../src/deluge/util/semver.cpp)
+target_compile_features(semver_fuzz PUBLIC cxx_std_23)
+target_include_directories(semver_fuzz PRIVATE ../../src/deluge)

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -1,0 +1,69 @@
+# Fuzz harnesses
+
+libFuzzer-based harnesses for attacker-reachable parsers in the
+firmware. All targets link against the real source under
+`src/deluge/`, so a crash here is a crash on the device.
+
+## Build
+
+libFuzzer requires clang. From the repository root:
+
+```
+CC=clang CXX=clang++ cmake -B build/fuzz -S tests/fuzz
+cmake --build build/fuzz
+```
+
+## Run
+
+Each binary accepts the usual libFuzzer flags:
+
+```
+./build/fuzz/pack_fuzz   -max_len=8192   -runs=1000000
+./build/fuzz/semver_fuzz -max_len=128    -runs=1000000
+./build/fuzz/memmove_fuzz -max_len=512   -runs=1000000
+```
+
+For a longer corpus-building run, point libFuzzer at a directory:
+
+```
+mkdir -p corpus/pack
+./build/fuzz/pack_fuzz corpus/pack -max_len=8192
+```
+
+## Current targets
+
+| Target | Source under test | Why it matters |
+| --- | --- | --- |
+| `pack_fuzz` | `src/deluge/util/pack.c` (`unpack_7bit_to_8bit`, `unpack_7to8_rle`, `pack_8bit_to_7bit`, `pack_8to7_rle`) | Every SysEx parsing path on the device runs input through these functions first. An out-of-bounds write here is reachable over USB-MIDI without any feature gating. |
+| `semver_fuzz` | `src/deluge/util/semver.cpp` (`SemVer::Parser`) | Firmware version strings come from files on the SD card. A crash on a malformed string would brick song-load. |
+| `memmove_fuzz` | In-harness reference `memmove` | Pre-existing harness, retained. |
+
+## Wanted follow-ups
+
+The four highest-value remaining targets all need mock infrastructure
+before they can link, so they are not included in this PR:
+
+1. **`MidiEngine::midiSysexReceived`** in `src/deluge/io/midi/midi_engine.cpp`.
+   Highest priority. Reachable directly from USB-MIDI. Needs mocks for
+   `MIDICable`, `display`, `l10n`, and the SysEx command dispatchers
+   (`HIDSysex`, `Debug`, `smSysex`).
+
+2. **`JsonDeserializer`** in `src/deluge/storage/JsonDeserializer.cpp`,
+   memory-backed mode. Reachable via the JSON-over-SysEx file API.
+   Needs `FileDeserializer`, `String`, and a no-op `Cluster` mock so
+   the deserializer skips its SD-cluster prefetch path.
+
+3. **`XMLDeserializer`** in `src/deluge/storage/Deserializer.cpp`.
+   Reachable via every preset and song load. Same mock surface as
+   `JsonDeserializer`.
+
+4. **`AudioFile::loadFile`** in `src/deluge/storage/audio/audio_file.cpp`.
+   Reachable via every sample and wavetable load. Needs an in-memory
+   `AudioFileReader` and a no-op `Sample` / `WaveTable` shim. Two
+   integer-overflow shapes in the WAV/AIFF chunk loop are the main
+   targets here.
+
+When adding any of these, follow the pattern in `pack_fuzz.c`:
+multiplex multiple entrypoints behind the first byte of the input so a
+single binary covers the whole parser surface and libFuzzer's coverage
+feedback works across all of them.

--- a/tests/fuzz/pack_fuzz.c
+++ b/tests/fuzz/pack_fuzz.c
@@ -1,0 +1,112 @@
+// Fuzz harness for the SysEx 7-bit pack / unpack and RLE routines in
+// src/deluge/util/pack.c. These functions sit in front of every SysEx
+// parsing path on the device, so any out-of-bounds write or read here
+// is reachable by an attacker over USB-MIDI.
+//
+// Build via tests/fuzz/CMakeLists.txt (libFuzzer requires clang).
+// Run with:   ./build/pack_fuzz -max_len=8192
+
+#include "../../src/deluge/util/pack.h"
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Some upper bound for destination buffers. SysEx messages on the wire are
+// bounded by the static incomingSysexBuffer (~1 KiB) plus a generous margin.
+#define DST_MAX (16 * 1024)
+
+static void check_unpack_7bit(const uint8_t* data, size_t size) {
+	if (size > DST_MAX) {
+		return;
+	}
+	uint8_t* src = (uint8_t*)malloc(size);
+	uint8_t* dst = (uint8_t*)malloc(DST_MAX);
+	if (!src || !dst) {
+		abort();
+	}
+	memcpy(src, data, size);
+
+	int32_t produced = unpack_7bit_to_8bit(dst, DST_MAX, src, (int32_t)size);
+	if (produced < 0 || produced > DST_MAX) {
+		abort();
+	}
+
+	free(src);
+	free(dst);
+}
+
+static void check_unpack_rle(const uint8_t* data, size_t size) {
+	if (size > DST_MAX) {
+		return;
+	}
+	uint8_t* src = (uint8_t*)malloc(size);
+	uint8_t* dst = (uint8_t*)malloc(DST_MAX);
+	if (!src || !dst) {
+		abort();
+	}
+	memcpy(src, data, size);
+
+	int32_t produced = unpack_7to8_rle(dst, DST_MAX, src, (int32_t)size);
+	// Negative return is the function's error signal and is fine.
+	if (produced > DST_MAX) {
+		abort();
+	}
+
+	free(src);
+	free(dst);
+}
+
+static void check_roundtrip(const uint8_t* data, size_t size) {
+	if (size == 0 || size > DST_MAX / 2) {
+		return;
+	}
+	uint8_t* original = (uint8_t*)malloc(size);
+	uint8_t* packed = (uint8_t*)malloc(DST_MAX);
+	uint8_t* unpacked = (uint8_t*)malloc(DST_MAX);
+	if (!original || !packed || !unpacked) {
+		abort();
+	}
+	memcpy(original, data, size);
+
+	int32_t packed_len = pack_8bit_to_7bit(packed, DST_MAX, original, (int32_t)size);
+	if (packed_len > 0) {
+		int32_t unpacked_len = unpack_7bit_to_8bit(unpacked, DST_MAX, packed, packed_len);
+		if (unpacked_len < (int32_t)size || memcmp(original, unpacked, size) != 0) {
+			abort();
+		}
+	}
+
+	int32_t rle_len = pack_8to7_rle(packed, DST_MAX, original, (int32_t)size);
+	if (rle_len > 0) {
+		int32_t unpacked_len = unpack_7to8_rle(unpacked, DST_MAX, packed, rle_len);
+		if (unpacked_len != (int32_t)size || memcmp(original, unpacked, size) != 0) {
+			abort();
+		}
+	}
+
+	free(original);
+	free(packed);
+	free(unpacked);
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+	if (size == 0) {
+		return 0;
+	}
+	// Use the first byte as a 3-way selector so libFuzzer covers each
+	// entrypoint without us shelling out to separate harnesses.
+	const uint8_t* rest = data + 1;
+	size_t rest_size = size - 1;
+	switch (data[0] & 0x03) {
+	case 0:
+		check_unpack_7bit(rest, rest_size);
+		break;
+	case 1:
+		check_unpack_rle(rest, rest_size);
+		break;
+	default:
+		check_roundtrip(rest, rest_size);
+		break;
+	}
+	return 0;
+}

--- a/tests/fuzz/semver_fuzz.cpp
+++ b/tests/fuzz/semver_fuzz.cpp
@@ -1,0 +1,26 @@
+// Fuzz harness for SemVer::Parser in src/deluge/util/semver.cpp.
+// Version strings flow from firmware files on the SD card into this
+// parser, so a crash or read past the end of the input is reachable
+// by an attacker who controls those files.
+//
+// Build via tests/fuzz/CMakeLists.txt (libFuzzer requires clang and a
+// C++23 stdlib that provides std::expected).
+
+#include "../../src/deluge/util/semver.h"
+#include <cstdint>
+#include <cstdlib>
+#include <string_view>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+	std::string_view input(reinterpret_cast<const char*>(data), size);
+	auto result = SemVer::parse(input);
+	if (result.has_value()) {
+		// On success, every parsed numeric field must round-trip into a
+		// uint8_t with no information loss. The parser uses std::from_chars
+		// into a uint8_t directly so this is a tautology today, but the
+		// check guards against future refactors that widen the field.
+		volatile uint8_t consume = result->major ^ result->minor ^ result->patch;
+		(void)consume;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

Adds libFuzzer harnesses for two attacker-reachable parsers in the firmware that have small, self-contained dependency graphs:

- `tests/fuzz/pack_fuzz.c` covers `unpack_7bit_to_8bit`, `unpack_7to8_rle`, `pack_8bit_to_7bit`, and `pack_8to7_rle` in `src/deluge/util/pack.c`. Every SysEx parsing path on the device runs input through these routines first, so any OOB write here is reachable from USB-MIDI.
- `tests/fuzz/semver_fuzz.cpp` covers `SemVer::Parser` in `src/deluge/util/semver.cpp`. Firmware version strings come from files on the SD card.

Refactors `tests/fuzz/CMakeLists.txt` so all three targets (the existing `memmove_fuzz` plus the two new ones) share a single set of libFuzzer flags and require clang. Adds a README with build/run instructions and a list of wanted larger targets (`midiSysexReceived`, `JsonDeserializer`, `XMLDeserializer`, `AudioFile::loadFile`) that still need mock infrastructure before they can link.

## Build & smoke test

```
CC=clang CXX=clang++ cmake -B build/fuzz -S tests/fuzz
cmake --build build/fuzz
./build/fuzz/pack_fuzz   -max_len=8192 -runs=5000
./build/fuzz/semver_fuzz -max_len=128  -runs=5000
```

Both new harnesses build clean under `-fsanitize=fuzzer,address,undefined` and run 5000 iterations on cold parsers without finding crashes. That is a clean baseline, not a proof of absence; longer runs and a CI integration are the natural next steps.

## Test plan

- [ ] `CC=clang CXX=clang++ cmake -B build/fuzz -S tests/fuzz` configures cleanly on a fresh checkout
- [ ] `cmake --build build/fuzz` produces three executables
- [ ] Each harness runs `-runs=10000` without crashing on the seed corpus
- [ ] Existing build pipelines are unaffected (this directory is not added to the main test build)

## Notes for reviewers

Kept this PR intentionally small and orthogonal: the harnesses link only against `pack.c` and `semver.cpp` and use no project mocks. The four larger fuzz targets in the README will each need a separate mock-shim PR before they can land.