### PR TITLE
Fix midi and trigger clock toggles

### DIFF
--- a/src/deluge/gui/menu_item/midi/device_is_relative.h
+++ b/src/deluge/gui/menu_item/midi/device_is_relative.h
@@ -21,7 +21,7 @@
 #include "io/midi/midi_device_manager.h"
 
 namespace deluge::gui::menu_item::midi {
-class IsRelative final : public Toggle {
+class DeviceIsRelative final : public Toggle {
 public:
 	using Toggle::Toggle;
 	void readCurrentValue() override { this->setValue(soundEditor.currentMIDICable->is_relative); }

--- a/src/deluge/gui/menu_item/midi/device_send_clock.h
+++ b/src/deluge/gui/menu_item/midi/device_send_clock.h
@@ -21,7 +21,7 @@
 #include "io/midi/midi_device_manager.h"
 
 namespace deluge::gui::menu_item::midi {
-class SendClock final : public Toggle {
+class DeviceSendClock final : public Toggle {
 public:
 	using Toggle::Toggle;
 	void readCurrentValue() override { this->setValue(soundEditor.currentMIDICable->sendClock); }

--- a/src/deluge/gui/menu_item/midi/receive_clock.h
+++ b/src/deluge/gui/menu_item/midi/receive_clock.h
@@ -16,18 +16,14 @@
  */
 #pragma once
 #include "gui/menu_item/toggle.h"
-#include "gui/ui/sound_editor.h"
-#include "io/midi/midi_device.h"
-#include "io/midi/midi_device_manager.h"
+#include "playback/playback_handler.h"
 
 namespace deluge::gui::menu_item::midi {
-class DeviceReceiveClock final : public Toggle {
+class ReceiveClock final : public ToggleBool {
 public:
-	using Toggle::Toggle;
-	void readCurrentValue() override { this->setValue(soundEditor.currentMIDICable->receiveClock); }
+	using ToggleBool::ToggleBool;
 	void writeCurrentValue() override {
-		soundEditor.currentMIDICable->receiveClock = this->getValue();
-		MIDIDeviceManager::anyChangesToSave = true;
+		playbackHandler.setMidiInClockEnabled(getValue());
 	}
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/midi/receive_clock.h
+++ b/src/deluge/gui/menu_item/midi/receive_clock.h
@@ -22,8 +22,6 @@ namespace deluge::gui::menu_item::midi {
 class ReceiveClock final : public ToggleBool {
 public:
 	using ToggleBool::ToggleBool;
-	void writeCurrentValue() override {
-		playbackHandler.setMidiInClockEnabled(getValue());
-	}
+	void writeCurrentValue() override { playbackHandler.setMidiInClockEnabled(getValue()); }
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/midi/send_clock.h
+++ b/src/deluge/gui/menu_item/midi/send_clock.h
@@ -16,18 +16,14 @@
  */
 #pragma once
 #include "gui/menu_item/toggle.h"
-#include "gui/ui/sound_editor.h"
-#include "io/midi/midi_device.h"
-#include "io/midi/midi_device_manager.h"
+#include "playback/playback_handler.h"
 
 namespace deluge::gui::menu_item::midi {
-class DeviceReceiveClock final : public Toggle {
+class SendClock final : public ToggleBool {
 public:
-	using Toggle::Toggle;
-	void readCurrentValue() override { this->setValue(soundEditor.currentMIDICable->receiveClock); }
+	using ToggleBool::ToggleBool;
 	void writeCurrentValue() override {
-		soundEditor.currentMIDICable->receiveClock = this->getValue();
-		MIDIDeviceManager::anyChangesToSave = true;
+		playbackHandler.setMidiOutClockMode(getValue());
 	}
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/menu_item/midi/send_clock.h
+++ b/src/deluge/gui/menu_item/midi/send_clock.h
@@ -22,8 +22,6 @@ namespace deluge::gui::menu_item::midi {
 class SendClock final : public ToggleBool {
 public:
 	using ToggleBool::ToggleBool;
-	void writeCurrentValue() override {
-		playbackHandler.setMidiOutClockMode(getValue());
-	}
+	void writeCurrentValue() override { playbackHandler.setMidiOutClockMode(getValue()); }
 };
 } // namespace deluge::gui::menu_item::midi

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -107,6 +107,8 @@
 #include "gui/menu_item/midi/mpe_to_mono.h"
 #include "gui/menu_item/midi/pgm.h"
 #include "gui/menu_item/midi/program.h"
+#include "gui/menu_item/midi/receive_clock.h"
+#include "gui/menu_item/midi/send_clock.h"
 #include "gui/menu_item/midi/sound/channel.h"
 #include "gui/menu_item/midi/sound/note_for_drum.h"
 #include "gui/menu_item/midi/sub.h"
@@ -1124,17 +1126,17 @@ Submenu midiCommandsMenu{
 // MIDI device submenu - for after we've selected which device we want it for
 
 midi::DefaultVelocityToLevel defaultVelocityToLevelMenu{STRING_FOR_VELOCITY};
-midi::SendClock sendClockMenu{STRING_FOR_CLOCK_OUT};
-midi::ReceiveClock receiveClockMenu{STRING_FOR_CLOCK_IN};
-midi::IsRelative is_relative_menu{STRING_FOR_IS_RELATIVE};
+midi::DeviceSendClock device_send_clock_menu{STRING_FOR_CLOCK_OUT};
+midi::DeviceReceiveClock device_receive_clock_menu{STRING_FOR_CLOCK_IN};
+midi::DeviceIsRelative device_is_relative_menu{STRING_FOR_IS_RELATIVE};
 midi::Device midiDeviceMenu{
     EMPTY_STRING,
     {
         &mpe::directionSelectorMenu,
         &defaultVelocityToLevelMenu,
-        &sendClockMenu,
-        &receiveClockMenu,
-        &is_relative_menu,
+        &device_send_clock_menu,
+        &device_receive_clock_menu,
+        &device_is_relative_menu,
     },
 };
 
@@ -1143,8 +1145,8 @@ ToggleBool midiInputDifferentiationMenu{STRING_FOR_DIFFERENTIATE_INPUTS, STRING_
                                         MIDIDeviceManager::differentiatingInputsByDevice};
 
 // MIDI clock menu
-ToggleBool midiClockOutStatusMenu{STRING_FOR_OUTPUT, STRING_FOR_MIDI_CLOCK_OUT, playbackHandler.midiOutClockEnabled};
-ToggleBool midiClockInStatusMenu{STRING_FOR_INPUT, STRING_FOR_MIDI_CLOCK_IN, playbackHandler.midiInClockEnabled};
+midi::SendClock send_clock_menu{STRING_FOR_OUTPUT, STRING_FOR_MIDI_CLOCK_OUT, playbackHandler.midiOutClockEnabled};
+midi::ReceiveClock receive_clock_menu{STRING_FOR_INPUT, STRING_FOR_MIDI_CLOCK_IN, playbackHandler.midiInClockEnabled};
 ToggleBool tempoMagnitudeMatchingMenu{STRING_FOR_TEMPO_MAGNITUDE_MATCHING, STRING_FOR_TEMPO_MAGNITUDE_MATCHING,
                                       playbackHandler.tempoMagnitudeMatchingEnabled};
 
@@ -1157,8 +1159,8 @@ Submenu midiClockMenu{
     STRING_FOR_CLOCK,
     STRING_FOR_MIDI_CLOCK,
     {
-        &midiClockInStatusMenu,
-        &midiClockOutStatusMenu,
+        &send_clock_menu,
+        &receive_clock_menu,
         &tempoMagnitudeMatchingMenu,
     },
 };

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -756,34 +756,40 @@ startAgain:
 		// And now we know how long the window's definitely going to be, see if we want to do any trigger clock or
 		// MIDI clock out ticks during it
 		if (!stemExport.renderingOffline()) {
-			if (playbackHandler.triggerClockOutTickScheduled) {
-				int32_t timeTilTriggerClockOutTick = playbackHandler.timeNextTriggerClockOutTick - audioSampleTimer;
-				if (std::cmp_less(timeTilTriggerClockOutTick, numSamples)) {
-					playbackHandler.doTriggerClockOutTick();
-					playbackHandler.scheduleTriggerClockOutTick(); // Schedules another one
+			// only send trigger clock out if you've enabled it
+			if (cvEngine.isTriggerClockOutputEnabled()) {
+				if (playbackHandler.triggerClockOutTickScheduled) {
+					int32_t timeTilTriggerClockOutTick = playbackHandler.timeNextTriggerClockOutTick - audioSampleTimer;
+					if (std::cmp_less(timeTilTriggerClockOutTick, numSamples)) {
+						playbackHandler.doTriggerClockOutTick();
+						playbackHandler.scheduleTriggerClockOutTick(); // Schedules another one
 
-					if (timeWithinWindowAtWhichMIDIOrGateOccurs == -1) {
-						timeWithinWindowAtWhichMIDIOrGateOccurs = timeTilTriggerClockOutTick;
+						if (timeWithinWindowAtWhichMIDIOrGateOccurs == -1) {
+							timeWithinWindowAtWhichMIDIOrGateOccurs = timeTilTriggerClockOutTick;
+						}
 					}
 				}
-			}
-			else {
-				playbackHandler.scheduleTriggerClockOutTick();
-			}
-
-			if (playbackHandler.midiClockOutTickScheduled) {
-				int32_t timeTilMIDIClockOutTick = playbackHandler.timeNextMIDIClockOutTick - audioSampleTimer;
-				if (std::cmp_less(timeTilMIDIClockOutTick, numSamples)) {
-					playbackHandler.doMIDIClockOutTick();
-					playbackHandler.scheduleMIDIClockOutTick(); // Schedules another one
-
-					if (timeWithinWindowAtWhichMIDIOrGateOccurs == -1) {
-						timeWithinWindowAtWhichMIDIOrGateOccurs = timeTilMIDIClockOutTick;
-					}
+				else {
+					playbackHandler.scheduleTriggerClockOutTick();
 				}
 			}
-			else {
-				playbackHandler.scheduleMIDIClockOutTick();
+
+			// only send midi clock out if you've enabled it
+			if (playbackHandler.currentlySendingMIDIOutputClocks()) {
+				if (playbackHandler.midiClockOutTickScheduled) {
+					int32_t timeTilMIDIClockOutTick = playbackHandler.timeNextMIDIClockOutTick - audioSampleTimer;
+					if (std::cmp_less(timeTilMIDIClockOutTick, numSamples)) {
+						playbackHandler.doMIDIClockOutTick();
+						playbackHandler.scheduleMIDIClockOutTick(); // Schedules another one
+
+						if (timeWithinWindowAtWhichMIDIOrGateOccurs == -1) {
+							timeWithinWindowAtWhichMIDIOrGateOccurs = timeTilMIDIClockOutTick;
+						}
+					}
+				}
+				else {
+					playbackHandler.scheduleMIDIClockOutTick();
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixed issue which would cause trigger and midi clocks to get sent out even though the global clock settings were disabled. Adding the missing guards to resolve the issue.

Also fixed issue introduced a while ago during toggle bool refactoring which accidentally dropped the use of setMidiInClockEnabled() and setMidiOutClockMode().

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4617