### PR TITLE
Fix midi automation view invalid param bug

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -1487,14 +1487,14 @@ bool SoundEditor::isEditingAutomationViewParam() {
 	MenuItem* currentMenuItem = getCurrentMenuItem();
 
 	// get the param kind and index for that menu item (if there is one)
-	// returns Kind::NONE / paramID = kNoSelection if we're not in a param menu
+	// returns Kind::NONE / paramID = kNoParamID if we're not in a param menu
 	deluge::modulation::params::Kind kind = currentMenuItem->getParamKind();
 	int32_t paramID = currentMenuItem->getParamIndex();
 
 	bool editingParamInAutomationArrangerView = false;
 	bool editingParamInAutomationClipView = false;
 
-	if (kind != deluge::modulation::params::Kind::NONE && paramID != kNoSelection) {
+	if (kind != deluge::modulation::params::Kind::NONE && paramID != deluge::modulation::params::kNoParamID) {
 		// are in automation arranger view and editing the same param open in the menu?
 		editingParamInAutomationArrangerView = automationView.onArrangerView
 		                                       && (kind == currentSong->lastSelectedParamKind)

--- a/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
@@ -351,7 +351,7 @@ void AutomationEditorLayoutModControllable::renderAutomationEditorDisplay7SEG(Cl
 		}
 		else if (getLastPadSelectedKnobPos() != kNoSelection) {
 			params::Kind lastSelectedParamKind = params::Kind::NONE;
-			int32_t lastSelectedParamID = kNoSelection;
+			int32_t lastSelectedParamID = params::kNoParamID;
 			if (getOnArrangerView()) {
 				lastSelectedParamKind = currentSong->lastSelectedParamKind;
 				lastSelectedParamID = currentSong->lastSelectedParamID;
@@ -403,7 +403,7 @@ void AutomationEditorLayoutModControllable::getAutomationParameterName(Clip* cli
                                                                        StringBuf& parameterName) {
 	if (getOnArrangerView() || outputType != OutputType::MIDI_OUT) {
 		params::Kind lastSelectedParamKind = params::Kind::NONE;
-		int32_t lastSelectedParamID = kNoSelection;
+		int32_t lastSelectedParamID = params::kNoParamID;
 		PatchSource lastSelectedPatchSource = PatchSource::NONE;
 		if (getOnArrangerView()) {
 			lastSelectedParamKind = currentSong->lastSelectedParamKind;

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -972,7 +972,7 @@ void AutomationView::renderDisplay(int32_t knobPosLeft, int32_t knobPosRight, bo
 	// if you're not in a MIDI instrument clip, convert the knobPos to the same range as the menu (0-50)
 	if (inAutomationEditor() && (onArrangerView || outputType != OutputType::MIDI_OUT)) {
 		params::Kind lastSelectedParamKind = params::Kind::NONE;
-		int32_t lastSelectedParamID = kNoSelection;
+		int32_t lastSelectedParamID = params::kNoParamID;
 		if (onArrangerView) {
 			lastSelectedParamKind = currentSong->lastSelectedParamKind;
 			lastSelectedParamID = currentSong->lastSelectedParamID;
@@ -3030,7 +3030,7 @@ void AutomationView::initParameterSelection(bool updateDisplay) {
 	initPadSelection();
 
 	if (onArrangerView) {
-		currentSong->lastSelectedParamID = kNoSelection;
+		currentSong->lastSelectedParamID = params::kNoParamID;
 		currentSong->lastSelectedParamKind = params::Kind::NONE;
 		currentSong->lastSelectedParamShortcutX = kNoSelection;
 		currentSong->lastSelectedParamShortcutY = kNoSelection;
@@ -3038,7 +3038,7 @@ void AutomationView::initParameterSelection(bool updateDisplay) {
 	}
 	else {
 		Clip* clip = getCurrentClip();
-		clip->lastSelectedParamID = kNoSelection;
+		clip->lastSelectedParamID = params::kNoParamID;
 		clip->lastSelectedParamKind = params::Kind::NONE;
 		clip->lastSelectedParamShortcutX = kNoSelection;
 		clip->lastSelectedParamShortcutY = kNoSelection;
@@ -3181,11 +3181,11 @@ bool AutomationView::onAutomationOverview() {
 
 bool AutomationView::inAutomationEditor() {
 	if (onArrangerView) {
-		if (currentSong->lastSelectedParamID == kNoSelection) {
+		if (currentSong->lastSelectedParamID == params::kNoParamID) {
 			return false;
 		}
 	}
-	else if (getCurrentClip()->lastSelectedParamID == kNoSelection) {
+	else if (getCurrentClip()->lastSelectedParamID == params::kNoParamID) {
 		return false;
 	}
 

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -224,7 +224,7 @@ void PerformanceView::initPadPress(PadPress& padPress) {
 	padPress.xDisplay = kNoSelection;
 	padPress.yDisplay = kNoSelection;
 	padPress.paramKind = params::Kind::NONE;
-	padPress.paramID = kNoSelection;
+	padPress.paramID = kNoParamID;
 }
 
 void PerformanceView::initFXPress(FXColumnPress& columnPress) {
@@ -237,7 +237,7 @@ void PerformanceView::initFXPress(FXColumnPress& columnPress) {
 
 void PerformanceView::initLayout(ParamsForPerformance& layout) {
 	layout.paramKind = params::Kind::NONE;
-	layout.paramID = kNoSelection;
+	layout.paramID = kNoParamID;
 	layout.xDisplay = kNoSelection;
 	layout.yDisplay = kNoSelection;
 	layout.rowColour[0] = 0;
@@ -378,7 +378,7 @@ void PerformanceView::renderRow(RGB* image, int32_t yDisplay) {
 		RGB& pixel = image[xDisplay];
 
 		// if an FX column has not been assigned a param, erase pad
-		if (layoutForPerformance[xDisplay].paramID == kNoSelection) {
+		if (layoutForPerformance[xDisplay].paramID == kNoParamID) {
 			pixel = colours::black;
 		}
 		else {
@@ -1010,7 +1010,7 @@ ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int3
 			if (!editingParam) {
 				bool ignorePadAction =
 				    defaultEditingMode && lastPadPress.isActive && (lastPadPress.xDisplay != xDisplay);
-				if (ignorePadAction || (layoutForPerformance[xDisplay].paramID == kNoSelection)) {
+				if (ignorePadAction || (layoutForPerformance[xDisplay].paramID == kNoParamID)) {
 					return ActionResult::DEALT_WITH;
 				}
 				normalPadAction(modelStack, xDisplay, yDisplay, on);
@@ -1344,7 +1344,7 @@ void PerformanceView::resetPerformanceView(ModelStackWithThreeMainThings* modelS
 			params::Kind lastSelectedParamKind = layoutForPerformance[xDisplay].paramKind; // kind;
 			int32_t lastSelectedParamID = layoutForPerformance[xDisplay].paramID;
 
-			if (lastSelectedParamID != kNoSelection) {
+			if (lastSelectedParamID != kNoParamID) {
 				padReleaseAction(modelStack, lastSelectedParamKind, lastSelectedParamID, xDisplay, false);
 			}
 		}
@@ -1362,7 +1362,7 @@ void PerformanceView::resetFXColumn(ModelStackWithThreeMainThings* modelStack, i
 		params::Kind lastSelectedParamKind = layoutForPerformance[xDisplay].paramKind; // kind;
 		int32_t lastSelectedParamID = layoutForPerformance[xDisplay].paramID;
 
-		if (lastSelectedParamID != kNoSelection) {
+		if (lastSelectedParamID != kNoParamID) {
 			padReleaseAction(modelStack, lastSelectedParamKind, lastSelectedParamID, xDisplay, false);
 		}
 	}
@@ -2066,7 +2066,7 @@ void PerformanceView::initializeHeldFX(int32_t xDisplay) {
 			    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
 			if ((layoutForPerformance[xDisplay].paramKind != params::Kind::NONE)
-			    && (layoutForPerformance[xDisplay].paramID != kNoSelection)) {
+			    && (layoutForPerformance[xDisplay].paramID != kNoParamID)) {
 				setParameterValue(modelStack, layoutForPerformance[xDisplay].paramKind,
 				                  layoutForPerformance[xDisplay].paramID, xDisplay,
 				                  defaultFXValues[xDisplay][fxPress[xDisplay].yDisplay], false);

--- a/src/deluge/gui/views/performance_view.h
+++ b/src/deluge/gui/views/performance_view.h
@@ -31,11 +31,11 @@ class ModelStackWithThreeMainThings;
 class ModelStackWithAutoParam;
 
 struct PadPress {
-	bool isActive;
-	int32_t xDisplay;
-	int32_t yDisplay;
-	deluge::modulation::params::Kind paramKind;
-	int32_t paramID;
+	bool isActive = false;
+	int32_t xDisplay = kNoSelection;
+	int32_t yDisplay = kNoSelection;
+	deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE;
+	int32_t paramID = deluge::modulation::params::kNoParamID;
 };
 
 struct FXColumnPress {
@@ -48,7 +48,7 @@ struct FXColumnPress {
 
 struct ParamsForPerformance {
 	deluge::modulation::params::Kind paramKind = deluge::modulation::params::Kind::NONE;
-	deluge::modulation::params::ParamType paramID;
+	int32_t paramID = deluge::modulation::params::kNoParamID;
 	int32_t xDisplay = kNoSelection;
 	int32_t yDisplay = kNoSelection;
 	RGB rowColour = deluge::gui::colours::black;

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -1077,7 +1077,7 @@ void AudioClip::writeDataToFile(Serializer& writer, Song* song) {
 	if (onAutomationClipView) {
 		writer.writeAttribute("onAutomationInstrumentClipView", 1);
 	}
-	if (lastSelectedParamID != kNoSelection) {
+	if (lastSelectedParamID != params::kNoParamID) {
 		writer.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		writer.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		writer.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -61,7 +61,7 @@ Clip::Clip(ClipType newType) : type(newType) {
 
 	// initialize automation clip view variables
 	onAutomationClipView = false;
-	lastSelectedParamID = kNoSelection;
+	lastSelectedParamID = params::kNoParamID;
 	lastSelectedParamKind = params::Kind::NONE;
 	lastSelectedParamShortcutX = kNoSelection;
 	lastSelectedParamShortcutY = kNoSelection;

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -2305,7 +2305,7 @@ void InstrumentClip::writeDataToFile(Serializer& writer, Song* song) {
 	if (onAutomationClipView) {
 		writer.writeAttribute("onAutomationInstrumentClipView", 1);
 	}
-	if (lastSelectedParamID != kNoSelection) {
+	if (lastSelectedParamID != params::kNoParamID) {
 		writer.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		writer.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		writer.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -138,9 +138,12 @@ int32_t MIDIInstrument::getKnobPosForNonExistentParam(int32_t whichModEncoder, M
 
 ModelStackWithAutoParam*
 MIDIInstrument::getParamToControlFromInputMIDIChannel(int32_t cc, ModelStackWithThreeMainThings* modelStack) {
+	// ensure that we are trying to create a param for a valid cc number
+	bool is_cc_valid = ((cc >= 0) && (cc < kNumCCExpression));
 
-	if (!modelStack->paramManager) { // Could be NULL - if the user is holding down an audition pad in Arranger, and we
-		                             // have no Clips
+	// if cc is not valid or param manager is null (which can happen if the user is holding down an audition pad in
+	// Arranger, and we have no clips)
+	if (!is_cc_valid || !modelStack->paramManager) {
 noParam:
 		return modelStack->addParamCollectionAndId(nullptr, nullptr, 0)->addAutoParam(nullptr); // "No param"
 	}
@@ -165,9 +168,6 @@ expressionParam:
 			goto noParam;
 		}
 		break;
-
-	case CC_NUMBER_NONE:
-		goto noParam;
 
 	default:
 		summary = modelStack->paramManager->getMIDIParamCollectionSummary();

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -191,7 +191,7 @@ Song::Song() : backedUpParamManagers(sizeof(BackedUpParamManager)) {
 	globalEffectable.compressor.setBaseGain(0.85);
 
 	// initialize automation arranger view variables
-	lastSelectedParamID = kNoSelection;
+	lastSelectedParamID = params::kNoParamID;
 	lastSelectedParamKind = params::Kind::NONE;
 	lastSelectedParamShortcutX = kNoSelection;
 	lastSelectedParamShortcutY = kNoSelection;
@@ -1179,7 +1179,7 @@ weAreInArrangementEditorOrInClipInstance:
 	writer.writeAttribute("affectEntire", affectEntire);
 	writer.writeAttribute("activeModFunction", globalEffectable.modKnobMode);
 
-	if (lastSelectedParamID != kNoSelection) {
+	if (lastSelectedParamID != params::kNoParamID) {
 		writer.writeAttribute("lastSelectedParamID", lastSelectedParamID);
 		writer.writeAttribute("lastSelectedParamKind", util::to_underlying(lastSelectedParamKind));
 		writer.writeAttribute("lastSelectedParamShortcutX", lastSelectedParamShortcutX);


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4550

Background:
- User reported issue where entering / exiting automation editor via the automation overview for a MIDI clip would result in previously recorded automation visually disappearing but still being sequenced (so it still existed).
- The user could get the recorded automation to seemly appear, disappear and re-appear.

Bisecting:
- I investigated and discovered that this issue was introduced in the 1.1 firmware. the 1.1 firmware introduced a lot of refactoring but it also changed how an unselected / invalid parameter is identified in automation view. 
- Previously I used kNoSelection. Firmware 1.1 introduced a variable called kNoParamID. Unfortunately kNoSelection was not consistently replaced with kNoParamID. So you had some spots comparing the param ID to kNoSelection and other spots to kNoParamID.
- The inconsistency checking for kNoParamID resulted in an invalid ParamID getting passed to create the modelStackWithParam for midi clips.

Cause:
- Because the getModelStackWithparam for MIDI clips just received a param ID but doesn't actually check that the param ID is valid, it can cause unintended behaviour whenever an invalid CC is passed to create a model stack with param.
- The root cause for the invalid param ID being passed for MIDI clips from automation view is due to inconsistent initializing of the lastSelectedParamID field when transitioning between the automation editor back to the automation overview (as mentioned above - using kNoParamID non-consistently).
- Automation view would sometimes compare / initialize lastSelectedParamID to kNoSelection and in other spots to kNoParamID. kNoParamID is what should've been used consistently throughout automation view.
- I also discovered similar behaviour pattern in performance view.

Fixes:
- the fix of the real issue is in the first commit which now prevents an invalid param to be selected in the automation editor for midi clips by checking that the cc passed is valid.
- the main fix from the automation view side was to ensure that kNoParamID is used consistently everywhere when comparing against param ID's in automation view so that it doesn't attempt to create an invalid parameter for midi clips
- I also applied this same fix to performance view to be sure.