### PR TITLE
fix: load MIDI CC learns for song sections from song files

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1952,7 +1952,9 @@ unknownTag:
 						}
 
 						if (id < kMaxNumSections) {
-							if (channel < 16 && note < 128) {
+							// channelOrZone can also be an MPE zone (16-17) or a CC learn
+							// (18-35, offset by IS_A_CC) - see LearnedMIDI (issue #4680)
+							if (channel < IS_A_CC + NUM_CHANNELS && note < 128) {
 								sections[id].launchMIDICommand.cable = cable;
 								sections[id].launchMIDICommand.channelOrZone = channel;
 								sections[id].launchMIDICommand.noteOrCC = note;


### PR DESCRIPTION
Fixes #4680

## Problem

MIDI CCs learned to launch song sections work at runtime, but after saving and restarting only note-on learns survive — CC learns are gone.

## Root cause

The save side is fine: sections write the raw `launchMIDICommand.channelOrZone`, and `LearnedMIDI` encodes CC learns as `channel + IS_A_CC` (18–35) and MPE zones as 16–17, so the CC data has been present in song files all along.

The bug is in the hand-rolled section loader in `Song::readFromFile`:

```cpp
if (channel < 16 && note < 128) {
```

This guard predates CC learning (added in #961) and silently drops any `channelOrZone` ≥ 16 — i.e. every CC learn (and MPE-zone note learns too). The generic `LearnedMIDI::readFromFile` used by every other CC-learnable feature imposes no such restriction, which is why MIDI-knob/global-command CC learns persist and section learns don't.

## Fix

Accept the full learned range: `channel < IS_A_CC + NUM_CHANNELS` (0–35: plain channels, MPE zones, CC-encoded channels).

A nice side effect: songs saved before this fix already contain the CC assignment, so they start working on load without re-learning.

## Testing

- Full release build compiles clean.
- **Not yet tested on hardware** — test procedure: learn a CC to a section (it launches), save, power cycle, reload, send the same CC → the section must launch. Note-on learns should behave exactly as before.
