### PR TITLE
Fix/ seamless audio clip loop click on section launch

### DIFF
--- a/src/deluge/model/clip/audio_clip.cpp
+++ b/src/deluge/model/clip/audio_clip.cpp
@@ -727,12 +727,11 @@ justDontTimeStretch:
 
 		// We want to do a fast release *before* the end, to finish right as the end is reached. So that any waveform
 		// after the end isn't heard.
-		// TODO: in an ideal world, would we only do this if there actually is some waveform "margin" after the end that
-		// we want to avoid hearing, and otherwise just do the release right at the end (does that already happen, I
-		// forgot?) It's perhaps a little bit surprising, but this even works and sounds perfect (you never hear any of
-		// the margin) when time-stretching is happening! Down to about half speed. Below that, you hear some of the
-		// margin.
-		if (static_cast<AudioOutput*>(this->output)->envelope.state < EnvelopeStage::FAST_RELEASE) {
+		// NOTE: only do this if there actually is some waveform "margin" after the end or before the beginning (if
+		// reversed) that we want to avoid hearing. Otherwise just do the release right at the start/end
+		if (static_cast<AudioOutput*>(this->output)->envelope.state < EnvelopeStage::FAST_RELEASE
+		    && ((guide.playDirection == 1) ? (sampleHolder.endPos < sample->lengthInSamples)
+		                                   : (sampleHolder.startPos != 0))) {
 
 			ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(0, nullptr);
 

--- a/src/deluge/playback/mode/session.cpp
+++ b/src/deluge/playback/mode/session.cpp
@@ -84,6 +84,19 @@ const Colour defaultClipSectionColours[] = {RGB::fromHue(102), // bright light b
                                             green.forTail(),
                                             magenta.forTail()};
 
+// Manual clip launch doesn't pre-arm an outgoing active audio clip when another clip is launching on the same output;
+// doLaunch() stops it when the incoming clip takes that output. Section launch keeps the same pre-launch state for
+// active audio clips on outputs that the target section will take.
+static ArmState
+getSectionLaunchStopArmStateForActiveClip(Clip* clip,
+                                          OpenAddressingHashTableWith32bitKey& outputsTakenBySectionLaunch) {
+	if (clip->type == ClipType::AUDIO && outputsTakenBySectionLaunch.lookup((uint32_t)clip->output)) {
+		return ArmState::OFF;
+	}
+
+	return ArmState::ON_NORMAL;
+}
+
 Session::Session() {
 	cancelAllLaunchScheduling();
 	lastSectionArmed = REALLY_OUT_OF_RANGE;
@@ -1638,6 +1651,37 @@ void Session::armClipsToStartOrSoloWithQuantization(uint32_t pos, uint32_t quant
 	// late-start
 	else {
 		OpenAddressingHashTableWith32bitKey outputsWeHavePickedAClipFor;
+		OpenAddressingHashTableWith32bitKey outputsTakenBySectionLaunch;
+
+		// Look ahead before the main arming pass so active audio clips can stay unarmed if this section launch will
+		// replace them on the same output. That matches manual clip launch, where doLaunch() stops the old clip when
+		// the incoming clip takes the output.
+		for (int32_t c = currentSong->sessionClips.getNumElements() - 1; c >= 0; c--) {
+			Clip* sectionClip = currentSong->sessionClips.getClipAtIndex(c);
+
+			// Clips outside the launched section are not incoming clips for this section launch.
+			if (sectionClip->section != section) {
+				continue;
+			}
+
+			// Fill clips are skipped by normal section launch, so they cannot take an output here.
+			if (sectionClip->launchStyle == LaunchStyle::FILL) {
+				continue;
+			}
+
+			// doLaunch() only records inactive armed clips as taking an output; already-active clips keep playing.
+			if (currentSong->isClipActive(sectionClip)) {
+				continue;
+			}
+
+			// doLaunch() also excludes pending overdubs that clone the output from its output-takeover list.
+			if (sectionClip->isPendingOverdub && sectionClip->willCloneOutputForOverdub()) {
+				continue;
+			}
+
+			bool alreadyPickedAClip = false;
+			outputsTakenBySectionLaunch.insert((uint32_t)sectionClip->output, &alreadyPickedAClip);
+		}
 
 		// Ok, we're going to do a big complex thing where we traverse just once (or occasionally twice) through all
 		// sessionClips. Reverse order so behaviour of this new code is the same as the old code
@@ -1672,7 +1716,10 @@ void Session::armClipsToStartOrSoloWithQuantization(uint32_t pos, uint32_t quant
 						for (int32_t d = currentSong->sessionClips.getNumElements() - 1; d > c; d--) {
 							Clip* thatClip = currentSong->sessionClips.getClipAtIndex(d);
 							if (thatClip->output == output) {
-								thatClip->armState = thatClip->activeIfNoSolo ? ArmState::ON_NORMAL : ArmState::OFF;
+								thatClip->armState = thatClip->activeIfNoSolo
+								                         ? getSectionLaunchStopArmStateForActiveClip(
+								                               thatClip, outputsTakenBySectionLaunch)
+								                         : ArmState::OFF;
 							}
 						}
 
@@ -1717,7 +1764,8 @@ weWantThisClipInactive:
 
 					// If it's active, arm it to stop
 					else if (thisClip->activeIfNoSolo) {
-						thisClip->armState = ArmState::ON_NORMAL;
+						thisClip->armState =
+						    getSectionLaunchStopArmStateForActiveClip(thisClip, outputsTakenBySectionLaunch);
 					}
 
 					// Or if it's already inactive...
@@ -1753,7 +1801,8 @@ weWantThisClipInactive:
 						// If we've already picked a Clip for this same Output, we definitely don't want this one
 						// remaining active, so arm it to stop
 						if (outputsWeHavePickedAClipFor.lookup((uint32_t)thisClip->output)) {
-							thisClip->armState = ArmState::ON_NORMAL;
+							thisClip->armState =
+							    getSectionLaunchStopArmStateForActiveClip(thisClip, outputsTakenBySectionLaunch);
 						}
 					}
 				}


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4737

Two fixes are included in this PR. 

## FIX 1 (symptom)

The first commit addresses a to do that was left by Rohan which did fix the click but isn't the real fix (see below).

This fix checks if there's any margin before/after the audio clips loop start/end and only does a release if there is any.

The releasing is what causes the click, so stopping that stops the click in the test song.

But since the click happens with section launching and not clip launching, something else must be at play (see fix below).

## FIX 2 (cause)

The real fix is in the second commit which the first fix revealed. 

This commit aligns section launch behaviour with manual clip launch behaviour to fix an audible click when launching a section that replaces an active audio clip with another clip on the same output.

### Clip launch behaviour:

When an audio clip is playing on an output and another clip is manually launched on the same output, the currently active audio clip is not armed to stop.

Because the active audio clip is not armed to stop, AudioClip::render does not trigger its release. It still sees the clip as continuing to loop.

Instead, Session::doLaunch stops the current active audio clip when the replacement clip takes the output.

### Current section launch behaviour:

When an audio clip is playing on an output and a section is launched with a clip on that same output, section launch arms the currently active audio clip to stop (it does this for all clips essentially, not just audio).

This causes AudioClip::render to trigger a release of the active audio clip because it sees the clip as stopping instead of looping. For seamless audio clip transitions, that release can cause an audible click.

### Fixed section launch behaviour:

To fix the audible click, section launch now follows the same behaviour as manual clip launch for active audio clips whose output will be taken by the launched section.

If there is a clip in the launched section that will take the same output as the current active audio clip, section launch does not arm the current active audio clip to stop.

Instead, Session::doLaunch stops the current active audio clip when the replacement clip takes the output.

As a result, AudioClip::render does not see the currently active audio clip as stopping, so it does not trigger the release that caused the click.