### PR TITLE
fix: don't free the SampleRecorder from inside the SD card routine (#3309)

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -568,7 +568,10 @@ void registerTasks() {
 	// these ones are actually "slow" -> file manager just checks if an sd card has been inserted, audio recorder checks
 	// if recordings are finished
 	addRepeatingTask([]() { audioFileManager.slowRoutine(); }, p++, 0.1, 0.1, 0.2, "audio file slow", RESOURCE_SD);
-	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.09, 0.1, "audio recorder slow", RESOURCE_NONE);
+	// Needs the SD resources: it can call finishRecording(), which frees the SampleRecorder, and that must not happen
+	// while the card routine is part-way through using it.
+	addRepeatingTask([]() { audioRecorder.slowRoutine(); }, p++, 0.01, 0.09, 0.1, "audio recorder slow",
+	                 RESOURCE_SD | RESOURCE_SD_ROUTINE);
 	// formerly part of cluster loading (why? no idea), actions undo/redo midi commands
 	addRepeatingTask([]() { playbackHandler.slowRoutine(); }, p++, 0.01, 0.09, 0.1, "playback slow routine",
 	                 RESOURCE_SD);

--- a/src/deluge/extern.h
+++ b/src/deluge/extern.h
@@ -20,6 +20,8 @@
 
 #include <cstdint>
 extern bool sdRoutineLock;
+// Defined in RZA1/diskio.c, so it has C linkage - several files declare it inline in their own extern "C" blocks.
+extern "C" uint8_t currentlyAccessingCard;
 extern int16_t zeroMPEValues[];
 extern bool allowSomeUserActionsEvenWhenInCardRoutine;
 extern bool readButtonsAndPads();

--- a/src/deluge/gui/ui/audio_recorder.cpp
+++ b/src/deluge/gui/ui/audio_recorder.cpp
@@ -179,7 +179,23 @@ void AudioRecorder::endRecordingSoon(int32_t buttonLatency) {
 }
 
 void AudioRecorder::slowRoutine() {
+	// finishRecording() frees the SampleRecorder, which discardRecorder() forbids doing from inside the SD card
+	// routine - the recorder may be suspended part-way through its own cardRoutine(), and freeing it there leaves
+	// that cardRoutine() running on freed memory (then freeing it a second time). As a scheduler task we're already
+	// held off by our RESOURCE_SD | RESOURCE_SD_ROUTINE registration; this guard covers the one call site that
+	// bypasses the scheduler, the legacy non-USE_TASK_MANAGER mainLoop.
+	if (sdRoutineLock || currentlyAccessingCard) {
+		return;
+	}
+
 	if (recordingSource >= AUDIO_INPUT_CHANNEL_FIRST_INTERNAL_OPTION) {
+		// setupRecordingToFile() always assigns recorder before recordingSource, so this can't happen - but don't let
+		// it become a silent hang: StemExport's yield loop waits on recordingSource, which only finishRecording()
+		// clears, so quietly skipping would wedge the export forever with nothing on screen.
+		if (recorder == nullptr) {
+			FREEZE_WITH_ERROR("E250");
+			return;
+		}
 		if (recorder->status >= RecorderStatus::COMPLETE) {
 			indicator_leds::setLedState(IndicatorLED::RECORD, (playbackHandler.recording == RecordingMode::NORMAL));
 			finishRecording();

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -1051,10 +1051,32 @@ void routine() {
 				sideChainHitPending = 0;
 				audioSampleTimer += numSamples;
 				doSomeOutputting();
-				// gross and hacky way to make sure the audio recorder writes all of its data so it can't be stolen
-				while (audioRecorder.recorder->firstUnwrittenClusterIndex
-				       < audioRecorder.recorder->currentRecordClusterIndex) {
-					doRecorderCardRoutines();
+
+				// Write out the recorder's completed clusters so they can't be stolen. There's no recorder at all
+				// between stems, and one that has hit a card error or been aborted (RAM exhaustion) will never
+				// advance firstUnwrittenClusterIndex again, because cardRoutine() early-returns in both cases -
+				// so bail on those, and bound the loop regardless rather than trusting that list to be complete.
+				SampleRecorder* recorder = audioRecorder.recorder;
+				if (recorder != nullptr) {
+					// Each call writes at most one cluster, and we don't render (so can't produce new ones) until
+					// the drain finishes. The slack covers calls that return without reaching this recorder at all:
+					// doRecorderCardRoutines() abandons its traversal whenever a recorder was recently created.
+					int32_t callsRemaining =
+					    recorder->currentRecordClusterIndex - recorder->firstUnwrittenClusterIndex + 8;
+
+					while (callsRemaining-- > 0) {
+						if (recorder->hadCardError || recorder->status >= RecorderStatus::COMPLETE
+						    || recorder->firstUnwrittenClusterIndex >= recorder->currentRecordClusterIndex) {
+							break;
+						}
+
+						doRecorderCardRoutines();
+
+						// doRecorderCardRoutines() can finish and free recorders - don't trust the pointer after it
+						if (audioRecorder.recorder != recorder) {
+							break;
+						}
+					}
 				}
 
 				audioFileManager.loadAnyEnqueuedClusters(128, false);
@@ -1560,7 +1582,15 @@ errorAfterAllocation:
 }
 
 // PLEASE don't call this if there's any chance you might be in the SD card routine...
+// ...because the recorder may be suspended part-way through its own cardRoutine(), and freeing it there leaves that
+// cardRoutine() operating on freed memory before handing it back to doRecorderCardRoutines() to be freed a second
+// time. That's a double free, and it surfaces as M123 from the allocator, a long way from here - so rather than
+// leaving the rule as a comment for each caller to honour, enforce it.
 void discardRecorder(SampleRecorder* recorder) {
+	if (ALPHA_OR_BETA_VERSION && (sdRoutineLock || currentlyAccessingCard)) {
+		FREEZE_WITH_ERROR("E251");
+	}
+
 	int32_t count = 0;
 	SampleRecorder** prevPointer = &firstRecorder;
 	while (*prevPointer) {

--- a/tests/unit/scheduler_tests.cpp
+++ b/tests/unit/scheduler_tests.cpp
@@ -65,7 +65,16 @@ void yield_2ms_with_lock() {
 TEST_GROUP(Scheduler){
 
     void setup(){taskManager = TaskManager();
+sdRoutineLock = false;
+currentlyAccessingCard = false;
 } // namespace
+
+// These are globals the ResourceChecker reads. Reset them here as well as in setup(), so that a test which fails
+// part-way through while holding one can't leave it locked and silently starve every later resource-gated task.
+void teardown() {
+	sdRoutineLock = false;
+	currentlyAccessingCard = false;
+}
 }
 ;
 
@@ -119,6 +128,36 @@ TEST(Scheduler, scheduleConditionalDoesntRun) {
 	// will load as blocked but immediately pass condition
 	addConditionalTask(sleep_50ns, 0, []() { return false; }, "sleep 50ns", RESOURCE_NONE);
 	// run the scheduler for just under 10ms, calling the function to sleep 50ns every 1ms
+	taskManager.start(0.0095);
+	mock().checkExpectations();
+};
+
+// The SD card busy-wait yields to the scheduler, so any task holding an SD resource must stay unrunnable for as long
+// as that resource is locked. AudioRecorder::slowRoutine() depends on this: it frees the SampleRecorder, and doing so
+// from inside the card routine leaves SampleRecorder::cardRoutine() running on freed memory.
+TEST(Scheduler, sdRoutineLockBlocksSdRoutineTask) {
+	mock().clear();
+	mock().expectNCalls(0, "sleep_50ns");
+	sdRoutineLock = true;
+	addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sd routine task", RESOURCE_SD_ROUTINE);
+	taskManager.start(0.0095);
+	mock().checkExpectations();
+};
+
+TEST(Scheduler, cardAccessBlocksSdTask) {
+	mock().clear();
+	mock().expectNCalls(0, "sleep_50ns");
+	currentlyAccessingCard = true;
+	addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sd task", RESOURCE_SD);
+	taskManager.start(0.0095);
+	mock().checkExpectations();
+};
+
+// ...and the blocking above is real, not just a task that never runs: with the resources free it runs every period.
+TEST(Scheduler, sdTaskRunsOnceResourcesUnlocked) {
+	mock().clear();
+	mock().expectNCalls(0.01 / 0.001, "sleep_50ns");
+	addRepeatingTask(sleep_50ns, 0, 0.001, 0.001, 0.001, "sd task", RESOURCE_SD | RESOURCE_SD_ROUTINE);
 	taskManager.start(0.0095);
 	mock().checkExpectations();
 };


### PR DESCRIPTION
Exporting audio offline could crash with M123, freeze mid-export, or fault outright. All three come from AudioRecorder::slowRoutine() freeing a SampleRecorder while that same recorder is suspended part-way through its own cardRoutine().

The trap is that status >= COMPLETE also matches ABORTED, and abort() fires from the audio routine when a long export exhausts RAM. So the recorder aborts mid-f_write, the SD yield picks the unguarded task, and it frees the recorder out from under itself. cardRoutine() resumes on freed memory and writes AWAITING_DELETION back into it; doRecorderCardRoutines() reads that and frees the block a second time. M123 is the allocator's double-free canary.

It is offline-only because the offline branch drains recorder writes from inside the audio routine with sdRoutineLock clear, so every write takes the yielding path - which is why reporters consistently see live rendering work.

- Guard AudioRecorder::slowRoutine() and register it RESOURCE_SD | RESOURCE_SD_ROUTINE, matching its siblings.
- Enforce discardRecorder()'s precondition (E251) rather than leaving it a comment for each caller to honour.
- Null-check the recorder in the offline drain loop (there is none between stems) and bound the loop: it made no progress once the recorder latched hadCardError or ABORTED, since cardRoutine() early-returns in both cases, which is the reported freeze.
- Cover the scheduler's resource gate with tests.