### PR TITLE
Fix/ Refactor and fix midi cc selection

### DIFF
--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -2878,19 +2878,7 @@ void AutomationView::selectMIDICC(int32_t offset, Clip* clip) {
 	if (onAutomationOverview()) {
 		clip->lastSelectedParamID = CC_NUMBER_NONE;
 	}
-	auto newCC = clip->lastSelectedParamID;
-	newCC += offset;
-	if (newCC < 0) {
-		newCC = CC_NUMBER_Y_AXIS;
-	}
-	else if (newCC >= kNumCCExpression) {
-		newCC = 0;
-	}
-	if (newCC == CC_EXTERNAL_MOD_WHEEL) {
-		// mod wheel is actually CC_NUMBER_Y_AXIS (122) internally
-		newCC += offset;
-	}
-	clip->lastSelectedParamID = newCC;
+	clip->lastSelectedParamID = MIDIInstrument::getNextSelectableCC(clip->lastSelectedParamID, offset);
 	automationParamType = AutomationParamType::PER_SOUND;
 }
 

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -606,22 +606,33 @@ Error MIDIInstrument::readMIDIParamFromFile(Deserializer& reader, int32_t readAu
 	return Error::NONE;
 }
 
+int32_t MIDIInstrument::getNextSelectableCC(int32_t cc, int32_t offset, bool includeNoCC) {
+	int32_t newCC = cc;
+	int32_t direction = (offset < 0) ? -1 : 1;
+	int32_t steps = (offset < 0) ? -offset : offset;
+	int32_t numSelectableCCs = includeNoCC ? kNumCCNumbersIncludingFake : kNumCCExpression;
+
+	for (int32_t i = 0; i < steps; i++) {
+		newCC += direction;
+		if (newCC < 0) {
+			newCC += numSelectableCCs;
+		}
+		else if (newCC >= numSelectableCCs) {
+			newCC -= numSelectableCCs;
+		}
+		if (newCC == CC_EXTERNAL_MOD_WHEEL) {
+			// Mod wheel is represented by CC_NUMBER_Y_AXIS internally.
+			newCC += direction;
+		}
+	}
+
+	return newCC;
+}
+
 int32_t MIDIInstrument::changeControlNumberForModKnob(int32_t offset, int32_t whichModEncoder, int32_t modKnobMode) {
 	int8_t* cc = &modKnobCCAssignments[modKnobMode * kNumPhysicalModKnobs + whichModEncoder];
 
-	int32_t newCC = *cc;
-
-	newCC += offset;
-	if (newCC < 0) {
-		newCC += kNumCCNumbersIncludingFake;
-	}
-	else if (newCC >= kNumCCNumbersIncludingFake) {
-		newCC -= kNumCCNumbersIncludingFake;
-	}
-	if (newCC == 1) {
-		// mod wheel is actually CC_NUMBER_Y_AXIS (122) internally
-		newCC += offset;
-	}
+	int32_t newCC = getNextSelectableCC(*cc, offset, true);
 
 	*cc = newCC;
 
@@ -641,14 +652,7 @@ int32_t MIDIInstrument::getFirstUnusedCC(ModelStackWithThreeMainThings* modelSta
 			return proposedCC;
 		}
 
-		proposedCC += direction;
-
-		if (proposedCC < 0) {
-			proposedCC += CC_NUMBER_NONE;
-		}
-		else if (proposedCC >= CC_NUMBER_NONE) {
-			proposedCC -= CC_NUMBER_NONE;
-		}
+		proposedCC = getNextSelectableCC(proposedCC, direction);
 
 		if (proposedCC == stopAt) {
 			return -1;
@@ -714,13 +718,7 @@ int32_t MIDIInstrument::moveAutomationToDifferentCC(int32_t offset, int32_t whic
 		return *cc;
 	}
 
-	int32_t newCC = *cc + offset;
-	if (newCC < 0) {
-		newCC += CC_NUMBER_NONE;
-	}
-	else if (newCC >= CC_NUMBER_NONE) {
-		newCC -= CC_NUMBER_NONE;
-	}
+	int32_t newCC = getNextSelectableCC(*cc, offset);
 
 	// Need to pick a new cc which is blank on all Clips' ParamManagers with this Instrument
 	// For each Clip in session and arranger for specific Output (that Output is "this")

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -68,6 +68,7 @@ public:
 
 	void sendNoteToInternal(bool on, int32_t note, uint8_t velocity, uint8_t channel);
 
+	static int32_t getNextSelectableCC(int32_t cc, int32_t offset, bool includeNoCC = false);
 	int32_t changeControlNumberForModKnob(int32_t offset, int32_t whichModEncoder, int32_t modKnobMode);
 	int32_t getFirstUnusedCC(ModelStackWithThreeMainThings* modelStack, int32_t direction, int32_t startAt,
 	                         int32_t stopAt);


### PR DESCRIPTION
Fix #4735 

Refactor and de-duplicate code that handles midi cc selection in midi clips and midi automation view.

MIDI Instrument now incldues helper function for getting the next selectable midi cc.