### PR TITLE
Fix early clamping when loading swing interval from song file

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1664,7 +1664,6 @@ unknownTag:
 				// both until the end. Also, in firmware pre V3.1.0-alpha, all "sync" values were stored as plain
 				// old ints, to be read irrespective of insideWorldTickMagnitude
 				swingInterval = reader.readTagOrAttributeValueInt();
-				swingInterval = std::min(swingInterval, (uint8_t)9);
 				reader.exitTag("swingInterval");
 			}
 
@@ -2081,6 +2080,7 @@ loadOutput:
 		// know we have enough info to do the conversion
 		swingInterval = convertSyncLevelFromFileValueToInternalValue(swingInterval);
 	}
+	swingInterval = std::min(swingInterval, (uint8_t)9);
 
 	setTimePerTimerTick(newTimePerTimerTick);
 


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4543

Fixed issue where some swing interval's would not get re-loaded properly from the song file due to clamping in the code.

This seems to be a longstanding issue that has existed since the original firmware due to lack of visibility into the swing interval that was re-loaded with the song file (there was no song menu, no song swing interval shortcut, etc)

--

### The example issue:

- save song with 128th note swing interval
- reload the song
- song is loaded with 64th note swing interval

--

### Investigation: 

save 3 song files with 3 different swing intervals and see the swingInterval and inputTickMagnitude saved to the file:

128th note file:
```
	inputTickMagnitude="2"
	swingInterval="10"
```

64th note file:
```
	inputTickMagnitude="2"
	swingInterval="9"
```

16th note file:
```
	inputTickMagnitude="2"
	swingInterval="7"
```

--

The deluge re-loads the swing interval in Song::readFromFile with the following logic:

```
swingInterval = reader.readTagOrAttributeValueInt();
swingInterval = std::min(swingInterval, (uint8_t)9);
swingInterval = convertSyncLevelFromFileValueToInternalValue(swingInterval);
```

```
int32_t Song::convertSyncLevelFromFileValueToInternalValue(int32_t fileValue) {

	// The file value is relative to insideWorldTickMagnitude etc, though if insideWorldTickMagnitude is 1 (which
	// used to be the default), it comes out as the same value anyway (kind of a side point)

	if (fileValue == 0) {
		return 0; // 0 means "off"
	}
	int32_t internalValue = fileValue + 1 - (getInputTickMagnitude());
	if (internalValue < 1) {
		internalValue = 1;
	}
	else if (internalValue > 9) {
		internalValue = 9;
	}

	return internalValue;
}
```

So if we substitute the above example values from the three song xml files, the calculations of the swing interval are as follows:

128th note file:
```
	inputTickMagnitude="2"
	swingInterval="10"
	
	deluge calculation:
	swingInterval = min(10, 9) = 9
	swingInterval = 9 + 1 - 2 = 8
	
	8 is the same calculation as 64th notes (see below)
	
```

64th note file:
```
	inputTickMagnitude="2"
	swingInterval="9"
	
	deluge calculation:
	swingInterval = min(9, 9) = 9
	swingInterval = 9 + 1 - 2 = 8
```

16th note file:
```
	inputTickMagnitude="2"
	swingInterval="7"
	
	deluge calculation:
	swingInterval = min(7,9) = 7
	swingInterval = 7 + 1 - 2 = 6
```

---

### The fix: 

move the min(interval, 9) clamp after the conversion calculation like this:

```
swingInterval = reader.readTagOrAttributeValueInt();
swingInterval = convertSyncLevelFromFileValueToInternalValue(swingInterval);
swingInterval = std::min(swingInterval, (uint8_t)9);
```

128th note file:
```
	inputTickMagnitude="2"
	swingInterval="10"
	
	deluge calculation:
	swingInterval = 10 + 1 - 2 = 9
	swingInterval = min(9, 9) = 9
	
	so now the calculated value is no longer the same as for 64th notes
```


