### PR TITLE
Fix glitch at power-on with Looper/Sampler audio clip (#4517)

### DIFF
--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -207,9 +207,10 @@ renderEnvelope:
 	                                     ? std::span{reinterpret_cast<StereoSample*>(bufferToTransferTo), render.size()}
 	                                     : render;
 
-	// add in the monitored audio if in sampler or looper mode
-	if (modeAllowsMonitoring() && modelStack->song->isOutputActiveInArrangement(this)
-	    && inputChannel != AudioInputChannel::SPECIFIC_OUTPUT) {
+	// add in the monitored audio if in sampler or looper mode. Suppress until the codec ADC has settled after
+	// power-on (issue #4517) - otherwise its power-on transient gets passed straight through to the output.
+	if (AudioEngine::inputMonitoringWarmedUp && modeAllowsMonitoring()
+	    && modelStack->song->isOutputActiveInArrangement(this) && inputChannel != AudioInputChannel::SPECIFIC_OUTPUT) {
 		rendered = true;
 		int32_t const* __restrict__ input_ptr = (int32_t const*)AudioEngine::i2sRXBufferPos;
 

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -168,6 +168,9 @@ bool renderInStereo = true;
 bool bypassCulling = false;
 bool audioRoutineLocked = false;
 uint32_t audioSampleTimer = 0;
+bool inputMonitoringWarmedUp = false;
+// ~500ms after power-on for the codec ADC to settle before we start monitoring its input (see inputMonitoringWarmedUp).
+constexpr uint32_t kInputMonitoringWarmupSamples = kSampleRate / 2;
 uint32_t i2sTXBufferPos;
 uint32_t i2sRXBufferPos;
 volatile int voices_started_this_render = 0;
@@ -599,6 +602,11 @@ bool calledFromScheduler = false;
 
 	sideChainHitPending = 0;
 	audioSampleTimer += numSamples;
+
+	// Once the codec has had time to settle after power-on, allow input monitoring. Latches true and stays true.
+	if (!inputMonitoringWarmedUp && audioSampleTimer >= kInputMonitoringWarmupSamples) {
+		inputMonitoringWarmedUp = true;
+	}
 
 	bypassCulling = false;
 }

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -191,6 +191,9 @@ extern bool micPluggedIn;
 extern bool lineInPluggedIn;
 extern bool renderInStereo;
 extern uint32_t audioSampleTimer;
+// Latches true once enough samples have elapsed since power-on for the codec ADC to settle. Until then, input
+// monitoring (Looper/Sampler) is suppressed so the codec's power-on transient isn't passed through to the output.
+extern bool inputMonitoringWarmedUp;
 extern bool mustUpdateReverbParamsBeforeNextRender;
 extern bool bypassCulling;
 extern uint32_t i2sTXBufferPos;


### PR DESCRIPTION
An empty audio clip set to Looper or Sampler monitors the codec input straight to the output. At power-on the codec ADC hasn't settled, so its power-on transient was passed through as a glitch (Player mode never monitors, so it was silent).

Suppress input monitoring until ~500ms after power-on, by which point the codec has settled. A latching AudioEngine::inputMonitoringWarmedUp flag is set once audioSampleTimer (free-running from boot) passes the threshold, gating only the codec-input monitoring branch.

Needs testing with a repro song (see #4517)