### PR TITLE
fix: don't drop CC-encoded section launch commands when loading a song (#4680)

### DIFF
--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -1952,7 +1952,9 @@ unknownTag:
 						}
 
 						if (id < kMaxNumSections) {
-							if (channel < 16 && note < 128) {
+							// channel may be a plain channel (0-15), an MPE zone (16-17), or CC-encoded
+							// (channel + IS_A_CC) — see LearnedMIDI::channelOrZone.
+							if (channel < IS_A_PC && note < 128) {
 								sections[id].launchMIDICommand.cable = cable;
 								sections[id].launchMIDICommand.channelOrZone = channel;
 								sections[id].launchMIDICommand.noteOrCC = note;


### PR DESCRIPTION
Learning a MIDI CC to a song section stores it as channel + IS_A_CC (18-35) in `LearnedMIDI::channelOrZone`, and the song file saves that raw value. The section loader only accepted channels 0-15, so everything else was dropped on load.