### PR TITLE
Fix patch cable polarity not saving properly

### DIFF
--- a/src/deluge/modulation/patch/patch_cable_set.cpp
+++ b/src/deluge/modulation/patch/patch_cable_set.cpp
@@ -998,7 +998,7 @@ void PatchCableSet::writePatchCablesToFile(Serializer& writer, bool writeAutomat
 
 				writer.writeOpeningTagBeginning("patchCable", true);
 				writer.writeAttribute("source", sourceToString(patchCables[d].from));
-				writer.writeAttribute("polarity", polarityToString(patchCables[c].polarity).data());
+				writer.writeAttribute("polarity", polarityToString(patchCables[d].polarity).data());
 				writer.insertCommaIfNeeded();
 				writer.write("\n");
 				writer.printIndents();


### PR DESCRIPTION
saving a range-adjusting cable wrote its parent cable’s polarity instead of its own

example:
- create cable Velocity->LPF - set polarity to unipolar
- then create range cable ENV1->Velocity->LPF - set polarity to bipolar

Save preset, re-load. ENV1->Velocity->LPF cable is loaded with unipolar from the parent cable (Velocity->LPF).