### PR TITLE
Fix/ slot browser file prefix out of bounds write

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -710,7 +710,10 @@ Error Browser::getUnusedSlot(OutputType outputType, String* newName, char const*
 
 	Error error;
 	// Names always carry the prefix now, on both displays, so there is one search key.
-	char filenameToStartAt[6]; // thingName is max 4 chars.
+	// Sean: thingName is usually max 4 chars (e.g. SONG, SYNT, KIT), but can be longer
+	// - e.g. "PATTERN" with pattern browser or "MIDIDEVICE" with midi device definition browser.
+	// it's used for proposing the file name and on 7SEG if you type a # it will prefix it
+	char filenameToStartAt[10];
 	strcpy(filenameToStartAt, thingName);
 	strcat(filenameToStartAt, ":"); // Colon is the first character after the digits.
 	error = readFileItemsFromFolderAndMemory(currentSong, outputType, getThingName(outputType), filenameToStartAt, NULL,

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -715,10 +715,8 @@ Error Browser::getUnusedSlot(OutputType outputType, String* newName, char const*
 	// it's used for proposing the file name and on 7SEG if you type a # it will prefix it
 	uint8_t buffer_size = 20;
 	char filenameToStartAt[buffer_size];
-	strncpy(filenameToStartAt, thingName,
-	        buffer_size - 2 - strlen(thingName)); // Leave 2 chars for "colon + null terminator"
-	strncat(filenameToStartAt, ":",
-	        buffer_size - 1 - strlen(filenameToStartAt)); // Colon is the first character after the digits.
+	strncpy(filenameToStartAt, thingName, buffer_size - 2); // Leave 2 chars for "colon + null terminator"
+	strcat(filenameToStartAt, ":");                         // Colon is the first character after the digits.
 	error = readFileItemsFromFolderAndMemory(currentSong, outputType, getThingName(outputType), filenameToStartAt, NULL,
 	                                         false, Availability::ANY, CATALOG_SEARCH_LEFT);
 

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -713,9 +713,12 @@ Error Browser::getUnusedSlot(OutputType outputType, String* newName, char const*
 	// Sean: thingName is usually max 4 chars (e.g. SONG, SYNT, KIT), but can be longer
 	// - e.g. "PATTERN" with pattern browser or "MIDIDEVICE" with midi device definition browser.
 	// it's used for proposing the file name and on 7SEG if you type a # it will prefix it
-	char filenameToStartAt[20];
-	strcpy(filenameToStartAt, thingName);
-	strcat(filenameToStartAt, ":"); // Colon is the first character after the digits.
+	uint8_t buffer_size = 20;
+	char filenameToStartAt[buffer_size];
+	strncpy(filenameToStartAt, thingName,
+	        buffer_size - 2 - strlen(thingName)); // Leave 2 chars for "colon + null terminator"
+	strncat(filenameToStartAt, ":",
+	        buffer_size - 1 - strlen(filenameToStartAt)); // Colon is the first character after the digits.
 	error = readFileItemsFromFolderAndMemory(currentSong, outputType, getThingName(outputType), filenameToStartAt, NULL,
 	                                         false, Availability::ANY, CATALOG_SEARCH_LEFT);
 

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -713,7 +713,7 @@ Error Browser::getUnusedSlot(OutputType outputType, String* newName, char const*
 	// Sean: thingName is usually max 4 chars (e.g. SONG, SYNT, KIT), but can be longer
 	// - e.g. "PATTERN" with pattern browser or "MIDIDEVICE" with midi device definition browser.
 	// it's used for proposing the file name and on 7SEG if you type a # it will prefix it
-	char filenameToStartAt[10];
+	char filenameToStartAt[20];
 	strcpy(filenameToStartAt, thingName);
 	strcat(filenameToStartAt, ":"); // Colon is the first character after the digits.
 	error = readFileItemsFromFolderAndMemory(currentSong, outputType, getThingName(outputType), filenameToStartAt, NULL,


### PR DESCRIPTION
Fix #4780 

Fixed freeze that would occur due to an out of bounds write to the file name array in Browser::getUnusedSlot

It assumed the file prefix was always 4 chars long (e.g. song, synt, kit) but with newer save ui's being added this is not always true anymore.

E.g. Pattern SAVE UI prefixes "PATTERN"
MIDI Device Definition SAVE UI prefixes "MIDIDEVICE"

Increasing the buffer sizes fixes the issue.

This out of bounds write was exposed by PR https://github.com/SynthstromAudible/DelugeFirmware/pull/4656 but I'm not sure why