### PR TITLE
Fix osc 2 wavetable index being incorrectly mapped to osc 1's CC in midi follow defaults

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -135,8 +135,8 @@ void MidiFollow::initDefaultMappings() {
 	soundParamToCC[params::LOCAL_OSC_B_PHASE_WIDTH] = 28;
 	ccToSoundParam[29] = params::LOCAL_CARRIER_1_FEEDBACK;
 	soundParamToCC[params::LOCAL_CARRIER_1_FEEDBACK] = 29;
-	ccToSoundParam[30] = params::LOCAL_OSC_A_WAVE_INDEX;
-	soundParamToCC[params::LOCAL_OSC_A_WAVE_INDEX] = 30;
+	ccToSoundParam[30] = params::LOCAL_OSC_B_WAVE_INDEX;
+	soundParamToCC[params::LOCAL_OSC_B_WAVE_INDEX] = 30;
 	ccToSoundParam[36] = params::UNPATCHED_START + params::UNPATCHED_REVERSE_PROBABILITY;
 	soundParamToCC[params::UNPATCHED_START + params::UNPATCHED_REVERSE_PROBABILITY] = 36;
 	ccToSoundParam[37] = params::UNPATCHED_START + params::UNPATCHED_SPREAD_VELOCITY;


### PR DESCRIPTION
- In the hardcoded MIDI follow default mappings, CC 30 was assigned to `LOCAL_OSC_A_WAVE_INDEX` instead of `LOCAL_OSC_B_WAVE_INDEX`. CC 30 sits at the end of the osc 2 parameter block (CC 26 = osc 2 volume, 28 = osc 2 phase width, 29 = carrier 1 feedback), mirroring osc 1's block where CC 25 controls its wave index.

- This caused two issues:
  1. Sending CC 30 moved osc 1's wavetable position, and osc 2's wasn't controllable via MIDI follow at all.
  2. The reverse mapping for osc 1's wave index was overwritten from CC 25 to CC 30, so MIDI feedback for that param reported the wrong CC.
  
- Fixed by mapping CC 30 to `LOCAL_OSC_B_WAVE_INDEX` in both directions, matching the documented default in `MIDIFollow.XML`.