### PR TITLE
Fix text highlight alignment in browser / rename UI

### DIFF
--- a/src/deluge/gui/ui/qwerty_ui.cpp
+++ b/src/deluge/gui/ui/qwerty_ui.cpp
@@ -160,7 +160,10 @@ void QwertyUI::drawTextForOLEDEditing(int32_t xPixel, int32_t xPixelMax, int32_t
 			highlightStartX = 0;
 		}
 		else {
-			highlightStartX = xPixel + kTextSpacingX * scrollAmount - 2;
+			// Start the highlight in the 1px gap that follows the previous character, rather than on top of that
+			// character's last column - otherwise the inversion eats a pixel column out of the letter before the
+			// cursor.
+			highlightStartX = xPixel + kTextSpacingX * scrollAmount - 1;
 		}
 		canvas.invertLeftEdgeForMenuHighlighting(highlightStartX, xPixelMax - highlightStartX, yPixel,
 		                                         yPixel + kTextSpacingY - 1);


### PR DESCRIPTION
Fixed the inverted highlight bar in the browser and rename UIs clipping the character to the left of the cursor when moving through the text with the horizontal encoder.

Regression from #4233, which reinstated this logic with a hardcoded -2 in place of the original adjustment (0 inside the string, 1 at its start).