### PR TITLE
1.3 Beta Prep / Update firmware downloads page

### DIFF
--- a/website/src/content/docs/downloads.mdx
+++ b/website/src/content/docs/downloads.mdx
@@ -46,9 +46,9 @@ Please report any bugs [on github](https://github.com/SynthstromAudible/DelugeFi
   </a>
 </div>
 
-## Development (Nightly) Firmware aka 1.3
+## Beta - 1.3.0 (Derbyshire)
 
-The current nightly build is available below. The nightly firmware captures the current state of development every day and might be broken but needs to be tested to find out.
+The current beta build is available below. The beta firmware captures the current state of development of the upcoming 1.3.0 (Derbyshire) community firmware release. Note that there may still be issues in the beta but it needs to be tested to find out. If you encounter issues, please report them here with detailed reproducible steps to ensure we can fix them: [Issues](https://github.com/SynthstromAudible/DelugeFirmware/issues)
 
 Be aware that in addition to new features there are large internal changes - we believe these will make the deluge more efficient and stable in the long term, but there may be short term issues with perceived performance due to interactions between sub systems.
 
@@ -59,7 +59,7 @@ Be aware that in addition to new features there are large internal changes - we 
     target="_blank"
     rel="noopener noreferrer"
   >
-    Download todays nightly build
+    Download todays beta build
   </a>
   <a
     className="btn"
@@ -67,11 +67,11 @@ Be aware that in addition to new features there are large internal changes - we 
     target="_blank"
     rel="noopener noreferrer"
   >
-    Changelog current nightly
+    Changelog current beta
   </a>
   <a
     className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/community_features.md"
+    href="https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/community_features.md"
     target="_blank"
     rel="noopener noreferrer"
   >

--- a/website/src/content/docs/downloads.mdx
+++ b/website/src/content/docs/downloads.mdx
@@ -59,7 +59,7 @@ Be aware that in addition to new features there are large internal changes - we 
     target="_blank"
     rel="noopener noreferrer"
   >
-    Download todays beta build
+    Download today's beta build
   </a>
   <a
     className="btn"


### PR DESCRIPTION
Updated references from 'Development (Nightly) Firmware' to 'Beta - 1.3.0 (Derbyshire)' and adjusted related text to reflect the beta status.