### PR TITLE
fix: don't revoke another audio output's monitoring claim

### DIFF
--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -59,9 +59,7 @@ AudioOutput::AudioOutput() : Output(OutputType::AUDIO) {
 }
 
 AudioOutput::~AudioOutput() {
-	if (outputRecordingFrom) {
-		outputRecordingFrom->setRenderingToAudioOutput(false, nullptr);
-	}
+	releaseMonitoringClaim();
 }
 
 void AudioOutput::cloneFrom(ModControllableAudio* other) {
@@ -88,9 +86,7 @@ void AudioOutput::cloneFrom(ModControllableAudio* other) {
 	if (inputChannel == AudioInputChannel::SPECIFIC_OUTPUT) {
 		outputRecordingFrom = ao->outputRecordingFrom;
 		// now steal the monitoring of the original track if necessary (i.e. we're a looper or sampler)
-		if (mode != AudioOutputMode::player) {
-			outputRecordingFrom->setRenderingToAudioOutput(true, this);
-		}
+		updateMonitoringClaim();
 	}
 }
 

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -110,14 +110,28 @@ public:
 			// can happen from bad save files
 			return;
 		}
-		if (outputRecordingFrom) {
+		releaseMonitoringClaim();
+		outputRecordingFrom = toRecordfrom;
+		updateMonitoringClaim();
+	}
+
+	/// Give up the monitoring duty on outputRecordingFrom, but only if we're the one currently holding it. Several
+	/// AudioOutputs can record from the same output (e.g. an overdub cloned from a sampler), and only the monitoring
+	/// one suppresses that output's own rendering in the song - clearing another's claim would render it twice.
+	void releaseMonitoringClaim() {
+		if (outputRecordingFrom && outputRecordingFrom->getOutputRecordingThis() == this) {
 			outputRecordingFrom->setRenderingToAudioOutput(false, nullptr);
 		}
-		outputRecordingFrom = toRecordfrom;
-		if (outputRecordingFrom) {
-			// If we are a SAMPLER or a LOOPER then we're monitoring the audio, so tell the other output that we're in
-			// charge of rendering
-			outputRecordingFrom->setRenderingToAudioOutput(mode != AudioOutputMode::player, this);
+	}
+
+	/// If we are a SAMPLER or a LOOPER then we're monitoring the audio, so tell the other output that we're in charge
+	/// of rendering.
+	void updateMonitoringClaim() {
+		if (outputRecordingFrom && mode != AudioOutputMode::player) {
+			outputRecordingFrom->setRenderingToAudioOutput(true, this);
+		}
+		else {
+			releaseMonitoringClaim();
 		}
 	}
 
@@ -129,10 +143,8 @@ public:
 		modeInt = (modeInt + offset) % kNumAudioOutputModes;
 
 		mode = static_cast<AudioOutputMode>(std::clamp<int>(modeInt, 0, kNumAudioOutputModes - 1));
-		if (outputRecordingFrom) {
-			// update the output we're recording from on whether we're monitoring
-			outputRecordingFrom->setRenderingToAudioOutput(mode != AudioOutputMode::player, this);
-		}
+		// update the output we're recording from on whether we're monitoring
+		updateMonitoringClaim();
 		renderUIsForOled(); // oled shows the type on the clip screen (including while holding a clip in song view)
 		if (display->have7SEG()) {
 			const char* type;


### PR DESCRIPTION
An AudioOutput monitoring a source output (inputChannel == SPECIFIC_OUTPUT) takes a single-owner claim on it, which suppresses that source's own rendering in Song::renderAudio. Several AudioOutputs can reference the same source though: a layering-loop overdub is cloned from the sampler and copies outputRecordingFrom, but stays a player and so never takes the claim.

The destructor, setOutputRecordingFrom() and scrollAudioOutputMode() all cleared the claim without checking they held it, so deleting the overdub clip revoked the sampler's claim. The source was then rendered both by the song loop and by the sampler, doubling it - audible as distortion.

Route all four sites through releaseMonitoringClaim(), which relinquishes only when this output is the current claimant.

Fixes #4643