### PR TITLE
DelugeCompanion/ Cleanup Shortcut Tags

### DIFF
--- a/website/src/components/deluge_companion/components/PageMain.svelte
+++ b/website/src/components/deluge_companion/components/PageMain.svelte
@@ -3,13 +3,20 @@
   import ViewFilter from "./ViewFilter.svelte";
   import { isShortcutDataLoading, searchQuery } from "../stores/search_store.js";
   import { filteredShortcuts } from "../stores/shortcut_store.js";
+  import { setAllShortcutTagsVisible } from "../stores/shortcut_tag_visibility_store.js";
   import { setAllShortcutDescriptionsVisible } from "../stores/shortcut_description_visibility_store.js";
 
   // Hide filters when an active search has no matches.
   $: hasNoSearchMatches =
     $searchQuery.trim().length > 0 && $filteredShortcuts.length === 0;
 
+  let areAllTagsVisible = false;
   let areAllDescriptionsVisible = false;
+
+  // Applies global tag visibility command across all currently rendered cards.
+  function onTagVisibilityChanged() {
+    setAllShortcutTagsVisible(areAllTagsVisible);
+  }
 
   // Applies global description visibility command across all currently rendered cards.
   function onDescriptionVisibilityChanged() {
@@ -35,7 +42,20 @@
       <ViewFilter />
     {/if}
 
-    <section class="description-visibility-toggle" aria-label="Shortcut description visibility">
+    <section class="shortcut-global-toggles" aria-label="Shortcut visibility controls">
+      <label class="description-visibility-label" for="toggle-shortcut-tags">
+        <input
+          id="toggle-shortcut-tags"
+          class="description-visibility-input"
+          type="checkbox"
+          bind:checked={areAllTagsVisible}
+          on:change={onTagVisibilityChanged}
+        />
+        <span class="description-visibility-text">
+          {areAllTagsVisible ? "Hide all shortcut tags" : "Show all shortcut tags"}
+        </span>
+      </label>
+
       <label class="description-visibility-label" for="toggle-shortcut-descriptions">
         <input
           id="toggle-shortcut-descriptions"
@@ -104,12 +124,15 @@
     background: color-mix(in srgb, var(--sl-color-bg) 88%, var(--sl-color-gray-6));
   }
 
-  .description-visibility-toggle {
+  .shortcut-global-toggles {
     margin-top: -0.25rem;
     border: 1px solid var(--sl-color-gray-5);
     border-radius: 0.5rem;
-    padding: 0.55rem 0.75rem;
+    padding: 0.4rem 0.75rem;
     background: color-mix(in srgb, var(--sl-color-bg) 88%, var(--sl-color-gray-6));
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
   }
 
   .description-visibility-label {
@@ -118,6 +141,7 @@
     gap: 0.55rem;
     cursor: pointer;
     user-select: none;
+    line-height: 1.15;
   }
 
   .description-visibility-input {

--- a/website/src/components/deluge_companion/components/Shortcut.svelte
+++ b/website/src/components/deluge_companion/components/Shortcut.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick } from "svelte";
+  import { onDestroy, onMount, tick } from "svelte";
   import type { Shortcut } from "../types/shortcut.js";
   import StepContainerView from "./step/StepContainer.svelte";
   import DelugeUiExternal from "./DelugeUiExternal.svelte";
@@ -20,6 +20,9 @@
   import {
     shortcutDescriptionVisibilityCommand,
   } from "../stores/shortcut_description_visibility_store.js";
+  import {
+    shortcutTagVisibilityCommand,
+  } from "../stores/shortcut_tag_visibility_store.js";
 
   // One shortcut card instance plus a stable id used by shared preview state.
   export let shortcut: Shortcut;
@@ -50,14 +53,127 @@
     [Firmwares.COMMUNITY]: "dc-badge-tip",
   };
 
+  type HeaderChip = {
+    key: string;
+    title: string;
+    className: string;
+  };
+
+  let headerChips: HeaderChip[] = [];
+
+  $: headerChips = [
+    ...(capabilityTitle
+      ? [
+          {
+            key: `capability-${capabilityTitle}`,
+            title: capabilityTitle,
+            className: "dc-capability-chip",
+          } satisfies HeaderChip,
+        ]
+      : []),
+    ...views.map(
+      (view): HeaderChip => ({
+        key: `view-${view.id}`,
+        title: view.title,
+        className: `dc-view-chip ${viewClassByColor[view.color] ?? "dc-view-neutral"}`,
+      }),
+    ),
+    ...firmwares.map(
+      (firmware): HeaderChip => ({
+        key: `firmware-${firmware.id}`,
+        title: `${firmware.title} Firmware`,
+        className: `dc-view-chip dc-firmware-chip ${firmwareBadgeClassById[firmware.id] ?? "dc-badge-note"}`,
+      }),
+    ),
+  ];
+
   let showDetails: boolean = false;
   let shortcutCardEl: HTMLDivElement | undefined;
   let areDescriptionSectionsExpanded: boolean = false;
   let areCommunitySectionsExpanded: boolean = false;
   let lastResetVersion = 0;
+  let lastTagVisibilityCommandVersion = 0;
   let lastDescriptionVisibilityCommandVersion = 0;
   let previousDescriptionExpandedBeforePreview: boolean | null = null;
   let previousCommunityExpandedBeforePreview: boolean | null = null;
+  let previousHeaderChipsExpandedBeforePreview: boolean | null = null;
+  let shortcutChipRowEl: HTMLDivElement | undefined;
+  let shortcutChipResizeObserver: ResizeObserver | undefined;
+  let chipRecalcTimeouts: ReturnType<typeof setTimeout>[] = [];
+  let hasCollapsedHeaderChips = false;
+  let areAllHeaderChipsExpanded = false;
+  let viewportWidth = 0;
+
+  // Recomputes collapsed chip visibility based on current row width.
+  // Returns void.
+  function recalculateVisibleHeaderChips() {
+    if (!shortcutChipRowEl || headerChips.length === 0) {
+      hasCollapsedHeaderChips = false;
+      areAllHeaderChipsExpanded = false;
+      return;
+    }
+
+    // Toggle is rendered outside this row, so native overflow is accurate.
+    hasCollapsedHeaderChips =
+      shortcutChipRowEl.scrollWidth > shortcutChipRowEl.clientWidth + 1;
+
+    // If everything now fits, reset expanded state back to compact mode.
+    if (!hasCollapsedHeaderChips) {
+      areAllHeaderChipsExpanded = false;
+    }
+  }
+
+  // Expands/collapses the full header-chip list.
+  // Returns void.
+  function toggleHeaderChips() {
+    areAllHeaderChipsExpanded = !areAllHeaderChipsExpanded;
+  }
+
+  // Schedules repeated recalculation passes to handle async layout settling.
+  // Returns void.
+  function scheduleHeaderChipRecalculation() {
+    chipRecalcTimeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+    chipRecalcTimeouts = [0, 60, 180, 360].map((delayMs) =>
+      setTimeout(recalculateVisibleHeaderChips, delayMs),
+    );
+    document.fonts?.ready.then(recalculateVisibleHeaderChips);
+  }
+
+  // React to chip data/layout changes after DOM updates settle.
+  $: if (shortcutChipRowEl) {
+    void tick().then(scheduleHeaderChipRecalculation);
+  }
+
+  // Recompute on viewport width changes captured by Svelte window binding.
+  $: if (viewportWidth > 0 && shortcutChipRowEl) {
+    void tick().then(scheduleHeaderChipRecalculation);
+  }
+
+  onMount(() => {
+    if (typeof ResizeObserver !== "undefined") {
+      shortcutChipResizeObserver = new ResizeObserver(() => {
+        scheduleHeaderChipRecalculation();
+      });
+
+      if (shortcutCardEl) {
+        shortcutChipResizeObserver.observe(shortcutCardEl);
+      }
+
+      if (shortcutChipRowEl) {
+        shortcutChipResizeObserver.observe(shortcutChipRowEl);
+      }
+    }
+
+    void tick().then(scheduleHeaderChipRecalculation);
+  });
+
+  onDestroy(() => {
+    chipRecalcTimeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+    chipRecalcTimeouts = [];
+
+    shortcutChipResizeObserver?.disconnect();
+    shortcutChipResizeObserver = undefined;
+  });
 
   // Computes the occupied top offset from sticky/fixed site chrome so
   // programmatic scroll positioning does not hide content under the header.
@@ -91,6 +207,21 @@
   // Card-local state mirrors the shared preview store.
   $: isPreviewOpen = $openHardwarePreviewIds.includes(shortcutPreviewId);
 
+  // Apply global header-tag visibility command exactly once per command version.
+  $: if (
+    $shortcutTagVisibilityCommand.version !==
+    lastTagVisibilityCommandVersion
+  ) {
+    lastTagVisibilityCommandVersion = $shortcutTagVisibilityCommand.version;
+    if (isPreviewOpen) {
+      // If command changes while preview is open, apply after preview closes.
+      previousHeaderChipsExpandedBeforePreview =
+        $shortcutTagVisibilityCommand.visible && hasCollapsedHeaderChips;
+    } else {
+      areAllHeaderChipsExpanded = $shortcutTagVisibilityCommand.visible && hasCollapsedHeaderChips;
+    }
+  }
+
   // Apply global visibility command exactly once per command version.
   $: if (
     $shortcutDescriptionVisibilityCommand.version !==
@@ -116,17 +247,22 @@
   $: if (showDetails !== isPreviewOpen) {
     showDetails = isPreviewOpen;
     if (showDetails) {
+      previousHeaderChipsExpandedBeforePreview = areAllHeaderChipsExpanded;
       previousDescriptionExpandedBeforePreview = areDescriptionSectionsExpanded;
       previousCommunityExpandedBeforePreview = areCommunitySectionsExpanded;
+      areAllHeaderChipsExpanded = false;
       areDescriptionSectionsExpanded = false;
       areCommunitySectionsExpanded = false;
     } else {
+      areAllHeaderChipsExpanded =
+          previousHeaderChipsExpandedBeforePreview ?? false;
       areDescriptionSectionsExpanded =
           previousDescriptionExpandedBeforePreview ??
           $shortcutDescriptionVisibilityCommand.visible;
       areCommunitySectionsExpanded =
           previousCommunityExpandedBeforePreview ??
           $shortcutDescriptionVisibilityCommand.visible;
+      previousHeaderChipsExpandedBeforePreview = null;
       previousDescriptionExpandedBeforePreview = null;
       previousCommunityExpandedBeforePreview = null;
     }
@@ -136,8 +272,10 @@
   $: if ($shortcutPreviewResetVersion !== lastResetVersion) {
     lastResetVersion = $shortcutPreviewResetVersion;
     // Global filter/search resets should restore the card to collapsed content state.
+    previousHeaderChipsExpandedBeforePreview = null;
     previousDescriptionExpandedBeforePreview = null;
     previousCommunityExpandedBeforePreview = null;
+    areAllHeaderChipsExpanded = false;
     areDescriptionSectionsExpanded = $shortcutDescriptionVisibilityCommand.visible;
     areCommunitySectionsExpanded = $shortcutDescriptionVisibilityCommand.visible;
     showDetails = false;
@@ -195,25 +333,35 @@
 <div bind:this={shortcutCardEl} class="shortcut-card rounded-lg p-4 text-[var(--sl-color-text)]">
   <!-- Header with firmware/capability/view chips and title. -->
   <div class="shortcut-header">
-    <div class="mb-0 flex flex-wrap gap-1 leading-none">
-      {#each firmwares as firmware}
-        <span
-          class={`dc-view-chip dc-firmware-chip ${firmwareBadgeClassById[firmware.id] ?? "dc-badge-note"}`}
+    <div class="shortcut-chip-strip mb-0 leading-none">
+      <div
+        bind:this={shortcutChipRowEl}
+        class="shortcut-chip-row"
+        class:shortcut-chip-row-expanded={
+          areAllHeaderChipsExpanded && hasCollapsedHeaderChips
+        }
+      >
+        {#each headerChips as chip (chip.key)}
+          <span class={chip.className}>
+            {chip.title}
+          </span>
+        {/each}
+      </div>
+
+      {#if hasCollapsedHeaderChips}
+        <button
+          type="button"
+          class="shortcut-chip-toggle"
+          aria-expanded={areAllHeaderChipsExpanded && hasCollapsedHeaderChips}
+          on:click={toggleHeaderChips}
         >
-          {firmware.title} Firmware
-        </span>
-      {/each}
-      {#if capabilityTitle}
-        <span class="dc-capability-chip">{capabilityTitle}</span>
+          {areAllHeaderChipsExpanded && hasCollapsedHeaderChips
+            ? "Show fewer tags"
+            : "Show more tags"}
+        </button>
       {/if}
-      {#each views as view}
-        <span
-          class={`dc-view-chip ${viewClassByColor[view.color] ?? "dc-view-neutral"}`}
-        >
-          {view.title}
-        </span>
-      {/each}
     </div>
+
     <h3 class="shortcut-title">
       <SearchHighlight text={shortcut.name} />
     </h3>
@@ -291,6 +439,8 @@
   {/if}
 </div>
 
+<svelte:window bind:innerWidth={viewportWidth} />
+
 <style>
   .shortcut-card {
     --dc-card-bg: rgb(70 84 104 / 0.22);
@@ -360,6 +510,61 @@
     min-width: 0;
   }
 
+  .shortcut-chip-strip {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.25rem;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .shortcut-chip-row {
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    gap: 0.25rem;
+    overflow: hidden;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .shortcut-chip-row-expanded {
+    flex-wrap: wrap;
+    align-items: flex-start;
+    overflow: visible;
+  }
+
+  .shortcut-chip-row > :global(*) {
+    flex: 0 0 auto;
+  }
+
+  .shortcut-chip-toggle {
+    display: inline-flex;
+    align-items: center;
+    white-space: nowrap;
+    border-radius: 0.3rem;
+    border: 1px dashed var(--dc-capability-chip-border);
+    padding: 0.2rem 0.52rem;
+    font-size: 0.75rem;
+    line-height: 1.1;
+    letter-spacing: 0.01em;
+    font-weight: 600;
+    text-transform: uppercase;
+    background: color-mix(in srgb, var(--dc-capability-chip-bg) 65%, transparent);
+    color: var(--dc-capability-chip-fg);
+    cursor: pointer;
+    margin: 0;
+    flex: 0 0 auto;
+    align-self: flex-start;
+    justify-self: end;
+    transition: background-color 120ms ease-out;
+  }
+
+  .shortcut-chip-toggle:hover {
+    background: color-mix(in srgb, var(--dc-capability-chip-bg) 78%, transparent);
+  }
+
   .shortcut-card {
     display: flex;
     flex-direction: column;
@@ -367,8 +572,6 @@
     width: 100%;
     min-width: 0;
     max-width: 100%;
-    content-visibility: auto;
-    contain-intrinsic-size: 18rem;
   }
 
   .shortcut-title {

--- a/website/src/components/deluge_companion/stores/shortcut_tag_visibility_store.ts
+++ b/website/src/components/deluge_companion/stores/shortcut_tag_visibility_store.ts
@@ -1,0 +1,15 @@
+import { writable } from "svelte/store"
+
+// Shared command that can expand/collapse header tags across all cards.
+// Default is collapsed to keep card headers compact.
+export const shortcutTagVisibilityCommand = writable({
+  visible: false,
+  version: 0,
+})
+
+export const setAllShortcutTagsVisible = (visible: boolean) => {
+  shortcutTagVisibilityCommand.update((command) => ({
+    visible,
+    version: command.version + 1,
+  }))
+}


### PR DESCRIPTION
Cleaned up shortcut card tags:

- Hide tags that wrap by default
- Add ability to show/hide tags
- Add toggle at the top to show hide all tags
- Re-order tags above shortcuts to: Capability > View > Firmware
- Adjust hardware preview to hide tags if they're open to maximize visibility