### PR TITLE
1.3 Beta Prep / Update community branch references to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The hardware is built around a Renesas RZ/A1L processor with an Arm® Cortex®-A
 ## Important links
 * For acquiring and using the firmware visit the [community firmware website](https://synthstromaudible.github.io/DelugeFirmware)
 * Once you have the firmware, consult our detailed [update guide](https://github.com/SynthstromAudible/DelugeFirmware/wiki/Update-guide) for instructions on how to install it
-* To contribute to the project with code, bug reports, suggestions, and feedback see: [How to contribute to Deluge Firmware](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/CONTRIBUTING.md)
+* To contribute to the project with code, bug reports, suggestions, and feedback see: [How to contribute to Deluge Firmware](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/CONTRIBUTING.md)
 * To learn about the toolchain, application, and to start working on the code continue with: [Getting Started with Deluge Development](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/dev/getting_started.md)
 * Please also visit the [Synthstrom Forum](https://forums.synthstrom.com/) and the community [Discord](https://discord.gg/BnRcyFSgaT) to interact with other users and the developers
 * You can donate to the project using the [Synthstrom Patreon](https://www.patreon.com/Synthstrom)

--- a/docs/features/midi_follow_mode.md
+++ b/docs/features/midi_follow_mode.md
@@ -221,7 +221,7 @@ For users of Loopy Pro, you will find a MIDI Follow template in this folder: [MI
     - Open again the "Deluge Midi Follow" project and click the pencil to edit the UI, and drag a rectangle selection all the page.
       Copy it, open your own project and in an empy page, paste it. Do the same with the other page with Stepped Dials.
 
-<img alt="image" src="https://raw.githubusercontent.com/SynthstromAudible/DelugeFirmware/refs/heads/community/contrib/midi_follow/loopy_pro/loopy-pro-template-snapshot.png">
+<img alt="image" src="https://raw.githubusercontent.com/SynthstromAudible/DelugeFirmware/refs/heads/main/contrib/midi_follow/loopy_pro/loopy-pro-template-snapshot.png">
 
 ## Appendix C - Touch OSC Template for Deluge MIDI Follow Mode
 
@@ -246,8 +246,8 @@ For users of the Electra One, you will find a MIDI Follow template in the Electr
 For users of Melbourne Instruments' Roto-Control, you will find MIDI Follow templates in this folder: [MIDI Follow Mode Roto-Control Templates]
 
 
-[MIDI Follow Mode Loopy Pro Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/loopy_pro
-[MIDI Follow Mode Touch OSC Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/touch_osc
+[MIDI Follow Mode Loopy Pro Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi_follow/loopy_pro
+[MIDI Follow Mode Touch OSC Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi_follow/touch_osc
 [MIDI Follow Mode Electra One Preset]:
 https://app.electra.one/preset/vZ6WBYb4xDpMGcpChejY
 [MIDI Follow Mode Roto-Control Templates]: ../../contrib/midi_follow/roto_control/

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -34,7 +34,7 @@ const config = defineConfig({
       },
       editLink: {
         baseUrl:
-          "https://github.dev/SynthstromAudible/DelugeFirmware/blob/community/website",
+          "https://github.dev/SynthstromAudible/DelugeFirmware/blob/main/website",
       },
       pagefind: {
         // See: https://pagefind.app/docs/ranking/

--- a/website/src/content/docs/development/deluge/guidelines.md
+++ b/website/src/content/docs/development/deluge/guidelines.md
@@ -12,7 +12,7 @@ Everybody is invited to contribute to this repository as further outlined below:
   maintainability/ease modification/improve structure), feature improvements, new features, easier accessibility,
   toolchain improvements, unit tests and many, many more.
 - For information on the decision making process for accepting Pull requests please see below and also see
-  the [Governance](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/GOVERNANCE.md) documentation.
+  the [Governance](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/GOVERNANCE.md) documentation.
 - To keep the list manageable all Pull requests without author activity for longer than two weeks will be labelled "
   stale" and will be closed after another week. The author is welcome to submit a new PR for the same work at any time.
 
@@ -41,7 +41,7 @@ The following requirements must be fulfilled for a Pull request to be mergable t
 <details><summary>Code specific</summary>
 
 - All project files, especially source files need to have a compatible license with the project.
-  See [LICENSE](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/LICENSE).
+  See [LICENSE](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/LICENSE).
 - There is no written standard on code guidelines yet but please make your code match the existing style as much as possible.
 - Exception: the old code uses GOTOs and single returns heavily - new C++ code should favour other flow control methods
   and early returns instead, the old code is a result of the project's roots in C.
@@ -103,9 +103,9 @@ transparent as possible:
 4. Once the Pull request is ready, fulfills all requirements outlined above, and is up to date with the `develop`
    branch, it can be converted from Draft and marked as ready for review.
 5. Having multiple reviews for every Pull request would be nice. Reviews from community members not mentioned in
-   the [CODEOWNERS](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/CODEOWNERS) file should be taken seriously and used as an important source of feedback, but have
+   the [CODEOWNERS](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/CODEOWNERS) file should be taken seriously and used as an important source of feedback, but have
    no decisional power on what gets merged into the `develop` branch.
-6. At least one member of the [CODEOWNERS](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/CODEOWNERS) file needs to review every pull request while also considering
+6. At least one member of the [CODEOWNERS](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/CODEOWNERS) file needs to review every pull request while also considering
    community reviews in their decision.
    - CODEOWNERS can decline merging a Pull request if it does not fulfill the requirements outlined above. They need to
      give clear feedback on which requirements have not been met and also provide an opportunity to improve the Pull
@@ -114,7 +114,7 @@ transparent as possible:
    - If one or more CODEOWNERS are sure the requirements have been met, they will merge the change into the `develop`
      branch.
    - For more information about governance and handling of decisional matters please take a look at
-     the [Governance](https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/GOVERNANCE.md) document.
+     the [Governance](https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/GOVERNANCE.md) document.
 
 In addition to this workflow it is not a requirement but would be nice if developers could help the maintenance of the
 project by:

--- a/website/src/content/docs/downloads.mdx
+++ b/website/src/content/docs/downloads.mdx
@@ -71,7 +71,7 @@ Be aware that in addition to new features there are large internal changes - we 
   </a>
   <a
     className="btn"
-    href="https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/community_features.md"
+    href="https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/community_features.md"
     target="_blank"
     rel="noopener noreferrer"
   >

--- a/website/src/content/docs/features/community_features.mdx
+++ b/website/src/content/docs/features/community_features.mdx
@@ -1413,5 +1413,5 @@ different firmware
 
   Description of said feature, first new feature please replace this
 
-[MIDI Follow Mode Loopy Pro Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/loopy_pro
-[MIDI Follow Mode Touch OSC Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/touch_osc
+[MIDI Follow Mode Loopy Pro Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi_follow/loopy_pro
+[MIDI Follow Mode Touch OSC Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi_follow/touch_osc

--- a/website/src/content/docs/features/midi_follow_mode.mdx
+++ b/website/src/content/docs/features/midi_follow_mode.mdx
@@ -269,7 +269,7 @@ There are premade MIDI Follow templates available for Loopy Pro for community fi
 
 <img
   alt="image"
-  src="https://raw.githubusercontent.com/SynthstromAudible/DelugeFirmware/refs/heads/community/contrib/midi_follow/loopy_pro/main_template/main-loopy-pro-template.png"
+  src="https://raw.githubusercontent.com/SynthstromAudible/DelugeFirmware/refs/heads/main/contrib/midi_follow/loopy_pro/main_template/main-loopy-pro-template.png"
 />
 
 ## Appendix C - Touch OSC Template for Deluge MIDI Follow Mode
@@ -306,7 +306,7 @@ For users of the Electra One, you will find a MIDI Follow template in the Electr
 
 For users of Melbourne Instruments' Roto-Control, you will find MIDI Follow templates in this folder: [MIDI Follow Mode Roto-Control Templates]
 
-[MIDI Follow Mode Loopy Pro Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/loopy_pro
-[MIDI Follow Mode Touch OSC Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/touch_osc
+[MIDI Follow Mode Loopy Pro Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi_follow/loopy_pro
+[MIDI Follow Mode Touch OSC Template]: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi_follow/touch_osc
 [MIDI Follow Mode Electra One Preset]: https://app.electra.one/preset/vZ6WBYb4xDpMGcpChejY
-[MIDI Follow Mode Roto-Control Templates]: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi_follow/roto_control
+[MIDI Follow Mode Roto-Control Templates]: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi_follow/roto_control

--- a/website/src/content/docs/features/save_load_patterns.mdx
+++ b/website/src/content/docs/features/save_load_patterns.mdx
@@ -132,7 +132,7 @@ After loading a Pattern, the Pattern is also copied into Clipboard and can be pa
 
 ### Additional Tools
 
-Under [contrib/midi2deluge](https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/midi2deluge), you will find two simple Tools - a WebApp and a python Script - that can generate Pattern-Files for the Deluge from simple Midi-Files.
+Under [contrib/midi2deluge](https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/midi2deluge), you will find two simple Tools - a WebApp and a python Script - that can generate Pattern-Files for the Deluge from simple Midi-Files.
 Important:The Tools where tested with the [Wikipedia Midifile Sample](https://en.wikipedia.org/wiki/File:MIDI_sample.mid) and may will not work with very complex Midi-Files.
 
 ![midi2Deluge](https://github.com/user-attachments/assets/902fdcd1-58e7-4992-8c02-6c0ad063233d)

--- a/website/src/content/docs/resources/midi_devices/definitions.mdx
+++ b/website/src/content/docs/resources/midi_devices/definitions.mdx
@@ -5,4 +5,4 @@ sidebar:
   label: Definition Files
 ---
 
-MIDI Device Definition Files can be found here: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/sd_card/MIDI_DEVICES/DEFINITION
+MIDI Device Definition Files can be found here: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/sd_card/MIDI_DEVICES/DEFINITION

--- a/website/src/content/docs/resources/midi_devices/presets.mdx
+++ b/website/src/content/docs/resources/midi_devices/presets.mdx
@@ -5,4 +5,4 @@ sidebar:
   label: Preset Files
 ---
 
-MIDI Device Preset Files can be found here: https://github.com/SynthstromAudible/DelugeFirmware/tree/community/contrib/sd_card/MIDI
+MIDI Device Preset Files can be found here: https://github.com/SynthstromAudible/DelugeFirmware/tree/main/contrib/sd_card/MIDI

--- a/website/src/logic/generated/metadata-cache.json
+++ b/website/src/logic/generated/metadata-cache.json
@@ -284,7 +284,7 @@
     "url": "https://www.youtube.com/watch?v=YykJfzpjMIM"
   },
   "https://www.youtube.com/watch?v=avUcqCHGcUs": {
-    "description": "Here is the link to the midi follow instructions, CC list, and loopy pro template: https://github.com/SynthstromAudible/DelugeFirmware/blob/community/docs/fe...",
+    "description": "Here is the link to the midi follow instructions, CC list, and loopy pro template: https://github.com/SynthstromAudible/DelugeFirmware/blob/main/docs/fe...",
     "image": "https://i.ytimg.com/vi/avUcqCHGcUs/maxresdefault.jpg?sqp=-oaymwEmCIAKENAF8quKqQMa8AEB-AH-CYAC0AWKAgwIABABGGUgSihEMA8=&rs=AOn4CLCTzaPEb396Wzjq4cuFY7L_q0KGHg",
     "siteName": "YouTube",
     "title": "DELUGE 1.1 MIDI FOLLOW BASICS // Deluge 1.1 Beethoven Firmware Tutorial",


### PR DESCRIPTION
Noticed some references on the website to the old /community/ branch. Fixed to point to main.