### PR TITLE
add error messages to sysex loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ add_compile_options(
 
         $<$<CONFIG:RELEASE,RELWITHDEBINFO>:-fuse-linker-plugin>
     # this makes the optimization better at the cost of linking being REALLY slow
-        $<$<CONFIG:RELEASE>:-flto-partition=none>
+        $<$<CONFIG:RELEASE,RELWITHDEBINFO>:-flto-partition=none>
 
         $<$<CONFIG:RELEASE,RELWITHDEBINFO>:-fdevirtualize-at-ltrans>
     -ffunction-sections

--- a/src/deluge/io/midi/sysex.cpp
+++ b/src/deluge/io/midi/sysex.cpp
@@ -144,6 +144,7 @@ void Debug::loadPacketReceived(uint8_t* data, int32_t len) {
 	uint32_t handshake_received;
 	unpack_7bit_to_8bit((uint8_t*)&handshake_received, 4, data + 2, 5);
 	if (handshake != handshake_received) {
+		FREEZE_WITH_ERROR("E997");
 		return;
 	}
 
@@ -154,6 +155,7 @@ void Debug::loadPacketReceived(uint8_t* data, int32_t len) {
 	}
 
 	if (load_buf == nullptr || pos + 512 > load_bufsize) {
+		FREEZE_WITH_ERROR("E999");
 		return;
 	}
 
@@ -173,10 +175,12 @@ void Debug::loadPacketReceived(uint8_t* data, int32_t len) {
 void Debug::loadCheckAndRun(uint8_t* data, int32_t len) {
 	uint32_t handshake = runtimeFeatureSettings.get(RuntimeFeatureSettingType::DevSysexAllowed);
 	if (handshake == 0) {
+		FREEZE_WITH_ERROR("E996");
 		return; // not allowed
 	}
 
 	if (len < 17 || load_buf == nullptr) {
+		FREEZE_WITH_ERROR("E995");
 		return; // cannot do that
 	}
 

--- a/src/deluge/util/chainload.cpp
+++ b/src/deluge/util/chainload.cpp
@@ -34,6 +34,7 @@ void chainload_from_buf(uint8_t* buffer, int buf_size) {
 
 	int32_t code_size = (int32_t)(user_code_end - user_code_start);
 	if (code_size > buf_size) {
+		FREEZE_WITH_ERROR("E994");
 		return;
 	}
 


### PR DESCRIPTION
Add error messages and build relwithdebinfo with single threaded lto as well. For reasons I don't understand sysex flashing with different lto settings sometimes fails so you can't reliably go release->relwithdebinfo otherwise