### PR TITLE
Add sustain (damper) pedal support (MIDI CC 64)

### DIFF
--- a/src/deluge/io/midi/midi_device.h
+++ b/src/deluge/io/midi/midi_device.h
@@ -81,6 +81,10 @@ public:
 	uint8_t rpnLSB;
 	uint8_t rpnMSB;
 	uint8_t bendRange;
+
+	// Sustain (damper) pedal state for this input channel (MIDI CC 64). While true, incoming
+	// note-offs on this cable+channel are held by PlaybackHandler until the pedal is released.
+	bool sustainPedalDown = false;
 };
 
 /*

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -3000,6 +3000,63 @@ bool PlaybackHandler::offerNoteToLearnedThings(MIDICable& cable, bool on, int32_
 	return foundAnything;
 }
 
+// ---- Sustain (damper) pedal helpers (MIDI CC 64) ----
+
+bool PlaybackHandler::holdSustainedNote(MIDICable& cable, int32_t channel, int32_t note, int32_t velocity) {
+	// If we're already holding this exact note, just refresh its release velocity.
+	for (int32_t i = 0; i < numHeldSustainNotes; i++) {
+		HeldSustainNote& h = heldSustainNotes[i];
+		if (h.cable == &cable && h.channel == channel && h.note == note) {
+			h.velocity = velocity;
+			return true;
+		}
+	}
+	if (numHeldSustainNotes >= kMaxNumHeldSustainNotes) {
+		return false; // Table full - caller will release the note normally.
+	}
+	HeldSustainNote& h = heldSustainNotes[numHeldSustainNotes++];
+	h.cable = &cable;
+	h.channel = (uint8_t)channel;
+	h.note = (uint8_t)note;
+	h.velocity = (uint8_t)velocity;
+	return true;
+}
+
+void PlaybackHandler::forgetSustainedNote(MIDICable& cable, int32_t channel, int32_t note) {
+	for (int32_t i = 0; i < numHeldSustainNotes; i++) {
+		HeldSustainNote& h = heldSustainNotes[i];
+		if (h.cable == &cable && h.channel == channel && h.note == note) {
+			heldSustainNotes[i] = heldSustainNotes[--numHeldSustainNotes];
+			return;
+		}
+	}
+}
+
+void PlaybackHandler::releaseSustainedNotesForChannel(MIDICable& cable, int32_t channel, bool* doingMidiThru) {
+	for (int32_t i = 0; i < numHeldSustainNotes;) {
+		HeldSustainNote& h = heldSustainNotes[i];
+		if (h.cable == &cable && h.channel == channel) {
+			int32_t note = h.note;
+			int32_t velocity = h.velocity;
+			// Remove the entry before replaying, so the replayed note-off can't be re-held.
+			heldSustainNotes[i] = heldSustainNotes[--numHeldSustainNotes];
+			noteMessageReceived(cable, false, channel, note, velocity, doingMidiThru);
+		}
+		else {
+			i++;
+		}
+	}
+}
+
+void PlaybackHandler::clearSustainedNotes() {
+	// Replay every deferred note-off so nothing is left hanging, then clear all pedal flags.
+	while (numHeldSustainNotes > 0) {
+		HeldSustainNote h = heldSustainNotes[--numHeldSustainNotes];
+		bool doingMidiThru = false;
+		noteMessageReceived(*h.cable, false, h.channel, h.note, h.velocity, &doingMidiThru);
+	}
+}
+
 void PlaybackHandler::noteMessageReceived(MIDICable& cable, bool on, int32_t channel, int32_t note, int32_t velocity,
                                           bool* doingMidiThru) {
 	// If user assigning/learning MIDI commands, do that
@@ -3019,6 +3076,23 @@ void PlaybackHandler::noteMessageReceived(MIDICable& cable, bool on, int32_t cha
 
 	if (offerNoteToLearnedThings(cable, on, channel, note)) {
 		return;
+	}
+
+	// Sustain (damper) pedal handling. Only for normal (non-MPE) channels 0-15.
+	if (channel >= 0 && channel < 16 && note >= 0 && note <= 127
+	    && !cable.ports[MIDI_DIRECTION_INPUT_TO_DELUGE].isChannelPartOfAnMPEZone(channel)) {
+		if (on) {
+			// A fresh note-on retriggers the note: drop any deferred note-off for it so the pedal
+			// release later on can't cut the new note short.
+			forgetSustainedNote(cable, channel, note);
+		}
+		else if (cable.inputChannels[channel].sustainPedalDown) {
+			// Pedal is down: defer this note-off until the pedal is released. If the store is full
+			// we fall through and release the note normally, so notes can never get stuck.
+			if (holdSustainedNote(cable, channel, note, velocity)) {
+				return;
+			}
+		}
 	}
 
 	bool shouldRecordNotesNowNow = shouldRecordNotesNow();
@@ -3186,6 +3260,23 @@ void PlaybackHandler::midiCCReceived(MIDICable& cable, uint8_t channel, uint8_t 
 		else if (offerNoteToLearnedThings(cable, value > 0, channelOrZone + IS_A_CC, ccNumber)) {
 			return;
 		}
+	}
+
+	// Sustain (damper) pedal: MIDI CC 64. Standard convention is value >= 64 means pressed.
+	// Handled here (after MIDI-learn, which is dealt with above) so a real pedal just works, while
+	// users can still learn CC64 to something else in MIDI-learn mode if they prefer.
+	if (!isMPE && ccNumber == 64 && channel < 16) {
+		bool pedalDown = (value >= 64);
+		MIDIInputChannel& inputChannel = cable.inputChannels[channel];
+		if (!pedalDown && inputChannel.sustainPedalDown) {
+			// Clear the flag *before* replaying note-offs so they aren't immediately re-held.
+			inputChannel.sustainPedalDown = false;
+			releaseSustainedNotesForChannel(cable, channel, doingMidiThru);
+		}
+		else {
+			inputChannel.sustainPedalDown = pedalDown;
+		}
+		return;
 	}
 
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];

--- a/src/deluge/playback/playback_handler.h
+++ b/src/deluge/playback/playback_handler.h
@@ -199,6 +199,11 @@ public:
 
 	void noteMessageReceived(MIDICable& cable, bool on, int32_t channel, int32_t note, int32_t velocity,
 	                         bool* doingMidiThru);
+
+	/// Release every note-off currently being held by a sustain (damper) pedal, and clear all
+	/// pedal state. Safe to call at any time (e.g. on playback stop or song swap) to avoid stuck notes.
+	void clearSustainedNotes();
+
 	bool subModeAllowsRecording();
 
 	float calculateBPM(float timePerInternalTick);
@@ -280,6 +285,27 @@ private:
 	void scheduleMIDIClockOutTickParamsKnown(uint32_t midiClockOutTicksPer, uint64_t fractionLastTimerTick,
 	                                         uint64_t fractionNextMIDIClockOutTick);
 	void scheduleMIDIClockOutTickFromExternalClock();
+
+	// --- Sustain (damper) pedal support (MIDI CC 64) ---
+	// While a channel's pedal is held, incoming note-offs are stored here and replayed when the
+	// pedal is released. Fixed-size and allocation-free so it is safe to touch from the MIDI thread.
+	struct HeldSustainNote {
+		MIDICable* cable;
+		uint8_t channel;
+		uint8_t note;
+		uint8_t velocity;
+	};
+	static constexpr int32_t kMaxNumHeldSustainNotes = 64;
+	HeldSustainNote heldSustainNotes[kMaxNumHeldSustainNotes];
+	int32_t numHeldSustainNotes = 0;
+
+	// Store a deferred note-off. Returns false if the table is full (caller should then let the
+	// note-off through normally so notes can never get stuck).
+	bool holdSustainedNote(MIDICable& cable, int32_t channel, int32_t note, int32_t velocity);
+	// Drop any deferred note-off matching cable+channel+note (used when a note is retriggered).
+	void forgetSustainedNote(MIDICable& cable, int32_t channel, int32_t note);
+	// Replay and clear all deferred note-offs for a given cable+channel (pedal released).
+	void releaseSustainedNotesForChannel(MIDICable& cable, int32_t channel, bool* doingMidiThru);
 };
 
 extern PlaybackHandler playbackHandler;


### PR DESCRIPTION
## What this does
Adds handling for the MIDI **sustain/damper pedal (CC 64)**, which the firmware did not
previously support. While the pedal is held (CC 64 value ≥ 64), incoming note-offs on that
cable + channel are deferred; when the pedal is released (value < 64), the held notes are
released together. This is the standard piano-pedal behaviour.

Previously CC 64 fell through the generic CC pipeline with no note-hold effect, so a
connected sustain pedal did nothing unless manually MIDI-learned to a parameter.

## Behaviour / scope
- Applies to **non-MPE** channels 0–15 only (MPE member channels use CCs for expression).
- Handled **after** MIDI-learn, so CC 64 can still be learned to something else if a user
  prefers; otherwise it acts as a pedal automatically.
- **Retrigger-safe:** playing a held note again cancels its pending note-off, so the pedal
  release can't cut the new note short.
- **Fail-safe:** the deferred-note store is fixed at 64 entries and allocation-free (safe on
  the MIDI/audio thread). If it ever fills, further note-offs pass straight through, so notes
  can never get stuck.
- **All-Notes-Off safe:** CC 123 (delivered internally as a sentinel note-off) always passes
  through, even with the pedal down.

## Implementation
- `MIDIInputChannel` gains a per-channel `sustainPedalDown` flag (stored alongside the
  existing per-channel MPE state).
- `PlaybackHandler::midiCCReceived` detects CC 64 and tracks pedal state per cable+channel.
- `PlaybackHandler::noteMessageReceived` defers note-offs while the pedal is down and cancels
  a pending note-off on retrigger.
- Helpers: `holdSustainedNote` / `forgetSustainedNote` / `releaseSustainedNotesForChannel`,
  plus `clearSustainedNotes()` as a cleanup/panic hook.

## Testing
- Built (Release) with `./dbt build release` and flashed to hardware (OLED). Verified with a
  real pedal: hold → notes sustain after key release; release → all notes stop; retrigger
  while held works; baseline (pedal up) unchanged.
- The core deferral algorithm was also exercised by a standalone logic harness covering
  pedal up/down, hold+release, retrigger cancellation, the 63/64 threshold, multi-channel
  and multi-cable isolation, the overflow fail-safe, and All-Notes-Off passthrough.

## Notes / possible follow-ups
- `clearSustainedNotes()` is provided but not yet wired into playback-stop / song-swap; could
  be hooked in as a belt-and-braces cleanup.
- Could later add an option to remap which CC acts as the pedal, or sostenuto (CC 66).

## Deluge tested on
OLED. (7SEG untested — behaviour is display-independent, but noting for completeness.)
