### PR TITLE
Fix/save name numbering window

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -570,6 +570,23 @@ bool isNumberedFamilyMember(char const* fileName, char const* prefix, int32_t pr
 	return *pos == '.' || *pos == 0;
 }
 
+/// If `fileName` is "<stem><letter>" plus an extension, returns 0-25 for that letter; -1 otherwise. Case does not
+/// matter, so "SONG185a.XML" and "SONG185A.Json" are the same variation.
+int32_t letterVariationOf(char const* fileName, char const* stem, int32_t stemLength) {
+	if (memcasecmp(fileName, stem, stemLength)) {
+		return -1;
+	}
+	char letter = fileName[stemLength];
+	if (letter >= 'a' && letter <= 'z') {
+		letter -= 32;
+	}
+	if (letter < 'A' || letter > 'Z') {
+		return -1;
+	}
+	char after = fileName[stemLength + 1];
+	return (after == '.' || after == 0) ? letter - 'A' : -1;
+}
+
 bool isAllowedFileExtension(char const* fileName, char const** allowedExtensions) {
 	char const* dotPos = strrchr(fileName, '.');
 	if (!dotPos) {
@@ -583,39 +600,64 @@ bool isAllowedFileExtension(char const* fileName, char const** allowedExtensions
 	return false;
 }
 
-/// Adapts the browser to the FileListView seam used by nextDefaultName(). The two halves are answered differently on
-/// purpose - see the contracts on FileListView.
+/// Adapts the browser to the FileListView seam used by nextDefaultName().
+///
+/// Each query combines two sources. The card is surveyed directly, because fileItems may be a window; and fileItems
+/// is then folded in, because it carries Instruments held in memory that are not on the card yet (see
+/// Song::addInstrumentsToFileItems - "in case the next one in line isn't saved"), whose names are equally taken.
+/// Folding in a window is safe here: it can only ever add variations, never hide one.
 class BrowserFileListView final : public deluge::gui::browser::FileListView {
 public:
-	bool contains(char const* nameWithExtension) const override {
-		bool foundExact = false;
-		Browser::fileItems.search(nameWithExtension, &foundExact);
-		return foundExact;
-	}
-
 	std::string highestNumberedName(char const* prefix) const override {
 		String highest;
-		// A scan that errors part-way still leaves the maximum it had reached, and that is never *above* the true
-		// answer, so keep it rather than throwing it away and falling all the way back to the floor.
-		(void)Browser::highestNumberedFileName(prefix, &highest);
+		surveyCard(prefix, &highest, nullptr);
 
-		// fileItems also carries Instruments held in memory that are not on the card yet (see
-		// Song::addInstrumentsToFileItems - "in case the next one in line isn't saved"), and those names are taken
-		// too. Being a window only means it can fail to raise this, never lower it, so it is safe to fold in.
 		int32_t prefixLength = strlen(prefix);
-		for (int32_t i = 0; i < Browser::fileItems.getNumElements(); i++) {
-			char const* name = ((FileItem*)Browser::fileItems.getElementAddress(i))->displayName;
+		forEachFileItem([&](char const* name) {
 			if (!isNumberedFamilyMember(name, prefix, prefixLength)) {
-				continue;
+				return;
 			}
 			if (highest.isEmpty() || strcmpspecial(name, highest.get()) > 0) {
-				if (highest.set(name) != Error::NONE) {
-					break;
-				}
+				highest.set(name); // On failure we keep the previous maximum, which is still a valid floor.
 			}
-		}
+		});
 
 		return highest.isEmpty() ? std::string{} : std::string{highest.get()};
+	}
+
+	uint32_t takenLetterSuffixes(char const* stem) const override {
+		uint32_t taken = 0;
+		surveyCard(stem, nullptr, &taken);
+
+		int32_t stemLength = strlen(stem);
+		forEachFileItem([&](char const* name) {
+			int32_t letter = letterVariationOf(name, stem, stemLength);
+			if (letter >= 0) {
+				taken |= 1U << letter;
+			}
+		});
+
+		return taken;
+	}
+
+private:
+	static void surveyCard(char const* stem, String* highestNumbered, uint32_t* takenLetters) {
+		if (Browser::fileItemsAreComplete()) {
+			return; // The folder is already in memory in full - no reason to go back to the card for it.
+		}
+		// A survey that errors part-way still reports what it had found, and neither summary can overstate the
+		// truth, so it is worth more than nothing.
+		(void)Browser::surveyNameVariations(stem, highestNumbered, takenLetters);
+	}
+
+	template <typename Fn>
+	static void forEachFileItem(Fn&& consider) {
+		for (int32_t i = 0; i < Browser::fileItems.getNumElements(); i++) {
+			FileItem* item = (FileItem*)Browser::fileItems.getElementAddress(i);
+			if (!item->isFolder) {
+				consider(item->displayName);
+			}
+		}
 	}
 };
 } // namespace
@@ -817,8 +859,13 @@ emptyFileItemsAndReturn:
 	goto doReturn;
 }
 
-Error Browser::highestNumberedFileName(char const* prefix, String* result) {
-	result->clear();
+Error Browser::surveyNameVariations(char const* stem, String* highestNumbered, uint32_t* takenLetters) {
+	if (highestNumbered) {
+		highestNumbered->clear();
+	}
+	if (takenLetters) {
+		*takenLetters = 0;
+	}
 
 	Error error = StorageManager::initSD();
 	if (error != Error::NONE) {
@@ -828,7 +875,7 @@ Error Browser::highestNumberedFileName(char const* prefix, String* result) {
 	staticDIR =
 	    D_TRY_CATCH(FatFS::Directory::open(currentDir.get()), fatError, { return fatfsErrorToDelugeError(fatError); });
 
-	int32_t prefixLength = strlen(prefix);
+	int32_t stemLength = strlen(stem);
 
 	while (true) {
 		audioFileManager.loadAnyEnqueuedClusters();
@@ -844,19 +891,25 @@ Error Browser::highestNumberedFileName(char const* prefix, String* result) {
 		if (staticFNO.fname[0] == '.' || (staticFNO.fattrib & AM_DIR)) {
 			continue; // Dot entry, or a folder - only files carry these names.
 		}
-		if (!isNumberedFamilyMember(staticFNO.fname, prefix, prefixLength)) {
-			continue;
-		}
 		if (!isAllowedFileExtension(staticFNO.fname, allowedFileExtensions)) {
 			continue;
 		}
 
-		// strcmpspecial compares digit runs numerically, so this finds the highest *number*, not the longest name:
-		// "MYTRACK 11.XML" beats "MYTRACK 9.XML".
-		if (result->isEmpty() || strcmpspecial(staticFNO.fname, result->get()) > 0) {
-			error = result->set(staticFNO.fname);
-			if (error != Error::NONE) {
-				break;
+		if (highestNumbered && isNumberedFamilyMember(staticFNO.fname, stem, stemLength)) {
+			// strcmpspecial compares digit runs numerically, so this finds the highest *number*, not the longest
+			// name: "MYTRACK 11.XML" beats "MYTRACK 9.XML".
+			if (highestNumbered->isEmpty() || strcmpspecial(staticFNO.fname, highestNumbered->get()) > 0) {
+				error = highestNumbered->set(staticFNO.fname);
+				if (error != Error::NONE) {
+					break;
+				}
+			}
+		}
+
+		if (takenLetters) {
+			int32_t letter = letterVariationOf(staticFNO.fname, stem, stemLength);
+			if (letter >= 0) {
+				*takenLetters |= 1U << letter;
 			}
 		}
 	}

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -587,6 +587,7 @@ int32_t letterVariationOf(char const* fileName, char const* stem, int32_t stemLe
 	return (after == '.' || after == 0) ? letter - 'A' : -1;
 }
 
+/// Whether `fileName` carries one of the extensions the browser lists, and so names a file a save could collide with.
 bool isAllowedFileExtension(char const* fileName, char const** allowedExtensions) {
 	char const* dotPos = strrchr(fileName, '.');
 	if (!dotPos) {

--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -553,13 +553,69 @@ tryReadingItems:
 }
 
 namespace {
-/// Adapts Browser::fileItems to the FileListView seam used by nextDefaultName().
+/// Whether `fileName` belongs to the "<prefix><digits>" family. The digits must run all the way to the extension:
+/// without that, a neighbour like "JAM 2024-01-05.XML" joins the "JAM " family, reads as number 2024, and sends the
+/// next save to "JAM 2025". Date-suffixed names are common on real cards.
+bool isNumberedFamilyMember(char const* fileName, char const* prefix, int32_t prefixLength) {
+	if (memcasecmp(fileName, prefix, prefixLength)) {
+		return false;
+	}
+	char const* pos = &fileName[prefixLength];
+	if (*pos < '0' || *pos > '9') {
+		return false;
+	}
+	while (*pos >= '0' && *pos <= '9') {
+		pos++;
+	}
+	return *pos == '.' || *pos == 0;
+}
+
+bool isAllowedFileExtension(char const* fileName, char const** allowedExtensions) {
+	char const* dotPos = strrchr(fileName, '.');
+	if (!dotPos) {
+		return false;
+	}
+	for (char const** thisExtension = allowedExtensions; *thisExtension; thisExtension++) {
+		if (!strcasecmp(dotPos + 1, *thisExtension)) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/// Adapts the browser to the FileListView seam used by nextDefaultName(). The two halves are answered differently on
+/// purpose - see the contracts on FileListView.
 class BrowserFileListView final : public deluge::gui::browser::FileListView {
 public:
 	bool contains(char const* nameWithExtension) const override {
 		bool foundExact = false;
 		Browser::fileItems.search(nameWithExtension, &foundExact);
 		return foundExact;
+	}
+
+	std::string highestNumberedName(char const* prefix) const override {
+		String highest;
+		// A scan that errors part-way still leaves the maximum it had reached, and that is never *above* the true
+		// answer, so keep it rather than throwing it away and falling all the way back to the floor.
+		(void)Browser::highestNumberedFileName(prefix, &highest);
+
+		// fileItems also carries Instruments held in memory that are not on the card yet (see
+		// Song::addInstrumentsToFileItems - "in case the next one in line isn't saved"), and those names are taken
+		// too. Being a window only means it can fail to raise this, never lower it, so it is safe to fold in.
+		int32_t prefixLength = strlen(prefix);
+		for (int32_t i = 0; i < Browser::fileItems.getNumElements(); i++) {
+			char const* name = ((FileItem*)Browser::fileItems.getElementAddress(i))->displayName;
+			if (!isNumberedFamilyMember(name, prefix, prefixLength)) {
+				continue;
+			}
+			if (highest.isEmpty() || strcmpspecial(name, highest.get()) > 0) {
+				if (highest.set(name) != Error::NONE) {
+					break;
+				}
+			}
+		}
+
+		return highest.isEmpty() ? std::string{} : std::string{highest.get()};
 	}
 };
 } // namespace
@@ -759,6 +815,54 @@ doReturn:
 emptyFileItemsAndReturn:
 	emptyFileItems();
 	goto doReturn;
+}
+
+Error Browser::highestNumberedFileName(char const* prefix, String* result) {
+	result->clear();
+
+	Error error = StorageManager::initSD();
+	if (error != Error::NONE) {
+		return error;
+	}
+
+	staticDIR =
+	    D_TRY_CATCH(FatFS::Directory::open(currentDir.get()), fatError, { return fatfsErrorToDelugeError(fatError); });
+
+	int32_t prefixLength = strlen(prefix);
+
+	while (true) {
+		audioFileManager.loadAnyEnqueuedClusters();
+
+		staticFNO = D_TRY_CATCH(staticDIR.read(), fatError, {
+			error = fatfsErrorToDelugeError(fatError);
+			break;
+		});
+
+		if (staticFNO.fname[0] == 0) {
+			break; /* End of dir */
+		}
+		if (staticFNO.fname[0] == '.' || (staticFNO.fattrib & AM_DIR)) {
+			continue; // Dot entry, or a folder - only files carry these names.
+		}
+		if (!isNumberedFamilyMember(staticFNO.fname, prefix, prefixLength)) {
+			continue;
+		}
+		if (!isAllowedFileExtension(staticFNO.fname, allowedFileExtensions)) {
+			continue;
+		}
+
+		// strcmpspecial compares digit runs numerically, so this finds the highest *number*, not the longest name:
+		// "MYTRACK 11.XML" beats "MYTRACK 9.XML".
+		if (result->isEmpty() || strcmpspecial(staticFNO.fname, result->get()) > 0) {
+			error = result->set(staticFNO.fname);
+			if (error != Error::NONE) {
+				break;
+			}
+		}
+	}
+
+	staticDIR.close();
+	return error;
 }
 
 void Browser::selectEncoderAction(int8_t offset) {

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -84,6 +84,13 @@ public:
 	static void deleteSomeFileItems(int32_t startAt, int32_t stopAt);
 	static void deleteFolderAndDuplicateItems(Availability instrumentAvailabilityRequirement = Availability::ANY);
 	Error getUnusedSlot(OutputType outputType, String* newName, char const* thingName);
+	/// Finds the greatest name in currentDir of the form "<prefix><digits>..." - the highest-numbered member of a
+	/// name family - or leaves `result` empty when the folder holds none. You must set currentDir first.
+	///
+	/// Scans the folder directly instead of reading fileItems, and holds only a running maximum. That is the point:
+	/// fileItems is a window around whichever file the browser is sitting on (FILE_ITEMS_MAX_NUM_ELEMENTS), and the
+	/// highest-numbered member of a family can be any distance from that in sort order.
+	static Error highestNumberedFileName(char const* prefix, String* result);
 	bool opened() override;
 	void cullSomeFileItems();
 	bool checkFP();

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -84,19 +84,26 @@ public:
 	static void deleteSomeFileItems(int32_t startAt, int32_t stopAt);
 	static void deleteFolderAndDuplicateItems(Availability instrumentAvailabilityRequirement = Availability::ANY);
 	Error getUnusedSlot(OutputType outputType, String* newName, char const* thingName);
-	/// Surveys currentDir for the existing variations of `stem`, in one pass. Either output may be null:
-	///   `highestNumbered` receives the greatest name of the form "<stem><digits>", or stays empty if there is none;
-	///   `takenLetters` receives a bit per existing "<stem><letter>", bit 0 meaning 'A'.
-	/// You must set currentDir first.
+	/// @brief Surveys currentDir in one pass for the existing variations of a name.
 	///
-	/// Reads the folder directly rather than fileItems, and keeps only those two summaries. That is the point:
-	/// fileItems is a window around whichever file the browser is sitting on (FILE_ITEMS_MAX_NUM_ELEMENTS), and a
-	/// member of a name family can be any distance from that in sort order. See fileItemsAreComplete(), which says
-	/// when the window is the whole folder and this pass can be skipped.
+	/// Reads the folder directly rather than fileItems, keeping only the two summaries. fileItems is a window around
+	/// whichever file the browser is sitting on (FILE_ITEMS_MAX_NUM_ELEMENTS), and a member of a name family can be
+	/// any distance from that in sort order, so it cannot answer this.
+	///
+	/// @pre currentDir names the folder to survey.
+	/// @param stem            The name the variations extend.
+	/// @param highestNumbered If non-null, receives the greatest name of the form "<stem><digits>", or is left empty
+	///                        when the folder holds none.
+	/// @param takenLetters    If non-null, receives a bit per existing "<stem><letter>", bit 0 meaning 'A'.
+	/// @return Error::NONE, or the card error that cut the pass short - in which case both outputs still hold what
+	///         had been found so far, neither of which can overstate the truth.
+	/// @see fileItemsAreComplete(), which says when this pass can be skipped entirely.
 	static Error surveyNameVariations(char const* stem, String* highestNumbered, uint32_t* takenLetters);
 
-	/// Whether fileItems currently holds every file the folder listed, rather than a culled window of them. When it
-	/// does, questions about the whole folder can be answered from memory without touching the card again.
+	/// @brief Whether fileItems holds every file the folder listed, rather than a culled window of them.
+	///
+	/// @return True when questions about the whole folder can be answered from fileItems alone, without going back
+	///         to the card.
 	static bool fileItemsAreComplete() { return !numFileItemsDeletedAtStart && !numFileItemsDeletedAtEnd; }
 	bool opened() override;
 	void cullSomeFileItems();

--- a/src/deluge/gui/ui/browser/browser.h
+++ b/src/deluge/gui/ui/browser/browser.h
@@ -84,13 +84,20 @@ public:
 	static void deleteSomeFileItems(int32_t startAt, int32_t stopAt);
 	static void deleteFolderAndDuplicateItems(Availability instrumentAvailabilityRequirement = Availability::ANY);
 	Error getUnusedSlot(OutputType outputType, String* newName, char const* thingName);
-	/// Finds the greatest name in currentDir of the form "<prefix><digits>..." - the highest-numbered member of a
-	/// name family - or leaves `result` empty when the folder holds none. You must set currentDir first.
+	/// Surveys currentDir for the existing variations of `stem`, in one pass. Either output may be null:
+	///   `highestNumbered` receives the greatest name of the form "<stem><digits>", or stays empty if there is none;
+	///   `takenLetters` receives a bit per existing "<stem><letter>", bit 0 meaning 'A'.
+	/// You must set currentDir first.
 	///
-	/// Scans the folder directly instead of reading fileItems, and holds only a running maximum. That is the point:
-	/// fileItems is a window around whichever file the browser is sitting on (FILE_ITEMS_MAX_NUM_ELEMENTS), and the
-	/// highest-numbered member of a family can be any distance from that in sort order.
-	static Error highestNumberedFileName(char const* prefix, String* result);
+	/// Reads the folder directly rather than fileItems, and keeps only those two summaries. That is the point:
+	/// fileItems is a window around whichever file the browser is sitting on (FILE_ITEMS_MAX_NUM_ELEMENTS), and a
+	/// member of a name family can be any distance from that in sort order. See fileItemsAreComplete(), which says
+	/// when the window is the whole folder and this pass can be skipped.
+	static Error surveyNameVariations(char const* stem, String* highestNumbered, uint32_t* takenLetters);
+
+	/// Whether fileItems currently holds every file the folder listed, rather than a culled window of them. When it
+	/// does, questions about the whole folder can be answered from memory without touching the card again.
+	static bool fileItemsAreComplete() { return !numFileItemsDeletedAtStart && !numFileItemsDeletedAtEnd; }
 	bool opened() override;
 	void cullSomeFileItems();
 	bool checkFP();

--- a/src/deluge/gui/ui/browser/default_name.cpp
+++ b/src/deluge/gui/ui/browser/default_name.cpp
@@ -150,9 +150,8 @@ std::string nextDefaultName(std::string_view currentName, std::string_view slotP
 	char letter = 0;
 	std::string stem = slotStem(currentName, slotPrefix, &letter);
 
-	// Slot-form name ("SONG185" / "SONG185A"): take the first free letter at or above the one we are on. Asking for
-	// the whole family at once, rather than testing candidates one at a time against the file list, is what makes
-	// this hold on a folder too big to fit in that list - the same trap the numeric path fell into.
+	// Slot-form name ("SONG185" / "SONG185A"): the first free letter at or above the one we are on. The whole family
+	// is fetched at once rather than tested a candidate at a time, so the answer holds however big the folder is.
 	if (!stem.empty()) {
 		uint32_t taken = files.takenLetterSuffixes(stem.c_str());
 		char from = (letter == 0) ? 'A' : static_cast<char>(letter + 1);
@@ -164,11 +163,10 @@ std::string nextDefaultName(std::string_view currentName, std::string_view slotP
 		return std::string{currentName}; // Letters exhausted.
 	}
 
-	// Anything else: one past the highest-numbered sibling.
-	//
-	// This asks for that one name rather than probing "<base> 2", "<base> 3", ... upwards, because contains() only
-	// sees a window around the file being saved: by "<base> 11" the "2" has fallen out of it and would be handed
-	// back as free. Numbering from the top also leaves gaps alone, so a deleted "<base> 3" is not silently reused.
+	// Anything else: one past the highest-numbered member of the family. Asking for that single name, rather than
+	// testing "<base> 2", "<base> 3", ... in turn, is again what makes the answer independent of how much of the
+	// folder the caller can see. Numbering from the top also leaves gaps alone, so a deleted "<base> 3" is not
+	// silently reused.
 	char delimiter = kNumericSuffixDelimiter;
 	std::string base = numericStem(currentName, &delimiter);
 	std::string prefix = base + delimiter;

--- a/src/deluge/gui/ui/browser/default_name.cpp
+++ b/src/deluge/gui/ui/browser/default_name.cpp
@@ -28,13 +28,6 @@ namespace {
 constexpr size_t kMaxSlotDigits = 3;
 constexpr int32_t kMaxNumericSuffix = 9999;
 
-bool exists(FileListView const& files, std::string const& nameWithoutExtension) {
-	// The browser lists both extensions (allowedFileExtensionsXML), and saving picks between them via writeJsonFlag, so
-	// a name is taken if *either* form is on the card. Probing only .XML would hand back a name that already exists.
-	return files.contains((nameWithoutExtension + ".XML").c_str())
-	       || files.contains((nameWithoutExtension + ".Json").c_str());
-}
-
 char upper(char c) {
 	return static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
 }
@@ -157,13 +150,15 @@ std::string nextDefaultName(std::string_view currentName, std::string_view slotP
 	char letter = 0;
 	std::string stem = slotStem(currentName, slotPrefix, &letter);
 
-	// Slot-form name ("SONG185" / "SONG185A"): advance the letter suffix.
+	// Slot-form name ("SONG185" / "SONG185A"): take the first free letter at or above the one we are on. Asking for
+	// the whole family at once, rather than testing candidates one at a time against the file list, is what makes
+	// this hold on a folder too big to fit in that list - the same trap the numeric path fell into.
 	if (!stem.empty()) {
+		uint32_t taken = files.takenLetterSuffixes(stem.c_str());
 		char from = (letter == 0) ? 'A' : static_cast<char>(letter + 1);
 		for (char c = from; c <= 'Z'; c++) {
-			std::string candidate = stem + c;
-			if (!exists(files, candidate)) {
-				return candidate;
+			if (!(taken & (1U << (c - 'A')))) {
+				return stem + c;
 			}
 		}
 		return std::string{currentName}; // Letters exhausted.

--- a/src/deluge/gui/ui/browser/default_name.cpp
+++ b/src/deluge/gui/ui/browser/default_name.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gui/ui/browser/default_name.h"
+#include <algorithm>
 #include <cctype>
 #include <cstdint>
 #include <cstring>
@@ -100,6 +101,37 @@ std::string numericStem(std::string_view name, char* delimiter) {
 	return std::string{name};
 }
 
+/// Reads the number a family member carries: the digit run straight after `prefix`, which must then run to the
+/// extension or to the end of the name. Returns 0 when `name` is not of that form, and kMaxNumericSuffix when the
+/// digits run past what we are willing to count to (so the caller stops rather than wrapping).
+///
+/// The "digits must reach the extension" rule is what keeps a neighbour like "JAM 2024-01-05.XML" out of the "JAM "
+/// family. Read as a member it would say the family had reached 2024, and the next save would land on "JAM 2025".
+int32_t numberOfSibling(std::string const& name, std::string_view prefix) {
+	if (name.size() <= prefix.size()) {
+		return 0;
+	}
+	for (size_t i = 0; i < prefix.size(); i++) {
+		if (upper(name[i]) != upper(prefix[i])) {
+			return 0;
+		}
+	}
+
+	int32_t number = 0;
+	size_t pos = prefix.size();
+	if (!std::isdigit(static_cast<unsigned char>(name[pos]))) {
+		return 0;
+	}
+	while (pos < name.size() && std::isdigit(static_cast<unsigned char>(name[pos]))) {
+		number = number * 10 + (name[pos] - '0');
+		if (number > kMaxNumericSuffix) {
+			return kMaxNumericSuffix;
+		}
+		pos++;
+	}
+	return (pos == name.size() || name[pos] == '.') ? number : 0;
+}
+
 } // namespace
 
 char const* numberPartOf(char const* name, char const* filePrefix) {
@@ -137,16 +169,24 @@ std::string nextDefaultName(std::string_view currentName, std::string_view slotP
 		return std::string{currentName}; // Letters exhausted.
 	}
 
-	// Anything else: advance the numeric suffix.
+	// Anything else: one past the highest-numbered sibling.
+	//
+	// This asks for that one name rather than probing "<base> 2", "<base> 3", ... upwards, because contains() only
+	// sees a window around the file being saved: by "<base> 11" the "2" has fallen out of it and would be handed
+	// back as free. Numbering from the top also leaves gaps alone, so a deleted "<base> 3" is not silently reused.
 	char delimiter = kNumericSuffixDelimiter;
 	std::string base = numericStem(currentName, &delimiter);
-	for (int32_t n = 2; n <= kMaxNumericSuffix; n++) {
-		std::string candidate = base + delimiter + std::to_string(n);
-		if (!exists(files, candidate)) {
-			return candidate;
-		}
+	std::string prefix = base + delimiter;
+
+	// The name we are saving over is itself on the card, so its own number is a floor the answer can never go below -
+	// which keeps this right even if the folder scan comes back empty because the card would not answer.
+	int32_t highest = std::max(numberOfSibling(files.highestNumberedName(prefix.c_str()), prefix),
+	                           numberOfSibling(std::string{currentName}, prefix));
+	if (highest >= kMaxNumericSuffix) {
+		return std::string{currentName}; // Numbers exhausted - the user will have to name this one.
 	}
-	return std::string{currentName};
+	// An unnumbered original ("MYTRACK.XML" alone) counts as 1, so the first variation is "MYTRACK 2".
+	return prefix + std::to_string(std::max<int32_t>(highest, 1) + 1);
 }
 
 } // namespace deluge::gui::browser

--- a/src/deluge/gui/ui/browser/default_name.h
+++ b/src/deluge/gui/ui/browser/default_name.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 
@@ -28,23 +29,23 @@ class FileListView {
 public:
 	virtual ~FileListView() = default;
 
-	/// True if the list holds this exact name. The name includes its extension, matching FileItem::displayName (the
-	/// CStringArray sort key).
+	/// Both queries ask about a whole family of names at once, and both must answer for the *entire* folder.
 	///
-	/// WINDOWED - only ask about names that sort *close* to the file being saved. Browser::fileItems holds at most
-	/// FILE_ITEMS_MAX_NUM_ELEMENTS entries around that file and is culled to about half of that as a folder is read,
-	/// so a name any real distance away is reported missing whether it exists or not. Probing a family of candidates
-	/// from one end is exactly the mistake that made "MYSONG 11" propose "MYSONG 2" and offer to overwrite it; use
-	/// highestNumberedName() for that.
-	virtual bool contains(char const* nameWithExtension) const = 0;
+	/// That shape is deliberate. There used to be a contains() here, answered out of Browser::fileItems, and names
+	/// were derived by testing candidates against it one at a time. fileItems holds at most
+	/// FILE_ITEMS_MAX_NUM_ELEMENTS entries around the file being saved and is culled to about half of that as a
+	/// folder is read, so a candidate any real distance away came back missing whether it existed or not - which is
+	/// how "MYSONG 11" came to propose "MYSONG 2" and offer to overwrite it. A question about the family as a whole
+	/// cannot be answered from a window by accident: the implementation has to go and look.
 
-	/// The greatest name of the form "<prefix><digits>..." on the card (extension included), or empty when there is
+	/// The greatest name of the form "<prefix><digits>" on the card (extension included), or empty when there is
 	/// none. "Greatest" is by the browser's ordering, in which digit runs compare numerically, so this is the
 	/// highest-numbered sibling: "MYTRACK 11.XML" beats "MYTRACK 9.XML".
-	///
-	/// EXACT - unlike contains(), this sees the whole folder however large, because the implementation scans it
-	/// rather than consulting the windowed file list.
 	virtual std::string highestNumberedName(char const* prefix) const = 0;
+
+	/// Which of "<stem>A" .. "<stem>Z" already exist, as a bitmask with bit 0 meaning 'A'. Names differing only in
+	/// case or in extension (.XML / .Json) count as the same letter.
+	virtual uint32_t takenLetterSuffixes(char const* stem) const = 0;
 };
 
 /// The delimiter used when giving a name its first numeric suffix ("MYTRACK" -> "MYTRACK 2").

--- a/src/deluge/gui/ui/browser/default_name.h
+++ b/src/deluge/gui/ui/browser/default_name.h
@@ -22,14 +22,29 @@
 
 namespace deluge::gui::browser {
 
-/// Read-only view over the browser's file list, so name derivation can be tested without a card, a display, or the
-/// browser's static state. Implemented over Browser::fileItems in the firmware, and over a vector in tests.
+/// Read-only view over the files on the card, so name derivation can be tested without a card, a display, or the
+/// browser's static state. Implemented over the Browser in the firmware, and over a vector in tests.
 class FileListView {
 public:
 	virtual ~FileListView() = default;
+
 	/// True if the list holds this exact name. The name includes its extension, matching FileItem::displayName (the
 	/// CStringArray sort key).
+	///
+	/// WINDOWED - only ask about names that sort *close* to the file being saved. Browser::fileItems holds at most
+	/// FILE_ITEMS_MAX_NUM_ELEMENTS entries around that file and is culled to about half of that as a folder is read,
+	/// so a name any real distance away is reported missing whether it exists or not. Probing a family of candidates
+	/// from one end is exactly the mistake that made "MYSONG 11" propose "MYSONG 2" and offer to overwrite it; use
+	/// highestNumberedName() for that.
 	virtual bool contains(char const* nameWithExtension) const = 0;
+
+	/// The greatest name of the form "<prefix><digits>..." on the card (extension included), or empty when there is
+	/// none. "Greatest" is by the browser's ordering, in which digit runs compare numerically, so this is the
+	/// highest-numbered sibling: "MYTRACK 11.XML" beats "MYTRACK 9.XML".
+	///
+	/// EXACT - unlike contains(), this sees the whole folder however large, because the implementation scans it
+	/// rather than consulting the windowed file list.
+	virtual std::string highestNumberedName(char const* prefix) const = 0;
 };
 
 /// The delimiter used when giving a name its first numeric suffix ("MYTRACK" -> "MYTRACK 2").
@@ -56,11 +71,15 @@ char const* numberPartOf(char const* name, char const* filePrefix);
 /// take the numeric path.
 ///
 /// Two forms:
-///   <slotPrefix><digits>[letter]  -> next unused letter:  SONG185 -> SONG185A -> SONG185B
-///   anything else                 -> next unused number:  MYTRACK -> "MYTRACK 2"
-///                                                         TRACK_1 -> TRACK_2 (an existing delimiter is reused)
+///   <slotPrefix><digits>[letter]  -> next unused letter:   SONG185 -> SONG185A -> SONG185B
+///   anything else                 -> highest number plus 1: MYTRACK -> "MYTRACK 2"
+///                                                          TRACK_1 -> TRACK_2 (an existing delimiter is reused)
 ///
-/// Returns `currentName` unchanged when no free variation exists (letters exhausted past Z).
+/// The numeric form counts up from the highest-numbered sibling rather than filling the lowest gap, so deleting
+/// "MYTRACK 3" does not make the next save reuse that name.
+///
+/// Returns `currentName` unchanged when no free variation exists (letters exhausted past Z, or the number would run
+/// past kMaxNumericSuffix).
 std::string nextDefaultName(std::string_view currentName, std::string_view slotPrefix, FileListView const& files);
 
 } // namespace deluge::gui::browser

--- a/src/deluge/gui/ui/browser/default_name.h
+++ b/src/deluge/gui/ui/browser/default_name.h
@@ -23,28 +23,35 @@
 
 namespace deluge::gui::browser {
 
-/// Read-only view over the files on the card, so name derivation can be tested without a card, a display, or the
-/// browser's static state. Implemented over the Browser in the firmware, and over a vector in tests.
+/// @brief Read-only view over the files on the card, so name derivation can be tested without a card, a display, or
+///        the browser's static state.
+///
+/// Implemented over the Browser in the firmware, and over a vector in tests. Both queries ask about a whole family
+/// of related names at once rather than about one candidate name.
+///
+/// @warning Both must answer for the *entire* folder. Browser::fileItems - the browser's own listing - holds at most
+///          FILE_ITEMS_MAX_NUM_ELEMENTS entries around the file being saved, culled to about half of that as a
+///          folder is read, so on its own it cannot answer either query on a folder of any size: it reports names
+///          missing that are really present, and the caller hands back a name that already exists on the card.
 class FileListView {
 public:
 	virtual ~FileListView() = default;
 
-	/// Both queries ask about a whole family of names at once, and both must answer for the *entire* folder.
+	/// @brief Finds the highest-numbered member of the "<prefix><digits>" name family.
 	///
-	/// That shape is deliberate. There used to be a contains() here, answered out of Browser::fileItems, and names
-	/// were derived by testing candidates against it one at a time. fileItems holds at most
-	/// FILE_ITEMS_MAX_NUM_ELEMENTS entries around the file being saved and is culled to about half of that as a
-	/// folder is read, so a candidate any real distance away came back missing whether it existed or not - which is
-	/// how "MYSONG 11" came to propose "MYSONG 2" and offer to overwrite it. A question about the family as a whole
-	/// cannot be answered from a window by accident: the implementation has to go and look.
-
-	/// The greatest name of the form "<prefix><digits>" on the card (extension included), or empty when there is
-	/// none. "Greatest" is by the browser's ordering, in which digit runs compare numerically, so this is the
-	/// highest-numbered sibling: "MYTRACK 11.XML" beats "MYTRACK 9.XML".
+	/// "Greatest" is by the browser's ordering, in which digit runs compare numerically, so "MYTRACK 11.XML" beats
+	/// "MYTRACK 9.XML".
+	///
+	/// @param prefix The family's common leading text, including any delimiter ("MYTRACK ").
+	/// @return The greatest matching name, extension included, or empty when the folder holds no member.
 	virtual std::string highestNumberedName(char const* prefix) const = 0;
 
-	/// Which of "<stem>A" .. "<stem>Z" already exist, as a bitmask with bit 0 meaning 'A'. Names differing only in
-	/// case or in extension (.XML / .Json) count as the same letter.
+	/// @brief Reports which single-letter variations of a name already exist.
+	///
+	/// Names differing only in case or in extension (.XML / .Json) are the same variation.
+	///
+	/// @param stem The name the letter is appended to ("SONG185").
+	/// @return A bitmask of the taken letters: bit 0 is 'A', through bit 25 for 'Z'.
 	virtual uint32_t takenLetterSuffixes(char const* stem) const = 0;
 };
 
@@ -62,25 +69,25 @@ inline constexpr char kNumericSuffixDelimiter = ' ';
 /// slot navigation dies for those songs.
 char const* numberPartOf(char const* name, char const* filePrefix);
 
-/// Derives the default name for the next variation of `currentName`.
-///
-/// `currentName` and the result are real on-card names: no extension, and no display-specific mangling (always
-/// "SONG185", never "185").
-///
-/// `slotPrefix` is the prefix that earns letter-suffix treatment - "SONG" for songs, and empty for everything else.
-/// Presets deliberately do NOT get letter suffixes: that would change current OLED preset behaviour. Pass "" and they
-/// take the numeric path.
+/// @brief Derives the default name for the next variation of a name being saved over.
 ///
 /// Two forms:
 ///   <slotPrefix><digits>[letter]  -> next unused letter:   SONG185 -> SONG185A -> SONG185B
 ///   anything else                 -> highest number plus 1: MYTRACK -> "MYTRACK 2"
 ///                                                          TRACK_1 -> TRACK_2 (an existing delimiter is reused)
 ///
-/// The numeric form counts up from the highest-numbered sibling rather than filling the lowest gap, so deleting
-/// "MYTRACK 3" does not make the next save reuse that name.
+/// The numeric form counts up from the highest-numbered member of the family rather than filling the lowest gap, so
+/// deleting "MYTRACK 3" does not make the next save reuse that name.
 ///
-/// Returns `currentName` unchanged when no free variation exists (letters exhausted past Z, or the number would run
-/// past kMaxNumericSuffix).
+/// @note Presets deliberately do NOT get letter suffixes - that would change OLED preset behaviour. They pass an
+///       empty @p slotPrefix and take the numeric path.
+///
+/// @param currentName The name being saved over, in real on-card form: no extension, and no display-specific
+///                    mangling (always "SONG185", never "185"). The result takes the same form.
+/// @param slotPrefix  The prefix that earns letter-suffix treatment - "SONG" for songs, empty for everything else.
+/// @param files       View over the folder being saved into.
+/// @return The next variation, or @p currentName unchanged when no free one exists: letters exhausted past Z, or
+///         numbers past 9999.
 std::string nextDefaultName(std::string_view currentName, std::string_view slotPrefix, FileListView const& files);
 
 } // namespace deluge::gui::browser

--- a/tests/unit/default_name_tests.cpp
+++ b/tests/unit/default_name_tests.cpp
@@ -147,10 +147,9 @@ TEST(DefaultNameTests, numericSuffixAdvances) {
 // --- Names are derived from the whole family, never by probing candidates one at a time ---
 
 TEST(DefaultNameTests, numericSuffixAdvancesPastEleven) {
-	// The reported bug: a song saved as "<name> 11" proposed "<name> 2" and offered to overwrite the real second
-	// file. Names were derived by testing "<name> 2", "<name> 3", ... against a windowed view of the folder, and by
-	// 11 the "2" had fallen outside that window and was reported free. Asking for the family's highest member
-	// instead leaves nothing for a window to hide.
+	// Guards the reported symptom: saving over "<name> 11" must offer 12, not 2. A caller that tests "<name> 2",
+	// "<name> 3", ... in turn gets this wrong the moment the low members fall outside the file list's window; the
+	// family's highest member is asked for directly so that there is nothing for a window to hide.
 	std::vector<std::string> folder;
 	for (int32_t i = 1; i <= 11; i++) {
 		folder.push_back("MY PROJECT " + std::to_string(i) + ".XML");
@@ -160,8 +159,8 @@ TEST(DefaultNameTests, numericSuffixAdvancesPastEleven) {
 }
 
 TEST(DefaultNameTests, letterSuffixAdvancesPastAWholeAlphabetOfVariations) {
-	// The same trap on the letter path: A, B, C ... were tested one at a time against that same windowed view, so
-	// with a dozen variations saved the later ones read as free and the UI offered to overwrite a real song.
+	// The same property on the letter path. Testing A, B, C ... one at a time against a windowed view goes wrong
+	// once a family runs past the window: a taken letter reads as free and the UI offers to overwrite a real song.
 	std::vector<std::string> folder{"SONG185.XML"};
 	for (char c = 'A'; c <= 'L'; c++) {
 		folder.push_back(std::string{"SONG185"} + c + ".XML");

--- a/tests/unit/default_name_tests.cpp
+++ b/tests/unit/default_name_tests.cpp
@@ -12,68 +12,60 @@ using deluge::gui::browser::FileListView;
 using deluge::gui::browser::nextDefaultName;
 
 namespace {
-/// Stands in for the card. contains() can be narrowed to a window, the way Browser::fileItems is; highestNumberedName()
-/// always sees the whole folder, the way the firmware's directory scan does.
+/// Stands in for a folder on the card. Both queries mirror Browser::surveyNameVariations: a name only counts when its
+/// suffix runs to the extension, and only when that extension is one the browser lists. Diverging here would let a
+/// test pass on a name the firmware would skip.
 class FakeFileList : public FileListView {
 public:
 	explicit FakeFileList(std::vector<std::string> names) : names_{std::move(names)} {}
 
-	/// A folder whose file list, as contains() sees it, holds only the entries within `radius` sort positions of
-	/// `centre` - what the browser's 20-entry window leaves behind on a card with plenty of songs on it.
-	static FakeFileList windowed(std::vector<std::string> names, std::string const& centre, size_t radius) {
-		FakeFileList list{std::move(names)};
-		std::vector<std::string> sorted = list.names_;
-		std::sort(sorted.begin(), sorted.end(),
-		          [](std::string const& a, std::string const& b) { return strcmpspecial(a.c_str(), b.c_str()) < 0; });
-		auto at = std::find(sorted.begin(), sorted.end(), centre);
-		CHECK(at != sorted.end());
-		size_t centreIndex = at - sorted.begin();
-		for (size_t i = 0; i < sorted.size(); i++) {
-			size_t distance = i > centreIndex ? i - centreIndex : centreIndex - i;
-			if (distance <= radius) {
-				list.window_.push_back(sorted[i]);
-			}
-		}
-		list.windowed_ = true;
-		return list;
-	}
-
-	bool contains(char const* nameWithExtension) const override {
-		for (auto const& n : (windowed_ ? window_ : names_)) {
-			if (strcmpspecial(n.c_str(), nameWithExtension) == 0) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	std::string highestNumberedName(char const* prefix) const override {
 		std::string highest;
-		size_t prefixLength = strlen(prefix);
-		for (auto const& n : names_) {
-			if (n.size() <= prefixLength || strncasecmp(n.c_str(), prefix, prefixLength) != 0) {
-				continue;
+		forEachVariationOf(prefix, [&](std::string const& name, size_t suffixAt, size_t suffixEnd) {
+			for (size_t i = suffixAt; i < suffixEnd; i++) {
+				if (!std::isdigit(static_cast<unsigned char>(name[i]))) {
+					return;
+				}
 			}
-			// Mirrors Browser::highestNumberedFileName: digits must reach the extension, and the extension must be
-			// one the browser lists. Diverging here would let a test pass on a name the firmware would skip.
-			size_t pos = prefixLength;
-			while (pos < n.size() && std::isdigit(static_cast<unsigned char>(n[pos]))) {
-				pos++;
+			if (highest.empty() || strcmpspecial(name.c_str(), highest.c_str()) > 0) {
+				highest = name;
 			}
-			if (pos == prefixLength || (pos != n.size() && n[pos] != '.')) {
-				continue;
-			}
-			if (!hasListedExtension(n)) {
-				continue;
-			}
-			if (highest.empty() || strcmpspecial(n.c_str(), highest.c_str()) > 0) {
-				highest = n;
-			}
-		}
+		});
 		return highest;
 	}
 
+	uint32_t takenLetterSuffixes(char const* stem) const override {
+		uint32_t taken = 0;
+		forEachVariationOf(stem, [&](std::string const& name, size_t suffixAt, size_t suffixEnd) {
+			if (suffixEnd - suffixAt != 1) {
+				return;
+			}
+			char letter = std::toupper(static_cast<unsigned char>(name[suffixAt]));
+			if (letter >= 'A' && letter <= 'Z') {
+				taken |= 1U << (letter - 'A');
+			}
+		});
+		return taken;
+	}
+
 private:
+	/// Calls `consider(name, suffixAt, suffixEnd)` for every listed file whose name is `stem` plus a non-empty
+	/// suffix running to the extension.
+	template <typename Fn>
+	void forEachVariationOf(char const* stem, Fn&& consider) const {
+		size_t stemLength = strlen(stem);
+		for (auto const& name : names_) {
+			size_t dot = name.rfind('.');
+			if (dot == std::string::npos || dot <= stemLength || !hasListedExtension(name)) {
+				continue;
+			}
+			if (strncasecmp(name.c_str(), stem, stemLength) != 0) {
+				continue;
+			}
+			consider(name, stemLength, dot);
+		}
+	}
+
 	/// allowedFileExtensionsXML, as the song and preset browsers set it.
 	static bool hasListedExtension(std::string const& name) {
 		size_t dot = name.rfind('.');
@@ -85,8 +77,6 @@ private:
 	}
 
 	std::vector<std::string> names_;
-	std::vector<std::string> window_;
-	bool windowed_ = false;
 };
 
 /// A card holding SONG001.XML .. SONGnnn.XML, as a vanilla card looks.
@@ -154,28 +144,50 @@ TEST(DefaultNameTests, numericSuffixAdvances) {
 	CHECK_EQUAL(std::string{"MYTRACK 4"}, nextDefaultName("MYTRACK", "SONG", files));
 }
 
-// --- The file list is a window, so candidates must not be probed from one end -------------
+// --- Names are derived from the whole family, never by probing candidates one at a time ---
 
-TEST(DefaultNameTests, numericSuffixAdvancesEvenWhenLowSiblingsAreOutsideTheFileListWindow) {
+TEST(DefaultNameTests, numericSuffixAdvancesPastEleven) {
 	// The reported bug: a song saved as "<name> 11" proposed "<name> 2" and offered to overwrite the real second
-	// file. Nothing is wrong with the folder - it is contains() that cannot see that far. Browser::fileItems keeps
-	// only ~8 entries either side of the file being saved, and by 11 the "2" has dropped out of it, so probing
-	// upwards from 2 believed it was free. The break lands at exactly 11 on any card with more than 20 songs.
+	// file. Names were derived by testing "<name> 2", "<name> 3", ... against a windowed view of the folder, and by
+	// 11 the "2" had fallen outside that window and was reported free. Asking for the family's highest member
+	// instead leaves nothing for a window to hide.
 	std::vector<std::string> folder;
 	for (int32_t i = 1; i <= 11; i++) {
 		folder.push_back("MY PROJECT " + std::to_string(i) + ".XML");
 	}
-	auto files = FakeFileList::windowed(folder, "MY PROJECT 11.XML", 8);
-	CHECK(!files.contains("MY PROJECT 2.XML")); // The window really does hide it.
+	FakeFileList files{folder};
 	CHECK_EQUAL(std::string{"MY PROJECT 12"}, nextDefaultName("MY PROJECT 11", "SONG", files));
 }
 
+TEST(DefaultNameTests, letterSuffixAdvancesPastAWholeAlphabetOfVariations) {
+	// The same trap on the letter path: A, B, C ... were tested one at a time against that same windowed view, so
+	// with a dozen variations saved the later ones read as free and the UI offered to overwrite a real song.
+	std::vector<std::string> folder{"SONG185.XML"};
+	for (char c = 'A'; c <= 'L'; c++) {
+		folder.push_back(std::string{"SONG185"} + c + ".XML");
+	}
+	FakeFileList files{std::move(folder)};
+	CHECK_EQUAL(std::string{"SONG185M"}, nextDefaultName("SONG185", "SONG", files));
+}
+
+TEST(DefaultNameTests, letterSuffixesAreCaseInsensitive) {
+	// The card may hold either case; they are the same file to FatFS and must be the same variation here.
+	FakeFileList files{{"SONG185.XML", "song185a.xml"}};
+	CHECK_EQUAL(std::string{"SONG185B"}, nextDefaultName("SONG185", "SONG", files));
+}
+
+TEST(DefaultNameTests, aLongerSuffixIsNotALetterVariation) {
+	// "SONG185AB" is its own name, not the "A" variation of SONG185, so it must not make A look taken.
+	FakeFileList files{{"SONG185.XML", "SONG185AB.XML"}};
+	CHECK_EQUAL(std::string{"SONG185A"}, nextDefaultName("SONG185", "SONG", files));
+}
+
 TEST(DefaultNameTests, numericSuffixNeverGoesBelowTheNameBeingSavedOver) {
-	// If the folder scan cannot answer - a card error, say - the name we are saving over is still known to exist, so
-	// its own number floors the result. Without this floor an unanswered scan would send "MY PROJECT 11" back to 2.
+	// If the folder survey cannot answer - a card error, say - the name we are saving over is still known to exist,
+	// so its own number floors the result. Without this floor an unanswered survey would send "MY PROJECT 11" to 2.
 	class SilentFileList : public FileListView {
-		bool contains(char const*) const override { return false; }
 		std::string highestNumberedName(char const*) const override { return {}; }
+		uint32_t takenLetterSuffixes(char const*) const override { return 0; }
 	} files;
 	CHECK_EQUAL(std::string{"MY PROJECT 12"}, nextDefaultName("MY PROJECT 11", "SONG", files));
 }

--- a/tests/unit/default_name_tests.cpp
+++ b/tests/unit/default_name_tests.cpp
@@ -1,7 +1,10 @@
 #include "CppUTest/TestHarness.h"
 #include "gui/ui/browser/default_name.h"
 #include "util/name_compare.h"
+#include <algorithm>
+#include <cctype>
 #include <cstdio>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -9,12 +12,34 @@ using deluge::gui::browser::FileListView;
 using deluge::gui::browser::nextDefaultName;
 
 namespace {
-/// Stands in for Browser::fileItems.
+/// Stands in for the card. contains() can be narrowed to a window, the way Browser::fileItems is; highestNumberedName()
+/// always sees the whole folder, the way the firmware's directory scan does.
 class FakeFileList : public FileListView {
 public:
 	explicit FakeFileList(std::vector<std::string> names) : names_{std::move(names)} {}
+
+	/// A folder whose file list, as contains() sees it, holds only the entries within `radius` sort positions of
+	/// `centre` - what the browser's 20-entry window leaves behind on a card with plenty of songs on it.
+	static FakeFileList windowed(std::vector<std::string> names, std::string const& centre, size_t radius) {
+		FakeFileList list{std::move(names)};
+		std::vector<std::string> sorted = list.names_;
+		std::sort(sorted.begin(), sorted.end(),
+		          [](std::string const& a, std::string const& b) { return strcmpspecial(a.c_str(), b.c_str()) < 0; });
+		auto at = std::find(sorted.begin(), sorted.end(), centre);
+		CHECK(at != sorted.end());
+		size_t centreIndex = at - sorted.begin();
+		for (size_t i = 0; i < sorted.size(); i++) {
+			size_t distance = i > centreIndex ? i - centreIndex : centreIndex - i;
+			if (distance <= radius) {
+				list.window_.push_back(sorted[i]);
+			}
+		}
+		list.windowed_ = true;
+		return list;
+	}
+
 	bool contains(char const* nameWithExtension) const override {
-		for (auto const& n : names_) {
+		for (auto const& n : (windowed_ ? window_ : names_)) {
 			if (strcmpspecial(n.c_str(), nameWithExtension) == 0) {
 				return true;
 			}
@@ -22,8 +47,46 @@ public:
 		return false;
 	}
 
+	std::string highestNumberedName(char const* prefix) const override {
+		std::string highest;
+		size_t prefixLength = strlen(prefix);
+		for (auto const& n : names_) {
+			if (n.size() <= prefixLength || strncasecmp(n.c_str(), prefix, prefixLength) != 0) {
+				continue;
+			}
+			// Mirrors Browser::highestNumberedFileName: digits must reach the extension, and the extension must be
+			// one the browser lists. Diverging here would let a test pass on a name the firmware would skip.
+			size_t pos = prefixLength;
+			while (pos < n.size() && std::isdigit(static_cast<unsigned char>(n[pos]))) {
+				pos++;
+			}
+			if (pos == prefixLength || (pos != n.size() && n[pos] != '.')) {
+				continue;
+			}
+			if (!hasListedExtension(n)) {
+				continue;
+			}
+			if (highest.empty() || strcmpspecial(n.c_str(), highest.c_str()) > 0) {
+				highest = n;
+			}
+		}
+		return highest;
+	}
+
 private:
+	/// allowedFileExtensionsXML, as the song and preset browsers set it.
+	static bool hasListedExtension(std::string const& name) {
+		size_t dot = name.rfind('.');
+		if (dot == std::string::npos) {
+			return false;
+		}
+		std::string extension = name.substr(dot + 1);
+		return strcasecmp(extension.c_str(), "XML") == 0 || strcasecmp(extension.c_str(), "Json") == 0;
+	}
+
 	std::vector<std::string> names_;
+	std::vector<std::string> window_;
+	bool windowed_ = false;
 };
 
 /// A card holding SONG001.XML .. SONGnnn.XML, as a vanilla card looks.
@@ -89,6 +152,60 @@ TEST(DefaultNameTests, renamedSongGetsANumericSuffix) {
 TEST(DefaultNameTests, numericSuffixAdvances) {
 	FakeFileList files{{"MYTRACK.XML", "MYTRACK 2.XML", "MYTRACK 3.XML"}};
 	CHECK_EQUAL(std::string{"MYTRACK 4"}, nextDefaultName("MYTRACK", "SONG", files));
+}
+
+// --- The file list is a window, so candidates must not be probed from one end -------------
+
+TEST(DefaultNameTests, numericSuffixAdvancesEvenWhenLowSiblingsAreOutsideTheFileListWindow) {
+	// The reported bug: a song saved as "<name> 11" proposed "<name> 2" and offered to overwrite the real second
+	// file. Nothing is wrong with the folder - it is contains() that cannot see that far. Browser::fileItems keeps
+	// only ~8 entries either side of the file being saved, and by 11 the "2" has dropped out of it, so probing
+	// upwards from 2 believed it was free. The break lands at exactly 11 on any card with more than 20 songs.
+	std::vector<std::string> folder;
+	for (int32_t i = 1; i <= 11; i++) {
+		folder.push_back("MY PROJECT " + std::to_string(i) + ".XML");
+	}
+	auto files = FakeFileList::windowed(folder, "MY PROJECT 11.XML", 8);
+	CHECK(!files.contains("MY PROJECT 2.XML")); // The window really does hide it.
+	CHECK_EQUAL(std::string{"MY PROJECT 12"}, nextDefaultName("MY PROJECT 11", "SONG", files));
+}
+
+TEST(DefaultNameTests, numericSuffixNeverGoesBelowTheNameBeingSavedOver) {
+	// If the folder scan cannot answer - a card error, say - the name we are saving over is still known to exist, so
+	// its own number floors the result. Without this floor an unanswered scan would send "MY PROJECT 11" back to 2.
+	class SilentFileList : public FileListView {
+		bool contains(char const*) const override { return false; }
+		std::string highestNumberedName(char const*) const override { return {}; }
+	} files;
+	CHECK_EQUAL(std::string{"MY PROJECT 12"}, nextDefaultName("MY PROJECT 11", "SONG", files));
+}
+
+TEST(DefaultNameTests, numericSuffixCountsFromTheHighestSiblingNotTheLowestGap) {
+	// Gaps are left alone: a deleted "MYTRACK 3" must not be handed back to the next save, which would quietly
+	// overwrite it if the user restored it. This also keeps the answer independent of how much of the folder is in
+	// the window.
+	FakeFileList files{{"MYTRACK.XML", "MYTRACK 2.XML", "MYTRACK 5.XML"}};
+	CHECK_EQUAL(std::string{"MYTRACK 6"}, nextDefaultName("MYTRACK 2", "SONG", files));
+}
+
+TEST(DefaultNameTests, numericSuffixIgnoresSiblingsThatOnlyLookNumbered) {
+	// "MYTRACK NOTES.XML" shares the prefix but carries no number, so it must not be read as one.
+	FakeFileList files{{"MYTRACK.XML", "MYTRACK NOTES.XML"}};
+	CHECK_EQUAL(std::string{"MYTRACK 2"}, nextDefaultName("MYTRACK", "SONG", files));
+}
+
+TEST(DefaultNameTests, numericSuffixIgnoresDateSuffixedNeighbours) {
+	// "JAM 2024-01-05.XML" starts with "JAM " and a digit, but its number does not run to the extension, so it is a
+	// neighbour and not a member of the "JAM " family. Counted as one it would read as 2024 and send the next save
+	// to "JAM 2025". Date-suffixed names are common on real cards.
+	FakeFileList files{{"JAM 3.XML", "JAM 2024-01-05.XML"}};
+	CHECK_EQUAL(std::string{"JAM 4"}, nextDefaultName("JAM 3", "SONG", files));
+}
+
+TEST(DefaultNameTests, numericSuffixIgnoresFilesTheBrowserWouldNotList) {
+	// A stray "MYTRACK 99.TXT" is not a song and cannot be overwritten by one, so it must not push the count to 100.
+	FakeFileList files{{"MYTRACK 2.XML", "MYTRACK 99.TXT"}};
+	CHECK_EQUAL(std::string{"MYTRACK 3"}, nextDefaultName("MYTRACK 2", "SONG", files));
 }
 
 TEST(DefaultNameTests, existingUnderscoreDelimiterIsReused) {


### PR DESCRIPTION
Basically a replace the save-numbering-suffix stuff, for both OLED and 7SEG. Needs serious testing and potentially changes before merging, but _should_ fix the class of bugs.

Includes a bunch of unit tests so this doesn't happen again.