### PR TITLE
Fix/ Toggle fill setting for held notes

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -573,6 +573,14 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 		return instrumentClipView.handleNoteRowEditorButtonAction(b, on, inCardRoutine);
 	}
 
+	// allow toggling fill mode while in the sound editor menu
+	else if (b == deluge::hid::button::SYNC_SCALING
+	         && runtimeFeatureSettings.get(RuntimeFeatureSettingType::SyncScalingAction)
+	                == RuntimeFeatureStateSyncScalingAction::Fill) {
+		currentSong->changeFillMode(on);
+		return ActionResult::DEALT_WITH;
+	}
+
 	else {
 		MenuItem* currentMenuItem = getCurrentMenuItem();
 		HorizontalMenu* asHorizontal = nullptr;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -2967,7 +2967,8 @@ void InstrumentClipView::adjustNoteParameterValue(int32_t withOffset, int32_t wi
 
 	bool inNoteEditor = getCurrentUI() == &soundEditor && (soundEditor.inNoteEditor() || soundEditor.inNoteRowEditor());
 
-	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE);
+	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE)
+	                || display->hasPopupOfType(PopupType::FILL);
 
 	// If just one press...
 	if (numEditPadPresses == 1) {
@@ -3059,6 +3060,12 @@ void InstrumentClipView::adjustNoteParameterValue(int32_t withOffset, int32_t wi
 									parameterValue++;
 									parameterHasBeenEdited = true;
 								}
+							}
+							// Wrap around for FILL when at max value
+							else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL
+							         && !inNoteEditor) {
+								parameterValue = parameterMinValue;
+								parameterHasBeenEdited = true;
 							}
 						}
 						// Decrementing
@@ -3264,6 +3271,12 @@ multiplePresses:
 							}
 						}
 					}
+					// Wrap around for FILL when at max value
+					else if (parameterValue == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL
+					         && !inNoteEditor) {
+						parameterValue = parameterMinValue;
+						parameterHasBeenEdited = true;
+					}
 				}
 				// Decrementing
 				else {
@@ -3384,6 +3397,9 @@ multiplePresses:
 		else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
 			displayIterance(Iterance::fromInt(parameterValue));
 		}
+		else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
+			displayFill(parameterValue);
+		}
 	}
 }
 
@@ -3441,6 +3457,19 @@ void InstrumentClipView::displayIterance(Iterance iterance) {
 	}
 	else {
 		display->displayPopup(buffer, 0, true, 255, 1, PopupType::ITERANCE);
+	}
+}
+
+void InstrumentClipView::displayFill(uint8_t mode) {
+	char buffer[(display->haveOLED()) ? 29 : 5];
+
+	strcpy(buffer, getFillString(mode));
+
+	if (display->haveOLED()) {
+		display->popupText(buffer, PopupType::FILL);
+	}
+	else {
+		display->displayPopup(buffer, 0, true, 255, 1, PopupType::FILL);
 	}
 }
 
@@ -3899,7 +3928,8 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 		return -1; // Get out if NoteRow doesn't exist and can't be created
 	}
 
-	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE);
+	bool hasPopup = display->hasPopupOfType(PopupType::PROBABILITY) || display->hasPopupOfType(PopupType::ITERANCE)
+	                || display->hasPopupOfType(PopupType::FILL);
 
 	uint16_t original_parameter{0};
 	bool parameter_has_been_edited = false;
@@ -3966,6 +3996,12 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 						parameter_value++;
 						parameter_has_been_edited = true;
 					}
+				}
+				// Wrap around for FILL when at max value
+				else if (parameter_value == parameterMaxValue && changeType == CORRESPONDING_NOTES_SET_FILL
+				         && !inNoteRowEditor) {
+					parameter_value = parameterMinValue;
+					parameter_has_been_edited = true;
 				}
 			}
 			// Decrementing
@@ -4043,6 +4079,9 @@ int32_t InstrumentClipView::setNoteRowParameterValue(int32_t withOffset, int32_t
 		}
 		else if (changeType == CORRESPONDING_NOTES_SET_ITERANCE) {
 			displayIterance(Iterance::fromInt(parameter_value));
+		}
+		else if (changeType == CORRESPONDING_NOTES_SET_FILL) {
+			displayFill(parameter_value);
 		}
 	}
 

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -371,6 +371,7 @@ private:
 	void nudgeNotes(int32_t offset);
 	void displayProbability(uint8_t probability, bool prevBase);
 	void displayIterance(Iterance iterance);
+	void displayFill(uint8_t mode);
 
 	// note row functions
 	void copyNotes(Serializer* writer, bool selectedDrumOnly = false);

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -332,7 +332,27 @@ doEndMidiLearnPressSession:
 	else if (b == SYNC_SCALING) {
 		if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::SyncScalingAction)
 		     == RuntimeFeatureStateSyncScalingAction::Fill)) {
-			currentSong->changeFillMode(on);
+			// If currently in the sound editor note editor / note row editor, keep this button as the global
+			// fill mode toggle rather than changing note fill values.
+			if (getCurrentUI() == &soundEditor && (soundEditor.inNoteEditor() || soundEditor.inNoteRowEditor())) {
+				currentSong->changeFillMode(on);
+				return ActionResult::DEALT_WITH;
+			}
+
+			// If note(s) pressed, adjust note fill
+			if (on && (currentUIMode == UI_MODE_NOTES_PRESSED || instrumentClipView.numEditPadPresses > 0)) {
+				instrumentClipView.adjustNoteFillWithOffset(1);
+				return ActionResult::DEALT_WITH;
+			}
+			// If audition pad pressed, adjust note row fill
+			else if (on && (currentUIMode == UI_MODE_AUDITIONING)) {
+				instrumentClipView.setNoteRowFillWithOffset(1);
+				return ActionResult::DEALT_WITH;
+			}
+			// Otherwise toggle fill mode
+			else {
+				currentSong->changeFillMode(on);
+			}
 		}
 		else if (on && currentUIMode == UI_MODE_NONE) {
 

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -23,6 +23,8 @@ enum class PopupType {
 	PROBABILITY,
 	/// Popup shown when editing note or row iterance.
 	ITERANCE,
+	/// Popup shown when editing note or row fill.
+	FILL,
 	/// Swing amount and interval
 	SWING,
 	/// Tempo

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -914,8 +914,13 @@ bool allowResyncingDuringClipLengthChange = true;
 
 void Song::changeFillMode(bool on) {
 	fillModeActive = on;
-	// we peek fill notes when fill is held so need to re render rows
-	uiNeedsRendering(&instrumentClipView, 0xFFFFFFFF, 0);
+
+	UI* root_ui = getRootUI();
+	if (root_ui == &instrumentClipView) {
+		// we peek fill notes when fill is held so need to re render rows
+		uiNeedsRendering(&instrumentClipView, 0xFFFFFFFF, 0);
+	}
+
 	if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::SyncScalingAction)
 	     == RuntimeFeatureStateSyncScalingAction::Fill)) {
 		indicator_leds::setLedState(IndicatorLED::SYNC_SCALING, on);

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -232,7 +232,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 - Enhanced existing note probability, iteration and fill function functionality by enabling you to use each type independently. This means that you can now apply probability to iteration and fill and you can also apply iteration to fill.
   - To edit probability, hold a note / audition pad and turn the select encoder to the left to display current probability value / set new probability value.
   - To edit iterance, hold a note / audition pad and turn the select encoder to the right to display current iterance value / set new iterance value.
-  - To edit fill, you need to access the new note and note row editor menu's.
+  - To edit fill, hold a note / audition pad and press sync scaling to view the current fill setting and cycle through fill modes.
 - Added new note and note row editor menu's to edit note and note row parameters.
   - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid.
   - Hold a note row audition pad and press the select encoder to enter the note row editor menu. While in the note row editor menu, the selected note row's audition pad will blink. You can select other note row's by pressing the note row audition pad or by scrolling with the vertical encoder.


### PR DESCRIPTION
fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3886

Holding 1+ Notes + press SyncScaling Iterates over the FILL Values with wrap around for the pressed notes
Holding Audition Pad + press SyncScaling Iterates over the FILL Values with wrap around for the corresponding Row
Pressing SyncScaling inside Menu's (Note/Row Editor, Song Menu, Settings) activates Fill-Mode
Change FILL-Mode in Note/Row Editor Menu does not wrap around

Stuff tweaked / added by me:
- holding note / audition + fill shows current value first before changing it
- added check for root UI = instrumentClipView before rendering fill mode colours over notes
- updated change log
- added some comments

Started by @busa-projects (in #4511) and just finished / polished up by me