### PR TITLE
Add first/last to iterance options

### DIFF
--- a/src/definitions_cxx.hpp
+++ b/src/definitions_cxx.hpp
@@ -706,13 +706,21 @@ enum class ArmState {
 };
 
 constexpr int32_t kNumProbabilityValues = 20;
-constexpr int32_t kNumIterancePresets = 35;                // 1of2 through 8of8 (indexes 1 through 35)
-constexpr int32_t kCustomIterancePreset = 36;              // The "CUSTOM" iterance value is right after "8of8"
-constexpr Iterance kCustomIteranceValue = Iterance{1, 1};  // "1of1"
-constexpr Iterance kDefaultIteranceValue = Iterance{0, 0}; // 0 means OFF
-constexpr int32_t kDefaultIterancePreset = 0;              // 0 means OFF
+constexpr int32_t kNumIterancePresets = 37; // first, last, then 1of2 through 8of8 (indexes 3 through 37)
+constexpr int32_t kCustomIterancePreset = kNumIterancePresets + 1; // The "CUSTOM" iterance value is right after "8of8"
+constexpr Iterance kCustomIteranceValue = Iterance{1, 1};          // "1of1"
+constexpr Iterance kDefaultIteranceValue = Iterance{0, 0};         // 0, 0 means OFF
+
+constexpr int32_t kFirstIterancePreset = 1;
+constexpr int32_t kLastIterancePreset = 2;
+constexpr Iterance kFirstIteranceValue = Iterance{0, 1}; // 0, 1 means first time only
+constexpr Iterance kLastIteranceValue = Iterance{0, 2};  // 0, 2 means last time only
+
+constexpr int32_t kDefaultIterancePreset = 0; // 0 means OFF
+// these are  only used for reading old songs
 constexpr int32_t kOldFillProbabilityValue = 0;
 constexpr int32_t kOldNotFillProbabilityValue = 128; // This is like the "latched" state of Fill (zero ORed with 128)
+
 constexpr int32_t kDefaultLiftValue = 64;
 
 enum FillMode : uint8_t {

--- a/src/deluge/gui/menu_item/note/iterance_preset.h
+++ b/src/deluge/gui/menu_item/note/iterance_preset.h
@@ -98,6 +98,12 @@ private:
 		else if (iterancePreset == kCustomIterancePreset) {
 			strcpy(buffer, "CUSTOM");
 		}
+		else if (iterancePreset == kFirstIterancePreset) {
+			strcpy(buffer, "1 ST");
+		}
+		else if (iterancePreset == kLastIterancePreset) {
+			strcpy(buffer, "LAST");
+		}
 		else {
 			Iterance iterance = iterancePresets[iterancePreset - 1];
 			int32_t i = iterance.divisor;

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3473,6 +3473,12 @@ void InstrumentClipView::displayIterance(Iterance iterance) {
 	else if (iterancePreset == kCustomIterancePreset) {
 		strcpy(buffer, display->haveOLED() ? "Iterance: CUSTOM" : "CUSTOM");
 	}
+	else if (iterancePreset == kFirstIterancePreset) {
+		strcpy(buffer, display->haveOLED() ? "Iterance: FIRST" : "1 ST");
+	}
+	else if (iterancePreset == kLastIterancePreset) {
+		strcpy(buffer, display->haveOLED() ? "Iterance: LAST" : "LAST");
+	}
 	else {
 		Iterance iterance = iterancePresets[iterancePreset - 1];
 		int32_t i = iterance.divisor;
@@ -3494,9 +3500,10 @@ void InstrumentClipView::displayIterance(Iterance iterance) {
 }
 
 void InstrumentClipView::displayFill(uint8_t mode) {
-	char buffer[(display->haveOLED()) ? 29 : 5];
+	auto buffer_length = display->haveOLED() ? 29 : 5;
+	char buffer[buffer_length];
 
-	strcpy(buffer, getFillString(mode));
+	strncpy(buffer, getFillString(mode), buffer_length);
 
 	if (display->haveOLED()) {
 		display->popupText(buffer, PopupType::FILL);

--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -59,6 +59,8 @@
 #include <new>
 #include <ranges>
 
+#include "playback/mode/playback_mode.h"
+
 namespace params = deluge::modulation::params;
 
 // Supplying song is optional, and basically only for the purpose of setting yScroll according to root note
@@ -713,6 +715,8 @@ void InstrumentClip::processCurrentPos(ModelStackWithTimelineCounter* modelStack
 			ticksTilNextNoteRowEvent = loopLength - lastProcessedPos;
 		}
 
+		// see if it's starting or ending - might be needed for iterance
+		bool ending = not currentPlaybackMode->willClipContinuePlayingAtEnd(modelStack);
 		static PendingNoteOnList pendingNoteOnList; // Making this static, which it really should have always been,
 		                                            // actually didn't help max stack usage at all somehow...
 		pendingNoteOnList.count = 0;
@@ -871,7 +875,7 @@ doNewProbability:
 					ModelStackWithNoteRow* modelStackWithNoteRow = modelStack->addNoteRow(
 					    pendingNoteOnList.pendingNoteOns[i].noteRowId, pendingNoteOnList.pendingNoteOns[i].noteRow);
 
-					conditionPassed = iterance.passesCheck(modelStackWithNoteRow->getRepeatCount());
+					conditionPassed = iterance.passesCheck(modelStackWithNoteRow->getRepeatCount(), ending);
 				}
 
 				// lastly, if after checking iteration we still have a note on

--- a/src/deluge/model/iterance/iterance.cpp
+++ b/src/deluge/model/iterance/iterance.cpp
@@ -27,12 +27,13 @@ uint16_t Iterance::toInt() {
 }
 
 Iterance Iterance::fromInt(int32_t value) {
-	Iterance iterance = Iterance{(uint8_t)(value >> 8), (uint8_t)(value & 0xFF)};
-	if (iterance.divisor < 1 || iterance.divisor > 8) {
-		// If divisor out of bounds, fall back to default value
-		iterance = kDefaultIteranceValue;
+	auto divisor = (uint8_t)(value >> 8);
+	auto step = (uint8_t)(value & 0xFF);
+	// guard against garbage
+	if ((divisor == 0 and step != 1 and step != 2) or divisor > 8) {
+		return kDefaultIteranceValue;
 	}
-	return iterance;
+	return Iterance{.divisor = divisor, .iteranceStep = step};
 }
 
 // To/from preset index

--- a/src/deluge/model/iterance/iterance.h
+++ b/src/deluge/model/iterance/iterance.h
@@ -20,6 +20,8 @@
 #include <bitset>
 #include <cstdint>
 
+/// Represents first, last, or an x of y iteration
+/// If divisor is zero then instead represents either first or last
 struct Iterance {
 	uint8_t divisor;
 	std::bitset<8> iteranceStep;
@@ -28,7 +30,18 @@ struct Iterance {
 		return other.divisor == divisor && other.iteranceStep == iteranceStep;
 	}
 
-	[[nodiscard]] bool passesCheck(int32_t repeatCount) const { return iteranceStep[repeatCount % divisor]; }
+	[[nodiscard]] bool passesCheck(int32_t repeatCount, bool ending) const {
+		// these aren't valid divisors so overloaded to be first/last instead
+		if (divisor == 0) {
+			if (iteranceStep == 1) {
+				return repeatCount == 0;
+			}
+			else {
+				return ending;
+			}
+		}
+		return iteranceStep[repeatCount % divisor];
+	}
 
 	[[nodiscard]] uint16_t toInt();
 	static Iterance fromInt(int32_t value);

--- a/src/deluge/util/lookuptables/lookuptables.cpp
+++ b/src/deluge/util/lookuptables/lookuptables.cpp
@@ -503,7 +503,9 @@ const bool noteCodeIsSharp[12] = {0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0};
  *   This iterance is Custom and will read as "5 and 6, of 6". Iterance value is 0x0630
  */
 
-const std::array<Iterance, 35> iterancePresets = {
+const std::array<Iterance, kNumIterancePresets> iterancePresets = {
+	Iterance{0, 1}, // first
+	Iterance{0, 2}, // last
 	Iterance{2, 0b1}, Iterance{2, 0b10},
 	Iterance{3, 0b1}, Iterance{3, 0b10}, Iterance{3, 0b100},
 	Iterance{4, 0b1}, Iterance{4, 0b10}, Iterance{4, 0b100}, Iterance{4, 0b1000},

--- a/src/deluge/util/lookuptables/lookuptables.h
+++ b/src/deluge/util/lookuptables/lookuptables.h
@@ -134,7 +134,7 @@ extern const uint8_t noteCodeToNoteLetter[];
 extern const uint8_t noteCodeToNoteLetterFlats[];
 extern const bool noteCodeIsSharp[];
 
-extern const std::array<Iterance, 35> iterancePresets;
+extern const std::array<Iterance, kNumIterancePresets> iterancePresets;
 
 #define MAX_CHORD_TYPES 9
 #define MAX_CHORD_NOTES 4


### PR DESCRIPTION
Adds two new iterance options to play only during the first loop or only the final one (e.g. when clip is queued to stop)