### PR TITLE
Fix misaligned audio clips when threshold recording is on

### DIFF
--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -139,7 +139,7 @@ bool AudioRecorder::setupRecordingToFile(AudioInputChannel newMode, int32_t newN
 	}
 
 	recorder = AudioEngine::getNewRecorder(newNumChannels, folderID, newMode, false, writeLoopPoints,
-	                                       kInternalButtonPressLatency, false, nullptr);
+	                                       kInternalButtonPressLatency, false, nullptr, {false});
 	if (!recorder) {
 		display->displayError(Error::INSUFFICIENT_RAM);
 		return false;

--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -172,9 +172,14 @@ Error AudioClip::beginLinearRecording(ModelStackWithTimelineCounter* modelStack,
 	}
 	bool shouldRecordMarginsNow =
 	    FlashStorage::audioClipRecordMargins && inputChannel < AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION;
+	// unless we're doing a tempoless recording we want to ignore the threshold setting
+	bool tempoless_recording =
+	    currentPlaybackMode->wantsToDoTempolessRecord(modelStack->getTimelineCounter()->getLastProcessedPos());
 
+	// recorder needs more config settings
 	recorder = AudioEngine::getNewRecorder(numChannels, AudioRecordingFolder::CLIPS, inputChannel, true,
-	                                       shouldRecordMarginsNow, buttonPressLatency, false, outputRecordingFrom);
+	                                       shouldRecordMarginsNow, buttonPressLatency, false, outputRecordingFrom,
+	                                       {.neverUseThreshold = not tempoless_recording});
 	if (!recorder) {
 		return Error::INSUFFICIENT_RAM;
 	}

--- a/src/deluge/model/sample/sample_recorder.cpp
+++ b/src/deluge/model/sample/sample_recorder.cpp
@@ -108,9 +108,10 @@ void SampleRecorder::detachSample() {
 	sample->removeReason("E400");
 }
 
+// config stuff
 Error SampleRecorder::setup(int32_t newNumChannels, AudioInputChannel newMode, bool newKeepingReasons,
                             bool shouldRecordExtraMargins, AudioRecordingFolder newFolderID, int32_t buttonPressLatency,
-                            Output* outputRecordingFrom_) {
+                            Output* outputRecordingFrom_, RecorderConfig config) {
 
 	outputRecordingFrom = outputRecordingFrom_;
 	keepingReasonsForFirstClusters = newKeepingReasons;
@@ -243,7 +244,7 @@ gotError:
 	int32_t lengthSamples = lengthSec * sample->sampleRate;
 	audioDataLengthBytesAsWrittenToFile = lengthSamples * 3 * recordingNumChannels;
 
-	setRecordingThreshold();
+	setRecordingThreshold(config);
 
 	// Riff chunk -------------------------------------------------------
 	writeInt32(&writePos, 0x46464952);                                                               // "RIFF"
@@ -293,9 +294,15 @@ gotError:
 	return Error::NONE;
 }
 
-void SampleRecorder::setRecordingThreshold() {
+void SampleRecorder::setRecordingThreshold(RecorderConfig config) {
+	if (config.neverUseThreshold) {
+		D_PRINTLN("ignoring threshold");
+	}
+	else {
+		D_PRINTLN("following settings");
+	}
 	// don't use threshold recording if we're resampling internal input
-	if (currentSong->thresholdRecordingMode == ThresholdRecordingMode::OFF
+	if (config.neverUseThreshold || currentSong->thresholdRecordingMode == ThresholdRecordingMode::OFF
 	    || mode >= AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION) {
 		startValueThreshold = 0;
 		thresholdRecording = false;

--- a/src/deluge/model/sample/sample_recorder.h
+++ b/src/deluge/model/sample/sample_recorder.h
@@ -46,14 +46,18 @@ class Sample;
 class Cluster;
 class AudioClip;
 class Output;
+struct RecorderConfig {
+	bool neverUseThreshold = false;
+};
+
 class SampleRecorder {
 public:
 	SampleRecorder() = default;
 	~SampleRecorder();
 	Error setup(int32_t newNumChannels, AudioInputChannel newMode, bool newKeepingReasons,
 	            bool shouldRecordExtraMargins, AudioRecordingFolder newFolderID, int32_t buttonPressLatency,
-	            Output* outputRecordingFrom);
-	void setRecordingThreshold();
+	            Output* outputRecordingFrom, RecorderConfig config = {});
+	void setRecordingThreshold(RecorderConfig config);
 	void feedAudio(std::span<StereoSample> input, bool applyGain = false, uint8_t gainToApply = 5);
 	Error cardRoutine();
 	void endSyncedRecording(int32_t buttonLatencyForTempolessRecording);

--- a/src/deluge/playback/mode/session.h
+++ b/src/deluge/playback/mode/session.h
@@ -93,6 +93,7 @@ public:
 	int32_t getPosAtWhichClipWillCut(ModelStackWithTimelineCounter const* modelStack) override;
 	bool willClipContinuePlayingAtEnd(ModelStackWithTimelineCounter const* modelStack) override;
 	bool willClipLoopAtSomePoint(ModelStackWithTimelineCounter const* modelStack) override;
+	// this is probably the only time we want an audio clip to use threshold sampling?
 	bool wantsToDoTempolessRecord(int32_t newPos) override;
 
 	uint8_t lastSectionArmed; // 255 means none. 254 means the action was switch-off-all-sections

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -2695,7 +2695,7 @@ void PlaybackHandler::finishTempolessRecording(bool shouldStartPlaybackAgain, in
 				if (!sampleHolder->audioFile) {
 					continue; // Could maybe happen if some error?
 				}
-
+				// todo: adjust for threshold recording
 				foundAnyYet = true;
 				uint64_t loopLengthSamples = sampleHolder->getDurationInSamples(true);
 				action = actionLogger.getNewAction(ActionType::RECORD, ActionAddition::ALLOWED);

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1513,9 +1513,10 @@ void slowRoutine() {
 	doRecorderCardRoutines();
 }
 
+// will need to take in the config argument
 SampleRecorder* getNewRecorder(int32_t numChannels, AudioRecordingFolder folderID, AudioInputChannel mode,
                                bool keepFirstReasons, bool writeLoopPoints, int32_t buttonPressLatency,
-                               bool shouldNormalize, Output* outputRecordingFrom) {
+                               bool shouldNormalize, Output* outputRecordingFrom, RecorderConfig config) {
 	Error error;
 
 	void* recorderMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(SampleRecorder));
@@ -1524,9 +1525,8 @@ SampleRecorder* getNewRecorder(int32_t numChannels, AudioRecordingFolder folderI
 	}
 
 	SampleRecorder* newRecorder = new (recorderMemory) SampleRecorder();
-
 	error = newRecorder->setup(numChannels, mode, keepFirstReasons, writeLoopPoints, folderID, buttonPressLatency,
-	                           outputRecordingFrom);
+	                           outputRecordingFrom, config);
 	if (error != Error::NONE) {
 errorAfterAllocation:
 		newRecorder->~SampleRecorder();

--- a/src/deluge/processing/engines/audio_engine.h
+++ b/src/deluge/processing/engines/audio_engine.h
@@ -170,7 +170,7 @@ void registerSideChainHit(int32_t strength);
 
 SampleRecorder* getNewRecorder(int32_t numChannels, AudioRecordingFolder folderID, AudioInputChannel mode,
                                bool keepFirstReasons, bool writeLoopPoints, int32_t buttonPressLatency,
-                               bool shouldNormalize, Output* outputRecordingFrom);
+                               bool shouldNormalize, Output* outputRecordingFrom, RecorderConfig config = {});
 void discardRecorder(SampleRecorder* recorder);
 bool isAnyInternalRecordingHappening();
 


### PR DESCRIPTION
need to follow up with some tweaks for tempoless recording but this is the 90% solution.  The problem with tempoless is the windows tend to be really small so audio is started too late, we really want 50-100 samples before hitting the threshold to be recorded and at low load we get like 10. 

My plan for that is recording everything and then adding markers to the file instead of actually cutting out the recorded audio 