### PR TITLE
fix: serialize filter mode OFF correctly in XML

### DIFF
--- a/src/deluge/model/mod_controllable/filters/filter_config.cpp
+++ b/src/deluge/model/mod_controllable/filters/filter_config.cpp
@@ -5,12 +5,16 @@
 // converts lpf/hpf mode to string for saving
 namespace deluge::dsp::filter {
 
-EnumStringMap<FilterMode, kNumFilterModes> filterMap({{{FilterMode::TRANSISTOR_12DB, "12dB"},
-                                                       {FilterMode::TRANSISTOR_24DB, "24dB"},
-                                                       {FilterMode::TRANSISTOR_24DB_DRIVE, "24dBDrive"},
-                                                       {FilterMode::SVF_BAND, "SVF_Band"},
-                                                       {FilterMode::SVF_NOTCH, "SVF_Notch"},
-                                                       {FilterMode::HPLADDER, "HPLadder"}}});
+// OFF must be in the map so it round-trips through XML (issue #4684). It also makes the
+// string->enum failure fallback (last variant) resolve to OFF, so files saved by builds
+// which wrote garbage for OFF load back as OFF rather than HPLadder.
+EnumStringMap<FilterMode, kNumFilterModes + 1> filterMap({{{FilterMode::TRANSISTOR_12DB, "12dB"},
+                                                           {FilterMode::TRANSISTOR_24DB, "24dB"},
+                                                           {FilterMode::TRANSISTOR_24DB_DRIVE, "24dBDrive"},
+                                                           {FilterMode::SVF_BAND, "SVF_Band"},
+                                                           {FilterMode::SVF_NOTCH, "SVF_Notch"},
+                                                           {FilterMode::HPLADDER, "HPLadder"},
+                                                           {FilterMode::OFF, "off"}}});
 
 EnumStringMap<FilterRoute, kNumFilterRoutes> routeMap({{
     {FilterRoute::LOW_TO_HIGH, "L2H"},

--- a/src/deluge/util/container/enum_to_string_map.hpp
+++ b/src/deluge/util/container/enum_to_string_map.hpp
@@ -24,7 +24,14 @@ public:
 		              "EnumStringMap requires an enum type with the same number of values as the initializer list");
 	}
 
-	constexpr const char* operator()(Enum a) { return stringList_[static_cast<std::underlying_type_t<Enum>>(a)]; }
+	/// Convert enum to string, returning the last mapped string if the value has no entry
+	constexpr const char* operator()(Enum a) {
+		auto index = static_cast<std::size_t>(static_cast<std::underlying_type_t<Enum>>(a));
+		if (index >= N) {
+			index = N - 1;
+		}
+		return stringList_[index];
+	}
 
 	/// Convert string to enum, returning enum variant N on failure
 	constexpr Enum operator()(const char* str) {


### PR DESCRIPTION
Fixes #4684

## Problem

Setting an LPF/HPF filter mode to **off** doesn't survive a save/load cycle. The XML ends up with garbage in the mode attribute (users observed `lpfMode="flanger"`), and on reload the filters come back as LP24 / HP12.

## Root cause

`FilterMode::OFF` has underlying value 6, but the serialization map is `EnumStringMap<FilterMode, kNumFilterModes>` where `kNumFilterModes == 6` deliberately excludes OFF — so the map's string table has entries for values 0–5 only:

- **Writing** an OFF filter (`lpfTypeToString` in `ModControllableAudio::writeAttributesToFile`) indexes `stringList_[6]` on a 6-element array — an out-of-bounds read whose garbage pointer happens to print as `"flanger"` on current builds.
- **Reading** any unrecognized string falls back to the last mapped variant, `HPLADDER` — so OFF could never round-trip.

## Fix

- Add `{FilterMode::OFF, "off"}` to the map and size it `kNumFilterModes + 1`. OFF now round-trips as `"off"`.
- Because the unknown-string fallback returns the last variant, it now resolves to OFF instead of HPLADDER — which also **repairs files already saved with a garbage mode string** by affected builds: they load as OFF, matching what the user had actually set.
- Bounds-check `EnumStringMap::operator()(Enum)` so a future enum/map size mismatch can't read out of bounds again.

## Testing

- Full release build compiles clean.
- **Not yet tested on hardware** — repro steps from the issue double as the test: set kit sound + kit FX (and synth/song) filters to off, save, power cycle, reload → modes must still be off, and the saved XML must show `lpfMode="off"` / `hpfMode="off"`. Also worth loading a song saved by a current beta with an OFF filter (garbage mode string) → should now load as off.
