### PR TITLE
Fix Filter mode "off" not saving in XML files

### DIFF
--- a/src/deluge/model/mod_controllable/filters/filter_config.cpp
+++ b/src/deluge/model/mod_controllable/filters/filter_config.cpp
@@ -10,7 +10,8 @@ EnumStringMap<FilterMode, kNumFilterModes> filterMap({{{FilterMode::TRANSISTOR_1
                                                        {FilterMode::TRANSISTOR_24DB_DRIVE, "24dBDrive"},
                                                        {FilterMode::SVF_BAND, "SVF_Band"},
                                                        {FilterMode::SVF_NOTCH, "SVF_Notch"},
-                                                       {FilterMode::HPLADDER, "HPLadder"}}});
+                                                       {FilterMode::HPLADDER, "HPLadder"},
+                                                       {FilterMode::OFF, "Off"}}});
 
 EnumStringMap<FilterRoute, kNumFilterRoutes> routeMap({{
     {FilterRoute::LOW_TO_HIGH, "L2H"},

--- a/src/deluge/model/mod_controllable/filters/filter_config.h
+++ b/src/deluge/model/mod_controllable/filters/filter_config.h
@@ -31,9 +31,8 @@ enum class FilterMode {
 	HPLADDER,
 	OFF, // Keep last as a sentinel. Signifies that the filter is not on, used for filter reset logic
 };
-constexpr int32_t kNumFilterModes = util::to_underlying(FilterMode::OFF);
+constexpr int32_t kNumFilterModes = util::to_underlying(FilterMode::OFF) + 1;
 constexpr FilterMode kLastLadder = FilterMode::TRANSISTOR_24DB_DRIVE;
-// Off is not an LPF mode but is used to reset filters
 constexpr int32_t kNumLPFModes = util::to_underlying(FilterMode::SVF_NOTCH) + 1;
 constexpr FilterMode lastLpfMode = FilterMode::SVF_NOTCH;
 constexpr FilterMode firstHPFMode = FilterMode::SVF_BAND;


### PR DESCRIPTION
Update number of filters modes and filter mode map to include off

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4684

- [ ] the fix works, but it still writes the wrong Lpfmode to the xml (it writes hpladder instead of off)