### PR TITLE
Fix arranger playback unable to start from bar 1 with Cross-Screen on

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -365,15 +365,16 @@ void PlaybackHandler::setupPlaybackUsingInternalClock(int32_t buttonPressLatency
 				bool recordingToArranger = isArrangerView && (recording == RecordingMode::NORMAL);
 				bool inArrangerCrossScreen = isArrangerView && currentSong->arrangerAutoScrollModeActive;
 
-				// start from current screen if:
-				// 1) restart shortcut is pressed and alternativePlaybackStartBehaviour is disabled
-				// 2) restart shortcut is not pressed and alternativePlaybackStartBehaviour is enabled
-				// 3) recording to arranger
-				// 4) in arranger view with cross screen auto scroll mode enabled
+				// Cross screen (arranger auto scroll) and alternativePlaybackStartBehaviour both flip the
+				// *default* direction so that plain play starts from the current screen; the restart shortcut
+				// always toggles the other way. This guarantees one combo starts from the current screen and
+				// the other from the beginning, even when cross screen and the community setting are both on
+				// (issue #3166). Recording into arranger always starts from the current screen.
 
-				startFromCurrentScreen = (isRestartShortcutPressed && !alternativePlaybackStartBehaviour)
-				                         || (!isRestartShortcutPressed && alternativePlaybackStartBehaviour)
-				                         || recordingToArranger || inArrangerCrossScreen;
+				bool startFromCurrentScreenByDefault = alternativePlaybackStartBehaviour || inArrangerCrossScreen;
+
+				startFromCurrentScreen =
+				    recordingToArranger || (isRestartShortcutPressed != startFromCurrentScreenByDefault);
 			}
 		}
 	}


### PR DESCRIPTION
Cross-Screen (arranger auto-scroll) was a top-level OR term forcing startFromCurrentScreen true unconditionally, so neither the <> restart shortcut nor the AlternativePlaybackStartBehaviour community setting could select a start from the beginning of the arrangement.

Treat Cross-Screen and the community setting as flipping the default start direction instead, with the restart shortcut always toggling the other way. This guarantees one combo starts from the current screen and the other from the beginning in every configuration, including both enabled at once.

Fixes #3166

This turns the play-button behavior into this logic table:
| Cross-Screen or Alt | Play | <> + Play 
| ---| --- | --- |
|off | beginning | current screen |
| on (either/both)  | current screen | beginning|
