### PR TITLE
Reject WAV/AIFF chunks that would overflow file position

### DIFF
--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -84,6 +84,17 @@ Error AudioFile::loadFile(AudioFileReader* reader, bool isAiff, bool makeWaveTab
 
 		uint32_t bytePosOfThisChunkData = reader->getBytePos();
 
+		// Reject chunks that would extend past the end of the file or wrap the
+		// 32-bit byte position. Either case means a malformed (or hostile)
+		// file rather than a real chunk; without this check, an attacker-
+		// supplied chunk length close to UINT32_MAX wraps bytePos to a small
+		// value or back behind bytePosOfThisChunkData, which prevents the
+		// while-loop from making forward progress and either spins or seeks
+		// backward through the file.
+		if (thisChunk.length > reader->fileSize - bytePosOfThisChunkData) {
+			return Error::FILE_UNSUPPORTED;
+		}
+
 		// Move on for next RIFF chunk
 		bytePos = bytePosOfThisChunkData + thisChunk.length;
 
@@ -293,6 +304,14 @@ doSetupWaveTable:
 					return error;
 				}
 				offset = swapEndianness32(offset);
+
+				// AIFF SSND has an 8-byte sub-header (offset + blockSize)
+				// followed by the audio data. Reject any offset that would
+				// underflow the audio-data length or push the start position
+				// past the end of the chunk.
+				if (offset > bytesCurrentChunkNotRoundedUp || bytesCurrentChunkNotRoundedUp - offset < 8) {
+					return Error::FILE_UNSUPPORTED;
+				}
 				audioDataLengthBytes = bytesCurrentChunkNotRoundedUp - offset - 8;
 
 				// If we're here, we found the data! Take note of where it starts


### PR DESCRIPTION
## Summary

Two integer-overflow shapes in `AudioFile::loadFile`, both reachable from a hostile WAV or AIFF file on the SD card.

1. The chunk-walking loop computes

       bytePos = bytePosOfThisChunkData + thisChunk.length

   in 32-bit arithmetic with `thisChunk.length` read directly from the file. A crafted chunk whose length is close to `UINT32_MAX` wraps `bytePos` either to a small value (so the next iteration of the while-loop satisfies `bytePos < reader->fileSize` and we keep going without progress) or to a position behind the start of the current chunk data (so the next read seeks backward). Both shapes manifest as the device hanging on SD card sample scan or sample preview.

2. AIFF SSND processing computes

       audioDataLengthBytes = bytesCurrentChunkNotRoundedUp - offset - 8

   where `offset` is read from the file. If `offset > bytesCurrentChunkNotRoundedUp - 8`, the unsigned subtraction underflows and `audioDataLengthBytes` becomes a near-4 GiB value that is then handed to the cluster cache and decoder.

Both fixes return `Error::FILE_UNSUPPORTED`, matching the pattern used elsewhere in this function (for example the strict COMM chunk length check at line 311).

## Deconfliction

Searched open and closed PRs and issues for AIFF, WAV chunk, audio_file, SSND, and integer overflow related work. No prior PR addresses this. The fuzz harnesses landed in #4498 do not yet cover this code (audio_file is one of the wanted follow-up targets), so this fix is independent.

## Test plan

- [ ] Loading a known-good WAV and AIFF still works
- [ ] A WAV with `chunk.length = 0xFFFFFFFE` returns `FILE_UNSUPPORTED` instead of hanging
- [ ] An AIFF SSND with `offset >= chunk_length - 8` returns `FILE_UNSUPPORTED`
- [ ] clang-format passes