### PR TITLE
DelugeCompanion/ Make deluge companion filter panel auto adjust sizing

### DIFF
--- a/website/src/components/deluge_companion/views/ShortcutsView.svelte
+++ b/website/src/components/deluge_companion/views/ShortcutsView.svelte
@@ -392,7 +392,7 @@
   }
 
   .dc-control-panel-content.open .dc-control-panel-shell {
-    height: calc(100dvh - var(--sl-nav-height, 3.5rem) - 11.75rem);
+    height: auto;
     max-height: calc(100dvh - var(--sl-nav-height, 3.5rem) - 11.75rem);
   }
 
@@ -430,7 +430,7 @@
     }
 
     .dc-control-panel.dc-mobile-panel-open .dc-control-panel-content.open .dc-control-panel-shell {
-      height: calc(100dvh - var(--sl-nav-height, 3.5rem) - 11.75rem);
+      height: auto;
       max-height: calc(100dvh - var(--sl-nav-height, 3.5rem) - 11.75rem);
     }
   }
@@ -456,7 +456,7 @@
     }
 
     .dc-control-panel.dc-mobile-panel-open .dc-control-panel-content.open .dc-control-panel-shell {
-      height: calc(100dvh - var(--sl-nav-height, 3.5rem) - 11.75rem);
+      height: auto;
       max-height: calc(100dvh - var(--sl-nav-height, 3.5rem) - 11.75rem);
     }
   }


### PR DESCRIPTION
Fix search and filter panel on smartphone and tablet modes so that when you collapse the filters the panel adjusts its height

Before Fix:

<img width="498" height="915" alt="Screenshot 2026-07-22 at 12 34 57 AM" src="https://github.com/user-attachments/assets/c3461041-7e65-4223-8136-836079411c33" />

After Fix:

<img width="497" height="917" alt="Screenshot 2026-07-22 at 12 34 34 AM" src="https://github.com/user-attachments/assets/0c3c0843-42be-41da-ba27-c825515d9666" />
