### PR TITLE
Fix skipped encoder ticks

### DIFF
--- a/src/deluge/hid/encoder_input.cpp
+++ b/src/deluge/hid/encoder_input.cpp
@@ -45,8 +45,10 @@ static int32_t nextSDTestDirection = 1;
 static uint32_t encodersWaitingForCardRoutineEnd;
 
 void interpretEncodersTask() {
-	interpretEncoders(false);
+	// Block before draining so an IRQ that arrives during interpretation can re-wake this task.
+	// Blocking after interpretEncoders() can strand a freshly queued tick until the next encoder IRQ.
 	blockTask(EncoderTaskID);
+	interpretEncoders(false);
 }
 
 bool interpretEncoders(bool skipActioning) {


### PR DESCRIPTION
Under load encoder ticks can get skipped, this fixes it