### PR TITLE
Fix homogenizeRegion dropping the region-start edit via a dangling pointer

### DIFF
--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -1336,8 +1336,8 @@ getValueNormalWay:
 				return -1;
 			}
 			edgeIndexes[REGION_EDGE_LEFT] += (int32_t)anyWrap;
-			// Theoretically we'd re-get the other edgeNode here - but in fact, if it already existed, we won't access
-			// it again anyway.
+			// Note: a pre-existing left edgeNode pointer captured above may now dangle if this insert relocated the
+			// backing store. We re-fetch it unconditionally before writing it, below.
 		}
 
 		edgeNodes[REGION_EDGE_RIGHT] = nodes.getElement(edgeIndexes[REGION_EDGE_RIGHT]);
@@ -1369,6 +1369,10 @@ getValueNormalWay:
 		edgeNodes[REGION_EDGE_LEFT] = nodes.getElement(edgeIndexes[REGION_EDGE_LEFT]);
 		edgeNodes[REGION_EDGE_LEFT]->pos = edgePositions[REGION_EDGE_LEFT];
 	}
+	// Re-fetch unconditionally: if the left node pre-existed, the above block was skipped, but the right-edge
+	// insertAtIndex may have relocated the backing store - which would dangle the pointer captured earlier.
+	// edgeIndexes[REGION_EDGE_LEFT] is kept correct through both blocks, so it's safe to re-derive from it.
+	edgeNodes[REGION_EDGE_LEFT] = nodes.getElement(edgeIndexes[REGION_EDGE_LEFT]);
 	edgeNodes[REGION_EDGE_LEFT]->value = reversed ? valueAtLateEdge : startValue;
 	edgeNodes[REGION_EDGE_LEFT]->interpolated = interpolateLeftNode;
 


### PR DESCRIPTION
homogenizeRegion captured raw ParamNode* pointers to both region-edge nodes up front, then handled the right edge, which can call insertAtIndex and reallocate/move the ParamNodeVector backing store - invalidating the captured left-edge pointer. The left-edge re-fetch lived inside the 'if (!edgeNodes[REGION_EDGE_LEFT])' block, so when a node already existed at the left edge that block was skipped, the re-fetch never ran, and the value/interpolated writes landed on the stale pre-insert pointer. The user's edit to the region's first pad was silently lost (or clobbered unrelated freed memory).

Re-fetch the left edge node unconditionally from its correctly maintained index immediately before writing it.