### PR TITLE
Fixes / Shortcut updates for deluge companion website

### DIFF
--- a/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
+++ b/website/src/components/deluge_companion/components/DelugeUiExternal.svelte
@@ -531,6 +531,10 @@
     svgElement.appendChild(overlay);
   }
 
+  function shouldUseStaticHighlight(actions: Set<Action> | undefined): boolean {
+    return !!actions?.has(Action.HOLD) && !actions.has(Action.PRESS);
+  }
+
   // Load SVG when container becomes available
   $: if (svgHost && !isSvgLoaded) {
     console.log("[DelugeUiExternal] Container detected, loading SVG...");
@@ -606,7 +610,8 @@
         const directSvgIds = getControlSvgIds(control as Control);
         if (directSvgIds.length > 0) {
           const isTurnControl = turnControls.has(control as Control);
-          const shouldBlinkTurn = shouldBlinkTurnControl(controlActions.get(control as Control));
+          const actions = controlActions.get(control as Control);
+          const shouldBlinkTurn = shouldBlinkTurnControl(actions);
 
           if (isTurnControl) {
             directSvgIds.forEach((id) => svgIdsToTurn.add(id));
@@ -616,6 +621,8 @@
             } else {
               directSvgIds.forEach((id) => svgIdsToStaticHighlight.add(id));
             }
+          } else if (shouldUseStaticHighlight(actions)) {
+            directSvgIds.forEach((id) => svgIdsToStaticHighlight.add(id));
           } else {
             directSvgIds.forEach((id) => svgIdsToHighlight.add(id));
           }
@@ -627,7 +634,8 @@
         for (const coord of coords) {
           const svgIds = getSvgIdsForCoordinate(coordinateToSvgIds, coord.x, coord.y);
           const isTurnControl = turnControls.has(control as Control);
-          const shouldBlinkTurn = shouldBlinkTurnControl(controlActions.get(control as Control));
+          const actions = controlActions.get(control as Control);
+          const shouldBlinkTurn = shouldBlinkTurnControl(actions);
 
           if (isTurnControl) {
             svgIds.forEach((id) => svgIdsToTurn.add(id));
@@ -636,6 +644,8 @@
             } else {
               svgIds.forEach((id) => svgIdsToStaticHighlight.add(id));
             }
+          } else if (shouldUseStaticHighlight(actions)) {
+            svgIds.forEach((id) => svgIdsToStaticHighlight.add(id));
           } else {
             svgIds.forEach((id) => svgIdsToHighlight.add(id));
           }

--- a/website/src/components/deluge_companion/components/demos/encoder_turn_demo.ts
+++ b/website/src/components/deluge_companion/components/demos/encoder_turn_demo.ts
@@ -11,7 +11,7 @@ export function shouldBlinkTurnControl(
   actions: Set<Action> | undefined,
 ): boolean {
   if (!actions) return false
-  return actions.has(Action.PRESS) || actions.has(Action.HOLD)
+  return actions.has(Action.PRESS)
 }
 
 export function clearTurnIndicators(

--- a/website/src/components/deluge_companion/data/shortcuts/00-system/01-settings/00-system_settings.md
+++ b/website/src/components/deluge_companion/data/shortcuts/00-system/01-settings/00-system_settings.md
@@ -64,7 +64,7 @@ Default metronome level is 50%.
 #COMMUNITY
 
 ```shortcut
-press(SHIFT) + press(LEARN) + press(ENTIRE)
+hold(SHIFT) + hold(LEARN) + press(ENTIRE)
 ```
 
 ```community

--- a/website/src/components/deluge_companion/data/shortcuts/00-system/02-controls/01-edit/01-system_controls_edit.md
+++ b/website/src/components/deluge_companion/data/shortcuts/00-system/02-controls/01-edit/01-system_controls_edit.md
@@ -68,7 +68,7 @@ To edit decimal values in the currently selected vertical menu, use the horizont
 #COMMUNITY #MENU #SYNTH #KIT #MIDI #CV
 
 ```shortcut
-press(SELECT) + turn(SELECT), hold(SHIFT) + turn(SELECT)
+hold(SELECT) + turn(SELECT), hold(SHIFT) + turn(SELECT)
 ```
 
 Press and turn select or hold shift and turn select to edit fine edit decimal values in the currently selected horizontal menu.

--- a/website/src/components/deluge_companion/data/shortcuts/00-system/02-controls/03-midi/03-system_controls_midi.md
+++ b/website/src/components/deluge_companion/data/shortcuts/00-system/02-controls/03-midi/03-system_controls_midi.md
@@ -120,7 +120,7 @@ Learns an external MIDI note to mute individual kit instruments / rows.
 #COMMUNITY #MIDI
 
 ```shortcut
-hold(SHIFT) + hold(LEARN)
+hold(SHIFT) + press(LEARN)
 ```
 
 Unlearns a MIDI Follow channel or device from the current MIDI Follow submenu.

--- a/website/src/components/deluge_companion/data/shortcuts/01-song/01-file/01-song_file.md
+++ b/website/src/components/deluge_companion/data/shortcuts/01-song/01-file/01-song_file.md
@@ -38,7 +38,7 @@ Note #1: Hold SHIFT and turn SELECT to fast-scroll songs on the display.
 #OFFICIAL
 
 ```shortcut
-press(LOAD), turn(SELECT), hold(TEMPO), press(LOAD)
+press(LOAD), turn(SELECT), hold(TEMPO) + press(LOAD)
 ```
 
 If you wish to maintain the tempo of the old song into the new one, press down on the tempo knob while you press the load button. And if tempo magnitude matching is enabled, then a multiple of the old song’s tempo may be used if it means a less drastic change to the new song’s tempo.

--- a/website/src/components/deluge_companion/data/shortcuts/01-song/03-fx-performance/00-fx.md
+++ b/website/src/components/deluge_companion/data/shortcuts/01-song/03-fx-performance/00-fx.md
@@ -38,7 +38,7 @@ Opens the value and parameter editing modes for Performance View.
 #COMMUNITY #PERFORMANCE
 
 ```shortcut
-press(SAVE) + press(PERFORMANCE)
+hold(SAVE) + press(PERFORMANCE)
 ```
 
 Saves edited Performance View values.
@@ -48,7 +48,7 @@ Saves edited Performance View values.
 #COMMUNITY #PERFORMANCE
 
 ```shortcut
-press(LOAD) + press(PERFORMANCE)
+hold(LOAD) + press(PERFORMANCE)
 ```
 
 Reloads the saved Performance View layout.

--- a/website/src/components/deluge_companion/data/shortcuts/02-playback/01-arranger/02-playback_arranger.md
+++ b/website/src/components/deluge_companion/data/shortcuts/02-playback/01-arranger/02-playback_arranger.md
@@ -16,7 +16,7 @@ press(GRID_UNLIT)
 #OFFICIAL #ARRANGER
 
 ```shortcut
-hold(GRID) + turn(SELECT)
+hold(GRID_LIT) + turn(SELECT)
 ```
 
 This command is fundamental to arranger principles. You can switch between Arranger only clips (white) or Clips assigned to different Sections in Session View.
@@ -64,7 +64,7 @@ hold(AUDITION) + turn(Y)
 #OFFICIAL #ARRANGER
 
 ```shortcut
-hold(GRID) + press(GRID)
+hold(GRID_LIT) + press(GRID)
 ```
 
 Used to shorten as well as lengthen clip instances.

--- a/website/src/components/deluge_companion/data/shortcuts/02-playback/02-session/02-playback_session.md
+++ b/website/src/components/deluge_companion/data/shortcuts/02-playback/02-session/02-playback_session.md
@@ -3,9 +3,9 @@ capability-order: 3
 sub-capability: Playback Mode (Session)
 sub-capability-order: 2
 
-# Create clip (empty row)
+# Create clip (empty row / grid pad)
 
-#OFFICIAL #SESSION_ROW
+#OFFICIAL #COMMUNITY #SESSION #SESSION_ROW #SESSION_GRID
 
 ```shortcut
 press(GRID_UNLIT)
@@ -13,12 +13,20 @@ press(GRID_UNLIT)
 
 Creates the clip and enters clip view. You can create unlimited clips. Scroll up or down in session row view to view more rows.
 
-# Enter clip (non-empty row)
+# Enter clip (non-empty row / grid pad)
 
-#OFFICIAL #SESSION
+#OFFICIAL #COMMUNITY #SESSION #SESSION_ROW #SESSION_GRID
 
 ```shortcut
-press(GRID)
+press(GRID_LIT)
+```
+
+# Enter last selected clip
+
+#OFFICIAL #SESSION #SESSION #SESSION_ROW #SESSION_GRID #PERFORMANCE
+
+```shortcut
+press(CLIP)
 ```
 
 Enters the clip to view or edit it. Return to song mode with the Song button.
@@ -48,7 +56,7 @@ Stops or starts the clip immediately.
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + turn(Y)
+hold(GRID_LIT) + turn(Y)
 ```
 
 # Clip section color - change or create new
@@ -88,7 +96,7 @@ Changes INFInite to a repeat count for the section. The display counts down; pre
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + press(GRID)
+hold(GRID_LIT) + press(GRID_UNLIT)
 ```
 
 Hold source clip and press destination pad.
@@ -100,7 +108,7 @@ Destination row can be another existing clip. The cloned clip is inserted.
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + press(SAVE)
+hold(GRID_LIT) + press(SAVE)
 ```
 
 Cannot undo delete.
@@ -138,7 +146,7 @@ press(ENTIRE), turn(PARAMETER)
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + turn(SELECT)
+hold(GRID_LIT) + turn(SELECT)
 ```
 
 # Change existing clip to synth
@@ -146,7 +154,7 @@ hold(GRID) + turn(SELECT)
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + press(SYNTH)
+hold(GRID_LIT) + press(SYNTH)
 ```
 
 On an empty clip, pressing SYNTH also changes it to a synth clip.
@@ -156,7 +164,7 @@ On an empty clip, pressing SYNTH also changes it to a synth clip.
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + press(MIDI)
+hold(GRID_LIT) + press(MIDI)
 ```
 
 On an empty clip, pressing MIDI also changes it to a MIDI clip.
@@ -166,7 +174,7 @@ On an empty clip, pressing MIDI also changes it to a MIDI clip.
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + press(CV)
+hold(GRID_LIT) + press(CV)
 ```
 
 On an empty clip, pressing CV also changes it to a CV clip.
@@ -176,15 +184,15 @@ On an empty clip, pressing CV also changes it to a CV clip.
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + press(SELECT)
+hold(GRID_LIT) + press(SELECT)
 ```
 
-# Check name and type of non-empty clip
+# Select and check name and type of non-empty clip
 
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID)
+hold(GRID_LIT)
 ```
 
 The LED flashes with the clip name and the clip-type LED lights up, for example MIDI.
@@ -194,7 +202,7 @@ The LED flashes with the clip name and the clip-type LED lights up, for example 
 #COMMUNITY #SESSION
 
 ```shortcut
-hold(GRID) + press(SELECT)
+hold(GRID_LIT) + press(SELECT)
 ```
 
 # Clip Settings Menu (Session Row View)
@@ -212,7 +220,7 @@ Uses status pad (mute/launch) in first column of sidebar.
 #OFFICIAL #SESSION
 
 ```shortcut
-hold(GRID) + hold(SHIFT) + turn(Y)
+hold(GRID_LIT) + hold(SHIFT) + turn(Y)
 ```
 
 In Session Row view, cycle through colors for the held pad row.

--- a/website/src/components/deluge_companion/data/shortcuts/04-clip/01-audio/04-clip_audio.md
+++ b/website/src/components/deluge_companion/data/shortcuts/04-clip/01-audio/04-clip_audio.md
@@ -18,7 +18,7 @@ Press an empty row / pad in session view.
 #OFFICIAL #COMMUNITY #SESSION
 
 ```shortcut
-hold(LEARN) + press(GRID), turn(SELECT), press(SELECT)
+hold(LEARN) + press(GRID_LIT), turn(SELECT), press(SELECT)
 ```
 
 ```community
@@ -30,7 +30,7 @@ The community firmware adds the ability to select an internal track as the input
 #OFFICIAL #COMMUNITY #SESSION
 
 ```shortcut
-press(GRID), turn(SELECT)
+hold(GRID_LIT) + turn(SELECT)
 ```
 
 ```community
@@ -128,7 +128,7 @@ The clip remains time-stretched, and shortened clips in waveform view play at a 
 #COMMUNITY #AUDIO
 
 ```shortcut
-press(Y) + press(X)
+hold(Y) + press(X)
 ```
 
 ```community

--- a/website/src/components/deluge_companion/data/shortcuts/04-clip/01-melodic/02-midi/04-clip_midi.md
+++ b/website/src/components/deluge_companion/data/shortcuts/04-clip/01-melodic/02-midi/04-clip_midi.md
@@ -70,7 +70,7 @@ Saves renamed MIDI CC labels into the current song.
 #COMMUNITY #MIDI
 
 ```shortcut
-press(SAVE) + press(MIDI)
+hold(SAVE) + press(MIDI)
 ```
 
 Saves renamed MIDI CC labels into the current MIDI preset.

--- a/website/src/components/deluge_companion/data/shortcuts/04-clip/03-kit/04-clip_kit.md
+++ b/website/src/components/deluge_companion/data/shortcuts/04-clip/03-kit/04-clip_kit.md
@@ -194,7 +194,7 @@ Lazy chop allows the grid pads to manually chop the sample into slices. Press th
 #OFFICIAL #COMMUNITY #KIT
 
 ```shortcut
-hold(SHIFT) + hold(GRID), hold(ENTIRE) + turn(SELECT)
+hold(SHIFT) + press(GRID), hold(ENTIRE) + turn(SELECT)
 ```
 
 Applies to all rows in a kit.

--- a/website/src/components/deluge_companion/data/shortcuts/05-sequencing/02-note/05-sequencing_note.md
+++ b/website/src/components/deluge_companion/data/shortcuts/05-sequencing/02-note/05-sequencing_note.md
@@ -8,27 +8,27 @@ sub-capability-order: 2
 #OFFICIAL #SYNTH #KIT #MIDI #CV
 
 ```shortcut
-hold(GRID) + press(GRID_UNLIT)
+hold(GRID_UNLIT) + press(GRID)
 ```
 
-Select two grid buttons on the same row.
+Select two grid pads on the same row.
 
 # Make long note across the next screen
 
 #OFFICIAL #SYNTH #KIT #MIDI #CV
 
 ```shortcut
-press(GRID), turn(X), hold(X) + press(GRID_UNLIT)
+press(GRID_UNLIT), turn(X), hold(X) + press(GRID)
 ```
 
-Move to the next screen, then select the two grid buttons on the same row.
+Move to the next screen, then select the grid pad on the same row.
 
 # Edit Note Repeat
 
 #OFFICIAL #SYNTH #KIT #MIDI #CV #AUTOMATION #AUTOMATION_VELOCITY
 
 ```shortcut
-hold(GRID) + press(Y) + turn(Y)
+hold(GRID_LIT) + press(Y) + turn(Y)
 ```
 
 Adjusts selected note's repeats.
@@ -38,7 +38,7 @@ Adjusts selected note's repeats.
 #OFFICIAL #SYNTH #KIT #MIDI #CV
 
 ```shortcut
-hold(GRID) + turn(X)
+hold(GRID_LIT) + turn(X)
 ```
 
 Multiple notes can be selected. New notes default to the last velocity setting. Default velocity is 64, with a range of 0-127.
@@ -48,7 +48,7 @@ Multiple notes can be selected. New notes default to the last velocity setting. 
 #OFFICIAL #COMMUNITY #SYNTH #KIT #MIDI #CV
 
 ```shortcut
-hold(GRID) + turn(SELECT)
+hold(GRID_LIT) + turn(SELECT)
 ```
 
 ```community
@@ -64,7 +64,7 @@ Community: A note can have both note probability and note iterance set.
 #OFFICIAL #COMMUNITY #SYNTH #KIT #MIDI #CV
 
 ```shortcut
-hold(GRID) + turn(SELECT)
+hold(GRID_LIT) + turn(SELECT)
 ```
 
 Multiple notes can be selected.
@@ -275,7 +275,7 @@ Community: A note row can have both note probability and note iterance set.
 #COMMUNITY #SYNTH #KIT #MIDI #CV #AUTOMATION #AUTOMATION_VELOCITY
 
 ```shortcut
-hold(GRID) + turn(X)
+hold(AUDITION) + turn(X)
 ```
 
 Adjusts the selected note row's velocity. All note's in the note row will be set with the same value.
@@ -295,7 +295,7 @@ Adjusts the selected note row's fill setting when the Community Feature is enabl
 #COMMUNITY #SYNTH #KIT #MIDI #CV #AUTOMATION #AUTOMATION_VELOCITY
 
 ```shortcut
-hold(GRID) + press(SELECT)
+hold(GRID_LIT) + press(SELECT)
 ```
 
 Opens the note editor menu for the held note.
@@ -345,7 +345,7 @@ Exits the note row editor menu.
 #COMMUNITY #SYNTH #KIT #MIDI #CV #AUTOMATION #AUTOMATION_VELOCITY
 
 ```shortcut
-press(Y) + turn(Y)
+hold(Y) + turn(Y)
 ```
 
 Transposes the selected note row while editing velocity data.

--- a/website/src/components/deluge_companion/data/shortcuts/05-sequencing/03-automation/05-sequencing_automation.md
+++ b/website/src/components/deluge_companion/data/shortcuts/05-sequencing/03-automation/05-sequencing_automation.md
@@ -78,7 +78,7 @@ In the automation view editor, press a single step or select a range of steps to
 #COMMUNITY #ARRANGER #SYNTH #KIT #MIDI #CV #AUTOMATION_PARAMETER #AUTOMATION_VELOCITY
 
 ```shortcut
-hold(GRID) + turn(PARAMETER)
+hold(GRID_LIT) + turn(PARAMETER)
 ```
 
 Hold note / step and turn gold knob(s) to adjust automation at the selected step
@@ -88,7 +88,7 @@ Hold note / step and turn gold knob(s) to adjust automation at the selected step
 #COMMUNITY #SYNTH #KIT #MIDI #CV #AUTOMATION_PARAMETER #AUTOMATION_VELOCITY
 
 ```shortcut
-hold(GRID) + turn(EXTERNAL)
+hold(GRID_LIT) + turn(EXTERNAL)
 ```
 
 Hold note / step and send external midi cc to adjust automation at the selected step for the learned parameter(s)

--- a/website/src/components/deluge_companion/data/shortcuts/06-recording/01-audio/03-recording_audio_export.md
+++ b/website/src/components/deluge_companion/data/shortcuts/06-recording/01-audio/03-recording_audio_export.md
@@ -10,7 +10,7 @@ sub-sub-capability-order: 3
 #COMMUNITY #ARRANGER #SESSION #KIT
 
 ```shortcut
-press(SAVE) + press(RECORD)
+hold(SAVE) + press(RECORD)
 ```
 
 Starts audio export from Session/Arranger, or Kit drum export when you are in Kit Instrument Clip View.

--- a/website/src/components/deluge_companion/data/shortcuts/08-controls/03-parameters/08-controls_parameters.md
+++ b/website/src/components/deluge_companion/data/shortcuts/08-controls/03-parameters/08-controls_parameters.md
@@ -94,7 +94,7 @@ Deletes recorded automation for the selected parameter.
 #COMMUNITY #ARRANGER
 
 ```shortcut
-press(SHIFT) + press(TEMPO)
+hold(SHIFT) + press(TEMPO)
 ```
 
 Deletes recorded automation for tempo in arranger view.

--- a/website/src/components/deluge_companion/data/v4.1.0.json
+++ b/website/src/components/deluge_companion/data/v4.1.0.json
@@ -194,11 +194,11 @@
       {
         "substeps": [
           {
-            "action": 0,
+            "action": 1,
             "control": 4
           },
           {
-            "action": 0,
+            "action": 1,
             "control": 9
           },
           {
@@ -220,7 +220,7 @@
         ]
       }
     ],
-    "description": "Press the Shift button, press the Learn / Input button, press the Affect Entire button."
+    "description": "Hold the Shift button, hold the Learn / Input button, press the Affect Entire button."
   },
   {
     "name": "Undo",
@@ -414,7 +414,7 @@
       {
         "substeps": [
           {
-            "action": 0,
+            "action": 1,
             "control": 34
           },
           {
@@ -447,7 +447,7 @@
         ]
       }
     ],
-    "description": "Press the Select (Settings) encoder, turn the Select (Settings) encoder. Hold the Shift button, turn the Select (Settings) encoder."
+    "description": "Hold the Select (Settings) encoder, turn the Select (Settings) encoder. Hold the Shift button, turn the Select (Settings) encoder."
   },
   {
     "name": "Check current zoom level",
@@ -1342,7 +1342,7 @@
             "control": 4
           },
           {
-            "action": 1,
+            "action": 0,
             "control": 9
           }
         ]
@@ -1359,7 +1359,7 @@
         ]
       }
     ],
-    "description": "Hold the Shift button, hold the Learn / Input button."
+    "description": "Hold the Shift button, press the Learn / Input button."
   },
   {
     "name": "New song",
@@ -3289,7 +3289,7 @@
     "description": "Press the Cross-screen button."
   },
   {
-    "name": "Create clip (empty row)",
+    "name": "Create clip (empty row / grid pad)",
     "capability": "02-playback_session",
     "capabilityParentId": "PLAYBACK",
     "capabilityOrder": 3,
@@ -3301,8 +3301,8 @@
         "control": 37
       }
     ],
-    "views": [3],
-    "firmware": [0],
+    "views": [2, 3, 4],
+    "firmware": [0, 1],
     "paragraphs": [
       {
         "spans": [
@@ -3315,7 +3315,7 @@
     "description": "Press the Unlit grid pad."
   },
   {
-    "name": "Enter clip (non-empty row)",
+    "name": "Enter clip (non-empty row / grid pad)",
     "capability": "02-playback_session",
     "capabilityParentId": "PLAYBACK",
     "capabilityOrder": 3,
@@ -3324,10 +3324,46 @@
     "steps": [
       {
         "action": 0,
-        "control": 36
+        "control": 38
       }
     ],
-    "views": [2],
+    "views": [2, 3, 4],
+    "firmware": [0, 1],
+    "paragraphs": [],
+    "description": "Press the Lit grid pad."
+  },
+  {
+    "name": "Select clip (non-empty row / grid pad)",
+    "capability": "02-playback_session",
+    "capabilityParentId": "PLAYBACK",
+    "capabilityOrder": 3,
+    "subCapabilityTitle": "Playback Mode (Session)",
+    "subCapabilityOrder": 2,
+    "steps": [
+      {
+        "action": 0,
+        "control": 10
+      }
+    ],
+    "views": [2, 3, 4],
+    "firmware": [0, 1],
+    "paragraphs": [],
+    "description": "Press the Clip button."
+  },
+  {
+    "name": "Enter last selected clip",
+    "capability": "02-playback_session",
+    "capabilityParentId": "PLAYBACK",
+    "capabilityOrder": 3,
+    "subCapabilityTitle": "Playback Mode (Session)",
+    "subCapabilityOrder": 2,
+    "steps": [
+      {
+        "action": 0,
+        "control": 10
+      }
+    ],
+    "views": [2, 3, 4, 0],
     "firmware": [0],
     "paragraphs": [
       {
@@ -3338,7 +3374,7 @@
         ]
       }
     ],
-    "description": "Press the Grid pad (lit or unlit)."
+    "description": "Press the Clip button."
   },
   {
     "name": "Launch clip - queue",
@@ -4090,7 +4126,7 @@
     "subCapabilityOrder": 1,
     "steps": [
       {
-        "action": 0,
+        "action": 1,
         "control": 36
       },
       {
@@ -4110,7 +4146,7 @@
         ]
       }
     ],
-    "description": "Press the Grid pad (lit or unlit). Turn the Select (Settings) encoder."
+    "description": "Hold the Grid pad (lit or unlit). Turn the Select (Settings) encoder."
   },
   {
     "name": "Create new audio track in arranger view",
@@ -4358,7 +4394,7 @@
       {
         "substeps": [
           {
-            "action": 0,
+            "action": 1,
             "control": 33
           },
           {
@@ -4380,7 +4416,7 @@
         ]
       }
     ],
-    "description": "Press the Vertical (Up/Down) encoder, press the Horizontal (Left/Right) encoder."
+    "description": "Hold the Vertical (Up/Down) encoder, press the Horizontal (Left/Right) encoder."
   },
   {
     "name": "Adjust audio clip length without timestretching",
@@ -5207,7 +5243,7 @@
       {
         "substeps": [
           {
-            "action": 0,
+            "action": 1,
             "control": 6
           },
           {
@@ -5228,7 +5264,7 @@
         ]
       }
     ],
-    "description": "Press the Save (Delete) button, press the MIDI button."
+    "description": "Hold the Save (Delete) button, press the MIDI button."
   },
   {
     "name": "Save MIDI CC Labels to File",
@@ -7397,7 +7433,7 @@
       {
         "substeps": [
           {
-            "action": 0,
+            "action": 1,
             "control": 33
           },
           {
@@ -7418,7 +7454,7 @@
         ]
       }
     ],
-    "description": "Press the Vertical (Up/Down) encoder, turn the Vertical (Up/Down) encoder."
+    "description": "Hold the Vertical (Up/Down) encoder, turn the Vertical (Up/Down) encoder."
   },
   {
     "name": "Clear Selected Note Row",


### PR DESCRIPTION
Tidying up some stuff in the deluge companion
- updated hold vs press usage in the shortcuts + the highlighting animations on the hardware preview