### PR TITLE
Fix sample osc transpose + horizontal menu note range editing

### DIFF
--- a/src/deluge/gui/menu_item/horizontal_menu.cpp
+++ b/src/deluge/gui/menu_item/horizontal_menu.cpp
@@ -38,7 +38,19 @@ namespace deluge::gui::menu_item {
 using namespace hid::display;
 
 void HorizontalMenu::beginSession(MenuItem* navigatedBackwardFrom) {
+	::MultiRange* selected_range = soundEditor.currentMultiRange;
+	int16_t selected_range_index = soundEditor.currentMultiRangeIndex;
+	const bool current_child_is_range_dependent = current_item_ != items.end() && (*current_item_)->isRangeDependent();
+	const bool should_preserve_range =
+	    current_child_is_range_dependent
+	    || (navigatedBackwardFrom != nullptr && navigatedBackwardFrom->isRangeDependent());
+
 	Submenu::beginSession(navigatedBackwardFrom);
+
+	if (should_preserve_range) {
+		soundEditor.currentMultiRange = selected_range;
+		soundEditor.currentMultiRangeIndex = selected_range_index;
+	}
 
 	for (const auto it : items) {
 		it->parent = this;
@@ -409,7 +421,17 @@ void HorizontalMenu::handleInstrumentButtonPress(std::span<MenuItem*> visible_pa
 			}
 
 			// Update the currently selected item
-			initializeItem(*current_item_);
+			const MenuPermission permission = initializeItem(*current_item_);
+
+			// Enter note range menu if we're selecting multi range item (e.g. sample transpose)
+			if (permission == MenuPermission::MUST_SELECT_RANGE
+			    && !(*current_item_)->allowToBeginSessionFromHorizontalMenu()) {
+				soundEditor.currentMultiRange = nullptr;
+				multiRangeMenu.menuItemHeadingTo = *current_item_;
+				soundEditor.enterSubmenu(&multiRangeMenu);
+				return;
+			}
+
 			updateDisplay();
 			updatePadLights();
 			return displayNotification(*current_item_);
@@ -644,10 +666,9 @@ void HorizontalMenu::handleItemAction(MenuItem* menuItem) {
 		return displayNotification(menuItem);
 	}
 
-	const auto result = menuItem->checkPermissionToBeginSession(
-	    soundEditor.currentModControllable, soundEditor.currentSourceIndex, &soundEditor.currentMultiRange);
+	const auto permission = initializeItem(menuItem);
 
-	if (result == MenuPermission::MUST_SELECT_RANGE) {
+	if (permission == MenuPermission::MUST_SELECT_RANGE) {
 		soundEditor.currentMultiRange = nullptr;
 		multiRangeMenu.menuItemHeadingTo = menuItem;
 		menuItem = &multiRangeMenu;
@@ -660,10 +681,10 @@ bool HorizontalMenu::hasItem(const MenuItem* item) {
 	return std::ranges::contains(items, item);
 }
 
-void HorizontalMenu::initializeItem(MenuItem* menuItem) {
+MenuPermission HorizontalMenu::initializeItem(MenuItem* menuItem) {
 	// if case the item is of type PatchCableStrength, we need to call this to properly set up a patch cable
-	menuItem->checkPermissionToBeginSession(soundEditor.currentModControllable, soundEditor.currentSourceIndex,
-	                                        &soundEditor.currentMultiRange);
+	return menuItem->checkPermissionToBeginSession(soundEditor.currentModControllable, soundEditor.currentSourceIndex,
+	                                               &soundEditor.currentMultiRange);
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/menu_item/horizontal_menu.h
+++ b/src/deluge/gui/menu_item/horizontal_menu.h
@@ -81,7 +81,7 @@ private:
 	static void renderPageCounters(const Paging& paging);
 	static void renderColumnLabel(MenuItem* menuItem, int32_t labelY, int32_t slotStartX, int32_t slotWidth,
 	                              bool isSelected);
-	static void initializeItem(MenuItem* menuItem);
+	static MenuPermission initializeItem(MenuItem* menuItem);
 
 	double currentKnobSpeed{0.0};
 	double calcNextKnobSpeed(int8_t offset);

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -153,7 +153,7 @@ public:
 		const int32_t numRanges = source.ranges.getNumElements();
 
 		if (soundEditor.currentSourceIndex != source_id_ || soundEditor.currentMultiRange == nullptr || numRanges <= 1
-			|| rangeIndex < 0 || rangeIndex >= numRanges || source.oscType != OscType::SAMPLE) {
+		    || rangeIndex < 0 || rangeIndex >= numRanges || source.oscType != OscType::SAMPLE) {
 			return;
 		}
 

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -144,5 +144,42 @@ public:
 		}
 		return true;
 	}
+
+	void getNotificationValue(StringBuf& valueBuf) override {
+		Decimal::getNotificationValue(valueBuf);
+
+		Source& source = soundEditor.currentSound->sources[source_id_];
+		const int32_t rangeIndex = soundEditor.currentMultiRangeIndex;
+		const int32_t numRanges = source.ranges.getNumElements();
+
+		if (soundEditor.currentSourceIndex != source_id_ || soundEditor.currentMultiRange == nullptr || numRanges <= 1
+			|| rangeIndex < 0 || rangeIndex >= numRanges || source.oscType != OscType::SAMPLE) {
+			return;
+		}
+
+		valueBuf.append(" (");
+
+		if (rangeIndex == 0) {
+			valueBuf.append(l10n::get(l10n::String::STRING_FOR_BOTTOM));
+		}
+		else {
+			char noteName[8];
+			noteCodeToString(source.ranges.getElement(rangeIndex - 1)->topNote + 1, noteName);
+			valueBuf.append(noteName);
+		}
+
+		valueBuf.append("-");
+
+		if (rangeIndex == numRanges - 1) {
+			valueBuf.append("top");
+		}
+		else {
+			char noteName[8];
+			noteCodeToString(source.ranges.getElement(rangeIndex)->topNote, noteName);
+			valueBuf.append(noteName);
+		}
+
+		valueBuf.append(")");
+	}
 };
 } // namespace deluge::gui::menu_item::sample

--- a/src/deluge/gui/menu_item/sample/transpose.h
+++ b/src/deluge/gui/menu_item/sample/transpose.h
@@ -43,9 +43,12 @@ public:
 
 		if (source.ranges.getNumElements() && soundEditor.currentSound->getSynthMode() != SynthMode::FM
 		    && source.oscType == OscType::SAMPLE) {
-			const auto* multiRange = static_cast<MultisampleRange*>(source.ranges.getElement(0));
-			transpose = multiRange->sampleHolder.transpose;
-			cents = multiRange->sampleHolder.cents;
+			const auto* multi_sample_range =
+			    soundEditor.currentSourceIndex == source_id_ && soundEditor.currentMultiRange != nullptr
+			        ? static_cast<MultisampleRange*>(soundEditor.currentMultiRange)
+			        : static_cast<MultisampleRange*>(source.ranges.getElement(0));
+			transpose = multi_sample_range->sampleHolder.transpose;
+			cents = multi_sample_range->sampleHolder.cents;
 		}
 		else {
 			transpose = source.transpose;
@@ -72,9 +75,9 @@ public:
 
 					if (source.ranges.getNumElements() && soundDrum->getSynthMode() != SynthMode::FM
 					    && source.oscType == OscType::SAMPLE) {
-						auto* multisampleRange = static_cast<MultisampleRange*>(source.ranges.getElement(0));
-						multisampleRange->sampleHolder.transpose = transpose;
-						multisampleRange->sampleHolder.setCents(cents);
+						auto* multi_sample_range = static_cast<MultisampleRange*>(source.ranges.getElement(0));
+						multi_sample_range->sampleHolder.transpose = transpose;
+						multi_sample_range->sampleHolder.setCents(cents);
 					}
 					else {
 						source.transpose = transpose;
@@ -95,9 +98,12 @@ public:
 
 			if (source.ranges.getNumElements() && soundEditor.currentSound->getSynthMode() != SynthMode::FM
 			    && source.oscType == OscType::SAMPLE) {
-				auto* multisampleRange = static_cast<MultisampleRange*>(source.ranges.getElement(0));
-				multisampleRange->sampleHolder.transpose = transpose;
-				multisampleRange->sampleHolder.setCents(cents);
+				auto* multi_sample_range =
+				    soundEditor.currentSourceIndex == source_id_ && soundEditor.currentMultiRange != nullptr
+				        ? static_cast<MultisampleRange*>(soundEditor.currentMultiRange)
+				        : static_cast<MultisampleRange*>(source.ranges.getElement(0));
+				multi_sample_range->sampleHolder.transpose = transpose;
+				multi_sample_range->sampleHolder.setCents(cents);
 			}
 			else {
 				source.transpose = transpose;

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -317,14 +317,14 @@ void SoundEditor::setLedStates() {
 	}
 }
 
-void SoundEditor::enterSubmenu(MenuItem* newItem) {
+void SoundEditor::enterSubmenu(MenuItem* newItem, MenuItem* navigatedBackwardFrom) {
 	// end current menu item session before beginning new menu item session
 	endScreen();
 
 	navigationDepth++;
 	menuItemNavigationRecord[navigationDepth] = newItem;
 	display->setNextTransitionDirection(1);
-	beginScreen();
+	beginScreen(navigatedBackwardFrom);
 }
 
 ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
@@ -355,6 +355,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 				if (newItem) {
 					if (newItem != NO_NAVIGATION) {
 						if (newItem->shouldEnterSubmenu()) {
+							MenuItem* navigatedBackwardFrom = nullptr;
 							MenuPermission result = newItem->checkPermissionToBeginSession(
 							    currentModControllable, currentSourceIndex, &currentMultiRange);
 
@@ -364,8 +365,15 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 									menu_item::multiRangeMenu.menuItemHeadingTo = newItem;
 									newItem = &menu_item::multiRangeMenu;
 								}
+								else {
+									HorizontalMenu* parent = maybeGetParentMenu(newItem);
+									if (parent != nullptr && parent->focusChild(newItem)) {
+										navigatedBackwardFrom = newItem;
+										newItem = parent;
+									}
+								}
 
-								enterSubmenu(newItem);
+								enterSubmenu(newItem, navigatedBackwardFrom);
 							}
 						}
 						else {
@@ -1762,12 +1770,8 @@ doMIDIOrCV:
 	// And we also have to set currentModControllable before focusing on the child item in a horizontal menu
 	currentModControllable = newModControllable;
 
-	// If we're on OLED, a parent menu & horizontal menus are in play,
-	// then we swap the parent in place of the child.
-	HorizontalMenu* parent = maybeGetParentMenu(newItem);
-	if (parent != nullptr && parent->focusChild(newItem)) {
-		newItem = parent;
-	}
+	MenuItem* horizontal_menu_child = newItem;
+	HorizontalMenu* parent = maybeGetParentMenu(horizontal_menu_child);
 
 	::MultiRange* newRange = currentMultiRange;
 
@@ -1775,7 +1779,8 @@ doMIDIOrCV:
 		newRange = nullptr;
 	}
 
-	MenuPermission result = newItem->checkPermissionToBeginSession(newModControllable, sourceIndex, &newRange);
+	MenuPermission result =
+	    horizontal_menu_child->checkPermissionToBeginSession(newModControllable, sourceIndex, &newRange);
 
 	if (result == MenuPermission::NO) {
 		display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PARAMETER_NOT_APPLICABLE));
@@ -1786,8 +1791,11 @@ doMIDIOrCV:
 		D_PRINTLN("must select range");
 
 		newRange = nullptr;
-		multiRangeMenu.menuItemHeadingTo = newItem;
+		multiRangeMenu.menuItemHeadingTo = horizontal_menu_child;
 		newItem = &multiRangeMenu;
+	}
+	else if (parent != nullptr && parent->focusChild(horizontal_menu_child)) {
+		newItem = parent;
 	}
 
 	if (display->haveOLED()) {

--- a/src/deluge/gui/ui/sound_editor.h
+++ b/src/deluge/gui/ui/sound_editor.h
@@ -130,7 +130,7 @@ public:
 	ActionResult exitUI() override { return exitCompletely(); };
 	ActionResult exitCompletely();
 	void goUpOneLevel();
-	void enterSubmenu(MenuItem* newItem);
+	void enterSubmenu(MenuItem* newItem, MenuItem* navigatedBackwardFrom = nullptr);
 	bool pcReceivedForMidiLearn(MIDICable& cable, int32_t channel, int32_t program) override;
 	bool noteOnReceivedForMidiLearn(MIDICable& cable, int32_t channel, int32_t note, int32_t velocity) override;
 	void markInstrumentAsEdited();


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4599

Fixed several issues:

1) refactoring of osc menu item code for horizontal menus broke oscillator multiple sample transpose (you could no longer edit the transpose for specific multi sample note ranges. It would always edit multi range index 0.

2) note range menu was inaccessible from horizontal menus. This meant that you could not select a specific range and edit the transpose value for that range.

With the above fixes, you can now:
- enter note range menu with horizontal menu enabled using shift/audition + osc transpose
- when you press select on a specific note range, it will open the horizotnal menu with the transpose menu item updated to show the transpose value of that note range. changing the transpose value now affects the transpose of the note range selected.
- when in the osc horizontal menu, if you press the button to select the osc transpose menu item, it will open the note range menu again.
- when you press select on transpose in horizontal menu it enters the "select patch cable source" menu. If you press back to go back to horizontal menu it will keep the previously selected note range and display that note range's transpose value (until you select another horizontal menu item)

Additional bonus UI enhancement for clarity:
- For multi samples, when editing transpose value in horizontal menu, the notification will show the note range that you're editing so that you don't have to remember it while editing the transpose value