### PR TITLE
fix: MIDI clock out mis-scheduled after catch-up, USB ring off-by-one

### DIFF
--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -644,7 +644,9 @@ void ConnectedUSBMIDIDevice::bufferMessage(uint32_t fullMessage) {
 		}
 		queued = ringBufWriteIdx - ringBufReadIdx;
 	}
-	if (queued > MIDI_SEND_BUFFER_LEN_RING) {
+	// >= : at queued == MIDI_SEND_BUFFER_LEN_RING the ring is exactly full, and writing would
+	// land on readIdx's slot, corrupting the oldest not-yet-sent message
+	if (queued >= MIDI_SEND_BUFFER_LEN_RING) {
 		// TODO: show some error message
 		return;
 	}

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -769,7 +769,12 @@ void PlaybackHandler::actionTimerTickPart2() {
 				// immediately otherwise set it to be done by the audio engine
 				if (fractionNextMIDIClockOutTick < fractionLastTimerTick) {
 					doMIDIClockOutTick();
-					fractionNextMIDIClockOutTick += midiClockOutTicksPer;
+					// One more out-tick = internalTicksPer in this fraction space (same as the
+					// analog block above). Adding midiClockOutTicksPer here scheduled the next
+					// tick early by (internalTicksPer - midiClockOutTicksPer) whenever the ratio
+					// isn't 1:1 - with the default insideWorldTickMagnitude of 2 that's 3/4 of a
+					// MIDI clock period early after every catch-up (issue #4687)
+					fractionNextMIDIClockOutTick += internalTicksPer;
 				}
 
 				// Schedule another MIDI clock output tick


### PR DESCRIPTION
Addresses #4687

> **Draft:** both changes are concrete, verifiable-by-reading defects and the build is clean, but the effect on the reported dropouts needs measurement on hardware (MIDI monitor / scope on the clock outs). This PR also documents the rest of the clock-out audit for whoever profiles it.

## What this fixes

**1. MIDI clock mis-scheduled after every catch-up tick** — `PlaybackHandler::actionTimerTickPart2()`

The catch-up block (emit an overdue clock at the timer tick) advanced the next-tick fraction by `midiClockOutTicksPer`, while the analog/trigger block directly above it correctly advances by `internalTicksPer`. In that cross-multiplied fraction space (out-tick positions are multiples of `internalTicksPer`, timer ticks are multiples of `midiClockOutTicksPer`), one more out-tick = `internalTicksPer`.

Consequence: whenever the ratio isn't 1:1 — the default `insideWorldTickMagnitude` is 2, giving 4:1 — the MIDI clock tick following any catch-up was scheduled **¾ of a clock period early**. Catch-ups happen precisely when the audio routine ran late (SD access, heavy UI rendering), so followers saw a long inter-tick gap followed by a short one, at random times, on top of the inherent lateness — i.e. the "random clock drop outs" signature, without long-term tick-count drift. The trigger/gate clock takes the same lateness but *without* this amplification, which fits the issue's report that both outputs misbehave under the same conditions but MIDI monitors show irregular spacing.

**2. USB MIDI send ring corrupts the oldest queued message when exactly full** — `ConnectedUSBMIDIDevice::bufferMessage()`

The full-check was `queued > MIDI_SEND_BUFFER_LEN_RING` (1024). At `queued == 1024` the ring is exactly full and `writeIdx & mask == readIdx & mask`, so the new message overwrote the oldest *not-yet-sent* one and pushed `queued` beyond the ring size. Clock bytes (0xF8) share this ring with everything else and have no priority, so under bursty traffic a queued clock could be silently destroyed. Now `>=` (the message is dropped instead, which is the intended behavior of this branch — see "known remaining issues" for the bigger picture).

## Verified against

- The parallel analog/trigger catch-up block ( `internalTicksPer`, correct) and `scheduleMIDIClockOutTick()`'s base formula `(lastMIDIClockOutTickDone + 1) * internalTicksPer`, which the buggy line must stay consistent with.
- `tests/unit/clock_output_scheduler_tests.cpp` covers only the external-clock-follow path (`computeExternalClockSchedule`), not this internal-master catch-up, so no existing test constrained this line. The catch-up logic is embedded in `PlaybackHandler` and isn't unit-testable without a refactor — flagging rather than attempting that here.

## Known remaining issues in this area (documented, deliberately not changed blind)

- `doMIDIClockOutTick()` early-returns while the `TIMER_MIDI_GATE_OUTPUT` flush ISR is armed (added by #4462 to prevent clock bursts). That defers a MIDI tick by up to one audio window and has no analog-side equivalent, so MIDI and gate can diverge slightly under load. Whether this deferral is still needed after this PR's scheduling fix is a hardware question.
- Outgoing MIDI has no realtime-priority path: clock competes FIFO with notes/CC in both the USB ring and the DIN TX buffer, and the DIN TX buffer (`bufferMIDIUart`) has no overflow guard at all (it also masks with `PIC_TX_BUFFER_SIZE`; benign today since the sizes match, but latent).
- Structural: clock decisions ride the audio-routine timebase (`audioSampleTimer`), which stalls during SD/card work — overdue ticks are then emitted bunched, one per window/timer-tick. That's the underlying "long gap" mechanism; a robust fix means emitting clock from a context that survives audio-routine starvation, which is an architecture change beyond this PR.

## How to verify on device

1. Deluge as clock master → MIDI monitor (the issue author's setup) and/or scope on the gate clock out; let it run several minutes at a fixed BPM with a busy song (audio clips, song-view scrolling, saving) and compare inter-tick interval plots before/after this branch.
2. The short-interval-after-long-interval pairs should disappear; residual bunching that remains points at the structural issue above.
3. Regression: external-clock-follow mode (Deluge as follower forwarding clock) is untouched; tempo/sync features (swing, magnitude changes, count-in) should behave identically.
