### PR TITLE
Fix click on an audio track's first note after loading a song

### DIFF
--- a/src/deluge/modulation/envelope.cpp
+++ b/src/deluge/modulation/envelope.cpp
@@ -118,7 +118,8 @@ considerEnvelopeStage:
 	return (lastValue - 1073741824) << 1; // Centre the range of the envelope around 0
 }
 
-int32_t Envelope::noteOn(bool directlyToDecay) {
+int32_t Envelope::noteOn(bool directlyToDecay, int32_t sustain) {
+	smoothedSustain = sustain;
 	ignoredNoteOff = false;
 	pos = 0;
 	if (!directlyToDecay) {
@@ -135,10 +136,10 @@ int32_t Envelope::noteOn(bool directlyToDecay) {
 
 int32_t Envelope::noteOn(uint8_t envelopeIndex, Sound* sound, Voice* voice) {
 	int32_t attack = voice->paramFinalValues[params::LOCAL_ENV_0_ATTACK + envelopeIndex];
-	smoothedSustain = voice->paramFinalValues[params::LOCAL_ENV_0_SUSTAIN + envelopeIndex];
+	int32_t sustain = voice->paramFinalValues[params::LOCAL_ENV_0_SUSTAIN + envelopeIndex];
 	bool directlyToDecay = (attack > 245632);
 
-	return noteOn(directlyToDecay);
+	return noteOn(directlyToDecay, sustain);
 }
 
 void Envelope::noteOff(uint8_t envelopeIndex, Sound* sound, ParamManagerForTimeline* paramManager) {

--- a/src/deluge/modulation/envelope.h
+++ b/src/deluge/modulation/envelope.h
@@ -35,7 +35,8 @@ public:
 	uint32_t timeEnteredState;
 	bool ignoredNoteOff;
 	uint32_t fastReleaseIncrement{1024};
-	int32_t noteOn(bool directlyToDecay);
+	/// `sustain` is the level the smoothed sustain starts from
+	int32_t noteOn(bool directlyToDecay, int32_t sustain);
 	int32_t noteOn(uint8_t envelopeIndex, Sound* sound, Voice* voice);
 	void noteOff(uint8_t envelopeIndex, Sound* sound, ParamManagerForTimeline* paramManager);
 	int32_t render(uint32_t numSamples, uint32_t attack, uint32_t decay, uint32_t sustain, uint32_t release,

--- a/src/deluge/processing/audio_output.cpp
+++ b/src/deluge/processing/audio_output.cpp
@@ -108,7 +108,7 @@ void AudioOutput::resetEnvelope() {
 		AudioClip* activeAudioClip = (AudioClip*)activeClip;
 
 		bool directlyToDecay = (activeAudioClip->attack == -2147483648);
-		envelope.noteOn(directlyToDecay);
+		envelope.noteOn(directlyToDecay, 2147483647);
 	}
 	amplitudeLastTime = 0;
 	overrideAmplitudeEnvelopeReleaseRate = 0;


### PR DESCRIPTION
Fixes Issue SynthstromAudible/DelugeFirmware#4828 (audible click when audio clip launches the first time after loading a song).

## Cause

* `Envelope::smoothedSustain` starts at 0 and is only populated by the `Voice` overload of `noteOn()`. 
* `AudioOutput::resetEnvelope()` used the bare `noteOn(bool)` and didn't set a sustain value like Synths are doing, resulting in a 0 `smoothedSustain` initial value only for audio clips.
* As a result, the clip's first play dipped from max down toward that zero initial `smoothedSustain` before ramping up rapidly, causing a pop.
* Once smoothedSustain reaches the target for a clip, it doesn't get reset, which is why the pop doesn't happen when the clip is played again. The default zero value has been erased.

Synth/kit voices were unaffected, but audio clips weren't setting a smoothedSustain initial value, causing it to default to zero.

## Fix

* pass `AudioOutput::resetEnvelope()` a sustain starting value through a new `sustain` param for `Envelope::noteOn`.
* set the audio sustain value to max since they do not have a sustain envelope param value like synths do - so `smoothedSustain` starts at its target and has nothing to ramp toward
* synths now pass their starting sustain setting through that new `sustain` param instead of setting smoothedSustain directly

## Verification

* Validated with reporter's song and samples on OLED Deluge.
* Confirmed no additional memory impact.