### PR TITLE
Restore bypass culling flag to RWCL

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -387,7 +387,9 @@ void routineWithClusterLoading(bool mayProcessUserActionsBetween) {
 	audioFileManager.loadAnyEnqueuedClusters(128, mayProcessUserActionsBetween);
 
 	if (!routineBeenCalled) {
-		// bypassCulling = true; // yolo? Sean: not sure if this is necessary
+		// This catch-up routine is already running after SD / cluster-loading work delayed audio. Release 1.2 skipped
+		// culling here so a one-off storage stall didn't get treated as a synth load problem.
+		bypassCulling = true;
 
 		logAction("call runRoutine() from routineWithClusterLoading()");
 		runRoutine();


### PR DESCRIPTION
Restored RWCL Bypass Culling Flag

Originally part of #4722

Separate commit as not entirely sure on impact