### PR TITLE
Cleanup dx7 memory allocation

### DIFF
--- a/src/deluge/dsp/dx/engine.cpp
+++ b/src/deluge/dsp/dx/engine.cpp
@@ -56,9 +56,9 @@ DxEngine::DxEngine() {
 
 gsl::owner<DxVoice*> DxEngine::solicitDxVoice() {
 #ifdef DX_PREALLOC
-	if (firstUnassignedDxVoice) {
-		DxVoice* toReturn = firstUnassignedDxVoice;
-		firstUnassignedDxVoice = firstUnassignedDxVoice->nextUnassigned;
+	if (dxEngine && dxEngine->firstUnassignedDxVoice) {
+		DxVoice* toReturn = dxEngine->firstUnassignedDxVoice;
+		dxEngine->firstUnassignedDxVoice = dxEngine->firstUnassignedDxVoice->nextUnassigned;
 		toReturn->preallocated = true;
 		return toReturn;
 	}

--- a/src/deluge/dsp/dx/engine.cpp
+++ b/src/deluge/dsp/dx/engine.cpp
@@ -22,10 +22,14 @@
 #include "dx7note.h"
 #include "engine.h"
 #include "math_lut.h"
+#include "memory/fast_allocator.h"
 #include "memory/memory_allocator_interface.h"
+#include "memory/object_pool.h"
 #include <new>
 
 DxEngine* dxEngine = nullptr;
+
+using DxVoicePool = deluge::memory::ObjectPool<DxVoice, deluge::memory::fast_allocator>;
 
 static void init_engine(void) {
 	// get ourselves an aligned pointer to use placement new with
@@ -59,11 +63,11 @@ DxVoice* DxEngine::solicitDxVoice() {
 		return toReturn;
 	}
 #endif
-	void* memory = allocMaxSpeed(sizeof(DxVoice));
-	if (!memory)
+	try {
+		return DxVoicePool::get().acquire().release();
+	} catch (deluge::exception e) {
 		return nullptr;
-
-	return new (memory) DxVoice();
+	}
 }
 
 void DxEngine::dxVoiceUnassigned(DxVoice* dxVoice) {
@@ -74,11 +78,11 @@ void DxEngine::dxVoiceUnassigned(DxVoice* dxVoice) {
 		return;
 	}
 #endif
-	delugeDealloc(dxVoice);
+	DxVoicePool::recycle(dxVoice);
 }
 
 DxPatch* DxEngine::newPatch(void) {
-	void* memory = allocMaxSpeed(sizeof(DxPatch));
+	void* memory = allocLowSpeed(sizeof(DxPatch));
 	return new (memory) DxPatch;
 }
 

--- a/src/deluge/dsp/dx/engine.cpp
+++ b/src/deluge/dsp/dx/engine.cpp
@@ -73,8 +73,8 @@ gsl::owner<DxVoice*> DxEngine::solicitDxVoice() {
 void DxEngine::dxVoiceUnassigned(gsl::owner<DxVoice*> dxVoice) {
 #ifdef DX_PREALLOC
 	if (dxVoice->preallocated) {
-		dxVoice->nextUnassigned = firstUnassignedDxVoice;
-		firstUnassignedDxVoice = dxVoice;
+		dxVoice->nextUnassigned = dxEngine->firstUnassignedDxVoice;
+		dxEngine->firstUnassignedDxVoice = dxVoice;
 		return;
 	}
 #endif

--- a/src/deluge/dsp/dx/engine.cpp
+++ b/src/deluge/dsp/dx/engine.cpp
@@ -54,7 +54,7 @@ DxEngine::DxEngine() {
 #endif
 }
 
-DxVoice* DxEngine::solicitDxVoice() {
+gsl::owner<DxVoice*> DxEngine::solicitDxVoice() {
 #ifdef DX_PREALLOC
 	if (firstUnassignedDxVoice) {
 		DxVoice* toReturn = firstUnassignedDxVoice;
@@ -70,7 +70,7 @@ DxVoice* DxEngine::solicitDxVoice() {
 	}
 }
 
-void DxEngine::dxVoiceUnassigned(DxVoice* dxVoice) {
+void DxEngine::dxVoiceUnassigned(gsl::owner<DxVoice*> dxVoice) {
 #ifdef DX_PREALLOC
 	if (dxVoice->preallocated) {
 		dxVoice->nextUnassigned = firstUnassignedDxVoice;

--- a/src/deluge/dsp/dx/engine.cpp
+++ b/src/deluge/dsp/dx/engine.cpp
@@ -44,25 +44,7 @@ static void init_engine(void) {
 	Env::init_sr(44100);
 }
 
-DxEngine::DxEngine() {
-#ifdef DX_PREALLOC
-	firstUnassignedDxVoice = &dxVoices[0];
-
-	for (int i = 0; i < kNumVoiceSamplesStatic - 1; i++) {
-		dxVoices[i].nextUnassigned = &dxVoices[i + 1];
-	}
-#endif
-}
-
 gsl::owner<DxVoice*> DxEngine::solicitDxVoice() {
-#ifdef DX_PREALLOC
-	if (dxEngine && dxEngine->firstUnassignedDxVoice) {
-		DxVoice* toReturn = dxEngine->firstUnassignedDxVoice;
-		dxEngine->firstUnassignedDxVoice = dxEngine->firstUnassignedDxVoice->nextUnassigned;
-		toReturn->preallocated = true;
-		return toReturn;
-	}
-#endif
 	try {
 		return DxVoicePool::get().acquire().release();
 	} catch (deluge::exception e) {
@@ -71,13 +53,6 @@ gsl::owner<DxVoice*> DxEngine::solicitDxVoice() {
 }
 
 void DxEngine::dxVoiceUnassigned(gsl::owner<DxVoice*> dxVoice) {
-#ifdef DX_PREALLOC
-	if (dxVoice->preallocated) {
-		dxVoice->nextUnassigned = dxEngine->firstUnassignedDxVoice;
-		dxEngine->firstUnassignedDxVoice = dxVoice;
-		return;
-	}
-#endif
 	DxVoicePool::recycle(dxVoice);
 }
 

--- a/src/deluge/dsp/dx/engine.h
+++ b/src/deluge/dsp/dx/engine.h
@@ -60,7 +60,7 @@ public:
 	FmCore engineModern;
 
 	gsl::owner<DxVoice*> solicitDxVoice();
-	void dxVoiceUnassigned(gsl::owner<DxVoice*> dxVoice);
+	static void dxVoiceUnassigned(gsl::owner<DxVoice*> dxVoice);
 	DxPatch* newPatch();
 };
 

--- a/src/deluge/dsp/dx/engine.h
+++ b/src/deluge/dsp/dx/engine.h
@@ -20,6 +20,7 @@
 #include "EngineMkI.h"
 #include "definitions_cxx.hpp"
 #include "dx7note.h"
+#include <gsl/gsl>
 
 // seems to cause crashes... maybe YAGNI
 // #define DX_PREALLOC
@@ -58,8 +59,8 @@ public:
 	EngineMkI engineMkI;
 	FmCore engineModern;
 
-	DxVoice* solicitDxVoice();
-	void dxVoiceUnassigned(DxVoice* dxVoice);
+	gsl::owner<DxVoice*> solicitDxVoice();
+	void dxVoiceUnassigned(gsl::owner<DxVoice*> dxVoice);
 	DxPatch* newPatch();
 };
 

--- a/src/deluge/dsp/dx/engine.h
+++ b/src/deluge/dsp/dx/engine.h
@@ -22,12 +22,9 @@
 #include "dx7note.h"
 #include <gsl/gsl>
 
-// seems to cause crashes... maybe YAGNI
-// #define DX_PREALLOC
-
 class DxEngine {
 public:
-	DxEngine();
+	DxEngine() = default;
 #define EXP2_LG_N_SAMPLES 10
 #define EXP2_N_SAMPLES (1 << EXP2_LG_N_SAMPLES)
 	int32_t exp2tab[EXP2_N_SAMPLES << 1];
@@ -50,11 +47,6 @@ public:
 #define FREQ_LG_N_SAMPLES 10
 #define FREQ_N_SAMPLES (1 << FREQ_LG_N_SAMPLES)
 	int32_t freq_lut[FREQ_N_SAMPLES + 1];
-
-#ifdef DX_PREALLOC
-	DxVoice dxVoices[kNumVoiceSamplesStatic];
-	DxVoice* firstUnassignedDxVoice;
-#endif
 
 	EngineMkI engineMkI;
 	FmCore engineModern;

--- a/src/deluge/dsp/dx/engine.h
+++ b/src/deluge/dsp/dx/engine.h
@@ -59,7 +59,7 @@ public:
 	EngineMkI engineMkI;
 	FmCore engineModern;
 
-	gsl::owner<DxVoice*> solicitDxVoice();
+	static gsl::owner<DxVoice*> solicitDxVoice();
 	static void dxVoiceUnassigned(gsl::owner<DxVoice*> dxVoice);
 	DxPatch* newPatch();
 };

--- a/src/deluge/model/voice/voice_unison_part_source.cpp
+++ b/src/deluge/model/voice/voice_unison_part_source.cpp
@@ -29,6 +29,10 @@
 #include "processing/source.h"
 #include "storage/multi_range/multisample_range.h"
 
+VoiceUnisonPartSource::~VoiceUnisonPartSource() {
+	unassign(false);
+}
+
 bool VoiceUnisonPartSource::noteOn(Voice* voice, Source* source, VoiceSamplePlaybackGuide* guide, uint32_t samplesLate,
                                    uint32_t oscRetriggerPhase, bool resetEverything, SynthMode synthMode,
                                    uint8_t velocity) {

--- a/src/deluge/model/voice/voice_unison_part_source.h
+++ b/src/deluge/model/voice/voice_unison_part_source.h
@@ -32,6 +32,7 @@ class DxVoice;
 class VoiceUnisonPartSource {
 public:
 	VoiceUnisonPartSource() = default;
+	~VoiceUnisonPartSource();
 	bool noteOn(Voice* voice, Source* source, VoiceSamplePlaybackGuide* voiceSource, uint32_t samplesLate,
 	            uint32_t oscPhase, bool resetEverything, SynthMode synthMode, uint8_t velocity);
 	void unassign(bool deletingSong);

--- a/src/deluge/model/voice/voice_unison_part_source.h
+++ b/src/deluge/model/voice/voice_unison_part_source.h
@@ -19,6 +19,7 @@
 
 #include "definitions_cxx.hpp"
 #include "model/sample/sample.h"
+#include <gsl/gsl>
 
 class TimeStretcher;
 class VoiceSamplePlaybackGuide;
@@ -45,5 +46,5 @@ public:
 	bool active;
 	VoiceSample* voiceSample = nullptr;
 	LivePitchShifter* livePitchShifter = nullptr;
-	DxVoice* dxVoice = nullptr;
+	gsl::owner<DxVoice*> dxVoice = nullptr;
 };

--- a/src/deluge/processing/source.cpp
+++ b/src/deluge/processing/source.cpp
@@ -20,6 +20,7 @@
 #include "dsp/dx/engine.h"
 #include "gui/ui/browser/sample_browser.h"
 #include "gui/ui/sound_editor.h"
+#include "memory/memory_allocator_interface.h"
 #include "model/sample/sample.h"
 #include "processing/engines/audio_engine.h"
 #include "processing/sound/sound.h"
@@ -47,6 +48,12 @@ Source::Source() {
 }
 
 Source::~Source() {
+	// destruct dxPatch if it was allocated
+	if (dxPatch != nullptr) {
+		dxPatch->~DxPatch();
+		delugeDealloc(dxPatch);
+		dxPatch = nullptr;
+	}
 	destructAllMultiRanges();
 }
 


### PR DESCRIPTION
Cleaned up dx7 memory allocation

- switched voice allocation to object pool
- switched dx patch allocation to low speed
- add dx patch deallocation to source destructor
- removed dx prealloc references