### PR TITLE
Remove a memory leak on every boot with a startup song

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -476,7 +476,6 @@ void setupStartupSong() {
 			}
 		}
 		// Load song, if we got this far!
-		void* songMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(Song));
 		currentSong->setSongFullPath(filename);
 		if (openUI(&loadSongUI)) {
 			loadSongUI.performLoad();


### PR DESCRIPTION
## Summary

Every boot that loads a startup song (TEMPLATE / LASTOPENED / LASTSAVED mode) unnecessarily allocates a Song-sized block of RAM for the whole session, reducing headroom for voices and sample clusters.

The allocation in `setupStartupSong()` is simply dead code: the pointer is never used, null-checked, or freed — `performLoad()` does its own Song allocation when it actually creates the song. The fix is deleting the line.

## Testing

- Validated that saved songs still load fine on boot with this line removed on OLED Deluge and DelugEmu.
- `./dbt build release` compiles and links cleanly with the change.
