### PR TITLE
MIDI Queue Manager

### DIFF
--- a/src/deluge/io/midi/cable_types/din.cpp
+++ b/src/deluge/io/midi/cable_types/din.cpp
@@ -15,12 +15,7 @@
  * If not, see <https://www.gnu.org/licenses/>.
  */
 
-extern "C" {
-#include "RZA1/uart/sio_char.h"
-}
-
 #include "din.h"
-#include "drivers/uart/uart.h"
 #include "gui/l10n/l10n.h"
 #include "io/midi/midi_engine.h"
 #include "storage/storage_manager.h"
@@ -43,18 +38,11 @@ void MIDICableDINPorts::sendMessage(MIDIMessage message) {
 }
 
 size_t MIDICableDINPorts::sendBufferSpace() const {
-	return uartGetTxBufferSpace(UART_ITEM_MIDI);
+	return midiEngine.serialSendBufferSpace();
 }
 
 void MIDICableDINPorts::sendSysex(const uint8_t* data, int32_t len) {
-	if (len < 3 || data[0] != 0xf0 || data[len - 1] != 0xf7) {
-		return;
-	}
-
-	// NB: beware of MIDI_TX_BUFFER_SIZE
-	for (int32_t i = 0; i < len; i++) {
-		bufferMIDIUart(data[i]);
-	}
+	midiEngine.sendSerialSysex(data, len);
 }
 
 bool MIDICableDINPorts::wantsToOutputMIDIOnChannel(MIDIMessage message, int32_t filter) const {

--- a/src/deluge/io/midi/cable_types/usb_common.cpp
+++ b/src/deluge/io/midi/cable_types/usb_common.cpp
@@ -16,7 +16,9 @@
  */
 
 #include "usb_common.h"
+#include "io/midi/midi_device_manager.h"
 #include "io/midi/midi_engine.h"
+#include "io/midi/midi_queue_manager.h"
 
 void MIDICableUSB::connectedNow(int32_t midiDeviceNum) {
 	connectionFlags |= (1 << midiDeviceNum);
@@ -39,14 +41,16 @@ void MIDICableUSB::sendMessage(MIDIMessage message) {
 
 	int32_t ip = 0;
 
-	uint32_t fullMessage = setupUSBMessage(message);
+	// Format the MIDI message as a USB-MIDI event with virtual cable 0.
+	uint32_t full_message = setupUSBMessage(message);
 
 	for (int32_t d = 0; d < MAX_NUM_USB_MIDI_DEVICES; d++) {
 		if (connectionFlags & (1 << d)) {
 			ConnectedUSBMIDIDevice* connectedDevice = &connectedUSBMIDIDevices[ip][d];
 			if (connectedDevice->canHaveMIDISent) {
-				uint32_t channeledMessage = fullMessage | (portNumber << 4);
-				connectedDevice->bufferMessage(fullMessage);
+				// Add this port's USB virtual cable number into event byte 0.
+				uint32_t usb_cable_message = full_message | (portNumber << 4);
+				connectedDevice->enqueue_message(usb_cable_message);
 			}
 		}
 	}
@@ -105,7 +109,7 @@ void MIDICableUSB::sendSysex(const uint8_t* data, int32_t len) {
 		// Since the message ends with 0xF7, we can assume that data[5] does exist.
 		// fake 0xF0, 0x7D, data[5] for first send
 		uint32_t packed = ((uint32_t)data[5] << 24) | 0x007DF004 | (portNumber << 4);
-		connectedDevice->bufferMessage(packed);
+		connectedDevice->enqueue_message(packed);
 		pos = 6;
 	}
 
@@ -130,7 +134,7 @@ void MIDICableUSB::sendSysex(const uint8_t* data, int32_t len) {
 		}
 		status |= (portNumber << 4);
 		uint32_t packed = ((uint32_t)byte2 << 24) | ((uint32_t)byte1 << 16) | ((uint32_t)byte0 << 8) | status;
-		connectedDevice->bufferMessage(packed);
+		connectedDevice->enqueue_message(packed);
 	}
 }
 

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -26,6 +26,7 @@
 #include "io/midi/device_specific/specific_midi_device.h"
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_engine.h"
+#include "io/midi/midi_queue_manager.h"
 #include "mem_functions.h"
 #include "memory/general_memory_allocator.h"
 #include "storage/storage_manager.h"
@@ -34,6 +35,7 @@
 #include <new>
 
 extern "C" {
+#include "RZA1/uart/sio_char.h"
 #include "RZA1/usb/r_usb_basic/src/driver/inc/r_usb_basic_define.h"
 #include "drivers/uart/uart.h"
 
@@ -47,6 +49,7 @@ extern uint8_t anyUSBSendingStillHappening[];
 #define MIDI_DEVICES_XML "SETTINGS/MIDIDevices.XML"
 
 PLACE_SDRAM_BSS ConnectedUSBMIDIDevice connectedUSBMIDIDevices[USB_NUM_USBIP][MAX_NUM_USB_MIDI_DEVICES];
+PLACE_SDRAM_BSS ConnectedDINMIDIDevice connectedDINMIDIDevice{};
 
 namespace MIDIDeviceManager {
 
@@ -658,69 +661,28 @@ checkDevice:
 
 } // namespace MIDIDeviceManager
 
-void ConnectedUSBMIDIDevice::bufferMessage(uint32_t fullMessage) {
-	uint32_t queued = ringBufWriteIdx - ringBufReadIdx;
-	if (queued > 16) {
-		if (!anyUSBSendingStillHappening[0]) {
-			midiEngine.flushUSBMIDIOutput();
-		}
-		queued = ringBufWriteIdx - ringBufReadIdx;
-	}
-	if (queued > MIDI_SEND_BUFFER_LEN_RING) {
-		// TODO: show some error message
-		return;
-	}
-
-	sendDataRingBuf[ringBufWriteIdx & MIDI_SEND_RING_MASK] = fullMessage;
-	ringBufWriteIdx++;
-
-	anythingInUSBOutputBuffer = true;
+/// Queues one USB-MIDI message, flushing or dropping if the queue cannot accept it.
+void ConnectedUSBMIDIDevice::enqueue_message(uint32_t fullMessage) {
+	queue_manager_.enqueue_message(fullMessage);
 }
 
+/// Returns whether this device has at least one queued USB-MIDI message to send.
 bool ConnectedUSBMIDIDevice::hasBufferedSendData() {
-	// must be the same unsigned type as ringBufWriteIdx/ringBufReadIdx
-	uint32_t queued = ringBufWriteIdx - ringBufReadIdx;
-	return queued > 0;
+	// True when at least one queued USB-MIDI message exists across any priority lane.
+	return queue_manager_.has_buffered_send_data();
 }
 
+/// Reports remaining USB queue capacity as MIDI payload bytes across all priority lanes.
 int ConnectedUSBMIDIDevice::sendBufferSpace() {
-	// must be the same unsigned type as ringBufWriteIdx/ringBufReadIdx
-	uint32_t queued = ringBufWriteIdx - ringBufReadIdx;
-	// each 4-byte MIDI-USB message contains 3 bytes of serial MIDI data
-	return (MIDI_SEND_BUFFER_LEN_RING - queued) * 3;
+	return queue_manager_.send_buffer_space();
 }
 
-// This tries to read data from the ring buffer, and
-// moves data into the smaller "dataSendingNow" buffer where
-// it is ready to be used by the hardware driver.
-bool ConnectedUSBMIDIDevice::consumeSendData() {
-	uint32_t queued = ringBufWriteIdx - ringBufReadIdx;
-	if (queued == 0) {
-		return false;
-	}
-
-	int32_t i = 0;
-	uint32_t max_size = MIDI_SEND_BUFFER_LEN_INNER;
-	if (g_usb_usbmode == USB_HOST) {
-		// many devices do not accept more than 64 bytes of data at a time
-		// likely this can be inferred from the device metadata somehow?
-
-		// some seem to take even less, especially with hubs involved. The hydrasynth seems to only respond to a max of
-		// 2 messages per transfer, the third gets blocked. For MPE this leads to ignoring note ons as the x and y
-		// resets are sent before the note on
-		max_size = MIDI_SEND_BUFFER_LEN_INNER_HOST;
-	}
-
-	int32_t to_send = std::min(queued, max_size);
-	for (i = 0; i < to_send; i++) {
-		memcpy(dataSendingNow + (i * 4), &sendDataRingBuf[ringBufReadIdx & MIDI_SEND_RING_MASK], 4);
-		ringBufReadIdx++;
-	}
-
-	numBytesSendingNow = to_send * 4;
-	return true;
+/// Moves queued USB messages into the contiguous transfer buffer used by the hardware driver.
+bool ConnectedUSBMIDIDevice::consume_queued_messages() {
+	return queue_manager_.consume_queued_messages(dataSendingNow, numBytesSendingNow, g_usb_usbmode == USB_HOST);
 }
 
+/// Resets volatile USB transfer state for a newly connected/initialized device.
 void ConnectedUSBMIDIDevice::setup() {
 	numBytesSendingNow = 0;
 	currentlyWaitingToReceive = false;
@@ -729,25 +691,50 @@ void ConnectedUSBMIDIDevice::setup() {
 	// default to only a single port
 	maxPortConnected = 0;
 }
+
+/// Initializes all USB device send/receive buffers and per-priority queue state.
 ConnectedUSBMIDIDevice::ConnectedUSBMIDIDevice() {
-	currentlyWaitingToReceive = 0;
 	sq = 0;
-	canHaveMIDISent = 0;
-	numBytesReceived = 0;
+	canHaveMIDISent = false;
+	setup();
 	memset(receiveData, 0, sizeof(receiveData));
 	memset(dataSendingNow, 0, MIDI_SEND_BUFFER_LEN_INNER * 4);
-	numBytesSendingNow = 0;
-	memset(sendDataRingBuf, 0, MIDI_SEND_BUFFER_LEN_RING);
-	ringBufWriteIdx = 0;
-	ringBufReadIdx = 0;
-
-	maxPortConnected = 0;
+	queue_manager_.reset_queue_storage();
 }
 
-/*
-    for (int32_t d = 0; d < hostedMIDIDevices.getNumElements(); d++) {
-        MIDIDeviceUSBHosted* device = (MIDIDeviceUSBHosted*)hostedMIDIDevices.getElement(d);
+/// Initializes DIN per-priority queue state.
+ConnectedDINMIDIDevice::ConnectedDINMIDIDevice() {
+	queue_manager_.reset_queue_storage();
+}
 
-    }
- */
+/// Resets serial pacing state so the next flush starts from a known baseline.
+void ConnectedDINMIDIDevice::reset_serial_state(uint32_t now_sample_timer) {
+	queue_manager_.reset_serial_state(now_sample_timer);
+}
+
+/// Returns whether any serial-priority lane currently has data pending.
+bool ConnectedDINMIDIDevice::has_serial_data() const {
+	return queue_manager_.has_serial_data();
+}
+
+/// Reports remaining DIN queue capacity for raw SysEx bytes.
+size_t ConnectedDINMIDIDevice::send_buffer_space() const {
+	return queue_manager_.send_buffer_space();
+}
+
+/// Encodes and enqueues one channel/system MIDI message into serial-priority lanes.
+void ConnectedDINMIDIDevice::enqueue_message(MIDIMessage message) {
+	queue_manager_.enqueue_message(message);
+}
+
+/// Queues one complete SysEx byte stream into serial-priority lanes.
+bool ConnectedDINMIDIDevice::enqueue_sysex(uint8_t const* data, int32_t len) {
+	return queue_manager_.enqueue_sysex(data, len);
+}
+
+/// Drains serial-priority queues into UART while enforcing DIN pacing and strict priority gates.
+void ConnectedDINMIDIDevice::consume_queued_messages(uint32_t now_sample_timer) {
+	queue_manager_.consume_queued_messages(now_sample_timer);
+}
+
 #pragma GCC diagnostic pop

--- a/src/deluge/io/midi/midi_device_manager.h
+++ b/src/deluge/io/midi/midi_device_manager.h
@@ -16,11 +16,14 @@
  */
 
 #pragma once
+#include "midi_queue_definitions.h"
 #ifdef __cplusplus
 #include "definitions_cxx.hpp"
 #include "io/midi/cable_types/din.h"
 #include "io/midi/cable_types/usb_common.h"
 #include "io/midi/cable_types/usb_device_cable.h"
+#include "io/midi/midi_queue_manager.h"
+#include "model/midi/message.h"
 #include "util/container/vector/named_thing_vector.h"
 class Serializer;
 class Deserializer;
@@ -30,24 +33,15 @@ class Deserializer;
 struct MIDICableUSB;
 #endif
 
-// size in 32-bit messages
-// NOTE: increasing this even more doesn't work.
-// Looks like a hardware limitation (maybe we more in FS mode)?
-#define MIDI_SEND_BUFFER_LEN_INNER 32
-// Seems to be the max for a hydrasynth on a usb hub? We should figure out how to find this from the device config but I
-// haven't seen anything below this yet. Widi bud's can do 3, both do fine at 16 without a hub involved
-#define MIDI_SEND_BUFFER_LEN_INNER_HOST 2
-
-// MUST be an exact power of two
-#define MIDI_SEND_BUFFER_LEN_RING 1024
-#define MIDI_SEND_RING_MASK (MIDI_SEND_BUFFER_LEN_RING - 1)
-
 #ifdef __cplusplus
-/*A ConnectedUSBMIDIDevice is used directly to interface with the USB driver
- * When a ConnectedUSBMIDIDevice has a numMessagesQueued>=MIDI_SEND_BUFFER_LEN and tries to add another,
- * all outputs are sent. The send routine calls the USB output function, points the
- * USB pipes FIFO buffer directly at the dataSendingNow array, and then sends.
- * Sends can also be triggered by the midiAndGateOutput interrupt
+/*
+ * A ConnectedUSBMIDIDevice is used directly to interface with the USB driver
+ * ConnectedUSBMIDIDevice holds per-device USB MIDI transfer state.
+ *
+ * Outgoing MIDI is queued in a private MIDIQueueManagerUSB, drained into
+ * dataSendingNow when a USB transfer starts, and sent with dataSendingNow as the
+ * USB pipe transfer buffer. Sends can also be triggered by the midiAndGateOutput
+ * interrupt.
  *
  * Reads are more complicated.
  * Actual reads are done by usb_cstd_usb_task, which has a commented out interrupt associated
@@ -62,12 +56,15 @@ class ConnectedUSBMIDIDevice {
 public:
 	MIDICableUSB* cable[4]; // If NULL, then no cable is connected here
 	ConnectedUSBMIDIDevice();
-	void bufferMessage(uint32_t fullMessage);
+	/// Classifies, optionally coalesces, and enqueues one outgoing MIDI message into USB priority lanes.
+	void enqueue_message(uint32_t fullMessage);
 	void setup();
-
-	// move data from ring buffer to dataSendingNow, assuming it is free
-	bool consumeSendData();
+	/// Drains queued USB messages into the hardware-send buffer.
+	bool consume_queued_messages();
+	/// Queue occupancy check (boolean form): true when any USB lane has queued output.
+	/// Conceptually matches DIN `has_serial_data()`.
 	bool hasBufferedSendData();
+	/// Remaining USB queue capacity reported as MIDI payload bytes.
 	int sendBufferSpace();
 #else
 // warning - accessed as a C struct from usb driver
@@ -88,17 +85,39 @@ struct ConnectedUSBMIDIDevice {
 	// This will show a value after the general flush function is called, throughout other Devices being sent to before
 	// this one, and until we've completed our send
 	uint8_t numBytesSendingNow;
-
-	// This is a ring buffer for data waiting to be sent which doesn't fit the smaller buffer above.
-	// Any code which wants to send midi data would use the writing side and append more messages.
-	// When we are ready to send data on this device, we consume data on the reading side and move it into the
-	// smaller dataSendingNow buffer above.
-	uint32_t sendDataRingBuf[MIDI_SEND_BUFFER_LEN_RING];
-	uint32_t ringBufWriteIdx;
-	uint32_t ringBufReadIdx;
-
 	uint8_t maxPortConnected;
+
+#ifdef __cplusplus
+
+private:
+	MIDIQueueManagerUSB queue_manager_{};
+#endif
 };
+
+#ifdef __cplusplus
+class ConnectedDINMIDIDevice {
+public:
+	ConnectedDINMIDIDevice();
+
+	/// Resets DIN pacing/allowance state to a known baseline at the provided sample timestamp.
+	/// Note: this does not clear queued DIN bytes.
+	void reset_serial_state(uint32_t now_sample_timer);
+	/// Queue occupancy check (boolean form): true when any DIN lane has queued output.
+	/// Conceptually matches USB `hasBufferedSendData()`.
+	[[nodiscard]] bool has_serial_data() const;
+	/// Remaining DIN queue capacity for raw SysEx bytes.
+	[[nodiscard]] size_t send_buffer_space() const;
+	/// Classifies, optionally coalesces, and enqueues one outgoing MIDI message into DIN priority lanes.
+	void enqueue_message(MIDIMessage message);
+	/// Queues one complete SysEx byte stream into DIN priority lanes.
+	bool enqueue_sysex(uint8_t const* data, int32_t len);
+	/// Drains queued DIN bytes into UART using send allowance, lane priorities, and CC gating.
+	void consume_queued_messages(uint32_t now_sample_timer);
+
+private:
+	MIDIQueueManagerDIN queue_manager_{};
+};
+#endif
 
 #ifdef __cplusplus
 namespace MIDIDeviceManager {
@@ -130,3 +149,6 @@ extern bool anyChangesToSave;
 #endif
 
 extern struct ConnectedUSBMIDIDevice connectedUSBMIDIDevices[][MAX_NUM_USB_MIDI_DEVICES];
+#ifdef __cplusplus
+extern ConnectedDINMIDIDevice connectedDINMIDIDevice;
+#endif

--- a/src/deluge/io/midi/midi_engine.cpp
+++ b/src/deluge/io/midi/midi_engine.cpp
@@ -26,6 +26,7 @@
 #include "io/midi/midi_device.h"
 #include "io/midi/midi_device_manager.h"
 #include "io/midi/midi_follow.h"
+#include "io/midi/midi_queue_manager.h"
 #include "io/midi/sysex.h"
 #include "mem_functions.h"
 #include "model/song/song.h"
@@ -87,7 +88,7 @@ void usbSendCompleteAsHost(int32_t ip) {
 	connectedDevice->numBytesSendingNow = 0; // We just do this instead from caller on A1 (see comment above)
 
 	// check if there was more to send on the same device, then resume sending
-	bool has_more = connectedDevice->consumeSendData();
+	bool has_more = connectedDevice->consume_queued_messages();
 	if (has_more) {
 		// TODO: do some cooperative scheduling here. so if there is a flood of data
 		// on connected device 1 and we just want to send a few notes on device 2,
@@ -154,7 +155,7 @@ void usbSendCompleteAsPeripheral(int32_t ip) {
 		return;
 	}
 
-	bool has_more = connectedDevice->consumeSendData();
+	bool has_more = connectedDevice->consume_queued_messages();
 	if (has_more) {
 		// this is already the case:
 		// anyUSBSendingStillHappening[ip] = 1;
@@ -166,8 +167,7 @@ void usbSendCompleteAsPeripheral(int32_t ip) {
 		                     connectedDevice->numBytesSendingNow);
 	}
 	else {
-		// this effectively serves as a lock, does the sending part of the device, including the read part of the
-		// ring buffer "belong" to ongoing/scheduled interrupts. Document this better.
+		// No queued follow-up transfer, so release the peripheral send-in-progress guard.
 		anyUSBSendingStillHappening[0] = 0;
 	}
 }
@@ -259,6 +259,8 @@ MidiEngine::MidiEngine() {
 	}
 
 	eventStackTop_ = eventStack_.begin();
+	// Start DIN pacing "now" and with no preloaded send allowance.
+	connectedDINMIDIDevice.reset_serial_state(AudioEngine::audioSampleTimer);
 }
 
 void flushUSBMIDIToHostedDevice(int32_t ip, int32_t d, bool resume) {
@@ -325,7 +327,7 @@ void MidiEngine::flushUSBMIDIOutput() {
 		if (aPeripheral) {
 			ConnectedUSBMIDIDevice* connectedDevice = &connectedUSBMIDIDevices[ip][0];
 
-			if (!connectedDevice->consumeSendData()) {
+			if (!connectedDevice->consume_queued_messages()) {
 				continue;
 			}
 
@@ -392,7 +394,7 @@ void MidiEngine::flushUSBMIDIOutput() {
 				ConnectedUSBMIDIDevice* connectedDevice = &connectedUSBMIDIDevices[ip][d];
 
 				if (connectedDevice->cable[0]) {
-					connectedDevice->consumeSendData();
+					connectedDevice->consume_queued_messages();
 				}
 				if (d == newStopSendingAfter) {
 					break;
@@ -415,7 +417,12 @@ getOut: {}
 }
 
 bool MidiEngine::anythingInOutputBuffer() {
-	return anythingInUSBOutputBuffer || (bool)uartGetTxBufferFullnessByItem(UART_ITEM_MIDI);
+	// Report pending outbound MIDI from all layers:
+	// 1) USB messages queued or an in-flight USB send that needs follow-up scheduling,
+	// 2) MidiQueueManager serial-priority lanes waiting to flush into UART, and
+	// 3) bytes already accepted by the UART TX FIFO but not yet transmitted.
+	return anythingInUSBOutputBuffer || connectedDINMIDIDevice.has_serial_data()
+	       || (bool)uartGetTxBufferFullnessByItem(UART_ITEM_MIDI);
 }
 
 void MidiEngine::sendNote(MIDISource source, bool on, int32_t note, uint8_t velocity, uint8_t channel, int32_t filter) {
@@ -550,9 +557,8 @@ uint32_t setupUSBMessage(MIDIMessage message) {
 
 void MidiEngine::sendUsbMidi(MIDIMessage message, int32_t filter) {
 	// TODO: Differentiate between ports on usb midi
-	bool isSystemMessage = message.isSystemMessage();
 
-	// formats message per USB midi spec on virtual cable 0
+	// Format the MIDI message as a USB-MIDI event with virtual cable 0.
 	uint32_t fullMessage = setupUSBMessage(message);
 	for (int32_t ip = 0; ip < USB_NUM_USBIP; ip++) {
 		int32_t potentialNumDevices = getPotentialNumConnectedUSBMIDIDevices(ip);
@@ -571,10 +577,9 @@ void MidiEngine::sendUsbMidi(MIDIMessage message, int32_t filter) {
 					// or if it's a message that this channel wants
 					if (connectedDevice->cable[p]->wantsToOutputMIDIOnChannel(message, filter)) {
 
-						// Or with the port to add the cable number to the full message. This
-						// is a bit hacky but it works
-						uint32_t channeled_message = fullMessage | (p << 4);
-						connectedDevice->bufferMessage(channeled_message);
+						// Add this port's USB virtual cable number into event byte 0.
+						uint32_t usb_cable_message = fullMessage | (p << 4);
+						connectedDevice->enqueue_message(usb_cable_message);
 					}
 				}
 			}
@@ -585,22 +590,21 @@ void MidiEngine::sendUsbMidi(MIDIMessage message, int32_t filter) {
 // Warning - this will sometimes (not always) be called in an ISR
 void MidiEngine::flushMIDI() {
 	flushUSBMIDIOutput();
+	// Drain prioritized DIN queues using the current audio-timer tick as the pacing clock.
+	connectedDINMIDIDevice.consume_queued_messages(AudioEngine::audioSampleTimer);
 	uartFlushIfNotSending(UART_ITEM_MIDI);
 }
 
 void MidiEngine::sendSerialMidi(MIDIMessage message) {
+	connectedDINMIDIDevice.enqueue_message(message);
+}
 
-	uint8_t statusByte = message.channel | (message.statusType << 4);
-	int32_t messageLength = bytesPerStatusMessage(statusByte);
-	bufferMIDIUart(statusByte);
+void MidiEngine::sendSerialSysex(uint8_t const* data, int32_t len) {
+	(void)connectedDINMIDIDevice.enqueue_sysex(data, len);
+}
 
-	if (messageLength >= 2) {
-		bufferMIDIUart(message.data1);
-
-		if (messageLength == 3) {
-			bufferMIDIUart(message.data2);
-		}
-	}
+size_t MidiEngine::serialSendBufferSpace() const {
+	return connectedDINMIDIDevice.send_buffer_space();
 }
 
 bool MidiEngine::checkIncomingSerialMidi() {

--- a/src/deluge/io/midi/midi_engine.h
+++ b/src/deluge/io/midi/midi_engine.h
@@ -83,6 +83,8 @@ public:
 	void flushMIDI();
 	void sendUsbMidi(MIDIMessage message, int32_t filter);
 	void sendSerialMidi(MIDIMessage message);
+	void sendSerialSysex(uint8_t const* data, int32_t len);
+	[[nodiscard]] size_t serialSendBufferSpace() const;
 
 	void sendPGMChange(MIDISource source, int32_t channel, int32_t pgm, int32_t filter);
 	void sendAllNotesOff(MIDISource source, int32_t channel, int32_t filter);

--- a/src/deluge/io/midi/midi_queue_definitions.h
+++ b/src/deluge/io/midi/midi_queue_definitions.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2026 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+enum QueueSendConstants {
+	// bfredl:
+	// size in 32-bit messages
+	// NOTE: increasing this even more doesn't work.
+	// Looks like a hardware limitation (maybe we more in FS mode)?
+	MIDI_SEND_BUFFER_LEN_INNER = 32,
+	// Mark Adams:
+	// Seems to be the max for a hydrasynth on a usb hub? We should figure out how to find this from the device config
+	// but I
+	// haven't seen anything below this yet. Widi bud's can do 3, both do fine at 16 without a hub involved
+	MIDI_SEND_BUFFER_LEN_INNER_HOST = 2,
+	// MUST be an exact power of two
+	MIDI_SEND_BUFFER_LEN_RING = 1024,
+	MIDI_SEND_RING_MASK = MIDI_SEND_BUFFER_LEN_RING - 1,
+};
+
+// Priority order is aligned with the LinnStrument ls_midi.ino strategy:
+// clock > notes > expression > CC > SysEx.
+// SysEx is lowest priority until it starts draining; once started, its transport
+// units remain contiguous until the terminating USB-MIDI event or DIN 0xF7 byte is sent.
+typedef enum QueuePriority {
+	QUEUE_PRIORITY_CLOCK = 0,
+	QUEUE_PRIORITY_NOTES = 1,
+	QUEUE_PRIORITY_EXPRESSION = 2,
+	QUEUE_PRIORITY_CC = 3,
+	QUEUE_PRIORITY_SYSEX = 4,
+	QUEUE_PRIORITY_COUNT = 5,
+} QueuePriority;

--- a/src/deluge/io/midi/midi_queue_manager.cpp
+++ b/src/deluge/io/midi/midi_queue_manager.cpp
@@ -1,0 +1,1107 @@
+/*
+ * Copyright © 2026 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "io/midi/midi_queue_manager.h"
+#include "io/midi/midi_engine.h"
+
+extern "C" {
+#include "RZA1/uart/sio_char.h"
+#include "drivers/uart/uart.h"
+
+extern uint8_t anyUSBSendingStillHappening[];
+}
+
+#include <algorithm>
+#include <cstring>
+
+/*
+ * MIDI Queue Manager Information
+ *
+ * This file contains shared queue policy plus USB and DIN transport queue managers.
+ * The queue managers are used by ConnectedUSBMIDIDevice and ConnectedDINMIDIDevice to stage outgoing messages for USB
+ * or DIN transfer.
+ */
+
+namespace {
+inline uint8_t status_byte(uint32_t packed) {
+	// In a packed USB-MIDI event, byte 1 is the MIDI status byte.
+	return static_cast<uint8_t>((packed >> 8) & 0xFF);
+}
+
+inline uint8_t data_1(uint32_t packed) {
+	// In a packed USB-MIDI event, byte 2 is MIDI data1.
+	return static_cast<uint8_t>((packed >> 16) & 0xFF);
+}
+
+inline uint8_t data_2(uint32_t packed) {
+	// In a packed USB-MIDI event, byte 3 is MIDI data2.
+	return static_cast<uint8_t>((packed >> 24) & 0xFF);
+}
+
+inline uint8_t usb_cin(uint32_t packed) {
+	// In a packed USB-MIDI event, the low nibble of byte 0 is the Code Index Number.
+	return static_cast<uint8_t>(packed & 0x0F);
+}
+
+inline uint32_t replace_data_2(uint32_t packed, uint8_t value) {
+	// Packed USB-MIDI event byte layout:
+	// byte 0 = cable/CIN
+	// byte 1 = MIDI status
+	// byte 2 = data1/CC number
+	// byte 3 = data2/value
+	//
+	// Preserve bytes 0-2 and replace only byte 3.
+	return (packed & 0x00FFFFFFu) | (static_cast<uint32_t>(value) << 24);
+}
+
+inline bool is_packed_channel_cc(uint32_t packed) {
+	// USB CC detection is based on the MIDI status byte inside the packed event.
+	return MIDIQueueManager::is_channel_cc_status_byte(status_byte(packed));
+}
+
+inline bool is_usb_sysex_event(uint32_t packed) {
+	// USB-MIDI SysEx events use CIN 0x4 for start/continue and 0x5..0x7 for endings.
+	uint8_t cin = usb_cin(packed);
+	return cin >= 0x4 && cin <= 0x7;
+}
+
+inline bool is_usb_sysex_end_event(uint32_t packed) {
+	// CIN 0x5, 0x6, and 0x7 terminate a USB-MIDI SysEx stream with 1, 2, or 3 bytes.
+	uint8_t cin = usb_cin(packed);
+	return cin >= 0x5 && cin <= 0x7;
+}
+
+// Shared constants for MIDI message lengths and SysEx start/end bytes.
+// The highest-priority DIN lane is drained one realtime/system byte at a time.
+constexpr int32_t k_midi_realtime_message_bytes = 1;
+// Channel voice messages are at most three serial bytes: status, data1, data2.
+constexpr int32_t k_midi_channel_message_max_bytes = 3;
+// DIN SysEx is queued as raw bytes and drains one serial byte at a time.
+constexpr int32_t k_midi_sysex_byte_count = 1;
+constexpr uint8_t k_midi_sysex_start_byte = 0xF0;
+constexpr uint8_t k_midi_sysex_end_byte = 0xF7;
+
+// USB queue constants.
+// USB-MIDI events are packed into a uint32_t with byte 0 in the lowest 8 bits:
+// byte 0 = cable/CIN, byte 1 = MIDI status, byte 2 = data1, byte 3 = data2.
+constexpr uint8_t k_usb_midi_event_packet_bytes = 4;
+// A USB-MIDI event can carry up to three MIDI payload bytes after the CIN/cable byte.
+constexpr uint8_t k_usb_midi_event_payload_bytes = 3;
+// When a USB device has more than this many queued messages, opportunistically
+// trigger a flush to keep latency bounded during bursts.
+constexpr uint32_t k_usb_flush_backlog_message_threshold = 16;
+// Maximum number of lowest-priority CC messages staged in one USB transfer. This
+// lets later clock/note/expression traffic preempt dense automation sooner.
+constexpr int32_t k_usb_cc_message_allowance_per_transfer = 8;
+
+// DIN serial pacing constants.
+// DIN pacing uses Q8 fixed-point bytes so fractional send allowance can accrue
+// smoothly between audio callbacks.
+constexpr int32_t k_serial_allowance_fraction_bits = 8;
+constexpr int32_t k_serial_allowance_fraction_scale = 1 << k_serial_allowance_fraction_bits;
+// DIN link throughput in Q8 fixed-point bytes/second (31.25 kbps ~= 3125 bytes/s).
+constexpr int32_t k_serial_bytes_per_second_Q8 = 3125 * k_serial_allowance_fraction_scale;
+// Maximum accumulated send allowance (Q8 bytes) allowed for one burst after idle time.
+constexpr int32_t k_serial_send_allowance_max_Q8 = MIDI_TX_BUFFER_SIZE * k_serial_allowance_fraction_scale;
+// Reserve some UART TX space so we do not fill the hardware buffer to the edge.
+constexpr int32_t k_serial_uart_headroom_bytes = 16;
+// Limit how much lowest-priority CC traffic can be staged ahead in the DIN UART buffer.
+// This keeps dense CC bursts from sitting on the wire ahead of later clock or note bytes
+// even when the software queues themselves are draining cleanly.
+constexpr int32_t k_serial_buffered_cc_bytes_cap = 24;
+
+} // namespace
+
+/// Classifies an outgoing MIDI message into shared queue priorities.
+QueuePriority MIDIQueueManager::classify_message(MIDIMessage message) {
+	if (message.isSystemMessage()) {
+		// Keep system/realtime messages in the highest-priority lane.
+		return QUEUE_PRIORITY_CLOCK;
+	}
+
+	switch (static_cast<MIDIStatusType>(message.statusType)) {
+	case MIDIStatusType::NoteOff:
+	case MIDIStatusType::NoteOn:
+		// Note on/off events are timing-sensitive, but below clock/system messages.
+		return QUEUE_PRIORITY_NOTES;
+
+	case MIDIStatusType::PolyphonicAftertouch:
+	case MIDIStatusType::ChannelAftertouch:
+	case MIDIStatusType::PitchBend:
+		// Expression data is important for feel, but can sit behind notes.
+		return QUEUE_PRIORITY_EXPRESSION;
+
+	case MIDIStatusType::ControlChange:
+		if (message.data1 == CC_EXTERNAL_MOD_WHEEL || message.data1 == CC_EXTERNAL_MPE_Y) {
+			// Mod wheel and MPE Y-axis are expressive CCs that should be prioritized above other CCs.
+			return QUEUE_PRIORITY_EXPRESSION;
+		}
+		// Other CC traffic is the lowest-priority channel voice traffic.
+		return QUEUE_PRIORITY_CC;
+
+	default:
+		// Unknown/non-note channel messages are safest in the lowest channel lane.
+		return QUEUE_PRIORITY_CC;
+	}
+}
+
+/* MIDI Queue Manager USB Transport
+ *
+ * This class manages a per-device USB-MIDI queue with multiple priority lanes.
+ * It is used by ConnectedUSBMIDIDevice to stage outgoing messages for USB transfer.
+ *
+ * When a USB send transaction starts, the ConnectedUSBMIDIDevice calls into this queue manager
+ * to consume queued messages and fill the transfer buffer. The transfer buffer is then sent
+ * to the device via the USB driver.
+ *
+ * After a USB send transaction completes, the ConnectedUSBMIDIDevice may call into this
+ * queue manager again to consume more queued messages if any remain.
+ *
+ * Priority lanes are drained in strict order: clock > notes > expression > CC > SysEx.
+ *
+ * CC messages may be coalesced into an existing queued entry instead of appended,
+ * to avoid sending stale values when a later message has already superseded it.
+ *
+ * The queue manager also tracks whether a SysEx stream is active, and keeps draining
+ * only SysEx events until the terminating event is sent. This prevents interleaving
+ * other MIDI traffic into a SysEx stream that may be split across multiple transfers.
+ *
+ * The queue manager does not handle USB transfer logic or callbacks; it only manages
+ * the queued messages and their priorities. The ConnectedUSBMIDIDevice class handles
+ * the actual USB send transactions and calls into this queue manager to get the next
+ * messages to send.
+ *
+ * Message queueing flow (Normal messages):
+ * Source
+ *  -> MIDIMessage
+ *  -> MIDICableUSB::sendMessage or MidiEngine::sendUsbMidi
+ *  -> setupUSBMessage
+ *  -> add virtual cable number
+ *  -> ConnectedUSBMIDIDevice::enqueue_message
+ *  -> MIDIQueueManagerUSB::enqueue_message
+ *  -> classify_packed_usb_priority
+ *  -> message is queued into correct priority lane
+ *
+ * Message queuing flow (SysEx messages):
+ * Source
+ *  -> SysEx bytes
+ *  -> MIDICableUSB::sendSysex
+ *  -> USB-MIDI event chunks
+ *  -> ConnectedUSBMIDIDevice::enqueue_message
+ *  -> MIDIQueueManagerUSB::enqueue_message
+ *  -> message is queued into QUEUE_PRIORITY_SYSEX priority lane
+ *
+ * Message sending flow:
+ * MidiEngine::flushMIDI
+ *   -> MidiEngine::flushUSBMIDIOutput
+ *   -> ConnectedUSBMIDIDevice::consume_queued_messages
+ *   -> MIDIQueueManagerUSB::consume_queued_messages
+ *   -> message is drained into dataSendingNow buffer in priority order
+ *   -> usb_send_start_rohan sends the dataSendingNow buffer to the connected USB device
+
+ * usbSendCompleteAsHost / usbSendCompleteAsPeripheral
+ *   -> ConnectedUSBMIDIDevice::consume_queued_messages
+ *   -> MIDIQueueManagerUSB::consume_queued_messages
+ *   -> any remaining queued messages are drained into dataSendingNow buffer in priority order
+ *   -> usb_send_start_rohan sends the dataSendingNow buffer to the connected USB device
+ */
+
+/// Resets all USB per-priority queues and CC scheduling bookkeeping.
+void MIDIQueueManagerUSB::reset_queue_storage() {
+	queue_manager_.clear_all();
+	sysex_drain_active_ = false;
+}
+
+bool MIDIQueueManagerUSB::has_buffered_send_data() const {
+	// True when at least one queued USB message exists across any priority lane.
+	return queue_manager_.total_queued_messages() > 0;
+}
+
+int MIDIQueueManagerUSB::send_buffer_space() const {
+	// Total queued USB messages currently buffered across all priority lanes.
+	uint32_t queued = queue_manager_.total_queued_messages();
+	// Maximum messages we can queue: usable slots per lane (ring-1) times number of lanes.
+	uint32_t total_capacity_messages = (MIDI_SEND_BUFFER_LEN_RING - 1) * QUEUE_PRIORITY_COUNT;
+	// Can't queue anymore: return 0 bytes of remaining capacity.
+	if (queued >= total_capacity_messages) {
+		return 0;
+	}
+
+	// Each 4-byte USB-MIDI event contains up to 3 bytes of MIDI payload.
+	// Report remaining capacity by payload bytes, not by 4-byte USB event slots.
+	return (total_capacity_messages - queued) * k_usb_midi_event_payload_bytes;
+}
+
+QueuePriority MIDIQueueManagerUSB::classify_packed_usb_priority(uint32_t packed) {
+	if (is_usb_sysex_event(packed)) {
+		// SysEx USB-MIDI events use CIN 0x4..0x7 and are already chunked by the caller.
+		return QUEUE_PRIORITY_SYSEX;
+	}
+
+	// Non-SysEx events are classified by decoding the MIDI status/data bytes.
+	uint8_t status = status_byte(packed);
+	MIDIMessage decoded{
+	    .statusType = static_cast<uint8_t>((status >> 4) & 0x0F),
+	    .channel = static_cast<uint8_t>(status & 0x0F),
+	    .data1 = data_1(packed),
+	    .data2 = data_2(packed),
+	};
+	return MIDIQueueManager::classify_message(decoded);
+}
+
+void MIDIQueueManagerUSB::enqueue_message(uint32_t full_message) {
+	// Total messages currently queued across all priority lanes for this device.
+	uint32_t queued = queue_manager_.total_queued_messages();
+	// If backlog grows, opportunistically kick a flush to keep latency bounded.
+	if (queued > k_usb_flush_backlog_message_threshold) {
+		// Only trigger a new flush when a send transaction is not already active.
+		if (anyUSBSendingStillHappening[0] == 0) {
+			midiEngine.flushUSBMIDIOutput();
+		}
+	}
+
+	// Determine which priority lane this packed USB-MIDI event belongs to.
+	QueuePriority priority = classify_packed_usb_priority(full_message);
+	// Occupancy of just the selected priority lane we are about to enqueue into.
+	uint16_t queue_size = queue_manager_.queue_count(static_cast<uint8_t>(priority));
+	// Keep one slot free in each ring so full/empty states stay distinguishable.
+	if (queue_size >= (MIDI_SEND_BUFFER_LEN_RING - 1)) {
+		// If nothing is currently transmitting, try flushing now to free space.
+		if (anyUSBSendingStillHappening[0] == 0) {
+			midiEngine.flushUSBMIDIOutput();
+		}
+		// Re-check after opportunistic flush.
+		queue_size = queue_manager_.queue_count(static_cast<uint8_t>(priority));
+		if (queue_size >= (MIDI_SEND_BUFFER_LEN_RING - 1)) {
+			// Still full: drop this message rather than overwrite unread queued data.
+			// TODO: show some error message
+			return;
+		}
+	}
+
+	// CC messages may be coalesced into an existing queued entry instead of appended.
+	bool queued_ok = enqueue_message_with_cc_policy(priority, full_message);
+
+	// Signal that at least one USB message is waiting so flush logic can schedule transmission.
+	if (queued_ok) {
+		anythingInUSBOutputBuffer = true;
+	}
+}
+
+/// Drains queued USB messages into the smaller `dataSendingNow` transfer buffer.
+bool MIDIQueueManagerUSB::consume_queued_messages(uint8_t* data_sending_now, uint8_t& num_bytes_sending_now,
+                                                  bool usb_host_mode) {
+	// Snapshot total queued messages across all priority lanes.
+	uint32_t queued = queue_manager_.total_queued_messages();
+	if (queued == 0) {
+		// Nothing pending: caller should not start a USB send transfer.
+		return false;
+	}
+
+	int32_t i = 0;
+	// bfredl:
+	// many devices do not accept more than 64 bytes of data at a time
+	// likely this can be inferred from the device metadata somehow?
+
+	// Mark Adams:
+	// some seem to take even less, especially with hubs involved. The hydrasynth seems to only respond to a max of
+	// 2 messages per transfer, the third gets blocked. For MPE this leads to ignoring note ons as the x and y
+	// resets are sent before the note on
+	uint32_t max_size = usb_host_mode ? MIDI_SEND_BUFFER_LEN_INNER_HOST : MIDI_SEND_BUFFER_LEN_INNER;
+	// Build at most one USB transfer worth of messages: no more than queued, and no more than the mode/device cap.
+	int32_t to_send = std::min<uint32_t>(queued, max_size);
+	// Keep CC bursts bounded per transfer so fresh clock/notes can preempt sooner.
+	int32_t cc_allowance_messages_remaining = k_usb_cc_message_allowance_per_transfer;
+	// Serialize `to_send` prioritized 4-byte USB messages into dataSendingNow.
+	for (i = 0; i < to_send; i++) {
+		uint32_t message = 0;
+		// Pull one prioritized USB message from the multi-lane ring queues.
+		USBSendContext context{message, cc_allowance_messages_remaining};
+		bool popped = false;
+
+		// Once a USB SysEx stream has started, keep draining only SysEx events
+		// until the terminating CIN is sent. USB transfer-size limits may split
+		// the stream across transfers, but other MIDI must not be interleaved.
+		if (sysex_drain_active_) {
+			popped = pop_sysex_message(context);
+			if (!popped) {
+				// Defensive recovery for malformed/truncated queue state: avoid
+				// permanently blocking other lanes if the SysEx lane ran dry.
+				sysex_drain_active_ = false;
+			}
+		}
+
+		if (popped) {
+			// Active SysEx already supplied this transfer slot, so copy it out
+			// and skip normal priority scanning to avoid interleaving other MIDI.
+			memcpy(data_sending_now + (i * k_usb_midi_event_packet_bytes), &message, k_usb_midi_event_packet_bytes);
+			continue;
+		}
+
+		// Scan lanes from highest to lowest priority and take one message from the first eligible lane.
+		for (uint8_t lane = static_cast<uint8_t>(QUEUE_PRIORITY_CLOCK);
+		     lane < static_cast<uint8_t>(QUEUE_PRIORITY_COUNT); lane++) {
+			QueuePriority priority = static_cast<QueuePriority>(lane);
+			if (!queue_manager_.queue_count(static_cast<uint8_t>(priority))) {
+				// Empty lanes cannot contribute to this transfer slot.
+				continue;
+			}
+
+			if (priority == QUEUE_PRIORITY_CC) {
+				auto cc_result = handle_cc_lane(priority, context);
+				if (cc_result == MIDIQueueManager::PriorityLaneTraversalResult::Popped) {
+					// The CC scheduler selected and removed a CC from somewhere in the lane.
+					popped = true;
+					break;
+				}
+				if (cc_result == MIDIQueueManager::PriorityLaneTraversalResult::Abort) {
+					// The CC lane cannot safely provide a message right now.
+					break;
+				}
+				if (cc_result == MIDIQueueManager::PriorityLaneTraversalResult::SkipLane) {
+					// Leave CC untouched for this transfer slot and continue traversal.
+					continue;
+				}
+				if (cc_result != MIDIQueueManager::PriorityLaneTraversalResult::PopLane) {
+					// Unknown traversal result: do not pop this lane.
+					continue;
+				}
+			}
+
+			bool lane_popped =
+			    priority == QUEUE_PRIORITY_SYSEX ? pop_sysex_message(context) : pop_lane(priority, context);
+			if (lane_popped) {
+				// Lane pop succeeded; this transfer slot is filled.
+				popped = true;
+				break;
+			}
+		}
+		if (!popped) {
+			// Queue state changed unexpectedly (or became empty); stop assembling this transfer.
+			break;
+		}
+		// Pack each 32-bit USB-MIDI event contiguously for the driver DMA/transfer buffer.
+		memcpy(data_sending_now + (i * k_usb_midi_event_packet_bytes), &message, k_usb_midi_event_packet_bytes);
+	}
+
+	// `i` is the number of USB messages assembled, each encoded USB-MIDI event is 4 bytes.
+	num_bytes_sending_now = static_cast<uint8_t>(i * k_usb_midi_event_packet_bytes);
+
+	// Tell caller whether we assembled at least one message to transmit.
+	return i > 0;
+}
+
+bool MIDIQueueManagerUSB::pop_lane(QueuePriority priority, USBSendContext& context) {
+	// USB queue entries are already complete USB-MIDI events, so one pop is one message.
+	return queue_manager_.pop_head(static_cast<uint8_t>(priority), context.message_out);
+}
+
+bool MIDIQueueManagerUSB::pop_sysex_message(USBSendContext& context) {
+	if (!pop_lane(QUEUE_PRIORITY_SYSEX, context)) {
+		return false;
+	}
+
+	// The SysEx lane only contains USB-MIDI SysEx events. CIN 0x4 means the
+	// logical SysEx continues; CIN 0x5..0x7 means this event terminates it.
+	sysex_drain_active_ = !is_usb_sysex_end_event(context.message_out);
+	return true;
+}
+
+/* **************************************************************** */
+/* USB MIDI CC specific queuing and scheduling functions start here */
+/* **************************************************************** */
+
+bool MIDIQueueManagerUSB::enqueue_message_with_cc_policy(QueuePriority priority, uint32_t queued_message) {
+	// For CC messages, first try to update an already-queued message for the same
+	// status/CC number. If this succeeds, no new queue entry is needed.
+	if (priority == QUEUE_PRIORITY_CC && coalesce_cc_message(queued_message)) {
+		return true;
+	}
+
+	// Otherwise append the message to its priority lane as normal.
+	bool queued_ok = enqueue_priority_message(priority, queued_message);
+	if (queued_ok && priority == QUEUE_PRIORITY_CC && is_packed_channel_cc(queued_message)) {
+		// Record that this CC number has unsent work so scheduled dequeue can prefer it.
+		queue_manager_.bump_cc_debt(data_1(queued_message));
+	}
+	return queued_ok;
+}
+
+bool MIDIQueueManagerUSB::coalesce_cc_message(uint32_t queued_message) {
+	if (!is_packed_channel_cc(queued_message)) {
+		// Only channel CC messages participate in value coalescing.
+		return false;
+	}
+
+	// Coalescing only updates the value byte. Cable/CIN, status, channel, and
+	// CC number stay in the original queue position.
+	uint8_t wanted_status = status_byte(queued_message);
+	uint8_t wanted_cc_number = data_1(queued_message);
+	auto begin_scan = [this](uint16_t& scan_position, uint16_t& limit) {
+		// Initialize a USB CC-lane scan and report how many queued events it can inspect.
+		return begin_cc_message_scan(scan_position, limit);
+	};
+	auto next_scan = [this](uint16_t& scan_position, uint16_t limit, uint16_t& candidate_offset, uint8_t& status,
+	                        uint8_t& cc_number) {
+		// Read the next USB event and adapt it into the generic coalescing result shape.
+		MIDIQueueManager::CCMessageScanEntry message{};
+		return MIDIQueueManager::adapt_cc_coalesce_scan_result(next_cc_message(scan_position, limit, message), message,
+		                                                       candidate_offset, status, cc_number);
+	};
+	auto update_matched = [this, queued_message](uint16_t latest_offset) {
+		// Replace only the queued value byte at the matching offset.
+		uint32_t current = queue_manager_.read_at(static_cast<uint8_t>(QUEUE_PRIORITY_CC), latest_offset);
+		queue_manager_.overwrite_at(static_cast<uint8_t>(QUEUE_PRIORITY_CC), latest_offset,
+		                            replace_data_2(current, data_2(queued_message)));
+	};
+
+	// The shared policy scans for the latest matching CC and calls update_matched if found.
+	return queue_manager_.coalesce_latest_matching_cc(wanted_status, wanted_cc_number, begin_scan, next_scan,
+	                                                  update_matched);
+}
+
+bool MIDIQueueManagerUSB::enqueue_priority_message(QueuePriority priority, uint32_t queued_message) {
+	// Append the packed event to the selected priority lane.
+	return queue_manager_.push(static_cast<uint8_t>(priority), queued_message);
+}
+
+MIDIQueueManager::PriorityLaneTraversalResult MIDIQueueManagerUSB::handle_cc_lane(QueuePriority priority,
+                                                                                  USBSendContext& context) {
+	// Decide whether the CC lane head needs scheduler handling.
+	uint32_t head_message = queue_manager_.head(static_cast<uint8_t>(priority));
+	auto pop_scheduled_cc = [this](uint32_t& message_out) { return pop_next_scheduled_cc_message(message_out); };
+	auto cc_result = MIDIQueueManager::try_pop_scheduled_cc(is_packed_channel_cc(head_message),
+	                                                        context.cc_allowance_messages_remaining > 0,
+	                                                        pop_scheduled_cc, context.message_out);
+	if (cc_result == MIDIQueueManager::CCScheduledPopResult::Popped) {
+		// Count only scheduled CC pops against the per-transfer CC allowance.
+		context.cc_allowance_messages_remaining--;
+		return MIDIQueueManager::PriorityLaneTraversalResult::Popped;
+	}
+	if (cc_result == MIDIQueueManager::CCScheduledPopResult::NotCC) {
+		// A non-CC message in the CC lane can use normal head popping.
+		return MIDIQueueManager::PriorityLaneTraversalResult::PopLane;
+	}
+	// Allowance exhaustion or pop failure means this lane should not emit now.
+	return MIDIQueueManager::PriorityLaneTraversalResult::SkipLane;
+}
+
+bool MIDIQueueManagerUSB::pop_next_scheduled_cc_message(uint32_t& message_out) {
+	// The generic CC policy owns selection order; USB supplies message-level scan
+	// and removal callbacks so this mirrors the DIN scheduled-pop path.
+	auto begin_scan = [this](uint16_t& scan_position, uint16_t& limit) {
+		// Initialize a USB CC-lane scan and report how many queued events it can inspect.
+		return begin_cc_message_scan(scan_position, limit);
+	};
+	auto next_scan = [this](uint16_t& scan_position, uint16_t limit, uint16_t& candidate_offset, uint8_t& cc_number) {
+		// Read the next USB event and adapt it into the generic scheduler result shape.
+		MIDIQueueManager::CCMessageScanEntry message{};
+		return MIDIQueueManager::adapt_cc_candidate_scan_result(next_cc_message(scan_position, limit, message), message,
+		                                                        candidate_offset, cc_number);
+	};
+	auto remove_selected = [this](uint16_t target_offset, uint32_t& popped_out) {
+		// Remove the selected USB event and return it as the message to send.
+		return remove_cc_message_at(target_offset, popped_out);
+	};
+
+	// Let the shared CC policy choose which CC number should be emitted next.
+	return queue_manager_.pop_next_scheduled_cc_candidate(begin_scan, next_scan, remove_selected, message_out);
+}
+
+bool MIDIQueueManagerUSB::begin_cc_message_scan(uint16_t& scan_position, uint16_t& limit) const {
+	// USB CC scan offsets are one queued event each, starting at the lane head.
+	scan_position = 0;
+	limit = queue_manager_.queue_count(static_cast<uint8_t>(QUEUE_PRIORITY_CC));
+	return limit > 0;
+}
+
+MIDIQueueManager::CCMessageScanResult
+MIDIQueueManagerUSB::next_cc_message(uint16_t& scan_position, uint16_t limit,
+                                     MIDIQueueManager::CCMessageScanEntry& message) const {
+	if (scan_position >= limit) {
+		// The scan has consumed every logical USB event in the CC lane.
+		return MIDIQueueManager::CCMessageScanResult::NoMore;
+	}
+
+	// Capture this logical offset before advancing to the next queued event.
+	uint16_t offset = scan_position;
+	scan_position++;
+	uint32_t queued = queue_manager_.read_at(static_cast<uint8_t>(QUEUE_PRIORITY_CC), offset);
+	if (!is_packed_channel_cc(queued)) {
+		// Valid queued event, but not a channel CC.
+		return MIDIQueueManager::CCMessageScanResult::Skip;
+	}
+
+	// Return the transport-neutral identity fields needed by the shared CC policy.
+	message = {
+	    .offset = offset,
+	    .status = status_byte(queued),
+	    .cc_number = data_1(queued),
+	};
+	return MIDIQueueManager::CCMessageScanResult::Found;
+}
+
+bool MIDIQueueManagerUSB::remove_cc_message_at(uint16_t target_offset, uint32_t& popped_out) {
+	// USB removes one packed event from the selected logical offset.
+	uint32_t removed_message[1] = {0};
+	if (!queue_manager_.remove_span_and_repack(static_cast<uint8_t>(QUEUE_PRIORITY_CC), target_offset, 1,
+	                                           removed_message, cc_reorder_scratch_.data())) {
+		// Invalid offset or repack failure: leave the caller without a message to send.
+		return false;
+	}
+
+	// Hand the removed event back to the transfer builder.
+	popped_out = removed_message[0];
+	return true;
+}
+
+/* MIDI Queue Manager DIN Transport
+ *
+ * This class manages the per-device DIN/serial MIDI queue with multiple priority lanes.
+ * It is used by ConnectedDINMIDIDevice to stage outgoing MIDI before bytes are accepted
+ * by the UART transmit buffer.
+ *
+ * Normal channel/system messages are encoded into raw serial MIDI bytes when queued.
+ * SysEx is queued as one complete raw byte stream, all-or-nothing, in the SysEx lane.
+ *
+ * During MidiEngine::flushMIDI, when a DIN send transaction starts, the ConnectedDINMIDIDevice calls into this queue
+ * manager to consume queued messages. The queue manager chooses complete MIDI messages or SysEx bytes according to
+ * priority, DIN send allowance, and available UART space, then writes the selected bytes with bufferMIDIUart().
+ *
+ * After bytes are staged in the UART transmit buffer, MidiEngine calls
+ * uartFlushIfNotSending() so the UART can continue sending them on the DIN port.
+ *
+ * After the DIN send transaction completes, future flushes call back into this queue manager to move more queued bytes
+ * when pacing and UART space allow it.
+ *
+ * Priority lanes are drained in strict order: clock > notes > expression > CC > SysEx.
+ *
+ * CC messages may be coalesced into an existing queued entry instead of appended,
+ * to avoid sending stale values when a later message has already superseded it.
+ *
+ * The queue manager also tracks whether a SysEx stream is active, and keeps draining
+ * only SysEx bytes until 0xF7 is sent. This prevents interleaving other MIDI traffic
+ * into a SysEx stream.
+ *
+ * DIN has much less bandwidth than USB, so the queue manager paces how many bytes can
+ * move into the UART on each flush and limits how much low-priority CC traffic can be
+ * staged ahead of later clock/note traffic.
+ *
+ * The queue manager does not handle UART flush state or hardware callbacks; it only
+ * manages queued bytes and their priorities. MidiEngine drives the flush cadence and
+ * the UART layer sends bytes after they are accepted by bufferMIDIUart().
+ *
+ * Message queueing flow (Normal messages):
+ * Source
+ *  -> MIDIMessage
+ *  -> MIDICableDINPorts::sendMessage or MidiEngine::sendMidi
+ *  -> MidiEngine::sendSerialMidi
+ *  -> ConnectedDINMIDIDevice::enqueue_message
+ *  -> MIDIQueueManagerDIN::enqueue_message
+ *  -> classify_message
+ *  -> message is queued into correct priority lane
+ *
+ * Message queueing flow (SysEx messages):
+ * Source
+ *  -> SysEx bytes
+ *  -> MIDICableDINPorts::sendSysex
+ *  -> MidiEngine::sendSerialSysex
+ *  -> ConnectedDINMIDIDevice::enqueue_sysex
+ *  -> MIDIQueueManagerDIN::enqueue_sysex
+ *  -> message is queued into QUEUE_PRIORITY_SYSEX priority lane
+ *
+ * Message sending flow:
+ * MidiEngine::flushMIDI
+ *   -> ConnectedDINMIDIDevice::consume_queued_messages
+ *   -> MIDIQueueManagerDIN::consume_queued_messages
+ *   -> bufferMIDIUart
+ *   -> uartFlushIfNotSending
+ *   -> UART TX buffer
+ *   -> UART driver
+ *   -> DIN serial output sends the UART TX buffer to the connected DIN device
+ */
+
+/// Resets all DIN per-priority queues and CC scheduling bookkeeping.
+void MIDIQueueManagerDIN::reset_queue_storage() {
+	queue_manager_.clear_all();
+	sysex_drain_active_ = false;
+}
+
+/// Resets serial pacing state so the next flush starts from a known baseline.
+void MIDIQueueManagerDIN::reset_serial_state(uint32_t now_sample_timer) {
+	// Start allowance accrual from the caller's current audio sample timestamp.
+	serial_allowance_last_update_ = now_sample_timer;
+	// Do not start with preloaded send allowance.
+	serial_allowance_Q8_ = 0;
+}
+
+/// Returns whether any serial-priority lane currently has data pending.
+bool MIDIQueueManagerDIN::has_serial_data() const {
+	return queue_manager_.has_any_data();
+}
+
+/// Reports remaining capacity in the raw-byte SysEx queue lane.
+size_t MIDIQueueManagerDIN::send_buffer_space() const {
+	return queue_manager_.space(static_cast<uint8_t>(QUEUE_PRIORITY_SYSEX));
+}
+
+/// Encodes and enqueues one channel/system MIDI message into serial-priority lanes.
+void MIDIQueueManagerDIN::enqueue_message(MIDIMessage message) {
+	// Classify once, then let the enqueue policy decide whether to coalesce or append.
+	QueuePriority priority = MIDIQueueManager::classify_message(message);
+	(void)enqueue_message_with_cc_policy(priority, message);
+}
+
+/// Queues one complete SysEx byte stream into the lowest-priority DIN lane.
+bool MIDIQueueManagerDIN::enqueue_sysex(uint8_t const* data, int32_t len) {
+	if (data == nullptr || len < 3 || data[0] != k_midi_sysex_start_byte || data[len - 1] != k_midi_sysex_end_byte) {
+		// The drain lock depends on receiving one complete SysEx stream: start byte,
+		// at least one payload/ID byte, and terminating 0xF7.
+		return false;
+	}
+
+	uint8_t lane = static_cast<uint8_t>(QUEUE_PRIORITY_SYSEX);
+	if (static_cast<uint32_t>(queue_manager_.space(lane)) < static_cast<uint32_t>(len)) {
+		// SysEx must be queued all-or-nothing so a partial stream cannot block the drain lock.
+		return false;
+	}
+
+	for (int32_t i = 0; i < len; i++) {
+		// DIN SysEx is already a raw byte stream, so store each byte unchanged.
+		if (!queue_manager_.push(lane, data[i])) {
+			// The space check above should make this unreachable unless queue state changes unexpectedly.
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/// Drains serial-priority queues into UART while enforcing DIN pacing and strict priority gates.
+void MIDIQueueManagerDIN::consume_queued_messages(uint32_t now_sample_timer) {
+	if (!has_serial_data()) {
+		// Fast exit when all lanes are empty; avoids pacing/space calculations.
+		return;
+	}
+
+	// Apply DIN pacing before deciding this iteration's send allowance. Q8
+	// units let partial serial bytes accumulate smoothly between audio callbacks.
+	uint32_t delta_samples = now_sample_timer - serial_allowance_last_update_;
+	if (delta_samples) {
+		serial_allowance_last_update_ = now_sample_timer;
+		serial_allowance_Q8_ +=
+		    static_cast<int32_t>((static_cast<uint64_t>(delta_samples) * k_serial_bytes_per_second_Q8) / kSampleRate);
+		if (serial_allowance_Q8_ > k_serial_send_allowance_max_Q8) {
+			serial_allowance_Q8_ = k_serial_send_allowance_max_Q8;
+		}
+	}
+
+	// Track total free MIDI UART capacity separately from the usable space for this flush.
+	// The raw value is also used below to estimate how many non-clock bytes are already
+	// staged in hardware/software UART buffering.
+	int32_t raw_uart_space = uartGetTxBufferSpace(UART_ITEM_MIDI);
+	int32_t uart_space = raw_uart_space - k_serial_uart_headroom_bytes;
+	if (uart_space <= 0) {
+		// Preserve a little headroom so other UART activity is not starved.
+		return;
+	}
+
+	// Bound how much queued CC traffic is staged ahead in the UART so later
+	// clock/note traffic can still preempt dense automation bursts.
+	int32_t cc_uart_allowance =
+	    std::max<int32_t>(0, k_serial_buffered_cc_bytes_cap - (MIDI_TX_BUFFER_SIZE - raw_uart_space));
+
+	// Convert the accumulated Q8 send allowance to bytes available for this drain pass.
+	int32_t send_allowance_bytes = serial_allowance_Q8_ >> k_serial_allowance_fraction_bits;
+	constexpr size_t k_clock_idx = QUEUE_PRIORITY_CLOCK;
+	if (send_allowance_bytes <= 0) {
+		if (sysex_drain_active_ || queue_manager_.empty(static_cast<uint8_t>(k_clock_idx))) {
+			// When the normal send allowance is zero, only realtime/system bytes
+			// may bypass pacing. Active SysEx must wait so clock cannot interleave.
+			return;
+		}
+		// Write one realtime/system byte anyway so clock/start/stop avoid extra jitter.
+		send_allowance_bytes = k_midi_realtime_message_bytes;
+	}
+
+	int32_t sent = 0;
+	constexpr size_t k_sysex_idx = QUEUE_PRIORITY_SYSEX;
+	// Keep draining while both UART capacity and send allowance remain.
+	while (uart_space > 0 && send_allowance_bytes > 0) {
+		// Hold one complete outgoing message while deciding which lane can pop next.
+		uint8_t bytes_to_send[k_midi_channel_message_max_bytes] = {0, 0, 0};
+		QueuePriority popped_priority = QUEUE_PRIORITY_CC;
+		DINSendContext context{bytes_to_send,     send_allowance_bytes, uart_space, k_midi_channel_message_max_bytes,
+		                       cc_uart_allowance, popped_priority};
+		bool popped = false;
+
+		// Once a DIN SysEx stream starts, keep draining only SysEx bytes until
+		// 0xF7 is sent. That preserves the MIDI rule that a SysEx stream is not
+		// interleaved with other serial MIDI bytes.
+		if (sysex_drain_active_) {
+			popped = pop_sysex_byte(context);
+			if (!popped) {
+				// Defensive recovery for truncated queue state: avoid permanently
+				// blocking other lanes if the SysEx lane ran dry before 0xF7.
+				sysex_drain_active_ = false;
+			}
+		}
+
+		if (!popped) {
+			// Scan from highest to lowest active DIN priority and pop one eligible message.
+			for (uint8_t lane = static_cast<uint8_t>(k_clock_idx); lane <= static_cast<uint8_t>(k_sysex_idx); lane++) {
+				QueuePriority priority = static_cast<QueuePriority>(lane);
+				if (!queue_manager_.queue_count(static_cast<uint8_t>(priority))) {
+					// Empty lanes cannot contribute bytes this pass.
+					continue;
+				}
+
+				if (priority == QUEUE_PRIORITY_CC) {
+					auto cc_result = handle_cc_lane(priority, context);
+					if (cc_result == MIDIQueueManager::PriorityLaneTraversalResult::Popped) {
+						// The CC scheduler selected and removed a complete CC message.
+						popped = true;
+						break;
+					}
+					if (cc_result == MIDIQueueManager::PriorityLaneTraversalResult::Abort) {
+						// The CC lane is blocked, malformed, or over its staging allowance.
+						break;
+					}
+					if (cc_result == MIDIQueueManager::PriorityLaneTraversalResult::SkipLane) {
+						// Skip CC for this pass and continue traversal.
+						continue;
+					}
+					if (cc_result != MIDIQueueManager::PriorityLaneTraversalResult::PopLane) {
+						// Unknown traversal result: do not pop this lane.
+						continue;
+					}
+				}
+
+				bool lane_popped =
+				    priority == QUEUE_PRIORITY_SYSEX ? pop_sysex_byte(context) : pop_lane(priority, context);
+				if (lane_popped) {
+					// Lane pop succeeded; bytes_to_send now contains one transport unit.
+					popped = true;
+					break;
+				}
+			}
+		}
+		if (!popped) {
+			// No lane could provide a complete message under the current limits.
+			break;
+		}
+
+		// Reconstruct how many bytes were popped so allowances can be debited correctly.
+		int32_t bytes_popped = k_midi_realtime_message_bytes;
+		if (popped_priority == QUEUE_PRIORITY_SYSEX) {
+			bytes_popped = k_midi_sysex_byte_count;
+		}
+		else if (popped_priority != QUEUE_PRIORITY_CLOCK) {
+			bytes_popped = bytesPerStatusMessage(bytes_to_send[0]);
+			if (bytes_popped <= 0) {
+				// Defensive: a popped non-clock message should always have a valid status.
+				break;
+			}
+		}
+
+		bool is_cc_message = (popped_priority == QUEUE_PRIORITY_CC);
+		if (is_cc_message && cc_uart_allowance < bytes_popped) {
+			// Yield until the hardware drains enough queued CC traffic; clock, note, and
+			// expression messages remain eligible so higher-priority output can still preempt
+			// dense automation at the next flush.
+			break;
+		}
+
+		for (int32_t i = 0; i < bytes_popped; i++) {
+			// Push selected bytes into the UART MIDI TX buffer.
+			bufferMIDIUart(bytes_to_send[i]);
+		}
+		sent += bytes_popped;
+		if (is_cc_message) {
+			// Only lowest-priority CC traffic consumes this staging cap. Higher-priority lanes
+			// still use queue ordering plus available UART space, but are not blocked by CC-only
+			// occupancy accounting.
+			cc_uart_allowance -= bytes_popped;
+		}
+		// Only commit scheduling state when a full 3-byte channel-CC frame with a
+		// valid CC number has actually been emitted to UART.
+		if (is_cc_message && MIDIQueueManager::is_three_byte_channel_cc(bytes_to_send[0], bytes_popped)
+		    && bytes_to_send[1] <= kMaxMIDIValue) {
+			queue_manager_.clear_cc_debt(bytes_to_send[1]);
+		}
+		uart_space -= bytes_popped;
+		send_allowance_bytes -= bytes_popped;
+	}
+
+	if (sent > 0) {
+		// Convert sent bytes back to Q8 units and subtract them from the send allowance.
+		serial_allowance_Q8_ = std::max<int32_t>(0, serial_allowance_Q8_ - sent * k_serial_allowance_fraction_scale);
+	}
+}
+
+bool MIDIQueueManagerDIN::pop_lane(QueuePriority priority, DINSendContext& context) {
+	if (priority == QUEUE_PRIORITY_CLOCK) {
+		// The highest-priority lane is emitted one realtime/system byte at a time.
+		if (context.allowance_bytes < k_midi_realtime_message_bytes
+		    || context.uart_space < k_midi_realtime_message_bytes || context.max_len < k_midi_realtime_message_bytes) {
+			// Caller cannot accept even the one-byte high-priority message.
+			return false;
+		}
+		// Pop exactly one byte and mark which priority supplied it.
+		bool popped = queue_manager_.pop_head(static_cast<uint8_t>(priority), context.out_bytes[0]);
+		if (popped) {
+			context.popped_priority = priority;
+		}
+		return popped;
+	}
+
+	// Non-clock DIN lanes are byte queues, so first validate that a complete
+	// message is available and fits the current allowance/UART/output limits.
+	uint8_t status = queue_manager_.head(static_cast<uint8_t>(priority));
+	int32_t message_len = 0;
+	auto head_check = MIDIQueueManager::validate_head_message_pop(
+	    status, queue_manager_.queue_count(static_cast<uint8_t>(priority)), context.allowance_bytes, context.uart_space,
+	    context.max_len, message_len);
+	if (head_check != MIDIQueueManager::HeadMessageCheckResult::Ready) {
+		return false;
+	}
+
+	// Pop the whole message atomically so partial MIDI frames are never emitted.
+	bool popped = queue_manager_.pop_many(static_cast<uint8_t>(priority), context.out_bytes, message_len);
+	if (popped) {
+		context.popped_priority = priority;
+	}
+	return popped;
+}
+
+bool MIDIQueueManagerDIN::pop_sysex_byte(DINSendContext& context) {
+	if (context.allowance_bytes < k_midi_sysex_byte_count || context.uart_space < k_midi_sysex_byte_count
+	    || context.max_len < k_midi_sysex_byte_count) {
+		// The caller cannot accept even one serial byte right now.
+		return false;
+	}
+
+	// SysEx is queued as raw DIN bytes, so one pop emits exactly one byte.
+	bool popped = queue_manager_.pop_head(static_cast<uint8_t>(QUEUE_PRIORITY_SYSEX), context.out_bytes[0]);
+	if (popped) {
+		context.popped_priority = QUEUE_PRIORITY_SYSEX;
+		// Keep the drain locked until the SysEx terminator itself has been sent.
+		sysex_drain_active_ = context.out_bytes[0] != k_midi_sysex_end_byte;
+	}
+	return popped;
+}
+
+/* **************************************************************** */
+/* DIN MIDI CC specific queuing and scheduling functions start here */
+/* **************************************************************** */
+
+bool MIDIQueueManagerDIN::enqueue_message_with_cc_policy(QueuePriority priority, MIDIMessage queued_message) {
+	// For CC messages, first try to update an already-queued message for the same
+	// status/CC number. If this succeeds, no new serial bytes are appended.
+	if (priority == QUEUE_PRIORITY_CC && coalesce_cc_message(queued_message)) {
+		return true;
+	}
+
+	// Otherwise encode and append the message bytes to the selected priority lane.
+	bool queued_ok = enqueue_priority_message(priority, queued_message);
+	if (queued_ok && priority == QUEUE_PRIORITY_CC && queued_message.data1 <= kMaxMIDIValue) {
+		// Record that this CC number has unsent work so scheduled dequeue can prefer it.
+		queue_manager_.bump_cc_debt(queued_message.data1);
+	}
+	return queued_ok;
+}
+
+bool MIDIQueueManagerDIN::coalesce_cc_message(MIDIMessage queued_message) {
+	if (!MIDIQueueManager::is_channel_cc_status_type(queued_message.statusType)) {
+		// Only channel CC messages participate in value coalescing.
+		return false;
+	}
+
+	// DIN coalescing overwrites only the queued value byte. Status/CC number
+	// bytes stay where they are so ordering remains stable.
+	uint8_t wanted_status = queued_message.channel | (queued_message.statusType << 4);
+	auto begin_scan = [this](uint16_t& scan_position, uint16_t& limit) {
+		// Initialize a DIN CC-lane scan and report how many raw bytes it can inspect.
+		return begin_cc_message_scan(scan_position, limit);
+	};
+	auto next_scan = [this](uint16_t& scan_position, uint16_t limit, uint16_t& candidate_offset, uint8_t& status,
+	                        uint8_t& cc_number) {
+		// Read the next complete DIN message and adapt it into the generic coalescing result shape.
+		MIDIQueueManager::CCMessageScanEntry message{};
+		return MIDIQueueManager::adapt_cc_coalesce_scan_result(next_cc_message(scan_position, limit, message), message,
+		                                                       candidate_offset, status, cc_number);
+	};
+	auto update_matched = [this, queued_message](uint16_t latest_offset) {
+		// DIN stores bytes, so the value byte is two bytes after the message status.
+		queue_manager_.overwrite_at(static_cast<uint8_t>(QUEUE_PRIORITY_CC), static_cast<uint16_t>(latest_offset + 2),
+		                            queued_message.data2);
+	};
+
+	// The shared policy scans for the latest matching CC and calls update_matched if found.
+	return queue_manager_.coalesce_latest_matching_cc(wanted_status, queued_message.data1, begin_scan, next_scan,
+	                                                  update_matched);
+}
+
+bool MIDIQueueManagerDIN::enqueue_priority_message(QueuePriority priority, MIDIMessage queued_message) {
+	// Convert the MIDIMessage container into raw serial MIDI bytes.
+	uint8_t status = queued_message.channel | (queued_message.statusType << 4);
+	uint8_t raw_bytes[k_midi_channel_message_max_bytes] = {status, queued_message.data1, queued_message.data2};
+	int32_t message_length = bytesPerStatusMessage(status);
+	if (message_length <= 0) {
+		// Nothing queueable for this status.
+		return true;
+	}
+
+	uint8_t lane = static_cast<uint8_t>(priority);
+	if (queue_manager_.space(lane) < message_length) {
+		// Do not enqueue a partial serial MIDI message.
+		return false;
+	}
+	for (int32_t i = 0; i < message_length; i++) {
+		// Store the complete message byte-by-byte in the selected priority lane.
+		if (!queue_manager_.push(lane, raw_bytes[i])) {
+			return false;
+		}
+	}
+	return true;
+}
+
+// Check whether the CC lane head can be considered, then tell the caller whether to pop, skip, or abort.
+MIDIQueueManager::PriorityLaneTraversalResult MIDIQueueManagerDIN::handle_cc_lane(QueuePriority priority,
+                                                                                  DINSendContext& context) {
+	// DIN must validate the complete message at the CC-lane head before deciding
+	// whether it should be scheduled or popped normally.
+	uint8_t status = queue_manager_.head(static_cast<uint8_t>(priority));
+	int32_t message_len = 0;
+	auto head_check = MIDIQueueManager::validate_head_message_pop(
+	    status, queue_manager_.queue_count(static_cast<uint8_t>(priority)), context.allowance_bytes, context.uart_space,
+	    context.max_len, message_len);
+	if (head_check != MIDIQueueManager::HeadMessageCheckResult::Ready) {
+		// Invalid or incomplete head data blocks the CC lane for this pass.
+		return MIDIQueueManager::PriorityLaneTraversalResult::Abort;
+	}
+
+	bool head_is_cc = MIDIQueueManager::is_three_byte_channel_cc(status, message_len);
+	auto pop_scheduled_cc = [this](uint8_t* out_bytes, int32_t allowance_bytes, int32_t uart_space, int32_t max_len,
+	                               QueuePriority& popped_priority) {
+		// Delegate scheduled removal to the DIN-specific complete-message popper.
+		return pop_next_scheduled_cc_message(out_bytes, allowance_bytes, uart_space, max_len, popped_priority);
+	};
+	auto cc_result = MIDIQueueManager::try_pop_scheduled_cc(
+	    head_is_cc, context.cc_uart_allowance >= MIDIQueueManager::k_channel_cc_message_length, pop_scheduled_cc,
+	    context.out_bytes, context.allowance_bytes, context.uart_space, context.max_len, context.popped_priority);
+	if (cc_result == MIDIQueueManager::CCScheduledPopResult::Popped) {
+		// A scheduled CC has already been copied into the send buffer.
+		return MIDIQueueManager::PriorityLaneTraversalResult::Popped;
+	}
+	if (cc_result == MIDIQueueManager::CCScheduledPopResult::NotCC) {
+		// Non-CC messages in this lane can be emitted in normal head order.
+		return MIDIQueueManager::PriorityLaneTraversalResult::PopLane;
+	}
+
+	// Allowance exhaustion or pop failure means the CC lane should not emit now.
+	return MIDIQueueManager::PriorityLaneTraversalResult::Abort;
+}
+
+bool MIDIQueueManagerDIN::pop_next_scheduled_cc_message(uint8_t* out_bytes, int32_t allowance_bytes, int32_t uart_space,
+                                                        int32_t max_len, QueuePriority& popped_priority) {
+	if (allowance_bytes < MIDIQueueManager::k_channel_cc_message_length
+	    || uart_space < MIDIQueueManager::k_channel_cc_message_length
+	    || max_len < MIDIQueueManager::k_channel_cc_message_length) {
+		// A DIN CC is three bytes; all caller limits must fit the complete message.
+		return false;
+	}
+
+	if (queue_manager_.queue_count(static_cast<uint8_t>(QUEUE_PRIORITY_CC))
+	    < MIDIQueueManager::k_channel_cc_message_length) {
+		// Fewer than three queued bytes cannot form a complete channel CC.
+		return false;
+	}
+
+	// DIN stores raw bytes, so scheduled CC popping must scan complete MIDI messages
+	// and remove a three-byte span rather than a single queue entry.
+	auto begin_scan = [this](uint16_t& scan_position, uint16_t& limit) {
+		// Initialize a DIN CC-lane scan and report how many raw bytes it can inspect.
+		return begin_cc_message_scan(scan_position, limit);
+	};
+	auto next_scan = [this](uint16_t& scan_position, uint16_t limit, uint16_t& candidate_offset, uint8_t& cc_number) {
+		// Read the next complete DIN message and adapt it into the generic scheduler result shape.
+		MIDIQueueManager::CCMessageScanEntry message{};
+		return MIDIQueueManager::adapt_cc_candidate_scan_result(next_cc_message(scan_position, limit, message), message,
+		                                                        candidate_offset, cc_number);
+	};
+	auto remove_selected = [this](uint16_t target_offset, uint8_t* out) {
+		// Remove the selected three-byte CC message and copy it into out.
+		return remove_cc_message_at(target_offset, out);
+	};
+
+	// Let the shared CC policy choose which CC number should be emitted next.
+	bool popped = queue_manager_.pop_next_scheduled_cc_candidate(begin_scan, next_scan, remove_selected, out_bytes);
+	if (popped) {
+		// Tell the drain loop these bytes came from the CC lane.
+		popped_priority = QUEUE_PRIORITY_CC;
+	}
+	return popped;
+}
+
+bool MIDIQueueManagerDIN::begin_cc_message_scan(uint16_t& scan_position, uint16_t& limit) const {
+	// DIN CC scan offsets are byte offsets, starting at the lane head.
+	scan_position = 0;
+	limit = queue_manager_.queue_count(static_cast<uint8_t>(QUEUE_PRIORITY_CC));
+	return limit >= MIDIQueueManager::k_channel_cc_message_length;
+}
+
+MIDIQueueManager::CCMessageScanResult
+MIDIQueueManagerDIN::next_cc_message(uint16_t& scan_position, uint16_t limit,
+                                     MIDIQueueManager::CCMessageScanEntry& message) const {
+	if (scan_position >= limit) {
+		// The scan has consumed every raw byte in the CC lane.
+		return MIDIQueueManager::CCMessageScanResult::NoMore;
+	}
+
+	// Decode the message length from the status byte at this logical byte offset.
+	uint8_t message_status = queue_manager_.read_at(static_cast<uint8_t>(QUEUE_PRIORITY_CC), scan_position);
+	int32_t message_len = bytesPerStatusMessage(message_status);
+	if (message_len <= 0 || static_cast<int32_t>(scan_position) + message_len > limit) {
+		// A truncated or unparseable byte stream means the lane cannot safely be
+		// repacked around a selected message.
+		return MIDIQueueManager::CCMessageScanResult::Invalid;
+	}
+
+	// Save the starting byte offset, then advance to the next complete MIDI message.
+	uint16_t offset = scan_position;
+	scan_position = static_cast<uint16_t>(scan_position + message_len);
+	if (!MIDIQueueManager::is_three_byte_channel_cc(message_status, message_len)) {
+		// Valid queued message, but not a three-byte channel CC.
+		return MIDIQueueManager::CCMessageScanResult::Skip;
+	}
+
+	// Return the transport-neutral identity fields needed by the shared CC policy.
+	message = {
+	    .offset = offset,
+	    .status = message_status,
+	    .cc_number = queue_manager_.read_at(static_cast<uint8_t>(QUEUE_PRIORITY_CC), static_cast<uint16_t>(offset + 1)),
+	};
+	return MIDIQueueManager::CCMessageScanResult::Found;
+}
+
+bool MIDIQueueManagerDIN::remove_cc_message_at(uint16_t target_offset, uint8_t* out) {
+	// DIN removes a three-byte CC span starting at the selected byte offset.
+	return queue_manager_.remove_span_and_repack(static_cast<uint8_t>(QUEUE_PRIORITY_CC), target_offset,
+	                                             MIDIQueueManager::k_channel_cc_message_length, out,
+	                                             cc_reorder_scratch_.data());
+}

--- a/src/deluge/io/midi/midi_queue_manager.h
+++ b/src/deluge/io/midi/midi_queue_manager.h
@@ -1,0 +1,775 @@
+/*
+ * Copyright © 2026 Sean Ditny
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "definitions_cxx.hpp"
+#include "io/midi/midi_queue_definitions.h"
+#include "model/midi/message.h"
+#include <array>
+#include <limits>
+#include <utility>
+
+template <typename T, uint16_t Capacity, size_t LaneCount>
+class MIDIQueueManagerDeviceState;
+
+/// Shared MIDI queue policy helpers used across transport-specific queue managers.
+///
+/// The transport managers below store different queue units: USB stores one
+/// packed USB-MIDI event per queue entry, while DIN stores raw serial bytes.
+/// This class contains only the policy decisions that are independent of that
+/// storage format: message classification, CC detection, and common gate checks.
+class MIDIQueueManager {
+public:
+	static constexpr uint8_t k_channel_cc_status_nibble = 0x0B;
+	static constexpr int32_t k_channel_cc_message_length = 3;
+
+	/// Returns true for channel-CC status bytes (0xBn).
+	static constexpr bool is_channel_cc_status_byte(uint8_t status) {
+		return (status >> 4) == k_channel_cc_status_nibble;
+	}
+
+	/// Returns true for channel-CC status-type nibbles.
+	static constexpr bool is_channel_cc_status_type(uint8_t status_type) {
+		return status_type == k_channel_cc_status_nibble;
+	}
+
+	/// Returns true only for full 3-byte channel-CC messages.
+	static constexpr bool is_three_byte_channel_cc(uint8_t status, int32_t message_len) {
+		return message_len == k_channel_cc_message_length && is_channel_cc_status_byte(status);
+	}
+
+	enum class CCMessageScanResult : uint8_t {
+		NoMore,
+		Skip,
+		Found,
+		Invalid,
+	};
+
+	struct CCMessageScanEntry {
+		uint16_t offset;
+		uint8_t status;
+		uint8_t cc_number;
+	};
+
+	enum class CandidateScanResult : uint8_t {
+		NoMore,
+		Skip,
+		Candidate,
+		Invalid,
+	};
+
+	enum class CoalesceScanResult : uint8_t {
+		NoMore,
+		Skip,
+		Matchable,
+		Invalid,
+	};
+
+	enum class CCScheduledPopResult : uint8_t {
+		NotCC,
+		AllowanceBlocked,
+		PopFailed,
+		Popped,
+	};
+
+	enum class PriorityLaneTraversalResult {
+		PopLane,
+		SkipLane,
+		Popped,
+		Abort,
+	};
+
+	enum class HeadMessageCheckResult : uint8_t {
+		Invalid,
+		InsufficientCapacity,
+		Ready,
+	};
+
+	/// Classifies an outgoing MIDI message into priority groups.
+	static QueuePriority classify_message(MIDIMessage message);
+
+	/// Converts a transport CC scan entry into the candidate shape used by scheduled dequeue.
+	static CandidateScanResult adapt_cc_candidate_scan_result(CCMessageScanResult scan_result,
+	                                                          CCMessageScanEntry const& message,
+	                                                          uint16_t& candidate_offset, uint8_t& cc_number) {
+		switch (scan_result) {
+		case CCMessageScanResult::NoMore:
+			// The transport scan reached the end of the lane.
+			return CandidateScanResult::NoMore;
+		case CCMessageScanResult::Skip:
+			// The scan saw a valid message, but it is not a scheduled-CC candidate.
+			return CandidateScanResult::Skip;
+		case CCMessageScanResult::Found:
+			// Copy the transport-neutral fields the scheduler needs to choose a CC.
+			cc_number = message.cc_number;
+			candidate_offset = message.offset;
+			return CandidateScanResult::Candidate;
+		case CCMessageScanResult::Invalid:
+			// Invalid scan state means the caller should stop and avoid repacking.
+			return CandidateScanResult::Invalid;
+		}
+
+		// Defensive fallback for compilers that do not prove the enum switch is exhaustive.
+		return CandidateScanResult::Invalid;
+	}
+
+	/// Converts a transport CC scan entry into the match shape used by CC coalescing.
+	static CoalesceScanResult adapt_cc_coalesce_scan_result(CCMessageScanResult scan_result,
+	                                                        CCMessageScanEntry const& message,
+	                                                        uint16_t& candidate_offset, uint8_t& status,
+	                                                        uint8_t& cc_number) {
+		switch (scan_result) {
+		case CCMessageScanResult::NoMore:
+			// The transport scan reached the end of the lane.
+			return CoalesceScanResult::NoMore;
+		case CCMessageScanResult::Skip:
+			// The scan saw a valid message, but it is not a coalescing candidate.
+			return CoalesceScanResult::Skip;
+		case CCMessageScanResult::Found:
+			// Copy enough identity to match exact status/channel plus CC number.
+			status = message.status;
+			cc_number = message.cc_number;
+			candidate_offset = message.offset;
+			return CoalesceScanResult::Matchable;
+		case CCMessageScanResult::Invalid:
+			// Invalid scan state means no reliable match can be made from here.
+			return CoalesceScanResult::Invalid;
+		}
+
+		// Defensive fallback for compilers that do not prove the enum switch is exhaustive.
+		return CoalesceScanResult::Invalid;
+	}
+
+	/// Shared CC gate helper: if head is CC and allowance permits, attempt a scheduled pop.
+	///
+	/// A transport asks this before popping the CC lane head. Non-CC messages
+	/// fall through to normal lane-order popping. CC messages only use the
+	/// scheduler when the caller's per-transfer/per-UART allowance still permits it.
+	template <typename PopFn, typename... Args>
+	static CCScheduledPopResult try_pop_scheduled_cc(bool head_is_cc, bool allowance_ok, PopFn pop_scheduled_fn,
+	                                                 Args&&... args) {
+		if (!head_is_cc) {
+			// The lane head is not a CC, so normal lane-order popping should handle it.
+			return CCScheduledPopResult::NotCC;
+		}
+		if (!allowance_ok) {
+			// CC scheduling is intentionally capped per transfer/flush.
+			return CCScheduledPopResult::AllowanceBlocked;
+		}
+		if (pop_scheduled_fn(std::forward<Args>(args)...)) {
+			// The transport found and removed the scheduled CC candidate.
+			return CCScheduledPopResult::Popped;
+		}
+		// The head was CC and allowance was available, but the transport could not pop one.
+		return CCScheduledPopResult::PopFailed;
+	}
+
+	/// Shared parser+fit gate for queued non-realtime MIDI messages.
+	///
+	/// Returns Ready only when the queue head decodes to a valid message length
+	/// and that complete message fits queue occupancy plus all caller limits.
+	static HeadMessageCheckResult validate_head_message_pop(uint8_t status, uint16_t queue_size,
+	                                                        int32_t allowance_bytes, int32_t uart_space,
+	                                                        int32_t max_len, int32_t& message_len_out) {
+		// Determine how many bytes must be emitted atomically for this status byte.
+		int32_t message_len = bytesPerStatusMessage(status);
+		if (message_len <= 0) {
+			// A non-positive length means this byte cannot start a valid queued message.
+			return HeadMessageCheckResult::Invalid;
+		}
+		if (queue_size < message_len || allowance_bytes < message_len || uart_space < message_len
+		    || max_len < message_len) {
+			// The message is recognizable, but the queue/caller cannot provide all bytes now.
+			return HeadMessageCheckResult::InsufficientCapacity;
+		}
+		// Return the decoded length so the caller can pop exactly one complete message.
+		message_len_out = message_len;
+		return HeadMessageCheckResult::Ready;
+	}
+};
+
+/// Stateful CC coalescing and scheduling policy instantiated per transport/device.
+///
+/// Dense automation can repeatedly queue the same CC number faster than the
+/// MIDI link can drain it. The policy balances two goals:
+/// 1. Coalesce queued CCs for the same status/CC number so stale intermediate
+///    values do not waste bandwidth.
+/// 2. Track "debt" for CC numbers that were coalesced or newly queued, then
+///    prefer debt-bearing CC numbers when choosing the next scheduled CC.
+///
+/// Transport-specific code supplies scan and removal callbacks because USB and
+/// DIN queues have different entry formats.
+class MIDICCQueuePolicy {
+public:
+	MIDICCQueuePolicy() { reset(); }
+
+	/// Clears scan scratch state, CC debt, and CC-number selection history.
+	void reset() {
+		// Mark every CC number as absent for the next scan.
+		first_offsets.fill(k_no_cc_offset);
+		// Drop any pending preference accumulated by queued/coalesced CC updates.
+		cc_debt.fill(0);
+		// Restart round-robin selection from CC 0.
+		next_cc_number = 0;
+	}
+
+	/// Scans one CC lane and records the first queued offset for each CC number.
+	///
+	/// Exact status/CC number duplicates are coalesced at enqueue time, so a
+	/// later value normally updates an existing queued entry instead of creating
+	/// a second candidate. Scheduled dequeue only needs the first remaining candidate
+	/// per CC number bucket so it does not pull a later distinct CC ahead of an
+	/// earlier one in the same bucket.
+	template <typename BeginScanFn, typename NextScanFn>
+	bool collect_first_cc_offsets_from_scan(BeginScanFn&& begin_scan, NextScanFn&& next_scan) {
+		// Rebuild the scratch map fresh for this scheduled-pop attempt.
+		first_offsets.fill(k_no_cc_offset);
+
+		uint16_t scan_position = 0;
+		uint16_t limit = 0;
+		if (!begin_scan(scan_position, limit)) {
+			// The transport has no CC lane entries available to scan.
+			return false;
+		}
+
+		bool saw_any_cc = false;
+		while (true) {
+			// Ask the transport for the next scan step. USB advances by one event;
+			// DIN advances by one complete MIDI message.
+			uint16_t candidate_offset = 0;
+			uint8_t cc_number = 0;
+			MIDIQueueManager::CandidateScanResult step = next_scan(scan_position, limit, candidate_offset, cc_number);
+			if (step == MIDIQueueManager::CandidateScanResult::NoMore) {
+				// We reached the scan limit; the scratch map now contains this pass's candidates.
+				break;
+			}
+			if (step == MIDIQueueManager::CandidateScanResult::Invalid) {
+				// A malformed lane cannot be safely reordered.
+				return false;
+			}
+			if (step == MIDIQueueManager::CandidateScanResult::Candidate) {
+				saw_any_cc = true;
+				if (cc_number <= kMaxMIDIValue && first_offsets[cc_number] == k_no_cc_offset) {
+					// Keep only the first remaining candidate for each CC number.
+					first_offsets[cc_number] = candidate_offset;
+				}
+			}
+		}
+
+		return saw_any_cc;
+	}
+
+	/// Finds the newest queued CC matching a status/CC number pair.
+	///
+	/// Enqueue-time coalescing intentionally updates the latest match, preserving
+	/// the queued order while ensuring the eventual send uses the freshest value.
+	template <typename BeginScanFn, typename NextScanFn>
+	int32_t find_latest_matching_cc_offset(uint8_t wanted_status, uint8_t wanted_cc_number, BeginScanFn&& begin_scan,
+	                                       NextScanFn&& next_scan) const {
+		uint16_t scan_position = 0;
+		uint16_t limit = 0;
+		if (!begin_scan(scan_position, limit)) {
+			// The transport has no CC lane entries available to scan.
+			return -1;
+		}
+
+		int32_t latest_offset = -1;
+		while (true) {
+			// Walk each transport-specific CC scan entry and keep replacing
+			// latest_offset when we find a newer exact status/CC match.
+			uint16_t candidate_offset = 0;
+			uint8_t status = 0;
+			uint8_t cc_number = 0;
+			MIDIQueueManager::CoalesceScanResult step =
+			    next_scan(scan_position, limit, candidate_offset, status, cc_number);
+			if (step == MIDIQueueManager::CoalesceScanResult::NoMore) {
+				// End of lane: return the newest match found, or -1 if there was none.
+				break;
+			}
+			if (step == MIDIQueueManager::CoalesceScanResult::Invalid) {
+				// Stop on malformed queue contents; any match already found is still usable.
+				break;
+			}
+			if (step == MIDIQueueManager::CoalesceScanResult::Matchable && status == wanted_status
+			    && cc_number == wanted_cc_number) {
+				// Keep the most recent matching offset so the freshest queued value is overwritten.
+				latest_offset = static_cast<int32_t>(candidate_offset);
+			}
+		}
+
+		return latest_offset;
+	}
+
+	/// Finds a matching queued CC, lets the transport update it, then records CC debt.
+	///
+	/// USB and DIN store different queue units, so the policy does not know how
+	/// to rewrite the queued value byte. The transport callback receives the
+	/// logical offset of the latest matching CC and performs that overwrite.
+	template <typename BeginScanFn, typename NextScanFn, typename UpdateMatchedFn>
+	bool coalesce_latest_matching_cc(uint8_t wanted_status, uint8_t wanted_cc_number, BeginScanFn&& begin_scan,
+	                                 NextScanFn&& next_scan, UpdateMatchedFn&& update_matched) {
+		// Search the lane for the newest queued value for this exact status/CC pair.
+		int32_t latest_offset =
+		    find_latest_matching_cc_offset(wanted_status, wanted_cc_number, std::forward<BeginScanFn>(begin_scan),
+		                                   std::forward<NextScanFn>(next_scan));
+		if (latest_offset < 0) {
+			// Nothing already queued, so the caller should append a new message instead.
+			return false;
+		}
+
+		// Let the transport rewrite the value byte in its own storage format.
+		update_matched(static_cast<uint16_t>(latest_offset));
+		// Record that this CC changed while queued, so scheduled dequeue prefers it.
+		bump_cc_debt(wanted_cc_number);
+		return true;
+	}
+
+	/// Selects and removes the next scheduled CC candidate from a transport-specific lane.
+	///
+	/// The lane scan discovers candidates, the policy chooses the CC number,
+	/// and the transport callback removes the selected queue span.
+	template <typename BeginScanFn, typename NextScanFn, typename RemoveSelectedFn, typename CallArg>
+	bool pop_next_scheduled_cc_candidate(BeginScanFn&& begin_scan, NextScanFn&& next_scan,
+	                                     RemoveSelectedFn&& remove_selected, CallArg&& out_arg) {
+		if (!collect_first_cc_offsets_from_scan(begin_scan, next_scan)) {
+			// No valid CC candidates were available to schedule.
+			return false;
+		}
+
+		uint16_t selected_offset = 0;
+		uint8_t selected_cc_number = 0;
+		if (!select_next_scheduled_cc(selected_offset, selected_cc_number)) {
+			// The scan produced no selectable CC number.
+			return false;
+		}
+
+		if (!remove_selected(selected_offset, std::forward<CallArg>(out_arg))) {
+			// The transport could not remove/copy the selected message span.
+			return false;
+		}
+
+		// Only advance scheduler state after the transport successfully removes the candidate.
+		commit_scheduled_cc_pop(selected_cc_number);
+		return true;
+	}
+
+	/// Records that a CC number has work waiting or was coalesced in place.
+	void bump_cc_debt(uint8_t cc_number) {
+		if (cc_number <= kMaxMIDIValue && cc_debt[cc_number] < k_max_cc_debt) {
+			// Saturate instead of wrapping so a very hot CC stays preferred.
+			cc_debt[cc_number]++;
+		}
+	}
+
+	/// Clears debt after a CC number's current value has actually been emitted.
+	void clear_cc_debt(uint8_t cc_number) {
+		if (cc_number <= kMaxMIDIValue) {
+			// Once the current value has left the queue, this CC no longer needs preference.
+			cc_debt[cc_number] = 0;
+		}
+	}
+
+private:
+	static constexpr uint16_t k_no_cc_offset = 0xFFFF;
+	static constexpr uint8_t k_max_cc_debt = std::numeric_limits<uint8_t>::max();
+
+	/// Scratch map built during one scheduled-pop scan: CC number -> first queued offset.
+	std::array<uint16_t, kMaxMIDIValue + 1> first_offsets{};
+	/// Saturating score used to prioritize CC numbers whose queued value changed.
+	std::array<uint8_t, kMaxMIDIValue + 1> cc_debt{};
+	/// Round-robin starting point so equal-debt CC numbers share service.
+	uint8_t next_cc_number{0};
+
+	/// Chooses a CC number using debt first, round-robin order as the fallback.
+	bool select_next_scheduled_cc(uint16_t& selected_offset, uint8_t& selected_cc_number) const {
+		// Track the first candidate in round-robin order as the fallback choice.
+		uint16_t first_round_robin_offset = k_no_cc_offset;
+		uint8_t first_round_robin_cc_number = 0;
+		// Track the highest-debt candidate as the preferred choice when debt exists.
+		uint16_t debt_selected_offset = k_no_cc_offset;
+		uint8_t debt_selected_cc_number = 0;
+		uint8_t debt_selected_value = 0;
+
+		for (uint16_t search = 0; search < (kMaxMIDIValue + 1); search++) {
+			// Start from next_cc_number and wrap through the 7-bit CC number range.
+			uint8_t cc_number = static_cast<uint8_t>((next_cc_number + search) & kMaxMIDIValue);
+			uint16_t target_offset = first_offsets[cc_number];
+			if (target_offset == k_no_cc_offset) {
+				// This CC number had no queued candidate in the current scan.
+				continue;
+			}
+
+			if (first_round_robin_offset == k_no_cc_offset) {
+				// First available candidate in round-robin order becomes the no-debt fallback.
+				first_round_robin_offset = target_offset;
+				first_round_robin_cc_number = cc_number;
+			}
+
+			uint8_t debt = cc_debt[cc_number];
+			if (debt_selected_offset == k_no_cc_offset || debt > debt_selected_value) {
+				// Prefer the CC number that accumulated the most queued/coalesced updates.
+				debt_selected_offset = target_offset;
+				debt_selected_cc_number = cc_number;
+				debt_selected_value = debt;
+			}
+		}
+
+		if (first_round_robin_offset == k_no_cc_offset) {
+			// The scan found no CC candidates at all.
+			return false;
+		}
+
+		// Use round-robin when no candidate has debt.
+		selected_offset = first_round_robin_offset;
+		selected_cc_number = first_round_robin_cc_number;
+		if (debt_selected_offset != k_no_cc_offset && debt_selected_value > 0) {
+			// Debt overrides round-robin so changed CC values are emitted promptly.
+			selected_offset = debt_selected_offset;
+			selected_cc_number = debt_selected_cc_number;
+		}
+
+		return true;
+	}
+
+	/// Advances the round-robin starting point and clears the serviced CC number's debt.
+	void commit_scheduled_cc_pop(uint8_t selected_cc_number) {
+		if (selected_cc_number <= kMaxMIDIValue) {
+			// The selected CC has now been serviced.
+			cc_debt[selected_cc_number] = 0;
+		}
+		// Resume the next scan after the serviced CC number.
+		next_cc_number = static_cast<uint8_t>((selected_cc_number + 1) & kMaxMIDIValue);
+	}
+};
+
+/// Power-of-two ring buffer lane shared by transport-specific queue managers.
+///
+/// The lane keeps one slot unused so `read_pos == write_pos` can represent
+/// empty. Therefore, usable capacity is `Capacity - 1`. All logical offsets are
+/// relative to `read_pos`, which lets callers scan or overwrite queued messages
+/// without exposing wrapped physical indices.
+template <typename T, uint16_t Capacity>
+class MIDIQueueLane {
+public:
+	static_assert(Capacity != 0);
+	static_assert((Capacity & (Capacity - 1)) == 0);
+	static constexpr uint16_t k_capacity = Capacity;
+
+	std::array<T, Capacity> data{};
+	uint16_t read_pos{0};
+	uint16_t write_pos{0};
+
+	[[nodiscard]] bool empty() const { return read_pos == write_pos; }
+	[[nodiscard]] uint16_t size() const { return static_cast<uint16_t>((write_pos - read_pos) & (Capacity - 1)); }
+	[[nodiscard]] uint16_t space() const { return static_cast<uint16_t>((Capacity - 1) - size()); }
+	[[nodiscard]] T peek(uint16_t offset = 0) const { return data[(read_pos + offset) & (Capacity - 1)]; }
+
+	bool push(T value) {
+		// Advance write position first so we can detect the one-unused-slot full case.
+		uint16_t next = static_cast<uint16_t>((write_pos + 1) & (Capacity - 1));
+		if (next == read_pos) {
+			return false;
+		}
+		// Store into the current write slot, then publish it by moving write_pos.
+		data[write_pos] = value;
+		write_pos = next;
+		return true;
+	}
+
+	bool pop(T& out) {
+		if (empty()) {
+			return false;
+		}
+		// Copy the oldest queued entry before advancing the read position.
+		out = data[read_pos];
+		read_pos = static_cast<uint16_t>((read_pos + 1) & (Capacity - 1));
+		return true;
+	}
+
+	bool pop_many(T* out, uint16_t count) {
+		if (size() < count) {
+			// The caller asked for an atomic span; do not partially pop it.
+			return false;
+		}
+		// Copy the contiguous logical span, even if the physical ring wraps.
+		for (uint16_t i = 0; i < count; i++) {
+			out[i] = data[(read_pos + i) & (Capacity - 1)];
+		}
+		// Commit the pop only after all requested entries were copied.
+		read_pos = static_cast<uint16_t>((read_pos + count) & (Capacity - 1));
+		return true;
+	}
+
+	/// Removes a logical span while preserving the order of all other entries.
+	///
+	/// Scheduled CC dequeue can select an item that is not at the lane head. This
+	/// helper copies survivors into caller-owned scratch storage, resets the
+	/// ring indices, then pushes the survivors back contiguously.
+	bool remove_span_and_repack(uint16_t target_offset, uint16_t remove_count, T* removed_out, T* scratch_buffer) {
+		uint16_t queue_size = size();
+		if (remove_count > queue_size || target_offset > static_cast<uint16_t>(queue_size - remove_count)) {
+			// The requested span is outside the current logical queue contents.
+			return false;
+		}
+
+		// Copy the selected span out first; this is the message the caller will emit.
+		for (uint16_t i = 0; i < remove_count; i++) {
+			removed_out[i] = peek(static_cast<uint16_t>(target_offset + i));
+		}
+
+		// Copy every entry except the selected span into scratch storage.
+		uint16_t scratch_size = 0;
+		uint16_t remove_end = static_cast<uint16_t>(target_offset + remove_count);
+		for (uint16_t i = 0; i < queue_size; i++) {
+			if (i >= target_offset && i < remove_end) {
+				// Skip the selected span so it is removed from the rebuilt queue.
+				continue;
+			}
+			scratch_buffer[scratch_size] = peek(i);
+			scratch_size++;
+		}
+
+		// Reset the ring, then rebuild it from the survivors so read/write positions stay simple.
+		clear();
+		for (uint16_t i = 0; i < scratch_size; i++) {
+			if (!push(scratch_buffer[i])) {
+				// Should not happen because survivors came from the same lane capacity.
+				return false;
+			}
+		}
+		return true;
+	}
+
+	void clear() {
+		// With this ring representation, equal positions mean empty.
+		read_pos = 0;
+		write_pos = 0;
+	}
+
+	void overwrite_at(uint16_t logical_offset, T value) { data[(read_pos + logical_offset) & (Capacity - 1)] = value; }
+};
+
+/// Fixed set of power-of-two queue lanes shared by a transport-specific manager.
+template <typename T, uint16_t Capacity, size_t LaneCount>
+class MIDIQueueStorage {
+public:
+	std::array<MIDIQueueLane<T, Capacity>, LaneCount> lanes{};
+
+	[[nodiscard]] uint16_t queue_count(uint8_t lane) const { return lanes[lane].size(); }
+	[[nodiscard]] uint32_t total_queued_messages() const {
+		uint32_t queued = 0;
+		for (auto const& queue_lane : lanes) {
+			// Sum all priority lanes so callers can make whole-device decisions.
+			queued += queue_lane.size();
+		}
+		return queued;
+	}
+
+	[[nodiscard]] T head(uint8_t lane) const { return lanes[lane].peek(); }
+	[[nodiscard]] T read_at(uint8_t lane, uint16_t logical_offset) const { return lanes[lane].peek(logical_offset); }
+
+	bool pop_head(uint8_t lane, T& out) { return lanes[lane].pop(out); }
+	bool push(uint8_t lane, T value) { return lanes[lane].push(value); }
+	void overwrite_at(uint8_t lane, uint16_t logical_offset, T value) {
+		lanes[lane].overwrite_at(logical_offset, value);
+	}
+	bool remove_span_and_repack(uint8_t lane, uint16_t target_offset, uint16_t remove_count, T* removed_out,
+	                            T* scratch_buffer) {
+		return lanes[lane].remove_span_and_repack(target_offset, remove_count, removed_out, scratch_buffer);
+	}
+	[[nodiscard]] bool empty(uint8_t lane) const { return lanes[lane].empty(); }
+	[[nodiscard]] uint16_t space(uint8_t lane) const { return lanes[lane].space(); }
+};
+
+template <typename T, uint16_t Capacity, size_t LaneCount>
+class MIDIQueueManagerDeviceState {
+public:
+	[[nodiscard]] uint16_t queue_count(uint8_t lane) const { return queue_storage.queue_count(lane); }
+	[[nodiscard]] uint32_t total_queued_messages() const { return queue_storage.total_queued_messages(); }
+	[[nodiscard]] T head(uint8_t lane) const { return queue_storage.head(lane); }
+	[[nodiscard]] T read_at(uint8_t lane, uint16_t logical_offset) const {
+		return queue_storage.read_at(lane, logical_offset);
+	}
+	bool pop_head(uint8_t lane, T& out) { return queue_storage.pop_head(lane, out); }
+	bool push(uint8_t lane, T value) { return queue_storage.push(lane, value); }
+	void overwrite_at(uint8_t lane, uint16_t logical_offset, T value) {
+		queue_storage.overwrite_at(lane, logical_offset, value);
+	}
+	bool remove_span_and_repack(uint8_t lane, uint16_t target_offset, uint16_t remove_count, T* removed_out,
+	                            T* scratch_buffer) {
+		return queue_storage.remove_span_and_repack(lane, target_offset, remove_count, removed_out, scratch_buffer);
+	}
+	[[nodiscard]] bool empty(uint8_t lane) const { return queue_storage.empty(lane); }
+	[[nodiscard]] uint16_t space(uint8_t lane) const { return queue_storage.space(lane); }
+	[[nodiscard]] bool has_any_data() const { return queue_storage.total_queued_messages() > 0; }
+	/// Clears all lanes plus the CC scheduling/coalescing bookkeeping.
+	void clear_all() {
+		for (auto& queue_lane : queue_storage.lanes) {
+			// Drop queued transport data from every priority lane.
+			queue_lane.clear();
+		}
+		// Reset scheduler state so stale debt/scan data does not survive a device reset.
+		cc_queue_policy.reset();
+	}
+	bool pop_many(uint8_t lane, T* out, uint16_t count) { return queue_storage.lanes[lane].pop_many(out, count); }
+
+	template <typename BeginScanFn, typename NextScanFn, typename UpdateMatchedFn>
+	bool coalesce_latest_matching_cc(uint8_t wanted_status, uint8_t wanted_cc_number, BeginScanFn&& begin_scan,
+	                                 NextScanFn&& next_scan, UpdateMatchedFn&& update_matched) {
+		return cc_queue_policy.coalesce_latest_matching_cc(
+		    wanted_status, wanted_cc_number, std::forward<BeginScanFn>(begin_scan), std::forward<NextScanFn>(next_scan),
+		    std::forward<UpdateMatchedFn>(update_matched));
+	}
+
+	template <typename BeginScanFn, typename NextScanFn, typename RemoveSelectedFn, typename CallArg>
+	bool pop_next_scheduled_cc_candidate(BeginScanFn&& begin_scan, NextScanFn&& next_scan,
+	                                     RemoveSelectedFn&& remove_selected, CallArg&& out_arg) {
+		return cc_queue_policy.pop_next_scheduled_cc_candidate(
+		    std::forward<BeginScanFn>(begin_scan), std::forward<NextScanFn>(next_scan),
+		    std::forward<RemoveSelectedFn>(remove_selected), std::forward<CallArg>(out_arg));
+	}
+
+	void bump_cc_debt(uint8_t cc_number) { cc_queue_policy.bump_cc_debt(cc_number); }
+	void clear_cc_debt(uint8_t cc_number) { cc_queue_policy.clear_cc_debt(cc_number); }
+
+private:
+	MIDIQueueStorage<T, Capacity, LaneCount> queue_storage{};
+	/// Per-device CC coalescing/scheduling policy layered on top of transport queue storage.
+	MIDICCQueuePolicy cc_queue_policy{};
+};
+
+class MIDIQueueManagerUSB {
+public:
+	/// Clears USB queue contents and CC scheduling bookkeeping for this device.
+	void reset_queue_storage();
+	[[nodiscard]] bool has_buffered_send_data() const;
+	[[nodiscard]] int send_buffer_space() const;
+	void enqueue_message(uint32_t full_message);
+	bool consume_queued_messages(uint8_t* data_sending_now, uint8_t& num_bytes_sending_now, bool usb_host_mode);
+
+	struct USBSendContext {
+		uint32_t& message_out;
+		int32_t& cc_allowance_messages_remaining;
+	};
+
+private:
+	/// Per-priority USB output queues. Each lane is a ring of packed USB-MIDI events;
+	/// consume_queued_messages() drains them into dataSendingNow in priority order.
+	MIDIQueueManagerDeviceState<uint32_t, MIDI_SEND_BUFFER_LEN_RING, QUEUE_PRIORITY_COUNT> queue_manager_{};
+
+	/// Classifies an outgoing MIDI message into priority groups.
+	[[nodiscard]] static QueuePriority classify_packed_usb_priority(uint32_t packed);
+	/// Pops one queued message according to strict USB priority ordering.
+	bool pop_lane(QueuePriority priority, USBSendContext& context);
+
+	/// Starts scanning the USB CC lane, where each logical entry is one queued message.
+	[[nodiscard]] bool begin_cc_message_scan(uint16_t& scan_position, uint16_t& limit) const;
+	/// Reads the next USB CC message scan entry shared by scheduled dequeue and coalescing scans.
+	[[nodiscard]] MIDIQueueManager::CCMessageScanResult
+	next_cc_message(uint16_t& scan_position, uint16_t limit, MIDIQueueManager::CCMessageScanEntry& message) const;
+	/// Removes one selected CC message from the USB queue lane.
+	[[nodiscard]] bool remove_cc_message_at(uint16_t target_offset, uint32_t& popped_out);
+	/// Pops the next scheduled CC message, possibly from deeper than the CC lane head.
+	[[nodiscard]] bool pop_next_scheduled_cc_message(uint32_t& message_out);
+	/// Replaces a queued matching CC message's value byte with the newest value.
+	[[nodiscard]] bool coalesce_cc_message(uint32_t queued_message);
+	/// Appends one packed USB-MIDI event to its priority lane.
+	[[nodiscard]] bool enqueue_priority_message(QueuePriority priority, uint32_t queued_message);
+	/// Applies USB enqueue-time CC coalescing/debt policy without callback glue.
+	[[nodiscard]] bool enqueue_message_with_cc_policy(QueuePriority priority, uint32_t queued_message);
+	[[nodiscard]] MIDIQueueManager::PriorityLaneTraversalResult handle_cc_lane(QueuePriority priority,
+	                                                                           USBSendContext& context);
+	/// Pops one queued SysEx event and keeps USB drain locked to SysEx until the ending event is sent.
+	[[nodiscard]] bool pop_sysex_message(USBSendContext& context);
+	/// Temporary lane-sized storage used when scheduled CC dequeue removes a selected message from the middle of the CC
+	/// ring. Survivors are copied here, the ring is reset, and then the survivors are pushed back in their original
+	/// order.
+	std::array<uint32_t, MIDI_SEND_BUFFER_LEN_RING> cc_reorder_scratch_{};
+	/// True after a USB SysEx start/continue event has been popped but before its terminating event has been sent.
+	bool sysex_drain_active_{false};
+};
+
+class MIDIQueueManagerDIN {
+public:
+	/// Clears DIN queue contents and CC scheduling bookkeeping for this device.
+	void reset_queue_storage();
+	/// Resets serial queue pacing state to a known baseline.
+	void reset_serial_state(uint32_t now_sample_timer);
+	/// Returns whether any serial-priority lane has pending bytes.
+	[[nodiscard]] bool has_serial_data() const;
+	/// Remaining DIN queue capacity for raw SysEx bytes.
+	[[nodiscard]] size_t send_buffer_space() const;
+	/// Queues one channel/system MIDI message into the serial-priority queues.
+	void enqueue_message(MIDIMessage message);
+	/// Queues one complete SysEx byte stream into the serial-priority queues.
+	bool enqueue_sysex(uint8_t const* data, int32_t len);
+	/// Drains serial-priority queues into UART under pacing and priority rules.
+	void consume_queued_messages(uint32_t now_sample_timer);
+
+	struct DINSendContext {
+		uint8_t* out_bytes;
+		int32_t allowance_bytes;
+		int32_t uart_space;
+		int32_t max_len;
+		int32_t cc_uart_allowance;
+		QueuePriority& popped_priority;
+	};
+
+private:
+	/// Number of active serial-priority lanes [clock..SysEx] scanned during dequeue.
+	static constexpr size_t k_serial_priority_count = QUEUE_PRIORITY_COUNT;
+	/// Power-of-two lane capacity. Larger than MIDI_TX_BUFFER_SIZE so a full
+	/// 1024-byte SysEx can fit despite the ring's one-unused-slot invariant.
+	static constexpr uint16_t k_serial_queue_capacity = MIDI_TX_BUFFER_SIZE * 2;
+	/// Per-priority byte rings holding pending DIN output grouped by queue policy.
+	MIDIQueueManagerDeviceState<uint8_t, k_serial_queue_capacity, k_serial_priority_count> queue_manager_{};
+	/// Last sample-timer tick used to accrue DIN send allowance.
+	uint32_t serial_allowance_last_update_{0};
+	/// Accumulated DIN send allowance in Q8 bytes (8 fractional bits).
+	int32_t serial_allowance_Q8_{0};
+	/// True after DIN begins draining a SysEx byte stream and before 0xF7 is sent.
+	bool sysex_drain_active_{false};
+
+	/// Pops one realtime/system byte or one complete MIDI message according to lane priority.
+	bool pop_lane(QueuePriority priority, DINSendContext& context);
+	/// Pops one queued SysEx byte and keeps DIN drain locked to SysEx until 0xF7 is sent.
+	bool pop_sysex_byte(DINSendContext& context);
+
+	/// Starts scanning the DIN CC lane, where a logical message spans 1-3 bytes.
+	[[nodiscard]] bool begin_cc_message_scan(uint16_t& scan_position, uint16_t& limit) const;
+	/// Reads the next complete DIN CC message scan entry shared by scheduled dequeue and coalescing scans.
+	[[nodiscard]] MIDIQueueManager::CCMessageScanResult
+	next_cc_message(uint16_t& scan_position, uint16_t limit, MIDIQueueManager::CCMessageScanEntry& message) const;
+	/// Removes one selected three-byte CC message from the byte queue.
+	[[nodiscard]] bool remove_cc_message_at(uint16_t target_offset, uint8_t* out);
+	/// Pops the next scheduled complete CC message while respecting DIN allowance and UART space.
+	[[nodiscard]] bool pop_next_scheduled_cc_message(uint8_t* out_bytes, int32_t allowance_bytes, int32_t uart_space,
+	                                                 int32_t max_len, QueuePriority& popped_priority);
+	/// Replaces the queued value byte for the latest matching status/CC number.
+	[[nodiscard]] bool coalesce_cc_message(MIDIMessage queued_message);
+	/// Encodes one MIDIMessage to serial bytes and appends it to a priority lane.
+	[[nodiscard]] bool enqueue_priority_message(QueuePriority priority, MIDIMessage queued_message);
+	/// Applies DIN enqueue-time CC coalescing/debt policy without callback glue.
+	[[nodiscard]] bool enqueue_message_with_cc_policy(QueuePriority priority, MIDIMessage queued_message);
+	[[nodiscard]] MIDIQueueManager::PriorityLaneTraversalResult handle_cc_lane(QueuePriority priority,
+	                                                                           DINSendContext& context);
+	/// Temporary lane-sized storage used when scheduled CC dequeue removes a selected three-byte message from the
+	/// middle of the CC byte ring. Survivors are copied here, the ring is reset, and then the survivors are pushed back
+	/// in order.
+	std::array<uint8_t, k_serial_queue_capacity> cc_reorder_scratch_{};
+};

--- a/src/deluge/io/midi/midi_queue_manager.md
+++ b/src/deluge/io/midi/midi_queue_manager.md
@@ -1,0 +1,657 @@
+# MIDI Queue Manager
+
+This document explains how the MIDI Queue Manager works. It describes the
+outgoing MIDI flow before and after the queue manager changes, the priority
+lanes used for scheduling, and the special handling used for dense MIDI CC
+traffic.
+
+## Solution description
+
+The MIDI Queue Manager system schedules outgoing MIDI over the USB and DIN
+transports based on the type of MIDI data being sent. Timing-sensitive data,
+such as clock and notes, gets a higher-priority path, while lower-priority data,
+such as ordinary CC's and SysEx, can wait when the transport is busy.
+USB and DIN each keep transport-specific queue manager code because they store
+and drain data differently: USB queues packed USB-MIDI events, while DIN queues
+raw serial MIDI bytes and drains them into the UART using a send allowance. Policy
+that is common to both transports, including message classification, CC
+coalescing, and scheduled CC selection, is centralized in shared classes.
+
+MIDI Device Manager owns the connected USB and DIN device classes, and those
+device classes own their queue manager state. Outgoing MIDI is forwarded through
+the appropriate device queue manager so it can be placed into a priority lane and
+later drained when the transport can send more data.
+
+USB SysEx is split into USB-MIDI event chunks and queued through the USB queue manager; DIN SysEx is
+queued as raw bytes through the DIN queue manager. Once either transport begins
+draining a SysEx stream, it stays on the SysEx lane until the terminating
+USB-MIDI event or DIN `0xF7` byte has been sent, so other MIDI cannot be
+interleaved inside the same SysEx message.
+
+One key principle is that a queued MIDI channel message must be sent as a
+complete message. The DIN queue manager does not emit partial note, expression,
+or CC messages. USB queue entries are already complete USB-MIDI events, so a USB
+dequeue emits one whole event. The queue manager can choose which priority lane
+to drain next, but once it chooses a queued message, it sends the complete
+transport unit for that message before moving on.
+
+MIDI CCs get special handling because dense automation / midi follow feedback can generate more
+low-priority traffic than the MIDI link can drain, especially over DIN where
+serial bandwidth is much lower than USB. Without special handling, a burst of
+ordinary CCs can sit ahead of later clock or note messages and cause jitter.
+
+For ordinary CCs, the queue manager combines two strategies. First, it coalesces
+stale queued values: if a new CC arrives for the same status/channel and CC
+number as one already waiting in the CC lane, the queued value byte is replaced
+with the latest value instead of appending another message. Second, it schedules
+CC dequeue with a per-transfer or UART-staging allowance. CC numbers with newly
+queued or coalesced values accumulate CC debt, so they are preferred when CC
+traffic resumes; when no CC has debt, selection falls back to round-robin order.
+This lets the queue catch up to the latest CC values while still leaving room
+for higher-priority MIDI.
+
+## What problem this solves
+
+Outgoing MIDI can contain a mix of very time-sensitive messages, such as clock
+and notes, and less time-sensitive messages, such as CC's and SysEx. If
+all messages are sent strictly in arrival order, as was done previously, a burst
+of low-priority data can sit ahead of later clock or note messages and cause
+timing jitter.
+
+The MIDI Queue Manager adds per-priority queues between "a message was produced"
+and "the transport is ready to send bytes". USB and DIN keep their
+transport-specific details, but they share the same policy for:
+
+- classifying outgoing messages by priority,
+- coalescing stale queued CC values,
+- choosing which CC should be scheduled next, and
+- avoiding partial channel messages.
+
+### Previous First-in, First-out (FIFO) behavior
+
+The previous implementation did not classify outgoing MIDI by priority. Once a
+message reached the transport, ordering was effectively FIFO within that
+transport path.
+
+For USB, messages were appended to the per-device `sendDataRingBuf` by
+`ConnectedUSBMIDIDevice::bufferMessage()`. `consumeSendData()` later copied
+entries out of that ring in the same order into `dataSendingNow` for the USB
+driver. For DIN, messages and SysEx bytes were written into the UART TX buffer
+with `bufferMIDIUart()`, and the UART drained accepted bytes in FIFO order.
+
+That FIFO behavior preserved arrival order, but it also meant ordinary CC or
+SysEx traffic already in the buffer could sit ahead of later clock, note, or
+expression messages. The queue manager changes that by inserting priority lanes
+before the transport drain.
+
+## Terms
+
+| Term | Meaning |
+| --- | --- |
+| `Transport` | USB or DIN protocol for sending MIDI out of the Deluge to another device. |
+| `MIDI message` | A logical MIDI event, such as clock, note on, expression, CC, or SysEx. |
+| `USB-MIDI event` | The 4-byte USB transport representation of MIDI data. For most channel voice messages, one USB-MIDI event contains one MIDI message. SysEx is the main exception: one logical SysEx message is split across multiple USB-MIDI events. |
+| `DIN byte` | One raw serial MIDI byte written to the DIN UART path. DIN channel messages are stored in the queue as 1 to 3 raw bytes. |
+| `Priority lane` | One ring buffer for a specific message priority. Higher-priority lanes are checked before lower-priority lanes when data is drained for sending. |
+| `Scheduled CC` | A CC selected by the shared CC policy. It may come from the middle of the CC lane instead of the lane head. |
+| `CC debt` | A small per-CC-number score that means "this CC has unsent work waiting". The score is increased when a CC is newly queued or coalesced, and cleared after that CC is emitted. |
+
+## Priority lanes
+
+The shared priority order is:
+
+| Lane | Contents | Notes |
+| --- | --- | --- |
+| `QUEUE_PRIORITY_CLOCK` | System/realtime messages | Highest priority. DIN drains these one byte at a time. |
+| `QUEUE_PRIORITY_NOTES` | Note on/off | Timing-sensitive channel voice messages. |
+| `QUEUE_PRIORITY_EXPRESSION` | Poly aftertouch, channel aftertouch, pitch bend, mod wheel CC, MPE Y CC | Expressive performance data that should sit ahead of ordinary CC's |
+| `QUEUE_PRIORITY_CC` | Other CC messages and fallback channel messages | Lowest-priority channel voice lane. Uses CC coalescing and scheduled dequeue. |
+| `QUEUE_PRIORITY_SYSEX` | USB SysEx event chunks and DIN SysEx bytes | Lowest priority until a SysEx stream starts draining. Once started, transport units are sent contiguously until the ending USB event or DIN `0xF7` byte. |
+
+## Before / after flow diagram
+
+This diagram shows the main architectural change. The MIDI Queue Manager flow is
+shown first, and the previous flow is shown below it. Each row flows left to
+right from message source to transport output. Solid arrows show message flow;
+dotted lines show shared policy used by both queue managers. The source box is
+repeated per transport row for readability; it represents the same outgoing MIDI
+sources. Green boxes are new queue-manager components; the red box is the
+previous queued-send buffer that was removed.
+
+```mermaid
+flowchart TB
+  subgraph AFTER["MIDI Queue Manager flow"]
+    direction TB
+
+    subgraph A_USB_ROW[" "]
+      direction LR
+      A_USB_SRC["Outgoing MIDI sources"]
+      A_USB_FORMAT["USB: setupUSBMessage or SysEx chunking"]
+      A_USB_QUEUE["MIDIQueueManagerUSB priority lanes"]
+      A_USB_DRAIN["USB scheduled drain"]
+      A_USB_TRANSFER["dataSendingNow -> USB driver"]
+
+      A_USB_SRC --> A_USB_FORMAT --> A_USB_QUEUE --> A_USB_DRAIN --> A_USB_TRANSFER
+    end
+
+    A_POLICY["Shared policy: classify messages, coalesce CC values, schedule CCs"]
+
+    subgraph A_DIN_ROW[" "]
+      direction LR
+      A_DIN_SRC["Outgoing MIDI sources"]
+      A_DIN_FORMAT["DIN: sendSerialMidi or sendSerialSysex"]
+      A_DIN_QUEUE["MIDIQueueManagerDIN priority lanes"]
+      A_DIN_DRAIN["DIN paced scheduled drain"]
+      A_DIN_UART["UART TX buffer"]
+      A_DIN_WIRE["DIN serial output"]
+
+      A_DIN_SRC --> A_DIN_FORMAT --> A_DIN_QUEUE --> A_DIN_DRAIN --> A_DIN_UART --> A_DIN_WIRE
+    end
+
+    A_USB_QUEUE -.- A_POLICY
+    A_POLICY -.- A_DIN_QUEUE
+  end
+
+  subgraph BEFORE["Previous flow"]
+    direction TB
+
+    subgraph B_USB_ROW[" "]
+      direction LR
+      B_USB_SRC["Outgoing MIDI sources"]
+      B_USB_FORMAT["USB: setupUSBMessage or SysEx chunking"]
+      B_USB_BUFFER["sendDataRingBuf queued USB ring"]
+      B_USB_TRANSFER["dataSendingNow -> USB driver"]
+
+      B_USB_SRC --> B_USB_FORMAT --> B_USB_BUFFER --> B_USB_TRANSFER
+    end
+
+    subgraph B_DIN_ROW[" "]
+      direction LR
+      B_DIN_SRC["Outgoing MIDI sources"]
+      B_DIN_BYTES["DIN: sendSerialMidi or sendSysex"]
+      B_DIN_UART["UART TX buffer"]
+      B_DIN_WIRE["DIN serial output"]
+
+      B_DIN_SRC --> B_DIN_BYTES --> B_DIN_UART --> B_DIN_WIRE
+    end
+
+    B_USB_SRC ~~~ B_DIN_SRC
+  end
+
+  A_DIN_SRC ~~~ B_USB_SRC
+
+  style AFTER fill:transparent,stroke:transparent
+  style BEFORE fill:transparent,stroke:transparent
+  style A_USB_ROW fill:transparent,stroke:transparent
+  style A_DIN_ROW fill:transparent,stroke:transparent
+  style B_USB_ROW fill:transparent,stroke:transparent
+  style B_DIN_ROW fill:transparent,stroke:transparent
+  classDef addedComponent fill:#183d2a,stroke:#3fb950,stroke-width:2px,color:#ffffff
+  classDef removedComponent fill:#4a1f24,stroke:#f85149,stroke-width:2px,color:#ffffff
+  class A_USB_QUEUE,A_USB_DRAIN,A_POLICY,A_DIN_QUEUE,A_DIN_DRAIN addedComponent
+  class B_USB_BUFFER removedComponent
+```
+
+## High-level data flow comparison
+
+These tables compare the previous path with the queue-manager path. Function
+names in the "Before" columns refer to the previous implementation.
+<mark>Highlighted</mark> steps are the parts that changed.
+
+### USB before / after
+
+<table>
+<thead>
+<tr>
+<th>Flow</th>
+<th>Before MIDI Queue Manager</th>
+<th>After MIDI Queue Manager</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Normal MIDI messages</td>
+<td><pre><code>Source
+  -> MIDIMessage
+  -> MIDICableUSB::sendMessage or MidiEngine::sendUsbMidi
+  -> setupUSBMessage
+  -> <mark>ConnectedUSBMIDIDevice::bufferMessage</mark>
+  -> <mark>sendDataRingBuf queued USB ring</mark></code></pre></td>
+<td><pre><code>Source
+  -> MIDIMessage
+  -> MIDICableUSB::sendMessage or MidiEngine::sendUsbMidi
+  -> setupUSBMessage
+  -> <mark>add virtual cable number</mark>
+  -> <mark>ConnectedUSBMIDIDevice::enqueue_message</mark>
+  -> <mark>MIDIQueueManagerUSB::enqueue_message</mark>
+  -> <mark>classify_packed_usb_priority</mark>
+  -> <mark>message is queued into correct priority lane</mark></code></pre></td>
+</tr>
+<tr>
+<td>SysEx</td>
+<td><pre><code>Source
+  -> SysEx bytes
+  -> MIDICableUSB::sendSysex
+  -> USB-MIDI event chunks
+  -> <mark>ConnectedUSBMIDIDevice::bufferMessage</mark>
+  -> <mark>sendDataRingBuf queued USB ring</mark></code></pre></td>
+<td><pre><code>Source
+  -> SysEx bytes
+  -> MIDICableUSB::sendSysex
+  -> USB-MIDI event chunks
+  -> <mark>ConnectedUSBMIDIDevice::enqueue_message</mark>
+  -> <mark>MIDIQueueManagerUSB::enqueue_message</mark>
+  -> <mark>message is queued into QUEUE_PRIORITY_SYSEX priority lane</mark></code></pre></td>
+</tr>
+<tr>
+<td>Flush / transfer start</td>
+<td><pre><code>MidiEngine::flushMIDI
+  -> MidiEngine::flushUSBMIDIOutput
+  -> <mark>ConnectedUSBMIDIDevice::consumeSendData</mark>
+  -> dataSendingNow
+  -> usb_send_start_rohan</code></pre></td>
+<td><pre><code>MidiEngine::flushMIDI
+  -> MidiEngine::flushUSBMIDIOutput
+  -> <mark>ConnectedUSBMIDIDevice::consume_queued_messages</mark>
+  -> <mark>MIDIQueueManagerUSB::consume_queued_messages</mark>
+  -> dataSendingNow
+  -> usb_send_start_rohan sends the dataSendingNow buffer to the connected USB device</code></pre></td>
+</tr>
+<tr>
+<td>Transfer completion</td>
+<td><pre><code>usbSendCompleteAsHost / usbSendCompleteAsPeripheral
+  -> <mark>consume more buffered data for the same device</mark>
+  -> start the next USB transfer</code></pre></td>
+<td><pre><code>usbSendCompleteAsHost / usbSendCompleteAsPeripheral
+  -> <mark>ConnectedUSBMIDIDevice::consume_queued_messages</mark>
+  -> <mark>MIDIQueueManagerUSB::consume_queued_messages</mark>
+  -> <mark>any remaining queued messages are drained into dataSendingNow buffer in priority order</mark>
+  -> <mark>usb_send_start_rohan sends the dataSendingNow buffer to the connected USB device</mark></code></pre></td>
+</tr>
+</tbody>
+</table>
+
+### DIN before / after
+
+<table>
+<thead>
+<tr>
+<th>Flow</th>
+<th>Before MIDI Queue Manager</th>
+<th>After MIDI Queue Manager</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Channel/system messages</td>
+<td><pre><code>Source
+  -> MIDIMessage
+  -> MIDICableDINPorts::sendMessage or MidiEngine::sendMidi
+  -> MidiEngine::sendSerialMidi
+  -> <mark>bufferMIDIUart</mark>
+  -> <mark>UART TX buffer</mark></code></pre></td>
+<td><pre><code>Source
+  -> MIDIMessage
+  -> MIDICableDINPorts::sendMessage or MidiEngine::sendMidi
+  -> MidiEngine::sendSerialMidi
+  -> <mark>ConnectedDINMIDIDevice::enqueue_message</mark>
+  -> <mark>MIDIQueueManagerDIN::enqueue_message</mark>
+  -> <mark>classify_message</mark>
+  -> <mark>priority lane</mark></code></pre></td>
+</tr>
+<tr>
+<td>Flush / UART staging</td>
+<td><pre><code>MidiEngine::flushMIDI
+  -> uartFlushIfNotSending
+  -> UART TX buffer
+  -> UART driver
+  -> DIN serial output</code></pre></td>
+<td><pre><code>MidiEngine::flushMIDI
+  -> <mark>ConnectedDINMIDIDevice::consume_queued_messages</mark>
+  -> <mark>MIDIQueueManagerDIN::consume_queued_messages</mark>
+  -> bufferMIDIUart
+  -> uartFlushIfNotSending
+  -> UART TX buffer
+  -> UART driver
+  -> DIN serial output</code></pre></td>
+</tr>
+<tr>
+<td>SysEx</td>
+<td><pre><code>Source
+  -> SysEx bytes
+  -> MIDICableDINPorts::sendSysex
+  -> bufferMIDIUart
+  -> UART TX buffer</code></pre></td>
+<td><pre><code>Source
+  -> SysEx bytes
+  -> MIDICableDINPorts::sendSysex
+  -> <mark>MidiEngine::sendSerialSysex</mark>
+  -> <mark>ConnectedDINMIDIDevice::enqueue_sysex</mark>
+  -> <mark>MIDIQueueManagerDIN::enqueue_sysex</mark>
+  -> <mark>QUEUE_PRIORITY_SYSEX</mark></code></pre></td>
+</tr>
+</tbody>
+</table>
+
+DIN SysEx now enters `MIDIQueueManagerDIN` instead of writing directly to
+`bufferMIDIUart`. It is queued all-or-nothing in the SysEx lane; once the DIN
+drain starts sending it, the drain stays locked to SysEx until the terminating
+`0xF7` byte has been accepted by the UART buffer.
+
+### Previous SysEx continuity
+
+The previous implementation kept SysEx streams continuous through FIFO ordering
+rather than through an explicit SysEx drain lock.
+
+For USB, `MIDICableUSB::sendSysex()` split one logical SysEx message into
+USB-MIDI event chunks and appended each chunk to `sendDataRingBuf` with
+`ConnectedUSBMIDIDevice::bufferMessage()`. `consumeSendData()` then copied those
+queued USB-MIDI events into `dataSendingNow` in the same FIFO order. Because one
+`sendSysex()` call appended all of its chunks consecutively, the USB drain sent
+those chunks consecutively too, even when the USB transfer size split the stream
+across multiple transfers.
+
+For DIN, `MIDICableDINPorts::sendSysex()` wrote the validated SysEx byte stream
+directly to the UART TX buffer by calling `bufferMIDIUart()` once per byte in a
+tight loop. The UART buffer then drained those accepted bytes in FIFO order, so
+the DIN SysEx bytes stayed contiguous on the serial output. The previous DIN
+path did not reserve space for the whole SysEx; it relied on this direct write
+loop and the existing `MIDI_TX_BUFFER_SIZE` limit.
+
+The queue manager keeps that intended behavior, but makes it explicit: SysEx is
+queued in the SysEx lane, and once a transport starts draining a SysEx stream it
+stays on that lane until the terminating USB-MIDI event or DIN `0xF7` byte has
+been sent.
+
+## Example flow scenarios
+
+These examples show how messages enter the queue manager and how they later
+leave the queue for the transport.
+
+### USB note message
+
+Queueing path:
+
+```text
+Source creates MIDIMessage::noteOn / noteOff
+  -> MidiEngine::sendMidi
+  -> MidiEngine::sendUsbMidi
+  -> setupUSBMessage
+  -> add USB virtual cable number
+  -> ConnectedUSBMIDIDevice::enqueue_message
+  -> MIDIQueueManagerUSB::enqueue_message
+  -> classify_packed_usb_priority
+  -> QUEUE_PRIORITY_NOTES
+  -> enqueue_priority_message
+  -> USB notes lane
+```
+
+`setupUSBMessage()` packs the channel message into one 32-bit USB-MIDI event:
+byte 0 is CIN/cable, byte 1 is MIDI status, byte 2 is data1, and byte 3 is
+data2. `MidiEngine::sendUsbMidi()` or `MIDICableUSB::sendMessage()` then adds
+the selected USB virtual cable number before passing the packed event to the
+connected device.
+
+Send-out path:
+
+```text
+MidiEngine::flushMIDI
+  -> MidiEngine::flushUSBMIDIOutput
+  -> ConnectedUSBMIDIDevice::consume_queued_messages
+  -> MIDIQueueManagerUSB::consume_queued_messages
+  -> scan priority lanes from clock to SysEx
+  -> pop the notes-lane USB-MIDI event
+  -> copy the 4-byte event into dataSendingNow
+  -> usb_send_start_rohan
+```
+
+If more USB data remains after a transfer completes,
+`usbSendCompleteAsHost()` or `usbSendCompleteAsPeripheral()` calls back into
+`ConnectedUSBMIDIDevice::consume_queued_messages()` to prepare the next USB
+transfer.
+
+### DIN ordinary CC message
+
+Queueing path:
+
+```text
+Source creates MIDIMessage::cc
+  -> MidiEngine::sendMidi
+  -> MidiEngine::sendSerialMidi
+  -> ConnectedDINMIDIDevice::enqueue_message
+  -> MIDIQueueManagerDIN::enqueue_message
+  -> MIDIQueueManager::classify_message
+  -> QUEUE_PRIORITY_CC
+  -> enqueue_message_with_cc_policy
+  -> coalesce_cc_message or enqueue_priority_message
+  -> DIN CC lane
+```
+
+Ordinary CCs enter the lowest-priority channel lane. If the same status/channel
+and CC number is already queued, `coalesce_cc_message()` overwrites the queued
+value byte with the newer value instead of appending another stale CC. The CC
+number's debt is bumped so the scheduler can prefer that refreshed CC the next
+time CC traffic is allowed to send. If there is no matching queued CC, the
+message is encoded into three serial bytes and appended to the DIN CC lane.
+
+Send-out path:
+
+```text
+MidiEngine::flushMIDI
+  -> ConnectedDINMIDIDevice::consume_queued_messages
+  -> MIDIQueueManagerDIN::consume_queued_messages
+  -> accrue DIN send allowance
+  -> check UART space and reserve headroom
+  -> scan priority lanes from clock to SysEx
+  -> handle_cc_lane
+  -> pop_next_scheduled_cc_message
+  -> bufferMIDIUart for each byte in the selected CC
+  -> uartFlushIfNotSending
+```
+
+The DIN drain only considers the CC lane after higher-priority lanes are empty or
+blocked. Before sending a CC, it verifies that the complete three-byte message
+fits the current send allowance, UART space, and CC staging allowance. The CC
+scheduler then scans the CC lane, prefers CC numbers with debt, and falls back
+to round-robin order when no candidate has debt. The selected three-byte CC is
+removed as one complete message, the lane is rebuilt around it, and the emitted
+CC number's debt is cleared.
+
+### SysEx message
+
+USB queueing path:
+
+```text
+Source provides SysEx bytes
+  -> MIDICableUSB::sendSysex
+  -> validate F0 ... F7 message
+  -> split into USB-MIDI SysEx event chunks
+  -> ConnectedUSBMIDIDevice::enqueue_message for each chunk
+  -> MIDIQueueManagerUSB::enqueue_message
+  -> classify_packed_usb_priority
+  -> QUEUE_PRIORITY_SYSEX
+```
+
+DIN queueing path:
+
+```text
+Source provides SysEx bytes
+  -> MIDICableDINPorts::sendSysex
+  -> MidiEngine::sendSerialSysex
+  -> ConnectedDINMIDIDevice::enqueue_sysex
+  -> MIDIQueueManagerDIN::enqueue_sysex
+  -> validate F0 ... F7 message
+  -> check the whole stream fits
+  -> push raw bytes into QUEUE_PRIORITY_SYSEX
+```
+
+Send-out behavior:
+
+```text
+Priority scan reaches QUEUE_PRIORITY_SYSEX
+  -> pop first SysEx transport unit
+  -> mark SysEx drain active
+  -> keep draining only SysEx
+  -> stop the lock after the ending USB-MIDI event or DIN 0xF7 byte is sent
+```
+
+SysEx remains the lowest-priority lane until it starts draining. Once USB pops a
+SysEx USB-MIDI event or DIN pops a SysEx byte, the transport stays locked to the
+SysEx lane until that logical SysEx message is complete. USB may still split the
+stream across multiple USB transfers, and DIN may still split it across multiple
+`flushMIDI()` calls because of serial pacing, but neither transport interleaves
+other MIDI inside the active SysEx stream.
+
+## CC coalescing and scheduling
+
+The CC lane has extra logic because ordinary CC automation can generate many
+messages faster than MIDI can send them, especially over DIN.
+
+### Enqueue-time coalescing
+
+When a new ordinary CC is queued, the queue manager first scans the CC lane for
+the latest queued message with the same status byte and CC number.
+
+- Same status byte means the same MIDI status type and channel.
+- Same CC number means the same value in `data1`.
+- The value byte, `data2`, is the only byte replaced.
+
+If a match exists, the queued value is overwritten and no new queue entry is
+added. This preserves the queued position while ensuring the eventually sent CC
+uses the newest value.
+
+USB and DIN perform the overwrite differently because they store different queue
+units:
+
+- USB replaces byte 3 inside one packed 32-bit USB-MIDI event.
+- DIN replaces the third serial byte of the queued 3-byte CC message.
+
+After a CC is newly queued or coalesced, its CC debt is bumped so the scheduler
+knows that CC has unsent work.
+
+### Scheduled CC dequeue
+
+When the CC lane is eligible to send, the scheduler does not blindly pop the
+lane head. Instead, it:
+
+1. Scans the CC lane.
+2. Records the first queued offset for each CC number into a scratch map.
+3. Selects the CC number with the highest debt.
+4. Falls back to round-robin order when no candidate has debt.
+5. Removes the selected message from the lane.
+6. Rebuilds the lane around the removed message so all other queued data keeps
+   its relative order.
+
+This lets hot CCs catch up to their latest value without allowing one CC number
+to dominate the lane indefinitely.
+
+The `cc_reorder_scratch_` buffers exist for step 6. A scheduled CC can be pulled
+from the middle of the CC lane, so the ring buffer cannot simply advance its
+read position. The selected message is copied out, all remaining entries are
+copied into scratch storage, and the lane is rebuilt from those survivors.
+
+## Transport-specific scheduling
+
+### USB scheduling
+
+USB queues one packed USB-MIDI event per lane entry. During
+`MIDIQueueManagerUSB::consume_queued_messages`, the manager builds one USB
+transfer by scanning priority lanes from highest to lowest and copying selected
+4-byte USB-MIDI events into `dataSendingNow`.
+
+USB SysEx is the exception to normal lane traversal. A logical SysEx message may
+span multiple USB-MIDI events: CIN `0x4` starts or continues the SysEx, and CIN
+`0x5`..`0x7` ends it. Once a SysEx event with CIN `0x4` has been popped, USB
+drain stays locked to the SysEx lane across transfer boundaries until an ending
+CIN is sent. This preserves the previous FIFO behavior that kept a SysEx message
+contiguous.
+
+Important USB limits:
+
+- Peripheral mode can stage up to `MIDI_SEND_BUFFER_LEN_INNER` USB-MIDI events
+  per transfer.
+- Host mode uses `MIDI_SEND_BUFFER_LEN_INNER_HOST`, which is smaller because
+  some hosted devices fail with larger transfers.
+- `k_usb_cc_message_allowance_per_transfer` caps how many scheduled CC messages can
+  be included in one transfer.
+- `k_usb_flush_backlog_message_threshold` opportunistically triggers a flush
+  when the queued backlog grows and no USB send is active.
+
+`send_buffer_space()` reports remaining USB queue capacity as MIDI payload bytes,
+not as 4-byte USB-MIDI event slots. This keeps the return value comparable with
+callers that think in MIDI bytes.
+
+### DIN scheduling
+
+DIN queues raw serial bytes, not packed events. For non-clock lanes, the manager
+validates that a full MIDI message is available and that the whole message fits
+the current send allowance before popping any bytes.
+
+DIN SysEx is queued as raw bytes in `QUEUE_PRIORITY_SYSEX`. Enqueueing is
+all-or-nothing so the queue cannot contain a partial SysEx stream. During drain,
+SysEx normally waits behind higher-priority lanes, but once the first SysEx byte
+is popped, the drain stays locked to the SysEx lane until the terminating `0xF7`
+byte is sent. This keeps one logical SysEx message contiguous even when pacing
+splits it across multiple `flushMIDI()` calls.
+
+DIN calculates a Q8 fixed-point send allowance to pace queue draining at the
+serial MIDI link rate:
+
+- The DIN link is treated as 3125 bytes per second.
+- Partial-byte allowance accrues between audio callbacks.
+- The allowance is capped so a long idle period cannot create an unlimited burst.
+- If the allowance is temporarily zero, no SysEx stream is active, and the
+  highest-priority system lane has data waiting, one realtime/system byte can
+  still be written to the UART.
+
+DIN also keeps UART headroom and applies a separate cap to how much queued CC
+traffic may be staged into the UART buffer. That cap prevents dense CC bursts
+from filling the UART ahead of later higher-priority messages.
+
+## Important invariants
+
+- A queued channel message must be emitted as a complete message. DIN does not
+  pop partial note, expression, or CC messages.
+- USB queue entries are already complete 4-byte USB-MIDI events, so one pop is
+  one USB-MIDI event.
+- A logical USB SysEx message can span multiple USB-MIDI events. Once USB starts
+  draining that stream, no other MIDI is interleaved until the terminating SysEx
+  event has been sent.
+- A logical DIN SysEx message can span many raw bytes. Once DIN starts draining
+  that stream, no other MIDI is interleaved until the terminating `0xF7` byte
+  has been sent.
+- DIN's highest-priority system lane is drained one byte at a time. Realtime
+  messages are naturally complete in one byte.
+- Priority ordering applies when draining queues, not when enqueueing.
+- CC coalescing only updates a queued value; it does not move the queued message.
+- Scheduled CC dequeue is the only path that intentionally removes a message
+  from the middle of a lane.
+- Each ring buffer keeps one slot unused so empty and full states are
+  distinguishable.
+- Logical offsets used while scanning are relative to the lane read position, not
+  physical array indices.
+
+## Main classes
+
+| Class | Role |
+| --- | --- |
+| `MIDIQueueManager` | Shared policy helpers for message classification, CC detection, scan result adaptation, and complete-message validation. |
+| `MIDICCQueuePolicy` | Per-device CC policy state. It owns the first-offset scratch map, CC debt, and round-robin CC selection point. |
+| `MIDIQueueLane` | Power-of-two ring buffer for one priority lane. |
+| `MIDIQueueStorage` | Fixed set of priority lanes. |
+| `MIDIQueueManagerDeviceState` | Combines queue storage with the per-device CC policy. |
+| `MIDIQueueManagerUSB` | USB-specific queue manager. Stores packed 32-bit USB-MIDI events and drains them into `dataSendingNow`. |
+| `MIDIQueueManagerDIN` | DIN-specific queue manager. Stores raw serial bytes, enforces serial pacing, keeps SysEx streams contiguous, and drains selected bytes into the MIDI UART buffer. |
+
+## Tests Performed
+
+- [x] Confirm that ./dbt loadfw release still works
+- [x] Confirm that ./dbt sysex-logging still works
+- [x] Confirm that https://bfredl.github.io/delugeclient/app.html still works for display emulation
+- [x] Confirm that https://bfredl.github.io/delugeclient/app.html still works for debug logs
+- [x] Confirm that you can automate all midi cc's and send out a stable midi clock and midi notes to another device (no clock or note jitter)
+- [x] Confirm that you can automate all midi cc's and send out all midi cc changes to another device (e.g. if you automate a sweep of all 120 cc's from 0-127, you see all 120 cc's sweeping from 0-127 on the other device)
+
+## Tests Not Performed
+
+- [ ] Confirm that sending out midi expression works as expected

--- a/src/deluge/model/midi/message.h
+++ b/src/deluge/model/midi/message.h
@@ -23,6 +23,18 @@
 /// Get the number of bytes associated with the provided status byte.
 size_t bytesPerStatusMessage(uint8_t status);
 
+/// 4-bit MIDI channel-message status nibble values.
+enum class MIDIStatusType : uint8_t {
+	NoteOff = 0x08,
+	NoteOn = 0x09,
+	PolyphonicAftertouch = 0x0A,
+	ControlChange = 0x0B,
+	ProgramChange = 0x0C,
+	ChannelAftertouch = 0x0D,
+	PitchBend = 0x0E,
+	System = 0x0F,
+};
+
 /// Container for a MIDI status message.
 ///
 /// See https://michd.me/jottings/midi-message-format-reference/ for a reference on the different status types and MIDI
@@ -37,7 +49,9 @@ struct MIDIMessage {
 	/// Optional data byte 2
 	uint8_t data2;
 
-	[[gnu::always_inline]] [[nodiscard]] bool isSystemMessage() const { return statusType == 0x0f; }
+	[[gnu::always_inline]] [[nodiscard]] bool isSystemMessage() const {
+		return statusType == static_cast<uint8_t>(MIDIStatusType::System);
+	}
 
 	/// @name Constructors for certain types of message
 	/// @{


### PR DESCRIPTION
## MIDI Queue Manager implementation

Implemented a new MIDI Queue Manager solution which replaces the existing first-in-first-out (FIFO)-style outgoing MIDI buffering with priority-based scheduling. 
- MIDI messages are now queued into priority lanes from highest to lowest priority: clock/system, notes, expression, ordinary CCs, and SysEx.

## Problem this solves
- This solves the issue where sending a large volume of lower priority MIDI can cause clock and note jitter because MIDI was being sent out on a first come-first out basis. So if you automate all MIDI CC's for example, they all get buffered to send and if clock and note are buffered while MIDI CC's are sending then clock and note sends get delayed resulting in jitter on the receiving device's end.

## Solution description

During normal, non-SysEx consumption of the priority queue buffer, higher-priority lanes are sent before lower-priority lanes. Lower-priority messages are only sent when no eligible higher-priority messages are waiting.

With the exception of SysEx, queued MIDI channel messages are sent completely (no partial messages). 
- DIN does not emit partial note, expression, or CC messages, and USB queue entries are sent as complete USB-MIDI events. 
- SysEx is the exception because one SysEx message may span multiple USB-MIDI events or many DIN bytes. SysEx remains lowest priority until it starts draining, but once a SysEx stream begins, the queue manager locks to the SysEx lane until the terminating USB-MIDI event or DIN 0xF7 byte has been sent. This preserves the previous FIFO behaviour where a SysEx stream was not mixed with other MIDI.

### Additional CC logic

With MIDI CC's, queuing by priority was not alone sufficient to stop clock and note jitter. This is because if you queued up a large volume of MIDI CC automation, for example, it could cause delays in the timing of clock and note sends. A one time delay was not an issue, but the cumulative impact of multiple delays resulted in jitter.
- For ordinary CCs, additional scheduling and coalescing logic was added to prevent large CC bursts from overwhelming the MIDI transport and causing unwanted clock, note, or expression jitter. 
- A limit / cap of the number of MIDI CC messages was added based on testing and tuning to prevent clock / note jitter (8 USB messages, 24 bytes for DIN messages). This could be tuned further if needed.
- Coalescing logic was added so that If a queued CC receives a newer value for the same status/channel and CC number while waiting to send, the queued value is updated instead of appending a stale duplicate (because if the clock is running and you've skipped sending a cc and you're also automating that cc, it is possible that the previous value you skipped has been updated by a new automated cc value). So this allows you to catch up the CC values to the current position.
- Finally, even with the above cap and coalescing logic, it was observed that not all CC's would get sent / updated properly because of the imposed limit / cap. This would result in an uneven / unfair queuing of MIDI CC's. To handle this, additional CC tracking was also added so CC numbers that are updated while waiting in the queue can be prioritized the next time CC traffic is allowed to send. When CC sending resumes, the scheduler scans queued CC messages and prefers CC numbers that have accumulated debt from being newly queued or coalesced with fresher values. If no queued CC has debt, selection falls back to round-robin order. This lets frequently updated CCs catch up to their latest value without allowing ordinary CC traffic to overwhelm higher-priority MIDI messages.

## Before / after flow diagram

This diagram shows the USB and DIN midi output flow and where the MIDI Queue Manager was inserted compared to the previous flow.

```mermaid
flowchart TB
  subgraph AFTER["MIDI Queue Manager flow"]
    direction TB

    subgraph A_USB_ROW[" "]
      direction LR
      A_USB_SRC["Outgoing MIDI sources"]
      A_USB_FORMAT["USB: setupUSBMessage or SysEx chunking"]
      A_USB_QUEUE["MIDIQueueManagerUSB priority lanes"]
      A_USB_DRAIN["USB scheduled drain"]
      A_USB_TRANSFER["dataSendingNow -> USB driver"]

      A_USB_SRC --> A_USB_FORMAT --> A_USB_QUEUE --> A_USB_DRAIN --> A_USB_TRANSFER
    end

    A_POLICY["Shared policy: classify messages, coalesce CC values, schedule CCs"]

    subgraph A_DIN_ROW[" "]
      direction LR
      A_DIN_SRC["Outgoing MIDI sources"]
      A_DIN_FORMAT["DIN: sendSerialMidi or sendSerialSysex"]
      A_DIN_QUEUE["MIDIQueueManagerDIN priority lanes"]
      A_DIN_DRAIN["DIN paced scheduled drain"]
      A_DIN_UART["UART TX buffer"]
      A_DIN_WIRE["DIN serial output"]

      A_DIN_SRC --> A_DIN_FORMAT --> A_DIN_QUEUE --> A_DIN_DRAIN --> A_DIN_UART --> A_DIN_WIRE
    end

    A_USB_QUEUE -.- A_POLICY
    A_POLICY -.- A_DIN_QUEUE
  end

  subgraph BEFORE["Previous flow"]
    direction TB

    subgraph B_USB_ROW[" "]
      direction LR
      B_USB_SRC["Outgoing MIDI sources"]
      B_USB_FORMAT["USB: setupUSBMessage or SysEx chunking"]
      B_USB_BUFFER["sendDataRingBuf queued USB ring"]
      B_USB_TRANSFER["dataSendingNow -> USB driver"]

      B_USB_SRC --> B_USB_FORMAT --> B_USB_BUFFER --> B_USB_TRANSFER
    end

    subgraph B_DIN_ROW[" "]
      direction LR
      B_DIN_SRC["Outgoing MIDI sources"]
      B_DIN_BYTES["DIN: sendSerialMidi or sendSysex"]
      B_DIN_UART["UART TX buffer"]
      B_DIN_WIRE["DIN serial output"]

      B_DIN_SRC --> B_DIN_BYTES --> B_DIN_UART --> B_DIN_WIRE
    end

    B_USB_SRC ~~~ B_DIN_SRC
  end

  A_DIN_SRC ~~~ B_USB_SRC

  style AFTER fill:transparent,stroke:transparent
  style BEFORE fill:transparent,stroke:transparent
  style A_USB_ROW fill:transparent,stroke:transparent
  style A_DIN_ROW fill:transparent,stroke:transparent
  style B_USB_ROW fill:transparent,stroke:transparent
  style B_DIN_ROW fill:transparent,stroke:transparent
  classDef addedComponent fill:#183d2a,stroke:#3fb950,stroke-width:2px,color:#ffffff
  classDef removedComponent fill:#4a1f24,stroke:#f85149,stroke-width:2px,color:#ffffff
  class A_USB_QUEUE,A_USB_DRAIN,A_POLICY,A_DIN_QUEUE,A_DIN_DRAIN addedComponent
  class B_USB_BUFFER removedComponent
```

### Data flows

Here's a more detailed comparison of the data flow that changed compared to the previous FIFO implementation <mark>Highlighted</mark> steps are the parts that changed.

#### USB before / after

<table>
<thead>
<tr>
<th>Flow</th>
<th>Before MIDI Queue Manager</th>
<th>After MIDI Queue Manager</th>
</tr>
</thead>
<tbody>
<tr>
<td>Normal MIDI messages</td>
<td><pre><code>Source
  -> MIDIMessage
  -> MIDICableUSB::sendMessage or MidiEngine::sendUsbMidi
  -> setupUSBMessage
  -> <mark>ConnectedUSBMIDIDevice::bufferMessage</mark>
  -> <mark>sendDataRingBuf queued USB ring</mark></code></pre></td>
<td><pre><code>Source
  -> MIDIMessage
  -> MIDICableUSB::sendMessage or MidiEngine::sendUsbMidi
  -> setupUSBMessage
  -> <mark>add virtual cable number</mark>
  -> <mark>ConnectedUSBMIDIDevice::enqueue_message</mark>
  -> <mark>MIDIQueueManagerUSB::enqueue_message</mark>
  -> <mark>classify_packed_usb_priority</mark>
  -> <mark>message is queued into correct priority lane</mark></code></pre></td>
</tr>
<tr>
<td>SysEx</td>
<td><pre><code>Source
  -> SysEx bytes
  -> MIDICableUSB::sendSysex
  -> USB-MIDI event chunks
  -> <mark>ConnectedUSBMIDIDevice::bufferMessage</mark>
  -> <mark>sendDataRingBuf queued USB ring</mark></code></pre></td>
<td><pre><code>Source
  -> SysEx bytes
  -> MIDICableUSB::sendSysex
  -> USB-MIDI event chunks
  -> <mark>ConnectedUSBMIDIDevice::enqueue_message</mark>
  -> <mark>MIDIQueueManagerUSB::enqueue_message</mark>
  -> <mark>message is queued into QUEUE_PRIORITY_SYSEX priority lane</mark></code></pre></td>
</tr>
<tr>
<td>Flush / transfer start</td>
<td><pre><code>MidiEngine::flushMIDI
  -> MidiEngine::flushUSBMIDIOutput
  -> <mark>ConnectedUSBMIDIDevice::consumeSendData</mark>
  -> dataSendingNow
  -> usb_send_start_rohan</code></pre></td>
<td><pre><code>MidiEngine::flushMIDI
  -> MidiEngine::flushUSBMIDIOutput
  -> <mark>ConnectedUSBMIDIDevice::consume_queued_messages</mark>
  -> <mark>MIDIQueueManagerUSB::consume_queued_messages</mark>
  -> dataSendingNow
  -> usb_send_start_rohan sends the dataSendingNow buffer to the connected USB device</code></pre></td>
</tr>
<tr>
<td>Transfer completion</td>
<td><pre><code>usbSendCompleteAsHost / usbSendCompleteAsPeripheral
  -> <mark>consume more buffered data for the same device</mark>
  -> start the next USB transfer</code></pre></td>
<td><pre><code>usbSendCompleteAsHost / usbSendCompleteAsPeripheral
  -> <mark>ConnectedUSBMIDIDevice::consume_queued_messages</mark>
  -> <mark>MIDIQueueManagerUSB::consume_queued_messages</mark>
  -> <mark>any remaining queued messages are drained into dataSendingNow buffer in priority order</mark>
  -> <mark>usb_send_start_rohan sends the dataSendingNow buffer to the connected USB device</mark></code></pre></td>
</tr>
</tbody>
</table>

#### DIN before / after

<table>
<thead>
<tr>
<th>Flow</th>
<th>Before MIDI Queue Manager</th>
<th>After MIDI Queue Manager</th>
</tr>
</thead>
<tbody>
<tr>
<td>Channel/system messages</td>
<td><pre><code>Source
  -> MIDIMessage
  -> MIDICableDINPorts::sendMessage or MidiEngine::sendMidi
  -> MidiEngine::sendSerialMidi
  -> <mark>bufferMIDIUart</mark>
  -> <mark>UART TX buffer</mark></code></pre></td>
<td><pre><code>Source
  -> MIDIMessage
  -> MIDICableDINPorts::sendMessage or MidiEngine::sendMidi
  -> MidiEngine::sendSerialMidi
  -> <mark>ConnectedDINMIDIDevice::enqueue_message</mark>
  -> <mark>MIDIQueueManagerDIN::enqueue_message</mark>
  -> <mark>classify_message</mark>
  -> <mark>priority lane</mark></code></pre></td>
</tr>
<tr>
<td>Flush / UART staging</td>
<td><pre><code>MidiEngine::flushMIDI
  -> uartFlushIfNotSending
  -> UART TX buffer
  -> UART driver
  -> DIN serial output</code></pre></td>
<td><pre><code>MidiEngine::flushMIDI
  -> <mark>ConnectedDINMIDIDevice::consume_queued_messages</mark>
  -> <mark>MIDIQueueManagerDIN::consume_queued_messages</mark>
  -> bufferMIDIUart
  -> uartFlushIfNotSending
  -> UART TX buffer
  -> UART driver
  -> DIN serial output</code></pre></td>
</tr>
<tr>
<td>SysEx</td>
<td><pre><code>Source
  -> SysEx bytes
  -> MIDICableDINPorts::sendSysex
  -> bufferMIDIUart
  -> UART TX buffer</code></pre></td>
<td><pre><code>Source
  -> SysEx bytes
  -> MIDICableDINPorts::sendSysex
  -> <mark>MidiEngine::sendSerialSysex</mark>
  -> <mark>ConnectedDINMIDIDevice::enqueue_sysex</mark>
  -> <mark>MIDIQueueManagerDIN::enqueue_sysex</mark>
  -> <mark>QUEUE_PRIORITY_SYSEX</mark></code></pre></td>
</tr>
</tbody>
</table>

## Tests Performed

- [x] Confirm that ./dbt loadfw release still works
- [x] Confirm that ./dbt sysex-logging still works
- [x] Confirm that https://bfredl.github.io/delugeclient/app.html still works for display emulation
- [x] Confirm that https://bfredl.github.io/delugeclient/app.html still works for debug logs
- [x] Confirm that you can automate all midi cc's and send out a stable midi clock and midi notes to another device (no clock or note jitter)
- [x] Confirm that you can automate all midi cc's and send out all midi cc changes to another device (e.g. if you automate a sweep of all 120 cc's from 0-127, you see all 120 cc's sweeping from 0-127 on the other device)

## Tests Not Performed

- [ ] Confirm that sending out midi expression works as expected