### PR TITLE
Fix stuck sidechain ducking in offline stem export

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1038,6 +1038,7 @@ void routine() {
 
 				numSamplesLastTime = numSamples;
 				renderAudioForStemExport(numSamples);
+				sideChainHitPending = 0;
 				audioSampleTimer += numSamples;
 				doSomeOutputting();
 				// gross and hacky way to make sure the audio recorder writes all of its data so it can't be stolen


### PR DESCRIPTION
## Fix stuck sidechain ducking in offline stem export

  Fixes clips exporting much quieter than live playback when offline rendering is enabled.
  
  ### Problem
  The live audio routine clears `sideChainHitPending` after every render window, but the offline stem-export loop never did. The first sidechain hit during an export stuck permanently: every subsequent 32-sample window re-registered the hit and re-triggered the ducking envelope, so any track with sidechain ducking was held at full attenuation for the rest of the file. Exports with live rendering were unaffected, since that path goes through the normal routine.

  ### Fix
  Clear `sideChainHitPending` after each `renderAudioForStemExport()` window, matching the live render path.

  ### Testing
  Export a song with a sidechain-ducked pad twice (normalization off): with offline rendering the pad stem should be heavily attenuated and never recover after the first hit; with this fix it should pump and recover identically to the live-render export.

Fixes #3255.

**PENDING TESTING ON DEVICE**