### PR TITLE
Fix horizontal menu UI consistency for patch cables

### DIFF
--- a/src/deluge/gui/menu_item/patch_cable_strength.h
+++ b/src/deluge/gui/menu_item/patch_cable_strength.h
@@ -46,6 +46,7 @@ public:
 	ActionResult buttonAction(hid::Button b, bool on, bool inCardRoutine) override;
 	void selectEncoderAction(int32_t offset) override;
 	void horizontalEncoderAction(int32_t offset) override;
+	[[nodiscard]] bool allowToBeginSessionFromHorizontalMenu() override { return true; }
 
 	modulation::params::Kind getParamKind();
 	uint32_t getParamIndex();

--- a/src/deluge/gui/menu_item/submenu.cpp
+++ b/src/deluge/gui/menu_item/submenu.cpp
@@ -192,11 +192,15 @@ bool Submenu::shouldForwardButtons() {
 
 MenuItem* Submenu::selectButtonPress() {
 	if (shouldForwardButtons()) {
+		// In horizontal menus, some items (e.g. patch cable menus like vibrato)
+		// should enter their own full-screen session before handling SELECT.
+		if ((*current_item_)->allowToBeginSessionFromHorizontalMenu()) {
+			return *current_item_;
+		}
 		return (*current_item_)->selectButtonPress();
 	}
-	else {
-		return *current_item_;
-	}
+
+	return *current_item_;
 }
 
 ActionResult Submenu::buttonAction(deluge::hid::Button b, bool on, bool inCardRoutine) {

--- a/src/deluge/gui/ui/menus.cpp
+++ b/src/deluge/gui/ui/menus.cpp
@@ -1487,10 +1487,6 @@ PLACE_SDRAM_BSS HorizontalMenu soundMasterMenu{
     STRING_FOR_MASTER,
     {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu, &vibratoMenu},
 };
-PLACE_SDRAM_BSS HorizontalMenu soundMasterMenuWithoutVibrato{
-    STRING_FOR_MASTER,
-    {&synthModeMenu, &volumeMenu, &panMenu, &masterTransposeMenu},
-};
 
 PLACE_SDRAM_BSS HorizontalMenuGroup sourceMenuGroup{
     {&source0Menu, &source1Menu, &modulator0Menu, &modulator1Menu, &oscMixerMenu}};
@@ -2015,7 +2011,7 @@ PLACE_SDRAM_DATA MenuItem* paramShortcutsForKitGlobalFX[][kDisplayHeight] = {
 };
 
 PLACE_SDRAM_BSS deluge::vector<HorizontalMenu*> horizontalMenusChainForSound = {
-	&recorderMenu, &soundMasterMenuWithoutVibrato,
+    &recorderMenu, &soundMasterMenu,
 	&sourceMenuGroup, &voiceMenuGroup, &envMenuGroup, &lfoMenuGroup,
 	&filtersMenuGroup, &eqMenu, &modFXMenu,
 	&reverbMenuGroup, &delayMenu, &soundDistortionMenu,

--- a/src/deluge/gui/ui/sound_editor.cpp
+++ b/src/deluge/gui/ui/sound_editor.cpp
@@ -370,7 +370,7 @@ ActionResult SoundEditor::buttonAction(deluge::hid::Button b, bool on, bool inCa
 								}
 								else {
 									HorizontalMenu* parent = maybeGetParentMenu(newItem);
-									if (parent != nullptr && parent->focusChild(newItem)) {
+									if (parent != nullptr && parent != currentMenuItem && parent->focusChild(newItem)) {
 										navigatedBackwardFrom = newItem;
 										newItem = parent;
 									}


### PR DESCRIPTION
Fix issue where with horizontal menu enabled UI was inconsistent between entering horizontal menu with vibrato vs accessing vibrato with shortcut

Now using the shortcut takes you into the horizontal menu and while in the horizontal menu you can press select on the patch cable menu item to open it into the full screen view where you can set the polarity

What changed:
- remove soundMasterMenuWithoutVibrato and use soundMasterMenu so that the grid shortcut for vibrato opens up into the horizontal menu
- override allowToBeginSessionFromHorizontalMenu() in patch cable strength menu to return true so that pressing select on a horizontal menu patch cable item returns the vertical menu for the patch cable (enabling us to enter into it)
- update Submenu::selectButtonPress() to call allowToBeginSessionFromHorizontalMenu() so it knows when to return the current item (instead of entering into the patch cable source menu)
- update sound editor button action so that it doesn't loop endlessly back to horizontal menu UI when pressing select

Confirmed working on my deluge

Also noted that it works for the side chain cable also

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4774