### PR TITLE
Fix tempo undo bug

### DIFF
--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -239,6 +239,11 @@ void ActionLogger::updateAction(Action* newAction) {
 
 void ActionLogger::recordUnautomatedParamChange(ModelStackWithAutoParam const* modelStack, ActionType actionType) {
 
+	// If this is a param where you should not record automated param changes (e.g. tempo) then exit
+	if (!modelStack->paramCollection->shouldRecordUnautomatedParamChange(modelStack)) {
+		return;
+	}
+
 	Action* action = getNewAction(actionType, ActionAddition::ALLOWED);
 	if (!action) {
 		return;

--- a/src/deluge/modulation/params/param_collection.h
+++ b/src/deluge/modulation/params/param_collection.h
@@ -78,6 +78,7 @@ public:
 	virtual bool mayParamInterpolate(int32_t paramId);
 	virtual bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) { return false; }
 	virtual bool doesParamIdAllowAutomation(ModelStackWithParamId const* modelStack) { return true; }
+	virtual bool shouldRecordUnautomatedParamChange(ModelStackWithParamId const* modelStack) { return true; }
 	virtual int32_t paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack);
 	virtual int32_t knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack);
 	virtual void notifyPingpongOccurred(ModelStackWithParamCollection* modelStack);

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -445,6 +445,10 @@ bool UnpatchedParamSet::doesParamIdAllowAutomation(ModelStackWithParamId const* 
 	return (modelStack->paramId != params::UNPATCHED_STUTTER_RATE);
 }
 
+bool UnpatchedParamSet::shouldRecordUnautomatedParamChange(ModelStackWithParamId const* modelStack) {
+	return (modelStack->paramId != params::UNPATCHED_TEMPO);
+}
+
 // PatchedParamSet --------------------------------------------------------------------------------------------
 
 PatchedParamSet::PatchedParamSet(ParamCollectionSummary* summary) : ParamSet(sizeof(PatchedParamSet), summary) {

--- a/src/deluge/modulation/params/param_set.h
+++ b/src/deluge/modulation/params/param_set.h
@@ -101,6 +101,7 @@ public:
 	void beenCloned(bool copyAutomation, int32_t reverseDirectionWithLength) override;
 	bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) override;
 	bool doesParamIdAllowAutomation(ModelStackWithParamId const* modelStack) override;
+	bool shouldRecordUnautomatedParamChange(ModelStackWithParamId const* modelStack) override;
 	int32_t paramValueToKnobPos(int32_t paramValue, ModelStackWithAutoParam* modelStack) override;
 	int32_t knobPosToParamValue(int32_t knobPos, ModelStackWithAutoParam* modelStack) override;
 	deluge::modulation::params::Kind getParamKind() override { return kind; }


### PR DESCRIPTION
Fix bug where adjusting tempo in non-automation context would not allow you to undo several tempo changes in a single undo press like before

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3105

Behaviour before fix:
- Initial tempo = 110
- Increase tempo to 120
- Press undo --> tempo goes from 120 to 119, then 118, then 117, until you reach 110

Behaviour after fix:
- Initial tempo = 110
- Increase tempo to 120
- Press undo --> tempo goes from 120 to 110 in a single press

Why this bug happened:
- When you set parameter values using AutoParam::setCurrentValueInResponseToUserInput it records an action log entry for unautomated param changes. This causes each tempo change to be recorded as a separate action.

To fix it I added a function to the unpatched param class which basically says - don't do that for the tempo param. All other param changes behave as before.