### PR TITLE
WIP: Wavetable browser preview improvements

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -19,6 +19,7 @@
 #include "fatfs.hpp"
 #include "hid/button.h"
 #include "model/sample/sample.h"
+#include "storage/wave_table/wave_table.h"
 #include "util/try.h"
 #include <ranges>
 #undef __GNU_VISIBLE
@@ -278,6 +279,13 @@ void SampleBrowser::exitAction() {
 		}
 	}
 
+	// graphicsRoutine drives the wavetable LED animation off this flag, so stop animating immediately while we
+	// tear down. Critically, keep currentlyShowingSamplePreview = true here: closeUI() reads that via
+	// SampleBrowser::renderMainPads() to decide whether to walk the stack and repaint the underlying view.
+	// Clearing it before close (which is what the previous version of this function did) made closeUI skip the
+	// repaint, leaving the wavetable's last frame on the LEDs.
+	lastRenderedWavetableSlicePos.reset();
+
 	Browser::exitAction();
 
 	if (redrawUI) {
@@ -286,6 +294,12 @@ void SampleBrowser::exitAction() {
 }
 
 void SampleBrowser::graphicsRoutine() {
+	// During the horizontal slide-in transition, PadLEDs::image is owned by the scroll animation. Don't overwrite it
+	// with the swept wavetable frame — let the scroll complete first, then we resume animating from the next tick.
+	if (currentUIMode == UI_MODE_HORIZONTAL_SCROLL) {
+		Browser::graphicsRoutine();
+		return;
+	}
 	// While ping-pong wavetable preview is running, redraw the LED grid each graphics tick (~15 ms) showing the
 	// current swept slice. The audio engine publishes the position; we only re-render when it has moved noticeably,
 	// to keep PIC bandwidth low.
@@ -634,8 +648,26 @@ void SampleBrowser::previewIfPossible(int32_t movementDirection) {
 		// In wavetable-preview mode we animate the LED grid in graphicsRoutine() from the audio-engine's swept slice
 		// position, so the still-frame Sample waveform render below is skipped entirely.
 		if (previewingAsWavetable) {
+			uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 			lastRenderedWavetableSlicePos.reset();
 			currentlyShowingSamplePreview = true; // for cleanup-on-leave logic
+			// Mirror the sample-preview path's greyout reassessment; without it the underlying view's pads can be left
+			// in a stale greyout state when the preview ends.
+			PadLEDs::reassessGreyout(true);
+
+			// Horizontal slide-in matching the sample-preview path: render slice 0 of the new wavetable into
+			// imageStore, then hand off to PadLEDs::horizontal::setupScroll. graphicsRoutine() suppresses its
+			// per-tick wavetable repaint while UI_MODE_HORIZONTAL_SCROLL is active so it doesn't fight the scroll.
+			if (movementDirection && !qwertyAlwaysVisible) {
+				WaveTable* wt = AudioEngine::getPreviewWavetableState(nullptr);
+				if (wt != nullptr && waveformRenderer.renderWaveTableSlice(wt, 0.0f, PadLEDs::imageStore)) {
+					memset(PadLEDs::transitionTakingPlaceOnRow, 1, sizeof(PadLEDs::transitionTakingPlaceOnRow));
+					PadLEDs::horizontal::setupScroll(movementDirection, kDisplayWidth);
+					currentUIMode = UI_MODE_HORIZONTAL_SCROLL;
+				}
+			}
+
+			PadLEDs::sendOutSidebarColours();
 			didDraw = true;
 		}
 		// If the Sample at least loaded, even if we didn't sound it, then try to render its waveform.
@@ -2075,7 +2107,11 @@ static const uint32_t zoomUIModes[] = {UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON
 
 ActionResult SampleBrowser::horizontalEncoderAction(int32_t offset) {
 	// Or, maybe we want to scroll or zoom around the waveform...
-	if (currentlyShowingSamplePreview
+	// Skip this path for wavetable previews: currentlyShowingSamplePreview is set true there so closeUI() walks the
+	// stack correctly, but waveformBasicNavigator.sample is never set up on the wavetable path, so dereferencing it
+	// in renderFullScreen → findPeaksPerCol would fault. For wavetable previews horizontal scroll falls through to
+	// Browser::horizontalEncoderAction (file change).
+	if (currentlyShowingSamplePreview && AudioEngine::getPreviewWavetableState(nullptr) == nullptr
 	    && (isUIModeActive(UI_MODE_HOLDING_HORIZONTAL_ENCODER_BUTTON) || waveformBasicNavigator.isZoomedIn())) {
 
 		// We're quite likely going to need to read the SD card to do either scrolling or zooming
@@ -2121,6 +2157,23 @@ ActionResult SampleBrowser::horizontalEncoderAction(int32_t offset) {
 ActionResult SampleBrowser::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
 	if (Buttons::isShiftButtonPressed()) {
 		return Browser::verticalEncoderAction(offset, false);
+	}
+	// When a wavetable preview is active, "borrow" the vertical encoder to scrub the wave index manually: each
+	// detent moves one cycle forward/back, and the auto ping-pong pauses until the user picks a new file
+	// (horizontal scroll → stopAnyPreviewing → manual flag cleared).
+	float dummy;
+	if (WaveTable* wt = AudioEngine::getPreviewWavetableState(&dummy); wt != nullptr && wt->numCycles > 1) {
+		float current =
+		    AudioEngine::getPreviewWavetableManualActive() ? AudioEngine::getPreviewWavetableManualSlicePos() : dummy;
+		float newPos = current + (float)offset;
+		if (newPos < 0.0f) {
+			newPos = 0.0f;
+		}
+		if (newPos > (float)(wt->numCycles - 1)) {
+			newPos = (float)(wt->numCycles - 1);
+		}
+		AudioEngine::setPreviewWavetableManualSlicePos(newPos);
+		return ActionResult::DEALT_WITH;
 	}
 	if (getRootUI() == &instrumentClipView) {
 		if (Buttons::isShiftButtonPressed() || Buttons::isButtonPressed(deluge::hid::button::X_ENC)) {

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -113,6 +113,8 @@ bool SampleBrowser::opened() {
 
 	autoLoadEnabled = false;
 
+	lastRenderedWavetableSlicePos.reset();
+
 	if (display->haveOLED()) {
 		fileIndexSelected = 0;
 	}
@@ -281,6 +283,29 @@ void SampleBrowser::exitAction() {
 	if (redrawUI) {
 		uiNeedsRendering(redrawUI);
 	}
+}
+
+void SampleBrowser::graphicsRoutine() {
+	// While ping-pong wavetable preview is running, redraw the LED grid each graphics tick (~15 ms) showing the
+	// current swept slice. The audio engine publishes the position; we only re-render when it has moved noticeably,
+	// to keep PIC bandwidth low.
+	float pos = 0.0f;
+	WaveTable* wt = AudioEngine::getPreviewWavetableState(&pos);
+	if (wt == nullptr) {
+		Browser::graphicsRoutine();
+		return;
+	}
+	if (lastRenderedWavetableSlicePos.has_value()) {
+		float delta = pos - *lastRenderedWavetableSlicePos;
+		if (delta < 0.02f && delta > -0.02f) {
+			return;
+		}
+	}
+	if (!waveformRenderer.renderWaveTableSlice(wt, pos, PadLEDs::image)) {
+		return;
+	}
+	lastRenderedWavetableSlicePos = pos;
+	PadLEDs::sendOutMainPadColours();
 }
 
 ActionResult SampleBrowser::timerCallback() {
@@ -587,7 +612,12 @@ void SampleBrowser::previewIfPossible(int32_t movementDirection) {
 			}
 		}
 
-		AudioEngine::previewSample(&filePath, &currentFileItem->filePointer, shouldActuallySound);
+		bool asWavetable =
+		    soundEditor.currentSource != nullptr && soundEditor.currentSource->oscType == OscType::WAVETABLE;
+		AudioEngine::previewSample(&filePath, &currentFileItem->filePointer, shouldActuallySound, asWavetable);
+		// previewSample may silently fall back to sample mode if the file isn't loadable as a wavetable;
+		// re-read the actual mode rather than trusting our asWavetable hint.
+		bool previewingAsWavetable = AudioEngine::getPreviewWavetableState(nullptr) != nullptr;
 
 		if (autoLoadEnabled && getCurrentClip()->type != ClipType::AUDIO) {
 			// Feature: if Load has been toggled on, then the file will be auto-loaded into the current instrument
@@ -601,8 +631,16 @@ void SampleBrowser::previewIfPossible(int32_t movementDirection) {
 		}
 		*/
 
+		// In wavetable-preview mode we animate the LED grid in graphicsRoutine() from the audio-engine's swept slice
+		// position, so the still-frame Sample waveform render below is skipped entirely.
+		if (previewingAsWavetable) {
+			lastRenderedWavetableSlicePos.reset();
+			currentlyShowingSamplePreview = true; // for cleanup-on-leave logic
+			didDraw = true;
+		}
 		// If the Sample at least loaded, even if we didn't sound it, then try to render its waveform.
-		if (AudioEngine::sampleForPreview->sources[0].ranges.getNumElements() >= 1) {
+		else if (AudioEngine::sampleForPreview->sources[0].ranges.getNumElements() >= 1
+		         && AudioEngine::sampleForPreview->sources[0].oscType == OscType::SAMPLE) {
 			AudioFile* sample = ((MultisampleRange*)AudioEngine::sampleForPreview->sources[0].ranges.getElement(0))
 			                        ->sampleHolder.audioFile;
 

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -20,6 +20,7 @@
 #include "definitions_cxx.hpp"
 #include "gui/ui/browser/browser.h"
 #include "hid/button.h"
+#include <optional>
 
 extern "C" {
 
@@ -57,6 +58,7 @@ public:
 	bool importFolderAsKit();
 	bool importFolderAsMultisamples();
 	ActionResult timerCallback() override;
+	void graphicsRoutine() override;
 	bool claimCurrentFile(int32_t mayDoPitchDetection = 1, int32_t mayDoSingleCycle = 1, int32_t mayDoWaveTable = 1,
 	                      bool loadWithoutExiting = false); // 0 means no. 1 means auto. 2 means yes definitely
 	bool renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
@@ -96,6 +98,8 @@ private:
 	bool currentlyShowingSamplePreview;
 
 	bool qwertyCurrentlyDrawnOnscreen; // This will linger as true even when qwertyVisible has been set to false
+
+	std::optional<float> lastRenderedWavetableSlicePos;
 };
 
 extern SampleBrowser sampleBrowser;

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -28,6 +28,8 @@
 #include "storage/audio/audio_file_manager.h"
 #include "storage/cluster/cluster.h"
 #include "storage/multi_range/multisample_range.h"
+#include "storage/wave_table/wave_table.h"
+#include <algorithm>
 #include <optional>
 #include <string.h>
 
@@ -627,18 +629,125 @@ void WaveformRenderer::drawColBar(int32_t xDisplay, int32_t min24, int32_t max24
 	}
 }
 
+// Each WaveTableBand cycle is laid out as cycleSizeNoDuplicates real samples followed by a small wrap-padding
+// region used by the sinc-interpolating audio renderer. We only need the real samples for visualisation.
+constexpr int32_t kWaveTableBandCyclePaddingSamples = 7;
+
+bool WaveformRenderer::renderWaveTableSlice(WaveTable* waveTable, float slicePos,
+                                            RGB thisImage[][kDisplayWidth + kSideBarWidth]) {
+	if (waveTable == nullptr || waveTable->bands.getNumElements() == 0 || waveTable->numCycles < 1) {
+		return false;
+	}
+
+	// Pick a band that covers the cycle range we want and has the most samples-per-cycle for the best detail.
+	int32_t cycleA = (int32_t)slicePos;
+	if (cycleA < 0) {
+		cycleA = 0;
+	}
+	if (cycleA > waveTable->numCycles - 1) {
+		cycleA = waveTable->numCycles - 1;
+	}
+	int32_t cycleB = std::min(cycleA + 1, waveTable->numCycles - 1);
+	float frac = slicePos - (float)cycleA;
+	if (frac < 0.0f) {
+		frac = 0.0f;
+	}
+	if (frac > 1.0f) {
+		frac = 1.0f;
+	}
+
+	WaveTableBand* bestBand = nullptr;
+	for (int32_t b = 0; b < waveTable->bands.getNumElements(); b++) {
+		WaveTableBand* band = (WaveTableBand*)waveTable->bands.getElementAddress(b);
+		if (cycleA < band->fromCycleNumber || cycleB >= band->toCycleNumber) {
+			continue;
+		}
+		if (bestBand == nullptr || band->cycleSizeNoDuplicates > bestBand->cycleSizeNoDuplicates) {
+			bestBand = band;
+		}
+	}
+	if (bestBand == nullptr) {
+		return false;
+	}
+
+	int32_t stride = bestBand->cycleSizeNoDuplicates + kWaveTableBandCyclePaddingSamples;
+	int32_t cycleSize = bestBand->cycleSizeNoDuplicates;
+	const int16_t* dataA = &bestBand->dataAccessAddress[(cycleA - bestBand->fromCycleNumber) * stride];
+	const int16_t* dataB = &bestBand->dataAccessAddress[(cycleB - bestBand->fromCycleNumber) * stride];
+	int32_t fracQ16 = (int32_t)(frac * 65536.0f);
+
+	// Clear the display area we're about to write.
+	for (int32_t y = 0; y < kDisplayHeight; y++) {
+		memset(thisImage[y], 0, kDisplayWidth * sizeof(RGB));
+	}
+
+	// Populate WaveformRenderData with per-column peaks from the blended cycle, then render through the
+	// standard normalization pipeline (getColBarPositions + drawColBar) for auto-scaling and centering.
+	WaveformRenderData data;
+	int32_t overallMin = INT32_MAX;
+	int32_t overallMax = INT32_MIN;
+
+	for (int32_t col = 0; col < kDisplayWidth; col++) {
+		int32_t startSample = (col * cycleSize) / kDisplayWidth;
+		int32_t endSample = ((col + 1) * cycleSize) / kDisplayWidth;
+		if (endSample <= startSample) {
+			endSample = startSample + 1;
+		}
+
+		int32_t minVal = INT32_MAX;
+		int32_t maxVal = INT32_MIN;
+		for (int32_t s = startSample; s < endSample; s++) {
+			int32_t a = dataA[s];
+			int32_t b = dataB[s];
+			int32_t blended = a + (((b - a) * fracQ16) >> 16);
+			if (blended < minVal) {
+				minVal = blended;
+			}
+			if (blended > maxVal) {
+				maxVal = blended;
+			}
+		}
+
+		data.minPerCol[col] = minVal << 16;
+		data.maxPerCol[col] = maxVal << 16;
+		data.colStatus[col] = COL_STATUS_INVESTIGATED;
+
+		if (data.minPerCol[col] < overallMin) {
+			overallMin = data.minPerCol[col];
+		}
+		if (data.maxPerCol[col] > overallMax) {
+			overallMax = data.maxPerCol[col];
+		}
+	}
+
+	int32_t valueCentrePoint = (overallMax >> 1) + (overallMin >> 1);
+	int32_t valueSpan = (overallMax >> kDisplayHeightMagnitude) - (overallMin >> kDisplayHeightMagnitude);
+	if (valueSpan == 0) {
+		valueSpan = 1;
+	}
+
+	for (int32_t col = 0; col < kDisplayWidth; col++) {
+		renderOneCol(col, thisImage, &data, valueCentrePoint, valueSpan, false, std::nullopt);
+	}
+
+	return true;
+}
+
 void WaveformRenderer::renderOneCol(Sample* sample, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth],
                                     WaveformRenderData* data, bool reversed, std::optional<RGB> rgb) {
+	renderOneCol(xDisplay, thisImage, data, sample->getFoundValueCentrePoint(), sample->getValueSpan(), reversed, rgb);
+}
+
+void WaveformRenderer::renderOneCol(int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth],
+                                    WaveformRenderData* data, int32_t valueCentrePoint, int32_t valueSpan,
+                                    bool reversed, std::optional<RGB> rgb) {
 	int32_t min24, max24;
 	int32_t brightness = rgb ? 256 : 128;
 
 	int32_t xDisplaySource = reversed ? (kDisplayWidth - 1 - xDisplay) : xDisplay;
 
 	if (data->colStatus[xDisplaySource] == COL_STATUS_INVESTIGATED) {
-
-		getColBarPositions(xDisplaySource, data, &min24, &max24, sample->getFoundValueCentrePoint(),
-		                   sample->getValueSpan());
-
+		getColBarPositions(xDisplaySource, data, &min24, &max24, valueCentrePoint, valueSpan);
 		drawColBar(xDisplay, min24, max24, thisImage, brightness, rgb);
 	}
 }

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -720,10 +720,21 @@ bool WaveformRenderer::renderWaveTableSlice(WaveTable* waveTable, float slicePos
 		}
 	}
 
-	int32_t valueCentrePoint = (overallMax >> 1) + (overallMin >> 1);
-	int32_t valueSpan = (overallMax >> kDisplayHeightMagnitude) - (overallMin >> kDisplayHeightMagnitude);
-	if (valueSpan == 0) {
-		valueSpan = 1;
+	int32_t valueCentrePoint;
+	int32_t valueSpan;
+	if (waveTable->globalValueSpan > 0) {
+		// Use the wavetable's global amplitude bounds — silent cycles render dark, loud cycles render with full
+		// vertical range. Without this, each slice was auto-normalised to its own min/max so a silent tail looked
+		// like full peaks because tiny sub-LSB wiggle got stretched to fill the screen.
+		valueCentrePoint = waveTable->globalValueCentrePoint;
+		valueSpan = waveTable->globalValueSpan;
+	}
+	else {
+		valueCentrePoint = (overallMax >> 1) + (overallMin >> 1);
+		valueSpan = (overallMax >> kDisplayHeightMagnitude) - (overallMin >> kDisplayHeightMagnitude);
+		if (valueSpan == 0) {
+			valueSpan = 1;
+		}
 	}
 
 	for (int32_t col = 0; col < kDisplayWidth; col++) {

--- a/src/deluge/gui/waveform/waveform_renderer.h
+++ b/src/deluge/gui/waveform/waveform_renderer.h
@@ -25,6 +25,7 @@
 class Sample;
 class MultisampleRange;
 class SampleRecorder;
+class WaveTable;
 struct WaveformRenderData;
 
 struct MarkerColumn {
@@ -46,6 +47,9 @@ public:
 	                       SampleRecorder* recorder, RGB rgb, bool reversed, int32_t xStart, int32_t xEnd);
 	void renderOneCol(Sample* sample, int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth],
 	                  WaveformRenderData* data, bool reversed = false, std::optional<RGB> rgb = std::nullopt);
+	void renderOneCol(int32_t xDisplay, RGB thisImage[][kDisplayWidth + kSideBarWidth], WaveformRenderData* data,
+	                  int32_t valueCentrePoint, int32_t valueSpan, bool reversed = false,
+	                  std::optional<RGB> rgb = std::nullopt);
 	void renderOneColForCollapseAnimation(int32_t xDisplay, int32_t xDisplayOutput, int32_t maxPeakFromZero,
 	                                      int32_t progress, RGB thisImage[][kDisplayWidth + kSideBarWidth],
 	                                      WaveformRenderData* data, std::optional<RGB> rgb, bool reversed,
@@ -57,6 +61,11 @@ public:
 	                                               int32_t valueCentrePoint, int32_t valueSpan);
 	bool findPeaksPerCol(Sample* sample, int64_t xScroll, uint64_t xZoom, WaveformRenderData* data,
 	                     SampleRecorder* recorder = nullptr, int32_t xStart = 0, int32_t xEnd = kDisplayWidth);
+
+	/// Renders one cycle of a wavetable to the LED grid, blending between adjacent cycles per the fractional part
+	/// of `slicePos`. Used by the wavetable browser preview to animate the current swept slice in lock-step with
+	/// the audio. Returns true if drawn, false if the wavetable can't be drawn (e.g. no bands).
+	bool renderWaveTableSlice(WaveTable* waveTable, float slicePos, RGB thisImage[][kDisplayWidth + kSideBarWidth]);
 
 	int8_t collapseAnimationToWhichRow;
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -27,6 +27,7 @@
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/load/load_song_ui.h"
 #include "gui/ui/slicer.h"
+#include "gui/ui/sound_editor.h"
 #include "gui/ui_timer_manager.h"
 #include "gui/views/view.h"
 #include "hid/display/display.h"
@@ -41,7 +42,9 @@
 #include "model/song/song.h"
 #include "model/voice/voice.h"
 #include "model/voice/voice_sample.h"
+#include "modulation/automation/auto_param.h"
 #include "modulation/envelope.h"
+#include "modulation/params/param_set.h"
 #include "modulation/patch/patch_cable_set.h"
 #include "processing/audio_output.h"
 #include "processing/engines/cv_engine.h"
@@ -50,12 +53,15 @@
 #include "processing/sound/sound.h"
 #include "processing/sound/sound_drum.h"
 #include "processing/sound/sound_instrument.h"
+#include "processing/source.h"
 #include "processing/stem_export/stem_export.h"
 #include "scheduler_api.h"
 #include "storage/audio/audio_file_manager.h"
 #include "storage/flash_storage.h"
+#include "storage/multi_range/multi_wave_table_range.h"
 #include "storage/multi_range/multisample_range.h"
 #include "storage/storage_manager.h"
+#include "storage/wave_table/wave_table.h"
 #include "timers_interrupts/timers_interrupts.h"
 #include "util/functions.h"
 #include "util/misc.h"
@@ -155,6 +161,17 @@ int32_t timeLastPopup{0};
 
 SoundDrum* sampleForPreview;
 ParamManagerForTimeline* paramManagerForSamplePreview;
+
+// Wavetable browse-preview ping-pong state. Active while sampleForPreview is in OscType::WAVETABLE.
+constexpr uint32_t kPreviewWavetableHalfPeriodSamples = kSampleRate * 2; // 2 s per direction
+constexpr float kPreviewWavetableDwellFraction = 0.4f;                   // hold each integer slice for 40% of segment
+bool previewWavetableActive = false;
+uint32_t previewWavetablePhaseSamples = 0;
+// Read by the LED preview renderer in SampleBrowser. Written by renderSamplePreview() on the audio thread; the
+// reader uses these values opportunistically — slight tearing is harmless because the LED render only needs a
+// "near-current" position to look animated.
+WaveTable* previewWavetableHandle = nullptr;
+float previewWavetableSlicePos = 0.0f;
 
 PLACE_SDRAM_BSS char paramManagerForSamplePreviewMemory[sizeof(ParamManagerForTimeline)];
 PLACE_SDRAM_BSS char sampleForPreviewMemory[sizeof(SoundDrum)];
@@ -833,12 +850,79 @@ void renderReverb(size_t numSamples) {
 		logAction("Reverb complete");
 	}
 }
+// Smooth ping-pong with per-slice dwell. tri ∈ [0, 1] sweeps linearly up and down; this pulls it toward integer
+// slice positions for the first kPreviewWavetableDwellFraction of each unit segment, then smoothsteps from one
+// slice to the next over the remainder. Returns a position in [0, numCycles - 1].
+static float shapedPingPongPosition(uint32_t phase, int32_t numCycles) {
+	if (numCycles <= 1) {
+		return 0.0f;
+	}
+	uint32_t fullPeriod = 2u * kPreviewWavetableHalfPeriodSamples;
+	uint32_t inPeriod = phase % fullPeriod;
+	float tri;
+	if (inPeriod < kPreviewWavetableHalfPeriodSamples) {
+		tri = (float)inPeriod / (float)kPreviewWavetableHalfPeriodSamples;
+	}
+	else {
+		tri = 2.0f - (float)inPeriod / (float)kPreviewWavetableHalfPeriodSamples;
+	}
+	float continuousPos = tri * (float)(numCycles - 1);
+	int32_t segInt = (int32_t)continuousPos; // continuousPos ≥ 0, so truncation == floor
+	float seg = (float)segInt;
+	float frac = continuousPos - seg;
+	float shaped;
+	if (frac < kPreviewWavetableDwellFraction) {
+		shaped = 0.0f;
+	}
+	else {
+		float t = (frac - kPreviewWavetableDwellFraction) / (1.0f - kPreviewWavetableDwellFraction);
+		shaped = t * t * (3.0f - 2.0f * t); // smoothstep
+	}
+	float pos = seg + shaped;
+	if (pos > (float)(numCycles - 1)) {
+		pos = (float)(numCycles - 1);
+	}
+	return pos;
+}
+
 void renderSamplePreview(size_t numSamples) { // Previewing sample
 	std::span renderingBuffer{renderingMemory.data(), numSamples};
 	std::span reverbBuffer{reverbMemory.data(), numSamples};
 
 	if (getCurrentUI() == &sampleBrowser || getCurrentUI() == &gui::context_menu::sample_browser::kit
 	    || getCurrentUI() == &gui::context_menu::sample_browser::synth || getCurrentUI() == &slicer) {
+
+		// Drive the wave-index parameter for ping-pong wavetable preview.
+		if (previewWavetableActive && sampleForPreview->sources[0].oscType == OscType::WAVETABLE) {
+			MultiWaveTableRange* range = nullptr;
+			if (sampleForPreview->sources[0].ranges.getNumElements() > 0) {
+				range = (MultiWaveTableRange*)sampleForPreview->sources[0].ranges.getElement(0);
+			}
+			WaveTable* waveTable = (range != nullptr) ? (WaveTable*)range->waveTableHolder.audioFile : nullptr;
+			int32_t numCycles = (waveTable != nullptr) ? waveTable->numCycles : 0;
+			if (numCycles > 1) {
+				float pos = shapedPingPongPosition(previewWavetablePhaseSamples, numCycles);
+				// Map pos ∈ [0, numCycles-1] to the patched-param value such that Voice's waveIndex
+				// (sourceWaveIndexLastTime + 2^30) sweeps the table from cycle 0 to cycle numCycles-1.
+				// Derivation: WaveTable::render expects waveIndex ∈ [0, 2^31] to span the cycle range.
+				float normalised = pos / (float)(numCycles - 1); // [0, 1]
+				int64_t paramValue = (int64_t)(normalised * 2147483647.0f) - 1073741824;
+				// setCurrentValueBasicForSetup skips the param LPF and change-notify path; that's deliberate —
+				// shapedPingPongPosition is already a continuous curve and our update granularity (one render
+				// window, ~3ms) is below audible zipper threshold for this param.
+				paramManagerForSamplePreview->getPatchedParamSet()
+				    ->params[params::LOCAL_OSC_A_WAVE_INDEX]
+				    .setCurrentValueBasicForSetup((int32_t)paramValue);
+				// Force paramFinalValues to be re-derived. Without this, the per-window performPatching()
+				// would skip this param since nothing in the patcher's "sources changed" mask flips.
+				sampleForPreview->recalculatePatchingToParam(params::LOCAL_OSC_A_WAVE_INDEX,
+				                                             paramManagerForSamplePreview);
+				// Publish for the LED preview renderer.
+				previewWavetableHandle = waveTable;
+				previewWavetableSlicePos = pos;
+			}
+			previewWavetablePhaseSamples += (uint32_t)numSamples;
+		}
 
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithThreeMainThings* modelStack = setupModelStackWithThreeMainThingsButNoNoteRow(
@@ -1343,18 +1427,80 @@ void registerSideChainHit(int32_t strength) {
 	sideChainHitPending = combineHitStrengths(strength, sideChainHitPending);
 }
 
-void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySound) {
-	stopAnyPreviewing();
-	MultisampleRange* range = (MultisampleRange*)sampleForPreview->sources[0].getOrCreateFirstRange();
-	if (!range) {
-		return;
+// Configure paramManagerForSamplePreview's envelope and oscillator state for either sample or wavetable preview.
+// Switching adjusts oscType, repeatMode, envelope sustain/release, and resets the wave-index parameter so the
+// ping-pong driver in renderSamplePreview() starts at slice 0.
+static void configurePreviewSoundForMode(bool asWavetable) {
+	PatchedParamSet* patchedParams = paramManagerForSamplePreview->getPatchedParamSet();
+
+	if (asWavetable) {
+		if (sampleForPreview->sources[0].oscType != OscType::WAVETABLE) {
+			sampleForPreview->sources[0].setOscType(OscType::WAVETABLE);
+		}
+		sampleForPreview->sources[0].repeatMode = SampleRepeatMode::LOOP;
+		// Long sustain so the voice keeps playing across the ping-pong sweep.
+		patchedParams->params[params::LOCAL_ENV_0_SUSTAIN].setCurrentValueBasicForSetup(2147483647);
+		patchedParams->params[params::LOCAL_ENV_0_RELEASE].setCurrentValueBasicForSetup(
+		    getParamFromUserValue(params::LOCAL_ENV_0_RELEASE, 30));
+		// Centre the wave-index param; renderSamplePreview() will overwrite this each block while ping-pong is active.
+		patchedParams->params[params::LOCAL_OSC_A_WAVE_INDEX].setCurrentValueBasicForSetup(0);
 	}
-	range->sampleHolder.filePath.set(path);
-	Error error = range->sampleHolder.loadFile(false, true, true, CLUSTER_LOAD_IMMEDIATELY, filePointer);
+	else {
+		if (sampleForPreview->sources[0].oscType != OscType::SAMPLE) {
+			sampleForPreview->sources[0].setOscType(OscType::SAMPLE);
+		}
+		// Restore the sample-preview envelope defaults from setupAsSample().
+		patchedParams->params[params::LOCAL_ENV_0_SUSTAIN].setCurrentValueBasicForSetup(
+		    getParamFromUserValue(params::LOCAL_ENV_0_SUSTAIN, 50));
+		patchedParams->params[params::LOCAL_ENV_0_RELEASE].setCurrentValueBasicForSetup(
+		    getParamFromUserValue(params::LOCAL_ENV_0_RELEASE, 0));
+	}
+}
+
+void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySound, bool asWavetable) {
+	stopAnyPreviewing();
+
+	configurePreviewSoundForMode(asWavetable);
+
+	AudioFileHolder* holder;
+	Error error;
+	if (asWavetable) {
+		MultiWaveTableRange* range = (MultiWaveTableRange*)sampleForPreview->sources[0].getOrCreateFirstRange();
+		if (!range) {
+			return;
+		}
+		holder = &range->waveTableHolder;
+		holder->filePath.set(path);
+		// makeWaveTableWorkAtAllCosts=true so unmarked but plausible single-cycle WAVs still preview as wavetables.
+		error = holder->loadFile(false, true, true, CLUSTER_LOAD_IMMEDIATELY, filePointer, true);
+		if (error == Error::FILE_NOT_LOADABLE_AS_WAVETABLE
+		    || error == Error::FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO) {
+			// Fall back to sample preview.
+			configurePreviewSoundForMode(false);
+			MultisampleRange* sampleRange = (MultisampleRange*)sampleForPreview->sources[0].getOrCreateFirstRange();
+			if (!sampleRange) {
+				return;
+			}
+			sampleRange->sampleHolder.filePath.set(path);
+			error = sampleRange->sampleHolder.loadFile(false, true, true, CLUSTER_LOAD_IMMEDIATELY, filePointer);
+			asWavetable = false;
+		}
+	}
+	else {
+		MultisampleRange* range = (MultisampleRange*)sampleForPreview->sources[0].getOrCreateFirstRange();
+		if (!range) {
+			return;
+		}
+		range->sampleHolder.filePath.set(path);
+		error = range->sampleHolder.loadFile(false, true, true, CLUSTER_LOAD_IMMEDIATELY, filePointer);
+	}
 
 	if (error != Error::NONE) {
 		display->displayError(error); // Rare, shouldn't cause later problems.
 	}
+
+	previewWavetableActive = asWavetable && error == Error::NONE;
+	previewWavetablePhaseSamples = 0;
 
 	if (shouldActuallySound) {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
@@ -1369,9 +1515,23 @@ void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySo
 void stopAnyPreviewing() {
 	sampleForPreview->killAllVoices();
 	if (sampleForPreview->sources[0].ranges.getNumElements()) {
-		MultisampleRange* range = (MultisampleRange*)sampleForPreview->sources[0].ranges.getElement(0);
-		range->sampleHolder.setAudioFile(nullptr);
+		MultiRange* range = (MultiRange*)sampleForPreview->sources[0].ranges.getElement(0);
+		range->getAudioFileHolder()->setAudioFile(nullptr);
 	}
+	previewWavetableActive = false;
+	previewWavetablePhaseSamples = 0;
+	previewWavetableHandle = nullptr;
+	previewWavetableSlicePos = 0.0f;
+}
+
+WaveTable* getPreviewWavetableState(float* slicePos) {
+	if (!previewWavetableActive) {
+		return nullptr;
+	}
+	if (slicePos != nullptr) {
+		*slicePos = previewWavetableSlicePos;
+	}
+	return previewWavetableHandle;
 }
 
 void getReverbParamsFromSong(Song* song) {

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -67,6 +67,7 @@
 #include "util/misc.h"
 #include <algorithm>
 #include <bits/ranges_algo.h>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <execution>
@@ -167,6 +168,10 @@ constexpr uint32_t kPreviewWavetableHalfPeriodSamples = kSampleRate * 2; // 2 s 
 constexpr float kPreviewWavetableDwellFraction = 0.4f;                   // hold each integer slice for 40% of segment
 bool previewWavetableActive = false;
 uint32_t previewWavetablePhaseSamples = 0;
+// Manual scrub: when active, renderSamplePreview() uses previewWavetableManualPos as the slice index instead of
+// running the ping-pong. Set by SampleBrowser's vertical encoder; cleared on stopAnyPreviewing (file change).
+bool previewWavetableManualActive = false;
+float previewWavetableManualPos = 0.0f;
 // Read by the LED preview renderer in SampleBrowser. Written by renderSamplePreview() on the audio thread; the
 // reader uses these values opportunistically — slight tearing is harmless because the LED render only needs a
 // "near-current" position to look animated.
@@ -901,7 +906,19 @@ void renderSamplePreview(size_t numSamples) { // Previewing sample
 			WaveTable* waveTable = (range != nullptr) ? (WaveTable*)range->waveTableHolder.audioFile : nullptr;
 			int32_t numCycles = (waveTable != nullptr) ? waveTable->numCycles : 0;
 			if (numCycles > 1) {
-				float pos = shapedPingPongPosition(previewWavetablePhaseSamples, numCycles);
+				float pos;
+				if (previewWavetableManualActive) {
+					pos = previewWavetableManualPos;
+					if (pos < 0.0f) {
+						pos = 0.0f;
+					}
+					if (pos > (float)(numCycles - 1)) {
+						pos = (float)(numCycles - 1);
+					}
+				}
+				else {
+					pos = shapedPingPongPosition(previewWavetablePhaseSamples, numCycles);
+				}
 				// Map pos ∈ [0, numCycles-1] to the patched-param value such that Voice's waveIndex
 				// (sourceWaveIndexLastTime + 2^30) sweeps the table from cycle 0 to cycle numCycles-1.
 				// Derivation: WaveTable::render expects waveIndex ∈ [0, 2^31] to span the cycle range.
@@ -1454,7 +1471,75 @@ static void configurePreviewSoundForMode(bool asWavetable) {
 		    getParamFromUserValue(params::LOCAL_ENV_0_SUSTAIN, 50));
 		patchedParams->params[params::LOCAL_ENV_0_RELEASE].setCurrentValueBasicForSetup(
 		    getParamFromUserValue(params::LOCAL_ENV_0_RELEASE, 0));
+		// Restore default pitch — the wavetable path may have shifted it down.
+		sampleForPreview->sources[0].transpose = 0;
+		sampleForPreview->sources[0].setCents(0);
 	}
+}
+
+// Pitch the wavetable preview so one stored cycle plays in exactly cycleSize output samples (i.e. the file would
+// sound the same as if it were played as raw PCM at the engine's native sample rate). At kNoteForDrum (60) the
+// wavetable would otherwise render at C4 = 261.63 Hz regardless of cycle length, which is many octaves above
+// the file's "intended" pitch.
+static void applyWavetablePitchForNativeRate(WaveTable* waveTable) {
+	if (waveTable == nullptr || waveTable->bands.getNumElements() == 0) {
+		return;
+	}
+	auto* band = (WaveTableBand*)waveTable->bands.getElementAddress(0);
+	int32_t cycleSize = band->cycleSizeNoDuplicates;
+	if (cycleSize <= 0) {
+		return;
+	}
+	// freq at note 60 = 440 * 2^((60 - 69) / 12) ≈ 261.6256 Hz. Target freq = kSampleRate / cycleSize.
+	constexpr float kFreqAtNoteForDrum = 261.6255653005986f;
+	float totalCents = 1200.0f * std::log2((float)kSampleRate / ((float)cycleSize * kFreqAtNoteForDrum));
+	int32_t totalCentsRounded = (int32_t)std::lround(totalCents);
+	int32_t transpose =
+	    totalCentsRounded / 100; // truncates toward zero, which is what we want for cents in (-100, 100)
+	int32_t cents = totalCentsRounded - transpose * 100;
+	sampleForPreview->sources[0].transpose = (int16_t)transpose;
+	sampleForPreview->sources[0].setCents(cents);
+}
+
+// Build a preview-only WaveTable: single-band, no FFT mipmap, NOT inserted into wavetableFiles. Reuses any cached
+// Sample (so re-previewing the same file is cheap). Caller owns lifetime — stopAnyPreviewing destroys it.
+static WaveTable* loadPreviewWavetable(String* path, FilePointer* filePointer, Error* errorOut) {
+	*errorOut = Error::NONE;
+	auto sampleResult =
+	    audioFileManager.getAudioFileFromFilename(*path, true, filePointer, AudioFileType::SAMPLE, false);
+	if (!sampleResult.has_value()) {
+		*errorOut = sampleResult.error();
+		return nullptr;
+	}
+	auto* sample = (Sample*)sampleResult.value();
+	if (sample == nullptr) {
+		*errorOut = Error::FILE_UNREADABLE;
+		return nullptr;
+	}
+	if (sample->numChannels != 1) {
+		*errorOut = Error::FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO;
+		return nullptr;
+	}
+	void* mem = GeneralMemoryAllocator::get().allocStealable(sizeof(WaveTable));
+	if (!mem) {
+		*errorOut = Error::INSUFFICIENT_RAM;
+		return nullptr;
+	}
+	auto* wt = new (mem) WaveTable;
+	wt->addReason(); // Keep alive while setup() runs and against mid-setup steal.
+	Error err = wt->setup(sample, 0, 0, 0, 0, RawDataFormat::NATIVE, nullptr, /*fastPreview=*/true);
+	if (err != Error::NONE) {
+		wt->~WaveTable();
+		delugeDealloc(mem);
+		*errorOut = err;
+		return nullptr;
+	}
+	wt->filePath.set(path);
+	wt->finalizeAfterLoad(sample->audioDataLengthBytes); // mirrors AudioFileManager's normal load path
+	wt->removeReason("E_PV1");                           // back to 0; holder will addReason on setAudioFile.
+	// Deliberately NOT inserted into audioFileManager.wavetableFiles — preview-only wavetables don't pollute
+	// the song-wide cache, and stopAnyPreviewing eagerly destroys them when the holder releases its reason.
+	return wt;
 }
 
 void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySound, bool asWavetable) {
@@ -1462,20 +1547,21 @@ void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySo
 
 	configurePreviewSoundForMode(asWavetable);
 
-	AudioFileHolder* holder;
-	Error error;
+	Error error = Error::NONE;
 	if (asWavetable) {
 		MultiWaveTableRange* range = (MultiWaveTableRange*)sampleForPreview->sources[0].getOrCreateFirstRange();
 		if (!range) {
 			return;
 		}
-		holder = &range->waveTableHolder;
+		AudioFileHolder* holder = &range->waveTableHolder;
 		holder->filePath.set(path);
-		// makeWaveTableWorkAtAllCosts=true so unmarked but plausible single-cycle WAVs still preview as wavetables.
-		error = holder->loadFile(false, true, true, CLUSTER_LOAD_IMMEDIATELY, filePointer, true);
-		if (error == Error::FILE_NOT_LOADABLE_AS_WAVETABLE
-		    || error == Error::FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO) {
-			// Fall back to sample preview.
+		WaveTable* wt = loadPreviewWavetable(path, filePointer, &error);
+		if (wt != nullptr) {
+			holder->setAudioFile(wt); // addReason for the holder.
+		}
+		else if (error == Error::FILE_NOT_LOADABLE_AS_WAVETABLE
+		         || error == Error::FILE_NOT_LOADABLE_AS_WAVETABLE_BECAUSE_STEREO) {
+			// Fall back to sample preview — file isn't wavetable-shaped.
 			configurePreviewSoundForMode(false);
 			MultisampleRange* sampleRange = (MultisampleRange*)sampleForPreview->sources[0].getOrCreateFirstRange();
 			if (!sampleRange) {
@@ -1502,6 +1588,18 @@ void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySo
 	previewWavetableActive = asWavetable && error == Error::NONE;
 	previewWavetablePhaseSamples = 0;
 
+	if (previewWavetableActive) {
+		auto* range = (MultiWaveTableRange*)sampleForPreview->sources[0].ranges.getElement(0);
+		auto* wt = (WaveTable*)range->waveTableHolder.audioFile;
+		applyWavetablePitchForNativeRate(wt);
+		// Publish the handle synchronously. renderSamplePreview() also writes this on each audio tick, but the UI
+		// thread queries getPreviewWavetableState() the moment previewSample() returns — if we wait for the audio
+		// thread to publish, that race leaves previewWavetableHandle == nullptr just long enough for the caller's
+		// "is this a wavetable preview?" check to read false (skipping the SHORTCUT_BLINK unset + scroll setup).
+		previewWavetableHandle = wt;
+		previewWavetableSlicePos = 0.0f;
+	}
+
 	if (shouldActuallySound) {
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithThreeMainThings* modelStack = setupModelStackWithThreeMainThingsButNoNoteRow(
@@ -1514,14 +1612,46 @@ void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySo
 
 void stopAnyPreviewing() {
 	sampleForPreview->killAllVoices();
+	AudioFile* prevFile = nullptr;
 	if (sampleForPreview->sources[0].ranges.getNumElements()) {
 		MultiRange* range = (MultiRange*)sampleForPreview->sources[0].ranges.getElement(0);
+		prevFile = range->getAudioFileHolder()->audioFile;
 		range->getAudioFileHolder()->setAudioFile(nullptr);
+	}
+	// Preview WaveTables are allocated outside the audioFileManager.wavetableFiles cache; once the holder
+	// drops its reason no other reference exists, so they'd otherwise linger in stealable memory and fragment
+	// it after dozens of files browsed. Destroy + free now. Samples stay in the sample cache (snappy
+	// back-scroll, sample data is small and cluster-reclaimable under pressure).
+	if (prevFile != nullptr && prevFile->type == AudioFileType::WAVETABLE && prevFile->numReasonsToBeLoaded <= 0
+	    && !audioFileManager.wavetableFiles.contains(&prevFile->filePath)) {
+		prevFile->~AudioFile();
+		delugeDealloc(prevFile);
 	}
 	previewWavetableActive = false;
 	previewWavetablePhaseSamples = 0;
 	previewWavetableHandle = nullptr;
 	previewWavetableSlicePos = 0.0f;
+	previewWavetableManualActive = false;
+	previewWavetableManualPos = 0.0f;
+	// Reset any pitch offset applied by applyWavetablePitchForNativeRate so the next sample preview is not detuned.
+	sampleForPreview->sources[0].transpose = 0;
+	sampleForPreview->sources[0].setCents(0);
+}
+
+void setPreviewWavetableManualSlicePos(float pos) {
+	previewWavetableManualActive = true;
+	previewWavetableManualPos = pos;
+	// Mirror into the public slicePos so the LED graphicsRoutine renders the chosen slice immediately on the next
+	// graphics tick, without having to wait a full audio render to sync.
+	previewWavetableSlicePos = pos;
+}
+
+float getPreviewWavetableManualSlicePos() {
+	return previewWavetableManualPos;
+}
+
+bool getPreviewWavetableManualActive() {
+	return previewWavetableManualActive;
 }
 
 WaveTable* getPreviewWavetableState(float* slicePos) {

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -42,6 +42,7 @@ class Voice;
 class VoiceSample;
 class TimeStretcher;
 class String;
+class WaveTable;
 class SideChain;
 class VoiceVector;
 class Freeverb;
@@ -142,8 +143,12 @@ void routineWithClusterLoading(bool mayProcessUserActionsBetween = false);
 void runRoutine();
 
 void init();
-void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySound);
+void previewSample(String* path, FilePointer* filePointer, bool shouldActuallySound, bool asWavetable = false);
 void stopAnyPreviewing();
+
+/// Returns the WaveTable currently being previewed in ping-pong mode, plus the current shaped slice position
+/// in [0, numCycles - 1]. nullptr if not in wavetable-preview mode.
+WaveTable* getPreviewWavetableState(float* slicePos);
 
 void songSwapAboutToHappen();
 void killAllVoices(bool deletingSong = false);

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -150,6 +150,13 @@ void stopAnyPreviewing();
 /// in [0, numCycles - 1]. nullptr if not in wavetable-preview mode.
 WaveTable* getPreviewWavetableState(float* slicePos);
 
+/// Manual scrub for the wavetable browse preview: pins the played/displayed slice to pos and pauses the ping-pong
+/// sweep. Cleared automatically by stopAnyPreviewing (i.e. on every new file selection), so a single horizontal
+/// scroll resumes auto-animation.
+void setPreviewWavetableManualSlicePos(float pos);
+float getPreviewWavetableManualSlicePos();
+bool getPreviewWavetableManualActive();
+
 void songSwapAboutToHappen();
 void killAllVoices(bool deletingSong = false);
 void logAction(char const* string);

--- a/src/deluge/storage/audio/audio_file.cpp
+++ b/src/deluge/storage/audio/audio_file.cpp
@@ -265,9 +265,22 @@ doSetupWaveTable:
 
 				if ((*(uint32_t*)data & 0x00FFFFFF) == charsToIntegerConstant('<', '!', '>', 0)) {
 					fileExplicitlySpecifiesSelfAsWaveTable = true;
-					int32_t number = memToUIntOrError(&data[3], &data[7]);
-
-					if (number >= 1) {
+					// Parse digits up to the first non-digit. memToUIntOrError() rejects the whole field if any
+					// byte is non-numeric, which silently fails on perfectly valid 1–3-digit cycle sizes like
+					// "<!>128 …" (data[3..6] = '1','2','8',' ' → returns -1 → cycle size falls back to 2048).
+					// Vital/Serum happen to always write 4 digits so nobody noticed.
+					int32_t number = 0;
+					bool gotAnyDigit = false;
+					for (int32_t i = 3; i < 7; i++) {
+						if (data[i] >= '0' && data[i] <= '9') {
+							number = number * 10 + (data[i] - '0');
+							gotAnyDigit = true;
+						}
+						else {
+							break;
+						}
+					}
+					if (gotAnyDigit && number >= 1) {
 						waveTableCycleSize = number;
 						D_PRINTLN("clm tag num samples per cycle:  %d", waveTableCycleSize);
 					}

--- a/src/deluge/storage/wave_table/wave_table.cpp
+++ b/src/deluge/storage/wave_table/wave_table.cpp
@@ -138,7 +138,7 @@ void dft_r2c(ne10_fft_cpx_int32_t* __restrict__ out, int32_t const* __restrict__
 
 Error WaveTable::setup(Sample* sample, int32_t rawFileCycleSize, uint32_t audioDataStartPosBytes,
                        uint32_t audioDataLengthBytes, int32_t byteDepth, RawDataFormat rawDataFormat,
-                       WaveTableReader* reader) {
+                       WaveTableReader* reader, bool fastPreview) {
 	AudioEngine::logAction("WaveTable::setup");
 
 	uint32_t originalSampleLengthInSamples;
@@ -235,8 +235,17 @@ tryGettingFFTConfig:
 	// numBands is set such that the "smallest" band will have 8 samples per cycle. Not 4 - because NE10 can't do FFTs
 	// that small unless we enable its additional C code, which would take up program size for little advantage.
 	{
-		int32_t numBands =
-		    fftCFGForInitialBand ? ((initialBandCycleMagnitude - 2) >> (NUM_OCTAVES_BETWEEN_WAVETABLE_BANDS - 1)) : 1;
+		int32_t numBands;
+		if (fastPreview) {
+			// Browse-preview path: one raw band, no mipmap mip-levels, no FFT processing. The render engine
+			// picks bands by phase increment — at preview pitch (~native sample rate) band 0 always wins.
+			numBands = 1;
+		}
+		else {
+			numBands = fftCFGForInitialBand
+			               ? ((initialBandCycleMagnitude - 2) >> (NUM_OCTAVES_BETWEEN_WAVETABLE_BANDS - 1))
+			               : 1;
+		}
 
 		// Don't refer to numBands after this! (Why? Because we might end up using less after all?)
 		error = bands.insertAtIndex(0, numBands);
@@ -291,6 +300,16 @@ gotError2:
 #else
 		                          1.25;
 #endif
+	}
+
+	// Browse-preview path: no FFT harmonic scan ever runs, so the per-cycle toCycleNumber update at the bottom of
+	// the cycle loop never fires. Mark band 0 as covering the full range up front, and raise maxPhaseIncrement to
+	// the max so any preview pitch lands on it (the single-band setup has no fallback bands to pick from).
+	if (fastPreview) {
+		auto* singleBand = (WaveTableBand*)bands.getElementAddress(0);
+		singleBand->fromCycleNumber = 0;
+		singleBand->toCycleNumber = numCycles;
+		singleBand->maxPhaseIncrement = 0xFFFFFFFF;
 	}
 
 	AudioEngine::logAction("bands set up");
@@ -747,6 +766,37 @@ transformBandToTimeDomain:
 		numCycleTransitionsNextPowerOf2 = 1 << numCycleTransitionsNextPowerOf2Magnitude;
 
 		waveIndexMultiplier = numCycleTransitions << (31 - numCycleTransitionsNextPowerOf2Magnitude);
+	}
+
+	// Compute global amplitude bounds so the preview LED renderer can normalise across the whole wavetable
+	// instead of per-cycle. Only done for fastPreview — the regular path produces multi-band data where global
+	// bounds aren't directly useful.
+	if (fastPreview && bands.getNumElements() >= 1) {
+		auto* band0 = (WaveTableBand*)bands.getElementAddress(0);
+		int32_t stride = band0->cycleSizeNoDuplicates + WAVETABLE_NUM_DUPLICATE_SAMPLES_AT_END_OF_CYCLE;
+		int16_t const* data = band0->dataAccessAddress;
+		int32_t overallMin = INT32_MAX;
+		int32_t overallMax = INT32_MIN;
+		for (int32_t c = 0; c < numCycles; c++) {
+			int16_t const* cyc = data + (int32_t)c * stride;
+			for (int32_t i = 0; i < band0->cycleSizeNoDuplicates; i++) {
+				int32_t v = (int32_t)cyc[i] << 16; // match the <<16 scaling used downstream in renderWaveTableSlice
+				if (v < overallMin) {
+					overallMin = v;
+				}
+				if (v > overallMax) {
+					overallMax = v;
+				}
+			}
+		}
+		if (overallMin >= overallMax) {
+			overallMax = overallMin + 1;
+		}
+		globalValueCentrePoint = (overallMax >> 1) + (overallMin >> 1);
+		globalValueSpan = (overallMax >> kDisplayHeightMagnitude) - (overallMin >> kDisplayHeightMagnitude);
+		if (globalValueSpan <= 0) {
+			globalValueSpan = 1;
+		}
 	}
 
 	// Dispose of temp memory

--- a/src/deluge/storage/wave_table/wave_table.h
+++ b/src/deluge/storage/wave_table/wave_table.h
@@ -50,7 +50,8 @@ public:
 	                int32_t waveIndexIncrement);
 	Error setup(Sample* sample, int32_t nativeNumSamplesPerCycle = 0, uint32_t audioDataStartPosBytes = 0,
 	            uint32_t audioDataLengthBytes = 0, int32_t byteDepth = 0,
-	            RawDataFormat rawDataFormat = RawDataFormat::NATIVE, WaveTableReader* reader = nullptr);
+	            RawDataFormat rawDataFormat = RawDataFormat::NATIVE, WaveTableReader* reader = nullptr,
+	            bool fastPreview = false);
 	void deleteAllBandsAndData();
 	void bandDataBeingStolen(WaveTableBandData* bandData);
 
@@ -65,6 +66,12 @@ public:
 	int32_t numCycleTransitionsNextPowerOf2Magnitude;
 	int32_t waveIndexMultiplier;
 	OrderedResizeableArrayWith32bitKey bands;
+
+	// Global amplitude bounds across all cycles, populated by fastPreview setup. Lets renderWaveTableSlice draw
+	// silent cycles as silent instead of auto-normalising tiny wiggle into full-screen peaks. Zero values mean
+	// "not computed; fall back to per-slice normalisation" (preserves behaviour for non-preview wavetables).
+	int32_t globalValueCentrePoint = 0;
+	int32_t globalValueSpan = 0;
 
 protected:
 	void numReasonsIncreasedFromZero() override;


### PR DESCRIPTION
WIP. Wavetable browse preview: ping-pong slice sweep with LED sync, file-native playback pitch, single-band fast load (no FFT mipmaps), uncached so memory doesn't fragment under heavy browsing, vertical-encoder slice scrub, global LED amplitude normalisation, plus a Serum `clm ` parser fix that accepts 1-3 digit cycle sizes.