### PR TITLE
Fix save UI freeze when file prefix is too long

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -708,13 +708,29 @@ everythingFinalized:
 // You must set currentDir before calling this.
 Error Browser::getUnusedSlot(OutputType outputType, String* newName, char const* thingName) {
 
+	// This helper assumes a concrete prefix (e.g. "SONG", "MidiDevice"). Reject null / empty
+	// early so prefix math below cannot walk arbitrary memory.
+	if (!thingName || !thingName[0]) {
+		return Error::BUG;
+	}
+
 	Error error;
 	// Names always carry the prefix now, on both displays, so there is one search key.
-	char filenameToStartAt[6]; // thingName is max 4 chars.
-	strcpy(filenameToStartAt, thingName);
-	strcat(filenameToStartAt, ":"); // Colon is the first character after the digits.
-	error = readFileItemsFromFolderAndMemory(currentSong, outputType, getThingName(outputType), filenameToStartAt, NULL,
-	                                         false, Availability::ANY, CATALOG_SEARCH_LEFT);
+	// Use dynamic storage: older fixed buffers here overflowed for long prefixes (e.g. "MidiDevice").
+	String filenameToStartAt;
+	error = filenameToStartAt.set(thingName);
+	if (error != Error::NONE) {
+		goto doReturn;
+	}
+	error = filenameToStartAt.concatenate(":"); // Colon is the first character after the digits.
+	if (error != Error::NONE) {
+		goto doReturn;
+	}
+
+	// The folder read must use the same prefix passed by the caller; deriving it from outputType can
+	// mismatch non-standard prefixes and break slot discovery.
+	error = readFileItemsFromFolderAndMemory(currentSong, outputType, thingName, filenameToStartAt.get(), NULL, false,
+	                                         Availability::ANY, CATALOG_SEARCH_LEFT);
 
 	if (error != Error::NONE) {
 doReturn:
@@ -726,6 +742,7 @@ doReturn:
 	{
 		int32_t freeSlotNumber = 1;
 		int32_t minNumDigits = 1;
+		size_t thingNameLength = strlen(thingName);
 		if (fileItems.getNumElements()) {
 			FileItem* fileItem = (FileItem*)fileItems.getElementAddress(fileItems.getNumElements() - 1);
 			String filename;
@@ -733,16 +750,22 @@ doReturn:
 			if (error != Error::NONE) {
 				goto emptyFileItemsAndReturn;
 			}
-			char const* readingChar = &filename.get()[strlen(thingName)];
-			freeSlotNumber = 0;
-			minNumDigits = 0;
-			while (*readingChar >= '0' && *readingChar <= '9') {
-				freeSlotNumber *= 10;
-				freeSlotNumber += *readingChar - '0';
-				minNumDigits++;
-				readingChar++;
+
+			char const* filenameChars = filename.get();
+			// Only parse numeric suffixes when the filename actually starts with the expected prefix.
+			// This prevents offsetting into unrelated names.
+			if (!memcasecmp(filenameChars, thingName, thingNameLength)) {
+				char const* readingChar = filenameChars + thingNameLength;
+				freeSlotNumber = 0;
+				minNumDigits = 0;
+				while (*readingChar >= '0' && *readingChar <= '9') {
+					freeSlotNumber *= 10;
+					freeSlotNumber += *readingChar - '0';
+					minNumDigits++;
+					readingChar++;
+				}
+				freeSlotNumber++;
 			}
-			freeSlotNumber++;
 		}
 
 		error = newName->set(thingName);

--- a/src/deluge/gui/ui/browser/default_name.cpp
+++ b/src/deluge/gui/ui/browser/default_name.cpp
@@ -107,6 +107,10 @@ char const* numberPartOf(char const* name, char const* filePrefix) {
 		return nullptr;
 	}
 	size_t prefixLength = strlen(filePrefix);
+	// Guard against short names before prefix indexing; some call paths probe partial user text.
+	if (strlen(name) < prefixLength) {
+		return nullptr;
+	}
 	for (size_t i = 0; i < prefixLength; i++) {
 		if (upper(name[i]) != upper(filePrefix[i])) {
 			return nullptr;


### PR DESCRIPTION
## Issue:

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4779

Opening the save UI for midi device definition files freezes due to file prefix being longer than expected (MIDI device definition file prefix is MIDIDevice).

I confirmed that if I save the save pattern UI's prefix to MIDIDevice also that it also freezes. So the bug is not isolated to just the MIDI Device Save UI. The freeze really is coming from the prefix.

The regression was introduced by PR #4656 

## LLM analysis and fix

### Root cause:

1. Stack buffer overflow in browser.cpp:709 in Browser::getUnusedSlot.
2. Before the fix, it used:
- char filenameToStartAt[6]
- strcpy(filenameToStartAt, thingName)
- strcat(filenameToStartAt, ":")
3. That only fits prefixes up to 4 chars plus ":" plus null. MidiDevice is much longer, so this overwrote stack memory and caused the freeze.

### Why this matched your observations:

1. The old reverted commit alone was not enough to freeze.
2. A later browser naming/path flow started exercising this code path with filePrefix set, which exposed the latent overflow.
3. Setting filePrefix to MidiDevice made it deterministic because prefix length exceeded the fixed buffer assumption.

### Secondary bug we also fixed:

1. The same function passed getThingName(outputType) instead of the actual thingName prefix to readFileItemsFromFolderAndMemory in browser.cpp:727.
2. For this path, outputType could map to SONG while the real prefix was MidiDevice, causing inconsistent search behavior.

### Additional hardening:

1. Short-name guard added in default_name.cpp:105 to avoid prefix compare reading past short strings.

So the actual freeze bug was the fixed-size prefix buffer overflow, with the later browser changes making that path active.