### PR TITLE
Fix midi follow not reading midi device

### DIFF
--- a/src/deluge/io/midi/midi_follow.cpp
+++ b/src/deluge/io/midi/midi_follow.cpp
@@ -1808,7 +1808,8 @@ void MidiFollow::readSpecificChannelSettingsFromFile(Deserializer& reader, MIDIF
 		}
 		// step into <device> tag
 		else if (!strcmp(tag_name, MIDI_DEFAULTS_SETTINGS_DEVICE_TAG)) {
-			MIDICable* cable = MIDIDeviceManager::readDeviceReferenceFromFile(reader);
+			midiEngine.midiFollowChannelType[util::to_underlying(type)].cable =
+			    MIDIDeviceManager::readDeviceReferenceFromFile(reader);
 		}
 		// exit so we can step into next tag
 		reader.exitTag();


### PR DESCRIPTION
Fix #4757

Fixed issue where midi follow would save midi device to MIDIFollow.xml and would read it but not store it in the midi follow channel type variable.