### PR TITLE
Fix DIN device disappearing when scrolling MIDI devices menu

### DIFF
--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -52,7 +52,7 @@ void Devices::beginSession(MenuItem* navigatedBackwardFrom) {
 
 	soundEditor.currentMIDICable = getCable(this->getValue());
 	if (display->haveOLED()) {
-		currentScroll = this->getValue();
+		currentScroll_ = this->getValue();
 	}
 	else {
 		drawValue();
@@ -86,8 +86,8 @@ void Devices::selectEncoderAction(int32_t offset) {
 	// Don't show devices which aren't connected. Sometimes we won't even have a name to display for them.
 
 	if (display->haveOLED()) {
-		if (this->getValue() < currentScroll) {
-			currentScroll = this->getValue();
+		if (this->getValue() < currentScroll_) {
+			currentScroll_ = this->getValue();
 		}
 		//
 		if (offset >= 0) {
@@ -95,7 +95,7 @@ void Devices::selectEncoderAction(int32_t offset) {
 			int32_t numSeen = 1;
 			while (d > lowestDeviceNum) {
 				d--;
-				if (d == currentScroll) {
+				if (d == currentScroll_) {
 					break;
 				}
 				auto device = getCable(d);
@@ -104,7 +104,7 @@ void Devices::selectEncoderAction(int32_t offset) {
 				}
 				numSeen++;
 				if (numSeen >= kOLEDMenuNumOptionsVisible) {
-					currentScroll = d;
+					currentScroll_ = d;
 					break;
 				}
 			}
@@ -154,7 +154,7 @@ void Devices::drawPixelsForOled() {
 
 	int32_t selectedRow = -1;
 
-	int32_t device_idx = currentScroll;
+	int32_t device_idx = currentScroll_;
 	size_t row = 0;
 	while (row < kOLEDMenuNumOptionsVisible && device_idx < MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
 		MIDICable* cable = getCable(device_idx);

--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -53,7 +53,7 @@ void Devices::beginSession(MenuItem* navigatedBackwardFrom) {
 
 	soundEditor.currentMIDICable = getCable(this->getValue());
 	if (display->haveOLED()) {
-		currentScroll_ = this->getValue();
+		current_scroll_ = this->getValue();
 	}
 	else {
 		drawValue();
@@ -87,14 +87,14 @@ void Devices::selectEncoderAction(int32_t offset) {
 	// Don't show devices which aren't connected. Sometimes we won't even have a name to display for them.
 
 	if (display->haveOLED()) {
-		currentScroll_ = std::min(this->getValue(), currentScroll_);
+		current_scroll_ = std::min(this->getValue(), current_scroll_);
 		//
 		if (offset >= 0) {
 			int32_t d = this->getValue();
 			int32_t numSeen = 1;
 			while (d > lowestDeviceNum) {
 				d--;
-				if (d == currentScroll_) {
+				if (d == current_scroll_) {
 					break;
 				}
 				auto device = getCable(d);
@@ -103,7 +103,7 @@ void Devices::selectEncoderAction(int32_t offset) {
 				}
 				numSeen++;
 				if (numSeen >= kOLEDMenuNumOptionsVisible) {
-					currentScroll_ = d;
+					current_scroll_ = d;
 					break;
 				}
 			}
@@ -153,7 +153,7 @@ void Devices::drawPixelsForOled() {
 
 	int32_t selectedRow = -1;
 
-	int32_t device_idx = currentScroll_;
+	int32_t device_idx = current_scroll_;
 	size_t row = 0;
 	while (row < kOLEDMenuNumOptionsVisible && device_idx < MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
 		MIDICable* cable = getCable(device_idx);

--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -25,6 +25,7 @@
 #include "io/midi/cable_types/usb_hosted.h"
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_device_manager.h"
+#include <algorithm>
 #include <etl/vector.h>
 #include <string_view>
 
@@ -86,9 +87,7 @@ void Devices::selectEncoderAction(int32_t offset) {
 	// Don't show devices which aren't connected. Sometimes we won't even have a name to display for them.
 
 	if (display->haveOLED()) {
-		if (this->getValue() < currentScroll_) {
-			currentScroll_ = this->getValue();
-		}
+		currentScroll_ = std::min(this->getValue(), currentScroll_);
 		//
 		if (offset >= 0) {
 			int32_t d = this->getValue();

--- a/src/deluge/gui/menu_item/midi/devices.h
+++ b/src/deluge/gui/menu_item/midi/devices.h
@@ -32,7 +32,7 @@ public:
 	void drawPixelsForOled();
 
 private:
-	int32_t currentScroll;
+	int32_t currentScroll_ = 0;
 };
 
 extern Devices devicesMenu;

--- a/src/deluge/gui/menu_item/midi/devices.h
+++ b/src/deluge/gui/menu_item/midi/devices.h
@@ -32,7 +32,7 @@ public:
 	void drawPixelsForOled();
 
 private:
-	size_t currentScroll;
+	int32_t currentScroll;
 };
 
 extern Devices devicesMenu;

--- a/src/deluge/gui/menu_item/midi/devices.h
+++ b/src/deluge/gui/menu_item/midi/devices.h
@@ -32,7 +32,7 @@ public:
 	void drawPixelsForOled();
 
 private:
-	int32_t currentScroll_ = 0;
+	int32_t current_scroll_ = 0;
 };
 
 extern Devices devicesMenu;


### PR DESCRIPTION
  **Issue:** In Settings → MIDI → Devices on OLED, scrolling down past DIN and then scrolling back up never brought DIN (or the upstream USB ports) back into view, and the selection highlight vanished.

  **Cause:** `currentScroll` was declared `size_t`, but the menu uses negative indices for built-in cables (DIN = -3, upstream USB = -2/-1). The signed/unsigned comparison in `selectEncoderAction` (`getValue() < currentScroll`) converted -3 to a huge unsigned value, so the viewport never scrolled back up once it had advanced to a hosted device (index ≥ 0) — the selection moved to DIN off-screen.
  
  **Fix:** Declare `currentScroll` as `int32_t` so all scroll comparisons are signed.

  **Testing:** Scroll down in the MIDI devices list until DIN leaves the frame, then scroll back up — DIN and upstream USB ports scroll back into view with the highlight intact. See attached videos.
  
- Before:
https://github.com/user-attachments/assets/0dad464b-a8dd-4d0c-8276-cc1f788ce7e9

- After: 
https://github.com/user-attachments/assets/5294b4f4-caa1-46b6-b246-6d7e913ae742

Fixes #4520.