### PR TITLE
Fix/ leave custom knob mappings when changing existing wavetable oscillation type's source

### DIFF
--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -861,6 +861,8 @@ doLoadAsWaveTable:
 			    goto doLoadAsSample;
 			}
 			*/
+			OscType current_osc_type = soundEditor.currentSource->getOscType();
+
 			soundEditor.currentSource->setOscType(OscType::WAVETABLE);
 
 			error = claimAudioFileForInstrument(makeWaveTableWorkAtAllCosts);
@@ -890,21 +892,24 @@ doLoadAsWaveTable:
 
 			// Alright, if we're still here, it was successfully loaded as a WaveTable!
 
-			if (soundEditor.currentSourceIndex == 0) { // Osc 1
-				soundEditor.currentSound->modKnobs[7][1].paramDescriptor.setToHaveParamOnly(
-				    params::LOCAL_OSC_A_WAVE_INDEX);
+			// if oscillator wasn't already a wavetable, update custom knob assignments, otherwise leave as is
+			if (current_osc_type != OscType::WAVETABLE) {
+				if (soundEditor.currentSourceIndex == 0) { // Osc 1
+					soundEditor.currentSound->modKnobs[7][1].paramDescriptor.setToHaveParamOnly(
+					    params::LOCAL_OSC_A_WAVE_INDEX);
 
-				if (!soundEditor.currentSound->modKnobs[7][0].paramDescriptor.isSetToParamWithNoSource(
-				        params::LOCAL_OSC_B_WAVE_INDEX)) {
-					soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamAndSource(
-					    params::LOCAL_OSC_A_WAVE_INDEX, PatchSource::LFO_LOCAL_1);
+					if (!soundEditor.currentSound->modKnobs[7][0].paramDescriptor.isSetToParamWithNoSource(
+					        params::LOCAL_OSC_B_WAVE_INDEX)) {
+						soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamAndSource(
+						    params::LOCAL_OSC_A_WAVE_INDEX, PatchSource::LFO_LOCAL_1);
+					}
 				}
+				else { // Osc 2
+					soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamOnly(
+					    params::LOCAL_OSC_B_WAVE_INDEX);
+				}
+				getCurrentOutput()->modKnobMode = 7;
 			}
-			else { // Osc 2
-				soundEditor.currentSound->modKnobs[7][0].paramDescriptor.setToHaveParamOnly(
-				    params::LOCAL_OSC_B_WAVE_INDEX);
-			}
-			getCurrentOutput()->modKnobMode = 7;
 			view.setKnobIndicatorLevels(); // Visually update.
 			view.setModLedStates();
 		}

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -237,6 +237,11 @@ bool Source::hasAnyLoopEndPoint() {
 	return false;
 }
 
+// Return current osc type
+OscType Source::getOscType() {
+	return oscType;
+}
+
 // If setting to SAMPLE or WAVETABLE, you must call killAllVoices before this, because ranges is going to get
 // emptied.
 void Source::setOscType(OscType newType) {

--- a/src/deluge/processing/source.h
+++ b/src/deluge/processing/source.h
@@ -65,6 +65,7 @@ public:
 	bool hasAtLeastOneAudioFileLoaded();
 	void doneReadingFromFile(Sound* sound);
 	bool hasAnyLoopEndPoint();
+	OscType getOscType();
 	void setOscType(OscType newType);
 
 	DxPatch* ensureDxPatch();


### PR DESCRIPTION
Fix issue where if synth is already a wavetable and you've changed the custom knob mappings that subsequent changes to the actual wavetable file would change the parameters mapped to the custom knobs to the default wavetable ones

Fix checks if source is already a wavetable osc and if so, doesn't change the settings

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2042