### PR TITLE
Revert "fix: make voice culling prompt and effective (#4721 follow-up)"

### DIFF
--- a/src/deluge/model/voice/voice.cpp
+++ b/src/deluge/model/voice/voice.cpp
@@ -2512,29 +2512,41 @@ bool Voice::doFastRelease(uint32_t releaseIncrement) {
 	}
 }
 
-bool Voice::speedUpRelease(uint32_t minFastReleaseIncrement) {
-	if (!doneFirstRender) {
-		return false;
+bool Voice::forceNormalRelease() {
+	if (doneFirstRender) {
+		// If no release-stage, we'll stop as soon as we can
+		if (!hasReleaseStage()) {
+			envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, SOFT_CULL_INCREMENT);
+		}
+		// otherwise we'll just let it get there on its own
+		else {
+			envelopes[0].unconditionalRelease();
+		}
+		return true;
 	}
 
+	// Or if first render not done yet, we actually don't want to hear anything at all, so just unassign it
+	else {
+		return false;
+	}
+}
+
+bool Voice::speedUpRelease() {
 	auto stage = envelopes[0].state;
 	if (stage == EnvelopeStage::RELEASE) {
 		auto currentRelease = paramFinalValues[params::LOCAL_ENV_0_RELEASE];
-		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE,
-		                                  std::max<uint32_t>(currentRelease * 2, minFastReleaseIncrement));
+		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, currentRelease * 2);
 		return true;
 	}
 	else if (stage == EnvelopeStage::FAST_RELEASE) {
 		auto currentRelease = envelopes[0].fastReleaseIncrement;
-		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE,
-		                                  std::max<uint32_t>(currentRelease * 2, minFastReleaseIncrement));
+		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, currentRelease * 2);
 		return true;
 	}
 
-	// Cull-driven release must not inherit a patch's long musical release, or culled voices can stack up.
+	// Or if we're not releasing just start the release
 	else {
-		envelopes[0].unconditionalRelease(EnvelopeStage::FAST_RELEASE, minFastReleaseIncrement);
-		return true;
+		return forceNormalRelease();
 	}
 }
 

--- a/src/deluge/model/voice/voice.h
+++ b/src/deluge/model/voice/voice.h
@@ -120,14 +120,9 @@ public:
 	/// Returns whether voice should still be left active
 	bool doImmediateRelease();
 
-	/// Already fading at (or faster than) the soft-cull rate. Cull victim selection and the voice limit
-	/// must treat such a voice as already gone, or it soaks up culls meant for live voices (issue #4721).
-	[[nodiscard]] bool isCullFading() const {
-		return envelopes[0].state >= EnvelopeStage::FAST_RELEASE
-		       && envelopes[0].fastReleaseIncrement >= SOFT_CULL_INCREMENT;
-	}
+	bool forceNormalRelease();
 
-	bool speedUpRelease(uint32_t minFastReleaseIncrement = SOFT_CULL_INCREMENT);
+	bool speedUpRelease();
 	bool shouldBeDeleted() { return delete_this_voice_; }
 
 	// This compares based on the priority of two voices

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -310,7 +310,9 @@ void terminateOneVoice(size_t numSamples) {
 	// seeding `best` unfiltered let an already-fast-releasing front voice absorb every cull in the window.
 	const Sound::ActiveVoice* best = nullptr;
 	for (const auto& voice : all_voices) {
-		if (voice->isCullFading()) {
+		// if we're not skipping releasing voices, or if we are and this one isn't in fast release
+		if (voice->envelopes[0].state >= EnvelopeStage::FAST_RELEASE
+		    && voice->envelopes[0].fastReleaseIncrement >= SOFT_CULL_INCREMENT) {
 			continue;
 		}
 		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {
@@ -339,13 +341,15 @@ void forceReleaseOneVoice(size_t num_samples) {
 		return;
 	}
 
-	// Don't spend another soft cull on a voice that's already disappearing at the cull fade rate. FAST_RELEASE has a
-	// high priority rating, so without this filter repeated soft culls can chase the same fading voice while long
-	// musical-release tails keep stacking up.
+	// Cover the first voice with the same treatment as the rest (see issue #4721) - previously it was seeded
+	// into `best` without the fast-release check, so a fast-releasing front voice was never sped up and could
+	// win the priority comparison, wasting the cull.
 	const Sound::ActiveVoice* best = nullptr;
 	for (const auto& voice : all_voices) {
-		if (voice->isCullFading()) {
-			continue;
+		// if a voice is already fast releasing just speed it up
+		if (voice->envelopes[0].state == EnvelopeStage::FAST_RELEASE) {
+			voice->speedUpRelease();
+			return;
 		}
 		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {
 			best = &voice;

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -4873,9 +4873,7 @@ ModelStackWithAutoParam* Sound::getParamFromMIDIKnob(MIDIKnob& knob, ModelStackW
 }
 
 const Sound::ActiveVoice& Sound::acquireVoice() noexcept(false) {
-	auto count_toward_voice_limit = [](const ActiveVoice& voice) { return !voice->isCullFading(); };
-
-	if (std::ranges::count_if(voices_, count_toward_voice_limit) >= maxVoiceCount) {
+	if (voices_.size() >= maxVoiceCount) {
 		this->terminateOneActiveVoice();
 	}
 
@@ -4949,7 +4947,9 @@ void Sound::terminateOneActiveVoice() {
 	// maxVoiceCount and the limiter sometimes chopped held notes instead (issue #4721).
 	ActiveVoice* best = nullptr;
 	for (ActiveVoice& voice : voices_) {
-		if (voice->isCullFading()) {
+		// skip voices which are already releasing faster than we're going to release them
+		if (voice->envelopes[0].state >= EnvelopeStage::FAST_RELEASE
+		    && voice->envelopes[0].fastReleaseIncrement >= SOFT_CULL_INCREMENT) {
 			continue;
 		}
 		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {
@@ -4984,7 +4984,9 @@ void Sound::forceReleaseOneActiveVoice() {
 	// it up to the cull-fade rate. This is intentional: a slow fade shouldn't be allowed to linger under load.
 	ActiveVoice* best = nullptr;
 	for (ActiveVoice& voice : voices_) {
-		if (voice->isCullFading()) {
+		// skip voices releasing faster than this - we'd rather release another voice
+		if (voice->envelopes[0].state >= EnvelopeStage::FAST_RELEASE
+		    && voice->envelopes[0].fastReleaseIncrement >= 4096) {
 			continue;
 		}
 		if (best == nullptr || (*best)->getPriorityRating() < voice->getPriorityRating()) {


### PR DESCRIPTION
This reverts commit 96cf3b428120a5d07257603be46e2f348f714d2f.