### PR TITLE
Burst guard on the MIDI/GATE clock inputs

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -518,6 +518,8 @@ void PlaybackHandler::setupPlayback(int32_t newPlaybackState, int32_t playFromPo
 	lastSwungTickActioned = 0;
 	lastTriggerClockOutTickDone = -1;
 	lastMIDIClockOutTickDone = -1;
+	timeLastMIDIClockOutTickSent = 0;
+	timeLastTriggerClockOutTickSent = 0;
 
 	swungTickScheduled = false;
 	triggerClockOutTickScheduled = false;
@@ -780,6 +782,7 @@ void PlaybackHandler::actionTimerTickPart2() {
 void PlaybackHandler::doTriggerClockOutTick() {
 	triggerClockOutTickScheduled = false;
 	lastTriggerClockOutTickDone++;
+	timeLastTriggerClockOutTickSent = AudioEngine::audioSampleTimer;
 	if (skipAnalogClocks) {
 		skipAnalogClocks--;
 	}
@@ -829,6 +832,23 @@ void PlaybackHandler::scheduleTriggerClockOutTickFromExternalClock() {
 	auto result = computeExternalClockSchedule(lastTriggerClockOutTickDone, lastInputTickReceived, internalTicksPer,
 	                                           analogOutTicksPer, inputTicksPer, internalTicksPerInput,
 	                                           timePerInputTickMovingAverage, timeLastInputTicks[0]);
+
+	// Burst guard (issue #3587), mirroring scheduleMIDIClockOutTickFromExternalClock(). After a blocking song
+	// load/save, buffered input clocks are drained in a tight loop and would each emit an output tick immediately,
+	// bursting the analog clock and desyncing followers. If we'd emit sooner than is physically possible at the
+	// current tempo, we're draining a backlog: skip the emit and realign instead, collapsing it to a single tick.
+	bool wouldEmit =
+	    (result.action == ClockScheduleAction::EmitAndSchedule || result.action == ClockScheduleAction::EmitAndResync);
+	if (wouldEmit && timePerInputTickMovingAverage != 0) {
+		// Real time we'd expect between successive analog out ticks at the current tempo.
+		uint64_t timePerAnalogOutTick = (uint64_t)timePerInputTickMovingAverage * internalTicksPer * inputTicksPer
+		                                / ((uint64_t)analogOutTicksPer * internalTicksPerInput);
+		uint32_t timeSinceLastSent = AudioEngine::audioSampleTimer - timeLastTriggerClockOutTickSent;
+		if (timeSinceLastSent < (timePerAnalogOutTick >> 1)) {
+			resyncAnalogOutTicksToInternalTicks();
+			return;
+		}
+	}
 
 	switch (result.action) {
 	case ClockScheduleAction::EmitAndResync:
@@ -889,6 +909,26 @@ void PlaybackHandler::scheduleMIDIClockOutTickFromExternalClock() {
 	                                           midiClockOutTicksPer, inputTicksPer, internalTicksPerInput,
 	                                           timePerInputTickMovingAverage, timeLastInputTicks[0]);
 
+	// Burst guard (issue #3587). A blocking operation such as a song load or save stalls MIDI servicing, so incoming
+	// clocks pile up in the input buffer and are then drained in a tight loop, each one wanting to emit an output
+	// clock immediately. The emit-one-then-resync logic in computeExternalClockSchedule() can't catch this because
+	// each backlog tick only puts us one tick behind. The result is a burst of clocks at a single instant that stalls
+	// or desyncs followers. So if we'd emit a clock sooner than is physically possible at the current tempo, we know
+	// we're draining a backlog: skip the emit and just realign the output counter, collapsing the backlog to a single
+	// clock instead of a burst.
+	bool wouldEmit =
+	    (result.action == ClockScheduleAction::EmitAndSchedule || result.action == ClockScheduleAction::EmitAndResync);
+	if (wouldEmit && timePerInputTickMovingAverage != 0) {
+		// Real time we'd expect between successive output clocks at the current tempo.
+		uint64_t timePerMIDIOutTick = (uint64_t)timePerInputTickMovingAverage * internalTicksPer * inputTicksPer
+		                              / ((uint64_t)midiClockOutTicksPer * internalTicksPerInput);
+		uint32_t timeSinceLastSent = AudioEngine::audioSampleTimer - timeLastMIDIClockOutTickSent;
+		if (timeSinceLastSent < (timePerMIDIOutTick >> 1)) {
+			resyncMIDIClockOutTicksToInternalTicks();
+			return;
+		}
+	}
+
 	switch (result.action) {
 	case ClockScheduleAction::EmitAndResync:
 		doMIDIClockOutTick();
@@ -918,6 +958,7 @@ void PlaybackHandler::doMIDIClockOutTick() {
 	}
 	midiClockOutTickScheduled = false;
 	lastMIDIClockOutTickDone++;
+	timeLastMIDIClockOutTickSent = AudioEngine::audioSampleTimer;
 	if (skipMidiClocks) {
 		skipMidiClocks--;
 	}

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -96,6 +96,9 @@ public:
 	bool midiClockOutTickScheduled;
 	uint32_t timeNextMIDIClockOutTick;
 	int64_t lastMIDIClockOutTickDone;
+	// audioSampleTimer when we last actually sent a MIDI clock out tick. Used to rate-limit emission under external
+	// clock so a backlog of buffered input clocks (e.g. drained after a blocking song load/save) can't burst out.
+	uint32_t timeLastMIDIClockOutTickSent;
 
 	// Playback
 	uint8_t playbackState;
@@ -140,6 +143,10 @@ public:
 	bool triggerClockOutTickScheduled;
 	uint32_t timeNextTriggerClockOutTick;
 	int64_t lastTriggerClockOutTickDone;
+	// audioSampleTimer when we last actually sent an analog/trigger clock out tick. Used to rate-limit emission under
+	// external clock so a backlog of buffered input clocks (e.g. drained after a blocking song load/save) can't burst
+	// out. See timeLastMIDIClockOutTickSent and issue #3587.
+	uint32_t timeLastTriggerClockOutTickSent;
 
 	uint32_t analogOutTicksPPQN; // Relative to the "external world", which also means relative to the displayed tempo
 	uint32_t analogInTicksPPQN;


### PR DESCRIPTION
Fixes #3587 

Problem: Song load blocks MIDI/GATE clock outputs, so all the accumulated messages in the DMA buffer would get sent out all at once. This is just a way to drop them, relying on the downstream systems' ability to maintain clock for a few seconds independently of the Deluge.

A more proper fix would be something like a timed ISR to output clock messages, but I think @m-m-adams tried that and had scheduling problems, so we can wait until 2.0 for that.