### PR TITLE
Revert "Fix ghost notes at start of linear MIDI recording (#4225) (#4477)

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -461,11 +461,13 @@ Error InstrumentClip::beginLinearRecording(ModelStackWithTimelineCounter* modelS
 					Iterance iterance = noteRow->getDefaultIterance();
 					int32_t fill = noteRow->getDefaultFill(modelStackWithNoteRow);
 					noteRow->attemptNoteAdd(0, 1, velocity, probability, iterance, fill, modelStackWithNoteRow, action);
-					// Always suppress re-trigger from the live MIDI stream: we just inserted this note at position 0
-					// via earlyNotes, so any note-on arriving before tick 1 (including clip-length-doubling replays)
-					// would produce a ghost note with zero/corrupted velocity. This applies whether or not the note
-					// is still physically held — note-offs and presses at tick >= 1 are unaffected.
-					noteRow->ignoreNoteOnsBefore_ = 1;
+					if (!thisDrum->earlyNoteStillActive) {
+						D_PRINTLN("skipping next note");
+
+						// We just inserted a note-on for an "early" note that is still sounding at time 0, so ignore
+						// note-ons until at least tick 1 to avoid double-playing that note
+						noteRow->ignoreNoteOnsBefore_ = 1;
+					}
 				}
 			}
 		}
@@ -489,10 +491,11 @@ Error InstrumentClip::beginLinearRecording(ModelStackWithTimelineCounter* modelS
 					Iterance iterance = noteRow->getDefaultIterance();
 					int32_t fill = noteRow->getDefaultFill(modelStackWithNoteRow);
 					noteRow->attemptNoteAdd(0, 1, velocity, probability, iterance, fill, modelStackWithNoteRow, action);
-					// Always suppress re-trigger: note at position 0 came from earlyNotes; any live note-on arriving
-					// before tick 1 (including those caused by clip-length-doubling) would ghost-duplicate it.
-					// Note-offs and note-ons at tick >= 1 are not suppressed.
-					noteRow->ignoreNoteOnsBefore_ = 1;
+					if (!still_active) {
+						// We just inserted a note-on for an "early" note that is still sounding at time 0, so ignore
+						// note-ons until at least tick 1 to avoid double-playing that note
+						noteRow->ignoreNoteOnsBefore_ = 1;
+					}
 				}
 			}
 


### PR DESCRIPTION
This reverts commit c00296604754466103f6f4d21878744567c1804b.

Reverting this commit because it does not fix issue #4225 (the fix will be in #4564).

This code has existed since official and this issue is not present in 1.2. So this fix is not the right one.

You can see the code existing here in 1.2:
https://github.com/SynthstromAudible/DelugeFirmware/blob/c23bc2fecb38ccbdcd3c187870f527277f66e726/src/deluge/model/clip/instrument_clip.cpp#L470

https://github.com/SynthstromAudible/DelugeFirmware/blob/c23bc2fecb38ccbdcd3c187870f527277f66e726/src/deluge/model/clip/instrument_clip.cpp#L498

And here in official:
https://github.com/SynthstromAudible/DelugeFirmware/blob/695b22af1e9fcc060e59868c83cf8e504bd57ff1/src/InstrumentClip.cpp#L429

https://github.com/SynthstromAudible/DelugeFirmware/blob/695b22af1e9fcc060e59868c83cf8e504bd57ff1/src/InstrumentClip.cpp#L453