### PR TITLE
[DRAFT] Fix/ Clean up and bug fix automation view auto param issues

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1487,14 +1487,14 @@ bool SoundEditor::isEditingAutomationViewParam() {
 	MenuItem* currentMenuItem = getCurrentMenuItem();
 
 	// get the param kind and index for that menu item (if there is one)
-	// returns Kind::NONE / paramID = kNoSelection if we're not in a param menu
+	// returns Kind::NONE / paramID = kNoParamID if we're not in a param menu
 	deluge::modulation::params::Kind kind = currentMenuItem->getParamKind();
 	int32_t paramID = currentMenuItem->getParamIndex();
 
 	bool editingParamInAutomationArrangerView = false;
 	bool editingParamInAutomationClipView = false;
 
-	if (kind != deluge::modulation::params::Kind::NONE && paramID != kNoSelection) {
+	if (kind != deluge::modulation::params::Kind::NONE && paramID != deluge::modulation::params::kNoParamID) {
 		// are in automation arranger view and editing the same param open in the menu?
 		editingParamInAutomationArrangerView = automationView.onArrangerView
 		                                       && (kind == currentSong->lastSelectedParamKind)

--- a/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
@@ -351,7 +351,7 @@ void AutomationEditorLayoutModControllable::renderAutomationEditorDisplay7SEG(Cl
 		}
 		else if (getLastPadSelectedKnobPos() != kNoSelection) {
 			params::Kind lastSelectedParamKind = params::Kind::NONE;
-			int32_t lastSelectedParamID = kNoSelection;
+			int32_t lastSelectedParamID = params::kNoParamID;
 			if (getOnArrangerView()) {
 				lastSelectedParamKind = currentSong->lastSelectedParamKind;
 				lastSelectedParamID = currentSong->lastSelectedParamID;
@@ -403,7 +403,7 @@ void AutomationEditorLayoutModControllable::getAutomationParameterName(Clip* cli
                                                                        StringBuf& parameterName) {
 	if (getOnArrangerView() || outputType != OutputType::MIDI_OUT) {
 		params::Kind lastSelectedParamKind = params::Kind::NONE;
-		int32_t lastSelectedParamID = kNoSelection;
+		int32_t lastSelectedParamID = params::kNoParamID;
 		PatchSource lastSelectedPatchSource = PatchSource::NONE;
 		if (getOnArrangerView()) {
 			lastSelectedParamKind = currentSong->lastSelectedParamKind;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -972,7 +972,7 @@ void AutomationView::renderDisplay(int32_t knobPosLeft, int32_t knobPosRight, bo
 	// if you're not in a MIDI instrument clip, convert the knobPos to the same range as the menu (0-50)
 	if (inAutomationEditor() && (onArrangerView || outputType != OutputType::MIDI_OUT)) {
 		params::Kind lastSelectedParamKind = params::Kind::NONE;
-		int32_t lastSelectedParamID = kNoSelection;
+		int32_t lastSelectedParamID = params::kNoParamID;
 		if (onArrangerView) {
 			lastSelectedParamKind = currentSong->lastSelectedParamKind;
 			lastSelectedParamID = currentSong->lastSelectedParamID;
@@ -3030,7 +3030,7 @@ void AutomationView::initParameterSelection(bool updateDisplay) {
 	initPadSelection();
 
 	if (onArrangerView) {
-		currentSong->lastSelectedParamID = kNoSelection;
+		currentSong->lastSelectedParamID = params::kNoParamID;
 		currentSong->lastSelectedParamKind = params::Kind::NONE;
 		currentSong->lastSelectedParamShortcutX = kNoSelection;
 		currentSong->lastSelectedParamShortcutY = kNoSelection;
@@ -3038,7 +3038,7 @@ void AutomationView::initParameterSelection(bool updateDisplay) {
 	}
 	else {
 		Clip* clip = getCurrentClip();
-		clip->lastSelectedParamID = kNoSelection;
+		clip->lastSelectedParamID = params::kNoParamID;
 		clip->lastSelectedParamKind = params::Kind::NONE;
 		clip->lastSelectedParamShortcutX = kNoSelection;
 		clip->lastSelectedParamShortcutY = kNoSelection;
@@ -3181,11 +3181,11 @@ bool AutomationView::onAutomationOverview() {
 
 bool AutomationView::inAutomationEditor() {
 	if (onArrangerView) {
-		if (currentSong->lastSelectedParamID == kNoSelection) {
+		if (currentSong->lastSelectedParamID == params::kNoParamID) {
 			return false;
 		}
 	}
-	else if (getCurrentClip()->lastSelectedParamID == kNoSelection) {
+	else if (getCurrentClip()->lastSelectedParamID == params::kNoParamID) {
 		return false;
 	}
 

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -676,6 +676,34 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 	Output* output = clip->output;
 	OutputType outputType = output->type;
 
+	// setup to check if context is valid for rendering
+	bool is_affect_entire_context = getAffectEntire();
+	bool is_kit = outputType == OutputType::KIT;
+	Drum* kit_selected_drum = (is_kit && !is_affect_entire_context) ? ((Kit*)output)->selectedDrum : nullptr;
+
+	// if we're not in arranger view
+	// and we're in a kit, with affect entire disabled
+	// and there is no drum selected
+	// then we have no valid automation context, clear pads and return
+	bool is_invalid_context = !onArrangerView && is_kit && !is_affect_entire_context && !kit_selected_drum;
+	if (is_invalid_context) {
+		for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
+			PadLEDs::clearColumnWithoutSending(xDisplay);
+		}
+		return;
+	}
+
+	// check if we're editing a kit's midi or cv drum
+	bool isMIDICVDrum = false;
+	if (is_kit && !is_affect_entire_context) {
+		DrumType kit_selected_drum_type = kit_selected_drum->type;
+		isMIDICVDrum = (kit_selected_drum_type == DrumType::MIDI) || (kit_selected_drum_type == DrumType::GATE);
+	}
+
+	// don't render automation editor if you've selected a MIDI or CV drum
+	bool render_automation_editor = inAutomationEditor() && !isMIDICVDrum;
+	bool render_note_editor = inNoteEditor();
+
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = nullptr;
 	ModelStackWithThreeMainThings* modelStackWithThreeMainThings = nullptr;
@@ -683,16 +711,34 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 	ModelStackWithNoteRow* modelStackWithNoteRow = nullptr;
 	int32_t effectiveLength = 0;
 	SquareInfo rowSquareInfo[kDisplayWidth];
+	params::Kind kind = params::Kind::NONE;
+	bool isBipolar = false;
 
 	if (onArrangerView) {
 		modelStackWithThreeMainThings = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
-		modelStackWithParam =
-		    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
+		if (render_automation_editor) {
+			modelStackWithParam =
+			    currentSong->getModelStackWithParam(modelStackWithThreeMainThings, currentSong->lastSelectedParamID);
+			if (!modelStackWithParam || !modelStackWithParam->autoParam) {
+				return;
+			}
+			kind = modelStackWithParam->paramCollection->getParamKind();
+			isBipolar = isParamBipolar(kind, modelStackWithParam->paramId);
+			effectiveLength = getEffectiveLength(nullptr);
+		}
 	}
 	else {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
-		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
-		if (inNoteEditor()) {
+		if (render_automation_editor) {
+			modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
+			if (!modelStackWithParam || !modelStackWithParam->autoParam) {
+				return;
+			}
+			kind = modelStackWithParam->paramCollection->getParamKind();
+			isBipolar = isParamBipolar(kind, modelStackWithParam->paramId);
+			effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
+		}
+		else if (render_note_editor) {
 			modelStackWithNoteRow = ((InstrumentClip*)clip)
 			                            ->getNoteRowOnScreen(instrumentClipView.lastAuditionedYDisplay,
 			                                                 modelStackWithTimelineCounter); // don't create
@@ -704,59 +750,33 @@ void AutomationView::performActualRender(RGB image[][kDisplayWidth + kSideBarWid
 		}
 	}
 
-	if (!inNoteEditor()) {
-		effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
-	}
+	// ok we've setup all the necessary model stacks, now we'll take care of rendering the automation editor, note
+	// editor, or automation overview
 
-	params::Kind kind = params::Kind::NONE;
-	bool isBipolar = false;
-
-	// if we have a valid model stack with param
-	// get the param Kind and param bipolar status
-	// so that it can be passed through the automation editor rendering
-	// calls below
-	if (modelStackWithParam && modelStackWithParam->autoParam) {
-		kind = modelStackWithParam->paramCollection->getParamKind();
-		isBipolar = isParamBipolar(kind, modelStackWithParam->paramId);
-	}
-
+	// only render if:
+	// you're on arranger view
+	// you're not in a kit where you haven't selected a drum and you haven't selected affect entire either
+	// you're not in a kit where no sound drum has been selected and you're not editing velocity
+	// you're in a kit where midi or CV sound drum has been selected and you're editing velocity
 	for (int32_t xDisplay = 0; xDisplay < kDisplayWidth; xDisplay++) {
-		// only render if:
-		// you're on arranger view
-		// you're not in a CV clip type
-		// you're not in a kit where you haven't selected a drum and you haven't selected affect entire either
-		// you're not in a kit where no sound drum has been selected and you're not editing velocity
-		// you're in a kit where midi or CV sound drum has been selected and you're editing velocity
-		if (onArrangerView || !(outputType == OutputType::KIT && !getAffectEntire() && !((Kit*)output)->selectedDrum)) {
-			bool isMIDICVDrum = false;
-			if (outputType == OutputType::KIT && !getAffectEntire()) {
-				isMIDICVDrum = (((Kit*)output)->selectedDrum
-				                && ((((Kit*)output)->selectedDrum->type == DrumType::MIDI)
-				                    || (((Kit*)output)->selectedDrum->type == DrumType::GATE)));
-			}
-
-			// if parameter has been selected, show Automation Editor
-			if (inAutomationEditor() && !isMIDICVDrum) {
-				automationEditorLayoutModControllable.renderAutomationEditor(
-				    modelStackWithParam, clip, image, occupancyMask, renderWidth, xScroll, xZoom, effectiveLength,
-				    xDisplay, drawUndefinedArea, kind, isBipolar);
-			}
-
-			// if note parameter has been selected, show Note Editor
-			else if (inNoteEditor()) {
-				automationEditorLayoutNote.renderNoteEditor(modelStackWithNoteRow, (InstrumentClip*)clip, image,
-				                                            occupancyMask, renderWidth, xScroll, xZoom, effectiveLength,
-				                                            xDisplay, drawUndefinedArea, rowSquareInfo[xDisplay]);
-			}
-
-			// if not editing a parameter, show Automation Overview
-			else {
-				renderAutomationOverview(modelStackWithTimelineCounter, modelStackWithThreeMainThings, clip, outputType,
-				                         image, occupancyMask, xDisplay, isMIDICVDrum);
-			}
+		// if parameter has been selected, show Automation Editor
+		if (render_automation_editor) {
+			automationEditorLayoutModControllable.renderAutomationEditor(
+			    modelStackWithParam, clip, image, occupancyMask, renderWidth, xScroll, xZoom, effectiveLength, xDisplay,
+			    drawUndefinedArea, kind, isBipolar);
 		}
+
+		// if note parameter has been selected, show Note Editor
+		else if (render_note_editor) {
+			automationEditorLayoutNote.renderNoteEditor(modelStackWithNoteRow, (InstrumentClip*)clip, image,
+			                                            occupancyMask, renderWidth, xScroll, xZoom, effectiveLength,
+			                                            xDisplay, drawUndefinedArea, rowSquareInfo[xDisplay]);
+		}
+
+		// if not editing a parameter, show Automation Overview
 		else {
-			PadLEDs::clearColumnWithoutSending(xDisplay);
+			renderAutomationOverview(modelStackWithTimelineCounter, modelStackWithThreeMainThings, clip, outputType,
+			                         image, occupancyMask, xDisplay, isMIDICVDrum);
 		}
 	}
 }

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2425,6 +2425,18 @@ void AutomationView::potentiallyVerticalScrollToSelectedDrum(InstrumentClip* cli
 // used to record live automations in
 void AutomationView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 
+	// if we're in automation overview or note editor
+	// then we want to changing the value of the parameter assigned to the mod encoder
+	if (!inAutomationEditor()) {
+		ClipNavigationTimelineView::modEncoderAction(whichModEncoder, offset);
+		return;
+	}
+
+	// ok we're on the automation editor, so both mod encoders will edit the currently selected parameter
+	// we have two possible actions: step editing or editing current value
+
+	// now we need to setup the model stack with param for the selected parameter in the selected context
+
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStackWithTimelineCounter = nullptr;
 	ModelStackWithThreeMainThings* modelStackWithThreeMainThings = nullptr;
@@ -2440,42 +2452,39 @@ void AutomationView::modEncoderAction(int32_t whichModEncoder, int32_t offset) {
 		Clip* clip = getCurrentClip();
 		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 	}
+
+	// if we don't have a model stack or auto param, then no parameter to edit, so return early
+	if (!modelStackWithParam || !modelStackWithParam->autoParam) {
+		return;
+	}
+
 	int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 
-	// if user holding a node down, we'll adjust the value of the selected parameter being automated
-	if (isUIModeActive(UI_MODE_NOTES_PRESSED) || padSelectionOn) {
-		if (inAutomationEditor()
-		    && ((instrumentClipView.numEditPadPresses > 0
-		         && ((int32_t)(instrumentClipView.timeLastEditPadPress + 80 * 44 - AudioEngine::audioSampleTimer) < 0))
-		        || padSelectionOn)) {
+	// if user holding a node down, or we're in pad selection mode
+	// we'll adjust the value of the selected parameter being automated at the step selected
+	bool is_step_editing = isUIModeActive(UI_MODE_NOTES_PRESSED) || padSelectionOn;
+
+	if (is_step_editing) {
+		if ((instrumentClipView.numEditPadPresses > 0
+		     && ((int32_t)(instrumentClipView.timeLastEditPadPress + 80 * 44 - AudioEngine::audioSampleTimer) < 0))
+		    || padSelectionOn) {
 
 			if (automationEditorLayoutModControllable.automationModEncoderActionForSelectedPad(
 			        modelStackWithParam, whichModEncoder, offset, effectiveLength)) {
 				return;
 			}
 		}
-		else if (inNoteEditor()) {
-			goto followOnAction;
-		}
 	}
 	// if playback is enabled and you are recording, you will be able to record in live automations for
 	// the selected parameter this code is also executed if you're just changing the current value of
 	// the parameter at the current mod position
 	else {
-		if (inAutomationEditor()) {
-			automationEditorLayoutModControllable.automationModEncoderActionForUnselectedPad(
-			    modelStackWithParam, whichModEncoder, offset, effectiveLength);
-		}
-		else {
-			goto followOnAction;
-		}
+		automationEditorLayoutModControllable.automationModEncoderActionForUnselectedPad(
+		    modelStackWithParam, whichModEncoder, offset, effectiveLength);
 	}
 
 	uiNeedsRendering(&automationView);
 	return;
-
-followOnAction:
-	ClipNavigationTimelineView::modEncoderAction(whichModEncoder, offset);
 }
 
 // used to change gold knob parameter, copy paste automation or to delete automation of the current selected parameter
@@ -2503,6 +2512,8 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 
 	// if we got here then we're in automation editor and we want to copy / paste or delete automation
 
+	// now we need to setup the model stack with param for the selected parameter in the selected context
+
 	Clip* clip = getCurrentClip();
 	OutputType outputType = clip->output->type;
 
@@ -2521,7 +2532,7 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 	}
 
-	// if we don't have an auto param, then no automation to copy / paste or delete, so return
+	// if we don't have a model stack with param or auto param, then no automation to copy / paste or delete, so return
 	if (!modelStackWithParam || !modelStackWithParam->autoParam) {
 		return;
 	}
@@ -2537,8 +2548,8 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 	}
 	// if they want to paste automation
 	else if (is_paste_action) {
-		automationEditorLayoutModControllable.pasteAutomation(modelStackWithParam, clip, effectiveLength,
-				                                                    xScroll, xZoom);
+		automationEditorLayoutModControllable.pasteAutomation(modelStackWithParam, clip, effectiveLength, xScroll,
+		                                                      xZoom);
 	}
 	// if they want to delete automation
 	else if (is_delete_action) {

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2478,8 +2478,30 @@ followOnAction:
 	ClipNavigationTimelineView::modEncoderAction(whichModEncoder, offset);
 }
 
-// used to copy paste automation or to delete automation of the current selected parameter
+// used to change gold knob parameter, copy paste automation or to delete automation of the current selected parameter
 void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
+
+	// if we're in automation overview or note editor
+	// then we want to allow toggling with mod encoder buttons to change
+	// mod encoder selections or copy / paste
+	if (!inAutomationEditor()) {
+		instrumentClipView.modEncoderButtonAction(whichModEncoder, on);
+		uiNeedsRendering(&automationView);
+		return;
+	}
+
+	// if we're not trying to copy / paste (holding learn) and not trying to delete (holding shift), return
+	// if we're releasing mod encoder button action, return (we don't do anything on release)
+	bool is_learn_pressed = Buttons::isButtonPressed(hid::button::LEARN);
+	bool is_shift_pressed = Buttons::isShiftButtonPressed();
+	bool is_copy_action = is_learn_pressed && !is_shift_pressed;
+	bool is_paste_action = is_learn_pressed && is_shift_pressed;
+	bool is_delete_action = !is_learn_pressed & is_shift_pressed;
+	if (!on || (!is_copy_action && !is_paste_action && !is_delete_action)) {
+		return;
+	}
+
+	// if we got here then we're in automation editor and we want to copy / paste or delete automation
 
 	Clip* clip = getCurrentClip();
 	OutputType outputType = clip->output->type;
@@ -2498,64 +2520,40 @@ void AutomationView::modEncoderButtonAction(uint8_t whichModEncoder, bool on) {
 		modelStackWithTimelineCounter = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 		modelStackWithParam = getModelStackWithParamForClip(modelStackWithTimelineCounter, clip);
 	}
+
+	// if we don't have an auto param, then no automation to copy / paste or delete, so return
+	if (!modelStackWithParam || !modelStackWithParam->autoParam) {
+		return;
+	}
+
 	int32_t effectiveLength = getEffectiveLength(modelStackWithTimelineCounter);
 
 	int32_t xScroll = currentSong->xScroll[navSysId];
 	int32_t xZoom = currentSong->xZoom[navSysId];
 
-	// If they want to copy or paste automation...
-	if (Buttons::isButtonPressed(hid::button::LEARN)) {
-		if (on) {
-			if (Buttons::isShiftButtonPressed()) {
-				// paste within Automation Editor
-				if (inAutomationEditor()) {
-					automationEditorLayoutModControllable.pasteAutomation(modelStackWithParam, clip, effectiveLength,
-					                                                      xScroll, xZoom);
-				}
-				// paste on Automation Overview / Note Editor
-				else {
-					instrumentClipView.pasteAutomation(whichModEncoder, navSysId);
-				}
-			}
-			else {
-				// copy within Automation Editor
-				if (inAutomationEditor()) {
-					automationEditorLayoutModControllable.copyAutomation(modelStackWithParam, clip, xScroll, xZoom);
-				}
-				// copy on Automation Overview / Note Editor
-				else {
-					instrumentClipView.copyAutomation(whichModEncoder, navSysId);
-				}
-			}
-		}
+	// if they want to copy automation...
+	if (is_copy_action) {
+		automationEditorLayoutModControllable.copyAutomation(modelStackWithParam, clip, xScroll, xZoom);
+	}
+	// if they want to paste automation
+	else if (is_paste_action) {
+		automationEditorLayoutModControllable.pasteAutomation(modelStackWithParam, clip, effectiveLength,
+				                                                    xScroll, xZoom);
+	}
+	// if they want to delete automation
+	else if (is_delete_action) {
+		Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE);
+		modelStackWithParam->autoParam->deleteAutomation(action, modelStackWithParam);
+
+		display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_DELETED));
+
+		displayAutomation(padSelectionOn, !display->have7SEG());
 	}
 
-	// delete automation of current parameter selected
-	else if (Buttons::isShiftButtonPressed() && inAutomationEditor()) {
-		if (modelStackWithParam && modelStackWithParam->autoParam) {
-			Action* action = actionLogger.getNewAction(ActionType::AUTOMATION_DELETE);
-			modelStackWithParam->autoParam->deleteAutomation(action, modelStackWithParam);
-
-			display->displayPopup(l10n::get(l10n::String::STRING_FOR_AUTOMATION_DELETED));
-
-			displayAutomation(padSelectionOn, !display->have7SEG());
-		}
-	}
-
-	// if we're in automation overview or note editor
-	// then we want to allow toggling with mod encoder buttons to change
-	// mod encoder selections
-	else if (!inAutomationEditor()) {
-		goto followOnAction;
-	}
-
+	// refresh automation editor grid to show copy / pasted automation or deleted automation
 	uiNeedsRendering(&automationView);
+
 	return;
-
-followOnAction: // it will come here when you are on the automation overview / in note editor iscreen
-
-	view.modEncoderButtonAction(whichModEncoder, on);
-	uiNeedsRendering(&automationView);
 }
 
 // select encoder action

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -1036,7 +1036,7 @@ void InstrumentClipView::modEncoderButtonAction(uint8_t whichModEncoder, bool on
 
 	// If they want to copy or paste automation...
 	if (Buttons::isButtonPressed(deluge::hid::button::LEARN)) {
-		if (on && getCurrentOutputType() != OutputType::CV) {
+		if (on) {
 			if (Buttons::isShiftButtonPressed()) {
 				pasteAutomation(whichModEncoder);
 			}

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -224,7 +224,7 @@ void PerformanceView::initPadPress(PadPress& padPress) {
 	padPress.xDisplay = kNoSelection;
 	padPress.yDisplay = kNoSelection;
 	padPress.paramKind = params::Kind::NONE;
-	padPress.paramID = kNoSelection;
+	padPress.paramID = kNoParamID;
 }
 
 void PerformanceView::initFXPress(FXColumnPress& columnPress) {
@@ -237,7 +237,7 @@ void PerformanceView::initFXPress(FXColumnPress& columnPress) {
 
 void PerformanceView::initLayout(ParamsForPerformance& layout) {
 	layout.paramKind = params::Kind::NONE;
-	layout.paramID = kNoSelection;
+	layout.paramID = kNoParamID;
 	layout.xDisplay = kNoSelection;
 	layout.yDisplay = kNoSelection;
 	layout.rowColour[0] = 0;
@@ -378,7 +378,7 @@ void PerformanceView::renderRow(RGB* image, int32_t yDisplay) {
 		RGB& pixel = image[xDisplay];
 
 		// if an FX column has not been assigned a param, erase pad
-		if (layoutForPerformance[xDisplay].paramID == kNoSelection) {
+		if (layoutForPerformance[xDisplay].paramID == kNoParamID) {
 			pixel = colours::black;
 		}
 		else {
@@ -1010,7 +1010,7 @@ ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int3
 			if (!editingParam) {
 				bool ignorePadAction =
 				    defaultEditingMode && lastPadPress.isActive && (lastPadPress.xDisplay != xDisplay);
-				if (ignorePadAction || (layoutForPerformance[xDisplay].paramID == kNoSelection)) {
+				if (ignorePadAction || (layoutForPerformance[xDisplay].paramID == kNoParamID)) {
 					return ActionResult::DEALT_WITH;
 				}
 				normalPadAction(modelStack, xDisplay, yDisplay, on);
@@ -1344,7 +1344,7 @@ void PerformanceView::resetPerformanceView(ModelStackWithThreeMainThings* modelS
 			params::Kind lastSelectedParamKind = layoutForPerformance[xDisplay].paramKind; // kind;
 			int32_t lastSelectedParamID = layoutForPerformance[xDisplay].paramID;
 
-			if (lastSelectedParamID != kNoSelection) {
+			if (lastSelectedParamID != kNoParamID) {
 				padReleaseAction(modelStack, lastSelectedParamKind, lastSelectedParamID, xDisplay, false);
 			}
 		}
@@ -1362,7 +1362,7 @@ void PerformanceView::resetFXColumn(ModelStackWithThreeMainThings* modelStack, i
 		params::Kind lastSelectedParamKind = layoutForPerformance[xDisplay].paramKind; // kind;
 		int32_t lastSelectedParamID = layoutForPerformance[xDisplay].paramID;
 
-		if (lastSelectedParamID != kNoSelection) {
+		if (lastSelectedParamID != kNoParamID) {
 			padReleaseAction(modelStack, lastSelectedParamKind, lastSelectedParamID, xDisplay, false);
 		}
 	}
@@ -2066,7 +2066,7 @@ void PerformanceView::initializeHeldFX(int32_t xDisplay) {
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
 			if ((layoutForPerformance[xDisplay].paramKind != params::Kind::NONE)
-			    && (layoutForPerformance[xDisplay].paramID != kNoSelection)) {
+			    && (layoutForPerformance[xDisplay].paramID != kNoParamID)) {
 				setParameterValue(modelStack, layoutForPerformance[xDisplay].paramKind,
 				                  layoutForPerformance[xDisplay].paramID, xDisplay,
 				                  defaultFXValues[xDisplay][fxPress[xDisplay].yDisplay], false);

--- a/src/deluge/gui/views/performance_view.h
+++ b/src/deluge/gui/views/performance_view.h
@@ -31,11 +31,11 @@ class ModelStackWithThreeMainThings;
 class ModelStackWithAutoParam;
 
 struct PadPress {
-	bool isActive;
-	int32_t xDisplay;
-	int32_t yDisplay;
-	deluge::modulation::params::Kind paramKind;
-	int32_t paramID;
+	bool isActive = false;
+	int32_t xDisplay = kNoSelection;
+	int32_t yDisplay = kNoSelection;
+	deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE;
+	int32_t paramID = deluge::modulation::params::kNoParamID;
 };
 
 struct FXColumnPress {
@@ -48,7 +48,7 @@ struct FXColumnPress {
 
 struct ParamsForPerformance {
 	deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE;
-	deluge::modulation::params::ParamType paramID;
+	int32_t paramID = deluge::modulation::params::kNoParamID;
 	int32_t xDisplay = kNoSelection;
 	int32_t yDisplay = kNoSelection;
 	RGB rowColour = deluge::gui::colours::black;

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1077,7 +1077,7 @@ void AudioClip::writeDataToFile(Serializer& writer, Song* song) {
 	if (onAutomationClipView) {
 		writer.writeAttribute("onAutomationInstrumentClipView", 1);
 	}
-	if (lastSelectedParamID != kNoSelection) {
+	if (lastSelectedParamID != params::kNoParamID) {
 		writer.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		writer.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		writer.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -61,7 +61,7 @@ Clip::Clip(ClipType newType) : type(newType) {
 
 	// initialize automation clip view variables
 	onAutomationClipView = false;
-	lastSelectedParamID = kNoSelection;
+	lastSelectedParamID = params::kNoParamID;
 	lastSelectedParamKind = params::Kind::NONE;
 	lastSelectedParamShortcutX = kNoSelection;
 	lastSelectedParamShortcutY = kNoSelection;

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2305,7 +2305,7 @@ void InstrumentClip::writeDataToFile(Serializer& writer, Song* song) {
 	if (onAutomationClipView) {
 		writer.writeAttribute("onAutomationInstrumentClipView", 1);
 	}
-	if (lastSelectedParamID != kNoSelection) {
+	if (lastSelectedParamID != params::kNoParamID) {
 		writer.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		writer.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		writer.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -138,9 +138,12 @@ int32_t MIDIInstrument::getKnobPosForNonExistentParam(int32_t whichModEncoder, M
 
 ModelStackWithAutoParam*
 MIDIInstrument::getParamToControlFromInputMIDIChannel(int32_t cc, ModelStackWithThreeMainThings* modelStack) {
+	// ensure that we are trying to create a param for a valid cc number
+	bool is_cc_valid = ((cc >= 0) && (cc < kNumCCExpression));
 
-	if (!modelStack->paramManager) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
-		                             // have no Clips
+	// if cc is not valid or param manager is null (which can happen if the user is holding down an audition pad in
+	// Arranger, and we have no clips)
+	if (!is_cc_valid || !modelStack->paramManager) {
 noParam:
 		return modelStack->addParamCollectionAndId(nullptr, nullptr, 0)->addAutoParam(nullptr); // "No param"
 	}
@@ -165,9 +168,6 @@ expressionParam:
 			goto noParam;
 		}
 		break;
-
-	case CC_NUMBER_NONE:
-		goto noParam;
 
 	default:
 		summary = modelStack->paramManager->getMIDIParamCollectionSummary();

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -191,7 +191,7 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	globalEffectable.compressor.setBaseGain(0.85);
 
 	// initialize automation arranger view variables
-	lastSelectedParamID = kNoSelection;
+	lastSelectedParamID = params::kNoParamID;
 	lastSelectedParamKind = params::Kind::NONE;
 	lastSelectedParamShortcutX = kNoSelection;
 	lastSelectedParamShortcutY = kNoSelection;
@@ -1179,7 +1179,7 @@ weAreInArrangementEditorOrInClipInstance:
 	writer.writeAttribute("affectEntire", affectEntire);
 	writer.writeAttribute("activeModFunction", globalEffectable.modKnobMode);
 
-	if (lastSelectedParamID != kNoSelection) {
+	if (lastSelectedParamID != params::kNoParamID) {
 		writer.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		writer.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		writer.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);


### PR DESCRIPTION
Background:
- User reported issue where entering / exiting automation editor via the automation overview for a MIDI clip would result in previously recorded automation visually disappearing but still being sequenced (so it still existed).
- The user could get the recorded automation to seemly appear, disappear and re-appear.

Bisecting:
- I investigated and discovered that this issue was introduced in the 1.1 firmware when I refactored a lot of the functions in automation view to de-duplicate code that gets the model stack with param for various actions.

Cause:
- Because the getModelStackWithparam for MIDI clips just received a param ID but don't actually check that the param ID is valid, it can cause unintended behaviour whenever an invalid CC is passed to create a model stack with param.
- The root cause for the invalid param ID being passed for MIDI clips from automation view is due to inconsistent initializing of the lastSelectedParamID field when transitioning between the automation editor back to the automation overview.
- Automation view would sometimes compare / initialize lastSelectedParamID to kNoSelection and in other spots to kNoParamID. kNoParamID is what should've been used consistently throughout automation view.
- I also discovered similar behaviour pattern in performance view.

Fixes:
- the main fix from the automation view side was to ensure that kNoParamID is used consistently everywhere when comparing against param ID's in automation view.
- I also applied this same fix to performance view to be sure.

Secondary fixes:
- The other changes I discovered compared to 1.0 that might be causing issues is that in 1.1 I refactored code to de-duplicate getModelStackWithParam calls / logic. Unfortunately it seems like there were some cases left, notably between automation editor and automation overview where we would set up a model stack with param for the automation editor and then set it up again for the automation overview.
- What I should've done is check what context we're in before setting up the model stack with param so we truly only set it up once.
- So I've also done that in a few functions (modEncoderAction, modEncoderButtonAction, performActualRender, and soon to be completed: padAction).
- Essentially I am adopting the "return early" / check context early principle to avoid executing code unless truly needed.

To do:
- [ ] When calling getModelStackWithParam for midi clip, check that the midi cc being provided is valid
- [ ] Cleanup model stack getting code in pad action
- [ ] double check everything