### PR TITLE
Fix sidebar transition animations

### DIFF
--- a/src/deluge/gui/colour/rgb.h
+++ b/src/deluge/gui/colour/rgb.h
@@ -174,11 +174,11 @@ public:
 	 *
 	 * @param sourceA The first colour
 	 * @param sourceB The second colour
-	 * @param indexA The blend amount for sourceA
-	 * @param indexB The blend amount for sourceB
+	 * @param indexA The blend amount for sourceA, out of 65536
+	 * @param indexB The blend amount for sourceB, out of 65536
 	 * @return RGB The new blended colour
 	 */
-	[[nodiscard]] static constexpr RGB blend2(RGB sourceA, RGB sourceB, uint16_t indexA, uint16_t indexB) {
+	[[nodiscard]] static constexpr RGB blend2(RGB sourceA, RGB sourceB, uint32_t indexA, uint32_t indexB) {
 		return transform2(sourceA, sourceB, [indexA, indexB](channel_type channelA, channel_type channelB) {
 			return blendChannel2(channelA, channelB, indexA, indexB);
 		});
@@ -307,15 +307,19 @@ private:
 	 * @return The blended channel value
 	 */
 	static constexpr channel_type blendChannel(uint32_t channelA, uint32_t channelB, uint16_t index) {
-		return blendChannel2(channelA, channelB, index, (std::numeric_limits<uint16_t>::max() - index + 1));
+		return blendChannel2(channelA, channelB, index, 65536 - index);
 	}
 
 	/**
 	 * @brief Blend two channels in differing proportions
+	 *
+	 * Weights are out of 65536, so a full weight does not fit a uint16_t: keep these parameters wide. Truncating
+	 * them silently turns "keep all of this channel" into "keep none of it" and produces black.
+	 *
 	 * @return The blended channel value
 	 */
-	static constexpr channel_type blendChannel2(uint32_t channelA, uint32_t channelB, uint16_t indexA,
-	                                            uint16_t indexB) {
+	static constexpr channel_type blendChannel2(uint32_t channelA, uint32_t channelB, uint32_t indexA,
+	                                            uint32_t indexB) {
 		uint32_t newRGB = rshift_round(channelA * indexA, 16) + rshift_round(channelB * indexB, 16);
 		return std::clamp<uint32_t>(newRGB, 0, channel_max);
 	}

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -833,12 +833,8 @@ bool KeyboardScreen::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth
 	layout_list[getCurrentInstrumentClip()->keyboardState.currentLayout]->renderSidebarPads(image);
 
 	if (occupancyMask) {
-		// Keyboard sidebars may contain black / empty pads. Marking those as empty keeps transition blends from
-		// pulling stale sidebar colours into the animation.
 		for (int32_t y = 0; y < kDisplayHeight; y++) {
-			for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
-				occupancyMask[y][x] = (image[y][x] == colours::black) ? 0 : 64;
-			}
+			PadLEDs::refreshSidebarOccupancy(image[y], occupancyMask[y]);
 		}
 	}
 

--- a/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
+++ b/src/deluge/gui/ui/keyboard/keyboard_screen.cpp
@@ -832,6 +832,16 @@ bool KeyboardScreen::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth
 
 	layout_list[getCurrentInstrumentClip()->keyboardState.currentLayout]->renderSidebarPads(image);
 
+	if (occupancyMask) {
+		// Keyboard sidebars may contain black / empty pads. Marking those as empty keeps transition blends from
+		// pulling stale sidebar colours into the animation.
+		for (int32_t y = 0; y < kDisplayHeight; y++) {
+			for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
+				occupancyMask[y][x] = (image[y][x] == colours::black) ? 0 : 64;
+			}
+		}
+	}
+
 	return true;
 }
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1840,6 +1840,8 @@ void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 
 		if (clip->type == ClipType::INSTRUMENT) {
 			instrumentClipView.recalculateColours();
+			// Automation view reuses instrument clip offscreen rows during explode animations.
+			instrumentClipView.fillOffScreenImageStores();
 		}
 
 		automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);
@@ -1949,7 +1951,9 @@ bool ArrangerView::transitionToArrangementEditor() {
 
 	memcpy(PadLEDs::imageStore[1], PadLEDs::image, (kDisplayWidth + kSideBarWidth) * kDisplayHeight * sizeof(RGB));
 	memcpy(PadLEDs::occupancyMaskStore[1], PadLEDs::occupancyMask, (kDisplayWidth + kSideBarWidth) * kDisplayHeight);
-	if (getCurrentUI() == &instrumentClipView) {
+	// Both instrument and automation views need the offscreen instrument rows for a complete collapse into Arranger.
+	if (getCurrentClip()->type == ClipType::INSTRUMENT
+	    && (getCurrentUI() == &instrumentClipView || getCurrentUI() == &automationView)) {
 		instrumentClipView.fillOffScreenImageStores();
 	}
 

--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1843,6 +1843,9 @@ void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 			// Automation view reuses instrument clip offscreen rows during explode animations.
 			instrumentClipView.fillOffScreenImageStores();
 		}
+		else {
+			PadLEDs::clearTransitionStoreOffScreenRows();
+		}
 
 		automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);
 	}

--- a/src/deluge/gui/views/audio_clip_view.cpp
+++ b/src/deluge/gui/views/audio_clip_view.cpp
@@ -251,6 +251,10 @@ bool AudioClipView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayWidth 
 		if (isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
 			armed |= view.renderMacros(macroColumn, y, -1, image, occupancyMask);
 		}
+
+		if (occupancyMask) {
+			PadLEDs::refreshSidebarOccupancy(image[y], occupancyMask[y]);
+		}
 	}
 	if (armed) {
 		view.flashPlayEnable();

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -165,6 +165,8 @@ void InstrumentClipView::focusRegained() {
 	ClipView::focusRegained();
 
 	auditioningSilently = false; // Necessary?
+	// The Session button release that would normally clear this can be missed if the view changed while it was held.
+	sessionMacroSidebarActive = false;
 
 	InstrumentClipMinder::focusRegained();
 
@@ -261,39 +263,33 @@ ActionResult InstrumentClipView::buttonAction(deluge::hid::Button b, bool on, bo
 	else if (b == SESSION_VIEW) {
 		if (on) {
 			if (currentUIMode == UI_MODE_NONE) {
+				currentUIMode = UI_MODE_HOLDING_SONG_BUTTON;
 				timeSongButtonPressed = AudioEngine::audioSampleTimer;
-				// Defer showing the macro sidebar until the long-press threshold. A short press can then transition
-				// straight to Session without flashing macro colours into the sidebar first.
-				sessionButtonPressPending = true;
+				// The macro sidebar colours are only drawn once the press passes the long-press threshold, so a short
+				// press can transition straight to Session without flashing them. Macro pad presses still work
+				// immediately, as they always have.
 				sessionMacroSidebarActive = false;
 				indicator_leds::setLedState(IndicatorLED::SESSION_VIEW, true);
 				uiTimerManager.setTimerSamples(TimerName::UI_SPECIFIC, kShortPressTime);
 			}
 		}
 		else {
-			if (!sessionButtonPressPending && !isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
+			if (!isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
 				return ActionResult::DEALT_WITH;
 			}
 			uiTimerManager.unsetTimer(TimerName::UI_SPECIFIC);
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
+			exitUIMode(UI_MODE_HOLDING_SONG_BUTTON);
 
-			// If the timer already promoted the press, or the release arrives after the threshold, consume it as a
-			// macro-sidebar press instead of transitioning to Session.
-			bool macroPress =
-			    sessionMacroSidebarActive
-			    || ((int32_t)(AudioEngine::audioSampleTimer - timeSongButtonPressed) >= (int32_t)kShortPressTime);
-
-			sessionButtonPressPending = false;
+			bool sidebarNeedsClearing = sessionMacroSidebarActive;
 			sessionMacroSidebarActive = false;
 
-			if (isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
-				exitUIMode(UI_MODE_HOLDING_SONG_BUTTON);
-			}
-
-			if (macroPress) {
-				uiNeedsRendering(this, 0, 0xFFFFFFFF);
+			if ((int32_t)(AudioEngine::audioSampleTimer - timeSongButtonPressed) >= (int32_t)kShortPressTime) {
+				if (sidebarNeedsClearing) {
+					uiNeedsRendering(this, 0, 0xFFFFFFFF);
+				}
 				indicator_leds::setLedState(IndicatorLED::SESSION_VIEW, false);
 				return ActionResult::DEALT_WITH;
 			}
@@ -871,10 +867,9 @@ passToOthers:
 ActionResult InstrumentClipView::timerCallback() {
 	using namespace deluge::hid::button;
 
-	// Promote a pending Session button press into macro-sidebar mode only after it is still held long enough.
-	if (sessionButtonPressPending && currentUIMode == UI_MODE_NONE && Buttons::isButtonPressed(SESSION_VIEW)
-	    && (int32_t)(AudioEngine::audioSampleTimer - timeSongButtonPressed) >= (int32_t)kShortPressTime) {
-		currentUIMode = UI_MODE_HOLDING_SONG_BUTTON;
+	// Reveal the macro sidebar only once the Session button has been held past the long-press threshold.
+	if (isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON) && !sessionMacroSidebarActive
+	    && Buttons::isButtonPressed(SESSION_VIEW)) {
 		sessionMacroSidebarActive = true;
 		uiNeedsRendering(this, 0, 0xFFFFFFFF);
 	}
@@ -1924,8 +1919,7 @@ doRegularEditPadActionProbably:
 		if (currentUIMode == UI_MODE_MIDI_LEARN) [[unlikely]] {
 			return commandLearnMutePad(y, velocity);
 		}
-		else if (sessionMacroSidebarActive) {
-			// The macro sidebar is now explicit state rather than any held Session button mode.
+		else if (isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
 			return commandActivateSongMacro(y, velocity);
 		}
 		else if (getCurrentOutputType() == OutputType::KIT && lastAuditionedYDisplay == y
@@ -5936,10 +5930,7 @@ bool InstrumentClipView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayW
 			}
 			drawAuditionSquare(i, image[i]);
 
-			// Sidebar cells that render black should not participate in transition blending.
-			for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
-				occupancyMask[i][x] = (image[i][x] == colours::black) ? 0 : 64;
-			}
+			PadLEDs::refreshSidebarOccupancy(image[i], occupancyMask[i]);
 		}
 	}
 	if (armed) {
@@ -5957,7 +5948,6 @@ void InstrumentClipView::drawMuteSquare(NoteRow* thisNoteRow, RGB thisImage[], u
 	if (view.midiLearnFlashOn && thisNoteRow && thisNoteRow->drum
 	    && thisNoteRow->drum->muteMIDICommand.containsSomething()) {
 		thisColour = colours::midi_command;
-		*thisOccupancy = 64;
 	}
 
 	else if (thisNoteRow == nullptr || !thisNoteRow->muted) {
@@ -5970,14 +5960,12 @@ void InstrumentClipView::drawMuteSquare(NoteRow* thisNoteRow, RGB thisImage[], u
 	}
 	else {
 		thisColour = menu_item::mutedColourMenu.getRGB();
-		*thisOccupancy = 64;
 	}
 
 	// If user assigning MIDI controls and has this Clip selected, flash to half brightness
 	if (view.midiLearnFlashOn && thisNoteRow != nullptr && view.thingPressedForMidiLearn == MidiLearn::NOTEROW_MUTE
 	    && thisNoteRow->drum && &thisNoteRow->drum->muteMIDICommand == view.learnedThing) {
 		thisColour = thisColour.dim();
-		*thisOccupancy = 64;
 	}
 
 	// Keep the occupancy mask in sync with the final colour, including kit rows with no note row.
@@ -7196,62 +7184,44 @@ void InstrumentClipView::fillOffScreenImageStores() {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
-	// Use the active timeline editor so automation and note views render offscreen rows with the same context.
-	TimelineView* editor_screen = getRootUI()->toTimelineView();
-
-	getCurrentClip()->renderAsSingleRow(modelStack, editor_screen, xScroll, xZoom, PadLEDs::imageStore[0],
+	// Render as the clip editor, not as whatever root UI is currently up: this is also called from Session and
+	// Arranger while they are still the root UI, and ArrangerView::supportsTriplets() is false, which would place
+	// the offscreen notes on different squares than the visible rows.
+	getCurrentClip()->renderAsSingleRow(modelStack, this, xScroll, xZoom, PadLEDs::imageStore[0],
 	                                    PadLEDs::occupancyMaskStore[0], false, 0, noteRowIndexBottom, 0, kDisplayWidth,
 	                                    true, false);
 	// Visible rows live in store rows 1..kDisplayHeight during clip transitions, so the top offscreen row is +1.
-	getCurrentClip()->renderAsSingleRow(modelStack, editor_screen, xScroll, xZoom,
-	                                    PadLEDs::imageStore[kDisplayHeight + 1],
+	getCurrentClip()->renderAsSingleRow(modelStack, this, xScroll, xZoom, PadLEDs::imageStore[kDisplayHeight + 1],
 	                                    PadLEDs::occupancyMaskStore[kDisplayHeight + 1], false, noteRowIndexTop,
 	                                    2147483647, 0, kDisplayWidth, true, false);
 
-	auto clearOffScreenSidebar = [](int32_t storeRow) {
-		for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
-			PadLEDs::imageStore[storeRow][x] = colours::black;
-			PadLEDs::occupancyMaskStore[storeRow][x] = 0;
-		}
-	};
+	// Fill in each offscreen row's sidebar the same way an onscreen row's would be, so the sidebar columns have real
+	// content to animate from top to bottom.
+	auto fillOffScreenSidebar = [this](int32_t yDisplay, int32_t storeRow) {
+		RGB* rowImage = PadLEDs::imageStore[storeRow];
+		uint8_t* rowOccupancy = PadLEDs::occupancyMaskStore[storeRow];
 
-	clearOffScreenSidebar(0);
-	clearOffScreenSidebar(kDisplayHeight + 1);
+		rowImage[kDisplayWidth + 1] = colours::black;
 
-	auto markOffScreenSidebarOccupancy = [](int32_t storeRow) {
-		for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
-			PadLEDs::occupancyMaskStore[storeRow][x] = (PadLEDs::imageStore[storeRow][x] == colours::black) ? 0 : 64;
-		}
-	};
-
-	drawMuteSquare(getCurrentInstrumentClip()->getNoteRowOnScreen(-1, currentSong), PadLEDs::imageStore[0],
-	               PadLEDs::occupancyMaskStore[0]);
-	drawMuteSquare(getCurrentInstrumentClip()->getNoteRowOnScreen(kDisplayHeight, currentSong),
-	               PadLEDs::imageStore[kDisplayHeight + 1], PadLEDs::occupancyMaskStore[kDisplayHeight + 1]);
-	markOffScreenSidebarOccupancy(0);
-	markOffScreenSidebarOccupancy(kDisplayHeight + 1);
-
-	if (getCurrentOutputType() != OutputType::KIT) {
-		// The root-note audition pad can sit just offscreen, so render it into the matching offscreen row.
-		auto renderOffScreenRootNote = [this](int32_t yDisplay, int32_t storeRow) {
+		drawMuteSquare(getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, currentSong), rowImage, rowOccupancy);
+		// The root-note audition pad can sit just offscreen. drawAuditionSquare() can't be reused here: it depends on
+		// state that only exists for onscreen rows.
+		if (getCurrentOutputType() != OutputType::KIT) {
 			int32_t yNote = getCurrentInstrumentClip()->getYNoteFromYDisplay(yDisplay, currentSong);
-			if (!isSameNote(yNote, currentSong->key.rootNote)) {
-				return;
+			if (isSameNote(yNote, currentSong->key.rootNote)) {
+				int32_t colourOffset = 0;
+				if (NoteRow* noteRow = getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, currentSong)) {
+					colourOffset = noteRow->getColourOffset(getCurrentInstrumentClip());
+				}
+				rowImage[kDisplayWidth + 1] = getCurrentInstrumentClip()->getMainColourFromY(yNote, colourOffset);
 			}
+		}
 
-			int32_t colourOffset = 0;
-			if (NoteRow* noteRow = getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, currentSong)) {
-				colourOffset = noteRow->getColourOffset(getCurrentInstrumentClip());
-			}
+		PadLEDs::refreshSidebarOccupancy(rowImage, rowOccupancy);
+	};
 
-			PadLEDs::imageStore[storeRow][kDisplayWidth + 1] =
-			    getCurrentInstrumentClip()->getMainColourFromY(yNote, colourOffset);
-			PadLEDs::occupancyMaskStore[storeRow][kDisplayWidth + 1] = 64;
-		};
-
-		renderOffScreenRootNote(-1, 0);
-		renderOffScreenRootNote(kDisplayHeight, kDisplayHeight + 1);
-	}
+	fillOffScreenSidebar(-1, 0);
+	fillOffScreenSidebar(kDisplayHeight, kDisplayHeight + 1);
 }
 
 uint32_t InstrumentClipView::getSquareWidth(int32_t square, int32_t effectiveLength) {

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -261,22 +261,38 @@ ActionResult InstrumentClipView::buttonAction(deluge::hid::Button b, bool on, bo
 	else if (b == SESSION_VIEW) {
 		if (on) {
 			if (currentUIMode == UI_MODE_NONE) {
-				currentUIMode = UI_MODE_HOLDING_SONG_BUTTON;
 				timeSongButtonPressed = AudioEngine::audioSampleTimer;
+				// Defer showing the macro sidebar until the long-press threshold. A short press can then transition
+				// straight to Session without flashing macro colours into the sidebar first.
+				sessionButtonPressPending = true;
+				sessionMacroSidebarActive = false;
 				indicator_leds::setLedState(IndicatorLED::SESSION_VIEW, true);
-				uiNeedsRendering(this, 0, 0xFFFFFFFF);
+				uiTimerManager.setTimerSamples(TimerName::UI_SPECIFIC, kShortPressTime);
 			}
 		}
 		else {
-			if (!isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
+			if (!sessionButtonPressPending && !isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
 				return ActionResult::DEALT_WITH;
 			}
+			uiTimerManager.unsetTimer(TimerName::UI_SPECIFIC);
 			if (inCardRoutine) {
 				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
-			exitUIMode(UI_MODE_HOLDING_SONG_BUTTON);
 
-			if ((int32_t)(AudioEngine::audioSampleTimer - timeSongButtonPressed) > kShortPressTime) {
+			// If the timer already promoted the press, or the release arrives after the threshold, consume it as a
+			// macro-sidebar press instead of transitioning to Session.
+			bool macroPress =
+			    sessionMacroSidebarActive
+			    || ((int32_t)(AudioEngine::audioSampleTimer - timeSongButtonPressed) >= (int32_t)kShortPressTime);
+
+			sessionButtonPressPending = false;
+			sessionMacroSidebarActive = false;
+
+			if (isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
+				exitUIMode(UI_MODE_HOLDING_SONG_BUTTON);
+			}
+
+			if (macroPress) {
 				uiNeedsRendering(this, 0, 0xFFFFFFFF);
 				indicator_leds::setLedState(IndicatorLED::SESSION_VIEW, false);
 				return ActionResult::DEALT_WITH;
@@ -847,6 +863,20 @@ passToOthers:
 		}
 
 		return ClipView::buttonAction(b, on, inCardRoutine);
+	}
+
+	return ActionResult::DEALT_WITH;
+}
+
+ActionResult InstrumentClipView::timerCallback() {
+	using namespace deluge::hid::button;
+
+	// Promote a pending Session button press into macro-sidebar mode only after it is still held long enough.
+	if (sessionButtonPressPending && currentUIMode == UI_MODE_NONE && Buttons::isButtonPressed(SESSION_VIEW)
+	    && (int32_t)(AudioEngine::audioSampleTimer - timeSongButtonPressed) >= (int32_t)kShortPressTime) {
+		currentUIMode = UI_MODE_HOLDING_SONG_BUTTON;
+		sessionMacroSidebarActive = true;
+		uiNeedsRendering(this, 0, 0xFFFFFFFF);
 	}
 
 	return ActionResult::DEALT_WITH;
@@ -1894,7 +1924,8 @@ doRegularEditPadActionProbably:
 		if (currentUIMode == UI_MODE_MIDI_LEARN) [[unlikely]] {
 			return commandLearnMutePad(y, velocity);
 		}
-		else if (isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
+		else if (sessionMacroSidebarActive) {
+			// The macro sidebar is now explicit state rather than any held Session button mode.
 			return commandActivateSongMacro(y, velocity);
 		}
 		else if (getCurrentOutputType() == OutputType::KIT && lastAuditionedYDisplay == y
@@ -5895,7 +5926,8 @@ bool InstrumentClipView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayW
 	bool armed = false;
 	for (int32_t i = 0; i < kDisplayHeight; i++) {
 		if (whichRows & (1 << i)) {
-			if (isUIModeActive(UI_MODE_HOLDING_SONG_BUTTON)) {
+			if (sessionMacroSidebarActive) {
+				// Only long-press Session mode draws macro colours into the mute column.
 				armed |= view.renderMacros(macroColumn, i, -1, image, occupancyMask);
 			}
 			else {
@@ -5903,6 +5935,11 @@ bool InstrumentClipView::renderSidebar(uint32_t whichRows, RGB image[][kDisplayW
 				               occupancyMask[i]);
 			}
 			drawAuditionSquare(i, image[i]);
+
+			// Sidebar cells that render black should not participate in transition blending.
+			for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
+				occupancyMask[i][x] = (image[i][x] == colours::black) ? 0 : 64;
+			}
 		}
 	}
 	if (armed) {
@@ -5942,6 +5979,9 @@ void InstrumentClipView::drawMuteSquare(NoteRow* thisNoteRow, RGB thisImage[], u
 		thisColour = thisColour.dim();
 		*thisOccupancy = 64;
 	}
+
+	// Keep the occupancy mask in sync with the final colour, including kit rows with no note row.
+	*thisOccupancy = (thisColour == colours::black) ? 0 : 64;
 }
 
 bool InstrumentClipView::isRowAuditionedByInstrument(int32_t yDisplay) {
@@ -7139,7 +7179,7 @@ void InstrumentClipView::fillOffScreenImageStores() {
 	uint32_t xZoom = currentSong->xZoom[NAVIGATION_CLIP];
 	uint32_t xScroll = currentSong->xScroll[NAVIGATION_CLIP];
 
-	// We're also going to fill up an extra, currently-offscreen imageStore row, with all notes currently offscreen
+	// Fill the rows just above and below the visible clip so collapse / expand animations have real source data.
 
 	int32_t noteRowIndexBottom, noteRowIndexTop;
 	if (getCurrentOutputType() == OutputType::KIT) {
@@ -7156,19 +7196,61 @@ void InstrumentClipView::fillOffScreenImageStores() {
 	char modelStackMemory[MODEL_STACK_MAX_SIZE];
 	ModelStackWithTimelineCounter* modelStack = currentSong->setupModelStackWithCurrentClip(modelStackMemory);
 
-	getCurrentClip()->renderAsSingleRow(modelStack, this, xScroll, xZoom, PadLEDs::imageStore[0],
+	// Use the active timeline editor so automation and note views render offscreen rows with the same context.
+	TimelineView* editor_screen = getRootUI()->toTimelineView();
+
+	getCurrentClip()->renderAsSingleRow(modelStack, editor_screen, xScroll, xZoom, PadLEDs::imageStore[0],
 	                                    PadLEDs::occupancyMaskStore[0], false, 0, noteRowIndexBottom, 0, kDisplayWidth,
 	                                    true, false);
-	getCurrentClip()->renderAsSingleRow(modelStack, this, xScroll, xZoom, PadLEDs::imageStore[kDisplayHeight],
-	                                    PadLEDs::occupancyMaskStore[kDisplayHeight], false, noteRowIndexTop, 2147483647,
-	                                    0, kDisplayWidth, true, false);
+	// Visible rows live in store rows 1..kDisplayHeight during clip transitions, so the top offscreen row is +1.
+	getCurrentClip()->renderAsSingleRow(modelStack, editor_screen, xScroll, xZoom,
+	                                    PadLEDs::imageStore[kDisplayHeight + 1],
+	                                    PadLEDs::occupancyMaskStore[kDisplayHeight + 1], false, noteRowIndexTop,
+	                                    2147483647, 0, kDisplayWidth, true, false);
 
-	// Clear sidebar pads from offscreen image stores
-	for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
-		PadLEDs::imageStore[0][x] = colours::black;
-		PadLEDs::imageStore[kDisplayHeight][x] = colours::black;
-		PadLEDs::occupancyMaskStore[0][x] = 0;
-		PadLEDs::occupancyMaskStore[kDisplayHeight][x] = 0;
+	auto clearOffScreenSidebar = [](int32_t storeRow) {
+		for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
+			PadLEDs::imageStore[storeRow][x] = colours::black;
+			PadLEDs::occupancyMaskStore[storeRow][x] = 0;
+		}
+	};
+
+	clearOffScreenSidebar(0);
+	clearOffScreenSidebar(kDisplayHeight + 1);
+
+	auto markOffScreenSidebarOccupancy = [](int32_t storeRow) {
+		for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
+			PadLEDs::occupancyMaskStore[storeRow][x] = (PadLEDs::imageStore[storeRow][x] == colours::black) ? 0 : 64;
+		}
+	};
+
+	drawMuteSquare(getCurrentInstrumentClip()->getNoteRowOnScreen(-1, currentSong), PadLEDs::imageStore[0],
+	               PadLEDs::occupancyMaskStore[0]);
+	drawMuteSquare(getCurrentInstrumentClip()->getNoteRowOnScreen(kDisplayHeight, currentSong),
+	               PadLEDs::imageStore[kDisplayHeight + 1], PadLEDs::occupancyMaskStore[kDisplayHeight + 1]);
+	markOffScreenSidebarOccupancy(0);
+	markOffScreenSidebarOccupancy(kDisplayHeight + 1);
+
+	if (getCurrentOutputType() != OutputType::KIT) {
+		// The root-note audition pad can sit just offscreen, so render it into the matching offscreen row.
+		auto renderOffScreenRootNote = [this](int32_t yDisplay, int32_t storeRow) {
+			int32_t yNote = getCurrentInstrumentClip()->getYNoteFromYDisplay(yDisplay, currentSong);
+			if (!isSameNote(yNote, currentSong->key.rootNote)) {
+				return;
+			}
+
+			int32_t colourOffset = 0;
+			if (NoteRow* noteRow = getCurrentInstrumentClip()->getNoteRowOnScreen(yDisplay, currentSong)) {
+				colourOffset = noteRow->getColourOffset(getCurrentInstrumentClip());
+			}
+
+			PadLEDs::imageStore[storeRow][kDisplayWidth + 1] =
+			    getCurrentInstrumentClip()->getMainColourFromY(yNote, colourOffset);
+			PadLEDs::occupancyMaskStore[storeRow][kDisplayWidth + 1] = 64;
+		};
+
+		renderOffScreenRootNote(-1, 0);
+		renderOffScreenRootNote(kDisplayHeight, kDisplayHeight + 1);
 	}
 }
 
@@ -7179,7 +7261,8 @@ uint32_t InstrumentClipView::getSquareWidth(int32_t square, int32_t effectiveLen
 
 void InstrumentClipView::flashDefaultRootNote() {
 	flashDefaultRootNoteOn = !flashDefaultRootNoteOn;
-	uiNeedsRendering(this, 0, 0xFFFFFFFF);
+	// Automation view can be the root UI while this timer owns the flash state.
+	uiNeedsRendering(getRootUI(), 0, 0xFFFFFFFF);
 	uiTimerManager.setTimer(TimerName::DEFAULT_ROOT_NOTE, kFlashTime);
 }
 

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -364,8 +364,8 @@ private:
 
 	int32_t quantizeAmount{};
 	uint32_t timeSongButtonPressed{};
-	// Session button state is split so short presses can transition without briefly drawing macro sidebar pads.
-	bool sessionButtonPressPending{};
+	// Set once a held Session button passes the long-press threshold, so short presses never flash macro colours into
+	// the sidebar on their way to Session view.
 	bool sessionMacroSidebarActive{};
 
 	std::array<RGB, kDisplayHeight> rowColour;

--- a/src/deluge/gui/views/instrument_clip_view.h
+++ b/src/deluge/gui/views/instrument_clip_view.h
@@ -78,6 +78,8 @@ public:
 	// BUTTON ACTION button press / release handling
 
 	ActionResult buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) override;
+	// Used to reveal Session macros only after the Session button has passed the long-press threshold.
+	ActionResult timerCallback() override;
 	ActionResult handleScaleButtonAction(bool on, bool inCardRoutine);
 	bool handleInstrumentChange(OutputType outputType);
 
@@ -362,6 +364,9 @@ private:
 
 	int32_t quantizeAmount{};
 	uint32_t timeSongButtonPressed{};
+	// Session button state is split so short presses can transition without briefly drawing macro sidebar pads.
+	bool sessionButtonPressPending{};
+	bool sessionMacroSidebarActive{};
 
 	std::array<RGB, kDisplayHeight> rowColour;
 	std::array<RGB, kDisplayHeight> rowTailColour;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -94,19 +94,6 @@ using namespace gui;
 
 PLACE_SDRAM_BSS SessionView sessionView{};
 
-namespace {
-// Transition stores render clip / automation views one row lower than keyboard view. Keep the
-// sidebar occupancy aligned with whichever store row the caller rendered into.
-void markRenderedSidebarStorePadsOccupied(int32_t firstStoreRow = 1) {
-	for (int32_t y = 0; y < kDisplayHeight; y++) {
-		int32_t storeRow = firstStoreRow + y;
-		for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
-			PadLEDs::occupancyMaskStore[storeRow][x] = (PadLEDs::imageStore[storeRow][x] == colours::black) ? 0 : 64;
-		}
-	}
-}
-} // namespace
-
 SessionView::SessionView() {
 	xScrollBeforeFollowingAutoExtendingLinearRecording = -1;
 	createClip = false;
@@ -2762,8 +2749,6 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 		return;
 	}
 
-	PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
-
 	bool onKeyboardScreen = ((clip->type == ClipType::INSTRUMENT) && ((InstrumentClip*)clip)->onKeyboardScreen);
 
 	// when transitioning back to clip, if keyboard view is enabled, it takes precedent
@@ -2775,9 +2760,11 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 		// offscreen rows so sidebar pads can animate the full height.
 		automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);
 		clip->renderSidebar(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1]);
-		markRenderedSidebarStorePadsOccupied();
 		if (clip->type == ClipType::INSTRUMENT) {
 			instrumentClipView.fillOffScreenImageStores();
+		}
+		else {
+			PadLEDs::clearTransitionStoreOffScreenRows();
 		}
 
 		PadLEDs::numAnimatedRows = kDisplayHeight + 2;
@@ -2788,7 +2775,8 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 		PadLEDs::setupInstrumentClipCollapseAnimation(true);
 
-		// Automation transitions prepare their stores before rendering, so restart progress after setup.
+		// Preparing the stores can take a while (fillOffScreenImageStores loads clusters), so only start the clock
+		// once we're ready to draw the first frame.
 		PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
 		PadLEDs::renderClipExpandOrCollapse();
 
@@ -2805,11 +2793,9 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 		if (onKeyboardScreen) {
 
-			instrumentClipView.recalculateColours();
 			// Keyboard view uses only its visible rows for this animation, so it starts at store row 0.
 			keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
 			keyboardScreen.renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
-			markRenderedSidebarStorePadsOccupied(0);
 
 			PadLEDs::numAnimatedRows = kDisplayHeight;
 			for (int32_t y = 0; y < PadLEDs::numAnimatedRows; y++) {
@@ -2828,8 +2814,6 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 			                                  false);
 			instrumentClipView.renderSidebar(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1]);
 
-			markRenderedSidebarStorePadsOccupied();
-
 			// Important that this is done after currentSong->xScroll is changed, above
 			instrumentClipView.fillOffScreenImageStores();
 
@@ -2842,6 +2826,8 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 		PadLEDs::setupInstrumentClipCollapseAnimation(true);
 
+		// As above: don't let the store setup eat into the animation's 200ms.
+		PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
 		PadLEDs::renderClipExpandOrCollapse();
 
 		// Hook point for specificMidiDevice
@@ -2862,6 +2848,7 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 			PadLEDs::setupAudioClipCollapseOrExplodeAnimation(clip);
 
+			PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
 			PadLEDs::renderAudioClipExpandOrCollapse();
 
 			PadLEDs::clearSideBar(); // Sends "now"
@@ -2909,6 +2896,9 @@ void SessionView::transitionToSessionView() {
 			if (getCurrentClip()->type == ClipType::INSTRUMENT) {
 				instrumentClipView.fillOffScreenImageStores();
 			}
+			else {
+				PadLEDs::clearTransitionStoreOffScreenRows();
+			}
 
 			// I didn't see a difference but the + 2 seems intentional
 			PadLEDs::numAnimatedRows = kDisplayHeight + 2;
@@ -2925,7 +2915,6 @@ void SessionView::transitionToSessionView() {
 				// transient sidebar colours before the first animation frame and reads as a blink.
 				memcpy(PadLEDs::imageStore, PadLEDs::image, sizeof(PadLEDs::image));
 				memcpy(PadLEDs::occupancyMaskStore, PadLEDs::occupancyMask, sizeof(PadLEDs::occupancyMask));
-				markRenderedSidebarStorePadsOccupied(0);
 
 				PadLEDs::numAnimatedRows = kDisplayHeight;
 				for (int32_t y = 0; y < kDisplayHeight; y++) {
@@ -2951,15 +2940,8 @@ void SessionView::transitionToSessionView() {
 		// Must set this after above render calls, or else they'll see it and not render
 		currentUIMode = UI_MODE_INSTRUMENT_CLIP_COLLAPSING;
 
-		// Set occupancy masks to full for the sidebar squares in the Store
-		if (!transitioningFromKeyboardScreen) {
-			// Clip / automation sidebars can animate from offscreen rows, so force their two sidebar columns to
-			// contribute even when the source row is empty.
-			for (int32_t y = 0; y < kDisplayHeight; y++) {
-				PadLEDs::occupancyMaskStore[y + 1][kDisplayWidth] = 64;
-				PadLEDs::occupancyMaskStore[y + 1][kDisplayWidth + 1] = 64;
-			}
-		}
+		// The sidebar occupancy the renderSidebar() calls above produced is authoritative: a black sidebar pad is
+		// empty, and forcing it to occupied would make drawSquare() marginalise the destination pad it collapses into.
 
 		PadLEDs::setupInstrumentClipCollapseAnimation(true, transitioningFromKeyboardScreen);
 
@@ -4586,6 +4568,9 @@ void SessionView::gridTransitionToViewForClip(Clip* clip) {
 			instrumentClipView.recalculateColours();
 			// Automation grid explode still needs the instrument rows above and below the visible display.
 			instrumentClipView.fillOffScreenImageStores();
+		}
+		else {
+			PadLEDs::clearTransitionStoreOffScreenRows();
 		}
 
 		automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -94,6 +94,19 @@ using namespace gui;
 
 PLACE_SDRAM_BSS SessionView sessionView{};
 
+namespace {
+// Transition stores render clip / automation views one row lower than keyboard view. Keep the
+// sidebar occupancy aligned with whichever store row the caller rendered into.
+void markRenderedSidebarStorePadsOccupied(int32_t firstStoreRow = 1) {
+	for (int32_t y = 0; y < kDisplayHeight; y++) {
+		int32_t storeRow = firstStoreRow + y;
+		for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
+			PadLEDs::occupancyMaskStore[storeRow][x] = (PadLEDs::imageStore[storeRow][x] == colours::black) ? 0 : 64;
+		}
+	}
+}
+} // namespace
+
 SessionView::SessionView() {
 	xScrollBeforeFollowingAutoExtendingLinearRecording = -1;
 	createClip = false;
@@ -2758,8 +2771,14 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 	if (clip->onAutomationClipView && !onKeyboardScreen) {
 		currentUIMode = UI_MODE_INSTRUMENT_CLIP_EXPANDING;
 
-		automationView.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore, false);
-		clip->renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+		// Store rows 1..kDisplayHeight hold the visible clip rows; rows 0 and kDisplayHeight + 1 are reserved for
+		// offscreen rows so sidebar pads can animate the full height.
+		automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);
+		clip->renderSidebar(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1]);
+		markRenderedSidebarStorePadsOccupied();
+		if (clip->type == ClipType::INSTRUMENT) {
+			instrumentClipView.fillOffScreenImageStores();
+		}
 
 		PadLEDs::numAnimatedRows = kDisplayHeight + 2;
 		for (int32_t y = 0; y < PadLEDs::numAnimatedRows; y++) {
@@ -2769,6 +2788,8 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 		PadLEDs::setupInstrumentClipCollapseAnimation(true);
 
+		// Automation transitions prepare their stores before rendering, so restart progress after setup.
+		PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
 		PadLEDs::renderClipExpandOrCollapse();
 
 		if (clip->type == ClipType::INSTRUMENT) {
@@ -2784,8 +2805,11 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 
 		if (onKeyboardScreen) {
 
+			instrumentClipView.recalculateColours();
+			// Keyboard view uses only its visible rows for this animation, so it starts at store row 0.
 			keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
 			keyboardScreen.renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+			markRenderedSidebarStorePadsOccupied(0);
 
 			PadLEDs::numAnimatedRows = kDisplayHeight;
 			for (int32_t y = 0; y < PadLEDs::numAnimatedRows; y++) {
@@ -2799,8 +2823,12 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 			// Won't have happened automatically because we haven't begun the "session"
 			instrumentClipView.recalculateColours();
 
-			instrumentClipView.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore, false);
-			instrumentClipView.renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+			// Non-keyboard clip views include one offscreen row above and below the visible rows.
+			instrumentClipView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1],
+			                                  false);
+			instrumentClipView.renderSidebar(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1]);
+
+			markRenderedSidebarStorePadsOccupied();
 
 			// Important that this is done after currentSong->xScroll is changed, above
 			instrumentClipView.fillOffScreenImageStores();
@@ -2872,9 +2900,15 @@ void SessionView::transitionToSessionView() {
 	}
 	else {
 		int32_t transitioningToRow = getClipPlaceOnScreen(getCurrentClip());
+		bool transitioningFromKeyboardScreen = false;
 		if (getCurrentUI() == &automationView) {
-			automationView.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore, false);
-			getCurrentClip()->renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+			// Automation collapse follows the same store layout as instrument clip view: offscreen row, visible rows,
+			// offscreen row.
+			automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);
+			getCurrentClip()->renderSidebar(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1]);
+			if (getCurrentClip()->type == ClipType::INSTRUMENT) {
+				instrumentClipView.fillOffScreenImageStores();
+			}
 
 			// I didn't see a difference but the + 2 seems intentional
 			PadLEDs::numAnimatedRows = kDisplayHeight + 2;
@@ -2886,8 +2920,12 @@ void SessionView::transitionToSessionView() {
 		else {
 			InstrumentClip* instrumentClip = getCurrentInstrumentClip();
 			if (instrumentClip->onKeyboardScreen) {
-				keyboardScreen.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore, false);
-				keyboardScreen.renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+				transitioningFromKeyboardScreen = true;
+				// Start keyboard collapse from the exact frame currently on the LEDs. Re-rendering here can change
+				// transient sidebar colours before the first animation frame and reads as a blink.
+				memcpy(PadLEDs::imageStore, PadLEDs::image, sizeof(PadLEDs::image));
+				memcpy(PadLEDs::occupancyMaskStore, PadLEDs::occupancyMask, sizeof(PadLEDs::occupancyMask));
+				markRenderedSidebarStorePadsOccupied(0);
 
 				PadLEDs::numAnimatedRows = kDisplayHeight;
 				for (int32_t y = 0; y < kDisplayHeight; y++) {
@@ -2896,8 +2934,10 @@ void SessionView::transitionToSessionView() {
 				}
 			}
 			else {
-				instrumentClipView.renderMainPads(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore, false);
-				instrumentClipView.renderSidebar(0xFFFFFFFF, PadLEDs::imageStore, PadLEDs::occupancyMaskStore);
+				// Instrument clip collapse renders visible rows into the middle of the transition store.
+				instrumentClipView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1],
+				                                  false);
+				instrumentClipView.renderSidebar(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1]);
 
 				// I didn't see a difference but the + 2 seems intentional
 				PadLEDs::numAnimatedRows = kDisplayHeight + 2;
@@ -2912,12 +2952,16 @@ void SessionView::transitionToSessionView() {
 		currentUIMode = UI_MODE_INSTRUMENT_CLIP_COLLAPSING;
 
 		// Set occupancy masks to full for the sidebar squares in the Store
-		for (int32_t y = 0; y < kDisplayHeight; y++) {
-			PadLEDs::occupancyMaskStore[y + 1][kDisplayWidth] = 64;
-			PadLEDs::occupancyMaskStore[y + 1][kDisplayWidth + 1] = 64;
+		if (!transitioningFromKeyboardScreen) {
+			// Clip / automation sidebars can animate from offscreen rows, so force their two sidebar columns to
+			// contribute even when the source row is empty.
+			for (int32_t y = 0; y < kDisplayHeight; y++) {
+				PadLEDs::occupancyMaskStore[y + 1][kDisplayWidth] = 64;
+				PadLEDs::occupancyMaskStore[y + 1][kDisplayWidth + 1] = 64;
+			}
 		}
 
-		PadLEDs::setupInstrumentClipCollapseAnimation(true);
+		PadLEDs::setupInstrumentClipCollapseAnimation(true, transitioningFromKeyboardScreen);
 
 		if (getCurrentUI() == &instrumentClipView) {
 			instrumentClipView.fillOffScreenImageStores();
@@ -4487,7 +4531,9 @@ void SessionView::gridTransitionToSessionView() {
 
 	memcpy(PadLEDs::imageStore[1], PadLEDs::image, (kDisplayWidth + kSideBarWidth) * kDisplayHeight * sizeof(RGB));
 	memcpy(PadLEDs::occupancyMaskStore[1], PadLEDs::occupancyMask, (kDisplayWidth + kSideBarWidth) * kDisplayHeight);
-	if (getCurrentUI() == &instrumentClipView) {
+	// Grid collapse uses the same offscreen instrument rows whether the current editor is notes or automation.
+	if (getCurrentClip()->type == ClipType::INSTRUMENT
+	    && (getCurrentUI() == &instrumentClipView || getCurrentUI() == &automationView)) {
 		instrumentClipView.fillOffScreenImageStores();
 	}
 
@@ -4538,6 +4584,8 @@ void SessionView::gridTransitionToViewForClip(Clip* clip) {
 
 		if (clip->type == ClipType::INSTRUMENT) {
 			instrumentClipView.recalculateColours();
+			// Automation grid explode still needs the instrument rows above and below the visible display.
+			instrumentClipView.fillOffScreenImageStores();
 		}
 
 		automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -94,6 +94,19 @@ using namespace gui;
 
 PLACE_SDRAM_BSS SessionView sessionView{};
 
+namespace {
+// Keyboard view's sidebar columns morph to/from the Session colours of the clip's row. The mute colour PadLEDs
+// already has; hand it the section colour, unless the clip's row is off-screen and there is nothing to morph to.
+void setUpKeyboardSidebarMorph(int32_t clipRow) {
+	if (clipRow < 0 || clipRow >= kDisplayHeight) {
+		return;
+	}
+	RGB sidebarRow[kDisplayWidth + kSideBarWidth]{};
+	sessionView.drawSectionSquare(clipRow, sidebarRow);
+	PadLEDs::enableKeyboardSidebarMorph(sidebarRow[kDisplayWidth + 1]);
+}
+} // namespace
+
 SessionView::SessionView() {
 	xScrollBeforeFollowingAutoExtendingLinearRecording = -1;
 	createClip = false;
@@ -2825,6 +2838,9 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 		}
 
 		PadLEDs::setupInstrumentClipCollapseAnimation(true);
+		if (onKeyboardScreen) {
+			setUpKeyboardSidebarMorph(clipPlaceOnScreen);
+		}
 
 		// As above: don't let the store setup eat into the animation's 200ms.
 		PadLEDs::recordTransitionBegin(kClipCollapseSpeed);
@@ -2943,7 +2959,10 @@ void SessionView::transitionToSessionView() {
 		// The sidebar occupancy the renderSidebar() calls above produced is authoritative: a black sidebar pad is
 		// empty, and forcing it to occupied would make drawSquare() marginalise the destination pad it collapses into.
 
-		PadLEDs::setupInstrumentClipCollapseAnimation(true, transitioningFromKeyboardScreen);
+		PadLEDs::setupInstrumentClipCollapseAnimation(true);
+		if (transitioningFromKeyboardScreen) {
+			setUpKeyboardSidebarMorph(transitioningToRow);
+		}
 
 		if (getCurrentUI() == &instrumentClipView) {
 			instrumentClipView.fillOffScreenImageStores();

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -304,6 +304,19 @@ void writeToSideBar(uint8_t sideBarX, uint8_t yDisplay, uint8_t red, uint8_t gre
 	image[yDisplay][sideBarX + kDisplayWidth] = RGB(red, green, blue);
 }
 
+void refreshSidebarOccupancy(RGB rowImage[], uint8_t rowOccupancyMask[]) {
+	for (int32_t x = kDisplayWidth; x < kDisplayWidth + kSideBarWidth; x++) {
+		rowOccupancyMask[x] = (rowImage[x] == gui::colours::black) ? 0 : 64;
+	}
+}
+
+void clearTransitionStoreOffScreenRows() {
+	for (int32_t storeRow : {int32_t{0}, int32_t{kDisplayHeight + 1}}) {
+		std::fill_n(imageStore[storeRow], kDisplayWidth + kSideBarWidth, gui::colours::black);
+		memset(occupancyMaskStore[storeRow], 0, kDisplayWidth + kSideBarWidth);
+	}
+}
+
 void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder, bool collapsingKeyboardScreen_) {
 	clipLength = getCurrentClip()->loopLength;
 	collapsingKeyboardScreen = collapsingKeyboardScreen_;
@@ -325,6 +338,14 @@ void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder, bool c
 			clipSectionSquareColour = gui::colours::black;
 		}
 	}
+}
+
+// Smoothstep, in 16.16. Avoids harsh colour changes on the sidebar while rows are moving quickly.
+uint16_t smoothProgress(uint16_t progress) {
+	uint32_t p = progress;
+	uint32_t pSquared = (p * p) >> 16;
+	uint32_t pCubed = (pSquared * p) >> 16;
+	return static_cast<uint16_t>(std::min<uint32_t>((3 * pSquared) - (2 * pCubed), 65535));
 }
 
 void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, int32_t progress) {
@@ -356,6 +377,13 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 		intensity2Array[i] = newRowPosition; // & 65535;
 		intensity1Array[i] = 65535 - intensity2Array[i];
 	}
+
+	// Blend amounts for the two sidebar columns. They don't vary per column, so work them out once.
+	bool expanding = isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING);
+	bool keyboardSidebarCollapsing = collapsingKeyboardScreen && isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING);
+	uint16_t clippedProgress = std::min<int32_t>(progress, 65535);
+	uint16_t muteBlendProgress = expanding ? smoothProgress(clippedProgress) : clippedProgress;
+	uint16_t keyboardGlobalDestinationBlend = keyboardSidebarCollapsing ? smoothProgress(65535 - clippedProgress) : 0;
 
 	int32_t greyStart =
 	    instrumentClipView.getSquareFromPos(clipLength - 1, NULL, currentSong->xScroll[NAVIGATION_CLIP]) + 1;
@@ -407,28 +435,9 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 			}
 		}
 
-		bool expandingMuteColumn = isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING) && col == kDisplayWidth;
-		bool collapsingKeyboardSidebar = collapsingKeyboardScreen && isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)
-		                                 && col >= kDisplayWidth && col < kDisplayWidth + kSideBarWidth;
-		uint16_t clippedProgress = std::min<int32_t>(progress, 65535);
-		// Smoothstep avoids harsh colour changes on the sidebar while rows are moving quickly.
-		auto smoothProgress = [](uint16_t progress) {
-			uint32_t p = progress;
-			uint32_t pSquared = (p * p) >> 16;
-			uint32_t pCubed = (pSquared * p) >> 16;
-			return static_cast<uint16_t>(std::min<uint32_t>((3 * pSquared) - (2 * pCubed), 65535));
-		};
-
-		uint16_t muteBlendProgress = clippedProgress;
-		if (expandingMuteColumn) {
-			muteBlendProgress = smoothProgress(muteBlendProgress);
-		}
-
-		uint16_t keyboardGlobalDestinationBlend = 0;
-		if (collapsingKeyboardSidebar) {
-			uint32_t collapseElapsed = 65535 - clippedProgress;
-			keyboardGlobalDestinationBlend = smoothProgress(std::min<uint32_t>(collapseElapsed, 65535));
-		}
+		bool expandingMuteColumn = expanding && col == kDisplayWidth;
+		bool collapsingKeyboardSidebar =
+		    keyboardSidebarCollapsing && col >= kDisplayWidth && col < kDisplayWidth + kSideBarWidth;
 
 		if (expandingMuteColumn && animatedRowGoingTo[0] >= 0 && animatedRowGoingTo[0] < kDisplayHeight) {
 			int32_t sessionMuteIntensity = 65535 - muteBlendProgress;
@@ -473,8 +482,9 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 						}
 						uint16_t proximityBlend = 0;
 						if (distanceFromDestination < kKeyboardColourBlendDistance) {
+							// 64-bit intermediate: the numerator reaches 3 * 65536 * 65535, well past INT32_MAX.
 							uint32_t proximityProgress =
-							    ((kKeyboardColourBlendDistance - distanceFromDestination) * 65535)
+							    ((uint64_t)(kKeyboardColourBlendDistance - distanceFromDestination) * 65535)
 							    / kKeyboardColourBlendDistance;
 							proximityBlend = smoothProgress(std::min<uint32_t>(proximityProgress, 65535));
 						}

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -105,6 +105,9 @@ bool sampleReversed;
 // Same for InstrumentClips
 int32_t clipLength;
 RGB clipMuteSquareColour;
+// Keyboard collapse needs both final sidebar colours because both keyboard sidebar columns animate into one row.
+RGB clipSectionSquareColour;
+bool collapsingKeyboardScreen;
 
 bool renderingLock;
 
@@ -113,6 +116,8 @@ uint32_t transitionStartTime;
 
 uint32_t greyoutCols;
 uint32_t greyoutRows;
+
+constexpr uint32_t kClipExpandCollapseRefreshMs = 25;
 
 void init() {
 	memset(slowFlashSquares, 255, sizeof(slowFlashSquares));
@@ -299,12 +304,26 @@ void writeToSideBar(uint8_t sideBarX, uint8_t yDisplay, uint8_t red, uint8_t gre
 	image[yDisplay][sideBarX + kDisplayWidth] = RGB(red, green, blue);
 }
 
-void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder) {
+void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder, bool collapsingKeyboardScreen_) {
 	clipLength = getCurrentClip()->loopLength;
+	collapsingKeyboardScreen = collapsingKeyboardScreen_;
 
 	if (collapsingOutOfClipMinder) {
 		// This shouldn't have to be done every time
 		clipMuteSquareColour = view.getClipMuteSquareColour(getCurrentClip(), clipMuteSquareColour);
+
+		// Keyboard collapse animates both sidebar columns into the session row, so cache the row's final section
+		// colour as well as the mute colour.
+		int32_t clipRow = collapsingKeyboardScreen ? sessionView.getClipPlaceOnScreen(getCurrentClip()) : -1;
+		if (collapsingKeyboardScreen && clipRow >= 0 && clipRow < kDisplayHeight) {
+			RGB sidebarRow[kDisplayWidth + kSideBarWidth];
+			memset(sidebarRow, 0, sizeof(sidebarRow));
+			sessionView.drawSectionSquare(clipRow, sidebarRow);
+			clipSectionSquareColour = sidebarRow[kDisplayWidth + 1];
+		}
+		else {
+			clipSectionSquareColour = gui::colours::black;
+		}
 	}
 }
 
@@ -324,11 +343,15 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 	// Do some pre figuring out, which applies to all columns
 	uint16_t* intensity1Array = (uint16_t*)miscStringBuffer;
 	uint16_t* intensity2Array = (uint16_t*)&miscStringBuffer[kMaxNumAnimatedRows * sizeof(uint16_t)];
+	// Full precision row positions are needed for keyboard sidebar colour blends, which depend on proximity to
+	// the destination session row.
+	int32_t newRowPositionArray[kMaxNumAnimatedRows];
 	int8_t newRowPosition1Array[kMaxNumAnimatedRows];
 
 	for (int32_t i = 0; i < numAnimatedRows; i++) {
 		int32_t newRowPosition = (int32_t)animatedRowGoingFrom[i] * 65536
 		                         + ((int32_t)animatedRowGoingTo[i] - animatedRowGoingFrom[i]) * (65536 - progress);
+		newRowPositionArray[i] = newRowPosition;
 		newRowPosition1Array[i] = newRowPosition >> 16;
 		intensity2Array[i] = newRowPosition; // & 65535;
 		intensity1Array[i] = 65535 - intensity2Array[i];
@@ -384,12 +407,43 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 			}
 		}
 
+		bool expandingMuteColumn = isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING) && col == kDisplayWidth;
+		bool collapsingKeyboardSidebar = collapsingKeyboardScreen && isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)
+		                                 && col >= kDisplayWidth && col < kDisplayWidth + kSideBarWidth;
+		uint16_t clippedProgress = std::min<int32_t>(progress, 65535);
+		// Smoothstep avoids harsh colour changes on the sidebar while rows are moving quickly.
+		auto smoothProgress = [](uint16_t progress) {
+			uint32_t p = progress;
+			uint32_t pSquared = (p * p) >> 16;
+			uint32_t pCubed = (pSquared * p) >> 16;
+			return static_cast<uint16_t>(std::min<uint32_t>((3 * pSquared) - (2 * pCubed), 65535));
+		};
+
+		uint16_t muteBlendProgress = clippedProgress;
+		if (expandingMuteColumn) {
+			muteBlendProgress = smoothProgress(muteBlendProgress);
+		}
+
+		uint16_t keyboardGlobalDestinationBlend = 0;
+		if (collapsingKeyboardSidebar) {
+			uint32_t collapseElapsed = 65535 - clippedProgress;
+			keyboardGlobalDestinationBlend = smoothProgress(std::min<uint32_t>(collapseElapsed, 65535));
+		}
+
+		if (expandingMuteColumn && animatedRowGoingTo[0] >= 0 && animatedRowGoingTo[0] < kDisplayHeight) {
+			int32_t sessionMuteIntensity = 65535 - muteBlendProgress;
+			PadLEDs::image[animatedRowGoingTo[0]][col] =
+			    drawSquare(clipMuteSquareColour, sessionMuteIntensity, PadLEDs::image[animatedRowGoingTo[0]][col],
+			               &occupancyMask[animatedRowGoingTo[0]][col], 64);
+		}
+
 		for (int32_t i = 0; i < numAnimatedRows; i++) {
 			if (!occupancyMaskStore[i][col]) {
 				continue; // Nothing to do if there was nothing in this square
 			}
 
-			RGB& squareColours = imageStore[i][col];
+			// Work on a local copy so per-row colour morphs do not alter the stored source frame.
+			RGB squareColours = imageStore[i][col];
 
 			int32_t intensity1 = intensity1Array[i];
 			int32_t intensity2 = intensity2Array[i];
@@ -397,15 +451,46 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 			if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)
 			    || isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING)) {
 
-				// If the audition column, fade it out as we go
-				if (col == kDisplayWidth + kSideBarWidth - 1) {
+				// Fade the clip-view audition column in when expanding. When collapsing,
+				// keep it visible until the follow-up fade blends to the session sidebar.
+				if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING) && col == kDisplayWidth + kSideBarWidth - 1) {
 					intensity1 = ((uint32_t)intensity1 * progress) >> 16;
 					intensity2 = ((uint32_t)intensity2 * progress) >> 16;
 				}
 
+				// Keyboard sidebar columns collapse from their source keyboard colours into the session colours.
+				if (collapsingKeyboardSidebar) {
+					RGB sessionSidebarColour = (col == kDisplayWidth) ? clipMuteSquareColour : clipSectionSquareColour;
+					uint16_t keyboardDestinationBlend = keyboardGlobalDestinationBlend;
+					if (animatedRowGoingTo[i] >= 0 && animatedRowGoingTo[i] < kDisplayHeight) {
+						constexpr int32_t kKeyboardColourBlendDistance = 3 * 65536;
+						// Cap the colour morph by distance so pads keep their keyboard colours until they are
+						// visually close to collapsing into the session clip row.
+						int32_t distanceFromDestination =
+						    newRowPositionArray[i] - ((int32_t)animatedRowGoingTo[i] * 65536);
+						if (distanceFromDestination < 0) {
+							distanceFromDestination = -distanceFromDestination;
+						}
+						uint16_t proximityBlend = 0;
+						if (distanceFromDestination < kKeyboardColourBlendDistance) {
+							uint32_t proximityProgress =
+							    ((kKeyboardColourBlendDistance - distanceFromDestination) * 65535)
+							    / kKeyboardColourBlendDistance;
+							proximityBlend = smoothProgress(std::min<uint32_t>(proximityProgress, 65535));
+						}
+						keyboardDestinationBlend = std::min(keyboardDestinationBlend, proximityBlend);
+					}
+					squareColours = RGB::blend(sessionSidebarColour, squareColours, keyboardDestinationBlend);
+				}
+
 				// If the mute-col, we want to alter the colour
-				if (col == kDisplayWidth) {
-					squareColours = RGB::blend(squareColours, clipMuteSquareColour, progress);
+				else if (col == kDisplayWidth) {
+					if (expandingMuteColumn) {
+						// Fade in the session mute pad underneath as the clip mute column expands out of it.
+						intensity1 = ((uint32_t)intensity1 * muteBlendProgress) >> 16;
+						intensity2 = ((uint32_t)intensity2 * muteBlendProgress) >> 16;
+					}
+					squareColours = RGB::blend(squareColours, clipMuteSquareColour, muteBlendProgress);
 				}
 			}
 
@@ -1058,7 +1143,8 @@ void renderClipExpandOrCollapse() {
 
 	renderInstrumentClipCollapseAnimation(0, kDisplayWidth + kSideBarWidth, progress);
 
-	uiTimerManager.setTimer(TimerName::MATRIX_DRIVER, UI_MS_PER_REFRESH);
+	// The sidebar rows move a long way over this short transition, so keep the samples close to one row apart.
+	uiTimerManager.setTimer(TimerName::MATRIX_DRIVER, kClipExpandCollapseRefreshMs);
 }
 
 void renderNoteRowExpandOrCollapse() {

--- a/src/deluge/hid/led/pad_leds.cpp
+++ b/src/deluge/hid/led/pad_leds.cpp
@@ -105,9 +105,11 @@ bool sampleReversed;
 // Same for InstrumentClips
 int32_t clipLength;
 RGB clipMuteSquareColour;
-// Keyboard collapse needs both final sidebar colours because both keyboard sidebar columns animate into one row.
+// Keyboard view has no mute / section columns of its own, so its two sidebar columns morph between the keyboard
+// colours and the Session colours of the row they collapse into (or expand out of). Both destination colours are
+// needed; the mute one is clipMuteSquareColour above.
 RGB clipSectionSquareColour;
-bool collapsingKeyboardScreen;
+bool morphKeyboardSidebar;
 
 bool renderingLock;
 
@@ -317,27 +319,19 @@ void clearTransitionStoreOffScreenRows() {
 	}
 }
 
-void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder, bool collapsingKeyboardScreen_) {
+void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder) {
 	clipLength = getCurrentClip()->loopLength;
-	collapsingKeyboardScreen = collapsingKeyboardScreen_;
+	morphKeyboardSidebar = false;
 
 	if (collapsingOutOfClipMinder) {
 		// This shouldn't have to be done every time
 		clipMuteSquareColour = view.getClipMuteSquareColour(getCurrentClip(), clipMuteSquareColour);
-
-		// Keyboard collapse animates both sidebar columns into the session row, so cache the row's final section
-		// colour as well as the mute colour.
-		int32_t clipRow = collapsingKeyboardScreen ? sessionView.getClipPlaceOnScreen(getCurrentClip()) : -1;
-		if (collapsingKeyboardScreen && clipRow >= 0 && clipRow < kDisplayHeight) {
-			RGB sidebarRow[kDisplayWidth + kSideBarWidth];
-			memset(sidebarRow, 0, sizeof(sidebarRow));
-			sessionView.drawSectionSquare(clipRow, sidebarRow);
-			clipSectionSquareColour = sidebarRow[kDisplayWidth + 1];
-		}
-		else {
-			clipSectionSquareColour = gui::colours::black;
-		}
 	}
+}
+
+void enableKeyboardSidebarMorph(RGB sessionSectionColour) {
+	morphKeyboardSidebar = true;
+	clipSectionSquareColour = sessionSectionColour;
 }
 
 // Smoothstep, in 16.16. Avoids harsh colour changes on the sidebar while rows are moving quickly.
@@ -380,10 +374,14 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 
 	// Blend amounts for the two sidebar columns. They don't vary per column, so work them out once.
 	bool expanding = isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING);
-	bool keyboardSidebarCollapsing = collapsingKeyboardScreen && isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING);
+	bool transitioning = expanding || isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING);
+	bool keyboardSidebarMorphing = morphKeyboardSidebar && transitioning;
 	uint16_t clippedProgress = std::min<int32_t>(progress, 65535);
 	uint16_t muteBlendProgress = expanding ? smoothProgress(clippedProgress) : clippedProgress;
-	uint16_t keyboardGlobalDestinationBlend = keyboardSidebarCollapsing ? smoothProgress(65535 - clippedProgress) : 0;
+	// How much of the Session sidebar colour to show. `progress` already runs backwards for a collapse, so this
+	// single expression covers both directions: it starts at the Session colours and ends at the keyboard ones when
+	// expanding, and does the reverse when collapsing.
+	uint16_t keyboardSessionBlend = keyboardSidebarMorphing ? smoothProgress(65535 - clippedProgress) : 0;
 
 	int32_t greyStart =
 	    instrumentClipView.getSquareFromPos(clipLength - 1, NULL, currentSong->xScroll[NAVIGATION_CLIP]) + 1;
@@ -436,8 +434,8 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 		}
 
 		bool expandingMuteColumn = expanding && col == kDisplayWidth;
-		bool collapsingKeyboardSidebar =
-		    keyboardSidebarCollapsing && col >= kDisplayWidth && col < kDisplayWidth + kSideBarWidth;
+		bool keyboardSidebarColumn =
+		    keyboardSidebarMorphing && col >= kDisplayWidth && col < kDisplayWidth + kSideBarWidth;
 
 		if (expandingMuteColumn && animatedRowGoingTo[0] >= 0 && animatedRowGoingTo[0] < kDisplayHeight) {
 			int32_t sessionMuteIntensity = 65535 - muteBlendProgress;
@@ -457,24 +455,17 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 			int32_t intensity1 = intensity1Array[i];
 			int32_t intensity2 = intensity2Array[i];
 
-			if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_COLLAPSING)
-			    || isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING)) {
+			if (transitioning) {
 
-				// Fade the clip-view audition column in when expanding. When collapsing,
-				// keep it visible until the follow-up fade blends to the session sidebar.
-				if (isUIModeActive(UI_MODE_INSTRUMENT_CLIP_EXPANDING) && col == kDisplayWidth + kSideBarWidth - 1) {
-					intensity1 = ((uint32_t)intensity1 * progress) >> 16;
-					intensity2 = ((uint32_t)intensity2 * progress) >> 16;
-				}
-
-				// Keyboard sidebar columns collapse from their source keyboard colours into the session colours.
-				if (collapsingKeyboardSidebar) {
-					RGB sessionSidebarColour = (col == kDisplayWidth) ? clipMuteSquareColour : clipSectionSquareColour;
-					uint16_t keyboardDestinationBlend = keyboardGlobalDestinationBlend;
+				// Keyboard's sidebar columns morph between their keyboard colours and the Session colours of the row
+				// they collapse into / expand out of, in whichever direction we're going.
+				if (keyboardSidebarColumn) {
+					RGB sessionColour = (col == kDisplayWidth) ? clipMuteSquareColour : clipSectionSquareColour;
+					uint16_t sessionBlend = keyboardSessionBlend;
 					if (animatedRowGoingTo[i] >= 0 && animatedRowGoingTo[i] < kDisplayHeight) {
 						constexpr int32_t kKeyboardColourBlendDistance = 3 * 65536;
-						// Cap the colour morph by distance so pads keep their keyboard colours until they are
-						// visually close to collapsing into the session clip row.
+						// Cap the morph by how far this row still is from the Session row, so pads hold their keyboard
+						// colours until they're visually close to it rather than changing colour across the display.
 						int32_t distanceFromDestination =
 						    newRowPositionArray[i] - ((int32_t)animatedRowGoingTo[i] * 65536);
 						if (distanceFromDestination < 0) {
@@ -488,9 +479,16 @@ void renderInstrumentClipCollapseAnimation(int32_t xStart, int32_t xEndOverall, 
 							    / kKeyboardColourBlendDistance;
 							proximityBlend = smoothProgress(std::min<uint32_t>(proximityProgress, 65535));
 						}
-						keyboardDestinationBlend = std::min(keyboardDestinationBlend, proximityBlend);
+						sessionBlend = std::min(sessionBlend, proximityBlend);
 					}
-					squareColours = RGB::blend(sessionSidebarColour, squareColours, keyboardDestinationBlend);
+					squareColours = RGB::blend(sessionColour, squareColours, sessionBlend);
+				}
+
+				// The clip's audition column has nowhere to go in Session view, so fade it as we go: `progress` runs
+				// forwards when expanding and backwards when collapsing, so this fades it in and out respectively.
+				else if (col == kDisplayWidth + kSideBarWidth - 1) {
+					intensity1 = ((uint32_t)intensity1 * progress) >> 16;
+					intensity2 = ((uint32_t)intensity2 * progress) >> 16;
 				}
 
 				// If the mute-col, we want to alter the colour

--- a/src/deluge/hid/led/pad_leds.h
+++ b/src/deluge/hid/led/pad_leds.h
@@ -103,6 +103,13 @@ extern bool scrollingToNothing;
 } // namespace vertical
 
 RGB prepareColour(int32_t x, int32_t y, RGB colourSource);
+/// Sync one row's sidebar occupancy to its colours. Sidebars can legitimately contain black pads, and transition
+/// blending treats an occupied-but-black pad as real content, so mark those empty instead.
+void refreshSidebarOccupancy(RGB rowImage[], uint8_t rowOccupancyMask[]);
+/// Blank store rows 0 and kDisplayHeight + 1. Clip collapse and explode animations span kDisplayHeight + 2 rows, so
+/// callers that can't fill the two offscreen rows with real content must clear them, or the animation drags in
+/// whatever the previous transition left there.
+void clearTransitionStoreOffScreenRows();
 void clearTickSquares(bool shouldSend = true);
 void setTickSquares(const uint8_t* squares, const uint8_t* colours);
 void renderExplodeAnimation(int32_t explodedness, bool shouldSendOut = true);

--- a/src/deluge/hid/led/pad_leds.h
+++ b/src/deluge/hid/led/pad_leds.h
@@ -112,7 +112,8 @@ void renderFade(int32_t progress);
 void recordTransitionBegin(uint32_t newTransitionLength);
 int32_t getTransitionProgress();
 void renderAudioClipExpandOrCollapse();
-void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder);
+// The keyboard-screen flag enables the two-column sidebar colour morph used when collapsing back to Session.
+void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder, bool collapsingKeyboardScreen = false);
 void setupAudioClipCollapseOrExplodeAnimation(AudioClip* clip);
 
 void setGreyoutAmount(float newAmount);

--- a/src/deluge/hid/led/pad_leds.h
+++ b/src/deluge/hid/led/pad_leds.h
@@ -119,8 +119,11 @@ void renderFade(int32_t progress);
 void recordTransitionBegin(uint32_t newTransitionLength);
 int32_t getTransitionProgress();
 void renderAudioClipExpandOrCollapse();
-// The keyboard-screen flag enables the two-column sidebar colour morph used when collapsing back to Session.
-void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder, bool collapsingKeyboardScreen = false);
+void setupInstrumentClipCollapseAnimation(bool collapsingOutOfClipMinder);
+/// Morph keyboard view's two sidebar columns to/from the Session sidebar colours of the row the clip collapses into
+/// or expands out of. Keyboard view has no mute / section columns of its own, so without this they would pop.
+/// Call after setupInstrumentClipCollapseAnimation(), which clears it.
+void enableKeyboardSidebarMorph(RGB sessionSectionColour);
 void setupAudioClipCollapseOrExplodeAnimation(AudioClip* clip);
 
 void setGreyoutAmount(float newAmount);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -75,6 +75,7 @@ add_executable(UnitTests
         chord_tests.cpp
         time_tests.cpp
         clock_output_scheduler_tests.cpp
+        rgb_tests.cpp
 )
 add_test(NAME UnitTests
         COMMAND UnitTests)

--- a/tests/unit/rgb_tests.cpp
+++ b/tests/unit/rgb_tests.cpp
@@ -1,0 +1,89 @@
+#include "CppUTest/TestHarness.h"
+#include "gui/colour/rgb.h"
+#include "util/functions.h"
+
+namespace {
+constexpr RGB kRed{255, 0, 0};
+constexpr RGB kGreen{0, 255, 0};
+constexpr RGB kBlack{0, 0, 0};
+
+void CHECK_RGB_NEAR(RGB expected, RGB actual, int32_t tolerance) {
+	CHECK_COMPARE(std::abs((int32_t)expected.r - (int32_t)actual.r), <=, tolerance);
+	CHECK_COMPARE(std::abs((int32_t)expected.g - (int32_t)actual.g), <=, tolerance);
+	CHECK_COMPARE(std::abs((int32_t)expected.b - (int32_t)actual.b), <=, tolerance);
+}
+} // namespace
+
+TEST_GROUP(RGBTests){};
+
+// blend(a, b, index) slides from b at index 0 to a at index 65535. Both endpoints must be a source colour:
+// an index of 0 used to overflow the weight for b (65536) into a uint16_t and return black, which made
+// transition animations flash black on any frame whose blend amount landed on zero.
+TEST(RGBTests, blendAtZeroIndexReturnsSourceB) {
+	CHECK_RGB_NEAR(kGreen, RGB::blend(kRed, kGreen, 0), 1);
+}
+
+TEST(RGBTests, blendAtMaxIndexReturnsSourceA) {
+	CHECK_RGB_NEAR(kRed, RGB::blend(kRed, kGreen, 65535), 1);
+}
+
+// blend2() takes the two weights separately, and drawSquare() passes it a weight of 65536 ("keep all of the colour
+// already in this square"). That does not fit a uint16_t either, so the square used to be wiped to black in exactly
+// the case where every bit of it was meant to be kept.
+TEST(RGBTests, blend2KeepsSourceAAtFullWeight) {
+	CHECK_RGB_NEAR(kRed, RGB::blend2(kRed, kGreen, 65536, 0), 1);
+}
+
+TEST(RGBTests, blend2SumsBothSourcesAtFullWeight) {
+	// Full weight on both is the saturating case: each channel clamps at its own max rather than wrapping.
+	CHECK_RGB_NEAR(RGB(255, 255, 0), RGB::blend2(kRed, kGreen, 65536, 65536), 1);
+}
+
+TEST(RGBTests, blendIsMonotonicAcrossTheRange) {
+	// Sweeping the index must never dip to black in the middle: r rises as g falls.
+	int32_t previousR = -1;
+	for (uint32_t index = 0; index <= 65535; index += 257) {
+		RGB blended = RGB::blend(kRed, kGreen, index);
+		CHECK_COMPARE((int32_t)blended.r, >=, previousR);
+		CHECK_COMPARE((int32_t)blended.r + (int32_t)blended.g, >=, 250);
+		previousR = blended.r;
+	}
+}
+
+// drawSquare() composites one animated source square onto a destination pad. Every pad animation - clip collapse and
+// expand, explode, fade, zoom, scroll - composites through it, so these pin the accumulation contract it relies on.
+TEST_GROUP(DrawSquareTests){};
+
+TEST(DrawSquareTests, drawingOntoAnEmptySquareGivesTheColour) {
+	uint8_t occupancy = 0;
+	CHECK_RGB_NEAR(kRed, drawSquare(kRed, 65535, kBlack, &occupancy, 64), 1);
+	CHECK_EQUAL(64, occupancy);
+}
+
+TEST(DrawSquareTests, drawingAtZeroIntensityLeavesTheSquareAlone) {
+	// A source row landing exactly on a pad boundary contributes zero intensity to the neighbouring pad. That must
+	// leave the pad as it was; it used to wipe it to black.
+	uint8_t occupancy = 64;
+	CHECK_RGB_NEAR(kRed, drawSquare(kGreen, 0, kRed, &occupancy, 64), 1);
+}
+
+TEST(DrawSquareTests, overlappingContributionsAccumulate) {
+	// Two half-intensity sources landing on one pad must both show up. Discarding what was already there would
+	// leave only the last writer (pure green), which is what made animations drop colour mid-flight.
+	uint8_t occupancy = 0;
+	RGB square = drawSquare(kRed, 32768, kBlack, &occupancy, 64);
+	square = drawSquare(kGreen, 32768, square, &occupancy, 64);
+
+	CHECK_RGB_NEAR(RGB(128, 128, 0), square, 1);
+	CHECK_EQUAL(64, occupancy);
+}
+
+TEST(DrawSquareTests, occupancySaturatesRatherThanWrapping) {
+	uint8_t occupancy = 0;
+	RGB square = kBlack;
+	for (int32_t i = 0; i < 8; i++) {
+		square = drawSquare(kRed, 65535, square, &occupancy, 64);
+	}
+	CHECK_EQUAL(64, occupancy);
+	CHECK_RGB_NEAR(kRed, square, 1);
+}


### PR DESCRIPTION
Fix sidebar transition animations - Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/1604

Sidebar animations from session row view to instrument clip view / automation view / keyboard view are less smooth compared to official.

Session macros were one contributing factor when transitioning back to session view as it would cause the sidebar to blink.

Automation view didn't have sidebar animations to begin with, and keyboard column controls were a recent addition so the animations weren't tuned very well.

Instrument Clip View I think was broken as a result of some refactoring potentially a while ago.

This issue has been present since the first community firmware release (1.0), so long-standing.

I think things are working really well now.

-- 

Unrelated fix:
- pressing scale button now flashes root notes in automation view as well