### PR TITLE
Fix/ Resume notes after transposing

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -6225,6 +6225,7 @@ void InstrumentClipView::commandTransposeScreen(int32_t offset, bool inOctave) {
 		uint8_t probability;
 		Iterance iterance;
 		uint8_t fill;
+		bool restartAfterMove;
 		StolenParamNodes stolenMPE[kNumExpressionDimensions]{0};
 	};
 
@@ -6233,6 +6234,7 @@ void InstrumentClipView::commandTransposeScreen(int32_t offset, bool inOctave) {
 	notesToMove.reserve(100);
 	// First pass: collect all notes from visible rows within screen bounds
 	Action* action = actionLogger.getNewAction(ActionType::NOTE_EDIT, ActionAddition::ALLOWED);
+	bool clipIsActiveAndPlaybackOn = playbackHandler.isEitherClockActive() && currentSong->isClipActive(clip);
 
 	auto num_note_rows = clip->getNumNoteRows();
 	for (int32_t index = 0; index < num_note_rows; index++) {
@@ -6265,6 +6267,19 @@ void InstrumentClipView::commandTransposeScreen(int32_t offset, bool inOctave) {
 					ntm.probability = note->probability;
 					ntm.iterance = note->iterance;
 					ntm.fill = note->fill;
+					ntm.restartAfterMove = false;
+
+					if (clipIsActiveAndPlaybackOn && !noteRow->muted && noteRow->sequenced) {
+						int32_t loopLength = modelStackWithNoteRow->getLoopLength();
+						int32_t howFarIntoNote = noteRow->getLivePos(modelStackWithNoteRow) - note->pos;
+						if (howFarIntoNote < 0) {
+							howFarIntoNote += loopLength;
+						}
+						ntm.restartAfterMove = howFarIntoNote < note->getLength();
+						if (ntm.restartAfterMove) {
+							noteRow->stopCurrentlyPlayingNote(modelStackWithNoteRow, true, note);
+						}
+					}
 
 					// Steal expression/MPE parameter data
 					ParamCollectionSummary* mpeParamsSummary = noteRow->paramManager.getExpressionParamSetSummary();
@@ -6343,6 +6358,10 @@ void InstrumentClipView::commandTransposeScreen(int32_t offset, bool inOctave) {
 							param->insertStolenNodes(modelStackWithAutoParam, ntm.pos, distanceToNextNote, loopLength,
 							                         action, &ntm.stolenMPE[m]);
 						}
+					}
+
+					if (ntm.restartAfterMove) {
+						destRow->resumePlayback(destModelStack, true, true);
 					}
 				}
 			}

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1302,10 +1302,47 @@ void InstrumentClip::seeWhatNotesWithinOctaveArePresent(NoteSet& notesWithinOcta
 	}
 }
 
+bool InstrumentClip::stopAllNotesPlayingForTranspose(ModelStackWithTimelineCounter* modelStack) {
+	bool shouldResumePlayingNotes = playbackHandler.isEitherClockActive() && modelStack->song->isClipActive(this);
+
+	// Stop every old pitch first. For active clips, keep sequenced as a temporary marker so only rows that were
+	// actually sounding before the transpose are restarted at their new pitch.
+	for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
+		NoteRow* thisNoteRow = noteRows.getElement(i);
+		bool wasSequenced = thisNoteRow->sequenced;
+		ModelStackWithNoteRow* modelStackWithNoteRow =
+		    modelStack->addNoteRow(getNoteRowId(thisNoteRow, i), thisNoteRow);
+		thisNoteRow->stopCurrentlyPlayingNote(modelStackWithNoteRow);
+		if (shouldResumePlayingNotes) {
+			thisNoteRow->sequenced = wasSequenced;
+		}
+	}
+
+	return shouldResumePlayingNotes;
+}
+
+void InstrumentClip::resumeNotesPlayingBeforeTranspose(ModelStackWithTimelineCounter* modelStack,
+                                                       bool shouldResumePlayingNotes) {
+	if (!shouldResumePlayingNotes) {
+		return;
+	}
+
+	for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
+		NoteRow* thisNoteRow = noteRows.getElement(i);
+		bool wasSequenced = thisNoteRow->sequenced;
+		thisNoteRow->sequenced = false;
+		if (wasSequenced && !thisNoteRow->muted) {
+			ModelStackWithNoteRow* modelStackWithNoteRow =
+			    modelStack->addNoteRow(getNoteRowId(thisNoteRow, i), thisNoteRow);
+			thisNoteRow->resumePlayback(modelStackWithNoteRow, true, true);
+		}
+	}
+	expectEvent();
+}
+
 /* Chromatic tranpose of all notes by fixed semitone amount */
 void InstrumentClip::transpose(int32_t semitones, ModelStackWithTimelineCounter* modelStack) {
-	// Make sure no notes sounding
-	stopAllNotesPlaying(modelStack);
+	bool shouldResumePlayingNotes = stopAllNotesPlayingForTranspose(modelStack);
 
 	// Must also do auditioned notes, since transpose can now be sequenced and change
 	// noterows while we hold an audition pad.
@@ -1317,6 +1354,8 @@ void InstrumentClip::transpose(int32_t semitones, ModelStackWithTimelineCounter*
 		NoteRow* thisNoteRow = noteRows.getElement(i);
 		thisNoteRow->y += semitones;
 	}
+
+	resumeNotesPlayingBeforeTranspose(modelStack, shouldResumePlayingNotes);
 
 	yScroll += semitones;
 	colourOffset -= semitones;
@@ -1344,8 +1383,7 @@ void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 		}
 	}
 
-	// Make sure no notes sounding
-	stopAllNotesPlaying(modelStack);
+	bool shouldResumePlayingNotes = stopAllNotesPlayingForTranspose(modelStack);
 
 	if (!this->isScaleModeClip()) {
 		// Non scale clip, transpose directly by semitone jumps
@@ -1411,6 +1449,7 @@ void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 			}
 		}
 	}
+	resumeNotesPlayingBeforeTranspose(modelStack, shouldResumePlayingNotes);
 	yScroll += change;
 }
 

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -247,6 +247,8 @@ private:
 	void deleteEmptyNoteRowsAtEitherEnd(bool onlyIfNoDrum, ModelStackWithTimelineCounter* modelStack,
 	                                    bool mustKeepLastOne = true, bool keepOnesWithMIDIInput = true);
 	void sendPendingNoteOn(ModelStackWithTimelineCounter* modelStack, PendingNoteOn* pendingNoteOn);
+	bool stopAllNotesPlayingForTranspose(ModelStackWithTimelineCounter* modelStack);
+	void resumeNotesPlayingBeforeTranspose(ModelStackWithTimelineCounter* modelStack, bool shouldResumePlayingNotes);
 	Error undoUnassignmentOfAllNoteRowsFromDrums(ModelStackWithTimelineCounter* modelStack);
 	void deleteBackedUpParamManagerMIDI();
 	bool possiblyDeleteEmptyNoteRow(NoteRow* noteRow, bool onlyIfNoDrum, Song* song, bool onlyIfNonNumeric = false,

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -3115,9 +3115,10 @@ void NoteRow::toggleMute(ModelStackWithNoteRow* modelStack, bool clipIsActiveAnd
 	}
 }
 
-void NoteRow::maybeStartLateNote(ModelStackWithNoteRow* modelStack, int32_t effectiveActualCurrentPos) {
+void NoteRow::maybeStartLateNote(ModelStackWithNoteRow* modelStack, int32_t effectiveActualCurrentPos,
+                                 bool restartCurrentNote) {
 	// See if our play-pos is inside of a note, which we might want to try playing...
-	int32_t i = notes.search(effectiveActualCurrentPos, LESS);
+	int32_t i = notes.search(effectiveActualCurrentPos + (restartCurrentNote ? 1 : 0), LESS);
 	bool wrapping = (i == -1);
 	if (wrapping) {
 		i = notes.getNumElements() - 1;
@@ -3129,12 +3130,17 @@ void NoteRow::maybeStartLateNote(ModelStackWithNoteRow* modelStack, int32_t effe
 	}
 
 	if (noteEnd > effectiveActualCurrentPos) {
-		// if we're not allowed we'll just come back here later (next tick)
-		attemptLateStartOfNextNoteToPlay(modelStack, note);
+		if (restartCurrentNote) {
+			playNote(true, modelStack, note);
+		}
+		else {
+			// if we're not allowed we'll just come back here later (next tick)
+			attemptLateStartOfNextNoteToPlay(modelStack, note);
+		}
 	}
 }
 // Attempts (possibly late) start of any note at or overlapping the currentPos
-void NoteRow::resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMakeSound) {
+void NoteRow::resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMakeSound, bool restartCurrentNote) {
 	if (noteRowMayMakeSound(clipMayMakeSound) && !sequenced && !isAuditioning(modelStack)) {
 
 		if (!notes.getNumElements()) {
@@ -3143,8 +3149,9 @@ void NoteRow::resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMake
 
 		int32_t effectiveActualCurrentPos = getLivePos(modelStack);
 
-		if ((runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes) == RuntimeFeatureStateToggle::On)) {
-			maybeStartLateNote(modelStack, effectiveActualCurrentPos);
+		if (restartCurrentNote
+		    || (runtimeFeatureSettings.get(RuntimeFeatureSettingType::CatchNotes) == RuntimeFeatureStateToggle::On)) {
+			maybeStartLateNote(modelStack, effectiveActualCurrentPos, restartCurrentNote);
 		}
 	}
 

--- a/src/deluge/model/note/note_row.h
+++ b/src/deluge/model/note/note_row.h
@@ -109,9 +109,10 @@ public:
 	bool generateRepeats(ModelStackWithNoteRow* modelStack, uint32_t oldLength, uint32_t newLength,
 	                     int32_t numRepeatsRounded, Action* action);
 	void toggleMute(ModelStackWithNoteRow* modelStack, bool clipIsActiveAndPlaybackIsOn);
-	void maybeStartLateNote(ModelStackWithNoteRow* modelStack, int32_t effectiveActualCurrentPos);
+	void maybeStartLateNote(ModelStackWithNoteRow* modelStack, int32_t effectiveActualCurrentPos,
+	                        bool restartCurrentNote = false);
 	bool hasNoNotes();
-	void resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMakeSound);
+	void resumePlayback(ModelStackWithNoteRow* modelStack, bool clipMayMakeSound, bool restartCurrentNote = false);
 	void writeToFile(Serializer& writer, int32_t drumIndex, InstrumentClip* clip);
 	Error readFromFile(Deserializer& reader, int32_t*, InstrumentClip*, Song* song, int32_t readAutomationUpToPos);
 	inline int32_t getNoteCode() { return y; }


### PR DESCRIPTION
Fix transpose cutting off notes by resuming them after transposing

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/2939

To do: 
- [ ] adjust approach - instead of stopping and restarting notes, don't stop and set a flag to tell the voice to re-calculate pitch on next render

## Before Video

https://github.com/user-attachments/assets/1388de05-8af0-418c-8218-d1c681b8539c

## After Video

https://github.com/user-attachments/assets/233e441b-38a0-4efe-aa20-9e536a802875