### PR TITLE
fix extraneous midi realtime messages on playback

### DIFF
--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -34,6 +34,7 @@
 #include "storage/smsysex.h"
 #include "timers_interrupts/timers_interrupts.h"
 #include "version.h"
+#include <algorithm>
 
 extern "C" {
 #include "RZA1/uart/sio_char.h"
@@ -439,11 +440,15 @@ void MidiEngine::sendAllNotesOff(MIDISource source, int32_t channel, int32_t fil
 	sendMidi(source, MIDIMessage::cc(channel, 123, 0), filter);
 }
 
+/// Saturate a value into the 7 bits a MIDI data byte gets. Callers derive these from internal 32-bit parameter values,
+/// which can land outside 0-127; letting one through sets bit 7 and the receiver reads it as a status byte instead - if
+/// it falls in 0xF8-0xFF that's a spurious System Real-Time message (see #4821).
+static uint8_t toDataByte(int32_t value) {
+	return static_cast<uint8_t>(std::clamp<int32_t>(value, 0, 127));
+}
+
 void MidiEngine::sendCC(MIDISource source, int32_t channel, int32_t cc, int32_t value, int32_t filter) {
-	if (value > 127) {
-		value = 127;
-	}
-	sendMidi(source, MIDIMessage::cc(channel, cc, value), filter);
+	sendMidi(source, MIDIMessage::cc(channel, cc, toDataByte(value)), filter);
 }
 
 void MidiEngine::sendClock(MIDISource source, bool sendUSB, int32_t howMany) {
@@ -486,13 +491,13 @@ void MidiEngine::sendPitchBend(MIDISource source, int32_t channel, uint16_t bend
 	sendMidi(source, MIDIMessage::pitchBend(channel, bend), filter);
 }
 
-void MidiEngine::sendChannelAftertouch(MIDISource source, int32_t channel, uint8_t value, int32_t filter) {
-	sendMidi(source, MIDIMessage::channelAftertouch(channel, value), filter);
+void MidiEngine::sendChannelAftertouch(MIDISource source, int32_t channel, int32_t value, int32_t filter) {
+	sendMidi(source, MIDIMessage::channelAftertouch(channel, toDataByte(value)), filter);
 }
 
-void MidiEngine::sendPolyphonicAftertouch(MIDISource source, int32_t channel, uint8_t value, uint8_t noteCode,
+void MidiEngine::sendPolyphonicAftertouch(MIDISource source, int32_t channel, int32_t value, uint8_t noteCode,
                                           int32_t filter) {
-	sendMidi(source, MIDIMessage::polyphonicAftertouch(channel, noteCode, value), filter);
+	sendMidi(source, MIDIMessage::polyphonicAftertouch(channel, noteCode, toDataByte(value)), filter);
 }
 
 void MidiEngine::sendMidi(MIDISource source, MIDIMessage message, int32_t filter, bool sendUSB) {

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -92,8 +92,10 @@ public:
 	///
 	/// @param bend Bend amount. Only the lower 14 bits are used
 	void sendPitchBend(MIDISource source, int32_t channel, uint16_t bend, int32_t filter);
-	void sendChannelAftertouch(MIDISource source, int32_t channel, uint8_t value, int32_t filter);
-	void sendPolyphonicAftertouch(MIDISource source, int32_t channel, uint8_t value, uint8_t noteCode, int32_t filter);
+	/// @param value Pressure amount. Saturated into 0-127
+	void sendChannelAftertouch(MIDISource source, int32_t channel, int32_t value, int32_t filter);
+	/// @param value Pressure amount. Saturated into 0-127
+	void sendPolyphonicAftertouch(MIDISource source, int32_t channel, int32_t value, uint8_t noteCode, int32_t filter);
 	bool anythingInOutputBuffer();
 	void setupUSBHostReceiveTransfer(int32_t ip, int32_t midiDeviceNum);
 	void flushUSBMIDIOutput();

--- a/src/deluge/modulation/automation/auto_param.cpp
+++ b/src/deluge/modulation/automation/auto_param.cpp
@@ -39,6 +39,8 @@
 #include "processing/engines/audio_engine.h"
 #include "storage/storage_manager.h"
 #include "util/functions.h"
+#include <algorithm>
+#include <cstdint>
 #include <math.h>
 
 #define SAMPLES_TO_CLEAR_AFTER_RECORD 8820          // 200ms
@@ -929,6 +931,14 @@ bool AutoParam::applyValueIncrement(int32_t value_increment) {
 	return (currentValue != oldValue);
 }
 
+/// multiplies a per-half-tick increment by a number of half ticks, clamping to the int32 range rather than wrapping.
+/// A steep increment (a short segment covering a big value change) times a large number of skipped ticks overflows an
+/// int32 easily, and a wrapped increment sends currentValue in the wrong direction entirely.
+static int32_t saturatingIncrement(int32_t incrementPerHalfTick, int64_t halfTicks) {
+	int64_t increment = (int64_t)incrementPerHalfTick * halfTicks;
+	return (int32_t)std::clamp<int64_t>(increment, INT32_MIN, INT32_MAX);
+}
+
 bool AutoParam::tickSamples(int32_t numSamples) {
 	// if we don't have any interpolation to apply, return false
 	if (!hasInterpolationIncrement()) {
@@ -939,9 +949,9 @@ bool AutoParam::tickSamples(int32_t numSamples) {
 
 	// non-float interpolation
 	if (valueIncrementPerHalfTick != 0) [[likely]] {
-		value_increment =
-		    multiply_32x32_rshift32_rounded(valueIncrementPerHalfTick, playbackHandler.getTimePerInternalTickInverse())
-		    * 6 * numSamples;
+		value_increment = saturatingIncrement(
+		    multiply_32x32_rshift32_rounded(valueIncrementPerHalfTick, playbackHandler.getTimePerInternalTickInverse()),
+		    (int64_t)6 * numSamples);
 	}
 	// float interpolation
 	else {
@@ -962,11 +972,11 @@ bool AutoParam::tickTicks(int32_t numTicks) {
 	}
 
 	int32_t value_increment = 0;
-	int32_t half_ticks = numTicks * 2;
+	int64_t half_ticks = (int64_t)numTicks * 2;
 
 	// non-float interpolation
 	if (valueIncrementPerHalfTick != 0) [[likely]] {
-		value_increment = valueIncrementPerHalfTick * half_ticks;
+		value_increment = saturatingIncrement(valueIncrementPerHalfTick, half_ticks);
 	}
 	// float interpolation
 	else {

--- a/src/deluge/modulation/params/param_manager.cpp
+++ b/src/deluge/modulation/params/param_manager.cpp
@@ -378,11 +378,20 @@ void ParamManagerForTimeline::processCurrentPos(ModelStackWithThreeMainThings* m
 
 		FOR_EACH_AUTOMATED_PARAM_COLLECTION_DEFINITELY_SOME_START
 
-		summary->paramCollection->processCurrentPos(modelStackWithParamCollection, ticksSkipped, reversed, didPingpong,
-		                                            true);
-		// if we can't interpolate by samples then we'll interpolate by ticks here instead
+		// If we can't interpolate by samples then we'll interpolate by ticks instead. This has to happen *before*
+		// processCurrentPos(), because that may reach a node and set up a new increment for the span we're about to
+		// begin - whereas the ticks we've skipped belong to the span we've just finished. Applying them to the new
+		// increment sends the value far past its target (a whole inter-node gap's worth of a few-tick ramp), which for
+		// MIDI output means expression values well outside 0-127.
 		if (!mayInterpolate && (summary->whichParamsAreInterpolating[0] != 0u)) {
 			summary->paramCollection->tickTicks(ticksSkipped, modelStackWithParamCollection);
+		}
+
+		summary->paramCollection->processCurrentPos(modelStackWithParamCollection, ticksSkipped, reversed, didPingpong,
+		                                            true);
+		// Re-check after processCurrentPos(): if a node has just started some interpolation, we need to come back every
+		// tick to advance it.
+		if (!mayInterpolate && (summary->whichParamsAreInterpolating[0] != 0u)) {
 			ticksTilNextEvent = 0;
 		}
 		ticksTilNextEvent = std::min(ticksTilNextEvent, summary->paramCollection->ticksTilNextEvent);


### PR DESCRIPTION
Basically a confluence of three bugs:
- an integer overflow
- lack of negative guards on the MIDI output
- interpolation ordering for skipped ticks in the param manager.

Edit: validated by original issue reporter as successful