### PR TITLE
fix: don't let empty note rows veto a clip transpose (#4823)

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1328,8 +1328,8 @@ bool InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
                                           ModelStackWithTimelineCounter* modelStack) {
 	// This method transposes every note row by up to an octave per call, currently
 	// used by the "hold and turn vertical encoder" and "shift + hold and turn
-	// vertical encoder" shortcuts. Returns false, changing nothing, if the transpose
-	// would push a note out of the playable range.
+	// vertical encoder" shortcuts. Returns false, changing nothing, if the clip holds no
+	// notes, or if the transpose would push one out of the playable range.
 
 	if (!direction) {
 		// It's not clear if we ever get "zero" as direction of change, but let's
@@ -1393,13 +1393,29 @@ bool InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 	// matching the limit that vertical scrolling enforces. We scan every row for the
 	// resulting extreme note rather than assuming the top/bottom row stays the extreme,
 	// because rows can shift by differing amounts.
+	//
+	// Only rows that actually hold notes get a vote, the same way the screen transpose
+	// picks its rows. An empty row is just grid state with no note to push anywhere, and
+	// songs written before this range check existed can carry empty rows far outside
+	// 0-127 (transposing used to be unbounded), where they would otherwise veto every
+	// transpose of the clip forever.
+	bool anyNotesFound = false;
 	int32_t extremeNewYNote = 0;
 	for (int32_t i = 0; i < numRows; i++) {
 		NoteRow* thisNoteRow = noteRows.getElement(i);
-		int32_t newYNote = thisNoteRow->y + shiftFor(thisNoteRow);
-		if (i == 0 || (change > 0 ? newYNote > extremeNewYNote : newYNote < extremeNewYNote)) {
-			extremeNewYNote = newYNote;
+		if (thisNoteRow->hasNoNotes()) {
+			continue;
 		}
+		int32_t newYNote = thisNoteRow->y + shiftFor(thisNoteRow);
+		if (!anyNotesFound || (change > 0 ? newYNote > extremeNewYNote : newYNote < extremeNewYNote)) {
+			extremeNewYNote = newYNote;
+			anyNotesFound = true;
+		}
+	}
+	// Nothing to transpose, and moving the rows and the scroll in step would be invisible
+	// anyway. Bail out rather than advance yScroll unbounded, as the empty-clip case above.
+	if (!anyNotesFound) {
+		return false;
 	}
 	if (!isScrollWithinRange(change, extremeNewYNote)) {
 		return false;
@@ -1408,9 +1424,20 @@ bool InstrumentClip::nudgeNotesVertically(int32_t direction, VerticalNudgeType t
 	// Make sure no notes sounding
 	stopAllNotesPlaying(modelStack);
 
-	for (int32_t i = 0; i < numRows; i++) {
+	for (int32_t i = 0; i < noteRows.getNumElements();) {
 		NoteRow* thisNoteRow = noteRows.getElement(i);
-		thisNoteRow->y += shiftFor(thisNoteRow);
+		int32_t newYNote = thisNoteRow->y + shiftFor(thisNoteRow);
+
+		// An empty row carried off the end of the note code range can never hold a note
+		// again, whatever the output type, so drop it rather than let it drift further
+		// out. That's what drains the stale rows described above.
+		if (thisNoteRow->hasNoNotes() && (newYNote < 0 || newYNote > kMaxMIDIValue)) {
+			noteRows.deleteNoteRowAtIndex(i);
+			continue;
+		}
+
+		thisNoteRow->y = newYNote;
+		i++;
 	}
 
 	yScroll += change;


### PR DESCRIPTION
The range guard added in #4661 scans every note row for the extreme destination, including empty ones. Songs written before that guard can carry empty rows far outside 0-127, because transposing used to be unbounded and only ever moved rows, never cleaned them up. 

Give only rows that hold notes a vote, the same way the screen transpose picks its rows, and drop empty rows that the transpose carries off the end of the note code range, so the stale ones drain away instead of drifting further out.