### PR TITLE
Add per device is relative toggle + Fix midi devices settings read/write

### DIFF
--- a/src/deluge/gui/l10n/english.json
+++ b/src/deluge/gui/l10n/english.json
@@ -205,6 +205,7 @@
     "STRING_FOR_CLOCK": "Clock",
     "STRING_FOR_CLOCK_OUT": "Clock Out",
     "STRING_FOR_CLOCK_IN": "Clock In",
+    "STRING_FOR_IS_RELATIVE": "Use Relative CC",
     "STRING_FOR_RUN_SIGNAL": "Run signal",
     "STRING_FOR_GATE_MODE_TITLE": "Gate out* mode",
     "STRING_FOR_GATE_OUTPUT_1": "Gate output 1",

--- a/src/deluge/gui/l10n/g_english.cpp
+++ b/src/deluge/gui/l10n/g_english.cpp
@@ -218,6 +218,7 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_CLOCK, "Clock"},
         {STRING_FOR_CLOCK_OUT, "Clock Out"},
         {STRING_FOR_CLOCK_IN, "Clock In"},
+        {STRING_FOR_IS_RELATIVE, "Use Relative CC"},
         {STRING_FOR_RUN_SIGNAL, "Run signal"},
         {STRING_FOR_GATE_MODE_TITLE, "Gate out* mode"},
         {STRING_FOR_GATE_OUTPUT_1, "Gate output 1"},

--- a/src/deluge/gui/l10n/g_seven_segment.cpp
+++ b/src/deluge/gui/l10n/g_seven_segment.cpp
@@ -113,6 +113,7 @@ PLACE_SDRAM_DATA Language seven_segment{
         {STRING_FOR_CLOCK, "CLK"},
         {STRING_FOR_CLOCK_OUT, "CLKO"},
         {STRING_FOR_CLOCK_IN, "CLKI"},
+        {STRING_FOR_IS_RELATIVE, "REL"},
         {STRING_FOR_RUN_SIGNAL, "RUN"},
         {STRING_FOR_GATE_MODE_TITLE, ""},
         {STRING_FOR_GATE_OUTPUT_1, "OUT1"},

--- a/src/deluge/gui/l10n/seven_segment.json
+++ b/src/deluge/gui/l10n/seven_segment.json
@@ -117,6 +117,7 @@
         "STRING_FOR_CLOCK": "CLK",
         "STRING_FOR_CLOCK_OUT": "CLKO",
         "STRING_FOR_CLOCK_IN": "CLKI",
+        "STRING_FOR_IS_RELATIVE": "REL",
 
         "STRING_FOR_RUN_SIGNAL": "RUN",
 

--- a/src/deluge/gui/l10n/strings.h
+++ b/src/deluge/gui/l10n/strings.h
@@ -218,6 +218,7 @@ enum class String : size_t {
 	STRING_FOR_CLOCK,
 	STRING_FOR_CLOCK_OUT,
 	STRING_FOR_CLOCK_IN,
+	STRING_FOR_IS_RELATIVE,
 	STRING_FOR_RUN_SIGNAL,
 
 	// gui/menu_item/gate/selection.h

--- a/src/deluge/gui/menu_item/midi/device_is_relative.h
+++ b/src/deluge/gui/menu_item/midi/device_is_relative.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Sean Ditny
+ * Copyright (c) 2014-2023 Synthstrom Audible Limited
  *
  * This file is part of The Synthstrom Audible Deluge Firmware.
  *
@@ -14,14 +14,20 @@
  * You should have received a copy of the GNU General Public License along with this program.
  * If not, see <https://www.gnu.org/licenses/>.
  */
-
 #pragma once
+#include "gui/menu_item/toggle.h"
+#include "gui/ui/sound_editor.h"
+#include "io/midi/midi_device.h"
+#include "io/midi/midi_device_manager.h"
 
-#include "definitions_cxx.hpp"
-#include "modulation/knob.h"
-#include "modulation/params/param_set.h"
-
-namespace MidiTakeover {
-int32_t calculateKnobPos(MIDICable& cable, int32_t knobPos, int32_t ccValue, MIDIKnob* knob = nullptr,
-                         bool doingMidiFollow = false, int32_t ccNumber = MIDI_CC_NONE, bool isStepEditing = false);
-} // namespace MidiTakeover
+namespace deluge::gui::menu_item::midi {
+class IsRelative final : public Toggle {
+public:
+	using Toggle::Toggle;
+	void readCurrentValue() override { this->setValue(soundEditor.currentMIDICable->is_relative); }
+	void writeCurrentValue() override {
+		soundEditor.currentMIDICable->is_relative = this->getValue();
+		MIDIDeviceManager::anyChangesToSave = true;
+	}
+};
+} // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -96,6 +96,7 @@
 #include "gui/menu_item/midi/device.h"
 #include "gui/menu_item/midi/device_definition/linked.h"
 #include "gui/menu_item/midi/device_definition/submenu.h"
+#include "gui/menu_item/midi/device_is_relative.h"
 #include "gui/menu_item/midi/device_receive_clock.h"
 #include "gui/menu_item/midi/device_send_clock.h"
 #include "gui/menu_item/midi/devices.h"
@@ -1124,6 +1125,7 @@ Submenu midiCommandsMenu{
 midi::DefaultVelocityToLevel defaultVelocityToLevelMenu{STRING_FOR_VELOCITY};
 midi::SendClock sendClockMenu{STRING_FOR_CLOCK_OUT};
 midi::ReceiveClock receiveClockMenu{STRING_FOR_CLOCK_IN};
+midi::IsRelative is_relative_menu{STRING_FOR_IS_RELATIVE};
 midi::Device midiDeviceMenu{
     EMPTY_STRING,
     {
@@ -1131,6 +1133,7 @@ midi::Device midiDeviceMenu{
         &defaultVelocityToLevelMenu,
         &sendClockMenu,
         &receiveClockMenu,
+        &is_relative_menu,
     },
 };
 

--- a/src/deluge/io/midi/midi_device.cpp
+++ b/src/deluge/io/midi/midi_device.cpp
@@ -34,6 +34,7 @@ MIDICable::MIDICable() {
 	connectionFlags = 0;
 	sendClock = true;
 	receiveClock = true;
+	is_relative = false;
 	defaultVelocityToLevel = 0; // Means none set.
 
 	// These defaults for MPE are prescribed in the MPE standard. Wish we had the same for regular MIDI
@@ -178,7 +179,7 @@ void MIDICable::sendAllMCMs() {
 bool MIDICable::worthWritingToFile() {
 	return (ports[MIDI_DIRECTION_INPUT_TO_DELUGE].worthWritingToFile()
 	        || ports[MIDI_DIRECTION_OUTPUT_FROM_DELUGE].worthWritingToFile() || hasDefaultVelocityToLevelSet()
-	        || !sendClock);
+	        || !sendClock || !receiveClock || is_relative);
 }
 
 void MIDICable::writePorts(Serializer& writer) {
@@ -209,17 +210,22 @@ void MIDICable::readFromFile(Deserializer& reader) {
 			receiveClock = reader.readTagOrAttributeValueInt();
 		}
 
+		else if (!strcmp(tagName, "is_relative")) {
+			is_relative = reader.readTagOrAttributeValueInt();
+		}
+
 		reader.exitTag();
 	}
 }
 
-// These only go into SETTINGS/MIDICables.XML
+// These only go into SETTINGS/MIDIDevices.XML
 void MIDICable::writeDefinitionAttributesToFile(Serializer& writer) {
 	if (hasDefaultVelocityToLevelSet()) {
 		writer.writeAttribute("defaultVolumeVelocitySensitivity", defaultVelocityToLevel);
 	}
 	writer.writeAttribute("sendClock", sendClock);
 	writer.writeAttribute("receiveClock", receiveClock);
+	writer.writeAttribute("is_relative", is_relative);
 }
 
 void MIDICable::writeToFile(Serializer& writer, char const* tagName) {

--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -156,6 +156,7 @@ public:
 	uint8_t connectionFlags;
 	bool sendClock;    // whether to send clocks to this device
 	bool receiveClock; // whether to receive clocks from this device
+	bool is_relative;  // whether this device receive's relative cc's (used with midi takeover)
 	uint8_t incomingSysexBuffer[1024];
 	int32_t incomingSysexPos = 0;
 

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -412,16 +412,6 @@ void writeDeviceReferenceToFlash(GlobalMIDICommand whichCommand, uint8_t* memory
 	}
 }
 
-void readMidiFollowDeviceReferenceFromFlash(MIDIFollowChannelType whichType, uint8_t const* memory) {
-	midiEngine.midiFollowChannelType[util::to_underlying(whichType)].cable = readCableFromFlash(memory);
-}
-
-void writeMidiFollowDeviceReferenceToFlash(MIDIFollowChannelType whichType, uint8_t* memory) {
-	if (midiEngine.midiFollowChannelType[util::to_underlying(whichType)].cable) {
-		midiEngine.midiFollowChannelType[util::to_underlying(whichType)].cable->writeToFlash(memory);
-	}
-}
-
 void writeDevicesToFile() {
 	if (!anyChangesToSave) {
 		return;
@@ -608,6 +598,32 @@ checkDevice:
 
 			if (device) {
 				device->sendClock = reader.readTagOrAttributeValueInt();
+			}
+		}
+		else if (!strcmp(tagName, "receiveClock")) {
+			// this is actually not much duplicated code, just checks for nulls and then an attempt to create a device
+			if (!device) {
+				if (!name.isEmpty() || vendorId) {
+					device = getOrCreateHostedMIDIDeviceFromDetails(&name, vendorId,
+					                                                productId); // Will return NULL if error.
+				}
+			}
+
+			if (device) {
+				device->receiveClock = reader.readTagOrAttributeValueInt();
+			}
+		}
+		else if (!strcmp(tagName, "is_relative")) {
+			// this is actually not much duplicated code, just checks for nulls and then an attempt to create a device
+			if (!device) {
+				if (!name.isEmpty() || vendorId) {
+					device = getOrCreateHostedMIDIDeviceFromDetails(&name, vendorId,
+					                                                productId); // Will return NULL if error.
+				}
+			}
+
+			if (device) {
+				device->is_relative = reader.readTagOrAttributeValueInt();
 			}
 		}
 

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -104,8 +104,6 @@ void slowRoutine();
 MIDICable* readDeviceReferenceFromFile(Deserializer& reader);
 void readDeviceReferenceFromFlash(GlobalMIDICommand whichCommand, uint8_t const* memory);
 void writeDeviceReferenceToFlash(GlobalMIDICommand whichCommand, uint8_t* memory);
-void readMidiFollowDeviceReferenceFromFlash(MIDIFollowChannelType whichType, uint8_t const* memory);
-void writeMidiFollowDeviceReferenceToFlash(MIDIFollowChannelType whichType, uint8_t* memory);
 void recountSmallestMPEZones();
 void writeDevicesToFile();
 void readAHostedDeviceFromFile(Deserializer& reader);

--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -912,7 +912,7 @@ Output* MidiFollow::midiCCReceivedForSelectedOrActiveClip(MIDICable& cable, uint
 
 					if (modelStackWithTimelineCounter) {
 						// See if it's learned to a parameter
-						handleReceivedCC(*modelStackWithTimelineCounter, clip, ccNumber, ccValue);
+						handleReceivedCC(cable, *modelStackWithTimelineCounter, clip, ccNumber, ccValue);
 					}
 				}
 			}
@@ -990,7 +990,7 @@ void MidiFollow::midiCCReceivedForSpecificTrack(MIDICable& cable, uint8_t channe
 
 						if (modelStackWithTimelineCounter) {
 							// See if it's learned to a parameter
-							handleReceivedCC(*modelStackWithTimelineCounter, clip, ccNumber, ccValue);
+							handleReceivedCC(cable, *modelStackWithTimelineCounter, clip, ccNumber, ccValue);
 						}
 					}
 				}
@@ -1018,8 +1018,8 @@ void MidiFollow::midiCCReceivedForSpecificTrack(MIDICable& cable, uint8_t channe
 /// if the cc has been learned, it sets the new value for that parameter
 /// this function works by first checking the active context to see if there is an active clip
 /// to determine if the cc intends to control a song level or clip level parameter
-void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithTimelineCounter, Clip* clip,
-                                  int32_t ccNumber, int32_t ccValue) {
+void MidiFollow::handleReceivedCC(MIDICable& cable, ModelStackWithTimelineCounter& modelStackWithTimelineCounter,
+                                  Clip* clip, int32_t ccNumber, int32_t ccValue) {
 
 	int32_t modPos = 0;
 	int32_t modLength = 0;
@@ -1065,7 +1065,8 @@ void MidiFollow::handleReceivedCC(ModelStackWithTimelineCounter& modelStackWithT
 		int32_t knobPos = modelStackWithParam->paramCollection->paramValueToKnobPos(currentValue, modelStackWithParam);
 
 		// calculate new knob position based on cc value received and deluge current value
-		int32_t newKnobPos = MidiTakeover::calculateKnobPos(knobPos, ccValue, nullptr, true, ccNumber, isStepEditing);
+		int32_t newKnobPos =
+		    MidiTakeover::calculateKnobPos(cable, knobPos, ccValue, nullptr, true, ccNumber, isStepEditing);
 
 		// is the cc being received for the same value as the current knob pos? If so, do nothing
 		if (newKnobPos != knobPos) {

--- a/src/deluge/io/midi/midi_follow.h
+++ b/src/deluge/io/midi/midi_follow.h
@@ -78,7 +78,8 @@ public:
 	void sendCCWithoutModelStackForMidiFollowFeedback(int32_t channel, bool isAutomation = false);
 	void sendCCForMidiFollowFeedback(int32_t channel, int32_t ccNumber, int32_t knobPos);
 
-	void handleReceivedCC(ModelStackWithTimelineCounter& modelStack, Clip* clip, int32_t ccNumber, int32_t ccValue);
+	void handleReceivedCC(MIDICable& cable, ModelStackWithTimelineCounter& modelStack, Clip* clip, int32_t ccNumber,
+	                      int32_t ccValue);
 
 private:
 	// initialize

--- a/src/deluge/io/midi/midi_takeover.cpp
+++ b/src/deluge/io/midi/midi_takeover.cpp
@@ -38,8 +38,8 @@ int32_t getPreviousKnobPos(int32_t knobPos, MIDIKnob* knob = nullptr, bool doing
 /// based on the midi takeover default setting of RELATIVE, JUMP, PICKUP, or SCALE
 /// this function will calculate the knob position that the deluge parameter that the midi cc
 /// received is learned to should be set at based on the midi cc value received
-int32_t MidiTakeover::calculateKnobPos(int32_t knobPos, int32_t ccValue, MIDIKnob* knob, bool doingMidiFollow,
-                                       int32_t ccNumber, bool isStepEditing) {
+int32_t MidiTakeover::calculateKnobPos(MIDICable& cable, int32_t knobPos, int32_t ccValue, MIDIKnob* knob,
+                                       bool doingMidiFollow, int32_t ccNumber, bool isStepEditing) {
 	/*
 
 	Step #1: Convert Midi Controller's CC Value to Deluge Knob Position Value
@@ -67,7 +67,8 @@ int32_t MidiTakeover::calculateKnobPos(int32_t knobPos, int32_t ccValue, MIDIKno
 	bool isRecording = playbackHandler.isEitherClockActive() && (playbackHandler.recording != RecordingMode::OFF);
 
 	// for controller's sending relative values
-	if (((knob != nullptr) && (knob->relative)) || (midiEngine.midiTakeover == MIDITakeoverMode::RELATIVE)) {
+	if (cable.is_relative || ((knob != nullptr) && (knob->relative))
+	    || (midiEngine.midiTakeover == MIDITakeoverMode::RELATIVE)) {
 		int32_t offset = ccValue;
 		if (offset >= 64) {
 			offset -= 128;

--- a/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
+++ b/src/deluge/model/mod_controllable/mod_controllable_audio.cpp
@@ -1112,7 +1112,7 @@ bool ModControllableAudio::offerReceivedCCToLearnedParamsForClip(MIDICable& cabl
 
 				// calculate new knob position based on value received and deluge current value
 				newKnobPos =
-				    MidiTakeover::calculateKnobPos(knobPos, value, &knob, false, CC_NUMBER_NONE, isStepEditing);
+				    MidiTakeover::calculateKnobPos(cable, knobPos, value, &knob, false, CC_NUMBER_NONE, isStepEditing);
 
 				// is the cc being received for the same value as the current knob pos? If so, do nothing
 				if (newKnobPos == knobPos) {
@@ -1202,7 +1202,7 @@ bool ModControllableAudio::offerReceivedCCToLearnedParamsForSong(
 
 				// calculate new knob position based on value received and deluge current value
 				newKnobPos =
-				    MidiTakeover::calculateKnobPos(knobPos, value, &knob, false, CC_NUMBER_NONE, isStepEditing);
+				    MidiTakeover::calculateKnobPos(cable, knobPos, value, &knob, false, CC_NUMBER_NONE, isStepEditing);
 
 				// is the cc being received for the same value as the current knob pos? If so, do nothing
 				if (newKnobPos == knobPos) {

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -345,8 +345,8 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 #### <ins>Devices</ins>
 
 - Added new `Use Relative CC` toggle within the configuration of each MIDI device in the `Settings > Defaults > MIDI > Devices` menu.
-- When enabled, regular (e.g. non expression) midi CCs received from this are processed as relative CCs, overriding the current MIDI takeover setting.
-- Note: the controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
+  - When enabled, regular (e.g. non expression) midi CCs received from a device are processed as relative CCs, overriding the current MIDI takeover setting.
+  - Note: the controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
 
 #### <ins>Learn</ins>
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -345,8 +345,8 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 #### <ins>Devices</ins>
 
 - Added new `Use Relative CC` toggle within the configuration of each MIDI device in the `Settings > Defaults > MIDI > Devices` menu.
- - When enabled, regular (e.g. non expression) midi CC's received from this are processed as relative cc's, overriding the current MIDI takeover setting.
- - Note: the controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
+- When enabled, regular (e.g. non expression) midi CC's received from this are processed as relative cc's, overriding the current MIDI takeover setting.
+- Note: the controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
 
 #### <ins>Learn</ins>
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -342,6 +342,12 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 
 ### MIDI
 
+#### <ins>Devices</ins>
+
+- Added new `Use Relative CC` toggle within the configuration of each MIDI device in the `Settings > Defaults > MIDI > Devices` menu.
+ - When enabled, regular (e.g. non expression) midi CC's received from this are processed as relative cc's, overriding the current MIDI takeover setting.
+ - Note: the controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
+
 #### <ins>Learn</ins>
 
 - Added new `MIDI LEARN` menu to the `SONG` menu. In `Song Grid View` this menu enables you to learn `Clip/Section Launch`. In `Song Row View` this menu enables you to learn the `Clip/Section Launch` and `Instrument`.
@@ -365,6 +371,8 @@ A `Favourites` feature has been added to the browser for most file types. The `F
     - If used together with `SHIFT`, it will trigger instant mute.
 - Added new default CC 90 to toggle solo of the active clip in a specific track.
   - Toggle solo: CC Value > 0 (Send a CC Value greater than 0 to toggle mute for the active clip in a specific track)
+- You can now use relative cc's together with non-relative cc's for different devices on the same MIDI follow channel.
+  - See the `Devices` section above for information on the per MIDI device `Use Relative CC` configuration.
 
 ### SD CARD
 

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -371,7 +371,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
     - If used together with `SHIFT`, it will trigger instant mute.
 - Added new default CC 90 to toggle solo of the active clip in a specific track.
   - Toggle solo: CC Value > 0 (Send a CC Value greater than 0 to toggle mute for the active clip in a specific track)
-- You can now use relative cc's together with non-relative cc's for different devices on the same MIDI follow channel.
+- You can now use relative CCs together with non-relative CCs for different devices on the same MIDI follow channel.
   - See the `Devices` section above for information on the per MIDI device `Use Relative CC` configuration.
 
 ### SD CARD

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -345,7 +345,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 #### <ins>Devices</ins>
 
 - Added new `Use Relative CC` toggle within the configuration of each MIDI device in the `Settings > Defaults > MIDI > Devices` menu.
-- When enabled, regular (e.g. non expression) midi CC's received from this are processed as relative cc's, overriding the current MIDI takeover setting.
+- When enabled, regular (e.g. non expression) midi CCs received from this are processed as relative CCs, overriding the current MIDI takeover setting.
 - Note: the controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
 
 #### <ins>Learn</ins>


### PR DESCRIPTION
Added new `Use Relative CC` toggle within the configuration of each MIDI device in the `Settings > Defaults > MIDI > Devices` menu.
 - When enabled, regular (e.g. non expression) midi CC's received from this are processed as relative cc's, overriding the current MIDI takeover setting.
 - Note: the controller must be actually sending relative value changes (127 for down and 1 for up) in order for this to work.
 
For MIDI follow, you can now use relative cc's together with non-relative cc's for different devices on the same MIDI follow channel.
  - See the `Devices` section above for information on the per MIDI device `Use Relative CC` configuration. 
  
  Fixed some observed issues with reading / writing midi devices settings from MIDIDevices.xml
  - MIDICable::worthWritingToFile() did not include receiveClock
  - MIDIDeviceManager::readAHostedDeviceFromFile() was not reading receiveClock from file
  
  Removed some midi follow FlashStorage read/write functions that are no longer needed
  
  Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4549
  Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4299