### PR TITLE
Fix "Startup fault F1" on every boot when startup song configured

### DIFF
--- a/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
+++ b/src/OSLikeStuff/task_scheduler/task_scheduler.cpp
@@ -226,6 +226,10 @@ void TaskManager::blockTask(TaskID id) {
 }
 
 void TaskManager::runTask(TaskID id) {
+	// runTask() can be entered while another task is mid-run (e.g. the audio task during an SD wait),
+	// so restore the caller's currentID on exit - otherwise yield() acts on the wrong task and a
+	// run-once task can be re-entered.
+	TaskID callerID = currentID;
 	countThisTask = true;
 	currentID = id;
 	auto* current_task = &list[currentID];
@@ -262,6 +266,7 @@ void TaskManager::runTask(TaskID id) {
 		}
 		lastFinishTime = timeNow;
 	}
+	currentID = callerID;
 }
 
 void TaskManager::runHighestPriTask() {


### PR DESCRIPTION
## Summary

With a startup song configured, the Deluge displays **"Startup fault F1" on every boot** — even though the song actually loads fine.

This happens because the SD card task loading the song doesn't finish before the audio task begins: the load waits on the SD card, the audio task runs nested inside that wait, and the scheduler's `currentID` is left pointing at the audio task instead of the still-running startup task. The scheduler then no longer knows the startup task is mid-run, starts it a second time, and the second run sees the crash-detection canary file the first run just wrote — which it reports as a startup fault.

The simplest fix is to store `currentID` when `runTask()` is entered and restore it on exit (two lines). This also covers any other run-once task that waits on the SD card, and keeps per-task timing stats attributed to the right task.

## Symptom

"Startup fault F1" on every boot with a startup song set; the song loads normally anyway, and no `__STARTUP_OFF_CHECK_*` canary file is left on the card.

## Testing

- Reproduced and verified on an OLED Deluge and under DelugEmu: without the fix the startup task runs twice and the F1 branch is taken; with the fix it runs once and the song loads cleanly.
- `./dbt build release` compiles and links cleanly.