### PR TITLE
Fix param manager error on instrument clip conversion to audio

### DIFF
--- a/src/deluge/gui/views/session_view.cpp
+++ b/src/deluge/gui/views/session_view.cpp
@@ -1801,14 +1801,12 @@ void SessionView::resyncNewClip(Clip* newClip, ModelStackWithTimelineCounter* mo
 }
 
 void SessionView::replaceInstrumentClipWithAudioClip(Clip* clip) {
-	int32_t clipIndex = currentSong->sessionClips.getIndexForClip(clip);
-
 	if (!clip || clip->type != ClipType::INSTRUMENT) {
 		return;
 	}
 
-	if (currentSong->sessionLayout == SessionLayoutType::SessionLayoutTypeGrid
-	    && currentSong->getClipWithOutput(clip->output, false, clip)) {
+	// don't convert a track to audio if it has clip instances in arranger or more than one clip in session view
+	if (clip->output->clipHasInstance(clip) || currentSong->getClipWithOutput(clip->output, false, clip)) {
 		display->displayPopup(deluge::l10n::get(
 		    deluge::l10n::String::STRING_FOR_INSTRUMENTS_WITH_CLIPS_CANT_BE_TURNED_INTO_AUDIO_TRACKS));
 		return;
@@ -1820,6 +1818,7 @@ void SessionView::replaceInstrumentClipWithAudioClip(Clip* clip) {
 		return;
 	}
 
+	int32_t clipIndex = currentSong->sessionClips.getIndexForClip(clip);
 	Clip* newClip = currentSong->replaceInstrumentClipWithAudioClip(clip, clipIndex);
 
 	if (!newClip) {

--- a/src/deluge/hid/display/display.cpp
+++ b/src/deluge/hid/display/display.cpp
@@ -1,8 +1,14 @@
 #include "display.h"
+#include "drivers/pic/pic.h"
 #include "gui/l10n/l10n.h"
 #include "gui/ui/ui.h"
+#include "hid/button.h"
 #include "hid/display/oled.h"
 #include "hid/display/seven_segment.h"
+
+extern "C" {
+#include "RZA1/uart/sio_char.h"
+}
 
 deluge::hid::Display* display = nullptr;
 namespace deluge::hid::display {
@@ -85,6 +91,32 @@ std::string_view getErrorMessage(Error error) {
 }
 
 bool have_oled_screen = false;
+
+void wait_for_select_encoder_press() {
+	// The PIC reports press and release with the same button code, prefixing releases with NEXT_PAD_OFF. Ignoring
+	// those means a freeze triggered from a select press isn't dismissed by that same press's release.
+	bool next_is_release = false;
+
+	while (true) {
+		PIC::flush();
+		uartFlushIfNotSending(UART_ITEM_MIDI);
+
+		uint8_t value;
+		if (!uartGetChar(UART_ITEM_PIC, (char*)&value)) {
+			continue;
+		}
+
+		if (value == static_cast<uint8_t>(PIC::Response::NEXT_PAD_OFF)) {
+			next_is_release = true;
+			continue;
+		}
+
+		if (value == deluge::hid::button::SELECT_ENC && !next_is_release) {
+			return;
+		}
+		next_is_release = false;
+	}
+}
 
 void swapDisplayType() {
 	using ::display; // this is c++

--- a/src/deluge/hid/display/display.h
+++ b/src/deluge/hid/display/display.h
@@ -124,6 +124,8 @@ extern deluge::hid::Display* display;
 
 namespace deluge::hid::display {
 void swapDisplayType();
+/// Blocks until the select encoder is newly pressed. Used by freezeWithError() to offer "attempt resume".
+void wait_for_select_encoder_press();
 // physical screen is oled
 extern bool have_oled_screen;
 } // namespace deluge::hid::display

--- a/src/deluge/hid/display/oled.cpp
+++ b/src/deluge/hid/display/oled.cpp
@@ -1309,19 +1309,8 @@ void OLED::freezeWithError(char const* text) {
 	DMACn(OLED_SPI_DMA_CHANNEL).CHCTRL_n |=
 	    DMAC_CHCTRL_0S_CLRTC | DMAC_CHCTRL_0S_SETEN; // ---- Enable DMA Transfer and clear TC bit ----
 
-	while (1) {
-		PIC::flush();
-		uartFlushIfNotSending(UART_ITEM_MIDI);
+	deluge::hid::display::wait_for_select_encoder_press();
 
-		uint8_t value;
-		bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
-		if (anything) {
-			if (value == 175) {
-				break;
-			}
-			else if (value == 249) {}
-		}
-	}
 	oledWaitingForMessage = 256;
 	spiBusCurrentlySending = false;
 

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -699,16 +699,7 @@ void SevenSegment::setTextVeryBasicA1(char const* text) {
 void SevenSegment::freezeWithError(char const* text) {
 	setTextVeryBasicA1(text);
 
-	while (1) {
-		PIC::flush();
-		uartFlushIfNotSending(UART_ITEM_MIDI);
-
-		uint8_t value;
-		bool anything = uartGetChar(UART_ITEM_PIC, (char*)&value);
-		if (anything && value == 175) {
-			break;
-		}
-	}
+	deluge::hid::display::wait_for_select_encoder_press();
 
 	setTextVeryBasicA1("OK");
 }

--- a/src/deluge/hid/display/seven_segment.cpp
+++ b/src/deluge/hid/display/seven_segment.cpp
@@ -693,7 +693,7 @@ void SevenSegment::setTextVeryBasicA1(char const* text) {
 	PIC::update7SEG(segments);
 }
 
-// Highest error code used, main branch: E453
+// Highest error code used, main branch: E455
 // Highest error code used, fix branch: i041
 
 void SevenSegment::freezeWithError(char const* text) {

--- a/src/deluge/model/song/song.cpp
+++ b/src/deluge/model/song/song.cpp
@@ -3150,6 +3150,13 @@ void Song::setTempoFromParams(int32_t magnitude, int8_t whichValue, bool shouldL
 void Song::deleteClipObject(Clip* clip, bool songBeingDestroyedToo, InstrumentRemoval instrumentRemovalInstruction) {
 
 	if (!songBeingDestroyedToo) {
+#if ALPHA_OR_BETA_VERSION
+		// Callers must remove any ClipInstances referencing this Clip first, or the arrangement is left pointing at
+		// freed memory - and pickAnActiveClipIfPossible() would pick this Clip back up mid-destruction (E411/E412).
+		if (clip->output && clip->output->clipHasInstance(clip)) {
+			FREEZE_WITH_ERROR("E455");
+		}
+#endif
 
 		char modelStackMemory[MODEL_STACK_MAX_SIZE];
 		ModelStackWithTimelineCounter* modelStack = setupModelStackWithTimelineCounter(modelStackMemory, this, clip);


### PR DESCRIPTION
Fix https://github.com/SynthstromAudible/DelugeFirmware/issues/4902

Couple fixes:
- Arranger was already preventing instrument track conversion to audio if clip instances exist in the arrangement. This extends that same logic to session view.
- Added freeze with error code to catch when you're trying to delete a clip that exists as a clip instance in arranger
- Fixed freeze with error code select encoder handling so that it waits for a press instead of responding to any select encoder message from the PIC. Before the fix pressing select would trigger the freeze and then releasing select would move to the next freeze code. So now we definitely see the first freeze code.

Re param manager error: it was essentially happening cause

1. you converted instrument clip in session view to audio clip
2. it then searches to see if it can assign another instrument clip as the active clip on that output 
3. it finds an arranger clip instance pointing to a clip that's been deleted
4. it tries to set the clip that clip instance is pointing to as the active clip
5. it then tries to setup patching for that clip which now has no patched param and patch cable param collections.
6. null param collection = E411/E412

Trying to fix the param manager stuff is another thing I'm looking at but in this case preventing conversion that would result in an invalid param manager state makes sense.