### PR TITLE
Fix iterance migration: account for FIRST/LAST shift in legacy song files

### DIFF
--- a/src/deluge/model/iterance/iterance_migration.cpp
+++ b/src/deluge/model/iterance/iterance_migration.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "model/iterance/iterance_migration.h"
+#include "definitions_cxx.hpp"
+#include <array>
+#include <cstdint>
+
+// iterancePresets is defined in lookuptables.cpp.
+extern const std::array<Iterance, kNumIterancePresets> iterancePresets;
+
+Iterance iteranceFromLegacyProbabilityByte(int32_t probability) {
+    // The old preset index (1-based) is encoded as probability - kNumProbabilityValues.
+    // FIRST and LAST were prepended to iterancePresets[], so the old index N now sits at
+    // array position N+1 (i.e. +2 for the prepend, -1 for 0-based indexing = net +1).
+    int32_t idx = probability - kNumProbabilityValues + 1;
+    // Defensive guard: idx should be 2..36 for any valid C1.2 file (old kNumIterancePresets=35).
+    if (idx < 2 || idx >= kNumIterancePresets) {
+        return kDefaultIteranceValue;
+    }
+    return iterancePresets[idx];
+}
+
+Iterance iteranceFromLegacyPresetIndex(int32_t presetIndex) {
+    // Shift all non-zero indices by +2 to skip the newly prepended FIRST and LAST.
+    if (presetIndex == 0) {
+        return kDefaultIteranceValue;
+    }
+    int32_t newIndex = presetIndex + 2;
+    if (newIndex > 0 && newIndex <= kNumIterancePresets) {
+        return iterancePresets[newIndex - 1];
+    }
+    if (newIndex == kCustomIterancePreset) {
+        return kCustomIteranceValue;
+    }
+    return kDefaultIteranceValue;
+}

--- a/src/deluge/model/iterance/iterance_migration.cpp
+++ b/src/deluge/model/iterance/iterance_migration.cpp
@@ -41,7 +41,7 @@ Iterance iteranceFromLegacyPresetIndex(int32_t presetIndex) {
         return kDefaultIteranceValue;
     }
     int32_t newIndex = presetIndex + 2;
-    if (newIndex > 0 && newIndex <= kNumIterancePresets) {
+    if (newIndex <= kNumIterancePresets) {
         return iterancePresets[newIndex - 1];
     }
     if (newIndex == kCustomIterancePreset) {

--- a/src/deluge/model/iterance/iterance_migration.cpp
+++ b/src/deluge/model/iterance/iterance_migration.cpp
@@ -24,28 +24,28 @@
 extern const std::array<Iterance, kNumIterancePresets> iterancePresets;
 
 Iterance iteranceFromLegacyProbabilityByte(int32_t probability) {
-    // The old preset index (1-based) is encoded as probability - kNumProbabilityValues.
-    // FIRST and LAST were prepended to iterancePresets[], so the old index N now sits at
-    // array position N+1 (i.e. +2 for the prepend, -1 for 0-based indexing = net +1).
-    int32_t idx = probability - kNumProbabilityValues + 1;
-    // Defensive guard: idx should be 2..36 for any valid C1.2 file (old kNumIterancePresets=35).
-    if (idx < 2 || idx >= kNumIterancePresets) {
-        return kDefaultIteranceValue;
-    }
-    return iterancePresets[idx];
+	// The old preset index (1-based) is encoded as probability - kNumProbabilityValues.
+	// FIRST and LAST were prepended to iterancePresets[], so the old index N now sits at
+	// array position N+1 (i.e. +2 for the prepend, -1 for 0-based indexing = net +1).
+	int32_t idx = probability - kNumProbabilityValues + 1;
+	// Defensive guard: idx should be 2..36 for any valid C1.2 file (old kNumIterancePresets=35).
+	if (idx < 2 || idx >= kNumIterancePresets) {
+		return kDefaultIteranceValue;
+	}
+	return iterancePresets[idx];
 }
 
 Iterance iteranceFromLegacyPresetIndex(int32_t presetIndex) {
-    // Shift all non-zero indices by +2 to skip the newly prepended FIRST and LAST.
-    if (presetIndex == 0) {
-        return kDefaultIteranceValue;
-    }
-    int32_t newIndex = presetIndex + 2;
-    if (newIndex <= kNumIterancePresets) {
-        return iterancePresets[newIndex - 1];
-    }
-    if (newIndex == kCustomIterancePreset) {
-        return kCustomIteranceValue;
-    }
-    return kDefaultIteranceValue;
+	// Shift all non-zero indices by +2 to skip the newly prepended FIRST and LAST.
+	if (presetIndex == 0) {
+		return kDefaultIteranceValue;
+	}
+	int32_t newIndex = presetIndex + 2;
+	if (newIndex <= kNumIterancePresets) {
+		return iterancePresets[newIndex - 1];
+	}
+	if (newIndex == kCustomIterancePreset) {
+		return kCustomIteranceValue;
+	}
+	return kDefaultIteranceValue;
 }

--- a/src/deluge/model/iterance/iterance_migration.h
+++ b/src/deluge/model/iterance/iterance_migration.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2024 Synthstrom Audible Limited
+ *
+ * This file is part of The Synthstrom Audible Deluge Firmware.
+ *
+ * The Synthstrom Audible Deluge Firmware is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU General Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with this program.
+ * If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "model/iterance/iterance.h"
+#include <cstdint>
+
+// Decodes an iterance value from the old C1.2 / pre-1.3 probability-byte encoding.
+//
+// Old format (noteHexLength==22 and the pre-lift else path): iterance was stored in
+// the probability field as (kNumProbabilityValues + legacyPresetIndex) where
+// legacyPresetIndex ran from 1 ("1 of 2") to 35 ("8 of 8").
+//
+// Commit 3ce3d41d prepended FIRST and LAST to iterancePresets[], shifting every
+// subsequent preset's array index by +2.  This function applies that correction.
+Iterance iteranceFromLegacyProbabilityByte(int32_t probability);
+
+// Decodes an iterance value from the old early-1.3-nightly preset-index encoding.
+//
+// Old format (noteHexLength==26): the preset index was stored directly.  In that
+// era the index space was: 0=OFF, 1=1of2 … 35=8of8, 36=custom.  After FIRST and
+// LAST were prepended the mapping is: 0=OFF, 1=FIRST, 2=LAST, 3=1of2 … 37=8of8,
+// 38=custom.  This function applies the +2 correction to non-zero indices.
+Iterance iteranceFromLegacyPresetIndex(int32_t presetIndex);

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -42,6 +42,7 @@
 #include "storage/storage_manager.h"
 #include "util/functions.h"
 #include "util/lookuptables/lookuptables.h"
+#include "model/iterance/iterance_migration.h"
 #include <new>
 #include <string.h>
 
@@ -3395,7 +3396,7 @@ doReadNoteData:
 				}
 				else if (noteHexLength == 26) { // if nightly firmware 1.3 with no custom iterances
 					fill = hexToIntFixedLength(&hexChars[24], 2);
-					iterance = Iterance::fromPresetIndex(hexToIntFixedLength(&hexChars[22], 2));
+					iterance = iteranceFromLegacyPresetIndex(hexToIntFixedLength(&hexChars[22], 2));
 					probability = hexToIntFixedLength(&hexChars[20], 2);
 					lift = hexToIntFixedLength(&hexChars[18], 2);
 					if (lift == 0 || lift > 127) {
@@ -3418,7 +3419,7 @@ doReadNoteData:
 					else if (probability > kNumProbabilityValues
 					         && probability <= kNumProbabilityValues + kNumIterancePresets) {
 						fill = FillMode::OFF;
-						iterance = iterancePresets[probability - kNumProbabilityValues - 1];
+						iterance = iteranceFromLegacyProbabilityByte(probability);
 						probability = kNumProbabilityValues; // 100% probability
 					}
 					else {
@@ -3446,7 +3447,7 @@ doReadNoteData:
 					else if (probability > kNumProbabilityValues
 					         && probability <= kNumProbabilityValues + kNumIterancePresets) {
 						fill = FillMode::OFF;
-						iterance = iterancePresets[probability - kNumProbabilityValues - 1];
+						iterance = iteranceFromLegacyProbabilityByte(probability);
 						probability = kNumProbabilityValues; // 100% probability
 					}
 					else {

--- a/src/deluge/model/note/note_row.cpp
+++ b/src/deluge/model/note/note_row.cpp
@@ -29,6 +29,7 @@
 #include "model/drum/drum_name.h"
 #include "model/drum/gate_drum.h"
 #include "model/instrument/kit.h"
+#include "model/iterance/iterance_migration.h"
 #include "model/note/copied_note_row.h"
 #include "model/note/note.h"
 #include "model/settings/runtime_feature_settings.h"
@@ -42,7 +43,6 @@
 #include "storage/storage_manager.h"
 #include "util/functions.h"
 #include "util/lookuptables/lookuptables.h"
-#include "model/iterance/iterance_migration.h"
 #include <new>
 #include <string.h>
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -64,7 +64,8 @@ file(GLOB_RECURSE deluge_SOURCES
         # For name comparison / default naming tests
         ../../src/deluge/util/name_compare.cpp
         ../../src/deluge/gui/ui/browser/default_name.cpp
-        # For iterance migration tests (iterancePresets stub is in iterance_migration_tests.cpp)
+        # For iterance migration tests (links against the real iterancePresets[]
+        # from lookuptables.cpp, already included above)
         ../../src/deluge/model/iterance/iterance_migration.cpp
 )
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -64,6 +64,8 @@ file(GLOB_RECURSE deluge_SOURCES
         # For name comparison / default naming tests
         ../../src/deluge/util/name_compare.cpp
         ../../src/deluge/gui/ui/browser/default_name.cpp
+        # For iterance migration tests (iterancePresets stub is in iterance_migration_tests.cpp)
+        ../../src/deluge/model/iterance/iterance_migration.cpp
 )
 
 add_executable(UnitTests
@@ -82,6 +84,7 @@ add_executable(UnitTests
         default_name_tests.cpp
         rgb_tests.cpp
         notes_state_tests.cpp
+        iterance_migration_tests.cpp
 )
 add_test(NAME UnitTests
         COMMAND UnitTests)

--- a/tests/unit/iterance_migration_tests.cpp
+++ b/tests/unit/iterance_migration_tests.cpp
@@ -6,8 +6,9 @@
  * before that commit encode iterance using the old (pre-shift) indices.  The migration
  * helpers must apply the +2 correction so those files load correctly.
  *
- * This file also provides a stub definition of iterancePresets so that
- * iterance_migration.cpp can be linked without pulling in all of lookuptables.cpp.
+ * These tests exercise the real iterancePresets[] from lookuptables.cpp (already
+ * pulled into the UnitTests binary for other suites), not a local copy, so they
+ * can't drift out of sync with production data.
  */
 
 #include "CppUTest/TestHarness.h"
@@ -15,27 +16,6 @@
 #include "model/iterance/iterance.h"
 #include "model/iterance/iterance_migration.h"
 #include <array>
-
-// ---------------------------------------------------------------------------
-// Stub: mirrors the real definition in lookuptables.cpp exactly.
-// Keep in sync with src/deluge/util/lookuptables/lookuptables.cpp.
-// ---------------------------------------------------------------------------
-const std::array<Iterance, kNumIterancePresets> iterancePresets = {
-    Iterance{0, 1}, // FIRST  (index 0)
-    Iterance{0, 2}, // LAST   (index 1)
-    // 1of2 … 8of8 (indices 2-36)
-    Iterance{2, 0b1},        Iterance{2, 0b10},
-    Iterance{3, 0b1},        Iterance{3, 0b10},        Iterance{3, 0b100},
-    Iterance{4, 0b1},        Iterance{4, 0b10},        Iterance{4, 0b100},        Iterance{4, 0b1000},
-    Iterance{5, 0b1},        Iterance{5, 0b10},        Iterance{5, 0b100},        Iterance{5, 0b1000},
-    Iterance{5, 0b10000},
-    Iterance{6, 0b1},        Iterance{6, 0b10},        Iterance{6, 0b100},        Iterance{6, 0b1000},
-    Iterance{6, 0b10000},    Iterance{6, 0b100000},
-    Iterance{7, 0b1},        Iterance{7, 0b10},        Iterance{7, 0b100},        Iterance{7, 0b1000},
-    Iterance{7, 0b10000},    Iterance{7, 0b100000},    Iterance{7, 0b1000000},
-    Iterance{8, 0b1},        Iterance{8, 0b10},        Iterance{8, 0b100},        Iterance{8, 0b1000},
-    Iterance{8, 0b10000},    Iterance{8, 0b100000},    Iterance{8, 0b1000000},    Iterance{8, 0b10000000},
-};
 
 // ---------------------------------------------------------------------------
 // iteranceFromLegacyProbabilityByte — C1.2 / pre-lift noteHexLength==22 path
@@ -84,6 +64,21 @@ TEST(IteranceLegacyProbability, result_is_never_LAST) {
         Iterance result = iteranceFromLegacyProbabilityByte(prob);
         CHECK_FALSE_TEXT(result == kLastIteranceValue, "legacy byte mapped to LAST");
     }
+}
+
+TEST(IteranceLegacyProbability, byte20_below_range_decodes_to_off) {
+    // probability 20 = kNumProbabilityValues(20) + 0: below the legacy iterance
+    // range (which starts at legacyPresetIndex 1), should fall back to default.
+    Iterance result = iteranceFromLegacyProbabilityByte(20);
+    CHECK(result == kDefaultIteranceValue);
+}
+
+TEST(IteranceLegacyProbability, byte56_above_range_decodes_to_off) {
+    // probability 56 = kNumProbabilityValues(20) + 36: one past the last legacy
+    // preset (35 = "8 of 8"), should fall back to default rather than reading
+    // out of bounds.
+    Iterance result = iteranceFromLegacyProbabilityByte(56);
+    CHECK(result == kDefaultIteranceValue);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/iterance_migration_tests.cpp
+++ b/tests/unit/iterance_migration_tests.cpp
@@ -1,0 +1,138 @@
+/*
+ * Tests for iterance migration helpers (iterance_migration.h).
+ *
+ * Background: commit 3ce3d41d prepended FIRST and LAST to iterancePresets[], shifting
+ * the existing 1of2…8of8 presets from indices 0-34 to indices 2-36.  Song files saved
+ * before that commit encode iterance using the old (pre-shift) indices.  The migration
+ * helpers must apply the +2 correction so those files load correctly.
+ *
+ * This file also provides a stub definition of iterancePresets so that
+ * iterance_migration.cpp can be linked without pulling in all of lookuptables.cpp.
+ */
+
+#include "CppUTest/TestHarness.h"
+#include "definitions_cxx.hpp"
+#include "model/iterance/iterance.h"
+#include "model/iterance/iterance_migration.h"
+#include <array>
+
+// ---------------------------------------------------------------------------
+// Stub: mirrors the real definition in lookuptables.cpp exactly.
+// Keep in sync with src/deluge/util/lookuptables/lookuptables.cpp.
+// ---------------------------------------------------------------------------
+const std::array<Iterance, kNumIterancePresets> iterancePresets = {
+    Iterance{0, 1}, // FIRST  (index 0)
+    Iterance{0, 2}, // LAST   (index 1)
+    // 1of2 … 8of8 (indices 2-36)
+    Iterance{2, 0b1},        Iterance{2, 0b10},
+    Iterance{3, 0b1},        Iterance{3, 0b10},        Iterance{3, 0b100},
+    Iterance{4, 0b1},        Iterance{4, 0b10},        Iterance{4, 0b100},        Iterance{4, 0b1000},
+    Iterance{5, 0b1},        Iterance{5, 0b10},        Iterance{5, 0b100},        Iterance{5, 0b1000},
+    Iterance{5, 0b10000},
+    Iterance{6, 0b1},        Iterance{6, 0b10},        Iterance{6, 0b100},        Iterance{6, 0b1000},
+    Iterance{6, 0b10000},    Iterance{6, 0b100000},
+    Iterance{7, 0b1},        Iterance{7, 0b10},        Iterance{7, 0b100},        Iterance{7, 0b1000},
+    Iterance{7, 0b10000},    Iterance{7, 0b100000},    Iterance{7, 0b1000000},
+    Iterance{8, 0b1},        Iterance{8, 0b10},        Iterance{8, 0b100},        Iterance{8, 0b1000},
+    Iterance{8, 0b10000},    Iterance{8, 0b100000},    Iterance{8, 0b1000000},    Iterance{8, 0b10000000},
+};
+
+// ---------------------------------------------------------------------------
+// iteranceFromLegacyProbabilityByte — C1.2 / pre-lift noteHexLength==22 path
+//
+// Old encoding: probability byte = kNumProbabilityValues + legacyPresetIndex
+//   legacyPresetIndex 1 = "1 of 2", 2 = "2 of 2", ..., 35 = "8 of 8"
+// ---------------------------------------------------------------------------
+TEST_GROUP(IteranceLegacyProbability){};
+
+TEST(IteranceLegacyProbability, byte21_decodes_to_1of2) {
+    // probability 21 = kNumProbabilityValues(20) + 1 = old "1 of 2"
+    Iterance result = iteranceFromLegacyProbabilityByte(21);
+    CHECK_EQUAL(2u, result.divisor);
+    CHECK_EQUAL(0b1u, (unsigned)result.iteranceStep.to_ulong());
+}
+
+TEST(IteranceLegacyProbability, byte22_decodes_to_2of2) {
+    Iterance result = iteranceFromLegacyProbabilityByte(22);
+    CHECK_EQUAL(2u, result.divisor);
+    CHECK_EQUAL(0b10u, (unsigned)result.iteranceStep.to_ulong());
+}
+
+TEST(IteranceLegacyProbability, byte23_decodes_to_1of3) {
+    Iterance result = iteranceFromLegacyProbabilityByte(23);
+    CHECK_EQUAL(3u, result.divisor);
+    CHECK_EQUAL(0b1u, (unsigned)result.iteranceStep.to_ulong());
+}
+
+TEST(IteranceLegacyProbability, byte55_decodes_to_8of8) {
+    // probability 55 = kNumProbabilityValues(20) + 35 = old "8 of 8" (last preset)
+    Iterance result = iteranceFromLegacyProbabilityByte(55);
+    CHECK_EQUAL(8u, result.divisor);
+    CHECK_EQUAL(0b10000000u, (unsigned)result.iteranceStep.to_ulong());
+}
+
+TEST(IteranceLegacyProbability, result_is_never_FIRST) {
+    // The whole point of the fix: no legacy probability value should map to FIRST.
+    for (int32_t prob = 21; prob <= 55; ++prob) {
+        Iterance result = iteranceFromLegacyProbabilityByte(prob);
+        CHECK_FALSE_TEXT(result == kFirstIteranceValue, "legacy byte mapped to FIRST");
+    }
+}
+
+TEST(IteranceLegacyProbability, result_is_never_LAST) {
+    for (int32_t prob = 21; prob <= 55; ++prob) {
+        Iterance result = iteranceFromLegacyProbabilityByte(prob);
+        CHECK_FALSE_TEXT(result == kLastIteranceValue, "legacy byte mapped to LAST");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// iteranceFromLegacyPresetIndex — early-1.3-nightly noteHexLength==26 path
+//
+// Old encoding: preset index stored directly; 0=OFF, 1=1of2, ..., 35=8of8, 36=custom
+// ---------------------------------------------------------------------------
+TEST_GROUP(IteranceLegacyPresetIndex){};
+
+TEST(IteranceLegacyPresetIndex, index0_decodes_to_off) {
+    Iterance result = iteranceFromLegacyPresetIndex(0);
+    CHECK(result == kDefaultIteranceValue);
+}
+
+TEST(IteranceLegacyPresetIndex, index1_decodes_to_1of2) {
+    // Old index 1 was "1 of 2"; after the +2 shift it lives at new index 3.
+    Iterance result = iteranceFromLegacyPresetIndex(1);
+    CHECK_EQUAL(2u, result.divisor);
+    CHECK_EQUAL(0b1u, (unsigned)result.iteranceStep.to_ulong());
+}
+
+TEST(IteranceLegacyPresetIndex, index2_decodes_to_2of2) {
+    Iterance result = iteranceFromLegacyPresetIndex(2);
+    CHECK_EQUAL(2u, result.divisor);
+    CHECK_EQUAL(0b10u, (unsigned)result.iteranceStep.to_ulong());
+}
+
+TEST(IteranceLegacyPresetIndex, index35_decodes_to_8of8) {
+    Iterance result = iteranceFromLegacyPresetIndex(35);
+    CHECK_EQUAL(8u, result.divisor);
+    CHECK_EQUAL(0b10000000u, (unsigned)result.iteranceStep.to_ulong());
+}
+
+TEST(IteranceLegacyPresetIndex, index36_decodes_to_custom) {
+    // Old "custom" index 36 maps to kCustomIterancePreset (38) → kCustomIteranceValue.
+    Iterance result = iteranceFromLegacyPresetIndex(36);
+    CHECK(result == kCustomIteranceValue);
+}
+
+TEST(IteranceLegacyPresetIndex, no_index_decodes_to_FIRST) {
+    for (int32_t idx = 0; idx <= 36; ++idx) {
+        Iterance result = iteranceFromLegacyPresetIndex(idx);
+        CHECK_FALSE_TEXT(result == kFirstIteranceValue, "legacy index mapped to FIRST");
+    }
+}
+
+TEST(IteranceLegacyPresetIndex, no_index_decodes_to_LAST) {
+    for (int32_t idx = 0; idx <= 36; ++idx) {
+        Iterance result = iteranceFromLegacyPresetIndex(idx);
+        CHECK_FALSE_TEXT(result == kLastIteranceValue, "legacy index mapped to LAST");
+    }
+}


### PR DESCRIPTION
Fixes #4890

## Problem

Commit 3ce3d41d (`save, load, playback, menu working #4844`) prepended FIRST (index 0) and LAST (index 1) to `iterancePresets[]`, shifting the existing 1of2…8of8 presets from array indices 0–34 to indices 2–36.

Three migration paths in `note_row.cpp` that read older song formats were not updated. As a result, any song saved with iteration-dependence set in C1.2.1 (or the early 1.3 nightlies that wrote `noteHexLength==26`) loads with the wrong preset:

| Legacy format | Value stored | Old resolution | After 3ce3d41d (bug) |
|---|---|---|---|
| `noteHexLength==22` (C1.2.1) | probability byte 21 = "1 of 2" | `iterancePresets[0]` = 1of2 ✓ | `iterancePresets[0]` = FIRST ✗ |
| `noteHexLength==26` (early 1.3 nightly) | preset index 1 = "1 of 2" | `fromPresetIndex(1)` = 1of2 ✓ | `fromPresetIndex(1)` = FIRST ✗ |
| Pre-lift `else` path | same as noteHexLength==22 | same | same ✗ |

## Fix

Two new helpers in `iterance_migration.cpp`:

- **`iteranceFromLegacyProbabilityByte(probability)`** — applies the +2 array offset for the `noteHexLength==22` and pre-lift-else paths
- **`iteranceFromLegacyPresetIndex(presetIndex)`** — shifts the stored index by +2 for the `noteHexLength==26` path

`note_row.cpp` now calls these instead of the raw array accesses and `fromPresetIndex()`.

## Tests

`tests/unit/iterance_migration_tests.cpp` covers:
- Boundary values: 1of2, 2of2, 1of3, 8of8 for both helper functions
- OFF (index 0) and custom (index 36) for `fromLegacyPresetIndex`
- Out-of-range probability bytes (below/above the legacy preset range) fall back to OFF
- Sweep asserts that no legacy probability byte or preset index maps to FIRST or LAST

Red → green verified locally (12 failures before fix, 0 after).

## Testing

Verified in the [DelugEmu](https://github.com/gramster/delugemu) QEMU-based emulator against a real C1.2.1-era song containing notes with legacy iterance-encoded probability bytes (21 = "1 of 2", 22 = "2 of 2"), loaded through the actual firmware LOAD SONG UI:

- **Before this fix** (current `main`): the notes decode to **FIRST** and **LAST**, reproducing the bug exactly as described above.
- **After this fix** (this branch): the same notes decode correctly to **1 of 2** and **2 of 2**.

Also confirmed the fixed firmware boots cleanly under emulation with no crash/fault, and that the real ARM-compiled `iterancePresets[]` data matches the values the migration helpers expect.
