### PR TITLE
Memory corruption / i028 bugfix

### DIFF
--- a/src/deluge/gui/waveform/waveform_renderer.cpp
+++ b/src/deluge/gui/waveform/waveform_renderer.cpp
@@ -437,7 +437,7 @@ cantReadData:
 				if ((nextSampleCluster->cluster != nullptr) && nextSampleCluster->cluster->numReasonsToBeLoaded < 0) {
 					FREEZE_WITH_ERROR("E450"); // Trying to catch errer before i028, which users have gotten.
 				}
-				nextCluster = nextSampleCluster->getCluster(sample, clusterIndexToDo, CLUSTER_LOAD_IMMEDIATELY);
+				nextCluster = nextSampleCluster->getCluster(sample, clusterIndexToDo + 1, CLUSTER_LOAD_IMMEDIATELY);
 
 				if (cluster->numReasonsToBeLoaded <= 0) {
 					FREEZE_WITH_ERROR("E342"); // Trying to catch E340 below, which Ron R got while recording
@@ -447,6 +447,9 @@ cantReadData:
 					audioFileManager.removeReasonFromCluster(*cluster, "po8w");
 					goto cantReadData;
 				}
+
+				// This entire block doesn't seem to actually do anything relevant - did I leave something out?
+				// Shouldn't it have moved startByteWithinCluster etc into nextCluster? Rohan
 			}
 
 			numBytesToRead = endByteWithinCluster - startByteWithinCluster;


### PR DESCRIPTION
This probably fixes the majority or all i028 and maybe other error messages that indicated memory corruption. This error although rare has occasionally shown up as far back as the official Synthstrom Deluge firmware.

The cause identified here was that a Cluster was getting its clusterIndex set wrong in some cases if the user viewed a waveform, as it was being loaded from the SD card.

This fix was actually found by AI, but description and pull request authored by a human.