### PR TITLE
Fix Live Input Pitch Shifter Infinite Loop Freeze

### DIFF
--- a/src/deluge/model/voice/voice_unison_part_source.cpp
+++ b/src/deluge/model/voice/voice_unison_part_source.cpp
@@ -25,6 +25,7 @@
 #include "model/voice/voice_sample.h"
 #include "playback/playback_handler.h"
 #include "processing/engines/audio_engine.h"
+#include "processing/live/live_pitch_shifter.h"
 #include "processing/source.h"
 #include "storage/multi_range/multisample_range.h"
 
@@ -102,6 +103,7 @@ void VoiceUnisonPartSource::unassign(bool deletingSong) {
 	}
 
 	if (livePitchShifter != nullptr) {
+		livePitchShifter->~LivePitchShifter();
 		delugeDealloc(livePitchShifter);
 		livePitchShifter = nullptr;
 	}

--- a/src/deluge/processing/live/live_input_buffer.cpp
+++ b/src/deluge/processing/live/live_input_buffer.cpp
@@ -28,6 +28,9 @@ extern "C" {
 LiveInputBuffer::LiveInputBuffer() {
 	upToTime = 0;
 	numRawSamplesProcessed = 0;
+	lastSampleRead = 0;
+	lastAngle = 0;
+	memset(angleLPFMem, 0, sizeof(angleLPFMem));
 }
 
 void LiveInputBuffer::giveInput(int32_t numSamples, uint32_t currentTime, OscType inputType) {
@@ -86,7 +89,8 @@ void LiveInputBuffer::giveInput(int32_t numSamples, uint32_t currentTime, OscTyp
 				difference = -difference;
 			}
 
-			int32_t percussiveness = ((uint64_t)difference * 262144 / angle) >> 1;
+			// guard against diving by 0
+			int32_t percussiveness = angle ? (((uint64_t)difference * 262144 / angle) >> 1) : 0;
 
 			percussiveness = getTanH<23>(percussiveness);
 

--- a/src/deluge/processing/live/live_input_buffer.cpp
+++ b/src/deluge/processing/live/live_input_buffer.cpp
@@ -89,7 +89,7 @@ void LiveInputBuffer::giveInput(int32_t numSamples, uint32_t currentTime, OscTyp
 				difference = -difference;
 			}
 
-			// guard against diving by 0
+			// guard against dividing by 0
 			int32_t percussiveness = angle ? (((uint64_t)difference * 262144 / angle) >> 1) : 0;
 
 			percussiveness = getTanH<23>(percussiveness);

--- a/src/deluge/processing/live/live_pitch_shifter.cpp
+++ b/src/deluge/processing/live/live_pitch_shifter.cpp
@@ -516,7 +516,7 @@ void LivePitchShifter::hopEnd(int32_t phaseIncrement, LiveInputBuffer* liveInput
 					}
 					int32_t percHere =
 					    liveInputBuffer
-					        ->percBuffer[(uint32_t)(percPos - howFarBackSearched) & (kPercBufferReductionSize - 1)];
+					        ->percBuffer[(uint32_t)(percPos - howFarBackSearched) & (kInputPercBufferSize - 1)];
 					totalPerc += percHere;
 				}
 
@@ -667,6 +667,10 @@ startSearch:
 
 		{
 			int32_t searchSizeHere = std::min(searchSize, searchSizeBoundary);
+			// guard against potential infinite do/while loop below
+			if (searchSizeHere <= 0) {
+				goto searchNextDirection;
+			}
 			endOffset = searchSizeHere * searchDirection;
 		}
 


### PR DESCRIPTION
Addresses freeze without error when using live input oscillator with a significant number of silent voices

Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4884

The culprit for the freeze seems to be an infinite do/while loop

Need to review to confirm if its the best fix as this was proposed by LLM, but tested and can confirm that it doesn't freeze with the test song anymore

The other changes are to prevent other UB
- Wrong initialized values
- Wrong buffer size used
- Calling the destructor before de-allocating