### PR TITLE
Fix buggy filter initialization

### DIFF
--- a/src/deluge/dsp/filter/filter_set.cpp
+++ b/src/deluge/dsp/filter/filter_set.cpp
@@ -191,8 +191,4 @@ int32_t FilterSet::setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode 
 	return filterGain;
 }
 
-void FilterSet::reset() {
-	memset(&lpfilter, 0, sizeof(LowPass));
-	memset(&hpfilter, 0, sizeof(HighPass));
-}
 } // namespace deluge::dsp::filter

--- a/src/deluge/dsp/filter/filter_set.h
+++ b/src/deluge/dsp/filter/filter_set.h
@@ -43,7 +43,9 @@ union HighPass {
 
 class FilterSet {
 public:
-	void reset();
+	FilterSet() { reset(); }
+	void reset() { memset(this, 0, sizeof(FilterSet)); }
+
 	int32_t setConfig(q31_t lpfFrequency, q31_t lpfResonance, FilterMode lpfmode, q31_t lpfMorph, q31_t hpfFrequency,
 	                  q31_t hpfResonance, FilterMode hpfmode, q31_t hpfMorph, q31_t filterGain, FilterRoute routing,
 	                  bool adjustVolumeForHPFResonance, q31_t* overallOscAmplitude);

--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -172,7 +172,6 @@ bool Voice::noteOn(ModelStackWithSoundFlags* modelStack, int32_t newNoteCodeBefo
 		modulatorAmplitudeLastTime.fill(0);
 		overallOscAmplitudeLastTime = 0;
 		doneFirstRender = false;
-
 		filterSet.reset();
 
 		lastSaturationTanHWorkingValue[0] = 2147483648;


### PR DESCRIPTION
when voices are reused the filter state wasn't reset properly. Fix it by just zeroing the whole filterset to match the initial state of a fresh voice

Fix #3474 