### PR TITLE
Fix external-clock freeze triggered by MIDI and CV channel expression automation

### DIFF
--- a/src/deluge/playback/playback_handler.cpp
+++ b/src/deluge/playback/playback_handler.cpp
@@ -1092,6 +1092,10 @@ void PlaybackHandler::scheduleSwungTick() {
 // This may be called when there already is one scheduled, to reschedule it, if the tempo has changed
 void PlaybackHandler::scheduleSwungTickFromInternalClock() {
 
+	// Tick-based MIDI/CV interpolation can produce a zero next-event interval via
+	// ParamManagerForTimeline::processCurrentPos. That value can propagate into swungTicksTilNextEvent
+	// during playback scheduling (see Clip::processCurrentPos). Clamp here so we always advance at least one swung
+	// tick instead of re-actioning the current tick forever.
 	if (swungTicksTilNextEvent < 1) {
 		swungTicksTilNextEvent = 1; // Shouldn't ultimately be necessary, but...
 	}
@@ -1749,6 +1753,14 @@ void PlaybackHandler::clockMessageReceived(uint32_t time) {
 }
 
 void PlaybackHandler::scheduleSwungTickFromExternalClock() {
+	// Tick-based MIDI/CV interpolation can produce a zero next-event interval via
+	// ParamManagerForTimeline::processCurrentPos. That value can propagate into swungTicksTilNextEvent
+	// during playback scheduling (see Clip::processCurrentPos). Clamp here so we always advance at least one swung
+	// tick instead of re-actioning the current tick forever.
+	if (swungTicksTilNextEvent < 1) {
+		swungTicksTilNextEvent = 1;
+	}
+
 	uint64_t nextSwungTick = lastSwungTickActioned + swungTicksTilNextEvent;
 	uint64_t internalTickPositionForNextSwungTickTimes50;
 	if (!currentSong->hasAnySwing()) {


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4734

Fix external-clock freeze triggered by MIDI and CV channel expression automation.

PR #3531 introduced a tick-based MIDI/CV interpolation path that can request an immediate reschedule by setting ticksTilNextEvent to 0 (which gets subsequently transferred to swungTicksTilNextEvent). Internal clock scheduling already clamps that case to 1, but external clock scheduling did not, which could leave playback stuck reprocessing the current tick and appearing frozen. Add the same clamp to the external-clock scheduler.