### PR TITLE
Fix USB host enumeration hang on string descriptor request (wLength=512)

### DIFF
--- a/src/RZA1/usb/r_usb_hmidi/src/inc/r_usb_hmidi.h
+++ b/src/RZA1/usb/r_usb_hmidi/src/inc/r_usb_hmidi.h
@@ -36,6 +36,10 @@
 
 #define USB_HMIDI_CLSDATASIZE (512)
 
+/* Largest possible string descriptor: bLength is a single byte, so 255. Requesting more than
+ * this hangs the control transfer on some device stacks (e.g. Disaster Area gen3 pedals). */
+#define USB_HMIDI_STRDESC_MAX_REQ (255)
+
 /* Host HID Task */                   // TODO: should these be changed if I re-introduce actual HID?
 #define USB_HMIDI_TSK (USB_TID_4)     /* Task ID */
 #define USB_HMIDI_MBX (USB_HMIDI_TSK) /* Mailbox ID */

--- a/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
+++ b/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
@@ -724,11 +724,7 @@ uint16_t usb_hmidi_get_string_desc(usb_utr_t* ptr, uint16_t addr, uint16_t strin
         usb_shmidi_class_request_setup[ptr->ip][2] = (uint16_t)(g_usb_hmidi_str_desc_data[ptr->ip][2]);
         usb_shmidi_class_request_setup[ptr->ip][2] |=
             (uint16_t)((uint16_t)(g_usb_hmidi_str_desc_data[ptr->ip][3]) << 8);
-        /* Request at most 255 bytes, not USB_HMIDI_CLSDATASIZE (512). String descriptors can't
-         * exceed 255 bytes anyway (bLength is one byte), only the first 32 characters get used,
-         * and some device stacks (e.g. Disaster Area gen3 pedals) hang the control transfer
-         * when wLength exceeds 255 - leaving the device permanently stuck mid-enumeration. */
-        usb_shmidi_class_request_setup[ptr->ip][3] = (uint16_t)255;
+        usb_shmidi_class_request_setup[ptr->ip][3] = (uint16_t)USB_HMIDI_STRDESC_MAX_REQ;
     }
     usb_shmidi_class_request_setup[ptr->ip][0] = (USB_GET_DESCRIPTOR | USB_DEV_TO_HOST | USB_STANDARD | USB_DEVICE);
     usb_shmidi_class_request_setup[ptr->ip][1] = (uint16_t)(USB_STRING_DESCRIPTOR + string);

--- a/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
+++ b/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
@@ -724,7 +724,11 @@ uint16_t usb_hmidi_get_string_desc(usb_utr_t* ptr, uint16_t addr, uint16_t strin
         usb_shmidi_class_request_setup[ptr->ip][2] = (uint16_t)(g_usb_hmidi_str_desc_data[ptr->ip][2]);
         usb_shmidi_class_request_setup[ptr->ip][2] |=
             (uint16_t)((uint16_t)(g_usb_hmidi_str_desc_data[ptr->ip][3]) << 8);
-        usb_shmidi_class_request_setup[ptr->ip][3] = (uint16_t)USB_HMIDI_CLSDATASIZE;
+        /* Request at most 255 bytes, not USB_HMIDI_CLSDATASIZE (512). String descriptors can't
+         * exceed 255 bytes anyway (bLength is one byte), only the first 32 characters get used,
+         * and some device stacks (e.g. Disaster Area gen3 pedals) hang the control transfer
+         * when wLength exceeds 255 - leaving the device permanently stuck mid-enumeration. */
+        usb_shmidi_class_request_setup[ptr->ip][3] = (uint16_t)255;
     }
     usb_shmidi_class_request_setup[ptr->ip][0] = (USB_GET_DESCRIPTOR | USB_DEV_TO_HOST | USB_STANDARD | USB_DEVICE);
     usb_shmidi_class_request_setup[ptr->ip][1] = (uint16_t)(USB_STRING_DESCRIPTOR + string);


### PR DESCRIPTION
## Summary

Fixes #4831.

Some USB MIDI devices (e.g. Disaster Area MIDI Baby gen3) hang the control transfer when the host requests a string descriptor with wLength > 255, stalling enumeration silently right after the LanguageID fetch. String descriptors can never exceed 255 bytes (`bLength` is a single byte), so the host now requests at most 255 instead of `USB_HMIDI_CLSDATASIZE` (512).

I made a constant for the value since the original source used a constant. And a comment for the why. Happy to simplify to just a 255 in-line if that is preferred.

## Testing

- Verified on hardware: MIDI Baby now enumerates and works; Arturia BeatStep and hubs unaffected.
- `./dbt build release` compiles and links cleanly.