### PR TITLE
Fix dangling midi-follow reference to destroyed Clip

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1843,6 +1843,9 @@ void SessionView::removeClip(Clip* clip) {
 
 	clip->stopAllNotesPlaying(currentSong); // Stops any MIDI-controlled auditioning / stuck notes
 
+	// Scrub the clip from MIDI-follow's note-off routing cache. ~Clip() also does this, but only covers the case where
+	// removeSessionClip() destructs the clip - if it has arranger instances the clip is kept as arrangement-only and
+	// never destructed, so we must scrub it here.
 	midiFollow.removeClip(clip);
 	currentSong->removeSessionClip(clip, clipIndex);
 

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -21,6 +21,7 @@
 #include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "io/debug/log.h"
+#include "io/midi/midi_follow.h"
 #include "memory/general_memory_allocator.h"
 #include "model/action/action_logger.h"
 #include "model/clip/audio_clip.h"
@@ -77,6 +78,8 @@ Clip::~Clip() {
 	if (getCurrentClip() == this) {
 		currentSong->setCurrentClip(nullptr);
 	}
+	// Ensure MIDI-follow doesn't keep a dangling pointer to this Clip for routing note-offs
+	midiFollow.removeClip(this);
 }
 
 // This is more exhaustive than copyBasicsFrom(), and is designed to be used *between* different Clip types, just for


### PR DESCRIPTION
Use-after-free bug where midi-follow would try to route a note-off to an already-deleted Clip.

Not validated on hardware yet.