### PR TITLE
[DRAFT] Proposed culling fix for weird kit culling issue?

### DIFF
--- a/src/deluge/processing/engines/audio_engine.cpp
+++ b/src/deluge/processing/engines/audio_engine.cpp
@@ -421,13 +421,16 @@ void runRoutine() {
 extern uint16_t g_usb_usbmode;
 
 uint8_t numRoutines = 0;
+// Cost of one completed render, paired with voices_started_this_render. A scheduler
+// task can contain two renders, so its runtime is not a per-render DSP measurement.
+int32_t lastRenderTimeSamples = 0;
 
 // not in header (private to audio engine)
 /// determines how many voices to cull based on num audio samples, current voices and numSamplesLimit
 void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 
 	bool culled = false;
-	// at high loads voicesStarted is limited to 2. Since starting voices is a heavy load and we know it's temporary
+	// At high loads voice starts are limited to 1. Since starting voices is a heavy load and we know it's temporary
 	// we can be a bit more lenient with the limit
 	auto max_num_samples = numSamplesLimit + (20 * voices_started_this_render);
 	static int32_t last_num_samples_over = 0;
@@ -500,12 +503,10 @@ void cullVoices(size_t numSamples, int32_t numAudio, int32_t numVoice) {
 
 // not in header (private to audio engine)
 /// set the direness level and cull any voices
-inline void setDireness(size_t numSamples) { // Consider direness and culling - before increasing the number of samples
-	// number of samples it took to do the last render
-	auto dspTime = (int32_t)(getAverageRunTimeForTask(routine_task_id) * 44100.);
-	size_t nonDSP = numSamples - dspTime;
-	// we don't care about the number that were rendered in the last go, only the ones taken by the first routine call
-	numSamples = std::max<int32_t>(dspTime - (int32_t)(numRoutines * numSamples), 0);
+inline void setDireness() {
+	// Use the previous render's measured cost even when this is the second render
+	// in a scheduler task. Buffer occupancy is not time spent rendering.
+	const size_t numSamples = lastRenderTimeSamples;
 
 	// don't smooth this - used for other decisions as well
 	if (numSamples >= direnessThreshold) {
@@ -590,7 +591,8 @@ bool calledFromScheduler = false;
 		return;
 	}
 	flushMIDIGateBuffers();
-	setDireness(numSamples);
+	setDireness();
+	const double renderStartTime = getSystemTime();
 
 	// Double the number of samples we're going to do - within some constraints
 	int32_t sampleThreshold = 6; // If too low, it'll lead to bigger audio windows and stuff
@@ -622,6 +624,7 @@ bool calledFromScheduler = false;
 
 	scheduleMidiGateOutISR(saddrPosAtStart, unadjustedNumSamplesBeforeLappingPlayHead,
 	                       timeWithinWindowAtWhichMIDIOrGateOccurs);
+	lastRenderTimeSamples = std::max<int32_t>(0, (getSystemTime() - renderStartTime) * kSampleRate);
 
 #if DO_AUDIO_LOG
 	dumpAudioLog();

--- a/src/deluge/processing/sound/sound.cpp
+++ b/src/deluge/processing/sound/sound.cpp
@@ -2350,11 +2350,22 @@ void Sound::stopParamLPF(ModelStackWithSoundFlags* modelStack) {
 void Sound::process_postarp_notes(ModelStackWithSoundFlags* modelStackWithSoundFlags, ArpeggiatorSettings* arpSettings,
                                   ArpReturnInstruction instruction) {
 	if (instruction.arpNoteOn) {
-		instruction.arpNoteOn->noteStatus[0] = ArpNoteStatus::PENDING;
+		// The melodic arp's arp-off path marks its returned note PLAYING before
+		// we have actually started it. Restore that pending state, but do not
+		// retrigger the first note of a chord whose other notes are still pending.
+		if (!instruction.arpNoteOn->isPending()) {
+			instruction.arpNoteOn->noteStatus[0] = ArpNoteStatus::PENDING;
+		}
 
 		for (int32_t n = 0; n < ARP_MAX_INSTRUCTION_NOTES; n++) {
 			if (instruction.arpNoteOn->noteCodeOnPostArp[n] == ARP_NOTE_NONE) {
 				break;
+			}
+			if (instruction.arpNoteOn->noteStatus[n] != ArpNoteStatus::PENDING) {
+				continue;
+			}
+			if (!AudioEngine::allowedToStartVoice()) {
+				break; // Leave the remaining notes pending for the next render.
 			}
 			invertReversed = instruction.invertReversed;
 


### PR DESCRIPTION
Fix #4911

--

Have not verified the fix proposed in this PR yet.

--

I experienced a strange issue

1. i load the attached song and i hit play. the song plays all 3 kits fine.
2. i then mute some drums in the third kit and the kit starts culling voices

> In kit DDD-1, I'm muting drums TOMH, TOMM, TOML, and RIM
> If i mute TOMH and TOMM, no issue. As soon as i mute one more (e.g. TOML or RIM) it starts culling. Play button blinks. Audible audio dropouts.
> From play off with those drums muted, if i start play it starts culling.
> if i unmute all of those drums it stops culling.

Why would this happen when fewer drums are playing?

[3Kits.XML](https://github.com/user-attachments/files/32018712/3Kits.XML)

LLM diagnosis:

> I found a concrete accounting mismatch that could explain why fewer drums trigger culling: the engine measures the runtime of an entire audio task, which can contain two renders, but uses that measurement as though it were the cost of one render. See [setDireness() (line 503)](/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/processing/engines/audio_engine.cpp:503) and the [render loop (line 1058)]
> (/Users/sean/Documents/GitHub/DelugeFirmwareSean/src/deluge/processing/engines/audio_engine.cpp:1058).
> 
> Reducing the workload can change whether a task performs one render or two. Consequently, individual renders could become cheaper while the measured task runtime increases. That can cross the culling threshold repeatedly, explaining why restarting doesn’t resolve it and unmuting could restore stable playback.
> 
> There’s another inconsistency: deferred notes start during rendering without incrementing the counter used to grant extra startup allowance.

LLM proposed fix:

> - Measure processing time per render.
> - Count and limit deferred voice starts.
> - Avoid retriggering already-playing chord notes during retries.

