### PR TITLE
Fix/ audio clip end transition causes clicks with seamless loops 

### DIFF
--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -727,12 +727,15 @@ justDontTimeStretch:
 
 		// We want to do a fast release *before* the end, to finish right as the end is reached. So that any waveform
 		// after the end isn't heard.
-		// TODO: in an ideal world, would we only do this if there actually is some waveform "margin" after the end that
-		// we want to avoid hearing, and otherwise just do the release right at the end (does that already happen, I
-		// forgot?) It's perhaps a little bit surprising, but this even works and sounds perfect (you never hear any of
-		// the margin) when time-stretching is happening! Down to about half speed. Below that, you hear some of the
-		// margin.
-		if (static_cast<AudioOutput*>(this->output)->envelope.state < EnvelopeStage::FAST_RELEASE) {
+		// NOTE: only do this if there actually is some waveform "margin" after the end that
+		// we want to avoid hearing. Otherwise just do the release right at the end
+		// Also, only do this if the Clip isn't going to be replaced by another Clip at the end,
+		// because then we don't want to do a release at all, because the next Clip will be doing its own release (if
+		// necessary)
+		if (static_cast<AudioOutput*>(this->output)->envelope.state < EnvelopeStage::FAST_RELEASE
+		    && ((guide.playDirection == 1) ? (sampleHolder.endPos < sample->lengthInSamples)
+		                                   : (sampleHolder.startPos != 0))
+		    && !(currentPlaybackMode == &session && session.willClipBeReplacedAtLaunch(modelStack))) {
 
 			ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(0, nullptr);
 

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -2705,6 +2705,33 @@ bool Session::willClipLoopAtSomePoint(ModelStackWithTimelineCounter const* model
 	return willClipContinuePlayingAtEnd(modelStack);
 }
 
+bool Session::willClipBeReplacedAtLaunch(ModelStackWithTimelineCounter const* modelStack) const {
+	if (!launchEventAtSwungTickCount || numRepeatsTilLaunch > 1) {
+		return false;
+	}
+
+	Clip* clip = (Clip*)modelStack->getTimelineCounter();
+	if (!modelStack->song->isClipActive(clip) || clip->armState != ArmState::ON_NORMAL) {
+		return false;
+	}
+
+	for (int32_t c = 0; c < modelStack->song->sessionClips.getNumElements(); c++) {
+		Clip* otherClip = modelStack->song->sessionClips.getClipAtIndex(c);
+		if (otherClip == clip || otherClip->output != clip->output || otherClip->armState == ArmState::OFF
+		    || modelStack->song->isClipActive(otherClip)) {
+			continue;
+		}
+
+		if (otherClip->isPendingOverdub && otherClip->willCloneOutputForOverdub()) {
+			continue;
+		}
+
+		return true;
+	}
+
+	return false;
+}
+
 // The point of this is to re-enable any other Clip with same Output
 bool Session::deletingClipWhichCouldBeAbandonedOverdub(Clip* clip) {
 

--- a/src/deluge/playback/mode/session.h
+++ b/src/deluge/playback/mode/session.h
@@ -93,6 +93,7 @@ public:
 	int32_t getPosAtWhichClipWillCut(ModelStackWithTimelineCounter const* modelStack) override;
 	bool willClipContinuePlayingAtEnd(ModelStackWithTimelineCounter const* modelStack) override;
 	bool willClipLoopAtSomePoint(ModelStackWithTimelineCounter const* modelStack) override;
+	bool willClipBeReplacedAtLaunch(ModelStackWithTimelineCounter const* modelStack) const;
 	// this is probably the only time we want an audio clip to use threshold sampling?
 	bool wantsToDoTempolessRecord(int32_t newPos) override;
 


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4737

## Description

Fixed issue which would cause a click when a section change causes a seamless transition for one audio clip droning loop to the another audio clip droning loop. Manual clip launching did not cause this click so it was a bug with the section change logic.

## Analysis

Manual clip launch arms only the incoming clip. The outgoing clip on the same output is not armed to stop; it gets displaced at doLaunch() because the output is taken by the new clip.

Section launch does something different: it arms active clips in other sections with ArmState::ON_NORMAL. For audio clips, that makes [AudioClip::render() (line 735)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/model/clip/audio_clip.cpp:735) decide the clip “won’t loop” and start a fast envelope release shortly before the launch point. That pre-fade is useful when a clip is truly stopping into silence, but wrong when another audio clip is about to replace it seamlessly. It can create the exact tiny gap/dip/click the issue describes.

## Fix

Added a fix [Session::willClipBeReplacedAtLaunch() (line 2708)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/playback/mode/session.cpp:2708), which detects “this active clip is armed to stop, but another inactive armed clip on the same output will take over at launch.”

Audio clips now skip the pre-launch fast release in only that replacement case: [audio_clip.cpp (line 735)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/model/clip/audio_clip.cpp:735).

Also addressed to do comment for true audio clip stops. The early fast-release now only runs when there’s actual post-end waveform margin: forward playback checks endPos < lengthInSamples, reverse playback checks startPos != 0.