### PR TITLE
Fix expression automation getting lost between non-kit to kit to different non-kit changes

### DIFF
--- a/src/deluge/model/clip/instrument_clip.cpp
+++ b/src/deluge/model/clip/instrument_clip.cpp
@@ -1697,9 +1697,6 @@ Error InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelStack
                                        InstrumentRemoval instrumentRemovalInstruction,
                                        InstrumentClip* favourClipForCloningParamManager, bool keepNoteRowsWithMIDIInput,
                                        bool giveMidiAssignmentsToNewInstrument) {
-
-	bool shouldBackUpExpressionParamsToo = false;
-
 	// If switching to Kit
 	if (newInstrument->type == OutputType::KIT) {
 
@@ -1708,10 +1705,6 @@ Error InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelStack
 
 			// Makes sure all NoteRows onscreen are populated, and deletes any empty NoteRows not onscreen.
 			prepareToEnterKitMode(modelStack->song);
-
-			shouldBackUpExpressionParamsToo =
-			    true; // If switching from non-Kit to Kit, expression params won't get used, so store them with the
-			          // backup in case the old MelodicInstrument gets used again later. Actually is this ideal?
 		}
 	}
 
@@ -1734,9 +1727,10 @@ Error InstrumentClip::changeInstrument(ModelStackWithTimelineCounter* modelStack
 		expectNoFurtherTicks(modelStack->song); // Still necessary? Probably.
 	}
 
+	// Also unassigns NoteRows and remembers Drum names.
 	detachFromOutput(modelStack, true, (newInstrument->type == OutputType::KIT), false, keepNoteRowsWithMIDIInput,
 	                 giveMidiAssignmentsToNewInstrument,
-	                 shouldBackUpExpressionParamsToo); // Will unassignAllNoteRowsFromDrums(), and remember Drum names
+	                 false); // Keep channel expression on the Clip across output-type changes.
 
 	Error error =
 	    setInstrument(newInstrument, modelStack->song, newParamManager,


### PR DESCRIPTION
Channel expression automation can get lost if you switch between synth - kit - midi

Conversely if you switch between synth - midi - cv it works fine.

This is because when switching from non-kit to kit it was storing the expression with the backup, but if you switch from synth - kit - midi it was leaving the expression params behind with the synth param manager backup and never making it to the midi clip because the midi clip would try to restore them from the midi param manager backup.

Not storing the expression params with the backup and just keeping them with the clip allows you to move between all instrument clip types without losing the expression automation.

There was a comment left by Rohan questioning whether the current logic is ideal. Evidently it is not so this solves that too.