### PR TITLE
Fix/ audio output specific track selector

### DIFF
--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -42,6 +42,7 @@ constexpr size_t kNumValues = 8;
 AudioInputSelector audioInputSelector{};
 
 namespace {
+// A saved source pointer can become stale if its instrument leaves the active song list, e.g. by being hibernated.
 Output* getRecordableOutputInSong(AudioOutput* audioOutput, Output* selectedOutput) {
 	if (!audioOutput->canRecordFrom(selectedOutput)) {
 		return nullptr;
@@ -56,6 +57,7 @@ Output* getRecordableOutputInSong(AudioOutput* audioOutput, Output* selectedOutp
 	return nullptr;
 }
 
+// Used when entering Track mode without a valid previous source.
 Output* getFirstRecordableOutput(AudioOutput* audioOutput) {
 	for (Output* output = currentSong->firstOutput; output; output = output->next) {
 		if (audioOutput->canRecordFrom(output)) {
@@ -138,6 +140,7 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 
 	auto valueOption = static_cast<Value>(currentOption);
 	if (display->haveOLED() && valueOption == Value::TRACK) {
+		// Keep Track on the first visible row so the selected track name has room below it.
 		scrollPos = currentOption;
 	}
 
@@ -174,6 +177,7 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 		break;
 	case Value::TRACK: {
 		audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
+		// Preserve the chosen source if possible; only choose a default when the previous source is gone.
 		Output* recordFrom = getRecordableOutputInSong(audioOutput, audioOutput->getOutputRecordingFrom());
 		if (!recordFrom) {
 			recordFrom = getFirstRecordableOutput(audioOutput);
@@ -201,6 +205,7 @@ ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 			audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
 			audioOutput->setOutputRecordingFrom(track);
 			if (display->have7SEG()) {
+				// OLED shows this persistently in renderOLED(); 7SEG still needs popup feedback.
 				display->popupTextTemporary(track->name.get());
 			}
 			// sets scroll to the position of specific output
@@ -227,6 +232,7 @@ void AudioInputSelector::renderOLED(deluge::hid::display::oled_canvas::Canvas& c
 		return;
 	}
 
+	// Show the selected target in the context menu footer.
 	Output* recordFrom = getRecordableOutputInSong(audioOutput, audioOutput->getOutputRecordingFrom());
 	char const* trackName = recordFrom ? recordFrom->name.get() : "No track";
 

--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -41,6 +41,32 @@ constexpr size_t kNumValues = 8;
 
 AudioInputSelector audioInputSelector{};
 
+namespace {
+Output* getRecordableOutputInSong(AudioOutput* audioOutput, Output* selectedOutput) {
+	if (!audioOutput->canRecordFrom(selectedOutput)) {
+		return nullptr;
+	}
+
+	for (Output* output = currentSong->firstOutput; output; output = output->next) {
+		if (output == selectedOutput) {
+			return selectedOutput;
+		}
+	}
+
+	return nullptr;
+}
+
+Output* getFirstRecordableOutput(AudioOutput* audioOutput) {
+	for (Output* output = currentSong->firstOutput; output; output = output->next) {
+		if (audioOutput->canRecordFrom(output)) {
+			return output;
+		}
+	}
+
+	return nullptr;
+}
+} // namespace
+
 char const* AudioInputSelector::getTitle() {
 	using enum l10n::String;
 	return l10n::get(STRING_FOR_AUDIO_SOURCE);
@@ -111,6 +137,9 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 	ContextMenu::selectEncoderAction(offset);
 
 	auto valueOption = static_cast<Value>(currentOption);
+	if (display->haveOLED() && valueOption == Value::TRACK) {
+		scrollPos = currentOption;
+	}
 
 	// When switching away from SPECIFIC_OUTPUT, clear the recording-from state
 	// so the previously-selected track is no longer silently muted
@@ -145,15 +174,9 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 		break;
 	case Value::TRACK: {
 		audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
-		// Default to the first recordable output. Skip MIDI/CV (and ourselves), matching padAction, which rejects
-		// them - recording audio from a non-audio output is meaningless and drives that output's renderOutput.
-		Output* recordFrom = nullptr;
-		for (int32_t i = 0; i < currentSong->getNumOutputs(); i++) {
-			Output* candidate = currentSong->getOutputFromIndex(i);
-			if (audioOutput->canRecordFrom(candidate)) {
-				recordFrom = candidate;
-				break;
-			}
+		Output* recordFrom = getRecordableOutputInSong(audioOutput, audioOutput->getOutputRecordingFrom());
+		if (!recordFrom) {
+			recordFrom = getFirstRecordableOutput(audioOutput);
 		}
 		audioOutput->setOutputRecordingFrom(recordFrom);
 		break;
@@ -164,6 +187,10 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 	}
 
 	defaultAudioOutputInputChannel = audioOutput->inputChannel;
+
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
 }
 
 // if they're in session view and press a clip's pad, record from that output
@@ -173,7 +200,9 @@ ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 		if (audioOutput->canRecordFrom(track)) {
 			audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
 			audioOutput->setOutputRecordingFrom(track);
-			display->popupTextTemporary(track->name.get());
+			if (display->have7SEG()) {
+				display->popupTextTemporary(track->name.get());
+			}
 			// sets scroll to the position of specific output
 			scrollPos = static_cast<int32_t>(Value::TRACK);
 			currentOption = scrollPos;
@@ -189,6 +218,22 @@ ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 		return ActionResult::DEALT_WITH;
 	}
 	return ContextMenu::padAction(x, y, on);
+}
+
+void AudioInputSelector::renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) {
+	ContextMenu::renderOLED(canvas);
+
+	if (audioOutput->inputChannel != AudioInputChannel::SPECIFIC_OUTPUT) {
+		return;
+	}
+
+	Output* recordFrom = getRecordableOutputInSong(audioOutput, audioOutput->getOutputRecordingFrom());
+	char const* trackName = recordFrom ? recordFrom->name.get() : "No track";
+
+	int32_t windowHeight = 40;
+	int32_t windowMinY = (OLED_MAIN_HEIGHT_PIXELS - windowHeight) >> 1;
+	int32_t textPixelY = windowMinY + 20 + kTextSpacingY;
+	canvas.drawString(trackName, 22, textPixelY, kTextSpacingX, kTextSpacingY, 0, OLED_MAIN_WIDTH_PIXELS - 26);
 }
 
 } // namespace deluge::gui::context_menu

--- a/src/deluge/gui/context_menu/audio_input_selector.cpp
+++ b/src/deluge/gui/context_menu/audio_input_selector.cpp
@@ -150,8 +150,7 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 		Output* recordFrom = nullptr;
 		for (int32_t i = 0; i < currentSong->getNumOutputs(); i++) {
 			Output* candidate = currentSong->getOutputFromIndex(i);
-			if (candidate != audioOutput && candidate->type != OutputType::MIDI_OUT
-			    && candidate->type != OutputType::CV) {
+			if (audioOutput->canRecordFrom(candidate)) {
 				recordFrom = candidate;
 				break;
 			}
@@ -171,7 +170,7 @@ void AudioInputSelector::selectEncoderAction(int8_t offset) {
 ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 	if (on && getUIUpOneLevel() == &sessionView) {
 		auto track = (&sessionView)->getOutputFromPad(x, y);
-		if (track && track->type != OutputType::MIDI_OUT && track->type != OutputType::CV) {
+		if (audioOutput->canRecordFrom(track)) {
 			audioOutput->inputChannel = AudioInputChannel::SPECIFIC_OUTPUT;
 			audioOutput->setOutputRecordingFrom(track);
 			display->popupTextTemporary(track->name.get());
@@ -179,6 +178,9 @@ ActionResult AudioInputSelector::padAction(int32_t x, int32_t y, int32_t on) {
 			scrollPos = static_cast<int32_t>(Value::TRACK);
 			currentOption = scrollPos;
 			renderUIsForOled();
+		}
+		else if (track && track == audioOutput) {
+			display->popupTextTemporary("Can't record self!");
 		}
 		else if (track) {
 			display->popupTextTemporary("Can't record MIDI or CV!");

--- a/src/deluge/gui/context_menu/audio_input_selector.h
+++ b/src/deluge/gui/context_menu/audio_input_selector.h
@@ -32,6 +32,7 @@ public:
 	bool setupAndCheckAvailability() override;
 	bool canSeeViewUnderneath() override { return true; }
 	ActionResult padAction(int32_t x, int32_t y, int32_t on) override;
+	void renderOLED(deluge::hid::display::oled_canvas::Canvas& canvas) override;
 	AudioOutput* audioOutput;
 
 	/// Title

--- a/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
+++ b/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
@@ -29,13 +29,19 @@ public:
 
 	void beginSession(MenuItem* navigatedBackwardFrom) override {
 		audioOutputBeingEdited = (AudioOutput*)getCurrentOutput();
-		if (audioOutputBeingEdited->getOutputRecordingFrom()) {
-			outputIndex = currentSong->getOutputIndex(audioOutputBeingEdited->getOutputRecordingFrom());
+		numOutputs = currentSong->getNumOutputs();
+
+		Output* selectedOutput = audioOutputBeingEdited->getOutputRecordingFrom();
+		outputIndex = getRecordableOutputIndex(selectedOutput);
+		if (outputIndex < 0) {
+			outputIndex = getNextRecordableOutputIndex(-1, 1);
+			selectedOutput = getOutputFromSelectedIndex();
+			audioOutputBeingEdited->setOutputRecordingFrom(selectedOutput);
 		}
-		else {
+
+		if (outputIndex < 0) {
 			outputIndex = 0;
 		}
-		numOutputs = currentSong->getNumOutputs();
 		if (display->haveOLED()) {
 			renderUIsForOled();
 		}
@@ -45,9 +51,12 @@ public:
 	}
 
 	void selectEncoderAction(int32_t offset) override {
-		outputIndex += offset;
-		outputIndex = std::clamp<int32_t>(outputIndex, 0, numOutputs - 1);
-		auto newRecordingFrom = currentSong->getOutputFromIndex(outputIndex);
+		int32_t newOutputIndex = getNextRecordableOutputIndex(outputIndex, offset);
+		if (newOutputIndex < 0) {
+			return;
+		}
+		outputIndex = newOutputIndex;
+		auto newRecordingFrom = getOutputFromSelectedIndex();
 		audioOutputBeingEdited->setOutputRecordingFrom(newRecordingFrom);
 		if (display->haveOLED()) {
 			renderUIsForOled();
@@ -60,13 +69,17 @@ public:
 		deluge::hid::display::oled_canvas::Canvas& canvas = hid::display::OLED::main;
 
 		// track
-		Output* output = currentSong->getOutputFromIndex(outputIndex);
+		Output* output = getOutputFromSelectedIndex();
+		if (!output) {
+			canvas.drawStringCentred("No track", OLED_MAIN_TOPMOST_PIXEL + 21, kTextSpacingX, kTextSpacingY);
+			return;
+		}
 
 		// track type
 		OutputType outputType = output->type;
 
 		// for midi instruments, get the channel
-		int32_t channel;
+		int32_t channel = 0;
 		if (outputType == OutputType::MIDI_OUT) {
 			Instrument* instrument = (Instrument*)output;
 			channel = ((NonAudioInstrument*)instrument)->getChannel();
@@ -80,7 +93,7 @@ public:
 		int32_t yPos = OLED_MAIN_TOPMOST_PIXEL + 28;
 
 		// draw the track name
-		char const* name = audioOutputBeingEdited->getOutputRecordingFrom()->name.get();
+		char const* name = output->name.get();
 
 		int32_t stringLengthPixels = canvas.getStringWidthInPixels(name, kTextTitleSizeY);
 
@@ -96,7 +109,8 @@ public:
 	}
 
 	void drawFor7seg() {
-		char const* text = audioOutputBeingEdited->getOutputRecordingFrom()->name.get();
+		Output* output = getOutputFromSelectedIndex();
+		char const* text = output ? output->name.get() : "No track";
 		display->setScrollingText(text, 0);
 	}
 
@@ -111,5 +125,59 @@ public:
 	// this is the index that the output is recording from
 	int32_t outputIndex{0};
 	int32_t numOutputs{0};
+
+private:
+	bool canRecordFromOutput(Output* output) const { return audioOutputBeingEdited->canRecordFrom(output); }
+
+	int32_t getRecordableOutputIndex(Output* output) const {
+		if (!canRecordFromOutput(output)) {
+			return -1;
+		}
+
+		int32_t index = 0;
+		for (Output* candidate = currentSong->firstOutput; candidate; candidate = candidate->next) {
+			if (candidate == output) {
+				return index;
+			}
+			index++;
+		}
+
+		return -1;
+	}
+
+	Output* getOutputFromSelectedIndex() const {
+		Output* output = currentSong->getOutputFromIndex(outputIndex);
+		return canRecordFromOutput(output) ? output : nullptr;
+	}
+
+	int32_t getNextRecordableOutputIndex(int32_t startIndex, int32_t offset) const {
+		if (offset == 0) {
+			return getOutputFromSelectedIndex()
+			           ? outputIndex
+			           : getRecordableOutputIndex(audioOutputBeingEdited->getOutputRecordingFrom());
+		}
+
+		int32_t direction = offset > 0 ? 1 : -1;
+		int32_t steps = offset > 0 ? offset : -offset;
+		int32_t selectedIndex = startIndex;
+
+		for (int32_t step = 0; step < steps; step++) {
+			int32_t candidateIndex = selectedIndex;
+			while (true) {
+				candidateIndex += direction;
+				if (candidateIndex < 0 || candidateIndex >= numOutputs) {
+					return selectedIndex;
+				}
+
+				Output* candidate = currentSong->getOutputFromIndex(candidateIndex);
+				if (canRecordFromOutput(candidate)) {
+					selectedIndex = candidateIndex;
+					break;
+				}
+			}
+		}
+
+		return selectedIndex;
+	}
 };
 } // namespace deluge::gui::menu_item::audio_clip

--- a/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
+++ b/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h
@@ -34,6 +34,7 @@ public:
 		Output* selectedOutput = audioOutputBeingEdited->getOutputRecordingFrom();
 		outputIndex = getRecordableOutputIndex(selectedOutput);
 		if (outputIndex < 0) {
+			// If the stored source was removed or became invalid, land on the first valid target instead.
 			outputIndex = getNextRecordableOutputIndex(-1, 1);
 			selectedOutput = getOutputFromSelectedIndex();
 			audioOutputBeingEdited->setOutputRecordingFrom(selectedOutput);
@@ -134,6 +135,7 @@ private:
 			return -1;
 		}
 
+		// Only outputs still in the main song list are selectable; hibernated instruments should not display here.
 		int32_t index = 0;
 		for (Output* candidate = currentSong->firstOutput; candidate; candidate = candidate->next) {
 			if (candidate == output) {
@@ -163,6 +165,7 @@ private:
 
 		for (int32_t step = 0; step < steps; step++) {
 			int32_t candidateIndex = selectedIndex;
+			// Walk the raw song indices, but stop only on rows the audio track can actually record from.
 			while (true) {
 				candidateIndex += direction;
 				if (candidateIndex < 0 || candidateIndex >= numOutputs) {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3578,6 +3578,7 @@ void Song::deleteOutput(Output* output) {
 
 void Song::moveInstrumentToHibernationList(Instrument* instrument) {
 
+	// Hibernated instruments stay allocated but leave the active output list, so audio tracks must stop targeting them.
 	clearRecordingFromReferencesTo(instrument);
 
 	removeOutputFromMainList(instrument);

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3578,6 +3578,8 @@ void Song::deleteOutput(Output* output) {
 
 void Song::moveInstrumentToHibernationList(Instrument* instrument) {
 
+	clearRecordingFromReferencesTo(instrument);
+
 	removeOutputFromMainList(instrument);
 
 	if (instrument->type == OutputType::MIDI_OUT) {

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -105,10 +105,13 @@ public:
 
 	Output* getOutputRecordingFrom() override { return outputRecordingFrom; }
 	void clearRecordingFrom() override { setOutputRecordingFrom(nullptr); }
+	bool canRecordFrom(Output const* source) const {
+		return source && source != this && source->type != OutputType::MIDI_OUT && source->type != OutputType::CV;
+	}
 	void setOutputRecordingFrom(Output* toRecordfrom) {
-		if (toRecordfrom == this) {
-			// can happen from bad save files
-			return;
+		if (toRecordfrom && !canRecordFrom(toRecordfrom)) {
+			// Can happen from bad save files or stale UI state.
+			toRecordfrom = nullptr;
 		}
 		releaseMonitoringClaim();
 		outputRecordingFrom = toRecordfrom;

--- a/src/deluge/processing/audio_output.h
+++ b/src/deluge/processing/audio_output.h
@@ -105,6 +105,7 @@ public:
 
 	Output* getOutputRecordingFrom() override { return outputRecordingFrom; }
 	void clearRecordingFrom() override { setOutputRecordingFrom(nullptr); }
+	// Specific-track recording only makes sense from another audio-capable output.
 	bool canRecordFrom(Output const* source) const {
 		return source && source != this && source->type != OutputType::MIDI_OUT && source->type != OutputType::CV;
 	}


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4677

What changed:

- Added AudioOutput::canRecordFrom() and made invalid sources clear instead of leaving stale pointers: [audio_output.h (line 108)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/processing/audio_output.h:108)

- Blocked self-selection from the audio input pad/context flow: [audio_input_selector.cpp (line 147)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/gui/context_menu/audio_input_selector.cpp:147)

- Made the specific-track selector skip self/MIDI/CV, keep its index synced, and render type/name from the same output: [specific_output_source_selector.h (line 30)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/gui/menu_item/audio_clip/specific_output_source_selector.h:30)

- Clear audio-track recording references before hibernating a deleted instrument: [song.cpp (line 3579)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/model/song/song.cpp:3579)
82f7895f3d

- Updated audio input selector UI to render the name of the specific track selected

https://github.com/user-attachments/assets/365409a1-cf55-4160-8137-fd2a1e1b0978