### PR TITLE
Fix/ Force tempo automation to use float interpolation increment

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -4627,7 +4627,7 @@ doHomogenize:
 		// These manual sets are in case we quantized forwards and the region we just created actually begins after
 		// "now"-time.
 		param->currentValue = value;
-		param->valueIncrementPerHalfTick = 0;
+		param->resetInterpolationIncrement();
 		// TODO: and to make it perfect, we'd also want to ignore any further nodes between now and the start of the
 		// region. Or, could probably get away with just deleting them.
 	}

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -53,7 +53,7 @@
 AutoParam::AutoParam() {
 	init();
 	currentValue = 0;
-	valueIncrementPerHalfTick = 0;
+	resetInterpolationIncrement();
 	renewedOverridingAtTime = 0;
 }
 
@@ -69,14 +69,14 @@ void AutoParam::cloneFrom(AutoParam* otherParam, bool copyAutomation) {
 		nodes.init();
 	}
 	currentValue = otherParam->currentValue;
-
+	resetInterpolationIncrement();
 	renewedOverridingAtTime = 0;
 }
 
 void AutoParam::copyOverridingFrom(AutoParam* otherParam) {
 	if (otherParam->renewedOverridingAtTime) {
 		renewedOverridingAtTime = otherParam->renewedOverridingAtTime;
-		valueIncrementPerHalfTick = 0;
+		resetInterpolationIncrement();
 	}
 	currentValue = otherParam->currentValue;
 }
@@ -102,7 +102,7 @@ void AutoParam::setCurrentValueInResponseToUserInput(int32_t value, ModelStackWi
 	int32_t oldValue = currentValue;
 	bool automatedBefore = isAutomated();
 	bool automationChanged = false;
-	valueIncrementPerHalfTick = 0;
+	resetInterpolationIncrement();
 
 	bool isPlaying =
 	    (playbackHandler.isEitherClockActive() && !playbackHandler.ticksLeftInCountIn
@@ -379,7 +379,7 @@ void AutoParam::deleteAutomation(Action* action, ModelStackWithAutoParam const* 
 		nodes.empty();
 	}
 
-	valueIncrementPerHalfTick = 0;
+	resetInterpolationIncrement();
 	renewedOverridingAtTime = 0;
 
 	if (shouldNotify && wasAutomated) {
@@ -391,7 +391,7 @@ void AutoParam::deleteAutomation(Action* action, ModelStackWithAutoParam const* 
 // I.e. a ParamSet must be notified if automation is deleted.
 void AutoParam::deleteAutomationBasicForSetup() {
 	nodes.empty();
-	valueIncrementPerHalfTick = 0;
+	resetInterpolationIncrement();
 	renewedOverridingAtTime = 0;
 }
 
@@ -451,7 +451,7 @@ int32_t AutoParam::processCurrentPos(ModelStackWithAutoParam const* modelStack, 
 	*/
 
 	// Stop any pre-existing interpolation (though we might set up some more, below)
-	valueIncrementPerHalfTick = 0;
+	resetInterpolationIncrement();
 
 	// Now start thinking about the *next* node, which we'll get to in a while
 	int32_t iRight = iJustReached + 1;
@@ -743,7 +743,7 @@ adjustNodeJustReached:
 
 	if (mayInterpolate) {
 		if ((reversed ? nodeJustReached : nextNodeInOurDirection)->interpolated) {
-			setupInterpolation(nextNodeInOurDirection, effectiveLength, currentPos, reversed);
+			setupInterpolation(modelStack, nextNodeInOurDirection, effectiveLength, currentPos, reversed);
 		}
 	}
 
@@ -771,9 +771,36 @@ getOut:
 	return ticksTilNextNode;
 }
 
+/// identifies if a parameter is currently interpolating
+/// the value increment is used to increment / decrement the parameters current value
+bool AutoParam::hasInterpolationIncrement() {
+	return valueIncrementPerHalfTick != 0 || value_increment_per_half_tick_float != 0.0f;
+}
+
+/// resets interpolation increment to zero (can happen if we reached parameter value limits)
+/// or if we've reached another node in which case we'll be re-calculating the increment
+void AutoParam::resetInterpolationIncrement() {
+	valueIncrementPerHalfTick = 0;
+	value_increment_per_half_tick_float = 0.0f;
+	interpolation_increment_remainder_float = 0.0f;
+}
+
+/// reverse the interpolation increment in case we're now interpolating backwards to the previous node
+void AutoParam::reverseInterpolationIncrement() {
+	valueIncrementPerHalfTick = -valueIncrementPerHalfTick;
+	value_increment_per_half_tick_float = -value_increment_per_half_tick_float;
+	interpolation_increment_remainder_float = -interpolation_increment_remainder_float;
+}
+
+/// identifies if the current parameter should use float interpolation (e.g. tempo)
+/// used with parameters that require more accuracy and/or have a smaller internal value range
+bool AutoParam::useFloatInterpolation(ModelStackWithAutoParam const* modelStack) {
+	return modelStack->paramCollection->shouldInterpolateWithFloat(modelStack);
+}
+
 // You now much check before calling this that interpolation should happen at all
-void AutoParam::setupInterpolation(ParamNode* nextNodeInOurDirection, int32_t effectiveLength, int32_t currentPos,
-                                   bool reversed) {
+void AutoParam::setupInterpolation(ModelStackWithAutoParam const* modelStack, ParamNode* nextNodeInOurDirection,
+                                   int32_t effectiveLength, int32_t currentPos, bool reversed) {
 
 	if (renewedOverridingAtTime == 1) {
 		return; // If it's latched-until-next-node-hit, we're not allowed to interpolate.
@@ -794,7 +821,9 @@ void AutoParam::setupInterpolation(ParamNode* nextNodeInOurDirection, int32_t ef
 		ticksTilNextNode += effectiveLength;
 	}
 
-	valueIncrementPerHalfTick = halfDistance / ticksTilNextNode;
+	bool use_float_interpolation = useFloatInterpolation(modelStack);
+
+	calculateInterpolationIncrement(halfDistance, ticksTilNextNode, use_float_interpolation);
 
 	// If automation still overridden (at least to some extent), limit how fast interpolation can occur
 	if (renewedOverridingAtTime) {
@@ -812,49 +841,141 @@ void AutoParam::setupInterpolation(ParamNode* nextNodeInOurDirection, int32_t ef
 			timeSinceOverridden = std::max(timeSinceOverridden, (int32_t)0);
 
 			int32_t limit = timeSinceOverridden << (26 - OVERRIDE_DURATION_MAGNITUDE_INTERPOLATING);
-			if (valueIncrementPerHalfTick > limit) {
-				valueIncrementPerHalfTick = limit;
-			}
-			else if (valueIncrementPerHalfTick < -limit) {
-				valueIncrementPerHalfTick = -limit;
-
-				// If we didn't even have to limit it, there's no need to be overriding anymore
-			}
-			else {
-				renewedOverridingAtTime = 0;
-			}
+			potentiallyOverrideInterpolationIncrement(limit, use_float_interpolation);
 		}
 	}
 }
 
-bool AutoParam::tickSamples(int32_t numSamples) {
-	if (!valueIncrementPerHalfTick) {
+/// calculates the amount to increment / decrement the current parameter value to interpolate to
+/// the next node's parameter value
+void AutoParam::calculateInterpolationIncrement(int32_t half_distance, int32_t ticks_til_next_node,
+                                                bool use_float_interpolation) {
+	if (use_float_interpolation) [[unlikely]] {
+		value_increment_per_half_tick_float = (float)half_distance / (float)ticks_til_next_node;
+	}
+	else {
+		valueIncrementPerHalfTick = half_distance / ticks_til_next_node;
+	}
+}
+
+/// used to limit how fast you interpolate
+void AutoParam::potentiallyOverrideInterpolationIncrement(int32_t limit, bool use_float_interpolation) {
+	if (use_float_interpolation) [[unlikely]] {
+		if (value_increment_per_half_tick_float > (float)limit) {
+			value_increment_per_half_tick_float = (float)limit;
+		}
+		else if (value_increment_per_half_tick_float < (float)-limit) {
+			value_increment_per_half_tick_float = (float)-limit;
+		}
+		else {
+			// If we didn't even have to limit it, there's no need to be overriding anymore
+			renewedOverridingAtTime = 0;
+		}
+	}
+	else {
+		if (valueIncrementPerHalfTick > limit) {
+			valueIncrementPerHalfTick = limit;
+		}
+		else if (valueIncrementPerHalfTick < -limit) {
+			valueIncrementPerHalfTick = -limit;
+		}
+		else {
+			// If we didn't even have to limit it, there's no need to be overriding anymore
+			renewedOverridingAtTime = 0;
+		}
+	}
+}
+
+/// used with float interpolation to accumulate increments between whole values
+/// so that you know when to increment the current parameter value by a whole value
+int32_t AutoParam::consumeFloatInterpolationIncrement(float value_increment) {
+	// accumulate float increments
+	interpolation_increment_remainder_float += value_increment;
+
+	// truncate the accumulated float increment so it's just the whole value
+	// (e.g. round 1.1 down to 1, or round 0.1 down to 0)
+	float whole_value_increment = truncf(interpolation_increment_remainder_float);
+
+	// subtract whole value from the accumulated amount to get the remainder (e.g. 1.1 - 1 = .1)
+	interpolation_increment_remainder_float -= whole_value_increment;
+
+	// return whole value increment (e.g. 1 or 0)
+	return (int32_t)whole_value_increment;
+}
+
+/// applies the whole value increment and resets interpolation increment if we've reached current value limits
+bool AutoParam::applyValueIncrement(int32_t value_increment) {
+	// if increment is 0, return false --> current value won't change
+	if (value_increment == 0) {
 		return false;
 	}
 
+	// store current value (so we can check if it changed below)
 	int32_t oldValue = currentValue;
-	currentValue +=
-	    multiply_32x32_rshift32_rounded(valueIncrementPerHalfTick, playbackHandler.getTimePerInternalTickInverse()) * 6
-	    * numSamples;
 
-	// Ensure no overflow
-	bool overflowOccurred = (valueIncrementPerHalfTick >= 0) ? (currentValue < oldValue) : (currentValue > oldValue);
-	if (overflowOccurred) {
-		currentValue = (valueIncrementPerHalfTick >= 0) ? 2147483647 : -2147483648;
-		valueIncrementPerHalfTick = 0;
+	// add value increment, clamp within the int32 limits (-2147483648, 2147483647)
+	currentValue = add_saturate(currentValue, value_increment);
+
+	// check if overflow occurred (e.g. increment would push current value over limit)
+	bool overflow_occurred = (value_increment > 0 && oldValue > INT32_MAX - value_increment)
+	                         || (value_increment < 0 && oldValue < INT32_MIN - value_increment);
+
+	// if overflow occurred, reset interpolation increment
+	if (overflow_occurred) {
+		resetInterpolationIncrement();
 	}
 
-	return true;
+	// return if we changed the current value
+	return (currentValue != oldValue);
+}
+
+bool AutoParam::tickSamples(int32_t numSamples) {
+	// if we don't have any interpolation to apply, return false
+	if (!hasInterpolationIncrement()) {
+		return false;
+	}
+
+	int32_t value_increment = 0;
+
+	// non-float interpolation
+	if (valueIncrementPerHalfTick != 0) [[likely]] {
+		value_increment =
+		    multiply_32x32_rshift32_rounded(valueIncrementPerHalfTick, playbackHandler.getTimePerInternalTickInverse())
+		    * 6 * numSamples;
+	}
+	// float interpolation
+	else {
+		float half_ticks =
+		    (float)playbackHandler.getTimePerInternalTickInverse() * (1.0f / 4294967296.0f) * 6.0f * numSamples;
+		value_increment = consumeFloatInterpolationIncrement(value_increment_per_half_tick_float * half_ticks);
+	}
+
+	// potentially update current value
+	// return if we've changed the current value
+	return applyValueIncrement(value_increment);
 }
 
 bool AutoParam::tickTicks(int32_t numTicks) {
-	if (valueIncrementPerHalfTick == 0) {
+	// if we don't have any interpolation to apply, return false
+	if (!hasInterpolationIncrement()) {
 		return false;
 	}
 
-	currentValue = add_saturate(currentValue, valueIncrementPerHalfTick * numTicks * 2);
+	int32_t value_increment = 0;
+	int32_t half_ticks = numTicks * 2;
 
-	return true;
+	// non-float interpolation
+	if (valueIncrementPerHalfTick != 0) [[likely]] {
+		value_increment = valueIncrementPerHalfTick * half_ticks;
+	}
+	// float interpolation
+	else {
+		value_increment = consumeFloatInterpolationIncrement(value_increment_per_half_tick_float * (float)half_ticks);
+	}
+
+	// potentially update current value
+	// return if we've changed the current value
+	return applyValueIncrement(value_increment);
 }
 
 void AutoParam::setValuePossiblyForRegion(int32_t value, ModelStackWithAutoParam const* modelStack, int32_t pos,
@@ -1031,7 +1152,7 @@ void AutoParam::setValueForRegion(uint32_t pos, uint32_t length, int32_t value,
 			mostRecentI = nodes.getNumElements() - 1;
 		}
 		if (mostRecentI == firstI) {
-			valueIncrementPerHalfTick = 0;
+			resetInterpolationIncrement();
 yesChangeCurrentValue:
 			currentValue = value;
 		}
@@ -1392,7 +1513,7 @@ bool AutoParam::grabValueFromPos(uint32_t pos, ModelStackWithAutoParam const* mo
 
 void AutoParam::setPlayPos(uint32_t pos, ModelStackWithAutoParam const* modelStack, bool reversed) {
 
-	valueIncrementPerHalfTick = 0; // We may calculate this, below
+	resetInterpolationIncrement(); // We may calculate this, below
 	renewedOverridingAtTime = 0;
 	if (nodes.getNumElements()) {
 		int32_t oldValue = currentValue;
@@ -1418,7 +1539,7 @@ void AutoParam::setPlayPos(uint32_t pos, ModelStackWithAutoParam const* modelSta
 			}
 
 			// Setup interpolation from the pos we're at now
-			setupInterpolation(nextNodeOurDirection, modelStack->getLoopLength(), pos, reversed);
+			setupInterpolation(modelStack, nextNodeOurDirection, modelStack->getLoopLength(), pos, reversed);
 		}
 
 		modelStack->paramCollection->notifyParamModifiedInSomeWay(modelStack, oldValue, false, true, true);
@@ -1849,7 +1970,7 @@ addNewNodeAt0IfNecessary:
 			action->recordParamChangeIfNotAlreadySnapshotted(modelStack, true); // Steal
 		}
 		nodes.empty();                 // Delete them - either if no action, or if the above chose not to steal them.
-		valueIncrementPerHalfTick = 0; // In case we were interpolating.
+		resetInterpolationIncrement(); // In case we were interpolating.
 	}
 }
 
@@ -2750,14 +2871,14 @@ setNodeValue:
 	}
 
 	if (!nodes.getNumElements()) {
-		valueIncrementPerHalfTick = 0; // In case we were interpolating.
+		resetInterpolationIncrement(); // In case we were interpolating.
 	}
 
 	nodes.testSequentiality("E334");
 }
 
 void AutoParam::notifyPingpongOccurred() {
-	valueIncrementPerHalfTick = -valueIncrementPerHalfTick;
+	reverseInterpolationIncrement();
 }
 
 void AutoParam::stealNodes(ModelStackWithAutoParam const* modelStack, int32_t pos, int32_t regionLength,

--- a/src/deluge/modulation/automation/auto_param.h
+++ b/src/deluge/modulation/automation/auto_param.h
@@ -129,7 +129,14 @@ public:
 
 	/// Current value of the AutoParam. Updated by several functions.
 	int32_t currentValue;
+
+	// interpolation to calculate current value
+	bool hasInterpolationIncrement();
+	void resetInterpolationIncrement();
 	int32_t valueIncrementPerHalfTick;
+	float value_increment_per_half_tick_float;
+	float interpolation_increment_remainder_float;
+
 	uint32_t renewedOverridingAtTime; // If 0, it's off. If 1, it's latched until we hit some nodes / automation
 
 	// "Latching" happens when you start recording values, but then stops if you arrive at any pre-existing values. So
@@ -138,8 +145,18 @@ public:
 private:
 	bool deleteRedundantNodeInLinearRun(int32_t lastNodeInRunI, int32_t effectiveLength,
 	                                    bool mayLoopAroundBackToEnd = true);
-	void setupInterpolation(ParamNode* nextNode, int32_t effectiveLength, int32_t currentPos, bool reversed);
+	void setupInterpolation(ModelStackWithAutoParam const* modelStack, ParamNode* nextNode, int32_t effectiveLength,
+	                        int32_t currentPos, bool reversed);
 	void homogenizeRegionTestSuccess(int32_t pos, int32_t regionEnd, int32_t startValue, bool interpolateStart,
 	                                 bool interpolateEnd);
 	void deleteNodesBeyondPos(int32_t pos);
+
+	// interpolation to calculate current value
+	bool useFloatInterpolation(ModelStackWithAutoParam const* modelStack);
+	void calculateInterpolationIncrement(int32_t half_distance, int32_t ticks_til_next_node,
+	                                     bool use_float_interpolation);
+	void potentiallyOverrideInterpolationIncrement(int32_t limit, bool use_float_interpolation);
+	void reverseInterpolationIncrement();
+	int32_t consumeFloatInterpolationIncrement(float value_increment);
+	bool applyValueIncrement(int32_t value_increment);
 };

--- a/src/deluge/modulation/midi/midi_param_collection.cpp
+++ b/src/deluge/modulation/midi/midi_param_collection.cpp
@@ -62,7 +62,7 @@ void MIDIParamCollection::tickTicks(int32_t numTicks, ModelStackWithParamCollect
 		MIDIParam* midiParam = params.getElement(i);
 		AutoParam* param = &midiParam->param;
 
-		if (param->valueIncrementPerHalfTick != 0) {
+		if (param->hasInterpolationIncrement()) {
 			int32_t oldValue = param->getCurrentValue();
 			bool shouldNotify = param->tickTicks(numTicks);
 			if (shouldNotify) { // Should always actually be true...
@@ -164,7 +164,7 @@ void MIDIParamCollection::processCurrentPos(ModelStackWithParamCollection* model
 			int32_t ticksTilNextEventThisParam = param->processCurrentPos(modelStackWithAutoParam, reversed,
 			                                                              didPingpong, false, true); // No interpolating
 			ticksTilNextEvent = std::min(ticksTilNextEvent, ticksTilNextEventThisParam);
-			if (param->valueIncrementPerHalfTick) {
+			if (param->hasInterpolationIncrement()) {
 				interpolating = true;
 			}
 		}

--- a/src/deluge/modulation/params/param_collection.h
+++ b/src/deluge/modulation/params/param_collection.h
@@ -76,6 +76,7 @@ public:
 	                                     // (wait why again?). May return NULL
 
 	virtual bool mayParamInterpolate(int32_t paramId);
+	virtual bool shouldInterpolateWithFloat(ModelStackWithParamId const* modelStack) { return false; }
 	virtual bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) { return false; }
 	virtual bool doesParamIdAllowAutomation(ModelStackWithParamId const* modelStack) { return true; }
 	virtual bool shouldRecordUnautomatedParamChange(ModelStackWithParamId const* modelStack) { return true; }

--- a/src/deluge/modulation/params/param_set.cpp
+++ b/src/deluge/modulation/params/param_set.cpp
@@ -103,7 +103,7 @@ void ParamSet::paramHasNoAutomationNow(ModelStackWithParamCollection const* mode
 	}
 
 inline void ParamSet::checkWhetherParamHasInterpolationNow(ModelStackWithParamCollection const* modelStack, int32_t p) {
-	if (params[p].valueIncrementPerHalfTick) {
+	if (params[p].hasInterpolationIncrement()) {
 		modelStack->summary->whichParamsAreInterpolating[p >> 5] |= ((uint32_t)1 << (p & 31));
 	}
 }
@@ -208,7 +208,7 @@ void ParamSet::readParam(Deserializer& reader, ParamCollectionSummary* summary, 
 void ParamSet::playbackHasEnded(ModelStackWithParamCollection* modelStack) {
 
 	FOR_EACH_FLAGGED_PARAM(modelStack->summary->whichParamsAreInterpolating);
-	params[p].valueIncrementPerHalfTick = 0;
+	params[p].resetInterpolationIncrement();
 	FOR_EACH_PARAM_END
 
 	modelStack->summary->resetInterpolationRecord(topUintToRepParams);
@@ -393,6 +393,17 @@ void UnpatchedParamSet::beenCloned(bool copyAutomation, int32_t reverseDirection
 	topUintToRepParams = (numParams_ - 1) >> 5;
 
 	ParamSet::beenCloned(copyAutomation, reverseDirectionWithLength);
+}
+
+bool UnpatchedParamSet::shouldInterpolateWithFloat(ModelStackWithParamId const* modelStack) {
+	// Global
+	if (modelStack->paramCollection->getParamKind() == deluge::modulation::params::Kind::UNPATCHED_GLOBAL) {
+		switch (modelStack->paramId) {
+		case params::UNPATCHED_TEMPO:
+			return true;
+		}
+	}
+	return false;
 }
 
 bool UnpatchedParamSet::shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) {

--- a/src/deluge/modulation/params/param_set.h
+++ b/src/deluge/modulation/params/param_set.h
@@ -99,6 +99,7 @@ class UnpatchedParamSet final : public ParamSet {
 public:
 	UnpatchedParamSet(ParamCollectionSummary* summary);
 	void beenCloned(bool copyAutomation, int32_t reverseDirectionWithLength) override;
+	bool shouldInterpolateWithFloat(ModelStackWithParamId const* modelStack) override;
 	bool shouldParamIndicateMiddleValue(ModelStackWithParamId const* modelStack) override;
 	bool doesParamIdAllowAutomation(ModelStackWithParamId const* modelStack) override;
 	bool shouldRecordUnautomatedParamChange(ModelStackWithParamId const* modelStack) override;

--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -335,7 +335,7 @@ goAgainWithoutIncrement:
 		if (patchCables[c].param.isAutomated()) {
 			flagCable(modelStack->summary->whichParamsAreAutomated, c);
 
-			if (patchCables[c].param.valueIncrementPerHalfTick) {
+			if (patchCables[c].param.hasInterpolationIncrement()) {
 				flagCable(modelStack->summary->whichParamsAreInterpolating, c);
 			}
 		}
@@ -593,7 +593,7 @@ void PatchCableSet::playbackHasEnded(ModelStackWithParamCollection* modelStack) 
 
 	FOR_EACH_FLAGGED_PARAM(modelStack->summary->whichParamsAreInterpolating)
 
-	patchCables[c].param.valueIncrementPerHalfTick = 0;
+	patchCables[c].param.resetInterpolationIncrement();
 
 	FOR_EACH_PARAM_END
 
@@ -660,7 +660,7 @@ void PatchCableSet::trimToLength(uint32_t newLength, ModelStackWithParamCollecti
 	ModelStackWithAutoParam* modelStackWithAutoParam = modelStack->addAutoParam(paramId, param);
 	param->trimToLength(newLength, action, modelStackWithAutoParam);
 
-	if (!param->valueIncrementPerHalfTick) {
+	if (!param->hasInterpolationIncrement()) {
 		unflagCable(modelStack->summary->whichParamsAreInterpolating, c);
 
 		bool stillAutomated = param->isAutomated();
@@ -726,7 +726,7 @@ void PatchCableSet::processCurrentPos(ModelStackWithParamCollection* modelStack,
 		int32_t ticksTilNextEventThisCable = param->processCurrentPos(modelStackWithAutoParam, reversed, didPingpong);
 		ticksTilNextEvent = std::min(ticksTilNextEvent, ticksTilNextEventThisCable);
 
-		if (param->valueIncrementPerHalfTick) {
+		if (param->hasInterpolationIncrement()) {
 			flagCable(modelStack->summary->whichParamsAreInterpolating, c);
 		}
 		FOR_EACH_PARAM_END
@@ -1129,7 +1129,7 @@ void PatchCableSet::nudgeNonInterpolatingNodesAtPos(int32_t pos, int32_t offset,
 
 	param->nudgeNonInterpolatingNodesAtPos(pos, offset, lengthBeforeLoop, action, modelStackWithParam);
 
-	if (!param->valueIncrementPerHalfTick) {
+	if (!param->hasInterpolationIncrement()) {
 		unflagCable(modelStack->summary->whichParamsAreInterpolating, c);
 
 		bool stillAutomated = param->isAutomated();


### PR DESCRIPTION
Fix issue with tempo automation interpolation not calculating correctly due to rounding errors. By using a float increment and a float remainder accumulation variable we can interpolate tempo values more frequently than was previously possible.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3221

I couldn't help it and had to do some small refactoring to make these changes more sane given that we're supporting both float and non-float interpolation now. Basically any spot that previously wrote to the non-float value increment now points to a helper function so that I can handle applying that same logic to float and non-float value increments.