### PR TITLE
Fix/ Make cloning in memory preset error useful

### DIFF
--- a/src/deluge/gui/l10n/english.json
+++ b/src/deluge/gui/l10n/english.json
@@ -12,7 +12,7 @@
     "STRING_FOR_ERROR_FILE_NOT_FOUND": "File not found",
     "STRING_FOR_ERROR_FILE_UNREADABLE": "File unreadable",
     "STRING_FOR_ERROR_FILE_UNSUPPORTED": "File unsupported",
-    "STRING_FOR_ERROR_FILE_NOT_SAVED": "Must save file before loading it",
+    "STRING_FOR_ERROR_FILE_NOT_SAVED": "Must save file before loading / cloning it",
     "STRING_FOR_ERROR_FILE_FIRMWARE_VERSION_TOO_NEW": "Your firmware version is too old to open this file",
     "STRING_FOR_ERROR_FOLDER_DOESNT_EXIST": "Folder not found",
     "STRING_FOR_ERROR_BUG": "Bug encountered",

--- a/src/deluge/gui/l10n/g_english.cpp
+++ b/src/deluge/gui/l10n/g_english.cpp
@@ -25,7 +25,7 @@ PLACE_SDRAM_DATA Language english{
         {STRING_FOR_ERROR_FILE_NOT_FOUND, "File not found"},
         {STRING_FOR_ERROR_FILE_UNREADABLE, "File unreadable"},
         {STRING_FOR_ERROR_FILE_UNSUPPORTED, "File unsupported"},
-        {STRING_FOR_ERROR_FILE_NOT_SAVED, "Must save file before loading it"},
+        {STRING_FOR_ERROR_FILE_NOT_SAVED, "Must save file before loading / cloning it"},
         {STRING_FOR_ERROR_FILE_FIRMWARE_VERSION_TOO_NEW, "Your firmware version is too old to open this file"},
         {STRING_FOR_ERROR_FOLDER_DOESNT_EXIST, "Folder not found"},
         {STRING_FOR_ERROR_BUG, "Bug encountered"},

--- a/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
+++ b/src/deluge/gui/ui/load/load_instrument_preset_ui.cpp
@@ -426,7 +426,10 @@ ActionResult LoadInstrumentPresetUI::timerCallback() {
 
 		bool fileExists = StorageManager::fileExists(filePath.get(), &currentFileItem->filePointer);
 		if (!fileExists) {
-			display->displayError(Error::FILE_NOT_FOUND);
+			// An unsaved (in-memory only) synth preset cannot be loaded / cloned because
+			// the XML is read from disk to create the instrument. If the preset hasn't
+			// been saved yet, there is no file on the SD card to read from.
+			display->displayError(Error::FILE_NOT_SAVED);
 			return ActionResult::DEALT_WITH;
 		}
 


### PR DESCRIPTION
Fix #2134 

Made error message displayed when trying to clone an in memory (unsaved) preset more useful by showing "Must save file before loading / cloning it" instead of "File not found".