### PR TITLE
docs: clarify song-view channel-change pad and fix a typo on the CV / Gate Engine page

### DIFF
--- a/website/src/content/docs/manual/engines/cv_gate_engine.mdx
+++ b/website/src/content/docs/manual/engines/cv_gate_engine.mdx
@@ -51,7 +51,7 @@ CV clips are not the only way to drive the gate outputs. Any row in a regular ki
 
 </Card>
 
-The channel can also be changed from song view: hold the clip’s pad and turn :key[Select]. The CV button flashes and the display shows the current channel while the pad is held.
+The channel can also be changed from song view: hold any pad in the clip’s row (rows layout) or the clip’s pad (grid layout) and turn :key[Select]. The CV button flashes and the display shows the current channel while the pad is held.
 
 A CV clip has no sound parameters, but pressing :key[Select] in clip view opens its menu, which includes the arpeggiator, play direction and (in “1 and 2” mode) the CV 2 Source setting. See the CV Instrument Menu on [Menu Hierarchies](/reference/menu_hierarchies) for the full list.
 
@@ -68,7 +68,7 @@ With the channel set to “1 and 2”, pitch goes to CV output 1 and notes to ga
 - **Aftertouch** - channel or polyphonic aftertouch. This is the default.
 - **Velocity** - the velocity of each note, set as the note begins.
 
-Both Y and Aftertouch are accesible in automation view for CV clips so they can be used to send a modulation signal out to your connected synth
+Both Y and Aftertouch are accessible in automation view for CV clips so they can be used to send a modulation signal out to your connected synth.
 
 Gate output 2 is not used by the clip in this mode, and remains available to gate kit rows.
 


### PR DESCRIPTION
Hello! Thanks for merging my CV/Gate docs. PR. A couple things I noticed are fixed with this PR.

"Hold the clip's pad" was ambiguous in song view. I missed that one when editing. I am trying to be very clear, since 'clips' pad' could mean at least three things. :)

Also fix "accesible" and a missing period typos.

Thanks!