### PR TITLE
fix: retrigger sounding notes after transpose

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1320,6 +1320,13 @@ void InstrumentClip::transpose(int32_t semitones, ModelStackWithTimelineCounter*
 
 	yScroll += semitones;
 	colourOffset -= semitones;
+
+	// Re-sound any notes we just cut off, at their new pitch, instead of leaving them silent until
+	// the sequencer next reaches their start position (issue #2939). NoteRow::resumePlayback() only
+	// late-starts notes when the CatchNotes community feature is enabled.
+	if (playbackHandler.isEitherClockActive() && modelStack->song->isClipActive(this)) {
+		resumePlayback(modelStack, true);
+	}
 }
 
 void InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType type,


### PR DESCRIPTION
Fixes #2939

## Problem

With a drone/held note sounding, master transpose (or MIDI transpose) cuts the note off, and it stays silent until the sequencer loops back around to the note's start.

## Root cause

`InstrumentClip::transpose()` calls `stopAllNotesPlaying()` (note-offs for every sounding row, clearing the rows' `sequenced` flag) and shifts the note rows — but never resumes playback afterwards. Nothing re-arms a note whose position the playhead is currently inside, so it only re-sounds on its next note-on.

## Fix

Call `resumePlayback()` at the end of `transpose()`, guarded by `playbackHandler.isEitherClockActive() && song->isClipActive(this)` — the same pattern `NoteRow::setLength()` already uses for the identical situation. This routes through the existing catch-notes late-start machinery (`NoteRow::maybeStartLateNote`), so:

- Held notes immediately re-sound **at their new pitch**, offset to their current mid-note position (a retrigger with a fresh attack, consistent with how catch-notes behaves for note adds / length changes / unmutes).
- The **Catch Notes** community setting (default on) is honored — with it off, behavior is unchanged from today.
- Both master transpose and MIDI transpose are covered, since both funnel into `InstrumentClip::transpose()` via `Song::transposeAllScaleModeClips()`, and the resume is per-clip and gated on clip activity.

## Testing

- Full release build compiles clean.
- **Not yet tested on hardware** — this one deserves an ear on a device: play a scale-mode clip with a note held across the loop, transpose mid-note → it should re-sound immediately at the new pitch. Also worth checking a scale-mode MIDI clip into external gear for clean off/on pairs (no stuck notes), and that transposing while stopped behaves as before.
