### PR TITLE
Fix/ midi follow mod encoder popups

### DIFF
--- a/src/deluge/gui/ui_timer_manager.cpp
+++ b/src/deluge/gui/ui_timer_manager.cpp
@@ -111,6 +111,10 @@ void UITimerManager::routine() {
 
 					break;
 
+				case TimerName::MOD_ENCODER_POPUP_FLUSH:
+					view.flushPendingModEncoderValuePopup();
+					break;
+
 				case TimerName::LED_BLINK:
 				case TimerName::LED_BLINK_TYPE_1:
 					indicator_leds::ledBlinkTimeout(i - util::to_underlying(TimerName::LED_BLINK));

--- a/src/deluge/gui/ui_timer_manager.h
+++ b/src/deluge/gui/ui_timer_manager.h
@@ -47,6 +47,7 @@ enum class TimerName {
 	PAD_SELECTION_SHORTCUT_BLINK,
 	NOTE_ROW_BLINK,
 	LOADING_ANIMATION,
+	MOD_ENCODER_POPUP_FLUSH,
 	SELECTED_CLIP_PULSE,
 	/// Idle countdown before the screensaver appears, then its frame clock while it shows
 	SCREENSAVER,

--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -1254,7 +1254,7 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 		}
 
 		// Only update notification if parameter info has changed AND we can take display ownership AND enough time has
-		// elapsed
+		// elapsed.
 		if (has_param_info_changed && can_take_display_ownership && has_min_time_elapsed) {
 			display->displayNotification(parameter_name.c_str(), parameter_value.c_str());
 
@@ -1276,6 +1276,22 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 			}
 			last_display_update_time = current_time;
 			last_actual_display_time = current_time; // Track when we actually updated the display
+			hasPendingModEncoderValuePopup = false;
+			uiTimerManager.unsetTimer(TimerName::MOD_ENCODER_POPUP_FLUSH);
+		}
+		else if (has_param_info_changed && can_take_display_ownership && !has_min_time_elapsed) {
+			// We have a newer value but we're still inside the rate-limit window.
+			// Queue this exact popup payload so the timer callback can display it as soon as throttling allows.
+			hasPendingModEncoderValuePopup = true;
+			pendingPopupKind = kind;
+			pendingPopupParamID = paramID;
+			pendingPopupKnobPos = newKnobPos;
+			pendingPopupSource1 = source1;
+			pendingPopupSource2 = source2;
+
+			uint32_t time_since_last_actual_display = current_time - last_actual_display_time;
+			uint32_t samples_until_flush = MIN_UPDATE_INTERVAL - time_since_last_actual_display;
+			uiTimerManager.setTimerSamples(TimerName::MOD_ENCODER_POPUP_FLUSH, samples_until_flush);
 		}
 		// Even if no display update needed, refresh timer if same parameter is being adjusted
 		else if (current_param_owns_display && display->hasPopupOfType(PopupType::NOTIFICATION)) {
@@ -1286,6 +1302,17 @@ void View::displayModEncoderValuePopup(params::Kind kind, int32_t paramID, int32
 	else {
 		display->displayPopup(parameter_value.c_str());
 	}
+}
+
+void View::flushPendingModEncoderValuePopup() {
+	// Timer callback for deferred popup delivery: if the latest value was throttled,
+	// replay it once the minimum update interval has elapsed.
+	if (!hasPendingModEncoderValuePopup || !display->haveOLED()) {
+		return;
+	}
+
+	displayModEncoderValuePopup(pendingPopupKind, pendingPopupParamID, pendingPopupKnobPos, pendingPopupSource1,
+	                            pendingPopupSource2);
 }
 
 // convert deluge internal knobPos range to same range as used by menu's.

--- a/src/deluge/gui/views/view.h
+++ b/src/deluge/gui/views/view.h
@@ -137,6 +137,7 @@ public:
 	int32_t calculateKnobPosForDisplay(deluge::modulation::params::Kind kind, int32_t paramID, int32_t knobPos);
 	void displayModEncoderValuePopup(deluge::modulation::params::Kind kind, int32_t paramID, int32_t newKnobPos,
 	                                 PatchSource source1 = PatchSource::NONE, PatchSource source2 = PatchSource::NONE);
+	void flushPendingModEncoderValuePopup();
 	void potentiallyMakeItHarderToTurnKnob(int32_t whichModEncoder, ModelStackWithAutoParam* modelStackWithParam,
 	                                       int32_t newKnobPos);
 	void sendMidiFollowFeedback(ModelStackWithAutoParam* modelStackWithParam = nullptr, int32_t knobPos = kNoSelection,
@@ -179,6 +180,13 @@ private:
 	static constexpr uint32_t MIN_DISPLAY_OWNERSHIP_TIME = kSampleRate; // 1 second (minimum juggling time)
 	static constexpr uint32_t DISPLAY_TIMEOUT = kSampleRate / 4;        // 0.25 seconds (ball drop timeout)
 	static constexpr uint32_t MIN_UPDATE_INTERVAL = kSampleRate / 22;   // ~45ms (minimum perceptible update frequency)
+
+	bool hasPendingModEncoderValuePopup = false;
+	deluge::modulation::params::Kind pendingPopupKind = deluge::modulation::params::Kind::NONE;
+	int32_t pendingPopupParamID = -1;
+	int32_t pendingPopupKnobPos = 0;
+	PatchSource pendingPopupSource1 = PatchSource::NONE;
+	PatchSource pendingPopupSource2 = PatchSource::NONE;
 };
 
 extern View view;


### PR DESCRIPTION
Fix #4514 

Fixed issue where mod encoder popups couldn't keep up with midi follow input and would not show the last value received

Final-value landing is now handled by a deferred flush timer in the popup path