### PR TITLE
DRAFT: Fill change fix 

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -572,6 +572,13 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 		return instrumentClipView.handleNoteRowEditorButtonAction(b, on, inCardRoutine);
 	}
 
+	else if (b == deluge::hid::button::SYNC_SCALING
+	         && runtimeFeatureSettings.get(RuntimeFeatureSettingType::SyncScalingAction)
+	                == RuntimeFeatureStateSyncScalingAction::Fill) {
+		currentSong->changeFillMode(on);
+		return ActionResult::DEALT_WITH;
+	}
+
 	else {
 		MenuItem* currentMenuItem = getCurrentMenuItem();
 		HorizontalMenu* asHorizontal = nullptr;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3996,9 +3996,9 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 					}
 				}
 				// Wrap around for FILL when at max value
-				else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL) {
-					parameterValue = parameterMinValue;
-					parameterHasBeenEdited = true;
+				else if (parameter_value == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL) {
+					parameter_value = parameterMinValue;
+					parameter_has_been_edited = true;
 				}
 			}
 			// Decrementing
@@ -4078,7 +4078,7 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 			displayIterance(Iterance::fromInt(parameter_value));
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
-			displayFill(parameterValue);
+			displayFill(parameter_value);
 		}
 	}
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2965,6 +2965,10 @@ void InstrumentClipView::adjustNoteParameterValue(int32_t withOffset, int32_t wi
 
 	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE);
 
+	bool isFillChange = Buttons::isButtonPressed(deluge::hid::button::SYNC_SCALING)
+	                    && (runtimeFeatureSettings.get(RuntimeFeatureSettingType::SyncScalingAction)
+	                        == RuntimeFeatureStateSyncScalingAction::Fill);
+
 	// If just one press...
 	if (numEditPadPresses == 1) {
 		// Find it
@@ -3011,7 +3015,7 @@ void InstrumentClipView::adjustNoteParameterValue(int32_t withOffset, int32_t wi
 				}
 
 				// If editing, continue edit
-				if (hasPopup || inNoteEditor) {
+				if (hasPopup || inNoteEditor || isFillChange) {
 					Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
 					if (!action) {
 						return;
@@ -3055,6 +3059,12 @@ void InstrumentClipView::adjustNoteParameterValue(int32_t withOffset, int32_t wi
 									parameterValue++;
 									parameterHasBeenEdited = true;
 								}
+							}
+							// Wrap around for FILL when at max value
+							else if (parameterValue == parameterMaxValue
+							         && changeType == CORRESPONDING_NOTES_SET_FILL) {
+								parameterValue = parameterMinValue;
+								parameterHasBeenEdited = true;
 							}
 						}
 						// Decrementing
@@ -3231,7 +3241,7 @@ multiplePresses:
 		}
 
 		// If editing, continue edit
-		if (hasPopup || inNoteEditor) {
+		if (hasPopup || inNoteEditor || isFillChange) {
 			Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
 			if (!action) {
 				return;
@@ -3259,6 +3269,11 @@ multiplePresses:
 								prevBase = false;
 							}
 						}
+					}
+					// Wrap around for FILL when at max value
+					else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL) {
+						parameterValue = parameterMinValue;
+						parameterHasBeenEdited = true;
 					}
 				}
 				// Decrementing

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3472,14 +3472,14 @@ void InstrumentClipView::displayFill(uint8_t mode) {
 	}
 }
 
-const char* InstrumentClipView::getFillString(uint8_t mode) {
+const char* InstrumentClipView::getFillString(uint8_t fill) {
 	// FILL mode
-	if (mode == FILL) {
+	if (fill == FILL) {
 		return "FILL";
 	}
 
 	// NO-FILL mode
-	if (mode == NOT_FILL) {
+	if (fill == NOT_FILL) {
 		return "NOT FILL";
 	}
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3395,6 +3395,9 @@ multiplePresses:
 		else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
 			displayIterance(Iterance::fromInt(parameterValue));
 		}
+		else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
+			displayFill(parameterValue);
+		}
 	}
 }
 
@@ -3455,14 +3458,27 @@ void InstrumentClipView::displayIterance(Iterance iterance) {
 	}
 }
 
-const char* InstrumentClipView::getFillString(uint8_t fill) {
+void InstrumentClipView::displayFill(uint8_t mode) {
+	char buffer[(display->haveOLED()) ? 29 : 5];
+
+	strcpy(buffer, getFillString(mode));
+
+	if (display->haveOLED()) {
+		display->popupText(buffer, PopupType::FILL);
+	}
+	else {
+		display->displayPopup(buffer, 0, true, 255, 1, PopupType::FILL);
+	}
+}
+
+const char* InstrumentClipView::getFillString(uint8_t mode) {
 	// FILL mode
-	if (fill == FILL) {
+	if (mode == FILL) {
 		return "FILL";
 	}
 
 	// NO-FILL mode
-	if (fill == NOT_FILL) {
+	if (mode == NOT_FILL) {
 		return "NOT FILL";
 	}
 
@@ -3910,7 +3926,8 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 		return -1; // Get out if NoteRow doesn't exist and can't be created
 	}
 
-	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE);
+	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE)
+	                || display->hasPopupOfType(PopupType::FILL);
 
 	uint16_t original_parameter{0};
 	bool parameter_has_been_edited = false;
@@ -3977,6 +3994,11 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 						parameter_value++;
 						parameter_has_been_edited = true;
 					}
+				}
+				// Wrap around for FILL when at max value
+				else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL) {
+					parameterValue = parameterMinValue;
+					parameterHasBeenEdited = true;
 				}
 			}
 			// Decrementing
@@ -4054,6 +4076,9 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
 			displayIterance(Iterance::fromInt(parameter_value));
+		}
+		else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
+			displayFill(parameterValue);
 		}
 	}
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3061,8 +3061,8 @@ void InstrumentClipView::adjustNoteParameterValue(int32_t withOffset, int32_t wi
 								}
 							}
 							// Wrap around for FILL when at max value
-							else if (parameterValue == parameterMaxValue
-							         && changeType == CORRESPONDING_NOTES_SET_FILL) {
+							else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL
+							         && !inNoteEditor) {
 								parameterValue = parameterMinValue;
 								parameterHasBeenEdited = true;
 							}
@@ -3271,7 +3271,8 @@ multiplePresses:
 						}
 					}
 					// Wrap around for FILL when at max value
-					else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL) {
+					else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL
+					         && !inNoteEditor) {
 						parameterValue = parameterMinValue;
 						parameterHasBeenEdited = true;
 					}
@@ -3996,7 +3997,8 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 					}
 				}
 				// Wrap around for FILL when at max value
-				else if (parameter_value == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL) {
+				else if (parameter_value == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL
+				         && !inNoteRowEditor) {
 					parameter_value = parameterMinValue;
 					parameter_has_been_edited = true;
 				}

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -371,6 +371,7 @@ private:
 	void nudgeNotes(int32_t offset);
 	void displayProbability(uint8_t probability, bool prevBase);
 	void displayIterance(Iterance iterance);
+	void displayFill(uint8_t mode);
 
 	// note row functions
 	void copyNotes(Serializer* writer, bool selectedDrumOnly = false);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -331,26 +331,29 @@ doEndMidiLearnPressSession:
 	else if (b == SYNC_SCALING) {
 		if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::SyncScalingAction)
 		     == RuntimeFeatureStateSyncScalingAction::Fill)) {
+			// If currently in the sound editor note editor / note row editor, keep this button as the global
+			// fill-mode toggle rather than changing note fill values.
+			if (getCurrentUI() == &soundEditor && (soundEditor.inNoteEditor() || soundEditor.inNoteRowEditor())) {
+				currentSong->changeFillMode(on);
+				return ActionResult::DEALT_WITH;
+			}
+
 			// If notes pressed, adjust note fill
 			if (on && (currentUIMode == UI_MODE_NOTES_PRESSED || instrumentClipView.numEditPadPresses > 0)) {
-				currentSong->changeFillMode(on);
 				instrumentClipView.adjustNoteFillWithOffset(1);
 				return ActionResult::DEALT_WITH;
 			}
 			else if (on && (currentUIMode == UI_MODE_AUDITIONING)) {
-				currentSong->changeFillMode(on);
 				instrumentClipView.setNoteRowFillWithOffset(1);
-				return ActionResult::DEALT_WITH;
-			}
-			else if (!on && (currentUIMode == UI_MODE_NOTES_PRESSED || instrumentClipView.numEditPadPresses > 0)) {
-				currentSong->changeFillMode(on);
 				return ActionResult::DEALT_WITH;
 			}
 			else {
 				currentSong->changeFillMode(on);
 			}
 		}
-		else if (on && currentUIMode == UI_MODE_NONE) {
+		else if (on
+		         && (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING
+		             || currentUIMode == UI_MODE_NOTES_PRESSED)) {
 
 			if (playbackHandler.recording == RecordingMode::ARRANGEMENT) {
 cant:
@@ -364,7 +367,7 @@ cant:
 
 			// If no scaling currently, start it, if we're on a Clip-minder screen
 			if (!currentSong->getSyncScalingClip()) {
-				if (!getCurrentUI()->toClipMinder()) {
+				if (!(getCurrentUI()->toClipMinder() || getRootUI()->toClipMinder())) {
 					indicator_leds::indicateAlertOnLed(IndicatorLED::CLIP_VIEW);
 					return ActionResult::DEALT_WITH;
 				}

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -335,7 +335,11 @@ doEndMidiLearnPressSession:
 			if (on && (currentUIMode == UI_MODE_NOTES_PRESSED || instrumentClipView.numEditPadPresses > 0)) {
 				currentSong->changeFillMode(on);
 				instrumentClipView.adjustNoteFillWithOffset(1);
-				uiNeedsRendering(&instrumentClipView, 0xFFFFFFFF, 0);
+				return ActionResult::DEALT_WITH;
+			}
+			else if (on && (currentUIMode == UI_MODE_AUDITIONING)) {
+				currentSong->changeFillMode(on);
+				instrumentClipView.setNoteRowFillWithOffset(1);
 				return ActionResult::DEALT_WITH;
 			}
 			else if (!on && (currentUIMode == UI_MODE_NOTES_PRESSED || instrumentClipView.numEditPadPresses > 0)) {

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -331,7 +331,20 @@ doEndMidiLearnPressSession:
 	else if (b == SYNC_SCALING) {
 		if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::SyncScalingAction)
 		     == RuntimeFeatureStateSyncScalingAction::Fill)) {
-			currentSong->changeFillMode(on);
+			// If notes pressed, adjust note fill
+			if (on && (currentUIMode == UI_MODE_NOTES_PRESSED || instrumentClipView.numEditPadPresses > 0)) {
+				currentSong->changeFillMode(on);
+				instrumentClipView.adjustNoteFillWithOffset(1);
+				uiNeedsRendering(&instrumentClipView, 0xFFFFFFFF, 0);
+				return ActionResult::DEALT_WITH;
+			}
+			else if (!on && (currentUIMode == UI_MODE_NOTES_PRESSED || instrumentClipView.numEditPadPresses > 0)) {
+				currentSong->changeFillMode(on);
+				return ActionResult::DEALT_WITH;
+			}
+			else {
+				currentSong->changeFillMode(on);
+			}
 		}
 		else if (on && currentUIMode == UI_MODE_NONE) {
 

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -23,6 +23,8 @@ enum class PopupType {
 	PROBABILITY,
 	/// Popup shown when editing note or row iterance.
 	ITERANCE,
+	/// Popup shown when editing note or row fill.
+	FILL,
 	/// Swing amount and interval
 	SWING,
 	/// Tempo


### PR DESCRIPTION
fix #3886


Still needs some testing, but following UseCases were successfully tested:

- Holding 1+ Notes + press SyncScaling Iterates over the FILL Values with wrap around for the pressed notes
- Holding Audition Pad  + press SyncScaling Iterates over the FILL Values with wrap around for the corresponding Row
- Pressing SyncScaling inside Menu's (Note/Row Editor, Song Menu, Settings) activates Fill-Mode
- Change FILL-Mode in Note/Row Editor Menu does not wrap around