### PR TITLE
fix: audio track specific-source selection oddities

### DIFF
--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -171,7 +171,7 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 	if (on && getUIUpOneLevel() == &sessionView) {
 		auto track = (&sessionView)->getOutputFromPad(x, y);
-		if (track && track->type != OutputType::MIDI_OUT && track->type != OutputType::CV) {
+		if (track && track != audioOutput && track->type != OutputType::MIDI_OUT && track->type != OutputType::CV) {
 			audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
 			audioOutput->setOutputRecordingFrom(track);
 			display->popupTextTemporary(track->name.get());
@@ -179,6 +179,9 @@ ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 			scrollPos = static_cast<int32_t>(Value::TRACK);
 			currentOption = scrollPos;
 			renderUIsForOled();
+		}
+		else if (track == audioOutput) {
+			display->popupTextTemporary("Can't record from itself!");
 		}
 		else if (track) {
 			display->popupTextTemporary("Can't record MIDI or CV!");

--- a/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
+++ b/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
@@ -33,7 +33,9 @@ public:
 			outputIndex = currentSong->getOutputIndex(audioOutputBeingEdited->getOutputRecordingFrom());
 		}
 		else {
-			outputIndex = 0;
+			// Nothing selected yet - park before the first output so the first clockwise
+			// scroll considers output 0
+			outputIndex = -1;
 		}
 		numOutputs = currentSong->getNumOutputs();
 		if (display->haveOLED()) {
@@ -45,9 +47,23 @@ public:
 	}
 
 	void selectEncoderAction(int32_t offset) override {
-		outputIndex += offset;
-		outputIndex = std::clamp<int32_t>(outputIndex, 0, numOutputs - 1);
-		auto newRecordingFrom = currentSong->getOutputFromIndex(outputIndex);
+		// Step to the next output in the scroll direction which we can actually record from -
+		// skip ourselves, MIDI and CV (issue #4677)
+		int32_t direction = (offset < 0) ? -1 : 1;
+		int32_t newIndex = outputIndex;
+		Output* newRecordingFrom = nullptr;
+		while (newRecordingFrom == nullptr) {
+			newIndex += direction;
+			if (newIndex < 0 || newIndex >= numOutputs) {
+				return; // no recordable output any further in this direction - stay put
+			}
+			Output* candidate = currentSong->getOutputFromIndex(newIndex);
+			if (candidate != audioOutputBeingEdited && candidate->type != OutputType::MIDI_OUT
+			    && candidate->type != OutputType::CV) {
+				newRecordingFrom = candidate;
+			}
+		}
+		outputIndex = newIndex;
 		audioOutputBeingEdited->setOutputRecordingFrom(newRecordingFrom);
 		if (display->haveOLED()) {
 			renderUIsForOled();
@@ -59,17 +75,24 @@ public:
 	void drawPixelsForOled() override {
 		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 
-		// track
-		Output* output = currentSong->getOutputFromIndex(outputIndex);
+		// Show the source that's actually stored, not whatever the scroll index points at -
+		// the stored one is what will be recorded (issue #4677)
+		Output* output = audioOutputBeingEdited->getOutputRecordingFrom();
+		if (output == nullptr) {
+			canvas.drawStringCentred("None", OLED_MAIN_TOPMOST_PIXEL + 14, kTextSpacingX, kTextSpacingY);
+			return;
+		}
 
 		// track type
 		OutputType outputType = output->type;
 
-		// for midi instruments, get the channel
-		int32_t channel;
+		int32_t channel = 0;
 		if (outputType == OutputType::MIDI_OUT) {
 			Instrument* instrument = (Instrument*)output;
 			channel = ((NonAudioInstrument*)instrument)->getChannel();
+		}
+		else if (outputType == OutputType::AUDIO) {
+			channel = static_cast<int32_t>(((AudioOutput*)output)->mode);
 		}
 
 		char const* outputTypeText = getOutputTypeName(outputType, channel);
@@ -80,7 +103,7 @@ public:
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 28;
 
 		// draw the track name
-		char const* name = audioOutputBeingEdited->getOutputRecordingFrom()->name.get();
+		char const* name = output->name.get();
 
 		int32_t stringLengthPixels = canvas.getStringWidthInPixels(name, kTextTitleSizeY);
 
@@ -96,8 +119,8 @@ public:
 	}
 
 	void drawFor7seg() {
-		char const* text = audioOutputBeingEdited->getOutputRecordingFrom()->name.get();
-		display->setScrollingText(text, 0);
+		Output* output = audioOutputBeingEdited->getOutputRecordingFrom();
+		display->setScrollingText(output != nullptr ? output->name.get() : "NONE", 0);
 	}
 
 	bool isRelevant(ModControllableAudio* modControllable, int32_t whichThing) override {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3578,6 +3578,11 @@ void Song::moveInstrumentToHibernationList(Instrument* instrument) {
 
 	removeOutputFromMainList(instrument);
 
+	// The instrument is leaving the main output list, so any audio track recording from it must
+	// let go of it now, same as when it's deleted - otherwise they'd keep displaying (and trying
+	// to record) a source which is no longer in the song (issue #4677)
+	clearRecordingFromReferencesTo(instrument);
+
 	if (instrument->type == OutputType::MIDI_OUT) {
 		setHibernatingMIDIInstrument((MIDIInstrument*)instrument);
 	}


### PR DESCRIPTION
Fixes #4677

Four related defects around picking another track as an audio track's input source ("specific track"):

## 1. An audio track could select itself (pad shortcut)

`AudioInputSelector::padAction` filtered MIDI and CV pads but not the audio track's own pad. `setOutputRecordingFrom(self)` silently rejects the assignment, so the UI claimed a selection that never happened.
**Fix:** filter it out like MIDI/CV, with a "Can't record from itself!" popup.

## 2. The TRACK scroll selector offered every output

`SpecificSourceOutputSelector::selectEncoderAction` clamped over *all* outputs — including the track itself, MIDI and CV. Landing on a rejected candidate desynced the scroll index from the stored source, which is where displays like "AUDIO - \<synth name\>" came from.
**Fix:** scrolling now steps to the next output that can actually be recorded from (skips self/MIDI/CV; stays put at the ends).

## 3. OLED drew the type and the name from different places

The type line came from the scroll index, the name line from the stored source pointer — they diverge (see 2) — and the MIDI channel variable was left uninitialized for non-MIDI outputs, garbling the "Audio …" label nondeterministically. The name line also dereferenced the stored source without a null check (7SEG path too).
**Fix:** render both lines from the stored source; zero-init the channel; pass the real `AudioOutputMode` for audio sources (matching `View::displayOutputName`); show "None"/"NONE" when no source is set.

## 4. Deleting an edited synth left a stale reference

Deleting an *edited* instrument hibernates it (`moveInstrumentToHibernationList`) rather than truly deleting it, and the hibernation path never called `clearRecordingFromReferencesTo()` — only `Song::deleteOutput` did. Audio tracks kept displaying (and pointing at) a source that was no longer in the song until the user cycled the input.
**Fix:** clear recording-from references when an instrument moves to the hibernation list, same as on deletion.

## Testing

- Full release build compiles clean.
- **Not yet tested on hardware** — test procedure: pad-select the track itself → popup, selection unchanged; scroll the TRACK selector both directions → never lands on self/MIDI/CV, type prefix always matches the name; delete an edited synth used as a source → display clears to "None" immediately; song with no valid source candidates → "None", no crash; and normal specific-track recording/monitoring still works.
