### PR TITLE
DelugeCompanion/ Fix search bar zoom in

### DIFF
--- a/website/src/components/deluge_companion/components/Search.svelte
+++ b/website/src/components/deluge_companion/components/Search.svelte
@@ -257,4 +257,12 @@
     box-shadow: 0 0 0 1px color-mix(in srgb, var(--sl-color-gray-5) 35%, transparent) inset;
   }
 
+  /* iOS Safari auto-zooms focused inputs below 16px. */
+  @media (hover: none) and (pointer: coarse) {
+    .search-field input[type="search"],
+    .search-field .toolbar-search-input {
+      font-size: 16px;
+    }
+  }
+
 </style>

--- a/website/src/content/docs/reference/deluge_companion.mdx
+++ b/website/src/content/docs/reference/deluge_companion.mdx
@@ -24,8 +24,8 @@ Full credit to [Florian Heft](https://fheft.github.io/deluge-companion/) and [Ma
 <details>
   <summary>Tips</summary>
   <Aside type="tip">
-    - Use the search and filters panel to quickly find shortcuts. - Click on a
-    shortcut to show the controls on the Deluge interface.
+    - Use the search and filters panel to quickly find shortcuts. 
+    - Click on a shortcut to show the controls on the Deluge interface.
   </Aside>
 </details>
 

--- a/website/src/content/docs/reference/deluge_companion.mdx
+++ b/website/src/content/docs/reference/deluge_companion.mdx
@@ -24,8 +24,8 @@ Full credit to [Florian Heft](https://fheft.github.io/deluge-companion/) and [Ma
 <details>
   <summary>Tips</summary>
   <Aside type="tip">
-    - Use the search and filters panel to quickly find shortcuts. 
-    - Click on a shortcut to show the controls on the Deluge interface.
+    - Use the search and filters panel to quickly find shortcuts. - Click on a
+    shortcut to show the controls on the Deluge interface.
   </Aside>
 </details>
 


### PR DESCRIPTION
Fixed issue for iOS where if the search bar text is less than 16px it zooms the page in and keeps it that way isn't nice.

This fix implements the second option mentioned here by making the search bar font 16px disabling the auto zoom: https://medium.com/@rares.popescu/2-ways-to-avoid-the-automatic-zoom-in-on-input-fields-8a71479e542e