### PR TITLE
Fix/ Favourites manager

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -1061,8 +1061,8 @@ enum SessionLayoutType : uint8_t {
 };
 
 enum FavouritesDefaultLayout : uint8_t {
-	FavouritesDefaultLayoutFavorites,
-	FavouritesDefaultLayoutFavoritesAndBanks,
+	FavouritesDefaultLayoutFavourites,
+	FavouritesDefaultLayoutFavouritesAndBanks,
 	FavouritesDefaultLayoutOff,
 	FavouritesDefaultLayoutMaxElement // Keep as boundary
 };

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1593,20 +1593,20 @@ ActionResult Browser::padAction(int32_t x, int32_t y, int32_t on) {
 			}
 			if (favouritesManager.isEmpty(x)) {
 				if (!getCurrentFileItem()->isFolder) {
-					favouritesManager.setFavorite(x, FavouritesManager::favouriteDefaultColor, filePath.get());
+					favouritesManager.setFavourite(x, FavouritesManager::favouriteDefaultColor, filePath.get());
 					favouritesChanged();
 				}
 			}
 			else {
-				favouritesManager.unsetFavorite(x);
+				favouritesManager.unsetFavourite(x);
 				favouritesChanged();
 			}
 		}
 		else {
-			const std::string favoritePath = favouritesManager.getFavoriteFilename(x);
+			const std::string favouritePath = favouritesManager.getFavouriteFilename(x);
 			favouritesChanged();
-			if (!favoritePath.empty()) {
-				setFileByFullPath(outputTypeToLoad, favoritePath.c_str());
+			if (!favouritePath.empty()) {
+				setFileByFullPath(outputTypeToLoad, favouritePath.c_str());
 			}
 			else {
 				display->displayPopup(l10n::get(l10n::String::STRING_FOR_FAVOURITES_EMPTY));
@@ -1912,5 +1912,5 @@ bool Browser::isFavouritesVisible() {
 bool Browser::isBanksVisible() {
 	return (getCurrentUI()->canDisplayFavourites() && qwertyVisible
 	        && FlashStorage::defaultFavouritesLayout
-	               == FavouritesDefaultLayout::FavouritesDefaultLayoutFavoritesAndBanks);
+	               == FavouritesDefaultLayout::FavouritesDefaultLayoutFavouritesAndBanks);
 }

--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -44,9 +44,9 @@ int32_t QwertyUI::scrollPosHorizontal;
 uint8_t QwertyUI::currentBank = 0;
 std::optional<uint8_t> QwertyUI::currentFavourite = std::nullopt;
 uint8_t QwertyUI::favouriteRow = 6;
-FavouritesDefaultLayout QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayout::FavouritesDefaultLayoutFavorites;
+FavouritesDefaultLayout QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayout::FavouritesDefaultLayoutFavourites;
 
-static constexpr float colourStep = 192 / 16;
+static constexpr float colourStep = 192 / kNumFavourites;
 
 bool QwertyUI::opened() {
 
@@ -54,13 +54,13 @@ bool QwertyUI::opened() {
 	enteredTextEditPos = 0;
 	enteredText.clear();
 	switch (FlashStorage::defaultFavouritesLayout) {
-	case FavouritesDefaultLayoutFavorites: {
-		QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayoutFavorites;
+	case FavouritesDefaultLayoutFavourites: {
+		QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayoutFavourites;
 		QwertyUI::favouriteRow = 7;
 		break;
 	}
-	case FavouritesDefaultLayoutFavoritesAndBanks: {
-		QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayoutFavoritesAndBanks;
+	case FavouritesDefaultLayoutFavouritesAndBanks: {
+		QwertyUI::favouritesLayoutSelected = FavouritesDefaultLayoutFavouritesAndBanks;
 		QwertyUI::favouriteRow = 6;
 		break;
 	}
@@ -423,7 +423,7 @@ void QwertyUI::renderFavourites() {
 	if (!getCurrentUI()->isFavouritesVisible()) {
 		return;
 	}
-	std::array<std::optional<uint8_t>, 16> colours = favouritesManager.getFavouriteColours();
+	std::array<std::optional<uint8_t>, kNumFavourites> colours = favouritesManager.getFavouriteColours();
 	currentBank = favouritesManager.currentBankNumber;
 	currentFavourite = favouritesManager.currentFavouriteNumber;
 
@@ -432,9 +432,9 @@ void QwertyUI::renderFavourites() {
 		return;
 	}
 
-	for (uint8_t i = 0; i < 16; i++) {
+	for (uint8_t i = 0; i < kNumFavourites; i++) {
 		// Render Banks
-		if (favouritesLayoutSelected == FavouritesDefaultLayout::FavouritesDefaultLayoutFavoritesAndBanks) {
+		if (favouritesLayoutSelected == FavouritesDefaultLayout::FavouritesDefaultLayoutFavouritesAndBanks) {
 			PadLEDs::image[favouriteBankRow][i] = RGB::fromHue(static_cast<int16_t>(i * colourStep));
 		}
 		// Render Favourites
@@ -506,7 +506,7 @@ ActionResult QwertyUI::timerCallback() {
 			PadLEDs::flashMainPad(QwertyUI::currentFavourite.value(), favouriteRow);
 		}
 
-		if (QwertyUI::favouritesLayoutSelected == FavouritesDefaultLayout::FavouritesDefaultLayoutFavoritesAndBanks) {
+		if (QwertyUI::favouritesLayoutSelected == FavouritesDefaultLayout::FavouritesDefaultLayoutFavouritesAndBanks) {
 			PadLEDs::flashMainPad(QwertyUI::currentBank, favouriteBankRow);
 		}
 

--- a/src/deluge/model/favourite/favourite_manager.cpp
+++ b/src/deluge/model/favourite/favourite_manager.cpp
@@ -42,8 +42,8 @@ void FavouritesManager::close() {
 
 void FavouritesManager::resetFavourites() {
 	favourites.clear();
-	favourites.resize(16);
-	for (uint8_t i = 0; i < 16; i++) {
+	favourites.resize(kNumFavourites);
+	for (uint8_t i = 0; i < kNumFavourites; i++) {
 		favourites[i].position = i;
 	}
 }
@@ -90,7 +90,7 @@ Error FavouritesManager::loadFavouritesFromFile(Deserializer& reader) {
 			while (*(tagName = reader.readNextTagOrAttributeName())) {
 				if (!strcmp(tagName, "position")) {
 					position = reader.readTagOrAttributeValueInt();
-					if (position >= 0 && position < 16) {
+					if (position >= 0 && position < kNumFavourites) {
 						favourites[position].position = position;
 					}
 					else {
@@ -160,52 +160,53 @@ void FavouritesManager::selectFavouritesBank(uint8_t bankNumber) {
 	loadFavouritesBank();
 }
 
-void FavouritesManager::setFavorite(uint8_t position, uint8_t colour, const std::string& filename) {
-	if (position >= 16)
+void FavouritesManager::setFavourite(uint8_t position, uint8_t colour, const std::string& filename) {
+	if (position >= kNumFavourites)
 		return;
 	if (favourites.size() <= position) {
-		favourites.resize(16);
+		favourites.resize(kNumFavourites);
 	}
 	currentFavouriteNumber = position;
-	favourites[position] = Favorite(position, static_cast<uint8_t>(colour), filename);
+	favourites[position] = Favourite(position, static_cast<uint8_t>(colour), filename);
 	saveFavouriteBank();
 }
 
-void FavouritesManager::unsetFavorite(uint8_t position) {
-	if (position >= 16)
+void FavouritesManager::unsetFavourite(uint8_t position) {
+	if (position >= kNumFavourites)
 		return;
 	currentFavouriteNumber = position;
-	favourites[position] = Favorite(position, std::nullopt, "");
+	favourites[position] = Favourite(position, std::nullopt, "");
 	saveFavouriteBank();
 }
 
 bool FavouritesManager::isEmpty(uint8_t position) const {
-	if (position >= 16 || favourites.size() <= position)
+	if (position >= kNumFavourites || favourites.size() <= position)
 		return true;
 	return !favourites[position].colour.has_value();
 }
 
-std::array<std::optional<uint8_t>, 16> FavouritesManager::getFavouriteColours() const {
-	std::array<std::optional<uint8_t>, 16> colours{};
-	for (uint8_t i = 0; i < 16 && i < favourites.size(); i++) {
+std::array<std::optional<uint8_t>, kNumFavourites> FavouritesManager::getFavouriteColours() const {
+	std::array<std::optional<uint8_t>, kNumFavourites> colours{};
+	for (uint8_t i = 0; i < kNumFavourites && i < favourites.size(); i++) {
 		colours[i] = favourites[i].colour;
 	}
 	return colours; // Copy elision makes this efficient
 }
 
 void FavouritesManager::changeColour(uint8_t position, int32_t offset) {
-	if (position < 16 && favourites.size() > position && favourites[position].colour.has_value()) {
-		favourites[position].colour = ((favourites[position].colour.value() + offset) % 16 + 16) % 16;
+	if (position < kNumFavourites && favourites.size() > position && favourites[position].colour.has_value()) {
+		favourites[position].colour =
+		    ((favourites[position].colour.value() + offset) % kNumFavourites + kNumFavourites) % kNumFavourites;
 		unsavedChanges = true;
 		return;
 	}
 	return;
 }
 
-const std::string& FavouritesManager::getFavoriteFilename(uint8_t position) {
+const std::string& FavouritesManager::getFavouriteFilename(uint8_t position) {
 	static const std::string emptyString = ""; // Safe default value
 	currentFavouriteNumber = position;
-	if (position >= 16 || favourites.size() <= position || !favourites[position].colour.has_value()) {
+	if (position >= kNumFavourites || favourites.size() <= position || !favourites[position].colour.has_value()) {
 		return emptyString; // Return a reference to an empty string instead of nullptr
 	}
 	return favourites[position].filename;

--- a/src/deluge/model/favourite/favourite_manager.cpp
+++ b/src/deluge/model/favourite/favourite_manager.cpp
@@ -22,27 +22,40 @@
 FavouritesManager favouritesManager{};
 
 FavouritesManager::FavouritesManager() {
-	favourites.resize(16);
+	resetFavourites();
 }
 
 FavouritesManager::~FavouritesManager() {
-	saveFavouriteBank();
+	if (!currentCategory.empty()) {
+		saveFavouriteBank();
+	}
 }
 void FavouritesManager::close() {
 	if (unsavedChanges) {
 		saveFavouriteBank();
 	}
-	favourites.clear();
-	// Dealoccating all memory
-	std::vector<Favorite>().swap(favourites);
+	resetFavourites();
+	currentCategory.clear();
+	currentFavouriteNumber = std::nullopt;
 	return;
 }
 
-void FavouritesManager::setCategory(const std::string& category) {
-	currentCategory = category;
+void FavouritesManager::resetFavourites() {
 	favourites.clear();
 	favourites.resize(16);
-	selectFavouritesBank(0);
+	for (uint8_t i = 0; i < 16; i++) {
+		favourites[i].position = i;
+	}
+}
+
+void FavouritesManager::setCategory(const std::string& category) {
+	if (unsavedChanges && !currentCategory.empty()) {
+		saveFavouriteBank();
+	}
+	currentCategory = category;
+	currentBankNumber = 0;
+	currentFavouriteNumber = std::nullopt;
+	loadFavouritesBank();
 }
 
 std::string FavouritesManager::getFilenameForSave() const {
@@ -50,38 +63,51 @@ std::string FavouritesManager::getFilenameForSave() const {
 }
 
 void FavouritesManager::loadFavouritesBank() {
-	favourites.clear();
-	favourites.resize(16);
+	resetFavourites();
 	std::string filePath = getFilenameForSave();
-	FilePointer fileToLoad;
+	FilePointer fileToLoad{};
 	bool fileExists = StorageManager::fileExists(filePath.c_str(), &fileToLoad);
 	if (!fileExists) {
-		// create emtpy File
+		// Create an empty bank and keep the in-memory defaults.
 		saveFavouriteBank();
+		return;
 	}
 	String path;
 	path.set(filePath.c_str());
 	Error error = StorageManager::loadFavouriteFile(&fileToLoad, &path);
+	if (error != Error::NONE) {
+		resetFavourites();
+	}
 }
 
 Error FavouritesManager::loadFavouritesFromFile(Deserializer& reader) {
 	reader.match('{');
 	char const* tagName;
-	uint8_t i = 0;
-	String fileName;
 	while (*(tagName = reader.readNextTagOrAttributeName())) {
 		if (!strcmp(tagName, "favourite")) {
+			int32_t position = -1;
+			String fileName;
 			while (*(tagName = reader.readNextTagOrAttributeName())) {
 				if (!strcmp(tagName, "position")) {
-					i = reader.readTagOrAttributeValueInt();
-					favourites[i].position = i;
+					position = reader.readTagOrAttributeValueInt();
+					if (position >= 0 && position < 16) {
+						favourites[position].position = position;
+					}
+					else {
+						position = -1;
+					}
 				}
 				else if (!strcmp(tagName, "colour")) {
-					favourites[i].colour = reader.readTagOrAttributeValueInt();
+					int32_t colour = reader.readTagOrAttributeValueInt();
+					if (position >= 0) {
+						favourites[position].colour = static_cast<uint8_t>(colour);
+					}
 				}
 				else if (!strcmp(tagName, "instrumentPresetFolder")) {
 					reader.readTagOrAttributeValueString(&fileName);
-					favourites[i].filename = fileName.get();
+					if (position >= 0) {
+						favourites[position].filename = fileName.get();
+					}
 				}
 			}
 		}
@@ -90,6 +116,9 @@ Error FavouritesManager::loadFavouritesFromFile(Deserializer& reader) {
 }
 
 void FavouritesManager::saveFavouriteBank() const {
+	if (currentCategory.empty()) {
+		return;
+	}
 
 	std::string filePath = getFilenameForSave();
 	Error error = StorageManager::createXMLFile(filePath.c_str(), smSerializer, true, true);
@@ -151,21 +180,21 @@ void FavouritesManager::unsetFavorite(uint8_t position) {
 }
 
 bool FavouritesManager::isEmpty(uint8_t position) const {
-	if (position >= 16)
+	if (position >= 16 || favourites.size() <= position)
 		return true;
 	return !favourites[position].colour.has_value();
 }
 
 std::array<std::optional<uint8_t>, 16> FavouritesManager::getFavouriteColours() const {
-	std::array<std::optional<uint8_t>, 16> colours;
-	for (uint8_t i = 0; i < 16; i++) {
+	std::array<std::optional<uint8_t>, 16> colours{};
+	for (uint8_t i = 0; i < 16 && i < favourites.size(); i++) {
 		colours[i] = favourites[i].colour;
 	}
 	return colours; // Copy elision makes this efficient
 }
 
 void FavouritesManager::changeColour(uint8_t position, int32_t offset) {
-	if (position < 16 && favourites[position].colour.has_value()) {
+	if (position < 16 && favourites.size() > position && favourites[position].colour.has_value()) {
 		favourites[position].colour = ((favourites[position].colour.value() + offset) % 16 + 16) % 16;
 		unsavedChanges = true;
 		return;
@@ -176,7 +205,7 @@ void FavouritesManager::changeColour(uint8_t position, int32_t offset) {
 const std::string& FavouritesManager::getFavoriteFilename(uint8_t position) {
 	static const std::string emptyString = ""; // Safe default value
 	currentFavouriteNumber = position;
-	if (position < 0 || position >= 16 || favourites.size() != 16 || !favourites[position].colour.has_value()) {
+	if (position >= 16 || favourites.size() <= position || !favourites[position].colour.has_value()) {
 		return emptyString; // Return a reference to an empty string instead of nullptr
 	}
 	return favourites[position].filename;

--- a/src/deluge/model/favourite/favourite_manager.h
+++ b/src/deluge/model/favourite/favourite_manager.h
@@ -27,7 +27,7 @@
 class FavouritesManager {
 public:
 	struct Favorite {
-		int position;
+		int position = 0;
 		std::optional<uint8_t> colour;
 		std::string filename;
 	};
@@ -48,10 +48,11 @@ public:
 	const std::string& getFavoriteFilename(uint8_t position);
 	static constexpr uint8_t favouriteDefaultColor = 4;
 
-	uint8_t currentBankNumber;
+	uint8_t currentBankNumber = 0;
 	std::optional<uint8_t> currentFavouriteNumber;
 
 private:
+	void resetFavourites();
 	void loadFavouritesBank();
 	void saveFavouriteBank() const;
 

--- a/src/deluge/model/favourite/favourite_manager.h
+++ b/src/deluge/model/favourite/favourite_manager.h
@@ -24,9 +24,11 @@
 #include <string>
 #include <vector>
 
+constexpr size_t kNumFavourites = 16;
+
 class FavouritesManager {
 public:
-	struct Favorite {
+	struct Favourite {
 		int position = 0;
 		std::optional<uint8_t> colour;
 		std::string filename;
@@ -38,14 +40,14 @@ public:
 
 	void setCategory(const std::string& category);
 	void selectFavouritesBank(uint8_t bankNumber);
-	void setFavorite(uint8_t position, uint8_t colour, const std::string& filename);
-	void unsetFavorite(uint8_t position);
+	void setFavourite(uint8_t position, uint8_t colour, const std::string& filename);
+	void unsetFavourite(uint8_t position);
 	bool isEmpty(uint8_t position) const;
 	Error loadFavouritesFromFile(Deserializer& reader);
 	void close();
-	std::array<std::optional<uint8_t>, 16> getFavouriteColours() const;
+	std::array<std::optional<uint8_t>, kNumFavourites> getFavouriteColours() const;
 	void changeColour(uint8_t position, int32_t offset);
-	const std::string& getFavoriteFilename(uint8_t position);
+	const std::string& getFavouriteFilename(uint8_t position);
 	static constexpr uint8_t favouriteDefaultColor = 4;
 
 	uint8_t currentBankNumber = 0;
@@ -60,7 +62,7 @@ private:
 	mutable bool unsavedChanges = false;
 
 	std::string currentCategory;
-	std::vector<Favorite> favourites;
+	std::vector<Favourite> favourites;
 };
 
 extern FavouritesManager favouritesManager;

--- a/src/deluge/model/favourite/favourite_manager.h
+++ b/src/deluge/model/favourite/favourite_manager.h
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include <etl/vector.h>
+
 constexpr size_t kNumFavourites = 16;
 
 class FavouritesManager {
@@ -62,7 +64,7 @@ private:
 	mutable bool unsavedChanges = false;
 
 	std::string currentCategory;
-	std::vector<Favourite> favourites;
+	etl::vector<Favourite, kNumFavourites> favourites;
 };
 
 extern FavouritesManager favouritesManager;

--- a/src/deluge/storage/flash_storage.cpp
+++ b/src/deluge/storage/flash_storage.cpp
@@ -328,7 +328,7 @@ void resetSettings() {
 	defaultSessionLayout = SessionLayoutType::SessionLayoutTypeRows;
 	defaultKeyboardLayout = KeyboardLayoutType::KeyboardLayoutTypeIsomorphic;
 
-	defaultFavouritesLayout = FavouritesDefaultLayoutFavorites;
+	defaultFavouritesLayout = FavouritesDefaultLayoutFavourites;
 
 	gridEmptyPadsUnarm = false;
 	gridEmptyPadsCreateRec = false;
@@ -747,7 +747,7 @@ void readSettings() {
 	}
 
 	if (buffer[185] >= util::to_underlying(FavouritesDefaultLayoutMaxElement)) {
-		defaultFavouritesLayout = FavouritesDefaultLayout::FavouritesDefaultLayoutFavorites;
+		defaultFavouritesLayout = FavouritesDefaultLayout::FavouritesDefaultLayoutFavourites;
 	}
 	else {
 		defaultFavouritesLayout = static_cast<FavouritesDefaultLayout>(buffer[185]);

--- a/tests/32bit_unit_tests/CMakeLists.txt
+++ b/tests/32bit_unit_tests/CMakeLists.txt
@@ -68,7 +68,7 @@ set_target_properties(MemoryManagerTests
         LINK_FLAGS -m32
 )
 
-target_link_libraries(MemoryManagerTests CppUTest CppUTestExt)
+target_link_libraries(MemoryManagerTests CppUTest CppUTestExt etl::etl)
 
 # strchr is seemingly different in x86
 target_compile_options(MemoryManagerTests PUBLIC
@@ -107,7 +107,7 @@ set_target_properties(SmallPointerTests
         LINK_FLAGS -m32
 )
 
-target_link_libraries(SmallPointerTests CppUTest CppUTestExt)
+target_link_libraries(SmallPointerTests CppUTest CppUTestExt etl::etl)
 
 # strchr is seemingly different in x86
 target_compile_options(SmallPointerTests PUBLIC


### PR DESCRIPTION
Fix some unintentional bugs from the favourites manager

Potentially fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4553

What changed:
- Avoids loading a missing favourites bank through a stale/uninitialized FilePointer.
- Stops FavouritesManager::close() from force-freeing the vector with std::vector<Favorite>().swap(...).
- Keeps the favourites vector in a valid 16-slot state.
- Bounds-checks favourite positions while parsing XML.
- Hardens accessors against an unexpectedly short vector.

--

Additional changes:
- use "favourites" everywhere instead of "favorites" for consistency
- replace std::vector with fixed size etl::vector
- replace "16" constants with kNumFavourites