### PR TITLE
fix: keep session row view responsive while audio clip waveforms load

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2663,6 +2663,12 @@ bool SessionView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth +
 
 	PadLEDs::renderingLock = true;
 
+	// Bound how many synchronous SD cluster loads audio clip waveforms may perform across this
+	// whole refresh, so scrolling stays responsive when many/long audio clips need their peaks
+	// (re)investigated. Rows left incomplete are re-requested below and fill in progressively
+	// (issue #4460).
+	waveformRenderer.singleRowLoadBudget = 2;
+
 	for (int32_t yDisplay = 0; yDisplay < kDisplayHeight; yDisplay++) {
 		if (whichRows & (1 << yDisplay)) {
 			bool success = renderRow(modelStack, yDisplay, image[yDisplay], occupancyMask[yDisplay], drawUndefinedArea);
@@ -2671,9 +2677,13 @@ bool SessionView::renderMainPads(uint32_t whichRows, RGB image[][kDisplayWidth +
 			}
 		}
 	}
+
+	waveformRenderer.singleRowLoadBudget = -1;
 	PadLEDs::renderingLock = false;
 
-	if (whichRowsCouldntBeRendered && image == PadLEDs::image) {
+	// Also when rendering into the store for a scroll animation: the flags persist until the UI
+	// unblocks, at which point the incomplete rows get re-rendered into the live image (issue #4460)
+	if (whichRowsCouldntBeRendered) {
 		requestRendering(this, whichRowsCouldntBeRendered, 0);
 	}
 

--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -77,10 +77,10 @@ bool WaveformRenderer::renderAsSingleRow(Sample* sample, int64_t xScroll, uint64
 	}
 
 	bool completeSuccess = findPeaksPerCol(sample, xScroll, xZoom, data, recorder, xStartSource, xEndSource);
-	if (!completeSuccess) {
-		return false;
-	}
 
+	// Even if not all columns could be investigated (SD busy, or load budget exhausted), still
+	// draw what we have - uninvestigated columns render black below, and returning false makes
+	// the caller re-request rendering until the waveform completes (issue #4460)
 	int32_t maxPeakFromZero = sample->getMaxPeakFromZero();
 
 	for (int32_t xDisplayOutput = xStart; xDisplayOutput < xEnd; xDisplayOutput++) {
@@ -108,7 +108,7 @@ bool WaveformRenderer::renderAsSingleRow(Sample* sample, int64_t xScroll, uint64
 		});
 	}
 
-	return true;
+	return completeSuccess;
 }
 
 // Value out of 255
@@ -408,6 +408,18 @@ bool WaveformRenderer::findPeaksPerCol(Sample* sample, int64_t xScrollSamples, u
 				                    // Malte P.
 			}
 
+			// If this column needs an actual SD read but the per-render load budget is spent,
+			// leave it uninvestigated for a follow-up render (issue #4460)
+			bool needsSdLoad = (sampleCluster->cluster == nullptr) || !sampleCluster->cluster->loaded;
+			if (needsSdLoad && singleRowLoadBudget == 0) {
+				data->colStatus[col] = 0;
+				hadAnyTroubleLoading = true;
+				continue;
+			}
+			if (needsSdLoad && singleRowLoadBudget > 0) {
+				singleRowLoadBudget--;
+			}
+
 			Cluster* cluster = sampleCluster->getCluster(sample, clusterIndexToDo, CLUSTER_LOAD_IMMEDIATELY);
 			if (!cluster) {
 cantReadData:
@@ -437,6 +449,17 @@ cantReadData:
 				if ((nextSampleCluster->cluster != nullptr) && nextSampleCluster->cluster->numReasonsToBeLoaded < 0) {
 					FREEZE_WITH_ERROR("E450"); // Trying to catch errer before i028, which users have gotten.
 				}
+
+				// Same budget rule as above for the boundary-straddling second cluster (issue #4460)
+				bool nextNeedsSdLoad = (nextSampleCluster->cluster == nullptr) || !nextSampleCluster->cluster->loaded;
+				if (nextNeedsSdLoad && singleRowLoadBudget == 0) {
+					audioFileManager.removeReasonFromCluster(*cluster, "po8w");
+					goto cantReadData;
+				}
+				if (nextNeedsSdLoad && singleRowLoadBudget > 0) {
+					singleRowLoadBudget--;
+				}
+
 				nextCluster = nextSampleCluster->getCluster(sample, clusterIndexToDo, CLUSTER_LOAD_IMMEDIATELY);
 
 				if (cluster->numReasonsToBeLoaded <= 0) {

--- a/src/deluge/gui/waveform/waveform_renderer.h
+++ b/src/deluge/gui/waveform/waveform_renderer.h
@@ -60,6 +60,13 @@ public:
 
 	int8_t collapseAnimationToWhichRow;
 
+	// When >= 0, findPeaksPerCol() may perform at most this many synchronous SD cluster loads,
+	// decrementing as it goes; columns which would need further loads are left uninvestigated and
+	// the render reports incomplete so the caller re-requests it. -1 means unlimited (default).
+	// Session view sets this around row rendering so scrolling doesn't stall on SD reads while
+	// waveforms for many/long audio clips are (re)investigated (issue #4460).
+	int32_t singleRowLoadBudget = -1;
+
 private:
 	int32_t getColBrightnessForSingleRow(int32_t xDisplay, int32_t maxPeakFromZero, WaveformRenderData* data);
 	void getColBarPositions(int32_t xDisplay, WaveformRenderData* data, int32_t* min24, int32_t* max24,


### PR DESCRIPTION
Addresses #4460

> **Draft:** the mechanism is build-verified but the budget value and the resulting feel need on-device profiling with a heavy song (e.g. the long-song project linked in the issue). Opening as a draft for exactly that.

## Problem

In song row view with many/long audio clips, vertical and horizontal scrolling gets laggy. The issue author localized it to `AudioClip::renderAsSingleRow` → `WaveformRenderer::findPeaksPerCol`.

## Analysis

`findPeaksPerCol` already caches per-column peaks (per clip, in `AudioClip::renderData`) and per-cluster min/max (`SampleCluster::investigatedWholeLength`), so *re*-rendering already-investigated regions is cheap. The lag comes from the first investigation after a scroll/zoom change (which invalidates the per-column cache) or for freshly scrolled-in clips: each uninvestigated column synchronously loads a sample cluster from SD (`CLUSTER_LOAD_IMMEDIATELY`). One refresh can stack dozens of blocking ~32KB SD reads — with clusters also subject to being stolen under memory pressure, heavy songs re-pay this cost repeatedly. The UI thread stalls for the whole batch.

## Change

- `WaveformRenderer` gets a `singleRowLoadBudget` (default `-1` = unlimited, current behavior everywhere).
- `SessionView::renderMainPads` sets it to **2 synchronous SD loads per whole refresh** around the row loop. Columns that would exceed the budget are left uninvestigated.
- `WaveformRenderer::renderAsSingleRow` now draws what it has even when incomplete (uninvestigated columns already render black) instead of bailing before drawing, and reports incomplete.
- The existing "couldn't be rendered" retry in `renderMainPads` re-requests those rows — now also when rendering into the image store for a scroll animation (the `uiNeedsRendering` flags persist until the UI unblocks) — so waveforms fill in progressively over successive refreshes instead of freezing the UI while everything loads.

Full-screen waveform UIs (sample browser preview, audio clip view, slicer, sample marker editor) and the clip transition animation are untouched — the budget is only active during session-view row refreshes.

## What to profile on device

- Load the long-song project from the issue, play, scroll vertically/horizontally in song row view: scrolling should stay responsive while waveforms fill in over a few refreshes.
- Whether a budget of 2 is the right trade (responsiveness vs. fill-in time) — the constant is in `SessionView::renderMainPads`.
- That vertical scroll-ins complete promptly while stopped (retry depends on the deferred re-render after the animation; if a row ever sticks partially rendered, that's the place to look).
