### PR TITLE
Fix/ 7 seg display toggle not refreshing in session view

### DIFF
--- a/src/deluge/gui/ui/ui.cpp
+++ b/src/deluge/gui/ui/ui.cpp
@@ -48,6 +48,12 @@ void UI::graphicsRoutine() {
 	}
 }
 
+void UI::displayOrLanguageChanged() {
+	if (display->haveOLED()) {
+		renderUIsForOled();
+	}
+}
+
 void UI::close() {
 	closeUI(this);
 }

--- a/src/deluge/gui/ui/ui.h
+++ b/src/deluge/gui/ui/ui.h
@@ -115,7 +115,7 @@ public:
 
 	virtual void focusRegained() {}
 	// the `display` and/or `chosenLanguage` object changed. redraw accordingly.
-	virtual void displayOrLanguageChanged() {}
+	virtual void displayOrLanguageChanged();
 	virtual bool canSeeViewUnderneath() { return false; }
 	/// Convert this clip to a clip minder. Returns true for views which manage a single clip,
 	/// false for song level views

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -476,6 +476,12 @@ void AutomationView::focusRegained() {
 		currentSong->affectEntire = true;
 		view.focusRegained();
 		view.setActiveModControllableTimelineCounter(currentSong);
+
+		// On 7SEG, automation display text is not updated by LED/grid rendering.
+		// Refresh it whenever automation regains focus (e.g. exiting a menu).
+		if (display->have7SEG()) {
+			renderDisplay();
+		}
 	}
 	else {
 		ClipView::focusRegained();

--- a/src/deluge/hid/display/display.cpp
+++ b/src/deluge/hid/display/display.cpp
@@ -100,7 +100,18 @@ void swapDisplayType() {
 	UI* ui = getCurrentUI();
 	if (ui) {
 		ui->displayOrLanguageChanged();
+
+		// Most UIs implement their 7SEG redraw in focusRegained(), not
+		// displayOrLanguageChanged(). When swapping from OLED to 7SEG, invoke
+		// focusRegained() so the numeric display is populated immediately.
+		if (!display->haveOLED()) {
+			ui->focusRegained();
+		}
 	}
+
+	// Apply any redraw request from displayOrLanguageChanged() immediately, so
+	// emulated display toggles are visible consistently regardless of active UI.
+	doAnyPendingUIRendering();
 }
 
 } // namespace deluge::hid::display


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4747

Fixed issue where 7 seg emulated display toggle was not refreshing the display on press consistently.

Fixed issue where arranger automation view display was not getting refreshed in 7seg display mode.