### PR TITLE
mark folders with a dot on 7seg

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1360,7 +1360,6 @@ void Browser::displayText(bool blinkImmediately) {
 				display->setText("----");
 			}
 			else {
-
 				// A name is always the full on-card name ("SONG185"). On 7SEG we render the numeric part alone
 				// ("185") so it fits the four-character display.
 				char const* numberPart = nameAfterPrefix(enteredText.get());
@@ -1383,8 +1382,10 @@ void Browser::displayText(bool blinkImmediately) {
 					// provide some context in case the post-fix is long
 					scrollStart = enteredTextEditPos - 2;
 				}
-
-				scrollingText = display->setScrollingText(enteredText.get(), scrollStart);
+				FileItem* currentFileItem = getCurrentFileItem();
+				bool currentItemIsFolder = currentFileItem && currentFileItem->isFolder;
+				auto dotPos = currentItemIsFolder ? 3 : 255;
+				scrollingText = display->setScrollingText(enteredText.get(), scrollStart, 600, -1, dotPos);
 			}
 		}
 	}

--- a/website/src/content/docs/features/community_features.mdx
+++ b/website/src/content/docs/features/community_features.mdx
@@ -106,6 +106,11 @@ A Favourites-Feature has been added to the Load-UIs for most File-Types. The Fav
 Tip:
 If you are Browsing Songs or Samples an dont want to have the Preview to hide the Keyboard on Scrolling, just press :key[Keyboard] to pin the Keyboard and the Favourites.
 
+### 2.5 - 7SEG Folder Indicator <Badge text="c1.3" variant="tip" />
+
+- On 7SEG the file browser now shows a dot in the lower-right corner when the currently selected item is a folder
+
+
 ## 3. General Improvements
 
 Here is a list of general improvements that have been made, ordered from newest to oldest:

--- a/website/src/content/docs/features/community_features.mdx
+++ b/website/src/content/docs/features/community_features.mdx
@@ -110,7 +110,6 @@ If you are Browsing Songs or Samples an dont want to have the Preview to hide th
 
 - On 7SEG the file browser now shows a dot in the lower-right corner when the currently selected item is a folder
 
-
 ## 3. General Improvements
 
 Here is a list of general improvements that have been made, ordered from newest to oldest:

--- a/website/src/content/docs/manual/user_interfaces/file_browser.mdx
+++ b/website/src/content/docs/manual/user_interfaces/file_browser.mdx
@@ -18,3 +18,5 @@ Depending on the type of file you are loading / saving, the file browser will op
 | Audio file             | SAMPLES                 |
 
 The file browser can be quickly exited without needing to press back multiple times by instead pressing one of the mute pads.
+
+Folders can be created by long pressing select. On OLED they show a distinct icon, on 7seg folders are marked with a dot in the right corner instead.


### PR DESCRIPTION
Sets a dot in the lower right to indicate folders. The rest is just expanding the default arguments so I could add the dot arg