### PR TITLE
Fix/ Add hosted device ports to midi devices menu

### DIFF
--- a/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
+++ b/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
@@ -60,6 +60,7 @@ static void usb_hhid_class_request_trans_result(usb_utr_t* mess, uint16_t data1,
 static void usb_hmidi_check_result(usb_utr_t* ptr, uint16_t unused, uint16_t status);
 static usb_er_t usb_hhid_data_trans(usb_utr_t* ptr, uint16_t pipe, uint32_t size, uint8_t* table, usb_cb_t complete);
 static void usb_hmidi_enumeration_sequence(usb_utr_t* mess);
+static uint8_t usb_hmidi_count_virtual_cables(uint8_t* table, uint16_t length);
 
 extern uint8_t currentDeviceNumWithSendPipe[];
 
@@ -287,6 +288,55 @@ uint16_t* g_p_usb_hmidi_pipe_table[USB_NUM_USBIP];     /* Pipe Table(DefEP) */
 uint8_t* g_p_usb_hmidi_config_table[USB_NUM_USBIP];    /* Configuration Descriptor Table */
 uint8_t* g_p_usb_hmidi_device_table[USB_NUM_USBIP];    /* Device Descriptor Table */
 uint8_t* g_p_usb_hmidi_interface_table[USB_NUM_USBIP]; /* Interface Descriptor Table */
+uint8_t hostedMIDIPortCountByDevice[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES] = {{1}};
+
+static uint8_t usb_hmidi_count_virtual_cables(uint8_t* table, uint16_t length)
+{
+    // USB-MIDI event packets encode virtual cable number in CN nibble.
+    // We estimate supported cable count from class-specific endpoint descriptors.
+    enum { USB_DT_INTERFACE_STD = 0x04, USB_DT_CS_ENDPOINT = 0x25, USB_MS_GENERAL_SUBTYP = 0x01 };
+
+    uint16_t offset      = 0;
+    uint8_t maxNumJacks  = 1;
+    uint8_t maxPortSlots = 4;
+
+    while ((offset + 1) < length)
+    {
+        uint8_t descriptorLength = table[offset];
+        if (descriptorLength == 0 || (offset + descriptorLength) > length)
+        {
+            break;
+        }
+
+        uint8_t descriptorType = table[offset + 1];
+        if (offset > 0 && descriptorType == USB_DT_INTERFACE_STD)
+        {
+            break; // Stop at the next interface.
+        }
+
+        if (descriptorType == USB_DT_CS_ENDPOINT && descriptorLength >= 4)
+        {
+            uint8_t descriptorSubtype = table[offset + 2];
+            if (descriptorSubtype == USB_MS_GENERAL_SUBTYP)
+            {
+                uint8_t numJacks = table[offset + 3];
+                if (numJacks > maxNumJacks)
+                {
+                    maxNumJacks = numJacks;
+                }
+            }
+        }
+
+        offset += descriptorLength;
+    }
+
+    if (maxNumJacks > maxPortSlots)
+    {
+        maxNumJacks = maxPortSlots;
+    }
+
+    return maxNumJacks;
+}
 
 /******************************************************************************
  Renesas Abstracted USB Driver functions
@@ -443,6 +493,14 @@ static void usb_hmidi_enumeration_sequence(usb_utr_t* mess)
             p_iftable = g_p_usb_hmidi_interface_table[mess->ip];
 
             desc_len = desc_len - (p_iftable - p_desc);
+
+            uint16_t* pipetbl = R_USB_HmidiGetPipetbl(mess, g_usb_hmidi_devaddr[mess->ip]);
+            int midiDeviceNum = (pipetbl - (uint16_t*)g_usb_hmidi_tmp_ep_tbl) / ((USB_EPL * 2) + 1);
+            if (midiDeviceNum >= 0 && midiDeviceNum < MAX_NUM_USB_MIDI_DEVICES)
+            {
+                hostedMIDIPortCountByDevice[mess->ip][midiDeviceNum] =
+                    usb_hmidi_count_virtual_cables(p_iftable, desc_len);
+            }
 
             /* pipe information table set */
             retval = usb_hmidi_pipe_info(mess, p_iftable, g_usb_hmidi_speed[mess->ip], desc_len);
@@ -829,8 +887,9 @@ void hmidi_detach(usb_utr_t* ptr, uint16_t devadr, uint16_t data2)
 
     // Clear endpoint table
     g_usb_hmidi_tmp_ep_tbl[USB_CFG_USE_USBIP][d][1] &= (uint16_t)(USB_BFREON | USB_CFG_SHTNAKON); /* PIPECFG */
-    g_usb_hmidi_tmp_ep_tbl[USB_CFG_USE_USBIP][d][3] = (uint16_t)(USB_NULL);                       /* PIPEMAXP */
-    g_usb_hmidi_tmp_ep_tbl[USB_CFG_USE_USBIP][d][4] = (uint16_t)(USB_NULL);                       /* PIPEPERI */
+    g_usb_hmidi_tmp_ep_tbl[USB_CFG_USE_USBIP][d][3]   = (uint16_t)(USB_NULL);                     /* PIPEMAXP */
+    g_usb_hmidi_tmp_ep_tbl[USB_CFG_USE_USBIP][d][4]   = (uint16_t)(USB_NULL);                     /* PIPEPERI */
+    hostedMIDIPortCountByDevice[USB_CFG_USE_USBIP][d] = 1;
 
     hostedDeviceDetached(USB_CFG_USE_USBIP, d);
 } /* End of function hid_detach() */

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -36,6 +36,7 @@ extern "C" {
 #include "drivers/uart/uart.h"
 
 extern uint8_t anyUSBSendingStillHappening[];
+extern uint8_t hostedMIDIPortCountByDevice[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES];
 }
 #pragma GCC diagnostic push
 // This is supported by GCC and other compilers should error (not warn), so turn off for this file
@@ -58,6 +59,56 @@ struct USBDev {
 	uint16_t productId;
 };
 std::array<USBDev, USB_NUM_USBIP> usbDeviceCurrentlyBeingSetUp{};
+
+char constexpr kHostedUSBPrefix[] = "Hosted USB: ";
+
+void buildHostedUSBDisplayName(char const* sourceName, uint8_t portNumber, String& outName) {
+	char const* baseName = sourceName;
+	if (!baseName || !*baseName) {
+		baseName = "Unknown Device";
+	}
+
+	// Strip the Hosted USB: prefix if already present.
+	size_t prefixLen = strlen(kHostedUSBPrefix);
+	if (strncmp(baseName, kHostedUSBPrefix, prefixLen) == 0) {
+		baseName += prefixLen;
+	}
+
+	// Strip any trailing " (Port N)" suffix so we can rebuild the canonical form.
+	size_t baseLen = strlen(baseName);
+	if (baseLen >= 9 && baseName[baseLen - 1] == ')') {
+		char const* portTag = strstr(baseName, " (Port ");
+		if (portTag) {
+			size_t tagPos = portTag - baseName;
+			bool allDigits = true;
+			for (size_t i = tagPos + 7; i + 1 < baseLen; i++) {
+				if (baseName[i] < '0' || baseName[i] > '9') {
+					allDigits = false;
+					break;
+				}
+			}
+			if (allDigits && (tagPos + 8) < baseLen) {
+				baseLen = tagPos;
+			}
+		}
+	}
+
+	outName.set(kHostedUSBPrefix);
+	outName.concatenateAtPos(baseName, outName.getLength(), baseLen);
+	outName.concatenate(" (Port ");
+	outName.concatenateInt(portNumber + 1);
+	outName.concatenate(")");
+}
+
+void renameHostedDeviceByPointer(MIDICableUSBHosted* device, String const& newName) {
+	for (int32_t i = 0; i < hostedMIDIDevices.getNumElements(); i++) {
+		if (hostedMIDIDevices.getElement(i) == device) {
+			String mutableName = newName;
+			hostedMIDIDevices.renameMember(i, &mutableName);
+			return;
+		}
+	}
+}
 
 // This class represents a thing you can send midi too,
 // the virtual cable is an implementation detail
@@ -104,7 +155,8 @@ extern "C" void giveDetailsOfDeviceBeingSetUp(int32_t ip, char const* name, uint
 }
 
 // name can be NULL, or an empty String
-MIDICableUSBHosted* getOrCreateHostedMIDIDeviceFromDetails(String* name, uint16_t vendorId, uint16_t productId) {
+MIDICableUSBHosted* getOrCreateHostedMIDIDeviceFromDetails(String* name, uint16_t vendorId, uint16_t productId,
+                                                           bool matchByVendorProduct = true) {
 
 	// Do we know any details about this device already?
 
@@ -130,16 +182,18 @@ MIDICableUSBHosted* getOrCreateHostedMIDIDeviceFromDetails(String* name, uint16_
 		}
 	}
 
-	// Ok, try searching by vendor / product id
-	for (int32_t i = 0; i < hostedMIDIDevices.getNumElements(); i++) {
-		auto* candidate = static_cast<MIDICableUSBHosted*>(hostedMIDIDevices.getElement(i));
+	if (matchByVendorProduct) {
+		// Ok, try searching by vendor / product id
+		for (int32_t i = 0; i < hostedMIDIDevices.getNumElements(); i++) {
+			auto* candidate = static_cast<MIDICableUSBHosted*>(hostedMIDIDevices.getElement(i));
 
-		if (candidate->vendorId == vendorId && candidate->productId == productId) {
-			// Update its name - if we got one and it's different
-			if (gotAName && !candidate->name.equals(name)) {
-				hostedMIDIDevices.renameMember(i, name);
+			if (candidate->vendorId == vendorId && candidate->productId == productId) {
+				// Update its name - if we got one and it's different
+				if (gotAName && !candidate->name.equals(name)) {
+					hostedMIDIDevices.renameMember(i, name);
+				}
+				return candidate;
 			}
-			return candidate;
 		}
 	}
 
@@ -185,6 +239,59 @@ MIDICableUSBHosted* getOrCreateHostedMIDIDeviceFromDetails(String* name, uint16_
 #endif
 
 	return device;
+}
+
+MIDICableUSBHosted* ensureHostedMIDIPortCable(int32_t ip, int32_t midiDeviceNum, uint8_t hostedPort) {
+	ConnectedUSBMIDIDevice* connectedDevice = &connectedUSBMIDIDevices[ip][midiDeviceNum];
+	if (hostedPort >= (sizeof(connectedDevice->cable) / sizeof(connectedDevice->cable[0]))) {
+		return nullptr;
+	}
+
+	if (!connectedDevice->cable[0]) {
+		return nullptr;
+	}
+
+	if (connectedDevice->cable[hostedPort]) {
+		connectedDevice->maxPortConnected = std::max<uint8_t>(connectedDevice->maxPortConnected, hostedPort);
+		return static_cast<MIDICableUSBHosted*>(connectedDevice->cable[hostedPort]);
+	}
+
+	auto* primaryCable = static_cast<MIDICableUSBHosted*>(connectedDevice->cable[0]);
+	if (hostedPort == 0) {
+		return primaryCable;
+	}
+
+	String portName;
+	buildHostedUSBDisplayName(primaryCable->name.get(), hostedPort, portName);
+
+	MIDICableUSBHosted* portCable =
+	    getOrCreateHostedMIDIDeviceFromDetails(&portName, primaryCable->vendorId, primaryCable->productId, false);
+	if (!portCable) {
+		return nullptr;
+	}
+
+	portCable->portNumber = hostedPort;
+	portCable->vendorId = primaryCable->vendorId;
+	portCable->productId = primaryCable->productId;
+	portCable->ports[MIDI_DIRECTION_INPUT_TO_DELUGE] = primaryCable->ports[MIDI_DIRECTION_INPUT_TO_DELUGE];
+	portCable->ports[MIDI_DIRECTION_OUTPUT_FROM_DELUGE] = primaryCable->ports[MIDI_DIRECTION_OUTPUT_FROM_DELUGE];
+	memcpy(portCable->mpeZoneBendRanges, primaryCable->mpeZoneBendRanges, sizeof(portCable->mpeZoneBendRanges));
+	memcpy(portCable->inputChannels, primaryCable->inputChannels, sizeof(portCable->inputChannels));
+	portCable->defaultVelocityToLevel = primaryCable->defaultVelocityToLevel;
+	portCable->sendClock = primaryCable->sendClock;
+	portCable->receiveClock = primaryCable->receiveClock;
+	portCable->is_relative = primaryCable->is_relative;
+	portCable->freshly_connected = false;
+
+	connectedDevice->cable[hostedPort] = portCable;
+	connectedDevice->maxPortConnected = std::max<uint8_t>(connectedDevice->maxPortConnected, hostedPort);
+
+	if (!(portCable->connectionFlags & (1 << midiDeviceNum))) {
+		portCable->connectedNow(midiDeviceNum);
+		recountSmallestMPEZones();
+	}
+
+	return portCable;
 }
 
 void recountSmallestMPEZonesForCable(MIDICable& cable) {
@@ -235,20 +342,36 @@ extern "C" void hostedDeviceConfigured(int32_t ip, int32_t midiDeviceNum) {
 		return; // Only if ran out of RAM - i.e. very unlikely.
 	}
 
+	String port1Name;
+	buildHostedUSBDisplayName(device->name.get(), 0, port1Name);
+	renameHostedDeviceByPointer(device, port1Name);
+
 	// Associate with USB port
 	ConnectedUSBMIDIDevice* connectedDevice = &connectedUSBMIDIDevices[ip][midiDeviceNum];
 
 	connectedDevice->setup();
-	int32_t ports = connectedDevice->maxPortConnected;
-	for (int32_t i = 0; i <= ports; i++) {
-		connectedDevice->cable[i] = device;
-	}
+	connectedDevice->cable[0] = device;
+	connectedDevice->maxPortConnected = 0;
+	device->portNumber = 0;
 
 	connectedDevice->sq = 0;
-	connectedDevice->canHaveMIDISent = (bool)strcmp(device->name.get(), "Synthstrom MIDI Foot Controller");
-	connectedDevice->canHaveMIDISent = (bool)strcmp(device->name.get(), "LUMI Keys BLOCK");
+	char const* rawDeviceName = usbDeviceCurrentlyBeingSetUp[ip].name.get();
+	connectedDevice->canHaveMIDISent =
+	    strcmp(rawDeviceName, "Synthstrom MIDI Foot Controller") && strcmp(rawDeviceName, "LUMI Keys BLOCK");
 
 	device->connectedNow(midiDeviceNum);
+
+	uint8_t numHostedPorts = hostedMIDIPortCountByDevice[ip][midiDeviceNum];
+	if (numHostedPorts == 0) {
+		numHostedPorts = 1;
+	}
+	numHostedPorts =
+	    std::min<uint8_t>(numHostedPorts, sizeof(connectedDevice->cable) / sizeof(connectedDevice->cable[0]));
+
+	for (uint8_t hostedPort = 1; hostedPort < numHostedPorts; hostedPort++) {
+		ensureHostedMIDIPortCable(ip, midiDeviceNum, hostedPort);
+	}
+
 	recountSmallestMPEZones(); // Must be called after setting device->connectionFlags
 
 	device->freshly_connected = true; // Used to trigger hookOnConnected from the input loop
@@ -703,11 +826,17 @@ void ConnectedUSBMIDIDevice::setup() {
 	numBytesSendingNow = 0;
 	currentlyWaitingToReceive = false;
 	numBytesReceived = 0;
+	for (auto& thisCable : cable) {
+		thisCable = nullptr;
+	}
 
 	// default to only a single port
 	maxPortConnected = 0;
 }
 ConnectedUSBMIDIDevice::ConnectedUSBMIDIDevice() {
+	for (auto& thisCable : cable) {
+		thisCable = nullptr;
+	}
 	currentlyWaitingToReceive = 0;
 	sq = 0;
 	canHaveMIDISent = 0;

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -24,6 +24,7 @@
 #include "util/container/vector/named_thing_vector.h"
 class Serializer;
 class Deserializer;
+class MIDICableUSBHosted;
 
 #else
 #include "definitions.h"
@@ -108,6 +109,7 @@ void recountSmallestMPEZones();
 void writeDevicesToFile();
 void readAHostedDeviceFromFile(Deserializer& reader);
 void readDevicesFromFile();
+MIDICableUSBHosted* ensureHostedMIDIPortCable(int32_t ip, int32_t midiDeviceNum, uint8_t hostedPort);
 
 extern MIDICableUSBUpstream upstreamUSBMIDICable1;
 extern MIDICableUSBUpstream upstreamUSBMIDICable2;

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -716,11 +716,16 @@ uint8_t usbCurrentlyInitialized = false;
 
 void MidiEngine::checkIncomingUsbSysex(uint8_t const* msg, int32_t ip, int32_t d, int32_t cableIdx) {
 	ConnectedUSBMIDIDevice* connected = &connectedUSBMIDIDevices[ip][d];
-	if (cableIdx > connectedUSBMIDIDevices[ip][d].maxPortConnected) {
-		// fallback to cable 0 since we don't support more than one port on hosted devices yet
+	if (cableIdx < 0 || cableIdx >= static_cast<int32_t>(sizeof(connected->cable) / sizeof(connected->cable[0]))) {
 		cableIdx = 0;
 	}
-	MIDICable& cable = *connectedUSBMIDIDevices[ip][d].cable[cableIdx];
+	if (!connected->cable[cableIdx] && g_usb_usbmode == USB_HOST) {
+		MIDIDeviceManager::ensureHostedMIDIPortCable(ip, d, cableIdx);
+	}
+	if (!connected->cable[cableIdx]) {
+		cableIdx = 0;
+	}
+	MIDICable& cable = *connected->cable[cableIdx];
 
 	uint8_t statusType = msg[0] & 15;
 	int32_t to_read = 0;
@@ -903,9 +908,17 @@ void MidiEngine::checkIncomingUsbMidi() {
 							// transmission so just ignore the rest of the frame
 							break;
 						}
-						// select appropriate device based on the cable number
-						if (cable > connectedUSBMIDIDevices[ip][d].maxPortConnected) {
-							// fallback to cable 0 since we don't support more than one port on hosted devices yet
+						// Hosted devices may expose multiple USB MIDI virtual cables.
+						if (cable >= (sizeof(connectedUSBMIDIDevices[ip][d].cable)
+						              / sizeof(connectedUSBMIDIDevices[ip][d].cable[0]))) {
+							cable = 0;
+						}
+						if (g_usb_usbmode == USB_HOST
+						    && (cable > connectedUSBMIDIDevices[ip][d].maxPortConnected
+						        || !connectedUSBMIDIDevices[ip][d].cable[cable])) {
+							MIDIDeviceManager::ensureHostedMIDIPortCable(ip, d, cable);
+						}
+						if (!connectedUSBMIDIDevices[ip][d].cable[cable]) {
 							cable = 0;
 						}
 						midiMessageReceived(*connectedUSBMIDIDevices[ip][d].cable[cable], statusType, channel, data1,


### PR DESCRIPTION
Fix #416 

Added menu entries to midi devices menu for configuring hosted midi device ports

note: this is a PoC to show how complex it would be do this, implementation might be not be perfect