### PR TITLE
Recency clock: date saved files in save order (no RTC needed)

### DIFF
--- a/src/RZA1/diskio.c
+++ b/src/RZA1/diskio.c
@@ -294,9 +294,111 @@ DRESULT disk_ioctl(BYTE pdrv, /* Physical drive nmuber (0..) */
     }
 }
 
+/* ---- Recency clock -------------------------------------------------------
+ * The Deluge has no real-time clock, so it used to stamp every saved file with
+ * time 0. Instead we COUNT: each save gets a packed FAT datetime later than the
+ * last, so sorting by date == sorting by save order. The counter is seeded at
+ * card mount from the newest date already on the card (fatClockSeedFromPacked,
+ * called from storage_manager) so it never goes backwards across power cycles.
+ * The resulting "dates" are synthetic (they look odd on a computer) but give
+ * true recency on the device. */
+static uint32_t fatClockSecs2               = 0;  /* 2-second units since 1980-01-01 */
+static const uint32_t fatClockStep          = 30; /* advance 60s per save (lots of headroom) */
+static const unsigned char fatMonthDays[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+static int fatIsLeap(uint32_t y)
+{
+    return ((y % 4 == 0 && y % 100 != 0) || y % 400 == 0);
+}
+
+/* 2-second-units-since-1980 -> packed FAT datetime */
+static DWORD fatPack(uint32_t s2)
+{
+    uint32_t secs = s2 * 2u;
+    uint32_t days = secs / 86400u;
+    uint32_t rem  = secs % 86400u;
+    uint32_t hour = rem / 3600u;
+    rem %= 3600u;
+    uint32_t minute = rem / 60u;
+    uint32_t sec    = rem % 60u;
+    uint32_t year   = 1980u;
+    while (1)
+    {
+        uint32_t diy = 365u + (uint32_t)fatIsLeap(year);
+        if (days >= diy)
+        {
+            days -= diy;
+            year++;
+        }
+        else
+            break;
+    }
+    uint32_t month = 1u;
+    while (1)
+    {
+        uint32_t dim = fatMonthDays[month - 1] + ((month == 2u) ? (uint32_t)fatIsLeap(year) : 0u);
+        if (days >= dim)
+        {
+            days -= dim;
+            month++;
+        }
+        else
+            break;
+    }
+    uint32_t day = days + 1u;
+    return ((DWORD)(year - 1980u) << 25) | ((DWORD)month << 21) | ((DWORD)day << 16) | ((DWORD)hour << 11)
+           | ((DWORD)minute << 5) | ((DWORD)(sec / 2u));
+}
+
+/* Bump the clock so it sits just after a packed FAT datetime seen on the card. */
+void fatClockSeedFromPacked(DWORD packed)
+{
+    uint32_t year = 1980u + ((packed >> 25) & 0x7Fu);
+    /* Don't seed off an implausible far-future date. A corrupt entry can decode to a year up near the FAT
+     * ceiling, and seeding there pins every later save at ~2106, which a computer renders as a 1970 garbage
+     * date. Skip anything from 2100 on. */
+    if (year >= 2100u)
+    {
+        return;
+    }
+    uint32_t month  = (packed >> 21) & 0x0Fu;
+    uint32_t day    = (packed >> 16) & 0x1Fu;
+    uint32_t hour   = (packed >> 11) & 0x1Fu;
+    uint32_t minute = (packed >> 5) & 0x3Fu;
+    uint32_t sec    = (packed & 0x1Fu) * 2u;
+    if (month < 1u)
+        month = 1u;
+    if (month > 12u)
+        month = 12u;
+    if (day < 1u)
+        day = 1u;
+    uint32_t days = 0u, y, m;
+    for (y = 1980u; y < year; y++)
+    {
+        days += 365u + (uint32_t)fatIsLeap(y);
+    }
+    for (m = 1u; m < month; m++)
+    {
+        days += fatMonthDays[m - 1] + ((m == 2u) ? (uint32_t)fatIsLeap(year) : 0u);
+    }
+    days += (day - 1u);
+    uint32_t s2 = (days * 86400u + hour * 3600u + minute * 60u + sec) / 2u;
+    if (s2 + fatClockStep > fatClockSecs2)
+    {
+        fatClockSecs2 = s2 + fatClockStep;
+    }
+}
+
 DWORD get_fattime(void)
 {
-    return 0;
+    if (fatClockSecs2 == 0u)
+    {
+        /* Not seeded (empty card, or all-zero dates): start at 2024-01-01 so dates look sane. */
+        fatClockSeedFromPacked(((DWORD)(2024u - 1980u) << 25) | ((DWORD)1u << 21) | ((DWORD)1u << 16));
+    }
+    DWORD t = fatPack(fatClockSecs2);
+    fatClockSecs2 += fatClockStep;
+    return t;
 }
 
 void disk_timerproc(UINT msPassed)

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -240,6 +240,44 @@ bool StorageManager::fileExists(char const* pathName, FilePointer* fp) {
 	return true;
 }
 
+// Recency: seed the synthetic save-clock (diskio.c) from the newest date already in SONGS, so files saved this
+// session sort AFTER everything already on the card. One bounded, read-only directory scan per fresh mount.
+static void seedRecencyClockFromCard() {
+	auto dres = FatFS::Directory::open("SONGS");
+	if (!dres) {
+		return; // no SONGS folder yet, get_fattime falls back to a sane base date
+	}
+	FatFS::Directory& dir = *dres;
+	DWORD maxPacked = 0;
+	for (int32_t guard = 0; guard < 100000; guard++) {
+		auto rr = dir.read();
+		if (!rr) {
+			break;
+		}
+		FatFS::FileInfo info = *rr;
+		if (info.fname[0] == 0) {
+			break; // end of directory
+		}
+		if ((info.fattrib & AM_DIR) != 0) {
+			continue;
+		}
+		// Skip implausible far-future dates. A corrupt entry up near the FAT year ceiling would otherwise
+		// look like the "newest" file and pin the clock at ~2106 for good (a computer shows that as 1970).
+		// Only seed from sane years.
+		uint32_t yearOffset = (uint32_t)((info.fdate >> 9) & 0x7Fu); // 0 = 1980
+		if (yearOffset >= 120u) {                                    // 2100 and up
+			continue;
+		}
+		DWORD packed = ((DWORD)info.fdate << 16) | (DWORD)info.ftime;
+		if (packed > maxPacked) {
+			maxPacked = packed;
+		}
+	}
+	if (maxPacked != 0) {
+		fatClockSeedFromPacked(maxPacked);
+	}
+}
+
 // Gets ready to access SD card.
 // You should call this before you're gonna do any accessing - otherwise any errors won't reflect if there's in fact
 // just no card inserted.
@@ -263,6 +301,7 @@ Error StorageManager::initSD() {
 	});
 	if (success) {
 		audioFileManager.firstCardRead(); // tell the audio file manager that we have a new card
+		seedRecencyClockFromCard();       // recency: keep new saves dated after existing ones
 		return Error::NONE;
 	}
 	return Error::SD_CARD;

--- a/src/fatfs/ff.h
+++ b/src/fatfs/ff.h
@@ -362,6 +362,8 @@ TCHAR* f_gets (TCHAR* buff, int len, FIL* fp);						/* Get a string from the fil
 /* RTC function */
 #if !FF_FS_READONLY && !FF_FS_NORTC
 DWORD get_fattime (void);
+/* Recency clock: seed the synthetic save-time counter from a packed FAT datetime seen on the card. */
+void fatClockSeedFromPacked (DWORD packed);
 #endif
 
 /* LFN support functions */


### PR DESCRIPTION
## What this does

The Deluge has no real-time clock, so `get_fattime()` returned `0` and every saved file got a zero/1980 date. That makes it impossible to sort the song browser by how recently you actually worked on something - all the dates are the same.

This adds a small monotonic "recency clock": each save gets a packed FAT datetime later than the last one, so sorting files by date is the same as sorting by save order. At card mount the counter is seeded from the newest date already in `SONGS/` (one bounded, read-only directory scan), so new saves always land after what is already on the card and the order never goes backwards across power cycles.

The synthetic dates look a little odd if you pop the card into a computer, but on the device they give true "most recently worked on" ordering, which is the thing you actually want when you sit down to keep working on a track.

It also clamps the seed: a corrupt directory entry sitting up near the FAT year ceiling (~2106) can't get adopted as "newest" and pin the clock up there forever. Without the clamp one bad entry poisons every later save, and a computer renders ~2106 as a 1970 garbage date, so it looks like every save lost its date.

## Why

This is the groundwork for sorting the song browser by recency. On its own it just makes saved files carry a sensible, ordered date instead of all sharing date 0.

## Files

- `src/RZA1/diskio.c` - the recency clock (`get_fattime`, `fatPack`, `fatClockSeedFromPacked`) plus the seed clamp
- `src/deluge/storage/storage_manager.cpp` - seed the clock at card mount from the newest date in `SONGS/`
- `src/fatfs/ff.h` - declare `fatClockSeedFromPacked`

## Testing

- Built Release for 7SEG.
- On hardware: saved several songs in sequence, confirmed each lands newest; power-cycled and confirmed new saves still sort after the existing ones (clock re-seeds from the card).
- Tested on a 7-segment Deluge.

## Notes

No menus, no settings, no behaviour change anywhere except the date stamped on saved files. Does not touch playback or the audio path.
