### PR TITLE
Fix stuck sidechain ducking in offline stem export

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1038,6 +1038,7 @@ void routine() {
 
 				numSamplesLastTime = numSamples;
 				renderAudioForStemExport(numSamples);
+				sideChainHitPending = 0;
 				audioSampleTimer += numSamples;
 				doSomeOutputting();
 				// gross and hacky way to make sure the audio recorder writes all of its data so it can't be stolen


### PR DESCRIPTION
The offline render loop never cleared sideChainHitPending, so the first sidechain hit re-triggered the ducking envelope every render window for the rest of the export, leaving sidechained tracks near-silent. Clear the flag after each window, matching the live render path.

Testing:
https://github.com/user-attachments/assets/cdfdc703-5db3-4c4c-83fe-70b599ab4144