### PR TITLE
Docs/ Add Context Menus to Shortcut Companion

### DIFF
--- a/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
+++ b/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
@@ -146,6 +146,12 @@
     });
   }
 
+  function clearDisplayFrameOverlay() {
+    svgElement?.querySelectorAll(".dc-display-frame-overlay").forEach((el) => {
+      el.remove();
+    });
+  }
+
   function getFirmwareGlyphForChar(char: string): FirmwareGlyph {
     const upper = char.toUpperCase();
     return FIRMWARE_MENU_GLYPHS[upper] ?? FIRMWARE_MENU_GLYPHS["?"];
@@ -450,6 +456,47 @@
     }
   }
 
+  function renderDisplayFrameOverlay() {
+    if (!svgElement) {
+      return;
+    }
+
+    const displayAnchor = getDisplayAnchor();
+    if (!displayAnchor.host) {
+      return;
+    }
+
+    const { x, y, width, height } = displayAnchor.rect;
+    const frameMaskPadding = 1.2;
+
+    const overlayGroup = createSvgElement("g");
+    overlayGroup.setAttribute("class", "dc-display-frame-overlay");
+
+    // Mask the baked-in frame first, then redraw one uniform thin white border.
+    const maskRect = createSvgElement("rect");
+    maskRect.setAttribute("x", `${x - frameMaskPadding}`);
+    maskRect.setAttribute("y", `${y - frameMaskPadding}`);
+    maskRect.setAttribute("width", `${width + frameMaskPadding * 2}`);
+    maskRect.setAttribute("height", `${height + frameMaskPadding * 2}`);
+    maskRect.setAttribute("fill", "rgb(0,0,0)");
+    maskRect.setAttribute("stroke", "none");
+    overlayGroup.appendChild(maskRect);
+
+    const frameRect = createSvgElement("rect");
+    frameRect.setAttribute("x", `${x}`);
+    frameRect.setAttribute("y", `${y}`);
+    frameRect.setAttribute("width", `${width}`);
+    frameRect.setAttribute("height", `${height}`);
+    frameRect.setAttribute("fill", "none");
+    frameRect.setAttribute("stroke", "rgb(231,232,233)");
+    frameRect.setAttribute("stroke-opacity", "0.72");
+    frameRect.setAttribute("stroke-width", "0.45");
+    frameRect.setAttribute("shape-rendering", "geometricPrecision");
+    overlayGroup.appendChild(frameRect);
+
+    displayAnchor.host.appendChild(overlayGroup);
+  }
+
   function appendDemoOverlay(target: Element, fill: string, stroke: string) {
     if (!svgElement || !(target instanceof SVGGraphicsElement)) return;
 
@@ -674,6 +721,7 @@
     clearTurnIndicators(svgElement);
     clearDemoOverlays();
     clearMenuOverlay();
+    clearDisplayFrameOverlay();
 
     // Add highlights to matched elements
     highlightedIds.forEach((id) => {
@@ -724,6 +772,7 @@
       }
     });
 
+    renderDisplayFrameOverlay();
     renderMenuOverlay();
   }
 </script>
@@ -794,6 +843,10 @@
   }
 
   :global(.dc-context-menu-overlay) {
+    pointer-events: none;
+  }
+
+  :global(.dc-display-frame-overlay) {
     pointer-events: none;
   }
 

--- a/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
+++ b/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
   import { Action } from "../data/actions.js";
+  import {
+    getMenuContextDefinition,
+    normalizeMenuRenderMethod,
+  } from "../data/menu_contexts.js";
   import { Control } from "../data/targets.js";
   import { getControlCoordinates } from "../data/control_coordinates.js";
   import { getControlSvgIds } from "../data/control_svg_ids.js";
@@ -21,9 +25,15 @@
     buildCoordinateToSvgIdsMap,
     getSvgIdsForCoordinate,
   } from "./svg/svg_id_helper.js";
-  import { isStep, type StepOrSubstep } from "../types/shortcut.js";
+  import { isStep, type Step, type StepOrSubstep } from "../types/shortcut.js";
 
   const qwertyPadColorMap = buildQwertyPadColorMap();
+  const DISPLAY_RECT_FALLBACK = {
+    x: 137.58,
+    y: 34.396,
+    width: 37.042,
+    height: 11.245,
+  };
 
   export let steps: StepOrSubstep[];
 
@@ -42,9 +52,78 @@
   let activeDemoId: string | undefined;
   let activeDemoLoop: DelugeDemoLoop | undefined;
   let demoCells: DemoCell[] = [];
+  let activeMenuStep: Step | undefined;
   let isSvgLoaded = false;
   let loadStatus: string = "Initializing...";
   const MIN_VISIBLE_DEMO_INTENSITY = 0.035;
+  const OLED_TEXT_CELL_WIDTH = 6;
+  const OLED_TEXT_DRAW_HEIGHT = 7;
+  const OLED_TEXT_TOP_OFFSET = 1;
+  const OLED_TEXT_PIXEL_GAP_RATIO = 0.12;
+
+  type FirmwareGlyph = {
+    width: number;
+    cols: readonly number[];
+  };
+
+  // Apple ][ 7px font data from firmware (font_apple/font_apple_desc), reduced to menu-relevant ASCII.
+  const FIRMWARE_MENU_GLYPHS: Record<string, FirmwareGlyph> = {
+    " ": { width: 2, cols: [0b00000000, 0b00000000] },
+    "#": { width: 5, cols: [0b00010100, 0b01111111, 0b00010100, 0b01111111, 0b00010100] },
+    "(": { width: 3, cols: [0b00011100, 0b00100010, 0b01000001] },
+    ")": { width: 3, cols: [0b01000001, 0b00100010, 0b00011100] },
+    "[": { width: 5, cols: [0b01111111, 0b01111111, 0b01000001, 0b01000001, 0b01000001] },
+    "]": { width: 5, cols: [0b01000001, 0b01000001, 0b01000001, 0b01111111, 0b01111111] },
+    "{": { width: 5, cols: [0b00001000, 0b00111110, 0b01110111, 0b01000001, 0b01000001] },
+    "}": { width: 5, cols: [0b01000001, 0b01000001, 0b01110111, 0b00111110, 0b00001000] },
+    "-": { width: 5, cols: [0b00001000, 0b00001000, 0b00001000, 0b00001000, 0b00001000] },
+    "/": { width: 5, cols: [0b00100000, 0b00010000, 0b00001000, 0b00000100, 0b00000010] },
+    ".": { width: 1, cols: [0b01000000] },
+    ":": { width: 1, cols: [0b00010100] },
+    "0": { width: 5, cols: [0b00111110, 0b01010001, 0b01001001, 0b01000101, 0b00111110] },
+    "1": { width: 3, cols: [0b01000010, 0b01111111, 0b01000000] },
+    "2": { width: 5, cols: [0b01100010, 0b01010001, 0b01001001, 0b01001001, 0b01000110] },
+    "3": { width: 5, cols: [0b00100001, 0b01000001, 0b01001001, 0b01001101, 0b00110011] },
+    "4": { width: 5, cols: [0b00011000, 0b00010100, 0b00010010, 0b01111111, 0b00010000] },
+    "5": { width: 5, cols: [0b00100111, 0b01000101, 0b01000101, 0b01000101, 0b00111001] },
+    "6": { width: 5, cols: [0b00111100, 0b01001010, 0b01001001, 0b01001001, 0b00110001] },
+    "7": { width: 5, cols: [0b00000001, 0b01110001, 0b00001001, 0b00000101, 0b00000011] },
+    "8": { width: 5, cols: [0b00110110, 0b01001001, 0b01001001, 0b01001001, 0b00110110] },
+    "9": { width: 5, cols: [0b01000110, 0b01001001, 0b01001001, 0b00101001, 0b00011110] },
+    "?": { width: 5, cols: [0b00000010, 0b00000001, 0b01011001, 0b00000101, 0b00000010] },
+    A: { width: 5, cols: [0b01111100, 0b00010010, 0b00010001, 0b00010010, 0b01111100] },
+    B: { width: 5, cols: [0b01111111, 0b01001001, 0b01001001, 0b01001001, 0b00110110] },
+    C: { width: 5, cols: [0b00111110, 0b01000001, 0b01000001, 0b01000001, 0b00100010] },
+    D: { width: 5, cols: [0b01111111, 0b01000001, 0b01000001, 0b01000001, 0b00111110] },
+    E: { width: 5, cols: [0b01111111, 0b01001001, 0b01001001, 0b01001001, 0b01000001] },
+    F: { width: 5, cols: [0b01111111, 0b00001001, 0b00001001, 0b00001001, 0b00000001] },
+    G: { width: 5, cols: [0b00111110, 0b01000001, 0b01000001, 0b01010001, 0b01110001] },
+    H: { width: 5, cols: [0b01111111, 0b00001000, 0b00001000, 0b00001000, 0b01111111] },
+    I: { width: 3, cols: [0b01000001, 0b01111111, 0b01000001] },
+    J: { width: 5, cols: [0b00100000, 0b01000000, 0b01000000, 0b01000000, 0b00111111] },
+    K: { width: 5, cols: [0b01111111, 0b00001000, 0b00010100, 0b00100010, 0b01000001] },
+    L: { width: 5, cols: [0b01111111, 0b01000000, 0b01000000, 0b01000000, 0b01000000] },
+    M: { width: 5, cols: [0b01111111, 0b00000010, 0b00001100, 0b00000010, 0b01111111] },
+    N: { width: 5, cols: [0b01111111, 0b00000100, 0b00001000, 0b00010000, 0b01111111] },
+    O: { width: 5, cols: [0b00111110, 0b01000001, 0b01000001, 0b01000001, 0b00111110] },
+    P: { width: 5, cols: [0b01111111, 0b00001001, 0b00001001, 0b00001001, 0b00000110] },
+    Q: { width: 5, cols: [0b00111110, 0b01000001, 0b01010001, 0b00100001, 0b01011110] },
+    R: { width: 5, cols: [0b01111111, 0b00001001, 0b00011001, 0b00101001, 0b01000110] },
+    S: { width: 5, cols: [0b00100110, 0b01001001, 0b01001001, 0b01001001, 0b00110010] },
+    T: { width: 5, cols: [0b00000001, 0b00000001, 0b01111111, 0b00000001, 0b00000001] },
+    U: { width: 5, cols: [0b00111111, 0b01000000, 0b01000000, 0b01000000, 0b00111111] },
+    V: { width: 5, cols: [0b00011111, 0b00100000, 0b01000000, 0b00100000, 0b00011111] },
+    W: { width: 5, cols: [0b01111111, 0b00100000, 0b00011000, 0b00100000, 0b01111111] },
+    X: { width: 5, cols: [0b01100011, 0b00010100, 0b00001000, 0b00010100, 0b01100011] },
+    Y: { width: 5, cols: [0b00000011, 0b00000100, 0b01111000, 0b00000100, 0b00000011] },
+    Z: { width: 5, cols: [0b01100001, 0b01010001, 0b01001001, 0b01000101, 0b01000011] },
+  };
+
+  function createSvgElement<K extends keyof SVGElementTagNameMap>(
+    tagName: K,
+  ): SVGElementTagNameMap[K] {
+    return document.createElementNS("http://www.w3.org/2000/svg", tagName);
+  }
 
   function extractCssDeclaration(style: string, property: string): string {
     const regex = new RegExp(`${property}\\s*:\\s*([^;]+)`, "i");
@@ -56,6 +135,252 @@
     svgElement?.querySelectorAll(".dc-demo-overlay").forEach((el) => {
       el.remove();
     });
+  }
+
+  function clearMenuOverlay() {
+    svgElement?.querySelectorAll(".dc-context-menu-overlay").forEach((el) => {
+      el.remove();
+    });
+  }
+
+  function getFirmwareGlyphForChar(char: string): FirmwareGlyph {
+    const upper = char.toUpperCase();
+    return FIRMWARE_MENU_GLYPHS[upper] ?? FIRMWARE_MENU_GLYPHS["?"];
+  }
+
+  function getDisplayAnchor() {
+    if (!svgElement) {
+      return {
+        host: undefined,
+        rect: DISPLAY_RECT_FALLBACK,
+      };
+    }
+
+    const displayGroup = svgElement.querySelector("#OLED-Display");
+    const displayRect = displayGroup?.querySelector("rect");
+
+    if (!displayRect) {
+      return {
+        host: undefined,
+        rect: DISPLAY_RECT_FALLBACK,
+      };
+    }
+
+    const x = Number.parseFloat(displayRect.getAttribute("x") ?? "");
+    const y = Number.parseFloat(displayRect.getAttribute("y") ?? "");
+    const width = Number.parseFloat(displayRect.getAttribute("width") ?? "");
+    const height = Number.parseFloat(displayRect.getAttribute("height") ?? "");
+
+    if (
+      !Number.isFinite(x) ||
+      !Number.isFinite(y) ||
+      !Number.isFinite(width) ||
+      !Number.isFinite(height)
+    ) {
+      return {
+        host: undefined,
+        rect: DISPLAY_RECT_FALLBACK,
+      };
+    }
+
+    return {
+      host: displayGroup,
+      rect: { x, y, width, height },
+    };
+  }
+
+  function renderMenuOverlay() {
+    if (!svgElement) {
+      return;
+    }
+
+    const menuStep = activeMenuStep;
+    if (!menuStep) {
+      return;
+    }
+
+    const menu = getMenuContextDefinition(menuStep.menuContext);
+    const menuTitle = menuStep.menuTitle ?? menu.title;
+    const menuRenderMethod = normalizeMenuRenderMethod(
+      menuStep.menuRenderMethod ?? menu.renderMethod,
+    );
+    const options =
+      menuStep.menuOptions && menuStep.menuOptions.length > 0
+        ? menuStep.menuOptions
+        : menu.options.length > 0
+          ? menu.options
+          : ["..."];
+    const displayAnchor = getDisplayAnchor();
+    const displayRect = displayAnchor.rect;
+    const selectedIndex = Math.min(
+      Math.max(menuStep.menuSelectedIndex ?? menu.selectedIndex ?? 0, 0),
+      options.length - 1,
+    );
+
+    const maxVisibleOptions = 2;
+    const visibleOptions = options.slice(0, maxVisibleOptions);
+    // Mirror firmware context_menu.cpp virtual OLED geometry (128x48).
+    const OLED_MAIN_WIDTH_PIXELS = 128;
+    const OLED_MAIN_HEIGHT_PIXELS = 48;
+    const K_TEXT_SPACING_Y = 9;
+    const WINDOW_WIDTH = 100;
+    const WINDOW_HEIGHT = 40;
+    const windowMinX = (OLED_MAIN_WIDTH_PIXELS - WINDOW_WIDTH) / 2;
+    const windowMaxX = OLED_MAIN_WIDTH_PIXELS - windowMinX;
+    const windowMinY = (OLED_MAIN_HEIGHT_PIXELS - WINDOW_HEIGHT) / 2;
+    const windowMaxY = OLED_MAIN_HEIGHT_PIXELS - windowMinY;
+
+    const toDisplayX = (oledX: number) =>
+      displayRect.x + (oledX / OLED_MAIN_WIDTH_PIXELS) * displayRect.width;
+    const toDisplayY = (oledY: number) =>
+      displayRect.y + (oledY / OLED_MAIN_HEIGHT_PIXELS) * displayRect.height;
+    const pixelScaleX = displayRect.width / OLED_MAIN_WIDTH_PIXELS;
+    const pixelScaleY = displayRect.height / OLED_MAIN_HEIGHT_PIXELS;
+
+    const snapX = (value: number) =>
+      displayRect.x +
+      Math.round((value - displayRect.x) / Math.max(pixelScaleX, 0.0001)) *
+        pixelScaleX;
+    const snapY = (value: number) =>
+      displayRect.y +
+      Math.round((value - displayRect.y) / Math.max(pixelScaleY, 0.0001)) *
+        pixelScaleY;
+    const snapW = (value: number) =>
+      Math.max(pixelScaleX, Math.round(value / Math.max(pixelScaleX, 0.0001)) * pixelScaleX);
+    const snapH = (value: number) =>
+      Math.max(pixelScaleY, Math.round(value / Math.max(pixelScaleY, 0.0001)) * pixelScaleY);
+
+    const overlayGroup = createSvgElement("g");
+    overlayGroup.setAttribute("class", "dc-context-menu-overlay");
+
+    // Virtual OLED framebuffer: 1 bit per pixel, rendered into SVG rects.
+    const oledBuffer = new Uint8Array(OLED_MAIN_WIDTH_PIXELS * OLED_MAIN_HEIGHT_PIXELS);
+    const indexAt = (x: number, y: number) => y * OLED_MAIN_WIDTH_PIXELS + x;
+    const setPixel = (x: number, y: number, value: 0 | 1) => {
+      if (x < 0 || y < 0 || x >= OLED_MAIN_WIDTH_PIXELS || y >= OLED_MAIN_HEIGHT_PIXELS) {
+        return;
+      }
+      oledBuffer[indexAt(x, y)] = value;
+    };
+    const invertPixel = (x: number, y: number) => {
+      if (x < 0 || y < 0 || x >= OLED_MAIN_WIDTH_PIXELS || y >= OLED_MAIN_HEIGHT_PIXELS) {
+        return;
+      }
+      const idx = indexAt(x, y);
+      oledBuffer[idx] = oledBuffer[idx] ? 0 : 1;
+    };
+
+    const drawHorizontalLine = (y: number, startX: number, endX: number) => {
+      for (let x = startX; x <= endX; x++) {
+        setPixel(x, y, 1);
+      }
+    };
+
+    const drawVerticalLine = (x: number, startY: number, endY: number) => {
+      for (let y = startY; y <= endY; y++) {
+        setPixel(x, y, 1);
+      }
+    };
+
+    const drawRectangle = (minX: number, minY: number, maxX: number, maxY: number) => {
+      drawHorizontalLine(minY, minX, maxX);
+      drawHorizontalLine(maxY, minX, maxX);
+      drawVerticalLine(minX, minY, maxY);
+      drawVerticalLine(maxX, minY, maxY);
+    };
+
+    const drawMenuText = (text: string, startX: number, startY: number, endX: number) => {
+      let pixelX = startX;
+      const renderY = startY + OLED_TEXT_TOP_OFFSET;
+      const uppercase = text.toUpperCase();
+
+      for (let i = 0; i < uppercase.length; i++) {
+        const glyph = getFirmwareGlyphForChar(uppercase[i] ?? " ");
+        const glyphStartX = pixelX + ((OLED_TEXT_CELL_WIDTH - glyph.width) >> 1);
+
+        for (let col = 0; col < glyph.width; col++) {
+          const colBits = glyph.cols[col] ?? 0;
+          for (let row = 0; row < OLED_TEXT_DRAW_HEIGHT; row++) {
+            if (((colBits >> row) & 1) === 0) {
+              continue;
+            }
+            setPixel(glyphStartX + col, renderY + row, 1);
+          }
+        }
+
+        pixelX += OLED_TEXT_CELL_WIDTH;
+        if (pixelX >= endX) {
+          break;
+        }
+      }
+    };
+
+    const invertArea = (xMin: number, width: number, startY: number, endY: number) => {
+      const xMax = xMin + width - 1;
+      for (let y = startY; y <= endY; y++) {
+        for (let x = xMin; x <= xMax; x++) {
+          invertPixel(x, y);
+        }
+      }
+    };
+
+    const invertAreaRounded = (xMin: number, width: number, startY: number, endY: number) => {
+      invertArea(xMin, width, startY, endY);
+      // Match SMALL rounded-corner behavior (1px corner clear).
+      const xMax = xMin + width - 1;
+      setPixel(xMin, startY, 0);
+      setPixel(xMax, startY, 0);
+      setPixel(xMin, endY, 0);
+      setPixel(xMax, endY, 0);
+    };
+
+    drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY);
+    drawHorizontalLine(windowMinY + 15, 22, OLED_MAIN_WIDTH_PIXELS - 30);
+    drawMenuText(menuTitle, 22, windowMinY + 6, OLED_MAIN_WIDTH_PIXELS);
+
+    visibleOptions.forEach((option, i) => {
+      const textPixelY = windowMinY + 18 + i * K_TEXT_SPACING_Y;
+      const textStartX =
+        menuRenderMethod === "NO_INVERSION" ? 23 + OLED_TEXT_CELL_WIDTH : 23;
+      drawMenuText(option, textStartX, textPixelY, OLED_MAIN_WIDTH_PIXELS - 27);
+
+      if (i === selectedIndex) {
+        if (menuRenderMethod === "ROUNDED_INVERSION") {
+          invertAreaRounded(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8);
+        } else if (menuRenderMethod === "NO_INVERSION") {
+          drawVerticalLine(22, textPixelY, textPixelY + 8);
+        } else {
+          invertArea(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8);
+        }
+      }
+    });
+
+    const pixelInsetX = (pixelScaleX * OLED_TEXT_PIXEL_GAP_RATIO) / 2;
+    const pixelInsetY = (pixelScaleY * OLED_TEXT_PIXEL_GAP_RATIO) / 2;
+    const pixelWidth = pixelScaleX * (1 - OLED_TEXT_PIXEL_GAP_RATIO);
+    const pixelHeight = pixelScaleY * (1 - OLED_TEXT_PIXEL_GAP_RATIO);
+
+    for (let y = 0; y < OLED_MAIN_HEIGHT_PIXELS; y++) {
+      for (let x = 0; x < OLED_MAIN_WIDTH_PIXELS; x++) {
+        if (!oledBuffer[indexAt(x, y)]) {
+          continue;
+        }
+        const px = createSvgElement("rect");
+        px.setAttribute("class", "dc-context-menu-glyph-pixel");
+        px.setAttribute("x", `${snapX(toDisplayX(x)) + pixelInsetX}`);
+        px.setAttribute("y", `${snapY(toDisplayY(y)) + pixelInsetY}`);
+        px.setAttribute("width", `${snapW(pixelWidth)}`);
+        px.setAttribute("height", `${snapH(pixelHeight)}`);
+        px.setAttribute("fill", "rgb(244, 247, 250)");
+        overlayGroup.appendChild(px);
+      }
+    }
+
+    if (displayAnchor.host) {
+      displayAnchor.host.appendChild(overlayGroup);
+    } else {
+      svgElement.appendChild(overlayGroup);
+    }
   }
 
   function appendDemoOverlay(target: Element, fill: string, stroke: string) {
@@ -124,6 +449,8 @@
             return step.substeps;
           }
         });
+
+      activeMenuStep = activeControls.filter((step) => step.action === Action.MENU).at(-1);
 
       const turnControls = new Set<Control>(
         activeControls
@@ -279,6 +606,7 @@
     });
     clearTurnIndicators(svgElement);
     clearDemoOverlays();
+    clearMenuOverlay();
 
     // Add highlights to matched elements
     highlightedIds.forEach((id) => {
@@ -328,6 +656,8 @@
         appendDemoOverlay(el, style.fill, style.stroke);
       }
     });
+
+    renderMenuOverlay();
   }
 </script>
 
@@ -394,6 +724,54 @@
   :global(.dc-demo-overlay) {
     pointer-events: none;
     transition: fill 120ms linear, stroke 120ms linear;
+  }
+
+  :global(.dc-context-menu-overlay) {
+    pointer-events: none;
+  }
+
+  :global(.dc-context-menu-window) {
+    fill: rgb(0, 0, 0);
+    stroke: none;
+    shape-rendering: crispEdges;
+  }
+
+  :global(.dc-context-menu-divider) {
+    stroke: rgb(244, 247, 250);
+    shape-rendering: crispEdges;
+  }
+
+  :global(.dc-context-menu-title) {
+    fill: rgb(244, 247, 250);
+    font-family: "Consolas", "Menlo", "Courier New", monospace;
+    font-weight: 400;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    font-synthesis: none;
+    font-kerning: none;
+    font-variant-ligatures: none;
+    text-rendering: geometricPrecision;
+  }
+
+  :global(.dc-context-menu-selection) {
+    fill: rgb(244, 247, 250);
+    shape-rendering: crispEdges;
+  }
+
+  :global(.dc-context-menu-option) {
+    fill: rgb(244, 247, 250);
+    font-family: "Consolas", "Menlo", "Courier New", monospace;
+    font-weight: 400;
+    letter-spacing: 0;
+    text-transform: uppercase;
+    font-synthesis: none;
+    font-kerning: none;
+    font-variant-ligatures: none;
+    text-rendering: geometricPrecision;
+  }
+
+  :global(.dc-context-menu-option.is-selected) {
+    fill: rgb(19, 23, 29);
   }
 
   :global(.dc-svg-highlight circle),

--- a/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
+++ b/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
@@ -3,6 +3,7 @@
   import { Action } from "../data/actions.js";
   import {
     getMenuContextDefinition,
+    isVerticalMenuContext,
     normalizeMenuRenderMethod,
   } from "../data/menu_contexts.js";
   import { Control } from "../data/targets.js";
@@ -60,6 +61,8 @@
   const OLED_TEXT_DRAW_HEIGHT = 7;
   const OLED_TEXT_TOP_OFFSET = 1;
   const OLED_TEXT_PIXEL_GAP_RATIO = 0.12;
+  const OLED_MENU_HORIZONTAL_INSET_RATIO = 0.035;
+  const OLED_MENU_VERTICAL_NUDGE_RATIO = 0.03;
 
   type FirmwareGlyph = {
     width: number;
@@ -211,18 +214,61 @@
           ? menu.options
           : ["..."];
     const displayAnchor = getDisplayAnchor();
-    const displayRect = displayAnchor.rect;
+    const displayRectRaw = displayAnchor.rect;
+    const horizontalInset =
+      displayRectRaw.width * OLED_MENU_HORIZONTAL_INSET_RATIO;
+    const verticalNudge =
+      displayRectRaw.height * OLED_MENU_VERTICAL_NUDGE_RATIO;
+    const displayRect = {
+      x: displayRectRaw.x + horizontalInset,
+      y: displayRectRaw.y + verticalNudge,
+      width: Math.max(displayRectRaw.width - horizontalInset * 2, 1),
+      height: displayRectRaw.height,
+    };
     const selectedIndex = Math.min(
       Math.max(menuStep.menuSelectedIndex ?? menu.selectedIndex ?? 0, 0),
       options.length - 1,
     );
 
-    const maxVisibleOptions = 2;
-    const visibleOptions = options.slice(0, maxVisibleOptions);
+    const isVerticalMenu = isVerticalMenuContext(menuStep.menuContext);
+    const maxVisibleOptions = isVerticalMenu ? 3 : 2;
+    let visibleOptions: string[] = [];
+    let selectedVisibleIndex = 0;
+
+    if (isVerticalMenu) {
+      // Mirror Submenu::drawPixelsForOled windowing: collect relevant items before/after,
+      // then balance the selected row toward the middle where possible.
+      const before = options.slice(0, selectedIndex).slice(-maxVisibleOptions);
+      const after = options.slice(selectedIndex, selectedIndex + maxVisibleOptions);
+
+      let pos = Math.floor((maxVisibleOptions - 1) / 2);
+      let tail = maxVisibleOptions - pos;
+
+      if (before.length < pos) {
+        pos = before.length;
+        tail = Math.min(maxVisibleOptions - pos, after.length);
+      } else if (after.length < tail) {
+        tail = after.length;
+        pos = Math.min(maxVisibleOptions - tail, before.length);
+      }
+
+      visibleOptions = [
+        ...before.slice(before.length - pos),
+        ...after.slice(0, tail),
+      ];
+      selectedVisibleIndex = pos;
+    } else {
+      visibleOptions = options.slice(0, maxVisibleOptions);
+      selectedVisibleIndex = Math.min(selectedIndex, Math.max(visibleOptions.length - 1, 0));
+    }
     // Mirror firmware context_menu.cpp virtual OLED geometry (128x48).
     const OLED_MAIN_WIDTH_PIXELS = 128;
     const OLED_MAIN_HEIGHT_PIXELS = 48;
+    const K_TEXT_SPACING_X = OLED_TEXT_CELL_WIDTH;
     const K_TEXT_SPACING_Y = 9;
+    const SCREEN_TITLE_Y = 1;
+    const SCREEN_TITLE_SEPARATOR_Y = 12;
+    const VERTICAL_BASE_Y = 14;
     const WINDOW_WIDTH = 100;
     const WINDOW_HEIGHT = 40;
     const windowMinX = (OLED_MAIN_WIDTH_PIXELS - WINDOW_WIDTH) / 2;
@@ -334,26 +380,47 @@
       setPixel(xMax, endY, 0);
     };
 
-    drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY);
-    drawHorizontalLine(windowMinY + 15, 22, OLED_MAIN_WIDTH_PIXELS - 30);
-    drawMenuText(menuTitle, 22, windowMinY + 6, OLED_MAIN_WIDTH_PIXELS);
+    if (isVerticalMenu) {
+      // Match MenuItem::renderOLED + Canvas::drawScreenTitle behavior for vertical submenus.
+      drawMenuText(menuTitle, 0, SCREEN_TITLE_Y, OLED_MAIN_WIDTH_PIXELS);
+      drawHorizontalLine(SCREEN_TITLE_SEPARATOR_Y, 0, OLED_MAIN_WIDTH_PIXELS - 1);
 
-    visibleOptions.forEach((option, i) => {
-      const textPixelY = windowMinY + 18 + i * K_TEXT_SPACING_Y;
-      const textStartX =
-        menuRenderMethod === "NO_INVERSION" ? 23 + OLED_TEXT_CELL_WIDTH : 23;
-      drawMenuText(option, textStartX, textPixelY, OLED_MAIN_WIDTH_PIXELS - 27);
+      // Match Submenu::drawSubmenuItemsForOled: rows at baseY + o*kTextSpacingY, full-width highlighting.
+      visibleOptions.forEach((option, i) => {
+        const textPixelY = VERTICAL_BASE_Y + i * K_TEXT_SPACING_Y;
+        drawMenuText(option, K_TEXT_SPACING_X, textPixelY, OLED_MAIN_WIDTH_PIXELS);
 
-      if (i === selectedIndex) {
-        if (menuRenderMethod === "ROUNDED_INVERSION") {
-          invertAreaRounded(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8);
-        } else if (menuRenderMethod === "NO_INVERSION") {
-          drawVerticalLine(22, textPixelY, textPixelY + 8);
-        } else {
-          invertArea(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8);
+        if (i === selectedVisibleIndex) {
+          if (menuRenderMethod === "NO_INVERSION") {
+            drawVerticalLine(0, textPixelY, textPixelY + 8);
+          } else if (menuRenderMethod === "NO_ROUNDING") {
+            invertArea(0, OLED_MAIN_WIDTH_PIXELS, textPixelY, textPixelY + 8);
+          } else {
+            invertAreaRounded(0, OLED_MAIN_WIDTH_PIXELS, textPixelY, textPixelY + 8);
+          }
         }
-      }
-    });
+      });
+    } else {
+      drawRectangle(windowMinX, windowMinY, windowMaxX, windowMaxY);
+      drawHorizontalLine(windowMinY + 15, 22, OLED_MAIN_WIDTH_PIXELS - 30);
+      drawMenuText(menuTitle, 22, windowMinY + 6, OLED_MAIN_WIDTH_PIXELS);
+
+      visibleOptions.forEach((option, i) => {
+        const textPixelY = windowMinY + 18 + i * K_TEXT_SPACING_Y;
+        const textStartX = menuRenderMethod === "NO_INVERSION" ? 23 + OLED_TEXT_CELL_WIDTH : 23;
+        drawMenuText(option, textStartX, textPixelY, OLED_MAIN_WIDTH_PIXELS - 27);
+
+        if (i === selectedVisibleIndex) {
+          if (menuRenderMethod === "ROUNDED_INVERSION") {
+            invertAreaRounded(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8);
+          } else if (menuRenderMethod === "NO_INVERSION") {
+            drawVerticalLine(22, textPixelY, textPixelY + 8);
+          } else {
+            invertArea(22, OLED_MAIN_WIDTH_PIXELS - 44, textPixelY, textPixelY + 8);
+          }
+        }
+      });
+    }
 
     const pixelInsetX = (pixelScaleX * OLED_TEXT_PIXEL_GAP_RATIO) / 2;
     const pixelInsetY = (pixelScaleY * OLED_TEXT_PIXEL_GAP_RATIO) / 2;

--- a/website/src/components/deluge_companion/components/svg/Deluge.svg
+++ b/website/src/components/deluge_companion/components/svg/Deluge.svg
@@ -653,7 +653,7 @@
         <circle cx="788.204" cy="225.808" r="64.258" style="fill:rgb(255,164,0);"/>
     </g>
     <g id="OLED-Display" serif:id="OLED Display" transform="matrix(0.999432,0,0,1.01281,0.785559,-4.64301)">
-        <rect x="1105.9" y="274.347" width="275.943" height="88.191"/>
+        <rect x="1105.9" y="274.347" width="275.943" height="88.191" style="fill:none;stroke:rgb(231,232,233);stroke-opacity:0.65;stroke-width:0.12px;stroke-linejoin:miter;stroke-miterlimit:1;shape-rendering:geometricPrecision;"/>
     </g>
     <g id="Synced" transform="matrix(0.799982,0,0,0.799982,358.176,50.5576)">
         <circle cx="1791.35" cy="252.765" r="8.109" style="fill:none;stroke:white;stroke-width:1.25px;stroke-linejoin:miter;stroke-miterlimit:1;"/>

--- a/website/src/components/deluge_companion/data/control_coordinates.ts
+++ b/website/src/components/deluge_companion/data/control_coordinates.ts
@@ -375,7 +375,7 @@ export const controlCoordinates: Partial<Record<Control, Coordinate[]>> = {
 
   // ========== External/Fallback ==========
   [Control.EXTERNAL]: [],
-  [Control.CONTEXT_MENU]: [],
+  [Control.MENU]: [],
   [Control.NONE]: [],
 }
 

--- a/website/src/components/deluge_companion/data/control_coordinates.ts
+++ b/website/src/components/deluge_companion/data/control_coordinates.ts
@@ -358,6 +358,15 @@ export const controlCoordinates: Partial<Record<Control, Coordinate[]>> = {
     { x: 3, y: 7 },
   ],
 
+  // ========== Oscillator Shortcuts ==========
+  [Control.OSC_TYPE]: [
+    { x: 2, y: 2 },
+    { x: 3, y: 2 },
+  ],
+
+  // ========== Voice Shortcuts ==========
+  [Control.VOICE_POLYPHONY]: [{ x: 7, y: 1 }],
+
   // ========== Patch Source Pads (X=15, right edge) ==========
   [Control.NOTE_PATCH_SOURCE]: [{ x: 15, y: 3 }],
   [Control.RANDOM_PATCH_SOURCE]: [{ x: 15, y: 2 }],
@@ -366,6 +375,7 @@ export const controlCoordinates: Partial<Record<Control, Coordinate[]>> = {
 
   // ========== External/Fallback ==========
   [Control.EXTERNAL]: [],
+  [Control.CONTEXT_MENU]: [],
   [Control.NONE]: [],
 }
 

--- a/website/src/components/deluge_companion/data/menu_contexts.ts
+++ b/website/src/components/deluge_companion/data/menu_contexts.ts
@@ -53,13 +53,6 @@ const contextMenuDefinitions: Record<string, ContextMenuDefinition> = {
     selectedIndex: 0,
     renderMethod: DEFAULT_MENU_RENDER_METHOD,
   },
-  OSCILLATOR_INPUT: {
-    label: "Sound > Oscillator > Type > Input",
-    title: "Osc. Type",
-    options: ["Input"],
-    selectedIndex: 0,
-    renderMethod: DEFAULT_MENU_RENDER_METHOD,
-  },
   LOAD_ALL: {
     label: "Sample(s) > Load All",
     title: "Sample(s)",
@@ -74,20 +67,44 @@ const contextMenuDefinitions: Record<string, ContextMenuDefinition> = {
     selectedIndex: 1,
     renderMethod: DEFAULT_MENU_RENDER_METHOD,
   },
-  CHOKE: {
-    label: "Sound > Voice > Polyphony > Choke",
-    title: "Polyphony",
-    options: ["Choke"],
-    selectedIndex: 0,
-    renderMethod: DEFAULT_MENU_RENDER_METHOD,
-  },
+}
+
+const verticalMenuDefinitions: Record<string, ContextMenuDefinition> = {
   COUNT_IN: {
     label: "Settings > Recording > Count-In Bars",
     title: "Recording",
-    options: ["Count-In Bars"],
+    options: ["Count-In Bars", "Quantization", "Loop Margins"],
     selectedIndex: 0,
     renderMethod: DEFAULT_MENU_RENDER_METHOD,
   },
+  OSCILLATOR_INPUT: {
+    label: "Sound > Oscillator > Type > Input",
+    title: "Oscillator Type",
+    options: [
+      "Input",
+      "Input Left",
+      "Input Right",
+      "Input Stereo",
+    ],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  CHOKE: {
+    label: "Sound > Voice > Polyphony > Choke",
+    title: "Polyphony",
+    options: ["Auto", "Polyphonic", "Monophonic", "Legato", "Choke"],
+    selectedIndex: 4,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+}
+
+function getMenuDefinition(
+  normalizedContext: string,
+): ContextMenuDefinition | undefined {
+  return (
+    contextMenuDefinitions[normalizedContext] ??
+    verticalMenuDefinitions[normalizedContext]
+  )
 }
 
 // Returns canonical context-menu key used by markdown parsing and rendering.
@@ -102,9 +119,15 @@ export function getMenuContextDefinition(
 ): ContextMenuDefinition {
   const normalized = normalizeMenuContext(context)
   return (
-    contextMenuDefinitions[normalized] ??
+    getMenuDefinition(normalized) ??
     contextMenuDefinitions[DEFAULT_MENU_CONTEXT]
   )
+}
+
+// Returns true when the context belongs to the vertical menu definition map.
+export function isVerticalMenuContext(context?: string): boolean {
+  const normalized = normalizeMenuContext(context)
+  return verticalMenuDefinitions[normalized] !== undefined
 }
 
 // Returns true when value maps to a known menu render method token.
@@ -124,7 +147,7 @@ export function normalizeMenuRenderMethod(value?: string): MenuRenderMethod {
 // Returns a compact, human-readable menu label for step chips.
 export function getMenuContextLabel(context?: string): string {
   const normalized = normalizeMenuContext(context)
-  const contextDefinition = contextMenuDefinitions[normalized]
+  const contextDefinition = getMenuDefinition(normalized)
 
   if (contextDefinition?.label && contextDefinition.label.trim().length > 0) {
     return contextDefinition.label

--- a/website/src/components/deluge_companion/data/menu_contexts.ts
+++ b/website/src/components/deluge_companion/data/menu_contexts.ts
@@ -1,0 +1,142 @@
+export type ContextMenuDefinition = {
+  label?: string
+  title: string
+  options: string[]
+  selectedIndex?: number
+  renderMethod?: MenuRenderMethod
+}
+
+export const MENU_RENDER_METHODS = [
+  "NO_ROUNDING",
+  "ROUNDED_INVERSION",
+  "NO_INVERSION",
+] as const
+
+export type MenuRenderMethod = (typeof MENU_RENDER_METHODS)[number]
+
+export const DEFAULT_MENU_RENDER_METHOD: MenuRenderMethod = "NO_ROUNDING"
+
+export const DEFAULT_MENU_CONTEXT = "NONE"
+
+const contextMenuDefinitions: Record<string, ContextMenuDefinition> = {
+  NONE: {
+    title: "Menu",
+    options: ["..."],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  CLONE: {
+    label: "Load Preset > Clone",
+    title: "Load Preset",
+    options: ["Clone"],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  BASIC: {
+    label: "Load File(s) > Basic",
+    title: "Load File(s)",
+    options: ["Multisamples", "Basic"],
+    selectedIndex: 1,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  MULTISAMPLES: {
+    label: "Load File(s) > Multisamples",
+    title: "Load File(s)",
+    options: ["Multisamples", "Basic"],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  SINGLE_CYCLE: {
+    label: "Load File(s) > Single-Cycle",
+    title: "Load File(s)",
+    options: ["Single-Cycle", "Wavetable"],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  OSCILLATOR_INPUT: {
+    label: "Sound > Oscillator > Type > Input",
+    title: "Osc. Type",
+    options: ["Input"],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  LOAD_ALL: {
+    label: "Sample(s) > Load All",
+    title: "Sample(s)",
+    options: ["Load All"],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  SLICE: {
+    label: "Sample(s) > Slice",
+    title: "Sample(s)",
+    options: ["Load All", "Slice"],
+    selectedIndex: 1,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  CHOKE: {
+    label: "Sound > Voice > Polyphony > Choke",
+    title: "Polyphony",
+    options: ["Choke"],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+  COUNT_IN: {
+    label: "Settings > Recording > Count-In Bars",
+    title: "Recording",
+    options: ["Count-In Bars"],
+    selectedIndex: 0,
+    renderMethod: DEFAULT_MENU_RENDER_METHOD,
+  },
+}
+
+// Returns canonical context-menu key used by markdown parsing and rendering.
+export function normalizeMenuContext(value?: string): string {
+  const normalized = value?.trim().toUpperCase()
+  return normalized && normalized.length > 0 ? normalized : DEFAULT_MENU_CONTEXT
+}
+
+// Returns context-menu definition or the default fallback when unknown.
+export function getMenuContextDefinition(
+  context?: string,
+): ContextMenuDefinition {
+  const normalized = normalizeMenuContext(context)
+  return (
+    contextMenuDefinitions[normalized] ??
+    contextMenuDefinitions[DEFAULT_MENU_CONTEXT]
+  )
+}
+
+// Returns true when value maps to a known menu render method token.
+export function isMenuRenderMethod(value: string): value is MenuRenderMethod {
+  return MENU_RENDER_METHODS.includes(value as MenuRenderMethod)
+}
+
+// Returns canonical render method, defaulting when omitted.
+export function normalizeMenuRenderMethod(value?: string): MenuRenderMethod {
+  const normalized = value?.trim().toUpperCase()
+  if (normalized && isMenuRenderMethod(normalized)) {
+    return normalized
+  }
+  return DEFAULT_MENU_RENDER_METHOD
+}
+
+// Returns a compact, human-readable menu label for step chips.
+export function getMenuContextLabel(context?: string): string {
+  const normalized = normalizeMenuContext(context)
+  const contextDefinition = contextMenuDefinitions[normalized]
+
+  if (contextDefinition?.label && contextDefinition.label.trim().length > 0) {
+    return contextDefinition.label
+  }
+
+  if (normalized === DEFAULT_MENU_CONTEXT) {
+    return "menu"
+  }
+
+  return normalized
+    .split("_")
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0) + segment.slice(1).toLowerCase())
+    .join(" ")
+}

--- a/website/src/components/deluge_companion/data/menu_contexts.ts
+++ b/website/src/components/deluge_companion/data/menu_contexts.ts
@@ -80,12 +80,7 @@ const verticalMenuDefinitions: Record<string, ContextMenuDefinition> = {
   OSCILLATOR_INPUT: {
     label: "Sound > Oscillator > Type > Input",
     title: "Oscillator Type",
-    options: [
-      "Input",
-      "Input Left",
-      "Input Right",
-      "Input Stereo",
-    ],
+    options: ["Input", "Input Left", "Input Right", "Input Stereo"],
     selectedIndex: 0,
     renderMethod: DEFAULT_MENU_RENDER_METHOD,
   },

--- a/website/src/components/deluge_companion/data/shortcut_descriptions.ts
+++ b/website/src/components/deluge_companion/data/shortcut_descriptions.ts
@@ -34,6 +34,7 @@ export const shortcutActionDescriptions: Record<
 
 export const shortcutControlDescriptions: Record<Control, string> = {
   [Control.NONE]: "control",
+  [Control.CONTEXT_MENU]: "context menu",
   [Control.RECORD]: "Record button",
   [Control.PLAY]: "Play button",
   [Control.LOAD]: "Load (New) button",
@@ -87,6 +88,8 @@ export const shortcutControlDescriptions: Record<Control, string> = {
   [Control.RANDOM_PATCH_SOURCE]: "'Random' patch source pad",
   [Control.VELOCITY_PATCH_SOURCE]: "'Velocity' patch source pad",
   [Control.NAME]: "'Name' grid pad",
+  [Control.OSC_TYPE]: "'Oscillator Type' grid pads",
+  [Control.VOICE_POLYPHONY]: "'Voice Polyphony' grid pad",
   [Control.QWERTY]: "QWERTY keyboard overlay",
 }
 

--- a/website/src/components/deluge_companion/data/shortcut_descriptions.ts
+++ b/website/src/components/deluge_companion/data/shortcut_descriptions.ts
@@ -34,7 +34,7 @@ export const shortcutActionDescriptions: Record<
 
 export const shortcutControlDescriptions: Record<Control, string> = {
   [Control.NONE]: "control",
-  [Control.CONTEXT_MENU]: "context menu",
+  [Control.MENU]: "Menu",
   [Control.RECORD]: "Record button",
   [Control.PLAY]: "Play button",
   [Control.LOAD]: "Load (New) button",

--- a/website/src/components/deluge_companion/data/shortcuts/04-clip/01-melodic/01-synth/04_clip_synth.md
+++ b/website/src/components/deluge_companion/data/shortcuts/04-clip/01-melodic/01-synth/04_clip_synth.md
@@ -36,7 +36,7 @@ Changes the current synth preset.
 #OFFICIAL #SYNTH
 
 ```shortcut
-hold(LOAD) + press(SYNTH), turn(SELECT), hold(LOAD) + menu(NONE), press(SELECT)
+hold(LOAD) + press(SYNTH), turn(SELECT), hold(LOAD), menu(CLONE), press(SELECT)
 ```
 
 A single preset can only appear in one active clip, so clone the original preset for multiple instances in the same song. It is good practice to clone first when tweaking to avoid affecting interdependent songs.
@@ -76,7 +76,7 @@ Deluge detects the pitch of provided samples regardless of filename, though for 
 #OFFICIAL #SYNTH
 
 ```shortcut
-hold(AUDITION) + press(LOAD), press(SELECT), turn(SELECT), hold(SELECT) + menu(NONE), press(SELECT)
+hold(AUDITION) + press(LOAD), press(SELECT), turn(SELECT), hold(SELECT), turn(SELECT) + menu(BASIC), press(SELECT)
 ```
 
 Hold Select and turn to choose BASIc, which loads a sample with no pitch detection.
@@ -86,7 +86,7 @@ Hold Select and turn to choose BASIc, which loads a sample with no pitch detecti
 #OFFICIAL #SYNTH
 
 ```shortcut
-hold(AUDITION) + press(LOAD), press(SELECT), turn(SELECT), hold(SELECT) + menu(NONE), press(SELECT)
+hold(AUDITION) + press(LOAD), press(SELECT), turn(SELECT), hold(SELECT), menu(MULTISAMPLES), press(SELECT)
 ```
 
 Scroll through folders to select a sample or parent folder for multi-samples. Hold Select and turn to choose MULTi for multi-sampling.
@@ -96,17 +96,17 @@ Scroll through folders to select a sample or parent folder for multi-samples. Ho
 #OFFICIAL #SYNTH
 
 ```shortcut
-hold(AUDITION) + press(LOAD), press(SELECT), turn(SELECT), hold(SELECT) + menu(NONE), press(SELECT)
+hold(AUDITION) + press(LOAD), press(SELECT), turn(SELECT), hold(SELECT), turn(SELECT) + menu(SINGLE_CYCLE), press(SELECT)
 ```
 
 Single-cycle waveforms should be under 20ms. Deluge automatically transposes to C and sets loop mode. Use the SINGle option to force samples into this mode.
 
-# External sound source
+# External oscillator sound source
 
 #OFFICIAL #SYNTH
 
 ```shortcut
-hold(SHIFT) + press(GRID), turn(SELECT), menu(NONE), press(PLAY)
+hold(SHIFT) + press(OSC_TYPE), turn(SELECT) + menu(OSCILLATOR_INPUT), press(SELECT)
 ```
 
 Use an external input as an oscillator source by selecting IN. You can pitch-shift around the source or play chords with several sequenced notes at once. A stereo-to-mono adapter can feed one source to OSC1 INL and another to OSC2 INR.

--- a/website/src/components/deluge_companion/data/shortcuts/04-clip/03-kit/04-clip_kit.md
+++ b/website/src/components/deluge_companion/data/shortcuts/04-clip/03-kit/04-clip_kit.md
@@ -42,7 +42,7 @@ hold(SAVE) + press(KIT), turn(SELECT), press(SELECT)
 #OFFICIAL #KIT
 
 ```shortcut
-hold(LOAD) + press(KIT), turn(SELECT), hold(LOAD) + menu(NONE), press(SELECT)
+hold(LOAD) + press(KIT), turn(SELECT), hold(LOAD), menu(CLONE), press(SELECT)
 ```
 
 A single preset can only appear in one active clip, so clone the original preset for multiple instances in the same song. It is good practice to clone first when tweaking to avoid affecting interdependent songs.
@@ -70,7 +70,7 @@ hold(SHIFT) + hold(AUDITION) + press(LOAD), turn(SELECT), press(SELECT)
 #OFFICIAL #KIT
 
 ```shortcut
-hold(SHIFT) + press(KIT), turn(SELECT), hold(SELECT), menu(NONE), press(SELECT)
+hold(SHIFT) + press(KIT), turn(SELECT), hold(SELECT), menu(LOAD_ALL), press(SELECT)
 ```
 
 Scroll to the parent folder of the samples you want, or to a sample within the folder, then choose ALL.
@@ -82,7 +82,7 @@ Beware of CPU and memory overhead when loading large amounts of samples into kit
 #OFFICIAL #KIT
 
 ```shortcut
-hold(SHIFT), press(KIT), turn(SELECT), hold(SELECT), menu(NONE), press(SELECT), menu(NONE), press(SELECT)
+hold(SHIFT), press(KIT), turn(SELECT), hold(SELECT), turn(select) + menu(SLICE), press(SELECT), turn(select), press(SELECT)
 ```
 
 Scroll to a sample, choose SLICE, then select the number of slices from 2-256.
@@ -94,7 +94,7 @@ You can add more samples to sliced kits, but not more slices to existing kits. O
 #OFFICIAL #KIT
 
 ```shortcut
-hold(AUDITION) + press(GRID), turn(SELECT), menu(NONE), press(SELECT)
+hold(AUDITION) + press(VOICE_POLYPHONY), turn(SELECT), menu(CHOKE), press(SELECT)
 ```
 
 Select CHOKe. When playing, this stops all other notes in the same kit that are set to the same choke group.

--- a/website/src/components/deluge_companion/data/shortcuts/06-recording/06-recording.md
+++ b/website/src/components/deluge_companion/data/shortcuts/06-recording/06-recording.md
@@ -102,7 +102,7 @@ press(GRID_UNLIT), press(KIT), turn(TEMPO)
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(SHIFT) + press(SELECT), menu(NONE), menu(NONE)
+hold(SHIFT) + press(SELECT), turn(SELECT) + press(SELECT), menu(COUNT_IN)
 ```
 
 # Grid View Loop Pads

--- a/website/src/components/deluge_companion/data/targets.ts
+++ b/website/src/components/deluge_companion/data/targets.ts
@@ -67,7 +67,7 @@ export enum Control {
   OSC_TYPE,
   VOICE_POLYPHONY,
   QWERTY,
-  CONTEXT_MENU,
+  MENU,
 }
 
 export const controlDescriptions: ControlDescriptions = {
@@ -75,8 +75,8 @@ export const controlDescriptions: ControlDescriptions = {
     title: "-",
     type: ControlType.none,
   },
-  [Control.CONTEXT_MENU]: {
-    title: "Context menu",
+  [Control.MENU]: {
+    title: "Menu",
     type: ControlType.none,
   },
   [Control.PLAY]: {

--- a/website/src/components/deluge_companion/data/targets.ts
+++ b/website/src/components/deluge_companion/data/targets.ts
@@ -64,12 +64,19 @@ export enum Control {
   RANDOM_PATCH_SOURCE,
   VELOCITY_PATCH_SOURCE,
   NAME,
+  OSC_TYPE,
+  VOICE_POLYPHONY,
   QWERTY,
+  CONTEXT_MENU,
 }
 
 export const controlDescriptions: ControlDescriptions = {
   [Control.NONE]: {
     title: "-",
+    type: ControlType.none,
+  },
+  [Control.CONTEXT_MENU]: {
+    title: "Context menu",
     type: ControlType.none,
   },
   [Control.PLAY]: {
@@ -379,6 +386,16 @@ export const controlDescriptions: ControlDescriptions = {
     title: "'Name' grid pad",
     type: ControlType.grid,
     classes: ["dc-grid-3-12"],
+  },
+  [Control.OSC_TYPE]: {
+    title: "'Oscillator Type' grid pads",
+    type: ControlType.grid,
+    classes: ["dc-grid-1-1", "dc-grid-1-2"],
+  },
+  [Control.VOICE_POLYPHONY]: {
+    title: "'Voice Polyphony' grid pad",
+    type: ControlType.grid,
+    classes: ["dc-grid-1-1"],
   },
   [Control.QWERTY]: {
     title: "Qwerty",

--- a/website/src/components/deluge_companion/data/v4.1.0.json
+++ b/website/src/components/deluge_companion/data/v4.1.0.json
@@ -330,7 +330,7 @@
     "steps": [
       {
         "action": 0,
-        "control": 53
+        "control": 55
       }
     ],
     "views": [],
@@ -4570,16 +4570,14 @@
         "control": 34
       },
       {
-        "substeps": [
-          {
-            "action": 1,
-            "control": 3
-          },
-          {
-            "action": 3,
-            "control": 0
-          }
-        ]
+        "action": 1,
+        "control": 3
+      },
+      {
+        "action": 3,
+        "control": 0,
+        "label": "Load Preset > Clone",
+        "menuContext": "CLONE"
       },
       {
         "action": 0,
@@ -4597,7 +4595,7 @@
         ]
       }
     ],
-    "description": "Hold the Load (New) button, press the Synth button. Turn the Select (Settings) encoder. Hold the Load (New) button, select an option from the on-screen menu. Press the Select (Settings) encoder."
+    "description": "Hold the Load (New) button, press the Synth button. Turn the Select (Settings) encoder. Hold the Load (New) button. Select an option from the on-screen menu. Press the Select (Settings) encoder."
   },
   {
     "name": "Save synth preset",
@@ -4761,14 +4759,20 @@
         "control": 34
       },
       {
+        "action": 1,
+        "control": 34
+      },
+      {
         "substeps": [
           {
-            "action": 1,
+            "action": 2,
             "control": 34
           },
           {
             "action": 3,
-            "control": 0
+            "control": 0,
+            "label": "Load File(s) > Basic",
+            "menuContext": "BASIC"
           }
         ]
       },
@@ -4788,7 +4792,7 @@
         ]
       }
     ],
-    "description": "Hold the Audition / Section button for row, press the Load (New) button. Press the Select (Settings) encoder. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder, select an option from the on-screen menu. Press the Select (Settings) encoder."
+    "description": "Hold the Audition / Section button for row, press the Load (New) button. Press the Select (Settings) encoder. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder. Turn the Select (Settings) encoder, select an option from the on-screen menu. Press the Select (Settings) encoder."
   },
   {
     "name": "Multi-sampling",
@@ -4822,16 +4826,14 @@
         "control": 34
       },
       {
-        "substeps": [
-          {
-            "action": 1,
-            "control": 34
-          },
-          {
-            "action": 3,
-            "control": 0
-          }
-        ]
+        "action": 1,
+        "control": 34
+      },
+      {
+        "action": 3,
+        "control": 0,
+        "label": "Load File(s) > Multisamples",
+        "menuContext": "MULTISAMPLES"
       },
       {
         "action": 0,
@@ -4849,7 +4851,7 @@
         ]
       }
     ],
-    "description": "Hold the Audition / Section button for row, press the Load (New) button. Press the Select (Settings) encoder. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder, select an option from the on-screen menu. Press the Select (Settings) encoder."
+    "description": "Hold the Audition / Section button for row, press the Load (New) button. Press the Select (Settings) encoder. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder. Select an option from the on-screen menu. Press the Select (Settings) encoder."
   },
   {
     "name": "Single cycle waveforms",
@@ -4883,14 +4885,20 @@
         "control": 34
       },
       {
+        "action": 1,
+        "control": 34
+      },
+      {
         "substeps": [
           {
-            "action": 1,
+            "action": 2,
             "control": 34
           },
           {
             "action": 3,
-            "control": 0
+            "control": 0,
+            "label": "Load File(s) > Single-Cycle",
+            "menuContext": "SINGLE_CYCLE"
           }
         ]
       },
@@ -4910,10 +4918,10 @@
         ]
       }
     ],
-    "description": "Hold the Audition / Section button for row, press the Load (New) button. Press the Select (Settings) encoder. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder, select an option from the on-screen menu. Press the Select (Settings) encoder."
+    "description": "Hold the Audition / Section button for row, press the Load (New) button. Press the Select (Settings) encoder. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder. Turn the Select (Settings) encoder, select an option from the on-screen menu. Press the Select (Settings) encoder."
   },
   {
-    "name": "External sound source",
+    "name": "External oscillator sound source",
     "capability": "04_clip_synth",
     "capabilityParentId": "CLIP",
     "capabilityOrder": 5,
@@ -4931,21 +4939,27 @@
           },
           {
             "action": 0,
-            "control": 36
+            "control": 53
           }
         ]
       },
       {
-        "action": 2,
-        "control": 34
-      },
-      {
-        "action": 3,
-        "control": 0
+        "substeps": [
+          {
+            "action": 2,
+            "control": 34
+          },
+          {
+            "action": 3,
+            "control": 0,
+            "label": "Sound > Oscillator > Type > Input",
+            "menuContext": "OSCILLATOR_INPUT"
+          }
+        ]
       },
       {
         "action": 0,
-        "control": 2
+        "control": 34
       }
     ],
     "views": [9],
@@ -4959,7 +4973,7 @@
         ]
       }
     ],
-    "description": "Hold the Shift button, press the Grid pad (lit or unlit). Turn the Select (Settings) encoder. Select an option from the on-screen menu. Press the Play button."
+    "description": "Hold the Shift button, press the 'Oscillator Type' grid pads. Turn the Select (Settings) encoder, select an option from the on-screen menu. Press the Select (Settings) encoder."
   },
   {
     "name": "Setup MIDI sequencing of notes",
@@ -5542,16 +5556,14 @@
         "control": 34
       },
       {
-        "substeps": [
-          {
-            "action": 1,
-            "control": 3
-          },
-          {
-            "action": 3,
-            "control": 0
-          }
-        ]
+        "action": 1,
+        "control": 3
+      },
+      {
+        "action": 3,
+        "control": 0,
+        "label": "Load Preset > Clone",
+        "menuContext": "CLONE"
       },
       {
         "action": 0,
@@ -5569,7 +5581,7 @@
         ]
       }
     ],
-    "description": "Hold the Load (New) button, press the Kit button. Turn the Select (Settings) encoder. Hold the Load (New) button, select an option from the on-screen menu. Press the Select (Settings) encoder."
+    "description": "Hold the Load (New) button, press the Kit button. Turn the Select (Settings) encoder. Hold the Load (New) button. Select an option from the on-screen menu. Press the Select (Settings) encoder."
   },
   {
     "name": "Load sample into a kit row",
@@ -5681,7 +5693,9 @@
       },
       {
         "action": 3,
-        "control": 0
+        "control": 0,
+        "label": "Sample(s) > Load All",
+        "menuContext": "LOAD_ALL"
       },
       {
         "action": 0,
@@ -5733,16 +5747,26 @@
         "control": 34
       },
       {
-        "action": 3,
-        "control": 0
+        "substeps": [
+          {
+            "action": 2,
+            "control": 34
+          },
+          {
+            "action": 3,
+            "control": 0,
+            "label": "Sample(s) > Slice",
+            "menuContext": "SLICE"
+          }
+        ]
       },
       {
         "action": 0,
         "control": 34
       },
       {
-        "action": 3,
-        "control": 0
+        "action": 2,
+        "control": 34
       },
       {
         "action": 0,
@@ -5767,7 +5791,7 @@
         ]
       }
     ],
-    "description": "Hold the Shift button. Press the Kit button. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder. Select an option from the on-screen menu. Press the Select (Settings) encoder. Select an option from the on-screen menu. Press the Select (Settings) encoder."
+    "description": "Hold the Shift button. Press the Kit button. Turn the Select (Settings) encoder. Hold the Select (Settings) encoder. Turn the Select (Settings) encoder, select an option from the on-screen menu. Press the Select (Settings) encoder. Turn the Select (Settings) encoder. Press the Select (Settings) encoder."
   },
   {
     "name": "Setting up choke group",
@@ -5785,7 +5809,7 @@
           },
           {
             "action": 0,
-            "control": 36
+            "control": 54
           }
         ]
       },
@@ -5795,7 +5819,9 @@
       },
       {
         "action": 3,
-        "control": 0
+        "control": 0,
+        "label": "Sound > Voice > Polyphony > Choke",
+        "menuContext": "CHOKE"
       },
       {
         "action": 0,
@@ -5813,7 +5839,7 @@
         ]
       }
     ],
-    "description": "Hold the Audition / Section button for row, press the Grid pad (lit or unlit). Turn the Select (Settings) encoder. Select an option from the on-screen menu. Press the Select (Settings) encoder."
+    "description": "Hold the Audition / Section button for row, press the 'Voice Polyphony' grid pad. Turn the Select (Settings) encoder. Select an option from the on-screen menu. Press the Select (Settings) encoder."
   },
   {
     "name": "Rename kit row or instrument",
@@ -9154,18 +9180,28 @@
         ]
       },
       {
-        "action": 3,
-        "control": 0
+        "substeps": [
+          {
+            "action": 2,
+            "control": 34
+          },
+          {
+            "action": 0,
+            "control": 34
+          }
+        ]
       },
       {
         "action": 3,
-        "control": 0
+        "control": 0,
+        "label": "Settings > Recording > Count-In Bars",
+        "menuContext": "COUNT_IN"
       }
     ],
     "views": [2],
     "firmware": [0],
     "paragraphs": [],
-    "description": "Hold the Shift button, press the Select (Settings) encoder. Select an option from the on-screen menu. Select an option from the on-screen menu."
+    "description": "Hold the Shift button, press the Select (Settings) encoder. Turn the Select (Settings) encoder, press the Select (Settings) encoder. Select an option from the on-screen menu."
   },
   {
     "name": "Grid View Loop Pads",

--- a/website/src/components/deluge_companion/lib/md-convert.ts
+++ b/website/src/components/deluge_companion/lib/md-convert.ts
@@ -7,6 +7,12 @@ import type {
   SubstepContainer,
 } from "../types/shortcut.js"
 import { Action } from "../data/actions.js"
+import {
+  getMenuContextLabel,
+  isMenuRenderMethod,
+  normalizeMenuRenderMethod,
+  normalizeMenuContext,
+} from "../data/menu_contexts.js"
 import { Control } from "../data/targets.js"
 import { Views } from "../data/views.js"
 import { Firmwares } from "../data/firmware.js"
@@ -17,23 +23,213 @@ import { describeShortcutSteps } from "../data/shortcut_descriptions.js"
  * Returns a normalized Step record.
  */
 const parseActionAndControl = (str: string): Step => {
-  const matches = str.match(/^(\w+)\(([^)]+)\)$/)
-  if (!matches) {
+  const openParenIndex = str.indexOf("(")
+  const closeParenIndex = str.lastIndexOf(")")
+
+  if (
+    openParenIndex <= 0 ||
+    closeParenIndex <= openParenIndex ||
+    closeParenIndex !== str.length - 1
+  ) {
     throw new Error(
       `Shortcut code not in format "action(Control)" in action "${str}"`,
     )
   }
-  const [, actionStr, controlStr] = matches
+
+  const actionStr = str.slice(0, openParenIndex)
+  const rawTarget = str.slice(openParenIndex + 1, closeParenIndex)
   const action = Action[actionStr.toUpperCase() as keyof typeof Action]
-  const control = Control[controlStr.toUpperCase() as keyof typeof Control]
+
   if (action === undefined) {
     throw new Error(
       `Shortcut action "${actionStr}" not recognized in shortcut "${str}"`,
     )
   }
+
+  const parseQuotedMenuPayload = (rawPayload: string) => {
+    const payload = rawPayload.trim()
+    let cursor = 0
+    let inQuotes = false
+    let escaping = false
+    let current = ""
+    const parts: string[] = []
+
+    while (cursor < payload.length) {
+      const char = payload[cursor]
+
+      if (escaping) {
+        current += char
+        escaping = false
+        cursor += 1
+        continue
+      }
+
+      if (char === "\\") {
+        current += char
+        escaping = true
+        cursor += 1
+        continue
+      }
+
+      if (char === '"') {
+        inQuotes = !inQuotes
+        current += char
+        cursor += 1
+        continue
+      }
+
+      if (char === "|" && !inQuotes) {
+        parts.push(current.trim())
+        current = ""
+        cursor += 1
+        continue
+      }
+
+      current += char
+      cursor += 1
+    }
+
+    if (inQuotes) {
+      throw new Error(
+        `MENU payload has unclosed quotes in shortcut "${str}". Use MENU("label"|"title"|"opt1;opt2"|0).`,
+      )
+    }
+
+    parts.push(current.trim())
+
+    if (parts.length === 0 || parts.length > 5) {
+      throw new Error(
+        `MENU payload supports 1 to 5 fields in shortcut "${str}". Use MENU("label"|"title"|"opt1;opt2"|0|NO_INVERSION).`,
+      )
+    }
+
+    const parseStringPart = (part: string, name: string) => {
+      if (!part.startsWith('"') || !part.endsWith('"')) {
+        throw new Error(
+          `MENU ${name} must be a double-quoted string in shortcut "${str}".`,
+        )
+      }
+
+      try {
+        const value = JSON.parse(part)
+        if (typeof value !== "string") {
+          throw new Error("not-string")
+        }
+        return value
+      } catch {
+        throw new Error(
+          `MENU ${name} has invalid quoting in shortcut "${str}".`,
+        )
+      }
+    }
+
+    const label = parseStringPart(parts[0], "label")
+    const title =
+      parts.length >= 2 ? parseStringPart(parts[1], "title") : undefined
+
+    const options =
+      parts.length >= 3
+        ? parseStringPart(parts[2], "options")
+            .split(";")
+            .map((option) => option.trim())
+            .filter(Boolean)
+        : undefined
+
+    const selectedIndex =
+      parts.length >= 4 ? Number.parseInt(parts[3], 10) : undefined
+
+    if (parts.length >= 4 && !Number.isInteger(selectedIndex)) {
+      throw new Error(
+        `MENU selected index must be an integer in shortcut "${str}".`,
+      )
+    }
+
+    const renderMethodToken =
+      parts.length >= 5
+        ? (() => {
+            const raw = parts[4].trim()
+            if (raw.startsWith('"') && raw.endsWith('"')) {
+              try {
+                const parsed = JSON.parse(raw)
+                if (typeof parsed !== "string") {
+                  throw new Error("not-string")
+                }
+                return parsed
+              } catch {
+                throw new Error(
+                  `MENU render method has invalid quoting in shortcut "${str}".`,
+                )
+              }
+            }
+            return raw
+          })()
+        : undefined
+
+    if (
+      renderMethodToken &&
+      !isMenuRenderMethod(renderMethodToken.toUpperCase())
+    ) {
+      throw new Error(
+        `MENU render method "${renderMethodToken}" not recognized in shortcut "${str}". Use NO_ROUNDING, ROUNDED_INVERSION, or NO_INVERSION.`,
+      )
+    }
+
+    return {
+      label,
+      title,
+      options,
+      selectedIndex,
+      renderMethod: renderMethodToken
+        ? normalizeMenuRenderMethod(renderMethodToken)
+        : undefined,
+    }
+  }
+
+  // MENU accepts semantic context keys (e.g. CLONE) and quoted payloads.
+  if (action === Action.MENU) {
+    const payload = rawTarget.trim()
+
+    if (payload.startsWith('"')) {
+      const parsed = parseQuotedMenuPayload(payload)
+      return {
+        action,
+        control: Control.NONE,
+        label: parsed.label,
+        menuContext: normalizeMenuContext(undefined),
+        menuTitle: parsed.title,
+        menuOptions: parsed.options,
+        menuSelectedIndex: parsed.selectedIndex,
+        menuRenderMethod: parsed.renderMethod,
+      }
+    }
+
+    const [contextPartRaw, renderPartRaw] = payload.split(":", 2)
+    const contextPart = contextPartRaw?.trim() ?? ""
+    const renderPart = renderPartRaw?.trim()
+
+    if (renderPart && !isMenuRenderMethod(renderPart.toUpperCase())) {
+      throw new Error(
+        `MENU render method "${renderPart}" not recognized in shortcut "${str}". Use NO_ROUNDING, ROUNDED_INVERSION, or NO_INVERSION.`,
+      )
+    }
+
+    const menuContext = normalizeMenuContext(contextPart)
+    return {
+      action,
+      control: Control.NONE,
+      label: getMenuContextLabel(menuContext),
+      menuContext,
+      menuRenderMethod: renderPart
+        ? normalizeMenuRenderMethod(renderPart)
+        : undefined,
+    }
+  }
+
+  const control = Control[rawTarget.toUpperCase() as keyof typeof Control]
+
   if (control === undefined) {
     throw new Error(
-      `Shortcut control "${controlStr}" not recognized in shortcut "${str}"`,
+      `Shortcut control "${rawTarget}" not recognized in shortcut "${str}"`,
     )
   }
   return {

--- a/website/src/components/deluge_companion/stores/control_store.ts
+++ b/website/src/components/deluge_companion/stores/control_store.ts
@@ -28,7 +28,6 @@ export const shortcutControlGroups: ShortcutControlGroup[] = [
       { id: Control.SYNC, title: "Sync-Scaling" },
       { id: Control.LEARN, title: "Learn / Input" },
       { id: Control.ENTIRE, title: "Affect Entire" },
-      { id: Control.CONTEXT_MENU, title: "Context Menu" },
     ],
   },
   {
@@ -47,6 +46,7 @@ export const shortcutControlGroups: ShortcutControlGroup[] = [
       { id: Control.POWER_SWITCH, title: "Power switch" },
       { id: Control.TRIPLETSVIEW, title: "Triplets View" },
       { id: Control.EXTERNAL, title: "External MIDI Controller" },
+      { id: Control.MENU, title: "Menu" },
     ],
   },
   {

--- a/website/src/components/deluge_companion/stores/control_store.ts
+++ b/website/src/components/deluge_companion/stores/control_store.ts
@@ -28,6 +28,7 @@ export const shortcutControlGroups: ShortcutControlGroup[] = [
       { id: Control.SYNC, title: "Sync-Scaling" },
       { id: Control.LEARN, title: "Learn / Input" },
       { id: Control.ENTIRE, title: "Affect Entire" },
+      { id: Control.CONTEXT_MENU, title: "Context Menu" },
     ],
   },
   {
@@ -90,6 +91,8 @@ export const shortcutControlGroups: ShortcutControlGroup[] = [
       { id: Control.RANDOM_PATCH_SOURCE, title: "Random Patch Source Pad" },
       { id: Control.VELOCITY_PATCH_SOURCE, title: "Velocity Patch Source Pad" },
       { id: Control.NAME, title: "Name Grid Pad" },
+      { id: Control.OSC_TYPE, title: "Oscillator Type Grid Pads" },
+      { id: Control.VOICE_POLYPHONY, title: "Voice Polyphony Grid Pad" },
     ],
   },
 ]

--- a/website/src/components/deluge_companion/stores/shortcut_store.ts
+++ b/website/src/components/deluge_companion/stores/shortcut_store.ts
@@ -15,8 +15,10 @@ import {
 } from "./capability_store"
 import { activeControl } from "./control_store"
 import { Firmwares } from "../data/firmware"
+import { Action } from "../data/actions"
 import { Control } from "../data/targets"
 import { Views } from "../data/views"
+import type { MenuRenderMethod } from "../data/menu_contexts"
 import type {
   Shortcut,
   StepOrSubstep,
@@ -30,8 +32,28 @@ import type {
 
 // Raw JSON steps can be single actions or substep containers.
 type RawStep =
-  | { action: number; control: number }
-  | { substeps: { action: number; control: number }[] }
+  | {
+      action: number
+      control: number
+      label?: string
+      menuContext?: string
+      menuTitle?: string
+      menuOptions?: string[]
+      menuSelectedIndex?: number
+      menuRenderMethod?: MenuRenderMethod
+    }
+  | {
+      substeps: {
+        action: number
+        control: number
+        label?: string
+        menuContext?: string
+        menuTitle?: string
+        menuOptions?: string[]
+        menuSelectedIndex?: number
+        menuRenderMethod?: MenuRenderMethod
+      }[]
+    }
 
 // Raw shortcut shape from generated JSON before runtime normalization.
 type RawShortcut = Omit<Shortcut, "steps" | "firmware"> & {
@@ -146,6 +168,11 @@ const collectControlsFromStep = (step: StepOrSubstep, ids: Set<Control>) => {
 
   // Branch: direct step control.
   ids.add(step.control)
+
+  // MENU uses Control.NONE in source data; add a dedicated pseudo-control for filtering.
+  if (step.action === Action.MENU) {
+    ids.add(Control.CONTEXT_MENU)
+  }
 }
 
 // Computes unique control ids used by one shortcut.

--- a/website/src/components/deluge_companion/stores/shortcut_store.ts
+++ b/website/src/components/deluge_companion/stores/shortcut_store.ts
@@ -171,7 +171,7 @@ const collectControlsFromStep = (step: StepOrSubstep, ids: Set<Control>) => {
 
   // MENU uses Control.NONE in source data; add a dedicated pseudo-control for filtering.
   if (step.action === Action.MENU) {
-    ids.add(Control.CONTEXT_MENU)
+    ids.add(Control.MENU)
   }
 }
 

--- a/website/src/components/deluge_companion/types/shortcut.ts
+++ b/website/src/components/deluge_companion/types/shortcut.ts
@@ -1,4 +1,5 @@
 import { ControlType, Control } from "../data/targets.js"
+import type { MenuRenderMethod } from "../data/menu_contexts.js"
 import type { Views } from "../data/views.js"
 import type { Firmwares } from "../data/firmware.js"
 import type { Action } from "../data/actions.js"
@@ -34,6 +35,11 @@ export type Step = {
   action: Action
   control: Control
   label?: string
+  menuContext?: string
+  menuTitle?: string
+  menuOptions?: string[]
+  menuSelectedIndex?: number
+  menuRenderMethod?: MenuRenderMethod
 }
 
 export type SubstepContainer = {


### PR DESCRIPTION
Added Context Menus to Shortcut Companion + Rendered Context Menu on the Hardware Preview

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4859

### Before
<img width="1048" height="493" alt="Screenshot 2026-08-24 at 4 13 02 PM" src="https://github.com/user-attachments/assets/a47d39e4-83ae-4e6e-93ab-a7d05f707306" />

### After
<img width="1153" height="490" alt="Screenshot 2026-08-24 at 4 13 23 PM" src="https://github.com/user-attachments/assets/dfeb05ac-0f15-44d1-b396-a0ed8cfe53f2" />

Also added Vertical Menus:

<img width="1171" height="493" alt="Screenshot 2026-08-24 at 8 11 15 PM" src="https://github.com/user-attachments/assets/8d2fb158-3dd4-4991-9341-8efe80d7eeb0" />