### PR TITLE
DelugeCompanion/ Tweak shortcut desc format + add show-hide all toggle

### DIFF
--- a/website/src/components/deluge_companion/components/PageMain.svelte
+++ b/website/src/components/deluge_companion/components/PageMain.svelte
@@ -3,10 +3,18 @@
   import ViewFilter from "./ViewFilter.svelte";
   import { isShortcutDataLoading, searchQuery } from "../stores/search_store.js";
   import { filteredShortcuts } from "../stores/shortcut_store.js";
+  import { setAllShortcutDescriptionsVisible } from "../stores/shortcut_description_visibility_store.js";
 
   // Hide filters when an active search has no matches.
   $: hasNoSearchMatches =
     $searchQuery.trim().length > 0 && $filteredShortcuts.length === 0;
+
+  let areAllDescriptionsVisible = false;
+
+  // Applies global description visibility command across all currently rendered cards.
+  function onDescriptionVisibilityChanged() {
+    setAllShortcutDescriptionsVisible(areAllDescriptionsVisible);
+  }
 </script>
 
 <main class="mb-8 flex flex-col gap-4">
@@ -26,6 +34,22 @@
     {#if !hasNoSearchMatches}
       <ViewFilter />
     {/if}
+
+    <section class="description-visibility-toggle" aria-label="Shortcut description visibility">
+      <label class="description-visibility-label" for="toggle-shortcut-descriptions">
+        <input
+          id="toggle-shortcut-descriptions"
+          class="description-visibility-input"
+          type="checkbox"
+          bind:checked={areAllDescriptionsVisible}
+          on:change={onDescriptionVisibilityChanged}
+        />
+        <span class="description-visibility-text">
+          {areAllDescriptionsVisible ? "Hide all shortcut descriptions" : "Show all shortcut descriptions"}
+        </span>
+      </label>
+    </section>
+
     <ShortcutList />
   {/if}
 </main>
@@ -78,5 +102,33 @@
   :global(html[data-theme="light"]) .loading-shortcuts {
     color: var(--sl-color-gray-3);
     background: color-mix(in srgb, var(--sl-color-bg) 88%, var(--sl-color-gray-6));
+  }
+
+  .description-visibility-toggle {
+    margin-top: -0.25rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    padding: 0.55rem 0.75rem;
+    background: color-mix(in srgb, var(--sl-color-bg) 88%, var(--sl-color-gray-6));
+  }
+
+  .description-visibility-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .description-visibility-input {
+    margin: 0;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .description-visibility-text {
+    font-size: 0.92rem;
+    font-weight: 600;
+    color: var(--sl-color-text);
   }
 </style>

--- a/website/src/components/deluge_companion/components/SearchHighlight.svelte
+++ b/website/src/components/deluge_companion/components/SearchHighlight.svelte
@@ -30,14 +30,3 @@
 </script>
 
 {@html highlightedHtml}
-
-<style>
-  :global(.dc-search-hit) {
-    background: color-mix(in srgb, var(--sl-color-accent, #60a5fa) 38%, transparent);
-    color: inherit;
-    border-radius: 0.18rem;
-    padding: 0 0.08rem;
-    box-decoration-break: clone;
-    -webkit-box-decoration-break: clone;
-  }
-</style>

--- a/website/src/components/deluge_companion/components/Shortcut.svelte
+++ b/website/src/components/deluge_companion/components/Shortcut.svelte
@@ -17,6 +17,9 @@
     setHardwarePreviewOpen,
     shortcutPreviewResetVersion,
   } from "../stores/preview_store.js";
+  import {
+    shortcutDescriptionVisibilityCommand,
+  } from "../stores/shortcut_description_visibility_store.js";
 
   // One shortcut card instance plus a stable id used by shared preview state.
   export let shortcut: Shortcut;
@@ -49,9 +52,12 @@
 
   let showDetails: boolean = false;
   let shortcutCardEl: HTMLDivElement | undefined;
-  let areDescriptionSectionsExpanded: boolean = true;
-  let areCommunitySectionsExpanded: boolean = true;
+  let areDescriptionSectionsExpanded: boolean = false;
+  let areCommunitySectionsExpanded: boolean = false;
   let lastResetVersion = 0;
+  let lastDescriptionVisibilityCommandVersion = 0;
+  let previousDescriptionExpandedBeforePreview: boolean | null = null;
+  let previousCommunityExpandedBeforePreview: boolean | null = null;
 
   // Computes the occupied top offset from sticky/fixed site chrome so
   // programmatic scroll positioning does not hide content under the header.
@@ -85,15 +91,44 @@
   // Card-local state mirrors the shared preview store.
   $: isPreviewOpen = $openHardwarePreviewIds.includes(shortcutPreviewId);
 
+  // Apply global visibility command exactly once per command version.
+  $: if (
+    $shortcutDescriptionVisibilityCommand.version !==
+    lastDescriptionVisibilityCommandVersion
+  ) {
+    lastDescriptionVisibilityCommandVersion =
+      $shortcutDescriptionVisibilityCommand.version;
+    if (isPreviewOpen) {
+      // If command changes while preview is open, apply after preview closes.
+      previousDescriptionExpandedBeforePreview =
+        $shortcutDescriptionVisibilityCommand.visible;
+      previousCommunityExpandedBeforePreview =
+        $shortcutDescriptionVisibilityCommand.visible;
+    } else {
+      areDescriptionSectionsExpanded =
+        $shortcutDescriptionVisibilityCommand.visible;
+      areCommunitySectionsExpanded =
+        $shortcutDescriptionVisibilityCommand.visible;
+    }
+  }
+
   // Keep card visibility and description expansion synced with shared preview state.
   $: if (showDetails !== isPreviewOpen) {
     showDetails = isPreviewOpen;
     if (showDetails) {
+      previousDescriptionExpandedBeforePreview = areDescriptionSectionsExpanded;
+      previousCommunityExpandedBeforePreview = areCommunitySectionsExpanded;
       areDescriptionSectionsExpanded = false;
       areCommunitySectionsExpanded = false;
     } else {
-      areDescriptionSectionsExpanded = true;
-      areCommunitySectionsExpanded = true;
+      areDescriptionSectionsExpanded =
+          previousDescriptionExpandedBeforePreview ??
+          $shortcutDescriptionVisibilityCommand.visible;
+      areCommunitySectionsExpanded =
+          previousCommunityExpandedBeforePreview ??
+          $shortcutDescriptionVisibilityCommand.visible;
+      previousDescriptionExpandedBeforePreview = null;
+      previousCommunityExpandedBeforePreview = null;
     }
   }
 
@@ -101,8 +136,10 @@
   $: if ($shortcutPreviewResetVersion !== lastResetVersion) {
     lastResetVersion = $shortcutPreviewResetVersion;
     // Global filter/search resets should restore the card to collapsed content state.
-    areDescriptionSectionsExpanded = true;
-    areCommunitySectionsExpanded = true;
+    previousDescriptionExpandedBeforePreview = null;
+    previousCommunityExpandedBeforePreview = null;
+    areDescriptionSectionsExpanded = $shortcutDescriptionVisibilityCommand.visible;
+    areCommunitySectionsExpanded = $shortcutDescriptionVisibilityCommand.visible;
     showDetails = false;
   }
 
@@ -182,20 +219,22 @@
     </h3>
   </div>
   <!-- Step sequence acts as preview toggle (mouse + keyboard accessible). -->
-  <div
-    role="button"
-    tabindex="0"
-    aria-expanded={showDetails}
-    class="shortcut-steps m-0 rounded-md p-1 text-left"
-    on:click={onStepsClicked}
-    on:keydown={onStepsKeydown}
-  >
-    <span class="shortcut-steps-inner">
-      {#each shortcut.steps as step (step)}
-        <StepContainerView bind:step />
-      {/each}
-    </span>
-  </div>
+  {#if shortcut.steps.length > 0}
+    <div
+      role="button"
+      tabindex="0"
+      aria-expanded={showDetails}
+      class="shortcut-steps m-0 rounded-md p-1 text-left"
+      on:click={onStepsClicked}
+      on:keydown={onStepsKeydown}
+    >
+      <span class="shortcut-steps-inner">
+        {#each shortcut.steps as step (step)}
+          <StepContainerView bind:step />
+        {/each}
+      </span>
+    </div>
+  {/if}
   <!-- Primary description section (default docs text). -->
   {#if shortcut.description || descriptionParagraphs.length > 0}
     <aside class="shortcut-aside shortcut-description-aside mt-4 rounded-md px-3 py-1" data-type="tip">
@@ -388,8 +427,20 @@
     margin-top: 0.5rem;
   }
 
+  .shortcut-description-aside {
+    padding-bottom: 0.15rem;
+  }
+
+  .shortcut-description-aside :global(p:last-child) {
+    margin-bottom: 0.2rem;
+  }
+
+  .shortcut-description-aside + .shortcut-aside[data-type="caution"] {
+    margin-top: 0;
+  }
+
   .description-aside-title {
-    margin: 0.35rem 0 0.2rem;
+    margin: 0;
     font-size: 0.76rem;
     line-height: 1.2;
     letter-spacing: 0.01em;
@@ -401,7 +452,7 @@
 
   .aside-title-button {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
     width: 100%;
     gap: 0.75rem;
@@ -416,7 +467,7 @@
 
   .aside-toggle-indicator {
     font-size: 0.72rem;
-    line-height: 1;
+    line-height: 1.2;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.02em;
@@ -424,7 +475,7 @@
   }
 
   .community-aside-title {
-    margin: 0.35rem 0 0.2rem;
+    margin: 0;
     font-size: 0.76rem;
     line-height: 1.2;
     letter-spacing: 0.01em;

--- a/website/src/components/deluge_companion/data/shortcuts/08-controls/03-parameters/08-controls_parameters.md
+++ b/website/src/components/deluge_companion/data/shortcuts/08-controls/03-parameters/08-controls_parameters.md
@@ -34,7 +34,7 @@ In the community firmware, turning a gold dial will display the name of the para
 Press Parameter Button
 
 ```community
-In the community firmware, turning a gold dial will display the name of the parameter it controls in addition to the current value on the OLED display.
+In the community firmware, pressing the circular buttons between the gold dials will display the parameters that each gold dial controls.
 ```
 
 # Delete automation of recorded parameter

--- a/website/src/components/deluge_companion/data/v4.1.0.json
+++ b/website/src/components/deluge_companion/data/v4.1.0.json
@@ -641,7 +641,7 @@
       }
     ],
     "views": [19, 9, 10, 11, 12],
-    "firmware": [1],
+    "firmware": [0],
     "paragraphs": [],
     "description": "Turn the Select (Settings) encoder."
   },
@@ -2634,7 +2634,7 @@
     "description": "Press the Audition / Section button for row."
   },
   {
-    "name": "Section repeat (hold audition for 1 sec)",
+    "name": "Section repeat",
     "capability": "02-playback_session",
     "capabilityParentId": "PLAYBACK",
     "capabilityOrder": 3,
@@ -2656,6 +2656,13 @@
       {
         "spans": [
           {
+            "text": "Hold audition for 1 sec to show repeat popup and then turn select."
+          }
+        ]
+      },
+      {
+        "spans": [
+          {
             "text": "Changes INFInite to a repeat count for the section. The display counts down; press Select to cancel the section switch during countdown."
           }
         ]
@@ -2664,7 +2671,7 @@
     "description": "Hold the Audition / Section button for row. Turn the Select (Settings) encoder."
   },
   {
-    "name": "Clone/duplicate clip (hold source, press destination)",
+    "name": "Clone/duplicate clip",
     "capability": "02-playback_session",
     "capabilityParentId": "PLAYBACK",
     "capabilityOrder": 3,
@@ -2687,6 +2694,13 @@
     "views": [2],
     "firmware": [0],
     "paragraphs": [
+      {
+        "spans": [
+          {
+            "text": "Hold source clip and press destination pad."
+          }
+        ]
+      },
       {
         "spans": [
           {
@@ -8935,7 +8949,7 @@
         "type": "community",
         "spans": [
           {
-            "text": "In the community firmware, turning a gold dial will display the name of the parameter it controls in addition to the current value on the OLED display."
+            "text": "In the community firmware, pressing the circular buttons between the gold dials will display the parameters that each gold dial controls."
           }
         ]
       }

--- a/website/src/components/deluge_companion/stores/shortcut_description_visibility_store.ts
+++ b/website/src/components/deluge_companion/stores/shortcut_description_visibility_store.ts
@@ -1,0 +1,15 @@
+import { writable } from "svelte/store"
+
+// Shared command that can expand/collapse description sections across all cards.
+// Default is hidden so users opt in to expanded prose content.
+export const shortcutDescriptionVisibilityCommand = writable({
+  visible: false,
+  version: 0,
+})
+
+export const setAllShortcutDescriptionsVisible = (visible: boolean) => {
+  shortcutDescriptionVisibilityCommand.update((command) => ({
+    visible,
+    version: command.version + 1,
+  }))
+}

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -38,3 +38,16 @@
     justify-content: flex-end;
   }
 }
+
+.dc-search-hit {
+  background: color-mix(
+    in srgb,
+    var(--sl-color-accent, #60a5fa) 38%,
+    transparent
+  );
+  color: inherit;
+  border-radius: 0.18rem;
+  padding: 0 0.08rem;
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}


### PR DESCRIPTION
Continued deluge companion tweaking.

- Adjusted formatting of shortcut descriptions to take up less space
- Collapse all shortcut descriptions by default
- Added a show/hide all shortcut descriptions toggle at the top above the first shortcut

Before::

<img width="406" height="225" alt="Screenshot 2026-07-18 at 12 02 23 PM" src="https://github.com/user-attachments/assets/e0ebb05a-db01-4fe4-b231-6d9da52f326d" />

After:

<img width="310" height="68" alt="Screenshot 2026-07-18 at 12 04 58 PM" src="https://github.com/user-attachments/assets/f347cf62-9aee-4740-9613-540755d177fb" />

<img width="385" height="168" alt="Screenshot 2026-07-18 at 12 04 37 PM" src="https://github.com/user-attachments/assets/3088927b-b8ce-4fac-9a73-65fa3b97639e" />

