### PR TITLE
Decreased SPI clock frequency to work with 2026 batch of OLEDs

### DIFF
--- a/src/deluge/deluge.cpp
+++ b/src/deluge/deluge.cpp
@@ -690,10 +690,11 @@ extern "C" int32_t deluge_main(void) {
 	setPinAsInput(LINE_OUT_DETECT_L.port, LINE_OUT_DETECT_L.pin);
 	setPinAsInput(LINE_OUT_DETECT_R.port, LINE_OUT_DETECT_R.pin);
 
-	// SPI for CV
+	// SPI for CV / OLED
 	R_RSPI_Create(SPI_CHANNEL_CV,
-	              have_oled ? 10000000 // Higher than this would probably work... but let's stick to the OLED
-	                                   // datasheet's spec of 100ns (10MHz).
+	              have_oled ? 4000000 // We used to use 10MHz, which is what the OEL9M0087-W-E OLED datasheet specified
+	                                  // (well, 100ns). But as of the 2026 batch of OLEDs, despite them being the same
+	                                  // model, 8.5MHz and higher causes glitching. 4MHz appears safe.
 	                        : 30000000,
 	              0, 32);
 	R_RSPI_Start(SPI_CHANNEL_CV);


### PR DESCRIPTION
Our newest batch of OLEDs for Deluge production, despite being the same OEL9M0087-W-E model as always, glitch if their clock frequency is above about 8.5MHz.

Previously, the code sets the SPI bus frequency at 10MHz and this had worked fine and been within the OLED datasheet's spec. This branch reduces it to 4MHz to be safe with the new OLEDs.

Hopefully this doesn't have too detrimental an effect in the instance where SPI has to be sent to the OLED and to the CV DAC at the same time (well, quick succession). There appears to be some provision in the code for CV SPI messages to jump ahead of OLED ones? Of course we want those to take priority.