### PR TITLE
Fix MIDI device list letting you select cached disconnected devices

### DIFF
--- a/src/deluge/gui/menu_item/midi/devices.cpp
+++ b/src/deluge/gui/menu_item/midi/devices.cpp
@@ -82,17 +82,26 @@ int32_t Devices::computeScrollForSelected(int32_t selected) {
 void Devices::selectEncoderAction(int32_t offset) {
 	offset = std::clamp<int32_t>(offset, -1, 1);
 
+	// Remember where we started. This is always a connected device (beginSession and every completed
+	// selectEncoderAction leave the selection on one), so if we run off the end while skipping disconnected
+	// devices we can restore it rather than leaving the selection stranded on a disconnected/cached device.
+	int32_t startValue = this->getValue();
+
 	do {
 		int32_t newValue = this->getValue() + offset;
 
 		if (newValue >= MIDIDeviceManager::hostedMIDIDevices.getNumElements()) {
 			if (display->haveOLED()) {
+				this->setValue(startValue);
+				soundEditor.currentMIDICable = getCable(startValue);
 				return;
 			}
 			newValue = lowestDeviceNum;
 		}
 		else if (newValue < lowestDeviceNum) {
 			if (display->haveOLED()) {
+				this->setValue(startValue);
+				soundEditor.currentMIDICable = getCable(startValue);
 				return;
 			}
 			newValue = MIDIDeviceManager::hostedMIDIDevices.getNumElements() - 1;


### PR DESCRIPTION
selectEncoderAction's skip-disconnected loop committed setValue/currentMIDICable to each candidate before checking connectionFlags. Scrolling off the end on OLED early-returns, leaving the selection stranded on the last disconnected device it stepped onto (e.g. a cached, unplugged Arturia). Pressing select then opened that cached device's settings.

Capture the entry selection (always a connected device) and restore it on the OLED boundary early-returns instead.

Fixes #4595