### PR TITLE
Increase the usb descriptor size limit to 512 and add some usb messages

### DIFF
--- a/src/RZA1/usb/r_usb_basic/src/driver/inc/r_usb_basic_define.h
+++ b/src/RZA1/usb/r_usb_basic/src/driver/inc/r_usb_basic_define.h
@@ -796,7 +796,7 @@
 
 /* Descriptor size */
 #define USB_DEVICESIZE (20u)  /* Device Descriptor size */
-#define USB_CONFIGSIZE (256u) /* Configuration Descriptor size */
+#define USB_CONFIGSIZE (512u) /* Configuration Descriptor size */
 
 /* Number of software retries when a no-response condition occurs during a transfer */
 #define USB_PIPEERROR (1u)

--- a/src/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
+++ b/src/RZA1/usb/r_usb_basic/src/driver/r_usb_hmanager.c
@@ -285,6 +285,7 @@ static uint16_t usb_hstd_enumeration(usb_utr_t* ptr)
                                 // By Rohan. Means couldn't find an available "driver" for this device. It could be a
                                 // 2nd hub.
                                 consoleTextIfAllBootedUp(l10n_get(l10n_STRING_FOR_USB_DEVICE_NOT_RECOGNIZED));
+                                usbDebugConsoleText("USB: no class match");     // TEMP DIAGNOSTIC
                                 ctrl.address = g_usb_hstd_device_addr[ptr->ip]; /* USB Device address */
                                 ctrl.module  = ptr->ip;                         /* Module number setting */
                                 usb_set_event(USB_STS_NOT_SUPPORT, &ctrl);      /* Set Event()  */

--- a/src/RZA1/usb/r_usb_basic/src/hw/r_usb_hreg_access.c
+++ b/src/RZA1/usb/r_usb_basic/src/hw/r_usb_hreg_access.c
@@ -40,6 +40,7 @@
  External variables and functions
  ***********************************************************************************************************************/
 extern uint8_t g_usb_std_uclksel;
+extern void usbDebugConsoleText(char const* text); // TEMP DIAGNOSTIC
 
 /***********************************************************************************************************************
  Function Name   : hw_usb_hset_rwupe
@@ -644,7 +645,8 @@ void hw_usb_hmodule_init(usb_ctrl_t* p_ctrl)
         {
             case USB_FS_JSTS: /* USB device already connected */
             case USB_LS_JSTS:
-                anythingInitiallyAttachedAsUSBHost = 1; // By Rohan
+                anythingInitiallyAttachedAsUSBHost = 1;     // By Rohan
+                usbDebugConsoleText("USB: device at boot"); // TEMP DIAGNOSTIC
 
                 if (USB_FS_JSTS == sts)
                 {

--- a/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
+++ b/src/RZA1/usb/r_usb_hmidi/src/r_usb_hmidi_driver.c
@@ -433,6 +433,7 @@ static void usb_hmidi_enumeration_sequence(usb_utr_t* mess)
             uint16_t vendorId  = *(uint16_t*)&g_p_usb_hmidi_device_table[USB_CFG_USE_USBIP][8];
             uint16_t productId = *(uint16_t*)&g_p_usb_hmidi_device_table[USB_CFG_USE_USBIP][10];
             giveDetailsOfDeviceBeingSetUp(USB_CFG_USE_USBIP, deviceName, vendorId, productId);
+            usbDebugConsoleText("USB: class matched"); // TEMP DIAGNOSTIC
 
             p_desc = g_p_usb_hmidi_config_table[mess->ip];
 
@@ -449,6 +450,7 @@ static void usb_hmidi_enumeration_sequence(usb_utr_t* mess)
             if (USB_ERROR == retval)
             {
                 USB_PRINTF0("### Device information error 2 !\n");
+                usbDebugConsoleText("USB: pipe info fail"); // TEMP DIAGNOSTIC
 
                 /* Enumeration Sequence Complete */
                 g_usb_hmidi_enum_seq[mess->ip] = USB_HHID_ENUM_COMPLETE;
@@ -458,6 +460,9 @@ static void usb_hmidi_enumeration_sequence(usb_utr_t* mess)
             }
             else
             {
+                USB_PRINTF0("USB: pipes OK\n");
+                usbDebugConsoleText("USB: pipes OK"); // TEMP DIAGNOSTIC
+
                 /* Enumeration Sequence Complete */
                 g_usb_hmidi_enum_seq[mess->ip] = USB_HHID_ENUM_COMPLETE;
 
@@ -794,6 +799,7 @@ void hmidi_configured(usb_utr_t* ptr, uint16_t devadr, uint16_t data2)
 
     uartPrint("configured MIDI device: ");
     uartPrintNumber(midiDeviceNum);
+    usbDebugConsoleText("USB: configured"); // TEMP DIAGNOSTIC
 
     int sendPipe    = g_usb_hmidi_tmp_ep_tbl[ptr->ip][midiDeviceNum][0];
     int isInterrupt = (sendPipe == USB_CFG_HMIDI_INT_SEND);

--- a/src/deluge/deluge.h
+++ b/src/deluge/deluge.h
@@ -33,6 +33,7 @@ extern void loadAnyEnqueuedClustersRoutine(void);
 extern void logAudioAction(char const* string);
 
 extern void consoleTextIfAllBootedUp(char const* text);
+extern void usbDebugConsoleText(char const* text); // TEMP DIAGNOSTIC
 typedef bool (*RunCondition)();
 bool yieldingRoutineWithTimeoutForSD(RunCondition until, double timeoutSeconds);
 void yieldingRoutineForSD(RunCondition until);

--- a/src/deluge/hid/display/display.cpp
+++ b/src/deluge/hid/display/display.cpp
@@ -131,3 +131,10 @@ extern "C" void consoleTextIfAllBootedUp(char const* text) {
 		display->consoleText(text);
 	}
 }
+
+// TEMP DIAGNOSTIC: show text on the OLED even during the boot USB init window
+extern "C" void usbDebugConsoleText(char const* text) {
+	if (display != nullptr) {
+		display->consoleText(text);
+	}
+}

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -129,3 +129,4 @@ extern bool have_oled_screen;
 } // namespace deluge::hid::display
 
 extern "C" void consoleTextIfAllBootedUp(char const* text);
+extern "C" void usbDebugConsoleText(char const* text); // TEMP DIAGNOSTIC

--- a/src/deluge/io/midi/midi_device_manager.cpp
+++ b/src/deluge/io/midi/midi_device_manager.cpp
@@ -255,6 +255,8 @@ extern "C" void hostedDeviceConfigured(int32_t ip, int32_t midiDeviceNum) {
 
 	device->freshly_connected = true; // Used to trigger hookOnConnected from the input loop
 
+	usbDebugConsoleText("USB: attached"); // TEMP DIAGNOSTIC
+
 	if (display->haveOLED()) {
 		String text;
 		text.set(&device->name);


### PR DESCRIPTION
My keyboard, the medeli mk 49 was failing to work with the deluge. It seems this was because the usb descriptors for the device are slightly longer than the 256byte limit. This patch increases the limit to 512, which resolves that problem.

It also adds a message window to the oled screen for a brief second at boot that gives an overview of the usb setup process, to provide a little more clarity on what's happening. 