### PR TITLE
Four ways a param lookup could freeze the unit

### DIFF
--- a/src/deluge/model/model_stack.cpp
+++ b/src/deluge/model/model_stack.cpp
@@ -245,7 +245,8 @@ ModelStackWithAutoParam* ModelStackWithThreeMainThings::getUnpatchedAutoParamFro
 
 ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchedAutoParamFromId(int32_t newParamId) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()
+	    && paramManager->containsPatchedParamCollections()) {
 		ParamCollectionSummary* summary = paramManager->getPatchedParamSetSummary();
 
 		ModelStackWithParamId* modelStackWithParamId =
@@ -258,7 +259,8 @@ ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchedAutoParamFromI
 
 ModelStackWithAutoParam* ModelStackWithThreeMainThings::getPatchCableAutoParamFromId(int32_t newParamId) {
 	ModelStackWithAutoParam* modelStackWithParam = nullptr;
-	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()) {
+	if (paramManager && paramManager->containsAnyParamCollectionsIncludingExpression()
+	    && paramManager->containsPatchedParamCollections()) {
 		ParamCollectionSummary* summary = paramManager->getPatchCableSetSummary();
 
 		ModelStackWithParamId* modelStackWithParamId =

--- a/src/deluge/modulation/params/param_manager.h
+++ b/src/deluge/modulation/params/param_manager.h
@@ -52,6 +52,11 @@ public:
 
 	inline bool containsAnyParamCollectionsIncludingExpression() { return summaries[0].paramCollection; }
 
+	/// True only if this ParamManager was set up with patching (i.e. it belongs to a Sound) and therefore actually
+	/// has a patched param set and a patch cable set. setupWithPatching() sets expressionParamSetOffset to 3;
+	/// setupUnpatched() and setupMIDI() set it to 1, and a manager whose collections were stolen/forgotten sits at 0.
+	inline bool containsPatchedParamCollections() { return expressionParamSetOffset >= 3; }
+
 	Error setupWithPatching();
 	Error setupUnpatched();
 	Error setupMIDI();


### PR DESCRIPTION
Four places where code asked a `ParamManager` for a param set it did not have. The summary
getters in `param_manager.h` freeze the unit on that (`FREEZE_WITH_ERROR("E410"/"E411")`)
rather than answering, so each one is a hard stop mid-session on a beta build — and on a
release build the assert is compiled out and the pointer is dereferenced anyway, so the
release behaviour is a null/garbage deref rather than a caught error.

All four were hit on hardware (OLED, 1.3 line) while driving params over MIDI Follow.

### 1. `model_stack.cpp` — patched getter, wrong guard

`getPatchedAutoParamFromId()` and `getPatchCableAutoParamFromId()` gated on
`containsAnyParamCollectionsIncludingExpression()`, which only tests `summaries[0]` and is
therefore true for essentially every ParamManager — including ones built by
`setupUnpatched()` (kits under affect-entire, audio clips) and `setupMIDI()`, neither of
which has a patched set at all. The next line then asks for one.

Added `containsPatchedParamCollections()` — `expressionParamSetOffset >= 3`, the value only
`setupWithPatching()` ever writes — and required it in both.

### 2. `model_stack.cpp` — unpatched getter, same shape

`getUnpatchedAutoParamFromId()` used the same over-broad test, which is true for a manager
holding only expression params. `summaries[0]` is the unpatched set only when the manager was
set up, so that path could hand back an `ExpressionParamSet` dressed up as unpatched params.
Now uses `containsAnyMainParamCollections()`.

### 3. `sound.cpp` — gold-knob indicator refresh

`getParamFromModEncoderDeeper()` went straight to the summary getters. The indicator refresh
calls it with whatever mod controllable and ParamManager are currently active, and those two
can belong to **different clips** — MIDI Follow pointed at one clip with a clip view open on
another. Now answers "no param", the same answer the macro-setup case already gives.

### 4. `midi_follow.cpp` — popup per CC overflows the OLED frame queue

Once the above return null instead of freezing, `displayParamControlError()` raises a popup
for every CC that fails to resolve. A knob sweep is a continuous CC stream, each popup queues
a full OLED frame, and the queue overflows and freezes on FULL in `enqueueOLEDFrame()`. So
fixing 1–3 without this one just trades a param freeze for a display freeze. Throttled to one
popup per 500 ms; the message still shows and still stands.

### Testing

Built and run on hardware. The freezes are replaced by the ordinary "can't control that
param" message, a knob sweep no longer takes the display down, and normal patched-param
control on synths and kit rows is unaffected.

These are containment fixes, deliberately: they do not stop a caller asking for the wrong
kind of param, they stop that mistake being fatal. The callers that can do it are worth
auditing separately.

All four files are identical on `community` to the fork they were found on, so the change
applies to stock unmodified; the build tested was a fork with other work on it, which is
worth knowing.
