### PR TITLE
Fix crash when displaying unspecified error message

### DIFF
--- a/src/RZA1/oled/oled_low_level.c
+++ b/src/RZA1/oled/oled_low_level.c
@@ -30,8 +30,6 @@
 #include "deluge/processing/engines/cv_engine_c_interface.h"
 #include "deluge/util/cfunctions.h"
 
-#define OLED_CODE_FOR_CV 1
-
 void setupSPIInterrupts()
 {
     setupAndEnableInterrupt(cvSPITransferComplete, INTC_ID_SPRI0 + SPI_CHANNEL_CV * 3, 5);
@@ -248,18 +246,25 @@ void sendSPITransferFromQueue()
 #endif
 
     // If it's OLED data...
-    if (spiDestinationSendingTo == 0)
+    if (spiDestinationSendingTo == SPI_DESTINATION_OLED)
     {
         oled_sending = true;
         initiateSelectingOled();
     }
 
     // Or if it's CV...
-    else
+    else if (spiDestinationSendingTo == SPI_DESTINATION_CV)
     {
         cv_sending = true;
         sendCVTransfer();
         cvSent();
+    }
+    else
+    {
+#if ALPHA_OR_BETA_VERSION
+        FREEZE_WITH_ERROR("SPI transfer destination is invalid");
+#endif
+        spiTransferQueueCurrentlySending = false;
     }
 }
 
@@ -269,7 +274,8 @@ void oledTransferComplete(uint32_t int_sense)
     // If anything else to send, and it's to the OLED again, then just go ahead - unless a CV word is
     // waiting, in which case we deselect so the CV can slip in ahead of the next frame.
     if (!cvPriorityPending && spiTransferQueueWritePos != spiTransferQueueReadPos
-        && spiTransferQueue[spiTransferQueueReadPos].destinationId == 0 && last_message_sent == OLED_MESSAGE_SELECT)
+        && spiTransferQueue[spiTransferQueueReadPos].destinationId == SPI_DESTINATION_OLED
+        && last_message_sent == OLED_MESSAGE_SELECT)
     {
         oledSelectingComplete();
     }
@@ -302,31 +308,30 @@ void cvSPITransferComplete(uint32_t sense)
         return;
     }
 
-    // If anything else to send, and it's to the CV DAC again, then just go ahead.
+    // If anything else to send, send it according to the actual queued destination.
     if (spiTransferQueueWritePos != spiTransferQueueReadPos
-        && spiTransferQueue[spiTransferQueueReadPos].destinationId == OLED_CODE_FOR_CV)
+        && spiTransferQueue[spiTransferQueueReadPos].destinationId == SPI_DESTINATION_CV)
     {
         sendCVTransfer();
     }
-
-    // Otherwise...
+    else if (spiTransferQueueWritePos != spiTransferQueueReadPos
+             && spiTransferQueue[spiTransferQueueReadPos].destinationId == SPI_DESTINATION_OLED)
+    {
+        spiDestinationSendingTo = SPI_DESTINATION_OLED;
+        oled_sending            = true;
+        cv_sending              = false;
+        initiateSelectingOled();
+    }
     else
     {
-        // And, if there's some OLED data waiting to send, do that.
+#if ALPHA_OR_BETA_VERSION
         if (spiTransferQueueWritePos != spiTransferQueueReadPos)
         {
-            spiDestinationSendingTo = 0;
-            oled_sending            = true;
-            cv_sending              = false;
-            initiateSelectingOled();
+            FREEZE_WITH_ERROR("SPI transfer destination is invalid");
         }
-
-        // Otherwise, we're all done.
-        else
-        {
-            spiTransferQueueCurrentlySending = false;
-            cv_sending                       = false;
-        }
+#endif
+        spiTransferQueueCurrentlySending = false;
+        cv_sending                       = false;
     }
 }
 

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -31,6 +31,7 @@
 #include "storage/flash_storage.h"
 #include "util/cfunctions.h"
 #include "util/d_string.h"
+#include <algorithm>
 #include <string.h>
 #include <string_view>
 
@@ -83,6 +84,14 @@ void OLED::clearMainImage() {
 }
 
 void moveAreaUpCrude(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, int32_t delta, ImageStore image) {
+	minX = std::clamp<int32_t>(minX, 0, OLED_MAIN_WIDTH_PIXELS - 1);
+	maxX = std::clamp<int32_t>(maxX, 0, OLED_MAIN_WIDTH_PIXELS - 1);
+	minY = std::clamp<int32_t>(minY, 0, OLED_MAIN_HEIGHT_PIXELS - 1);
+	maxY = std::clamp<int32_t>(maxY, 0, OLED_MAIN_HEIGHT_PIXELS - 1);
+
+	if (maxX < minX || maxY < minY || delta <= 0) {
+		return;
+	}
 
 	int32_t firstRow = minY >> 3;
 	int32_t lastRow = maxY >> 3;
@@ -102,7 +111,7 @@ void moveAreaUpCrude(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY, int
 	// Move final sub-row amount
 	if (delta) {
 		for (int32_t x = minX; x <= maxX; x++) {
-			uint8_t carry;
+			uint8_t carry = 0;
 
 			for (int32_t row = lastRow; row >= firstRow; row--) {
 				uint8_t prevBitsHere = image[row][x];
@@ -124,15 +133,20 @@ int32_t popupMaxY;
 
 void OLED::setupPopup(PopupType type, int32_t width, int32_t height, std::optional<int32_t> startX,
                       std::optional<int32_t> startY) {
-	height = std::clamp<int32_t>(height, 0, OLED_MAIN_HEIGHT_PIXELS);
-	oledPopupWidth = width;
-	popupHeight = height;
 	popupType = type;
 
+	width = std::clamp<int32_t>(width, 0, OLED_MAIN_WIDTH_PIXELS - 1);
+	height = std::clamp<int32_t>(height, 0, OLED_MAIN_HEIGHT_PIXELS - 1);
+
 	popupMinX = startX.has_value() ? startX.value() : (OLED_MAIN_WIDTH_PIXELS - width) / 2;
-	popupMaxX = popupMinX + width;
+	popupMinX = std::clamp<int32_t>(popupMinX, 0, OLED_MAIN_WIDTH_PIXELS - 1);
+	popupMaxX = std::clamp<int32_t>(popupMinX + width, popupMinX, OLED_MAIN_WIDTH_PIXELS - 1);
 	popupMinY = startY.has_value() ? startY.value() : (OLED_MAIN_HEIGHT_PIXELS - height) / 2;
-	popupMaxY = popupMinY + height;
+	popupMinY = std::clamp<int32_t>(popupMinY, 0, OLED_MAIN_HEIGHT_PIXELS - 1);
+	popupMaxY = std::clamp<int32_t>(popupMinY + height, popupMinY, OLED_MAIN_HEIGHT_PIXELS - 1);
+
+	oledPopupWidth = popupMaxX - popupMinX + 1;
+	popupHeight = popupMaxY - popupMinY + 1;
 
 	popup.clearAreaExact(popupMinX, popupMinY, popupMaxX, popupMaxY);
 
@@ -156,6 +170,15 @@ struct ConsoleItem {
 ConsoleItem consoleItemStoreDontAccessDirectly[MAX_NUM_CONSOLE_ITEMS] = {0};
 int32_t numConsoleItems = 0;
 
+void normalizeConsoleItemCount() {
+	numConsoleItems = std::clamp<int32_t>(numConsoleItems, 0, MAX_NUM_CONSOLE_ITEMS);
+}
+
+bool hasConsoleItems() {
+	normalizeConsoleItemCount();
+	return numConsoleItems > 0;
+}
+
 // There is suspicion that we're under or overflowing the memory for the consoleItems
 // array: so we've renamed it to consoleItemStoreDontAccessDirectly, and have this class
 // act as a guard to catch out of bounds accesses.
@@ -176,7 +199,7 @@ public:
 ConsoleItemAccessor consoleItems;
 
 void OLED::drawConsoleTopLine() {
-	if (numConsoleItems <= 0) {
+	if (!hasConsoleItems()) {
 		return;
 	}
 	console.drawHorizontalLine(consoleItems[numConsoleItems - 1].minY - 1, consoleMinX + 1, consoleMaxX - 1);
@@ -184,6 +207,9 @@ void OLED::drawConsoleTopLine() {
 
 // Returns y position (minY)
 int32_t OLED::setupConsole(int32_t height) {
+	normalizeConsoleItemCount();
+	height = std::clamp<int32_t>(height, 1, kConsoleImageHeight - 2);
+
 	consoleMinX = 4;
 	consoleMaxX = OLED_MAIN_WIDTH_PIXELS - consoleMinX;
 
@@ -193,8 +219,8 @@ int32_t OLED::setupConsole(int32_t height) {
 	if (numConsoleItems) {
 
 		// If hit max num console items...
-		if (numConsoleItems == MAX_NUM_CONSOLE_ITEMS) {
-			numConsoleItems--;
+		if (numConsoleItems >= MAX_NUM_CONSOLE_ITEMS) {
+			numConsoleItems = MAX_NUM_CONSOLE_ITEMS - 1;
 			shouldRedrawTopLine = true;
 		}
 
@@ -212,12 +238,13 @@ int32_t OLED::setupConsole(int32_t height) {
 		if (howMuchTooLow > 0) {
 
 			// Move their min and max values up
+			int32_t topSurvivingItem = numConsoleItems;
 			for (int32_t i = numConsoleItems; i >= 0; i--) {
 				// numConsoleItems hasn't been updated yet - there's actually one more
 				consoleItems[i].minY -= howMuchTooLow;
 				// If at all offscreen, scrap that one
 				if (consoleItems[i].minY < 1) {
-					numConsoleItems = i - 1; // It's still going to get 1 added to it, below
+					topSurvivingItem = i - 1; // It's still going to get 1 added to it, below
 					shouldRedrawTopLine = true;
 				}
 
@@ -226,8 +253,10 @@ int32_t OLED::setupConsole(int32_t height) {
 
 			// Do the actual copying
 			// numConsoleItems hasn't been updated yet - there's actually one more
-			moveAreaUpCrude(consoleMinX, consoleItems[numConsoleItems].minY - 1, consoleMaxX,
-			                consoleItems[1].maxY + howMuchTooLow, howMuchTooLow, console.hackGetImageStore());
+			numConsoleItems = std::max<int32_t>(topSurvivingItem, 0);
+			int32_t moveMinY = consoleItems[numConsoleItems].minY - 1;
+			int32_t moveMaxY = consoleItems[1].maxY + howMuchTooLow;
+			moveAreaUpCrude(consoleMinX, moveMinY, consoleMaxX, moveMaxY, howMuchTooLow, console.hackGetImageStore());
 		}
 	}
 
@@ -293,12 +322,12 @@ void copyRowWithMask(uint8_t destMask, uint8_t sourceRow[], uint8_t destRow[], i
 
 void copyBackgroundAroundForeground(ImageStore backgroundImage, ImageStore foregroundImage, int32_t minX, int32_t minY,
                                     int32_t maxX, int32_t maxY) {
-	if (maxX < 0 || minX < 0 || maxX < minX || minX > OLED_MAIN_WIDTH_PIXELS || maxX > OLED_MAIN_WIDTH_PIXELS)
+	if (maxX < 0 || minX < 0 || maxX < minX || minX >= OLED_MAIN_WIDTH_PIXELS || maxX >= OLED_MAIN_WIDTH_PIXELS)
 	    [[unlikely]] {
 		// D for Display
 		FREEZE_WITH_ERROR("D001");
 	}
-	if (maxY < 0 || minY < 0 || maxY < minY || minY > OLED_MAIN_HEIGHT_PIXELS || maxY > OLED_MAIN_HEIGHT_PIXELS)
+	if (maxY < 0 || minY < 0 || maxY < minY || minY >= OLED_MAIN_HEIGHT_PIXELS || maxY >= OLED_MAIN_HEIGHT_PIXELS)
 	    [[unlikely]] {
 		FREEZE_WITH_ERROR("D002");
 	}
@@ -343,7 +372,7 @@ void OLED::sendMainImage() {
 
 	oledCurrentImage = &main.hackGetImageStore()[0];
 
-	if (numConsoleItems) {
+	if (hasConsoleItems()) {
 		copyBackgroundAroundForeground(main.hackGetImageStore(), console.hackGetImageStore(), consoleMinX,
 		                               consoleItems[numConsoleItems - 1].minY - 1, consoleMaxX,
 		                               OLED_MAIN_HEIGHT_PIXELS - 1);
@@ -522,6 +551,21 @@ findNextStringSplitPoint:
 	}
 	// line width exceeds maximum
 	else {
+		if (lineLengthBeforeThisWord <= 0) {
+			int32_t splitLength = std::max<int32_t>(lineLength - 1, 1);
+			int32_t splitWidth = std::min<int32_t>(lineWidth, textLineBreakdown->maxWidthPerLine);
+			addLine(textLineBreakdown, lineStart, splitWidth, splitLength);
+			if (textLineBreakdown->numLines == TEXT_MAX_NUM_LINES) {
+				return;
+			}
+			lineStart += splitLength;
+			wordStart = lineStart;
+			lineWidth = 0;
+			lineLength = 0;
+			charSpacing = 0;
+			goto findNextStringSplitPoint;
+		}
+
 		// if we reached line break or end of string, we don't need extra spacing after it
 		lineWidthBeforeThisWord -= charSpacing;
 		addLine(textLineBreakdown, lineStart, lineWidthBeforeThisWord, lineLengthBeforeThisWord);
@@ -562,10 +606,10 @@ void OLED::drawPermanentPopupLookingText(char const* text) {
 	int32_t textHeight = textLineBreakdown.numLines * kTextSpacingY;
 
 	int32_t minX = (OLED_MAIN_WIDTH_PIXELS - textWidth - doubleMargin) >> 1;
-	int32_t maxX = OLED_MAIN_WIDTH_PIXELS - minX;
+	int32_t maxX = OLED_MAIN_WIDTH_PIXELS - minX - 1;
 
 	int32_t minY = (OLED_MAIN_HEIGHT_PIXELS - textHeight - doubleMargin) >> 1;
-	int32_t maxY = OLED_MAIN_HEIGHT_PIXELS - minY;
+	int32_t maxY = OLED_MAIN_HEIGHT_PIXELS - minY - 1;
 
 	main.drawRectangle(minX, minY, maxX, maxY);
 
@@ -828,9 +872,10 @@ void OLED::consoleText(char const* text) {
 
 	breakStringIntoLines(text, &textLineBreakdown, charHeight);
 
-	int32_t textPixelY = setupConsole(textLineBreakdown.numLines * charHeight + 1) + 1;
+	int32_t numLines = std::min<int32_t>(textLineBreakdown.numLines, (kConsoleImageHeight - 3) / charHeight);
+	int32_t textPixelY = setupConsole(numLines * charHeight + 1) + 1;
 
-	for (int32_t l = 0; l < textLineBreakdown.numLines; l++) {
+	for (int32_t l = 0; l < numLines; l++) {
 		console.drawString(std::string_view{textLineBreakdown.lines[l], textLineBreakdown.lineLengths[l]}, textPixelX,
 		                   textPixelY, charWidth, charHeight);
 		textPixelY += charHeight;
@@ -1048,7 +1093,7 @@ void OLED::scrollingAndBlinkingTimerEvent() {
 
 void OLED::consoleTimerEvent() {
 	// If console active
-	if (!numConsoleItems) {
+	if (!hasConsoleItems()) {
 		return;
 	}
 
@@ -1078,7 +1123,7 @@ void OLED::consoleTimerEvent() {
 		int32_t lastRow = consoleItems[0].maxY >> 3;
 
 		for (int32_t x = consoleMinX; x <= consoleMaxX; x++) {
-			uint8_t carry;
+			uint8_t carry = 0;
 
 			for (int32_t row = lastRow; row >= firstRow; row--) {
 				uint8_t prevBitsHere = console.hackGetImageStore()[row][x];

--- a/src/deluge/hid/display/oled_canvas/canvas.cpp
+++ b/src/deluge/hid/display/oled_canvas/canvas.cpp
@@ -21,13 +21,35 @@
 #include "gui/fonts/fonts.h"
 #include "storage/flash_storage.h"
 
+#include <algorithm>
 #include <hid/display/oled.h>
 #include <math.h>
 #include <vector>
 
 using deluge::hid::display::oled_canvas::Canvas;
 
+namespace {
+constexpr int32_t kMaxX = OLED_MAIN_WIDTH_PIXELS - 1;
+constexpr int32_t kMaxY = OLED_MAIN_HEIGHT_PIXELS - 1;
+
+bool clipRect(int32_t& minX, int32_t& minY, int32_t& maxX, int32_t& maxY) {
+	if (maxX < minX || maxY < minY || maxX < 0 || minX > kMaxX || maxY < 0 || minY > kMaxY) {
+		return false;
+	}
+
+	minX = std::clamp<int32_t>(minX, 0, kMaxX);
+	maxX = std::clamp<int32_t>(maxX, 0, kMaxX);
+	minY = std::clamp<int32_t>(minY, 0, kMaxY);
+	maxY = std::clamp<int32_t>(maxY, 0, kMaxY);
+	return true;
+}
+} // namespace
+
 void Canvas::clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t maxY) {
+	if (!clipRect(minX, minY, maxX, maxY)) {
+		return;
+	}
+
 	int32_t firstRow = minY >> 3;
 	int32_t lastRow = maxY >> 3;
 
@@ -69,21 +91,43 @@ void Canvas::clearAreaExact(int32_t minX, int32_t minY, int32_t maxX, int32_t ma
 }
 
 void Canvas::drawPixel(int32_t x, int32_t y) {
+	if (x < 0 || x > kMaxX || y < 0 || y > kMaxY) {
+		return;
+	}
+
 	int32_t yRow = y >> 3;
 	image_[yRow][x] |= 1 << (y & 0x7);
 }
 
 void Canvas::clearPixel(int32_t x, int32_t y) {
+	if (x < 0 || x > kMaxX || y < 0 || y > kMaxY) {
+		return;
+	}
+
 	int32_t yRow = y >> 3;
 	image_[yRow][x] &= ~(1 << (y & 0x7));
 }
 
 void Canvas::invertPixel(int32_t x, int32_t y) {
+	if (x < 0 || x > kMaxX || y < 0 || y > kMaxY) {
+		return;
+	}
+
 	int32_t yRow = y >> 3;
 	image_[yRow][x] ^= 1 << (y & 0x7);
 }
 
 void Canvas::drawHorizontalLine(int32_t pixelY, int32_t startX, int32_t endX) {
+	if (pixelY < 0 || pixelY > kMaxY || endX < startX || endX < 0 || startX > kMaxX) {
+		return;
+	}
+
+	startX = std::clamp<int32_t>(startX, 0, kMaxX);
+	endX = std::clamp<int32_t>(endX, 0, kMaxX);
+	if (endX < startX) {
+		return;
+	}
+
 	uint8_t mask = 1 << (pixelY & 7);
 
 	uint8_t* __restrict__ currentPos = &image_[pixelY >> 3][startX];
@@ -95,6 +139,16 @@ void Canvas::drawHorizontalLine(int32_t pixelY, int32_t startX, int32_t endX) {
 }
 
 void Canvas::drawVerticalLine(int32_t pixelX, int32_t startY, int32_t endY) {
+	if (pixelX < 0 || pixelX > kMaxX || endY < startY || endY < 0 || startY > kMaxY) {
+		return;
+	}
+
+	startY = std::clamp<int32_t>(startY, 0, kMaxY);
+	endY = std::clamp<int32_t>(endY, 0, kMaxY);
+	if (endY < startY) {
+		return;
+	}
+
 	int32_t firstRowY = startY >> 3;
 	int32_t lastRowY = endY >> 3;
 
@@ -672,6 +726,12 @@ void Canvas::drawScreenTitle(std::string_view title, bool drawSeparator) {
 }
 
 void Canvas::invertArea(int32_t xMin, int32_t width, int32_t startY, int32_t endY) {
+	int32_t xMax = xMin + width - 1;
+	if (!clipRect(xMin, startY, xMax, endY)) {
+		return;
+	}
+	width = xMax - xMin + 1;
+
 	int32_t firstRowY = startY >> 3;
 	int32_t lastRowY = endY >> 3;
 


### PR DESCRIPTION
Fix crash that would occur when calling display->displayError(Error::Unspecified);

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4582

# Issues Found
## Console item overflow / bad bookkeeping
numConsoleItems could drift outside the valid 0..3 range, or be used after scroll-up logic removed items. That triggers D003.

## Long OLED console text could create bad geometry
The newer pixel-width line wrapper can produce bad/empty lines for over-wide unbroken strings. That can make consoleText() request too-tall console items on the 48px OLED.

## OLED popup/compositor off-by-one writes
Several paths treated maxX/maxY as inclusive, but allowed values like 128 or 48. On a 128x48 image, valid maxes are 127 and 47. That can scribble past the display buffer and later corrupt numConsoleItems.

## Canvas primitives had no clipping
Raw drawing calls like lines, pixels, clear areas, and invert areas trusted callers completely. One bad coordinate could write outside the OLED image.

## SPI error was likely downstream
The SPI queue code also assumed “not CV means OLED” in one path. If memory/state was already corrupted, it could report “SPI transfer destination” instead of the earlier D003.

# Fixes

## In oled.cpp:
- Clamp console item heights and counts.
- Fix console scroll-up bookkeeping.
- Cap consoleText() to visible OLED height.
- Fix long-word wrapping so it doesn’t create zero-length lines.
- Clamp popup coordinates to valid OLED bounds.
- Tighten compositor bounds checks so maxX == 128 / maxY == 48 are invalid.
- Fix permanent popup rectangle max coordinate off-by-one.
- Initialize uninitialized scroll carry bytes.

## In oled_canvas/canvas.cpp:
- Add clipping/sanity checks to clearAreaExact, pixel ops, horizontal/vertical lines, and invert areas.

## In oled_low_level.c:
- Replace magic OLED/CV destination checks with enum constants.
- Make CV-completion dispatch use the actual queued destination.
- Stop treating every non-CV queue item as OLED.