### PR TITLE
Fix issue with DX7 browser 'back' navigation

### DIFF
--- a/src/deluge/gui/menu_item/dx/cartridge.cpp
+++ b/src/deluge/gui/menu_item/dx/cartridge.cpp
@@ -175,7 +175,7 @@ void DxCartridge::selectEncoderAction(int32_t offset) {
 
 MenuItem* DxCartridge::selectButtonPress() {
 	soundEditor.exitCompletely();
-	return nullptr;
+	return NO_NAVIGATION;
 }
 
 } // namespace deluge::gui::menu_item

--- a/src/deluge/gui/ui/browser/dx_browser.cpp
+++ b/src/deluge/gui/ui/browser/dx_browser.cpp
@@ -110,11 +110,12 @@ void DxSyxBrowser::enterKeyPress() {
 		// TODO: c.f. slotbrowser, we might just be able to pass a file pointer to the FAT loader
 		String path;
 		getCurrentFilePath(&path);
-		close();
 
 		if (!path.isEmpty()) {
 			if (menu_item::dxCartridge.tryLoad(path.get())) {
 				soundEditor.enterSubmenu(&menu_item::dxCartridge);
+				soundEditor.shouldGoUpOneLevelOnBegin = false;
+				close();
 			}
 		}
 


### PR DESCRIPTION
Fixed issue where when in the DX7 preset browser, pressing back would take you back to the root DX7 Source Menu instead of back one level to the DX7 Syx Browser