### PR TITLE
Fix chord keyboard layout toggle re-rendering

### DIFF
--- a/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
+++ b/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp
@@ -246,12 +246,18 @@ void KeyboardLayoutChord::handleControlButton(int32_t x, int32_t y) {
 	// 	}
 	// }
 	if (x == kDisplayWidth - 1 && y == kDisplayHeight - 1) {
-		mode = ChordKeyboardMode::ROW;
+		if (mode != ChordKeyboardMode::ROW) {
+			mode = ChordKeyboardMode::ROW;
+			keyboardScreen.requestRendering();
+		}
 		char const* shortLong[2] = {"ROW", "Chord Row Mode"};
 		display->displayPopup(shortLong);
 	}
 	else if (x == kDisplayWidth - 1 && y == kDisplayHeight - 2) {
-		mode = ChordKeyboardMode::COLUMN;
+		if (mode != ChordKeyboardMode::COLUMN) {
+			mode = ChordKeyboardMode::COLUMN;
+			keyboardScreen.requestRendering();
+		}
 		char const* shortLong[2] = {"COLM", "Chord Column Mode"};
 		display->displayPopup(shortLong);
 	}


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4741

Fix regression from PR #4660, which changed KeyboardScreen::padAction() to skip main-grid rendering unless the active note state changes. That optimization is sensible for rapid keyboard playing, but the chord keyboard layout’s blue/purple mode buttons change KeyboardLayoutChord::mode without changing currentNotesState, so the main grid was no longer refreshed until a later key press changed notes.

I fixed it in [chord_keyboard.cpp (line 248)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/gui/ui/keyboard/layout/chord_keyboard.cpp:248): when the embedded row/column mode buttons actually change mode, they now call keyboardScreen.requestRendering().