### PR TITLE
Autosave + crash recovery: don't lose an unsaved jam

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -402,6 +402,16 @@ void setupStartupSong() {
 	auto defaultSongFullPath = "SONGS/DEFAULT.XML";
 	auto filename =
 	    startupSongMode == StartupSongMode::TEMPLATE ? defaultSongFullPath : runtimeFeatureSettings.getStartupSong();
+
+	// Recovery: if an unsaved song was left behind (power loss), load it INSTEAD of the normal startup
+	// song, through this exact same proven path so it inherits the crash-protection canary below.
+	// Presence of the file means unsaved work existed (a Save deletes it).
+	bool recoveringUnsavedSong = StorageManager::fileExists("SYSTEM/RECOVER.XML");
+	if (recoveringUnsavedSong) {
+		filename = "SYSTEM/RECOVER.XML";
+		startupSongMode = StartupSongMode::LASTOPENED; // force the load path (not TEMPLATE/BLANK)
+	}
+
 	String failSafePath;
 	failSafePath.concatenate("SONGS/__STARTUP_OFF_CHECK_");
 	auto size = strlen(filename) + 1;
@@ -473,6 +483,16 @@ void setupStartupSong() {
 			if (startupSongMode == StartupSongMode::TEMPLATE) {
 				// Wipe the name so the Save action asks you for a new song
 				currentSong->name.clear();
+			}
+			if (recoveringUnsavedSong) {
+				// Tell the user, don't do it silently. (Keep the file: it stays until a Save clears it,
+				// so a second power flip before saving still recovers.)
+				display->consoleText("Recovered unsaved song");
+				// The song was loaded from SYSTEM/RECOVER.XML, so the Deluge would otherwise name it
+				// "RECOVER" and save it into SYSTEM/. Clear the name (so Save asks for a real name) and
+				// point it at SONGS/, so the recovered jam saves like any normal song, no "RECOVER" dupes.
+				currentSong->name.clear();
+				currentSong->dirPath.set("SONGS");
 			}
 		}
 		else {
@@ -579,6 +599,17 @@ void registerTasks() {
 	// formerly part of cluster loading (why? no idea), actions undo/redo midi commands
 	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.09, 0.1, "playback slow routine",
 	                 RESOURCE_SD);
+	// Autosave/recovery: if the song changed, the card is free, and we're NOT playing, write the
+	// recovery file. Card-safe (RESOURCE_SD_ROUTINE) and never during playback, so it can't glitch
+	// live audio.
+	addRepeatingTask(
+	    []() {
+		    if (songNeedsRecoverySave && !currentlyAccessingCard && !playbackHandler.isEitherClockActive()) {
+			    songNeedsRecoverySave = false;
+			    StorageManager::writeRecoveryFile();
+		    }
+	    },
+	    p++, 0.5, 2.0, 10.0, "autosave recovery", RESOURCE_SD_ROUTINE);
 	// 31-39: Idle priority (40 for dyn tasks)
 	p = 31;
 	addRepeatingTask(&(PIC::flush), p++, 0.001, 0.001, 0.02, "PIC flush", RESOURCE_NONE);

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -164,7 +164,26 @@ void LoadSongUI::enterKeyPress() {
 	}
 
 	else {
+		// Load-guard: don't let an accidental load (e.g. a double-LOAD) wipe unsaved work. A first LOAD
+		// over an unsaved song just arms and warns; you press LOAD again to actually load. Covers a
+		// never-saved jam and an edited existing song (same dirty flag). Navigating away or BACK resets
+		// the arm (see currentFileChanged/exitAction), and it never forces a save: a second LOAD just
+		// discards the unwanted song. performLoad stays on its normal lifecycle below.
+		if (songNeedsRecoverySave && !confirmedLoadOverUnsaved) {
+			confirmedLoadOverUnsaved = true;
+			display->displayPopup("Unsaved - press LOAD again to load over");
+			return;
+		}
+		confirmedLoadOverUnsaved = false;
+
 		performLoad(); // May fail
+
+		// Loading a different song abandons the previous song's unsaved work, by the user's choice, so
+		// clear the recovery file. This keeps "RECOVER exists if and only if there's unsaved work" true
+		// on load-away (without it you'd get re-recovered every boot). The new song re-creates RECOVER
+		// once it's edited.
+		StorageManager::clearRecoveryFile();
+
 		if (FlashStorage::defaultStartupSongMode == StartupSongMode::LASTOPENED) {
 			runtimeFeatureSettings.writeSettingsToFile();
 		}
@@ -696,6 +715,9 @@ ignoring the file extension.
 
 void LoadSongUI::currentFileChanged(int32_t movementDirection) {
 
+	// Selection moved, so re-confirm a load-over-unsaved (can't load the wrong song on a stale arm).
+	confirmedLoadOverUnsaved = false;
+
 	if (movementDirection && !qwertyAlwaysVisible) {
 		qwertyVisible = false;
 		qwertyCurrentlyDrawnOnscreen = false;
@@ -804,6 +826,8 @@ ActionResult LoadSongUI::verticalEncoderAction(int32_t offset, bool inCardRoutin
 }
 
 void LoadSongUI::exitAction() {
+
+	confirmedLoadOverUnsaved = false; // leaving the load browser cancels any armed load-over
 
 	// If parts of the old song have been deleted, sorry, there's no way we can exit without loading a new song
 	if (deletedPartsOfOldSong) {

--- a/src/deluge/gui/ui/load/load_song_ui.h
+++ b/src/deluge/gui/ui/load/load_song_ui.h
@@ -56,6 +56,9 @@ private:
 	bool performingLoad;
 	bool scrollingIntoSlot;
 	bool qwertyCurrentlyDrawnOnscreen;
+	// Load-guard: armed by a first LOAD over unsaved work; a second LOAD confirms. Reset on
+	// navigation/exit so a stale arm can't load the wrong song. (See enterKeyPress.)
+	bool confirmedLoadOverUnsaved = false;
 	void doQueueLoadNextSongIfAvailable(int8_t offset);
 	// int32_t findNextFile(int32_t offset);
 	void exitThisUI();

--- a/src/deluge/gui/ui/save/save_song_ui.cpp
+++ b/src/deluge/gui/ui/save/save_song_ui.cpp
@@ -511,6 +511,11 @@ cardError:
 	// While we're at it, save MIDI devices if there's anything new to save.
 	MIDIDeviceManager::writeDevicesToFile();
 
+	// Work is now safe in a named slot, so drop the recovery file + dirty flag. This is the event that
+	// keeps "RECOVER exists if and only if there's unsaved work" true (no clean-shutdown signal, so
+	// Save is it).
+	StorageManager::clearRecoveryFile();
+
 	close();
 	return true;
 }

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1783,6 +1783,9 @@ bool SessionView::insertAndResyncNewClip(Clip* newClip, int32_t yDisplay) {
 		return false;
 	}
 
+	// Song structure changed, so flag an autosave (the card-safe task writes RECOVER.XML when stopped).
+	songNeedsRecoverySave = true;
+
 	// resync new clip play pos
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStack* modelStack = setupModelStackWithSong(modelStackMemory, currentSong);

--- a/src/deluge/model/action/action_logger.cpp
+++ b/src/deluge/model/action/action_logger.cpp
@@ -83,11 +83,20 @@ void ActionLogger::deleteLastAction() {
 	delugeDealloc(toDelete);
 }
 
+// Autosave/recovery dirty flag (defined in storage_manager.cpp). Declared here to avoid pulling
+// the whole storage header into the action logger.
+extern bool songNeedsRecoverySave;
+
 Action* ActionLogger::getNewAction(ActionType newActionType, ActionAddition addToExistingIfPossible) {
 
 	if (!currentSong) {
 		return nullptr;
 	}
+
+	// Any undoable edit (notes, params, groove, structure...) flows through here, so mark the song
+	// for recovery autosave. Cheap bool; the card-safe task does the actual save when stopped.
+	songNeedsRecoverySave = true;
+
 	deleteLog(AFTER);
 
 	// If not on a View, not allowed!

--- a/src/deluge/storage/storage_manager.cpp
+++ b/src/deluge/storage/storage_manager.cpp
@@ -70,6 +70,10 @@ FileDeserializer* activeDeserializer = &smDeserializer;
 
 const bool writeJsonFlag = false;
 
+// Autosave/recovery dirty flag (see storage_manager.h). Set on a structural change, consumed by the
+// card-safe autosave task in registerTasks().
+bool songNeedsRecoverySave = false;
+
 Serializer& GetSerializer() {
 	if (writeJsonFlag) {
 		return smJsonSerializer;
@@ -218,6 +222,42 @@ bool StorageManager::fileExists(char const* pathName) {
 
 	FRESULT result = f_stat(pathName, &staticFNO);
 	return (result == FR_OK);
+}
+
+// Reserved recovery paths. Kept out of SONGS/ on purpose: the song browser only scans SONGS/, so these
+// never show up in the song list and can't collide with a song someone actually named "Recovery".
+char const* const kRecoveryFinalPath = "SYSTEM/RECOVER.XML";
+char const* const kRecoveryTempPath = "SYSTEM/RECOVER.TMP";
+
+// Autosave: write the current song to SYSTEM/RECOVER.XML via a temp file + atomic rename, so a power
+// loss mid-write can't corrupt the recovery copy. Same write/verify sequence as a normal save, but no
+// UI and no named-save side effects. The caller has to make sure the card is free first.
+Error StorageManager::writeRecoveryFile() {
+	if (currentSong == nullptr) {
+		return Error::NONE;
+	}
+	Error error = createXMLFile(kRecoveryTempPath, smSerializer, true, false); // mayOverwrite, no error popups
+	if (error != Error::NONE) {
+		return error;
+	}
+	currentSong->writeToFile();
+	error = GetSerializer().closeFileAfterWriting(kRecoveryTempPath,
+	                                              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<song\n", "\n</song>\n");
+	if (error != Error::NONE) {
+		return error;
+	}
+	f_unlink(kRecoveryFinalPath);                    // harmless if it doesn't exist yet
+	f_rename(kRecoveryTempPath, kRecoveryFinalPath); // atomic swap into place
+	return Error::NONE;
+}
+
+// Clear the recovery file and the dirty flag. Called after a manual Save (work is safe now) and on
+// load-away. This is the invariant that makes presence-at-boot mean "unsaved work was lost": RECOVER
+// exists if and only if there is unsaved work. Save is the "work is safe" event that clears it.
+void StorageManager::clearRecoveryFile() {
+	songNeedsRecoverySave = false; // so the autosave task won't immediately re-create it
+	f_unlink(kRecoveryFinalPath);  // harmless if it doesn't exist
+	f_unlink(kRecoveryTempPath);
 }
 
 // Lets you get the FilePointer for the file.

--- a/src/deluge/storage/storage_manager.h
+++ b/src/deluge/storage/storage_manager.h
@@ -365,9 +365,19 @@ extern JsonDeserializer smJsonDeserializer;
 extern Serializer& GetSerializer();
 extern FileDeserializer* activeDeserializer;
 
+// Autosave/recovery: a structural change sets this; a low-priority card-safe task writes the recovery
+// file when transport is stopped and the card is free. See writeRecoveryFile().
+extern bool songNeedsRecoverySave;
+
 namespace StorageManager {
 
 std::expected<FatFS::File, Error> createFile(char const* filePath, bool mayOverwrite);
+// Serialize the current song to SYSTEM/RECOVER.XML (temp + atomic rename). UI-free; does not touch the
+// user's named-save state. Caller must ensure the card is free (not currentlyAccessingCard).
+Error writeRecoveryFile();
+// Delete the recovery file + clear the dirty flag. Call after a manual Save / on load-away. This is what
+// makes "RECOVER exists if and only if there is unsaved work" hold without a clean-shutdown signal.
+void clearRecoveryFile();
 Error createXMLFile(char const* pathName, XMLSerializer& writer, bool mayOverwrite = false, bool displayErrors = true);
 Error createJsonFile(char const* pathName, JsonSerializer& writer, bool mayOverwrite = false,
                      bool displayErrors = true);


### PR DESCRIPTION
## What this does

The Deluge has no autosave, so a power loss or a stray button press can wipe a jam you never got around to naming. This adds a small safety net, with no impact on live playing.

It comes in three parts that share one invariant.

**Autosave.** Any undoable edit or structural change flags the song dirty. A low-priority, card-safe task (`RESOURCE_SD_ROUTINE`) writes `SYSTEM/RECOVER.XML` when transport is stopped and the card is free, via a temp file plus atomic rename so a power loss mid-write can't corrupt the recovery copy. It never runs during playback, so it can't glitch live audio. RECOVER lives outside `SONGS/`, so it never shows up in the song browser and can't collide with a song you named.

**Recover on boot.** If `SYSTEM/RECOVER.XML` is present at startup, the recovered song is loaded instead of the normal startup song, through the same proven load path, and the device says `Recovered unsaved song`. Its name is cleared and it's pointed at `SONGS/`, so saving works like any normal song with no "RECOVER" duplicates.

**Load-guard.** A first LOAD over an unsaved song just arms and warns (`Unsaved - press LOAD again to load over`); a second LOAD actually loads. Navigating away or BACK resets the arm. This stops an accidental double-LOAD from throwing away unsaved work.

The invariant: **RECOVER exists if and only if there is unsaved work.** A manual Save (or loading a different song) clears it, since there's no clean-shutdown signal to key off.

## Why

A no-RTC, card-based instrument has no equivalent of a DAW's autosave. Losing an unnamed jam to a power blip is a real and painful failure mode. This recovers it without changing how saving or playing works.

## Files

- `storage_manager.{cpp,h}` - `writeRecoveryFile()` / `clearRecoveryFile()` + the dirty flag
- `deluge.cpp` - the card-safe autosave task, and recover-on-boot in `setupStartupSong()`
- `action_logger.cpp`, `session_view.cpp` - set the dirty flag on edits / structural changes
- `save_song_ui.cpp` - clear recovery on a manual Save
- `load_song_ui.{cpp,h}` - the load-guard

## Testing

- Built Release for 7SEG.
- On hardware (7-segment): edited an unnamed jam, pulled power, confirmed it came back on the next boot with the "Recovered unsaved song" message; confirmed a manual Save clears the recovery file; confirmed a double-LOAD warns before loading over unsaved work.

## Notes

Autosave only writes while stopped and only when the card is otherwise free, so it stays off the live-audio path entirely. No new menus or settings.
