### PR TITLE
fix: show favourites row when loading a synth (#4674)

### DIFF
--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -63,6 +63,11 @@ bool LoadInstrumentPresetUI::getGreyoutColsAndRows(uint32_t* cols, uint32_t* row
 
 bool LoadInstrumentPresetUI::opened() {
 
+	// The QWERTY keyboard is always shown in this UI (qwertyAlwaysVisible stays true), so the favourites row should
+	// be too. The static qwertyVisible flag can be left false by another browser (e.g. song load with the keyboard
+	// toggled off); without resetting it here the favourites row would stay hidden until something else set it. #4674
+	qwertyVisible = true;
+
 	if (getRootUI() == &keyboardScreen) {
 		PadLEDs::skipGreyoutFade();
 	}


### PR DESCRIPTION
The favourites row only renders when the shared static qwertyVisible flag is true. The instrument/synth load UI always shows the QWERTY keyboard (qwertyAlwaysVisible stays true) but never reset qwertyVisible on entry, so if another browser (e.g. song load with the keyboard toggled off) had left it false, the favourites row stayed hidden even though the keyboard was drawn.

Reset qwertyVisible to true when the instrument preset UI opens.