### PR TITLE
fix: guard against null activeClip crash when changing audio clip input

### DIFF
--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -143,10 +143,22 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 	case Value::OUTPUT:
 		audioOutput->inputChannel = AudioInputChannel::OUTPUT;
 		break;
-	case Value::TRACK:
+	case Value::TRACK: {
 		audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
-		audioOutput->setOutputRecordingFrom(currentSong->getOutputFromIndex(0));
+		// Default to the first recordable output. Skip MIDI/CV (and ourselves), matching padAction, which rejects
+		// them - recording audio from a non-audio output is meaningless and drives that output's renderOutput.
+		Output* recordFrom = nullptr;
+		for (int32_t i = 0; i < currentSong->getNumOutputs(); i++) {
+			Output* candidate = currentSong->getOutputFromIndex(i);
+			if (candidate != audioOutput && candidate->type != OutputType::MIDI_OUT
+			    && candidate->type != OutputType::CV) {
+				recordFrom = candidate;
+				break;
+			}
+		}
+		audioOutput->setOutputRecordingFrom(recordFrom);
 		break;
+	}
 
 	default:
 		audioOutput->inputChannel = AudioInputChannel::NONE;

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -123,6 +123,11 @@ bool AudioOutput::modeAllowsMonitoring() const {
 		return false;
 	}
 	if (mode == AudioOutputMode::sampler) {
+		// Reachable with a null activeClip via the SPECIFIC_OUTPUT branch, which renders a record-source output
+		// directly and so bypasses the inValidState guard in Song::renderAudio.
+		if (!activeClip) {
+			return false;
+		}
 		auto& activeAudioClip = static_cast<AudioClip&>(*activeClip);
 		return activeAudioClip.isEmpty();
 	}
@@ -260,8 +265,11 @@ renderEnvelope:
 			}
 		}
 	}
+	// Only render the record-source if it has an active clip: Output::renderOutput is documented to be called only
+	// when there's an activeClip, but this branch bypasses the inValidState guard in Song::renderAudio.
 	else if (modeAllowsMonitoring() && modelStack->song->isOutputActiveInArrangement(this)
-	         && inputChannel == AudioInputChannel::SPECIFIC_OUTPUT && (outputRecordingFrom != nullptr)) {
+	         && inputChannel == AudioInputChannel::SPECIFIC_OUTPUT && (outputRecordingFrom != nullptr)
+	         && (outputRecordingFrom->getActiveClip() != nullptr)) {
 		rendered = true;
 		std::byte modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStack* songModelStack = setupModelStackWithSong(modelStackMemory, currentSong);


### PR DESCRIPTION
A recorded audio clip now stays in sampler mode (#4288), and AudioOutput::modeAllowsMonitoring() dereferences activeClip unconditionally for sampler mode. The main render loop skips !inValidState outputs (set together with activeClip=nullptr), but the SPECIFIC_OUTPUT monitoring branch renders its record-source output directly, bypassing that guard, so a detached sampler source can reach the deref and hard-fault.

- modeAllowsMonitoring(): return false when activeClip is null
- SPECIFIC_OUTPUT branch: only render the record-source if it has an active clip
- audio input selector TRACK option: pick the first non-MIDI/non-CV, non-self output instead of index 0, matching padAction's guard