### PR TITLE
fix: clear all record-source pointers to an output before deleting it

### DIFF
--- a/src/deluge/model/output.h
+++ b/src/deluge/model/output.h
@@ -222,14 +222,16 @@ public:
 		return false;
 	}
 	Output* getOutputRecordingThis() { return outputRecordingThisOutput; }
+	// only for audio outputs, will be used for instruments when I implement routing notes between clips
+	virtual void clearRecordingFrom() {}
+	/// Which output this one records from, or nullptr. Only audio outputs ever record from another output.
+	virtual Output* getOutputRecordingFrom() { return nullptr; }
 
 protected:
 	virtual Clip* createNewClipForArrangementRecording(ModelStack* modelStack) = 0;
 	bool recorderIsEchoing{false};
 	// for clearing pointers when this output is deleted
 	Output* outputRecordingThisOutput{nullptr};
-	// only for audio outputs, will be used for instruments when I implement routing notes between clips
-	virtual void clearRecordingFrom() {}
 	Clip* activeClip{nullptr};
 	SampleRecorder* recorder{nullptr};
 };

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -297,6 +297,9 @@ void Song::deleteAllOutputs(Output** prevPointer) {
 		Output* toDelete = *prevPointer;
 		*prevPointer = toDelete->next;
 
+		// toDelete is already unlinked, so this only visits outputs that are still alive
+		clearRecordingFromReferencesTo(toDelete);
+
 		void* toDealloc = dynamic_cast<void*>(toDelete);
 		toDelete->~Output();
 		delugeDealloc(toDealloc);
@@ -3548,7 +3551,19 @@ deleteIt:
 	}
 }
 
+// Call before an Output is destructed. Output only remembers the one AudioOutput that monitors it, but any number of
+// AudioOutputs can be recording from it (a cloned overdub copies the pointer without taking over the monitoring), and
+// each of those would be left pointing at freed memory.
+void Song::clearRecordingFromReferencesTo(Output* output) {
+	for (Output* other = firstOutput; other; other = other->next) {
+		if (other != output && other->getOutputRecordingFrom() == output) {
+			other->clearRecordingFrom();
+		}
+	}
+}
+
 void Song::deleteOutput(Output* output) {
+	clearRecordingFromReferencesTo(output);
 	for (int y = 0; y < 8; y++) {
 		auto& m = sessionMacros[y];
 		if (m.kind == OUTPUT_CYCLE && m.output == output) {

--- a/src/deluge/model/song/song.h
+++ b/src/deluge/model/song/song.h
@@ -366,6 +366,7 @@ public:
 	bool hasAnyPendingNextOverdubs();
 	Output* getNextAudioOutput(int32_t offset, Output* oldOutput, Availability availabilityRequirement);
 	void deleteOutput(Output* output);
+	void clearRecordingFromReferencesTo(Output* output);
 	void cullAudioClipVoice();
 	int32_t getYScrollSongViewWithoutPendingOverdubs();
 	int32_t removeOutputFromMainList(Output* output, bool stopAnyAuditioningFirst = true);

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -103,7 +103,7 @@ public:
 
 	AudioOutputMode mode{AudioOutputMode::player};
 
-	Output* getOutputRecordingFrom() { return outputRecordingFrom; }
+	Output* getOutputRecordingFrom() override { return outputRecordingFrom; }
 	void clearRecordingFrom() override { setOutputRecordingFrom(nullptr); }
 	void setOutputRecordingFrom(Output* toRecordfrom) {
 		if (toRecordfrom == this) {


### PR DESCRIPTION
Output tracks only the single AudioOutput that monitors it (outputRecordingThisOutput), and its destructor clears just that one. But any number of AudioOutputs can hold an outputRecordingFrom pointer to it: AudioOutput::cloneFrom copies the pointer to a layering-loop overdub, which stays a player and so never takes over the monitoring.

Deleting the source output therefore left those other AudioOutputs pointing at freed memory, which ~AudioOutput and setOutputRecordingFrom() both dereference.

Walk the output list and clear every reference before the object goes away. Both call sites unlink the output first, so the walk only visits outputs that are still alive.