### PR TITLE
Fix dbt load fw issue on Mac + show configured screensaver while loading fw over sysex

### DIFF
--- a/scripts/tasks/util.py
+++ b/scripts/tasks/util.py
@@ -2,6 +2,7 @@ import fileinput
 import multiprocessing
 import os
 import shutil
+import site
 import subprocess
 import sys
 import sysconfig
@@ -11,8 +12,45 @@ from pathlib import Path
 
 
 def install_rtmidi():
+    for base in site.getsitepackages():
+        stale = Path(base) / "rtmidi"
+        if stale.exists():
+            if stale.is_dir():
+                shutil.rmtree(stale, ignore_errors=True)
+            else:
+                stale.unlink(missing_ok=True)
+
+    env = os.environ.copy()
+    cert = None
+    try:
+        import certifi
+
+        cert = certifi.where()
+    except (ImportError, AttributeError):
+        for candidate in (
+            "/etc/ssl/cert.pem",
+            "/etc/ssl/certs/ca-certificates.crt",
+            "/etc/pki/tls/certs/ca-bundle.crt",
+            "/private/etc/ssl/cert.pem",
+        ):
+            if os.path.exists(candidate):
+                cert = candidate
+                break
+    if cert:
+        env["SSL_CERT_FILE"] = cert
+        env["REQUESTS_CA_BUNDLE"] = cert
+
     subprocess.check_call(
-        [sys.executable, "-m", "pip", "install", "python-rtmidi==1.5.8"]
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-cache-dir",
+            "--force-reinstall",
+            "python-rtmidi==1.5.8",
+        ],
+        env=env,
     )
 
 

--- a/scripts/toolchain/dbtenv.sh
+++ b/scripts/toolchain/dbtenv.sh
@@ -390,8 +390,29 @@ dbtenv_main()
         export TERMINFO_DIRS="$TOOLCHAIN_ARCH_DIR/ncurses/share/terminfo";
     fi
 
-    export SSL_CERT_FILE=$(python3 -c 'import site; print(site.getsitepackages()[-1])')/certifi/cacert.pem
-    export REQUESTS_CA_BUNDLE="$SSL_CERT_FILE";
+    export SSL_CERT_FILE=$(python3 - <<'PY'
+import os
+try:
+    import certifi
+    print(certifi.where())
+except Exception:
+    for p in (
+        '/etc/ssl/cert.pem',
+        '/etc/ssl/certs/ca-certificates.crt',
+        '/etc/pki/tls/certs/ca-bundle.crt',
+        '/private/etc/ssl/cert.pem',
+    ):
+        if os.path.exists(p):
+            print(p)
+            break
+    else:
+        print('')
+PY
+)
+    if [ -z "$SSL_CERT_FILE" ]; then
+        unset SSL_CERT_FILE;
+    fi
+    export REQUESTS_CA_BUNDLE="${SSL_CERT_FILE:-$REQUESTS_CA_BUNDLE}";
 
     if [ -n "${DBT_DID_UNPACKING}" ]; then
       dbtenv_setup_python

--- a/scripts/toolchain/requirements.txt
+++ b/scripts/toolchain/requirements.txt
@@ -1,5 +1,6 @@
 certifi==2026.7.22
 setuptools==84.0.0
 pyserial==3.5
+python-rtmidi==1.5.8
 ansi==0.3.7
 pre-commit==4.6.2

--- a/src/deluge/io/midi/sysex.cpp
+++ b/src/deluge/io/midi/sysex.cpp
@@ -18,9 +18,11 @@
  */
 
 #include "io/midi/sysex.h"
+#include "hid/display/screensaver.h"
 #include "io/debug/print.h"
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_engine.h"
+#include "storage/flash_storage.h"
 #include "util/chainload.h"
 
 #include "util/pack.h"
@@ -125,6 +127,11 @@ static void firstPacket(uint8_t* data, int32_t len) {
 	PadLEDs::sendOutSidebarColours();
 	deluge::hid::display::OLED::clearMainImage();
 	deluge::hid::display::OLED::sendMainImage();
+
+	// Show the configured screensaver while the firmware payload is streaming in.
+	if (FlashStorage::screensaverMode != ScreensaverMode::OFF && ::display->haveOLED()) {
+		deluge::hid::display::Screensaver::timerEvent();
+	}
 
 	boostTask(midiEngine.routine_task_id);
 }


### PR DESCRIPTION
./dbt loadfw release wasn't working on my Mac so first commit fixed that

Second commit triggers the configured screensaver during firmware load. It looks really nice :)

