### PR TITLE
Fix bug getting stuck in ui mode clip pressed in song row view

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2736,8 +2736,6 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 			                             // what if we're in a Clip view?
 			break;
 		}
-		// No break
-	case UI_MODE_CLIP_PRESSED_IN_SONG_VIEW:
 
 	case UI_MODE_HOLDING_STATUS_PAD:
 		if (on) {
@@ -2751,6 +2749,9 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 		}
 		break;
 
+	// No break
+	case UI_MODE_CLIP_PRESSED_IN_SONG_VIEW:
+		[[fallthrough]] // fall through into UI_MODE_STUTTERING so you can toggle clip status while holding a clip
 	case UI_MODE_STUTTERING:
 		// this code is needed to allow users to launch clips while stuttering
 		// without it the deluge becomes unresponsive if you try to launch a clip while stuttering

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2751,7 +2751,7 @@ ActionResult View::clipStatusPadAction(Clip* clip, bool on, int32_t yDisplayIfIn
 
 	// No break
 	case UI_MODE_CLIP_PRESSED_IN_SONG_VIEW:
-		[[fallthrough]] // fall through into UI_MODE_STUTTERING so you can toggle clip status while holding a clip
+	[[fallthrough]] // fall through into UI_MODE_STUTTERING so you can toggle clip status while holding a clip
 	case UI_MODE_STUTTERING:
 		// this code is needed to allow users to launch clips while stuttering
 		// without it the deluge becomes unresponsive if you try to launch a clip while stuttering


### PR DESCRIPTION
Fixed bug where when holding a clip in song row view, if you then launched another clip and waited to release the clip you're holding until after the other clip launched that you would get stuck in ui mode clip pressed

This happened because the stutter branch got moved below the ui mode holding status pad but the ui mode clip pressed in song view branch which previously fell through into that branch got left behind.

Fixed by moving the clip pressed in song view branch down as it was not supposed to fall through into the status pad branch.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4049