### PR TITLE
Fix/ Linear recording early note array issues (ghost notes, note length)

### DIFF
--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -500,7 +500,7 @@ bool MelodicInstrument::setActiveClip(ModelStackWithTimelineCounter* modelStack,
 }
 
 bool MelodicInstrument::isNoteRowStillAuditioningAsLinearRecordingEnded(NoteRow* noteRow) {
-	return notesAuditioned.contains(noteRow->y) && earlyNotes.contains(noteRow->y);
+	return notesAuditioned.contains(noteRow->y) && !earlyNotes.contains(noteRow->y);
 }
 
 void MelodicInstrument::stopAnyAuditioning(ModelStack* modelStack) {

--- a/src/deluge/model/instrument/melodic_instrument.cpp
+++ b/src/deluge/model/instrument/melodic_instrument.cpp
@@ -562,7 +562,11 @@ void MelodicInstrument::beginAuditioningForNote(ModelStack* modelStack, int32_t 
 void MelodicInstrument::endAuditioningForNote(ModelStack* modelStack, int32_t note, int32_t velocity) {
 
 	notesAuditioned.erase(note);
-	earlyNotes[note].still_active = false; // set no longer active
+	// if this note was recorded as an early note, then set no longer active
+	if (earlyNotes.contains(note)) {
+		earlyNotes[note].still_active = false;
+	}
+
 	if (!activeClip) {
 		return;
 	}


### PR DESCRIPTION
Fix a couple of issues with linear recording:
- creation of ghost notes with 0 velocity (Fix #4225)
- note length not set correctly for notes still auditioning at end of linear recording

## Commit 1 - Fix creating ghost notes with velocity 0 at the start of linear recording

Only mark early note as no longer active if the note was previously recorded as an early note

Otherwise new early note array entry gets created with velocity initialized to zero.

This issue was accidentally introduced as part of the earlyNoteArray refactoring here: https://github.com/SynthstromAudible/DelugeFirmware/commit/d4e546315c2b3f433a28aee5c4b81de9707ee15b#diff-d65a552ab6c02e0608eb996d9408fe5ad38e1e153a6186f5c47852a84cf8e8e2L145-L556

Previously, in 1.2 firmwares and earlier, earlyNotes.noteNoLongerActive(note) would get called which would check that the note exists in the early note array:

https://github.com/SynthstromAudible/DelugeFirmware/blob/c23bc2fecb38ccbdcd3c187870f527277f66e726/src/deluge/model/instrument/melodic_instrument.cpp#L552

https://github.com/SynthstromAudible/DelugeFirmware/blob/c23bc2fecb38ccbdcd3c187870f527277f66e726/src/deluge/util/container/array/early_note_array.cpp#L52 

## Commit 2 - Fix note row auditioning check at the end of linear recording

This fixes issue where note still held at end of linear recording is not extended properly to the end of the clip

A change was accidentally introduced as part of the earlyNoteArray refactoring here: https://github.com/SynthstromAudible/DelugeFirmware/commit/d4e546315c2b3f433a28aee5c4b81de9707ee15b#diff-d65a552ab6c02e0608eb996d9408fe5ad38e1e153a6186f5c47852a84cf8e8e2R500

This commit restores the logic from the 1.2 firmware

In the 1.2 firmware and earlier firmwares, the check looked like this:

- Return true if note is auditioned and not found in early note array
https://github.com/SynthstromAudible/DelugeFirmware/blob/c23bc2fecb38ccbdcd3c187870f527277f66e726/src/deluge/model/instrument/melodic_instrument.cpp#L508

In the 1.3 firmware:

- Return true if note is auditioned and found in the early note array
https://github.com/SynthstromAudible/DelugeFirmware/blob/c59e75804de6bf565ea77037ad53202106a60fcc/src/deluge/model/instrument/melodic_instrument.cpp#L503

## To do:
- [x] test when I'm back in front of Deluge