### PR TITLE
Add mod button popups to midi clips

### DIFF
--- a/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
+++ b/src/deluge/gui/views/automation/editor_layout/mod_controllable.cpp
@@ -443,48 +443,7 @@ void AutomationEditorLayoutModControllable::getAutomationParameterName(Clip* cli
 		}
 	}
 	else {
-		if (clip->lastSelectedParamID == CC_NUMBER_NONE) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_PARAM));
-		}
-		else if (clip->lastSelectedParamID == CC_NUMBER_PITCH_BEND) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
-		}
-		else if (clip->lastSelectedParamID == CC_NUMBER_AFTERTOUCH) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
-		}
-		else if (clip->lastSelectedParamID == CC_EXTERNAL_MOD_WHEEL || clip->lastSelectedParamID == CC_NUMBER_Y_AXIS) {
-			parameterName.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
-		}
-		else {
-			MIDIInstrument* midiInstrument = (MIDIInstrument*)clip->output;
-			bool appendedName = false;
-
-			if (clip->lastSelectedParamID >= 0 && clip->lastSelectedParamID < kNumRealCCNumbers) {
-				std::string_view name = midiInstrument->getNameFromCC(clip->lastSelectedParamID);
-				// if we have a name for this midi cc set by the user, display that instead of the cc number
-				if (!name.empty()) {
-					parameterName.append(name.data());
-					appendedName = true;
-				}
-			}
-
-			// if we don't have a midi cc name set, draw CC number instead
-			if (!appendedName) {
-				if (display->haveOLED()) {
-					parameterName.append("CC ");
-					parameterName.appendInt(clip->lastSelectedParamID);
-				}
-				else {
-					if (clip->lastSelectedParamID < 100) {
-						parameterName.append("CC");
-					}
-					else {
-						parameterName.append("C");
-					}
-					parameterName.appendInt(clip->lastSelectedParamID);
-				}
-			}
-		}
+		((MIDIInstrument*)clip->output)->appendCCName(parameterName, clip->lastSelectedParamID);
 	}
 }
 

--- a/src/deluge/model/clip/instrument_clip_minder.cpp
+++ b/src/deluge/model/clip/instrument_clip_minder.cpp
@@ -131,52 +131,9 @@ void InstrumentClipMinder::drawMIDIControlNumber(int32_t controlNumber, bool aut
 
 	DEF_STACK_STRING_BUF(buffer, 30);
 
-	bool doScroll = false;
-
-	if (controlNumber == CC_NUMBER_NONE) {
-		buffer.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_PARAM));
-	}
-	else if (controlNumber == CC_NUMBER_PITCH_BEND) {
-		buffer.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
-	}
-	else if (controlNumber == CC_NUMBER_AFTERTOUCH) {
-		buffer.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
-	}
-	else if (controlNumber == CC_NUMBER_Y_AXIS) {
-		// in mono expression this is mod wheel, and y-axis is not directly controllable
-		buffer.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
-	}
-	else {
-		MIDIInstrument* midiInstrument = (MIDIInstrument*)getCurrentOutput();
-		bool appendedName = false;
-
-		if (controlNumber >= 0 && controlNumber < kNumRealCCNumbers) {
-			std::string_view name = midiInstrument->getNameFromCC(controlNumber);
-			// if we have a name for this midi cc set by the user, display that instead of the cc number
-			if (!name.empty()) {
-				buffer.append(name.data());
-				doScroll = name.size() > 4;
-				appendedName = true;
-			}
-		}
-
-		// if we don't have a midi cc name set, draw CC number instead
-		if (!appendedName) {
-			if (display->haveOLED()) {
-				buffer.append("CC ");
-				buffer.appendInt(controlNumber);
-			}
-			else {
-				if (controlNumber < 100) {
-					buffer.append("CC");
-				}
-				else {
-					buffer.append("C");
-				}
-				buffer.appendInt(controlNumber);
-			}
-		}
-	}
+	MIDIInstrument* midiInstrument = (MIDIInstrument*)getCurrentOutput();
+	bool usedCustomName = midiInstrument->appendCCName(buffer, controlNumber);
+	bool doScroll = usedCustomName && buffer.size() > 4;
 
 	if (display->haveOLED()) {
 		if (automationExists) {

--- a/src/deluge/model/instrument/midi_instrument.cpp
+++ b/src/deluge/model/instrument/midi_instrument.cpp
@@ -17,9 +17,11 @@
 
 #include "model/instrument/midi_instrument.h"
 #include "definitions_cxx.hpp"
+#include "gui/l10n/l10n.h"
 #include "gui/ui/ui.h"
 #include "gui/views/view.h"
 #include "hid/buttons.h"
+#include "hid/display/display.h"
 #include "hid/display/oled.h"
 #include "io/midi/midi_engine.h"
 #include "io/midi/midi_transpose.h"
@@ -32,6 +34,7 @@
 #include "modulation/midi/midi_param_collection.h"
 #include "modulation/params/param_set.h"
 #include "storage/storage_manager.h"
+#include "util/d_stringbuf.h"
 #include <cstring>
 #include <string_view>
 
@@ -97,6 +100,46 @@ bool MIDIInstrument::doesAutomationExistOnMIDIParam(ModelStackWithThreeMainThing
 	return automationExists;
 }
 
+bool MIDIInstrument::appendCCName(StringBuf& buf, int32_t cc) {
+	if (cc == CC_NUMBER_NONE) {
+		buf.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_PARAM));
+	}
+	else if (cc == CC_NUMBER_PITCH_BEND) {
+		buf.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_PITCH_BEND));
+	}
+	else if (cc == CC_NUMBER_AFTERTOUCH) {
+		buf.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_CHANNEL_PRESSURE));
+	}
+	else if (cc == CC_EXTERNAL_MOD_WHEEL || cc == CC_NUMBER_Y_AXIS) {
+		buf.append(deluge::l10n::get(deluge::l10n::String::STRING_FOR_MOD_WHEEL));
+	}
+	else {
+		if (cc >= 0 && cc < kNumRealCCNumbers) {
+			std::string_view name = getNameFromCC(cc);
+			// if we have a name for this midi cc set by the user, display that instead of the cc number
+			if (!name.empty()) {
+				buf.append(name.data());
+				return true;
+			}
+		}
+		// if we don't have a midi cc name set, draw CC number instead
+		if (display->haveOLED()) {
+			buf.append("CC ");
+			buf.appendInt(cc);
+		}
+		else {
+			if (cc < 100) {
+				buf.append("CC");
+			}
+			else {
+				buf.append("C");
+			}
+			buf.appendInt(cc);
+		}
+	}
+	return false;
+}
+
 void MIDIInstrument::modButtonAction(uint8_t whichModButton, bool on, ParamManagerForTimeline* paramManager) {
 	// If we're leaving this mod function or anything else is happening, we want to be sure that stutter has stopped
 	if (currentUIMode == UI_MODE_SELECTING_MIDI_CC) {
@@ -107,6 +150,36 @@ void MIDIInstrument::modButtonAction(uint8_t whichModButton, bool on, ParamManag
 		else {
 			InstrumentClipMinder::redrawNumericDisplay();
 		}
+		return;
+	}
+
+	int32_t ccTop = modKnobCCAssignments[modKnobMode * kNumPhysicalModKnobs + 1];
+	int32_t ccBottom = modKnobCCAssignments[modKnobMode * kNumPhysicalModKnobs + 0];
+
+	DEF_STACK_STRING_BUF(popupMsg, 100);
+
+	// OLED/7SEG pattern: show top knob when pressed, bottom knob when released (7SEG);
+	// show both top and bottom when pressed (OLED).
+	if (display->haveOLED() || on) {
+		appendCCName(popupMsg, ccTop);
+	}
+	if (display->haveOLED()) {
+		popupMsg.append("\n");
+	}
+	if (display->haveOLED() || !on) {
+		appendCCName(popupMsg, ccBottom);
+	}
+
+	if (display->haveOLED()) {
+		if (on) {
+			display->popupText(popupMsg.c_str());
+		}
+		else {
+			display->cancelPopup();
+		}
+	}
+	else {
+		display->displayPopup(popupMsg.c_str());
 	}
 }
 

--- a/src/deluge/model/instrument/midi_instrument.h
+++ b/src/deluge/model/instrument/midi_instrument.h
@@ -20,6 +20,7 @@
 #include "definitions_cxx.hpp"
 #include "model/instrument/non_audio_instrument.h"
 #include "util/containers.h"
+#include "util/d_stringbuf.h"
 #include <array>
 #include <string_view>
 
@@ -121,6 +122,10 @@ public:
 		return sendsToMPE() ? "zone" : sendsToInternal() ? "internalDest" : "channel";
 	}
 	char const* getSubSlotXMLTag() override { return "suffix"; }
+
+	/// Appends a CC name/number to buf for the given CC assignment.
+	/// Returns true if a user-defined custom name was appended (caller may want to enable scrolling on 7SEG).
+	bool appendCCName(StringBuf& buf, int32_t cc);
 
 	ModelStackWithAutoParam* getModelStackWithParam(ModelStackWithTimelineCounter* modelStack, Clip* clip,
 	                                                int32_t paramID, deluge::modulation::params::Kind paramKind,


### PR DESCRIPTION
Pressing and holding mod buttons now shows the CC's assigned to gold knobs for midi clips

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4776