### PR TITLE
fix: bound clip transpose to the playable note range (#2320)

### DIFF
--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -6185,14 +6185,17 @@ ActionResult InstrumentClipView::commandTransposeKey(int32_t offset, bool inCard
 		return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 	}
 
-	actionLogger.deleteAllLogs();
-
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
 	InstrumentClip* clip = getCurrentInstrumentClip();
 	auto nudgeType = Buttons::isShiftButtonPressed() ? VerticalNudgeType::ROW : VerticalNudgeType::OCTAVE;
-	clip->nudgeNotesVertically(offset, nudgeType, modelStack);
+	if (!clip->nudgeNotesVertically(offset, nudgeType, modelStack)) {
+		// Out of range, so nothing changed - leave the undo history alone.
+		return ActionResult::DEALT_WITH;
+	}
+
+	actionLogger.deleteAllLogs(); // Can't undo past this
 
 	recalculateColours();
 	uiNeedsRendering(getRootUI(), 0xFFFFFFFF, 0xFFFFFFFF);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1324,15 +1324,17 @@ void InstrumentClip::transpose(int32_t semitones, ModelStackWithTimelineCounter*
 
 void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType type,
                                           ModelStackWithTimelineCounter* modelStack) {
-	// This method is limited to no more than an octave of "change", currently used
-	// by the "hold and turn vertical encoder" and "shift + hold and turn vertical
-	// encoder" shorcuts.
+	// This method transposes every note row by up to an octave per call, currently
+	// used by the "hold and turn vertical encoder" and "shift + hold and turn
+	// vertical encoder" shortcuts.
 
 	if (!direction) {
 		// It's not clear if we ever get "zero" as direction of change, but let's
 		// make sure we behave sensibly in that case as well.
 		return;
 	}
+
+	int32_t numRows = noteRows.getNumElements();
 
 	int32_t change = direction > 0 ? 1 : -1;
 	if (type == VerticalNudgeType::OCTAVE) {
@@ -1344,73 +1346,71 @@ void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 		}
 	}
 
+	const MusicalKey& key = modelStack->song->key;
+	const bool wholeOctave = std::abs(change) == key.modeNotes.count();
+
+	// Work out the semitone shift a given note row will receive. Every row moves in
+	// the same direction as `change`, so a scale clip stays internally consistent.
+	auto semitoneShiftFor = [&](NoteRow* noteRow) -> int32_t {
+		if (!isScaleModeClip()) {
+			// Non scale clip, transpose directly by semitone (or octave) jumps
+			return change;
+		}
+		if (wholeOctave) {
+			return (change > 0) ? 12 : -12;
+		}
+		// Scale clip changing less than an octave, transpose by scale note jumps
+		int32_t numModeNotes = key.modeNotes.count();
+		int32_t yNoteWithinOctave = key.intervalOf(noteRow->getNoteCode());
+		int32_t oldModeNoteIndex = 0;
+		for (; oldModeNoteIndex < numModeNotes; oldModeNoteIndex++) {
+			if (key.modeNotes[oldModeNoteIndex] == yNoteWithinOctave) {
+				break;
+			}
+		}
+		int32_t newModeNoteIndex = (oldModeNoteIndex + change + numModeNotes) % numModeNotes;
+		int32_t shift = key.modeNotes[newModeNoteIndex] - key.modeNotes[oldModeNoteIndex];
+		if (change > 0 && newModeNoteIndex <= oldModeNoteIndex) {
+			shift += 12; // wrapped up into the next octave
+		}
+		else if (change < 0 && newModeNoteIndex >= oldModeNoteIndex) {
+			shift -= 12; // wrapped down into the previous octave
+		}
+		return shift;
+	};
+
+	// Reject the whole transpose if it would push any note out of the playable range,
+	// matching the limit that vertical scrolling enforces. We scan every row for the
+	// resulting extreme note rather than assuming the top/bottom row stays the
+	// extreme, because a scale clip's out-of-scale rows can shift by uneven amounts.
+	if (numRows > 0) {
+		NoteRow* firstRow = noteRows.getElement(0);
+		int32_t highestNewYNote = firstRow->y + semitoneShiftFor(firstRow);
+		int32_t lowestNewYNote = highestNewYNote;
+		for (int32_t i = 1; i < numRows; i++) {
+			NoteRow* thisNoteRow = noteRows.getElement(i);
+			int32_t newYNote = thisNoteRow->y + semitoneShiftFor(thisNoteRow);
+			if (newYNote > highestNewYNote) {
+				highestNewYNote = newYNote;
+			}
+			if (newYNote < lowestNewYNote) {
+				lowestNewYNote = newYNote;
+			}
+		}
+		int32_t extremeNewYNote = (change > 0) ? highestNewYNote : lowestNewYNote;
+		if (!isScrollWithinRange(change, extremeNewYNote)) {
+			return;
+		}
+	}
+
 	// Make sure no notes sounding
 	stopAllNotesPlaying(modelStack);
 
-	if (!this->isScaleModeClip()) {
-		// Non scale clip, transpose directly by semitone jumps
-		for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
-			NoteRow* thisNoteRow = noteRows.getElement(i);
-			// transpose by semitones or by octave
-			thisNoteRow->y += change;
-		}
+	for (int32_t i = 0; i < numRows; i++) {
+		NoteRow* thisNoteRow = noteRows.getElement(i);
+		thisNoteRow->y += semitoneShiftFor(thisNoteRow);
 	}
-	else {
-		// Scale clip, transpose by scale note jumps
 
-		// wanting to change a full octave
-		if (std::abs(change) == modelStack->song->key.modeNotes.count()) {
-			int32_t changeInSemitones = (change > 0) ? 12 : -12;
-			for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
-				NoteRow* thisNoteRow = noteRows.getElement(i);
-				// transpose by semitones or by octave
-				thisNoteRow->y += changeInSemitones;
-			}
-		}
-
-		// wanting to change less than an octave
-		else {
-			for (int32_t i = 0; i < noteRows.getNumElements(); i++) {
-				MusicalKey key = modelStack->song->key;
-				NoteRow* thisNoteRow = noteRows.getElement(i);
-				int32_t changeInSemitones = 0;
-				int32_t yNoteWithinOctave = key.intervalOf(thisNoteRow->getNoteCode());
-				int32_t oldModeNoteIndex = 0;
-				for (; oldModeNoteIndex < key.modeNotes.count(); oldModeNoteIndex++) {
-					if (key.modeNotes[oldModeNoteIndex] == yNoteWithinOctave) {
-						break;
-					}
-				}
-				int32_t newModeNoteIndex = (oldModeNoteIndex + change + modelStack->song->key.modeNotes.count())
-				                           % modelStack->song->key.modeNotes.count();
-
-				int32_t s = 0;
-				if ((change > 0 && newModeNoteIndex > oldModeNoteIndex)
-				    || (change < 0 && newModeNoteIndex < oldModeNoteIndex)) {
-					// within the same octave
-					changeInSemitones = modelStack->song->key.modeNotes[newModeNoteIndex]
-					                    - modelStack->song->key.modeNotes[oldModeNoteIndex];
-					s = 1;
-				}
-				else {
-					if (change > 0) {
-						// go up an octave
-						changeInSemitones = modelStack->song->key.modeNotes[newModeNoteIndex]
-						                    - modelStack->song->key.modeNotes[oldModeNoteIndex] + 12;
-						s = 2;
-					}
-					else {
-						// go down an octave
-						changeInSemitones = modelStack->song->key.modeNotes[newModeNoteIndex]
-						                    - modelStack->song->key.modeNotes[oldModeNoteIndex] - 12;
-						s = 3;
-					}
-				}
-				// transpose by semitones
-				thisNoteRow->y += changeInSemitones;
-			}
-		}
-	}
 	yScroll += change;
 }
 

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -51,8 +51,10 @@
 #include "processing/engines/cv_engine.h"
 #include "processing/sound/sound_instrument.h"
 #include "storage/storage_manager.h"
+#include "util/const_functions.h"
 #include "util/firmware_version.h"
 #include "util/try.h"
+#include <array>
 #include <cmath>
 #include <new>
 #include <ranges>
@@ -1322,85 +1324,85 @@ void InstrumentClip::transpose(int32_t semitones, ModelStackWithTimelineCounter*
 	colourOffset -= semitones;
 }
 
-void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType type,
+bool InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType type,
                                           ModelStackWithTimelineCounter* modelStack) {
 	// This method transposes every note row by up to an octave per call, currently
 	// used by the "hold and turn vertical encoder" and "shift + hold and turn
-	// vertical encoder" shortcuts.
+	// vertical encoder" shortcuts. Returns false, changing nothing, if the transpose
+	// would push a note out of the playable range.
 
 	if (!direction) {
 		// It's not clear if we ever get "zero" as direction of change, but let's
 		// make sure we behave sensibly in that case as well.
-		return;
+		return false;
+	}
+
+	// A Kit's rows are drums rather than pitches, and isScrollWithinRange() below must
+	// not be called for one.
+	if (output->type == OutputType::KIT) {
+		return false;
 	}
 
 	int32_t numRows = noteRows.getNumElements();
-
-	int32_t change = direction > 0 ? 1 : -1;
-	if (type == VerticalNudgeType::OCTAVE) {
-		if (isScaleModeClip()) {
-			change *= modelStack->song->key.modeNotes.count();
-		}
-		else {
-			change *= 12;
-		}
+	if (!numRows) {
+		return false;
 	}
 
 	const MusicalKey& key = modelStack->song->key;
-	const bool wholeOctave = std::abs(change) == key.modeNotes.count();
+	int32_t numModeNotes = key.modeNotes.count();
 
-	// Work out the semitone shift a given note row will receive. Every row moves in
-	// the same direction as `change`, so a scale clip stays internally consistent.
-	auto semitoneShiftFor = [&](NoteRow* noteRow) -> int32_t {
-		if (!isScaleModeClip()) {
-			// Non scale clip, transpose directly by semitone (or octave) jumps
-			return change;
-		}
-		if (wholeOctave) {
-			return (change > 0) ? 12 : -12;
-		}
+	int32_t change = direction > 0 ? 1 : -1;
+	if (type == VerticalNudgeType::OCTAVE) {
+		change *= isScaleModeClip() ? numModeNotes : 12;
+	}
+
+	// The semitone shift each note row will receive, indexed by the row's interval above
+	// the key's root. Every entry moves in the same direction as `change`, but rows can
+	// move by differing amounts, since scale degrees are unevenly spaced.
+	std::array<int32_t, 12> shiftForInterval;
+
+	if (!isScaleModeClip() || std::abs(change) == numModeNotes) {
+		// Non scale clip (semitone or octave jumps), or a scale clip moving a whole
+		// octave: every row moves by the same fixed amount.
+		shiftForInterval.fill(isScaleModeClip() ? ((change > 0) ? 12 : -12) : change);
+	}
+	else {
 		// Scale clip changing less than an octave, transpose by scale note jumps
-		int32_t numModeNotes = key.modeNotes.count();
-		int32_t yNoteWithinOctave = key.intervalOf(noteRow->getNoteCode());
-		int32_t oldModeNoteIndex = 0;
-		for (; oldModeNoteIndex < numModeNotes; oldModeNoteIndex++) {
-			if (key.modeNotes[oldModeNoteIndex] == yNoteWithinOctave) {
-				break;
+		for (int32_t interval = 0; interval < 12; interval++) {
+			int32_t degree = key.modeNotes.degreeOf(interval);
+			int32_t newDegree;
+			if (degree >= 0) {
+				newDegree = degree + change;
 			}
+			else {
+				// Out of scale, so it sits between two degrees: land it on the
+				// neighbouring degree in the direction we're travelling.
+				int32_t degreesBelow = key.modeNotes.degreesBelow(interval);
+				newDegree = (change > 0) ? degreesBelow + change - 1 : degreesBelow + change;
+			}
+			// A degree outside the scale's bounds wraps into the octave above or below.
+			int32_t wrappedDegree = mod(newDegree, numModeNotes);
+			int32_t octaves = (newDegree - wrappedDegree) / numModeNotes;
+			shiftForInterval[interval] = key.modeNotes[wrappedDegree] + 12 * octaves - interval;
 		}
-		int32_t newModeNoteIndex = (oldModeNoteIndex + change + numModeNotes) % numModeNotes;
-		int32_t shift = key.modeNotes[newModeNoteIndex] - key.modeNotes[oldModeNoteIndex];
-		if (change > 0 && newModeNoteIndex <= oldModeNoteIndex) {
-			shift += 12; // wrapped up into the next octave
-		}
-		else if (change < 0 && newModeNoteIndex >= oldModeNoteIndex) {
-			shift -= 12; // wrapped down into the previous octave
-		}
-		return shift;
-	};
+	}
+
+	auto shiftFor = [&](NoteRow* noteRow) { return shiftForInterval[key.intervalOf(noteRow->getNoteCode())]; };
 
 	// Reject the whole transpose if it would push any note out of the playable range,
 	// matching the limit that vertical scrolling enforces. We scan every row for the
-	// resulting extreme note rather than assuming the top/bottom row stays the
-	// extreme, because a scale clip's out-of-scale rows can shift by uneven amounts.
-	if (numRows > 0) {
-		NoteRow* firstRow = noteRows.getElement(0);
-		int32_t highestNewYNote = firstRow->y + semitoneShiftFor(firstRow);
-		int32_t lowestNewYNote = highestNewYNote;
-		for (int32_t i = 1; i < numRows; i++) {
-			NoteRow* thisNoteRow = noteRows.getElement(i);
-			int32_t newYNote = thisNoteRow->y + semitoneShiftFor(thisNoteRow);
-			if (newYNote > highestNewYNote) {
-				highestNewYNote = newYNote;
-			}
-			if (newYNote < lowestNewYNote) {
-				lowestNewYNote = newYNote;
-			}
+	// resulting extreme note rather than assuming the top/bottom row stays the extreme,
+	// because rows can shift by differing amounts.
+	int32_t extremeNewYNote = 0;
+	for (int32_t i = 0; i < numRows; i++) {
+		NoteRow* thisNoteRow = noteRows.getElement(i);
+		int32_t newYNote = thisNoteRow->y + shiftFor(thisNoteRow);
+		if (i == 0 || (change > 0 ? newYNote > extremeNewYNote : newYNote < extremeNewYNote)) {
+			extremeNewYNote = newYNote;
 		}
-		int32_t extremeNewYNote = (change > 0) ? highestNewYNote : lowestNewYNote;
-		if (!isScrollWithinRange(change, extremeNewYNote)) {
-			return;
-		}
+	}
+	if (!isScrollWithinRange(change, extremeNewYNote)) {
+		return false;
 	}
 
 	// Make sure no notes sounding
@@ -1408,10 +1410,11 @@ void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 
 	for (int32_t i = 0; i < numRows; i++) {
 		NoteRow* thisNoteRow = noteRows.getElement(i);
-		thisNoteRow->y += semitoneShiftFor(thisNoteRow);
+		thisNoteRow->y += shiftFor(thisNoteRow);
 	}
 
 	yScroll += change;
+	return true;
 }
 
 // Lock rendering before calling this!

--- a/src/deluge/model/clip/instrument_clip.h
+++ b/src/deluge/model/clip/instrument_clip.h
@@ -69,7 +69,8 @@ public:
 	void replaceMusicalMode(const ScaleChange& changes, ModelStackWithTimelineCounter* modelStack);
 	void seeWhatNotesWithinOctaveArePresent(NoteSet&, MusicalKey);
 	void transpose(int32_t, ModelStackWithTimelineCounter* modelStack);
-	void nudgeNotesVertically(int32_t direction, VerticalNudgeType, ModelStackWithTimelineCounter* modelStack);
+	/// Returns false, changing nothing, if the transpose would leave the playable note range.
+	bool nudgeNotesVertically(int32_t direction, VerticalNudgeType, ModelStackWithTimelineCounter* modelStack);
 	void expectNoFurtherTicks(Song* song, bool actuallySoundChange = true) override;
 	Error clone(ModelStackWithTimelineCounter* modelStack, bool shouldFlattenReversing = false) const override;
 	NoteRow* createNewNoteRowForYVisual(int32_t, Song* song);

--- a/src/deluge/model/scale/note_set.cpp
+++ b/src/deluge/model/scale/note_set.cpp
@@ -50,13 +50,17 @@ int8_t NoteSet::highestNotIn(NoteSet other) const {
 	return -1;
 }
 
+int8_t NoteSet::degreesBelow(uint8_t note) const {
+	// Mask everything before the note
+	uint16_t mask = ~(0xffff << note);
+	// How many notes under mask?
+	uint16_t under = bits & mask;
+	return std::popcount(under);
+}
+
 int8_t NoteSet::degreeOf(uint8_t note) const {
 	if (has(note)) {
-		// Mask everything before the note
-		uint16_t mask = ~(0xffff << note);
-		// How many notes under mask?
-		uint16_t under = bits & mask;
-		return std::popcount(under);
+		return degreesBelow(note);
 	}
 	else {
 		return -1;

--- a/src/deluge/model/scale/note_set.h
+++ b/src/deluge/model/scale/note_set.h
@@ -52,6 +52,12 @@ public:
 	 * This is the scale degree of the note if the NoteSet represents a scale and has a root.
 	 */
 	int8_t degreeOf(uint8_t note) const;
+	/** Returns number of notes lower than the note given, whether or not it is present.
+	 *
+	 * Unlike degreeOf(), a note absent from the NoteSet gets the index it would occupy
+	 * if it were added -- ie. the degree of the note immediately above it.
+	 */
+	int8_t degreesBelow(uint8_t note) const;
 	/** Marks all semitones as being part of the NoteSet.
 	 */
 	void fill() { bits = 0xfff; }


### PR DESCRIPTION
nudgeNotesVertically() (the "hold and turn vertical encoder" clip transpose) added the offset to every note row's y with no bounds checking. Each step was capped at an octave, but nothing limited the accumulated value, so repeated transposes pushed note codes arbitrarily far outside the valid 0-127 MIDI range. That produced garbage octave displays (noteCodeToString computes octave = noteCode/12 - 2 on the unclamped code), out-of-range voice pitch (super-slow to warbling audio), and a corrupted, sticky display state.

Reject the whole transpose when it would push any note out of range, reusing isScrollWithinRange so transpose and vertical scrolling now enforce identical, output-type-aware limits (synth osc transpose, CV voltage, MIDI). Every row's resulting note is scanned for the extreme rather than assuming the top/bottom row stays the extreme, so a scale clip's out-of-scale rows (which shift by uneven amounts) can't slip past the check.

The three transpose branches are folded into one semitoneShiftFor helper so the range check and the applied shift can't diverge.