### PR TITLE
Revert "fix: voice-cull victim selection never filtered the first voice (#4721) (#4722)"

### DIFF
--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -2512,29 +2512,41 @@ bool Voice::doFastRelease(uint32_t releaseIncrement) {
 	}
 }
 
-bool Voice::speedUpRelease(uint32_t minFastReleaseIncrement) {
-	if (!doneFirstRender) {
-		return false;
+bool Voice::forceNormalRelease() {
+	if (doneFirstRender) {
+		// If no release-stage, we'll stop as soon as we can
+		if (!hasReleaseStage()) {
+			envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, SOFT_CULL_INCREMENT);
+		}
+		// otherwise we'll just let it get there on its own
+		else {
+			envelopes[0].unconditionalRelease();
+		}
+		return true;
 	}
 
+	// Or if first render not done yet, we actually don't want to hear anything at all, so just unassign it
+	else {
+		return false;
+	}
+}
+
+bool Voice::speedUpRelease() {
 	auto stage = envelopes[0].state;
 	if (stage == EnvelopeStage::RELEASE) {
 		auto currentRelease = paramFinalValues[params::LOCAL_ENV_0_RELEASE];
-		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE,
-		                                  std::max<uint32_t>(currentRelease * 2, minFastReleaseIncrement));
+		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, currentRelease * 2);
 		return true;
 	}
 	else if (stage == EnvelopeStage::FAST_RELEASE) {
 		auto currentRelease = envelopes[0].fastReleaseIncrement;
-		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE,
-		                                  std::max<uint32_t>(currentRelease * 2, minFastReleaseIncrement));
+		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, currentRelease * 2);
 		return true;
 	}
 
-	// Cull-driven release must not inherit a patch's long musical release, or culled voices can stack up.
+	// Or if we're not releasing just start the release
 	else {
-		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, minFastReleaseIncrement);
-		return true;
+		return forceNormalRelease();
 	}
 }
 

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -120,14 +120,9 @@ public:
 	/// Returns whether voice should still be left active
 	bool doImmediateRelease();
 
-	/// Already fading at (or faster than) the soft-cull rate. Cull victim selection and the voice limit
-	/// must treat such a voice as already gone, or it soaks up culls meant for live voices (issue #4721).
-	[[nodiscard]] bool isCullFading() const {
-		return envelopes[0].state >= EnvelopeStage::FAST_RELEASE
-		       && envelopes[0].fastReleaseIncrement >= SOFT_CULL_INCREMENT;
-	}
+	bool forceNormalRelease();
 
-	bool speedUpRelease(uint32_t minFastReleaseIncrement = SOFT_CULL_INCREMENT);
+	bool speedUpRelease();
 	bool shouldBeDeleted() { return delete_this_voice_; }
 
 	// This compares based on the priority of two voices

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -306,20 +306,14 @@ void terminateOneVoice(size_t numSamples) {
 		return;
 	}
 
-	// The skip filter must apply to the first voice too (see Sound::terminateOneActiveVoice / issue #4721):
-	// seeding `best` unfiltered let an already-fast-releasing front voice absorb every cull in the window.
-	const Sound::ActiveVoice* best = nullptr;
-	for (const auto& voice : all_voices) {
-		if (voice->isCullFading()) {
+	const Sound::ActiveVoice* best = &all_voices.front();
+	for (const auto& voice : all_voices | std::views::drop(1)) {
+		// if we're not skipping releasing voices, or if we are and this one isn't in fast release
+		if (voice->envelopes[0].state >= EnvelopeStage::FAST_RELEASE
+		    && voice->envelopes[0].fastReleaseIncrement >= SOFT_CULL_INCREMENT) {
 			continue;
 		}
-		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {
-			best = &voice;
-		}
-	}
-
-	if (best == nullptr) {
-		return;
+		best = (*best)->getPriorityRating() < voice->getPriorityRating() ? &voice : best;
 	}
 
 	const Sound::ActiveVoice& voice = *best;
@@ -339,21 +333,14 @@ void forceReleaseOneVoice(size_t num_samples) {
 		return;
 	}
 
-	// Don't spend another soft cull on a voice that's already disappearing at the cull fade rate. FAST_RELEASE has a
-	// high priority rating, so without this filter repeated soft culls can chase the same fading voice while long
-	// musical-release tails keep stacking up.
-	const Sound::ActiveVoice* best = nullptr;
-	for (const auto& voice : all_voices) {
-		if (voice->isCullFading()) {
-			continue;
+	const Sound::ActiveVoice* best = &all_voices.front();
+	for (const auto& voice : all_voices | std::views::drop(1)) {
+		// if a voice is already fast releasing just speed it up
+		if (voice->envelopes[0].state == EnvelopeStage::FAST_RELEASE) {
+			voice->speedUpRelease();
+			return;
 		}
-		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {
-			best = &voice;
-		}
-	}
-
-	if (best == nullptr) {
-		return;
+		best = (*best)->getPriorityRating() < voice->getPriorityRating() ? &voice : best;
 	}
 
 	const Sound::ActiveVoice& voice = *best;

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -4873,9 +4873,7 @@ ModelStackWithAutoParam* Sound::getParamFromMIDIKnob(MIDIKnob& knob, ModelStackW
 }
 
 const Sound::ActiveVoice& Sound::acquireVoice() noexcept(false) {
-	auto count_toward_voice_limit = [](const ActiveVoice& voice) { return !voice->isCullFading(); };
-
-	if (std::ranges::count_if(voices_, count_toward_voice_limit) >= maxVoiceCount) {
+	if (voices_.size() >= maxVoiceCount) {
 		this->terminateOneActiveVoice();
 	}
 
@@ -4943,18 +4941,14 @@ void Sound::terminateOneActiveVoice() {
 		return;
 	}
 
-	// The eligibility filter must apply to EVERY voice, including the first: seeding `best` with front()
-	// unfiltered meant a just-fast-released front voice (highest rating, since FAST_RELEASE outranks every
-	// sounding stage) absorbed every subsequent terminate in the same render window - so chords overran
-	// maxVoiceCount and the limiter sometimes chopped held notes instead (issue #4721).
-	ActiveVoice* best = nullptr;
-	for (ActiveVoice& voice : voices_) {
-		if (voice->isCullFading()) {
+	ActiveVoice* best = &voices_.front();
+	for (ActiveVoice& voice : voices_ | std::views::drop(1)) {
+		// skip voices which are already releasing faster than we're going to release them
+		if (voice->envelopes[0].state >= EnvelopeStage::FAST_RELEASE
+		    && voice->envelopes[0].fastReleaseIncrement >= SOFT_CULL_INCREMENT) {
 			continue;
 		}
-		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {
-			best = &voice;
-		}
+		best = (*best)->getPriorityRating() < voice->getPriorityRating() ? &voice : best;
 	}
 
 	if (best == nullptr) {
@@ -4962,10 +4956,7 @@ void Sound::terminateOneActiveVoice() {
 	}
 
 	const ActiveVoice& voice = *best;
-	// SOFT_CULL_INCREMENT = a 128-sample (~2.9 ms) fade, matching release 1.2's voice-limit steal. Faster rates
-	// (the 4x, 32-sample sub-millisecond one) read as a pop on sustained material when a low maxVoices makes every
-	// note-on steal (issue #4721).
-	bool still_rendering = voice->doFastRelease(SOFT_CULL_INCREMENT);
+	bool still_rendering = voice->doFastRelease(4 * SOFT_CULL_INCREMENT);
 
 	if (!still_rendering) {
 		this->freeActiveVoice(voice);
@@ -4977,26 +4968,19 @@ void Sound::forceReleaseOneActiveVoice() {
 		return;
 	}
 
-	// As in terminateOneActiveVoice: the filter must cover the first voice too, or an already-fast-releasing
-	// front voice (highest rating) soaks up every call in the window.
-	// Note isCullFading() only protects voices already fading at >= SOFT_CULL_INCREMENT; a voice fast-releasing
-	// more slowly (increment in [4096, SOFT_CULL_INCREMENT)) is still eligible, so speedUpRelease() below doubles
-	// it up to the cull-fade rate. This is intentional: a slow fade shouldn't be allowed to linger under load.
-	ActiveVoice* best = nullptr;
-	for (ActiveVoice& voice : voices_) {
-		if (voice->isCullFading()) {
+	ActiveVoice* best = &voices_.front();
+	for (ActiveVoice& voice : voices_ | std::views::drop(1)) {
+		// skip voices releasing faster than this - we'd rather release another voice
+		if (voice->envelopes[0].state >= EnvelopeStage::FAST_RELEASE
+		    && voice->envelopes[0].fastReleaseIncrement >= 4096) {
 			continue;
 		}
-		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {
-			best = &voice;
-		}
-	}
-
-	if (best == nullptr) {
-		return;
+		best = (*best)->getPriorityRating() < voice->getPriorityRating() ? &voice : best;
 	}
 
 	const ActiveVoice& voice = *best;
+
+	auto stage = voice->envelopes[0].state;
 
 	bool still_rendering = voice->speedUpRelease();
 


### PR DESCRIPTION
This reverts commit 4bf178fe84f30d8b031a84998741fff421d60dd8.

Reverting cause we noticed some issues that need more testing.