### PR TITLE
fix: un-dim all columns as a clip auto-extends while recording (#1047)

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -929,6 +929,13 @@ bool AutomationView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth
 	}
 }
 
+void AutomationView::clipNeedsReRendering(Clip* clip) {
+	// When on the arranger's automation, we're not displaying a Clip at all.
+	if (!onArrangerView && clip == getCurrentClip()) {
+		uiNeedsRendering(this);
+	}
+}
+
 /*render's what is displayed on OLED or 7SEG screens when in Automation View
 
 On Automation Overview:

--- a/src/deluge/gui/views/automation_view.h
+++ b/src/deluge/gui/views/automation_view.h
@@ -84,6 +84,7 @@ public:
 	                         TimelineView* timelineView, bool tripletsOnHere, int32_t xDisplay);
 	bool renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth + kSideBarWidth],
 	                   uint8_t occupancyMask[][kDisplayWidth + kSideBarWidth]) override;
+	void clipNeedsReRendering(Clip* clip) override;
 	void renderDisplay(int32_t knobPosLeft = kNoSelection, int32_t knobPosRight = kNoSelection,
 	                   bool modEncoderAction = false);
 	void displayAutomation(bool padSelected = false, bool updateDisplay = true);

--- a/src/deluge/model/clip/clip.cpp
+++ b/src/deluge/model/clip/clip.cpp
@@ -17,8 +17,9 @@
 
 #include "model/clip/clip.h"
 #include "definitions_cxx.hpp"
+#include "gui/ui/root_ui.h"
+#include "gui/ui/ui.h"
 #include "gui/views/automation_view.h"
-#include "gui/views/session_view.h"
 #include "gui/views/view.h"
 #include "io/debug/log.h"
 #include "memory/general_memory_allocator.h"
@@ -819,7 +820,12 @@ void Clip::posReachedEnd(ModelStackWithTimelineCounter* modelStack) {
 
 			loopLength += originalLength;
 
-			sessionView.clipNeedsReRendering(this);
+			// Whichever view is showing this Clip needs to re-render, not just SessionView - e.g. in a clip view, the
+			// area drawn as being past the end of the Clip just shrank.
+			RootUI* rootUI = getRootUI();
+			if (rootUI) {
+				rootUI->clipNeedsReRendering(this);
+			}
 
 			// For InstrumentClips only, we record and make undoable the length-change here. For AudioClips, on the
 			// other hand, it happens in one go at the end of the recording - because for those, if recording is aborted


### PR DESCRIPTION
While linearly recording, Clip::posReachedEnd() auto-extends the Clip and then asked SessionView to re-render. uiNeedsRendering() only marks rows dirty for a UI that's in the open navigation hierarchy, and entering a Clip swaps the root UI, so that call did nothing while in a clip view.

The only rows that got redrawn were the ones receiving recorded notes, and since the past-the-end "undefined area" is drawn per row from the Clip's current length, only those rows un-dimmed. Everything else caught up at the end of recording, when finishLinearRecording() does a full re-render.

Notify the actual root UI instead, as finishLinearRecording() already does. This is a no-op change when SessionView is the root UI.

AutomationView draws the same undefined area but never overrode clipNeedsReRendering(), so it had the same bug - and stayed stale even after recording ended. Give it the override, guarded on !onArrangerView since it isn't showing a Clip in that mode.