### PR TITLE
Fix/ filter initialization bug

### DIFF
--- a/src/deluge/dsp/filter/filter.h
+++ b/src/deluge/dsp/filter/filter.h
@@ -113,6 +113,10 @@ public:
 			dryFade = 1;
 			wetLevel = 0;
 		}
+		else {
+			dryFade = 0;
+			wetLevel = ONE_Q31;
+		}
 	}
 
 	inline void updateBlend() {

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -146,20 +146,22 @@ int32_t FilterSet::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode 
 	if (LPFOn) {
 		if ((lpfMode_ == FilterMode::SVF_BAND) || (lpfMode_ == FilterMode::SVF_NOTCH)) {
 			if (SpecificFilter(lastLPFMode_).getFamily() != FilterFamily::SVF) {
-				lpfilter.svf.reset(lastLPFMode_ == FilterMode::OFF);
+				lpfilter.svf.reset(lastLPFMode_ == FilterMode::OFF && fadeLPFOnNextEnable_);
 			}
 			filterGain = lpfilter.svf.configure(lpfFrequency, lpfResonance, lpfMode_, lpfMorph, filterGain);
 		}
 		else {
 			if (SpecificFilter(lastLPFMode_).getFamily() != FilterFamily::LP_LADDER) {
-				lpfilter.ladder.reset(lastLPFMode_ == FilterMode::OFF);
+				lpfilter.ladder.reset(lastLPFMode_ == FilterMode::OFF && fadeLPFOnNextEnable_);
 			}
 			filterGain = lpfilter.ladder.configure(lpfFrequency, lpfResonance, lpfMode_, lpfMorph, filterGain);
 		}
 		lastLPFMode_ = lpfMode_;
+		fadeLPFOnNextEnable_ = false;
 	}
 	else {
 		lastLPFMode_ = FilterMode::OFF;
+		fadeLPFOnNextEnable_ = true;
 	}
 	// This changes the overall amplitude so that, with resonance on 50%, the amplitude is the same as it was pre June
 	// 2017
@@ -170,7 +172,7 @@ int32_t FilterSet::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode 
 		if (hpfMode_ == FilterMode::HPLADDER) {
 			filterGain = hpfilter.ladder.configure(hpfFrequency, hpfResonance, hpfmode, hpfMorph, filterGain);
 			if (lastHPFMode_ != hpfMode_) {
-				hpfilter.ladder.reset(lastHPFMode_ == FilterMode::OFF);
+				hpfilter.ladder.reset(lastHPFMode_ == FilterMode::OFF && fadeHPFOnNextEnable_);
 			}
 		}
 		// otherwise it's an SVF ((lpfmode == FilterMode::SVF_BAND) || (lpfmode == FilterMode::SVF_NOTCH))
@@ -179,13 +181,15 @@ int32_t FilterSet::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode 
 			filterGain =
 			    hpfilter.svf.configure(hpfFrequency, hpfResonance, hpfmode, ((1 << 29) - 1) - hpfMorph, filterGain);
 			if (lastHPFMode_ != hpfMode_) {
-				hpfilter.svf.reset(lastHPFMode_ == FilterMode::OFF);
+				hpfilter.svf.reset(lastHPFMode_ == FilterMode::OFF && fadeHPFOnNextEnable_);
 			}
 		}
 		lastHPFMode_ = hpfMode_;
+		fadeHPFOnNextEnable_ = false;
 	}
 	else {
 		lastHPFMode_ = FilterMode::OFF;
+		fadeHPFOnNextEnable_ = true;
 	}
 
 	return filterGain;
@@ -199,6 +203,8 @@ void FilterSet::reset() {
 	hpfMode_ = FilterMode::OFF;
 	lastHPFMode_ = FilterMode::OFF;
 	routing_ = FilterRoute::HIGH_TO_LOW;
+	fadeLPFOnNextEnable_ = false;
+	fadeHPFOnNextEnable_ = false;
 	LPFOn = false;
 	HPFOn = false;
 }

--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -194,5 +194,12 @@ int32_t FilterSet::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode 
 void FilterSet::reset() {
 	memset(&lpfilter, 0, sizeof(LowPass));
 	memset(&hpfilter, 0, sizeof(HighPass));
+	lpfMode_ = FilterMode::OFF;
+	lastLPFMode_ = FilterMode::OFF;
+	hpfMode_ = FilterMode::OFF;
+	lastHPFMode_ = FilterMode::OFF;
+	routing_ = FilterRoute::HIGH_TO_LOW;
+	LPFOn = false;
+	HPFOn = false;
 }
 } // namespace deluge::dsp::filter

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -59,11 +59,11 @@ public:
 	inline bool isOn() { return HPFOn || LPFOn; }
 
 private:
-	FilterMode lpfMode_;
-	FilterMode lastLPFMode_;
-	FilterMode hpfMode_;
-	FilterMode lastHPFMode_;
-	FilterRoute routing_;
+	FilterMode lpfMode_{FilterMode::OFF};
+	FilterMode lastLPFMode_{FilterMode::OFF};
+	FilterMode hpfMode_{FilterMode::OFF};
+	FilterMode lastHPFMode_{FilterMode::OFF};
+	FilterRoute routing_{FilterRoute::HIGH_TO_LOW};
 
 	void renderLPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement = 1);
 	void renderLPFLongStereo(q31_t* startSample, q31_t* endSample);
@@ -77,7 +77,7 @@ private:
 	LowPass lpfilter;
 	HighPass hpfilter;
 
-	bool LPFOn;
-	bool HPFOn;
+	bool LPFOn{false};
+	bool HPFOn{false};
 };
 } // namespace deluge::dsp::filter

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -64,6 +64,8 @@ private:
 	FilterMode hpfMode_{FilterMode::OFF};
 	FilterMode lastHPFMode_{FilterMode::OFF};
 	FilterRoute routing_{FilterRoute::HIGH_TO_LOW};
+	bool fadeLPFOnNextEnable_{false};
+	bool fadeHPFOnNextEnable_{false};
 
 	void renderLPFLong(q31_t* startSample, q31_t* endSample, int32_t sampleIncrement = 1);
 	void renderLPFLongStereo(q31_t* startSample, q31_t* endSample);


### PR DESCRIPTION
Fixed bug with filter initialization which can affect the auditioning of kit drums

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3474

## Diagnosis

### First fix - initialize values

The repro song has the kick LPF low (0x10000000) and the rim LPF open (0x7FFFFFFF). The suspicious bug was in pooled voice/filter state: Voice objects are reused, and FilterSet::reset() only cleared the ladder/SVF state buffers. It did not reset the filter mode bookkeeping (lastLPFMode_, lastHPFMode_, LPFOn, HPFOn). That means a freshly reset/reused voice could still believe it was already in a prior filter mode and skip part of the cold filter reinitialization path, causing the first render window or two to sound wrong.

### Second fix - note-on reset starts fully wet/filtered, while live off-to-on filter changes can still use the dry fade

Filter::reset(true) is not just “reset filter memory.” It starts a dry-to-wet crossfade:
- dryFade = 1
- wetLevel = 0
- then filterMono/filterStereo blends mostly dry signal for ~500 samples

For a kick, those first ~500 samples are the transient, so it sounds effectively unfiltered.

The first initialization fix made FilterSet::reset() set lastLPFMode_ = OFF every time a voice starts. Then setConfig() saw “LPF was off, now LPF is on” and called lpfilter.ladder.reset(true) on every kick. So the “first bad render” became the consistent sound.

The better diagnosis is: the intermittent bug is likely the kick sometimes inheriting “LPF was OFF” bookkeeping from a recycled voice, especially after auditioning the rim whose LPF is effectively off/open. That triggers the anti-click dry fade on the kick’s first hit.

This fix updates it so the note-on reset starts fully wet/filtered, while live off-to-on filter changes can still use the dry fade

## Before

https://github.com/user-attachments/assets/9be8d394-7c18-4721-9bbc-99ea2bf1808e

## After

https://github.com/user-attachments/assets/68661e64-b01c-4f56-a174-369b18b6ccf3