### PR TITLE
Fix favourites / banks pad action

### DIFF
--- a/src/deluge/gui/ui/browser/browser.cpp
+++ b/src/deluge/gui/ui/browser/browser.cpp
@@ -1440,47 +1440,52 @@ ActionResult Browser::buttonAction(deluge::hid::Button b, bool on, bool inCardRo
 }
 
 ActionResult Browser::padAction(int32_t x, int32_t y, int32_t on) {
+	bool inFavouriteOrBanksColumn = (x >= 0 && x < static_cast<int32_t>(kNumFavourites));
 
-	if (isFavouritesVisible() && y == favouriteRow && on) {
-		if (sdRoutineLock) {
-			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
-		}
-		if (Buttons::isShiftButtonPressed()) {
-			String filePath;
-			Error error = getCurrentFilePath(&filePath);
-			if (error != Error::NONE) {
-				display->displayPopup(l10n::get(l10n::String::STRING_FOR_ERROR_FILE_NOT_FOUND));
+	if (isFavouritesVisible() && inFavouriteOrBanksColumn && y == favouriteRow) {
+		if (on) {
+			if (sdRoutineLock) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
 			}
-			if (favouritesManager.isEmpty(x)) {
-				if (!getCurrentFileItem()->isFolder) {
-					favouritesManager.setFavourite(x, FavouritesManager::favouriteDefaultColor, filePath.get());
+			if (Buttons::isShiftButtonPressed()) {
+				String filePath;
+				Error error = getCurrentFilePath(&filePath);
+				if (error != Error::NONE) {
+					display->displayPopup(l10n::get(l10n::String::STRING_FOR_ERROR_FILE_NOT_FOUND));
+				}
+				if (favouritesManager.isEmpty(x)) {
+					if (!getCurrentFileItem()->isFolder) {
+						favouritesManager.setFavourite(x, FavouritesManager::favouriteDefaultColor, filePath.get());
+						favouritesChanged();
+					}
+				}
+				else {
+					favouritesManager.unsetFavourite(x);
 					favouritesChanged();
 				}
 			}
 			else {
-				favouritesManager.unsetFavourite(x);
+				const std::string favouritePath = favouritesManager.getFavouriteFilename(x);
 				favouritesChanged();
-			}
-		}
-		else {
-			const std::string favouritePath = favouritesManager.getFavouriteFilename(x);
-			favouritesChanged();
-			if (!favouritePath.empty()) {
-				setFileByFullPath(outputTypeToLoad, favouritePath.c_str());
-			}
-			else {
-				display->displayPopup(l10n::get(l10n::String::STRING_FOR_FAVOURITES_EMPTY));
+				if (!favouritePath.empty()) {
+					setFileByFullPath(outputTypeToLoad, favouritePath.c_str());
+				}
+				else {
+					display->displayPopup(l10n::get(l10n::String::STRING_FOR_FAVOURITES_EMPTY));
+				}
 			}
 		}
 		return ActionResult::DEALT_WITH;
 	}
-	else if (isBanksVisible() && y == favouriteBankRow && on) {
-		if (sdRoutineLock) {
-			return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+	else if (isBanksVisible() && inFavouriteOrBanksColumn && y == favouriteBankRow) {
+		if (on) {
+			if (sdRoutineLock) {
+				return ActionResult::REMIND_ME_OUTSIDE_CARD_ROUTINE;
+			}
+			favouritesManager.selectFavouritesBank(x);
+			favouritesChanged();
+			return ActionResult::DEALT_WITH;
 		}
-		favouritesManager.selectFavouritesBank(x);
-		favouritesChanged();
-		return ActionResult::DEALT_WITH;
 	}
 	else {
 		return QwertyUI::padAction(x, y, on);


### PR DESCRIPTION
Fixed favourites and banks pad action handling to confirm the column pressed is relevant. 

Currently it tries to handle favourites or banks pad action if you press the sidebar pads which it shouldn't.

The code would also allow favourites / banks pad releases to go through the qwerty pad action function which I don't think it should.

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4799

Tested on my deluge, confirmed working