### PR TITLE
Fix/ Refactor note iterance preset display logic

### DIFF
--- a/src/deluge/gui/menu_item/note/iterance_preset.h
+++ b/src/deluge/gui/menu_item/note/iterance_preset.h
@@ -67,54 +67,32 @@ public:
 	}
 
 	void drawPixelsForOled() override {
-		const std::string value = getIteranceDisplayValue("%d of %d");
+		const std::string value = get_iterance_display_value("%d of %d", Iterance::DisplayLabelType::LONG);
 		OLED::main.drawStringCentred(value.data(), 18 + OLED_MAIN_TOPMOST_PIXEL, kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
 	void renderInHorizontalMenu(const SlotPosition& slot) override {
-		const std::string value = getIteranceDisplayValue("%d:%d");
+		const std::string value = get_iterance_display_value("%d:%d", Iterance::DisplayLabelType::SHORT);
 		OLED::main.drawStringCentered(value.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
 		                              kTextSpacingX, kTextSpacingY, slot.width);
 	}
 
 	void drawValue() override {
-		const std::string value = getIteranceDisplayValue("%dof%d");
+		const std::string value = get_iterance_display_value("%dof%d", Iterance::DisplayLabelType::SHORT);
 		display->setText(value);
 	}
 
-	void getNotificationValue(StringBuf& valueBuf) override { valueBuf.append(getIteranceDisplayValue("%d of %d")); }
+	void getNotificationValue(StringBuf& valueBuf) override {
+		valueBuf.append(get_iterance_display_value("%d of %d", Iterance::DisplayLabelType::LONG));
+	}
 
 	void writeCurrentValue() override { ; }
 
 private:
-	std::string getIteranceDisplayValue(const std::string& format) {
+	std::string get_iterance_display_value(const std::string& format, Iterance::DisplayLabelType label_type) {
 		char buffer[20];
-
-		int32_t iterancePreset = this->getValue();
-
-		if (iterancePreset == kDefaultIterancePreset) {
-			strcpy(buffer, "OFF");
-		}
-		else if (iterancePreset == kCustomIterancePreset) {
-			strcpy(buffer, "CUSTOM");
-		}
-		else if (iterancePreset == kFirstIterancePreset) {
-			strcpy(buffer, "1 ST");
-		}
-		else if (iterancePreset == kLastIterancePreset) {
-			strcpy(buffer, "LAST");
-		}
-		else {
-			Iterance iterance = iterancePresets[iterancePreset - 1];
-			int32_t i = iterance.divisor;
-			for (; i >= 0; i--) {
-				// try to find which iteration step index is active
-				if (iterance.iteranceStep[i]) {
-					break;
-				}
-			}
-			sprintf(buffer, format.data(), i + 1, iterance.divisor);
-		}
+		Iterance::format_preset_display_value(this->getValue(), buffer, sizeof(buffer),
+		                                      {.step_format = format.c_str(), .label_type = label_type});
 
 		return std::string(buffer);
 	}

--- a/src/deluge/gui/menu_item/note_row/iterance_preset.h
+++ b/src/deluge/gui/menu_item/note_row/iterance_preset.h
@@ -25,7 +25,6 @@
 #include "model/model_stack.h"
 #include "model/note/note_row.h"
 #include "model/song/song.h"
-#include "util/lookuptables/lookuptables.h"
 
 extern gui::menu_item::Submenu noteRowCustomIteranceRootMenu;
 
@@ -80,48 +79,32 @@ public:
 	}
 
 	void drawPixelsForOled() override {
-		const std::string value = getIteranceDisplayValue("%d of %d");
+		const std::string value = get_iterance_display_value("%d of %d", Iterance::DisplayLabelType::LONG);
 		OLED::main.drawStringCentred(value.data(), 18 + OLED_MAIN_TOPMOST_PIXEL, kTextHugeSpacingX, kTextHugeSizeY);
 	}
 
 	void renderInHorizontalMenu(const SlotPosition& slot) override {
-		const std::string value = getIteranceDisplayValue("%d:%d");
+		const std::string value = get_iterance_display_value("%d:%d", Iterance::DisplayLabelType::SHORT);
 		OLED::main.drawStringCentered(value.data(), slot.start_x, slot.start_y + kHorizontalMenuSlotYOffset,
 		                              kTextSpacingX, kTextSpacingY, slot.width);
 	}
 
 	void drawValue() override {
-		const std::string value = getIteranceDisplayValue("%dof%d");
+		const std::string value = get_iterance_display_value("%dof%d", Iterance::DisplayLabelType::SHORT);
 		display->setText(value);
 	}
 
-	void getNotificationValue(StringBuf& valueBuf) override { valueBuf.append(getIteranceDisplayValue("%d of %d")); }
+	void getNotificationValue(StringBuf& valueBuf) override {
+		valueBuf.append(get_iterance_display_value("%d of %d", Iterance::DisplayLabelType::LONG));
+	}
 
 	void writeCurrentValue() override { ; }
 
 private:
-	std::string getIteranceDisplayValue(const std::string& format) {
+	std::string get_iterance_display_value(const std::string& format, Iterance::DisplayLabelType label_type) {
 		char buffer[20];
-
-		int32_t iterancePreset = this->getValue();
-
-		if (iterancePreset == kDefaultIterancePreset) {
-			strcpy(buffer, "OFF");
-		}
-		else if (iterancePreset == kCustomIterancePreset) {
-			strcpy(buffer, "CUSTOM");
-		}
-		else {
-			Iterance iterance = iterancePresets[iterancePreset - 1];
-			int32_t i = iterance.divisor;
-			for (; i >= 0; i--) {
-				// try to find which iteration step index is active
-				if (iterance.iteranceStep[i]) {
-					break;
-				}
-			}
-			sprintf(buffer, format.data(), i + 1, iterance.divisor);
-		}
+		Iterance::format_preset_display_value(this->getValue(), buffer, sizeof(buffer),
+		                                      {.step_format = format.c_str(), .label_type = label_type});
 
 		return std::string(buffer);
 	}

--- a/src/deluge/gui/views/instrument_clip_view.cpp
+++ b/src/deluge/gui/views/instrument_clip_view.cpp
@@ -3463,33 +3463,11 @@ void InstrumentClipView::displayProbability(uint8_t probability, bool prevBase) 
 
 void InstrumentClipView::displayIterance(Iterance iterance) {
 	char buffer[(display->haveOLED()) ? 29 : 5];
-
-	// Iteration dependence
-	int32_t iterancePreset = iterance.toPresetIndex();
-
-	if (iterancePreset == kDefaultIterancePreset) {
-		strcpy(buffer, display->haveOLED() ? "Iterance: OFF" : "OFF");
-	}
-	else if (iterancePreset == kCustomIterancePreset) {
-		strcpy(buffer, display->haveOLED() ? "Iterance: CUSTOM" : "CUSTOM");
-	}
-	else if (iterancePreset == kFirstIterancePreset) {
-		strcpy(buffer, display->haveOLED() ? "Iterance: FIRST" : "1 ST");
-	}
-	else if (iterancePreset == kLastIterancePreset) {
-		strcpy(buffer, display->haveOLED() ? "Iterance: LAST" : "LAST");
-	}
-	else {
-		Iterance iterance = iterancePresets[iterancePreset - 1];
-		int32_t i = iterance.divisor;
-		for (; i >= 0; i--) {
-			// try to find which iteration step index is active
-			if (iterance.iteranceStep[i]) {
-				break;
-			}
-		}
-		sprintf(buffer, display->haveOLED() ? "Iterance: %d of %d" : "%dof%d", i + 1, iterance.divisor);
-	}
+	iterance.format_display_value(
+	    buffer, sizeof(buffer),
+	    {.step_format = display->haveOLED() ? "%d of %d" : "%dof%d",
+	     .prefix = display->haveOLED() ? "Iterance: " : "",
+	     .label_type = display->haveOLED() ? Iterance::DisplayLabelType::LONG : Iterance::DisplayLabelType::SHORT});
 
 	if (display->haveOLED()) {
 		display->popupText(buffer, PopupType::ITERANCE);

--- a/src/deluge/model/iterance/iterance.cpp
+++ b/src/deluge/model/iterance/iterance.cpp
@@ -17,12 +17,45 @@
 
 #include "model/iterance/iterance.h"
 #include "definitions_cxx.hpp"
+#include "lib/printf.h"
 #include "util/lookuptables/lookuptables.h"
 #include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+char const* get_first_label(Iterance::DisplayLabelType label_type) {
+	return label_type == Iterance::DisplayLabelType::LONG ? "FIRST" : display->haveOLED() ? "1ST" : "1 ST";
+}
+
+int32_t get_active_step_display_number(Iterance const& iterance) {
+	if (iterance.divisor == 0) {
+		return iterance.iteranceStep[0] ? 1 : 0;
+	}
+
+	for (int32_t i = iterance.divisor - 1; i >= 0; i--) {
+		if (iterance.iteranceStep[i]) {
+			return i + 1;
+		}
+	}
+
+	return 0;
+}
+
+void copy_with_prefix(char* buffer, size_t buffer_size, char const* prefix, char const* value) {
+	if (buffer_size == 0) {
+		return;
+	}
+	strcpy(buffer, prefix);
+	strcat(buffer, value);
+}
+
+} // namespace
 
 // To/from int
 
-uint16_t Iterance::toInt() {
+uint16_t Iterance::toInt() const {
 	return (uint16_t)(divisor << 8) | (uint16_t)(iteranceStep.to_ulong() & 0xFF);
 }
 
@@ -40,7 +73,7 @@ Iterance Iterance::fromInt(int32_t value) {
 
 // This methods takes the iterance value and searches the table of iterance presets for a match
 // If no match is found it will return kCustomIterancePreset (which is equal to '1of1')
-int32_t Iterance::toPresetIndex() {
+int32_t Iterance::toPresetIndex() const {
 	if (iteranceStep.none() && divisor == 0) {
 		// A value of 0 means OFF
 		return 0;
@@ -69,5 +102,34 @@ Iterance Iterance::fromPresetIndex(int32_t presetIndex) {
 	else {
 		// Default: Off
 		return kDefaultIteranceValue;
+	}
+}
+
+void Iterance::format_display_value(char* buffer, size_t buffer_size, DisplayOptions options) const {
+	format_preset_display_value(toPresetIndex(), buffer, buffer_size, options);
+}
+
+void Iterance::format_preset_display_value(int32_t preset_index, char* buffer, size_t buffer_size,
+                                           DisplayOptions options) {
+	if (preset_index == kDefaultIterancePreset) {
+		copy_with_prefix(buffer, buffer_size, options.prefix, "OFF");
+	}
+	else if (preset_index == kCustomIterancePreset) {
+		copy_with_prefix(buffer, buffer_size, options.prefix, "CUSTOM");
+	}
+	else if (options.label_type != DisplayLabelType::NUMERIC && preset_index == kFirstIterancePreset) {
+		copy_with_prefix(buffer, buffer_size, options.prefix, get_first_label(options.label_type));
+	}
+	else if (options.label_type != DisplayLabelType::NUMERIC && preset_index == kLastIterancePreset) {
+		copy_with_prefix(buffer, buffer_size, options.prefix, "LAST");
+	}
+	else if (preset_index > 0 && preset_index <= kNumIterancePresets) {
+		Iterance iterance = iterancePresets[preset_index - 1];
+		char value_buffer[20];
+		sprintf(value_buffer, options.step_format, get_active_step_display_number(iterance), iterance.divisor);
+		copy_with_prefix(buffer, buffer_size, options.prefix, value_buffer);
+	}
+	else {
+		copy_with_prefix(buffer, buffer_size, options.prefix, "OFF");
 	}
 }

--- a/src/deluge/model/iterance/iterance.h
+++ b/src/deluge/model/iterance/iterance.h
@@ -18,11 +18,24 @@
 #pragma once
 
 #include <bitset>
+#include <cstddef>
 #include <cstdint>
 
 /// Represents first, last, or an x of y iteration
 /// If divisor is zero then instead represents either first or last
 struct Iterance {
+	enum class DisplayLabelType : uint8_t {
+		NUMERIC,
+		SHORT,
+		LONG,
+	};
+
+	struct DisplayOptions {
+		char const* step_format;
+		char const* prefix = "";
+		DisplayLabelType label_type = DisplayLabelType::SHORT;
+	};
+
 	uint8_t divisor;
 	std::bitset<8> iteranceStep;
 
@@ -43,9 +56,13 @@ struct Iterance {
 		return iteranceStep[repeatCount % divisor];
 	}
 
-	[[nodiscard]] uint16_t toInt();
+	[[nodiscard]] uint16_t toInt() const;
 	static Iterance fromInt(int32_t value);
 
-	[[nodiscard]] int32_t toPresetIndex();
+	[[nodiscard]] int32_t toPresetIndex() const;
 	static Iterance fromPresetIndex(int32_t presetIndex);
+
+	void format_display_value(char* buffer, size_t buffer_size, DisplayOptions options) const;
+	static void format_preset_display_value(int32_t preset_index, char* buffer, size_t buffer_size,
+	                                        DisplayOptions options);
 };


### PR DESCRIPTION
Refactored triplicated note iterance preset display logic into the iterance logic into iterance class

- Fixed issue where First and Last Iterance Presets display as 1 : 0 or 0 : 0 on OLED in the Note Row Editor. 
- Fixed OLED horizontal menu text to show 1st instead of 1 st.
- Fixed OLED horizontal menu notification text to show FIRST instead of 1 st.
- Fixed OLED vertical menu text to show FIRST instead of 1 st.

