### PR TITLE
Fix incorrect reading of kit affect entire cc's from midi follow file

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -1068,11 +1068,11 @@ void MidiFollow::writeDefaultMappingsToFile() {
 		char const* paramNameSound;
 		char const* paramNameGlobal;
 		if (soundParamId != PARAM_ID_NONE && soundParamId < params::UNPATCHED_START) {
-			paramNameSound = params::paramNameForFile(params::Kind::PATCHED, soundParamId);
+			paramNameSound = params::paramNameForFile(params::Kind::PATCHED, soundParamId, true);
 			writeTag = true;
 		}
 		else if (soundParamId != PARAM_ID_NONE && soundParamId >= params::UNPATCHED_START) {
-			paramNameSound = params::paramNameForFile(params::Kind::UNPATCHED_SOUND, soundParamId);
+			paramNameSound = params::paramNameForFile(params::Kind::UNPATCHED_SOUND, soundParamId, true);
 			writeTag = true;
 		}
 		if (writeTag) {
@@ -1082,8 +1082,8 @@ void MidiFollow::writeDefaultMappingsToFile() {
 		}
 		else {
 			if (globalParamId != PARAM_ID_NONE) {
-				paramNameGlobal =
-				    params::paramNameForFile(params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_START + globalParamId);
+				paramNameGlobal = params::paramNameForFile(params::Kind::UNPATCHED_GLOBAL,
+				                                           params::UNPATCHED_START + globalParamId, true);
 				writeTag = strcmp(paramNameGlobal, paramNameSound) != 0;
 			}
 			if (writeTag) {
@@ -1161,7 +1161,7 @@ void MidiFollow::readDefaultMappingsFromFile(Deserializer& reader) {
 		int32_t value = reader.readTagOrAttributeValueInt();
 		// Loop through patched sound params
 		for (uint8_t paramId = 0; paramId < params::GLOBAL_NONE; paramId++) {
-			if (!strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED, paramId))) {
+			if (!strcmp(tagName, params::paramNameForFile(params::Kind::PATCHED, paramId, true))) {
 				soundParamToCC[paramId] = value;
 				ccToSoundParam[value] = paramId;
 				foundParam = true;
@@ -1172,7 +1172,7 @@ void MidiFollow::readDefaultMappingsFromFile(Deserializer& reader) {
 			// Loop through unpatched sound params (if not found before)
 			for (uint8_t paramId = 0; paramId < params::UNPATCHED_SOUND_MAX_NUM; paramId++) {
 				if (!strcmp(tagName, params::paramNameForFile(params::Kind::UNPATCHED_SOUND,
-				                                              params::UNPATCHED_START + paramId))) {
+				                                              params::UNPATCHED_START + paramId, true))) {
 					soundParamToCC[params::UNPATCHED_START + paramId] = value;
 					ccToSoundParam[value] = params::UNPATCHED_START + paramId;
 					foundParam = true;
@@ -1182,8 +1182,8 @@ void MidiFollow::readDefaultMappingsFromFile(Deserializer& reader) {
 		}
 		// Loop through global params
 		for (uint8_t paramId = 0; paramId < params::UNPATCHED_GLOBAL_MAX_NUM; paramId++) {
-			if (!strcmp(tagName,
-			            params::paramNameForFile(params::Kind::UNPATCHED_GLOBAL, params::UNPATCHED_START + paramId))) {
+			if (!strcmp(tagName, params::paramNameForFile(params::Kind::UNPATCHED_GLOBAL,
+			                                              params::UNPATCHED_START + paramId, true))) {
 				globalParamToCC[paramId] = value;
 				ccToGlobalParam[value] = paramId;
 				break;

--- a/src/deluge/modulation/params/param.cpp
+++ b/src/deluge/modulation/params/param.cpp
@@ -368,7 +368,7 @@ bool paramNeedsLPF(ParamType p, bool fromAutomation) {
 	}
 }
 
-constexpr char const* paramNameForFileConst(Kind const kind, ParamType const param) {
+constexpr char const* paramNameForFileConst(Kind const kind, ParamType const param, bool forMidiFollowFile = false) {
 	using enum Kind;
 	if (kind == UNPATCHED_SOUND && param >= UNPATCHED_START + UNPATCHED_NUM_SHARED) {
 		// Unpatched params just for Sounds
@@ -420,12 +420,18 @@ constexpr char const* paramNameForFileConst(Kind const kind, ParamType const par
 			return "reverbAmount";
 
 		case UNPATCHED_VOLUME:
+			if (forMidiFollowFile) {
+				return "volumePostFX";
+			}
 			return "volume";
 
 		case UNPATCHED_SIDECHAIN_VOLUME:
 			return "sidechainCompressorVolume";
 
 		case UNPATCHED_PITCH_ADJUST:
+			if (forMidiFollowFile) {
+				return "pitch";
+			}
 			return "pitchAdjust";
 
 		// explicit fallthrough cases
@@ -692,8 +698,8 @@ constexpr char const* paramNameForFileConst(Kind const kind, ParamType const par
 
 	return "none";
 }
-char const* paramNameForFile(Kind const kind, ParamType const param) {
-	return paramNameForFileConst(kind, param);
+char const* paramNameForFile(Kind const kind, ParamType const param, bool forMidiFollowFile) {
+	return paramNameForFileConst(kind, param, forMidiFollowFile);
 }
 constexpr ParamType fileStringToParamConst(Kind kind, char const* name, bool allowPatched) {
 	int32_t start = allowPatched ? 0 : UNPATCHED_START;

--- a/src/deluge/modulation/params/param.h
+++ b/src/deluge/modulation/params/param.h
@@ -287,7 +287,7 @@ bool paramNeedsLPF(ParamType p, bool fromAutomation);
 /// UNPATCHED_START. The Kind is used to distinguish between UNPATCHED_Sound
 /// (when kind == UNPATCHED_SOUND) and UNPATCHED_GlobalEffectable (when kind == UNPATCHED_GLOBAL) as these
 /// two sub-ranges would otherwise overlap.
-char const* paramNameForFile(Kind kind, ParamType param);
+char const* paramNameForFile(Kind kind, ParamType param, bool forMidiFollowFile = false);
 
 /// Given a string and the expected Kind, attempts to find the ParamType value for that param.
 ///


### PR DESCRIPTION
Fixed issue where it would not read the cc's to control kit affect entire global params for volume and pitch because it was trying to match against different param name strings

We only write one string per cc to the midi follow file