### PR TITLE
fix UB where hi =< low in clamp

### DIFF
--- a/src/deluge/gui/menu_item/patch_cables.cpp
+++ b/src/deluge/gui/menu_item/patch_cables.cpp
@@ -121,7 +121,8 @@ void PatchCables::selectEncoderAction(int32_t offset) {
 	currentValue = newValue;
 
 	if (display->haveOLED()) {
-		scrollPos = std::clamp<int>(newValue - 1, 0, set->numPatchCables - kOLEDMenuNumOptionsVisible);
+		int32_t max = std::max<int32_t>(0, set->numPatchCables - kOLEDMenuNumOptionsVisible);
+		scrollPos = std::clamp<int32_t>(newValue - 1, 0, max);
 	}
 
 	readValueAgain(); // redraw


### PR DESCRIPTION
Fixes #4491 

Validated on hardware: repro before patch, no repro after