### PR TITLE
Enhancement/ Note editor - identify edited notes by highlighting them yellow

### DIFF
--- a/src/deluge/gui/menu_item/note/fill.h
+++ b/src/deluge/gui/menu_item/note/fill.h
@@ -52,9 +52,6 @@ public:
 	void selectEncoderAction(int32_t offset) final override {
 		instrumentClipView.adjustNoteFillWithOffset(offset);
 		readValueAgain();
-		if (currentSong->isFillModeActive()) {
-			uiNeedsRendering(&instrumentClipView);
-		}
 	}
 
 	void drawPixelsForOled() override {

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -712,6 +712,8 @@ ActionResult SoundEditor::exitCompletely() {
 	}
 	else if (inNoteEditor()) {
 		instrumentClipView.exitNoteEditor();
+		// refresh grid to potentially unhighlight edited notes
+		uiNeedsRendering(this, 0xFFFFFFFF, 0);
 	}
 	else if (inNoteRowEditor()) {
 		instrumentClipView.exitNoteRowEditor();

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3152,6 +3152,11 @@ void InstrumentClipView::adjustNoteParameterValue(int32_t withOffset, int32_t wi
 
 					noteRow->changeNotesAcrossAllScreens(editPadPresses[i].intendedPos, modelStackWithNoteRow, action,
 					                                     changeType, parameterValue);
+
+					// if we're in the note editor, refresh grid to show edited note
+					if (getCurrentUI() == &soundEditor && soundEditor.inNoteEditor()) {
+						uiNeedsRendering(this, 1 << editPadPresses[i].yDisplay, 0);
+					}
 				}
 				else {
 					// In the case the operation didn't change anything, we need to transform Iterance back from preset
@@ -3513,6 +3518,8 @@ bool InstrumentClipView::enterNoteEditor() {
 			}
 			openUI(&soundEditor);
 			blinkSelectedNote();
+			// refresh grid to potentially highlight already edited notes
+			uiNeedsRendering(this, 0xFFFFFFFF, 0);
 			return true;
 		}
 	}
@@ -3532,6 +3539,8 @@ void InstrumentClipView::exitNoteEditor() {
 		lastSelectedNoteYDisplay = kNoSelection;
 	}
 	resetSelectedNoteBlinking();
+	// refresh grid to potentially unhighlight edited notes
+	uiNeedsRendering(this, 0xFFFFFFFF, 0);
 }
 
 void InstrumentClipView::handleNoteEditorEditPadAction(int32_t x, int32_t y, int32_t on) {

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -1990,12 +1990,24 @@ void NoteRow::renderRow(TimelineView* editorScreen, RGB rowColour, RGB rowTailCo
 					}
 				}
 			}
-			if (drewNote && currentSong->isFillModeActive()) {
-				if (note->fill == FillMode::FILL) {
-					pixel = deluge::gui::colours::blue;
+			// if we're not dealing with a blurred note or a note tail
+			if (pixel != rowBlurColour && pixel != rowTailColour) {
+				// if fill mode is active, identify the notes that are fill or not-fill
+				if (drewNote && currentSong->isFillModeActive()) {
+					if (note->fill == FillMode::FILL) {
+						pixel = deluge::gui::colours::blue;
+					}
+					else if (note->fill == FillMode::NOT_FILL) {
+						pixel = deluge::gui::colours::red;
+					}
 				}
-				else if (note->fill == FillMode::NOT_FILL) {
-					pixel = deluge::gui::colours::red;
+				// if you're in the note editor, identify the notes that have non-default parameters
+				else if (drewNote && getCurrentUI() == &soundEditor && soundEditor.inNoteEditor()) {
+					// if note has non-default settings for probability, iterance or fill
+					if (note->getProbability() != kNumProbabilityValues || note->getIterance() != kDefaultIteranceValue
+					    || note->getFill() != FillMode::OFF) {
+						pixel = deluge::gui::colours::yellow;
+					}
 				}
 			}
 		}

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -234,7 +234,7 @@ A `Favourites` feature has been added to the browser for most file types. The `F
   - To edit iterance, hold a note / audition pad and turn the select encoder to the right to display current iterance value / set new iterance value.
   - To edit fill, hold a note / audition pad and press sync scaling to view the current fill setting and cycle through fill modes.
 - Added new note and note row editor menu's to edit note and note row parameters.
-  - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid.
+  - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid. In addition, notes which have had their probability, iterance or fill settings changed from default will be highlighted yellow to help quickly identify edited notes.
   - Hold a note row audition pad and press the select encoder to enter the note row editor menu. While in the note row editor menu, the selected note row's audition pad will blink. You can select other note row's by pressing the note row audition pad or by scrolling with the vertical encoder.
   - The iteration is now also customizable with custom iteration steps. If you scroll the iteration parameter all the way to the right, you will see the `CUSTOM` option. If you click the :key[Select] encoder, a new menu will appear to select the `DIVISOR` parameter (you can select from 1 to 8), and also as many `ITERATION #` toggles as `DIVISOR` is set, to allow you to activate or deactivate each iteration step.
 

--- a/website/src/content/docs/features/community_features.mdx
+++ b/website/src/content/docs/features/community_features.mdx
@@ -983,7 +983,7 @@ For a detailed description of this feature, please refer to the feature document
 - For a detailed description of this feature as well the button shortcuts/combos, please refer to the feature documentation: [Note / Note Row Editor Documentation](/features/note_noterow_editor)
 
 - (#2641) <Badge text="c1.3" variant="tip" /> Added new note and note row editor menu's to edit note and note row parameters.
-  - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid.
+  - Hold a note and press the select encoder to enter the note editor menu. While in the note editor menu, the selected note will blink. You can select other notes by pressing the notes on the grid. In addition, notes which have had their probability, iterance or fill settings changed from default will be highlighted yellow to help quickly identify edited notes.
   - Hold a note row audition pad and press the select encoder to enter the note row editor menu. While in the note row editor menu, the select note row audition pad will blink. You can select other note row's by pressing the note row audition pad.
 
 ### 4.3.13 - Auto Load sample when browsing

--- a/website/src/content/docs/features/note_noterow_editor.mdx
+++ b/website/src/content/docs/features/note_noterow_editor.mdx
@@ -28,7 +28,7 @@ If playback is off, you will hear what that note sounds like. You can toggle whe
 
 ### Selecting a Note
 
-While in the note editor menu, the selected note will blink.
+While in the note editor menu, the selected note will blink. In addition, notes which have had their probability, iterance or fill settings changed from default will be highlighted yellow to help quickly identify edited notes.
 
 You can select another note by pressing the note (:key[PAD]) on the grid.
 


### PR DESCRIPTION
Identify notes with edited probability, iterance or fill parameters by highlighting the note head of edited notes yellow `**In the note editor only**`

Response to: https://github.com/SynthstromAudible/DelugeFirmware/discussions/4609 and https://github.com/SynthstromAudible/DelugeFirmware/issues/4473