### PR TITLE
fix: release stuck keyboard-view notes when pads are pressed rapidly

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -296,10 +296,17 @@ bool readButtonsAndPads() {
 
 		// "No presses happening" message
 		else if (value == PIC::Response::NO_PRESSES_HAPPENING) {
-			if (!sdRoutineLock) {
-				matrixDriver.noPressesHappening(sdRoutineLock);
-				Buttons::noPressesHappening(sdRoutineLock);
+			// This is the safety net that releases any pad the firmware still thinks is held (e.g. because a
+			// release event was lost under load). It must not be dropped while the SD routine holds the lock -
+			// otherwise stuck notes persist until the pad is pressed again (see issue #3168). Defer it, exactly
+			// like pad/button events above, so it runs once the routine ends.
+			if (sdRoutineLock) {
+				uartPutCharBack(UART_ITEM_PIC);
+				waitingForSDRoutineToEnd = true;
+				return false;
 			}
+			matrixDriver.noPressesHappening(sdRoutineLock);
+			Buttons::noPressesHappening(sdRoutineLock);
 		}
 		else if (util::to_underlying(value) == oledWaitingForMessage && deluge::hid::display::have_oled_screen) {
 			uiTimerManager.setTimer(TimerName::OLED_LOW_LEVEL, 3);

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -187,7 +187,14 @@ ActionResult KeyboardScreen::padAction(int32_t x, int32_t y, int32_t velocity) {
 		updateActiveNotes();
 	}
 
-	requestRendering();
+	// The main pad grid only changes when the set of active notes changes, but rendering it re-transmits the whole
+	// grid over UART. During rapid pressing that competes with reading incoming pad events; the reporter of #3168
+	// specifically saw redundant redraws (e.g. a second finger on an already-lit note, or lifting one of two
+	// fingers on the same note - both leave the highlight unchanged). Skip the main render for those no-op events,
+	// but always refresh the sidebar since column-control pads can change it. uiNeedsRendering OR-accumulates, so
+	// this can never suppress a render another code path already requested.
+	uint32_t mainRowsToRender = (currentNotesState.states != lastNotesState.states) ? 0xFFFFFFFF : 0;
+	uiNeedsRendering(this, mainRowsToRender, 0xFFFFFFFF);
 	return ActionResult::DEALT_WITH;
 }
 

--- a/src/deluge/gui/ui/keyboard/layout/velocity_drums.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/velocity_drums.cpp
@@ -56,6 +56,13 @@ void KeyboardLayoutVelocityDrums::evaluatePads(PressedPad presses[kMaxNumKeyboar
 		    (velocityFromCoords(x, y, edge_size_x, edge_size_y) >> 1); // uses bitshift to divide by two, to get 0-127
 		// D_PRINTLN("note, velocity: %d, %d", note, velocity);
 		auto note_on_idx = currentNotesState.enableNote(note, velocity);
+		// enableNote returns `count` (>= the number of tracked notes) when the note could not be added - either
+		// the state is full or the note is out of range (e.g. a kit with more drums than kHighestKeyboardNote).
+		// A real add or retrigger always returns an index < count. Guard against the failure sentinels so we
+		// never index note_on_times / currentNotesState.notes past the live entries.
+		if (note_on_idx >= currentNotesState.count) {
+			continue;
+		}
 
 		if ((active_notes & (1 << note_on_idx)) == 0) {
 			active_notes |= 1 << note_on_idx;

--- a/src/deluge/gui/ui/keyboard/notes_state.h
+++ b/src/deluge/gui/ui/keyboard/notes_state.h
@@ -66,7 +66,7 @@ struct NotesState {
 
 	[[nodiscard]] NoteArray::const_iterator begin() const { return notes.begin(); }
 
-	[[nodiscard]] NoteArray::const_iterator end() const { return notes.end() + count; }
+	[[nodiscard]] NoteArray::const_iterator end() const { return notes.begin() + count; }
 
 	NoteArray::size_type enableNote(uint8_t note, uint8_t velocity, bool generatedNote = false,
 	                                int16_t* mpeValues = nullptr) {

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(UnitTests
         chord_tests.cpp
         time_tests.cpp
         clock_output_scheduler_tests.cpp
+        notes_state_tests.cpp
 )
 add_test(NAME UnitTests
         COMMAND UnitTests)

--- a/tests/unit/notes_state_tests.cpp
+++ b/tests/unit/notes_state_tests.cpp
@@ -1,0 +1,54 @@
+#include "CppUTest/TestHarness.h"
+#include "definitions_cxx.hpp"
+#include "gui/ui/keyboard/notes_state.h"
+
+using deluge::gui::ui::keyboard::kHighestKeyboardNote;
+using deluge::gui::ui::keyboard::NotesState;
+
+TEST_GROUP(NotesStateTests){};
+
+// Regression for the const iterator: end() must be begin() + count, not
+// notes.end() + count (which walks far past the array).
+TEST(NotesStateTests, constIterationVisitsExactlyCountNotes) {
+	NotesState state;
+	state.enableNote(10, 64);
+	state.enableNote(20, 64);
+	state.enableNote(30, 64);
+
+	const NotesState& constState = state;
+	size_t visited = 0;
+	for (auto it = constState.begin(); it != constState.end(); ++it) {
+		++visited;
+	}
+	CHECK_EQUAL(3, visited);
+}
+
+TEST(NotesStateTests, enableNoteTruncatesAtMaxWithoutOverflowingIndex) {
+	NotesState state;
+	// Enable one more than the maximum number of simultaneous notes.
+	for (uint8_t note = 0; note < kMaxNumActiveNotes + 1; ++note) {
+		auto idx = state.enableNote(note, 64);
+		// The returned index must always be a valid slot the caller can index,
+		// or equal to count (the documented "not added" sentinel) - never past it.
+		CHECK(idx <= kMaxNumActiveNotes);
+	}
+	CHECK_EQUAL(kMaxNumActiveNotes, state.count);
+	// The overflow note must not have been recorded.
+	CHECK_FALSE(state.noteEnabled(kMaxNumActiveNotes));
+}
+
+TEST(NotesStateTests, enableNoteDedupIncrementsActivationCount) {
+	NotesState state;
+	auto first = state.enableNote(42, 64);
+	auto second = state.enableNote(42, 64);
+	CHECK_EQUAL(first, second);
+	CHECK_EQUAL(1, state.count);
+	CHECK_EQUAL(1, state.notes[first].activationCount);
+}
+
+TEST(NotesStateTests, outOfRangeNoteIsIgnored) {
+	NotesState state;
+	state.enableNote(kHighestKeyboardNote, 64); // out of range, must be ignored
+	CHECK_EQUAL(0, state.count);
+	CHECK_FALSE(state.noteEnabled(kHighestKeyboardNote));
+}


### PR DESCRIPTION
In the keyboard views, rapidly pressing many pads could leave notes stuck on and lock the user out of the view, worst with kits whose samples are loading from the SD card. The firmware tracks pad state in a shadow array (pressedPads) that only clears a note when a matching release event is processed. Under load a release can be lost, and the PIC's NO_PRESSES_HAPPENING recovery signal - which reconciles the shadow state against the pads that are actually held - was silently dropped whenever the SD routine held sdRoutineLock. The stuck note then persisted until the pad was pressed again, and scrolling/zooming re-mapped the phantom-active pads to new notes.

- deluge.cpp: defer NO_PRESSES_HAPPENING during sdRoutineLock (put the byte back, exactly like pad/button events) instead of dropping it, so the release-stuck-pads safety net always runs once the routine ends.
- keyboard_screen.cpp: only re-render/re-transmit the main pad grid when the active-note set actually changes, cutting redundant full-grid UART sends that compete with reading incoming pad events during rapid pressing. The sidebar is still refreshed since column-control pads can change it, and uiNeedsRendering OR-accumulates so this never suppresses another render.
- velocity_drums.cpp: guard against indexing note_on_times / currentNotesState.notes past the live entries when enableNote reports the note could not be added (state full, or out of range for kits with more drums than kHighestKeyboardNote).
- notes_state.h: fix NotesState::end() const, which returned notes.end() + count and walked past the array; covered by new unit tests.