### PR TITLE
Fix/ midi and analog clock sync in sd card routine

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -965,7 +965,14 @@ extern "C" void routineForSD(void) {
 	sdRoutineLock = true;
 	static UIStage step = UIStage::oled;
 	AudioEngine::logAction("from routineForSD()");
+	// process audio
 	AudioEngine::runRoutine();
+#ifdef USE_TASK_MANAGER // if using task manager, midi and analog clock are processed separately from audio
+	// process midi clock
+	playbackHandler.midiRoutine();
+	// process analog clock
+	playbackHandler.routine();
+#endif
 	switch (step) {
 	case UIStage::oled:
 		if (display->haveOLED()) {

--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -138,7 +138,10 @@ void PlaybackHandler::midiRoutine() {
 
 // This function will be called repeatedly, at all times, to see if it's time to do a tick, and such
 void PlaybackHandler::routine() {
-
+	if ((stemExport.processStarted && stemExport.renderOffline)) [[unlikely]] {
+		//  todo - should add the ability to block the task in the task manager instead but whatever
+		return;
+	}
 	// Check analog clock input
 	if (triggerClockRisingEdgesProcessed != triggerClockRisingEdgesReceived) {
 		uint32_t time =

--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -554,7 +554,10 @@ bool calledFromScheduler = false;
 		D_PRINTLN("Audio routine latency high: %.3fms", (current_time - last_call_time) * 1000.);
 	}
 	last_call_time = current_time;
-#ifndef USE_TASK_MANAGER
+#ifndef USE_TASK_MANAGER // if not using task manager, midi and analog clock are processed together with audio
+	// process midi clock
+	playbackHandler.midiRoutine();
+	// process analog clock
 	playbackHandler.routine();
 #endif
 	// At this point, there may be MIDI, including clocks, waiting to be sent.


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/3512

## Issue
if your deluge is receiving clock and you enter settings menu and then hit back to exit without changing anything, it enters sd card routine to save changes.

When the deluge is clock sync'd you'll notice that the clock basically fails and your audio gets interrupted / distorted.

## Analysis

In 1.1 this was not an issue.

I've diagnosed it to basically this:

### 1.1 behaviour

In 1.1 without the scheduler the flow was:

routineForSD() -> audio routine -> playbackHandler.routine() -> MIDI polling

### Current behaviour

The current flow is

routineForSD() -> audio routine

playbackHandler.routine() is its own task now
and MIDI polling was separated from playbackHandler.routine() into playbackHandler.midiRoutine()

Because they get executed separately from audio routineForSD() via the scheduler, the result is a delay in playback handler routine and midi routine processing.

thus the deluge get's a glitch in external clock sync.

## Solution

fixed by deliberately syncing clocks while using task manager in sd card routine

also added logic for blocking analog clock while exporting stems in the same way we block midi clock.