### PR TITLE
fix building on macos with current clang

### DIFF
--- a/src/definitions.h
+++ b/src/definitions.h
@@ -76,8 +76,15 @@ extern void freezeWithError(char const* errmsg);
 // Paul: It seems this area is not executable, could not find a reason in the datasheet, marked NOLOAD now
 #define PLACE_INTERNAL_FRUNK __attribute__((__section__(".frunk_bss")))
 
+#ifndef IN_UNIT_TESTS
 #define PLACE_SDRAM_BSS __attribute__((__section__(".sdram_bss")))
 #define PLACE_SDRAM_DATA __attribute__((__section__(".sdram_data")))
 #define PLACE_SDRAM_RODATA __attribute__((__section__(".sdram_rodata")))
 // #define PLACE_SDRAM_TEXT __attribute__((__section__(".sdram_text"))) // Paul: I had problems with execution from
 // SDRAM, maybe timing?
+#else
+#define PLACE_SDRAM_BSS
+#define PLACE_SDRAM_DATA
+#define PLACE_SDRAM_RODATA
+#define PLACE_SDRAM_TEXT
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DELUGE_C_STANDARD 23)
 set(DELUGE_CXX_STANDARD 23)
 
 enable_testing()
+add_compile_options(-Wno-unknown-warning-option)
 #needs to support -m32 since the memory tests assume a 32 bit architecture
 if (UNIX AND NOT APPLE)
     add_compile_options(-m32 -Og -ggdb3)


### PR DESCRIPTION
turn off warn unknown warnings and guard macros