### PR TITLE
enable fast math and some O3 options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,7 +154,7 @@ endif(DOXYGEN_FOUND)
 
 # Global compilation options
 add_compile_options(
-
+    -ffast-math
     # Feature flags
     -fdiagnostics-parseable-fixits
     -fsigned-char
@@ -166,8 +166,10 @@ add_compile_options(
     # Optimization level
     $<$<CONFIG:DEBUG>:-Og>
     $<$<CONFIG:RELEASE,RELWITHDEBINFO>:-O2>
+        $<$<CONFIG:RELEASE,RELWITHDEBINFO>:-fsplit-loops>
+        $<$<CONFIG:RELEASE,RELWITHDEBINFO>:-funswitch-loops>
 
-    # does not block inlining, just blocks considering all functions for inlining
+        # does not block inlining, just blocks considering all functions for inlining
     # https://developer.arm.com/documentation/100067/0600/Compiler-Command-line-Options/-finline-functions---fno-inline-functions?lang=en
     -fno-inline-functions
 

--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -476,7 +476,6 @@ void setupStartupSong() {
 			}
 		}
 		// Load song, if we got this far!
-		void* songMemory = GeneralMemoryAllocator::get().allocMaxSpeed(sizeof(Song));
 		currentSong->setSongFullPath(filename);
 		if (openUI(&loadSongUI)) {
 			loadSongUI.performLoad();


### PR DESCRIPTION
Worked through the O3 optimization options and confirmed that these are safe to enable on our code base. I had problems with tree vectorize and ipa-cp-clone increased bin size so I've left those out

Also remove an unused allocation 