### PR TITLE
Fixed wrong key combination in Pattern doc page

### DIFF
--- a/website/src/content/docs/features/save_load_patterns.mdx
+++ b/website/src/content/docs/features/save_load_patterns.mdx
@@ -59,7 +59,7 @@ You will Find the Pattern Files nn the following Structure on the Root of your S
 - Load Melodic Pattern: :key[LOAD] + :key[HORIZONTAL]
 
 - Load Melodic Pattern without overwriting existing Notes:
-  :key[SAVE] + :key[CROSSSCREEN] + :key[HORIZONTAL]
+  :key[LOAD] + :key[CROSSSCREEN] + :key[HORIZONTAL]
 
 - Load Melodic Pattern without scaling original File:
   :key[LOAD] + :key[SCALE] + :key[HORIZONTAL]
@@ -81,7 +81,7 @@ Press and hold :key[PLAY] while in Pattern-Load Menu
 
 - Load Kit Pattern without overwriting existing Notes:
   1. Enable :key[AFFECTENTIRE]
-  2. :key[SAVE] + :key[CROSSSCREEN] + :key[HORIZONTAL]
+  2. :key[LOAD] + :key[CROSSSCREEN] + :key[HORIZONTAL]
 
 - Load Kit Pattern without scaling original File:
   1. Enable :key[AFFECTENTIRE]
@@ -105,7 +105,7 @@ _Remark: If noScaling is set, Pattern will allways overwrite existing Notes and 
 - Load Drum Pattern without overwriting existing Notes:
   1. Disable :key[AFFECTENTIRE]
   2. Select Drum Row to save (:key[AUDITION PAD])
-  3. :key[SAVE] + :key[CROSSSCREEN] + :key[HORIZONTAL]
+  3. :key[LOAD] + :key[CROSSSCREEN] + :key[HORIZONTAL]
 
 - Load Drum Pattern without scaling original File:
   1. Disable :key[AFFECTENTIRE]


### PR DESCRIPTION
Loading a Melodic Pattern without overwriting existing Notes is done with the LOAD button, not the SAVE one.