### PR TITLE
Fix mapping of ArpOctaveMode::UP_DOWN to string

### DIFF
--- a/src/deluge/util/functions.cpp
+++ b/src/deluge/util/functions.cpp
@@ -1205,7 +1205,7 @@ ArpOctaveMode stringToArpOctaveMode(char const* string) {
 		return ArpOctaveMode::DOWN;
 	}
 	else if (!strcmp(string, "upDown")) {
-		return ArpOctaveMode::RANDOM;
+		return ArpOctaveMode::UP_DOWN;
 	}
 	else if (!strcmp(string, "alt")) {
 		return ArpOctaveMode::ALTERNATE;


### PR DESCRIPTION
ArpOctaveMode::UP_DOWN was not mapped properly to a string in the code so you could not re-load ArpOctaveMode::UP_DOWN if you saved it. It would get loaded as ArpOctaveMode::RANDOM instead.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4827