### PR TITLE
fix: initialize automation status string in OLED automation editor

### DIFF
--- a/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
@@ -280,16 +280,13 @@ void AutomationEditorLayoutModControllable::renderAutomationEditorDisplayOLED(
 		modelStackWithParam = getModelStackWithParamForClip(modelStack, clip);
 	}
 
-	char const* isAutomated;
+	char const* isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_OFF);
 
 	// check if Parameter is currently automated so that the automation status can be drawn on
 	// the screen with the Parameter Name
 	if (modelStackWithParam && modelStackWithParam->autoParam) {
 		if (modelStackWithParam->autoParam->isAutomated()) {
 			isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_ON);
-		}
-		else {
-			isAutomated = l10n::get(l10n::String::STRING_FOR_AUTOMATION_OFF);
 		}
 	}
 


### PR DESCRIPTION
renderAutomationEditorDisplayOLED() left `isAutomated` uninitialized and only assigned it inside `if (modelStackWithParam && ->autoParam)`, then unconditionally passed it to drawStringCentred(). When no auto param exists for the selected parameter, a garbage stack pointer was dereferenced as a string.

Default it to the "automation off" string, which is what a nonexistent param means.