### PR TITLE
Fix zoom animation for out-of-bounds clip area on empty rows

### DIFF
--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -854,10 +854,6 @@ bool AudioClipView::setupScroll(uint32_t oldScroll) {
 	return ClipView::setupScroll(oldScroll);
 }
 
-void AudioClipView::tellMatrixDriverWhichRowsContainSomethingZoomable() {
-	memset(PadLEDs::transitionTakingPlaceOnRow, 1, sizeof(PadLEDs::transitionTakingPlaceOnRow));
-}
-
 uint32_t AudioClipView::getMaxLength() {
 	if (endMarkerVisible) {
 		return getCurrentClip()->loopLength + 1;

--- a/src/deluge/gui/views/audio_clip_view.h
+++ b/src/deluge/gui/views/audio_clip_view.h
@@ -35,7 +35,6 @@ public:
 	bool renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) override;
 	bool setupScroll(uint32_t oldScroll) override;
-	void tellMatrixDriverWhichRowsContainSomethingZoomable() override;
 	[[nodiscard]] bool supportsTriplets() const override { return false; }
 	ClipMinder* toClipMinder() override { return this; }
 

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -7235,13 +7235,6 @@ bool InstrumentClipView::getAffectEntire() {
 	return getCurrentInstrumentClip()->affectEntire;
 }
 
-void InstrumentClipView::tellMatrixDriverWhichRowsContainSomethingZoomable() {
-	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
-		NoteRow* noteRow = getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, currentSong);
-		PadLEDs::transitionTakingPlaceOnRow[yDisplay] = (noteRow && !noteRow->hasNoNotes());
-	}
-}
-
 void InstrumentClipView::notifyPlaybackBegun() {
 	reassessAllAuditionStatus();
 }

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -188,7 +188,6 @@ public:
 	void cancelAllAuditioning();
 	void modEncoderButtonAction(uint8_t whichModEncoder, bool on) override;
 
-	void tellMatrixDriverWhichRowsContainSomethingZoomable() override;
 	void drawDrumName(Drum* drum, bool justPopUp = false);
 	void notifyPlaybackBegun() override;
 	void openedInBackground();

--- a/src/deluge/gui/views/timeline_view.cpp
+++ b/src/deluge/gui/views/timeline_view.cpp
@@ -61,6 +61,10 @@ bool TimelineView::calculateZoomPinSquares(uint32_t oldScroll, uint32_t newScrol
 	return true;
 }
 
+void TimelineView::tellMatrixDriverWhichRowsContainSomethingZoomable() {
+	memset(PadLEDs::transitionTakingPlaceOnRow, 1, sizeof(PadLEDs::transitionTakingPlaceOnRow));
+}
+
 ActionResult TimelineView::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {
 	using namespace deluge::hid::button;
 

--- a/src/deluge/gui/views/timeline_view.h
+++ b/src/deluge/gui/views/timeline_view.h
@@ -39,8 +39,11 @@ public:
 	virtual bool setupScroll(uint32_t oldScroll); // Returns false if no animation needed
 	[[nodiscard]] virtual int32_t getNavSysId() const { return NAVIGATION_CLIP; }
 
-	virtual void tellMatrixDriverWhichRowsContainSomethingZoomable() {
-	} // SessionView doesn't have this because it does this a different way. Sorry, confusing I know
+	// By default, animate every row during a zoom transition. A row that renders identically before and after simply
+	// animates invisibly, so skipping rows is only ever a micro-optimization (e.g. ArrangerView overrides this to skip
+	// empty output rows). SessionView doesn't use this; it does the equivalent a different way, in
+	// calculateZoomPinSquares().
+	virtual void tellMatrixDriverWhichRowsContainSomethingZoomable();
 
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
 	void displayZoomLevel(bool justPopup = false);


### PR DESCRIPTION
Since zoom can now go beyond a clip's length (#1962), every row renders a grey "undefined area" whose boundary moves during a zoom transition. But InstrumentClipView::tellMatrixDriverWhichRowsContainSomethingZoomable only flagged rows with notes for animation, so on note-less rows that grey boundary snapped instead of sliding.

Animating a row that renders identically before and after is invisible, so skipping rows is only ever a micro-optimization. Make "animate every row" the TimelineView base default and drop the now-identical InstrumentClipView and AudioClipView overrides. ArrangerView keeps its override: its empty output rows are solid black with no moving grey boundary, so skipping them is still valid.

Fixes #3363