### PR TITLE
Fix/ issue where browser only searches forward

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1277,6 +1277,11 @@ notFound:
 
 	// If it didn't match exactly, that's ok, but we need to try some other stuff before we accept that result.
 	if (memcasecmp(fileItem->displayName, enteredText.get(), enteredTextEditPos)) {
+		// If the search landed on the first cached item, the folder cache may be missing earlier entries.
+		if (i == 0 && !doneNewRead) {
+			goto doNewRead;
+		}
+
 		// this code is original but I don't know what it does. Slot browser maybe?
 		// Just updated to append to the string instead of replacing the tilde
 		if (numExtraZeroesAdded < 4) {


### PR DESCRIPTION
Fixed issue where browser could search for files starting with the current file's starting letter or letters that follow in the alphabet but not files starting with letters earlier in the alphabet (e.g. if selected file starts with 'S' it lets you search for files starting with 'T' but not files starting with 'B'

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4510

This fix restores some code that was removed by a previous search fix PR #4422 to handle searching for earlier entries removed cash