### PR TITLE
Fix/ Scrolling in note and note row editor horizontal menus

### DIFF
--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -305,6 +305,12 @@ void HorizontalMenu::selectEncoderAction(int32_t offset) {
 		return;
 	}
 
+	// check if you're permitted to edit this horizontal menu item
+	if (!child->selectEncoderActionIsPermitted()) {
+		// No action if select encoder action is not permitted
+		return;
+	}
+
 	child->selectEncoderAction(offset * calcNextKnobSpeed(offset));
 	focusChild(child);
 	displayNotification(child);

--- a/src/deluge/gui/menu_item/menu_item.h
+++ b/src/deluge/gui/menu_item/menu_item.h
@@ -321,6 +321,8 @@ public:
 
 	deluge::gui::menu_item::HorizontalMenu* parent{nullptr};
 
+	virtual bool selectEncoderActionIsPermitted() { return true; }
+
 	/// @}
 };
 

--- a/src/deluge/gui/menu_item/note/selected_note.h
+++ b/src/deluge/gui/menu_item/note/selected_note.h
@@ -37,5 +37,10 @@ public:
 		display->displayPopup("Select Note");
 		return false;
 	}
+
+	// only allow select encoder action if you've selected a note to edit
+	bool selectEncoderActionIsPermitted() override {
+		return shouldEnterSubmenu();
+	}
 };
 } // namespace deluge::gui::menu_item::note

--- a/src/deluge/gui/menu_item/note/selected_note.h
+++ b/src/deluge/gui/menu_item/note/selected_note.h
@@ -39,8 +39,6 @@ public:
 	}
 
 	// only allow select encoder action if you've selected a note to edit
-	bool selectEncoderActionIsPermitted() override {
-		return shouldEnterSubmenu();
-	}
+	bool selectEncoderActionIsPermitted() override { return shouldEnterSubmenu(); }
 };
 } // namespace deluge::gui::menu_item::note

--- a/src/deluge/gui/menu_item/note_row/selected_note_row.h
+++ b/src/deluge/gui/menu_item/note_row/selected_note_row.h
@@ -39,6 +39,11 @@ public:
 		return true;
 	}
 
+	// only allow select encoder action if you've selected a note row to edit
+	bool selectEncoderActionIsPermitted() override {
+		return shouldEnterSubmenu();
+	}
+
 	ModelStackWithNoteRow* getIndividualNoteRow(ModelStackWithTimelineCounter* modelStack) {
 		auto* clip = static_cast<InstrumentClip*>(modelStack->getTimelineCounter());
 		ModelStackWithNoteRow* modelStackWithNoteRow =

--- a/src/deluge/gui/menu_item/note_row/selected_note_row.h
+++ b/src/deluge/gui/menu_item/note_row/selected_note_row.h
@@ -40,9 +40,7 @@ public:
 	}
 
 	// only allow select encoder action if you've selected a note row to edit
-	bool selectEncoderActionIsPermitted() override {
-		return shouldEnterSubmenu();
-	}
+	bool selectEncoderActionIsPermitted() override { return shouldEnterSubmenu(); }
 
 	ModelStackWithNoteRow* getIndividualNoteRow(ModelStackWithTimelineCounter* modelStack) {
 		auto* clip = static_cast<InstrumentClip*>(modelStack->getTimelineCounter());

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3561,10 +3561,10 @@ void InstrumentClipView::handleNoteEditorEditPadAction(int32_t x, int32_t y, int
 }
 
 // before scrolling, we need to reset the note selection
-// if we're in a submenu, we'll need to go up a level
+// if we're in a submenu or horizontal menu, we'll need to go up a level
 void InstrumentClipView::deselectNoteAndGoUpOneLevel() {
 	exitNoteEditor();
-	if (soundEditor.getCurrentMenuItem() != &noteEditorRootMenu || runtimeFeatureSettings.isOn(HorizontalMenus)) {
+	if (soundEditor.getCurrentMenuItem() != &noteEditorRootMenu) {
 		soundEditor.goUpOneLevel();
 	}
 }


### PR DESCRIPTION
Fixed the note editor to allow horizontal and vertical scrolling.

Previously scrolling would kick you out of the menu. Now scrolling deselects the note and blocks editing of note parameters until you've selected a note again. As in vertical menu, it will display "Select Note" whenever you attempt to edit a parameter when you haven't selected a note.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4586