### PR TITLE
Fix/ Align velocity view shortcut with instrument clip view

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -881,15 +881,6 @@ void AutomationView::renderAutomationOverview(ModelStackWithTimelineCounter* mod
 		else {
 			pixel = colours::black; // erase pad
 		}
-
-		if (!onArrangerView && !(outputType == OutputType::KIT && getAffectEntire())
-		    && clip->type == ClipType::INSTRUMENT) {
-			// highlight velocity pad
-			if (xDisplay == kVelocityShortcutX && yDisplay == kVelocityShortcutY) {
-				pixel = colours::grey;
-				occupancyMask[yDisplay][xDisplay] = 64;
-			}
-		}
 	}
 }
 
@@ -1773,6 +1764,30 @@ ActionResult AutomationView::handleEditPadAction(ModelStackWithAutoParam* modelS
 		return ActionResult::DEALT_WITH;
 	}
 
+	// potentially enter or refresh note velocity editor if you're in an instrument clip, holding audition pad and
+	// pressing PatchSource::Velocity shortcut
+	if (!onArrangerView && clip->type == ClipType::INSTRUMENT && isUIModeActive(UI_MODE_AUDITIONING)
+	    && isNoteVelocityEditorShortcut(x, y)) {
+		// don't enter if we're in a kit with affect entire enabled
+		if (!(outputType == OutputType::KIT && getAffectEntire())) {
+			if (outputType == OutputType::KIT) {
+				potentiallyVerticalScrollToSelectedDrum((InstrumentClip*)clip, output);
+			}
+			initParameterSelection(false);
+			automationParamType = AutomationParamType::NOTE_VELOCITY;
+			clip->lastSelectedParamShortcutX = x;
+			clip->lastSelectedParamShortcutY = y;
+			blinkShortcuts();
+			renderDisplay();
+			uiNeedsRendering(&automationView);
+			// if you're in note editor, turn led on
+			if (((InstrumentClip*)clip)->wrapEditing) {
+				indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, true);
+			}
+		}
+		return ActionResult::DEALT_WITH;
+	}
+
 	int32_t xScroll = currentSong->xScroll[navSysId];
 	int32_t xZoom = currentSong->xZoom[navSysId];
 
@@ -1799,6 +1814,10 @@ ActionResult AutomationView::handleEditPadAction(ModelStackWithAutoParam* modelS
 		}
 	}
 	return ActionResult::DEALT_WITH;
+}
+
+bool AutomationView::isNoteVelocityEditorShortcut(int32_t x, int32_t y) {
+	return (x == kVelocityShortcutX && y == kVelocityShortcutY);
 }
 
 /// handles shortcut pad actions, including:
@@ -1830,7 +1849,7 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 
 			shortcutPress = true;
 		}
-		// this means you are selecting a parameter
+		// this means you are selecting a parameter / entering or refreshing note editor
 		if (shortcutPress || onAutomationOverview()) {
 			// don't change parameters this way if we're in the menu
 			if (getCurrentUI() == &automationView) {
@@ -1859,38 +1878,14 @@ bool AutomationView::shortcutPadAction(ModelStackWithAutoParam* modelStackWithPa
 // overview or by using a grid shortcut combo
 void AutomationView::handleParameterSelection(Clip* clip, Output* output, OutputType outputType, int32_t xDisplay,
                                               int32_t yDisplay) {
-	// PatchSource::Velocity shortcut
-	// Enter Velocity Note Editor
-	if (xDisplay == kVelocityShortcutX && yDisplay == kVelocityShortcutY) {
-		if (clip->type == ClipType::INSTRUMENT) {
-			// don't enter if we're in a kit with affect entire enabled
-			if (!(outputType == OutputType::KIT && getAffectEntire())) {
-				if (outputType == OutputType::KIT) {
-					potentiallyVerticalScrollToSelectedDrum((InstrumentClip*)clip, output);
-				}
-				initParameterSelection(false);
-				automationParamType = AutomationParamType::NOTE_VELOCITY;
-				clip->lastSelectedParamShortcutX = xDisplay;
-				clip->lastSelectedParamShortcutY = yDisplay;
-				blinkShortcuts();
-				renderDisplay();
-				uiNeedsRendering(&automationView);
-				// if you're in note editor, turn led on
-				if (((InstrumentClip*)clip)->wrapEditing) {
-					indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, true);
-				}
-			}
-			return;
-		}
-	}
 	// potentially select a regular automatable parameter
-	else if (!onArrangerView
-	         && (outputType == OutputType::SYNTH
-	             || (outputType == OutputType::KIT && !getAffectEntire() && ((Kit*)output)->selectedDrum
-	                 && ((Kit*)output)->selectedDrum->type == DrumType::SOUND))
-	         && ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-	             || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
-	             || params::isPatchCableShortcut(xDisplay, yDisplay))) {
+	if (!onArrangerView
+	    && (outputType == OutputType::SYNTH
+	        || (outputType == OutputType::KIT && !getAffectEntire() && ((Kit*)output)->selectedDrum
+	            && ((Kit*)output)->selectedDrum->type == DrumType::SOUND))
+	    && ((patchedParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+	        || (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] != kNoParamID)
+	        || params::isPatchCableShortcut(xDisplay, yDisplay))) {
 		// don't allow automation of portamento in kit's
 		if ((outputType == OutputType::KIT)
 		    && (unpatchedNonGlobalParamShortcuts[xDisplay][yDisplay] == params::UNPATCHED_PORTAMENTO)) {
@@ -3205,8 +3200,7 @@ void AutomationView::setAutomationParamType() {
 	automationParamType = AutomationParamType::PER_SOUND;
 	if (!inAutomationEditor()) {
 		Clip* clip = getCurrentClip();
-		if ((clip->lastSelectedParamShortcutX == kVelocityShortcutX)
-		    && (clip->lastSelectedParamShortcutY == kVelocityShortcutY)) {
+		if (isNoteVelocityEditorShortcut(clip->lastSelectedParamShortcutX, clip->lastSelectedParamShortcutY)) {
 			automationParamType = AutomationParamType::NOTE_VELOCITY;
 		}
 	}

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -172,6 +172,8 @@ public:
 	int32_t rightPadSelectedY;
 	int32_t lastPadSelectedKnobPos;
 
+	bool isNoteVelocityEditorShortcut(int32_t x, int32_t y);
+
 private:
 	// button action functions
 	void handleSessionButtonAction(Clip* clip, bool on);

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -101,9 +101,6 @@ extern "C" {}
 
 using namespace deluge::gui;
 
-constexpr uint8_t kVelocityShortcutX = 15;
-constexpr uint8_t kVelocityShortcutY = 1;
-
 PLACE_SDRAM_DATA InstrumentClipView instrumentClipView{};
 
 InstrumentClipView::InstrumentClipView() : numEditPadPresses(0) {
@@ -1864,7 +1861,7 @@ ActionResult InstrumentClipView::padAction(int32_t x, int32_t y, int32_t velocit
 		if (velocity && (!isUIModeActive(UI_MODE_AUDITIONING) || !editedAnyPerNoteRowStuffSinceAuditioningBegan)) {
 			// are we trying to enter the automation view velocity note editor
 			// by pressing audition pad + velocity shortcut?
-			if (isUIModeActive(UI_MODE_AUDITIONING) && (x == kVelocityShortcutX && y == kVelocityShortcutY)) {
+			if (isUIModeActive(UI_MODE_AUDITIONING) && automationView.isNoteVelocityEditorShortcut(x, y)) {
 				return commandEnterNoteVelocityEditor(x, y);
 			}
 			// otherwise let's check for another shortcut pad action

--- a/website/src/content/docs/changelogs/CHANGELOG.mdx
+++ b/website/src/content/docs/changelogs/CHANGELOG.mdx
@@ -278,12 +278,18 @@ A `Favourites` feature has been added to the browser for most file types. The `F
 ##### General
 
 - Fixed Quantize/Humanize bug which would freeze the velocity view UI
+- Updated shortcut for `Note Velocity View`. You can now only enter `Note Velocity View` by holding `Audition Pad` + pressing the `Velocity` pad.
 
 #### <ins>Automation View</ins>
 
 ##### Defaults
 
 - The `Settings/Defaults/Automation/Shift` toggle now only applies to Clip View. In Arranger View if you use `shift + <>` to insert / delete time at a specific point in the arrangement, all paramet[...]
+
+##### Automation Overview and Shortcuts
+
+- Removed the `Note Velocity View` shortcut from the Automation Overview. The `Velocity` pad on the Automation Overview now represents the Automatable parameter `Velocity Spread`
+- Updated shortcut for `Note Velocity View`. You can now only enter `Note Velocity View` by holding `Audition Pad` + pressing the `Velocity` pad.
 
 ##### Parameters
 

--- a/website/src/content/docs/features/automation_view_velocity_editor.mdx
+++ b/website/src/content/docs/features/automation_view_velocity_editor.mdx
@@ -40,7 +40,7 @@ Note Velocity Editing View that has been added as part of the existing Automatio
 
 ### Enter the Velocity Editor View
 
-- While in the Automation Instrument Clip View, use Shift + Velocity or press Velocity pad on Automation Overview to enter the Velocity Note Editor
+- While in the Automation Instrument Clip View, hold Audition pad + Press Velocity shortcut pad
   OR
 - While in the Instrument Clip View, hold Audition pad + Press Velocity shortcut pad
 


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4438

Aligned velocity view shortcuts in automation view with instrument clip view.

- Removed the `Note Velocity View` shortcut from the Automation Overview. The `Velocity` pad on the Automation Overview now represents the Automatable parameter `Velocity Spread`
- Updated shortcut for `Note Velocity View`. You can now only enter `Note Velocity View` by holding `Audition Pad` + pressing the `Velocity` pad.