### PR TITLE
Fix performance view - getting stuck in stutter UI mode on menu entry

### DIFF
--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -244,6 +244,9 @@ bool SoundEditor::getGreyoutColsAndRows(uint32_t* cols, uint32_t* rows) {
 			*cols = 0xFFFFFFFE;
 		}
 		break;
+	case UIType::PERFORMANCE:
+		doGreyout = false;
+		break;
 	default:
 		*cols = 0xFFFFFFFF;
 		break;
@@ -343,8 +346,8 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 	// Encoder button
 	if (b == SELECT_ENC) {
 		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING
-		    || currentUIMode == UI_MODE_NOTES_PRESSED
-		    || currentUIMode == UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR) {
+		    || currentUIMode == UI_MODE_NOTES_PRESSED || currentUIMode == UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR
+		    || currentUIMode == UI_MODE_STUTTERING) {
 			if (!on && !Buttons::selectButtonPressUsedUp) {
 				if (inCardRoutine) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -414,8 +417,8 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 	// Back button
 	else if (b == BACK) {
 		if (currentUIMode == UI_MODE_NONE || currentUIMode == UI_MODE_AUDITIONING
-		    || currentUIMode == UI_MODE_NOTES_PRESSED
-		    || currentUIMode == UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR) {
+		    || currentUIMode == UI_MODE_NOTES_PRESSED || currentUIMode == UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR
+		    || currentUIMode == UI_MODE_STUTTERING) {
 			if (on) {
 				if (inCardRoutine) {
 					return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
@@ -1020,7 +1023,7 @@ void SoundEditor::scrollFinished() {
 }
 
 const uint32_t selectEncoderUIModes[] = {UI_MODE_HOLDING_AFFECT_ENTIRE_IN_SOUND_EDITOR, UI_MODE_NOTES_PRESSED,
-                                         UI_MODE_AUDITIONING, 0};
+                                         UI_MODE_AUDITIONING, UI_MODE_STUTTERING, 0};
 
 void SoundEditor::selectEncoderAction(int8_t offset) {
 	int8_t scaledOffset = offset;
@@ -1446,6 +1449,11 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 		}
 	}
 
+	// Allow using performance view pads while in the sound editor menu
+	else if (rootUI == &performanceView) {
+		return performanceView.padAction(x, y, on);
+	}
+
 	// Otherwise...
 	if (currentUIMode == UI_MODE_NONE && on) {
 		if (getCurrentMenuItem() == &firmwareVersionMenu && y == 7) {
@@ -1471,12 +1479,6 @@ ActionResult SoundEditor::padAction(int32_t x, int32_t y, int32_t on) {
 				display->displayPopup(buffer);
 				return ActionResult::DEALT_WITH;
 			}
-		}
-
-		// used in performanceView to ignore pad presses when you just exited soundEditor
-		// with a padAction
-		if (rootUI == &performanceView) {
-			performanceView.justExitedSoundEditor = true;
 		}
 
 		exitCompletely();

--- a/src/deluge/gui/views/performance_view.cpp
+++ b/src/deluge/gui/views/performance_view.cpp
@@ -192,8 +192,6 @@ PerformanceView::PerformanceView() {
 
 	performanceLayoutBackedUp = false;
 
-	justExitedSoundEditor = false;
-
 	timeKeyboardShortcutPress = 0;
 
 	resetPadPressInfo();
@@ -465,6 +463,11 @@ bool PerformanceView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidt
 ///
 /// XXX: This should take a canvas and render to it rather than pulling the main image all the time.
 void PerformanceView::renderViewDisplay() {
+	// don't update display if we're in the menu
+	if (getCurrentUI() != this) {
+		return;
+	}
+
 	if (defaultEditingMode) {
 		if (display->haveOLED()) {
 			deluge::hid::display::oled_canvas::Canvas& image = deluge::hid::display::OLED::main;
@@ -541,6 +544,11 @@ void PerformanceView::renderViewDisplay() {
 
 /// Render Parameter Name and Value set when using Performance Pads
 void PerformanceView::renderFXDisplay(params::Kind paramKind, int32_t paramID, int32_t knobPos) {
+	// don't update display if we're in the menu
+	if (getCurrentUI() != this) {
+		return;
+	}
+
 	if (editingParam) {
 		// display parameter name
 		char parameterName[30];
@@ -987,86 +995,79 @@ ActionResult PerformanceView::buttonAction(deluge::hid::Button b, bool on, bool 
 }
 
 ActionResult PerformanceView::padAction(int32_t xDisplay, int32_t yDisplay, int32_t on) {
-	if (!justExitedSoundEditor) {
-		char modelStackMemory[MODEL_STACK_MAX_SIZE];
-		ModelStackWithThreeMainThings* modelStack =
-		    currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
+	char modelStackMemory[MODEL_STACK_MAX_SIZE];
+	ModelStackWithThreeMainThings* modelStack = currentSong->setupModelStackWithSongAsTimelineCounter(modelStackMemory);
 
-		// if pad was pressed in main deluge grid (not sidebar)
-		if (xDisplay < kDisplayWidth) {
-			if (on) {
-				// if it's a shortcut press, enter soundEditor menu for that parameter
-				// but not if you're in default editing mode
-				if (Buttons::isShiftButtonPressed()) {
-					if (defaultEditingMode) {
-						return ActionResult::DEALT_WITH;
-					}
-					else {
-						return soundEditor.potentialShortcutPadAction(xDisplay, yDisplay, on);
-					}
-				}
-			}
-			// if not in param editor (so, regular performance view or value editor)
-			if (!editingParam) {
-				bool ignorePadAction =
-				    defaultEditingMode && lastPadPress.isActive && (lastPadPress.xDisplay != xDisplay);
-				if (ignorePadAction || (layoutForPerformance[xDisplay].paramID == kNoParamID)) {
+	// if pad was pressed in main deluge grid (not sidebar)
+	if (xDisplay < kDisplayWidth) {
+		if (on) {
+			// if it's a shortcut press, enter soundEditor menu for that parameter
+			// but not if you're in default editing mode
+			if (Buttons::isShiftButtonPressed()) {
+				if (defaultEditingMode) {
 					return ActionResult::DEALT_WITH;
 				}
-				normalPadAction(modelStack, xDisplay, yDisplay, on);
+				else {
+					return soundEditor.potentialShortcutPadAction(xDisplay, yDisplay, on);
+				}
 			}
-			// editing mode & editing parameter FX assignments
-			else {
-				paramEditorPadAction(modelStack, xDisplay, yDisplay, on);
-			}
-			uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
 		}
-		// if pad was pressed in sidebar and you're not in an editing mode
-		else if ((xDisplay >= kDisplayWidth) && !defaultEditingMode) {
-			// don't interact with sidebar if VU Meter is displayed
-			// and you're in the volume/pan mod knob mode (0)
-			if (view.displayVUMeter && (view.getModKnobMode() == 0)) {
+		// if not in param editor (so, regular performance view or value editor)
+		if (!editingParam) {
+			bool ignorePadAction = defaultEditingMode && lastPadPress.isActive && (lastPadPress.xDisplay != xDisplay);
+			if (ignorePadAction || (layoutForPerformance[xDisplay].paramID == kNoParamID)) {
 				return ActionResult::DEALT_WITH;
 			}
-			// if in arranger view
-			if (currentSong->lastClipInstanceEnteredStartPos != -1) {
-				// pressing the first column in sidebar to trigger sections / clips
-				if (xDisplay == kDisplayWidth) {
-					arrangerView.handleStatusPadAction(yDisplay, on, this);
-				}
-				// pressing the second column in sidebar to audition / edit instrument
-				else {
-					arrangerView.handleAuditionPadAction(yDisplay, on, this);
-					// when you let go of audition pad action, you need to reset led states
-					if (!on) {
-						setCentralLEDStates();
-					}
-				}
+			normalPadAction(modelStack, xDisplay, yDisplay, on);
+		}
+		// editing mode & editing parameter FX assignments
+		else {
+			paramEditorPadAction(modelStack, xDisplay, yDisplay, on);
+		}
+		uiNeedsRendering(this, 0xFFFFFFFF, 0); // refresh main pads only
+	}
+	// if pad was pressed in sidebar and you're not in an editing mode
+	else if ((xDisplay >= kDisplayWidth) && !defaultEditingMode) {
+		// don't interact with sidebar if VU Meter is displayed
+		// and you're in the volume/pan mod knob mode (0)
+		if (view.displayVUMeter && (view.getModKnobMode() == 0)) {
+			return ActionResult::DEALT_WITH;
+		}
+		// if in arranger view
+		if (currentSong->lastClipInstanceEnteredStartPos != -1) {
+			// pressing the first column in sidebar to trigger sections / clips
+			if (xDisplay == kDisplayWidth) {
+				arrangerView.handleStatusPadAction(yDisplay, on, this);
 			}
-			// if in session view
+			// pressing the second column in sidebar to audition / edit instrument
 			else {
-				// if in row mode
-				if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeRows) {
-					sessionView.padAction(xDisplay, yDisplay, on);
-				}
-				// if in grid mode
-				else {
-					// if you're in grid song view and you pressed / release a pad in the section launcher column
-					if (xDisplay == kDisplayWidth) {
-						sessionView.gridHandlePads(xDisplay, yDisplay, on);
-					}
-					// if you pressed the green or blue mode pads, go back to grid view and change mode
-					else if ((yDisplay == GridMode::GREEN) || (yDisplay == GridMode::BLUE)) {
-						releaseViewOnExit(modelStack);
-						changeRootUI(&sessionView);
-						sessionView.gridHandlePads(xDisplay, yDisplay, on);
-					}
+				arrangerView.handleAuditionPadAction(yDisplay, on, this);
+				// when you let go of audition pad action, you need to reset led states
+				if (!on) {
+					setCentralLEDStates();
 				}
 			}
 		}
-	}
-	else if (!on) {
-		justExitedSoundEditor = false;
+		// if in session view
+		else {
+			// if in row mode
+			if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeRows) {
+				sessionView.padAction(xDisplay, yDisplay, on);
+			}
+			// if in grid mode
+			else {
+				// if you're in grid song view and you pressed / release a pad in the section launcher column
+				if (xDisplay == kDisplayWidth) {
+					sessionView.gridHandlePads(xDisplay, yDisplay, on);
+				}
+				// if you pressed the green or blue mode pads, go back to grid view and change mode
+				else if ((yDisplay == GridMode::GREEN) || (yDisplay == GridMode::BLUE)) {
+					releaseViewOnExit(modelStack);
+					changeRootUI(&sessionView);
+					sessionView.gridHandlePads(xDisplay, yDisplay, on);
+				}
+			}
+		}
 	}
 	return ActionResult::DEALT_WITH;
 }

--- a/src/deluge/gui/views/performance_view.h
+++ b/src/deluge/gui/views/performance_view.h
@@ -113,7 +113,6 @@ public:
 	void resetPerformanceView(ModelStackWithThreeMainThings* modelStack);
 	bool defaultEditingMode;
 	bool editingParam; // if you're not editing a param, you're editing a value
-	bool justExitedSoundEditor;
 
 	// public so Action Logger can access it
 	FXColumnPress fxPress[kDisplayWidth];


### PR DESCRIPTION
Performance view would allow menu entry while holding a stutter pad, resulting in the stutter UI mode getting stuck on and preventing further actions from taking place while in the menu

Fix by allowing the use of performance view pads while in the menu. entering the menu with stutter on won't block back button press in menu or select encoder press / scrolling so you can use the menu normally.

Pads pressed before entering menu and released after entering menu get forwarded to performance view so they can be released.

With the horizontal menus now, using the performance view pads together with the horizontal menus is actually a great experience :)

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4607