### PR TITLE
Fix display of favourites and banks bug

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -120,7 +120,6 @@ bool Browser::checkFP() {
 void Browser::close() {
 	emptyFileItems();
 	favouritesManager.close();
-	favouritesVisible = false;
 	QwertyUI::close();
 }
 
@@ -1577,7 +1576,7 @@ ActionResult Browser::buttonAction(deluge::hid::Button b, bool on, bool inCardRo
 
 ActionResult Browser::padAction(int32_t x, int32_t y, int32_t on) {
 
-	if (favouritesVisible && y == favouriteRow && on) {
+	if (isFavouritesVisible() && y == favouriteRow && on) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -1610,7 +1609,7 @@ ActionResult Browser::padAction(int32_t x, int32_t y, int32_t on) {
 		}
 		return ActionResult::DEALT_WITH;
 	}
-	else if (favouritesVisible && banksVisible && y == favouriteBankRow && on) {
+	else if (isBanksVisible() && y == favouriteBankRow && on) {
 		if (sdRoutineLock) {
 			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 		}
@@ -1629,7 +1628,7 @@ void Browser::favouritesChanged() {
 }
 
 ActionResult Browser::verticalEncoderAction(int32_t offset, bool inCardRoutine) {
-	if (favouritesVisible) {
+	if (isFavouritesVisible()) {
 		if (Buttons::isShiftButtonPressed()) {
 			if (favouritesManager.currentFavouriteNumber.has_value()) {
 				favouritesManager.changeColour(favouritesManager.currentFavouriteNumber.value(), offset);
@@ -1898,4 +1897,15 @@ void Browser::sortFileItems() {
 			numFileItemsDeletedAtStart += itemsToDeleteAtStart;
 		}
 	}
+}
+
+bool Browser::isFavouritesVisible() {
+	return (getCurrentUI()->canDisplayFavourites() && qwertyVisible
+	        && FlashStorage::defaultFavouritesLayout != FavouritesDefaultLayout::FavouritesDefaultLayoutOff);
+}
+
+bool Browser::isBanksVisible() {
+	return (getCurrentUI()->canDisplayFavourites() && qwertyVisible
+	        && FlashStorage::defaultFavouritesLayout
+	               == FavouritesDefaultLayout::FavouritesDefaultLayoutFavoritesAndBanks);
 }

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -107,6 +107,8 @@ public:
 		exitAction();
 		return ActionResult::ACTIONED_AND_CAUSED_CHANGE;
 	}
+	bool isFavouritesVisible() override;
+	bool isBanksVisible() override;
 
 protected:
 	Error setEnteredTextFromCurrentFilename();

--- a/src/deluge/gui/ui/browser/sample_browser.cpp
+++ b/src/deluge/gui/ui/browser/sample_browser.cpp
@@ -242,7 +242,6 @@ void SampleBrowser::currentFileChanged(int32_t movementDirection) {
 	// Can start scrolling right now, while next preview loads
 	if (movementDirection && (currentlyShowingSamplePreview || qwertyVisible) && !qwertyAlwaysVisible) {
 		qwertyVisible = false;
-		favouritesVisible = false;
 
 		uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 
@@ -490,7 +489,6 @@ ActionResult SampleBrowser::buttonAction(deluge::hid::Button b, bool on, bool in
 		indicator_leds::setLedState(IndicatorLED::KEYBOARD, qwertyAlwaysVisible);
 		qwertyVisible = qwertyAlwaysVisible;
 		if (qwertyVisible) {
-			favouritesVisible = true;
 			qwertyCurrentlyDrawnOnscreen = true;
 			drawKeys();
 		}
@@ -714,7 +712,6 @@ possiblyExit:
 				}
 
 				qwertyVisible = true;
-				favouritesVisible = true;
 
 				uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 				PadLEDs::reassessGreyout(true);
@@ -2080,7 +2077,6 @@ ActionResult SampleBrowser::horizontalEncoderAction(int32_t offset) {
 	}
 	else {
 		qwertyVisible = true;
-		favouritesVisible = true;
 
 		uiTimerManager.unsetTimer(TimerName::SHORTCUT_BLINK);
 		PadLEDs::reassessGreyout(true);

--- a/src/deluge/gui/ui/browser/sample_browser.h
+++ b/src/deluge/gui/ui/browser/sample_browser.h
@@ -71,6 +71,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::SAMPLE_BROWSER; }
+	bool canDisplayFavourites() override { return true; }
 
 protected:
 	void enterKeyPress() override;

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -50,9 +50,11 @@ namespace encoders = deluge::hid::encoders;
 LoadInstrumentPresetUI loadInstrumentPresetUI{};
 
 bool LoadInstrumentPresetUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
-	if (showingAuditionPads() && !qwertyAlwaysVisible) {
+	// grey out the mute pads, not the audition pads or main pads
+	if (showingAuditionPads()) {
 		*cols = 0b10;
 	}
+	// grey out everything
 	else {
 		*cols = 0xFFFFFFFF;
 	}

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.h
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.h
@@ -77,6 +77,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::LOAD_INSTRUMENT_PRESET; }
+	bool canDisplayFavourites() override { return true; }
 
 protected:
 	void enterKeyPress() override;

--- a/src/deluge/gui/ui/load/load_pattern_ui.cpp
+++ b/src/deluge/gui/ui/load/load_pattern_ui.cpp
@@ -39,7 +39,14 @@ static constexpr const char* PATTERN_MELODIC_DEFAULT_FOLDER = "PATTERNS/MELODIC"
 LoadPatternUI loadPatternUI{};
 
 bool LoadPatternUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
-	*cols = 0xFFFFFFFF;
+	// greyout the sidebar, not the main pads
+	if (qwertyVisible) {
+		*cols = 0x03;
+	}
+	// greyout everything
+	else {
+		*cols = 0xFFFFFFFF;
+	}
 	return true;
 }
 

--- a/src/deluge/gui/ui/load/load_pattern_ui.h
+++ b/src/deluge/gui/ui/load/load_pattern_ui.h
@@ -48,6 +48,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::LOAD_PATTERN; }
+	bool canDisplayFavourites() override { return true; }
 
 protected:
 	void folderContentsReady(int32_t entryDirection) override;

--- a/src/deluge/gui/ui/load/load_song_ui.cpp
+++ b/src/deluge/gui/ui/load/load_song_ui.cpp
@@ -230,7 +230,6 @@ ActionResult LoadSongUI::buttonAction(deluge::hid::Button b, bool on, bool inCar
 		indicator_leds::setLedState(IndicatorLED::KEYBOARD, qwertyAlwaysVisible);
 		qwertyVisible = qwertyAlwaysVisible;
 		if (qwertyVisible) {
-			favouritesVisible = true;
 			drawKeys();
 			qwertyCurrentlyDrawnOnscreen = true;
 		}
@@ -747,7 +746,6 @@ void LoadSongUI::currentFileChanged(int32_t movementDirection) {
 
 	if (movementDirection && !qwertyAlwaysVisible) {
 		qwertyVisible = false;
-		favouritesVisible = false;
 		qwertyCurrentlyDrawnOnscreen = false;
 
 		// Start horizontal scrolling
@@ -973,7 +971,6 @@ ActionResult LoadSongUI::padAction(int32_t x, int32_t y, int32_t on) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
 			qwertyVisible = true;
-			favouritesVisible = true;
 			displayText(false); // This will also draw the QWERTY keys
 
 			// Process first press only if its not a favourite row press to prevent blind keypresses

--- a/src/deluge/gui/ui/load/load_song_ui.h
+++ b/src/deluge/gui/ui/load/load_song_ui.h
@@ -40,6 +40,7 @@ public:
 
 	// ui
 	UIType getUIType() override { return UIType::LOAD_SONG; }
+	bool canDisplayFavourites() override { return true; }
 
 protected:
 	void displayText(bool blinkImmediately = false) override;

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -19,6 +19,7 @@
 #include "definitions_cxx.hpp"
 #include "extern.h"
 #include "gui/colour/colour.h"
+#include "gui/ui/browser/browser.h"
 #include "gui/ui_timer_manager.h"
 #include "hid/display/display.h"
 #include "hid/display/oled.h"
@@ -42,9 +43,7 @@ int32_t QwertyUI::scrollPosHorizontal;
 
 uint8_t QwertyUI::currentBank = 0;
 std::optional<uint8_t> QwertyUI::currentFavourite = std::nullopt;
-bool QwertyUI::favouritesVisible = false;
 uint8_t QwertyUI::favouriteRow = 6;
-bool QwertyUI::banksVisible = false;
 FavouritesDefaultLayout QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayout::FavouritesDefaultLayoutFavorites;
 
 static constexpr float colourStep = 192 / 16;
@@ -58,13 +57,11 @@ bool QwertyUI::opened() {
 	case FavouritesDefaultLayoutFavorites: {
 		QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayoutFavorites;
 		QwertyUI::favouriteRow = 7;
-		QwertyUI::banksVisible = false;
 		break;
 	}
 	case FavouritesDefaultLayoutFavoritesAndBanks: {
 		QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayoutFavoritesAndBanks;
 		QwertyUI::favouriteRow = 6;
-		QwertyUI::banksVisible = true;
 		break;
 	}
 	default: {
@@ -121,7 +118,7 @@ void QwertyUI::drawKeys() {
 		PadLEDs::image[kQwertyHomeRow - 1][13 + x] = colours::blue;
 	}
 
-	if (favouritesVisible) {
+	if (getCurrentUI()->isFavouritesVisible()) {
 		renderFavourites();
 	}
 	PadLEDs::sendOutMainPadColours();
@@ -423,7 +420,7 @@ ActionResult QwertyUI::padAction(int32_t x, int32_t y, int32_t on) {
 
 void QwertyUI::renderFavourites() {
 
-	if (!favouritesVisible) {
+	if (!getCurrentUI()->isFavouritesVisible()) {
 		return;
 	}
 	std::array<std::optional<uint8_t>, 16> colours = favouritesManager.getFavouriteColours();
@@ -503,7 +500,7 @@ ActionResult QwertyUI::timerCallback() {
 	}
 
 	// Flash selected Bank & Favourite Pads
-	if (favouritesVisible) {
+	if (getCurrentUI()->isFavouritesVisible()) {
 
 		if (QwertyUI::currentFavourite.has_value()) {
 			PadLEDs::flashMainPad(QwertyUI::currentFavourite.value(), favouriteRow);

--- a/src/deluge/gui/ui/qwerty_ui.h
+++ b/src/deluge/gui/ui/qwerty_ui.h
@@ -62,8 +62,6 @@ protected:
 
 	static int16_t enteredTextEditPos;
 	static int32_t scrollPosHorizontal;
-	static bool favouritesVisible;
-	static bool banksVisible;
 
 private:
 	static uint8_t currentBank;

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -168,6 +168,10 @@ public:
 	/// \brief What mod controllable context is this UI using? E.g. Automation View can use the Song
 	///		   ModControllable when in Arranger but the Clip ModControllable when in a Clip.
 	virtual UIModControllableContext getUIModControllableContext() { return UIModControllableContext::NONE; }
+	virtual bool canDisplayFavourites() { return false; }
+	virtual bool isFavouritesVisible() { return false; }
+	virtual bool isBanksVisible() { return false; }
+
 #if ENABLE_MATRIX_DEBUG
 	const char* getUIName();
 #endif

--- a/src/deluge/model/favourite/favourite_manager.h
+++ b/src/deluge/model/favourite/favourite_manager.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "definitions_cxx.hpp"
-#include "model/favourite/favourite_manager.h"
 #include "storage/storage_manager.h"
 #include <cstdint>
 #include <functional>


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4545

Replaces PR https://github.com/SynthstromAudible/DelugeFirmware/pull/4560

Also fixed regression introduced by PR https://github.com/SynthstromAudible/DelugeFirmware/pull/3391 which greyed out the qwerty UI. Fixed grey out for load pattern UI as well so that it greys out the sidebar (it was only greying out mute pads before).