### PR TITLE
Fix E078 crash on time-stretched looping sample presets (#4515)

### DIFF
--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -940,7 +940,14 @@ optForDirectReading:
 
 			D_PRINTLN("setupNewPlayHead failed. Sticking with old");
 
-			*voiceSample = SampleLowLevelReader(olderPartReader, true); // Steals all reasons back
+			// Restore ONLY the SampleLowLevelReader base state from olderPartReader (stealing its cluster reasons
+			// back). Assigning to the whole VoiceSample - `*voiceSample = SampleLowLevelReader(...)` - does NOT bind
+			// the base operator=: VoiceSample declares its own operator= (hiding the base one), so this routes through
+			// the implicit VoiceSample(SampleLowLevelReader&&) conversion plus the defaulted VoiceSample move-assign,
+			// which overwrites timeStretcher/cache with their default nulls. That both nulls voiceSample->timeStretcher
+			// mid-render (null deref) and orphans this live TimeStretcher so endTimeStretching() never runs for it,
+			// leaking its perc-lookahead cluster reasons -> Sample::numReasonsDecreasedToZero E078 (issue #4515).
+			static_cast<SampleLowLevelReader&>(*voiceSample) = SampleLowLevelReader(olderPartReader, true);
 			playHeadStillActive[PLAY_HEAD_NEWER] = playHeadStillActive[PLAY_HEAD_OLDER];
 			playHeadStillActive[PLAY_HEAD_OLDER] = false;
 

--- a/src/deluge/dsp/timestretch/time_stretcher.cpp
+++ b/src/deluge/dsp/timestretch/time_stretcher.cpp
@@ -349,6 +349,15 @@ bool TimeStretcher::hopEnd(SamplePlaybackGuide* guide, VoiceSample* voiceSample,
 
 		int32_t position = speedLog - (768 << 20);
 
+		// interpolateTableSigned reads table[whichValue] AND table[whichValue + 1], with whichValue = position >> 25.
+		// The coarse tables have 5 entries (indices 0..4), so position must stay strictly below 2^27 or whichValue
+		// reaches 4 and the +1 read runs one past the end. The speedLog clamp above is inclusive (speedLog == 896<<20
+		// gives position == 2^27), so pin position to the top of the valid 27-bit range - the interpolation there still
+		// resolves to the last table entry, matching the intended ceiling.
+		if (position >= (128 << 20)) {
+			position = (128 << 20) - 1;
+		}
+
 		minBeamWidth = interpolateTableSigned(position, 27, minHopSizeCoarse, 2) >> 16;
 		maxBeamWidth = interpolateTableSigned(position, 27, maxHopSizeCoarse, 2) >> 16;
 		crossfadeProportional = interpolateTableSigned(position, 27, crossfadeProportionalCoarse, 2) << 8;

--- a/src/deluge/model/voice/voice_sample.h
+++ b/src/deluge/model/voice/voice_sample.h
@@ -37,10 +37,17 @@ class VoiceSample final : public SampleLowLevelReader {
 public:
 	VoiceSample() = default;
 	explicit VoiceSample(VoiceSample& other) = default;
-	VoiceSample(SampleLowLevelReader&& other) : SampleLowLevelReader{std::move(other)} {}
+	// explicit: an implicit conversion here is a footgun. `*voiceSample = SampleLowLevelReader(...)` would silently
+	// build a temporary VoiceSample (with default-null timeStretcher/cache) and memberwise-move it over the live one,
+	// nulling timeStretcher mid-flight and orphaning it (leaking its reasons -> E078, see TimeStretcher::hopEnd).
+	// Assign through the SampleLowLevelReader base subobject instead when you only mean to replace the reader state.
+	explicit VoiceSample(SampleLowLevelReader&& other) : SampleLowLevelReader{std::move(other)} {}
 	~VoiceSample() override { endTimeStretching(); }
 	VoiceSample& operator=(const VoiceSample& other) = delete;
-	VoiceSample& operator=(VoiceSample&& other) = default;
+	// Deleted: the defaulted memberwise move-assign would overwrite timeStretcher/cache without endTimeStretching(),
+	// leaking whatever the destination currently owns. VoiceSamples are pool-managed and referenced by pointer, so no
+	// object-level move-assign is needed; if one ever is, give it a body that releases resources first.
+	VoiceSample& operator=(VoiceSample&& other) = delete;
 
 	void noteOn(SamplePlaybackGuide* guide, uint32_t samplesLate, int32_t priorityRating);
 	bool noteOffWhenLoopEndPointExists(Voice* voice, VoiceSamplePlaybackGuide* voiceSource);

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -3132,8 +3132,11 @@ void Sound::setNumUnison(int32_t newNum, ModelStackWithSoundFlags* modelStack) {
 							VoiceSample& newVoiceSample = *newPart->voiceSample;
 							VoiceSample& oldVoiceSample = *oldPart->voiceSample;
 
-							// Just clones the SampleLowLevelReader stuff
-							newVoiceSample = SampleLowLevelReader(oldVoiceSample);
+							// Just clones the SampleLowLevelReader stuff - assign through the base subobject so this
+							// can't slice via the implicit VoiceSample(SampleLowLevelReader&&) conversion and clobber
+							// the derived members (timeStretcher/cache). See the matching guard in
+							// TimeStretcher::hopEnd.
+							static_cast<SampleLowLevelReader&>(newVoiceSample) = SampleLowLevelReader(oldVoiceSample);
 							newVoiceSample.pendingSamplesLate = oldVoiceSample.pendingSamplesLate;
 							newVoiceSample.doneFirstRenderYet = true;
 


### PR DESCRIPTION
Fixes #4515 — loading/switching the 1.2 Competition B-side presets **"Busted Mf"** and **"Kirk"** crashes with error **E078**. Both are synth presets whose oscillator is a **time-stretched, looping sample** (`type=sample`, `loopMode=LOOP`, `timeStretchEnable=1`).

E078 fires in `Sample::numReasonsDecreasedToZero()` — a cluster reference-count leak: a `Sample`'s holder reason drops to zero while one of its clusters still holds a reason.

The leak comes from `TimeStretcher::hopEnd`. When `setupNewPlayHead` fails during a hop, it restored the reader from the older play-head with:

```cpp
*voiceSample = SampleLowLevelReader(olderPartReader, true);
```

`VoiceSample` declares its own `operator=`, which **hides** the base `SampleLowLevelReader::operator=`. So this statement does not assign the base subobject — it routes through the implicit `VoiceSample(SampleLowLevelReader&&)` conversion plus the defaulted `VoiceSample` move-assign, which overwrites `timeStretcher`/`cache` with their default nulls. That:

1. **nulls `voiceSample->timeStretcher` mid-render** → null-pointer dereference in `VoiceSample::render`, and
2. **orphans the live `TimeStretcher`**, so `endTimeStretching()` never runs for it and its perc-lookahead cluster reasons leak → **E078** when the preset is later swapped out.

This is a regression from `8a117b442`, which replaced the old base-only `voiceSample->cloneFrom(&olderPartReader, true)` with the slicing assignment. On release firmware the leak-detection freeze is disabled, but the underlying leak (and the null deref) still exist.