### PR TITLE
Add bright/dim indication for the activated macros

### DIFF
--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -574,7 +574,12 @@ ActionResult AudioClipView::padAction(int32_t x, int32_t y, int32_t on) {
 			if (sdRoutineLock) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
-			if (!on) {
+			// render that you're holding the macro
+			if (on) {
+				uiNeedsRendering(this, 0, 0xFFFFFFFF);
+			}
+			// activate macro on release
+			else {
 				view.activateMacro(y);
 			}
 			return ActionResult::DEALT_WITH;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2219,8 +2219,12 @@ ActionResult InstrumentClipView::commandActivateSongMacro(int32_t y, int32_t vel
 	if (sdRoutineLock) {
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
-	if (!velocity) {
-		// TODO: long press..
+	// render that you're holding the macro
+	if (velocity) {
+		uiNeedsRendering(this, 0, 0xFFFFFFFF);
+	}
+	// activate macro on release
+	else {
 		view.activateMacro(y);
 	}
 	return ActionResult::DEALT_WITH;

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2859,6 +2859,11 @@ bool View::renderMacros(int32_t column, uint32_t y, int32_t selectedMacro, RGB i
 		occupancyMask[y][column] = true;
 	}
 
+	// Dim macros at rest so that pressing one visibly brightens it to its full colour, giving
+	// feedback that the press registered (issue #3244).
+	bool held_macro = matrixDriver.isPadPressed(column, y);
+	image[y][column] = image[y][column].adjust(255, (held_macro ? 1 : 8));
+
 	return armed;
 }
 


### PR DESCRIPTION
Add bright/dim indication for the activated macros in keyboard and clip views

Fix #3244 