### PR TITLE
Fix edge case blocking changing CV to/from both from clip view with arranger

### DIFF
--- a/src/deluge/gui/views/view.cpp
+++ b/src/deluge/gui/views/view.cpp
@@ -2339,8 +2339,15 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 		// CV
 		if (outputType == OutputType::CV) {
 			while (true) {
+				auto oldChannel = newChannel;
 				newChannel = CVInstrument::navigateChannels(newChannel, offset);
-
+				int channelToSearch = newChannel;
+				if (newChannel == CVInstrumentMode::both) {
+					// in this case we just need to make sure the one were not about to give up is free
+					// there probably should be a gatekeeper managing the cv/gate resources but that's a lot to
+					// change and this doesn't matter much
+					channelToSearch = oldNonAudioInstrument->getChannel() == 0 ? 1 : 0;
+				}
 				if (newChannel == oldNonAudioInstrument->getChannel()) {
 					display->displayPopup(deluge::l10n::get(deluge::l10n::String::STRING_FOR_NO_UNUSED_CHANNELS));
 					return;
@@ -2349,21 +2356,21 @@ void View::navigateThroughPresetsForInstrumentClip(int32_t offset, ModelStackWit
 				if (availabilityRequirement == Availability::ANY) {
 					break;
 				}
+				// check if we can move this clip to another instrument that has a vacant spot in this section
 				else if (availabilityRequirement == Availability::INSTRUMENT_AVAILABLE_IN_SESSION) {
-					int channelToSearch = newChannel;
-					if (newChannel == CVInstrumentMode::both) {
-						// in this case we just need to make sure the one were not about to give up is free
-						// there probably should be a gatekeeper managing the cv/gate resources but that's a lot to
-						// change and this doesn't matter much
-						channelToSearch = oldNonAudioInstrument->getChannel() == 0 ? 1 : 0;
-					}
 					if (!modelStack->song->doesNonAudioSlotHaveActiveClipInSession(outputType, channelToSearch)) {
 						break;
 					}
 				}
+				// or if we want to move the whole instrument over
 				else if (availabilityRequirement == Availability::INSTRUMENT_UNUSED) {
-					if (!modelStack->song->getInstrumentFromPresetSlot(outputType, newChannel, -1, nullptr, nullptr,
-					                                                   false)) {
+					if (oldChannel == both && oldInstrumentCanBeReplaced) {
+						// both blocks 1 and 2 but we're about to give one up, so that means it's available
+						break;
+					}
+					// in this case we're replacing the whole instrument so same logic applies as above,
+					if (!modelStack->song->getInstrumentFromPresetSlot(outputType, channelToSearch, -1, nullptr,
+					                                                   nullptr, false)) {
 						break;
 					}
 				}


### PR DESCRIPTION
giving up both means 1 and 2 are each free so skip checking. This codepath is only hit if you enter a clip from arranger view and then try to change it's CV channel to or from both so it slipped by for a while