### PR TITLE
Fix/ PIC empty reads blocking boot factory reset

### DIFF
--- a/src/deluge/drivers/pic/pic.h
+++ b/src/deluge/drivers/pic/pic.h
@@ -219,7 +219,11 @@ public:
 	 */
 	static Response read() {
 		uint8_t value;
-		uartGetChar(UART_ITEM_PIC, (char*)&value);
+		// uartGetChar leaves value untouched when the RX buffer is empty.
+		// Report that explicitly so empty polls cannot look like real PIC events.
+		if (!uartGetChar(UART_ITEM_PIC, (char*)&value)) {
+			return Response::NONE;
+		}
 		return Response{value};
 	}
 
@@ -249,7 +253,13 @@ public:
 		uint16_t timeWaitBegan = *TCNT[TIMER_SYSTEM_FAST];
 		int32_t result = 1; // error with failure by default
 		while ((uint16_t)(*TCNT[TIMER_SYSTEM_FAST] - timeWaitBegan) < timeout) {
-			result = handler(PIC::read());
+			Response value = PIC::read();
+			if (value == Response::NONE) {
+				// Match the old boot-time scan, which waited for actual UART bytes.
+				// Empty polls must not poison the RESET_SETTINGS guard.
+				continue;
+			}
+			result = handler(value);
 			if (result != 0) {
 				return result;
 			}


### PR DESCRIPTION
Ensure PIC::read() returns Response::NONE when the PIC UART RX buffer is empty, instead of interpreting an untouched local value as a real response.

Also skip Response::NONE in the callback-based PIC::read(timeout, handler) loop. This restores the old boot-time scan behavior, where only actual UART bytes were processed, and prevents empty polls from setting the “other button/event” guard before RESET_SETTINGS arrives.

This fixes a path where holding Select during boot could fail to call FlashStorage::resetSettings().