### PR TITLE
Validate firmware-load size in SysEx firstPacket()

### DIFF
--- a/src/deluge/io/midi/sysex.cpp
+++ b/src/deluge/io/midi/sysex.cpp
@@ -99,25 +99,51 @@ static uint8_t* load_buf;
 static size_t load_bufsize;
 static size_t load_codesize;
 
+// Generous upper bound on the firmware payload size that a SysEx load can
+// request. The Deluge firmware binary is well under 4 MiB; rejecting larger
+// values bounds what an attacker who has guessed or learned the dev-sysex
+// handshake can ask the allocator to do, and prevents a header with
+// user_code_end < user_code_start from wrapping the unsigned subtraction
+// into a near-4 GiB requested size.
+static constexpr size_t MAX_FIRMWARE_LOAD_SIZE = 4 * 1024 * 1024;
+
 static void firstPacket(uint8_t* data, int32_t len) {
 	uint8_t tmpbuf[0x40] __attribute__((aligned(CACHE_LINE_SIZE)));
 
 	unpack_7bit_to_8bit(tmpbuf, 0x40, data + 9, 0x4a);
 	uint32_t user_code_start = *(uint32_t*)(tmpbuf + OFF_USER_CODE_START);
 	uint32_t user_code_end = *(uint32_t*)(tmpbuf + OFF_USER_CODE_END);
-	load_codesize = (int32_t)(user_code_end - user_code_start);
-	if (load_bufsize < load_codesize) {
+
+	// Reject inverted, empty, or oversized ranges before doing any
+	// arithmetic on the unsigned difference.
+	if (user_code_end <= user_code_start) {
+		return;
+	}
+	size_t requested_codesize = (size_t)(user_code_end - user_code_start);
+	if (requested_codesize > MAX_FIRMWARE_LOAD_SIZE) {
+		return;
+	}
+
+	if (load_bufsize < requested_codesize) {
 		if (load_buf != nullptr) {
 			delugeDealloc(load_buf);
+			load_buf = nullptr;
 		}
-		load_bufsize = load_codesize + (511 - ((load_codesize - 1) & 511));
+		size_t requested_bufsize = requested_codesize + (511 - ((requested_codesize - 1) & 511));
 
-		load_buf = (uint8_t*)GeneralMemoryAllocator::get().allocMaxSpeed(load_bufsize);
-		if (load_buf == nullptr) {
-			// fail :(
+		uint8_t* new_buf = (uint8_t*)GeneralMemoryAllocator::get().allocMaxSpeed(requested_bufsize);
+		if (new_buf == nullptr) {
+			// Allocation failed. Keep load_buf and load_bufsize coherent so
+			// that loadPacketReceived's "pos + 512 > load_bufsize" check
+			// cannot pass against a stale (large) load_bufsize while load_buf
+			// is null or points at a smaller previous allocation.
+			load_bufsize = 0;
 			return;
 		}
+		load_buf = new_buf;
+		load_bufsize = requested_bufsize;
 	}
+	load_codesize = requested_codesize;
 
 	// Pad LED Progress Bar Init
 	PadLEDs::clearAllPadsWithoutSending();


### PR DESCRIPTION
## Summary

Follow-up to #4497, which flagged this in its description as a wanted next step.

`firstPacket()` in `src/deluge/io/midi/sysex.cpp` reads `user_code_start` and `user_code_end` from an attacker-supplied SysEx header and computes the load size as an unsigned subtraction with no sanity checks:

    load_codesize = (int32_t)(user_code_end - user_code_start);

If `user_code_end < user_code_start`, the unsigned subtraction wraps to ~4 GiB before the `int32_t` cast, and assigning back into `load_codesize` (`size_t`, 32-bit on this platform) preserves the wrapped value. The branch below then tries to allocate at that size and, on `allocMaxSpeed` failure, leaves `load_bufsize` updated to the new (large) value while `load_buf` is null or still points at a smaller previous allocation. A subsequent `loadPacketReceived()` then passes its `pos + 512 > load_bufsize` bounds check against the stale large value and unpacks 512 bytes into the smaller buffer, producing a heap overflow before `chainload_from_buf()` jumps into the loaded bytes.

Reaching this requires the `DevSysexAllowed` runtime feature flag and the matching handshake value, but those mitigations do not justify treating attacker-influenced 32-bit fields as trustworthy.

This PR tightens `firstPacket()` so:

- `user_code_end > user_code_start` is required
- the requested code size is capped at `MAX_FIRMWARE_LOAD_SIZE` (4 MiB; firmware is well under this)
- `load_buf` and `load_bufsize` stay coherent on allocation failure: both reset to "no buffer"
- `load_codesize` is updated only after a successful path so a rejected first packet doesn't leave a stale code size behind

Behaviour for legitimate firmware loads is unchanged.

## Deconfliction

I checked open and closed PRs and issues in this area before filing:

- #4497 (open): the SysEx identity-bounds fix; this PR is the follow-up that PR's description called out
- #1451 (merged 2024): refactored the loader-script size handling in `loadCheckAndRun()`. That change was orthogonal to input validation; this PR does not reintroduce the `WRONG_SIZE` comparison removed there.
- #4140/#4141 (merged): performance work for SysEx loading, unrelated.
- No open issues found describing this concern.

## Test plan

- [ ] Run a normal firmware load via `scripts/tasks/task-loadfw.py` and confirm it still succeeds end-to-end (handshake, all packets, CRC, chainload).
- [ ] Manually craft a SysEx first packet with `user_code_end < user_code_start` and confirm the device ignores it (no crash, no allocator pressure).
- [ ] Manually craft a first packet requesting a size above 4 MiB and confirm it is rejected.
- [ ] Confirm clang-format passes (workflow already enforces).

## Notes for reviewers

Kept the fix surgical: only `firstPacket()` is touched. The progress-bar divisor `(load_bufsize - 0xffff)` in `loadPacketReceived()` has its own oddities (potential division-by-near-zero when `load_bufsize` is small, plus an out-of-range `pad / 18` row index for some sizes) but those are display-only and worth a separate PR rather than mixing concerns here.