### PR TITLE
Small audio_file/wave_table/output bugfixes from audit

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -840,7 +840,8 @@ extern "C" int32_t deluge_main(void) {
 		int32_t fileSize = (uint32_t)getNoise() % 1000000;
 
 		char fileName[20];
-		strcpy(fineName, "TEST/") intToString(fileNumber, &fileName[5], 4);
+		strcpy(fileName, "TEST/");
+		intToString(fileNumber, &fileName[5], 4);
 		strcat(fileName, ".TXT");
 
 		result = f_open(&fil, fileName, FA_CREATE_ALWAYS | FA_WRITE);

--- a/src/deluge/model/output.cpp
+++ b/src/deluge/model/output.cpp
@@ -281,7 +281,7 @@ bool Output::writeDataToFile(Serializer& writer, Clip* clipForSavingOutputOnly, 
 				else {
 					clipCode = thisInstance->clip->indexForSaving;
 					if (thisInstance->clip->section == 255) {
-						clipCode |= (1 << 31);
+						clipCode |= ((uint32_t)1 << 31);
 					}
 				}
 

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -57,7 +57,7 @@ Error AudioFile::loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTab
 	// This stuff for AIFF files only
 	int16_t sustainLoopBeginMarkerId = -1;
 	int16_t sustainLoopEndMarkerId = -1;
-	uint16_t numMarkers;
+	uint16_t numMarkers = 0;
 	int16_t markerIDs[MAX_NUM_MARKERS];
 	uint32_t markerPositions[MAX_NUM_MARKERS];
 
@@ -143,14 +143,12 @@ doSetupWaveTable:
 				switch (bits) {
 				case 8:
 					rawDataFormat = RawDataFormat::UNSIGNED_8;
-					// No break
+					[[fallthrough]];
 				case 16:
 				case 24:
 				case 32:
 					byteDepth = bits >> 3;
 					break;
-				case 256 ... 65535:
-					__builtin_unreachable();
 				default:
 					return Error::FILE_UNSUPPORTED;
 				}

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -429,7 +429,7 @@ gotError5:
 			}                                                                                                          \
 			value32 &= bitMask;                                                                                        \
 			if (rawDataFormat == RawDataFormat::UNSIGNED_8) {                                                          \
-				value32 += (1 << 31);                                                                                  \
+				value32 += ((uint32_t)1 << 31);                                                                        \
 			}                                                                                                          \
 		}                                                                                                              \
 		*(cycleBufferDestination++) =                                                                                  \


### PR DESCRIPTION
## Summary

Three small, isolated bugfixes spotted during a static audit. Each is contained to one or two lines and addresses real undefined behaviour or actual broken code:

1. **Uninitialised `numMarkers` and reachable `__builtin_unreachable()` in AudioFile::loadFile** (`src/deluge/storage/audio/audio_file.cpp`). `numMarkers` is declared without an initializer but the AIFF post-MARK loop iterates `0..numMarkers` whenever a sustain-loop marker id was set, so a malformed AIFF without a MARK chunk read past the marker arrays with a garbage stack value. Separately, the WAV `fmt` chunk had a `case 256 ... 65535: __builtin_unreachable();` arm; the bit-depth field is read directly from the file as `uint16_t`, so the full 0..65535 range is reachable from a hostile WAV and the unreachable hint becomes UB. The `default` arm already returns `FILE_UNSUPPORTED`. Replace the `// No break` fallthrough comment with `[[fallthrough]]` while in the same switch.

2. **Signed shift into sign bit** (`src/deluge/model/output.cpp:284`, `src/deluge/storage/wave_table/wave_table.cpp:432`). `(1 << 31)` shifts a signed `1` into the sign bit, which is implementation-defined in C++17 and undefined earlier. Other places in the codebase use `((uint32_t)1 << 31)`; match that pattern.

3. **TEST_SD_WRITE block does not compile** (`src/deluge/deluge.cpp`). Inside `#ifdef TEST_SD_WRITE`, the buffer is `fileName` but `strcpy` writes to `fineName`, and the call is missing its terminating `;` so `intToString(...)` is parsed as a continuation. Fix the typo and split into two statements so the macro can be enabled when needed.

## Test plan

- [ ] Existing unit and integration tests pass
- [ ] clang-format passes
- [ ] Loading a known-good WAV and AIFF still works
- [ ] Loading a malformed AIFF (missing MARK chunk, sustain loop id set) no longer reads past marker arrays