### PR TITLE
Fix/ song naming for OLED - allow songs to start with numerical digits

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -983,7 +983,7 @@ bool Browser::predictExtendedText() {
 	// typing begins with a digit, treat the prefix as implicitly typed - otherwise "1" would match nothing. The typed
 	// portion of enteredText is [0, enteredTextEditPos), so the prefix has to go *into* enteredText and be counted,
 	// not merely prepended to the search key.
-	if (filePrefix && enteredTextEditPos > 0) {
+	if (display->have7SEG() && filePrefix && enteredTextEditPos > 0) {
 		char const* typed = enteredText.get();
 		if (typed[0] >= '0' && typed[0] <= '9') {
 			int32_t prefixLength = strlen(filePrefix);


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4714

Fix issue which would prevent OLED users from creating song files that start with a digit. This is because the predictive text feature would default the file prefix song when typing a digit on OLED.

Fix by gating for 7SEG display only.