### PR TITLE
Fix bug with arranger automation view

### DIFF
--- a/src/deluge/gui/views/arranger_view.cpp
+++ b/src/deluge/gui/views/arranger_view.cpp
@@ -1838,6 +1838,12 @@ void ArrangerView::transitionToClipView(ClipInstance* clipInstance) {
 	if (clip->onAutomationClipView && !onKeyboardScreen) {
 		PadLEDs::explodeAnimationYOriginBig = yPressedEffective << 16;
 
+		// Transition pre-render can happen before AutomationView::opened(). Force clip context so we don't
+		// accidentally render stale arranger automation state into the animation store.
+		automationView.onArrangerView = false;
+		automationView.navSysId = automationView.getNavSysId();
+		automationView.setAutomationParamType();
+
 		if (clip->type == ClipType::INSTRUMENT) {
 			instrumentClipView.recalculateColours();
 			// Automation view reuses instrument clip offscreen rows during explode animations.

--- a/src/deluge/gui/views/automation_view.cpp
+++ b/src/deluge/gui/views/automation_view.cpp
@@ -423,11 +423,11 @@ void AutomationView::initializeView() {
 	// let the view know if we're dealing with an automation parameter or a note parameter
 	setAutomationParamType();
 
-	InstrumentClip* clip = getCurrentInstrumentClip();
-	Output* output = clip->output;
-	OutputType outputType = output->type;
-
 	if (!onArrangerView) {
+		InstrumentClip* clip = getCurrentInstrumentClip();
+		Output* output = clip->output;
+		OutputType outputType = output->type;
+
 		// only applies to instrument clips (not audio)
 		if (clip) {
 			// check if we for some reason, left the automation view, then switched clip types, then came back in
@@ -457,13 +457,13 @@ void AutomationView::initializeView() {
 				indicator_leds::setLedState(IndicatorLED::CROSS_SCREEN_EDIT, inNoteEditor());
 			}
 		}
-	}
 
-	// if we're in the note editor and we're in a kit,
-	// check that the lastAuditionedYDisplay is in sync with the selected drum
-	if (inNoteEditor()) {
-		if (outputType == OutputType::KIT) {
-			potentiallyVerticalScrollToSelectedDrum(clip, output);
+		// if we're in the note editor and we're in a kit,
+		// check that the lastAuditionedYDisplay is in sync with the selected drum
+		if (inNoteEditor()) {
+			if (outputType == OutputType::KIT) {
+				potentiallyVerticalScrollToSelectedDrum(clip, output);
+			}
 		}
 	}
 }
@@ -3199,7 +3199,7 @@ bool AutomationView::inAutomationEditor() {
 
 void AutomationView::setAutomationParamType() {
 	automationParamType = AutomationParamType::PER_SOUND;
-	if (!inAutomationEditor()) {
+	if (!onArrangerView && !inAutomationEditor()) {
 		Clip* clip = getCurrentClip();
 		if (isNoteVelocityEditorShortcut(clip->lastSelectedParamShortcutX, clip->lastSelectedParamShortcutY)) {
 			automationParamType = AutomationParamType::NOTE_VELOCITY;

--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -2769,6 +2769,12 @@ void SessionView::transitionToViewForClip(Clip* clip) {
 	if (clip->onAutomationClipView && !onKeyboardScreen) {
 		currentUIMode = UI_MODE_INSTRUMENT_CLIP_EXPANDING;
 
+		// Transition pre-render can happen before AutomationView::opened(). Force clip context so we don't
+		// accidentally render stale arranger automation state into the animation store.
+		automationView.onArrangerView = false;
+		automationView.navSysId = automationView.getNavSysId();
+		automationView.setAutomationParamType();
+
 		// Store rows 1..kDisplayHeight hold the visible clip rows; rows 0 and kDisplayHeight + 1 are reserved for
 		// offscreen rows so sidebar pads can animate the full height.
 		automationView.renderMainPads(0xFFFFFFFF, &PadLEDs::imageStore[1], &PadLEDs::occupancyMaskStore[1], false);
@@ -4582,6 +4588,12 @@ void SessionView::gridTransitionToViewForClip(Clip* clip) {
 	// over automation and instrument clip views.
 	if (clip->onAutomationClipView && !onKeyboardScreen) {
 		PadLEDs::explodeAnimationYOriginBig = clipY << 16;
+
+		// Transition pre-render can happen before AutomationView::opened(). Force clip context so we don't
+		// accidentally render stale arranger automation state into the animation store.
+		automationView.onArrangerView = false;
+		automationView.navSysId = automationView.getNavSysId();
+		automationView.setAutomationParamType();
 
 		if (clip->type == ClipType::INSTRUMENT) {
 			instrumentClipView.recalculateColours();


### PR DESCRIPTION
Fixed bug where arranger automation view would enter note velocity automation view if you had previously selected a clip that is in that view.

Also fixed bug where stale arranger automation view image would get used when animating the transition from arranger view or session view to automation clip view.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4841

Tested on my deluge, works.